### PR TITLE
Guard inline-array span conversion helpers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
@@ -58,6 +58,19 @@ public class CrossAssemblyMethodFactsTests
     }
 
     [Fact]
+    public void CrossAssemblyInlineArrayHelper_RecoversInlineArrayTypeArgumentFact()
+    {
+        using var fixture = CrossAssemblyFixture.Create();
+        using var source = MetadataSource.Open(fixture.ConsumerPath);
+        var call = SingleCall(source, nameof(CrossAssemblyFixtureMethods.UseExternalInlineArray), "InlineArrayAsSpan");
+
+        Assert.Equal(MetadataFactState.Yes, call.Callee.DeclaringTypeCompilerGenerated);
+        Assert.Equal(MetadataFactState.Yes, call.Callee.TypeArguments[0].DeclaredInlineArray);
+        Assert.True(MemberIdentity.IsInlineArraySpanConversionHelper(call, out var arrayType));
+        Assert.Equal(MetadataFactState.Yes, arrayType.DeclaredInlineArray);
+    }
+
+    [Fact]
     public void MissingCrossAssemblyMetadata_KeepsFactsUnknown()
     {
         using var fixture = CrossAssemblyFixture.Create();
@@ -143,6 +156,12 @@ public class CrossAssemblyMethodFactsTests
                         [CompilerGenerated]
                         public static int Run(int value) => value + 1;
                     }
+
+                    [InlineArray(4)]
+                    public struct ExternalInline4
+                    {
+                        private int _element0;
+                    }
                     """);
                 string consumerPath = Emit(
                     directory,
@@ -179,6 +198,12 @@ public class CrossAssemblyMethodFactsTests
 
                         public static bool UseUri(string value)
                             => System.Uri.TryCreate(value, System.UriKind.Absolute, out var uri) && uri is not null;
+
+                        public static int UseExternalInlineArray(ExternalInline4 buffer, int index)
+                        {
+                            System.Span<int> span = buffer;
+                            return span[index];
+                        }
                     }
                     """,
                     [MetadataReference.CreateFromFile(libraryPath)]);
@@ -254,5 +279,6 @@ public class CrossAssemblyMethodFactsTests
         public const string UseGenerated = nameof(UseGenerated);
         public const string UseExternalDelegate = nameof(UseExternalDelegate);
         public const string UseUri = nameof(UseUri);
+        public const string UseExternalInlineArray = nameof(UseExternalInlineArray);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InlineArrayElementRefPassTests.cs
@@ -6,8 +6,9 @@ public class InlineArrayElementRefPassTests
 {
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
-    static readonly TypeRef Buffer = TypeRef.Definition("UserAssembly", "Samples", "Inline4", ValueTypeHint.ValueType);
-    static readonly TypeRef RuntimeBuffer = TypeRef.Definition("UserAssembly", "Samples", "ArgumentData", ValueTypeHint.ValueType);
+    static readonly TypeRef Buffer = TypeRef.Definition("UserAssembly", "Samples", "Inline4", ValueTypeHint.ValueType, MetadataFactState.Yes);
+    static readonly TypeRef NonInlineBuffer = TypeRef.Definition("UserAssembly", "Samples", "NotInline4", ValueTypeHint.ValueType, MetadataFactState.No);
+    static readonly TypeRef RuntimeBuffer = TypeRef.Definition("UserAssembly", "Samples", "ArgumentData", ValueTypeHint.ValueType, MetadataFactState.Yes);
     static readonly TypeRef SpanInt = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Span`1"), [Int32]);
 
     [Fact]
@@ -64,6 +65,34 @@ public class InlineArrayElementRefPassTests
     public void LocalBufferWithElementRefStore_StaysOutOfPlaceConversion()
     {
         var function = LocalBufferAsSpan(includeElementStore: true);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<InlineArraySpanConversion>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsSpan");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void LookalikeInlineArrayAsSpanWithoutGeneratedEvidence_StaysCall()
+    {
+        var function = FieldBufferAsSpan(
+            Buffer,
+            LookalikeHelper("InlineArrayAsSpan", [TypeRef.ByRef(Buffer), Int32], SpanInt, Buffer));
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<InlineArraySpanConversion>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InlineArrayAsSpan");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void InlineArrayAsSpanOverNonInlineArrayType_StaysCall()
+    {
+        var function = FieldBufferAsSpan(
+            NonInlineBuffer,
+            Helper("InlineArrayAsSpan", [TypeRef.ByRef(NonInlineBuffer), Int32], SpanInt, NonInlineBuffer));
 
         new InlineArrayCollectionPass().Run(function, PassContext.None);
 
@@ -172,6 +201,21 @@ public class InlineArrayElementRefPassTests
         return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [Buffer, SpanInt], body);
     }
 
+    static IrFunction FieldBufferAsSpan(TypeRef bufferType, MethodRef helper)
+    {
+        var field = new FieldRef(TypeRef.Definition("Synthetic", "", "T"), "_buffer", bufferType);
+        var block = new Block();
+        block.Add(new StoreLocal(0, SpanInt, new Call(
+            helper,
+            isVirtual: false,
+            [new LoadFieldAddress(field, instance: null), new Constant(4, Int32)])));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(Void, [], HasThis: true, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [SpanInt], body);
+    }
+
     static IrFunction FieldBufferWithSpanAndElementRef(
         MethodRef elementRef,
         IReadOnlyList<IrExpression> extraElementRefArguments,
@@ -231,9 +275,12 @@ public class InlineArrayElementRefPassTests
     }
 
     static MethodRef Helper(string name, IReadOnlyList<TypeRef> parameterTypes)
-        => Helper(name, parameterTypes, TypeRef.ByRef(Int32));
+        => Helper(name, parameterTypes, TypeRef.ByRef(Int32), Buffer);
 
     static MethodRef Helper(string name, IReadOnlyList<TypeRef> parameterTypes, TypeRef returnType)
+        => Helper(name, parameterTypes, returnType, Buffer);
+
+    static MethodRef Helper(string name, IReadOnlyList<TypeRef> parameterTypes, TypeRef returnType, TypeRef bufferType)
         => new(
             TypeRef.Definition(TypeRef.CoreLibrary, "", "<PrivateImplementationDetails>"),
             name,
@@ -241,7 +288,19 @@ public class InlineArrayElementRefPassTests
             [.. parameterTypes],
             HasThis: false)
         {
-            TypeArguments = [Buffer, Int32],
+            TypeArguments = [bufferType, Int32],
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+
+    static MethodRef LookalikeHelper(string name, IReadOnlyList<TypeRef> parameterTypes, TypeRef returnType, TypeRef bufferType)
+        => new(
+            TypeRef.Definition(TypeRef.CoreLibrary, "", "<PrivateImplementationDetails>"),
+            name,
+            returnType,
+            [.. parameterTypes],
+            HasThis: false)
+        {
+            TypeArguments = [bufferType, Int32],
         };
 
     static MethodRef RuntimeHelper(string name, IReadOnlyList<TypeRef> parameterTypes)

--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -9,9 +9,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// assembly's metadata cannot state on its own. A bare type token (a
 /// <c>newobj</c> target, a <c>box</c>/<c>sizeof</c> operand) carries no
 /// <c>VALUETYPE</c>/<c>CLASS</c> byte, so <see cref="TypeRef.ValueTypeHint"/> is
-/// <see cref="ValueTypeHint.Unknown"/> for cross-assembly references; collection
-/// initializer raising also needs interface evidence from the defining assembly.
-/// This resolver locates that assembly and reads the answer from its metadata.
+/// <see cref="ValueTypeHint.Unknown"/> for cross-assembly references; direct
+/// inline-array span conversion raising also needs <c>[InlineArray]</c> evidence,
+/// and collection initializer raising needs interface evidence from the defining
+/// assembly. This resolver locates that assembly and reads the answer from its
+/// metadata.
 /// </summary>
 /// <remarks>
 /// Precision-preserving: a fact is returned only when the defining assembly is
@@ -35,6 +37,7 @@ internal sealed class CrossAssemblyTypeResolver
     readonly MetadataReader _selfReader;
     readonly MetadataContext _context;
     readonly Dictionary<TypeRef, ValueTypeHint> _valueTypeCache = [];
+    readonly Dictionary<TypeRef, MetadataFactState> _inlineArrayCache = [];
     readonly Dictionary<MethodRef, ResolvedMethodFacts?> _methodFactCache = [];
     readonly Dictionary<(TypeRef Type, TypeRef Interface), MetadataFactState> _interfaceCache = [];
 
@@ -46,14 +49,14 @@ internal sealed class CrossAssemblyTypeResolver
     }
 
     /// <summary>
-    /// Returns <paramref name="type"/> with its declared value-type-ness stamped
-    /// when this resolver can confirm it from the defining assembly; returns the
-    /// type unchanged when it already carries a hint, is not a cross-assembly
-    /// named definition, or cannot be resolved.
+    /// Returns <paramref name="type"/> with cross-assembly type facts stamped
+    /// when this resolver can confirm them from the defining assembly; returns the
+    /// type unchanged when it already carries the needed facts, is not a
+    /// cross-assembly named definition, or cannot be resolved.
     /// </summary>
     public TypeRef Upgrade(TypeRef type)
     {
-        if (type.Kind != TypeRefKind.Definition || type.ValueTypeHint != ValueTypeHint.Unknown)
+        if (type.Kind != TypeRefKind.Definition)
             return type;
         if (string.IsNullOrEmpty(type.Assembly))
             return type;
@@ -61,8 +64,20 @@ internal sealed class CrossAssemblyTypeResolver
         if (type.Assembly == TypeRefDecoder.Canonical(_selfSimpleName))
             return type;
 
-        var hint = ResolveValueTypeHint(type);
-        return hint == ValueTypeHint.Unknown ? type : type.WithValueTypeHint(hint);
+        var result = type;
+        if (result.ValueTypeHint == ValueTypeHint.Unknown)
+        {
+            var hint = ResolveValueTypeHint(type);
+            if (hint != ValueTypeHint.Unknown)
+                result = result.WithValueTypeHint(hint);
+        }
+        if (result.InlineArray == MetadataFactState.Unknown)
+        {
+            var inlineArray = ResolveInlineArrayFact(type);
+            if (inlineArray != MetadataFactState.Unknown)
+                result = result.WithInlineArrayFact(inlineArray);
+        }
+        return result;
     }
 
     /// <summary>
@@ -74,6 +89,7 @@ internal sealed class CrossAssemblyTypeResolver
     /// </summary>
     public MethodRef Upgrade(MethodRef callee, bool resolveRequiresUnsafe)
     {
+        callee = UpgradeTypeReferences(callee);
         bool needsRefKinds = NeedsParameterRefKinds(callee);
         bool needsGenerated = NeedsGeneratedFacts(callee);
         bool needsUnsafe = resolveRequiresUnsafe && !callee.RequiresUnsafe;
@@ -113,6 +129,33 @@ internal sealed class CrossAssemblyTypeResolver
             IsExtension = needsExtension ? resolved.IsExtension : callee.IsExtension,
         };
     }
+
+    MethodRef UpgradeTypeReferences(MethodRef method)
+        => method with
+        {
+            DeclaringType = UpgradeTypeReference(method.DeclaringType),
+            ReturnType = UpgradeTypeReference(method.ReturnType),
+            ParameterTypes = [.. method.ParameterTypes.Select(UpgradeTypeReference)],
+            TypeArguments = [.. method.TypeArguments.Select(UpgradeTypeReference)],
+        };
+
+    TypeRef UpgradeTypeReference(TypeRef type) => type.Kind switch
+    {
+        TypeRefKind.Definition => Upgrade(type),
+        TypeRefKind.GenericInstance => TypeRef.GenericInstance(
+            UpgradeTypeReference(type.ElementType!),
+            [.. type.TypeArguments.Select(UpgradeTypeReference)]),
+        TypeRefKind.SzArray => TypeRef.SzArray(UpgradeTypeReference(type.ElementType!)),
+        TypeRefKind.Array => TypeRef.MdArray(UpgradeTypeReference(type.ElementType!), type.Rank),
+        TypeRefKind.ByRef => TypeRef.ByRef(UpgradeTypeReference(type.ElementType!)),
+        TypeRefKind.Pointer => TypeRef.Pointer(UpgradeTypeReference(type.ElementType!)),
+        TypeRefKind.Pinned => TypeRef.Pinned(UpgradeTypeReference(type.ElementType!)),
+        TypeRefKind.FunctionPointer => TypeRef.FunctionPointer(
+            UpgradeTypeReference(type.ElementType!),
+            [.. type.TypeArguments.Select(UpgradeTypeReference)],
+            type.CallingConvention),
+        _ => type,
+    };
 
     /// <summary>
     /// Returns whether a cross-assembly type implements an interface, resolving
@@ -364,6 +407,25 @@ internal sealed class CrossAssemblyTypeResolver
         return hint;
     }
 
+    MetadataFactState ResolveInlineArrayFact(TypeRef type)
+    {
+        if (_inlineArrayCache.TryGetValue(type, out var cached))
+            return cached;
+
+        var fact = MetadataFactState.Unknown;
+        try
+        {
+            if (Locate(type) is { } location)
+                fact = ReadInlineArrayFact(location);
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+        {
+        }
+
+        _inlineArrayCache[type] = fact;
+        return fact;
+    }
+
     TypeLocation? Locate(TypeRef type)
     {
         string name = type.Name.Replace('+', '.');
@@ -422,6 +484,19 @@ internal sealed class CrossAssemblyTypeResolver
         return baseName is "System.ValueType" or "System.Enum"
             ? ValueTypeHint.ValueType
             : ValueTypeHint.ReferenceType;
+    }
+
+    MetadataFactState ReadInlineArrayFact(TypeLocation location)
+    {
+        if (_context.Open(location.AssemblyPath) is not { } assembly)
+            return MetadataFactState.Unknown;
+        if (!assembly.TryGetType(location.FullTypeName, out var handle))
+            return MetadataFactState.Unknown;
+
+        var typeDef = assembly.Reader.GetTypeDefinition(handle);
+        return MethodDefinitionFacts.HasInlineArrayAttribute(assembly.Reader, typeDef)
+            ? MetadataFactState.Yes
+            : MetadataFactState.No;
     }
 
     static string? BaseTypeName(MetadataReader reader, EntityHandle baseType) => baseType.Kind switch

--- a/src/ILInspector.Decompiler/Pipeline/Facts/CollectionExpressionRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/CollectionExpressionRecoveryFacts.cs
@@ -8,7 +8,7 @@ internal sealed class CollectionExpressionRecoveryFacts : ILoweringFactProvider
             new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.CollectionExpression)),
             typeof(InlineArrayCollectionPass),
             [
-                new FactPrimitive("member.privateimpl-inline-array", "InlineArrayCollectionPass exact <PrivateImplementationDetails>.InlineArray* helper checks"),
+                new FactPrimitive("member.privateimpl-inline-array", "InlineArrayCollectionPass exact generated <PrivateImplementationDetails>.InlineArray* helper checks plus inline-array type evidence"),
                 new FactPrimitive("member.corelib-identity:ReadOnlySpan.ctor", "MemberIdentity.IsReadOnlySpanArrayConstructor"),
                 new FactPrimitive("member.corelib-identity:Span.ctor", "MemberIdentity.IsSpanArrayConstructor"),
                 new FactPrimitive("member.corelib-identity:ReadOnlySpan.CopyTo", "MemberIdentity.IsReadOnlySpanCopyTo"),

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -514,6 +514,34 @@ public static class MemberIdentity
         return true;
     }
 
+    public static bool IsInlineArraySpanConversionHelper(Call call, out TypeRef arrayType)
+    {
+        arrayType = null!;
+        if (call.IsVirtual
+            || call.Callee is not
+            {
+                HasThis: false,
+                Name: "InlineArrayAsSpan" or "InlineArrayAsReadOnlySpan",
+                DeclaringType: var declaringType,
+                DeclaringTypeCompilerGenerated: MetadataFactState.Yes,
+                TypeArguments: [var helperArrayType, var element],
+                ParameterTypes: [var byRefArray, var count],
+                ReturnType: var returnType,
+            }
+            || call.Arguments.Count != 2
+            || !IsPrivateImplementationDetailsType(declaringType)
+            || helperArrayType.DeclaredInlineArray != MetadataFactState.Yes
+            || !byRefArray.Equals(TypeRef.ByRef(helperArrayType))
+            || !count.Equals(s_int)
+            || !IsExpectedInlineArraySpanReturn(call.Callee.Name, returnType, element))
+        {
+            return false;
+        }
+
+        arrayType = helperArrayType;
+        return true;
+    }
+
     public static bool IsGenericListType(TypeRef? type, out TypeRef element)
     {
         element = null!;
@@ -587,6 +615,22 @@ public static class MemberIdentity
 
     static bool IsCollectionsMarshalType(TypeRef type)
         => IsCoreLibraryOrFacadeType(type, "System.Runtime.InteropServices", "CollectionsMarshal", "System.Runtime.InteropServices");
+
+    static bool IsPrivateImplementationDetailsType(TypeRef type)
+        => NamedDefinition(type) is
+        {
+            Kind: TypeRefKind.Definition,
+            Namespace: "",
+            Name: "<PrivateImplementationDetails>",
+        };
+
+    static bool IsExpectedInlineArraySpanReturn(string helperName, TypeRef returnType, TypeRef element)
+    {
+        string expected = helperName == "InlineArrayAsReadOnlySpan" ? "ReadOnlySpan`1" : "Span`1";
+        return returnType is { Kind: TypeRefKind.GenericInstance, ElementType: { } definition, TypeArguments: [var actualElement] }
+            && IsCoreLibraryType(definition, "System", expected)
+            && actualElement.Equals(element);
+    }
 
     static bool TryValueTupleArity(string name, out int arity)
     {

--- a/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
@@ -43,6 +43,9 @@ internal static class MethodDefinitionFacts
     internal static bool HasCompilerGeneratedAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes)
         => HasAttribute(reader, attributes, "System.Runtime.CompilerServices", "CompilerGeneratedAttribute");
 
+    internal static bool HasInlineArrayAttribute(MetadataReader reader, TypeDefinition type)
+        => HasAttribute(reader, type.GetCustomAttributes(), "System.Runtime.CompilerServices", "InlineArrayAttribute");
+
     // The compiler stamps ExtensionAttribute on an extension method (and on its
     // declaring class and module). The method-level mark is the precise signal.
     internal static bool HasExtensionAttribute(MetadataReader reader, MethodDefinition method)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -442,9 +442,7 @@ public sealed class InlineArrayCollectionPass : IIrPass
         {
             if (span.Parent is null)
                 continue;
-            if (!IsPrivateImpl(span.Callee, "InlineArrayAsReadOnlySpan") && !IsPrivateImpl(span.Callee, "InlineArrayAsSpan"))
-                continue;
-            if (span.Callee.TypeArguments is not [var arrayType, _])
+            if (!MemberIdentity.IsInlineArraySpanConversionHelper(span, out var arrayType))
                 continue;
             if (span.ResultType is not { } spanType)
                 continue;
@@ -463,7 +461,9 @@ public sealed class InlineArrayCollectionPass : IIrPass
     static bool CanRaisePlaceConversion(IrFunction function, IrExpression place, TypeRef arrayType)
         => place switch
         {
-            LoadFieldAddress or LoadArgumentAddress or LoadElementAddress => true,
+            LoadFieldAddress field => field.Field.Type.Equals(arrayType),
+            LoadArgumentAddress argument => argument.Type.Equals(arrayType),
+            LoadElementAddress element => element.ElementType.Equals(arrayType),
             LoadLocalAddress local => local.Type.Equals(arrayType) && IsInitOnlyLocalBuffer(function, local.Index),
             _ => false,
         };

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -118,8 +118,30 @@ public sealed class TypeRef : IEquatable<TypeRef>
     public ValueTypeHint DeclaredValueTypeHint =>
         Kind == TypeRefKind.GenericInstance ? ElementType?.ValueTypeHint ?? ValueTypeHint.Unknown : ValueTypeHint;
 
-    public static TypeRef Definition(string assembly, string ns, string name, ValueTypeHint valueTypeHint = ValueTypeHint.Unknown)
-        => new(TypeRefKind.Definition) { Assembly = assembly, Namespace = ns, Name = name, ValueTypeHint = valueTypeHint };
+    /// <summary>
+    /// Metadata <c>[InlineArray]</c> evidence on this named definition. Like
+    /// <see cref="ValueTypeHint"/>, this is provenance rather than identity and is
+    /// intentionally excluded from equality.
+    /// </summary>
+    public MetadataFactState InlineArray { get; private init; } = MetadataFactState.Unknown;
+
+    public MetadataFactState DeclaredInlineArray =>
+        Kind == TypeRefKind.GenericInstance ? ElementType?.InlineArray ?? MetadataFactState.Unknown : InlineArray;
+
+    public static TypeRef Definition(
+        string assembly,
+        string ns,
+        string name,
+        ValueTypeHint valueTypeHint = ValueTypeHint.Unknown,
+        MetadataFactState inlineArray = MetadataFactState.Unknown)
+        => new(TypeRefKind.Definition)
+        {
+            Assembly = assembly,
+            Namespace = ns,
+            Name = name,
+            ValueTypeHint = valueTypeHint,
+            InlineArray = inlineArray,
+        };
 
     /// <summary>
     /// Returns a copy of this named definition carrying <paramref name="hint"/>.
@@ -129,7 +151,10 @@ public sealed class TypeRef : IEquatable<TypeRef>
     /// returned unchanged.
     /// </summary>
     public TypeRef WithValueTypeHint(ValueTypeHint hint)
-        => Kind == TypeRefKind.Definition ? Definition(Assembly, Namespace, Name, hint) : this;
+        => Kind == TypeRefKind.Definition ? Definition(Assembly, Namespace, Name, hint, InlineArray) : this;
+
+    public TypeRef WithInlineArrayFact(MetadataFactState fact)
+        => Kind == TypeRefKind.Definition ? Definition(Assembly, Namespace, Name, ValueTypeHint, fact) : this;
 
     public static TypeRef CoreLib(string ns, string name)
         => Definition(CoreLibrary, ns, name);

--- a/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
@@ -53,12 +53,17 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         if (typeDef.IsNested)
         {
             var declaring = GetTypeFromDefinition(reader, typeDef.GetDeclaringType(), 0);
-            return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{name}", HintFrom(rawTypeKind));
+            return TypeRef.Definition(
+                declaring.Assembly,
+                declaring.Namespace,
+                $"{declaring.Name}+{name}",
+                HintFrom(rawTypeKind),
+                InlineArrayFact(reader, typeDef));
         }
         string assembly = reader.IsAssembly
             ? Canonical(reader.GetString(reader.GetAssemblyDefinition().Name))
             : "";
-        return TypeRef.Definition(assembly, ns, name, HintFrom(rawTypeKind));
+        return TypeRef.Definition(assembly, ns, name, HintFrom(rawTypeKind), InlineArrayFact(reader, typeDef));
     }
 
     public TypeRef GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
@@ -153,6 +158,11 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         ElementTypeClass => ValueTypeHint.ReferenceType,
         _ => ValueTypeHint.Unknown,
     };
+
+    static MetadataFactState InlineArrayFact(MetadataReader reader, TypeDefinition typeDef)
+        => MethodDefinitionFacts.HasInlineArrayAttribute(reader, typeDef)
+            ? MetadataFactState.Yes
+            : MetadataFactState.No;
 
     /// <summary>Canonicalizes corelib spellings so facade choice never affects identity.</summary>
     internal static string Canonical(string assemblyName) => assemblyName is


### PR DESCRIPTION
## Summary

- Require direct `InlineArrayAsSpan` / `InlineArrayAsReadOnlySpan` cast raises to use a generated `<PrivateImplementationDetails>` helper with an exact signature.
- Require positive `[InlineArray]` type evidence on the helper buffer type before replacing the helper call with an `InlineArraySpanConversion`.
- Propagate cross-assembly `[InlineArray]` type facts through method type arguments so genuine external inline-array buffers still raise.
- Add adversarial fixtures for lookalike span helpers and non-inline buffer types, plus a cross-assembly positive fact-recovery canary.

Closes #1364.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -v:q -m:1
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -class "ILInspector.Decompiler.Tests.InlineArrayElementRefPassTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -class "ILInspector.Decompiler.Tests.CrossAssemblyMethodFactsTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -class "ILInspector.Decompiler.Tests.IrImporterTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -class "ILInspector.Decompiler.Tests.IdiomShapeScorecardTests"
```

Generated current-main baseline, then diffed this branch against it:

```bash
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
  --diff-corpus-baseline /tmp/main-corpus-baseline-1364-final.json \
  --quality-diff-card \
  --emit-corpus-delta /tmp/corpus-delta-1364-final.json \
  --compile-cap 25 \
  --corpus-fidelity-cap 3 \
  --max-examples 3
```

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,104 methods
Correctness coverage: validity sampled 350 / 88,104 (0.40%); fidelity sampled 22 / 88,104 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-25). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 88,091 -> 88,104 (+13)
- ILInspector.Decompiler: 5,081 -> 5,094 methods (+13)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,453 (87.92%) | 77,464 (87.92%) | +11 |
| Conditional-branch residual | 2,309 (2.62%) | 2,310 (2.62%) | +1 |
| Forward-merge stops | 2,300 (2.61%) | 2,301 (2.61%) | +1 |
| Full malformed | 47 | 47 | 0 |
| Semantic defects | 4/350 — sampled 350 / 88,091 (0.40%) | 4/350 — sampled 350 / 88,104 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,091 (0.02%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,104 (0.02%) | 0 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor matched baseline tolerances.

Per-method delta artifact: `/tmp/corpus-delta-1364-final.json`
```

Changed-method fidelity over the final delta:

```text
CHANGED-METHOD COMPILE-BACK over 67 current changed methods (67 attempted)

  exact opcode match : 2
  opcode diff (Full) : 0
  not Full           : 0
  recompile fail     : 12
  context fail       : 53
```

The changed methods that did not compile back are harness context/skeleton failures; there are no `Full` opcode diffs.

## Adversarial review

Requested Opus 4.8 review. It found one medium issue: the first version only stamped `[InlineArray]` facts for same-assembly type definitions, so genuine cross-assembly inline-array buffers would falsely decline. Follow-up commit `df3157c7` fixes that by recursively propagating cross-assembly type facts through method type references and adds `CrossAssemblyInlineArrayHelper_RecoversInlineArrayTypeArgumentFact`.
