### PR TITLE
Tighten RuntimeHelpers.InitializeArray RVA signature gate (#1472)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
@@ -169,6 +169,87 @@ public class RvaSpanPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void InitializeArray_RealSignature_RaisesToArrayLiteral()
+    {
+        var function = BuildInitializeArrayRaising(RealInitializeArray());
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<ArrayLiteral>());
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InitializeArray");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void InitializeArray_WrongFirstParameter_IsNotRaised()
+    {
+        // #1472: a corelib `RuntimeHelpers.InitializeArray` overload whose first
+        // parameter is not `System.Array` (here `System.Object`) is not the real
+        // initializer; the RVA fold must decline rather than drop the call.
+        var lookalike = new MethodRef(
+            TypeRef.CoreLib("System.Runtime.CompilerServices", "RuntimeHelpers"),
+            "InitializeArray",
+            TypeRef.CoreLib("System", "Void"),
+            [TypeRef.CoreLib("System", "Object"), s_runtimeFieldHandle],
+            HasThis: false);
+        var function = BuildInitializeArrayRaising(lookalike);
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ArrayLiteral>());
+        Assert.Single(function.Descendants.OfType<NewArray>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InitializeArray");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void InitializeArray_NonVoidReturn_IsNotRaised()
+    {
+        var lookalike = new MethodRef(
+            TypeRef.CoreLib("System.Runtime.CompilerServices", "RuntimeHelpers"),
+            "InitializeArray",
+            s_int,
+            [TypeRef.CoreLib("System", "Array"), s_runtimeFieldHandle],
+            HasThis: false);
+        var function = BuildInitializeArrayRaising(lookalike);
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ArrayLiteral>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InitializeArray");
+        function.CheckInvariant();
+    }
+
+    static MethodRef RealInitializeArray()
+        => new MethodRef(
+            TypeRef.CoreLib("System.Runtime.CompilerServices", "RuntimeHelpers"),
+            "InitializeArray",
+            TypeRef.CoreLib("System", "Void"),
+            [TypeRef.CoreLib("System", "Array"), s_runtimeFieldHandle],
+            HasThis: false);
+
+    static IrFunction BuildInitializeArrayRaising(MethodRef initMethod)
+    {
+        var intArray = TypeRef.SzArray(s_int);
+        var token = new LoadToken(RuntimeTokenKind.Field, null, "<PrivateImplementationDetails>.Blob")
+        {
+            FieldRvaData = [1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0],
+        };
+        var block = new Block();
+        block.Add(new StoreLocal(0, intArray, new NewArray(s_int, new Constant(3, s_int))));
+        block.Add(new ExpressionStatement(new Call(initMethod, isVirtual: false, [new LoadLocal(0, intArray), token])));
+        block.Add(new Return(new LoadLocal(0, intArray)));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(intArray, [], HasThis: false, GenericParameterCount: 0),
+            [intArray],
+            body);
+    }
+
     static IrFunction BuildReadOnlySpanByteCtor(byte[] blob, int spanLength)
         => BuildReadOnlySpanCtor(s_byte, s_readOnlySpanByte, blob, spanLength);
 

--- a/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
@@ -217,6 +217,24 @@ public class RvaSpanPassTests
         new RvaSpanPass().Run(function, PassContext.None);
 
         Assert.Empty(function.Descendants.OfType<ArrayLiteral>());
+        Assert.Single(function.Descendants.OfType<NewArray>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InitializeArray");
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void InitializeArray_GenericArity_IsNotRaised()
+    {
+        // #1472: a corelib `RuntimeHelpers.InitializeArray<T>` look-alike carries a
+        // MethodSpec instantiation (non-empty TypeArguments). The real BCL method is
+        // non-generic, so the RVA fold must decline rather than drop the call.
+        var lookalike = RealInitializeArray() with { TypeArguments = [s_int] };
+        var function = BuildInitializeArrayRaising(lookalike);
+
+        new RvaSpanPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ArrayLiteral>());
+        Assert.Single(function.Descendants.OfType<NewArray>());
         Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "InitializeArray");
         function.CheckInvariant();
     }

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -10,6 +10,7 @@ public static class MemberIdentity
     static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef s_char = TypeRef.CoreLib("System", "Char");
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_array = TypeRef.CoreLib("System", "Array");
     static readonly TypeRef s_exception = TypeRef.CoreLib("System", "Exception");
     static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
@@ -549,8 +550,11 @@ public static class MemberIdentity
                 "System.Runtime.CompilerServices",
                 "RuntimeHelpers",
                 "InitializeArray")
+            && call.Callee.TypeArguments.IsEmpty
+            && call.Callee.ReturnType.Equals(s_void)
             && call.Arguments.Count == 2
-            && call.Callee.ParameterTypes is [_, var handle]
+            && call.Callee.ParameterTypes is [var array, var handle]
+            && array.Equals(s_array)
             && handle.Equals(s_runtimeFieldHandle);
 
     public static bool IsCollectionsMarshalSetCount(Call call, out TypeRef element)


### PR DESCRIPTION
Fixes #1472. Follow-up from the #1461 (#1399) adversarial review.

## Gap

`RvaSpanPass`'s `InitializeArray` RVA fold gated only on exact corelib identity (`IsStaticCoreLibraryMethod`, which already rejects user `RuntimeHelpers` lookalikes) + arg count + `RuntimeFieldHandle` second parameter. It did **not** validate the full signature, unlike the ReadOnlySpan ctor path (#1461) and CreateSpan path. The residual risk is a malformed/spoofed corelib-shaped `InitializeArray` overload having its call dropped and the array folded.

## Change

Tighten `MemberIdentity.IsRuntimeHelpersInitializeArray` to also require:

- no generic arity (`TypeArguments.IsEmpty`);
- return type `void`;
- first parameter `System.Array`

— the real `static void InitializeArray(System.Array, System.RuntimeFieldHandle)`.

## Evidence

`RvaSpanPassTests` (12/12) + `MemberIdentityTests` (16/16):

- **Positive canary** `InitializeArray_RealSignature_RaisesToArrayLiteral`: the real signature still folds to an array literal and drops the call.
- **Adversarial** `InitializeArray_WrongFirstParameter_IsNotRaised` (first param `System.Object`) and `InitializeArray_NonVoidReturn_IsNotRaised`: both stay lowered, call survives, `NewArray` preserved.
- Existing InitializeArray and ReadOnlySpan/CreateSpan tests unchanged.

```
RvaSpanPassTests     Total: 12, Failed: 0
MemberIdentityTests  Total: 16, Failed: 0
```

Decline-only hardening, no behavior change for valid input. Product path constraints preserved (SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading).
