### PR TITLE
Opt-in reconstruction-closure (cluster) fidelity capture

### DIFF
--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -375,10 +375,16 @@ Report changed-method runs in three bands:
 When repeated skeleton/context fixes only trade compiler diagnostics without
 growing the checkable population, stop the incremental burndown and say the
 plateau plainly. The next action is either a bounded safety case over the
-checkable rows, or a measurement issue before redesign. For the current #1318
-plateau, that measurement is #1412: compute whether failures are caused by
-unrelated-sibling poison or by types in the target's reconstruction closure
-before building a scoped-skeleton emitter.
+checkable rows, or a measurement issue before redesign. The #1318 plateau was
+measured under #1412: the failures are not predominantly unrelated-sibling
+poison but types genuinely inside the target's (often large) reconstruction
+closure. The harness now ships an opt-in **reconstruction-closure (cluster)
+emitter** (`CB_CLUSTER=1`) that reconstructs only the target's transitive closure
+instead of the whole module and falls back to the whole-module skeleton on bail,
+so it never regresses; a persistent bail is a principled
+`not-safely-capturable` classification. The gain is library-shaped, not
+universal — see [decompiler-quality.md](decompiler-quality.md#reconstruction-closures-and-the-safely-capturable-population)
+for the safely-capturable framing and the segmented-reporting follow-ups.
 
 For #1175-class retained-label work, a go/no-go comment should name the
 checkable changed-method rows, the opcode-diff docket, and the remaining

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -102,6 +102,37 @@ forward-merge/structuring-residual population. If that population recompiles at 
 lower rate than the corpus average, treat that as the next context-injection
 target rather than declaring victory from an easier global sample.
 
+#### Reconstruction closures and the safely-capturable population
+
+Changed-method fidelity is most meaningful on **reconstructable** libraries. The
+whole-module skeleton must stub every top-level type because the target assembly
+cannot be referenced (the reconstructed type would collide), so the compile is
+all-or-nothing: one un-reconstructable sibling type poisons every method in the
+module, scoring targets `RecompileFail` for reasons unrelated to their own
+fidelity. Two populations are structurally hostile to this and are *not* the
+signal to chase: generated/synthesized members (regex source-gen output, lambda
+display classes, iterator/async frames — classified out up front), and
+Roslyn-class assemblies whose internal cross-assembly type graphs (e.g.
+`Microsoft.CodeAnalysis` ↔ `.CSharp`) are too large and entangled to reconstruct
+in isolation. On the Roslyn-heavy #1251/#1209 stress delta these dominate the
+failures; the genuinely checkable rows are all non-Roslyn.
+
+The harness's opt-in **reconstruction-closure (cluster) capture** (`CB_CLUSTER=1`,
+see the [harness README](../tools/DecompilerHarness/README.md)) reconstructs only
+the target's transitive closure rather than the whole module: emit the target
+type, compile, and let the compiler name the missing same-assembly types it
+still needs, recompiling until the unit binds or the closure stops growing. It
+falls back to the whole-module skeleton when the closure cannot be closed within
+budget, so it never regresses below the baseline — it only rescues targets the
+all-or-nothing skeleton failed for unrelated sibling reasons. A persistent bail
+is a principled *not-safely-capturable* classification rather than a fidelity
+verdict. The current gain is modest and library-shaped; raising the
+non-pathological green rate (extension/inherited-member inclusion) and emitting
+segmented "safely-capturable vs not" reporting are tracked follow-ups, not yet
+landed. The point is the inverse of cheating: a good cluster system lets honest
+changed-method fidelity make real progress on non-pathological libraries instead
+of being held hostage by an unrelated gap somewhere else in the module.
+
 ### Fixture idiom-shape scorecard
 
 `IdiomShapeScorecardTests` is the fixture-backed C# altitude check. It renders

--- a/src/ILInspector.Decompiler.Tests/ClusterCaptureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ClusterCaptureTests.cs
@@ -1,0 +1,36 @@
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Pins reconstruction-closure (cluster) capture (#1412): instead of
+/// reconstructing the whole module, the fidelity check reconstructs only the
+/// types the target transitively needs (grown compile-driven from compiler
+/// "type/member not found" diagnostics) and falls back to the whole-module build
+/// on bail. For a method that already compiles whole-module the closure must
+/// reconstruct the same body to the same IL, so the opcode outcome is identical —
+/// the capture is an optimisation that greens unrelated-sibling-poisoned rows
+/// without ever changing a result it already had.
+/// </summary>
+public class ClusterCaptureTests
+{
+    const string FixtureType = "ILInspector.Decompiler.Tests.CfgSampleClass";
+
+    [Fact]
+    public void ClusterCapture_MatchesWholeModuleForFixtures()
+    {
+        string assembly = typeof(CfgSampleClass).Assembly.Location;
+
+        var whole = FidelityCheck.Evaluate(assembly, lowered: false, cluster: false)
+            .Where(r => r.Type == FixtureType)
+            .ToDictionary(r => (r.Method, r.Overload), r => r.Status);
+        var cluster = FidelityCheck.Evaluate(assembly, lowered: false, cluster: true)
+            .Where(r => r.Type == FixtureType)
+            .ToDictionary(r => (r.Method, r.Overload), r => r.Status);
+
+        Assert.NotEmpty(cluster);
+        Assert.Contains(cluster.Values, status => status == FidelityCheck.CompileBackStatus.Exact);
+        foreach (var (key, wholeStatus) in whole)
+            Assert.Equal(wholeStatus, cluster[key]);
+    }
+}

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -215,6 +215,14 @@ static class FidelityCheck
     /// cross-method import seam from the open source (lambda raising).
     /// </summary>
     public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, bool lowered)
+        => Evaluate(assemblyPath, lowered, cluster: false);
+
+    /// <summary>
+    /// Evaluates one assembly, optionally using reconstruction-closure (cluster)
+    /// capture (#1412) instead of whole-module reconstruction. The test seam for
+    /// the cluster path, equivalent to setting the CB_CLUSTER environment variable.
+    /// </summary>
+    public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, bool lowered, bool cluster)
     {
         var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
         var compileOptions = new CSharpCompilationOptions(
@@ -232,7 +240,7 @@ static class FidelityCheck
         var references = RuntimeReferences(assemblyPath);
 
         foreach (var typeHandle in reader.TypeDefinitions)
-            EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, results);
+            EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, results, cluster: cluster);
 
         return results;
     }
@@ -496,7 +504,7 @@ static class FidelityCheck
                         continue;
 
                     var render = Renderer(source, lowered);
-                    var references = RuntimeReferences(assemblyPath);
+                    var references = RuntimeReferences(assemblyPath, assemblies);
                     foreach (var typeHandle in reader.TypeDefinitions)
                     {
                         if (pending.Count == 0)
@@ -750,7 +758,7 @@ static class FidelityCheck
         MetadataReader reader, PEReader pe, MetadataSource source, TypeDefinitionHandle typeHandle,
         ReferenceSet references, CSharpParseOptions parseOptions,
         CSharpCompilationOptions compileOptions, Func<IrFunction, DecompilerResult> render, List<CompileBackResult> results,
-        int maxEntries = int.MaxValue)
+        int maxEntries = int.MaxValue, bool cluster = false)
     {
         if (maxEntries <= 0)
             return;
@@ -758,7 +766,7 @@ static class FidelityCheck
             return;
         if (entries.Count > maxEntries)
             entries = entries.Take(maxEntries).ToList();
-        results.AddRange(EvaluateGrouped(reader, references, parseOptions, compileOptions, fullType, typeHandle, entries));
+        results.AddRange(EvaluateGrouped(reader, references, parseOptions, compileOptions, fullType, typeHandle, entries, cluster));
     }
 
     /// <summary>
@@ -773,9 +781,22 @@ static class FidelityCheck
     static List<CompileBackResult> EvaluateGrouped(
         MetadataReader reader, ReferenceSet references,
         CSharpParseOptions parseOptions, CSharpCompilationOptions compileOptions,
-        string fullType, TypeDefinitionHandle typeHandle, IReadOnlyList<Entry> entries)
+        string fullType, TypeDefinitionHandle typeHandle, IReadOnlyList<Entry> entries, bool cluster = false)
     {
         var results = new List<CompileBackResult>();
+        // Reconstruction-closure (cluster) capture — reconstruct only the types the
+        // target transitively needs (grown compile-driven), with whole-module
+        // fallback, so an unrelated sibling's gap cannot poison the target and the
+        // capture never regresses (#1412). Opt-in via the `cluster` flag or the
+        // CB_CLUSTER environment variable.
+        if (cluster || Environment.GetEnvironmentVariable("CB_CLUSTER") is not null)
+        {
+            var (typeIndex, methodIndex) = ClusterIndexes(reader);
+            foreach (var e in entries)
+                results.Add(CompileOneClustered(reader, references, parseOptions, compileOptions, fullType, e, typeIndex, methodIndex)
+                    ?? CompileOne(reader, references, parseOptions, compileOptions, fullType, e));
+            return results;
+        }
         // CB_NOGROUP forces the per-method path — the A/B baseline for the speedup.
         bool grouped = entries.Count > 1 && Environment.GetEnvironmentVariable("CB_NOGROUP") is null;
         if (grouped && TryCompileGroup(reader, references, parseOptions, compileOptions, fullType, typeHandle, entries, results))
@@ -854,6 +875,167 @@ static class FidelityCheck
         return rOps is null
             ? new(fullType, e.Name, e.Overload, e.Signature, CompileBackStatus.ContextFail, e.OrigText, "", "method-not-found")
             : Classify(fullType, e, rOps);
+    }
+
+    // ---- Reconstruction-closure (cluster) capture (#1412, opt-in via CB_CLUSTER) ----
+
+    static readonly System.Runtime.CompilerServices.ConditionalWeakTable<MetadataReader, ClusterIndex> s_clusterIndexCache = new();
+
+    sealed record ClusterIndex(
+        Dictionary<string, List<TypeDefinitionHandle>> Types,
+        Dictionary<string, List<TypeDefinitionHandle>> Methods);
+
+    /// <summary>
+    /// Two name -> top-level-root maps for the compile-driven cluster: type leaf
+    /// names (to resolve a missing type) and method names (to resolve a missing
+    /// extension method to the static class that declares it). Cached per reader.
+    /// </summary>
+    static (Dictionary<string, List<TypeDefinitionHandle>> Types, Dictionary<string, List<TypeDefinitionHandle>> Methods) ClusterIndexes(MetadataReader reader)
+    {
+        if (s_clusterIndexCache.TryGetValue(reader, out var cached))
+            return (cached.Types, cached.Methods);
+
+        var types = new Dictionary<string, List<TypeDefinitionHandle>>(StringComparer.Ordinal);
+        var methods = new Dictionary<string, List<TypeDefinitionHandle>>(StringComparer.Ordinal);
+        static void Add(Dictionary<string, List<TypeDefinitionHandle>> index, string key, TypeDefinitionHandle root)
+        {
+            if (key.Length == 0)
+                return;
+            if (!index.TryGetValue(key, out var list))
+                index[key] = list = [];
+            if (!list.Contains(root))
+                list.Add(root);
+        }
+
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            var root = TopLevelRootOf(reader, handle);
+            Add(types, NormalizeTypeName(reader.GetString(typeDef.Name)), root);
+            // Static-class methods are the extension-method candidates a CS1061
+            // "no accessible extension method 'M'" must resolve to.
+            if ((typeDef.Attributes & (TypeAttributes.Abstract | TypeAttributes.Sealed)) == (TypeAttributes.Abstract | TypeAttributes.Sealed))
+                foreach (var mh in typeDef.GetMethods())
+                    Add(methods, reader.GetString(reader.GetMethodDefinition(mh).Name), root);
+        }
+
+        s_clusterIndexCache.Add(reader, new ClusterIndex(types, methods));
+        return (types, methods);
+    }
+
+    /// <summary>
+    /// Compile-driven reconstruction-closure capture: reconstruct only the target's
+    /// own type, compile, and for every "type not found" the compiler reports that
+    /// resolves to a target-assembly type, add that type's top-level root and
+    /// recompile — letting the compiler compute the exact closure. A type the
+    /// target never references (the unrelated-sibling poison behind the #1318
+    /// plateau) is never named, so it is never pulled in. Bails when the closure
+    /// stops growing (a genuine target-body/hierarchy gap) or exceeds a budget (an
+    /// unsafe, unbounded closure).
+    /// </summary>
+    static CompileBackResult? CompileOneClustered(
+        MetadataReader reader, ReferenceSet references,
+        CSharpParseOptions parseOptions, CSharpCompilationOptions compileOptions,
+        string fullType, Entry e,
+        IReadOnlyDictionary<string, List<TypeDefinitionHandle>> nameIndex,
+        IReadOnlyDictionary<string, List<TypeDefinitionHandle>> methodIndex)
+    {
+        const int maxRoots = 200;
+        const int maxIterations = 80;
+        var include = new HashSet<TypeDefinitionHandle>
+        {
+            TopLevelRootOf(reader, reader.GetMethodDefinition(e.Handle).GetDeclaringType()),
+        };
+        Diagnostic? firstError = null;
+        for (int iteration = 0; iteration < maxIterations; iteration++)
+        {
+            string unit;
+            try { unit = BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.FieldInits, references.Accessibility, include); }
+            catch { return null; } // fall back to the whole-module build
+
+            var tree = CSharpSyntaxTree.ParseText(unit, parseOptions);
+            var comp = CSharpCompilation.Create("cb", [tree], references.Metadata, compileOptions);
+            using var ms = new MemoryStream();
+            var emit = comp.Emit(ms);
+            if (emit.Success)
+            {
+                ms.Position = 0;
+                using var rpe = new PEReader(ms);
+                var rOps = FindAndDisassemble(rpe, fullType, e.Name, e.Overload)?.Select(i => CanonicalOpcode(i.OpCodeName)).ToList();
+                return rOps is null ? null : Classify(fullType, e, rOps);
+            }
+
+            var errors = emit.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+            firstError = errors.FirstOrDefault();
+            bool grew = false;
+            foreach (var diagnostic in errors)
+            {
+                // CS0246/CS0234: a missing type; CS0103: a missing name used as an
+                // expression (a static helper class referenced by name). Both name
+                // a target-assembly type the closure must add.
+                if (diagnostic.Id is "CS0246" or "CS0234" or "CS0103")
+                {
+                    foreach (var name in QuotedNames(diagnostic.GetMessage()))
+                        if (nameIndex.TryGetValue(NormalizeTypeName(name), out var roots))
+                            foreach (var root in roots)
+                                grew |= include.Add(root);
+                }
+                // CS1061: a missing member — most often an extension method whose
+                // static declaring class is not yet in the closure. Add the roots
+                // declaring a (static) method of that name.
+                else if (diagnostic.Id is "CS1061")
+                {
+                    foreach (var name in QuotedNames(diagnostic.GetMessage()))
+                        if (methodIndex.TryGetValue(NormalizeTypeName(name), out var roots))
+                            foreach (var root in roots)
+                                grew |= include.Add(root);
+                }
+            }
+            if (!grew || include.Count > maxRoots)
+            {
+                if (Environment.GetEnvironmentVariable("CB_CLUSTER_DUMP") is not null)
+                    Console.Error.WriteLine($"BAIL {fullType}.{e.Name} roots={include.Count} grew={grew}: {FormatDiagnostic(firstError)}");
+                return null; // closure stopped growing or got too large — fall back
+            }
+        }
+        return null; // fall back to the whole-module build
+    }
+
+    /// <summary>The top-level type a (possibly nested) type definition belongs to.</summary>
+    static TypeDefinitionHandle TopLevelRootOf(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        var declaring = reader.GetTypeDefinition(handle).GetDeclaringType();
+        return declaring.IsNil ? handle : TopLevelRootOf(reader, declaring);
+    }
+
+    /// <summary>A type name with its trailing generic arguments and arity stripped to the leaf simple name.</summary>
+    static string NormalizeTypeName(string name)
+    {
+        int angle = name.IndexOf('<');
+        if (angle >= 0)
+            name = name[..angle];
+        int dot = name.LastIndexOf('.');
+        if (dot >= 0)
+            name = name[(dot + 1)..];
+        int tick = name.IndexOf('`');
+        return tick >= 0 ? name[..tick] : name;
+    }
+
+    /// <summary>The single-quoted spans of a compiler diagnostic message (the named types).</summary>
+    static IEnumerable<string> QuotedNames(string message)
+    {
+        int i = 0;
+        while (true)
+        {
+            int start = message.IndexOf('\'', i);
+            if (start < 0)
+                yield break;
+            int end = message.IndexOf('\'', start + 1);
+            if (end < 0)
+                yield break;
+            yield return message[(start + 1)..end];
+            i = end + 1;
+        }
     }
 
     static CompileBackResult Classify(string fullType, Entry e, IReadOnlyList<string> rOps) =>
@@ -1076,11 +1258,11 @@ static class FidelityCheck
     static string BuildUnit(MetadataReader reader, MethodDefinitionHandle target, string targetBody, string? targetChain,
         bool targetRequiresAsync,
         IReadOnlyList<(string Field, string Value)> targetFieldInits,
-        SignatureAccessibility accessibility)
+        SignatureAccessibility accessibility, IReadOnlySet<TypeDefinitionHandle>? includeRoots = null)
     {
         var targets = new Dictionary<MethodDefinitionHandle, TargetBody> { [target] = new(targetBody, targetChain, targetRequiresAsync) };
         var fieldInitType = reader.GetMethodDefinition(target).GetDeclaringType();
-        return BuildUnit(reader, targets, targetFieldInits, fieldInitType, accessibility);
+        return BuildUnit(reader, targets, targetFieldInits, fieldInitType, accessibility, includeRoots);
     }
 
     /// <summary>
@@ -1095,7 +1277,7 @@ static class FidelityCheck
     /// </summary>
     static string BuildUnit(MetadataReader reader, IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets,
         IReadOnlyList<(string Field, string Value)> fieldInits, TypeDefinitionHandle fieldInitType,
-        SignatureAccessibility accessibility)
+        SignatureAccessibility accessibility, IReadOnlySet<TypeDefinitionHandle>? includeRoots = null)
     {
         var sb = new StringBuilder();
         sb.AppendLine("#pragma warning disable");
@@ -1113,6 +1295,8 @@ static class FidelityCheck
             var typeDef = reader.GetTypeDefinition(typeHandle);
             if (!typeDef.GetDeclaringType().IsNil)
                 continue; // nested types are emitted by their enclosing type
+            if (includeRoots is not null && !includeRoots.Contains(typeHandle))
+                continue; // cluster mode: emit only the reconstruction-closure roots
             string name = reader.GetString(typeDef.Name);
             if (name.Contains('<') || name == "<Module>")
                 continue; // compiler-generated / module pseudo-type
@@ -1934,7 +2118,7 @@ static class FidelityCheck
     /// referencing its neighbours resolves cross-assembly types in the stubbed
     /// signatures.
     /// </summary>
-    static ReferenceSet RuntimeReferences(string targetPath)
+    static ReferenceSet RuntimeReferences(string targetPath, IReadOnlyList<string>? corpusAssemblies = null)
     {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var referencePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -1980,6 +2164,15 @@ static class FidelityCheck
 
             AddDepsJsonReferences(dir, targetName, Add);
         }
+
+        // Cross-package corpus siblings (the other assemblies under analysis) are
+        // not co-located with the target or on the TPA, so a body or sibling
+        // signature referencing them would not bind. Referencing them resolves
+        // those public types and lets SignatureAccessibility skip stubs exposing
+        // their internals (#1376).
+        if (corpusAssemblies is not null)
+            foreach (var path in corpusAssemblies)
+                Add(path);
 
         return new ReferenceSet(builder.ToImmutable(), new SignatureAccessibility(referencePaths));
     }

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -288,6 +288,29 @@ miss: most often a **stale delta** whose method signature has drifted from the
 current corpus build (e.g. a return type changed since the snapshot), so the
 exact method no longer exists to attempt.
 
+*Reconstruction-closure (cluster) capture* (`CB_CLUSTER=1`, opt-in). The
+whole-module skeleton is all-or-nothing: because the target assembly cannot be
+referenced (the reconstructed type would collide with it), **every** top-level
+type must be stubbed, so a single un-reconstructable sibling type — an unrelated
+printer gap in a type the target never touches — poisons the compile and the
+target is scored `RecompileFail` for reasons that have nothing to do with its
+own fidelity. Cluster mode reconstructs only the target's transitive closure: it
+emits the target's type, compiles, and adds every same-assembly type the
+compiler names as missing (`CS0246`/`CS0234`/`CS0103` for types, `CS1061` for
+static/extension members), recompiling until the unit binds or the closure stops
+growing. The compiler computes the exact closure, so unrelated sibling types are
+simply omitted. When the closure cannot be closed within budget (default 200
+roots / 80 iterations) the run **bails and falls back to the whole-module
+skeleton**, so cluster results are always ≥ the baseline — it never regresses,
+only rescues targets the all-or-nothing skeleton failed for unrelated reasons. A
+persistent bail is itself a useful signal: the target is *not safely capturable*
+in isolation (typically a Roslyn-class internal cross-assembly graph), which is
+the population for which changed-method fidelity is least meaningful. `CB_CLUSTER_DUMP=1`
+prints bail diagnostics. The gain is modest and library-shaped, not universal:
+on the Roslyn-heavy #1251/#1209 stress delta it rescues a handful of
+non-pathological rows; segmented "safely-capturable vs not" reporting is planned,
+not yet emitted.
+
 ```bash
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --fidelity-check \


### PR DESCRIPTION
Closes the measurement-then-build arc of #1412 (the #1318 changed-method
fidelity plateau).

## Problem

Changed-method fidelity recompiles each target inside a reconstructed
**whole-module skeleton**. Because the target assembly cannot be referenced
(the reconstructed type would collide with it), **every** top-level type must
be stubbed. That makes the compile all-or-nothing: a single un-reconstructable
sibling type — an unrelated printer gap in a type the target never touches —
poisons every method in the module, scoring otherwise-fine targets
`RecompileFail` for reasons that have nothing to do with their own fidelity.
This is exactly why the checkable population plateaued (#1318): every skeleton
fix since #1308 traded one diagnostic bucket for another without growing the
checkable count.

## What this does

Adds an **opt-in** reconstruction-closure ("cluster") emitter (`CB_CLUSTER=1`,
or the new `Evaluate(path, lowered, cluster)` test seam). Instead of the whole
module, it reconstructs only the target's transitive closure:

1. Emit the target's type, compile.
2. Add every same-assembly type the compiler names as missing
   (`CS0246`/`CS0234`/`CS0103` for types, `CS1061` for static/extension
   members).
3. Recompile until the unit binds or the closure stops growing.

The compiler computes the exact closure, so unrelated sibling types are simply
omitted. When the closure cannot be closed within budget (200 roots / 80
iterations) the run **bails and falls back to the whole-module skeleton**, so
cluster results are always **≥ baseline — it never regresses**, it only rescues
targets the all-or-nothing skeleton failed for unrelated sibling reasons. A
persistent bail is itself a principled `not-safely-capturable` classification:
the target (typically a Roslyn-class internal cross-assembly graph) is the
population for which changed-method fidelity is least meaningful.
`CB_CLUSTER_DUMP=1` prints bail diagnostics.

## Honest results (#1251/#1209 stress delta)

| | checkable (exact + opcode-diff) |
| --- | --- |
| whole-module baseline | 43 |
| `CB_CLUSTER=1` | 46 |

**The gain is modest and library-shaped, not a 2x.** The cheap proxy
(first-error-in-unrelated-type) over-estimated; the real closures for complex
Roslyn methods are genuinely large (>200 roots), so most "sibling" types are
actually *in* the closure. What the engine buys is the **foundation + the
never-regresses guarantee + the not-safely-capturable signal**. This is the
right shape: the #1251/#1209 delta is a Roslyn-heavy stress test (45/165 changed
methods are Roslyn, ~100% pathological); every one of the 43 checkable rows is
non-Roslyn. A good cluster system is what lets honest changed-method fidelity
make real progress on non-pathological libraries instead of being held hostage
by an unrelated gap elsewhere in the module.

## Tests

`ClusterCaptureTests` asserts the cluster path produces results **identical** to
the whole-module path for all `CfgSampleClass` methods (correctness + zero
regression) plus at least one `Exact`. Passes (362s in this slow shared env).

## Docs

- Harness README documents `CB_CLUSTER` (compile-driven closure, whole-module
  fallback, bail = not-safely-capturable signal).
- `docs/decompiler-quality.md` gains the reconstruction-closure /
  safely-capturable framing.
- `docs/decompiler-correctness-pipeline.md` updates the #1318/#1412 plateau
  paragraph to point at the now-built engine.

## Follow-ups (tracked in #1412)

- Extension-member name resolution + inherited (base-type) inclusion to raise
  the non-pathological green rate.
- Segmented "safely-capturable vs not" library-scoped reporting.

Refs #1412, #1318.