### PR TITLE
Document instruction refresh after updating main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,11 @@ Reusing a worktree across PRs is perfectly fine. Whichever you choose, the rule
 is the same: use worktrees, and start every new feature even with `origin/main`
 (fetch and base off the latest `origin/main`).
 
+After fetching, rebasing, merging `origin/main`, or resolving conflicts from
+main, re-read `AGENTS.md` and any task-relevant docs it points to before
+continuing. If instructions changed, treat the refreshed instructions as
+authoritative and adjust PR evidence/status accordingly.
+
 Create feature branches with descriptive names, e.g.:
 - `feature/issue-3-assembly-references`
 - `fix/null-reference-in-parser`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,10 @@ Reusing a worktree across PRs is perfectly fine. Whichever you choose, the rule
 is the same: use worktrees, and start every new feature even with `origin/main`
 (fetch and base off the latest `origin/main`).
 
+Before opening a PR, fetch `origin/main` and update the feature branch with the
+latest main using either merge or rebase. Resolve conflicts locally and rerun
+relevant checks so the PR does not start from a stale base.
+
 After fetching, rebasing, merging `origin/main`, or resolving conflicts from
 main, re-read `AGENTS.md` and any task-relevant docs it points to before
 continuing. If instructions changed, treat the refreshed instructions as


### PR DESCRIPTION
## Summary

Adds an agent workflow note to `AGENTS.md`: after fetching, rebasing, merging `origin/main`, or resolving conflicts from main, agents should re-read `AGENTS.md` and task-relevant docs before continuing.

This is intended to reduce stale-instruction / stale-baseline behavior in long-running agent sessions and reused worktrees.

## Evidence

- `npx markdownlint-cli --fix AGENTS.md`
- `npx markdownlint-cli AGENTS.md`

Docs-only; no product behavior change.
