### PR TITLE
Require corelib identity for Range/Index slice raise (#1460)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RangeFromGetSubArrayPassTests.cs
@@ -68,6 +68,84 @@ public class RangeFromGetSubArrayPassTests
         function.CheckInvariant();
     }
 
+    // #1460: a user-assembly `System.Range.StartAt` factory returning the corelib
+    // Range type still type-checks inside the (real corelib) GetSubArray call, but
+    // is not the corelib factory; raising `a[i..]` would drop its side effects.
+    [Fact]
+    public void GetSubArray_FromUserRangeStartAtLookalike_IsNotRaised()
+    {
+        var function = BuildGetSubArrayWithRange(BuildUserRangeStartAt());
+
+        new RangeFromGetSubArrayPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "StartAt");
+        function.CheckInvariant();
+    }
+
+    // #1460: a user-assembly `System.Index.op_Implicit` conversion returning the
+    // corelib Index type, used as an endpoint of the real corelib Range ctor.
+    [Fact]
+    public void GetSubArray_FromUserIndexConversionLookalike_IsNotRaised()
+    {
+        var function = BuildGetSubArrayWithRange(BuildRangeCtorWithUserIndexConversion());
+
+        new RangeFromGetSubArrayPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<SliceExpression>());
+        Assert.Contains(function.Descendants.OfType<Call>(), c => c.Callee.Name == "op_Implicit");
+        function.CheckInvariant();
+    }
+
+    static IrFunction BuildGetSubArrayWithRange(IrExpression rangeArg)
+    {
+        var getSubArray = new MethodRef(
+            TypeRef.CoreLib("System.Runtime.CompilerServices", "RuntimeHelpers"),
+            "GetSubArray",
+            s_intArray,
+            [s_intArray, s_range],
+            HasThis: false);
+        var block = new Block();
+        block.Add(new Return(new Call(getSubArray, isVirtual: false, [new LoadArgument(0, "a", s_intArray), rangeArg])));
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(
+            s_intArray,
+            [new Parameter("a", s_intArray), new Parameter("i", s_int), new Parameter("j", s_int)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [], body);
+    }
+
+    static IrExpression BuildUserRangeStartAt()
+    {
+        var indexImplicit = new MethodRef(s_index, "op_Implicit", s_index, [s_int], HasThis: false);
+        var userStartAt = new MethodRef(
+            TypeRef.Definition("UserAssembly", "System", "Range"),
+            "StartAt",
+            s_range,
+            [s_index],
+            HasThis: false);
+        return new Call(userStartAt, isVirtual: false,
+            [new Call(indexImplicit, isVirtual: false, [new LoadArgument(1, "i", s_int)])]);
+    }
+
+    static IrExpression BuildRangeCtorWithUserIndexConversion()
+    {
+        var rangeCtor = new MethodRef(s_range, ".ctor", s_void, [s_index, s_index], HasThis: true);
+        var userImplicit = new MethodRef(
+            TypeRef.Definition("UserAssembly", "System", "Index"),
+            "op_Implicit",
+            s_index,
+            [s_int],
+            HasThis: false);
+        return new NewObject(rangeCtor,
+        [
+            new Call(userImplicit, isVirtual: false, [new LoadArgument(1, "i", s_int)]),
+            new Call(userImplicit, isVirtual: false, [new LoadArgument(2, "j", s_int)]),
+        ]);
+    }
+
     [Fact]
     public void GetSubArray_FromOnly_RendersOpenEnd()
     {

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -13,6 +13,7 @@ public static class MemberIdentity
     static readonly TypeRef s_exception = TypeRef.CoreLib("System", "Exception");
     static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef s_range = TypeRef.CoreLib("System", "Range");
+    static readonly TypeRef s_index = TypeRef.CoreLib("System", "Index");
     static readonly TypeRef s_runtimeFieldHandle = TypeRef.CoreLib("System", "RuntimeFieldHandle");
     static readonly TypeRef s_runtimeTypeHandle = TypeRef.CoreLib("System", "RuntimeTypeHandle");
     static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
@@ -94,6 +95,48 @@ public static class MemberIdentity
             && arrayParameter.Equals(arrayReturn)
             && rangeParameter.Equals(s_range);
     }
+
+    /// <summary>Corelib <c>System.Range..ctor(Index, Index)</c> — the <c>i..j</c> construction.</summary>
+    public static bool IsRangeConstructor(MethodRef ctor)
+        => ctor is { Name: ".ctor", HasThis: true, TypeArguments.IsEmpty: true, ParameterTypes: [var start, var end] }
+            && IsCoreLibraryType(ctor.DeclaringType, "System", "Range")
+            && start.Equals(s_index)
+            && end.Equals(s_index);
+
+    /// <summary>Corelib <c>System.Range.StartAt(Index): Range</c> — the <c>i..</c> factory.</summary>
+    public static bool IsRangeStartAt(MethodRef method)
+        => IsRangeEndpointFactory(method, "StartAt");
+
+    /// <summary>Corelib <c>System.Range.EndAt(Index): Range</c> — the <c>..j</c> factory.</summary>
+    public static bool IsRangeEndAt(MethodRef method)
+        => IsRangeEndpointFactory(method, "EndAt");
+
+    static bool IsRangeEndpointFactory(MethodRef method, string name)
+        => method is { HasThis: false, TypeArguments.IsEmpty: true, ParameterTypes: [var endpoint] }
+            && method.Name == name
+            && IsCoreLibraryType(method.DeclaringType, "System", "Range")
+            && endpoint.Equals(s_index)
+            && IsCoreLibraryType(method.ReturnType, "System", "Range");
+
+    /// <summary>Corelib <c>System.Range.All</c> getter — the <c>..</c> whole-range.</summary>
+    public static bool IsRangeAllGetter(MethodRef accessor)
+        => accessor is { Name: "get_All", HasThis: false, TypeArguments.IsEmpty: true, ParameterTypes.IsEmpty: true }
+            && IsCoreLibraryType(accessor.DeclaringType, "System", "Range")
+            && IsCoreLibraryType(accessor.ReturnType, "System", "Range");
+
+    /// <summary>Corelib <c>System.Index.op_Implicit(int): Index</c> — the from-start <c>(Index)i</c> conversion.</summary>
+    public static bool IsIndexFromStartConversion(MethodRef method)
+        => method is { Name: "op_Implicit", HasThis: false, TypeArguments.IsEmpty: true, ParameterTypes: [var value] }
+            && IsCoreLibraryType(method.DeclaringType, "System", "Index")
+            && value.Equals(s_int)
+            && IsCoreLibraryType(method.ReturnType, "System", "Index");
+
+    /// <summary>Corelib <c>System.Index..ctor(int, bool)</c> — the from-end <c>^n</c> index.</summary>
+    public static bool IsIndexFromEndConstructor(MethodRef ctor)
+        => ctor is { Name: ".ctor", HasThis: true, TypeArguments.IsEmpty: true, ParameterTypes: [var value, var fromEnd] }
+            && IsCoreLibraryType(ctor.DeclaringType, "System", "Index")
+            && value.Equals(s_int)
+            && fromEnd.Equals(s_bool);
 
     public static bool IsTypeGetTypeFromHandle(Call call)
         => !call.IsVirtual

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RangeFromGetSubArrayPass.cs
@@ -177,13 +177,13 @@ public sealed class RangeFromGetSubArrayPass : IIrPass
         end = null;
         switch (rangeArg)
         {
-            case NewObject { Constructor.DeclaringType: { Namespace: "System", Name: "Range" }, Arguments: [var lo, var hi] }:
+            case NewObject { Arguments: [var lo, var hi] } construction when MemberIdentity.IsRangeConstructor(construction.Constructor):
                 return TryEndpoint(lo, out start) && TryEndpoint(hi, out end);
-            case Call { Callee: { Name: "StartAt", DeclaringType: { Namespace: "System", Name: "Range" } }, Arguments: [var lo] }:
+            case Call { Arguments: [var lo] } startAt when MemberIdentity.IsRangeStartAt(startAt.Callee):
                 return TryEndpoint(lo, out start);
-            case Call { Callee: { Name: "EndAt", DeclaringType: { Namespace: "System", Name: "Range" } }, Arguments: [var hi] }:
+            case Call { Arguments: [var hi] } endAt when MemberIdentity.IsRangeEndAt(endAt.Callee):
                 return TryEndpoint(hi, out end);
-            case LoadProperty { HasInstance: false, PropertyName: "All", Accessor.DeclaringType: { Namespace: "System", Name: "Range" } }:
+            case LoadProperty { HasInstance: false } all when MemberIdentity.IsRangeAllGetter(all.Accessor):
                 return true; // Range.All → `..`
             default:
                 return false;
@@ -201,10 +201,10 @@ public sealed class RangeFromGetSubArrayPass : IIrPass
     {
         switch (index)
         {
-            case Call { Callee: { Name: "op_Implicit", DeclaringType: { Namespace: "System", Name: "Index" } }, Arguments: [var inner] }:
+            case Call { Arguments: [var inner] } conversion when MemberIdentity.IsIndexFromStartConversion(conversion.Callee):
                 endpoint = new Endpoint(inner, FromEnd: false);
                 return true;
-            case NewObject { Constructor.DeclaringType: { Namespace: "System", Name: "Index" }, Arguments: [var offset, Constant { Value: true }] }:
+            case NewObject { Arguments: [var offset, Constant { Value: true }] } fromEnd when MemberIdentity.IsIndexFromEndConstructor(fromEnd.Constructor):
                 endpoint = new Endpoint(offset, FromEnd: true);
                 return true;
             default:


### PR DESCRIPTION
Fixes #1460. Row 3 (Cluster B) of the #1453 wave-2 over-raise burndown.

## Over-raise claim being narrowed

`RangeFromGetSubArrayPass` raises `RuntimeHelpers.GetSubArray(a, range)` to an `a[i..j]` slice, but recognized the `System.Range` construction (`new Range` / `StartAt` / `EndAt` / `All`) and the from-start `System.Index` `op_Implicit` endpoint by **namespace+name only** — no corelib assembly or signature identity. The outer `GetSubArray` is exact-corelib, but a user assembly's `[UserAsm]System.Range.StartAt(Index): corelib Range` (or `[UserAsm]System.Index.op_Implicit(int): corelib Index`) returns the corelib type, so the surrounding IL still type-checks. The pass matched it by name and raised `a[i..]`, **dropping the user factory/conversion call's observable behavior** at `Full`.

Same class as #1399 (RvaSpan `ReadOnlySpan` lookalike).

## Fix

Add exact `MemberIdentity` predicates and route `TryReadRange`/`TryEndpoint` through them:

- `IsRangeConstructor` (corelib `Range..ctor(Index, Index)`), `IsRangeStartAt` / `IsRangeEndAt` (`(Index): Range`), `IsRangeAllGetter` (`get_All: Range`);
- `IsIndexFromStartConversion` (corelib `Index.op_Implicit(int): Index`), `IsIndexFromEndConstructor` (corelib `Index..ctor(int, bool)`).

Each requires `Assembly == TypeRef.CoreLibrary` plus the exact parameter/return types. User Range/Index lookalikes now stay as calls; the real corelib positives still raise. (The string/span path was already exact via `IsStringSubstring`/`IsSpanSlice`.)

## Evidence

`RangeFromGetSubArrayPassTests` (26/26) + `MemberIdentityTests` (16/16):

- **Adversarial** `GetSubArray_FromUserRangeStartAtLookalike_IsNotRaised` and `GetSubArray_FromUserIndexConversionLookalike_IsNotRaised`: user `System.Range.StartAt` / `System.Index.op_Implicit` (returning the corelib type) stay as calls; no slice.
- Existing positives still raise: `a[i..j]`, `a[i..]`, `a[i..^1]`, `a[^3..^1]`, `a[..^1]`, `a[..]`, plus string/span ranges; `new Index(i, false)` from-start-ctor and manual substring/slice negatives unchanged.

```
RangeFromGetSubArrayPassTests   Total: 26, Failed: 0
MemberIdentityTests             Total: 16, Failed: 0
```

Full `src/ILInspector.Decompiler.Tests` running; summary to follow.

Decline-only; cannot move corpus compile-check/fidelity in a way needing a card. Product path constraints preserved (SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading).

## Adversarial review

Will request cross-model adversarial review (GPT-5.5) and post the summary per AGENTS.md.
