### PR TITLE
Require accessor metadata for property sugar

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -49,6 +49,15 @@ public class CfgSampleClass
     public static void UnhookProcessExit(System.AppDomain domain, System.EventHandler h)
         => domain.ProcessExit -= h;
 
+    public static event Action? LocalStaticEvent { add { } remove { } }
+    public event Action? LocalInstanceEvent { add { } remove { } }
+
+    public static void HookLocalStaticEvent(Action h)
+        => LocalStaticEvent += h;
+
+    public static void UnhookLocalInstanceEvent(CfgSampleClass target, Action h)
+        => target.LocalInstanceEvent -= h;
+
     // A parameter named with a C# keyword (`delegate`): the metadata name is the
     // bare keyword, so every reference must be @-escaped (`@delegate`) or it is
     // CS1001 "Identifier expected". Exercises the LoadArgument render path.

--- a/src/ILInspector.Decompiler.Tests/EventSubscriptionRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EventSubscriptionRenderingTests.cs
@@ -2,10 +2,10 @@ using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
 
-// An IL call to an event's compiler-generated add_/remove_ accessor cannot be
+// An IL call to a metadata-confirmed event add_/remove_ accessor cannot be
 // spelled as a direct method call in C# — `e.add_X(h)` is CS0571 "cannot
-// explicitly call operator or accessor". The PropertySugarPass must raise such
-// calls to an EventSubscription, which the printer renders as `e += h` / `e -= h`.
+// explicitly call operator or accessor". PropertySugarPass must raise such calls
+// to an EventSubscription, which the printer renders as `e += h` / `e -= h`.
 public class EventSubscriptionRenderingTests
 {
     static IrFunction Raised(string methodName)
@@ -23,31 +23,31 @@ public class EventSubscriptionRenderingTests
     [Fact]
     public void StaticEventAdd_RaisesToPlusEquals()
     {
-        var function = Raised(nameof(CfgSampleClass.HookConsoleCancel));
+        var function = Raised(nameof(CfgSampleClass.HookLocalStaticEvent));
 
         var subscription = Assert.Single(function.Descendants.OfType<EventSubscription>());
         Assert.True(subscription.IsAdd);
-        Assert.Equal("CancelKeyPress", subscription.EventName);
+        Assert.Equal("LocalStaticEvent", subscription.EventName);
         // The lowered add_ accessor call is gone.
-        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "add_CancelKeyPress");
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "add_LocalStaticEvent");
 
-        var output = Print(nameof(CfgSampleClass.HookConsoleCancel));
-        Assert.Contains("Console.CancelKeyPress += h;", output);
-        Assert.DoesNotContain("add_CancelKeyPress", output);
+        var output = Print(nameof(CfgSampleClass.HookLocalStaticEvent));
+        Assert.Contains("LocalStaticEvent += h;", output);
+        Assert.DoesNotContain("add_LocalStaticEvent", output);
     }
 
     [Fact]
     public void InstanceEventRemove_RaisesToMinusEquals()
     {
-        var function = Raised(nameof(CfgSampleClass.UnhookProcessExit));
+        var function = Raised(nameof(CfgSampleClass.UnhookLocalInstanceEvent));
 
         var subscription = Assert.Single(function.Descendants.OfType<EventSubscription>());
         Assert.False(subscription.IsAdd);
-        Assert.Equal("ProcessExit", subscription.EventName);
-        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "remove_ProcessExit");
+        Assert.Equal("LocalInstanceEvent", subscription.EventName);
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "remove_LocalInstanceEvent");
 
-        var output = Print(nameof(CfgSampleClass.UnhookProcessExit));
-        Assert.Contains("domain.ProcessExit -= h;", output);
-        Assert.DoesNotContain("remove_ProcessExit", output);
+        var output = Print(nameof(CfgSampleClass.UnhookLocalInstanceEvent));
+        Assert.Contains("target.LocalInstanceEvent -= h;", output);
+        Assert.DoesNotContain("remove_LocalInstanceEvent", output);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/EventSubscriptionRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EventSubscriptionRenderingTests.cs
@@ -37,6 +37,21 @@ public class EventSubscriptionRenderingTests
     }
 
     [Fact]
+    public void TrustedPlatformStaticEventAdd_StillRaisesToPlusEquals()
+    {
+        var function = Raised(nameof(CfgSampleClass.HookConsoleCancel));
+
+        var subscription = Assert.Single(function.Descendants.OfType<EventSubscription>());
+        Assert.True(subscription.IsAdd);
+        Assert.Equal("CancelKeyPress", subscription.EventName);
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "add_CancelKeyPress");
+
+        var output = Print(nameof(CfgSampleClass.HookConsoleCancel));
+        Assert.Contains("Console.CancelKeyPress += h;", output);
+        Assert.DoesNotContain("add_CancelKeyPress", output);
+    }
+
+    [Fact]
     public void InstanceEventRemove_RaisesToMinusEquals()
     {
         var function = Raised(nameof(CfgSampleClass.UnhookLocalInstanceEvent));
@@ -49,5 +64,20 @@ public class EventSubscriptionRenderingTests
         var output = Print(nameof(CfgSampleClass.UnhookLocalInstanceEvent));
         Assert.Contains("target.LocalInstanceEvent -= h;", output);
         Assert.DoesNotContain("remove_LocalInstanceEvent", output);
+    }
+
+    [Fact]
+    public void TrustedPlatformInstanceEventRemove_StillRaisesToMinusEquals()
+    {
+        var function = Raised(nameof(CfgSampleClass.UnhookProcessExit));
+
+        var subscription = Assert.Single(function.Descendants.OfType<EventSubscription>());
+        Assert.False(subscription.IsAdd);
+        Assert.Equal("ProcessExit", subscription.EventName);
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "remove_ProcessExit");
+
+        var output = Print(nameof(CfgSampleClass.UnhookProcessExit));
+        Assert.Contains("domain.ProcessExit -= h;", output);
+        Assert.DoesNotContain("remove_ProcessExit", output);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/PropertySugarPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PropertySugarPassTests.cs
@@ -77,6 +77,21 @@ public class PropertySugarPassTests
     }
 
     [Fact]
+    public void NameInferredCoreLibraryGetter_StillRaises()
+    {
+        var coreHolder = TypeRef.CoreLib("Synthetic", "Holder");
+        var function = GetterFunction(
+            new MethodRef(coreHolder, "get_Count", Int32, [], HasThis: true) { IsSpecialName = true },
+            [new LoadArgument(0, "self", coreHolder)]);
+
+        new PropertySugarPass().Run(function, PassContext.None);
+
+        var property = Assert.Single(function.Descendants.OfType<LoadProperty>());
+        Assert.True(property.HasInstance);
+        Assert.Equal("Count", property.PropertyName);
+    }
+
+    [Fact]
     public void StaticNonIndexedSetter_StillRaises()
     {
         var function = SetterFunction(Accessor("set_Count", Void, [Int32], hasThis: false), [new Constant(42, Int32)]);

--- a/src/ILInspector.Decompiler.Tests/PropertySugarPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PropertySugarPassTests.cs
@@ -4,7 +4,7 @@ namespace ILInspector.Decompiler.Tests;
 
 public class PropertySugarPassTests
 {
-    static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
+    static readonly TypeRef Holder = TypeRef.Definition("SyntheticAssembly", "Synthetic", "Holder");
     static readonly TypeRef Action = TypeRef.CoreLib("System", "Action");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
@@ -66,6 +66,17 @@ public class PropertySugarPassTests
     }
 
     [Fact]
+    public void NameInferredGetter_StaysCall()
+    {
+        var function = GetterFunction(NameInferredSpecialName("get_Count", Int32, [], hasThis: true), [new LoadArgument(0, "self", Holder)]);
+
+        new PropertySugarPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<LoadProperty>());
+        Assert.Single(function.Descendants.OfType<Call>());
+    }
+
+    [Fact]
     public void StaticNonIndexedSetter_StillRaises()
     {
         var function = SetterFunction(Accessor("set_Count", Void, [Int32], hasThis: false), [new Constant(42, Int32)]);
@@ -75,6 +86,19 @@ public class PropertySugarPassTests
         var property = Assert.Single(function.Descendants.OfType<StoreProperty>());
         Assert.False(property.HasInstance);
         Assert.Empty(property.IndexArguments);
+    }
+
+    [Fact]
+    public void NameInferredSetter_StaysCall()
+    {
+        var function = SetterFunction(
+            NameInferredSpecialName("set_Count", Void, [Int32], hasThis: true),
+            [new LoadArgument(0, "self", Holder), new Constant(42, Int32)]);
+
+        new PropertySugarPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+        Assert.Single(function.Descendants.OfType<Call>());
     }
 
     [Fact]
@@ -115,7 +139,32 @@ public class PropertySugarPassTests
         Assert.Equal("Changed", subscription.EventName);
     }
 
+    [Fact]
+    public void NameInferredEventAccessor_StaysCall()
+    {
+        var function = EventFunction(NameInferredSpecialName("add_Changed", Void, [Action], hasThis: true));
+
+        new PropertySugarPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<EventSubscription>());
+        Assert.Single(function.Descendants.OfType<Call>());
+    }
+
     static MethodRef Accessor(string name, TypeRef returnType, System.Collections.Immutable.ImmutableArray<TypeRef> parameters, bool hasThis)
+        => new(Holder, name, returnType, parameters, hasThis)
+        {
+            IsSpecialName = true,
+            AccessorKind = name switch
+            {
+                _ when name.StartsWith("get_", StringComparison.Ordinal) => AccessorKind.PropertyGet,
+                _ when name.StartsWith("set_", StringComparison.Ordinal) => AccessorKind.PropertySet,
+                _ when name.StartsWith("add_", StringComparison.Ordinal) => AccessorKind.EventAdd,
+                _ when name.StartsWith("remove_", StringComparison.Ordinal) => AccessorKind.EventRemove,
+                _ => AccessorKind.None,
+            },
+        };
+
+    static MethodRef NameInferredSpecialName(string name, TypeRef returnType, System.Collections.Immutable.ImmutableArray<TypeRef> parameters, bool hasThis)
         => new(Holder, name, returnType, parameters, hasThis) { IsSpecialName = true };
 
     static IrFunction GetterFunction(MethodRef accessor, IReadOnlyList<IrExpression> arguments)

--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -79,7 +79,8 @@ internal sealed class CrossAssemblyTypeResolver
         bool needsUnsafe = resolveRequiresUnsafe && !callee.RequiresUnsafe;
         bool needsExtension = NeedsExtensionFacts(callee);
         bool needsDelegate = NeedsDelegateFact(callee);
-        if (!needsRefKinds && !needsGenerated && !needsUnsafe && !needsExtension && !needsDelegate)
+        bool needsAccessor = NeedsAccessorFact(callee);
+        if (!needsRefKinds && !needsGenerated && !needsUnsafe && !needsExtension && !needsDelegate && !needsAccessor)
             return callee;
 
         var type = NamedDefinition(callee.DeclaringType);
@@ -111,6 +112,7 @@ internal sealed class CrossAssemblyTypeResolver
             DeclaringTypeCompilerGenerated = needsGenerated ? resolved.DeclaringTypeCompilerGenerated : callee.DeclaringTypeCompilerGenerated,
             DeclaringTypeIsDelegate = needsDelegate ? resolved.DeclaringTypeIsDelegate : callee.DeclaringTypeIsDelegate,
             IsExtension = needsExtension ? resolved.IsExtension : callee.IsExtension,
+            AccessorKind = needsAccessor ? resolved.AccessorKind : callee.AccessorKind,
         };
     }
 
@@ -250,7 +252,8 @@ internal sealed class CrossAssemblyTypeResolver
                     FactState(methodCompilerGenerated),
                     FactState(typeCompilerGenerated),
                     FactState(IsDelegateType(reader, typeDef)),
-                    FactState(MethodDefinitionFacts.HasExtensionAttribute(reader, method)));
+                    FactState(MethodDefinitionFacts.HasExtensionAttribute(reader, method)),
+                    MethodDefinitionFacts.ReadAccessorKind(reader, typeDef, methodHandle));
             }
 
             return null;
@@ -481,6 +484,13 @@ internal sealed class CrossAssemblyTypeResolver
             && method.ParameterTypes[0].Equals(TypeRef.CoreLib("System", "Object"))
             && method.ParameterTypes[1].Equals(TypeRef.CoreLib("System", "IntPtr"));
 
+    static bool NeedsAccessorFact(MethodRef method)
+        => method.AccessorKind == AccessorKind.Unknown
+            && (method.Name.StartsWith("get_", StringComparison.Ordinal)
+                || method.Name.StartsWith("set_", StringComparison.Ordinal)
+                || method.Name.StartsWith("add_", StringComparison.Ordinal)
+                || method.Name.StartsWith("remove_", StringComparison.Ordinal));
+
     static bool IsDelegateType(MetadataReader reader, TypeDefinition typeDef)
     {
         try { return BaseTypeName(reader, typeDef.BaseType) is "System.MulticastDelegate"; }
@@ -495,5 +505,6 @@ internal sealed class CrossAssemblyTypeResolver
         MetadataFactState CompilerGenerated,
         MetadataFactState DeclaringTypeCompilerGenerated,
         MetadataFactState DeclaringTypeIsDelegate,
-        MetadataFactState IsExtension);
+        MetadataFactState IsExtension,
+        AccessorKind AccessorKind);
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1709,6 +1709,7 @@ public static class IrImporter
                 return new MethodRef(declaring, methodName, signature.ReturnType, signature.ParameterTypes, signature.Header.IsInstance)
                 {
                     IsSpecialName = (method.Attributes & System.Reflection.MethodAttributes.SpecialName) != 0,
+                    AccessorKind = MethodDefinitionFacts.ReadAccessorKind(reader, declaringType, (MethodDefinitionHandle)handle),
                     ParameterRefKinds = parameterRefKinds.Kinds,
                     ParameterRefKindsFacts = parameterRefKinds.State,
                     RequiresUnsafe = MethodDefinitionFacts.HasRequiresUnsafeAttribute(reader, method),
@@ -1734,6 +1735,9 @@ public static class IrImporter
                 string memberName = reader.GetString(member.Name);
                 var parameterTypes = ImmutableArray.CreateRange(signature.ParameterTypes.Select(p => p.Instantiate(typeArguments, [])));
                 var parameterRefKinds = MemberReferenceRefKinds(reader, member, memberName, parameterTypes);
+                var accessorKind = MemberReferenceAccessorKind(reader, member, memberName);
+                if (accessorKind == AccessorKind.Unknown && IsTrustedPlatformMemberReference(reader, member.Parent))
+                    accessorKind = AccessorKindFromName(memberName);
                 return new MethodRef(
                     declaring,
                     memberName,
@@ -1741,14 +1745,16 @@ public static class IrImporter
                     parameterTypes,
                     signature.Header.IsInstance)
                 {
-                    // MemberRefs carry no flags; accessor-shape naming is the
-                    // strongest local evidence without assembly resolution.
+                    // MemberRefs carry no flags; keep name-inferred SpecialName
+                    // separate from AccessorKind so property/event sugar requires
+                    // positive metadata semantics rather than a get_/set_ prefix.
                     IsSpecialName = memberName.StartsWith("get_", StringComparison.Ordinal)
                         || memberName.StartsWith("set_", StringComparison.Ordinal)
                         || memberName.StartsWith("add_", StringComparison.Ordinal)
                         || memberName.StartsWith("remove_", StringComparison.Ordinal)
                         || memberName.StartsWith("op_", StringComparison.Ordinal)
                         || memberName is ".ctor" or ".cctor",
+                    AccessorKind = accessorKind,
                     DeclaringTypeIsDelegate = MemberIdentity.IsKnownCoreLibraryDelegateType(declaring)
                         ? MetadataFactState.Yes
                         : MetadataFactState.Unknown,
@@ -1900,6 +1906,90 @@ public static class IrImporter
                 return MethodDefinitionFacts.ReadParameterRefKinds(reader, method, parameterTypes);
         }
         return new ParameterRefKindResult([], ParameterRefKindFacts.Unknown);
+    }
+
+    static bool IsTrustedPlatformMemberReference(MetadataReader reader, EntityHandle parent) => parent.Kind switch
+    {
+        HandleKind.TypeReference => IsTrustedPlatformTypeReference(reader, (TypeReferenceHandle)parent),
+        HandleKind.TypeSpecification => IsTrustedPlatformTypeSpecification(reader, (TypeSpecificationHandle)parent),
+        _ => false,
+    };
+
+    static bool IsTrustedPlatformTypeReference(MetadataReader reader, TypeReferenceHandle handle)
+    {
+        var typeRef = reader.GetTypeReference(handle);
+        return typeRef.ResolutionScope.Kind switch
+        {
+            HandleKind.AssemblyReference => IsTrustedPlatformAssembly(reader, (AssemblyReferenceHandle)typeRef.ResolutionScope),
+            HandleKind.TypeReference => IsTrustedPlatformTypeReference(reader, (TypeReferenceHandle)typeRef.ResolutionScope),
+            _ => false,
+        };
+    }
+
+    static bool IsTrustedPlatformTypeSpecification(MetadataReader reader, TypeSpecificationHandle handle)
+    {
+        var type = TypeRefDecoder.Instance.GetTypeFromSpecification(reader, GenericScope.Empty, handle, 0);
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        return definition is { Kind: TypeRefKind.Definition }
+            && (definition.Assembly == TypeRef.CoreLibrary || PlatformKeys.IsPlatform(PlatformToken(reader, definition.Assembly)));
+    }
+
+    static bool IsTrustedPlatformAssembly(MetadataReader reader, AssemblyReferenceHandle handle)
+    {
+        var reference = reader.GetAssemblyReference(handle);
+        return PlatformKeys.IsPlatform(ToHex(reader.GetBlobBytes(reference.PublicKeyOrToken)));
+    }
+
+    static string? PlatformToken(MetadataReader reader, string assemblyName)
+    {
+        foreach (var handle in reader.AssemblyReferences)
+        {
+            var reference = reader.GetAssemblyReference(handle);
+            if (reader.GetString(reference.Name) == assemblyName)
+                return ToHex(reader.GetBlobBytes(reference.PublicKeyOrToken));
+        }
+        return null;
+    }
+
+    static string ToHex(byte[] bytes)
+    {
+        var chars = new char[bytes.Length * 2];
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            chars[i * 2] = "0123456789abcdef"[bytes[i] >> 4];
+            chars[i * 2 + 1] = "0123456789abcdef"[bytes[i] & 0xF];
+        }
+        return new string(chars);
+    }
+
+    static AccessorKind MemberReferenceAccessorKind(MetadataReader reader, MemberReference member, string memberName)
+    {
+        if (DeclaringTypeDefinition(reader, member.Parent) is not { } typeHandle)
+            return AccessorKind.Unknown;
+
+        var memberSignature = reader.GetBlobBytes(member.Signature);
+        foreach (var methodHandle in reader.GetTypeDefinition(typeHandle).GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != memberName)
+                continue;
+            if (reader.GetBlobBytes(method.Signature).AsSpan().SequenceEqual(memberSignature))
+                return MethodDefinitionFacts.ReadAccessorKind(reader, reader.GetTypeDefinition(typeHandle), methodHandle);
+        }
+        return AccessorKind.Unknown;
+    }
+
+    static AccessorKind AccessorKindFromName(string memberName)
+    {
+        if (memberName.StartsWith("get_", StringComparison.Ordinal))
+            return AccessorKind.PropertyGet;
+        if (memberName.StartsWith("set_", StringComparison.Ordinal))
+            return AccessorKind.PropertySet;
+        if (memberName.StartsWith("add_", StringComparison.Ordinal))
+            return AccessorKind.EventAdd;
+        if (memberName.StartsWith("remove_", StringComparison.Ordinal))
+            return AccessorKind.EventRemove;
+        return AccessorKind.Unknown;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -11,6 +11,9 @@ public enum MetadataFactState { Unknown, No, Yes }
 /// <summary>Whether by-ref parameter keyword metadata was needed and recovered.</summary>
 public enum ParameterRefKindFacts { Unknown, NotRequired, Known }
 
+/// <summary>Positive metadata evidence that a method is a property/event accessor.</summary>
+public enum AccessorKind { Unknown, None, PropertyGet, PropertySet, EventAdd, EventRemove }
+
 /// <summary>A materialized method reference — callee identity with symbolic types, no metadata handles.</summary>
 public sealed record MethodRef(
     TypeRef DeclaringType,
@@ -50,12 +53,20 @@ public sealed record MethodRef(
     public bool RequiresUnsafe { get; init; }
 
     /// <summary>
-    /// Metadata SpecialName evidence (accessors, operators). Exact for
-    /// same-assembly MethodDefs; cross-assembly MemberRefs carry no flags,
-    /// so the resolver falls back to accessor-shape naming — the strongest
-    /// local evidence available without assembly resolution.
+    /// Metadata SpecialName evidence (accessors, operators, constructors). Exact
+    /// for MethodDefs; unresolved MemberRefs carry no flags, so the importer may
+    /// infer this from compiler-reserved names only to preserve spellability
+    /// diagnostics. C# property/event/operator sugar must use narrower facts.
     /// </summary>
     public bool IsSpecialName { get; init; }
+
+    /// <summary>
+    /// Exact property/event accessor evidence from metadata semantics. MemberRefs
+    /// whose defining method cannot be resolved stay <see cref="AccessorKind.Unknown"/>
+    /// even when their name looks like an accessor; raising property/event syntax
+    /// requires a positive value here, not name-inferred <see cref="IsSpecialName"/>.
+    /// </summary>
+    public AccessorKind AccessorKind { get; init; } = AccessorKind.Unknown;
 
     /// <summary>
     /// Metadata <c>[CompilerGenerated]</c> evidence on this method, or

--- a/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
@@ -57,6 +57,29 @@ internal static class MethodDefinitionFacts
         return (method.ImplAttributes & AsyncImplFlag) != 0;
     }
 
+    internal static AccessorKind ReadAccessorKind(MetadataReader reader, TypeDefinition declaringType, MethodDefinitionHandle method)
+    {
+        foreach (var propertyHandle in declaringType.GetProperties())
+        {
+            var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
+            if (accessors.Getter == method)
+                return AccessorKind.PropertyGet;
+            if (accessors.Setter == method)
+                return AccessorKind.PropertySet;
+        }
+
+        foreach (var eventHandle in declaringType.GetEvents())
+        {
+            var accessors = reader.GetEventDefinition(eventHandle).GetAccessors();
+            if (accessors.Adder == method)
+                return AccessorKind.EventAdd;
+            if (accessors.Remover == method)
+                return AccessorKind.EventRemove;
+        }
+
+        return AccessorKind.None;
+    }
+
     internal static ImmutableArray<string> GenericParameterNames(MetadataReader reader, GenericParameterHandleCollection handles)
     {
         if (handles.Count == 0)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/PropertySugarPass.cs
@@ -53,7 +53,7 @@ public sealed class PropertySugarPass : IIrPass
     }
 
     static bool IsGetter(MethodRef callee)
-        => callee.IsSpecialName
+        => HasAccessorEvidence(callee, AccessorKind.PropertyGet)
             && callee.Name.StartsWith("get_", StringComparison.Ordinal)
             && callee.Name.Length > "get_".Length
             && callee.ReturnType is not { Namespace: "System", Name: "Void" }
@@ -61,7 +61,7 @@ public sealed class PropertySugarPass : IIrPass
             && (callee.HasThis || callee.ParameterTypes.Length == 0);
 
     static bool IsSetter(MethodRef callee)
-        => callee.IsSpecialName
+        => HasAccessorEvidence(callee, AccessorKind.PropertySet)
             && callee.Name.StartsWith("set_", StringComparison.Ordinal)
             && callee.Name.Length > "set_".Length
             && callee.ParameterTypes.Length >= 1
@@ -76,12 +76,37 @@ public sealed class PropertySugarPass : IIrPass
     {
         isAdd = callee.Name.StartsWith("add_", StringComparison.Ordinal);
         bool isRemove = callee.Name.StartsWith("remove_", StringComparison.Ordinal);
-        if (!callee.IsSpecialName || (!isAdd && !isRemove))
+        if ((isAdd && !HasAccessorEvidence(callee, AccessorKind.EventAdd))
+            || (isRemove && !HasAccessorEvidence(callee, AccessorKind.EventRemove))
+            || (!isAdd && !isRemove))
+        {
             return false;
+        }
         int prefix = isAdd ? "add_".Length : "remove_".Length;
         return callee.Name.Length > prefix
             && callee.TypeArguments.IsEmpty
             && callee.ParameterTypes.Length == 1
             && callee.ReturnType is { Namespace: "System", Name: "Void" };
     }
+
+    static bool HasAccessorEvidence(MethodRef callee, AccessorKind expected)
+        => callee.AccessorKind == expected
+            || (callee.AccessorKind == AccessorKind.Unknown
+                && IsCoreLibrary(callee.DeclaringType)
+                && NameMatchesKind(callee.Name, expected));
+
+    static bool IsCoreLibrary(TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        return definition is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary };
+    }
+
+    static bool NameMatchesKind(string name, AccessorKind kind) => kind switch
+    {
+        AccessorKind.PropertyGet => name.StartsWith("get_", StringComparison.Ordinal),
+        AccessorKind.PropertySet => name.StartsWith("set_", StringComparison.Ordinal),
+        AccessorKind.EventAdd => name.StartsWith("add_", StringComparison.Ordinal),
+        AccessorKind.EventRemove => name.StartsWith("remove_", StringComparison.Ordinal),
+        _ => false,
+    };
 }


### PR DESCRIPTION
## Summary

Fixes #1450 by separating property/event accessor evidence from name-inferred `SpecialName`.

`PropertySugarPass` now requires positive `AccessorKind` metadata before raising user-assembly `get_`/`set_`/`add_`/`remove_`-shaped calls. The importer stamps that fact from MethodDef property/event semantics, same-assembly TypeSpec MemberRefs, and the existing cross-assembly metadata resolver when a referenced assembly is available. A narrow trusted-platform fallback preserves common framework accessors in no-locator test contexts; arbitrary unresolved user assemblies stay `Unknown` and do not raise.

## Evidence

Shape proof:

- Positive property and event canaries still raise when accessor semantics are known.
- Near misses with name-inferred `IsSpecialName` but no `AccessorKind` stay calls for getter, setter, and event-shaped names.

Validation:

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.PropertySugarPassTests -class ILInspector.Decompiler.Tests.EventSubscriptionRenderingTests -class ILInspector.Decompiler.Tests.LoweredViewTests -class ILInspector.Decompiler.Tests.NullCoalescingAssignmentPassTests -class ILInspector.Decompiler.Tests.ForeachStatementPassTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release -v:q`

Generated quality card against the checked-in baseline reports the same stale-baseline regressions on local main. Branch vs main shows the expected fixture-method count increase and no unexpected movement.

Branch card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,106 methods
Correctness coverage: validity sampled 350 / 88,106 (0.40%); fidelity sampled 22 / 88,106 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,106 (+736)
- dotnet-inspect: 11,710 -> 12,186 methods (+476)
- ILInspector.Analysis: 500 -> 661 methods (+161)
- ILInspector.Decompiler: 5,004 -> 5,096 methods (+92)
- ILInspector.Metadata: 1,824 -> 1,831 methods (+7)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,469 (87.93%) | +575 |
| Conditional-branch residual | 2,290 (2.62%) | 2,308 (2.62%) | +18 |
| Forward-merge stops | 2,284 (2.61%) | 2,299 (2.61%) | +15 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,106 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,106 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.
```

Local main control:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,089 methods
Correctness coverage: validity sampled 350 / 88,089 (0.40%); fidelity sampled 22 / 88,089 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,089 (+719)
- dotnet-inspect: 11,710 -> 12,186 methods (+476)
- ILInspector.Analysis: 500 -> 661 methods (+161)
- ILInspector.Decompiler: 5,004 -> 5,079 methods (+75)
- ILInspector.Metadata: 1,824 -> 1,831 methods (+7)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,452 (87.92%) | +558 |
| Conditional-branch residual | 2,290 (2.62%) | 2,308 (2.62%) | +18 |
| Forward-merge stops | 2,284 (2.61%) | 2,299 (2.61%) | +15 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,089 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,089 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.
```
