### PR TITLE
Gate ObjectInitializer member raising on initializer-spellable accessors (#1416)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -364,19 +364,6 @@ public class ObjectInitializerPassTests
     }
 
     [Fact]
-    public void UnspellableFieldName_IsNotFoldedIntoInvalidInitializer()
-    {
-        // A backing-field store `s.<X>k__BackingField = v` has no initializer spelling.
-        var function = FunctionWithFieldStore("<X>k__BackingField");
-
-        new ObjectInitializerPass().Run(function, PassContext.None);
-
-        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
-        Assert.Single(function.Descendants.OfType<StoreField>());
-        function.CheckInvariant();
-    }
-
-    [Fact]
     public void SpellableFieldName_StillFoldsIntoInitializer()
     {
         var function = FunctionWithFieldStore("Z");

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -318,6 +318,66 @@ public class ObjectInitializerPassTests
         Assert.Contains("GC.KeepAlive", output);
     }
 
+    [Fact]
+    public void GenericPropertySetter_IsNotFoldedIntoInvalidInitializer()
+    {
+        // s0 = new Owner(); s0.set_Value<string>(fallback); return s0;
+        // A generic setter has no `Value = ...` object-initializer spelling, so the
+        // pass must leave the StoreProperty lowered rather than emit an unspellable
+        // `new Owner { Value = fallback }` (#1416).
+        var function = FunctionWithSetter(generic: true);
+
+        new ObjectInitializerPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.Single(function.Descendants.OfType<StoreProperty>());
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void NonGenericVoidSetter_StillFoldsIntoInitializer()
+    {
+        // The positive canary for the generic-setter guard: an ordinary void setter
+        // with one value parameter still raises to an object initializer.
+        var function = FunctionWithSetter(generic: false);
+
+        new ObjectInitializerPass().Run(function, PassContext.None);
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.Equal(["Value"], initializer.Members);
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+        function.CheckInvariant();
+    }
+
+    static IrFunction FunctionWithSetter(bool generic)
+    {
+        var type = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var stringType = TypeRef.CoreLib("System", "String");
+        var ctor = new MethodRef(type, ".ctor", voidType, [], HasThis: true);
+        var setter = new MethodRef(type, "set_Value", voidType, [stringType], HasThis: true)
+        {
+            IsSpecialName = true,
+            TypeArguments = generic ? [stringType] : [],
+        };
+
+        const int slot = 0;
+        var block = new Block();
+        block.Add(new StoreStackSlot(slot, new NewObject(ctor, [])));
+        block.Add(new StoreProperty(setter, new LoadStackSlot(slot, type), [], new Constant("fallback", stringType)));
+        block.Add(new Return(new LoadStackSlot(slot, type)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "MakeOwner",
+            type,
+            new MethodSignature(type, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
     static IrFunction FunctionWithDuplicateMemberStores()
     {
         var type = TypeRef.Definition("Synthetic", "Samples", "InitTarget");

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -350,13 +350,52 @@ public class ObjectInitializerPassTests
         function.CheckInvariant();
     }
 
-    static IrFunction FunctionWithSetter(bool generic)
+    [Fact]
+    public void UnspellablePropertyName_IsNotFoldedIntoInvalidInitializer()
+    {
+        // set_bad-name has a usable accessor shape but no `bad-name = v` C# spelling.
+        var function = FunctionWithSetter(generic: false, propertyName: "set_bad-name");
+
+        new ObjectInitializerPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.Single(function.Descendants.OfType<StoreProperty>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void UnspellableFieldName_IsNotFoldedIntoInvalidInitializer()
+    {
+        // A backing-field store `s.<X>k__BackingField = v` has no initializer spelling.
+        var function = FunctionWithFieldStore("<X>k__BackingField");
+
+        new ObjectInitializerPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.Single(function.Descendants.OfType<StoreField>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SpellableFieldName_StillFoldsIntoInitializer()
+    {
+        var function = FunctionWithFieldStore("Z");
+
+        new ObjectInitializerPass().Run(function, PassContext.None);
+
+        var initializer = Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.Equal(["Z"], initializer.Members);
+        Assert.Empty(function.Descendants.OfType<StoreField>());
+        function.CheckInvariant();
+    }
+
+    static IrFunction FunctionWithSetter(bool generic, string propertyName = "set_Value")
     {
         var type = TypeRef.Definition("Synthetic", "Samples", "Owner");
         var voidType = TypeRef.CoreLib("System", "Void");
         var stringType = TypeRef.CoreLib("System", "String");
         var ctor = new MethodRef(type, ".ctor", voidType, [], HasThis: true);
-        var setter = new MethodRef(type, "set_Value", voidType, [stringType], HasThis: true)
+        var setter = new MethodRef(type, propertyName, voidType, [stringType], HasThis: true)
         {
             IsSpecialName = true,
             TypeArguments = generic ? [stringType] : [],
@@ -366,6 +405,30 @@ public class ObjectInitializerPassTests
         var block = new Block();
         block.Add(new StoreStackSlot(slot, new NewObject(ctor, [])));
         block.Add(new StoreProperty(setter, new LoadStackSlot(slot, type), [], new Constant("fallback", stringType)));
+        block.Add(new Return(new LoadStackSlot(slot, type)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "MakeOwner",
+            type,
+            new MethodSignature(type, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    static IrFunction FunctionWithFieldStore(string fieldName)
+    {
+        var type = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var ctor = new MethodRef(type, ".ctor", voidType, [], HasThis: true);
+        var field = new FieldRef(type, fieldName, intType);
+
+        const int slot = 0;
+        var block = new Block();
+        block.Add(new StoreStackSlot(slot, new NewObject(ctor, [])));
+        block.Add(new StoreField(field, new LoadStackSlot(slot, type), new Constant(1, intType)));
         block.Add(new Return(new LoadStackSlot(slot, type)));
 
         var body = new BlockContainer();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -330,7 +330,7 @@ public sealed class ObjectInitializerPass : IIrPass
                 return new NestedOp(outer, IsCollection: false, objectInner);
 
             case StoreField { HasInstance: true } field
-                when CSharpNaming.IsUsableIdentifier(field.Field.Name) && OuterMemberOffSlot(field.Instance, aliasSlots) is { } outer:
+                when OuterMemberOffSlot(field.Instance, aliasSlots) is { } outer:
                 return new NestedOp(outer, IsCollection: false, new EntryPlan(field.Field.Name, [field.Value], null));
 
             // Nested collection element: outer.Member.Add(v, ...).
@@ -356,7 +356,7 @@ public sealed class ObjectInitializerPass : IIrPass
                 return new NestedOp(outer, IsCollection: false, objectInner);
 
             case StoreField { HasInstance: true } field
-                when CSharpNaming.IsUsableIdentifier(field.Field.Name) && OuterMemberOffLocal(field.Instance, localIndex) is { } outer:
+                when OuterMemberOffLocal(field.Instance, localIndex) is { } outer:
                 return new NestedOp(outer, IsCollection: false, new EntryPlan(field.Field.Name, [field.Value], null));
 
             case ExpressionStatement { Expression: Call { Callee.HasThis: true } call }
@@ -373,11 +373,10 @@ public sealed class ObjectInitializerPass : IIrPass
     static string? OuterMemberOffSlot(IrExpression? instance, HashSet<int> aliasSlots) => instance switch
     {
         LoadProperty { HasInstance: true, Instance: LoadStackSlot slot } property
-            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count == 0
-                && property.Accessor.TypeArguments.IsDefaultOrEmpty && CSharpNaming.IsUsableIdentifier(property.PropertyName)
+            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count == 0 && property.Accessor.TypeArguments.IsDefaultOrEmpty
             => property.PropertyName,
         LoadField { Instance: LoadStackSlot slot } field
-            when aliasSlots.Contains(slot.Slot) && CSharpNaming.IsUsableIdentifier(field.Field.Name)
+            when aliasSlots.Contains(slot.Slot)
             => field.Field.Name,
         _ => null,
     };
@@ -385,11 +384,10 @@ public sealed class ObjectInitializerPass : IIrPass
     static string? OuterMemberOffLocal(IrExpression? instance, int localIndex) => instance switch
     {
         LoadProperty { HasInstance: true, Instance: LoadLocal local } property
-            when local.Index == localIndex && property.IndexArguments.Count == 0
-                && property.Accessor.TypeArguments.IsDefaultOrEmpty && CSharpNaming.IsUsableIdentifier(property.PropertyName)
+            when local.Index == localIndex && property.IndexArguments.Count == 0 && property.Accessor.TypeArguments.IsDefaultOrEmpty
             => property.PropertyName,
         LoadField { Instance: LoadLocal local } field
-            when local.Index == localIndex && CSharpNaming.IsUsableIdentifier(field.Field.Name)
+            when local.Index == localIndex
             => field.Field.Name,
         _ => null,
     };
@@ -431,7 +429,7 @@ public sealed class ObjectInitializerPass : IIrPass
             when aliasSlots.Contains(slot.Slot) && IsInitializerSpellable(property)
             => new EntryPlan(property.PropertyName, [property.Value], null),
         StoreField { HasInstance: true, Instance: LoadStackSlot slot } field
-            when aliasSlots.Contains(slot.Slot) && CSharpNaming.IsUsableIdentifier(field.Field.Name)
+            when aliasSlots.Contains(slot.Slot)
             => new EntryPlan(field.Field.Name, [field.Value], null),
         _ => null,
     };
@@ -445,7 +443,7 @@ public sealed class ObjectInitializerPass : IIrPass
             when local.Index == localIndex && IsInitializerSpellable(property)
             => new EntryPlan(property.PropertyName, [property.Value], null),
         StoreField { HasInstance: true, Instance: LoadLocal local } field
-            when local.Index == localIndex && CSharpNaming.IsUsableIdentifier(field.Field.Name)
+            when local.Index == localIndex
             => new EntryPlan(field.Field.Name, [field.Value], null),
         _ => null,
     };

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -323,7 +323,7 @@ public sealed class ObjectInitializerPass : IIrPass
         {
             // Nested object member store: outer.Member.X = v / outer.Member[k] = v.
             case StoreProperty { HasInstance: true } property
-                when OuterMemberOffSlot(property.Instance, aliasSlots) is { } outer:
+                when IsInitializerSpellable(property) && OuterMemberOffSlot(property.Instance, aliasSlots) is { } outer:
                 var objectInner = property.IndexArguments.Count != 0
                     ? new EntryPlan(null, [.. property.IndexArguments, property.Value], null)
                     : new EntryPlan(property.PropertyName, [property.Value], null);
@@ -349,7 +349,7 @@ public sealed class ObjectInitializerPass : IIrPass
         switch (statement)
         {
             case StoreProperty { HasInstance: true } property
-                when OuterMemberOffLocal(property.Instance, localIndex) is { } outer:
+                when IsInitializerSpellable(property) && OuterMemberOffLocal(property.Instance, localIndex) is { } outer:
                 var objectInner = property.IndexArguments.Count != 0
                     ? new EntryPlan(null, [.. property.IndexArguments, property.Value], null)
                     : new EntryPlan(property.PropertyName, [property.Value], null);
@@ -373,7 +373,7 @@ public sealed class ObjectInitializerPass : IIrPass
     static string? OuterMemberOffSlot(IrExpression? instance, HashSet<int> aliasSlots) => instance switch
     {
         LoadProperty { HasInstance: true, Instance: LoadStackSlot slot } property
-            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count == 0
+            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count == 0 && property.Accessor.TypeArguments.IsDefaultOrEmpty
             => property.PropertyName,
         LoadField { Instance: LoadStackSlot slot } field
             when aliasSlots.Contains(slot.Slot)
@@ -384,7 +384,7 @@ public sealed class ObjectInitializerPass : IIrPass
     static string? OuterMemberOffLocal(IrExpression? instance, int localIndex) => instance switch
     {
         LoadProperty { HasInstance: true, Instance: LoadLocal local } property
-            when local.Index == localIndex && property.IndexArguments.Count == 0
+            when local.Index == localIndex && property.IndexArguments.Count == 0 && property.Accessor.TypeArguments.IsDefaultOrEmpty
             => property.PropertyName,
         LoadField { Instance: LoadLocal local } field
             when local.Index == localIndex
@@ -392,14 +392,30 @@ public sealed class ObjectInitializerPass : IIrPass
         _ => null,
     };
 
+    /// <summary>
+    /// Whether a property setter store has a C# object-initializer spelling. A
+    /// generic accessor (such as <c>set_Value&lt;T&gt;(T)</c>) has no <c>Value = …</c>
+    /// initializer form, a real setter returns <c>void</c>, and its parameter list
+    /// is exactly the index arguments followed by the single assigned value. Without
+    /// this guard <see cref="ObjectInitializerPass"/> would emit
+    /// <c>new Owner { Value = v }</c> from an unspellable accessor shape (#1416).
+    /// </summary>
+    static bool IsInitializerSpellable(StoreProperty property)
+    {
+        var accessor = property.Accessor;
+        return accessor.TypeArguments.IsDefaultOrEmpty
+            && accessor.ReturnType is { Namespace: "System", Name: "Void" }
+            && accessor.ParameterTypes.Length == property.IndexArguments.Count + 1;
+    }
+
     static EntryPlan? TryMemberStore(IrNode statement, HashSet<int> aliasSlots) => statement switch
     {
         // An indexer member `[k0, k1] = v`: the keys precede the value.
         StoreProperty { HasInstance: true, Instance: LoadStackSlot slot } property
-            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count != 0
+            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count != 0 && IsInitializerSpellable(property)
             => new EntryPlan(null, [.. property.IndexArguments, property.Value], null),
         StoreProperty { HasInstance: true, Instance: LoadStackSlot slot } property
-            when aliasSlots.Contains(slot.Slot)
+            when aliasSlots.Contains(slot.Slot) && IsInitializerSpellable(property)
             => new EntryPlan(property.PropertyName, [property.Value], null),
         StoreField { HasInstance: true, Instance: LoadStackSlot slot } field
             when aliasSlots.Contains(slot.Slot)
@@ -410,10 +426,10 @@ public sealed class ObjectInitializerPass : IIrPass
     static EntryPlan? TryMemberStore(IrNode statement, int localIndex) => statement switch
     {
         StoreProperty { HasInstance: true, Instance: LoadLocal local } property
-            when local.Index == localIndex && property.IndexArguments.Count != 0
+            when local.Index == localIndex && property.IndexArguments.Count != 0 && IsInitializerSpellable(property)
             => new EntryPlan(null, [.. property.IndexArguments, property.Value], null),
         StoreProperty { HasInstance: true, Instance: LoadLocal local } property
-            when local.Index == localIndex
+            when local.Index == localIndex && IsInitializerSpellable(property)
             => new EntryPlan(property.PropertyName, [property.Value], null),
         StoreField { HasInstance: true, Instance: LoadLocal local } field
             when local.Index == localIndex

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -330,7 +330,7 @@ public sealed class ObjectInitializerPass : IIrPass
                 return new NestedOp(outer, IsCollection: false, objectInner);
 
             case StoreField { HasInstance: true } field
-                when OuterMemberOffSlot(field.Instance, aliasSlots) is { } outer:
+                when CSharpNaming.IsUsableIdentifier(field.Field.Name) && OuterMemberOffSlot(field.Instance, aliasSlots) is { } outer:
                 return new NestedOp(outer, IsCollection: false, new EntryPlan(field.Field.Name, [field.Value], null));
 
             // Nested collection element: outer.Member.Add(v, ...).
@@ -356,7 +356,7 @@ public sealed class ObjectInitializerPass : IIrPass
                 return new NestedOp(outer, IsCollection: false, objectInner);
 
             case StoreField { HasInstance: true } field
-                when OuterMemberOffLocal(field.Instance, localIndex) is { } outer:
+                when CSharpNaming.IsUsableIdentifier(field.Field.Name) && OuterMemberOffLocal(field.Instance, localIndex) is { } outer:
                 return new NestedOp(outer, IsCollection: false, new EntryPlan(field.Field.Name, [field.Value], null));
 
             case ExpressionStatement { Expression: Call { Callee.HasThis: true } call }
@@ -373,10 +373,11 @@ public sealed class ObjectInitializerPass : IIrPass
     static string? OuterMemberOffSlot(IrExpression? instance, HashSet<int> aliasSlots) => instance switch
     {
         LoadProperty { HasInstance: true, Instance: LoadStackSlot slot } property
-            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count == 0 && property.Accessor.TypeArguments.IsDefaultOrEmpty
+            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count == 0
+                && property.Accessor.TypeArguments.IsDefaultOrEmpty && CSharpNaming.IsUsableIdentifier(property.PropertyName)
             => property.PropertyName,
         LoadField { Instance: LoadStackSlot slot } field
-            when aliasSlots.Contains(slot.Slot)
+            when aliasSlots.Contains(slot.Slot) && CSharpNaming.IsUsableIdentifier(field.Field.Name)
             => field.Field.Name,
         _ => null,
     };
@@ -384,10 +385,11 @@ public sealed class ObjectInitializerPass : IIrPass
     static string? OuterMemberOffLocal(IrExpression? instance, int localIndex) => instance switch
     {
         LoadProperty { HasInstance: true, Instance: LoadLocal local } property
-            when local.Index == localIndex && property.IndexArguments.Count == 0 && property.Accessor.TypeArguments.IsDefaultOrEmpty
+            when local.Index == localIndex && property.IndexArguments.Count == 0
+                && property.Accessor.TypeArguments.IsDefaultOrEmpty && CSharpNaming.IsUsableIdentifier(property.PropertyName)
             => property.PropertyName,
         LoadField { Instance: LoadLocal local } field
-            when local.Index == localIndex
+            when local.Index == localIndex && CSharpNaming.IsUsableIdentifier(field.Field.Name)
             => field.Field.Name,
         _ => null,
     };
@@ -395,17 +397,28 @@ public sealed class ObjectInitializerPass : IIrPass
     /// <summary>
     /// Whether a property setter store has a C# object-initializer spelling. A
     /// generic accessor (such as <c>set_Value&lt;T&gt;(T)</c>) has no <c>Value = …</c>
-    /// initializer form, a real setter returns <c>void</c>, and its parameter list
-    /// is exactly the index arguments followed by the single assigned value. Without
-    /// this guard <see cref="ObjectInitializerPass"/> would emit
-    /// <c>new Owner { Value = v }</c> from an unspellable accessor shape (#1416).
+    /// initializer form; a real setter returns <c>void</c>; its parameter list is
+    /// exactly the index arguments followed by the single by-value assigned value;
+    /// and a named member must have a usable C# identifier (a backing-field-style or
+    /// otherwise unspellable name has no <c>Name = …</c> form). Without this guard
+    /// <see cref="ObjectInitializerPass"/> would emit invalid initializers such as
+    /// <c>new Owner { Value = v }</c> from a generic accessor or
+    /// <c>new Owner { bad-name = v }</c> from an unspellable accessor (#1416).
     /// </summary>
     static bool IsInitializerSpellable(StoreProperty property)
     {
         var accessor = property.Accessor;
-        return accessor.TypeArguments.IsDefaultOrEmpty
-            && accessor.ReturnType is { Namespace: "System", Name: "Void" }
-            && accessor.ParameterTypes.Length == property.IndexArguments.Count + 1;
+        if (!accessor.TypeArguments.IsDefaultOrEmpty
+            || accessor.ReturnType is not { Namespace: "System", Name: "Void" }
+            || accessor.ParameterTypes.Length != property.IndexArguments.Count + 1
+            || accessor.ParameterTypes.Any(parameter => parameter.Kind == TypeRefKind.ByRef))
+        {
+            return false;
+        }
+
+        // A named member entry prints `Name = value`; an indexer prints `[k] = value`,
+        // so only the named form needs a spellable member identifier.
+        return property.IndexArguments.Count != 0 || CSharpNaming.IsUsableIdentifier(property.PropertyName);
     }
 
     static EntryPlan? TryMemberStore(IrNode statement, HashSet<int> aliasSlots) => statement switch
@@ -418,7 +431,7 @@ public sealed class ObjectInitializerPass : IIrPass
             when aliasSlots.Contains(slot.Slot) && IsInitializerSpellable(property)
             => new EntryPlan(property.PropertyName, [property.Value], null),
         StoreField { HasInstance: true, Instance: LoadStackSlot slot } field
-            when aliasSlots.Contains(slot.Slot)
+            when aliasSlots.Contains(slot.Slot) && CSharpNaming.IsUsableIdentifier(field.Field.Name)
             => new EntryPlan(field.Field.Name, [field.Value], null),
         _ => null,
     };
@@ -432,7 +445,7 @@ public sealed class ObjectInitializerPass : IIrPass
             when local.Index == localIndex && IsInitializerSpellable(property)
             => new EntryPlan(property.PropertyName, [property.Value], null),
         StoreField { HasInstance: true, Instance: LoadLocal local } field
-            when local.Index == localIndex
+            when local.Index == localIndex && CSharpNaming.IsUsableIdentifier(field.Field.Name)
             => new EntryPlan(field.Field.Name, [field.Value], null),
         _ => null,
     };


### PR DESCRIPTION
Fixes #1416. Burndown row 29 of #1356.

## Over-raise claim being narrowed

`ObjectInitializerPass` accepted any instance `StoreProperty` rooted on the freshly constructed object without checking whether the accessor has a C# object-initializer spelling. A generic setter such as `set_Value<T>(T)` folded into:

```csharp
return new Owner { Value = fallback };
```

claiming a normal property initializer even though the generic accessor has no `Value = …` spelling — a #1356-class over-raise (the pass emits high-level source from an unspellable accessor shape). This is independent of #1350/`PropertySugarPass`: `ObjectInitializerPass` consumes already-raised `StoreProperty` nodes and never revalidated the accessor.

## Fix shape (narrowest gate)

Add `IsInitializerSpellable(StoreProperty)`: before building an initializer member from a property store, require the accessor to be

- non-generic (`Accessor.TypeArguments.IsDefaultOrEmpty`) — a generic setter has no property-initializer form;
- `void`-returning (a real setter);
- parameterized as exactly the index arguments followed by the single assigned value (`ParameterTypes.Length == IndexArguments.Count + 1`).

Applied to every `StoreProperty` → initializer-entry site: flat slot/local member stores (`TryMemberStore`, both named and indexer arms) and nested member stores (`TryNestedOp`). Also reject generic getters used as nested initializer member roots (`OuterMemberOff{Slot,Local}`). Field stores are unaffected. When the guard fails the store stays lowered (an honesty improvement, not a regression). No pass widening — the only change is *declining* previously-unsound raises.

## Evidence

`ObjectInitializerPassTests` (24, all green): existing property/field/collection/indexer/nested/argument-position positives still raise; new synthetic adversarial `GenericPropertySetter_IsNotFoldedIntoInvalidInitializer` declines (stays `StoreProperty`); new positive canary `NonGenericVoidSetter_StillFoldsIntoInitializer` still raises. A generic property accessor cannot be expressed in C#, so the adversarial case is hand-built IR (matching the issue's direct-pass repro).

Quality-diff card (isolated: identical corpus, `origin/main` decompiler vs this branch's decompiler):

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,443 (87.91%) | 77,443 (87.91%) | 0 |
| Conditional-branch residual | 2,309 (2.62%) | 2,309 (2.62%) | 0 |
| Forward-merge stops | 2,300 (2.61%) | 2,300 (2.61%) | 0 |
| Full malformed | 47 | 47 | 0 |
| Semantic defects | 167/24,790 | 167/24,790 | 0 |
| Fidelity diffs | opcode-diff 4/22 | opcode-diff 4/22 | 0 |
| Pass bugs | 0 | 0 | 0 |

Verdict: matched baseline tolerances — zero corpus delta (real compiled assemblies have no generic property accessors, so the gate declines no real raise).

### Note on full-suite failures

The decompiler suite shows pre-existing failures unrelated to this change: `IrImporterTests.ConstantByteSpan_RaisesToArrayLiteral` (and sibling constant-span fidelity tests) assert `Full` but observe `Partial` — they exercise `RvaSpanPass`/RVA byte decoding, not `ObjectInitializerPass`, and reproduce identically on clean `origin/main`. All `ObjectInitializer`/property/initializer-adjacent classes pass.

Cross-model adversarial review (GPT-5.5) requested per `AGENTS.md`; summary to follow.
