### PR TITLE
Escape keyword local-function names in the printer (#1465)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LocalFunctionKeywordEscapeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionKeywordEscapeTests.cs
@@ -1,0 +1,56 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class LocalFunctionKeywordEscapeTests
+{
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+
+    // Builds `int M() { int <name>() => 1; return <name>(); }` and prints it.
+    static string PrintWithLocalFunction(string name)
+    {
+        var localBody = new BlockContainer();
+        var localBlock = new Block();
+        localBlock.Add(new Return(new Constant(1, s_int)));
+        localBody.Add(localBlock);
+        var localFunction = new LocalFunctionStatement(
+            name, s_int, [], isStatic: false, [], [], usesUpdatedMemorySafetyRules: false, skipLocalsInit: false, localBody);
+
+        var block = new Block();
+        block.Add(localFunction);
+        block.Add(new Return(new LocalFunctionInvocation(name, s_int, [])));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(s_int, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        return CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+    }
+
+    // #1465: a recovered local function named with a C# keyword must be @-escaped at
+    // both its declaration header and its invocation, not emitted raw at Full.
+    [Fact]
+    public void KeywordLocalFunctionName_IsEscapedAtDeclarationAndInvocation()
+    {
+        var output = PrintWithLocalFunction("return");
+
+        Assert.Contains("@return(", output);            // declaration header escaped
+        Assert.Contains("return @return();", output);   // invocation escaped
+        Assert.DoesNotContain("int return(", output);   // header not emitted raw
+        Assert.DoesNotContain("return return()", output);
+    }
+
+    [Fact]
+    public void OrdinaryLocalFunctionName_IsUnchanged()
+    {
+        var output = PrintWithLocalFunction("Helper");
+
+        Assert.Contains("Helper(", output);
+        Assert.Contains("return Helper();", output);
+        Assert.DoesNotContain("@Helper", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -857,7 +857,7 @@ public sealed partial class CSharpPrinter
         {
             string modifier = localFunction.IsStatic ? "static " : "";
             string parameters = string.Join(", ", localFunction.Parameters.Select(p => $"{TypeText(p.Type)} {CSharpNaming.EscapeIdentifier(p.Name)}"));
-            string header = $"{modifier}{TypeText(localFunction.ReturnType)} {localFunction.Name}({parameters})";
+            string header = $"{modifier}{TypeText(localFunction.ReturnType)} {CSharpNaming.EscapeIdentifier(localFunction.Name)}({parameters})";
             if (localFunction.ExpressionBody is { } body)
             {
                 sb.Append(pad).Append(header).Append(" => ").Append(Expression(body)).AppendLine(";");
@@ -1417,7 +1417,7 @@ public sealed partial class CSharpPrinter
         DelegateCreation d => $"new {TypeText(d.DelegateType)}({MethodGroupText(d.Method, d.Target)})",
         InterpolatedStringExpression i => InterpolatedStringText(i),
         Lambda lam => LambdaText(lam),
-        LocalFunctionInvocation inv => $"{inv.Name}({Arguments(inv.Arguments)})",
+        LocalFunctionInvocation inv => $"{CSharpNaming.EscapeIdentifier(inv.Name)}({Arguments(inv.Arguments)})",
         AddressOfMethod m => AddressOfMethodText(m),
         LoadFunctionPointer p => $"/* {p.Describe()} */",
         LoadProperty p => PropertyTarget(p.Accessor, p.HasInstance ? p.Instance : null, p.IndexArguments, p.PropertyName, p.IsVirtual),


### PR DESCRIPTION
Fixes #1465. Row 8 (Cluster C) of the #1453 wave-2 over-raise burndown.

## Over-raise claim being narrowed

`CSharpPrinter` emitted recovered local-function names **raw** at two C# identifier sites — the declaration header and `LocalFunctionInvocation` — so a local function whose recovered source name is a C# keyword (e.g. `return`) rendered invalid C# while the method stayed `Full`:

```csharp
int return() => 1;
return return();
```

(Parameter names were already escaped at the same header; only the function name and the invocation were not.)

## Fix

Route the declaration header name (`CSharpPrinter.AppendStatement`) and the `LocalFunctionInvocation` name (`CSharpPrinter.Expression`) through the existing `CSharpNaming.EscapeIdentifier`, which `@`-prefixes reserved keywords. Identifier-spelling fix only — no evidence/over-raise semantics change.

## Evidence

New `LocalFunctionKeywordEscapeTests` (2/2) + `LocalFunctionRaisingPassTests` (17/17):

- **Adversarial** `KeywordLocalFunctionName_IsEscapedAtDeclarationAndInvocation`: a local function named `return` renders `int @return() => 1;` and `return @return();` (no raw `int return(` / `return return()`).
- **Canary** `OrdinaryLocalFunctionName_IsUnchanged`: an ordinary name (`Helper`) is unchanged, no spurious `@`.

```
LocalFunctionKeywordEscapeTests   Total: 2, Failed: 0
LocalFunctionRaisingPassTests     Total: 17, Failed: 0
```

Full `src/ILInspector.Decompiler.Tests` running; summary to follow.

Pure identifier escaping; no behavior change for non-keyword names. Product path constraints preserved (SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading).
