### PR TITLE
Fix ReadOnlySpan RVA ctor identity to (void*, int) — #1399 regression

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RvaSpanPassTests.cs
@@ -188,7 +188,7 @@ public class RvaSpanPassTests
             spanType,
             ".ctor",
             TypeRef.CoreLib("System", "Void"),
-            [TypeRef.ByRef(element), s_int],
+            [TypeRef.Pointer(TypeRef.CoreLib("System", "Void")), s_int],
             HasThis: true);
         var field = new FieldRef(
             TypeRef.Definition("CoreLib", "", "<PrivateImplementationDetails>"),

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -288,7 +288,7 @@ public static class MemberIdentity
 
     /// <summary>
     /// Exact identity for csc's constant-<c>ReadOnlySpan&lt;T&gt;</c> RVA optimization
-    /// constructor — corelib <c>System.ReadOnlySpan`1</c>'s <c>(ref T, int)</c> ctor.
+    /// constructor — corelib <c>System.ReadOnlySpan`1</c>'s <c>(void*, int)</c> ctor.
     /// A user assembly can define a <c>System.ReadOnlySpan&lt;T&gt;</c> lookalike with
     /// the same name/shape, so the raise must check exact corelib identity rather than
     /// the type name (#1399).
@@ -302,12 +302,12 @@ public static class MemberIdentity
                 HasThis: true,
                 TypeArguments.IsEmpty: true,
                 DeclaringType: var declaringType,
-                ParameterTypes: [var reference, var length],
+                ParameterTypes: [var pointer, var length],
             }
             || newObject.Arguments.Count != 2
             || !IsCoreLibraryType(declaringType, "System", "ReadOnlySpan`1")
             || declaringType.TypeArguments is not [var spanElement]
-            || !reference.Equals(TypeRef.ByRef(spanElement))
+            || !pointer.Equals(TypeRef.Pointer(s_void))
             || !length.Equals(s_int))
         {
             return false;


### PR DESCRIPTION
Regression fix for #1461 (#1399).

## Regression

#1461 added `MemberIdentity.IsReadOnlySpanRvaConstructor` gating the constant-`ReadOnlySpan<T>` RVA raise on a `(ref T, int)` constructor. But csc's 1-byte-element optimization uses the **unsafe `ReadOnlySpan<T>(void* pointer, int length)`** ctor (the same `(void*, int)` shape as `IsStackAllocSpanConstructor`), confirmed by dumping the real `CfgSampleClass.ConstantByteSpan` fixture:

```
ctor decl=ReadOnlySpan<byte> hasThis=True ret=void
params: Pointer:void*, Definition:int
```

The synthetic test fixture (`BuildReadOnlySpanCtor`) used `(ref T, int)`, matching the wrong predicate, so the synthetic `RvaSpanPassTests` passed — while the **real-fixture** `IrImporterTests.ConstantByteSpan_RaisesToArrayLiteral` regressed: the raise declined, the `<PrivateImplementationDetails>` type stayed unspellable, and fidelity dropped Full → Partial.

It slipped through because #1461's full suite never completed under heavy machine contention (only the synthetic `RvaSpanPassTests`/`MemberIdentityTests` were verified). The #1461 cross-model reviewer explicitly flagged this false-negative risk; I incorrectly dismissed it based on the (wrong) synthetic fixture.

## Fix

- `IsReadOnlySpanRvaConstructor` now requires the real `(void*, int)` ctor (`pointer.Equals(TypeRef.Pointer(s_void))`), mirroring `IsStackAllocSpanConstructor`.
- The synthetic `BuildReadOnlySpanCtor` fixture is updated to `(void*, int)` so it matches real csc.

The user-assembly `System.ReadOnlySpan<byte>` lookalike still declines via corelib identity; the real corelib byte-RVA positive raises again.

## Evidence

```
RvaSpanPassTests   Total: 9, Failed: 0
IrImporterTests    Total: 64, Failed: 0   (incl. ConstantByteSpan_RaisesToArrayLiteral, was failing)
```
