### PR TITLE
Decline non-spellable calli instead of emitting invalid fp(x) (#1435)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CallIndirectSpellabilityPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CallIndirectSpellabilityPassTests.cs
@@ -122,5 +122,36 @@ public class CallIndirectSpellabilityPassTests
         Assert.Single(function.Descendants.OfType<UnsupportedNode>());
         Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
     }
+
+    // #1435 (adversarial review): a `&Method` address has a delegate* result type
+    // but cannot be invoked directly — `(&Target)(x)` is invalid C# (CS0149); it
+    // needs a `(delegate*<...>)` cast first. Decline rather than emit it at Full.
+    [Fact]
+    public void AddressOfMethodOperand_DegradesToPartial()
+    {
+        var target = new MethodRef(TypeRef.Definition("Synthetic", "", "T"), "Target", s_int, [s_int], HasThis: false);
+        var call = new CallIndirect(new AddressOfMethod(target), [new LoadArgument(1, "x", s_int)], s_int, [s_int])
+        {
+            CallingConvention = "",
+            IsInstance = false,
+        };
+        var block = new Block(0);
+        block.Add(new Return(call));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(s_int, [new Parameter("x", s_int)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new CallIndirectSpellabilityPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CallIndirect>());
+        Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
 }
+
 

--- a/src/ILInspector.Decompiler.Tests/CallIndirectSpellabilityPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CallIndirectSpellabilityPassTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class CallIndirectSpellabilityPassTests
+{
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_intPtr = TypeRef.CoreLib("System", "IntPtr");
+    static readonly TypeRef s_managedFp = TypeRef.FunctionPointer(s_int, [s_int], "");
+
+    static IrFunction BuildCalli(IrExpression pointer, string convention, bool isInstance, int extraArgs = 0)
+    {
+        var arguments = new List<IrExpression>();
+        for (int i = 0; i < extraArgs; i++)
+            arguments.Add(new LoadArgument(2 + i, $"r{i}", s_int));
+        arguments.Add(new LoadArgument(1, "x", s_int));
+        var call = new CallIndirect(pointer, arguments, s_int, [s_int])
+        {
+            CallingConvention = convention,
+            IsInstance = isInstance,
+        };
+        var block = new Block(0);
+        block.Add(new Return(call));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(s_int, [new Parameter("p", pointer.ResultType ?? s_intPtr), new Parameter("x", s_int)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    // #1435 positive canary: a typed managed delegate*<int,int> operand with a
+    // matching convention, non-instance, stays Full and renders fp(x).
+    [Fact]
+    public void TypedManagedDelegatePointer_StaysFullAndRendersInvocation()
+    {
+        var function = BuildCalli(new LoadArgument(0, "p", s_managedFp), convention: "", isInstance: false);
+
+        new CallIndirectSpellabilityPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<CallIndirect>());
+        Assert.Empty(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("p(x)", CSharpPrinter.Print(function).Output);
+    }
+
+    // #1435 (1): an untyped IntPtr operand is not a callable delegate*; fp(x) would
+    // not compile. Must degrade to Partial with an honest marker.
+    [Fact]
+    public void UntypedPointerOperand_DegradesToPartial()
+    {
+        var function = BuildCalli(new LoadArgument(0, "p", s_intPtr), convention: "", isInstance: false);
+
+        new CallIndirectSpellabilityPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CallIndirect>());
+        Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        Assert.DoesNotContain("p(x)", CSharpPrinter.Print(function).Output);
+    }
+
+    // #1435 (2): an instance function pointer has no C# delegate* spelling (and the
+    // receiver/parameter lists are off by one).
+    [Fact]
+    public void InstanceCalli_DegradesToPartial()
+    {
+        var function = BuildCalli(new LoadArgument(0, "p", s_managedFp), convention: "", isInstance: true, extraArgs: 1);
+
+        new CallIndirectSpellabilityPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CallIndirect>());
+        Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    // #1435 (3): the call-site convention does not match the operand delegate*'s
+    // convention — fp(x) would mis-describe the call.
+    [Fact]
+    public void ConventionMismatch_DegradesToPartial()
+    {
+        var function = BuildCalli(new LoadArgument(0, "p", s_managedFp), convention: "unmanaged[Cdecl]", isInstance: false);
+
+        new CallIndirectSpellabilityPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CallIndirect>());
+        Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CallIndirectSpellabilityPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CallIndirectSpellabilityPassTests.cs
@@ -89,4 +89,38 @@ public class CallIndirectSpellabilityPassTests
         Assert.Single(function.Descendants.OfType<UnsupportedNode>());
         Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
     }
+
+    // #1435 (adversarial review): the call-site signature disagrees with the
+    // operand delegate*'s signature — a delegate*<int,int> (one parameter) invoked
+    // through a two-parameter calli would render `p(a, b)`, invalid for the operand.
+    [Fact]
+    public void SignatureArityMismatch_DegradesToPartial()
+    {
+        var call = new CallIndirect(
+            new LoadArgument(0, "p", s_managedFp),
+            [new LoadArgument(1, "a", s_int), new LoadArgument(2, "b", s_int)],
+            s_int,
+            [s_int, s_int])
+        {
+            CallingConvention = "",
+            IsInstance = false,
+        };
+        var block = new Block(0);
+        block.Add(new Return(call));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(s_int, [new Parameter("p", s_managedFp), new Parameter("a", s_int), new Parameter("b", s_int)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new CallIndirectSpellabilityPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CallIndirect>());
+        Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
 }
+

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1304,7 +1304,11 @@ public static class IrImporter
                     var arguments = new IrExpression[argumentCount];
                     for (int i = argumentCount - 1; i >= 0; i--)
                         arguments[i] = Pop(stack);
-                    var callIndirect = new CallIndirect(pointer, arguments, signature.ReturnType, signature.ParameterTypes);
+                    var callIndirect = new CallIndirect(pointer, arguments, signature.ReturnType, signature.ParameterTypes)
+                    {
+                        CallingConvention = TypeRefDecoder.ConventionText(signature.Header.CallingConvention),
+                        IsInstance = signature.Header.IsInstance,
+                    };
                     if (signature.ReturnType is { Name: "Void", Namespace: "System" })
                         body.Add(new ExpressionStatement(callIndirect));
                     else

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1276,6 +1276,21 @@ public sealed class CallIndirect : IrExpression
     public TypeRef ReturnType { get; }
     public ImmutableArray<TypeRef> ParameterTypes { get; }
 
+    /// <summary>
+    /// The C# calling-convention spelling carried by the <c>calli</c> standalone
+    /// signature (empty = managed, else <c>unmanaged</c>/<c>unmanaged[Cdecl]</c>…),
+    /// in the same form as <see cref="TypeRef.CallingConvention"/> on a
+    /// <c>delegate*</c> type, so the two can be compared for a spellable invocation.
+    /// </summary>
+    public string CallingConvention { get; init; } = "";
+
+    /// <summary>
+    /// Whether the call-site signature is an instance function pointer (the
+    /// receiver is in <see cref="Arguments"/> but absent from
+    /// <see cref="ParameterTypes"/>). C# has no instance <c>delegate*</c> spelling.
+    /// </summary>
+    public bool IsInstance { get; init; }
+
     /// <summary>The function-pointer value being invoked.</summary>
     public IrExpression Pointer => (IrExpression)Children[0];
     /// <summary>Call arguments (the function pointer's own parameters, receiver included when the signature carries one).</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CallIndirectSpellabilityPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CallIndirectSpellabilityPass.cs
@@ -37,11 +37,18 @@ public sealed class CallIndirectSpellabilityPass : IIrPass
     }
 
     // Faithful as `fp(x)` only when the operand is a typed, non-instance
-    // `delegate*` whose calling convention matches the call-site signature.
+    // `delegate*` whose calling convention AND signature (return + parameter types)
+    // match the call-site signature. A standalone calli signature can disagree with
+    // a typed operand's `delegate*` type (arity or type mismatch), which `fp(args)`
+    // cannot spell faithfully.
     static bool IsSpellable(CallIndirect call)
         => !call.IsInstance
             && call.Pointer.ResultType is { Kind: TypeRefKind.FunctionPointer } pointer
-            && pointer.CallingConvention == call.CallingConvention;
+            && pointer.CallingConvention == call.CallingConvention
+            && pointer.ElementType is { } returnType
+            && returnType.Equals(call.ReturnType)
+            && pointer.TypeArguments.Length == call.ParameterTypes.Length
+            && pointer.TypeArguments.SequenceEqual(call.ParameterTypes);
 
     static string Reason(CallIndirect call)
     {
@@ -49,7 +56,9 @@ public sealed class CallIndirectSpellabilityPass : IIrPass
             return "instance function pointer has no C# delegate* spelling";
         if (call.Pointer.ResultType is not { Kind: TypeRefKind.FunctionPointer } pointer)
             return $"function-pointer operand is {call.Pointer.ResultType?.ToDisplayString() ?? "untyped"}, not a spellable delegate*";
-        return $"calling convention '{Display(call.CallingConvention)}' does not match the operand delegate* '{Display(pointer.CallingConvention)}'";
+        if (pointer.CallingConvention != call.CallingConvention)
+            return $"calling convention '{Display(call.CallingConvention)}' does not match the operand delegate* '{Display(pointer.CallingConvention)}'";
+        return $"call-site signature does not match the operand delegate* '{pointer.ToDisplayString()}'";
     }
 
     static string Display(string convention) => convention.Length == 0 ? "managed" : convention;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CallIndirectSpellabilityPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CallIndirectSpellabilityPass.cs
@@ -43,6 +43,7 @@ public sealed class CallIndirectSpellabilityPass : IIrPass
     // cannot spell faithfully.
     static bool IsSpellable(CallIndirect call)
         => !call.IsInstance
+            && call.Pointer is not AddressOfMethod
             && call.Pointer.ResultType is { Kind: TypeRefKind.FunctionPointer } pointer
             && pointer.CallingConvention == call.CallingConvention
             && pointer.ElementType is { } returnType
@@ -54,6 +55,8 @@ public sealed class CallIndirectSpellabilityPass : IIrPass
     {
         if (call.IsInstance)
             return "instance function pointer has no C# delegate* spelling";
+        if (call.Pointer is AddressOfMethod)
+            return "a &Method address must be cast to a delegate* before it can be invoked";
         if (call.Pointer.ResultType is not { Kind: TypeRefKind.FunctionPointer } pointer)
             return $"function-pointer operand is {call.Pointer.ResultType?.ToDisplayString() ?? "untyped"}, not a spellable delegate*";
         if (pointer.CallingConvention != call.CallingConvention)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CallIndirectSpellabilityPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CallIndirectSpellabilityPass.cs
@@ -1,0 +1,56 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Keeps <c>calli</c> invocations honest. <see cref="CallIndirect"/> renders as
+/// <c>fp(x)</c>, which is only valid C# when the pointer operand is a spellable,
+/// non-instance <c>delegate*</c> whose calling convention matches the call-site
+/// signature. The importer discards none of that, but the printer would emit
+/// <c>fp(x)</c> for an untyped (<c>nint</c>/<c>IntPtr</c>) operand, an instance
+/// function pointer (no C# spelling, and the receiver/parameter lists are off by
+/// one), or a convention mismatch — all uncompilable while reporting
+/// <see cref="DecompilationFidelity.Full"/> (#1435).
+///
+/// <para>This pass replaces every such non-spellable <c>calli</c> with an
+/// <see cref="UnsupportedNode"/>, so the C# view shows an honest marker and
+/// fidelity caps to <see cref="DecompilationFidelity.Partial"/> instead of
+/// claiming a faithful call. A <c>calli</c> through a typed managed/unmanaged
+/// <c>delegate*</c> with a matching convention still raises to <c>fp(x)</c> at
+/// <c>Full</c>. Runs last in the diagnostics band, alongside
+/// <see cref="FunctionPointerDiagnosticsPass"/>.</para>
+/// </summary>
+public sealed class CallIndirectSpellabilityPass : IIrPass
+{
+    public string Name => "calli-spellability";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var call in function.Descendants.OfType<CallIndirect>().ToList())
+        {
+            if (call.Parent is null || IsSpellable(call))
+                continue;
+
+            context.Stepper.StepOver("decline unspellable calli (not a matching delegate* invocation)", call);
+            var marker = new UnsupportedNode(0, "calli", Reason(call));
+            marker.InheritSourceOffset(call);
+            call.ReplaceWith(marker);
+        }
+    }
+
+    // Faithful as `fp(x)` only when the operand is a typed, non-instance
+    // `delegate*` whose calling convention matches the call-site signature.
+    static bool IsSpellable(CallIndirect call)
+        => !call.IsInstance
+            && call.Pointer.ResultType is { Kind: TypeRefKind.FunctionPointer } pointer
+            && pointer.CallingConvention == call.CallingConvention;
+
+    static string Reason(CallIndirect call)
+    {
+        if (call.IsInstance)
+            return "instance function pointer has no C# delegate* spelling";
+        if (call.Pointer.ResultType is not { Kind: TypeRefKind.FunctionPointer } pointer)
+            return $"function-pointer operand is {call.Pointer.ResultType?.ToDisplayString() ?? "untyped"}, not a spellable delegate*";
+        return $"calling convention '{Display(call.CallingConvention)}' does not match the operand delegate* '{Display(pointer.CallingConvention)}'";
+    }
+
+    static string Display(string convention) => convention.Length == 0 ? "managed" : convention;
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -275,6 +275,9 @@ public static class IrPasses
         // Last: any function-pointer load still standing fed something other
         // than a delegate constructor — record the honest residual diagnostic.
         new FunctionPointerDiagnosticsPass(),
+        // calli through a non-spellable operand (untyped/instance/convention
+        // mismatch) renders an honest marker instead of an uncompilable fp(x).
+        new CallIndirectSpellabilityPass(),
         new RefKindDiagnosticsPass(),
     ];
 

--- a/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
@@ -110,7 +110,7 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         => TypeRef.FunctionPointer(signature.ReturnType, signature.ParameterTypes, ConventionText(signature.Header.CallingConvention));
 
     /// <summary>The C# calling-convention spelling for a function pointer: empty for a managed pointer, the <c>unmanaged</c> keyword (with the specific convention in brackets) otherwise.</summary>
-    static string ConventionText(SignatureCallingConvention convention) => convention switch
+    public static string ConventionText(SignatureCallingConvention convention) => convention switch
     {
         SignatureCallingConvention.Default => "",
         SignatureCallingConvention.CDecl => "unmanaged[Cdecl]",


### PR DESCRIPTION
Fixes #1435. Row 33 of the #1356 over-raise burndown.

## Over-raise claim being narrowed

`calli` was imported keeping only return/parameter types — the **calling convention was dropped** and `CallIndirect` carried no convention/instance facts. The printer rendered `fp(x)` for managed / `unmanaged[...]` / instance calli alike, **at `Full`**, including uncompilable cases:

1. **Untyped pointer operand** (`nint`/`IntPtr`): `fp(x)` invokes an `IntPtr`, not callable in C#.
2. **Instance calli**: no C# instance-`delegate*` spelling, and `Arguments` (receiver included) vs `ParameterTypes` (receiver excluded) are off by one.
3. **Convention mismatch** vs the operand `delegate*` type.

## Fix

- Carry the call-site **calling convention** (via the now-exposed `TypeRefDecoder.ConventionText` — the same spelling `delegate*` types use, so they compare directly) and the **`IsInstance`** flag on `CallIndirect`, populated at the calli import site.
- Add `CallIndirectSpellabilityPass` (diagnostics band, alongside `FunctionPointerDiagnosticsPass`): a calli is faithful as `fp(x)` only when the operand is a **typed, non-instance `delegate*` whose convention matches** the call site. Otherwise it is replaced with an `UnsupportedNode`, so the C# view shows an honest `/* … */` marker and fidelity caps to **`Partial`** instead of claiming a faithful call.

Typed managed/unmanaged `delegate*` calli still raise to `fp(x)` at `Full`.

## Evidence

`CallIndirectSpellabilityPassTests` (4/4) + `IrImporterTests/Calli*` (4/4):

- **Adversarial**: untyped `IntPtr`-operand calli, instance calli, and convention-mismatched calli all degrade to `Partial` with a marker (no `p(x)`).
- **Positive canary**: a typed managed `delegate*<int,int>` operand (matching convention, non-instance) stays `Full` and renders `p(x)`; existing `InvokesFunctionPointer` / unmanaged / generic-unmanaged calli positives unchanged.

```
CallIndirectSpellabilityPassTests   Total: 4, Failed: 0
IrImporterTests/Calli*              Total: 4, Failed: 0
```

> Note: the broader `IrImporterTests` suite on this branch has one **pre-existing** failure (`ConstantByteSpan_RaisesToArrayLiteral`) that is unrelated to this change — it is a #1399/#1461 regression fixed in **#1496**. This PR should land after (or rebase on) #1496; this branch's calli changes are independent and green.

Product path constraints preserved (SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading).

## Adversarial review

Will request cross-model adversarial review (GPT-5.5) and post the summary per AGENTS.md.
