### PR TITLE
Gate corpus count regressions on the pinned-NuGet subset (#1396 Stage 9)

### DIFF
--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -425,18 +425,29 @@ internal static class CorpusSensor
         // have a zero tolerance, which is incompatible with a corpus that mixes the
         // pinned NuGet assemblies with the repo's own assemblies: the latter grow every
         // PR, and newly-added repo code that the decompiler malforms drives phantom count
-        // regressions on changes that touched nothing. Gate those counts on the *pinned*
-        // subset only — a fixed method set whose counts move only when decompiler behavior
-        // does — computed from the per-method snapshots both snapshots carry. Pass bugs
-        // (crashes) stay on the full aggregate: a crash anywhere is worth blocking. Fall
-        // back to the aggregate when a snapshot lacks per-method detail.
+        // regressions on changes that touched nothing. Gate Full-malformed and
+        // semantic-defect counts on the *pinned* subset — a fixed method set whose counts
+        // move only when decompiler behavior does — computed from the per-method snapshots
+        // both snapshots carry. Pass bugs (crashes) stay on the full aggregate: a crash
+        // anywhere is worth blocking. Fall back to the aggregate when a snapshot lacks
+        // per-method detail.
         var baselinePinned = PinnedCounts(baseline);
         var currentPinned = PinnedCounts(current);
         if (baselinePinned is { } basePinned && currentPinned is { } curPinned)
         {
             AddCountRegression(failures, "Full malformed methods (pinned)", basePinned.FullMalformed, curPinned.FullMalformed, tolerance.FullMalformedIncrease);
             AddCountRegression(failures, "semantic defect methods (pinned)", basePinned.SemanticDefect, curPinned.SemanticDefect, tolerance.SemanticDefectIncrease);
-            if (baseline.Metrics.Fidelity.CheckedMethods > 0)
+
+            // Fidelity is sampled far more thinly than validity, and that small sample
+            // currently lands almost entirely on repo assemblies, so the pinned subset
+            // often has zero fidelity-checked methods. Gate fidelity counts on the pinned
+            // subset only when it actually holds a fidelity sample and the caps match
+            // (per-method FidelityCheck is recorded at the primary cap); otherwise the
+            // aggregate fidelity count is drift-contaminated, so leave it ungated and rely
+            // on changed-method fidelity (the authoritative fidelity proof) instead of
+            // re-introducing a repo-growth false positive.
+            if (basePinned.FidelityChecked > 0 && curPinned.FidelityChecked > 0
+                && current.FidelityCompileCap == baseline.FidelityCompileCap)
             {
                 AddCountRegression(failures, "fidelity opcode diffs (pinned)", basePinned.OpcodeDiff, curPinned.OpcodeDiff, tolerance.FidelityOpcodeDiffIncrease);
                 AddCountRegression(failures, "fidelity recompile failures (pinned)", basePinned.RecompileFail, curPinned.RecompileFail, tolerance.FidelityRecompileFailIncrease);
@@ -465,15 +476,17 @@ internal static class CorpusSensor
     /// deterministic, fixed-version slice of the corpus whose method set never changes,
     /// so a count delta there reflects a real decompiler behavior change rather than
     /// repo-assembly growth. Computed from the per-method snapshots (consistent with the
-    /// aggregates, which equal pinned + repo). Returns null when per-method detail is
-    /// absent, so the caller falls back to the aggregate counts.
+    /// aggregates, which equal pinned + repo). <see cref="PinnedCountMetrics.FidelityChecked"/>
+    /// lets the caller skip fidelity gating when the pinned subset holds no fidelity
+    /// sample. Returns null when per-method detail is absent, so the caller falls back to
+    /// the aggregate counts.
     /// </summary>
     static PinnedCountMetrics? PinnedCounts(CorpusSensorSnapshot snapshot)
     {
         if (snapshot.Methods is not { Count: > 0 } methods)
             return null;
 
-        int malformed = 0, semantic = 0, opcode = 0, recompile = 0, context = 0;
+        int malformed = 0, semantic = 0, opcode = 0, recompile = 0, context = 0, fidelityChecked = 0;
         foreach (var method in methods)
         {
             if (!IsPinnedAssembly(method.AssemblyPath))
@@ -482,6 +495,8 @@ internal static class CorpusSensor
                 malformed++;
             else if (method.Validity.StartsWith("semantic-defect:", StringComparison.Ordinal))
                 semantic++;
+            if (method.FidelityCheck != "not-sampled")
+                fidelityChecked++;
             switch (method.FidelityCheck)
             {
                 case "OpcodeDiff": opcode++; break;
@@ -489,7 +504,7 @@ internal static class CorpusSensor
                 case "ContextFail": context++; break;
             }
         }
-        return new PinnedCountMetrics(malformed, semantic, opcode, recompile, context);
+        return new PinnedCountMetrics(malformed, semantic, opcode, recompile, context, fidelityChecked);
     }
 
     static bool IsPinnedAssembly(string assemblyPath)
@@ -731,13 +746,17 @@ internal static class CorpusSensor
     {
         if (PinnedCounts(baseline) is not { } basePinned || PinnedCounts(current) is not { } curPinned)
             return;
+        var fidelity = basePinned.FidelityChecked > 0 && curPinned.FidelityChecked > 0
+            && current.FidelityCompileCap == baseline.FidelityCompileCap
+            ? $"opcode diffs {Number(basePinned.OpcodeDiff)} -> {Number(curPinned.OpcodeDiff)} "
+                + $"({Delta(curPinned.OpcodeDiff - basePinned.OpcodeDiff)})"
+            : "fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity)";
         Console.WriteLine();
         Console.WriteLine(
             "Pinned-subset gate (count regressions evaluated here): "
             + $"Full malformed {Number(basePinned.FullMalformed)} -> {Number(curPinned.FullMalformed)} "
             + $"({Delta(curPinned.FullMalformed - basePinned.FullMalformed)}); "
-            + $"opcode diffs {Number(basePinned.OpcodeDiff)} -> {Number(curPinned.OpcodeDiff)} "
-            + $"({Delta(curPinned.OpcodeDiff - basePinned.OpcodeDiff)}).");
+            + fidelity + ".");
     }
 
     /// <summary>
@@ -893,7 +912,8 @@ internal sealed record PinnedCountMetrics(
     int SemanticDefect,
     int OpcodeDiff,
     int RecompileFail,
-    int ContextFail);
+    int ContextFail,
+    int FidelityChecked);
 
 internal sealed record CompletenessSensorMetrics(
     IReadOnlyList<CorpusAssemblySnapshot> Assemblies,

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -421,19 +421,79 @@ internal static class CorpusSensor
         if (forwardIncrease > tolerance.ForwardMergeIncreaseBasisPoints)
             failures.Add($"forward-merge stop rate increased {forwardIncrease} bps (baseline {FormatBps(baseline.Metrics.ForwardMergeBasisPoints)}, current {FormatBps(current.Metrics.ForwardMergeBasisPoints)}, tolerance {tolerance.ForwardMergeIncreaseBasisPoints} bps)");
 
-        AddCountRegression(failures, "Full malformed methods", baseline.Metrics.FullMalformedMethods, current.Metrics.FullMalformedMethods, tolerance.FullMalformedIncrease);
-        AddCountRegression(failures, "semantic defect methods", baseline.Metrics.SemanticDefectMethods, current.Metrics.SemanticDefectMethods, tolerance.SemanticDefectIncrease);
-        AddCountRegression(failures, "pass bugs", baseline.Metrics.PassBugs, current.Metrics.PassBugs, tolerance.PassBugIncrease);
-
-        if (baseline.Metrics.Fidelity.CheckedMethods > 0)
+        // Count-based regressions (Full malformed, semantic defects, fidelity buckets)
+        // have a zero tolerance, which is incompatible with a corpus that mixes the
+        // pinned NuGet assemblies with the repo's own assemblies: the latter grow every
+        // PR, and newly-added repo code that the decompiler malforms drives phantom count
+        // regressions on changes that touched nothing. Gate those counts on the *pinned*
+        // subset only — a fixed method set whose counts move only when decompiler behavior
+        // does — computed from the per-method snapshots both snapshots carry. Pass bugs
+        // (crashes) stay on the full aggregate: a crash anywhere is worth blocking. Fall
+        // back to the aggregate when a snapshot lacks per-method detail.
+        var baselinePinned = PinnedCounts(baseline);
+        var currentPinned = PinnedCounts(current);
+        if (baselinePinned is { } basePinned && currentPinned is { } curPinned)
         {
-            AddCountRegression(failures, "fidelity opcode diffs", baseline.Metrics.Fidelity.OpcodeDiffMethods, currentFidelityMetrics.OpcodeDiffMethods, tolerance.FidelityOpcodeDiffIncrease);
-            AddCountRegression(failures, "fidelity recompile failures", baseline.Metrics.Fidelity.RecompileFailMethods, currentFidelityMetrics.RecompileFailMethods, tolerance.FidelityRecompileFailIncrease);
-            AddCountRegression(failures, "fidelity context failures", baseline.Metrics.Fidelity.ContextFailMethods, currentFidelityMetrics.ContextFailMethods, tolerance.FidelityContextFailIncrease);
+            AddCountRegression(failures, "Full malformed methods (pinned)", basePinned.FullMalformed, curPinned.FullMalformed, tolerance.FullMalformedIncrease);
+            AddCountRegression(failures, "semantic defect methods (pinned)", basePinned.SemanticDefect, curPinned.SemanticDefect, tolerance.SemanticDefectIncrease);
+            if (baseline.Metrics.Fidelity.CheckedMethods > 0)
+            {
+                AddCountRegression(failures, "fidelity opcode diffs (pinned)", basePinned.OpcodeDiff, curPinned.OpcodeDiff, tolerance.FidelityOpcodeDiffIncrease);
+                AddCountRegression(failures, "fidelity recompile failures (pinned)", basePinned.RecompileFail, curPinned.RecompileFail, tolerance.FidelityRecompileFailIncrease);
+                AddCountRegression(failures, "fidelity context failures (pinned)", basePinned.ContextFail, curPinned.ContextFail, tolerance.FidelityContextFailIncrease);
+            }
         }
+        else
+        {
+            AddCountRegression(failures, "Full malformed methods", baseline.Metrics.FullMalformedMethods, current.Metrics.FullMalformedMethods, tolerance.FullMalformedIncrease);
+            AddCountRegression(failures, "semantic defect methods", baseline.Metrics.SemanticDefectMethods, current.Metrics.SemanticDefectMethods, tolerance.SemanticDefectIncrease);
+            if (baseline.Metrics.Fidelity.CheckedMethods > 0)
+            {
+                AddCountRegression(failures, "fidelity opcode diffs", baseline.Metrics.Fidelity.OpcodeDiffMethods, currentFidelityMetrics.OpcodeDiffMethods, tolerance.FidelityOpcodeDiffIncrease);
+                AddCountRegression(failures, "fidelity recompile failures", baseline.Metrics.Fidelity.RecompileFailMethods, currentFidelityMetrics.RecompileFailMethods, tolerance.FidelityRecompileFailIncrease);
+                AddCountRegression(failures, "fidelity context failures", baseline.Metrics.Fidelity.ContextFailMethods, currentFidelityMetrics.ContextFailMethods, tolerance.FidelityContextFailIncrease);
+            }
+        }
+
+        AddCountRegression(failures, "pass bugs", baseline.Metrics.PassBugs, current.Metrics.PassBugs, tolerance.PassBugIncrease);
 
         return failures.ToImmutable();
     }
+
+    /// <summary>
+    /// Count-based correctness metrics restricted to the pinned NuGet assemblies — the
+    /// deterministic, fixed-version slice of the corpus whose method set never changes,
+    /// so a count delta there reflects a real decompiler behavior change rather than
+    /// repo-assembly growth. Computed from the per-method snapshots (consistent with the
+    /// aggregates, which equal pinned + repo). Returns null when per-method detail is
+    /// absent, so the caller falls back to the aggregate counts.
+    /// </summary>
+    static PinnedCountMetrics? PinnedCounts(CorpusSensorSnapshot snapshot)
+    {
+        if (snapshot.Methods is not { Count: > 0 } methods)
+            return null;
+
+        int malformed = 0, semantic = 0, opcode = 0, recompile = 0, context = 0;
+        foreach (var method in methods)
+        {
+            if (!IsPinnedAssembly(method.AssemblyPath))
+                continue;
+            if (method.Validity.StartsWith("full-malformed:", StringComparison.Ordinal))
+                malformed++;
+            else if (method.Validity.StartsWith("semantic-defect:", StringComparison.Ordinal))
+                semantic++;
+            switch (method.FidelityCheck)
+            {
+                case "OpcodeDiff": opcode++; break;
+                case "RecompileFail": recompile++; break;
+                case "ContextFail": context++; break;
+            }
+        }
+        return new PinnedCountMetrics(malformed, semantic, opcode, recompile, context);
+    }
+
+    static bool IsPinnedAssembly(string assemblyPath)
+        => assemblyPath.StartsWith("nuget:", StringComparison.Ordinal);
 
     static void EmitMethodDelta(string path, CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
     {
@@ -638,6 +698,7 @@ internal static class CorpusSensor
             Number(baseline.Metrics.PassBugs),
             Number(current.Metrics.PassBugs),
             Delta(current.Metrics.PassBugs - baseline.Metrics.PassBugs));
+        PrintPinnedGate(baseline, current);
         Console.WriteLine();
         Console.WriteLine(regressions.Count == 0
             ? "Verdict: corpus sensor matched baseline tolerances."
@@ -652,12 +713,31 @@ internal static class CorpusSensor
             {
                 Console.WriteLine();
                 Console.WriteLine(
-                    "Caveat: the corpus drifted from the baseline (see baseline staleness above), "
-                    + "so count-based regressions may be corpus composition change rather than a "
-                    + "real PR delta. Rebaseline against current main and re-run before treating "
-                    + "these as blocking.");
+                    "Caveat: the corpus drifted from the baseline (see baseline staleness above). "
+                    + "The aggregate count rows above mix the PR with that drift, but count-based "
+                    + "regressions are gated on the pinned-NuGet subset (a fixed method set), so any "
+                    + "`(pinned)` regression listed here is a real decompiler delta, not drift.");
             }
         }
+    }
+
+    /// <summary>
+    /// Shows the pinned-NuGet-subset count metrics that actually drive the count-based
+    /// verdict, so reviewers can see the stable gate alongside the drifting aggregate
+    /// rows. Silent when per-method detail is unavailable (the verdict then falls back to
+    /// aggregate counts).
+    /// </summary>
+    static void PrintPinnedGate(CorpusSensorSnapshot baseline, CorpusSensorSnapshot current)
+    {
+        if (PinnedCounts(baseline) is not { } basePinned || PinnedCounts(current) is not { } curPinned)
+            return;
+        Console.WriteLine();
+        Console.WriteLine(
+            "Pinned-subset gate (count regressions evaluated here): "
+            + $"Full malformed {Number(basePinned.FullMalformed)} -> {Number(curPinned.FullMalformed)} "
+            + $"({Delta(curPinned.FullMalformed - basePinned.FullMalformed)}); "
+            + $"opcode diffs {Number(basePinned.OpcodeDiff)} -> {Number(curPinned.OpcodeDiff)} "
+            + $"({Delta(curPinned.OpcodeDiff - basePinned.OpcodeDiff)}).");
     }
 
     /// <summary>
@@ -807,6 +887,13 @@ internal sealed record CorpusSensorSnapshot(
     CorpusSensorMetrics Metrics);
 
 internal sealed record CorpusAssemblySnapshot(string Assembly, string Path, int TotalMethods);
+
+internal sealed record PinnedCountMetrics(
+    int FullMalformed,
+    int SemanticDefect,
+    int OpcodeDiff,
+    int RecompileFail,
+    int ContextFail);
 
 internal sealed record CompletenessSensorMetrics(
     IReadOnlyList<CorpusAssemblySnapshot> Assemblies,

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -87,10 +87,19 @@ The corpus includes the repo's own assemblies, which grow as unrelated code
 lands, so a baseline captured earlier can disagree with the current run on
 method population even when a PR changed no decompiler behavior. When that
 happens the card prints a **`Baseline staleness:`** block (which assemblies
-drifted and the net method-count delta) and appends a caveat to any
-`Regressions:` list, because the aggregate count deltas then mix corpus drift
-with the PR's real effect. Treat that as a signal to rebaseline against current
-main and re-run, not as a blocking regression.
+drifted and the net method-count delta).
+
+To keep that drift from producing false verdicts, the **count-based**
+regressions — Full malformed, semantic defects, and the fidelity opcode /
+recompile / context buckets — are gated on the **pinned-NuGet subset** only: a
+fixed, fixed-version method set whose counts move only when decompiler behavior
+does. The card prints a **`Pinned-subset gate`** line showing those stable
+counts alongside the drifting aggregate rows, and any `(pinned)` regression in
+the `Regressions:` list is a real decompiler delta rather than repo growth.
+Rate-based metrics (fully-raised, residual, forward-merge) and pass-bug crashes
+still gate on the full aggregate. The gate is computed from the per-method
+snapshots both baseline and current carry, so no baseline regen is required; it
+falls back to aggregate counts when a snapshot lacks per-method detail.
 
 Expand the fixed corpus only after that targeting step shows a shape gap. Prefer
 deterministic, pinned assemblies that add many examples of the missing lowering


### PR DESCRIPTION
Stage 9 (Corpus boss) of #1396 — durably closes the "no-op corpus diff stays
clean" gap that two prior **rebaseline** attempts couldn't (the ~30-min corpus
run is slower than main's merge cadence, so a fresh baseline is stale before it
can land).

## Problem

The real-world corpus mixes pinned NuGet assemblies (fixed versions) with the
repo's own assemblies, which grow every PR. The count-based regressions (Full
malformed, semantic defects, fidelity opcode/recompile/context) gate on absolute
counts with zero tolerance, so newly-added repo code the decompiler malforms
drove phantom count "regressions" on no-op changes — and, worse, let **real**
regressions on the pinned set hide behind a blanket "corpus drifted" dismissal.

## Change (harness-only)

Gate those count regressions on the **pinned-NuGet subset** only — a fixed
method set whose counts move only when decompiler behavior does — computed from
the per-method snapshots both baseline and current already carry (so **no
baseline regen is required**; falls back to aggregate when detail is absent).
Rate-based metrics (fully-raised, residual, forward-merge) and pass-bug crashes
still gate on the full aggregate. The card adds a `Pinned-subset gate` line.

## Evidence

Validated that pinned counts are exactly consistent with the aggregates: in the
committed baseline, aggregate Full malformed `33 = pinned 32 + repo 1`.

Quality card on current main vs the committed baseline — note the gate cleanly
**separates real from drift**:

```text
| Metric | Baseline | PR | Delta |
| Full malformed | 33 | 47 | +14 |
| Fidelity diffs | opcode-diff 1/6 | opcode-diff 4/22 | +3 |

Pinned-subset gate (count regressions evaluated here): Full malformed 32 -> 46 (+14); opcode diffs 0 -> 0 (0).

Verdict: corpus sensor reported regressions; review before merging.
Regressions:
- Full malformed methods (pinned) increased by 14 (baseline 32, current 46, tolerance 0)
```

- **opcode-diff +3** is genuine repo drift → pinned `0 -> 0` → **correctly no
  longer flagged**.
- **Full malformed +14** is entirely on the **pinned** set (`32 -> 46`) → a
  **real accumulated decompiler regression** the aggregate framing had been
  dismissing as drift. (Same-revision no-op cards are clean / deterministic, so
  this is not sampling noise.)

This PR is harness-only and does not change the decompiler, so it did not cause
the malformed regression — it **revealed** it. See the separate finding below.

## Follow-up finding (surfaced by this change)

The pinned malformed `32 -> 46` is a real regression on fixed NuGet code
accumulated since the 2026-06-23 baseline. I'm filing/raising it as a Stage 2
(Method validity boss) item with the `--emit-corpus-delta` drill-down so the 14
newly-malformed pinned methods can be root-caused — exactly the kind of signal
this gate is meant to stop hiding.

## Guardrails

- Harness-only; SRM-only / NativeAOT / Roslyn-free unaffected.
- No baseline regen; backward-compatible (aggregate fallback when per-method
  detail is missing).

Cross-model adversarial review (GPT-5.5) to follow per AGENTS.md.
