### PR TITLE
Require closure-holder evidence for delegate-cache collapse (#1480)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LambdaCacheHolderEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaCacheHolderEvidenceTests.cs
@@ -1,0 +1,66 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Adversarial guard for LambdaCachePass declaring-type evidence (issue #1480).
+// IsDelegateCacheField anchored the cache idiom on the `<>9__` field-name shape
+// alone. A foreign or preinitialized field wearing that name on an ordinary type
+// would be erased. Require the declaring type to also be a generated `<>c` closure
+// holder. csc only ever emits `<>9__` caches on `<>c` (or generic `<>c__N`), so the
+// positive canary still collapses; the negative (same name on an ordinary type)
+// must stay the lazy-null guarded shape.
+public class LambdaCacheHolderEvidenceTests
+{
+    static readonly TypeRef Owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+    static readonly TypeRef Action = TypeRef.CoreLib("System", "Action");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+
+    static IrFunction Build(TypeRef cacheHolder)
+    {
+        var cacheField = new FieldRef(cacheHolder, "<>9__0_0", Action);
+        var target = new MethodRef(Owner, "Target", Void, [], HasThis: false);
+        var use = new MethodRef(Owner, "Use", Void, [Action], HasThis: false);
+
+        // then: t = new Action(Target); cache = t; result = t;
+        var then = new Block(0);
+        then.Add(new StoreStackSlot(2, new DelegateCreation(Action, target, isVirtual: false, new Constant(null, Object))));
+        then.Add(new StoreField(cacheField, null, new LoadStackSlot(2, Action)));
+        then.Add(new StoreStackSlot(1, new LoadStackSlot(2, Action)));
+
+        // s0 = cache; result = s0; if (s0 is null) { then } use(result);
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new LoadField(cacheField, null)));
+        block.Add(new StoreStackSlot(1, new LoadStackSlot(0, Action)));
+        block.Add(new IfStatement(new LogicalNot(new LoadStackSlot(0, Action)), then, elseArm: null));
+        block.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadStackSlot(1, Action)])));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var function = new IrFunction("M", Owner, new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0), [], container);
+        new LambdaCachePass().Run(function, PassContext.None);
+        function.CheckInvariant();
+        return function;
+    }
+
+    [Fact]
+    public void CacheFieldOnClosureHolder_Collapses()
+    {
+        // The csc shape: the cache field lives on the generated `<>c` closure holder.
+        var function = Build(TypeRef.Definition("Synthetic", "Samples", "Owner+<>c"));
+
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+        Assert.DoesNotContain(function.Descendants.OfType<LoadField>(), l => l.Field.Name == "<>9__0_0");
+    }
+
+    [Fact]
+    public void CacheNamedFieldOnOrdinaryType_StaysUnfolded()
+    {
+        // A `<>9__`-named field on an ordinary (non-`<>c`) type is not proof of a
+        // compiler cache — leave the lazy-null guarded shape intact.
+        var function = Build(Owner);
+
+        Assert.Single(function.Descendants.OfType<IfStatement>());
+        Assert.Contains(function.Descendants.OfType<StoreField>(), s => s.Field.Name == "<>9__0_0");
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaCachePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaCachePass.cs
@@ -228,12 +228,31 @@ public sealed class LambdaCachePass : IIrPass
 
     // The compiler names the per-lambda cache field <>9__N_M (on the static <>c
     // closure holder) and static method-group cache fields <N>__MethodName (on
-    // the <>O holder); the generated field name is the anchor for the idiom.
+    // the <>O holder). The generated field name alone is not proof: a foreign or
+    // preinitialized field wearing that name on an ordinary type must not be
+    // erased. Require the declaring type to also be a generated cache holder so
+    // the field-name anchor is backed by declaring-type evidence (#1480).
     static bool IsDelegateCacheField(FieldRef field)
-        => field.Name.StartsWith("<>9__", StringComparison.Ordinal)
-            || (field.DeclaringType.Name.EndsWith("+<>O", StringComparison.Ordinal)
+        => (field.Name.StartsWith("<>9__", StringComparison.Ordinal)
+                && IsStaticClosureHolder(field.DeclaringType))
+            || (HolderLeafName(field.DeclaringType) == "<>O"
                 && field.Name.StartsWith("<", StringComparison.Ordinal)
                 && field.Name.Contains(">__", StringComparison.Ordinal));
+
+    // The static closure holder is named `<>c` for a non-generic context and
+    // `<>c__N` (a generic instance `Outer<T>+<>c__N`) for lambdas in a generic
+    // method; both carry the `<>9__` cache fields. Accept the `<>c` closure-holder
+    // family (rejecting any ordinary type, which cannot bear a `<>`-prefixed name),
+    // looking through a generic instance whose own Name is empty.
+    static bool IsStaticClosureHolder(TypeRef type)
+        => HolderLeafName(type).StartsWith("<>c", StringComparison.Ordinal);
+
+    static string HolderLeafName(TypeRef type)
+    {
+        string name = type.Kind == TypeRefKind.GenericInstance ? type.ElementType?.Name ?? "" : type.Name;
+        int plus = name.LastIndexOf('+');
+        return plus < 0 ? name : name[(plus + 1)..];
+    }
 
     static bool FieldReferencesOnlyWithin(IrFunction function, FieldRef field, IReadOnlyCollection<IrNode> allowed)
         => function.Descendants


### PR DESCRIPTION
Fixes #1480 (row 12 of #1453).

## Over-raise claim narrowed

`LambdaCachePass.IsDelegateCacheField` anchored the per-lambda cache idiom on the `<>9__` field-name shape alone, with no declaring-type evidence. A foreign or preinitialized field wearing that name on an ordinary type would be collapsed — dropping its guarded null check and assignment — while reporting success.

## Fix

Require the `<>9__` cache field's declaring type to be a generated `<>c` closure holder, looking through a generic instance (`Outer<T>+<>c__N`, whose own `TypeRef.Name` is empty with the holder name on the element type). The `<>O` method-group branch is routed through the same generic-instance-aware leaf-name helper.

## Soundness / blast radius

csc only emits `<>9__` caches on the `<>c` family (static `<>c` and generic `<>c__N`). All **284** CoreLib `<>9__` field refs still qualify (0 rejected by the new gate), so the change is corpus-neutral — it only declines the name-only lookalike on a non-generated type.

> Note: `CorpusSweepGateTests` is currently red on a clean `origin/main` checkout (Full-fidelity 97.98% / 40183, just under the 98% floor) — a **pre-existing** drift unrelated to this PR (identical count with and without this change). Flagged separately; not introduced here.

## Evidence

`LambdaCacheHolderEvidenceTests`: a synthetic-IR negative (`<>9__0_0` field on an ordinary type stays the lazy-null guarded shape) that **fails without this change**, plus a `<>c`-holder positive canary that still collapses. Existing `LambdaCachePassTests` (6) green.
