### PR TITLE
Validate counting iterator recurrence shape

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -90,6 +90,46 @@ public class IteratorReconstructionPassTests
     }
 
     [Fact]
+    public void CountingLoopIterator_IncrementFromNonLoopField_Declines()
+    {
+        var (kickoff, handoff, moveNext) = CountingLoopFixture(incrementLeft: new Constant(0, TypeRef.CoreLib("System", "Int32")));
+
+        Assert.False(CountingLoopReconstruction.TryReconstruct(moveNext, kickoff, handoff, out var statements));
+        Assert.Empty(statements);
+        kickoff.CheckInvariant();
+        moveNext.CheckInvariant();
+    }
+
+    [Fact]
+    public void CountingLoopIterator_ResumeSideEffectStatement_Declines()
+    {
+        var (kickoff, handoff, moveNext) = CountingLoopFixture(resumeMiddle: ResumeSideEffectStatement());
+
+        Assert.False(CountingLoopReconstruction.TryReconstruct(moveNext, kickoff, handoff, out var statements));
+        Assert.Empty(statements);
+        kickoff.CheckInvariant();
+        moveNext.CheckInvariant();
+    }
+
+    [Fact]
+    public void CountingLoopIterator_PostfixTempCopy_StillReconstructs()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var loopField = LoopField(intType);
+        var tempStore = new StoreLocal(1, intType, new LoadField(loopField, new LoadArgument(0, "this", StateMachineType())));
+        var (kickoff, handoff, moveNext) = CountingLoopFixture(
+            resumeMiddle: tempStore,
+            incrementLeft: new LoadLocal(1, intType));
+
+        Assert.True(CountingLoopReconstruction.TryReconstruct(moveNext, kickoff, handoff, out var statements));
+        Assert.Equal(2, statements.Count);
+        Assert.IsType<StoreLocal>(statements[0]);
+        Assert.IsType<WhileLoop>(statements[1]);
+        kickoff.CheckInvariant();
+        moveNext.CheckInvariant();
+    }
+
+    [Fact]
     public void NestedLoopIterator_ReconstructsNestedLoops()
     {
         var function = Raised(nameof(CfgSampleClass.YieldGrid));
@@ -424,5 +464,122 @@ public class IteratorReconstructionPassTests
             moveNextBody);
 
         return (function, moveNext, sideEffect);
+    }
+
+    static (IrFunction Kickoff, NewObject Handoff, IrFunction MoveNext) CountingLoopFixture(
+        IrNode? resumeMiddle = null,
+        IrExpression? incrementLeft = null)
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var enumerable = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"),
+            [intType]);
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Outer");
+        var stateMachine = StateMachineType();
+        var stateField = new FieldRef(stateMachine, "<>1__state", intType);
+        var currentField = new FieldRef(stateMachine, "<>2__current", intType);
+        var loopField = LoopField(intType);
+        var constructor = new MethodRef(
+            stateMachine,
+            ".ctor",
+            voidType,
+            [intType],
+            HasThis: true)
+        {
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+        var handoff = new NewObject(constructor, [new Constant(-2, intType)]);
+        var kickoffBlock = new Block(0);
+        kickoffBlock.Add(new Return(handoff));
+        var kickoffBody = new BlockContainer();
+        kickoffBody.Add(kickoffBlock);
+        var kickoff = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(enumerable, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            kickoffBody);
+
+        var dispatch0 = new Block(0);
+        dispatch0.Add(new StoreLocal(0, intType, new LoadField(stateField, This(stateMachine))));
+        dispatch0.Add(new ConditionalBranch(new LogicalNot(new LoadLocal(0, intType)), targetOffset: 10));
+
+        var dispatch1 = new Block(1);
+        dispatch1.Add(new ConditionalBranch(
+            new Comparison(ComparisonKind.Equal, false, new LoadLocal(0, intType), new Constant(1, intType)),
+            targetOffset: 40));
+
+        var defaultReturn = new Block(2);
+        defaultReturn.Add(new Return(new Constant(false, boolType)));
+
+        var init = new Block(10);
+        init.Add(new StoreField(stateField, This(stateMachine), new Constant(-1, intType)));
+        init.Add(new StoreField(loopField, This(stateMachine), new Constant(0, intType)));
+        init.Add(new Branch(50));
+
+        var yield = new Block(30);
+        yield.Add(new StoreField(currentField, This(stateMachine), new LoadField(loopField, This(stateMachine))));
+        yield.Add(new StoreField(stateField, This(stateMachine), new Constant(1, intType)));
+        yield.Add(new Return(new Constant(true, boolType)));
+
+        var resume = new Block(40);
+        resume.Add(new StoreField(stateField, This(stateMachine), new Constant(-1, intType)));
+        if (resumeMiddle is not null)
+            resume.Add(resumeMiddle);
+        resume.Add(new StoreField(
+            loopField,
+            This(stateMachine),
+            new Binary(
+                BinaryKind.Add,
+                isChecked: false,
+                isUnsigned: false,
+                incrementLeft ?? new LoadField(loopField, This(stateMachine)),
+                new Constant(1, intType))));
+
+        var cond = new Block(50);
+        cond.Add(new ConditionalBranch(
+            new Comparison(
+                ComparisonKind.LessThan,
+                isUnsigned: false,
+                new LoadField(loopField, This(stateMachine)),
+                new Constant(4, intType)),
+            targetOffset: 30));
+
+        var terminal = new Block(51);
+        terminal.Add(new Return(new Constant(false, boolType)));
+
+        var moveNextBody = new BlockContainer();
+        foreach (var block in new[] { dispatch0, dispatch1, defaultReturn, init, yield, resume, cond, terminal })
+            moveNextBody.Add(block);
+        var moveNext = new IrFunction(
+            "MoveNext",
+            stateMachine,
+            new MethodSignature(boolType, [], HasThis: true, GenericParameterCount: 0),
+            [],
+            moveNextBody);
+        return (kickoff, handoff, moveNext);
+    }
+
+    static TypeRef StateMachineType()
+        => TypeRef.Definition("Synthetic", "Samples", "Outer+<M>d__0");
+
+    static FieldRef LoopField(TypeRef intType)
+        => new(StateMachineType(), "<i>5__2", intType);
+
+    static LoadArgument This(TypeRef stateMachine)
+        => new(0, "this", stateMachine);
+
+    static IrNode ResumeSideEffectStatement()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var effect = new MethodRef(
+            TypeRef.Definition("Synthetic", "Samples", "Effects"),
+            "SideEffect",
+            intType,
+            [],
+            HasThis: false);
+        return new StoreLocal(1, intType, new Call(effect, isVirtual: false, []));
     }
 }

--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -130,6 +130,23 @@ public class IteratorReconstructionPassTests
     }
 
     [Fact]
+    public void CountingLoopIterator_PostfixTempWithExtraLoad_Declines()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var loopField = LoopField(intType);
+        var tempStore = new StoreLocal(1, intType, new LoadField(loopField, new LoadArgument(0, "this", StateMachineType())));
+        var (kickoff, handoff, moveNext) = CountingLoopFixture(
+            resumeMiddle: tempStore,
+            incrementLeft: new LoadLocal(1, intType),
+            yieldValue: new LoadLocal(1, intType));
+
+        Assert.False(CountingLoopReconstruction.TryReconstruct(moveNext, kickoff, handoff, out var statements));
+        Assert.Empty(statements);
+        kickoff.CheckInvariant();
+        moveNext.CheckInvariant();
+    }
+
+    [Fact]
     public void NestedLoopIterator_ReconstructsNestedLoops()
     {
         var function = Raised(nameof(CfgSampleClass.YieldGrid));
@@ -468,7 +485,8 @@ public class IteratorReconstructionPassTests
 
     static (IrFunction Kickoff, NewObject Handoff, IrFunction MoveNext) CountingLoopFixture(
         IrNode? resumeMiddle = null,
-        IrExpression? incrementLeft = null)
+        IrExpression? incrementLeft = null,
+        IrExpression? yieldValue = null)
     {
         var intType = TypeRef.CoreLib("System", "Int32");
         var boolType = TypeRef.CoreLib("System", "Boolean");
@@ -520,7 +538,7 @@ public class IteratorReconstructionPassTests
         init.Add(new Branch(50));
 
         var yield = new Block(30);
-        yield.Add(new StoreField(currentField, This(stateMachine), new LoadField(loopField, This(stateMachine))));
+        yield.Add(new StoreField(currentField, This(stateMachine), yieldValue ?? new LoadField(loopField, This(stateMachine))));
         yield.Add(new StoreField(stateField, This(stateMachine), new Constant(1, intType)));
         yield.Add(new Return(new Constant(true, boolType)));
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CountingLoopReconstruction.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CountingLoopReconstruction.cs
@@ -93,11 +93,8 @@ internal static class CountingLoopReconstruction
             || incName != loopField.Name
             || increment.Right is not Constant stepConstant)
             return false;
-        // Any statements between the state store and the increment are the `i++`
-        // temp copy (`temp = <loopvar>`); nothing else belongs in this slice.
-        for (var i = 1; i < resumeChildren.Count - 1; i++)
-            if (resumeChildren[i] is not StoreLocal)
-                return false;
+        if (!IncrementReadsLoopField(moveNext, resumeChildren, increment.Left, loopField.Name))
+            return false;
         var resumeIndex = blocks.ToList().IndexOf(resumeBlock);
         if (resumeIndex + 1 >= blocks.Count || blocks[resumeIndex + 1] != condBlock)
             return false;
@@ -140,6 +137,28 @@ internal static class CountingLoopReconstruction
         statements.Add(loop);
         return true;
     }
+
+    static bool IncrementReadsLoopField(IrFunction moveNext, IReadOnlyList<IrNode> resumeChildren, IrExpression left, string loopFieldName)
+    {
+        if (IsLoopFieldLoad(left, loopFieldName))
+            return resumeChildren.Count == 2;
+
+        if (left is not LoadLocal temp
+            || resumeChildren.Count != 3
+            || resumeChildren[1] is not StoreLocal { Index: var storedTemp, Value: var value }
+            || storedTemp != temp.Index
+            || !IsLoopFieldLoad(value, loopFieldName))
+        {
+            return false;
+        }
+
+        return moveNext.Descendants.OfType<StoreLocal>().Count(store => store.Index == temp.Index) == 1
+            && moveNext.Descendants.OfType<LoadLocal>().Count(load => load.Index == temp.Index) == 1;
+    }
+
+    static bool IsLoopFieldLoad(IrExpression expression, string loopFieldName)
+        => expression is LoadField { Instance: LoadArgument { Index: 0 }, Field.Name: var name }
+            && name == loopFieldName;
 
     // Rebuilds an expression in the kickoff's scope: the hoisted loop field becomes
     // the loop local, hoisted parameter fields become the kickoff's parameters, and


### PR DESCRIPTION
## Summary

Fixes #1463 by tightening `CountingLoopReconstruction`'s resume-block proof.

The recognizer now requires the resume increment to read the loop field directly, or through the single dead postfix temp copy (`temp = loopField; loopField = temp + step`). Any other intervening resume statement or non-loop-field increment left operand makes the counting-loop reconstruction decline instead of substituting `i` and dropping work.

## Evidence

Shape proof:

- Positive canary: normal postfix-temp counting iterator still reconstructs to declaration + while loop.
- Adversarial negatives:
  - increment left operand not reading the loop field declines;
  - resume middle statement with a side-effecting call declines.

Validation:

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.IteratorReconstructionPassTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -v:q`

Generated quality card against the checked-in baseline reports the same stale-baseline regressions on local main. Branch vs main shows only the expected fixture-method count increase and no unexpected movement.

Branch card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,094 methods
Correctness coverage: validity sampled 350 / 88,094 (0.40%); fidelity sampled 22 / 88,094 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,094 (+724)
- dotnet-inspect: 11,710 -> 12,186 methods (+476)
- ILInspector.Analysis: 500 -> 661 methods (+161)
- ILInspector.Decompiler: 5,004 -> 5,084 methods (+80)
- ILInspector.Metadata: 1,824 -> 1,831 methods (+7)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,453 (87.92%) | +559 |
| Conditional-branch residual | 2,290 (2.62%) | 2,308 (2.62%) | +18 |
| Forward-merge stops | 2,284 (2.61%) | 2,299 (2.61%) | +15 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,094 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,094 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.
```

Local main control:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,089 methods
Correctness coverage: validity sampled 350 / 88,089 (0.40%); fidelity sampled 22 / 88,089 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,089 (+719)
- dotnet-inspect: 11,710 -> 12,186 methods (+476)
- ILInspector.Analysis: 500 -> 661 methods (+161)
- ILInspector.Decompiler: 5,004 -> 5,079 methods (+75)
- ILInspector.Metadata: 1,824 -> 1,831 methods (+7)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,452 (87.92%) | +558 |
| Conditional-branch residual | 2,290 (2.62%) | 2,308 (2.62%) | +18 |
| Forward-merge stops | 2,284 (2.61%) | 2,299 (2.61%) | +15 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,089 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,089 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.
```
