### PR TITLE
Block static-field delegate inlining across effects

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -186,6 +186,40 @@ public class ExpressionInliningPassTests
     }
 
     [Fact]
+    public void StaticFieldDelegateCreation_PriorEffectInUseStatement_BlocksLiveRangeInlining()
+    {
+        var receiverField = new FieldRef(Holder, "Receiver", Object);
+        var target = new MethodRef(Holder, "M", Void, [], HasThis: true);
+        var sideEffect = new MethodRef(Holder, "SideEffect", Int32, [], HasThis: false);
+        var use = new MethodRef(Holder, "Use", Void, [Int32, Action], HasThis: false);
+
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new DelegateCreation(
+            Action,
+            target,
+            isVirtual: false,
+            new LoadField(receiverField, instance: null))));
+        block.Add(new ExpressionStatement(new Call(
+            use,
+            isVirtual: false,
+            [new Call(sideEffect, isVirtual: false, []), new LoadStackSlot(0, Action)])));
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new ExpressionInliningPass().Run(function, PassContext.None);
+
+        Assert.Contains(block.Children.OfType<StoreStackSlot>(), store => store.Slot == 0);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void StaticFieldDelegateCreation_AdjacentUse_StillInlines()
     {
         var receiverField = new FieldRef(Holder, "Receiver", Object);

--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -152,4 +152,67 @@ public class ExpressionInliningPassTests
         Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
         function.CheckInvariant();
     }
+
+    [Fact]
+    public void StaticFieldDelegateCreation_EffectBetweenStoreAndUse_BlocksLiveRangeInlining()
+    {
+        var receiverField = new FieldRef(Holder, "Receiver", Object);
+        var target = new MethodRef(Holder, "M", Void, [], HasThis: true);
+        var sideEffect = new MethodRef(Holder, "SideEffect", Void, [], HasThis: false);
+        var use = new MethodRef(Holder, "Use", Void, [Action], HasThis: false);
+
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new DelegateCreation(
+            Action,
+            target,
+            isVirtual: false,
+            new LoadField(receiverField, instance: null))));
+        block.Add(new ExpressionStatement(new Call(sideEffect, isVirtual: false, [])));
+        block.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadStackSlot(0, Action)])));
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new ExpressionInliningPass().Run(function, PassContext.None);
+
+        Assert.Contains(block.Children.OfType<StoreStackSlot>(), store => store.Slot == 0);
+        Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void StaticFieldDelegateCreation_AdjacentUse_StillInlines()
+    {
+        var receiverField = new FieldRef(Holder, "Receiver", Object);
+        var target = new MethodRef(Holder, "M", Void, [], HasThis: true);
+        var use = new MethodRef(Holder, "Use", Void, [Action], HasThis: false);
+
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new DelegateCreation(
+            Action,
+            target,
+            isVirtual: false,
+            new LoadField(receiverField, instance: null))));
+        block.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadStackSlot(0, Action)])));
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new ExpressionInliningPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<StoreStackSlot>());
+        Assert.Empty(function.Descendants.OfType<LoadStackSlot>());
+        Assert.Single(function.Descendants.OfType<DelegateCreation>());
+        function.CheckInvariant();
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -196,7 +196,7 @@ public sealed class ExpressionInliningPass : IIrPass
                     if (use is null
                         && (reads.Any(r => Writes(stmt, r.Kind, r.Index))
                             || WritesStaticDelegateTarget(stmt, value)
-                            || (ReadsStaticDelegateTarget(value) && HasObservableEffect(stmt))))
+                            || (RequiresFirstEvaluation(value) && HasObservableEffect(stmt))))
                     {
                         blocked = true;
                         break;
@@ -207,7 +207,7 @@ public sealed class ExpressionInliningPass : IIrPass
 
                 // A value that reads places must still evaluate first at the use
                 // site; an effect-free value that reads nothing can land anywhere.
-                if (reads.Count > 0 && !IsFirstEvaluatedLeaf(use, useStatement))
+                if ((reads.Count > 0 || RequiresFirstEvaluation(value)) && !IsFirstEvaluatedLeaf(use, useStatement))
                     continue;
 
                 var inlined = (IrExpression)block.Children[si].DetachChildren()[0];
@@ -318,6 +318,10 @@ public sealed class ExpressionInliningPass : IIrPass
 
     static bool ReadsStaticDelegateTarget(IrExpression value)
         => value is DelegateCreation { Target: LoadField { Instance: null } };
+
+    static bool RequiresFirstEvaluation(IrExpression value)
+        => value is DelegateCreation { Target: LoadField { Instance: null }, Method: var method }
+            && !GeneratedCodeIdentity.IsNonCapturingLambdaMethod(method);
 
     static bool HasObservableEffect(IrNode statement)
         => statement.Descendants.Prepend(statement).Any(static node => node is

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -195,7 +195,8 @@ public sealed class ExpressionInliningPass : IIrPass
                     }
                     if (use is null
                         && (reads.Any(r => Writes(stmt, r.Kind, r.Index))
-                            || WritesStaticDelegateTarget(stmt, value)))
+                            || WritesStaticDelegateTarget(stmt, value)
+                            || (ReadsStaticDelegateTarget(value) && HasObservableEffect(stmt))))
                     {
                         blocked = true;
                         break;
@@ -314,6 +315,13 @@ public sealed class ExpressionInliningPass : IIrPass
             && statement.Descendants.Prepend(statement)
                 .OfType<StoreField>()
                 .Any(store => !store.HasInstance && store.Field.Equals(field));
+
+    static bool ReadsStaticDelegateTarget(IrExpression value)
+        => value is DelegateCreation { Target: LoadField { Instance: null } };
+
+    static bool HasObservableEffect(IrNode statement)
+        => statement.Descendants.Prepend(statement).Any(static node => node is
+            Call or CallIndirect or NewObject or DelegateCreation or StoreField or StoreProperty or StoreElement or Throw);
 
     /// <summary>
     /// The first statement of the block after <paramref name="block"/>, when


### PR DESCRIPTION
## Summary

- Keep `ExpressionInliningPass` from moving a `DelegateCreation` whose target is a static-field read across an intervening observable effect.
- Preserve adjacent-use inlining so compiler-cache/static-field delegate shapes still collapse when no side effect separates store and use.
- Add the adversarial side-effect-between-store-and-use fixture plus an adjacent-use positive canary.

Fixes #1449.

## Evidence

Shape proof:

- `StaticFieldDelegateCreation_EffectBetweenStoreAndUse_BlocksLiveRangeInlining` passes.
- `StaticFieldDelegateCreation_AdjacentUse_StillInlines` passes.
- Existing same-field-write guard still passes.

Focused tests after latest main merge:

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ExpressionInliningPassTests
# 7 passed
```

Broader validation:

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release
```

This reproduces the same three current-main baseline failures unrelated to this branch (`ConstantByteSpan_RaisesToArrayLiteral`, `CorpusSweepGateTests.CoreLibSweep_MeetsHealthFloors`, `FidelityGateTests.PinnedFixesStayOpcodeExact`). The same failing classes fail on `origin/main`.

Quality card:

```text
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,177 methods
Correctness coverage: validity sampled 350 / 88,177 (0.40%); fidelity sampled 22 / 88,177 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,177 (+807)
- dotnet-inspect: 11,710 -> 12,186 methods (+476)
- ILInspector.Analysis: 500 -> 661 methods (+161)
- ILInspector.Decompiler: 5,004 -> 5,167 methods (+163)
- ILInspector.Metadata: 1,824 -> 1,831 (+7)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,510 (87.90%) | +616 |
| Conditional-branch residual | 2,290 (2.62%) | 2,310 (2.62%) | +20 |
| Forward-merge stops | 2,284 (2.61%) | 2,301 (2.61%) | +17 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,177 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,177 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- fully-raised rate dropped 11 bps (baseline 88.01%, current 87.90%, tolerance 10 bps)
- Full malformed methods increased by 14 (baseline 33, current 47, tolerance 0)
- fidelity opcode diffs increased by 3 (baseline 1, current 4, tolerance 0)

Caveat: the corpus drifted from the baseline (see baseline staleness above), so count-based regressions may be corpus composition change rather than a real PR delta.
```
