### PR TITLE
Improve diff Analysis Diff: machine output, change isolation, ranking

### DIFF
--- a/docs/design/graph-signal-annotations.md
+++ b/docs/design/graph-signal-annotations.md
@@ -88,6 +88,36 @@ Nodes from an assembly other than the selected member's own carry their source i
 `--fields Source`. This mirrors the `Callers` table's cross-assembly `Source`
 column for the bounded reverse graph.
 
+## Version-to-version analysis diff
+
+The same per-method signals power `diff -S "Analysis Diff"`, which compares two
+versions of an assembly and reports body-level signal deltas (allocations,
+copies, reflection, throws/catches/finallys, unsafe, constructed-exception sets,
+and optimization-opportunity shapes) per method. This is **complementary** to the
+single-version `Top Leverage` / `Optimization Opportunities` views: the diff finds
+what *changed* between versions, while the single-version views find *longstanding*
+cost that a diff is blind to (both sides are equally costly, so the delta is zero).
+
+```bash
+diff --package Newtonsoft.Json@12.0.3..13.0.3 -S "Analysis Diff" --changed
+```
+
+Rows are classified and ranked so the highest-value movements surface first:
+
+- **In-place change vs added/removed.** A row is an *in-place* change only when the
+  member is present in both versions. Added/removed members (`0 -> N` / `N -> 0`)
+  are the dominant noise on a major-version bump and are pushed below in-place
+  changes. `--changed` drops them entirely, leaving only true deltas.
+- **Magnitude ranking.** Within in-place changes, rows sort by descending
+  `|delta|`, so a `+5` allocation regression ranks above a `+1`.
+- **Direction.** A positive delta on a cost signal is a *regression*; negative is an
+  *improvement*. The summary splits the counts (`N regressions, M improvements,
+  K added/removed`).
+
+Machine output honors `--tsv` and `--jsonl` (the section serializes through the
+projected-table writer, like every other tabular section), so an agent can consume
+the deltas directly instead of parsing markdown.
+
 ## Growing the vocabulary
 
 The model is deliberately small and grows by adding a field to `MethodSignals`

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -753,6 +753,15 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void DiffCommand_WithChangedOption_ParsesCorrectly()
+    {
+        var result = CommandLineBuilder.CreateRootCommand().Parse(["diff", "--library", "old/Foo.dll..new/Foo.dll", "-S", "Analysis Diff", "--changed"]);
+
+        Assert.Empty(result.Errors);
+        Assert.Equal("diff", result.CommandResult.Command.Name);
+    }
+
+    [Fact]
     public void DiffCommand_WithTypeArgument_ParsesCorrectly()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(["diff", "JsonSerializer", "--package", "System.Text.Json@8.0.0..9.0.0"]);

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -138,4 +138,36 @@ public class DiffCommandTests
             "No in-place analysis signal changes detected.",
             DiffCommand.BuildAnalysisSummary(total: 0, regressions: 0, improvements: 0, addedRemoved: 0, changedOnly: true));
     }
+
+    [Fact]
+    public void BuildAnalysisDiffView_VersionsPlain_NoMarkdownForMachineOutput()
+    {
+        var view = DiffOutputFormatter.BuildAnalysisDiffView(
+            "Sample",
+            [new AnalysisDiffRow("`T.M()`", "allocations", "0", "1", "+1", null, null)],
+            "1 regression (1 signal)",
+            "old.dll",
+            "new.dll");
+
+        // Versions must not carry markdown emphasis; it is serialized verbatim into TSV/JSONL.
+        Assert.Equal("old.dll -> new.dll", view.Versions);
+        Assert.DoesNotContain("**", view.Versions);
+    }
+
+    [Fact]
+    public void BuildAnalysisDiffView_EmptyRows_CalloutMatchesSummary()
+    {
+        // When --changed filters out all rows but added/removed changes existed,
+        // the callout must agree with the summary rather than claim "no changes".
+        var view = DiffOutputFormatter.BuildAnalysisDiffView(
+            "Sample",
+            [],
+            "No in-place analysis signal changes detected.",
+            "old.dll",
+            "new.dll");
+
+        var markdown = DiffOutputFormatter.RenderAnalysisDiffView(view);
+        Assert.Contains("No in-place analysis signal changes detected.", markdown);
+        Assert.DoesNotContain("No analysis signal changes detected.", markdown);
+    }
 }

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -1,4 +1,5 @@
 using ILInspector.Metadata;
+using DotnetInspector.Commands;
 using DotnetInspector.Output;
 using DotnetInspector.Views;
 
@@ -87,5 +88,54 @@ public class DiffCommandTests
         Assert.Contains("allocations", markdown);
         Assert.Contains("+1", markdown);
         Assert.Contains("IL_0001", markdown);
+    }
+
+    private static DiffCommand.RankedAnalysisRow Ranked(string member, string signal, int magnitude, int direction, bool inBoth)
+        => new(new AnalysisDiffRow($"`{member}`", signal, "0", magnitude.ToString(), $"+{magnitude}", null, null), magnitude, direction, inBoth);
+
+    [Fact]
+    public void RankAnalysisRows_OrdersInPlaceChangesByDescendingMagnitude()
+    {
+        var input = new List<DiffCommand.RankedAnalysisRow>
+        {
+            Ranked("Type.Added()", "allocations", 9, +1, inBoth: false),   // added member, large magnitude
+            Ranked("Type.Small()", "allocations", 1, +1, inBoth: true),
+            Ranked("Type.Big()", "allocations", 5, +1, inBoth: true),
+        };
+
+        var result = DiffCommand.RankAnalysisRows(input, changedOnly: false);
+
+        // In-place changes rank above added/removed members; within in-place, larger magnitude first.
+        Assert.Equal("`Type.Big()`", result.Rows[0].Member);
+        Assert.Equal("`Type.Small()`", result.Rows[1].Member);
+        Assert.Equal("`Type.Added()`", result.Rows[2].Member);
+    }
+
+    [Fact]
+    public void RankAnalysisRows_ChangedOnly_DropsAddedRemovedMembers()
+    {
+        var input = new List<DiffCommand.RankedAnalysisRow>
+        {
+            Ranked("Type.Added()", "allocations", 3, +1, inBoth: false),
+            Ranked("Type.Kept()", "allocations", 2, -1, inBoth: true),
+        };
+
+        var result = DiffCommand.RankAnalysisRows(input, changedOnly: true);
+
+        Assert.Single(result.Rows);
+        Assert.Equal("`Type.Kept()`", result.Rows[0].Member);
+        Assert.Equal("1 improvement (1 signal)", result.Summary);
+    }
+
+    [Fact]
+    public void BuildAnalysisSummary_SplitsRegressionsImprovementsAddedRemoved()
+    {
+        Assert.Equal(
+            "2 regressions, 1 improvement, 5 added/removed (8 signals)",
+            DiffCommand.BuildAnalysisSummary(total: 8, regressions: 2, improvements: 1, addedRemoved: 5, changedOnly: false));
+
+        Assert.Equal(
+            "No in-place analysis signal changes detected.",
+            DiffCommand.BuildAnalysisSummary(total: 0, regressions: 0, improvements: 0, addedRemoved: 0, changedOnly: true));
     }
 }

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -48,6 +48,7 @@ public static class InspectionCommandDefinitions
         var nameOnlyOption = new Option<bool>("--name-only") { Description = "Show only type names that changed" };
         var breakingOption = new Option<bool>("--breaking") { Description = "Show only breaking changes" };
         var additiveOption = new Option<bool>("--additive") { Description = "Show only additive changes" };
+        var changedOption = new Option<bool>("--changed") { Description = "Analysis Diff only: show only in-place changes to members present in both versions (drop added/removed members)" };
         var legendOption = new Option<bool>("--legend") { Description = "Show legend explaining change symbols" };
 
         diffCommand.Arguments.Add(argsArg);
@@ -62,6 +63,7 @@ public static class InspectionCommandDefinitions
         diffCommand.Options.Add(nameOnlyOption);
         diffCommand.Options.Add(breakingOption);
         diffCommand.Options.Add(additiveOption);
+        diffCommand.Options.Add(changedOption);
         diffCommand.Options.Add(legendOption);
         opts.AddOutputOptionsTo(diffCommand);
         opts.AddNuGetOptionsTo(diffCommand);
@@ -69,7 +71,7 @@ public static class InspectionCommandDefinitions
 
         var commandArgs = new DiffOptionsParser.DiffCommandArgs(
             argsArg, packageOption, platformOption, libraryOption, frameworkOption, tfmOption, allOption,
-            typeFilterOption, opts.OneLine, opts.NoHeaders, nameOnlyOption, breakingOption, additiveOption, legendOption);
+            typeFilterOption, opts.OneLine, opts.NoHeaders, nameOnlyOption, breakingOption, additiveOption, changedOption, legendOption);
 
         diffCommand.SetAction(async (parseResult, ct) =>
         {

--- a/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
@@ -30,6 +30,7 @@ public static class DiffOptionsParser
         Option<bool> NameOnlyOption,
         Option<bool> BreakingOption,
         Option<bool> AdditiveOption,
+        Option<bool> ChangedOption,
         Option<bool> LegendOption);
 
     /// <summary>
@@ -114,6 +115,7 @@ public static class DiffOptionsParser
             NameOnly = parseResult.GetValue(args.NameOnlyOption),
             Breaking = parseResult.GetValue(args.BreakingOption),
             Additive = parseResult.GetValue(args.AdditiveOption),
+            ChangedOnly = parseResult.GetValue(args.ChangedOption),
             Legend = parseResult.GetValue(args.LegendOption),
             SourceOptions = opts.ParseNuGetSourceOptions(parseResult),
             Discover = opts.ParseDiscover(parseResult),

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -92,9 +92,21 @@ public class DiffCommand
             {
                 if (SelectsAnalysisDiff(options))
                 {
-                    var rows = BuildAnalysisDiffRows(inputs.FromPaths, inputs.ToPaths, options);
-                    var output = DiffOutputFormatter.RenderAnalysisDiffMarkdown(inputs.Name, rows, inputs.FromVersion, inputs.ToVersion);
-                    Console.WriteLine(OutputFormatter.ApplyRowLimit(output, options.Rows));
+                    var analysis = BuildAnalysisDiff(inputs.FromPaths, inputs.ToPaths, options);
+                    var view = DiffOutputFormatter.BuildAnalysisDiffView(inputs.Name, analysis.Rows, analysis.Summary, inputs.FromVersion, inputs.ToVersion);
+                    if (options.Tsv || options.Jsonl)
+                    {
+                        OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
+                            options.Columns, options.Fields,
+                            (writer, formatter, writerOptions) =>
+                                MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions),
+                            options.Rows);
+                    }
+                    else
+                    {
+                        var output = DiffOutputFormatter.RenderAnalysisDiffView(view);
+                        Console.WriteLine(OutputFormatter.ApplyRowLimit(output, options.Rows));
+                    }
                     return 0;
                 }
 
@@ -335,25 +347,67 @@ public class DiffCommand
     private static bool SelectsAnalysisDiff(DiffOptions options)
         => options.Select?.Any(value => string.Equals(value, "Analysis Diff", StringComparison.OrdinalIgnoreCase)) == true;
 
-    private static List<AnalysisDiffRow> BuildAnalysisDiffRows(IReadOnlyList<string> fromPaths, IReadOnlyList<string> toPaths, DiffOptions options)
+    internal sealed record AnalysisDiffResult(List<AnalysisDiffRow> Rows, string Summary);
+
+    // A diff row plus the metadata used to rank and classify it. Magnitude is the
+    // absolute numeric movement (for ordering); Direction is +1 regression (more
+    // cost), -1 improvement (less cost), 0 neutral; InBoth is true when the member
+    // is present in both versions (an in-place change vs an added/removed member).
+    internal sealed record RankedAnalysisRow(AnalysisDiffRow Row, int Magnitude, int Direction, bool InBoth);
+
+    private static AnalysisDiffResult BuildAnalysisDiff(IReadOnlyList<string> fromPaths, IReadOnlyList<string> toPaths, DiffOptions options)
     {
         var oldSnapshot = BuildAnalysisSnapshot(fromPaths, options);
         var newSnapshot = BuildAnalysisSnapshot(toPaths, options);
-        var rows = new List<AnalysisDiffRow>();
-        foreach (var key in oldSnapshot.Keys.Union(newSnapshot.Keys).OrderBy(key => key, StringComparer.Ordinal))
+        var ranked = new List<RankedAnalysisRow>();
+        foreach (var key in oldSnapshot.Keys.Union(newSnapshot.Keys))
         {
             oldSnapshot.TryGetValue(key, out var oldMethod);
             newSnapshot.TryGetValue(key, out var newMethod);
             var display = newMethod?.Display ?? oldMethod?.Display ?? key;
-            AddCountRows(rows, display, oldMethod?.Signals, newMethod?.Signals);
-            AddExceptionRow(rows, display, oldMethod?.Signals, newMethod?.Signals);
-            AddOptimizationRows(rows, display, oldMethod?.Opportunities, newMethod?.Opportunities);
+            var inBoth = oldMethod is not null && newMethod is not null;
+            AddCountRows(ranked, display, inBoth, oldMethod?.Signals, newMethod?.Signals);
+            AddExceptionRow(ranked, display, inBoth, oldMethod?.Signals, newMethod?.Signals);
+            AddOptimizationRows(ranked, display, inBoth, oldMethod?.Opportunities, newMethod?.Opportunities);
         }
-        return rows
-            .OrderBy(row => row.Member, StringComparer.Ordinal)
-            .ThenBy(row => row.Signal, StringComparer.Ordinal)
-            .ThenBy(row => row.Shape ?? "", StringComparer.Ordinal)
+
+        return RankAnalysisRows(ranked, options.ChangedOnly);
+    }
+
+    // Applies the changed-only filter, ranks rows (in-place changes first, then by
+    // descending movement magnitude), and builds the summary line. Pure function
+    // over already-classified rows so it can be unit-tested without assemblies.
+    internal static AnalysisDiffResult RankAnalysisRows(IReadOnlyList<RankedAnalysisRow> ranked, bool changedOnly)
+    {
+        var selected = changedOnly ? ranked.Where(row => row.InBoth).ToList() : ranked.ToList();
+
+        var regressions = selected.Count(row => row.InBoth && row.Direction > 0);
+        var improvements = selected.Count(row => row.InBoth && row.Direction < 0);
+        var addedRemoved = selected.Count(row => !row.InBoth);
+
+        var rows = selected
+            .OrderByDescending(row => row.InBoth)
+            .ThenByDescending(row => row.Magnitude)
+            .ThenBy(row => row.Row.Member, StringComparer.Ordinal)
+            .ThenBy(row => row.Row.Signal, StringComparer.Ordinal)
+            .ThenBy(row => row.Row.Shape ?? "", StringComparer.Ordinal)
+            .Select(row => row.Row)
             .ToList();
+
+        var summary = BuildAnalysisSummary(rows.Count, regressions, improvements, addedRemoved, changedOnly);
+        return new AnalysisDiffResult(rows, summary);
+    }
+
+    internal static string BuildAnalysisSummary(int total, int regressions, int improvements, int addedRemoved, bool changedOnly)
+    {
+        if (total == 0)
+            return changedOnly ? "No in-place analysis signal changes detected." : "No analysis signal changes detected.";
+        var parts = new List<string>(3);
+        if (regressions > 0) parts.Add($"{regressions} regression{(regressions == 1 ? "" : "s")}");
+        if (improvements > 0) parts.Add($"{improvements} improvement{(improvements == 1 ? "" : "s")}");
+        if (!changedOnly && addedRemoved > 0) parts.Add($"{addedRemoved} added/removed");
+        var detail = parts.Count > 0 ? string.Join(", ", parts) : $"{total} changed signal{(total == 1 ? "" : "s")}";
+        return $"{detail} ({total} signal{(total == 1 ? "" : "s")})";
     }
 
     private sealed record AnalysisMethod(string Display, MethodSignals Signals, List<OptimizationOpportunity> Opportunities);
@@ -412,48 +466,58 @@ public class DiffCommand
     private static string FormatMethod(MethodIdentity method)
         => $"{method.DeclaringType.ToQualifiedDisplayString()}.{method.Name}({string.Join(", ", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
 
-    private static void AddCountRows(List<AnalysisDiffRow> rows, string display, MethodSignals? oldSignals, MethodSignals? newSignals)
+    private static void AddCountRows(List<RankedAnalysisRow> rows, string display, bool inBoth, MethodSignals? oldSignals, MethodSignals? newSignals)
     {
-        AddCountRow(rows, display, "allocations", oldSignals?.Allocations ?? 0, newSignals?.Allocations ?? 0, Evidence(oldSignals, newSignals));
-        AddCountRow(rows, display, "copies", oldSignals?.Copies ?? 0, newSignals?.Copies ?? 0, Evidence(oldSignals, newSignals));
-        AddCountRow(rows, display, "reflection", oldSignals?.Reflection ?? 0, newSignals?.Reflection ?? 0, Evidence(oldSignals, newSignals));
-        AddCountRow(rows, display, "throws", oldSignals?.Throws ?? 0, newSignals?.Throws ?? 0, Evidence(oldSignals, newSignals));
-        AddCountRow(rows, display, "catches", oldSignals?.Catches ?? 0, newSignals?.Catches ?? 0, Evidence(oldSignals, newSignals));
-        AddCountRow(rows, display, "finallys", oldSignals?.Finallys ?? 0, newSignals?.Finallys ?? 0, Evidence(oldSignals, newSignals));
-        AddCountRow(rows, display, "unsafe", oldSignals?.Unsafe == true ? 1 : 0, newSignals?.Unsafe == true ? 1 : 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, inBoth, "allocations", oldSignals?.Allocations ?? 0, newSignals?.Allocations ?? 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, inBoth, "copies", oldSignals?.Copies ?? 0, newSignals?.Copies ?? 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, inBoth, "reflection", oldSignals?.Reflection ?? 0, newSignals?.Reflection ?? 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, inBoth, "throws", oldSignals?.Throws ?? 0, newSignals?.Throws ?? 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, inBoth, "catches", oldSignals?.Catches ?? 0, newSignals?.Catches ?? 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, inBoth, "finallys", oldSignals?.Finallys ?? 0, newSignals?.Finallys ?? 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, inBoth, "unsafe", oldSignals?.Unsafe == true ? 1 : 0, newSignals?.Unsafe == true ? 1 : 0, Evidence(oldSignals, newSignals));
     }
 
-    private static void AddCountRow(List<AnalysisDiffRow> rows, string display, string signal, int oldValue, int newValue, string? evidence)
+    private static void AddCountRow(List<RankedAnalysisRow> rows, string display, bool inBoth, string signal, int oldValue, int newValue, string? evidence)
     {
         if (oldValue == newValue)
             return;
-        rows.Add(new AnalysisDiffRow(
-            MarkoutInline.Code(display),
-            signal,
-            oldValue.ToString(),
-            newValue.ToString(),
-            FormatDelta(newValue - oldValue),
-            null,
-            evidence));
+        var delta = newValue - oldValue;
+        rows.Add(new RankedAnalysisRow(
+            new AnalysisDiffRow(
+                MarkoutInline.Code(display),
+                signal,
+                oldValue.ToString(),
+                newValue.ToString(),
+                FormatDelta(delta),
+                null,
+                evidence),
+            Math.Abs(delta),
+            Math.Sign(delta),
+            inBoth));
     }
 
-    private static void AddExceptionRow(List<AnalysisDiffRow> rows, string display, MethodSignals? oldSignals, MethodSignals? newSignals)
+    private static void AddExceptionRow(List<RankedAnalysisRow> rows, string display, bool inBoth, MethodSignals? oldSignals, MethodSignals? newSignals)
     {
         var oldTypes = oldSignals?.ExceptionTypes ?? [];
         var newTypes = newSignals?.ExceptionTypes ?? [];
         if (oldTypes.SequenceEqual(newTypes))
             return;
-        rows.Add(new AnalysisDiffRow(
-            MarkoutInline.Code(display),
-            "constructed-exceptions",
-            FormatList(oldTypes),
-            FormatList(newTypes),
-            "changed",
-            null,
-            Evidence(oldSignals, newSignals)));
+        var delta = newTypes.Length - oldTypes.Length;
+        rows.Add(new RankedAnalysisRow(
+            new AnalysisDiffRow(
+                MarkoutInline.Code(display),
+                "constructed-exceptions",
+                FormatList(oldTypes),
+                FormatList(newTypes),
+                "changed",
+                null,
+                Evidence(oldSignals, newSignals)),
+            Math.Max(1, Math.Abs(delta)),
+            Math.Sign(delta),
+            inBoth));
     }
 
-    private static void AddOptimizationRows(List<AnalysisDiffRow> rows, string display, List<OptimizationOpportunity>? oldOps, List<OptimizationOpportunity>? newOps)
+    private static void AddOptimizationRows(List<RankedAnalysisRow> rows, string display, bool inBoth, List<OptimizationOpportunity>? oldOps, List<OptimizationOpportunity>? newOps)
     {
         var oldCounts = CountShapes(oldOps);
         var newCounts = CountShapes(newOps);
@@ -463,14 +527,19 @@ public class DiffCommand
             var newValue = newCounts.GetValueOrDefault(shape);
             if (oldValue == newValue)
                 continue;
-            rows.Add(new AnalysisDiffRow(
-                MarkoutInline.Code(display),
-                "optimization",
-                oldValue.ToString(),
-                newValue.ToString(),
-                FormatDelta(newValue - oldValue),
-                shape,
-                FormatOptimizationEvidence(oldOps, newOps, shape)));
+            var delta = newValue - oldValue;
+            rows.Add(new RankedAnalysisRow(
+                new AnalysisDiffRow(
+                    MarkoutInline.Code(display),
+                    "optimization",
+                    oldValue.ToString(),
+                    newValue.ToString(),
+                    FormatDelta(delta),
+                    shape,
+                    FormatOptimizationEvidence(oldOps, newOps, shape)),
+                Math.Abs(delta),
+                Math.Sign(delta),
+                inBoth));
         }
     }
 
@@ -647,6 +716,7 @@ public record DiffOptions
     public bool NameOnly { get; init; }
     public bool Breaking { get; init; }
     public bool Additive { get; init; }
+    public bool ChangedOnly { get; init; }
     public bool Legend { get; init; }
     public string[]? Discover { get; init; }
     public bool Tree { get; init; }

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -111,10 +111,10 @@ public static class DiffOutputFormatter
         => new()
         {
             Title = $"Analysis Diff: {name}",
-            Versions = $"**{fromVersion}** -> **{toVersion}**",
+            Versions = $"{fromVersion} -> {toVersion}",
             Summary = summary,
             Status = rows.Count == 0
-                ? new Callout(CalloutSeverity.Note, "No analysis signal changes detected.")
+                ? new Callout(CalloutSeverity.Note, summary)
                 : new Callout(CalloutSeverity.Note, "Analysis signal changes are body-level evidence, not public API compatibility changes."),
             Rows = rows.Count > 0 ? rows.ToList() : null
         };

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -104,21 +104,35 @@ public static class DiffOutputFormatter
         return writer.ToString().TrimEnd();
     }
 
-    public static string RenderAnalysisDiffMarkdown(string name, IReadOnlyList<AnalysisDiffRow> rows, string fromVersion, string toVersion)
-    {
-        var view = new AnalysisDiffView
+    /// <summary>
+    /// Builds the Analysis Diff view with a caller-supplied summary line.
+    /// </summary>
+    public static AnalysisDiffView BuildAnalysisDiffView(string name, IReadOnlyList<AnalysisDiffRow> rows, string summary, string fromVersion, string toVersion)
+        => new()
         {
             Title = $"Analysis Diff: {name}",
             Versions = $"**{fromVersion}** -> **{toVersion}**",
-            Summary = rows.Count == 0 ? "No analysis signal changes detected." : $"{rows.Count} changed analysis signals",
+            Summary = summary,
             Status = rows.Count == 0
                 ? new Callout(CalloutSeverity.Note, "No analysis signal changes detected.")
                 : new Callout(CalloutSeverity.Note, "Analysis signal changes are body-level evidence, not public API compatibility changes."),
             Rows = rows.Count > 0 ? rows.ToList() : null
         };
+
+    /// <summary>
+    /// Renders an Analysis Diff view to markdown.
+    /// </summary>
+    public static string RenderAnalysisDiffView(AnalysisDiffView view)
+    {
         var writer = new MarkoutWriter(new MarkdownFormatter());
         DiffViewContext.Default.Serialize(view, writer);
         return writer.ToString().TrimEnd();
+    }
+
+    public static string RenderAnalysisDiffMarkdown(string name, IReadOnlyList<AnalysisDiffRow> rows, string fromVersion, string toVersion)
+    {
+        var summary = rows.Count == 0 ? "No analysis signal changes detected." : $"{rows.Count} changed analysis signals";
+        return RenderAnalysisDiffView(BuildAnalysisDiffView(name, rows, summary, fromVersion, toVersion));
     }
 
     internal static string FormatSummaryCounts(int breaking, int additive, int potentiallyBreaking)


### PR DESCRIPTION
## Summary

The version-to-version Analysis Diff (`dotnet-inspect diff -S \"Analysis Diff\"`) compares per-method body-level signals (allocations, copies, reflection, throws/catches/finallys, unsafe, constructed-exception sets, optimization-opportunity shapes) between two assembly versions. It worked, but three gaps blocked real perf-triage use. This PR closes them.

This is **complementary** to the single-version `Top Leverage` / `Optimization Opportunities` views: the diff finds what *changed* between versions, while the single-version views find *longstanding* cost that a diff is blind to (both sides equally costly → zero delta).

## Changes

| Gap | Before | After |
| --- | --- | --- |
| **A — machine output** | `--tsv`/`--jsonl` were ignored; the section always emitted a markdown table | Routes the `AnalysisDiffView` through `OutputFormatter.WriteProjectedTable` (same path as the one-line diff), so agents get real TSV rows / JSON objects |
| **B — signal isolation** | Major-version diffs are dominated by added/removed-member noise (`0 → N`) | New `--changed` flag keeps only in-place changes to members present in **both** versions; the default view ranks in-place changes above added/removed |
| **C — ranking** | Alphabetical sort buried large deltas | Rows rank by descending `\|delta\|`; the summary splits counts into `N regressions, M improvements, K added/removed` |

## Why it matters

- `--tsv`/`--jsonl` are the primary machine-consumption formats for an agent-facing tool; silently emitting markdown there was a correctness bug.
- On a major bump (e.g. `System.Text.Json@9.0.0..10.0.0`) every row was new-API noise; `--changed` cuts Newtonsoft.Json `12.0.3..13.0.3` from 202 rows to the 34 real in-place deltas.
- Magnitude ranking surfaces the biggest movement first (a `+5` allocation regression now ranks above a `+1`).

## Design notes

- Ranking/summary logic is extracted into pure, unit-tested seams (`DiffCommand.RankAnalysisRows` / `BuildAnalysisSummary`) operating on `RankedAnalysisRow` (carrying `Magnitude`, `Direction`, `InBoth`). `InBoth` (member present in both snapshots) is the definition of an in-place change; a signature change (overload gains a parameter) shows as removed + added and is correctly classified as added/removed, not in-place.
- `RenderAnalysisDiffMarkdown` is preserved for back-compat.
- Documented in `docs/design/graph-signal-annotations.md`.

## Validation

- Synthetic known-answer assembly: a deliberate regression in an existing method is caught exactly (allocations 1→3, copies 0→2).
- Real-world: Newtonsoft.Json `12.0.3..13.0.3` `--changed` surfaces genuine in-place deltas (e.g. `JToken.SelectToken` allocations 2→1) ranked and split into regressions/improvements.
- Ranking: a `+5` row ranks above a `+1` row.
- Full `dotnet-inspect.Tests` suite green (1316 total, 0 failed, 9 skipped — ilasm-dependent). 5 new tests cover ranking order, the `--changed` filter, summary partitioning, and `--changed` option parsing.

## Test plan

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll -class DotnetInspector.Tests.DiffCommandTests`
- `dotnet artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll -class DotnetInspector.Tests.CommandLineTests`

> Adversarial review requested from GPT-5.5 (different model family); result will be posted as a comment.