### PR TITLE
Prune low-value optimization-opportunity shapes

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -465,13 +465,13 @@ public class LibraryBodyIndexTests
     [Theory]
     [InlineData(nameof(OptimizationOpportunityFixtures.NonCapturingLambda))]
     [InlineData(nameof(OptimizationOpportunityFixtures.StaticMethodGroup))]
-    public void OptimizationOpportunities_NonCapturingDelegateIsNotLabelledCapturing_SingleRow(string methodName)
+    public void OptimizationOpportunities_NonCapturingDelegate_NotReported(string methodName)
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 
-        // De-dup: exactly one delegate row, and it is not labelled capturing.
-        var shape = Assert.Single(DelegateShapes(index, methodName));
-        Assert.Equal("delegate-allocation", shape);
+        // Non-capturing lambdas and static method groups are cached by the compiler, so they
+        // are not a high-value allocation signal and no delegate row is emitted for them.
+        Assert.Empty(DelegateShapes(index, methodName));
     }
 
     [Fact]
@@ -496,9 +496,9 @@ public class LibraryBodyIndexTests
     {
         var index = LibraryBodyIndex.Open(typeof(OpportunityRecordFixture).Assembly.Location);
 
-        // Record synthesized members (e.g. get_EqualityContract) are [CompilerGenerated]
-        // instance methods that never touch instance state, so without suppression they
-        // would surface as noisy instance-method-no-state rows. None should be emitted.
+        // Record synthesized members (e.g. get_EqualityContract) are [CompilerGenerated],
+        // so they are excluded from optimization-opportunity scanning entirely. None should
+        // surface.
         Assert.DoesNotContain(index.OptimizationOpportunities, opportunity =>
             opportunity.Method.DeclaringType.Name == nameof(OpportunityRecordFixture));
     }
@@ -512,6 +512,7 @@ public class LibraryBodyIndexTests
         => index.OptimizationOpportunities
             .Where(o => o.Method.Name == methodName && o.Shape is "delegate-allocation" or "capturing-delegate")
             .Select(o => o.Shape);
+
 
     [Fact]
     public void TopUnsafeLeverage_RanksRequiresUnsafeMethodsByCallers()

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -826,8 +826,6 @@ public sealed class LibraryBodyIndex
         {
             var opportunities = ImmutableArray.CreateBuilder<OptimizationOpportunity>();
             int? pendingConstant = null;
-            bool hasThisAccess = false;
-            bool hasInstanceStateAccess = false;
             // Delegate creation is `<push target>; ldftn/ldvirtftn M; newobj DelegateCtor`.
             // Track the pending function-pointer load so a single row is emitted at the
             // newobj (one row per delegate allocation), classified by the target.
@@ -908,12 +906,16 @@ public sealed class LibraryBodyIndex
                     {
                         pendingConstant = null;
                         ReadInt32(il, ref position, offset);
-                        if (pendingDelegateOffset is { } ldftnOffset)
+                        if (pendingDelegateOffset is not null)
                         {
                             // A function pointer was just loaded, so this newobj is the delegate
-                            // allocation. Emit one row, classifying capture from the target.
-                            opportunities.Add(pendingDelegateCapturing
-                                ? new OptimizationOpportunity(
+                            // allocation. Only a capturing delegate (closure over a receiver or
+                            // captured locals) allocates per call; non-capturing lambdas and
+                            // static method groups are cached by the compiler, so they are not a
+                            // high-value signal and are not reported.
+                            if (pendingDelegateCapturing)
+                            {
+                                opportunities.Add(new OptimizationOpportunity(
                                     caller,
                                     "capturing-delegate",
                                     "delegate over a captured receiver or closure",
@@ -921,16 +923,8 @@ public sealed class LibraryBodyIndex
                                     "high",
                                     IsInLoopRegion(offset, loopRegions),
                                     offset,
-                                    null)
-                                : new OptimizationOpportunity(
-                                    caller,
-                                    "delegate-allocation",
-                                    "delegate over a static method or cached lambda",
-                                    "If invoked repeatedly, a cached or static delegate avoids re-allocating it.",
-                                    "medium",
-                                    IsInLoopRegion(offset, loopRegions),
-                                    offset,
-                                    "Non-capturing; the compiler may already cache it."));
+                                    null));
+                            }
                             pendingDelegateOffset = null;
                         }
                         break;
@@ -984,24 +978,20 @@ public sealed class LibraryBodyIndex
                     }
                     case ILOpCode.Ldarg_0:
                         pendingConstant = null;
-                        hasThisAccess = true;
                         break;
                     case ILOpCode.Ldarg:
                         pendingConstant = null;
-                        if (ReadInt16(il, ref position, offset) == 0)
-                            hasThisAccess = true;
+                        ReadInt16(il, ref position, offset);
                         break;
                     case ILOpCode.Ldarg_s:
                         pendingConstant = null;
-                        if (ReadByte(il, ref position, offset) == 0)
-                            hasThisAccess = true;
+                        ReadByte(il, ref position, offset);
                         break;
                     case ILOpCode.Ldfld:
                     case ILOpCode.Ldflda:
                     case ILOpCode.Stfld:
                         pendingConstant = null;
                         ReadInt32(il, ref position, offset);
-                        hasInstanceStateAccess = true;
                         break;
                     default:
                         pendingConstant = null;
@@ -1013,19 +1003,6 @@ public sealed class LibraryBodyIndex
                 // Stack-neutral nops between the ldftn and newobj (e.g. Debug IL) are skipped.
                 if (opcode is not (ILOpCode.Ldftn or ILOpCode.Ldvirtftn or ILOpCode.Newobj or ILOpCode.Nop))
                     pendingDelegateOffset = null;
-            }
-
-            if (!caller.IsStatic && !hasThisAccess && !hasInstanceStateAccess && caller.Name != ".ctor" && caller.Name != ".cctor")
-            {
-                opportunities.Add(new OptimizationOpportunity(
-                    caller,
-                    "instance-method-no-state",
-                    "Instance method with no this-state access",
-                    "Consider making the method static if it does not rely on instance state.",
-                    "medium",
-                    false,
-                    null,
-                    "Keep public API compatibility in mind."));
             }
 
             return opportunities.ToImmutable();

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -333,10 +333,10 @@ public class SectionPipelineTests
                 new OptimizationOpportunitySummary
                 {
                     Member = "Some.Type.Method()",
-                    Shape = "instance-method-no-state",
-                    Evidence = "Instance method with no this-state access",
-                    Fix = "Consider making the method static if it does not rely on instance state.",
-                    Confidence = "medium",
+                    Shape = "capturing-delegate",
+                    Evidence = "delegate over a captured receiver or closure",
+                    Fix = "Each call allocates a closure delegate; a static local function with explicit state parameters avoids it.",
+                    Confidence = "high",
                     Loop = "",
                 }
             ]


### PR DESCRIPTION
## Summary

Shapes are WIP and we want to carry only high-value signal. This prunes two medium-confidence `Optimization Opportunities` shapes that are mostly noise, so the surviving rows are the ones worth acting on.

| Shape removed | Why it is low-value |
| --- | --- |
| `instance-method-no-state` | "Make this method static" is a codegen/style nudge with ~zero runtime impact and public-API-compatibility churn, not a performance finding. It fired on every stateless property getter, dominating the noise. |
| `delegate-allocation` (medium) | Fired on non-capturing lambdas and static method groups, which the C# compiler caches in static fields, so there is **no per-call allocation**. Its own caveat already said "the compiler may already cache it." |

The genuine per-call closure case is unaffected: it is still reported as the high-confidence **`capturing-delegate`** shape.

Surviving shapes: `stackalloc-candidate` (high), `capturing-delegate` (high), `temporary-byte-array-copy` (high), `span-to-array-copy` (medium), `small-array` (medium).

## Evidence

`delegate-allocation` was demonstrably noise: on `Aspire.Hosting`, `CustomResourceSnapshot.ComputeHealthStatus` was flagged for the non-capturing lambda `r => r.Status`, which Roslyn caches (zero per-call cost). After this change the `Aspire.Hosting` Optimization Opportunities histogram is:

```
168 capturing-delegate
103 small-array
```

The two pruned shapes are gone and the high-confidence signal leads.

## Implementation

- `src/ILInspector.Analysis/LibraryBodyIndex.cs`: a non-capturing delegate `newobj` no longer emits a row; the `instance-method-no-state` emission and its now-dead this-access tracking (`hasThisAccess`/`hasInstanceStateAccess` and the `ldarg`/`ldfld` bookkeeping) are removed. IL operand parsing is unchanged.
- Tests updated: non-capturing delegate fixtures now assert **no** delegate row; the record-suppression test comment is corrected; the section-pipeline sample row uses `capturing-delegate`.

## Test plan

- `dotnet build src/ILInspector.Analysis -c Release`
- `dotnet artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tests.dll` — 64 pass
- `dotnet artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll` — 1318 pass, 9 skipped (ilasm-dependent)

## Note

The `delegate-allocation` removal touches the same IL delegate-classification area as the in-flight `fix/issue-1480-lambda-cache-evidence` work. If that lands a precise "is-cached" refinement instead, reconcile at merge; this PR takes the simpler "drop the noisy bucket, keep `capturing-delegate`" path. A precise instance-method-group delegate shape (method groups over instance methods do allocate per call) could be added later as a deliberate high-confidence signal.
