### PR TITLE
Gate nested property-root member names in ObjectInitializer (follow-up to #1416)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -388,6 +388,36 @@ public class ObjectInitializerPassTests
         function.CheckInvariant();
     }
 
+    [Fact]
+    public void NestedUnspellablePropertyRoot_IsNotFoldedIntoInvalidInitializer()
+    {
+        // s0 = new Owner(); s0.get_bad-name().X = 1; return s0;
+        // The nested root property name has no `bad-name = { ... }` initializer spelling.
+        var type = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var ctor = new MethodRef(type, ".ctor", voidType, [], HasThis: true);
+        var getBadName = new MethodRef(type, "get_bad-name", type, [], HasThis: true) { IsSpecialName = true };
+        var setX = new MethodRef(type, "set_X", voidType, [intType], HasThis: true) { IsSpecialName = true };
+
+        const int slot = 0;
+        var block = new Block();
+        block.Add(new StoreStackSlot(slot, new NewObject(ctor, [])));
+        block.Add(new StoreProperty(setX, new LoadProperty(getBadName, new LoadStackSlot(slot, type), []), [], new Constant(1, intType)));
+        block.Add(new Return(new LoadStackSlot(slot, type)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "MakeOwner", type, new MethodSignature(type, [], HasThis: false, GenericParameterCount: 0), [], body);
+
+        new ObjectInitializerPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.Single(function.Descendants.OfType<StoreProperty>());
+        function.CheckInvariant();
+    }
+
     static IrFunction FunctionWithSetter(bool generic, string propertyName = "set_Value")
     {
         var type = TypeRef.Definition("Synthetic", "Samples", "Owner");

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -388,7 +388,8 @@ public sealed class ObjectInitializerPass : IIrPass
     static string? OuterMemberOffSlot(IrExpression? instance, HashSet<int> aliasSlots) => instance switch
     {
         LoadProperty { HasInstance: true, Instance: LoadStackSlot slot } property
-            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count == 0 && property.Accessor.TypeArguments.IsDefaultOrEmpty
+            when aliasSlots.Contains(slot.Slot) && property.IndexArguments.Count == 0
+                && property.Accessor.TypeArguments.IsDefaultOrEmpty && CSharpNaming.IsUsableIdentifier(property.PropertyName)
             => property.PropertyName,
         LoadField { Instance: LoadStackSlot slot } field
             when aliasSlots.Contains(slot.Slot)
@@ -399,7 +400,8 @@ public sealed class ObjectInitializerPass : IIrPass
     static string? OuterMemberOffLocal(IrExpression? instance, int localIndex) => instance switch
     {
         LoadProperty { HasInstance: true, Instance: LoadLocal local } property
-            when local.Index == localIndex && property.IndexArguments.Count == 0 && property.Accessor.TypeArguments.IsDefaultOrEmpty
+            when local.Index == localIndex && property.IndexArguments.Count == 0
+                && property.Accessor.TypeArguments.IsDefaultOrEmpty && CSharpNaming.IsUsableIdentifier(property.PropertyName)
             => property.PropertyName,
         LoadField { Instance: LoadLocal local } field
             when local.Index == localIndex


### PR DESCRIPTION
Follow-up to #1416 / PR #1492 (merged). Completes the final adversarial-review finding.

## Context

#1492 landed the #1416 fix (gate `ObjectInitializerPass` member raising on initializer-spellable property accessors) and closed #1416. During that PR the field-name gating was reverted because it broke iterator/async reconstruction (compiler-generated state-machine field stores like `<>3__param` are legitimately folded and consumed downstream). That revert also dropped the usable-identifier check from the **nested property roots** — a property-side hole the cross-model reviewer (GPT-5.5) flagged as the one remaining blocking issue, which merged before it could be restored.

## The remaining over-raise

`OuterMemberOffSlot` / `OuterMemberOffLocal` accept a `LoadProperty` member-access root by name without checking the name is a usable C# identifier, so:

```
s0 = new Owner();
s0.get_bad-name().X = 1;
return s0;
```

folds into invalid C#:

```csharp
return new Owner { bad-name = { X = 1 } };
```

## Fix

Restore `CSharpNaming.IsUsableIdentifier(property.PropertyName)` on the `LoadProperty` arms of both `OuterMemberOff*` helpers (alongside the existing generic-getter `TypeArguments.IsDefaultOrEmpty` check). `LoadField` roots stay ungated so compiler-generated state-machine field construction still folds for the iterator/async passes — nested property-getter roots are not part of state-machine construction, so this does not regress iterators.

## Evidence

Adds `NestedUnspellablePropertyRoot_IsNotFoldedIntoInvalidInitializer`. On the current `origin/main` base:

- `ObjectInitializerPassTests`: 28/28
- `IteratorReconstructionPassTests`: 35/35
- `IteratorAcknowledgmentPassTests`: 9/9

The change is a single `when`-clause predicate on the nested property root; it declines only unspellable nested roots (not present in real csc output), so corpus impact is zero (the #1492 quality cards were already zero-delta).

GPT-5.5 reviewer's final verdict on the parent PR: property named-member identifier gate "still needed for both flat property stores and nested property roots"; field gate "acceptable to exclude." This PR applies exactly that guidance.
