### PR TITLE
Add high-confidence instance-method-group-delegate shape

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -474,6 +474,19 @@ public class LibraryBodyIndexTests
         Assert.Empty(DelegateShapes(index, methodName));
     }
 
+    [Theory]
+    [InlineData(nameof(OptimizationOpportunityFixtures.InstanceMethodGroup))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.VirtualInstanceMethodGroup))]
+    public void OptimizationOpportunities_InstanceMethodGroup_IsInstanceMethodGroupDelegate(string methodName)
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // An instance method group binds a runtime receiver and is never compiler-cached, so
+        // it allocates a delegate per call -> a single instance-method-group-delegate row.
+        var shape = Assert.Single(DelegateShapes(index, methodName));
+        Assert.Equal("instance-method-group-delegate", shape);
+    }
+
     [Fact]
     public void OptimizationOpportunities_CarryContainingMethodRootReach()
     {
@@ -510,7 +523,7 @@ public class LibraryBodyIndexTests
 
     static IEnumerable<string> DelegateShapes(LibraryBodyIndex index, string methodName)
         => index.OptimizationOpportunities
-            .Where(o => o.Method.Name == methodName && o.Shape is "delegate-allocation" or "capturing-delegate")
+            .Where(o => o.Method.Name == methodName && o.Shape is "delegate-allocation" or "capturing-delegate" or "instance-method-group-delegate")
             .Select(o => o.Shape);
 
 
@@ -614,6 +627,22 @@ public class OptimizationOpportunityFixtures
     }
 
     private static int ParseLength(string value) => value.Length;
+
+    // Instance method group -> per-call delegate binding the receiver (never cached).
+    public Func<string, int> InstanceMethodGroup()
+    {
+        return InstanceParseLength;
+    }
+
+    private int InstanceParseLength(string value) => value.Length + _field;
+
+    // Virtual instance method group -> ldvirtftn, also a per-call delegate.
+    public Func<int> VirtualInstanceMethodGroup()
+    {
+        return VirtualHelper;
+    }
+
+    public virtual int VirtualHelper() => _field;
 }
 
 // A source-generated type (mirrors the [GeneratedCode] System.Text.Json source generator

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -831,6 +831,10 @@ public sealed class LibraryBodyIndex
             // newobj (one row per delegate allocation), classified by the target.
             int? pendingDelegateOffset = null;
             bool pendingDelegateCapturing = false;
+            bool pendingDelegateInstanceGroup = false;
+            // The opcode that loaded the delegate receiver (the instruction before ldftn).
+            // A static method group loads `ldnull`; a real instance receiver is anything else.
+            ILOpCode previousOpcode = default;
             int position = 0;
             while (position < il.Length)
             {
@@ -909,10 +913,10 @@ public sealed class LibraryBodyIndex
                         if (pendingDelegateOffset is not null)
                         {
                             // A function pointer was just loaded, so this newobj is the delegate
-                            // allocation. Only a capturing delegate (closure over a receiver or
-                            // captured locals) allocates per call; non-capturing lambdas and
-                            // static method groups are cached by the compiler, so they are not a
-                            // high-value signal and are not reported.
+                            // allocation. Two cases allocate a delegate per call and are worth
+                            // reporting: a closure (captures locals/receiver) and an instance
+                            // method group (binds the receiver). Non-capturing lambdas and static
+                            // method groups are compiler-cached, so they are not reported.
                             if (pendingDelegateCapturing)
                             {
                                 opportunities.Add(new OptimizationOpportunity(
@@ -920,6 +924,18 @@ public sealed class LibraryBodyIndex
                                     "capturing-delegate",
                                     "delegate over a captured receiver or closure",
                                     "Each call allocates a closure delegate; a static local function with explicit state parameters avoids it.",
+                                    "high",
+                                    IsInLoopRegion(offset, loopRegions),
+                                    offset,
+                                    null));
+                            }
+                            else if (pendingDelegateInstanceGroup)
+                            {
+                                opportunities.Add(new OptimizationOpportunity(
+                                    caller,
+                                    "instance-method-group-delegate",
+                                    "delegate over an instance method group (binds the receiver)",
+                                    "Each call allocates a delegate that binds the receiver; cache it in a field when the receiver is stable, or use a static method with explicit state.",
                                     "high",
                                     IsInLoopRegion(offset, loopRegions),
                                     offset,
@@ -968,12 +984,20 @@ public sealed class LibraryBodyIndex
                         int token = ReadInt32(il, ref position, offset);
                         // Defer emission to the following newobj (de-dup). Capture is decided
                         // by the target method's declaring type: a lambda that closes over state
-                        // is emitted on a compiler-generated display class; a non-capturing
-                        // lambda (the `<>c` cache), a static method group, or an instance method
-                        // group is not.
+                        // is emitted on a compiler-generated display class. An instance method
+                        // group binds a runtime receiver (never cached), so it allocates per call
+                        // too; we recognize it as a target on an ordinary type (nested
+                        // compiler-generated names contain "<>") whose receiver is a real
+                        // instance (the preceding load is not `ldnull`). Non-capturing lambdas
+                        // (`<>c` cache) and static method groups (`ldnull` receiver) are
+                        // compiler-cached and not reported.
                         var ftnTarget = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
                         pendingDelegateOffset = offset;
                         pendingDelegateCapturing = IsClosureTarget(ftnTarget);
+                        pendingDelegateInstanceGroup = !pendingDelegateCapturing
+                            && ftnTarget.Kind != MemberKind.Unsupported
+                            && !ftnTarget.DeclaringType.Name.Contains("<>", StringComparison.Ordinal)
+                            && previousOpcode != ILOpCode.Ldnull;
                         break;
                     }
                     case ILOpCode.Ldarg_0:
@@ -1003,6 +1027,11 @@ public sealed class LibraryBodyIndex
                 // Stack-neutral nops between the ldftn and newobj (e.g. Debug IL) are skipped.
                 if (opcode is not (ILOpCode.Ldftn or ILOpCode.Ldvirtftn or ILOpCode.Newobj or ILOpCode.Nop))
                     pendingDelegateOffset = null;
+
+                // Remember the receiver-bearing instruction. Nops never carry the receiver, so
+                // they do not overwrite it (Debug IL can interleave them before the ldftn).
+                if (opcode != ILOpCode.Nop)
+                    previousOpcode = opcode;
             }
 
             return opportunities.ToImmutable();


### PR DESCRIPTION
## Summary

Adds a high-confidence `instance-method-group-delegate` Optimization Opportunity shape. This **recovers a real allocation signal** that was previously buried in the noisy medium `delegate-allocation` shape removed in #1506.

A delegate over an **instance** method group binds a runtime receiver and is **never** compiler-cached, so it allocates a delegate per call. This is the genuine, actionable subset of the old `delegate-allocation` bucket; the cached cases (non-capturing lambdas, static method groups) stay unreported.

## Detection

At the delegate `newobj`, classify the deferred `ldftn`/`ldvirtftn` target:

| Case | Receiver | Target type | Result |
| --- | --- | --- | --- |
| capturing lambda | display-class instance | `…+<>c__DisplayClass…` | `capturing-delegate` (unchanged) |
| **instance method group / `this`-binding lambda** | real instance | ordinary type | **`instance-method-group-delegate` (high)** |
| non-capturing lambda | `<>c` singleton | `…+<>c` (contains `<>`) | not reported |
| static method group | `ldnull` | ordinary type | not reported |

So the rule is: target type name does **not** contain `<>` (nested compiler-generated lambda/closure types do) **and** the receiver-load before the `ldftn` is not `ldnull` (which marks static method groups). No compiler caching to second-guess, so confidence is `high`.

This also correctly catches `this`-binding lambdas, which Roslyn emits as plain instance methods on the containing type (not a display class) — a per-call allocation the old medium bucket dismissed as "maybe cached."

## Evidence

On `Aspire.Hosting`, the Optimization Opportunities histogram is now:

```
168 capturing-delegate
161 instance-method-group-delegate
103 small-array
```

The 161 rows are genuine per-call delegate allocations on high-reach members, e.g. `EndpointReference.GetEndpointAnnotation()` (root reach 32, `IL_002F`) — its predicate is a `this`-binding lambda, so the delegate binds `this` and allocates every call.

## Tests

- New fixtures `InstanceMethodGroup` (non-virtual) and `VirtualInstanceMethodGroup` (`ldvirtftn`); both assert a single `instance-method-group-delegate` row.
- Existing `NonCapturingLambda` / `StaticMethodGroup` still assert **no** delegate row; `CapturingLambda` still `capturing-delegate`.
- `dotnet artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tests.dll` — 66 pass.
- `dotnet artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll` — 1318 pass, 9 skipped.
