### PR TITLE
Operationalize cluster capture: provenance, escalation order, segmented bands

### DIFF
--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -367,10 +367,25 @@ Report changed-method runs in three bands:
    opcode-diff, `NotFull`, recompile-fail, and context-fail counts.
 2. **Checkable population** — `Exact` rows that pin a green set and `OpcodeDiff`
    rows that become the semantic docket. These are the rows a PR may cite as
-   compile-back evidence.
+   compile-back evidence. Under cluster mode (`CB_CLUSTER=1`) this band is
+   reported by **capture provenance** — *checkable whole-module* (bound under the
+   whole-module skeleton) and *checkable cluster-rescued* (bound only after the
+   target's transitive closure was reconstructed in isolation, i.e. a row a single
+   unrelated sibling gap had been poisoning). Both are equally citable; the split
+   only shows how much of the checkable population depended on closure isolation.
 3. **Uncheckable population** — rows classified by reason, such as
    generated/synthesized member, stale delta target, missing reference, or
-   `not-safely-capturable: <reason>`. Do not count them as passing.
+   `not-safely-capturable` (failed the whole-module attempt *and* the closure
+   escalation — typically a Roslyn-class internal cross-assembly graph). Do not
+   count them as passing.
+
+The operational order is **escalate, do not cluster-first**: run the cheap
+whole-module grouped compile, then escalate only the rows it could not check to
+the (per-method, iterative) closure path, and treat a closure bail as
+`not-safely-capturable`. A whole-module `Exact` is already trustworthy and a
+closure cannot make it worse (it falls back), so escalation reaches the same
+checkable population as attempting the closure on every row, far more cheaply,
+while the three bands fall out of the capture provenance for free.
 
 When repeated skeleton/context fixes only trade compiler diagnostics without
 growing the checkable population, stop the incremental burndown and say the
@@ -378,13 +393,13 @@ plateau plainly. The next action is either a bounded safety case over the
 checkable rows, or a measurement issue before redesign. The #1318 plateau was
 measured under #1412: the failures are not predominantly unrelated-sibling
 poison but types genuinely inside the target's (often large) reconstruction
-closure. The harness now ships an opt-in **reconstruction-closure (cluster)
-emitter** (`CB_CLUSTER=1`) that reconstructs only the target's transitive closure
-instead of the whole module and falls back to the whole-module skeleton on bail,
-so it never regresses; a persistent bail is a principled
-`not-safely-capturable` classification. The gain is library-shaped, not
-universal — see [decompiler-quality.md](decompiler-quality.md#reconstruction-closures-and-the-safely-capturable-population)
-for the safely-capturable framing and the segmented-reporting follow-ups.
+closure. The harness ships an opt-in **reconstruction-closure (cluster) emitter**
+(`CB_CLUSTER=1`) that reconstructs only the target's transitive closure instead
+of the whole module and falls back to the whole-module skeleton on bail, so it
+never regresses, emitting the safely-capturable bands above. The gain is
+library-shaped, not universal — see
+[decompiler-quality.md](decompiler-quality.md#reconstruction-closures-and-the-safely-capturable-population)
+for the framing and the extension/inherited-member follow-ups.
 
 For #1175-class retained-label work, a go/no-go comment should name the
 checkable changed-method rows, the opcode-diff docket, and the remaining

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -122,16 +122,21 @@ see the [harness README](../tools/DecompilerHarness/README.md)) reconstructs onl
 the target's transitive closure rather than the whole module: emit the target
 type, compile, and let the compiler name the missing same-assembly types it
 still needs, recompiling until the unit binds or the closure stops growing. It
-falls back to the whole-module skeleton when the closure cannot be closed within
-budget, so it never regresses below the baseline — it only rescues targets the
-all-or-nothing skeleton failed for unrelated sibling reasons. A persistent bail
-is a principled *not-safely-capturable* classification rather than a fidelity
-verdict. The current gain is modest and library-shaped; raising the
-non-pathological green rate (extension/inherited-member inclusion) and emitting
-segmented "safely-capturable vs not" reporting are tracked follow-ups, not yet
-landed. The point is the inverse of cheating: a good cluster system lets honest
-changed-method fidelity make real progress on non-pathological libraries instead
-of being held hostage by an unrelated gap somewhere else in the module.
+runs in **escalation** order — the cheap whole-module compile first, and only the
+rows it could not check are escalated to the closure path, which reaches the same
+checkable population as attempting the closure everywhere at a fraction of the
+cost. A row falls back to its whole-module result when the closure cannot be
+closed within budget, so it never regresses below the baseline — it only rescues
+targets the all-or-nothing skeleton failed for unrelated sibling reasons. A
+persistent bail is a principled *not-safely-capturable* classification rather than
+a fidelity verdict, and the changed-method report prints the segmented
+**safely-capturable bands** (checkable whole-module, checkable cluster-rescued,
+not-safely-capturable) from each row's capture provenance. The current gain is
+modest and library-shaped; raising the non-pathological green rate
+(extension/inherited-member inclusion) is a tracked follow-up. The point is the
+inverse of cheating: a good cluster system lets honest changed-method fidelity
+make real progress on non-pathological libraries instead of being held hostage by
+an unrelated gap somewhere else in the module.
 
 ### Fixture idiom-shape scorecard
 

--- a/src/ILInspector.Decompiler.Tests/ClusterCaptureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ClusterCaptureTests.cs
@@ -5,32 +5,50 @@ namespace ILInspector.Decompiler.Tests;
 /// <summary>
 /// Pins reconstruction-closure (cluster) capture (#1412): instead of
 /// reconstructing the whole module, the fidelity check reconstructs only the
-/// types the target transitively needs (grown compile-driven from compiler
-/// "type/member not found" diagnostics) and falls back to the whole-module build
-/// on bail. For a method that already compiles whole-module the closure must
-/// reconstruct the same body to the same IL, so the opcode outcome is identical —
-/// the capture is an optimisation that greens unrelated-sibling-poisoned rows
-/// without ever changing a result it already had.
+/// types a target transitively needs (grown compile-driven from compiler
+/// "type/member not found" diagnostics), falling back to the whole-module build
+/// on bail. Two properties matter and are pinned here against
+/// <see cref="FidelityCheck.ClusterMode.ForceAll"/> (the closure attempted for
+/// every row, so the engine is exercised on the fixture rather than only on the
+/// unrelated-sibling-poisoned rows that happen to exist in a given corpus):
+///
+/// 1. <b>It never changes a result.</b> For a method the whole-module build
+///    already classifies, the closure must reconstruct the same body to the same
+///    IL, so the opcode <i>status</i> is identical — the capture is an
+///    optimisation that rescues poisoned rows, never a path that can flip a
+///    verdict. A divergence here is a real closure bug.
+/// 2. <b>The closure path actually runs.</b> At least one fixture row is captured
+///    with <see cref="FidelityCheck.CaptureMode.Cluster"/> provenance and an
+///    <c>Exact</c> status — proving a real result came from the closure and not
+///    from the whole-module fallback (without this the suite would pass even if
+///    the closure always bailed).
 /// </summary>
 public class ClusterCaptureTests
 {
     const string FixtureType = "ILInspector.Decompiler.Tests.CfgSampleClass";
 
     [Fact]
-    public void ClusterCapture_MatchesWholeModuleForFixtures()
+    public void ClusterCapture_NeverChangesAResult_AndTheClosurePathRuns()
     {
         string assembly = typeof(CfgSampleClass).Assembly.Location;
 
-        var whole = FidelityCheck.Evaluate(assembly, lowered: false, cluster: false)
+        var whole = FidelityCheck.Evaluate(assembly, lowered: false, FidelityCheck.ClusterMode.Off)
             .Where(r => r.Type == FixtureType)
             .ToDictionary(r => (r.Method, r.Overload), r => r.Status);
-        var cluster = FidelityCheck.Evaluate(assembly, lowered: false, cluster: true)
+        var forced = FidelityCheck.Evaluate(assembly, lowered: false, FidelityCheck.ClusterMode.ForceAll)
             .Where(r => r.Type == FixtureType)
-            .ToDictionary(r => (r.Method, r.Overload), r => r.Status);
+            .ToList();
 
-        Assert.NotEmpty(cluster);
-        Assert.Contains(cluster.Values, status => status == FidelityCheck.CompileBackStatus.Exact);
-        foreach (var (key, wholeStatus) in whole)
-            Assert.Equal(wholeStatus, cluster[key]);
+        Assert.NotEmpty(whole);
+        Assert.NotEmpty(forced);
+
+        // 1. The closure never changes a whole-module verdict.
+        foreach (var row in forced)
+            Assert.Equal(whole[(row.Method, row.Overload)], row.Status);
+
+        // 2. The closure path genuinely produced a checkable result (not fallback).
+        Assert.Contains(forced, r =>
+            r.Capture == FidelityCheck.CaptureMode.Cluster &&
+            r.Status == FidelityCheck.CompileBackStatus.Exact);
     }
 }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -192,10 +192,43 @@ static class FidelityCheck
         ContextFail,
     }
 
+    /// <summary>
+    /// Which reconstruction produced a row — the provenance the segmented
+    /// "safely-capturable" bands read (#1412). <see cref="WholeModule"/> bound (or
+    /// failed) under the whole-module skeleton; <see cref="Cluster"/> bound under
+    /// the reconstruction closure after the whole-module attempt failed (an
+    /// unrelated-sibling rescue); <see cref="ClusterBailed"/> failed the
+    /// whole-module attempt *and* the closure escalation — the principled
+    /// not-safely-capturable signal.
+    /// </summary>
+    public enum CaptureMode
+    {
+        WholeModule,
+        Cluster,
+        ClusterBailed,
+    }
+
+    /// <summary>
+    /// How the fidelity loop reconstructs each target (#1412). <see cref="Off"/> is
+    /// whole-module only. <see cref="Escalate"/> runs the cheap whole-module
+    /// compile first and escalates only the rows it could not check to the
+    /// (per-method, iterative) closure path — the operational order, since a
+    /// whole-module Exact never needs re-checking and only its failures can
+    /// improve. <see cref="ForceAll"/> attempts the closure for every row first;
+    /// it exercises the closure engine maximally and is the test seam.
+    /// </summary>
+    public enum ClusterMode
+    {
+        Off,
+        Escalate,
+        ForceAll,
+    }
+
     /// <summary>One method's fidelity check result, with both opcode streams for diagnostics.</summary>
     public sealed record CompileBackResult(
         string Type, string Method, int Overload, string Signature, CompileBackStatus Status,
-        string OriginalOpcodes, string RecompiledOpcodes, string? Detail);
+        string OriginalOpcodes, string RecompiledOpcodes, string? Detail,
+        CaptureMode Capture = CaptureMode.WholeModule);
 
     /// <summary>
     /// Runs the fidelity check loop over one assembly and returns a structured result
@@ -215,14 +248,23 @@ static class FidelityCheck
     /// cross-method import seam from the open source (lambda raising).
     /// </summary>
     public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, bool lowered)
-        => Evaluate(assemblyPath, lowered, cluster: false);
+        => Evaluate(assemblyPath, lowered, ClusterMode.Off);
 
     /// <summary>
-    /// Evaluates one assembly, optionally using reconstruction-closure (cluster)
-    /// capture (#1412) instead of whole-module reconstruction. The test seam for
-    /// the cluster path, equivalent to setting the CB_CLUSTER environment variable.
+    /// Compatibility overload: <paramref name="cluster"/> true selects the
+    /// operational <see cref="ClusterMode.Escalate"/> path (whole-module first,
+    /// then escalate only its failures to the reconstruction closure).
     /// </summary>
     public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, bool lowered, bool cluster)
+        => Evaluate(assemblyPath, lowered, cluster ? ClusterMode.Escalate : ClusterMode.Off);
+
+    /// <summary>
+    /// Evaluates one assembly with the chosen reconstruction-closure (cluster)
+    /// strategy (#1412). The test seam for the cluster path; the CB_CLUSTER
+    /// environment variable selects <see cref="ClusterMode.Escalate"/> for the
+    /// console path.
+    /// </summary>
+    public static IReadOnlyList<CompileBackResult> Evaluate(string assemblyPath, bool lowered, ClusterMode clusterMode)
     {
         var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
         var compileOptions = new CSharpCompilationOptions(
@@ -240,7 +282,7 @@ static class FidelityCheck
         var references = RuntimeReferences(assemblyPath);
 
         foreach (var typeHandle in reader.TypeDefinitions)
-            EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, results, cluster: cluster);
+            EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, results, clusterMode: clusterMode);
 
         return results;
     }
@@ -576,6 +618,7 @@ static class FidelityCheck
         Console.WriteLine($"  not Full           : {notFull}");
         Console.WriteLine($"  recompile fail     : {recompileFail}");
         Console.WriteLine($"  context fail       : {contextFail}");
+        PrintCaptureBands(rows);
         PrintTargetFailureBuckets(rows, CompileBackStatus.RecompileFail, "  recompile-fail buckets:");
         PrintTargetRecompileCodes(rows);
         PrintTargetFailureBuckets(rows, CompileBackStatus.ContextFail, "  context-fail buckets:");
@@ -583,6 +626,29 @@ static class FidelityCheck
         PrintTargetExamples(rows, CompileBackStatus.RecompileFail, "Recompile-fail examples", maxExamples, includeOpcodes: false);
         PrintTargetExamples(rows, CompileBackStatus.ContextFail, "Context-fail examples", maxExamples, includeOpcodes: false);
         PrintTargetExamples(rows, CompileBackStatus.NotFull, "Not-Full examples", maxExamples, includeOpcodes: false);
+    }
+
+    /// <summary>
+    /// The segmented "safely-capturable" bands (#1412), printed only when a
+    /// cluster mode produced provenance. A checkable row (Exact or OpcodeDiff)
+    /// captured whole-module needs no closure; one captured under the closure is
+    /// an unrelated-sibling rescue; a ClusterBailed row failed both the
+    /// whole-module attempt and the closure escalation — the principled
+    /// not-safely-capturable band, which must not be counted as passing.
+    /// </summary>
+    static void PrintCaptureBands(IReadOnlyList<TargetedCompileBackResult> rows)
+    {
+        static bool Checkable(CompileBackStatus s) => s is CompileBackStatus.Exact or CompileBackStatus.OpcodeDiff;
+        int wholeModuleCheckable = rows.Count(row => row.Result.Capture == CaptureMode.WholeModule && Checkable(row.Result.Status));
+        int clusterRescued = rows.Count(row => row.Result.Capture == CaptureMode.Cluster && Checkable(row.Result.Status));
+        int notSafelyCapturable = rows.Count(row => row.Result.Capture == CaptureMode.ClusterBailed && !Checkable(row.Result.Status));
+        if (clusterRescued == 0 && notSafelyCapturable == 0)
+            return; // whole-module-only run — no cluster provenance to report
+
+        Console.WriteLine("  safely-capturable bands:");
+        Console.WriteLine($"    checkable (whole-module)   : {wholeModuleCheckable}");
+        Console.WriteLine($"    checkable (cluster-rescued): {clusterRescued}");
+        Console.WriteLine($"    not-safely-capturable      : {notSafelyCapturable}");
     }
 
     /// <summary>
@@ -758,7 +824,7 @@ static class FidelityCheck
         MetadataReader reader, PEReader pe, MetadataSource source, TypeDefinitionHandle typeHandle,
         ReferenceSet references, CSharpParseOptions parseOptions,
         CSharpCompilationOptions compileOptions, Func<IrFunction, DecompilerResult> render, List<CompileBackResult> results,
-        int maxEntries = int.MaxValue, bool cluster = false)
+        int maxEntries = int.MaxValue, ClusterMode clusterMode = ClusterMode.Off)
     {
         if (maxEntries <= 0)
             return;
@@ -766,7 +832,7 @@ static class FidelityCheck
             return;
         if (entries.Count > maxEntries)
             entries = entries.Take(maxEntries).ToList();
-        results.AddRange(EvaluateGrouped(reader, references, parseOptions, compileOptions, fullType, typeHandle, entries, cluster));
+        results.AddRange(EvaluateGrouped(reader, references, parseOptions, compileOptions, fullType, typeHandle, entries, clusterMode));
     }
 
     /// <summary>
@@ -781,28 +847,61 @@ static class FidelityCheck
     static List<CompileBackResult> EvaluateGrouped(
         MetadataReader reader, ReferenceSet references,
         CSharpParseOptions parseOptions, CSharpCompilationOptions compileOptions,
-        string fullType, TypeDefinitionHandle typeHandle, IReadOnlyList<Entry> entries, bool cluster = false)
+        string fullType, TypeDefinitionHandle typeHandle, IReadOnlyList<Entry> entries, ClusterMode clusterMode = ClusterMode.Off)
     {
-        var results = new List<CompileBackResult>();
-        // Reconstruction-closure (cluster) capture — reconstruct only the types the
-        // target transitively needs (grown compile-driven), with whole-module
-        // fallback, so an unrelated sibling's gap cannot poison the target and the
-        // capture never regresses (#1412). Opt-in via the `cluster` flag or the
-        // CB_CLUSTER environment variable.
-        if (cluster || Environment.GetEnvironmentVariable("CB_CLUSTER") is not null)
+        // CB_CLUSTER selects the operational escalation path for the console runs.
+        if (clusterMode == ClusterMode.Off && Environment.GetEnvironmentVariable("CB_CLUSTER") is not null)
+            clusterMode = ClusterMode.Escalate;
+
+        // ForceAll: attempt the reconstruction closure for every row first — the
+        // maximal exercise of the closure engine (the test seam, #1412). A row the
+        // closure binds carries Cluster provenance; a bail falls back to the
+        // whole-module per-method build (ClusterBailed), so the result is never
+        // worse than whole-module.
+        if (clusterMode == ClusterMode.ForceAll)
         {
             var (typeIndex, methodIndex) = ClusterIndexes(reader);
+            var forced = new List<CompileBackResult>(entries.Count);
             foreach (var e in entries)
-                results.Add(CompileOneClustered(reader, references, parseOptions, compileOptions, fullType, e, typeIndex, methodIndex)
-                    ?? CompileOne(reader, references, parseOptions, compileOptions, fullType, e));
-            return results;
+            {
+                var captured = CompileOneClustered(reader, references, parseOptions, compileOptions, fullType, e, typeIndex, methodIndex);
+                forced.Add(captured is not null
+                    ? captured with { Capture = CaptureMode.Cluster }
+                    : CompileOne(reader, references, parseOptions, compileOptions, fullType, e) with { Capture = CaptureMode.ClusterBailed });
+            }
+            return forced;
         }
-        // CB_NOGROUP forces the per-method path — the A/B baseline for the speedup.
+
+        // Whole-module reconstruction — the cheap, grouped common case. CB_NOGROUP
+        // forces the per-method path (the A/B baseline for the speedup).
+        var results = new List<CompileBackResult>();
         bool grouped = entries.Count > 1 && Environment.GetEnvironmentVariable("CB_NOGROUP") is null;
-        if (grouped && TryCompileGroup(reader, references, parseOptions, compileOptions, fullType, typeHandle, entries, results))
-            return results;
-        foreach (var e in entries)
-            results.Add(CompileOne(reader, references, parseOptions, compileOptions, fullType, e));
+        if (!(grouped && TryCompileGroup(reader, references, parseOptions, compileOptions, fullType, typeHandle, entries, results)))
+        {
+            results.Clear();
+            foreach (var e in entries)
+                results.Add(CompileOne(reader, references, parseOptions, compileOptions, fullType, e));
+        }
+
+        // Escalation: reconstruct only the rows whole-module could not check —
+        // every reconstructed type is the target's own transitive closure, so an
+        // unrelated sibling's gap cannot poison an otherwise-faithful target. The
+        // closure's whole-module fallback guarantees the escalated result is never
+        // worse than the whole-module one, so the capture never regresses (#1412).
+        // A row that fails both is ClusterBailed — the not-safely-capturable band.
+        if (clusterMode == ClusterMode.Escalate)
+        {
+            var (typeIndex, methodIndex) = ClusterIndexes(reader);
+            for (int i = 0; i < results.Count && i < entries.Count; i++)
+            {
+                if (results[i].Status is not (CompileBackStatus.RecompileFail or CompileBackStatus.ContextFail))
+                    continue;
+                var captured = CompileOneClustered(reader, references, parseOptions, compileOptions, fullType, entries[i], typeIndex, methodIndex);
+                results[i] = captured is not null
+                    ? captured with { Capture = CaptureMode.Cluster }
+                    : results[i] with { Capture = CaptureMode.ClusterBailed };
+            }
+        }
         return results;
     }
 

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -308,17 +308,30 @@ emits the target's type, compiles, and adds every same-assembly type the
 compiler names as missing (`CS0246`/`CS0234`/`CS0103` for types, `CS1061` for
 static/extension members), recompiling until the unit binds or the closure stops
 growing. The compiler computes the exact closure, so unrelated sibling types are
-simply omitted. When the closure cannot be closed within budget (default 200
-roots / 80 iterations) the run **bails and falls back to the whole-module
-skeleton**, so cluster results are always ≥ the baseline — it never regresses,
-only rescues targets the all-or-nothing skeleton failed for unrelated reasons. A
-persistent bail is itself a useful signal: the target is *not safely capturable*
-in isolation (typically a Roslyn-class internal cross-assembly graph), which is
-the population for which changed-method fidelity is least meaningful. `CB_CLUSTER_DUMP=1`
-prints bail diagnostics. The gain is modest and library-shaped, not universal:
-on the Roslyn-heavy #1251/#1209 stress delta it rescues a handful of
-non-pathological rows; segmented "safely-capturable vs not" reporting is planned,
-not yet emitted.
+simply omitted.
+
+`CB_CLUSTER=1` runs the **escalation** order: the cheap whole-module grouped
+compile first, and only the rows it could not check (`RecompileFail`/`ContextFail`)
+are escalated to the per-method closure path. A whole-module `Exact` never needs
+re-checking — only its failures can improve — so escalation reaches the same
+checkable population as attempting the closure on every row, at a fraction of the
+cost. When the closure cannot be closed within budget (default 200 roots / 80
+iterations) the row **falls back to its whole-module result**, so cluster results
+are always ≥ the baseline: it never regresses, only rescues targets the
+all-or-nothing skeleton failed for unrelated reasons. A persistent bail is itself
+a useful signal — the target is *not safely capturable* in isolation (typically a
+Roslyn-class internal cross-assembly graph), the population for which
+changed-method fidelity is least meaningful. `CB_CLUSTER_DUMP=1` prints bail
+diagnostics.
+
+Each row carries its capture provenance (whole-module, cluster-rescued, or
+cluster-bailed), and the changed-method report prints the segmented
+**safely-capturable bands** — checkable whole-module, checkable cluster-rescued,
+and not-safely-capturable — so a go/no-go comment can separate the rows it may
+cite as compile-back evidence from the rows it must not count as passing. The
+gain is modest and library-shaped, not universal: on a Roslyn-heavy stress delta
+it rescues a handful of non-pathological rows. Raising the non-pathological green
+rate (extension/inherited-member inclusion) is a tracked follow-up.
 
 ```bash
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \


### PR DESCRIPTION
Follow-up to #1484 (#1412). Addresses the GPT-5.5 review finding on #1484 — that
`ClusterCaptureTests` could pass even if the closure path never ran (whole-module
fallback made `cluster == baseline` trivially) — and operationalizes the engine
for the correctness gauntlet per the escalation model discussed on #1318/#1175.

## What changed

**Provenance.** `CompileBackResult` carries a `CaptureMode` (`WholeModule`,
`Cluster`, `ClusterBailed`) recording how each row was reconstructed, so a row
bound by the closure is distinguishable from one that fell back to the
whole-module skeleton.

**Escalation order (not cluster-first).** `CB_CLUSTER` now runs
`ClusterMode.Escalate`: the cheap whole-module grouped compile first, escalating
**only** the rows it could not check (`RecompileFail`/`ContextFail`) to the
per-method closure path. A whole-module `Exact` is already trustworthy and the
closure can only fall back (never worse), so escalation reaches the **same
checkable population** as attempting the closure on every row, at a fraction of
the cost. Verified on `CfgSampleClass`: escalation leaves all 375/11/1/97
whole-module verdicts untouched (0 of 99 failures there are unrelated-sibling
poison — they are genuine body gaps); on the `#1251/#1209` delta it still rescues
without ever regressing.

**Segmented bands.** The changed-method report prints safely-capturable bands
from the provenance — *checkable whole-module*, *checkable cluster-rescued*,
*not-safely-capturable* (failed whole-module **and** the closure escalation). A
go/no-go comment may cite the first two and must not count the third as passing.
Sample on the (stale) delta:

```
  safely-capturable bands:
    checkable (whole-module)   : 0
    checkable (cluster-rescued): 1
    not-safely-capturable      : 44
```

**Test (the review fix).** `ClusterCaptureTests` now drives
`ClusterMode.ForceAll` (closure attempted for every row, so the engine is
exercised on the fixture rather than only on whatever poisoned rows a corpus
happens to contain) and asserts both: (1) the closure **never changes** a
whole-module verdict, and (2) at least one fixture row is `Exact` with `Cluster`
provenance — proving the closure path genuinely produced a checkable result, not
fallback. This fails if the closure always bails (the gap the review flagged) or
if it ever flips a verdict.

**Docs.** Harness README, `decompiler-quality.md`, and
`decompiler-correctness-pipeline.md` updated for the escalation order and the
three-band reporting rule.

## Why escalation, not cluster-first

Cluster-first is the cleaner *concept* (isolate the target from sibling poison),
but operationally the closure is the expensive path (per-method, iterative) and
whole-module is the cheap grouped common case. Escalation pays the closure cost
only on rows that actually failed, and — because the closure's whole-module
fallback guarantees a result is never worse than baseline — it captures 100% of
the cluster upside (it rescues exactly the `whole-module-fail ∧ closure-ok` set,
the only way the closure can ever exceed baseline). The three bands then fall out
of the provenance for free.

## Validation

- `ClusterCaptureTests` passes (285s) — the closure path is exercised and proven
  to produce a real `Cluster`-provenance `Exact` while never flipping a verdict.
- The escalation refactor is behavior-preserving for the default (`Off`) path:
  the whole-module fidelity summary is byte-identical (375/11/1/97).
- This change is **isolated to the harness + its test + docs** (5 files:
  `FidelityCheck.cs`, `ClusterCaptureTests.cs`, README + 2 docs); it touches no
  product decompiler code.

### Pre-existing, unrelated local failures (not introduced here)

The full local decompiler suite currently shows two failures that are **in
product decompiler code this PR does not touch**, from in-flight `calli` work on
`main`: `LoweringCoverageTests.EveryPipelinePassType_IsClassified_ByOneRegister`
(`CallIndirectSpellabilityPass` not yet registered in `LoweringCoverage`) and
`IrImporterTests.UnmanagedCallersOnly_StdcallMethodAddress_PreservesFunctionPointerWitness`.
The only fixture-relevant failure seen during this work — `ConstantByteSpan` — was
a `main` regression already fixed by #1496 and now passes. CI against the merge
target is the authoritative gate.

Refs #1412, #1318, #1484.