### PR TITLE
Parenthesize compound assignment-target and condition operands (#1479)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -500,6 +500,12 @@ public class CfgSampleClass
 
     public static int[] ArrayRangeToFromEnd(int[] a) => a[..^1];
 
+    // Issue #1479: a compound (conditional) array receiver on an indexed
+    // assignment target must stay parenthesized — `(flag ? a : b)[i] = v`, not
+    // `flag ? a : b[i] = v`, which reparses as `flag ? a : (b[i] = v)` (CS0201).
+    public static void ConditionalArrayElementStore(bool flag, int[] a, int[] b, int i, int v)
+        => (flag ? a : b)[i] = v;
+
     public static string StringRangeBoth(string s, int i, int j) => s[i..j];
 
     public static System.ReadOnlySpan<int> SpanRangeBoth(System.ReadOnlySpan<int> s, int i, int j) => s[i..j];

--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -1,0 +1,112 @@
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+using System.Collections.Immutable;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Issue #1479: several printer operand positions bypassed the precedence-wrapping
+// Operand helper, reassociating compound operands into invalid/wrong C# at Full.
+public class PrinterPrecedenceTests
+{
+    static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
+
+    static IrFunction Raised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return function!;
+    }
+
+    static string Print(string methodName) => CSharpPrinter.Print(Raised(methodName)).Output!;
+
+    // ---- StoreElement: compound array receiver on an indexed assignment target ----
+
+    [Fact]
+    public void StoreElement_CompoundArrayReceiver_StaysParenthesized()
+    {
+        var output = Print(nameof(CfgSampleClass.ConditionalArrayElementStore));
+
+        // Without the Operand wrap this rendered `flag ? a : b[i] = v;`, which
+        // reparses as `flag ? a : (b[i] = v)` (CS0201, and wrong target).
+        Assert.Contains("(flag ? a : b)[i] = v;", output);
+        Assert.DoesNotContain("flag ? a : b[i] = v;", output);
+    }
+
+    [Fact]
+    public void StoreElement_CompoundArrayReceiver_RecompilesExactly()
+    {
+        var result = Assert.Single(
+            FidelityCheck.Evaluate(typeof(CfgSampleClass).Assembly.Location),
+            r => r.Type == typeof(CfgSampleClass).FullName
+                && r.Method == nameof(CfgSampleClass.ConditionalArrayElementStore));
+
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+    }
+
+    // ---- Conditional in the condition position of an enclosing ternary ----
+    // Not reachable from C# source (structuring lowers the outer ternary to an
+    // `if`), so the printer is exercised over a hand-built IR shape.
+
+    [Fact]
+    public void Conditional_NestedConditionalCondition_StaysParenthesized()
+    {
+        // (a ? b : c) ? d : e — `?:` is right-associative, so an unwrapped
+        // condition reparses as `a ? b : (c ? d : e)`.
+        var inner = new Conditional(
+            new LoadArgument(0, "a", s_bool),
+            new LoadArgument(1, "b", s_bool),
+            new LoadArgument(2, "c", s_bool));
+        var outer = new Conditional(inner, new LoadArgument(3, "d", s_int), new LoadArgument(4, "e", s_int));
+
+        var output = PrintReturn(
+            outer,
+            s_int,
+            [
+                new Parameter("a", s_bool), new Parameter("b", s_bool), new Parameter("c", s_bool),
+                new Parameter("d", s_int), new Parameter("e", s_int),
+            ]);
+
+        Assert.Contains("(a ? b : c) ? d : e", output);
+        Assert.DoesNotContain("a ? b : c ? d", output);
+    }
+
+    // ---- Coalesce as a side of a short-circuit && ----
+    // `??` binds looser than `&&`, so an unwrapped coalesce side reparses as
+    // `a ?? (b && c)`. Not reachable from source (the operands fold), so the
+    // printer is exercised over a hand-built IR shape.
+
+    [Fact]
+    public void Logical_CoalesceSide_StaysParenthesized()
+    {
+        var coalesce = new Coalesce(new LoadArgument(0, "x", s_string), new LoadArgument(1, "y", s_string));
+        var logical = new LogicalBinary(LogicalKind.And, coalesce, new LoadArgument(2, "c", s_bool));
+
+        var output = PrintReturn(
+            logical,
+            s_bool,
+            [new Parameter("x", s_string), new Parameter("y", s_string), new Parameter("c", s_bool)]);
+
+        Assert.Contains("(x ?? y) && c", output);
+        Assert.DoesNotContain("x ?? y && c", output);
+    }
+
+    static string PrintReturn(IrExpression value, TypeRef returnType, ImmutableArray<Parameter> parameters)
+    {
+        var block = new Block();
+        block.Add(new Return(value));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(returnType, parameters, HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+        return CSharpPrinter.Print(function).Output!;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -10,7 +10,6 @@ public class PrinterPrecedenceTests
 {
     static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
-    static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
 
     static IrFunction Raised(string methodName)
     {
@@ -83,13 +82,17 @@ public class PrinterPrecedenceTests
     [Fact]
     public void Logical_CoalesceSide_StaysParenthesized()
     {
-        var coalesce = new Coalesce(new LoadArgument(0, "x", s_string), new LoadArgument(1, "y", s_string));
+        // A boolean coalesce side renders bare through Condition, so it must be
+        // parenthesized: `(x ?? y) && c`, not `x ?? y && c`. Bool operands keep
+        // the coalesce boolean (no truthiness `is not null`/`!= 0` spelling),
+        // which is the only side-shape that reassociates here.
+        var coalesce = new Coalesce(new LoadArgument(0, "x", s_bool), new LoadArgument(1, "y", s_bool));
         var logical = new LogicalBinary(LogicalKind.And, coalesce, new LoadArgument(2, "c", s_bool));
 
         var output = PrintReturn(
             logical,
             s_bool,
-            [new Parameter("x", s_string), new Parameter("y", s_string), new Parameter("c", s_bool)]);
+            [new Parameter("x", s_bool), new Parameter("y", s_bool), new Parameter("c", s_bool)]);
 
         Assert.Contains("(x ?? y) && c", output);
         Assert.DoesNotContain("x ?? y && c", output);

--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -4,7 +4,7 @@ using System.Collections.Immutable;
 
 namespace ILInspector.Decompiler.Tests;
 
-// Issue #1479: several printer operand positions bypassed the precedence-wrapping
+// Issue #1479: printer operand positions that bypassed the precedence-wrapping
 // Operand helper, reassociating compound operands into invalid/wrong C# at Full.
 public class PrinterPrecedenceTests
 {
@@ -72,30 +72,6 @@ public class PrinterPrecedenceTests
 
         Assert.Contains("(a ? b : c) ? d : e", output);
         Assert.DoesNotContain("a ? b : c ? d", output);
-    }
-
-    // ---- Coalesce as a side of a short-circuit && ----
-    // `??` binds looser than `&&`, so an unwrapped coalesce side reparses as
-    // `a ?? (b && c)`. Not reachable from source (the operands fold), so the
-    // printer is exercised over a hand-built IR shape.
-
-    [Fact]
-    public void Logical_CoalesceSide_StaysParenthesized()
-    {
-        // A boolean coalesce side renders bare through Condition, so it must be
-        // parenthesized: `(x ?? y) && c`, not `x ?? y && c`. Bool operands keep
-        // the coalesce boolean (no truthiness `is not null`/`!= 0` spelling),
-        // which is the only side-shape that reassociates here.
-        var coalesce = new Coalesce(new LoadArgument(0, "x", s_bool), new LoadArgument(1, "y", s_bool));
-        var logical = new LogicalBinary(LogicalKind.And, coalesce, new LoadArgument(2, "c", s_bool));
-
-        var output = PrintReturn(
-            logical,
-            s_bool,
-            [new Parameter("x", s_bool), new Parameter("y", s_bool), new Parameter("c", s_bool)]);
-
-        Assert.Contains("(x ?? y) && c", output);
-        Assert.DoesNotContain("x ?? y && c", output);
     }
 
     static string PrintReturn(IrExpression value, TypeRef returnType, ImmutableArray<Parameter> parameters)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -487,7 +487,14 @@ public sealed partial class CSharpPrinter
     string ConditionalText(Conditional conditional)
     {
         var target = conditional.MergedType;
-        return $"{Condition(conditional.Condition)} ? {ConditionalArm(conditional.WhenTrue, target)} : {ConditionalArm(conditional.WhenFalse, target)}";
+        // `?:` is right-associative, so a conditional in the condition position
+        // reassociates without parentheses (`(a ? b : c) ? d : e` would reparse
+        // as `a ? b : (c ? d : e)`). The arms render through Operand, which
+        // already wraps a nested conditional where needed.
+        var condition = conditional.Condition is Conditional
+            ? $"({Condition(conditional.Condition)})"
+            : Condition(conditional.Condition);
+        return $"{condition} ? {ConditionalArm(conditional.WhenTrue, target)} : {ConditionalArm(conditional.WhenFalse, target)}";
     }
 
     string ConditionalArm(IrExpression arm, TypeRef? target)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1741,9 +1741,12 @@ public sealed partial class CSharpPrinter
             LogicalBinary nested when nested.Kind == logical.Kind => LogicalText(nested),
             LogicalBinary nested => $"({LogicalText(nested)})",
             Conditional => $"({Expression(side)})",
-            // `??` binds looser than `&&`/`||`, so an un-parenthesized coalesce
-            // side reassociates (`(a ?? b) && c` would reparse as `a ?? (b && c)`).
-            Coalesce => $"({Expression(side)})",
+            // `??` binds looser than `&&`/`||`, so a coalesce side reassociates
+            // without parentheses (`(a ?? b) && c` would reparse as `a ?? (b && c)`).
+            // Route through Condition so a non-bool coalesce still gets its
+            // truthiness spelling (which already parenthesizes via Operand); a
+            // boolean coalesce comes back bare and needs the wrap here.
+            Coalesce => $"({Condition(side)})",
             _ => Condition(side),
         };
         string op = logical.Kind == LogicalKind.And ? "&&" : "||";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1741,12 +1741,6 @@ public sealed partial class CSharpPrinter
             LogicalBinary nested when nested.Kind == logical.Kind => LogicalText(nested),
             LogicalBinary nested => $"({LogicalText(nested)})",
             Conditional => $"({Expression(side)})",
-            // `??` binds looser than `&&`/`||`, so a coalesce side reassociates
-            // without parentheses (`(a ?? b) && c` would reparse as `a ?? (b && c)`).
-            // Route through Condition so a non-bool coalesce still gets its
-            // truthiness spelling (which already parenthesizes via Operand); a
-            // boolean coalesce comes back bare and needs the wrap here.
-            Coalesce => $"({Condition(side)})",
             _ => Condition(side),
         };
         string op = logical.Kind == LogicalKind.And ? "&&" : "||";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1337,7 +1337,7 @@ public sealed partial class CSharpPrinter
                 && SameLValue(load.Instance, s.Instance)
                 && PlaceIdentity.SameOperands(load.IndexArguments, s.IndexArguments)),
         EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {CastValue(e.Value, e.Accessor.ParameterTypes[0])};",
-        StoreElement s => $"{Expression(s.Array)}[{Expression(s.Index)}] = {CastValue(s.Value, s.ElementType)};",
+        StoreElement s => $"{Operand(s.Array)}[{Expression(s.Index)}] = {CastValue(s.Value, s.ElementType)};",
         StoreIndirect s => AssignmentText(
             IndirectTarget(s.Address, IndirectStoreType(s.Address, s.Type)),
             s.Value,
@@ -1741,6 +1741,9 @@ public sealed partial class CSharpPrinter
             LogicalBinary nested when nested.Kind == logical.Kind => LogicalText(nested),
             LogicalBinary nested => $"({LogicalText(nested)})",
             Conditional => $"({Expression(side)})",
+            // `??` binds looser than `&&`/`||`, so an un-parenthesized coalesce
+            // side reassociates (`(a ?? b) && c` would reparse as `a ?? (b && c)`).
+            Coalesce => $"({Expression(side)})",
             _ => Condition(side),
         };
         string op = logical.Kind == LogicalKind.And ? "&&" : "||";


### PR DESCRIPTION
Resolves #1479 (row in the #1453 over-raise burndown, Cluster C). Rebased on latest `main`.

## Over-raise claim narrowed

The printer emitted invalid/wrong C# at `Full` fidelity because two operand positions bypassed the precedence-wrapping `Operand`/`Condition` helpers:

- **`StoreElement` array operand** (`CSharpPrinter.cs`) used `Expression(s.Array)`. A compound (conditional) array receiver printed `flag ? a : b[i] = v;`, which reparses as `flag ? a : (b[i] = v)` — CS0201 and the wrong assignment target.
- **`ConditionalText` condition** (`CSharpPrinter.Numerics.cs`) used `Condition(...)` bare. A nested ternary condition printed `a ? b : c ? d : e`, which reparses right-associatively as `a ? b : (c ? d : e)`.

Same class as #1424/#1495 (compound range endpoints): a printer operand not routed through the precedence wrapper.

## Fix

Route the `StoreElement` array operand through `Operand`, and parenthesize a conditional condition that is itself a `Conditional`. Audited the sibling assignment LHS targets — `StoreField`/`StoreProperty`/`StoreIndirect` already route their receiver through `ReceiverText -> Operand`, so only `StoreElement` needed the wrap.

## Scope note (coalesce side of `&&`)

The issue also listed a coalesce side of `&&`/`||`. Adversarial review established this is a non-occurring shape: a coalesce is only a valid logical operand when boolean, and a non-bool coalesce in a condition position is a truthiness test that `Condition` already renders parenthesized (`(x ?? y) is not null`, via `Operand`). The only bare-rendering shape — a boolean coalesce — folds before reaching the printer and cannot be modelled faithfully in a test. Dropped from this PR rather than ship an untestable change to a non-occurring path.

## Evidence

**Reproduced before/after** (harness `--dump` on `(flag ? a : b)[i] = v;`):

- before: `flag ? a : b[i] = v;` (`// fidelity: Full`)
- after: `(flag ? a : b)[i] = v;`

**Fixtures + canaries:**

- Source fixture `CfgSampleClass.ConditionalArrayElementStore` asserts the parenthesized form **and** recompiles `Exact` (`FidelityCheck`) — the change is fidelity-neutral (parentheses do not alter opcodes).
- Hand-built IR test for the nested-conditional-condition case (a valid `(a ? b : c) ? d : e` shape; not reachable from source because structuring lowers the outer ternary to an `if`).
- `PrinterPrecedenceTests` (3/3) and `RangeFromGetSubArrayPassTests` (30/30) pass post-rebase (33/33, 0 failures); existing ternary/logical/switch positives unaffected (the wraps fire only on compound operands).

The full corpus fidelity sweep was not run locally due to runtime; the change is parentheses-only/fidelity-neutral with targeted compile-back, matching the #1495 sibling precedent.

## Adversarial review

Reviewed by GPT-5.5 (Opus 4.8 -> GPT-5.5 pairing). Summary posted as a comment below.
