### PR TITLE
Document curator tracker formats

### DIFF
--- a/docs/decompiler-burndown-curator.md
+++ b/docs/decompiler-burndown-curator.md
@@ -53,6 +53,18 @@ Choose the tracker shape before opening or extending a broad queue.
   own issues. Do not duplicate row discussion in tracker comments when each row
   already has a linked issue.
 
+Every tracker format must optimize for two failure modes:
+
+- **Claim races.** Avoid making the issue body the first write for claims. Claim
+  with an append-only comment on the row issue or tracker, then immediately
+  re-read recent comments and open PRs for that row. If another agent claimed or
+  opened a PR first, back off and explicitly release or pivot your claim. Curator
+  sweeps should reconcile duplicate claims before assigning more work.
+- **Low-context next work.** Do not require agents to read a huge tracker just to
+  find a row. Keep a short stats/open-rows block near the top, cluster rows by
+  bug family, and split new waves when the open list becomes hard to scan. The
+  tracker should answer "what can I take next?" before the full table.
+
 ## Default sweep
 
 For active decompiler burndown issues:

--- a/docs/decompiler-burndown-curator.md
+++ b/docs/decompiler-burndown-curator.md
@@ -33,6 +33,26 @@ The curator must escalate instead of deciding when the question is:
   substrate;
 - a new oracle/gate or change to verification strategy.
 
+## Tracker format
+
+Choose the tracker shape before opening or extending a broad queue.
+
+- Use the **#1453 format** for concrete bug burndowns: a compact stats block,
+  clustered row tables by bug family, one linked GitHub issue per row, short
+  claim/status comments, and periodic curator refresh comments. This worked
+  better than one comment per item because the linked issue is already the
+  durable per-row discussion thread.
+- Avoid letting the **#1356 format** grow indefinitely: one large unclustered
+  mutable table is easy to scan at first, but it goes stale quickly during merge
+  bursts and creates repeated curator reconciliation work. Split a new wave or
+  switch to clustered rows before the table becomes hard to audit.
+- Use the **#1396 format** for staged capability trackers, not bug burndowns:
+  keep a stable body scoreboard, use comments for claims/progress, and check a
+  stage only when it is routine enough for agents without curator judgment.
+- Use **comment-per-item** only when items are too small or ephemeral for their
+  own issues. Do not duplicate row discussion in tracker comments when each row
+  already has a linked issue.
+
 ## Default sweep
 
 For active decompiler burndown issues:


### PR DESCRIPTION
## Summary

Records the tracker-format finding from #1146/#1356/#1396/#1453 in the decompiler burndown curator guide.

Guidance added:

- use the #1453 clustered table + linked issue format for concrete bug burndowns;
- avoid growing #1356-style unclustered mutable tables indefinitely;
- reserve the #1396 scoreboard/comment-claim model for staged capability trackers;
- use comment-per-item only for ephemeral items that do not deserve their own issues.

## Evidence

- `npx markdownlint-cli --fix docs/decompiler-burndown-curator.md`
- `npx markdownlint-cli docs/decompiler-burndown-curator.md`

Docs-only; no product behavior change.
