### PR TITLE
Decline nested-tuple equality flattening to wrong arity (#1406)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1852,6 +1852,27 @@ public class CfgSampleClass
     // Arity-3 element-literal tuple equality, to exercise the general N-ary chain.
     public static bool TupleLiteralEquals3(int a, int b, int c, int d, int e, int f) => (a, b, c) == (d, e, f);
 
+    // Nested-tuple equality (#1406 adversarial): `(a, (b, c))` is NOT an arity-3 flat
+    // tuple. csc lowers it to `a==d && (b==e && c==f)` — a right-leaning chain whose
+    // top `&&` has a LogicalBinary right child (the nested boundary). Flattening it to
+    // `(a, b, c) == (d, e, f)` would be the wrong tuple shape at a false Full, so the
+    // pass must decline and leave the honest `&&` form.
+    public static bool TupleNestedEquals(int a, int b, int c, int d, int e, int f)
+        => (a, (b, c)) == (d, (e, f));
+
+    // Both-nested: `((a, b), (c, d))` lowers to `(a==e && b==f) && (c==g && d==h)`,
+    // whose top `&&` also has a LogicalBinary right child. Must likewise decline.
+    public static bool TupleNestedEquals2(int a, int b, int c, int d, int e, int f, int g, int h)
+        => ((a, b), (c, d)) == ((e, f), (g, h));
+
+    // Head-nested boundary case: `((a, b), c)` lowers to `(a==d && b==e) && c==f` —
+    // the SAME strictly left-leaning tree as the flat `(a, b, c)` form, and to
+    // byte-identical IL, so it is genuinely indistinguishable and stays flattened.
+    // This is faithful (recompiles exactly), not an over-raise — a positive canary
+    // for the left-leaning gate.
+    public static bool TupleHeadNestedEquals(int a, int b, int c, int d, int e, int f)
+        => ((a, b), c) == ((d, e), f);
+
     // Mixed: one literal operand, one tuple-variable operand. csc spills the
     // literal's elements AND the tuple variable, comparing the literal elements
     // against the variable's Item1/Item2 loads.

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -56,6 +56,14 @@ public class FidelityGateTests
         "CollectionListLiteral",
         "GotoCommonExit",
         "NeitherOr",
+        // TupleNestedEquals / TupleNestedEquals2 are the #1406 nested-tuple declines:
+        // `(a, (b, c)) == (d, (e, f))` is no longer over-raised to a wrong-arity flat
+        // tuple. It honestly degrades to the equivalent `&&` chain, which is correct
+        // C# but recompiles to a different branch structure than csc's tuple-`==`
+        // lowering (the over-raise it replaced was also not opcode-exact). An honest
+        // lower altitude, not opcode-exact — tracked here, not a regression.
+        "TupleNestedEquals",
+        "TupleNestedEquals2",
         // RuntimeInlineArrayForeach is the runtime-style inline-array enumerator
         // frontier from #1045: helper cleanup makes the body representable, but
         // recompiling `(V_1)[i]` reintroduces an extra span conversion call before

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -51,6 +51,12 @@ public class LoweredFidelityGateTests
         "GotoCommonExit",
         "NeitherOr",
         "ReverseCopy",
+        // TupleNestedEquals / TupleNestedEquals2: the #1406 nested-tuple declines.
+        // The lowered view shows the same `&&` chain, which recompiles to a
+        // different branch structure than csc's tuple-`==` lowering — an honest
+        // lower altitude, not opcode-exact (see the sugared FidelityGateTests docket).
+        "TupleNestedEquals",
+        "TupleNestedEquals2",
         // RuntimeInlineArrayForeach is the runtime-style inline-array enumerator
         // frontier from #1045: the lowered view is representable, but recompiles
         // through an extra span conversion before the element-ref helper.

--- a/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TupleBinaryOperatorPassTests.cs
@@ -112,6 +112,45 @@ public class TupleBinaryOperatorPassTests
     }
 
     [Fact]
+    public void NestedTupleEquality_DoesNotFlattenToFlatArity()
+    {
+        // `(a, (b, c)) == (d, (e, f))` lowers to `a==d && (b==e && c==f)`, a
+        // right-leaning chain. Flattening it to `(a, b, c) == (d, e, f)` would be the
+        // wrong tuple shape at false Full (#1406), so the pass declines.
+        var function = Raised(nameof(CfgSampleClass.TupleNestedEquals));
+
+        Assert.Empty(function.Descendants.OfType<TupleBinaryExpression>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.DoesNotContain("(a, b, c) ==", output);
+        Assert.Contains("&&", output);
+    }
+
+    [Fact]
+    public void NestedTupleEquality_BothNested_DoesNotFlatten()
+    {
+        // `((a, b), (c, d)) == ((e, f), (g, h))` lowers to
+        // `(a==e && b==f) && (c==g && d==h)`; the top `&&` right child is a
+        // LogicalBinary boundary, so it must not flatten to arity-4.
+        var function = Raised(nameof(CfgSampleClass.TupleNestedEquals2));
+
+        Assert.Empty(function.Descendants.OfType<TupleBinaryExpression>());
+        Assert.DoesNotContain("(a, b, c, d) ==", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void HeadNestedTupleEquality_StaysFlattened()
+    {
+        // `((a, b), c) == ((d, e), f)` lowers to the SAME strictly left-leaning tree
+        // as the flat `(a, b, c)` form and to byte-identical IL, so it is genuinely
+        // indistinguishable and stays flattened — faithful, not an over-raise. A
+        // positive canary that the left-leaning gate keeps real arity-N raises.
+        var function = Raised(nameof(CfgSampleClass.TupleHeadNestedEquals));
+
+        var tupleBinary = Assert.Single(function.Descendants.OfType<TupleBinaryExpression>());
+        Assert.Equal(3, ((TupleExpression)tupleBinary.Left).Elements.Count);
+    }
+
+    [Fact]
     public void TupleMixedLiteralLeft_RaisesLiteralAgainstVariable()
     {
         var function = Raised(nameof(CfgSampleClass.TupleMixedLiteralLeft));

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TupleBinaryOperatorPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TupleBinaryOperatorPass.cs
@@ -437,13 +437,24 @@ public sealed class TupleBinaryOperatorPass : IIrPass
         }
     }
 
-    // A `(a, b, c) == ...` lowering is a left-nested chain of the same logical
-    // kind whose leaves are element comparisons, in tuple element order.
+    // A `(a, b, c) == ...` lowering is a strictly LEFT-leaning chain of the same
+    // logical kind whose leaves are element comparisons, in tuple element order:
+    // each level's RIGHT operand is a single element comparison. A right operand
+    // that is itself a same-kind LogicalBinary is a NESTED-tuple boundary — e.g.
+    // `(a, (b, c)) == (d, (e, f))` lowers to `a==d && (b==e && c==f)`, and
+    // `((a, b), (c, d)) == …` to `(a==e && b==f) && (c==g && d==h)`. Those lower to
+    // different IL than the flat arity-N form (an extra short-circuit exit per
+    // nesting level), so flattening across the boundary would render the wrong tuple
+    // shape at a false `Full`. Decline instead, leaving the honest `&&`/`||` form.
+    // (A head-nested `((a, b), c) == ((d, e), f)` lowers to the same left-leaning
+    // tree as the flat form and is genuinely IL-indistinguishable, so it stays
+    // flattened — that is faithful, not an over-raise.)
     static bool TryFlatten(IrExpression node, LogicalKind kind, ComparisonKind comparisonKind, List<Comparison> comparisons)
     {
         if (node is LogicalBinary logical)
         {
             return logical.Kind == kind
+                && logical.Right is not LogicalBinary
                 && TryFlatten(logical.Left, kind, comparisonKind, comparisons)
                 && TryFlatten(logical.Right, kind, comparisonKind, comparisons);
         }


### PR DESCRIPTION
Closes #1406 (row 24 of the #1356 over-raise burndown).

## Over-raise claim being narrowed

`TupleBinaryOperatorPass` flattened a left-nested `&&`/`||` chain of element comparisons into one flat tuple `==`/`!=`, with no awareness of nested-tuple boundaries. `(a, (b, c)) == (d, (e, f))` lowers to `a==d && (b==e && c==f)` — the same leaf comparisons as the flat `(a, b, c) == (d, e, f)` — so the pass rendered it as the **flat (wrong-arity) tuple** while reporting `Full`, even though the two source forms compile to **different IL**.

## Fix

The nesting **is** recoverable at this stage (verified by dumping the IR after boolean-folding): a flat `(a, b, c) == …` lowers to a strictly **left-leaning** chain (every level's right operand is a single element comparison), whereas a nested element produces a same-kind `LogicalBinary` on the **right**:

- `(a, (b, c)) == (d, (e, f))` → `a==d && (b==e && c==f)`
- `((a, b), (c, d)) == …` → `(a==e && b==f) && (c==g && d==h)`

Gate `TryFlatten` on that: **decline when a right operand is itself a `LogicalBinary`**, leaving the honest `&&`/`||` form (an honest lower altitude). One narrow predicate; the pass is not widened.

A head-nested `((a, b), c) == ((d, e), f)` lowers to the *same* left-leaning tree as the flat form and to **byte-identical IL**, so it stays flattened — that is faithful (recompiles exactly), not an over-raise.

## Evidence

Verified through the cross-method import seam (`TupleBinaryOperatorPassTests`):

- `NestedTupleEquality_DoesNotFlattenToFlatArity` — `(a,(b,c))==…` declines (no `TupleBinaryExpression`, renders `a == d && b == e && c == f`).
- `NestedTupleEquality_BothNested_DoesNotFlatten` — `((a,b),(c,d))==…` declines.
- `HeadNestedTupleEquality_StaysFlattened` — `((a,b),c)==…` still raises (IL-indistinguishable positive canary).
- Existing `TupleLiteralEqualityArity3_RaisesAllElements` (flat positive) still raises.

`src/ILInspector.Decompiler.Tests`: full suite green except 3 **pre-existing environmental** flakes (`ConstantByteSpan_RaisesToArrayLiteral`, `FidelityGateTests.PinnedFixesStayOpcodeExact`/ConstantByteSpan, `CorpusSweepGateTests.CoreLibSweep_MeetsHealthFloors`) — each verified to fail identically on clean `origin/main` (compile-back / CoreLib-version environment issues, unrelated to this change).

The declined `&&` form is semantically correct but not opcode-exact with csc's tuple-`==` lowering (the over-raise it replaced was not exact either), so `TupleNestedEquals`/`TupleNestedEquals2` are recorded in the sugared and lowered fidelity-gate dockets as honest lower-altitude declines.

**Corpus quality card** (vs fresh `origin/main` baseline, 14 assemblies / 88,127 methods): **all deltas 0** (nested-tuple comparisons are rare; declining them does not move structure/validity/fidelity metrics).

```
| Metric | Baseline | PR | Delta |
| Fully raised | 77,464 (87.90%) | 77,464 (87.90%) | 0 |
| Full malformed | 47 | 47 | 0 |
| Fidelity diffs | opcode-diff 4/22, exact 18 | opcode-diff 4/22, exact 18 | 0 |
Verdict: corpus sensor matched baseline tolerances.
```

Product path unchanged: SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading. Cross-model adversarial review (GPT-5.5) to follow.
