### PR TITLE
Document burndown grooming and finding routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,11 @@ For decompiler-affecting PRs, follow this evidence and review contract:
   per-method delta artifact and changed-method fidelity result, or state
   explicitly that changed methods are not currently checkable.
 - Add targeted improved examples and still-flat near misses for behavior changes.
+- Synthetic IR fixtures are useful for unreachable near misses, but identity or
+  lowering-shape gates should also include a real importer/compiled-fixture
+  canary when one exists. If the full decompiler suite cannot complete, state
+  that limitation and run the closest real-importer tests, not only synthetic
+  pass tests.
 - Do not paste raw `--dump --steps` walls into PR bodies; link drill-down
   artifacts when needed.
 - Request adversarial review from another model family at the end, or earlier if

--- a/docs/decompiler-burndown-curator.md
+++ b/docs/decompiler-burndown-curator.md
@@ -234,6 +234,38 @@ issues changed:
 5. If the issue changed under an active fix, re-check whether the current branch
    is still needed or has been superseded.
 
+### Periodic issue grooming
+
+Every active burndown needs periodic grooming even when no PR check wakes the
+curator. The grooming pass is the outer-loop maintenance that keeps row status,
+claim state, and the top "next work" view honest.
+
+Each grooming pass should:
+
+1. refresh the stats/open-rows block near the top of the tracker;
+2. reconcile every live row against its linked issue and PR state;
+3. detect duplicate or stale claims and ask one owner to release, pivot, or open
+   a PR;
+4. add newly found rows only when they have a concrete issue and done signal;
+5. split or close the wave when the open list becomes hard to scan.
+
+Use a backoff cadence so hot queues stay current without wasting cycles during
+cold periods:
+
+- **Hot** — recent claims, comments, merges, CI failures, or multiple open PRs:
+  groom every `10-20m`, and reset the timer whenever new tracker activity
+  appears.
+- **Cooling** — two consecutive grooming passes find no row/status changes:
+  back off to `30-60m`.
+- **Cold** — no open PRs, no recent claims, and only stable open rows remain:
+  groom daily, before assigning new work, or before declaring the queue current.
+- **Terminal** — all rows are `Done`/`Pivoted` or superseded: close the tracker
+  or post the successor lane, then stop grooming that issue.
+
+The cadence is a minimum hygiene rule, not a scheduler that blocks urgent work.
+If a human asks for a fresh scan or a merge burst lands, groom immediately and
+then resume the appropriate backoff band.
+
 This prevents agents from over-focusing on stale PR state while the work queue
 moves elsewhere. The outer-loop query can be lightweight (`gh issue list
 --search 'burndown in:title,body'`, plus `gh issue view <n>` for monitored

--- a/docs/decompiler-burndown-curator.md
+++ b/docs/decompiler-burndown-curator.md
@@ -246,8 +246,11 @@ Each grooming pass should:
 2. reconcile every live row against its linked issue and PR state;
 3. detect duplicate or stale claims and ask one owner to release, pivot, or open
    a PR;
-4. add newly found rows only when they have a concrete issue and done signal;
-5. split or close the wave when the open list becomes hard to scan.
+4. route review/agent findings to a durable home: a linked issue, PR fix,
+   tracker row, or docs update. Do not leave concrete findings only in PR
+   comments, tracker comments, or memory;
+5. add newly found rows only when they have a concrete issue and done signal;
+6. split or close the wave when the open list becomes hard to scan.
 
 Use a backoff cadence so hot queues stay current without wasting cycles during
 cold periods:


### PR DESCRIPTION
## Summary

Updates curator/evidence guidance with three workflow requirements:

- periodic issue grooming for active burndowns, with hot/cooling/cold/terminal backoff;
- review/agent findings must be routed to a durable home (issue, PR fix, tracker row, or docs), not left only in comments or memory;
- synthetic IR fixtures are useful for unreachable near misses, but identity/lowering-shape gates need a real importer or compiled-fixture canary when one exists, and PRs should state when full-suite validation could not complete.

## Evidence

- `npx markdownlint-cli --fix docs/decompiler-burndown-curator.md AGENTS.md`
- `npx markdownlint-cli docs/decompiler-burndown-curator.md AGENTS.md`

Docs-only; no product behavior change.
