### PR TITLE
Require spellable property deconstruction targets

### DIFF
--- a/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
@@ -353,6 +353,21 @@ public class DeconstructionAssignmentPassTests
     }
 
     [Fact]
+    public void GenericPropertySetterTarget_IsNotRaised()
+    {
+        var function = BuildValueTupleFieldStoresWithPropertyTarget(sourceNamedTupleTemp: false, genericSetter: true);
+
+        new DeconstructionAssignmentPass().Run(function, PassContext.None);
+
+        Assert.DoesNotContain(function.Descendants.OfType<DeconstructionAssignment>(), _ => true);
+        var store = Assert.Single(function.Descendants.OfType<StoreProperty>());
+        Assert.Equal("Count", store.PropertyName);
+        Assert.Single(store.Accessor.TypeArguments);
+        Assert.Contains(function.Descendants.OfType<LoadField>(), field => field.Field.Name is "Item1" or "Item2");
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void ValueTupleFieldStoresWithSourceNamedTupleTemp_IsNotRaised()
     {
         var function = BuildValueTupleFieldStoresWithPropertyTarget(sourceNamedTupleTemp: true);
@@ -544,13 +559,16 @@ public class DeconstructionAssignmentPassTests
             body);
     }
 
-    static IrFunction BuildValueTupleFieldStoresWithPropertyTarget(bool sourceNamedTupleTemp, bool sideEffectingReceiver = false)
+    static IrFunction BuildValueTupleFieldStoresWithPropertyTarget(bool sourceNamedTupleTemp, bool sideEffectingReceiver = false, bool genericSetter = false)
     {
         var intType = TypeRef.CoreLib("System", "Int32");
         var voidType = TypeRef.CoreLib("System", "Void");
         var tupleType = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ValueTuple`2"), [intType, intType]);
         var nodeType = TypeRef.Definition("UserAssembly", "Samples", "Node");
-        var setCount = new MethodRef(nodeType, "set_Count", voidType, [intType], HasThis: true);
+        var setCount = new MethodRef(nodeType, "set_Count", voidType, [intType], HasThis: true)
+        {
+            TypeArguments = genericSetter ? [intType] : [],
+        };
         var getCount = new MethodRef(nodeType, "get_Count", intType, [], HasThis: true);
         var makeNode = new MethodRef(TypeRef.Definition("UserAssembly", "Samples", "Factory"), "MakeNode", nodeType, [], HasThis: false);
         IrExpression propertyReceiver = sideEffectingReceiver

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
@@ -284,7 +284,7 @@ public sealed class DeconstructionAssignmentPass : IIrPass
 
     static bool IsSimplePropertyTarget(StoreProperty property, TupleSeed seed)
     {
-        if (property.Accessor.ParameterTypes.Length == 0 || property.IndexArguments.Count != 0)
+        if (!IsSpellablePropertySetterTarget(property))
             return false;
 
         return property.Instance switch
@@ -295,6 +295,14 @@ public sealed class DeconstructionAssignmentPass : IIrPass
             _ => false,
         };
     }
+
+    static bool IsSpellablePropertySetterTarget(StoreProperty property)
+        => property.Accessor.Name.StartsWith("set_", StringComparison.Ordinal)
+            && property.Accessor.TypeArguments.IsEmpty
+            && property.Accessor.ReturnType is { Namespace: "System", Name: "Void" }
+            && property.Accessor.ParameterTypes.Length == 1
+            && property.IndexArguments.Count == 0
+            && property.Accessor.HasThis == property.HasInstance;
 
     static bool IsSupportedFieldTarget(IrFunction function, StoreField field)
         => !field.HasInstance


### PR DESCRIPTION
## Summary

Fixes #1420 by making `DeconstructionAssignmentPass` decline property deconstruction targets whose setter accessor has no C# assignment-target spelling.

The value-tuple deconstruction path now requires a property setter target to be a non-generic `set_` accessor with `void` return, exactly one value parameter, no index arguments, and static/instance shape consistent with the target node. Generic property setters now remain lowered instead of producing invalid `(owner.Value, x) = pair;` syntax.

## Evidence

Shape proof:

- Adversarial negative: generic setter target stays lowered; no `DeconstructionAssignment` is produced and the `StoreProperty`/`ItemN` reads remain.
- Positive canary: existing local/field/property deconstruction tests still raise.

Validation:

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.DeconstructionAssignmentPassTests` — 32/32 passed.
- `dotnet build src/dotnet-inspect -c Release -v:q` — passed.
- Full `src/ILInspector.Decompiler.Tests` is currently blocked by unrelated calli baseline failures on current main:
  - `LoweringCoverageTests.EveryPipelinePassType_IsClassified_ByOneRegister` (`CallIndirectSpellabilityPass` classification)
  - `IrImporterTests.UnmanagedCallersOnly_StdcallMethodAddress_PreservesFunctionPointerWitness`
  These two failures also reproduce on pristine current main for the same test filter.

Generated quality card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,261 methods
Correctness coverage: validity sampled 350 / 88,261 (0.40%); fidelity sampled 22 / 88,261 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,261 (+891)
- dotnet-inspect: 11,710 -> 12,238 methods (+528)
- ILInspector.Analysis: 500 -> 661 methods (+161)
- ILInspector.Decompiler: 5,004 -> 5,199 methods (+195)
- ILInspector.Metadata: 1,824 -> 1,831 methods (+7)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,596 (87.92%) | +702 |
| Conditional-branch residual | 2,290 (2.62%) | 2,311 (2.62%) | +21 |
| Forward-merge stops | 2,284 (2.61%) | 2,302 (2.61%) | +18 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,261 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,261 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (count regressions evaluated here): Full malformed 32 -> 46 (+14); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Verdict: corpus sensor reported regressions; review before merging.
```
