### PR TITLE
Wrap mixed-sign constant arithmetic in unchecked (#1467)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MixedSignArithmeticConstantTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignArithmeticConstantTests.cs
@@ -77,4 +77,18 @@ public class MixedSignArithmeticConstantTests
             Render(Arith(BinaryKind.Add,
                 new Constant(-1, s_int),
                 Arith(BinaryKind.Multiply, new Constant(2u, s_uint), new Constant(-3, s_int)))));
+
+    // An out-of-range constant reinterpreted by an explicit `(uint)` cast (not the
+    // mixed-sign reconciliation) is also covered: the whole constant binary wraps so
+    // the surrounding `+ 1` cannot overflow at compile time.
+    [Fact]
+    public void OutOfRangeConvertCastConstant_WholeBinaryIsUnchecked()
+    {
+        var output = Render(Arith(BinaryKind.Add,
+            new ILInspector.Decompiler.Pipeline.Convert(s_uint, isChecked: false, isUnsigned: false, new Constant(-1, s_int)),
+            new Constant(1, s_int)));
+
+        Assert.StartsWith("return unchecked(", output);
+        Assert.Contains("(uint)", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/MixedSignArithmeticConstantTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignArithmeticConstantTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// #1467: mixed-sign arithmetic over two integer constants where the signed side is
+// out of the unsigned range is a C# *constant expression*, evaluated in a checked
+// context — so the out-of-range cast and the arithmetic overflow are CS0220/CS0221
+// errors unless the whole expression is `unchecked(...)`. (The negative-constant
+// shape is reachable via IL but not natural C#, which folds `(uint)(-1)`, so these
+// are synthetic-IR fixtures.) The rendered forms below were verified to compile.
+public class MixedSignArithmeticConstantTests
+{
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_uint = TypeRef.CoreLib("System", "UInt32");
+
+    static string Render(IrExpression value)
+    {
+        var block = new Block(0);
+        block.Add(new Return(value));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(s_uint, [new Parameter("x", s_uint)], HasThis: false, GenericParameterCount: 0),
+            ImmutableArray<TypeRef>.Empty,
+            body);
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    static Binary Arith(BinaryKind kind, IrExpression left, IrExpression right)
+        => new(kind, isChecked: false, isUnsigned: false, left, right);
+
+    [Fact]
+    public void NegativeConstantPlusUnsigned_WrapsWholeBinaryInUnchecked()
+        => Assert.Equal(
+            "return unchecked((uint)-1 + 1);",
+            Render(Arith(BinaryKind.Add, new Constant(-1, s_int), new Constant(1u, s_uint))));
+
+    [Fact]
+    public void UnsignedMinusNegativeConstant_WrapsWholeBinaryInUnchecked()
+        => Assert.Equal(
+            "return unchecked(1 - (uint)-1);",
+            Render(Arith(BinaryKind.Subtract, new Constant(1u, s_uint), new Constant(-1, s_int))));
+
+    [Fact]
+    public void NegativeConstantTimesUnsigned_WrapsWholeBinaryInUnchecked()
+        => Assert.Equal(
+            "return unchecked((uint)-2 * 3);",
+            Render(Arith(BinaryKind.Multiply, new Constant(-2, s_int), new Constant(3u, s_uint))));
+
+    // A negative constant added to a non-constant unsigned operand is not a constant
+    // expression, so it cannot overflow at compile time: the per-operand
+    // `unchecked((uint)-1)` cast is enough and the whole binary is not wrapped.
+    [Fact]
+    public void NegativeConstantPlusVariable_KeepsPerOperandUncheckedOnly()
+        => Assert.Equal(
+            "return unchecked((uint)-1) + x;",
+            Render(Arith(BinaryKind.Add, new Constant(-1, s_int), new LoadArgument(0, "x", s_uint))));
+}

--- a/src/ILInspector.Decompiler.Tests/MixedSignArithmeticConstantTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignArithmeticConstantTests.cs
@@ -58,4 +58,23 @@ public class MixedSignArithmeticConstantTests
         => Assert.Equal(
             "return unchecked((uint)-1) + x;",
             Render(Arith(BinaryKind.Add, new Constant(-1, s_int), new LoadArgument(0, "x", s_uint))));
+
+    // Nested constant arithmetic: only the OUTERMOST constant binary wraps, so the
+    // whole constant expression is covered once (no nested `unchecked`), and the
+    // surrounding constant `+`/`*` cannot overflow at compile time.
+    [Fact]
+    public void NestedConstantArithmetic_WrapsOnlyOutermost_Left()
+        => Assert.Equal(
+            "return unchecked(((uint)-1 * 2) + 3);",
+            Render(Arith(BinaryKind.Add,
+                Arith(BinaryKind.Multiply, new Constant(-1, s_int), new Constant(2u, s_uint)),
+                new Constant(3u, s_uint))));
+
+    [Fact]
+    public void NestedConstantArithmetic_WrapsOnlyOutermost_Right()
+        => Assert.Equal(
+            "return unchecked((uint)-1 + (2 * (uint)-3));",
+            Render(Arith(BinaryKind.Add,
+                new Constant(-1, s_int),
+                Arith(BinaryKind.Multiply, new Constant(2u, s_uint), new Constant(-3, s_int)))));
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -128,18 +128,27 @@ public sealed partial class CSharpPrinter
             && IsIntegerConstantExpression(binary)
             && SubtreeReinterpretsOutOfRangeConstant(binary);
 
-    /// <summary>Whether a mixed-sign arithmetic anywhere in the constant subtree casts an out-of-range signed constant to unsigned — the cast that needs <c>unchecked</c>.</summary>
+    /// <summary>Whether a mixed-sign arithmetic reconciliation or an explicit cast anywhere in the constant subtree reinterprets an out-of-range signed constant as unsigned — the cast that needs <c>unchecked</c>.</summary>
     bool SubtreeReinterpretsOutOfRangeConstant(IrExpression expression)
     {
-        while (expression is Convert { IsChecked: false } convert)
-            expression = convert.Operand;
-        if (expression is not Binary binary)
-            return false;
-        if (MixedSignArithmetic(binary)
-            && (IsOutOfRangeUnsignedConstant(binary.Left) || IsOutOfRangeUnsignedConstant(binary.Right)))
-            return true;
-        return SubtreeReinterpretsOutOfRangeConstant(binary.Left)
-            || SubtreeReinterpretsOutOfRangeConstant(binary.Right);
+        switch (expression)
+        {
+            case Convert { IsChecked: false, Target: var target } convert:
+                // An explicit cast of an out-of-range constant to unsigned, e.g. `(uint)(-1)`.
+                if (TypeFamilies.IsUnsignedIntegerPrimitive(target)
+                    && TryGetIntegerConstant(convert.Operand, out long value)
+                    && !TypeFamilies.ConstantFits(value, target))
+                    return true;
+                return SubtreeReinterpretsOutOfRangeConstant(convert.Operand);
+            case Binary binary:
+                if (MixedSignArithmetic(binary)
+                    && (IsOutOfRangeUnsignedConstant(binary.Left) || IsOutOfRangeUnsignedConstant(binary.Right)))
+                    return true;
+                return SubtreeReinterpretsOutOfRangeConstant(binary.Left)
+                    || SubtreeReinterpretsOutOfRangeConstant(binary.Right);
+            default:
+                return false;
+        }
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -87,23 +87,22 @@ public sealed partial class CSharpPrinter
         // `count * (nuint)stride` — a no-op same-width cast, so the opcode and its
         // stack width are unchanged.
         bool mixedSign = MixedSignBitwise(binary) || MixedSignArithmetic(binary);
-        // A mixed-sign arithmetic over two integer constants where the signed side
-        // is out of the unsigned range is a *constant expression*: C# evaluates it
-        // in a checked context (even unchecked add/sub/mul of constants), so both
-        // the out-of-range cast and the arithmetic overflow are CS0220/CS0221
-        // errors unless the whole expression is `unchecked(...)`. Wrap the whole
-        // binary and drop the per-operand `unchecked` so the cast is covered once.
-        bool uncheckedConstant = !wrap
-            && MixedSignArithmetic(binary)
-            && IsIntegerConstantExpression(binary.Left)
-            && IsIntegerConstantExpression(binary.Right)
-            && (IsOutOfRangeUnsignedConstant(binary.Left) || IsOutOfRangeUnsignedConstant(binary.Right));
-        string left = mixedSign ? BitwiseUnsignedOperand(binary.Left, wrapConstantCast: !uncheckedConstant)
+        // A constant +/-/* whose subtree reinterprets an out-of-range signed
+        // constant as unsigned (e.g. `(uint)-1 + 1`) is a C# *constant expression*:
+        // the compiler evaluates it in a checked context (even unchecked add/sub/mul
+        // of constants), so the cast and any arithmetic overflow are CS0220/CS0221
+        // errors unless an enclosing `unchecked(...)` covers them. Wrap the
+        // *outermost* such constant binary once and drop the inner/per-operand
+        // `unchecked` so the whole expression is covered without nesting.
+        bool parentWraps = binary.Parent is Binary parent && IsUncheckedConstantArithmetic(parent);
+        bool uncheckedConstant = !wrap && !parentWraps && IsUncheckedConstantArithmetic(binary);
+        bool covered = uncheckedConstant || parentWraps;
+        string left = mixedSign ? BitwiseUnsignedOperand(binary.Left, wrapConstantCast: !covered)
             : castLeft ? UnsignedOperand(binary.Left)
             : Operand(binary.Left);
         bool isShift = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight;
         string right = isShift ? ShiftCount(binary)
-            : mixedSign ? BitwiseUnsignedOperand(binary.Right, wrapConstantCast: !uncheckedConstant)
+            : mixedSign ? BitwiseUnsignedOperand(binary.Right, wrapConstantCast: !covered)
             : castBoth ? UnsignedOperand(binary.Right)
             : Operand(binary.Right);
         string text = $"{left} {BinaryOperator(binary)} {right}";
@@ -114,6 +113,33 @@ public sealed partial class CSharpPrinter
         if (wrap)
             return $"checked({text})";
         return uncheckedConstant ? $"unchecked({text})" : text;
+    }
+
+    /// <summary>
+    /// An unchecked <c>+</c>/<c>-</c>/<c>*</c> that is a C# integer constant
+    /// expression whose subtree reinterprets an out-of-range signed constant as
+    /// unsigned. Such an expression is evaluated in a checked constant context and
+    /// must sit inside an <c>unchecked(...)</c> to compile. Used to wrap the
+    /// outermost such binary (and detect that a parent already wraps it).
+    /// </summary>
+    bool IsUncheckedConstantArithmetic(Binary binary)
+        => !binary.IsChecked
+            && binary.Kind is BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply
+            && IsIntegerConstantExpression(binary)
+            && SubtreeReinterpretsOutOfRangeConstant(binary);
+
+    /// <summary>Whether a mixed-sign arithmetic anywhere in the constant subtree casts an out-of-range signed constant to unsigned — the cast that needs <c>unchecked</c>.</summary>
+    bool SubtreeReinterpretsOutOfRangeConstant(IrExpression expression)
+    {
+        while (expression is Convert { IsChecked: false } convert)
+            expression = convert.Operand;
+        if (expression is not Binary binary)
+            return false;
+        if (MixedSignArithmetic(binary)
+            && (IsOutOfRangeUnsignedConstant(binary.Left) || IsOutOfRangeUnsignedConstant(binary.Right)))
+            return true;
+        return SubtreeReinterpretsOutOfRangeConstant(binary.Left)
+            || SubtreeReinterpretsOutOfRangeConstant(binary.Right);
     }
 
     /// <summary>
@@ -243,12 +269,15 @@ public sealed partial class CSharpPrinter
             && !TypeFamilies.ConstantFits(value, unsigned);
     }
 
-    /// <summary>Whether an operand reduces (through unchecked conv nodes) to an integer constant of any width/signedness — i.e. it contributes to a C# constant expression.</summary>
+    /// <summary>Whether an operand reduces (through unchecked conv nodes, and nested unchecked +/-/* of constants) to a C# integer constant expression.</summary>
     static bool IsIntegerConstantExpression(IrExpression expression)
     {
         while (expression is Convert { IsChecked: false } convert)
             expression = convert.Operand;
-        return expression is Constant { Value: sbyte or byte or short or ushort or int or uint or long or ulong };
+        return expression is Constant { Value: sbyte or byte or short or ushort or int or uint or long or ulong }
+            || (expression is Binary { IsChecked: false, Kind: BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply } binary
+                && IsIntegerConstantExpression(binary.Left)
+                && IsIntegerConstantExpression(binary.Right));
     }
 
     /// <summary>The integer value an expression reduces to, peeling unchecked conv nodes; false when it is not a constant.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -87,12 +87,23 @@ public sealed partial class CSharpPrinter
         // `count * (nuint)stride` — a no-op same-width cast, so the opcode and its
         // stack width are unchanged.
         bool mixedSign = MixedSignBitwise(binary) || MixedSignArithmetic(binary);
-        string left = mixedSign ? BitwiseUnsignedOperand(binary.Left)
+        // A mixed-sign arithmetic over two integer constants where the signed side
+        // is out of the unsigned range is a *constant expression*: C# evaluates it
+        // in a checked context (even unchecked add/sub/mul of constants), so both
+        // the out-of-range cast and the arithmetic overflow are CS0220/CS0221
+        // errors unless the whole expression is `unchecked(...)`. Wrap the whole
+        // binary and drop the per-operand `unchecked` so the cast is covered once.
+        bool uncheckedConstant = !wrap
+            && MixedSignArithmetic(binary)
+            && IsIntegerConstantExpression(binary.Left)
+            && IsIntegerConstantExpression(binary.Right)
+            && (IsOutOfRangeUnsignedConstant(binary.Left) || IsOutOfRangeUnsignedConstant(binary.Right));
+        string left = mixedSign ? BitwiseUnsignedOperand(binary.Left, wrapConstantCast: !uncheckedConstant)
             : castLeft ? UnsignedOperand(binary.Left)
             : Operand(binary.Left);
         bool isShift = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight;
         string right = isShift ? ShiftCount(binary)
-            : mixedSign ? BitwiseUnsignedOperand(binary.Right)
+            : mixedSign ? BitwiseUnsignedOperand(binary.Right, wrapConstantCast: !uncheckedConstant)
             : castBoth ? UnsignedOperand(binary.Right)
             : Operand(binary.Right);
         string text = $"{left} {BinaryOperator(binary)} {right}";
@@ -100,7 +111,9 @@ public sealed partial class CSharpPrinter
         // the default (unchecked) C# context would drop — spell it explicitly so
         // the recompiled IL keeps the .ovf opcode. Wrap only the outermost checked
         // node (wrap); a nested one is already covered by the enclosing context.
-        return wrap ? $"checked({text})" : text;
+        if (wrap)
+            return $"checked({text})";
+        return uncheckedConstant ? $"unchecked({text})" : text;
     }
 
     /// <summary>
@@ -206,15 +219,36 @@ public sealed partial class CSharpPrinter
     /// legal (CS0221); any other signed operand takes the same-width reinterpret
     /// cast, which emits no opcode.
     /// </summary>
-    string BitwiseUnsignedOperand(IrExpression operand)
+    string BitwiseUnsignedOperand(IrExpression operand, bool wrapConstantCast = true)
     {
         var unsigned = TypeFamilies.UnsignedCounterpart(EffectiveType(operand));
         if (unsigned is null)
             return Operand(operand);
         string cast = $"({TypeText(unsigned)}){Operand(operand)}";
-        return TryGetIntegerConstant(operand, out long value) && !TypeFamilies.ConstantFits(value, unsigned)
+        return wrapConstantCast && TryGetIntegerConstant(operand, out long value) && !TypeFamilies.ConstantFits(value, unsigned)
             ? $"unchecked({cast})"
             : cast;
+    }
+
+    /// <summary>
+    /// An integer constant whose value does not fit its unsigned counterpart (e.g.
+    /// a negative signed constant reinterpreted as <c>uint</c>) — the operand whose
+    /// cast is a compile-time overflow unless an enclosing <c>unchecked</c> covers it.
+    /// </summary>
+    bool IsOutOfRangeUnsignedConstant(IrExpression operand)
+    {
+        var unsigned = TypeFamilies.UnsignedCounterpart(EffectiveType(operand));
+        return unsigned is not null
+            && TryGetIntegerConstant(operand, out long value)
+            && !TypeFamilies.ConstantFits(value, unsigned);
+    }
+
+    /// <summary>Whether an operand reduces (through unchecked conv nodes) to an integer constant of any width/signedness — i.e. it contributes to a C# constant expression.</summary>
+    static bool IsIntegerConstantExpression(IrExpression expression)
+    {
+        while (expression is Convert { IsChecked: false } convert)
+            expression = convert.Operand;
+        return expression is Constant { Value: sbyte or byte or short or ushort or int or uint or long or ulong };
     }
 
     /// <summary>The integer value an expression reduces to, peeling unchecked conv nodes; false when it is not a constant.</summary>


### PR DESCRIPTION
Fixes #1467. Row 10 (Cluster C) of the #1453 wave-2 over-raise burndown.

## Bug

A mixed-sign `+`/`-`/`*` over two integer constants where the signed side is out of the unsigned range — e.g. the IR `Add { Constant(-1, Int32), Constant(1, UInt32) }` — is a C# **constant expression**, which the compiler evaluates in a **checked** context (even for unchecked `add`/`sub`/`mul`). The printer reconciled the signed operand with a per-operand `unchecked` cast only:

```csharp
return unchecked((uint)-1) + 1;   // CS0220: the constant `+` still overflows in checked-constant context
```

…so the surrounding constant arithmetic still failed to compile while the method reported `Full`. (Verified against the real compiler — even the issue's own suggested `unchecked((uint)(-1)) + 1u` fails the same way; the **whole** expression needs `unchecked`.)

## Fix

When a mixed-sign arithmetic binary is a constant expression (both operands integer constants) with an out-of-range unsigned-cast operand, wrap the **whole** binary in `unchecked(...)` and drop the now-redundant per-operand wrap:

```csharp
return unchecked((uint)-1 + 1);   // compiles; same unsigned reinterpretation
```

Non-constant cases (a negative constant plus a variable) are not compile-time constant expressions and cannot overflow at compile time, so they keep the per-operand `unchecked` only. Bitwise mixed-sign and variable arithmetic cases are unchanged.

## Evidence

New `MixedSignArithmeticConstantTests` (4/4) + existing `MixedSignBitwiseTests` (4/4) / `MixedSignComparisonTests` (4/4):

- Negative-constant `+`/`-`/`*` render `unchecked((uint)-1 + 1)` etc. — **verified to compile** with the real C# compiler.
- A negative constant plus a variable keeps `unchecked((uint)-1) + x` (per-operand only).

The negative-constant shape is reachable via IL but not natural C# (csc folds `(uint)(-1)`), so the fixtures are synthetic IR; the rendered forms were compile-checked.

Full `src/ILInspector.Decompiler.Tests` running; summary to follow. Printer identifier/numeric spelling fix — no over-raise semantics change.

## Adversarial review

Will request cross-model adversarial review (GPT-5.5) and post the summary per AGENTS.md.
