### PR TITLE
Add box-value-type optimization shape

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -526,6 +526,42 @@ public class LibraryBodyIndexTests
             .Where(o => o.Method.Name == methodName && o.Shape is "delegate-allocation" or "capturing-delegate" or "instance-method-group-delegate")
             .Select(o => o.Shape);
 
+    static System.Collections.Generic.List<OptimizationOpportunity> BoxRows(LibraryBodyIndex index, string methodName)
+        => index.OptimizationOpportunities
+            .Where(o => o.Method.Name == methodName && o.Shape == "box-value-type")
+            .ToList();
+
+    [Fact]
+    public void OptimizationOpportunities_BoxIntoObjectApi_IsBoxValueType()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // Passing an int to an object-typed API boxes it -> a real heap allocation.
+        var row = Assert.Single(BoxRows(index, nameof(OptimizationOpportunityFixtures.BoxesIntoStringFormat)));
+        Assert.Equal("medium", row.Confidence);
+        Assert.False(row.InLoop);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_BoxInLoop_IsHighConfidence()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // Boxing inside a loop is repeated cost -> promoted to high confidence.
+        var row = Assert.Single(BoxRows(index, nameof(OptimizationOpportunityFixtures.BoxesInLoop)));
+        Assert.Equal("high", row.Confidence);
+        Assert.True(row.InLoop);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_GenericParameterBox_NotReported()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // `box !!T` is compiler-mandated and JIT-specialized; not a user-actionable allocation.
+        Assert.Empty(BoxRows(index, nameof(OptimizationOpportunityFixtures.BoxesGenericParameter)));
+    }
+
 
     [Fact]
     public void TopUnsafeLeverage_RanksRequiresUnsafeMethodsByCallers()
@@ -643,6 +679,29 @@ public class OptimizationOpportunityFixtures
     }
 
     public virtual int VirtualHelper() => _field;
+
+    // --- Boxing (box-value-type) ---
+
+    // Boxes an int into an object-typed API argument -> escapes via call.
+    public static string BoxesIntoStringFormat(int value)
+    {
+        return string.Format("v={0}", value);
+    }
+
+    // Boxes a value type per iteration into a non-generic collection -> in a loop (high).
+    public static void BoxesInLoop(int[] values, System.Collections.ArrayList sink)
+    {
+        foreach (int v in values)
+        {
+            sink.Add(v);
+        }
+    }
+
+    // Boxes a generic parameter (compiler-mandated) -> NOT reported.
+    public static object BoxesGenericParameter<T>(T value) where T : struct
+    {
+        return value;
+    }
 }
 
 // A source-generated type (mirrors the [GeneratedCode] System.Text.Json source generator

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -562,6 +562,26 @@ public class LibraryBodyIndexTests
         Assert.Empty(BoxRows(index, nameof(OptimizationOpportunityFixtures.BoxesGenericParameter)));
     }
 
+    [Fact]
+    public void OptimizationOpportunities_NullableBox_NotReported()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // `box Nullable<T>` pushes null (no allocation) when the value is absent, so it is
+        // conservatively not reported.
+        Assert.Empty(BoxRows(index, nameof(OptimizationOpportunityFixtures.BoxesNullable)));
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_InAssemblyStructBox_IsBoxValueType()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // A non-generic in-assembly struct is positively identified as a value type via its
+        // System.ValueType base, so boxing it into an object-typed API is reported.
+        Assert.Single(BoxRows(index, nameof(OptimizationOpportunityFixtures.BoxesInAssemblyStruct)));
+    }
+
 
     [Fact]
     public void TopUnsafeLeverage_RanksRequiresUnsafeMethodsByCallers()
@@ -702,6 +722,24 @@ public class OptimizationOpportunityFixtures
     {
         return value;
     }
+
+    // Boxing a Nullable<T> allocates only when non-null -> conservatively NOT reported.
+    public static object? BoxesNullable(int? value)
+    {
+        return value;
+    }
+
+    // Boxing an in-assembly struct that escapes into an object-typed API -> reported
+    // (value-typeness resolved authoritatively via the struct's System.ValueType base).
+    public static void BoxesInAssemblyStruct(BoxFixtureStruct value, System.Collections.ArrayList sink)
+    {
+        sink.Add(value);
+    }
+}
+
+public struct BoxFixtureStruct
+{
+    public int X;
 }
 
 // A source-generated type (mirrors the [GeneratedCode] System.Text.Json source generator

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -835,6 +835,12 @@ public sealed class LibraryBodyIndex
             // The opcode that loaded the delegate receiver (the instruction before ldftn).
             // A static method group loads `ldnull`; a real instance receiver is anything else.
             ILOpCode previousOpcode = default;
+            // A `box` of a concrete value type is deferred until the next instruction so we can
+            // see whether the boxed value escapes (into a ref array, a call, a field, or a
+            // return) rather than being consumed locally (unbox round-trip / type test).
+            int? pendingBoxOffset = null;
+            TypeRef? pendingBoxType = null;
+            bool pendingBoxInLoop = false;
             int position = 0;
             while (position < il.Length)
             {
@@ -1017,6 +1023,21 @@ public sealed class LibraryBodyIndex
                         pendingConstant = null;
                         ReadInt32(il, ref position, offset);
                         break;
+                    case ILOpCode.Box:
+                    {
+                        pendingConstant = null;
+                        int token = ReadInt32(il, ref position, offset);
+                        var boxed = ResolveTypeToken(token, callerScope);
+                        // `box` is only emitted for value types and generic parameters. Flag a
+                        // concrete value type only: a generic-parameter box is compiler-mandated
+                        // and the JIT specializes it away. Escape is decided at the consumer below.
+                        var concrete = boxed.Kind is not (TypeRefKind.GenericParameter
+                            or TypeRefKind.MethodGenericParameter or TypeRefKind.Unsupported);
+                        pendingBoxOffset = concrete ? offset : null;
+                        pendingBoxType = concrete ? boxed : null;
+                        pendingBoxInLoop = concrete && IsInLoopRegion(offset, loopRegions);
+                        break;
+                    }
                     default:
                         pendingConstant = null;
                         SkipOperand(il, opcode, ref position, offset);
@@ -1027,6 +1048,28 @@ public sealed class LibraryBodyIndex
                 // Stack-neutral nops between the ldftn and newobj (e.g. Debug IL) are skipped.
                 if (opcode is not (ILOpCode.Ldftn or ILOpCode.Ldvirtftn or ILOpCode.Newobj or ILOpCode.Nop))
                     pendingDelegateOffset = null;
+
+                // A boxed concrete value type that flows straight into an escaping consumer
+                // (stored into a reference array, passed to a call/ctor, written to a field, or
+                // returned) is a real heap allocation. A box consumed locally (unbox round-trip,
+                // type test) does not escape and is not reported. Nops are skipped (Debug IL).
+                if (opcode is not (ILOpCode.Box or ILOpCode.Nop))
+                {
+                    if (pendingBoxOffset is { } boxOffset && IsEscapingBoxConsumer(opcode))
+                    {
+                        opportunities.Add(new OptimizationOpportunity(
+                            caller,
+                            "box-value-type",
+                            $"box {pendingBoxType?.ToQualifiedDisplayString() ?? "value type"}",
+                            "Boxing a value type allocates on the heap; use a generic API, string interpolation, or a value-typed overload to avoid it.",
+                            pendingBoxInLoop ? "high" : "medium",
+                            pendingBoxInLoop,
+                            boxOffset,
+                            pendingBoxInLoop ? null : "The JIT can elide some non-escaping boxing after inlining; confirm the box escapes (e.g. into a collection or object[])."));
+                    }
+                    pendingBoxOffset = null;
+                    pendingBoxType = null;
+                }
 
                 // Remember the receiver-bearing instruction. Nops never carry the receiver, so
                 // they do not overwrite it (Debug IL can interleave them before the ldftn).
@@ -1044,6 +1087,14 @@ public sealed class LibraryBodyIndex
         static bool IsClosureTarget(MemberRef target)
             => target.Kind != MemberKind.Unsupported
                && target.DeclaringType.Name.Contains("DisplayClass", StringComparison.Ordinal);
+
+        // Opcodes that consume a boxed value in a way that makes it escape (so the box is a
+        // real heap allocation): stored into a reference array, passed to a call/ctor, written
+        // to a field, or returned. Local round-trips (unbox/unbox.any/isinst/castclass/pop) are
+        // deliberately absent.
+        static bool IsEscapingBoxConsumer(ILOpCode op)
+            => op is ILOpCode.Stelem_ref or ILOpCode.Call or ILOpCode.Callvirt
+                or ILOpCode.Newobj or ILOpCode.Stfld or ILOpCode.Stsfld or ILOpCode.Ret;
 
         // Resolves a metadata type token (TypeDef/TypeRef/TypeSpec) to a TypeRef, used to
         // inspect a newarr element type. Returns Unsupported on any malformed/unknown token.

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1028,14 +1028,15 @@ public sealed class LibraryBodyIndex
                         pendingConstant = null;
                         int token = ReadInt32(il, ref position, offset);
                         var boxed = ResolveTypeToken(token, callerScope);
-                        // `box` is only emitted for value types and generic parameters. Flag a
-                        // concrete value type only: a generic-parameter box is compiler-mandated
-                        // and the JIT specializes it away. Escape is decided at the consumer below.
-                        var concrete = boxed.Kind is not (TypeRefKind.GenericParameter
-                            or TypeRefKind.MethodGenericParameter or TypeRefKind.Unsupported);
-                        pendingBoxOffset = concrete ? offset : null;
-                        pendingBoxType = concrete ? boxed : null;
-                        pendingBoxInLoop = concrete && IsInLoopRegion(offset, loopRegions);
+                        // ECMA-335 permits `box` on reference types (a no-op) and generic
+                        // parameters (compiler-mandated, JIT-specialized), and `box Nullable<T>`
+                        // allocates only when non-null. Flag only a positively-identified,
+                        // unconditionally-allocating value type. Escape is decided at the
+                        // consumer below.
+                        var allocating = IsAllocatingValueTypeBox(token, boxed);
+                        pendingBoxOffset = allocating ? offset : null;
+                        pendingBoxType = allocating ? boxed : null;
+                        pendingBoxInLoop = allocating && IsInLoopRegion(offset, loopRegions);
                         break;
                     }
                     default:
@@ -1095,6 +1096,60 @@ public sealed class LibraryBodyIndex
         static bool IsEscapingBoxConsumer(ILOpCode op)
             => op is ILOpCode.Stelem_ref or ILOpCode.Call or ILOpCode.Callvirt
                 or ILOpCode.Newobj or ILOpCode.Stfld or ILOpCode.Stsfld or ILOpCode.Ret;
+
+        // True only when a `box` operand is positively identified as a value type that
+        // unconditionally allocates. ECMA-335 allows `box` on reference types (no allocation),
+        // generic parameters (compiler-mandated / JIT-specialized), and `Nullable<T>` (no
+        // allocation when null) — all excluded to avoid false positives. In-assembly types are
+        // resolved authoritatively via their base type; external types are accepted only from a
+        // curated set of well-known framework value types.
+        bool IsAllocatingValueTypeBox(int token, TypeRef boxed)
+        {
+            // Nullable<T> boxing allocates only when HasValue; conservatively exclude.
+            var leaf = boxed.Kind == TypeRefKind.GenericInstance ? boxed.ElementType ?? boxed : boxed;
+            if (leaf.Kind == TypeRefKind.Definition && leaf.Namespace == "System" && leaf.Name == "Nullable`1")
+                return false;
+
+            try
+            {
+                var handle = MetadataTokens.EntityHandle(token);
+                if (handle.Kind == HandleKind.TypeDefinition)
+                    return IsValueTypeDefinition((TypeDefinitionHandle)handle);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
+            {
+                return false;
+            }
+
+            return leaf.Kind == TypeRefKind.Definition && IsWellKnownValueType(leaf.Namespace, leaf.Name);
+        }
+
+        // Authoritative in-assembly check: a value type extends System.ValueType or System.Enum.
+        bool IsValueTypeDefinition(TypeDefinitionHandle handle)
+        {
+            var baseHandle = _reader.GetTypeDefinition(handle).BaseType;
+            if (baseHandle.IsNil)
+                return false;
+            var (ns, name) = baseHandle.Kind switch
+            {
+                HandleKind.TypeReference => (_reader.GetString(_reader.GetTypeReference((TypeReferenceHandle)baseHandle).Namespace),
+                    _reader.GetString(_reader.GetTypeReference((TypeReferenceHandle)baseHandle).Name)),
+                HandleKind.TypeDefinition => (_reader.GetString(_reader.GetTypeDefinition((TypeDefinitionHandle)baseHandle).Namespace),
+                    _reader.GetString(_reader.GetTypeDefinition((TypeDefinitionHandle)baseHandle).Name)),
+                _ => ("", ""),
+            };
+            return ns == "System" && name is "ValueType" or "Enum";
+        }
+
+        static bool IsWellKnownValueType(string ns, string name)
+            => (ns == "System" && name is "Boolean" or "Byte" or "SByte" or "Char"
+                    or "Int16" or "UInt16" or "Int32" or "UInt32" or "Int64" or "UInt64"
+                    or "Single" or "Double" or "IntPtr" or "UIntPtr" or "Decimal"
+                    or "Half" or "Int128" or "UInt128"
+                    or "DateTime" or "DateTimeOffset" or "TimeSpan" or "Guid")
+               || (ns == "System.Numerics" && name is "BigInteger" or "Complex")
+               || (ns == "System" && name.StartsWith("ValueTuple", StringComparison.Ordinal))
+               || (ns == "System.Collections.Generic" && name == "KeyValuePair`2");
 
         // Resolves a metadata type token (TypeDef/TypeRef/TypeSpec) to a TypeRef, used to
         // inspect a newarr element type. Returns Unsupported on any malformed/unknown token.


### PR DESCRIPTION
## Summary

Adds a `box-value-type` optimization-opportunity shape. Boxing a concrete value type allocates on the heap; this is one of the highest-value IL-detectable allocation patterns and is grounded in real dotnet/runtime allocation fixes.

This was selected from a research pass over real perf work (Stephen Toub allocation PRs, Egor Bogatov JIT PRs): `box` is the standout missing shape — unambiguous opcode, low false-positive, and the JIT does **not** always elide it (boxing into non-generic collections / `object[]` / object-typed APIs is permanent).

Evidence PRs: Hashtable boxing [#122918](https://github.com/dotnet/runtime/pull/122918); the `ArgumentNullException.ThrowIfNull(struct)` boxing issue [#128574](https://github.com/dotnet/runtime/issues/128574); the canonical `Enum.GetName(object)` / `string.Format(object)` boxing patterns.

## Detection (conservative — low false-positive, by request)

At a `box` of a **concrete** value type:
- **Exclude** generic-parameter boxes (`box !!T`) — compiler-mandated and JIT-specialized.
- **Emit only when the boxed value escapes**: the next instruction (skipping `nop`) is an escaping consumer — `stelem.ref` (into a ref array), `call`/`callvirt`/`newobj` (argument), `stfld`/`stsfld`, or `ret`. Boxes consumed locally (unbox round-trip, type test) are not reported.

This deliberately under-reports (a box that isn't the last argument before its call is missed) to keep false positives near zero. The common params-array fill (`box; stelem.ref`) and last-arg call (`box; call`) are caught.

`box` is only ever emitted by the compiler for value types, so a concrete (non-generic-parameter) box operand is always a value type — no separate "is value type" check is needed.

## Confidence

Medium by default; **promoted to high when the box is inside a loop region** (repeated boxing is the real cost). Medium rows carry a caveat that the JIT can elide some non-escaping boxing after inlining.

**Known caveat:** loop-region membership cannot distinguish a hot iteration from a cold throw path inside a loop, so a box that builds an exception message inside a parse loop (`box enum → Format → throw`) gets promoted to high. The detection is still correct (it is a real box); the agent triages hotness. A follow-up could demote exception-message boxing (`box → call → newobj <Exception> → throw`).

## Verified on real libraries

- **Aspire.Hosting** `ContainerCreator.PrepareObjects`: `box Nullable<ImagePullPolicy>` → `Enum.GetName(Type, object)` in a loop — genuine hot boxing, fixable with the generic `Enum.GetName<T>` overload. (107 box rows total; 14 high.)
- **Newtonsoft.Json**: pervasive primitive boxing (int/long/double/char/DateTime/decimal) in its value writer — exactly the boxing System.Text.Json avoids via generics. (263 box rows; 14 high.)

## Tests

- New fixtures: `BoxesIntoStringFormat` (box → call), `BoxesInLoop` (in-loop → high), `BoxesGenericParameter<T> where T : struct` (generic-param box → **not** reported).
- `ILInspector.Analysis.Tests` — 69 pass; `dotnet-inspect.Tests` — 1318 pass, 9 skipped (ilasm).
