### PR TITLE
Cluster capture: namespace-segment closure inclusion (measured +99 on Newtonsoft)

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -132,8 +132,10 @@ persistent bail is a principled *not-safely-capturable* classification rather th
 a fidelity verdict, and the changed-method report prints the segmented
 **safely-capturable bands** (checkable whole-module, checkable cluster-rescued,
 not-safely-capturable) from each row's capture provenance. The current gain is
-modest and library-shaped; raising the non-pathological green rate
-(extension/inherited-member inclusion) is a tracked follow-up. The point is the
+modest and library-shaped, and improves lever by lever as the closure learns to
+resolve more of what the compiler names: namespace-segment inclusion (the
+dominant `CS0234` bail, ~81% on Newtonsoft.Json) landed first; constructor-stub
+signature fidelity (`CS7036`/`CS1729`) is the next measured lever. The point is the
 inverse of cheating: a good cluster system lets honest changed-method fidelity
 make real progress on non-pathological libraries instead of being held hostage by
 an unrelated gap somewhere else in the module.

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -860,11 +860,11 @@ static class FidelityCheck
         // worse than whole-module.
         if (clusterMode == ClusterMode.ForceAll)
         {
-            var (typeIndex, methodIndex) = ClusterIndexes(reader);
+            var (typeIndex, methodIndex, namespaceIndex) = ClusterIndexes(reader);
             var forced = new List<CompileBackResult>(entries.Count);
             foreach (var e in entries)
             {
-                var captured = CompileOneClustered(reader, references, parseOptions, compileOptions, fullType, e, typeIndex, methodIndex);
+                var captured = CompileOneClustered(reader, references, parseOptions, compileOptions, fullType, e, typeIndex, methodIndex, namespaceIndex);
                 forced.Add(captured is not null
                     ? captured with { Capture = CaptureMode.Cluster }
                     : CompileOne(reader, references, parseOptions, compileOptions, fullType, e) with { Capture = CaptureMode.ClusterBailed });
@@ -891,12 +891,12 @@ static class FidelityCheck
         // A row that fails both is ClusterBailed — the not-safely-capturable band.
         if (clusterMode == ClusterMode.Escalate)
         {
-            var (typeIndex, methodIndex) = ClusterIndexes(reader);
+            var (typeIndex, methodIndex, namespaceIndex) = ClusterIndexes(reader);
             for (int i = 0; i < results.Count && i < entries.Count; i++)
             {
                 if (results[i].Status is not (CompileBackStatus.RecompileFail or CompileBackStatus.ContextFail))
                     continue;
-                var captured = CompileOneClustered(reader, references, parseOptions, compileOptions, fullType, entries[i], typeIndex, methodIndex);
+                var captured = CompileOneClustered(reader, references, parseOptions, compileOptions, fullType, entries[i], typeIndex, methodIndex, namespaceIndex);
                 results[i] = captured is not null
                     ? captured with { Capture = CaptureMode.Cluster }
                     : results[i] with { Capture = CaptureMode.ClusterBailed };
@@ -982,20 +982,24 @@ static class FidelityCheck
 
     sealed record ClusterIndex(
         Dictionary<string, List<TypeDefinitionHandle>> Types,
-        Dictionary<string, List<TypeDefinitionHandle>> Methods);
+        Dictionary<string, List<TypeDefinitionHandle>> Methods,
+        Dictionary<string, List<TypeDefinitionHandle>> Namespaces);
 
     /// <summary>
-    /// Two name -> top-level-root maps for the compile-driven cluster: type leaf
-    /// names (to resolve a missing type) and method names (to resolve a missing
-    /// extension method to the static class that declares it). Cached per reader.
+    /// Three name -> top-level-root maps for the compile-driven cluster: type leaf
+    /// names (to resolve a missing type), method names (to resolve a missing
+    /// extension method to the static class that declares it), and namespace names
+    /// (to resolve a missing namespace segment — a `CS0234` whose body reference
+    /// lives in a sub-namespace the leaf-name index cannot name). Cached per reader.
     /// </summary>
-    static (Dictionary<string, List<TypeDefinitionHandle>> Types, Dictionary<string, List<TypeDefinitionHandle>> Methods) ClusterIndexes(MetadataReader reader)
+    static (Dictionary<string, List<TypeDefinitionHandle>> Types, Dictionary<string, List<TypeDefinitionHandle>> Methods, Dictionary<string, List<TypeDefinitionHandle>> Namespaces) ClusterIndexes(MetadataReader reader)
     {
         if (s_clusterIndexCache.TryGetValue(reader, out var cached))
-            return (cached.Types, cached.Methods);
+            return (cached.Types, cached.Methods, cached.Namespaces);
 
         var types = new Dictionary<string, List<TypeDefinitionHandle>>(StringComparer.Ordinal);
         var methods = new Dictionary<string, List<TypeDefinitionHandle>>(StringComparer.Ordinal);
+        var namespaces = new Dictionary<string, List<TypeDefinitionHandle>>(StringComparer.Ordinal);
         static void Add(Dictionary<string, List<TypeDefinitionHandle>> index, string key, TypeDefinitionHandle root)
         {
             if (key.Length == 0)
@@ -1011,6 +1015,10 @@ static class FidelityCheck
             var typeDef = reader.GetTypeDefinition(handle);
             var root = TopLevelRootOf(reader, handle);
             Add(types, NormalizeTypeName(reader.GetString(typeDef.Name)), root);
+            // A top-level type's namespace maps to its own root, so a missing
+            // namespace segment can pull in every root declared directly in it.
+            if (typeDef.GetDeclaringType().IsNil)
+                Add(namespaces, reader.GetString(typeDef.Namespace), handle);
             // Static-class methods are the extension-method candidates a CS1061
             // "no accessible extension method 'M'" must resolve to.
             if ((typeDef.Attributes & (TypeAttributes.Abstract | TypeAttributes.Sealed)) == (TypeAttributes.Abstract | TypeAttributes.Sealed))
@@ -1018,8 +1026,8 @@ static class FidelityCheck
                     Add(methods, reader.GetString(reader.GetMethodDefinition(mh).Name), root);
         }
 
-        s_clusterIndexCache.Add(reader, new ClusterIndex(types, methods));
-        return (types, methods);
+        s_clusterIndexCache.Add(reader, new ClusterIndex(types, methods, namespaces));
+        return (types, methods, namespaces);
     }
 
     /// <summary>
@@ -1037,7 +1045,8 @@ static class FidelityCheck
         CSharpParseOptions parseOptions, CSharpCompilationOptions compileOptions,
         string fullType, Entry e,
         IReadOnlyDictionary<string, List<TypeDefinitionHandle>> nameIndex,
-        IReadOnlyDictionary<string, List<TypeDefinitionHandle>> methodIndex)
+        IReadOnlyDictionary<string, List<TypeDefinitionHandle>> methodIndex,
+        IReadOnlyDictionary<string, List<TypeDefinitionHandle>> namespaceIndex)
     {
         const int maxRoots = 200;
         const int maxIterations = 80;
@@ -1074,10 +1083,22 @@ static class FidelityCheck
                 // a target-assembly type the closure must add.
                 if (diagnostic.Id is "CS0246" or "CS0234" or "CS0103")
                 {
-                    foreach (var name in QuotedNames(diagnostic.GetMessage()))
+                    var names = QuotedNames(diagnostic.GetMessage()).ToList();
+                    foreach (var name in names)
                         if (nameIndex.TryGetValue(NormalizeTypeName(name), out var roots))
                             foreach (var root in roots)
                                 grew |= include.Add(root);
+                    // CS0234 names a missing namespace SEGMENT ("'Serialization'
+                    // does not exist in the namespace 'Newtonsoft.Json'") rather
+                    // than a leaf type, so the leaf-name index cannot resolve it.
+                    // Reconstruct the full namespace from the two quoted spans
+                    // (parent + '.' + child) and pull in the roots declared
+                    // directly in it; the compile-driven loop walks any deeper
+                    // segment on the next iteration.
+                    if (diagnostic.Id is "CS0234" && names.Count == 2
+                        && namespaceIndex.TryGetValue($"{names[1]}.{names[0]}", out var nsRoots))
+                        foreach (var root in nsRoots)
+                            grew |= include.Add(root);
                 }
                 // CS1061: a missing member — most often an extension method whose
                 // static declaring class is not yet in the closure. Add the roots

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -308,7 +308,13 @@ emits the target's type, compiles, and adds every same-assembly type the
 compiler names as missing (`CS0246`/`CS0234`/`CS0103` for types, `CS1061` for
 static/extension members), recompiling until the unit binds or the closure stops
 growing. The compiler computes the exact closure, so unrelated sibling types are
-simply omitted.
+simply omitted. A `CS0234` names a missing namespace *segment*
+(`'Serialization' does not exist in the namespace 'Newtonsoft.Json'`) rather than
+a leaf type, so the closure reconstructs the full namespace from the diagnostic's
+two quoted spans and pulls in the roots declared directly in it — without this,
+any body that reaches into a sub-namespace stalls the closure (it was the dominant
+bail on real libraries: ~81% on Newtonsoft.Json, driving exact-match from 7.9% to
+10.3%).
 
 `CB_CLUSTER=1` runs the **escalation** order: the cheap whole-module grouped
 compile first, and only the rows it could not check (`RecompileFail`/`ContextFail`)
@@ -330,8 +336,10 @@ cluster-bailed), and the changed-method report prints the segmented
 and not-safely-capturable — so a go/no-go comment can separate the rows it may
 cite as compile-back evidence from the rows it must not count as passing. The
 gain is modest and library-shaped, not universal: on a Roslyn-heavy stress delta
-it rescues a handful of non-pathological rows. Raising the non-pathological green
-rate (extension/inherited-member inclusion) is a tracked follow-up.
+it rescues a handful of non-pathological rows. After namespace inclusion the
+dominant remaining bail on real libraries is constructor-signature mismatch in the
+reconstructed stubs (`CS7036`/`CS1729`); sharpening the skeleton's constructor
+emission is the next tracked follow-up.
 
 ```bash
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \


### PR DESCRIPTION
Follow-up to #1509 (#1412). After operationalizing the cluster engine, I measured
its bail population on real non-pathological libraries (the docs' measure-then-fix
discipline) and built the dominant lever it found.

## Measurement

Ran `CB_CLUSTER=1 CB_CLUSTER_DUMP=1 --fidelity-check` over whole libraries and
histogrammed the closure bails:

| bail code | Newtonsoft.Json | meaning |
| --- | --- | --- |
| **CS0234** | **2534 / 3136 (81%)** | body reaches a sub-namespace the closure never includes |
| CS7036 | 140 | constructor arg mismatch |
| CS1061 | 121 | extension/inherited member |
| others | — | — |

All bails were `grew=False` with **none hitting the 200-root budget cap** — so the
limiter was not closure size (the Roslyn pathology) but the closure being unable
to *name* what it needed. The `CS0234` message names a namespace **segment**
(`'Serialization' does not exist in the namespace 'Newtonsoft.Json'`), not a leaf
type, and the closure's index is keyed by type leaf name — so it could never act
on it.

## Fix

Namespace-keyed inclusion: index each top-level type's namespace to its root, and
on `CS0234` reconstruct the full namespace from the diagnostic's two quoted spans
(`parent + '.' + child`) and pull in the roots declared directly in it. The
compile-driven loop walks any deeper segment on the next iteration.

## Measured impact

| library | exact before | exact after | checkable Δ | CS0234 bails |
| --- | --- | --- | --- | --- |
| Newtonsoft.Json | 272 (7.92%) | **355 (10.33%)** | **+99** | 2534 → **0** |
| NuGet.Versioning | — | 66 (25.00%) | — | **0** |

Same pattern on both; the lever generalizes.

## What's next (separate follow-up)

After namespace inclusion the dominant remaining bail is **constructor-signature
mismatch** in the reconstructed stubs (`CS7036` 1498 + `CS1729` 817 on
Newtonsoft) — sharpening the skeleton's constructor emission is the next measured
lever. Closures now average ~134 roots and still don't hit the 200 cap, so budget
is not the limiter.

## Safety / validation

- **Bail-safe / never-regresses unchanged**: a closure that over-includes and
  exceeds budget falls back to the whole-module skeleton, so a row is never worse
  than its whole-module verdict.
- `ClusterCaptureTests` (ForceAll engine exercise + never-changes-a-verdict
  invariant) stays green (533s).
- Change is **harness-only** (3 files: `FidelityCheck.cs`, README, quality doc);
  no product decompiler code touched.

Refs #1412, #1509.