### PR TITLE
Escape keyword parameter names in API signatures

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -985,7 +985,8 @@ public static class ApiSurfaceExtractor
         object? defaultValue,
         bool acceptsNullDefault)
     {
-        var parameter = modifier is null ? $"{type} {name}" : $"{modifier} {type} {name}";
+        var escapedName = EscapeIdentifier(name);
+        var parameter = modifier is null ? $"{type} {escapedName}" : $"{modifier} {type} {escapedName}";
         if (!hasDefault)
             return parameter;
 
@@ -997,6 +998,22 @@ public static class ApiSurfaceExtractor
 
         return $"{parameter} = {FormatDefaultValue(reader, defaultValue, type, acceptsNullDefault)}";
     }
+
+    private static string EscapeIdentifier(string name)
+        => ReservedKeywords.Contains(name) ? "@" + name : name;
+
+    private static readonly HashSet<string> ReservedKeywords = new(StringComparer.Ordinal)
+    {
+        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
+        "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else",
+        "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
+        "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
+        "long", "namespace", "new", "null", "object", "operator", "out", "override", "params",
+        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
+        "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
+        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
+        "void", "volatile", "while",
+    };
 
     private static string FormatDecimalLiteral(decimal value)
         => value.ToString("G29", CultureInfo.InvariantCulture) + "m";

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -31,6 +31,27 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_EscapesKeywordParameterNamesInMethodSignatures()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var testType = surface.Types.FirstOrDefault(t => t.Name == nameof(SampleKeywordParameterHost));
+        Assert.NotNull(testType);
+
+        var instance = testType.Members.FirstOrDefault(m => m.Name == nameof(SampleKeywordParameterHost.Instance));
+        Assert.NotNull(instance);
+        Assert.Equal("int Instance(int @object, string @class)", instance.Signature);
+
+        var staticMethod = testType.Members.FirstOrDefault(m => m.Name == nameof(SampleKeywordParameterHost.Static));
+        Assert.NotNull(staticMethod);
+        Assert.Equal("int Static(int @params, int @void)", staticMethod.Signature);
+    }
+
+    [Fact]
     public void Extract_SurfacesTopLevelInternalTypesOnlyUnderIncludeAll()
     {
         var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
@@ -677,6 +698,13 @@ public class SampleClassForTesting
     public void MethodWithDateTimeConstantDefault(
         [System.Runtime.InteropServices.Optional, System.Runtime.CompilerServices.DateTimeConstant(637000000000000000L)] System.DateTime when) { }
     public void MethodWithStringDefault(string text = "a\"b\\c\n\u0001") { }
+}
+
+public class SampleKeywordParameterHost
+{
+    public int Instance(int @object, string @class) => @object + @class.Length;
+
+    public static int Static(int @params, int @void) => @params + @void;
 }
 
 public enum SampleColor

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2047,6 +2047,20 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_KeywordParameterNames_EscapesSignatureAndDecompiledSourceHeader()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(SampleKeywordParameterHost).FullName!, "--library", TestAssemblyPath,
+            nameof(SampleKeywordParameterHost.Instance), "-S", "Signature,Decompiled Source", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("public int Instance(int @object, string @class)", output);
+        Assert.DoesNotContain("public int Instance(int object, string class)", output);
+        Assert.Contains("@object + @class.Length", output);
+    }
+
+    [Fact]
     public async Task Member_SelectedOverload_SelectAnnotatedSource_RendersMixedView()
     {
         var options = new MemberOptions


### PR DESCRIPTION
Fixes #1485.

## Summary

- Escape reserved C# keyword parameter names when formatting API surface signatures.
- This fixes both the `Signature` section and the `Decompiled Source` declaration header, which reuses `member.Signature`.
- Add extractor and command-level regression coverage for `@object`, `@class`, `@params`, and `@void` parameter names.

## Evidence

- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`
  - Succeeded.
- Focused dotnet-inspect tests:
  - `dotnet run --project src/dotnet-inspect.Tests -c Release -- -filter '/dotnet-inspect.Tests/DotnetInspector.Tests/ApiSurfaceExtractorTests/*' -filter '/dotnet-inspect.Tests/DotnetInspector.Tests/CommandExecutionTests/Member_KeywordParameterNames_EscapesSignatureAndDecompiledSourceHeader'`
  - 35 passed, 0 failed.
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release`
  - 226 passed, 0 failed.
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
  - 1320 total, 0 failed, 9 skipped (`ilasm`/`ildasm` unavailable).

### Decompiler quality diff

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,262 methods
Correctness coverage: validity sampled 350 / 88,262 (0.40%); fidelity sampled 22 / 88,262 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,262 (+892)
- dotnet-inspect: 11,710 -> 12,238 methods (+528)
- ILInspector.Analysis: 500 -> 661 methods (+161)
- ILInspector.Decompiler: 5,004 -> 5,198 methods (+194)
- ILInspector.Metadata: 1,824 -> 1,833 methods (+9)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,597 (87.92%) | +703 |
| Conditional-branch residual | 2,290 (2.62%) | 2,311 (2.62%) | +21 |
| Forward-merge stops | 2,284 (2.61%) | 2,302 (2.61%) | +18 |
| Full malformed | 33 | 32 | -1 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,262 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,262 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (count regressions evaluated here): Full malformed 32 -> 32 (0); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Verdict: corpus sensor matched baseline tolerances.
```

## Adversarial review

Opus 4.8 found no blocking issues. It verified the keyword set is the canonical reserved-keyword set, `FormatParameter` composes escaped names through modifiers/defaults/DateTimeConstant, and the command test exercises the `Decompiled Source` header path through `member.Signature`.
