### PR TITLE
Cluster capture: synthetic parameterless ctor stubs (measured +1049 checkable on Newtonsoft)

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -134,8 +134,10 @@ a fidelity verdict, and the changed-method report prints the segmented
 not-safely-capturable) from each row's capture provenance. The current gain is
 modest and library-shaped, and improves lever by lever as the closure learns to
 resolve more of what the compiler names: namespace-segment inclusion (the
-dominant `CS0234` bail, ~81% on Newtonsoft.Json) landed first; constructor-stub
-signature fidelity (`CS7036`/`CS1729`) is the next measured lever. The point is the
+dominant `CS0234` bail, ~81% on Newtonsoft.Json) and a synthetic parameterless
+constructor stub for reconstructed classes whose base lacks one (the `CS1729`/`CS7036`
+implicit-`base()` bail) together took Newtonsoft.Json exact-match from 7.9% to
+35.4%; inherited/extension members (`CS1061`) are the next measured lever. The point is the
 inverse of cheating: a good cluster system lets honest changed-method fidelity
 make real progress on non-pathological libraries instead of being held hostage by
 an unrelated gap somewhere else in the module.

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1515,17 +1515,6 @@ static class FidelityCheck
         foreach (var fh in typeDef.GetFields())
             EmitField(reader, fh, typeContext, thisFieldInits, accessibility, sb, pad + "    ");
 
-        // A reconstructed class whose base type has no parameterless constructor
-        // makes every derived stub's compiler-synthesized `base()` call fail
-        // (CS1729/CS7036) — the dominant non-pathological cluster bail once
-        // namespace inclusion lands. Inject a throwing parameterless stub when the
-        // type has none of its own so the implicit chain binds (transitively, as
-        // every reconstructed class lacking one gets the same stub). Stub bodies
-        // are never opcode-compared, so the synthetic ctor cannot change a
-        // target's fidelity.
-        if (keyword == "class" && !IsStaticClass(typeDef) && !HasParameterlessInstanceCtor(reader, typeDef))
-            sb.AppendLine($"{pad}    public {Identifier(name)}() {{ throw null; }}");
-
         foreach (var mh in typeDef.GetMethods())
         {
             var hasTarget = targets.TryGetValue(mh, out var target);
@@ -1536,6 +1525,21 @@ static class FidelityCheck
                 accessibility,
                 sb, pad + "    ");
         }
+
+        // A reconstructed class whose base type has no parameterless constructor
+        // makes every derived stub's compiler-synthesized `base()` call fail
+        // (CS1729/CS7036) — the dominant non-pathological cluster bail once
+        // namespace inclusion lands. Inject a throwing parameterless stub when the
+        // type has none of its own so the implicit chain binds (transitively, as
+        // every reconstructed class lacking one gets the same stub). Emitted AFTER
+        // the real methods so it takes the last `.ctor` ordinal: the recompiled
+        // lookup matches constructors by name + overload ordinal (not signature),
+        // so a synthetic ctor emitted earlier would shift a real ctor target's
+        // ordinal and compare it against this throwing stub. Last-ordinal keeps the
+        // real ctors at 0..k-1 and the synthetic at k (never requested), so it
+        // cannot change a target's fidelity.
+        if (keyword == "class" && !IsStaticClass(typeDef) && !HasParameterlessInstanceCtor(reader, typeDef))
+            sb.AppendLine($"{pad}    public {Identifier(name)}() {{ throw null; }}");
 
         foreach (var nested in typeDef.GetNestedTypes())
         {

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1515,6 +1515,17 @@ static class FidelityCheck
         foreach (var fh in typeDef.GetFields())
             EmitField(reader, fh, typeContext, thisFieldInits, accessibility, sb, pad + "    ");
 
+        // A reconstructed class whose base type has no parameterless constructor
+        // makes every derived stub's compiler-synthesized `base()` call fail
+        // (CS1729/CS7036) — the dominant non-pathological cluster bail once
+        // namespace inclusion lands. Inject a throwing parameterless stub when the
+        // type has none of its own so the implicit chain binds (transitively, as
+        // every reconstructed class lacking one gets the same stub). Stub bodies
+        // are never opcode-compared, so the synthetic ctor cannot change a
+        // target's fidelity.
+        if (keyword == "class" && !IsStaticClass(typeDef) && !HasParameterlessInstanceCtor(reader, typeDef))
+            sb.AppendLine($"{pad}    public {Identifier(name)}() {{ throw null; }}");
+
         foreach (var mh in typeDef.GetMethods())
         {
             var hasTarget = targets.TryGetValue(mh, out var target);
@@ -1844,6 +1855,32 @@ static class FidelityCheck
 
     static bool RequiresUnsafeSignature(string typeText)
         => typeText.Contains('*', StringComparison.Ordinal);
+
+    /// <summary>A static class — <c>abstract sealed</c> — cannot carry an instance constructor.</summary>
+    static bool IsStaticClass(TypeDefinition typeDef)
+        => (typeDef.Attributes & (TypeAttributes.Abstract | TypeAttributes.Sealed)) == (TypeAttributes.Abstract | TypeAttributes.Sealed);
+
+    /// <summary>
+    /// Whether the type declares a parameterless instance constructor of its own,
+    /// so the reconstructed stub does not need a synthetic one injected. Decode
+    /// failures conservatively report <c>true</c> to avoid a duplicate-member emit.
+    /// </summary>
+    static bool HasParameterlessInstanceCtor(MetadataReader reader, TypeDefinition typeDef)
+    {
+        foreach (var mh in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(mh);
+            if (method.Attributes.HasFlag(MethodAttributes.Static) || reader.GetString(method.Name) != ".ctor")
+                continue;
+            try
+            {
+                if (method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method)).ParameterTypes.Length == 0)
+                    return true;
+            }
+            catch { return true; }
+        }
+        return false;
+    }
 
     /// <summary>
     /// The C# spellings <see cref="Clean"/> produces for primitive types — the

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -336,10 +336,13 @@ cluster-bailed), and the changed-method report prints the segmented
 and not-safely-capturable — so a go/no-go comment can separate the rows it may
 cite as compile-back evidence from the rows it must not count as passing. The
 gain is modest and library-shaped, not universal: on a Roslyn-heavy stress delta
-it rescues a handful of non-pathological rows. After namespace inclusion the
-dominant remaining bail on real libraries is constructor-signature mismatch in the
-reconstructed stubs (`CS7036`/`CS1729`); sharpening the skeleton's constructor
-emission is the next tracked follow-up.
+it rescues a handful of non-pathological rows. The closure improves lever by
+lever as it learns to satisfy what the compiler names — namespace-segment
+inclusion (the dominant `CS0234` bail) and a synthetic parameterless constructor
+stub for reconstructed classes whose base lacks one (so a derived stub's implicit
+`base()` binds instead of failing `CS1729`/`CS7036`) together took Newtonsoft.Json
+exact-match from 7.9% to 35.4%. The dominant remaining bail is then inherited and
+extension members (`CS1061`); resolving those is the next tracked follow-up.
 
 ```bash
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \


### PR DESCRIPTION
Follow-up to #1519 (#1412). Re-measured the cluster engine's bail population after
namespace inclusion and built the dominant lever it found.

## Measurement

After #1519, `CS1729` + `CS7036` were the dominant Newtonsoft.Json bail (2315),
all at large closures (~168 roots). Sample messages:

```
CS1729: 'JValue' does not contain a constructor that takes 0 arguments
CS7036: no argument given for required parameter 'underlyingType' of
        'JsonContainerContract.JsonContainerContract(Type)'
```

These are **implicit `base()` failures**: a reconstructed class derives from an
in-assembly base (`JValue`, `JsonContainerContract`) that has *no parameterless
constructor*, so every derived stub's compiler-synthesized `base()` call fails.

## Fix

Inject a throwing parameterless constructor stub (`public T() { throw null; }`)
into every reconstructed class that has none of its own (skipping static classes,
which cannot carry instance ctors). A derived stub's implicit `base()` then binds
— transitively, since every class lacking one gets the same stub and the chain
bottoms out at `object` or an omitted external base. A real parameterless ctor in
metadata is detected, so none is duplicated.

The synthetic ctor is emitted **after** the real method loop so it takes the last
`.ctor` overload ordinal — the recompiled lookup matches constructors by name +
ordinal (not signature), so emitting it earlier would shift a real ctor target's
ordinal and compare it against the throwing stub (caught by adversarial review;
see the review comment).

## Measured impact

| library | exact before | exact after | checkable Δ | CS1729+CS7036 |
| --- | --- | --- | --- | --- |
| Newtonsoft.Json | 355 (10.33%) | **1276 (37.15%)** | **+1049** | 2315 → 11 |
| NuGet.Versioning | 66 (25.00%) | **125 (47.35%)** | +59 | → 0 |

## What's next (separate follow-up)

The dominant remaining bail is now **inherited/extension members** (`CS1061`, 879
on Newtonsoft) — the next measured lever.

## Safety / validation

- **The synthetic ctor takes the last `.ctor` ordinal**, so a real ctor target's
  overload is never compared against it; a metadata parameterless ctor is detected
  so none is duplicated — the synthetic ctor cannot change a target's fidelity.
- The injection is on the **shared** `BuildUnit`, so it affects the whole-module
  path too; `FidelityGateTests` (incl. `NoNewOpcodeDiffsBeyondKnownDocket`),
  `LoweredFidelityGateTests`, and `ClusterCaptureTests` all stay green — the
  shared path gains **no new opcode diffs**.
- **Never-regresses unchanged**: a closure that still fails falls back to the
  whole-module skeleton.
- Change is **harness-only** (3 files: `FidelityCheck.cs`, README, quality doc);
  no product decompiler code touched.

## Review

GPT-5.5 adversarial review caught a HIGH-severity ctor-ordinal bug in the first
commit (now fixed in the second commit); the corrected numbers are above. See the
review comment for details.

Refs #1412, #1519.