### PR TITLE
Check raised member names for spellability

### DIFF
--- a/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
@@ -159,6 +159,29 @@ public class UnspeakableNameFidelityTests
     }
 
     [Fact]
+    public void RaisedEventSubscriptionUnspellableEvent_DegradesToPartial()
+    {
+        var add = new MethodRef(Target, "add_bad-name", Void, [Action], HasThis: false);
+        var subscription = new EventSubscription(
+            add,
+            isAdd: true,
+            instance: null,
+            new LoadArgument(0, "handler", Action));
+        var function = Function(Void, [new Parameter("handler", Action)], [], Container(subscription, new Return(null)));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void RaisedAnonymousObjectUnspellableProperty_DegradesToPartial()
+    {
+        var anonymous = new AnonymousObject(Target, ["bad-name"], [new Constant(1, Int32)]);
+        var function = Function(Target, [], [], Container(new Return(anonymous)));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
     public void RaisedObjectInitializerUsableMember_StaysFull()
     {
         var initializer = new ObjectInitializerExpression(
@@ -166,6 +189,20 @@ public class UnspeakableNameFidelityTests
             isCollection: false,
             [new InitializerEntry("GoodName", [new Constant(1, Int32)])]);
         var function = Function(Target, [], [], Container(new Return(initializer)));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void RaisedEventSubscriptionUsableEvent_StaysFull()
+    {
+        var add = new MethodRef(Target, "add_GoodName", Void, [Action], HasThis: false);
+        var subscription = new EventSubscription(
+            add,
+            isAdd: true,
+            instance: null,
+            new LoadArgument(0, "handler", Action));
+        var function = Function(Void, [new Parameter("handler", Action)], [], Container(subscription, new Return(null)));
 
         Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
     }

--- a/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
@@ -14,12 +14,20 @@ public class UnspeakableNameFidelityTests
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef Action = TypeRef.CoreLib("System", "Action");
+    static readonly TypeRef Target = TypeRef.Definition("Synthetic", "Samples", "Target");
 
     static IrFunction Function(ImmutableArray<TypeRef> locals, BlockContainer body)
     {
         var signature = new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0);
         return new IrFunction("M", Object, signature, locals, body);
+    }
+
+    static IrFunction Function(TypeRef returnType, ImmutableArray<Parameter> parameters, ImmutableArray<TypeRef> locals, BlockContainer body)
+    {
+        var signature = new MethodSignature(returnType, parameters, HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Target, signature, locals, body);
     }
 
     static BlockContainer Container(params IrNode[] statements)
@@ -85,4 +93,83 @@ public class UnspeakableNameFidelityTests
 
         Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
     }
+
+    [Fact]
+    public void RaisedObjectInitializerUnspellableMember_DegradesToPartial()
+    {
+        var initializer = new ObjectInitializerExpression(
+            NewTarget(),
+            isCollection: false,
+            [new InitializerEntry("bad-name", [new Constant(1, Int32)])]);
+        var function = Function(Target, [], [], Container(new Return(initializer)));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void RaisedNestedInitializerUnspellableMember_DegradesToPartial()
+    {
+        var nested = new InitializerBlock(
+            isCollection: false,
+            [new InitializerEntry("bad-name", [new Constant(1, Int32)])]);
+        var initializer = new ObjectInitializerExpression(
+            NewTarget(),
+            isCollection: false,
+            [new InitializerEntry("Inner", [nested])]);
+        var function = Function(Target, [], [], Container(new Return(initializer)));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void RaisedDeconstructionUnspellableFieldTarget_DegradesToPartial()
+    {
+        var tuple = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ValueTuple`1"), [Int32]);
+        var target = DeconstructionTarget.FieldTarget(new FieldRef(Target, "bad-name", Int32), isThisInstance: false);
+        var deconstruction = new DeconstructionAssignment([target], new LoadArgument(0, "tuple", tuple));
+        var function = Function(Void, [new Parameter("tuple", tuple)], [], Container(deconstruction, new Return(null)));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void RaisedDeconstructionUnspellablePropertyTarget_DegradesToPartial()
+    {
+        var tuple = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ValueTuple`1"), [Int32]);
+        var setter = new MethodRef(Target, "set_bad-name", Void, [Int32], HasThis: false);
+        var target = DeconstructionTarget.Property(setter, instance: null, indexArguments: [], isVirtual: false);
+        var deconstruction = new DeconstructionAssignment([target], new LoadArgument(0, "tuple", tuple));
+        var function = Function(Void, [new Parameter("tuple", tuple)], [], Container(deconstruction, new Return(null)));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void RaisedRecursivePropertyPatternUnspellableProperty_DegradesToPartial()
+    {
+        var getter = new MethodRef(Target, "get_bad-name", Int32, [], HasThis: true);
+        var pattern = new RecursivePropertyDeclarationPattern(
+            new LoadArgument(0, "value", Target),
+            getter,
+            Int32,
+            localIndex: 0);
+        var function = Function(Boolean, [new Parameter("value", Target)], [Int32], Container(new Return(pattern)));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void RaisedObjectInitializerUsableMember_StaysFull()
+    {
+        var initializer = new ObjectInitializerExpression(
+            NewTarget(),
+            isCollection: false,
+            [new InitializerEntry("GoodName", [new Constant(1, Int32)])]);
+        var function = Function(Target, [], [], Container(new Return(initializer)));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    static NewObject NewTarget()
+        => new(new MethodRef(Target, ".ctor", Void, [], HasThis: true), []);
 }

--- a/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
@@ -38,6 +38,10 @@ internal static class CSharpSpellability
             StoreProperty store => PropertyReason(store.PropertyName),
             NullCoalescingFieldAssignment assignment => FieldReason(assignment.Field),
             NullCoalescingPropertyAssignment assignment => PropertyReason(assignment.PropertyName),
+            ObjectInitializerExpression initializer => InitializerMembersReason(initializer.Members),
+            InitializerBlock block => InitializerMembersReason(block.Members),
+            DeconstructionTarget target => DeconstructionTargetReason(target),
+            RecursivePropertyDeclarationPattern pattern => PropertyReason(pattern.PropertyName),
             _ => null,
         };
     }
@@ -94,6 +98,26 @@ internal static class CSharpSpellability
         => CSharpNaming.IsUsableIdentifier(name)
             ? null
             : $"property name '{name}' has no C# spelling";
+
+    static string? InitializerMembersReason(IEnumerable<string?> members)
+    {
+        foreach (var member in members)
+        {
+            if (member is null)
+                continue;
+            if (!CSharpNaming.IsUsableIdentifier(member))
+                return $"initializer member name '{member}' has no C# spelling";
+        }
+        return null;
+    }
+
+    static string? DeconstructionTargetReason(DeconstructionTarget target)
+        => target.Kind switch
+        {
+            DeconstructionTargetKind.Field when target.Field is { } field => FieldReason(field),
+            DeconstructionTargetKind.Property => PropertyReason(target.PropertyName),
+            _ => null,
+        };
 
     static string? TypeReason(TypeRef type)
     {

--- a/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
@@ -38,10 +38,12 @@ internal static class CSharpSpellability
             StoreProperty store => PropertyReason(store.PropertyName),
             NullCoalescingFieldAssignment assignment => FieldReason(assignment.Field),
             NullCoalescingPropertyAssignment assignment => PropertyReason(assignment.PropertyName),
+            AnonymousObject anonymous => InitializerMembersReason(anonymous.PropertyNames),
             ObjectInitializerExpression initializer => InitializerMembersReason(initializer.Members),
             InitializerBlock block => InitializerMembersReason(block.Members),
             DeconstructionTarget target => DeconstructionTargetReason(target),
             RecursivePropertyDeclarationPattern pattern => PropertyReason(pattern.PropertyName),
+            EventSubscription subscription => PropertyReason(subscription.EventName),
             _ => null,
         };
     }


### PR DESCRIPTION
## Summary

- Extend the final C# spellability gate to inspect raised nodes that carry emitted member names as metadata.
- Covered raised object/nested initializers, deconstruction field/property targets, recursive property declaration patterns, event subscriptions, and anonymous object property names.
- Unspellable raised names now degrade honestly to `Partial` instead of reporting `Full` invalid C#; ordinary spellable raised names stay `Full`.

Closes #1464.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -v:q -m:1
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -class "ILInspector.Decompiler.Tests.UnspeakableNameFidelityTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -class "ILInspector.Decompiler.Tests.EventSubscriptionRenderingTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -class "ILInspector.Decompiler.Tests.AnonymousObjectPassTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -class "ILInspector.Decompiler.Tests.ObjectInitializerPassTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -class "ILInspector.Decompiler.Tests.DeconstructionAssignmentPassTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -class "ILInspector.Decompiler.Tests.IsPatternPassTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -class "ILInspector.Decompiler.Tests.IdiomShapeScorecardTests"
```

Full `src/ILInspector.Decompiler.Tests` is blocked by a current-main baseline failure unrelated to this branch:

```text
LoweringCoverageTests.EveryPipelinePassType_IsClassified_ByOneRegister
Pipeline pass types classified by neither a Roslyn-forward register nor NativePasses: CallIndirectSpellabilityPass
```

Generated current-main corpus baseline, then diffed this branch against it:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,263 methods
Correctness coverage: validity sampled 350 / 88,263 (0.40%); fidelity sampled 22 / 88,263 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-25). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 88,261 -> 88,263 (+2)
- ILInspector.Decompiler: 5,199 -> 5,201 (+2)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,596 (87.92%) | 77,598 (87.92%) | +2 |
| Conditional-branch residual | 2,311 (2.62%) | 2,311 (2.62%) | 0 |
| Forward-merge stops | 2,302 (2.61%) | 2,302 (2.61%) | 0 |
| Full malformed | 47 | 47 | 0 |
| Semantic defects | 4/350 — sampled 350 / 88,261 (0.40%) | 4/350 — sampled 350 / 88,263 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,261 (0.02%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,263 (0.02%) | 0 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (count regressions evaluated here): Full malformed 46 -> 46 (0); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Verdict: corpus sensor matched baseline tolerances.
```

Changed-method fidelity over the delta:

```text
CHANGED-METHOD COMPILE-BACK over 29 current changed methods (29 attempted)

  exact opcode match : 1
  opcode diff (Full) : 0
  not Full           : 0
  recompile fail     : 1
  context fail       : 27
```

The non-checkable rows are harness context/skeleton failures; there are no `Full` opcode diffs.

## Adversarial review

Requested Opus 4.8 review. It found one in-scope gap (`EventSubscription`) and one adjacent low-risk gap (`AnonymousObject`); both are included in the final fix. Follow-up review found no remaining significant issues.
