### PR TITLE
Import private members in validity shell to kill phantom CS0308 (#1396)

### DIFF
--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -25,7 +25,12 @@ internal static class LibraryReport
             allowUnsafe: true,
             nullableContextOptions: NullableContextOptions.Disable)
             .WithSpecificDiagnosticOptions(new Dictionary<string, ReportDiagnostic>())
-            .WithMetadataImportOptions(MetadataImportOptions.Internal);
+            // Import private members too — see ValidityCheck for the rationale: a
+            // faithful call to a non-public overload (private generic helpers, internal
+            // ctors) otherwise mis-binds to a public sibling and reports a phantom
+            // binding error (e.g. CS0308 on `Enum.ToString<sbyte, byte>`). Keep this in
+            // sync with ValidityCheck so the aggregate report matches --validity-check.
+            .WithMetadataImportOptions(MetadataImportOptions.All);
 
         foreach (var assembly in assemblies)
         {

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -140,16 +140,22 @@ static class ValidityCheck
             OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true,
             nullableContextOptions: NullableContextOptions.Disable)
             .WithSpecificDiagnosticOptions(new Dictionary<string, ReportDiagnostic>())
-            // Import internal members of the referenced runtime assemblies. When a
-            // decompiled body legitimately calls an INTERNAL overload of the target
-            // assembly (e.g. the internal `Span<T>(ref T, int)` ctor), the external
-            // shell cannot access it; without the internal members imported, Roslyn
-            // never sees the intended overload and mis-binds to a public sibling,
-            // reporting a misleading CS1615/CS1620 (wrong ref/out keyword). Imported,
-            // it recognizes the intended-but-inaccessible member and reports CS0122
-            // instead — already filtered as visibility noise. The recovered keyword
-            // is correct; the diagnostic was an artifact of the external shell.
-            .WithMetadataImportOptions(MetadataImportOptions.Internal);
+            // Import ALL members of the referenced runtime assemblies, including
+            // private ones. When a decompiled body legitimately calls a non-public
+            // overload of the target assembly (e.g. the internal `Span<T>(ref T, int)`
+            // ctor, or the PRIVATE generic helper `Enum.ToString<TUnderlying, TStorage>`
+            // that the public `Enum.ToString()` dispatches to), the external shell
+            // cannot access it; without the member imported, Roslyn never sees the
+            // intended overload and mis-binds to a public sibling, reporting a
+            // misleading diagnostic that is purely a shell artifact — CS1615/CS1620
+            // (wrong ref/out keyword) for an internal ctor, or CS0308 ("the non-generic
+            // method 'Enum.ToString()' cannot be used with type arguments") for a
+            // private generic overload, where the faithful `Enum.ToString<sbyte, byte>`
+            // call binds to the public non-generic sibling. Importing All lets Roslyn
+            // recognize the intended-but-inaccessible member (reporting CS0122, already
+            // filtered as visibility noise) instead of these phantom binding errors;
+            // the recovered call is correct and round-trips to the same member.
+            .WithMetadataImportOptions(MetadataImportOptions.All);
 
         int semChecked = 0;
         var results = new List<MethodResult>();


### PR DESCRIPTION
## Stage 2 (method validity boss) — kill phantom CS0308 from the validity shell

### Root cause
`--validity-check` / `--library-report` compile each decompiled body in an external reference shell that imported only **Internal** members of the target runtime assembly. A faithful decompiled call to a **private** generic helper overload mis-binds to its public non-generic sibling:

```csharp
// System.Enum::ToString (raised — correct output)
0 => Enum.ToString<sbyte, byte>(V_0, ref V_1),
...
```

`Enum` really does have `private static string ToString<TUnderlyingValue, TStorage>(RuntimeType, ref byte)` (verified by reflection), which the public `Enum.ToString()` dispatches to. But the shell only sees the public non-generic `ToString()` overloads, so Roslyn reports a phantom:

> CS0308: The non-generic method 'Enum.ToString()' cannot be used with type arguments

The render is **correct and round-trips**; the diagnostic is purely a shell artifact. The same artifact produced one CS0079 on a private event-backing field.

### Fix
Import `MetadataImportOptions.All` (private members too) in the validity + library compile shells. This is the generic-arity / private-member analog of the internal-ctor case the comment already documented (CS1615/CS1620 → CS0122 visibility noise). Roslyn now sees the intended-but-private overload and binds the faithful call instead of emitting a phantom binding error. `LibraryReport` kept in sync so the aggregate matches `--validity-check`.

### Evidence (.NET 11 preview.5 CoreLib, `--compile-cap 4000`)
Non-noise semantic-binding methods: **89 → 85**. Code-bucket diff (only changes):

```
-     CS0308: 25
-     CS0079: 1
```

Per-method defect-set diff — exactly **3 cleared, 0 regressed**, no method gained a defect:

```
System.Enum::ToString             CS0308 -> (none)
System.Enum::Format               CS0308 -> (none)
System.AppDomain::OnProcessExit   CS0079 -> (none)
```

Every other bucket (CS0266, CS0159, CS1615, CS0034, …) is byte-for-byte unchanged — importing private members introduced **no** new mis-binds. This sharpens the Stage 2 signal (phantom-free) without suppressing any diagnostic code, so a genuine fabricated-type-arg defect would still surface.

### Scope notes
- Harness/measurement only — no product decompiler change.
- `CS0266` (53, the largest remaining real bucket) is **out of scope**; the pointer-assignment-cast slice is already claimed as #1458.

Refs #1396 (Stage 2).
