### PR TITLE
Report unspellable member names in raised containers to fidelity (#1464)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
@@ -159,4 +159,26 @@ public class UnspeakableNameFidelityTests
 
         Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
     }
+
+    [Fact]
+    public void EventSubscriptionUnspellableName_DegradesToPartial()
+    {
+        // C.bad-name += null; — the raised EventSubscription carries the event name
+        // after the add_ Call that would have flagged it was detached.
+        var accessor = new MethodRef(SampleType, "add_bad-name", Void, [Action], HasThis: false);
+        var subscription = new EventSubscription(accessor, isAdd: true, instance: null, value: new Constant(null, Action));
+        var function = Function([], Container(subscription, new Return(null)));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void EventSubscriptionNormalName_StaysFull()
+    {
+        var accessor = new MethodRef(SampleType, "add_Changed", Void, [Action], HasThis: false);
+        var subscription = new EventSubscription(accessor, isAdd: true, instance: null, value: new Constant(null, Action));
+        var function = Function([], Container(subscription, new Return(null)));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
@@ -85,4 +85,78 @@ public class UnspeakableNameFidelityTests
 
         Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
     }
+
+    static readonly TypeRef SampleType = TypeRef.Definition("Synthetic", "Samples", "C");
+
+    static ObjectInitializerExpression Initializer(string? member)
+    {
+        var ctor = new MethodRef(SampleType, ".ctor", Void, [], HasThis: true);
+        return new ObjectInitializerExpression(
+            new NewObject(ctor, []),
+            isCollection: false,
+            [new InitializerEntry(member, [new Constant(1, Int32)])]);
+    }
+
+    [Fact]
+    public void ObjectInitializerUnspellableMember_DegradesToPartial()
+    {
+        // new C { bad-name = 1 } — the raised container holds the member name string
+        // after the StoreProperty that would have flagged it was detached.
+        var function = Function([], Container(new Return(Initializer("bad-name"))));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void ObjectInitializerNormalMember_StaysFull()
+    {
+        var function = Function([], Container(new Return(Initializer("Value"))));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void DeconstructionPropertyTargetUnspellable_DegradesToPartial()
+    {
+        var setter = new MethodRef(SampleType, "set_bad-name", Void, [Int32], HasThis: true);
+        var target = DeconstructionTarget.Property(setter, new LoadArgument(0, "this", SampleType), [], isVirtual: false);
+        var function = Function([], Container(
+            new DeconstructionAssignment([target], new Constant(null, Object)),
+            new Return(null)));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void DeconstructionFieldTargetUnspellable_DegradesToPartial()
+    {
+        var field = new FieldRef(SampleType, "bad-name", Int32);
+        var target = DeconstructionTarget.FieldTarget(field, isThisInstance: true);
+        var function = Function([], Container(
+            new DeconstructionAssignment([target], new Constant(null, Object)),
+            new Return(null)));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void RecursivePropertyPatternUnspellableSubpattern_DegradesToPartial()
+    {
+        // value is { bad-name: int t }
+        var getter = new MethodRef(SampleType, "get_bad-name", Int32, [], HasThis: true);
+        var pattern = new RecursivePropertyDeclarationPattern(new LoadArgument(0, "value", Object), getter, Int32, 1);
+        var function = Function([Object, Int32], Container(new ExpressionStatement(pattern), new Return(null)));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void RecursivePropertyPatternNormalSubpattern_StaysFull()
+    {
+        var getter = new MethodRef(SampleType, "get_Length", Int32, [], HasThis: true);
+        var pattern = new RecursivePropertyDeclarationPattern(new LoadArgument(0, "value", Object), getter, Int32, 1);
+        var function = Function([Object, Int32], Container(new ExpressionStatement(pattern), new Return(null)));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
@@ -38,8 +38,28 @@ internal static class CSharpSpellability
             StoreProperty store => PropertyReason(store.PropertyName),
             NullCoalescingFieldAssignment assignment => FieldReason(assignment.Field),
             NullCoalescingPropertyAssignment assignment => PropertyReason(assignment.PropertyName),
+            // Raised containers copy member names out of the lower-level store/load
+            // nodes and detach those originals, so the bare member text they print
+            // (Member = value / Property: T t / deconstruction target) is the only
+            // place an unspellable metadata name now survives. Mirror what the
+            // printer emits: initializer/property-pattern/deconstruction-property
+            // names print raw; a deconstruction field target prints through
+            // FieldTarget (backing-field demangle then raw). (#1464)
+            ObjectInitializerExpression initializer => MemberNamesReason(initializer.Members),
+            InitializerBlock block => MemberNamesReason(block.Members),
+            DeconstructionTarget { Kind: DeconstructionTargetKind.Property } target => PropertyReason(target.PropertyName),
+            DeconstructionTarget { Kind: DeconstructionTargetKind.Field, Field: { } field } => FieldReason(field),
+            RecursivePropertyDeclarationPattern pattern => PropertyReason(pattern.PropertyName),
             _ => null,
         };
+    }
+
+    static string? MemberNamesReason(IEnumerable<string?> members)
+    {
+        foreach (var member in members)
+            if (member is { } name && PropertyReason(name) is { } reason)
+                return reason;
+        return null;
     }
 
     static IEnumerable<TypeRef> RenderedTypes(IrNode node)

--- a/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
@@ -50,6 +50,7 @@ internal static class CSharpSpellability
             DeconstructionTarget { Kind: DeconstructionTargetKind.Property } target => PropertyReason(target.PropertyName),
             DeconstructionTarget { Kind: DeconstructionTargetKind.Field, Field: { } field } => FieldReason(field),
             RecursivePropertyDeclarationPattern pattern => PropertyReason(pattern.PropertyName),
+            EventSubscription subscription => PropertyReason(subscription.EventName),
             _ => null,
         };
     }


### PR DESCRIPTION
Fixes #1464. Cluster C, row 7 of the #1453 wave-2 over-raise burndown.

## Over-raise claim being narrowed

`ObjectInitializerPass`, `DeconstructionAssignmentPass`, and recursive property-pattern raising copy member names out of the lower-level `LoadProperty`/`StoreProperty`/`StoreField` nodes and then **detach those originals**. `CSharpSpellability` only inspected the lower-level nodes, so a raised container could print a raw member name with no C# spelling while the method still reported `Full`:

```csharp
new C { bad-name = 1 };
(bad-name, other) = tuple;
value is { bad-name: int t };
```

## Fix shape

Extend `CSharpSpellability.UnrepresentableMetadataNameReason` to inspect the raised containers the printer emits bare, mirroring exactly what each printer path emits:

- `ObjectInitializerExpression` / `InitializerBlock` — each non-null member name (raw, per `CSharpPrinter.RaisedExpressions`);
- `DeconstructionTarget` property (raw, via `PropertyTarget`) and field (`FieldReason` = backing-field demangle then raw, matching `FieldTarget`);
- `RecursivePropertyDeclarationPattern` subpattern name (raw).

Unspellable names now cap fidelity at `Partial` (honest degradation) instead of producing `Full` invalid C#. This is the fidelity-path option from the issue (the backstop the #1416 reviewer also suggested), not a pass widening — no raise behavior changes.

This is distinct from #1416 (generic property setters unspellable as initializer members, fixed by declining the fold in the pass). #1464 is the general fidelity backstop for any unspellable field/property/subpattern name across the raised containers.

## Why iterators/async are unaffected

Compiler-generated state-machine construction (`new <M>d__0 { <>3__param = p }`) is folded by `ObjectInitializerPass` but consumed/erased by the iterator/async reconstruction passes before `Fidelity` is computed on the final tree, so the unspellable `<>3__*` names never reach this check. Verified: `IteratorReconstructionPassTests` 35/35, `IteratorAcknowledgmentPassTests` 9/9, `ObjectInitializerPassTests` 28/28, `DeconstructionAssignmentPassTests` 31/31.

## Evidence

`UnspeakableNameFidelityTests` (10, all green) — new adversarial Partial fixtures for unspellable object-initializer member, deconstruction property target, deconstruction field target, and recursive property subpattern, plus positive `Full` canaries (normal initializer member, normal recursive property pattern).

Quality-diff card (isolated: identical corpus, `origin/main` decompiler vs this branch):

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,596 (87.92%) | 77,596 (87.92%) | 0 |
| Conditional-branch residual | 2,311 | 2,311 | 0 |
| Forward-merge stops | 2,302 | 2,302 | 0 |
| Full malformed | 47 | 47 | 0 |
| Semantic defects | 188/24,878 | 188/24,878 | 0 |
| Fidelity diffs | opcode-diff 4/22 | opcode-diff 4/22 | 0 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate: Full malformed 46 -> 46 (0). Verdict: matched baseline tolerances — zero corpus delta (real compiled assemblies have no unspellable initializer/deconstruction/pattern member names; this is a backstop for hand-written/metadata-only IL).

Full `src/ILInspector.Decompiler.Tests` suite: only the 2 pre-existing failures unrelated to this change (`LoweringCoverageTests.EveryPipelinePassType_IsClassified_ByOneRegister`, `IrImporterTests.UnmanagedCallersOnly_StdcallMethodAddress_PreservesFunctionPointerWitness`), both reproduce on clean `origin/main`.

Cross-model adversarial review (GPT-5.5) requested per `AGENTS.md`; summary to follow.
