### PR TITLE
Raise calli through &Method to Full via a delegate* cast

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CallIndirectSpellabilityPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CallIndirectSpellabilityPassTests.cs
@@ -125,7 +125,9 @@ public class CallIndirectSpellabilityPassTests
 
     // A `&Method` address whose delegate* result type matches the call site is
     // spellable: a bare `(&Target)(x)` is invalid C# (CS0149), but the printer
-    // casts it — `((delegate*<int, int>)&Target)(x)` — so it stays Full.
+    // casts it — `((delegate*<int, int>)&Target)(x)` — so it stays Full. The
+    // managed target (not [UnmanagedCallersOnly]) is addressable as a managed
+    // delegate*.
     [Fact]
     public void AddressOfMethodOperand_WithMatchingDelegatePointer_StaysFullWithCast()
     {
@@ -140,14 +142,70 @@ public class CallIndirectSpellabilityPassTests
         Assert.Contains("((delegate*<int, int>)&Target)(x)", CSharpPrinter.Print(function).Output);
     }
 
+    // An [UnmanagedCallersOnly] target addressed through a matching unmanaged
+    // delegate* is spellable with the unmanaged cast and stays Full.
+    [Fact]
+    public void AddressOfMethodOperand_UnmanagedCallersOnlyTarget_StaysFullWithCast()
+    {
+        var target = new MethodRef(TypeRef.Definition("Synthetic", "", "T"), "Target", s_int, [s_int], HasThis: false)
+        {
+            IsUnmanagedCallersOnly = MetadataFactState.Yes,
+        };
+        var unmanagedFp = TypeRef.FunctionPointer(s_int, [s_int], "unmanaged[Stdcall]");
+        var function = BuildCalli(new AddressOfMethod(target, unmanagedFp), convention: "unmanaged[Stdcall]", isInstance: false);
+
+        new CallIndirectSpellabilityPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<CallIndirect>());
+        Assert.Empty(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("((delegate* unmanaged[Stdcall]<int, int>)&Target)(x)", CSharpPrinter.Print(function).Output);
+    }
+
     // A `&Method` operand whose delegate* convention disagrees with the call site
     // cannot be spelled faithfully even with a cast; it must degrade to Partial.
     [Fact]
     public void AddressOfMethodOperand_ConventionMismatch_DegradesToPartial()
     {
         var target = new MethodRef(TypeRef.Definition("Synthetic", "", "T"), "Target", s_int, [s_int], HasThis: false);
-        var unmanagedFp = TypeRef.FunctionPointer(s_int, [s_int], "Stdcall");
+        var unmanagedFp = TypeRef.FunctionPointer(s_int, [s_int], "unmanaged[Stdcall]");
         var function = BuildCalli(new AddressOfMethod(target, unmanagedFp), convention: "", isInstance: false);
+
+        new CallIndirectSpellabilityPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CallIndirect>());
+        Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    // An unmanaged-convention cast of a target without [UnmanagedCallersOnly]
+    // evidence would be `(delegate* unmanaged[...])&ManagedMethod` — CS8757. Absent
+    // positive UCO evidence, decline rather than emit invalid C# at Full.
+    [Fact]
+    public void AddressOfMethodOperand_UnmanagedWithoutCallersOnlyEvidence_DegradesToPartial()
+    {
+        var target = new MethodRef(TypeRef.Definition("Synthetic", "", "T"), "Target", s_int, [s_int], HasThis: false);
+        var unmanagedFp = TypeRef.FunctionPointer(s_int, [s_int], "unmanaged[Stdcall]");
+        var function = BuildCalli(new AddressOfMethod(target, unmanagedFp), convention: "unmanaged[Stdcall]", isInstance: false);
+
+        new CallIndirectSpellabilityPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CallIndirect>());
+        Assert.Single(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    // A managed-convention cast of a known [UnmanagedCallersOnly] target would be
+    // `(delegate*<...>)&UcoMethod` — CS8757 (a UCO method is not managed-
+    // addressable). Decline.
+    [Fact]
+    public void AddressOfMethodOperand_ManagedCastOfUnmanagedCallersOnlyTarget_DegradesToPartial()
+    {
+        var target = new MethodRef(TypeRef.Definition("Synthetic", "", "T"), "Target", s_int, [s_int], HasThis: false)
+        {
+            IsUnmanagedCallersOnly = MetadataFactState.Yes,
+        };
+        var function = BuildCalli(new AddressOfMethod(target, s_managedFp), convention: "", isInstance: false);
 
         new CallIndirectSpellabilityPass().Run(function, PassContext.None);
 

--- a/src/ILInspector.Decompiler.Tests/CallIndirectSpellabilityPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CallIndirectSpellabilityPassTests.cs
@@ -123,28 +123,31 @@ public class CallIndirectSpellabilityPassTests
         Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
     }
 
-    // #1435 (adversarial review): a `&Method` address has a delegate* result type
-    // but cannot be invoked directly — `(&Target)(x)` is invalid C# (CS0149); it
-    // needs a `(delegate*<...>)` cast first. Decline rather than emit it at Full.
+    // A `&Method` address whose delegate* result type matches the call site is
+    // spellable: a bare `(&Target)(x)` is invalid C# (CS0149), but the printer
+    // casts it — `((delegate*<int, int>)&Target)(x)` — so it stays Full.
     [Fact]
-    public void AddressOfMethodOperand_DegradesToPartial()
+    public void AddressOfMethodOperand_WithMatchingDelegatePointer_StaysFullWithCast()
     {
         var target = new MethodRef(TypeRef.Definition("Synthetic", "", "T"), "Target", s_int, [s_int], HasThis: false);
-        var call = new CallIndirect(new AddressOfMethod(target), [new LoadArgument(1, "x", s_int)], s_int, [s_int])
-        {
-            CallingConvention = "",
-            IsInstance = false,
-        };
-        var block = new Block(0);
-        block.Add(new Return(call));
-        var body = new BlockContainer();
-        body.Add(block);
-        var function = new IrFunction(
-            "M",
-            TypeRef.Definition("Synthetic", "", "T"),
-            new MethodSignature(s_int, [new Parameter("x", s_int)], HasThis: false, GenericParameterCount: 0),
-            [],
-            body);
+        var function = BuildCalli(new AddressOfMethod(target, s_managedFp), convention: "", isInstance: false);
+
+        new CallIndirectSpellabilityPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<CallIndirect>());
+        Assert.Empty(function.Descendants.OfType<UnsupportedNode>());
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("((delegate*<int, int>)&Target)(x)", CSharpPrinter.Print(function).Output);
+    }
+
+    // A `&Method` operand whose delegate* convention disagrees with the call site
+    // cannot be spelled faithfully even with a cast; it must degrade to Partial.
+    [Fact]
+    public void AddressOfMethodOperand_ConventionMismatch_DegradesToPartial()
+    {
+        var target = new MethodRef(TypeRef.Definition("Synthetic", "", "T"), "Target", s_int, [s_int], HasThis: false);
+        var unmanagedFp = TypeRef.FunctionPointer(s_int, [s_int], "Stdcall");
+        var function = BuildCalli(new AddressOfMethod(target, unmanagedFp), convention: "", isInstance: false);
 
         new CallIndirectSpellabilityPass().Run(function, PassContext.None);
 

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -306,7 +306,10 @@ public class IrImporterTests
         Assert.Equal(["int"], call.ParameterTypes.Select(t => t.ToDisplayString()).ToArray());
 
         string output = CSharpPrinter.PrintRaised(function).Output!;
-        Assert.Contains("return (&UnmanagedStdcallTarget)(value);", output);
+        // A bare `&Method` address cannot be invoked directly — `(&Method)(value)`
+        // is invalid C# (CS0149). The printer casts it to its delegate* result type
+        // first, which compiles and stays Full (#1435 / calli &Method cast).
+        Assert.Contains("return ((delegate* unmanaged[Stdcall]<int, int>)&UnmanagedStdcallTarget)(value);", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1604,8 +1604,16 @@ public sealed partial class CSharpPrinter
     string CollectionElementText(IrExpression element)
         => element is CollectionSpreadElement spread ? $"..{Expression(spread.Source)}" : Expression(element);
 
+    // A `&Method` operand cannot be invoked directly — `(&Method)(x)` is invalid
+    // C# (CS0149) — so cast it to its delegate* result type first. The
+    // CallIndirectSpellabilityPass guarantees the result type is a matching
+    // delegate* before such a node survives to print.
     string FunctionPointerOperand(IrExpression pointer)
-        => pointer is AddressOfMethod ? $"({Expression(pointer)})" : Operand(pointer);
+        => pointer is AddressOfMethod
+            ? pointer.ResultType is { Kind: TypeRefKind.FunctionPointer } fp
+                ? $"(({TypeText(fp)}){Expression(pointer)})"
+                : $"({Expression(pointer)})"
+            : Operand(pointer);
 
     /// <summary>
     /// The C# place a load/store-indirect reads or writes. Dereferencing a

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1728,6 +1728,7 @@ public static class IrImporter
                     IsExtension = FactState(MethodDefinitionFacts.HasExtensionAttribute(reader, method)),
                     IsPInvoke = FactState(MethodDefinitionFacts.IsPInvoke(method)),
                     IsRuntimeAsync = FactState(MethodDefinitionFacts.IsRuntimeAsync(method)),
+                    IsUnmanagedCallersOnly = FactState(MethodDefinitionFacts.IsUnmanagedCallersOnly(reader, method)),
                 };
             }
             case HandleKind.MemberReference:

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -125,6 +125,17 @@ public sealed record MethodRef(
     public MetadataFactState IsRuntimeAsync { get; init; } = MetadataFactState.Unknown;
 
     /// <summary>
+    /// Metadata <c>[UnmanagedCallersOnly]</c> evidence on this method. Such a
+    /// method is addressable only as an <em>unmanaged</em> <c>delegate*</c>; a
+    /// normal managed method is addressable only as a managed <c>delegate*</c>.
+    /// The calli-spellability gate uses this to reject casting an <c>&amp;Method</c>
+    /// address to a mismatched convention class (CS8757) when only
+    /// <see cref="MetadataFactState.Yes"/>/<see cref="MetadataFactState.No"/> is
+    /// known.
+    /// </summary>
+    public MetadataFactState IsUnmanagedCallersOnly { get; init; } = MetadataFactState.Unknown;
+
+    /// <summary>
     /// True when a managed-pointer argument is passed to a by-ref parameter of
     /// this callee while <see cref="ParameterRefKinds"/> is empty — the callee
     /// resolved as a MemberReference (cross-assembly, or a same-assembly call on

--- a/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
@@ -60,6 +60,14 @@ internal static class MethodDefinitionFacts
         return (method.ImplAttributes & AsyncImplFlag) != 0;
     }
 
+    // A method marked [UnmanagedCallersOnly] is addressable only as an unmanaged
+    // function pointer (with its declared calling convention); a normal managed
+    // method is addressable only as a managed delegate*. The presence flag lets
+    // the calli-spellability gate reject a convention-class mismatch when casting
+    // an &Method address (CS8757).
+    internal static bool IsUnmanagedCallersOnly(MetadataReader reader, MethodDefinition method)
+        => HasAttribute(reader, method.GetCustomAttributes(), "System.Runtime.InteropServices", "UnmanagedCallersOnlyAttribute");
+
     internal static bool IsOperator(MethodDefinition method, string methodName, bool hasThis)
         => !hasThis
             && methodName.StartsWith("op_", StringComparison.Ordinal)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CallIndirectSpellabilityPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CallIndirectSpellabilityPass.cs
@@ -15,8 +15,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// fidelity caps to <see cref="DecompilationFidelity.Partial"/> instead of
 /// claiming a faithful call. A <c>calli</c> through a typed managed/unmanaged
 /// <c>delegate*</c> with a matching convention still raises to <c>fp(x)</c> at
-/// <c>Full</c>. Runs last in the diagnostics band, alongside
-/// <see cref="FunctionPointerDiagnosticsPass"/>.</para>
+/// <c>Full</c>. An <see cref="AddressOfMethod"/> operand (<c>&amp;Method</c>) is
+/// also spellable when its <c>delegate*</c> result type matches the call site:
+/// the printer casts it — <c>((delegate*&lt;...&gt;)&amp;Method)(x)</c> — because a
+/// bare <c>(&amp;Method)(x)</c> is invalid C# (CS0149). Runs last in the
+/// diagnostics band, alongside <see cref="FunctionPointerDiagnosticsPass"/>.</para>
 /// </summary>
 public sealed class CallIndirectSpellabilityPass : IIrPass
 {
@@ -40,10 +43,10 @@ public sealed class CallIndirectSpellabilityPass : IIrPass
     // `delegate*` whose calling convention AND signature (return + parameter types)
     // match the call-site signature. A standalone calli signature can disagree with
     // a typed operand's `delegate*` type (arity or type mismatch), which `fp(args)`
-    // cannot spell faithfully.
+    // cannot spell faithfully. An `&Method` operand qualifies too — the printer
+    // wraps it in a `(delegate*<...>)` cast (a bare `(&Method)(x)` is invalid C#).
     static bool IsSpellable(CallIndirect call)
         => !call.IsInstance
-            && call.Pointer is not AddressOfMethod
             && call.Pointer.ResultType is { Kind: TypeRefKind.FunctionPointer } pointer
             && pointer.CallingConvention == call.CallingConvention
             && pointer.ElementType is { } returnType
@@ -55,8 +58,6 @@ public sealed class CallIndirectSpellabilityPass : IIrPass
     {
         if (call.IsInstance)
             return "instance function pointer has no C# delegate* spelling";
-        if (call.Pointer is AddressOfMethod)
-            return "a &Method address must be cast to a delegate* before it can be invoked";
         if (call.Pointer.ResultType is not { Kind: TypeRefKind.FunctionPointer } pointer)
             return $"function-pointer operand is {call.Pointer.ResultType?.ToDisplayString() ?? "untyped"}, not a spellable delegate*";
         if (pointer.CallingConvention != call.CallingConvention)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CallIndirectSpellabilityPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CallIndirectSpellabilityPass.cs
@@ -44,7 +44,9 @@ public sealed class CallIndirectSpellabilityPass : IIrPass
     // match the call-site signature. A standalone calli signature can disagree with
     // a typed operand's `delegate*` type (arity or type mismatch), which `fp(args)`
     // cannot spell faithfully. An `&Method` operand qualifies too — the printer
-    // wraps it in a `(delegate*<...>)` cast (a bare `(&Method)(x)` is invalid C#).
+    // wraps it in a `(delegate*<...>)` cast (a bare `(&Method)(x)` is invalid C#) —
+    // but only when the target method is addressable at that convention class, so
+    // the cast cannot become `(delegate* unmanaged[...])&ManagedMethod` (CS8757).
     static bool IsSpellable(CallIndirect call)
         => !call.IsInstance
             && call.Pointer.ResultType is { Kind: TypeRefKind.FunctionPointer } pointer
@@ -52,7 +54,23 @@ public sealed class CallIndirectSpellabilityPass : IIrPass
             && pointer.ElementType is { } returnType
             && returnType.Equals(call.ReturnType)
             && pointer.TypeArguments.Length == call.ParameterTypes.Length
-            && pointer.TypeArguments.SequenceEqual(call.ParameterTypes);
+            && pointer.TypeArguments.SequenceEqual(call.ParameterTypes)
+            && AddressIsConventionAddressable(call.Pointer, pointer.CallingConvention);
+
+    // For an `&Method` operand the cast spelling only compiles when the method's
+    // addressability matches the convention class: an unmanaged `delegate*` needs
+    // an [UnmanagedCallersOnly] target, a managed `delegate*` needs a non-UCO
+    // target. A non-`&Method` operand (an already-typed `delegate*` value) carries
+    // no such constraint. Unknown UCO evidence is treated conservatively — only a
+    // managed cast is allowed without positive evidence.
+    static bool AddressIsConventionAddressable(IrExpression operand, string convention)
+    {
+        if (operand is not AddressOfMethod address)
+            return true;
+        return convention.Length == 0
+            ? address.Method.IsUnmanagedCallersOnly != MetadataFactState.Yes
+            : address.Method.IsUnmanagedCallersOnly == MetadataFactState.Yes;
+    }
 
     static string Reason(CallIndirect call)
     {
@@ -62,6 +80,8 @@ public sealed class CallIndirectSpellabilityPass : IIrPass
             return $"function-pointer operand is {call.Pointer.ResultType?.ToDisplayString() ?? "untyped"}, not a spellable delegate*";
         if (pointer.CallingConvention != call.CallingConvention)
             return $"calling convention '{Display(call.CallingConvention)}' does not match the operand delegate* '{Display(pointer.CallingConvention)}'";
+        if (!AddressIsConventionAddressable(call.Pointer, pointer.CallingConvention))
+            return $"&Method target is not addressable as a '{Display(pointer.CallingConvention)}' delegate* (UnmanagedCallersOnly convention-class mismatch)";
         return $"call-site signature does not match the operand delegate* '{pointer.ToDisplayString()}'";
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -85,6 +85,8 @@ internal static class NativePasses
     // ───────── Diagnostic — record an honest residual fidelity gap (does not raise) ─────────
     [Native(NativeCategory.Diagnostic, "function-pointer load with no C# spelling — DEC0006 residual")]
     public static FunctionPointerDiagnosticsPass FunctionPointerDiagnostics => new();
+    [Native(NativeCategory.Diagnostic, "non-spellable calli (untyped/instance/convention or signature mismatch) — declines to an honest marker")]
+    public static CallIndirectSpellabilityPass CallIndirectSpellability => new();
     [Native(NativeCategory.Diagnostic, "lost in/out/ref kind at a call site — DEC0007 residual")]
     public static RefKindDiagnosticsPass RefKindDiagnostics => new();
     [Native(NativeCategory.Diagnostic, "direct .ctor call with no C# statement spelling — DEC0004 residual")]


### PR DESCRIPTION
Found while engaging the #1396 correctness-gauntlet tracker.

## Problem

`IrImporterTests.UnmanagedCallersOnly_StdcallMethodAddress_PreservesFunctionPointerWitness` (the #1071 witness) fails on `main`: it expected a `calli` through an `&Method` address to render as `return (&UnmanagedStdcallTarget)(value);` — but that is **invalid C# (CS0149)**: a bare method address cannot be invoked directly. PR #1435 (`CallIndirectSpellabilityPass`) correctly declined that shape but did not update the test, so it now caps to `Partial` + an "Unsupported calli" marker.

The address, however, carries a typed `delegate*` result type, so it **is** faithfully spellable once cast:

```csharp
((delegate* unmanaged[Stdcall]<int, int>)&UnmanagedStdcallTarget)(value)  // compiles
```

## Fix

- `CallIndirectSpellabilityPass.IsSpellable` no longer blanket-excludes `AddressOfMethod`; it qualifies on the same `delegate*` convention + signature match as any typed operand. A non-matching `&Method` (e.g. convention mismatch) still declines to an honest marker.
- `CSharpPrinter` wraps an `AddressOfMethod` function-pointer operand in a cast to its `delegate*` result type, so `calli` through `&Method` renders compilable C# at `Full`.
- Register `CallIndirectSpellabilityPass` in `NativePasses` — it was added in #1435 but never classified, which the `LoweringCoverage` register test flags. (This only surfaces in the decompiler suite, which PR CI does not run — see the Stage 0 note below.)

## Tests

- Updated the #1071 witness to the compilable cast form.
- Rewrote the `CallIndirectSpellabilityPass` `AddressOfMethod` test from decline → spellable-with-cast, and added a convention-mismatch decline negative.
- Focused classes green (LoweringCoverage + CallIndirectSpellability + IrImporter, 77/77). Full `ILInspector.Decompiler.Tests` run + corpus quality-diff card to follow as a comment.

## Stage 0 finding (reported on #1396)

This regression and the missing `NativePasses` classification both merged green because **PR CI (`ci.yml`) does not run `src/ILInspector.Decompiler.Tests`** — that suite runs only in `decompiler-daily.yml`. Filing the process gap on the #1396 tracker.

Closes nothing automatically; relates to #1071, #1435, #1396.