### PR TITLE
Preserve trapping redundant branch conditions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/RedundantBranchEliminationPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RedundantBranchEliminationPassTests.cs
@@ -4,6 +4,10 @@ namespace ILInspector.Decompiler.Tests;
 
 public class RedundantBranchEliminationPassTests
 {
+    static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_object = TypeRef.CoreLib("System", "Object");
+
     static IrFunction TwoBlocks(IrNode block0Terminator)
     {
         var container = new BlockContainer();
@@ -14,13 +18,22 @@ public class RedundantBranchEliminationPassTests
         b0.Add(block0Terminator);   // targets IL_0008 — the immediately following block
         b1.Add(new Return(null));
         var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0);
-        return new IrFunction("M", TypeRef.CoreLib("System", "Object"), signature, [], container);
+        return new IrFunction("M", s_object, signature, [], container);
     }
 
     static Comparison PureCondition()
     {
-        var i32 = TypeRef.CoreLib("System", "Int32");
-        return new Comparison(ComparisonKind.Equal, isUnsigned: false, new Constant(1, i32), new Constant(0, i32));
+        return new Comparison(ComparisonKind.Equal, isUnsigned: false, new Constant(1, s_int), new Constant(0, s_int));
+    }
+
+    static void AssertKeepsConditional(IrExpression condition)
+    {
+        var function = TwoBlocks(new ConditionalBranch(condition, targetOffset: 8));
+
+        new RedundantBranchEliminationPass().Run(function, PassContext.None);
+
+        Assert.IsType<ConditionalBranch>(Assert.Single(function.Body.Blocks[0].Children));
+        function.CheckInvariant();
     }
 
     [Fact]
@@ -40,8 +53,7 @@ public class RedundantBranchEliminationPassTests
     {
         // The branch is still dead, but evaluating a call condition is observable,
         // so the conservative pass leaves it in place rather than elide the call.
-        var boolType = TypeRef.CoreLib("System", "Boolean");
-        var call = new Call(new MethodRef(TypeRef.CoreLib("System", "Object"), "Probe", boolType, [], HasThis: false), isVirtual: false, []);
+        var call = new Call(new MethodRef(s_object, "Probe", s_bool, [], HasThis: false), isVirtual: false, []);
         var function = TwoBlocks(new ConditionalBranch(call, targetOffset: 8));
 
         new RedundantBranchEliminationPass().Run(function, PassContext.None);
@@ -54,9 +66,8 @@ public class RedundantBranchEliminationPassTests
     {
         // Even a redundant conditional branch must preserve an ldsfld condition:
         // reading a static field can trigger the declaring type's .cctor.
-        var boolType = TypeRef.CoreLib("System", "Boolean");
         var holder = TypeRef.Definition("SyntheticAssembly", "Samples", "Holder");
-        var field = new FieldRef(holder, "Gate", boolType);
+        var field = new FieldRef(holder, "Gate", s_bool);
         var function = TwoBlocks(new ConditionalBranch(new LoadField(field, instance: null), targetOffset: 8));
 
         new RedundantBranchEliminationPass().Run(function, PassContext.None);
@@ -69,15 +80,88 @@ public class RedundantBranchEliminationPassTests
     {
         // ldsflda Holder::Gate; ldind.u1; brtrue.s next — taking a static field's address
         // also triggers the declaring type's .cctor, so this redundant branch must stay too.
-        var boolType = TypeRef.CoreLib("System", "Boolean");
         var holder = TypeRef.Definition("SyntheticAssembly", "Samples", "Holder");
-        var field = new FieldRef(holder, "Gate", boolType);
-        var condition = new LoadIndirect(boolType, new LoadFieldAddress(field, instance: null));
+        var field = new FieldRef(holder, "Gate", s_bool);
+        var condition = new LoadIndirect(s_bool, new LoadFieldAddress(field, instance: null));
         var function = TwoBlocks(new ConditionalBranch(condition, targetOffset: 8));
 
         new RedundantBranchEliminationPass().Run(function, PassContext.None);
 
         Assert.IsType<ConditionalBranch>(Assert.Single(function.Body.Blocks[0].Children));
+    }
+
+    [Fact]
+    public void RemovesConditionalBranchToFallthrough_WhenConditionUsesPureArithmetic()
+    {
+        var condition = new Comparison(
+            ComparisonKind.GreaterThan,
+            isUnsigned: false,
+            new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadArgument(0, "x", s_int), new Constant(1, s_int)),
+            new Constant(0, s_int));
+        var function = TwoBlocks(new ConditionalBranch(condition, targetOffset: 8));
+
+        new RedundantBranchEliminationPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Body.Blocks[0].Children);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void KeepsConditionalBranchToFallthrough_WhenConditionLoadsArrayElement()
+    {
+        var array = new LoadArgument(0, "items", TypeRef.SzArray(s_int));
+        var index = new LoadArgument(1, "index", s_int);
+        var condition = new Comparison(
+            ComparisonKind.GreaterThan,
+            isUnsigned: false,
+            new LoadElement(s_int, array, index),
+            new Constant(0, s_int));
+
+        AssertKeepsConditional(condition);
+    }
+
+    [Fact]
+    public void KeepsConditionalBranchToFallthrough_WhenConditionDivides()
+    {
+        var condition = new Comparison(
+            ComparisonKind.GreaterThan,
+            isUnsigned: false,
+            new Binary(BinaryKind.Divide, isChecked: false, isUnsigned: false, new LoadArgument(0, "x", s_int), new LoadArgument(1, "y", s_int)),
+            new Constant(0, s_int));
+
+        AssertKeepsConditional(condition);
+    }
+
+    [Fact]
+    public void KeepsConditionalBranchToFallthrough_WhenConditionUsesCheckedConversion()
+    {
+        var condition = new Comparison(
+            ComparisonKind.GreaterThan,
+            isUnsigned: false,
+            new ILInspector.Decompiler.Pipeline.Convert(
+                s_int,
+                isChecked: true,
+                isUnsigned: false,
+                new LoadArgument(0, "x", TypeRef.CoreLib("System", "Int64"))),
+            new Constant(0, s_int));
+
+        AssertKeepsConditional(condition);
+    }
+
+    [Fact]
+    public void KeepsConditionalBranchToFallthrough_WhenConditionCastsOrUnboxes()
+    {
+        AssertKeepsConditional(new CastClass(s_object, new LoadArgument(0, "value", s_object)));
+        AssertKeepsConditional(new UnboxAny(s_int, new LoadArgument(0, "value", s_object)));
+    }
+
+    [Fact]
+    public void KeepsConditionalBranchToFallthrough_WhenConditionReadsInstanceField()
+    {
+        var holder = TypeRef.Definition("SyntheticAssembly", "Samples", "Holder");
+        var field = new FieldRef(holder, "Gate", s_bool);
+
+        AssertKeepsConditional(new LoadField(field, new LoadArgument(0, "holder", holder)));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/RedundantBranchEliminationPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/RedundantBranchEliminationPass.cs
@@ -41,15 +41,26 @@ public sealed class RedundantBranchEliminationPass : IIrPass
     }
 
     /// <summary>
-    /// Whether evaluating the expression has no observable effect, so dropping it
-    /// is sound. Conservative: any call-like node (or an unsupported one) is
-    /// assumed to have side effects, leaving its branch in place rather than risk
-    /// eliding an effect. A static field access is also treated as effectful because
-    /// <c>ldsfld</c>/<c>ldsflda</c> can trigger the declaring type's static constructor.
+    /// Whether evaluating the expression is non-observable, so dropping it is
+    /// sound. This is an allow-list: a condition may be side-effect-free but still
+    /// observable because it can trap (array bounds, divide-by-zero, casts, null
+    /// dereferences, checked conversions). Anything outside the proven-safe set
+    /// keeps the redundant branch in place.
     /// </summary>
-    static bool IsSideEffectFree(IrExpression condition)
-        => condition.Descendants.Prepend(condition).All(node => node is not
-            (Call or CallIndirect or NewObject or DelegateCreation or UnsupportedNode)
-            and not LoadField { Instance: null }
-            and not LoadFieldAddress { Instance: null });
+    static bool IsSideEffectFree(IrExpression condition) => condition switch
+    {
+        Constant or LoadLocal or LoadArgument or LoadStackSlot
+            or LoadLocalAddress or LoadArgumentAddress or TypeOf or SizeOf => true,
+        Comparison comparison => IsSideEffectFree(comparison.Left) && IsSideEffectFree(comparison.Right),
+        LogicalNot logicalNot => IsSideEffectFree(logicalNot.Operand),
+        LogicalBinary logical => IsSideEffectFree(logical.Left) && IsSideEffectFree(logical.Right),
+        Unary unary => IsSideEffectFree(unary.Operand),
+        Binary { Kind: BinaryKind.Divide or BinaryKind.Remainder } => false,
+        Binary { IsChecked: true } => false,
+        Binary binary => IsSideEffectFree(binary.Left) && IsSideEffectFree(binary.Right),
+        Convert { IsChecked: true } => false,
+        Convert convert => IsSideEffectFree(convert.Operand),
+        IsInstance isInstance => IsSideEffectFree(isInstance.Operand),
+        _ => false,
+    };
 }


### PR DESCRIPTION
Fixes #1468.

## Over-raise claim narrowed

`RedundantBranchEliminationPass` removed conditional branches to the immediately following block when the condition passed a blacklist-style `IsSideEffectFree` check. That dropped conditions that can throw while evaluating, suppressing observable behavior such as array bounds/null checks, divide-by-zero, checked conversion overflow, invalid casts/unboxing, and instance-field null dereferences.

## Fix

Replace the blacklist with a conservative allow-list of condition expressions that are proven non-observable. The pass still drops redundant branches for constants, local/argument/stack-slot loads, simple comparisons, logical wrappers, unchecked arithmetic (except div/rem), unchecked conversions, and `isinst` over safe operands. Everything outside the allow-list keeps the branch.

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.RedundantBranchEliminationPassTests`
  - 11 passed, 0 failed.
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`
  - Succeeded.
- Full `src/ILInspector.Decompiler.Tests` was attempted before the final `origin/main` sync but did not reach a terminal summary after several minutes; it had already surfaced unrelated current-main failures in `LoweringCoverageTests.EveryPipelinePassType_IsClassified_ByOneRegister` (`CallIndirectSpellabilityPass`) and `IrImporterTests.UnmanagedCallersOnly_StdcallMethodAddress_PreservesFunctionPointerWitness`.
- Decompiler quality card was attempted with the prepared 14-assembly corpus and a 900s timeout; the harness produced no output before timing out, so there is no generated quality card to paste.

## Adversarial review

Opus 4.8 reviewed the change. Result: no blocking findings. It specifically verified that the allow-list excludes the issue's trapping families and that the retained leaf/wrapper nodes are non-trapping under the current IR semantics.
