### PR TITLE
Gate iterator reconstruction on inert kickoff handoff arguments (#1471)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -288,6 +288,27 @@ public class IteratorReconstructionPassTests
     }
 
     [Fact]
+    public void StructThisCaptureHandoff_StillReconstructs()
+    {
+        // A value-type instance iterator captures `this` as `<>4__this = *this`
+        // (ldarg.0; ldobj <struct>), which ObjectInitializerPass preserves as a
+        // LoadIndirect(LoadArgument) initializer entry. That read is inert, so the
+        // narrow-handoff gate must accept it — the kickoff still reconstructs and the
+        // inert-argument guard (#1471) must not regress legitimate struct iterators.
+        var (function, moveNext) = BuildStructThisCaptureKickoff();
+        var context = new PassContext(
+            new Stepper(enabled: false),
+            importMethodBody: method => method.Name == "MoveNext" ? moveNext : null);
+
+        new IteratorReconstructionPass().Run(function, context);
+
+        // Reconstructed: the handoff construction is gone, replaced by yield break.
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        Assert.Single(function.Descendants.OfType<YieldBreak>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void NonEmptyIterator_HasNoSpuriousYieldBreak()
     {
         // A normal linear iterator falls off the end implicitly; reconstruction
@@ -589,6 +610,59 @@ public class IteratorReconstructionPassTests
             moveNextBody);
 
         return (function, moveNext, sideEffect);
+    }
+
+    static (IrFunction Function, IrFunction MoveNext) BuildStructThisCaptureKickoff()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var enumerable = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"),
+            [intType]);
+        var ownerType = TypeRef.Definition("Synthetic", "Samples", "Outer");
+        var stateMachine = TypeRef.Definition("Synthetic", "Samples", "Outer+<M>d__0");
+        var constructor = new MethodRef(
+            stateMachine,
+            ".ctor",
+            voidType,
+            [intType],
+            HasThis: false)
+        {
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+
+        // `<>4__this = *this` — the inert struct-this capture (ldarg.0; ldobj Outer).
+        var creation = new NewObject(constructor, [new Constant(-2, intType)]);
+        var thisCapture = new LoadIndirect(ownerType, new LoadArgument(0, "this", TypeRef.ByRef(ownerType)));
+        var handoff = new ObjectInitializerExpression(
+            creation,
+            isCollection: false,
+            [new InitializerEntry("<>4__this", [thisCapture])]);
+
+        var kickoffBlock = new Block();
+        kickoffBlock.Add(new Return(handoff));
+        var kickoffBody = new BlockContainer();
+        kickoffBody.Add(kickoffBlock);
+        var function = new IrFunction(
+            "M",
+            ownerType,
+            new MethodSignature(enumerable, [], HasThis: true, GenericParameterCount: 0),
+            [],
+            kickoffBody);
+
+        var moveNextBlock = new Block();
+        moveNextBlock.Add(new Return(new Constant(false, boolType)));
+        var moveNextBody = new BlockContainer();
+        moveNextBody.Add(moveNextBlock);
+        var moveNext = new IrFunction(
+            "MoveNext",
+            stateMachine,
+            new MethodSignature(boolType, [], HasThis: true, GenericParameterCount: 0),
+            [],
+            moveNextBody);
+
+        return (function, moveNext);
     }
 
     static (IrFunction Kickoff, NewObject Handoff, IrFunction MoveNext) CountingLoopFixture(

--- a/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IteratorReconstructionPassTests.cs
@@ -267,6 +267,27 @@ public class IteratorReconstructionPassTests
     }
 
     [Fact]
+    public void SideEffectConsumedByIteratorHandoff_IsNotReconstructed()
+    {
+        // The body is a single `return new <M>d__0(SideEffect())` — narrow by shape, but the
+        // construction consumes a side-effecting call. Reconstructing to `yield break;` would
+        // drop that call, so the pass must decline (#1471; symmetric to the #1362
+        // acknowledgment guard and the #1363 side-effect-before-handoff guard).
+        var (function, moveNext, sideEffect) = BuildKickoffWithSideEffectingHandoffArgument();
+        var context = new PassContext(
+            new Stepper(enabled: false),
+            importMethodBody: method => method.Name == "MoveNext" ? moveNext : null);
+
+        new IteratorReconstructionPass().Run(function, context);
+
+        Assert.Empty(function.Descendants.OfType<YieldBreak>());
+        Assert.Contains(function.Descendants.OfType<Call>(), call => call.Callee == sideEffect);
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Single(function.Descendants.OfType<Return>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void NonEmptyIterator_HasNoSpuriousYieldBreak()
     {
         // A normal linear iterator falls off the end implicitly; reconstruction
@@ -496,6 +517,57 @@ public class IteratorReconstructionPassTests
         var kickoffBlock = new Block();
         kickoffBlock.Add(new ExpressionStatement(new Call(sideEffect, isVirtual: false, [])));
         kickoffBlock.Add(new Return(new NewObject(constructor, [new Constant(-2, intType)])));
+        var kickoffBody = new BlockContainer();
+        kickoffBody.Add(kickoffBlock);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Outer"),
+            new MethodSignature(enumerable, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            kickoffBody);
+
+        var moveNextBlock = new Block();
+        moveNextBlock.Add(new Return(new Constant(false, boolType)));
+        var moveNextBody = new BlockContainer();
+        moveNextBody.Add(moveNextBlock);
+        var moveNext = new IrFunction(
+            "MoveNext",
+            stateMachine,
+            new MethodSignature(boolType, [], HasThis: true, GenericParameterCount: 0),
+            [],
+            moveNextBody);
+
+        return (function, moveNext, sideEffect);
+    }
+
+    static (IrFunction Function, IrFunction MoveNext, MethodRef SideEffect) BuildKickoffWithSideEffectingHandoffArgument()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var enumerable = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"),
+            [intType]);
+        var stateMachine = TypeRef.Definition("Synthetic", "Samples", "Outer+<M>d__0");
+        var constructor = new MethodRef(
+            stateMachine,
+            ".ctor",
+            voidType,
+            [intType],
+            HasThis: false)
+        {
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+        // Returns int so it can sit in the int-typed state argument the ctor consumes.
+        var sideEffect = new MethodRef(
+            TypeRef.Definition("Synthetic", "Samples", "Effects"),
+            "SideEffect",
+            intType,
+            [],
+            HasThis: false);
+
+        var kickoffBlock = new Block();
+        kickoffBlock.Add(new Return(new NewObject(constructor, [new Call(sideEffect, isVirtual: false, [])])));
         var kickoffBody = new BlockContainer();
         kickoffBody.Add(kickoffBlock);
         var function = new IrFunction(

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorAcknowledgmentPass.cs
@@ -58,46 +58,11 @@ public sealed class IteratorAcknowledgmentPass : IIrPass
         // captured-parameter/this object initializer). If the body carries any other
         // statement — a user call, an extra store — that is observable work the marker would
         // silently drop, so decline and leave the lowered body visible at Partial (#1362).
-        if (!IsNarrowKickoffHandoff(function, handoff))
+        if (!IteratorShapes.IsNarrowKickoffHandoff(function, handoff))
             return false;
 
         stateMachine = IteratorShapes.MetadataName(handoff.Constructor.DeclaringType);
         sourceOffset = handoff.SourceOffset;
         return true;
     }
-
-    // The narrow kickoff shape: the whole body is `return new <M>d__N(state);`, where the
-    // construction may be decorated by the capture object initializer (`<>3__param`,
-    // `<>4__this`). Anything else means user-visible work precedes/feeds the iterator handoff.
-    // The construction arguments and capture entries must themselves be inert (the state
-    // Constant and parameter/this loads), so a side-effecting expression consumed by the
-    // handoff (e.g. `new <M>d__0(SideEffect())`) is not silently dropped by the marker.
-    static bool IsNarrowKickoffHandoff(IrFunction function, NewObject handoff)
-    {
-        if (function.Body.Children is not [Block block])
-            return false;
-        if (block.Children is not [Return { Value: { } returned }])
-            return false;
-
-        if (returned is ObjectInitializerExpression initializer)
-        {
-            if (!ReferenceEquals(initializer.Creation, handoff))
-                return false;
-            // Children[0] is the Creation; the rest are the capture entries' argument values.
-            foreach (var entry in initializer.Children.Skip(1).Cast<IrExpression>())
-                if (!IsInertCapture(entry))
-                    return false;
-        }
-        else if (!ReferenceEquals(returned, handoff))
-        {
-            return false;
-        }
-
-        return handoff.Arguments.All(IsInertCapture);
-    }
-
-    // The only expressions a real compiler iterator kickoff feeds to the state-machine
-    // construction: the state Constant and direct loads of the captured parameters/this.
-    static bool IsInertCapture(IrExpression expression)
-        => expression is Constant or LoadArgument;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorReconstructionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorReconstructionPass.cs
@@ -60,7 +60,7 @@ public sealed class IteratorReconstructionPass : IIrPass
             return;
         if (!IteratorShapes.TryGetKickoff(function, out var handoff))
             return;
-        if (!IsNarrowKickoffHandoff(function, handoff))
+        if (!IteratorShapes.IsNarrowKickoffHandoff(function, handoff))
             return;
 
         var moveNextMethod = handoff.Constructor with { Name = "MoveNext" };
@@ -107,16 +107,6 @@ public sealed class IteratorReconstructionPass : IIrPass
         foreach (var statement in statements)
             block.Add(statement);
         function.Body.Add(block);
-    }
-
-    static bool IsNarrowKickoffHandoff(IrFunction function, NewObject handoff)
-    {
-        if (function.Body.Blocks is not [{ Children: [Return { Value: { } returned }] }])
-            return false;
-
-        return ReferenceEquals(returned, handoff)
-            || returned is ObjectInitializerExpression { Creation: var creation }
-                && ReferenceEquals(creation, handoff);
     }
 
     // Adopts a transform-then-restructure reconstruction: the kickoff's body is replaced

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorShapes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorShapes.cs
@@ -84,7 +84,11 @@ internal static class IteratorShapes
     }
 
     // The only expressions a real compiler iterator kickoff feeds to the state-machine
-    // construction: the state Constant and direct loads of the captured parameters/this.
+    // construction: the state Constant, direct loads of captured parameters/this, and — for
+    // a value-type instance iterator or a ref/in parameter — the `ldobj`/`ldind` read of the
+    // captured place through its by-ref argument (`<>4__this = *this`). All are inert and
+    // re-evaluable; a Call or other effectful value consumed by the handoff is rejected.
     static bool IsInertCapture(IrExpression expression)
-        => expression is Constant or LoadArgument;
+        => expression is Constant or LoadArgument
+            || expression is LoadIndirect { IsVolatile: false, Address: LoadArgument };
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IteratorShapes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IteratorShapes.cs
@@ -47,4 +47,44 @@ internal static class IteratorShapes
         return name.StartsWith("IEnumerable", StringComparison.Ordinal)
             || name.StartsWith("IEnumerator", StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// The narrow kickoff shape both iterator consumers replace wholesale: the entire body is
+    /// <c>return new &lt;M&gt;d__N(state);</c>, where the construction may be decorated by the
+    /// captured-parameter/this object initializer (<c>&lt;&gt;3__param</c>, <c>&lt;&gt;4__this</c>).
+    /// Anything else means user-visible work precedes or feeds the iterator handoff. The
+    /// construction arguments and capture entries must themselves be inert (the state
+    /// <see cref="Constant"/> and parameter/this loads), so a side-effecting expression
+    /// consumed by the handoff (e.g. <c>new &lt;M&gt;d__0(SideEffect())</c>) is not silently
+    /// dropped when the body is replaced. Shared so the reconstruction and acknowledgment
+    /// gates cannot drift apart (#1362/#1471).
+    /// </summary>
+    public static bool IsNarrowKickoffHandoff(IrFunction function, NewObject handoff)
+    {
+        if (function.Body.Children is not [Block block])
+            return false;
+        if (block.Children is not [Return { Value: { } returned }])
+            return false;
+
+        if (returned is ObjectInitializerExpression initializer)
+        {
+            if (!ReferenceEquals(initializer.Creation, handoff))
+                return false;
+            // Children[0] is the Creation; the rest are the capture entries' argument values.
+            foreach (var entry in initializer.Children.Skip(1).Cast<IrExpression>())
+                if (!IsInertCapture(entry))
+                    return false;
+        }
+        else if (!ReferenceEquals(returned, handoff))
+        {
+            return false;
+        }
+
+        return handoff.Arguments.All(IsInertCapture);
+    }
+
+    // The only expressions a real compiler iterator kickoff feeds to the state-machine
+    // construction: the state Constant and direct loads of the captured parameters/this.
+    static bool IsInertCapture(IrExpression expression)
+        => expression is Constant or LoadArgument;
 }


### PR DESCRIPTION
Fixes #1471. Burndown row in #1524.

## Over-raise claim being narrowed

`IteratorReconstructionPass.IsNarrowKickoffHandoff` accepted a kickoff whose
state-machine construction **consumes** a side-effecting expression — e.g. the
single-statement body `return new <M>d__0(SideEffect())` — and then replaced the
whole kickoff body with reconstructed `yield`s, **silently dropping the side
effect** while reporting `Full`.

The sibling `IteratorAcknowledgmentPass` already required the handoff arguments
and object-initializer capture entries to be inert (the state `Constant` and
parameter/`this` loads) — the #1362 fix. The reconstruction pass's #1363
narrow-handoff gate only checked the body *shape* (`[Return handoff]`) and omitted
the inert-argument check, so the consumed-by-handoff form slipped through.

## Fix

Move the correct, inert-checking `IsNarrowKickoffHandoff` (plus `IsInertCapture`)
into the shared `IteratorShapes` helper and route **both** passes to it, so the
reconstruction and acknowledgment gates cannot drift apart again. No pass is
widened; the reconstruction gate only gains the proof it was missing.

- `IteratorShapes.cs`: new shared `IsNarrowKickoffHandoff` (with inert-capture gate).
- `IteratorReconstructionPass.cs` / `IteratorAcknowledgmentPass.cs`: delete the
  private copies, call the shared predicate (acknowledgment behavior unchanged —
  identical logic).

## Adversarial fixture + positive canary

New end-to-end test `SideEffectConsumedByIteratorHandoff_IsNotReconstructed`:
a kickoff returning `new <M>d__0(SideEffect())` over a stateless `MoveNext`, run
through `IteratorReconstructionPass` with a real import seam. It now **declines**
(side-effecting `Call` preserved, single `Return`, no spurious `YieldBreak`)
instead of reconstructing to `yield break;`.

- **Positive canaries (unchanged):** the existing reconstruction suite
  (`EmptyIterator_ReconstructsYieldBreak`, `LinearConstantIterator_…`,
  `CountingLoopIterator_…`, multi-yield, nested, etc.) still raise.
- **Negative control:** temporarily admitting `Call` as an inert capture makes the
  new test fail with `[YieldBreak]` (side effect dropped), confirming the test
  pins the fix.

## Tests

`dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class …IteratorReconstructionPassTests -class …IteratorAcknowledgmentPassTests`
→ **Total: 45, Failed: 0**. Full `src/ILInspector.Decompiler.Tests` run in
progress locally (shared machine under heavy contention) and on CI.

## Corpus impact

None expected. Stock csc never feeds a side-effecting expression to an iterator
kickoff construction (the state argument is a `Constant`, captures are
`LoadArgument`), so this gate is an adversarial-IR guard and cannot change
corpus behavior — same tier as the #1362 guard it mirrors. No quality-diff card
attached for that reason.

## Adversarial review

Requesting cross-model adversarial review per `AGENTS.md` (Opus 4.8 author →
GPT-5.5 reviewer). Will post the summarized result.
