### PR TITLE
Report unspellable local-function names to fidelity (#1531)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
@@ -261,4 +261,48 @@ public class UnspeakableNameFidelityTests
 
     static NewObject NewTarget()
         => new(new MethodRef(Target, ".ctor", Void, [], HasThis: true), []);
+
+    [Fact]
+    public void RaisedLocalFunctionInvocationUnspellableName_DegradesToPartial()
+    {
+        // bad-name(); — the raised invocation carries the demangled name after the
+        // original Call that MethodReason would have flagged was replaced.
+        var invocation = new LocalFunctionInvocation("bad-name", Void, []);
+        var function = Function([], Container(new ExpressionStatement(invocation), new Return(null)));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void RaisedLocalFunctionKeywordName_StaysFull()
+    {
+        // A keyword local-function name escapes to @return (valid C#) per #1465, so
+        // the keyword-tolerant predicate must NOT degrade it.
+        var invocation = new LocalFunctionInvocation("return", Void, []);
+        var function = Function([], Container(new ExpressionStatement(invocation), new Return(null)));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void RaisedLocalFunctionStatementUnspellableName_DegradesToPartial()
+    {
+        var statement = new LocalFunctionStatement(
+            "bad-name", Void, [], isStatic: true, [], [],
+            usesUpdatedMemorySafetyRules: false, skipLocalsInit: false, Container(new Return(null)));
+        var function = Function([], Container(statement, new Return(null)));
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void RaisedLocalFunctionStatementUsableName_StaysFull()
+    {
+        var statement = new LocalFunctionStatement(
+            "Local", Void, [], isStatic: true, [], [],
+            usesUpdatedMemorySafetyRules: false, skipLocalsInit: false, Container(new Return(null)));
+        var function = Function([], Container(statement, new Return(null)));
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
@@ -44,6 +44,8 @@ internal static class CSharpSpellability
             DeconstructionTarget target => DeconstructionTargetReason(target),
             RecursivePropertyDeclarationPattern pattern => PropertyReason(pattern.PropertyName),
             EventSubscription subscription => PropertyReason(subscription.EventName),
+            LocalFunctionStatement statement => LocalFunctionReason(statement.Name),
+            LocalFunctionInvocation invocation => LocalFunctionReason(invocation.Name),
             _ => null,
         };
     }
@@ -100,6 +102,16 @@ internal static class CSharpSpellability
         => CSharpNaming.IsUsableIdentifier(name)
             ? null
             : $"property name '{name}' has no C# spelling";
+
+    // A local function name is emitted through CSharpNaming.EscapeIdentifier, so a
+    // reserved keyword (e.g. return -> @return) is spellable; only a name with
+    // invalid identifier characters (e.g. a hand-written `bad-name`) has no C#
+    // spelling. Use the keyword-tolerant predicate to avoid degrading the
+    // keyword-escaped local functions #1465 made Full.
+    static string? LocalFunctionReason(string name)
+        => CSharpNaming.IsEscapableIdentifier(name)
+            ? null
+            : $"local function name '{name}' has no C# spelling";
 
     static string? InitializerMembersReason(IEnumerable<string?> members)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -11,6 +11,16 @@ internal static class CSharpNaming
 {
     /// <summary>A name safe to emit bare as a C# identifier: letters/digits/underscore, no leading digit, and not a reserved keyword (which would need an <c>@</c> escape).</summary>
     public static bool IsUsableIdentifier(string name)
+        => IsEscapableIdentifier(name) && !ReservedKeywords.Contains(name);
+
+    /// <summary>
+    /// A name C# can emit as an identifier, possibly via an <c>@</c> escape: valid
+    /// identifier characters and start, regardless of whether it is a reserved
+    /// keyword. This distinguishes an escapable keyword like <c>return</c> (which
+    /// <see cref="EscapeIdentifier"/> renders as the legal <c>@return</c>) from a
+    /// fundamentally unspellable metadata name like <c>bad-name</c>.
+    /// </summary>
+    public static bool IsEscapableIdentifier(string name)
     {
         if (string.IsNullOrEmpty(name) || !(char.IsLetter(name[0]) || name[0] == '_'))
             return false;
@@ -19,7 +29,7 @@ internal static class CSharpNaming
             if (!(char.IsLetterOrDigit(c) || c == '_'))
                 return false;
         }
-        return !ReservedKeywords.Contains(name);
+        return true;
     }
 
     /// <summary>An identifier safe to emit in C# source: a reserved keyword is


### PR DESCRIPTION
Fixes #1531. Spun out of #1464's adversarial review.

## Over-raise claim being narrowed

`LocalFunctionRaisingPass` replaces the original `Call` with a `LocalFunctionInvocation` (and appends a `LocalFunctionStatement`) carrying the demangled source name, detaching the `Call`. `CSharpSpellability` therefore no longer saw the name, so a local function whose demangled name is not a valid C# identifier (e.g. a hand-written/obfuscated `<M>g__bad-name|0_0` → `bad-name`) printed at `Full`:

```csharp
bad-name();
static void bad-name() { ... }
```

This is the local-function surface deliberately scoped out of #1464 (the bare-emitted member-name raised containers).

## Fix shape

The local-function printer emits the name through `CSharpNaming.EscapeIdentifier` (declaration `CSharpPrinter.cs:860`, invocation `:1420`), so a reserved keyword (`return` → `@return`) is spellable — and the merged #1465 relies on that. A keyword-rejecting check would false-`Partial` those.

Add a keyword-tolerant predicate `CSharpNaming.IsEscapableIdentifier` (valid identifier characters/start, keyword allowed) and route the existing `IsUsableIdentifier` through it (`IsUsableIdentifier = IsEscapableIdentifier && !keyword`, behavior-preserving). New `CSharpSpellability` arms for `LocalFunctionStatement`/`LocalFunctionInvocation` use `IsEscapableIdentifier`, so a name degrades to `Partial` only when it has no `@`-escapable spelling — leaving #1465's keyword-escaped local functions `Full`. No raise behavior changes; this only relabels fidelity (honest degradation).

## Evidence

`UnspeakableNameFidelityTests` (20, green) — new fixtures: unspellable `bad-name` invocation and statement → `Partial`; keyword `return` (→ `@return`) and ordinary `Local` → `Full` (#1465-protection canaries).

Behavior-preserving refactor verified across `IsUsableIdentifier` consumers: `AnonymousObjectPassTests` 13/13, `PropertySugarPassTests` 13/13, `LocalFunctionRaisingPassTests` 17/17, `ReadableLocalNamesTests` 4/4, `TypeSourceCheckTests` 27/27, `UnspellableTypeFidelityTests` 2/2.

Quality-diff card (isolated: identical corpus, branch base `f9f3f22c` decompiler vs this branch):

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,626 (87.90%) | 77,626 (87.90%) | 0 |
| Conditional-branch residual | 2,319 | 2,319 | 0 |
| Forward-merge stops | 2,309 | 2,309 | 0 |
| Full malformed | 32 | 32 | 0 |
| Semantic defects | 188/24,906 | 188/24,906 | 0 |
| Fidelity diffs | opcode-diff 5/34 | opcode-diff 5/34 | 0 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate: Full malformed 32 -> 32 (0); opcode diffs 1 -> 1 (0). Verdict: matched baseline tolerances — zero corpus delta (real local functions always have valid demangled names; this is a backstop for hand-written/metadata-only IL).

### Full-suite failures are pre-existing

The decompiler suite shows 15 failures, all in recompile/opcode/skeleton **gate** tests that depend on the local compiler/runtime environment and reproduce on the clean branch base `f9f3f22c` (individually verified: `SkeletonEmitTests.SkeletonRestatesGenericConstraints`, `RangeFromGetSubArrayPassTests.GetSubArray_CompoundEndpointFixtures_RecompileExactly`, `PrinterPrecedenceTests.StoreElement_CompoundArrayReceiver_RecompilesExactly`, plus the long-standing `LoweringCoverageTests.EveryPipelinePassType_IsClassified_ByOneRegister` and `IrImporterTests.UnmanagedCallersOnly_StdcallMethodAddress_PreservesFunctionPointerWitness`). This change is a behavior-preserving `IsUsableIdentifier` refactor plus fidelity-label-only local-function arms — it cannot affect recompilation or opcode-exactness, and every non-recompile/non-gate test passes.

## Adversarial review

GPT-5.5 (per `AGENTS.md`): **no blocking issues**, `IsUsableIdentifier` refactor confirmed semantically exact, `IsEscapableIdentifier` confirmed the correct mirror of the printer's keyword-only escaping. Two non-blocking caveats: (1) a pre-existing `CSharpNaming.MethodName` demangle bug when the enclosing method name contains `g__` — filed as **#1549**; my arm honestly reports those mis-demangled (genuinely invalid) names as `Partial`. (2) an esoteric hand-written `@foo` metadata-name case (never real C# output). Local-function parameter names are a pre-existing general parameter-name gap, not introduced here.
