### PR TITLE
Preserve function pointer signature modifiers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FunctionPointerDiagnosticsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FunctionPointerDiagnosticsPassTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
@@ -8,6 +10,28 @@ public class FunctionPointerDiagnosticsPassTests
     private static readonly TypeRef Owner = TypeRef.CoreLib("Synthetic", "Owner");
     private static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     private static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+
+    [Theory]
+    [InlineData(nameof(FunctionPointerModifierFixture.SuppressField), "delegate* unmanaged[SuppressGCTransition]<int, int>")]
+    [InlineData(nameof(FunctionPointerModifierFixture.InField), "delegate*<in int, void>")]
+    [InlineData(nameof(FunctionPointerModifierFixture.OutField), "delegate*<out int, void>")]
+    public void TypeRefDecoder_PreservesFunctionPointerSignatureModifiers(string fieldName, string expected)
+    {
+        var type = DecodeFixtureField(fieldName);
+
+        Assert.Equal(expected, type.ToDisplayString());
+    }
+
+    [Fact]
+    public void CallIndirect_PreservesInOutFunctionPointerArgumentKeywords()
+    {
+        string output = PrintRaised(nameof(FunctionPointerModifierFixture.InvokeInOut));
+
+        Assert.Contains("input(in value);", output);
+        Assert.Contains("output(out", output);
+        Assert.DoesNotContain("input(ref value);", output);
+        Assert.DoesNotContain("output(ref", output);
+    }
 
     [Fact]
     public void Run_DiagnosesVirtualFunctionPointerAsLdvirtftn()
@@ -111,10 +135,60 @@ public class FunctionPointerDiagnosticsPassTests
 
         var signature = new MethodSignature(
             Void,
-            ImmutableArray.Create(new Parameter("this", Owner)),
+            ImmutableArray.Create(new ILInspector.Decompiler.Pipeline.Parameter("this", Owner)),
             HasThis: true,
             GenericParameterCount: 0);
 
         return new IrFunction("M", Owner, signature, [], body);
+    }
+
+    static TypeRef DecodeFixtureField(string fieldName)
+    {
+        using var stream = File.OpenRead(typeof(FunctionPointerModifierFixture).Assembly.Location);
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        var type = FixtureType(reader);
+        foreach (var handle in type.GetFields())
+        {
+            var field = reader.GetFieldDefinition(handle);
+            if (reader.GetString(field.Name) == fieldName)
+                return field.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+        }
+        throw new InvalidOperationException($"Field {fieldName} not found.");
+    }
+
+    static TypeDefinition FixtureType(MetadataReader reader)
+    {
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(handle);
+            if (reader.GetString(type.Name) == nameof(FunctionPointerModifierFixture))
+                return type;
+        }
+        throw new InvalidOperationException("Fixture type not found.");
+    }
+
+    static string PrintRaised(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(FunctionPointerModifierFixture).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(FunctionPointerModifierFixture).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+}
+
+public unsafe class FunctionPointerModifierFixture
+{
+    public delegate* unmanaged[SuppressGCTransition]<int, int> SuppressField;
+    public delegate*<in int, void> InField;
+    public delegate*<out int, void> OutField;
+
+    public static void InvokeInOut(delegate*<in int, void> input, delegate*<out int, void> output, int value)
+    {
+        input(in value);
+        output(out int result);
+        _ = result;
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -171,7 +171,9 @@ public sealed partial class CSharpPrinter
         => string.Join(", ", arguments.Select(Expression));
 
     static ImmutableArray<ArgumentRefKind> CallIndirectRefKinds(CallIndirect call)
-        => [.. call.ParameterTypes.Select(t => t.Kind == TypeRefKind.ByRef ? ArgumentRefKind.Ref : ArgumentRefKind.Value)];
+        => call.ParameterRefKinds.IsDefaultOrEmpty
+            ? [.. call.ParameterTypes.Select(t => t.Kind == TypeRefKind.ByRef ? ArgumentRefKind.Ref : ArgumentRefKind.Value)]
+            : call.ParameterRefKinds;
 
     /// <summary>
     /// Arguments paired positionally with the callee's parameter types, casting
@@ -180,7 +182,11 @@ public sealed partial class CSharpPrinter
     /// that already align 1:1 with the parameters (the receiver of an instance
     /// call is dropped first), so index i maps to parameterTypes[i].
     /// </summary>
-    string Arguments(IEnumerable<IrExpression> arguments, IReadOnlyList<TypeRef> parameterTypes, ImmutableArray<ArgumentRefKind> refKinds)
+    string Arguments(
+        IEnumerable<IrExpression> arguments,
+        IReadOnlyList<TypeRef> parameterTypes,
+        ImmutableArray<ArgumentRefKind> refKinds,
+        bool explicitIn = false)
     {
         var parts = new List<string>();
         int i = 0;
@@ -188,7 +194,7 @@ public sealed partial class CSharpPrinter
         {
             var parameter = i < parameterTypes.Count ? parameterTypes[i] : null;
             var refKind = i < refKinds.Length ? refKinds[i] : ArgumentRefKind.Value;
-            parts.Add(RefArgument(argument, parameter, refKind)
+            parts.Add(RefArgument(argument, parameter, refKind, explicitIn)
                 ?? (parameter is not null ? CastValue(argument, parameter) : Expression(argument)));
             i++;
         }
@@ -205,14 +211,16 @@ public sealed partial class CSharpPrinter
     /// cross-assembly MemberRef carries no parameter rows) or the argument is not
     /// a simple place — both leave the existing spelling untouched.
     /// </summary>
-    string? RefArgument(IrExpression argument, TypeRef? parameter, ArgumentRefKind refKind)
+    string? RefArgument(IrExpression argument, TypeRef? parameter, ArgumentRefKind refKind, bool explicitIn)
     {
         if (parameter is not { Kind: TypeRefKind.ByRef } || refKind == ArgumentRefKind.Value)
             return null;
         // `in` accepts a value argument (the compiler introduces a temporary), so
         // any place- or value-spelling works and the keyword stays implicit.
         if (refKind == ArgumentRefKind.In)
-            return ArgumentPlace(argument);
+            return (explicitIn ? ArgumentLvalue(argument) : ArgumentPlace(argument)) is { } inPlace
+                ? explicitIn ? $"in {inPlace}" : inPlace
+                : null;
         // `out`/`ref` require a genuine assignable lvalue; a cast (unbox) is not
         // one (`out (T)x` is CS0206), so leave those to the default spelling.
         if (ArgumentLvalue(argument) is not { } place)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1413,7 +1413,7 @@ public sealed partial class CSharpPrinter
             : $"{Operand(id.Target)}{(id.IsIncrement ? "++" : "--")}",
         Convert v => ConvertText(v),
         Call c => CallText(c),
-        CallIndirect ci => $"{FunctionPointerOperand(ci.Pointer)}({Arguments(ci.Arguments, ci.ParameterTypes, CallIndirectRefKinds(ci))})",
+        CallIndirect ci => $"{FunctionPointerOperand(ci.Pointer)}({Arguments(ci.Arguments, ci.ParameterTypes, CallIndirectRefKinds(ci), explicitIn: true)})",
         DelegateCreation d => $"new {TypeText(d.DelegateType)}({MethodGroupText(d.Method, d.Target)})",
         InterpolatedStringExpression i => InterpolatedStringText(i),
         Lambda lam => LambdaText(lam),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1306,7 +1306,7 @@ public static class IrImporter
                         arguments[i] = Pop(stack);
                     var callIndirect = new CallIndirect(pointer, arguments, signature.ReturnType, signature.ParameterTypes)
                     {
-                        CallingConvention = TypeRefDecoder.ConventionText(signature.Header.CallingConvention),
+                        CallingConvention = TypeRefDecoder.ConventionText(signature.Header.CallingConvention, signature.ReturnType),
                         IsInstance = signature.Header.IsInstance,
                     };
                     if (signature.ReturnType is { Name: "Void", Namespace: "System" })

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1278,10 +1278,12 @@ public sealed class CallIndirect : IrExpression
             AddChild(argument);
         ReturnType = returnType;
         ParameterTypes = parameterTypes;
+        ParameterRefKinds = TypeRef.FunctionPointerParameterRefKindsFor(parameterTypes);
     }
 
     public TypeRef ReturnType { get; }
     public ImmutableArray<TypeRef> ParameterTypes { get; }
+    public ImmutableArray<ArgumentRefKind> ParameterRefKinds { get; }
 
     /// <summary>
     /// The C# calling-convention spelling carried by the <c>calli</c> standalone

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -43,6 +43,8 @@ public enum ValueTypeHint
     ReferenceType,
 }
 
+readonly record struct TypeRefCustomModifier(bool IsRequired, string Namespace, string Name);
+
 /// <summary>
 /// Symbolic type identity for the pipeline (docs/decompiler-ir.md):
 /// assembly identity, name, and shape as a structured, comparable value.
@@ -97,6 +99,11 @@ public sealed class TypeRef : IEquatable<TypeRef>
 
     /// <summary>The C# calling-convention spelling of a function pointer (empty = managed, e.g. <c>unmanaged</c>, <c>unmanaged[Cdecl]</c>); empty otherwise.</summary>
     public string CallingConvention { get; private init; } = "";
+
+    /// <summary>Function-pointer parameter ref-kinds, aligned with <see cref="TypeArguments"/> when <see cref="Kind"/> is <see cref="TypeRefKind.FunctionPointer"/>.</summary>
+    public ImmutableArray<ArgumentRefKind> FunctionPointerParameterRefKinds { get; private init; } = [];
+
+    ImmutableArray<TypeRefCustomModifier> CustomModifiers { get; init; } = [];
 
     /// <summary>
     /// Whether the signature token that produced this type said struct or class
@@ -183,7 +190,114 @@ public sealed class TypeRef : IEquatable<TypeRef>
 
     /// <summary>A function pointer over <paramref name="parameters"/> returning <paramref name="returnType"/>; <paramref name="callingConvention"/> is the C# spelling (empty = managed).</summary>
     public static TypeRef FunctionPointer(TypeRef returnType, ImmutableArray<TypeRef> parameters, string callingConvention)
-        => new(TypeRefKind.FunctionPointer) { ElementType = returnType, TypeArguments = parameters, CallingConvention = callingConvention };
+    {
+        bool suppressGcTransition = HasCustomModifier(
+            returnType,
+            isRequired: false,
+            "System.Runtime.CompilerServices",
+            "CallConvSuppressGCTransition");
+        var cleanReturn = returnType.WithoutCustomModifiers();
+        var cleanParameters = ImmutableArray.CreateRange(parameters.Select(p => p.WithoutCustomModifiers()));
+        var parameterRefKinds = FunctionPointerParameterRefKindsFor(parameters);
+        string convention = AddSuppressGcTransition(callingConvention, suppressGcTransition);
+        return FunctionPointer(cleanReturn, cleanParameters, convention, parameterRefKinds);
+    }
+
+    static TypeRef FunctionPointer(
+        TypeRef returnType,
+        ImmutableArray<TypeRef> parameters,
+        string callingConvention,
+        ImmutableArray<ArgumentRefKind> parameterRefKinds)
+        => new(TypeRefKind.FunctionPointer)
+        {
+            ElementType = returnType,
+            TypeArguments = parameters,
+            CallingConvention = callingConvention,
+            FunctionPointerParameterRefKinds = parameterRefKinds,
+        };
+
+    internal static ImmutableArray<ArgumentRefKind> FunctionPointerParameterRefKindsFor(ImmutableArray<TypeRef> parameters)
+        => [.. parameters.Select(FunctionPointerParameterRefKind)];
+
+    static ArgumentRefKind FunctionPointerParameterRefKind(TypeRef parameter)
+    {
+        if (parameter.Kind != TypeRefKind.ByRef)
+            return ArgumentRefKind.Value;
+        if (HasCustomModifier(parameter, isRequired: true, "System.Runtime.InteropServices", "InAttribute")
+            || HasCustomModifier(parameter, isRequired: true, "System.Runtime.CompilerServices", "IsReadOnlyAttribute")
+            || HasCustomModifier(parameter, isRequired: true, "System.Runtime.CompilerServices", "RequiresLocationAttribute"))
+        {
+            return ArgumentRefKind.In;
+        }
+        if (HasCustomModifier(parameter, isRequired: true, "System.Runtime.InteropServices", "OutAttribute"))
+            return ArgumentRefKind.Out;
+        return ArgumentRefKind.Ref;
+    }
+
+    static string AddSuppressGcTransition(string callingConvention, bool suppressGcTransition)
+    {
+        if (!suppressGcTransition)
+            return callingConvention;
+        if (callingConvention.Length == 0 || callingConvention == "unmanaged")
+            return "unmanaged[SuppressGCTransition]";
+        const string prefix = "unmanaged[";
+        return callingConvention.StartsWith(prefix, StringComparison.Ordinal) && callingConvention.EndsWith(']')
+            ? callingConvention[..^1] + ", SuppressGCTransition]"
+            : callingConvention;
+    }
+
+    internal TypeRef WithCustomModifier(TypeRef modifier, bool isRequired)
+        => modifier is { Kind: TypeRefKind.Definition }
+            ? Copy(customModifiers: CustomModifiers.Add(new TypeRefCustomModifier(isRequired, modifier.Namespace, modifier.Name)))
+            : this;
+
+    TypeRef WithoutCustomModifiers()
+    {
+        TypeRef? element = ElementType?.WithoutCustomModifiers();
+        ImmutableArray<TypeRef> typeArguments = TypeArguments;
+        bool changed = !CustomModifiers.IsDefaultOrEmpty || !ReferenceEquals(element, ElementType);
+        if (!TypeArguments.IsDefaultOrEmpty)
+        {
+            var builder = ImmutableArray.CreateBuilder<TypeRef>(TypeArguments.Length);
+            foreach (var argument in TypeArguments)
+            {
+                var clean = argument.WithoutCustomModifiers();
+                changed |= !ReferenceEquals(clean, argument);
+                builder.Add(clean);
+            }
+            typeArguments = builder.MoveToImmutable();
+        }
+        return changed ? Copy(element, typeArguments, customModifiers: []) : this;
+    }
+
+    static bool HasCustomModifier(TypeRef type, bool isRequired, string ns, string name)
+        => type.CustomModifiers.Any(modifier =>
+            modifier.IsRequired == isRequired
+            && modifier.Namespace == ns
+            && modifier.Name == name);
+
+    TypeRef Copy(
+        TypeRef? elementType = null,
+        ImmutableArray<TypeRef>? typeArguments = null,
+        ImmutableArray<TypeRefCustomModifier>? customModifiers = null,
+        ImmutableArray<ArgumentRefKind>? functionPointerParameterRefKinds = null)
+        => new(Kind)
+        {
+            Assembly = Assembly,
+            Namespace = Namespace,
+            Name = Name,
+            ElementType = elementType ?? ElementType,
+            TypeArguments = typeArguments ?? TypeArguments,
+            Rank = Rank,
+            GenericParameterIndex = GenericParameterIndex,
+            GenericParameterName = GenericParameterName,
+            UnsupportedReason = UnsupportedReason,
+            CallingConvention = CallingConvention,
+            FunctionPointerParameterRefKinds = functionPointerParameterRefKinds ?? FunctionPointerParameterRefKinds,
+            ValueTypeHint = ValueTypeHint,
+            InlineArray = InlineArray,
+            CustomModifiers = customModifiers ?? CustomModifiers,
+        };
 
     /// <summary>
     /// Substitutes generic parameters with the given arguments (type
@@ -228,7 +342,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
                     changed |= !ReferenceEquals(substituted, parameter);
                     builder.Add(substituted);
                 }
-                return changed ? FunctionPointer(returnType, builder.MoveToImmutable(), CallingConvention) : this;
+                return changed ? FunctionPointer(returnType, builder.MoveToImmutable(), CallingConvention, FunctionPointerParameterRefKinds) : this;
             }
             default:
                 return this;
@@ -277,6 +391,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
             || GenericParameterIndex != other.GenericParameterIndex
             || UnsupportedReason != other.UnsupportedReason
             || CallingConvention != other.CallingConvention
+            || FunctionPointerParameterRefKinds.Length != other.FunctionPointerParameterRefKinds.Length
             || !Equals(ElementType, other.ElementType)
             || TypeArguments.Length != other.TypeArguments.Length)
         {
@@ -285,6 +400,11 @@ public sealed class TypeRef : IEquatable<TypeRef>
         for (int i = 0; i < TypeArguments.Length; i++)
         {
             if (!TypeArguments[i].Equals(other.TypeArguments[i]))
+                return false;
+        }
+        for (int i = 0; i < FunctionPointerParameterRefKinds.Length; i++)
+        {
+            if (FunctionPointerParameterRefKinds[i] != other.FunctionPointerParameterRefKinds[i])
                 return false;
         }
         // GenericParameterName is a naming aid, not identity: 'T' at index 0
@@ -304,6 +424,8 @@ public sealed class TypeRef : IEquatable<TypeRef>
         hash.Add(Rank);
         hash.Add(GenericParameterIndex);
         hash.Add(CallingConvention);
+        foreach (var kind in FunctionPointerParameterRefKinds)
+            hash.Add(kind);
         hash.Add(ElementType);
         foreach (var arg in TypeArguments)
             hash.Add(arg);
@@ -464,9 +586,25 @@ public sealed class TypeRef : IEquatable<TypeRef>
     /// </summary>
     string RenderFunctionPointer(TypeRef? scope = null)
     {
-        var parts = TypeArguments.Select(p => p.ToDisplayString(scope)).Append(ElementType!.ToDisplayString(scope));
+        var parts = TypeArguments.Select((p, index) => FunctionPointerParameterText(p, index, scope)).Append(ElementType!.ToDisplayString(scope));
         string convention = CallingConvention.Length > 0 ? $" {CallingConvention}" : "";
         return $"delegate*{convention}<{string.Join(", ", parts)}>";
+    }
+
+    string FunctionPointerParameterText(TypeRef parameter, int index, TypeRef? scope)
+    {
+        var kind = index >= 0 && index < FunctionPointerParameterRefKinds.Length
+            ? FunctionPointerParameterRefKinds[index]
+            : parameter.Kind == TypeRefKind.ByRef ? ArgumentRefKind.Ref : ArgumentRefKind.Value;
+        if (kind == ArgumentRefKind.Value || parameter.Kind != TypeRefKind.ByRef)
+            return parameter.ToDisplayString(scope);
+        string element = parameter.ElementType!.ToDisplayString(scope);
+        return kind switch
+        {
+            ArgumentRefKind.In => $"in {element}",
+            ArgumentRefKind.Out => $"out {element}",
+            _ => $"ref {element}",
+        };
     }
 
     static string StripArity(string name)

--- a/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRefDecoder.cs
@@ -120,6 +120,12 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         _ => "unmanaged",
     };
 
+    public static string ConventionText(SignatureCallingConvention convention, TypeRef returnType)
+    {
+        var pointer = TypeRef.FunctionPointer(returnType, [], ConventionText(convention));
+        return pointer.CallingConvention;
+    }
+
     /// <summary>
     /// Custom modifiers are seen through to the unmodified type. The three that
     /// occur in practice — <c>modreq(InAttribute)</c> (an <c>in</c>/<c>ref readonly</c>
@@ -142,7 +148,21 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
     /// distinction, model it then.
     /// </summary>
     public TypeRef GetModifiedType(TypeRef modifier, TypeRef unmodifiedType, bool isRequired)
-        => unmodifiedType;
+        => IsRepresentedFunctionPointerModifier(modifier, isRequired)
+            ? unmodifiedType.WithCustomModifier(modifier, isRequired)
+            : unmodifiedType;
+
+    static bool IsRepresentedFunctionPointerModifier(TypeRef modifier, bool isRequired)
+        => modifier is { Kind: TypeRefKind.Definition }
+            && ((isRequired
+                    && modifier.Namespace == "System.Runtime.InteropServices"
+                    && modifier.Name is "InAttribute" or "OutAttribute")
+                || (isRequired
+                    && modifier.Namespace == "System.Runtime.CompilerServices"
+                    && modifier.Name is "IsReadOnlyAttribute" or "RequiresLocationAttribute")
+                || (!isRequired
+                    && modifier.Namespace == "System.Runtime.CompilerServices"
+                    && modifier.Name == "CallConvSuppressGCTransition"));
 
     static string NameAt(ImmutableArray<string> names, int index)
         => index >= 0 && index < names.Length ? names[index] : "";


### PR DESCRIPTION
## Summary

Fixes #1499 by preserving function-pointer signature modifiers through the decompiler type model:

- renders `delegate* unmanaged[SuppressGCTransition]<...>` instead of dropping the suppressed-GC-transition modifier;
- renders `delegate*<in ...>` / `delegate*<out ...>` parameter modifiers instead of flattening them to `ref`;
- uses the decoded calli parameter ref-kinds so indirect calls spell `p(in value)` / `p(out value)` where required.

## Evidence

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.FunctionPointerDiagnosticsPassTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.RefArgumentRenderingTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.CallIndirectSpellabilityPassTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.UnsafeEmitterTests`

Full `src/ILInspector.Decompiler.Tests` currently has two unrelated origin/main failures reproduced on a clean `origin/main` worktree:

- `LoweringCoverageTests.EveryPipelinePassType_IsClassified_ByOneRegister`
- `IrImporterTests.UnmanagedCallersOnly_StdcallMethodAddress_PreservesFunctionPointerWitness`

Generated quality diff card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,294 methods
Correctness coverage: validity sampled 350 / 88,294 (0.40%); fidelity sampled 22 / 88,294 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,294 (+924)
- dotnet-inspect: 11,710 -> 12,238 methods (+528)
- ILInspector.Analysis: 500 -> 661 methods (+161)
- ILInspector.Decompiler: 5,004 -> 5,232 methods (+228)
- ILInspector.Metadata: 1,824 -> 1,831 methods (+7)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,624 (87.92%) | +730 |
| Conditional-branch residual | 2,290 (2.62%) | 2,312 (2.62%) | +22 |
| Forward-merge stops | 2,284 (2.61%) | 2,303 (2.61%) | +19 |
| Full malformed | 33 | 47 | +14 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,294 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,294 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (count regressions evaluated here): Full malformed 32 -> 46 (+14); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- Full malformed methods (pinned) increased by 14 (baseline 32, current 46, tolerance 0)
```

The same quality-card regression reproduces on current `origin/main`; origin/main validity check and this branch both report `Full malformed: 83`, so this PR is not the source of the malformed-count increase.

## Adversarial review

Opus 4.8 reviewed the patch and found no blocking issues. It flagged a low-confidence `in (T)x` edge for explicit calli `in` arguments; I tightened the explicit `in` path to require an lvalue before adding the `in` keyword, then reran focused tests and build successfully.
