### PR TITLE
Keep switch-targeted join blocks out of structured arms (#1517)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StructuringGotoScopeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringGotoScopeTests.cs
@@ -1,0 +1,84 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Adversarial guard for issue #1517. StructuringPass must not wrap a forward
+// diamond arm around a block that an outside control transfer still targets —
+// most commonly a surviving (unraised) SwitchBranch dispatch, or the sibling
+// arm. Nesting such a block puts its label inside the arm's braces while the
+// outside goto stays at the container scope, which the C# compiler rejects with
+// CS0159 ("no such label within the scope of the goto"). The pass must keep the
+// container flat instead. csc never emits this shape directly (the switch is
+// usually raised), so these are synthetic-IR near-misses, paired with a clean
+// positive diamond canary that must still raise.
+public class StructuringGotoScopeTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Owner = TypeRef.CoreLib("Synthetic", "T");
+
+    static IrExpression Cond() =>
+        new Comparison(ComparisonKind.Equal, isUnsigned: false, new LoadArgument(0, "a", Int32), new Constant(0, Int32));
+
+    static IrFunction Structured(Block[] blocks)
+    {
+        var container = new BlockContainer();
+        foreach (var block in blocks)
+            container.Add(block);
+        var signature = new MethodSignature(Int32, [new Parameter("a", Int32)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", Owner, signature, [Int32], container);
+        new StructuringPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+        return function;
+    }
+
+    // A clean forward diamond:
+    //   if (a == 0) goto trueArm;   // b0, false arm falls through
+    //   falseArm: goto join;        // b1
+    //   trueArm:  V_0 = 1;          // b2, falls into join
+    //   join:     return V_0;       // b3
+    static Block[] CleanDiamond()
+    {
+        var b0 = new Block(0);
+        b0.Add(new ConditionalBranch(Cond(), 24));     // -> trueArm (b2 @ 24)
+        var b1 = new Block(8);                          // false arm
+        b1.Add(new Branch(32));                         // -> join
+        var b2 = new Block(24);                         // true arm head
+        b2.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        var b3 = new Block(32);                         // join
+        b3.Add(new Return(new LoadLocal(0, Int32)));
+        return [b0, b1, b2, b3];
+    }
+
+    [Fact]
+    public void CleanDiamond_RaisesToIfElse()
+    {
+        var function = Structured(CleanDiamond());
+        Assert.NotEmpty(function.Descendants.OfType<IfStatement>());
+    }
+
+    [Fact]
+    public void SwitchTargetInsideArm_StaysFlat()
+    {
+        // Same diamond, but a leading (unraised) switch also dispatches into the
+        // true-arm head (b2 @ 24). Wrapping b2 in the else arm would strand the
+        // switch's `goto IL_0018` inside the braces (CS0159); the pass must keep
+        // the whole container flat rather than raise the diamond.
+        var sw = new Block(0);
+        sw.Add(new SwitchBranch(new LoadArgument(0, "a", Int32), [24]));   // case 0 -> trueArm head
+        var b1 = new Block(8);
+        b1.Add(new ConditionalBranch(Cond(), 24));      // diamond conditional -> trueArm
+        var b2 = new Block(16);                          // false arm
+        b2.Add(new Branch(32));                          // -> join
+        var b3 = new Block(24);                          // true arm head, ALSO a switch target
+        b3.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        var b4 = new Block(32);                          // join
+        b4.Add(new Return(new LoadLocal(0, Int32)));
+
+        var function = Structured([sw, b1, b2, b3, b4]);
+
+        // Declined: no diamond raised, so the switch target keeps a container-level
+        // label and the SwitchBranch survives at top level (legal gotos).
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+        Assert.NotEmpty(function.Descendants.OfType<SwitchBranch>());
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -542,7 +542,7 @@ public sealed class StructuringPass : IIrPass
                 continue;  // an internal jump stays inside the arm — legal
             foreach (var child in blocks[source].Children)
             {
-                if (child is not SwitchBranch switchBranch)
+                if (child is not SwitchBranch switchBranch || IsStateMachineDispatch(switchBranch))
                     continue;
                 foreach (int targetOffset in switchBranch.TargetOffsets)
                 {
@@ -554,6 +554,17 @@ public sealed class StructuringPass : IIrPass
         }
         return false;
     }
+
+    /// <summary>
+    /// A compiler state-machine dispatch — <c>switch (this.&lt;&gt;1__state)</c> in
+    /// an iterator/async <c>MoveNext</c>. These run before the iterator/async
+    /// reconstruction passes (which consume the dispatch and its resume blocks),
+    /// so the switch never reaches the printer and nesting its targets is safe.
+    /// Only a <em>surviving</em> user switch strands a label, so the scope guard
+    /// excludes the state dispatch (matching the field the reconstruction keys on).
+    /// </summary>
+    static bool IsStateMachineDispatch(SwitchBranch switchBranch) =>
+        switchBranch.Value is LoadField { Instance: LoadArgument { Index: 0 }, Field.Name: "<>1__state" };
 
     /// <summary>
     /// An infinite (<c>while (true)</c>) loop headed at <paramref name="head"/>:

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -389,6 +389,12 @@ public sealed class StructuringPass : IIrPass
                     // true arm.
                     if (FindRegionExitDiamond(ctx, falseStart, target, stop, joinIndex) is { } exitDiamond)
                     {
+                        if (RegionExternallyEntered(ctx, falseStart, target)
+                            || RegionExternallyEntered(ctx, target, exitDiamond.LocalJoin))
+                        {
+                            ctx.Recorder?.Record("arm-externally-entered");
+                            return false;
+                        }
                         if (!Validate(ctx, falseStart, target, joinIndex: exitDiamond.ExitTarget, breakTarget, continueTarget)
                             || !Validate(ctx, target, exitDiamond.LocalJoin, joinIndex: exitDiamond.ExitTarget, breakTarget, continueTarget))
                         {
@@ -399,6 +405,16 @@ public sealed class StructuringPass : IIrPass
                     }
                     if (FindDiamondJoin(blocks, offsetToIndex, falseStart, target, stop) is { } join)
                     {
+                        // Neither arm may enclose a block an outside goto still
+                        // targets (e.g. a surviving SwitchBranch dispatch, or the
+                        // sibling arm): nesting it would print a goto into the arm
+                        // braces (CS0159). Stay flat instead.
+                        if (RegionExternallyEntered(ctx, falseStart, target)
+                            || RegionExternallyEntered(ctx, target, join))
+                        {
+                            ctx.Recorder?.Record("arm-externally-entered");
+                            return false;
+                        }
                         // False arm exits by goto join; true arm falls (or
                         // returns) into join.
                         if (!Validate(ctx, falseStart, target, joinIndex: join, breakTarget, continueTarget)
@@ -410,6 +426,11 @@ public sealed class StructuringPass : IIrPass
                         break;
                     }
                     // Guard form: arm is (i+1, target), continues at target.
+                    if (RegionExternallyEntered(ctx, falseStart, target))
+                    {
+                        ctx.Recorder?.Record("arm-externally-entered");
+                        return false;
+                    }
                     if (!Validate(ctx, falseStart, target, joinIndex: target, breakTarget, continueTarget))
                         return false;
                     i = target;
@@ -499,6 +520,39 @@ public sealed class StructuringPass : IIrPass
             }
         }
         return count;
+    }
+
+    /// <summary>
+    /// True when a block inside the arm range <c>[start, stop)</c> is the target
+    /// of an unraised <see cref="SwitchBranch"/> dispatch located <em>outside</em>
+    /// that range. <see cref="Validate"/> treats a surviving SwitchBranch as
+    /// fallthrough (it raises no switch here), so the dispatch is printed as a
+    /// chain of <c>goto</c>s that nothing dissolves. Wrapping one of its targets
+    /// inside an arm's braces would strand those gotos as jumps <em>into</em> the
+    /// braced scope (CS0159), so the region must stay flat. Conditional/unconditional
+    /// guards are not checked: they are either consumed by the if/diamond shape or
+    /// inlined as shared terminators, so they leave no surviving label.
+    /// </summary>
+    static bool RegionExternallyEntered(Ctx ctx, int start, int stop)
+    {
+        var blocks = ctx.Blocks;
+        for (int source = 0; source < blocks.Count; source++)
+        {
+            if (source >= start && source < stop)
+                continue;  // an internal jump stays inside the arm — legal
+            foreach (var child in blocks[source].Children)
+            {
+                if (child is not SwitchBranch switchBranch)
+                    continue;
+                foreach (int targetOffset in switchBranch.TargetOffsets)
+                {
+                    if (ctx.OffsetToIndex.TryGetValue(targetOffset, out int target)
+                        && target >= start && target < stop)
+                        return true;  // switch dispatches into this arm
+                }
+            }
+        }
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #1517.

## The bug

`StructuringPass` raised a forward-branch diamond/guard whose arm lexically
absorbed a block that a surviving, unraised `SwitchBranch` dispatch still
targets. `Validate` treats a `SwitchBranch` terminator as fallthrough (it raises
no switch here), so the dispatch prints as a chain of `goto IL_xxxx;`. When the
arm enclosed one of those targets, the target's label landed inside the arm's
braces while the gotos stayed at the container scope — a jump *into* a scope the
C# compiler rejects (`CS0159` "no such label within the scope of the goto"),
emitted while the method was reported `Full`.

`System.DateTimeFormat::GetAllDateTimes` (CoreLib) is the canonical case: a
switch dispatch survives unraised, then an if/else puts its target `IL_00B0` in
the `else` arm, stranding eight `goto IL_00B0;`/`goto IL_011A;`.

## The fix

`RegionExternallyEntered`: before raising a diamond (`FindDiamondJoin` /
`FindRegionExitDiamond`) or a guard arm, decline when a block in the arm range is
the target of a `SwitchBranch` located outside that range. The container then
stays flat, so the dispatch keeps container-level labels and the gotos stay
legal (an honesty improvement — invalid `Full` becomes valid `Partial`).

Two deliberate narrowings keep the guard from over-declining:
- **Only `SwitchBranch` sources are checked.** An unraised switch always survives
  to print and is never inlined; conditional/unconditional guards are either
  consumed by the if/diamond shape or inlined as shared terminators, so they
  strand no label. (Checking them regressed comparison-tree case bodies.)
- **State-machine dispatch is excluded.** Structuring runs before the
  iterator/async reconstruction passes, so an iterator `MoveNext`'s
  `switch (this.<>1__state)` is still a `SwitchBranch` here — but it is consumed
  with its resume blocks before printing, so nesting its targets never strands a
  label. The guard skips a `SwitchBranch` on `this.<>1__state` (the field the
  reconstruction keys on); only a surviving *user* switch trips it.

## Evidence

**CoreLib `--validity-check` (apples-to-apples, same assembly before/after):**

| | baseline | this PR |
| --- | ---: | ---: |
| `Full` | 37,984 | 37,982 |
| CS0159 (goto-into-scope) | 19 | 1 |
| `Full` malformed (parse) | 0 | 0 |

Every binding-error code stays equal or decreases (−18 CS0159, plus −3 CS0034 /
−2 CS0266 / −2 CS0149 from the two methods that now render flat); nothing
regresses. Two methods degrade `Full`→`Partial` — the honest result. The one
remaining CS0159 is a pre-existing, distinct *missing-label* (dropped-block)
shape unrelated to arm scoping.

**Tests:** adds `StructuringGotoScopeTests` (a `SwitchBranch`-into-arm near-miss
that must stay flat, plus a clean-diamond canary that must still raise). The
structuring/switch/loop/diamond/comparison-tree/iterator test classes — the ones
this change exercises — pass (212 run, 0 failed).

**Test-environment note (not a regression):** the full `ILInspector.Decompiler.Tests`
run cannot go green in this sandbox: the recompile-back tests
(`*PinnedFixesStayOpcodeExact`, `SkeletonEmitTests.*`, `*RecompileExactly`) hang
spawning `csc`, and two tests fail (`LoweringCoverageTests.EveryPipelinePassType`
on the unrelated `CallIndirectSpellabilityPass`, and
`IrImporterTests.UnmanagedCallersOnly_StdcallMethodAddress`). All of these
reproduce identically on clean `origin/main` (8a494e57) without this change —
verified by running them on the base commit (the recompile tests time out there
too; a hang cannot be caused by a structuring-logic change). CI should run the
full suite normally.

Cross-model adversarial review requested per `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
