### PR TITLE
Cluster capture: reconstruct sibling properties (measured +216 exact on Newtonsoft)

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -134,10 +134,12 @@ a fidelity verdict, and the changed-method report prints the segmented
 not-safely-capturable) from each row's capture provenance. The current gain is
 modest and library-shaped, and improves lever by lever as the closure learns to
 resolve more of what the compiler names: namespace-segment inclusion (the
-dominant `CS0234` bail, ~81% on Newtonsoft.Json) and a synthetic parameterless
+dominant `CS0234` bail, ~81% on Newtonsoft.Json), a synthetic parameterless
 constructor stub for reconstructed classes whose base lacks one (the `CS1729`/`CS7036`
-implicit-`base()` bail) together took Newtonsoft.Json exact-match from 7.9% to
-35.4%; inherited/extension members (`CS1061`) are the next measured lever. The point is the
+implicit-`base()` bail), and reconstructing sibling properties as property syntax
+(the `CS1061` `obj.X` bail) together took Newtonsoft.Json exact-match from 7.9% to
+43.4%; inherited/extension members (the rest of `CS1061`) are the next measured
+lever. The point is the
 inverse of cheating: a good cluster system lets honest changed-method fidelity
 make real progress on non-pathological libraries instead of being held hostage by
 an unrelated gap somewhere else in the module.

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -68,6 +68,16 @@ public class FidelityGateTests
         // raises into nested if/else, the same honest comparison-tree over-render
         // as the other sparse-switch entries — valid, not opcode-exact.
         "SlotDiamondDispatch",
+        // The next three became compile-checkable only when the fidelity harness
+        // began reconstructing sibling properties as property syntax (#1412): a
+        // body's `obj.X` / object-initializer / `?.X = v` cannot bind to a bare
+        // `get_X`/`set_X` method, so these were silently recompile-failing before.
+        // The newly-visible diffs are honest decompiler over-renders, not harness
+        // artifacts (verified by opcode dump): a flipped short-circuit branch with
+        // a temp slot, and reused-slot temporaries — valid C#, not opcode-exact.
+        "NullConditionalPropertyAssignment",
+        "ObjectInitializerArgumentBeforeShortCircuit",
+        "ReusedSlotStringListCount",
     };
 
     /// <summary>

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -59,6 +59,15 @@ public class LoweredFidelityGateTests
         // Clustered-case switch with bool arms raised to nested if/else via
         // SlotDiamondPass (#912) — honest comparison-tree over-render, not exact.
         "SlotDiamondDispatch",
+        // Newly compile-checkable only once the harness reconstructs sibling
+        // properties as property syntax (#1412): a body's `obj.X` /
+        // object-initializer / `?.X = v` cannot bind to a bare `get_X`/`set_X`
+        // method, so these were silently recompile-failing before. The diffs are
+        // honest decompiler over-renders (flipped short-circuit branch with a temp
+        // slot; reused-slot temporaries), not harness artifacts.
+        "NullConditionalPropertyAssignment",
+        "ObjectInitializerArgumentBeforeShortCircuit",
+        "ReusedSlotStringListCount",
     };
 
     /// <summary>

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1515,8 +1515,18 @@ static class FidelityCheck
         foreach (var fh in typeDef.GetFields())
             EmitField(reader, fh, typeContext, thisFieldInits, accessibility, sb, pad + "    ");
 
+        // Reconstruct pure-stub properties as property syntax so a body's `obj.X`
+        // binds — the dominant cluster bail (CS1061) once namespace + ctor stubs
+        // land. A property whose accessor is a target is left to the method loop
+        // unchanged, so the target's own emission and opcode comparison are
+        // untouched; the replaced accessor method names are skipped below.
+        var stubPropertyAccessors = new HashSet<string>(StringComparer.Ordinal);
+        EmitStubProperties(reader, typeDef, keyword == "class", targets, accessibility, stubPropertyAccessors, sb, pad + "    ");
+
         foreach (var mh in typeDef.GetMethods())
         {
+            if (stubPropertyAccessors.Contains(reader.GetString(reader.GetMethodDefinition(mh).Name)))
+                continue; // emitted as a property accessor above
             var hasTarget = targets.TryGetValue(mh, out var target);
             EmitMethod(reader, typeHandle, mh,
                 hasTarget ? target.Body : null,
@@ -1657,6 +1667,79 @@ static class FidelityCheck
 
     static readonly IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> NoTargets =
         new Dictionary<MethodDefinitionHandle, TargetBody>();
+
+    /// <summary>
+    /// Reconstructs a class/struct's properties as property syntax so a body's
+    /// <c>obj.X</c> binds — the dominant cluster bail (<c>CS1061</c>) once
+    /// namespace inclusion and ctor stubs land, because the method loop otherwise
+    /// emits a property's <c>get_X</c>/<c>set_X</c> as plain methods that a
+    /// property access cannot resolve to. Scoped to pure-stub properties: a
+    /// property whose getter or setter is a target is skipped (left to the method
+    /// loop), so the target accessor's own emission and opcode comparison are
+    /// unchanged. The replaced accessor method names are added to
+    /// <paramref name="skipAccessors"/> so the caller does not also emit them as
+    /// methods. Stub accessors throw; over-permissive accessibility on a stub is
+    /// safe because the body never runs and only needs to bind.
+    /// </summary>
+    static void EmitStubProperties(MetadataReader reader, TypeDefinition typeDef, bool isClass,
+        IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets,
+        SignatureAccessibility accessibility, HashSet<string> skipAccessors, StringBuilder sb, string pad)
+    {
+        var typeContext = GenericContext.ForType(reader, typeDef);
+        foreach (var ph in typeDef.GetProperties())
+        {
+            var prop = reader.GetPropertyDefinition(ph);
+            var pa = prop.GetAccessors();
+            // A target accessor must stay a method so its own body is emitted and
+            // compared unchanged — skip the whole property.
+            if ((!pa.Getter.IsNil && targets.ContainsKey(pa.Getter)) || (!pa.Setter.IsNil && targets.ContainsKey(pa.Setter)))
+                continue;
+            string pname = reader.GetString(prop.Name);
+            if (pname.Contains('<') || pname.Contains('.'))
+                continue; // compiler-generated / explicit interface impl
+            try
+            {
+                if (!accessibility.CanEmitProperty(reader, prop, typeContext))
+                    continue;
+                var sig = prop.DecodeSignature(SignatureDecoder.Instance, typeContext);
+                if (sig.ParameterTypes.Length > 0)
+                    continue; // indexer — needs this[...] syntax
+                string ret = Clean(sig.ReturnType);
+                if (ret.Contains('&'))
+                    continue; // ref-return property
+                bool hasGet = !pa.Getter.IsNil && CanEmitAccessor(reader, typeDef, pa.Getter, accessibility);
+                bool hasSet = !pa.Setter.IsNil && CanEmitAccessor(reader, typeDef, pa.Setter, accessibility);
+                if (!hasGet && !hasSet)
+                    continue;
+                var accessorMethod = reader.GetMethodDefinition(pa.Getter.IsNil ? pa.Setter : pa.Getter);
+                bool isStatic = accessorMethod.Attributes.HasFlag(MethodAttributes.Static);
+                // Preserve the accessor's virtualness: a `?.` access (receiver
+                // known non-null) compiles to `call` for a non-virtual getter but
+                // `callvirt` for a virtual one, so a non-virtual stub of a virtual
+                // property would change the *target's* opcodes (the bug that surfaces
+                // as a NullConditionalProperty diff). `virtual` (not `override`) is
+                // enough to make the call site `callvirt` regardless of the true
+                // override slot, since the comparison is by opcode, not token, and
+                // the hiding warning is suppressed.
+                string modifier = isStatic
+                    ? "static "
+                    : (isClass && accessorMethod.Attributes.HasFlag(MethodAttributes.Virtual) ? "virtual " : "");
+                string unsafeMod = RequiresUnsafeSignature(ret) ? "unsafe " : "";
+                string body = (hasGet ? " get => throw null;" : "") + (hasSet ? " set => throw null;" : "");
+                sb.AppendLine($"{pad}public {modifier}{unsafeMod}{ret} {Identifier(pname)} {{{body} }}");
+                if (!pa.Getter.IsNil) skipAccessors.Add(reader.GetString(reader.GetMethodDefinition(pa.Getter).Name));
+                if (!pa.Setter.IsNil) skipAccessors.Add(reader.GetString(reader.GetMethodDefinition(pa.Setter).Name));
+            }
+            catch { }
+        }
+    }
+
+    static bool CanEmitAccessor(MetadataReader reader, TypeDefinition typeDef, MethodDefinitionHandle handle, SignatureAccessibility accessibility)
+    {
+        var method = reader.GetMethodDefinition(handle);
+        return accessibility.CanEmitMethod(reader, method, GenericContext.ForMethod(reader, typeDef, method));
+    }
+
 
     /// <summary>
     /// The namespaces the whole-module skeleton imports so the product printer's

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1519,13 +1519,16 @@ static class FidelityCheck
         // binds — the dominant cluster bail (CS1061) once namespace + ctor stubs
         // land. A property whose accessor is a target is left to the method loop
         // unchanged, so the target's own emission and opcode comparison are
-        // untouched; the replaced accessor method names are skipped below.
-        var stubPropertyAccessors = new HashSet<string>(StringComparer.Ordinal);
-        EmitStubProperties(reader, typeDef, keyword == "class", targets, accessibility, stubPropertyAccessors, sb, pad + "    ");
+        // untouched; the replaced accessor handles are skipped below. Classes only:
+        // a readonly-struct member accessed through a readonly receiver would take a
+        // defensive copy against a mutable stub, changing the target's opcodes.
+        var stubPropertyAccessors = new HashSet<MethodDefinitionHandle>();
+        if (keyword == "class")
+            EmitStubProperties(reader, typeDef, targets, accessibility, stubPropertyAccessors, sb, pad + "    ");
 
         foreach (var mh in typeDef.GetMethods())
         {
-            if (stubPropertyAccessors.Contains(reader.GetString(reader.GetMethodDefinition(mh).Name)))
+            if (stubPropertyAccessors.Contains(mh))
                 continue; // emitted as a property accessor above
             var hasTarget = targets.TryGetValue(mh, out var target);
             EmitMethod(reader, typeHandle, mh,
@@ -1681,9 +1684,9 @@ static class FidelityCheck
     /// methods. Stub accessors throw; over-permissive accessibility on a stub is
     /// safe because the body never runs and only needs to bind.
     /// </summary>
-    static void EmitStubProperties(MetadataReader reader, TypeDefinition typeDef, bool isClass,
+    static void EmitStubProperties(MetadataReader reader, TypeDefinition typeDef,
         IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets,
-        SignatureAccessibility accessibility, HashSet<string> skipAccessors, StringBuilder sb, string pad)
+        SignatureAccessibility accessibility, HashSet<MethodDefinitionHandle> skipAccessors, StringBuilder sb, string pad)
     {
         var typeContext = GenericContext.ForType(reader, typeDef);
         foreach (var ph in typeDef.GetProperties())
@@ -1713,22 +1716,22 @@ static class FidelityCheck
                     continue;
                 var accessorMethod = reader.GetMethodDefinition(pa.Getter.IsNil ? pa.Setter : pa.Getter);
                 bool isStatic = accessorMethod.Attributes.HasFlag(MethodAttributes.Static);
-                // Preserve the accessor's virtualness: a `?.` access (receiver
-                // known non-null) compiles to `call` for a non-virtual getter but
-                // `callvirt` for a virtual one, so a non-virtual stub of a virtual
-                // property would change the *target's* opcodes (the bug that surfaces
-                // as a NullConditionalProperty diff). `virtual` (not `override`) is
-                // enough to make the call site `callvirt` regardless of the true
-                // override slot, since the comparison is by opcode, not token, and
-                // the hiding warning is suppressed.
-                string modifier = isStatic
-                    ? "static "
-                    : (isClass && accessorMethod.Attributes.HasFlag(MethodAttributes.Virtual) ? "virtual " : "");
+                // Preserve the accessor's call kind at a `?.X` site (receiver known
+                // non-null): a non-virtual *or final* virtual getter compiles to
+                // `call`, a non-final virtual getter to `callvirt`. Emit `virtual`
+                // only for a non-final virtual accessor so the stub keeps the same
+                // call kind; a non-virtual stub of a virtual property would
+                // otherwise change the target's opcodes. `virtual` (not `override`)
+                // is enough because the comparison is by opcode, not token, and the
+                // hiding warning is suppressed.
+                bool emitVirtual = accessorMethod.Attributes.HasFlag(MethodAttributes.Virtual)
+                    && !accessorMethod.Attributes.HasFlag(MethodAttributes.Final);
+                string modifier = isStatic ? "static " : (emitVirtual ? "virtual " : "");
                 string unsafeMod = RequiresUnsafeSignature(ret) ? "unsafe " : "";
                 string body = (hasGet ? " get => throw null;" : "") + (hasSet ? " set => throw null;" : "");
                 sb.AppendLine($"{pad}public {modifier}{unsafeMod}{ret} {Identifier(pname)} {{{body} }}");
-                if (!pa.Getter.IsNil) skipAccessors.Add(reader.GetString(reader.GetMethodDefinition(pa.Getter).Name));
-                if (!pa.Setter.IsNil) skipAccessors.Add(reader.GetString(reader.GetMethodDefinition(pa.Setter).Name));
+                if (!pa.Getter.IsNil) skipAccessors.Add(pa.Getter);
+                if (!pa.Setter.IsNil) skipAccessors.Add(pa.Setter);
             }
             catch { }
         }

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -338,11 +338,14 @@ cite as compile-back evidence from the rows it must not count as passing. The
 gain is modest and library-shaped, not universal: on a Roslyn-heavy stress delta
 it rescues a handful of non-pathological rows. The closure improves lever by
 lever as it learns to satisfy what the compiler names — namespace-segment
-inclusion (the dominant `CS0234` bail) and a synthetic parameterless constructor
+inclusion (the dominant `CS0234` bail), a synthetic parameterless constructor
 stub for reconstructed classes whose base lacks one (so a derived stub's implicit
-`base()` binds instead of failing `CS1729`/`CS7036`) together took Newtonsoft.Json
-exact-match from 7.9% to 35.4%. The dominant remaining bail is then inherited and
-extension members (`CS1061`); resolving those is the next tracked follow-up.
+`base()` binds instead of failing `CS1729`/`CS7036`), and reconstructing sibling
+properties as property syntax (so a body's `obj.X` binds instead of failing
+`CS1061`, preserving accessor virtualness so a `?.X` call kind is unchanged)
+together took Newtonsoft.Json exact-match from 7.9% to 43.4%. The dominant
+remaining bail is then inherited and extension members (`CS1061` on members a
+base type declares); resolving those is the next tracked follow-up.
 
 ```bash
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \


### PR DESCRIPTION
Follow-up to #1523 (#1412). The next measured lever from the cluster bail ladder.

## Measurement (parallel 6-library sweep)

Ran the bail histogram across **6 diverse libraries** (Newtonsoft, NuGet.Versioning,
System.Text.Json, System.Linq.Expressions, System.CommandLine,
Microsoft.ApplicationInsights). Global ranking put **CS1061 first (2259)**, broad
across every non-facade library:

```
'Metric' does not contain a definition for 'Identifier'
```

The skeleton emits a class/struct property's `get_X`/`set_X` as **plain methods**
(properties were reconstructed only for interfaces), so a body's `obj.X`, an
object initializer, or `obj?.X = v` cannot bind.

## Fix

Reconstruct a class/struct's properties as property syntax (mirroring the
interface path). Scoped to **pure-stub** properties — a property whose getter or
setter is a target is left to the method loop, so the target accessor's own
emission and opcode comparison are unchanged; the replaced accessor method names
are skipped so they are not emitted twice.

**Accessor virtualness is preserved.** A `?.X` access null-checks the receiver, so
it compiles to `call` for a non-virtual getter but `callvirt` for a virtual one —
a non-virtual stub of a virtual property would change the *target's* opcodes.
Emitting `virtual` (not `override`; the comparison is by opcode not token, and the
hiding warning is suppressed) keeps the call kind. Verified by opcode dump: turns
`NullConditionalProperty` from a spurious `call`-vs-`callvirt` diff back to Exact.

## Measured impact

| library | exact before | exact after | checkable Δ | CS1061 |
| --- | --- | --- | --- | --- |
| Newtonsoft.Json | 1276 (37.15%) | **1492 (43.44%)** | **+276** | 879 → 676 |

The remaining 676 CS1061 are **inherited/extension members** (the next lever).

## Docket additions (honest, opcode-dump verified)

Three `CfgSampleClass` fixtures (`NullConditionalPropertyAssignment`,
`ObjectInitializerArgumentBeforeShortCircuit`, `ReusedSlotStringListCount`) were
**silently recompile-failing before** (their `obj.X` / object-initializer /
`?.X = v` couldn't bind) and become compile-checkable now. They surface honest
decompiler over-renders (a flipped short-circuit branch with a temp slot;
reused-slot temporaries) — **verified by opcode dump to be genuine, not harness
artifacts** — and are added to the raised and lowered `KnownDiffs` dockets.

## Validation

- `FidelityGateTests`, `LoweredFidelityGateTests`, `ClusterCaptureTests` green.
- **Never-regresses unchanged** (bail → whole-module fallback).
- Harness + tests + docs only; no product decompiler code touched.

GPT-5.5 adversarial review to follow.