### PR TITLE
Retain comparison-tree leave-targeted tails

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ComparisonTreeBoolArmPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ComparisonTreeBoolArmPassTests.cs
@@ -1,0 +1,96 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ComparisonTreeBoolArmPassTests
+{
+    static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
+
+    [Fact]
+    public void SharedFalseTail_WithoutLeaveTarget_FoldsAndDropsTail()
+    {
+        var function = BuildFunction(includeLeaveToTail: false);
+
+        new ComparisonTreeBoolArmPass().Run(function, PassContext.None);
+
+        var arm = Assert.Single(function.Body.Blocks, b => b.StartOffset == 20);
+        var ret = Assert.IsType<Return>(Assert.Single(arm.Children));
+        Assert.IsType<LogicalBinary>(ret.Value);
+        Assert.DoesNotContain(function.Body.Blocks, b => b.StartOffset is 24 or 28 or 60);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SharedFalseTail_TargetedByNestedLeave_IsRetained()
+    {
+        var function = BuildFunction(includeLeaveToTail: true);
+
+        new ComparisonTreeBoolArmPass().Run(function, PassContext.None);
+
+        var arm = Assert.Single(function.Body.Blocks, b => b.StartOffset == 20);
+        var ret = Assert.IsType<Return>(Assert.Single(arm.Children));
+        Assert.IsType<LogicalBinary>(ret.Value);
+        Assert.DoesNotContain(function.Body.Blocks, b => b.StartOffset is 24 or 28);
+        Assert.Contains(function.Body.Blocks, b => b.StartOffset == 60);
+        Assert.Contains(function.Descendants.OfType<Leave>(), leave => leave.TargetOffset == 60);
+        function.CheckInvariant();
+    }
+
+    static IrFunction BuildFunction(bool includeLeaveToTail)
+    {
+        LoadArgument X() => new(0, "x", s_int);
+        LoadArgument Y() => new(1, "y", s_int);
+        Constant C(int value) => new(value, s_int);
+
+        var container = new BlockContainer();
+        var b0 = new Block(0);
+        b0.Add(new ConditionalBranch(new Comparison(ComparisonKind.Equal, false, X(), C(0)), 20));
+        var b4 = new Block(4);
+        b4.Add(new ConditionalBranch(new Comparison(ComparisonKind.Equal, false, X(), C(1)), 44));
+        var b8 = new Block(8);
+        b8.Add(new ConditionalBranch(new Comparison(ComparisonKind.Equal, false, X(), C(2)), 48));
+        var b12 = new Block(12);
+        b12.Add(new ConditionalBranch(new Comparison(ComparisonKind.Equal, false, X(), C(3)), 52));
+        var rangeLow = new Block(20);
+        rangeLow.Add(new ConditionalBranch(new Comparison(ComparisonKind.LessThan, false, Y(), C(64)), 60));
+        var rangeHigh = new Block(24);
+        rangeHigh.Add(new ConditionalBranch(new Comparison(ComparisonKind.GreaterThan, false, Y(), C(127)), 60));
+
+        foreach (var block in (Block[])[
+            b0, b4, b8, b12, BoolReturn(16, false), rangeLow, rangeHigh, BoolReturn(28, true),
+            BoolReturn(44, true), BoolReturn(48, false), BoolReturn(52, true), BoolReturn(60, false)])
+        {
+            container.Add(block);
+        }
+        if (includeLeaveToTail)
+            container.Add(LeaveTargetingTail());
+
+        var signature = new MethodSignature(s_bool,
+            [new Parameter("x", s_int), new Parameter("y", s_int)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [s_bool], container);
+    }
+
+    static Block BoolReturn(int offset, bool value)
+    {
+        var block = new Block(offset);
+        block.Add(new StoreLocal(0, s_bool, new Constant(value, s_bool)));
+        block.Add(new Return(new LoadLocal(0, s_bool)));
+        return block;
+    }
+
+    static Block LeaveTargetingTail()
+    {
+        var tryBody = new BlockContainer();
+        var leaveBlock = new Block(100);
+        leaveBlock.Add(new Leave(60));
+        tryBody.Add(leaveBlock);
+        var finallyBody = new BlockContainer();
+        var finallyBlock = new Block(104);
+        finallyBlock.Add(new EndFinally());
+        finallyBody.Add(finallyBlock);
+        var block = new Block(96);
+        block.Add(new TryFinally(tryBody, finallyBody));
+        return block;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ComparisonTreeBoolArmPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ComparisonTreeBoolArmPass.cs
@@ -66,7 +66,7 @@ public sealed class ComparisonTreeBoolArmPass : IIrPass
             if (TryMatch(blocks, offsetToIndex, p, out var match)
                 && NoExternalEntry(blocks, p, match.SuccessIndex, leaveTargets))
             {
-                Fold(container, p, match, stepper);
+                Fold(container, p, match, leaveTargets, stepper);
                 return true;
             }
         }
@@ -192,7 +192,7 @@ public sealed class ComparisonTreeBoolArmPass : IIrPass
         _ => [],
     };
 
-    static void Fold(BlockContainer container, int p, Match match, Stepper stepper)
+    static void Fold(BlockContainer container, int p, Match match, HashSet<int> leaveTargets, Stepper stepper)
     {
         var blocks = container.Blocks.ToList();
 
@@ -220,7 +220,7 @@ public sealed class ComparisonTreeBoolArmPass : IIrPass
                 kept.Add(blocks[idx]);
 
         var tail = blocks[match.TailIndex];
-        if (kept.Contains(tail) && !HasIncoming(kept, tail.StartOffset))
+        if (kept.Contains(tail) && !leaveTargets.Contains(tail.StartOffset) && !HasIncoming(kept, tail.StartOffset))
             kept.Remove(tail);
 
         foreach (var block in blocks)


### PR DESCRIPTION
## Summary

Fixes #1469 by keeping `ComparisonTreeBoolArmPass` from deleting a shared bool-return tail when any nested `Leave` still targets that tail offset.

The pass already computes function-wide `leaveTargets`; this threads that set into the fold and treats `leaveTargets.Contains(tail.StartOffset)` as incoming before removing the tail.

## Shape proof

- Added `SharedFalseTail_WithoutLeaveTarget_FoldsAndDropsTail` as the positive canary: the comparison-tree bool arm still folds and drops the unreferenced false tail.
- Added `SharedFalseTail_TargetedByNestedLeave_IsRetained` as the adversarial fixture: the arm still folds, blocks 24/28 are consumed, the tail block remains, and the nested `Leave` still targets it.

Before/after evidence:

```text
origin/main + new tests:
SharedFalseTail_TargetedByNestedLeave_IsRetained failed
Assert.Contains() Failure: tail block offset 60 was not retained

this branch:
ComparisonTreeBoolArmPassTests Total: 2, Errors: 0, Failed: 0
```

## Validation

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/ComparisonTreeBoolArmPassTests/*"
ILInspector.Decompiler.Tests Total: 2, Errors: 0, Failed: 0

dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet
Build succeeded. 0 Warning(s), 0 Error(s)
```

Full `src/ILInspector.Decompiler.Tests` was run after merging latest `origin/main`, but current main has unrelated compile-back/skeleton/cluster failures in this environment. Spot checks on pristine `origin/main` reproduce the same classes of failures (`PrinterPrecedenceTests`, `RangeFromGetSubArrayPassTests`, `SkeletonEmitTests`, `ClusterCaptureTests`; earlier also `LoweringCoverageTests`/`IrImporterTests` before #1537 landed). The new focused tests and product build are green.

Generated quality card after merging latest `origin/main`:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,347 methods
Correctness coverage: validity sampled 350 / 88,347 (0.40%); fidelity sampled 34 / 88,347 (0.04%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,347 (+977)
- dotnet-inspect: 11,710 -> 12,240 methods (+530)
- ILInspector.Analysis: 500 -> 665 methods (+165)
- ILInspector.Decompiler: 5,004 -> 5,277 methods (+273)
- ILInspector.Metadata: 1,824 -> 1,833 methods (+9)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,658 (87.90%) | +764 |
| Conditional-branch residual | 2,290 (2.62%) | 2,320 (2.63%) | +30 |
| Forward-merge stops | 2,284 (2.61%) | 2,310 (2.61%) | +26 |
| Full malformed | 33 | 32 | -1 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,347 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 5/34, exact 29, recompile-failed 0, context-failed 0; sampled 34 / 88,347 (0.04%) | +4 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (count regressions evaluated here): Full malformed 32 -> 32 (0); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- fully-raised rate dropped 11 bps (baseline 88.01%, current 87.90%, tolerance 10 bps)

Caveat: the corpus drifted from the baseline (see baseline staleness above). The aggregate count rows above mix the PR with that drift, but count-based regressions are gated on the pinned-NuGet subset (a fixed method set), so any `(pinned)` regression listed here is a real decompiler delta, not drift.
```

Changed-method fidelity is not separately applicable: this is a synthetic IR control-flow bug fixture rather than a corpus-derived changed-method population.
