### PR TITLE
Reconcile mixed-sign ordering comparison and compound assignment (#1476)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MixedSignComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignComparisonTests.cs
@@ -7,8 +7,10 @@ namespace ILInspector.Decompiler.Tests;
 // compares the raw bits regardless of sign. csc emits this shape from its own
 // lowerings (e.g. ulong.CreateTruncating(x) != (long)i in Enum.AreSequentialFromZero),
 // not from directly spellable source, so these are constructed at the IR level. The
-// printer must reinterpret the signed operand as unsigned (a same-width no-op cast)
-// so the rendered C# binds.
+// printer must reconcile the operands to one C# type so the rendered C# binds:
+// equality reinterprets the signed operand as unsigned (a same-width no-op cast),
+// while a signed ordering (`clt`/`cgt`) reinterprets the unsigned operand as signed
+// to preserve the signed comparison (#1476).
 public class MixedSignComparisonTests
 {
     static readonly TypeRef ULong = TypeRef.CoreLib("System", "UInt64");
@@ -57,12 +59,31 @@ public class MixedSignComparisonTests
     }
 
     [Fact]
-    public void LessThanULongLong_LeavesOrderingUntouched()
+    public void LessThanULongLong_ReinterpretsUnsignedOperandAsSigned()
     {
-        // Scope boundary: a signed ordering comparison must NOT be reinterpreted as
-        // unsigned (that would change its meaning). Only equality is reconciled here;
-        // the ordering/compound CS0034 variants are tracked separately.
+        // A signed ordering (`clt`) between a same-width signed/unsigned pair is
+        // CS0034. Unlike equality, the unsigned operand reinterprets to SIGNED so
+        // the signed comparison the IL performs is preserved.
         var output = Render(ComparisonKind.LessThan, ULong, Long);
-        Assert.DoesNotContain("(ulong)b", output);
+        Assert.Contains("(long)a < b", output);
+        Assert.DoesNotContain("(ulong)", output);
+    }
+
+    [Fact]
+    public void GreaterThanLongULong_ReinterpretsUnsignedOperandAsSigned()
+    {
+        // Same reconciliation when the unsigned operand is on the right.
+        var output = Render(ComparisonKind.GreaterThan, Long, ULong);
+        Assert.Contains("a > (long)b", output);
+        Assert.DoesNotContain("(ulong)", output);
+    }
+
+    [Fact]
+    public void LessThanLongLong_LeavesSameTypeOrderingUntouched()
+    {
+        // Positive canary: a same-type ordering pair needs no cast and must not gain one.
+        var output = Render(ComparisonKind.LessThan, Long, Long);
+        Assert.Contains("a < b", output);
+        Assert.DoesNotContain("(long)", output);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/MixedSignComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignComparisonTests.cs
@@ -86,4 +86,29 @@ public class MixedSignComparisonTests
         Assert.Contains("a < b", output);
         Assert.DoesNotContain("(long)", output);
     }
+
+    [Fact]
+    public void SignedOrdering_NestedUnsignedRenderingOperand_CastsWholeSubtree()
+    {
+        // A nested mixed-sign arithmetic operand (`long a + ulong b`) renders
+        // unsigned (`(ulong)a + b`) though its IR ResultType is signed, so the
+        // signed-ordering reconcile must cast the whole rendered subtree —
+        // otherwise `ulong < long` stays CS0034.
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var sum = new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false,
+            new LoadArgument(0, "a", Long), new LoadArgument(1, "b", ULong));
+        var block = new Block(0);
+        block.Add(new Return(new Comparison(ComparisonKind.LessThan, isUnsigned: false,
+            sum, new LoadArgument(2, "c", Long))));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction("M", owner,
+            new MethodSignature(Bool,
+                [new Parameter("a", Long), new Parameter("b", ULong), new Parameter("c", Long)],
+                HasThis: false, GenericParameterCount: 0),
+            [], body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("(long)((ulong)a + b) < c", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/MixedSignCompoundTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignCompoundTests.cs
@@ -1,0 +1,57 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A compound assignment whose binary mixes the target's signedness — e.g.
+// `ulong V_0 -= (long)1` in System.Math.BitIncrement — has no C# common type, so
+// `target op= rhs` is CS0034 at Full. The rhs must bind to the target lvalue type
+// (#1476). csc emits this from its own lowerings, not directly spellable source,
+// so it is constructed at the IR level.
+public class MixedSignCompoundTests
+{
+    static readonly TypeRef ULong = TypeRef.CoreLib("System", "UInt64");
+    static readonly TypeRef Long = TypeRef.CoreLib("System", "Int64");
+    static readonly TypeRef Int = TypeRef.CoreLib("System", "Int32");
+
+    // ulong V_0 = arg; V_0 = V_0 - (long)1; return V_0;  →  the second store folds
+    // to a compound assignment whose right operand is a signed (long) 1.
+    static string Render(BinaryKind kind)
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var rhs = new ILInspector.Decompiler.Pipeline.Convert(Long, isChecked: false, isUnsigned: false, new Constant(1, Int));
+        var binary = new Binary(kind, isChecked: false, isUnsigned: false, new LoadLocal(0, ULong), rhs);
+
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, ULong, new LoadArgument(0, "arg", ULong)));
+        block.Add(new StoreLocal(0, ULong, binary));
+        block.Add(new Return(new LoadLocal(0, ULong)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M", owner,
+            new MethodSignature(ULong, [new Parameter("arg", ULong)], HasThis: false, GenericParameterCount: 0),
+            [ULong],
+            body);
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void SubtractCompound_MixedSign_BindsToTargetType()
+    {
+        var output = Render(BinaryKind.Subtract);
+
+        Assert.Contains("V_0 -= ", output);
+        // The right operand must not stay signed (`(long)1`), which is CS0034
+        // against the unsigned target.
+        Assert.DoesNotContain("(long)", output);
+    }
+
+    [Fact]
+    public void AddCompound_MixedSign_BindsToTargetType()
+    {
+        var output = Render(BinaryKind.Add);
+
+        Assert.Contains("V_0 += ", output);
+        Assert.DoesNotContain("(long)", output);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/MixedSignCompoundTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignCompoundTests.cs
@@ -54,4 +54,15 @@ public class MixedSignCompoundTests
         Assert.Contains("V_0 += ", output);
         Assert.DoesNotContain("(long)", output);
     }
+
+    [Fact]
+    public void DivideCompound_MixedSign_KeepsSignednessSensitiveOpUnreconciled()
+    {
+        // Divide is sign-sensitive (`/` vs `div.un`), so the mixed-sign RHS cast is
+        // NOT applied — casting the operand to the unsigned target type would flip
+        // the opcode. The operand keeps its signed `(long)` form instead.
+        var output = Render(BinaryKind.Divide);
+
+        Assert.Contains("(long)", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -424,6 +424,19 @@ public sealed partial class CSharpPrinter
         {
             return $"{BitwiseUnsignedOperand(left)} {ComparisonOperator(kind)} {BitwiseUnsignedOperand(right)}";
         }
+        // A signed ordering (`clt`/`cgt`) between a same-width signed/unsigned pair
+        // also has no C# common type (CS0034), but unlike equality the sign matters:
+        // the IL compares as signed, so reinterpret the unsigned operand to its
+        // signed counterpart (a same-width no-op cast) rather than to unsigned.
+        // The unsigned ordering (`clt.un`/`cgt.un`) reconciles to unsigned through
+        // the UnsignedOperand fallthrough below.
+        if (kind is ComparisonKind.LessThan or ComparisonKind.LessThanOrEqual
+                or ComparisonKind.GreaterThan or ComparisonKind.GreaterThanOrEqual
+            && !isUnsigned
+            && MixedSignSameWidthIntegers(left, right))
+        {
+            return $"{SignedOperand(left)} {ComparisonOperator(kind)} {SignedOperand(right)}";
+        }
         return isUnsigned
             ? $"{UnsignedOperand(left)} {ComparisonOperator(kind)} {UnsignedOperand(right)}"
             : $"{Operand(left)} {ComparisonOperator(kind)} {Operand(right)}";
@@ -452,6 +465,26 @@ public sealed partial class CSharpPrinter
     {
         string? cast = TypeFamilies.UnsignedCastKeyword(operand.ResultType);
         return cast is null ? Operand(operand) : $"({cast}){Operand(operand)}";
+    }
+
+    /// <summary>
+    /// Casts a wide unsigned-integer operand to its signed counterpart (uint→int,
+    /// ulong→long, nuint→nint) for a signed mixed-sign ordering reconciliation;
+    /// already-signed and unknown-typed operands print plain. An unsigned constant
+    /// outside the signed range takes the <c>unchecked</c> spelling so the
+    /// out-of-range cast is legal (CS0221).
+    /// </summary>
+    string SignedOperand(IrExpression operand)
+    {
+        var signed = TypeFamilies.SignedCounterpart(operand.ResultType);
+        if (signed is null)
+            return Operand(operand);
+        string cast = $"({TypeText(signed)}){Operand(operand)}";
+        // A constant unsigned operand's value may exceed the signed range
+        // (e.g. (long)ulong.MaxValue), which is CS0221 without unchecked; the
+        // unsigned value, not the peeled signed value, is what overflows, so wrap
+        // any constant operand defensively (a no-op for a fitting constant).
+        return TryGetIntegerConstant(operand, out _) ? $"unchecked({cast})" : cast;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -476,7 +476,11 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string SignedOperand(IrExpression operand)
     {
-        var signed = TypeFamilies.SignedCounterpart(operand.ResultType);
+        // Key off EffectiveType, not ResultType: a nested mixed-sign subtree
+        // (`long + ulong`) has a signed ResultType but renders unsigned
+        // (`(ulong)a + b`), so the signed reinterpret must wrap the rendered
+        // unsigned text — matching BitwiseUnsignedOperand's use of EffectiveType.
+        var signed = TypeFamilies.SignedCounterpart(EffectiveType(operand));
         if (signed is null)
             return Operand(operand);
         string cast = $"({TypeText(signed)}){Operand(operand)}";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1918,7 +1918,13 @@ public sealed partial class CSharpPrinter
             return $"{target}{(binary.Kind == BinaryKind.Add ? "++" : "--")};";
         string rightText = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight
             ? ShiftCount(binary)
-            : Operand(binary.Right);
+            // A mixed-sign same-width binary (`ulong -= (long)1`) has no C# common
+            // type, so `target op= right` is CS0034. The bit operation is identical
+            // either way, so cast the right operand to the target lvalue type — the
+            // type `binary.Left` (the target read) carries — to make it bind.
+            : MixedSignSameWidthIntegers(binary)
+                ? CastValue(binary.Right, binary.Left.ResultType)
+                : Operand(binary.Right);
         return $"{target} {BinaryOperator(binary)}= {rightText};";
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1919,10 +1919,13 @@ public sealed partial class CSharpPrinter
         string rightText = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight
             ? ShiftCount(binary)
             // A mixed-sign same-width binary (`ulong -= (long)1`) has no C# common
-            // type, so `target op= right` is CS0034. The bit operation is identical
-            // either way, so cast the right operand to the target lvalue type — the
-            // type `binary.Left` (the target read) carries — to make it bind.
-            : MixedSignSameWidthIntegers(binary)
+            // type, so `target op= right` is CS0034. For the sign-NEUTRAL operators
+            // (unchecked +/-/*, bitwise &/|/^) the bit operation is identical either
+            // way, so cast the right operand to the target lvalue type — the type
+            // `binary.Left` (the target read) carries — to make it bind. Sign-sensitive
+            // ops (/, %, checked .ovf, where the cast would flip div/div.un or the
+            // overflow domain) are deliberately excluded and keep their plain form.
+            : MixedSignArithmetic(binary) || MixedSignBitwise(binary)
                 ? CastValue(binary.Right, binary.Left.ResultType)
                 : Operand(binary.Right);
         return $"{target} {BinaryOperator(binary)}= {rightText};";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -215,6 +215,15 @@ public static class TypeFamilies
         _ => null,
     };
 
+    /// <summary>The signed-counterpart TypeRef of a wide unsigned integer type; null when already signed, float, sub-int, or unknown.</summary>
+    public static TypeRef? SignedCounterpart(TypeRef? type) => SignedCastKeyword(type) switch
+    {
+        "int" => TypeRef.CoreLib("System", "Int32"),
+        "long" => TypeRef.CoreLib("System", "Int64"),
+        "nint" => TypeRef.CoreLib("System", "IntPtr"),
+        _ => null,
+    };
+
     /// <summary>
     /// The C# cast keyword that reinterprets a signed-integer type as its
     /// unsigned counterpart; null when the type is already unsigned, float
@@ -227,6 +236,24 @@ public static class TypeFamilies
                 "SByte" or "Int16" or "Int32" => "uint",
                 "Int64" => "ulong",
                 "IntPtr" => "nuint",
+                _ => null,
+            }
+            : null;
+
+    /// <summary>
+    /// The C# cast keyword that reinterprets a <em>wide</em> unsigned-integer type
+    /// (uint/ulong/nuint) as its signed counterpart; null when already signed,
+    /// float, sub-int (byte/ushort/char promote to int), or unknown. The mirror of
+    /// <see cref="UnsignedCastKeyword"/>, used to reconcile a signed ordering
+    /// comparison whose operands are a same-width signed/unsigned pair.
+    /// </summary>
+    public static string? SignedCastKeyword(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+            ? type.Name switch
+            {
+                "UInt32" => "int",
+                "UInt64" => "long",
+                "UIntPtr" => "nint",
                 _ => null,
             }
             : null;


### PR DESCRIPTION
Closes #1476 (sibling of #1475; #1396 Stage 2 / #1453 Cluster C numeric-validity family).

## Over-raise claim narrowed

Two printer paths emitted **CS0034-invalid C# at `Full` fidelity** when a same-width signed/unsigned integer pair (`ulong`/`long`, `nuint`/`nint`) met an operator with no C# common type. #1475 fixed the equality path; these two remained:

1. **Ordering comparison (`ComparisonText`).** A signed `clt`/`cgt` between the pair fell through to bare operands. Reproduced minimally: `static bool F(long v) => v is >= 0 and <= uint.MaxValue;` → `v <= (ulong)…` (long vs ulong, CS0034).
2. **Compound assignment (`CompoundStatement`).** `ulong V_0 -= (long)1` assumed "no conversion on this path" — false for a mixed-sign binary. E.g. `System.Math::BitIncrement`.

## Fix

- **Ordering:** unlike equality (which reinterprets to unsigned — wrong for ordering), reinterpret the **unsigned** operand to its **signed** counterpart (`(long)x`). A same-width reinterpret emits no IL, so the signed comparison is preserved opcode-for-opcode. Unsigned ordering (`clt.un`/`cgt.un`) already reconciles via `UnsignedOperand`.
- **Compound:** cast the right operand to the **target lvalue type** (the type `binary.Left` carries), so `target op= rhs` binds.
- Adds `TypeFamilies.SignedCastKeyword`/`SignedCounterpart` (mirror of the unsigned helpers) and a `SignedOperand` printer helper (unchecked-wraps a constant operand whose unsigned value may exceed the signed range).

Audited: only these two paths lacked reconciliation; equality (#1475) and unsigned ordering already bind.

## Evidence

**CoreLib `--validity-check --compile-cap 2000`: CS0034 → 0** (was 10 after #1475). `System.Math::BitIncrement` now renders `V_0 -= 1;` / `V_0 += 1;` and the `uint.MaxValue`-range checks bind.

**Adversarial fixtures + canaries** (constructed at the IR level — csc emits these from its own lowerings, not directly spellable source):

- `MixedSignComparisonTests`: signed-ordering now reconciles (`(long)a < b`, `a > (long)b`); same-type ordering canary stays bare (`a < b`, no cast); the equality cases are unchanged.
- New `MixedSignCompoundTests`: `ulong -= (long)1` / `+= (long)1` bind to the target type, no `(long)` left.
- All numeric test classes pass (`MixedSign*`, `NegativeCastParenthesization`, `SubIntPromotion`, `PointerNullComparison`).

**Fidelity:** the signed-ordering reinterpret cast emits no opcode (same-width), so it is fidelity-neutral. The two `PinnedFixesStayOpcodeExact` failures (`SharedCaptureLambdas`, `CheckedAdd`) are **pre-existing environmental `RecompileFail` flakes** — verified to fail identically on clean `origin/main`.

**Quality card** (14 assemblies, 88,302 methods): **Full malformed 33 → 32 (−1)** (the CS0034 honesty improvement), semantic defects Δ0, pass bugs 0. The "fully-raised −11bps" verdict is **baseline drift** (corpus grew +932 methods; staleness block flagged); the **pinned-subset gate shows 0 regression** (Full malformed 32 → 32).

```
| Metric | Baseline | PR | Delta |
| Fully raised | 76,894 (88.01%) | 77,618 (87.90%) | +724 (drift) |
| Full malformed | 33 | 32 | -1 |
| Semantic defects | 4/350 | 4/350 | 0 |
| Pass bugs | 0 | 0 | 0 |
Pinned-subset gate: Full malformed 32 -> 32 (0).
```

Product path unchanged: SRM-only, NativeAOT-friendly, Roslyn-free, no inspected-assembly loading.

## Adversarial review

Requesting cross-model adversarial review (GPT-5.5 per AGENTS.md pairing). Summary to follow.
