### PR TITLE
Rank Performance Triage by triage priority (hot pay-dirt first)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,11 @@ names, and signal sets may change between releases.
 The whole-assembly call-graph analyzer ranks the members worth optimizing or
 hardening first. Select `Top Leverage` to rank members by direct callers,
 `Root Reach` (distinct entry points that transitively reach a member), fanout,
-depth, and loop calls; `Performance Triage` re-ranks the same leverage
-against actionable rewrite shapes (small non-escaping arrays, temporary or
-span-to-array copies, capturing delegates, stateless instance methods). Drill
+depth, and loop calls; `Performance Triage` surfaces the highest-value
+allocation pay-dirt first — ranking in-loop (hot) and high-confidence
+opportunities ahead of raw leverage — across actionable rewrite shapes (small
+non-escaping arrays, temporary or span-to-array copies, capturing and instance
+method-group delegates, and value-type boxing). Drill
 candidates with `Call Graph` (bounded outbound tree) and `Caller Graph`
 (bounded reverse tree to entry points), and project per-node cost with
 `--fields`. Ranking rows carry a copyable `Stable` selector, `Visibility`, and

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -230,7 +230,7 @@ public class OutputFormatterTests
     }
 
     [Fact]
-    public void ScanOptimizationOpportunities_PopulatesRootReachAndOrdersByLeverage()
+    public void ScanOptimizationOpportunities_OrdersByTriagePriority()
     {
         var rows = LibraryMetadataService.ScanOptimizationOpportunities(
             typeof(OutputFormatterTests).Assembly.Location, new VerboseLogger(false));
@@ -239,10 +239,23 @@ public class OutputFormatterTests
         Assert.NotEmpty(rows);
         // Root Reach is the leverage join: at least one opportunity sits in a reached method.
         Assert.Contains(rows, r => r.RootReach > 0);
-        // Rows are ordered by descending Root Reach so leveraged opportunities surface first.
+
+        // Triage priority: in-loop (hot) rows first, then by confidence, then by descending
+        // Root Reach. Verify the composite key is monotonically non-increasing.
+        static (int loop, int conf, int reach) Key(OptimizationOpportunitySummary r) =>
+            (r.Loop == "loop" ? 1 : 0,
+             r.Confidence == "high" ? 2 : r.Confidence == "medium" ? 1 : 0,
+             r.RootReach);
         for (int i = 1; i < rows.Count; i++)
-            Assert.True(rows[i - 1].RootReach >= rows[i].RootReach,
-                $"rows not ordered by descending Root Reach at index {i}");
+            Assert.True(Compare(Key(rows[i - 1]), Key(rows[i])) >= 0,
+                $"rows not ordered by triage priority at index {i}");
+
+        static int Compare((int loop, int conf, int reach) a, (int loop, int conf, int reach) b)
+        {
+            if (a.loop != b.loop) return a.loop - b.loop;
+            if (a.conf != b.conf) return a.conf - b.conf;
+            return a.reach - b.reach;
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -718,7 +718,12 @@ internal static class LibraryMetadataService
             var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
             var rows = index.OptimizationOpportunities
                 .Where(opportunity => !IsGeneratedMethod(opportunity.Method, generatedFrameworkTypes))
-                .OrderByDescending(opportunity => opportunity.RootReach)
+                // Performance Triage ordering: surface pay-dirt first. In-loop (repeated, hot)
+                // allocations lead, then by confidence, then by call-graph leverage (root reach).
+                // This is distinct from Top Leverage, which ranks purely by reach.
+                .OrderByDescending(opportunity => opportunity.InLoop)
+                .ThenByDescending(opportunity => ConfidenceRank(opportunity.Confidence))
+                .ThenByDescending(opportunity => opportunity.RootReach)
                 .ThenBy(opportunity => opportunity.Method.DeclaringType.ToQualifiedDisplayString(), StringComparer.Ordinal)
                 .ThenBy(opportunity => opportunity.Method.Name, StringComparer.Ordinal)
                 .ThenBy(opportunity => opportunity.ILOffset ?? -1)
@@ -743,6 +748,14 @@ internal static class LibraryMetadataService
             return null;
         }
     }
+
+    // Triage ordering weight for a confidence label (high allocations are the surest pay-dirt).
+    static int ConfidenceRank(string confidence) => confidence switch
+    {
+        "high" => 2,
+        "medium" => 1,
+        _ => 0,
+    };
 
     internal static List<IntegrationSignal>? ScanOpenTelemetry(string path, VerboseLogger logger)
     {

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -575,7 +575,8 @@ public class LibraryInspectionView
 
     public bool HasOptimizationOpportunities => _data.OptimizationOpportunities is { Count: > 0 };
 
-    // Rows arrive pre-ordered from the scanner (root reach desc, declaring type, member, IL offset).
+    // Rows arrive pre-ordered from the scanner by triage priority (in-loop first, then
+    // confidence, then root reach), so the highest-value pay-dirt surfaces first.
     [MarkoutSection(Name = "Performance Triage", ShowWhenProperty = nameof(HasOptimizationOpportunities))]
     public List<OptimizationOpportunityRow>? OptimizationOpportunitiesSection =>
         _data.OptimizationOpportunities?


### PR DESCRIPTION
## Summary

The section was renamed to **Performance Triage** (#1530) but still ranked purely by call-graph leverage (`Root Reach`) — making it identical in ordering to `Top Leverage`. Triage means *prioritize*, and the pay-dirt discriminator validated repeatedly this work is **whether an allocation is in a loop** (repeated/hot) vs a one-time construction or error path.

This reorders Performance Triage so the highest-value pay-dirt surfaces first:

1. **in-loop (hot) first**,
2. then **confidence** (high allocations are the surest pay-dirt),
3. then **root reach** (leverage),
4. then the existing stable tiebreakers (type, member, IL offset, shape).

## Why

The repeated lesson from applying the shapes to real libraries:

- **Polly**: 296 `instance-method-group-delegate`, **zero in loops** → all policy-construction (known-good). Reach-first ranking buried this.
- **Markout**: `new string[2]` **inside a render loop** → real pay-dirt.

Ranking in-loop + high-confidence first means the agent reading top-down hits genuine pay-dirt immediately, and the section is now meaningfully distinct from `Top Leverage` (pure reach).

## Effect (Newtonsoft.Json, top rows)

Before: whatever had the highest reach. After:

```
box-value-type      reach 78  high  loop
box-value-type      reach 34  high  loop
capturing-delegate  reach 24  high  loop
box-value-type      reach 9   high  loop
...
```

## Changes

- `LibraryMetadataService.ScanOptimizationOpportunities`: composite triage ordering + a `ConfidenceRank` helper.
- Updated the ordering test to assert the composite key (in-loop, confidence, reach) is monotonically non-increasing.
- Updated the view comment and the README section description (which also still listed the removed `stateless instance methods` shape and omitted the `box-value-type` / `instance-method-group-delegate` shapes).

No new CLI surface; opt-out is unchanged (`--fields`/`-S` still work). `dotnet-inspect.Tests` 1321 pass (9 ilasm-skipped); markdownlint clean.
