### PR TITLE
Escape keyword type-name segments in the fidelity harness skeleton (fixes #1542)

### DIFF
--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1425,7 +1425,7 @@ static class FidelityCheck
             string ns = reader.GetString(typeDef.Namespace);
             if (ns.Length > 0)
             {
-                sb.AppendLine($"namespace {ns}");
+                sb.AppendLine($"namespace {EscapeNamespace(ns)}");
                 sb.AppendLine("{");
                 EmitType(reader, typeHandle, targets, fieldInits, fieldInitType, accessibility, sb, 1);
                 sb.AppendLine("}");
@@ -2294,9 +2294,13 @@ static class FidelityCheck
     /// The Roslyn-free metadata signature decoder emits these bare, but the
     /// declaration side already escapes them (via <see cref="Identifier"/>), so an
     /// unescaped reference is invalid C# (`public event @return;`) that poisons the
-    /// whole reconstructed unit. Primitive type keywords (`int`, `void`, …) and the
-    /// structural `ref` prefix are legitimate spellings and are left alone, as are
-    /// the composite type string's `&lt;&gt;[],.*` punctuation.
+    /// whole reconstructed unit. A standalone primitive type keyword (`int`,
+    /// `void`, …) and the structural `ref` prefix are legitimate spellings and stay
+    /// bare; the same word as a *qualified* segment (preceded by `.`, so it can only
+    /// be a namespace/type identifier) is escaped to match its escaped declaration.
+    /// A standalone generic argument literally named with a primitive keyword stays
+    /// ambiguous at string level (the decoder yields the same text for the primitive
+    /// and the identifier) — an astronomically-rare case this does not regress.
     /// </summary>
     static string EscapeTypeKeywords(string type)
     {
@@ -2314,7 +2318,11 @@ static class FidelityCheck
                     i++;
                 string word = type[start..i];
                 bool alreadyEscaped = start > 0 && type[start - 1] == '@';
-                if (!alreadyEscaped && word is not ("void" or "ref") && !IsPrimitiveTypeName(word)
+                bool qualifiedSegment = start > 0 && type[start - 1] == '.';
+                // A bare primitive/`ref` is a real type spelling/by-ref prefix; the
+                // same word after a `.` can only be an identifier segment.
+                bool bareSpelling = (word is "void" or "ref" || IsPrimitiveTypeName(word)) && !qualifiedSegment;
+                if (!alreadyEscaped && !bareSpelling
                     && (SyntaxFacts.GetKeywordKind(word) != SyntaxKind.None || SyntaxFacts.GetContextualKeywordKind(word) != SyntaxKind.None))
                     sb.Append('@');
                 sb.Append(word);
@@ -2327,6 +2335,13 @@ static class FidelityCheck
         }
         return sb.ToString();
     }
+
+    /// <summary>
+    /// `@`-escapes each dotted segment of a namespace so a reserved-keyword segment
+    /// (`namespace Foo.event`) is legal C# and matches the escaped type references
+    /// <see cref="EscapeTypeKeywords"/> produces.
+    /// </summary>
+    static string EscapeNamespace(string ns) => string.Join('.', ns.Split('.').Select(Identifier));
 
     static string? ConstantText(MetadataReader reader, ConstantHandle handle)
     {

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2285,7 +2285,47 @@ static class FidelityCheck
             return "object";
         if (type.Contains("delegate*"))
             return "void*"; // a pointer-sized stand-in; calls through it are rare
-        return type;
+        return EscapeTypeKeywords(type);
+    }
+
+    /// <summary>
+    /// `@`-escapes keyword identifier segments in a decoded type name — a generic
+    /// parameter, namespace, or type segment literally named `event`/`class`/etc.
+    /// The Roslyn-free metadata signature decoder emits these bare, but the
+    /// declaration side already escapes them (via <see cref="Identifier"/>), so an
+    /// unescaped reference is invalid C# (`public event @return;`) that poisons the
+    /// whole reconstructed unit. Primitive type keywords (`int`, `void`, …) and the
+    /// structural `ref` prefix are legitimate spellings and are left alone, as are
+    /// the composite type string's `&lt;&gt;[],.*` punctuation.
+    /// </summary>
+    static string EscapeTypeKeywords(string type)
+    {
+        if (type.Length == 0 || !type.Any(c => char.IsLetter(c) || c == '_'))
+            return type;
+        var sb = new StringBuilder(type.Length);
+        int i = 0;
+        while (i < type.Length)
+        {
+            char c = type[i];
+            if (char.IsLetter(c) || c == '_')
+            {
+                int start = i;
+                while (i < type.Length && (char.IsLetterOrDigit(type[i]) || type[i] == '_'))
+                    i++;
+                string word = type[start..i];
+                bool alreadyEscaped = start > 0 && type[start - 1] == '@';
+                if (!alreadyEscaped && word is not ("void" or "ref") && !IsPrimitiveTypeName(word)
+                    && (SyntaxFacts.GetKeywordKind(word) != SyntaxKind.None || SyntaxFacts.GetContextualKeywordKind(word) != SyntaxKind.None))
+                    sb.Append('@');
+                sb.Append(word);
+            }
+            else
+            {
+                sb.Append(c);
+                i++;
+            }
+        }
+        return sb.ToString();
     }
 
     static string? ConstantText(MetadataReader reader, ConstantHandle handle)


### PR DESCRIPTION
Fixes #1542.

## Problem

The changed-method fidelity harness reconstructs a whole-module C# skeleton of the
assembly and recompiles it. Type *references* are rendered by the Roslyn-free
metadata `SignatureDecoder`, which emits an identifier segment literally named with
a keyword (a generic parameter, namespace, or type named `event`/`class`/…) **bare**.
The declaration side already `@`-escapes such names (via `Identifier`), so an
unescaped reference is invalid C#:

```csharp
public event @return;   // CS1001: Identifier expected
```

That one malformed member poisons the whole reconstructed unit, so every method in
it fails to recompile.

#1521 added the keyword fixture `@class<@event>` to the test assembly (which the
harness includes in every whole-module skeleton), turning `FidelityGateTests` and
`LoweredFidelityGateTests` **red on `main`** (`SharedCaptureLambdas` RecompileFail).
#1521 fixed the *product* decompiler's type-source escaping but not the *harness's*
separate renderer.

## Fix

Route `Clean()` (the harness's central type-name post-processor — every field,
parameter, return, and property type flows through it) through a new
`EscapeTypeKeywords` that `@`-escapes keyword identifier segments in a composite
type string, leaving alone:
- primitive type keywords (`int`, `void`, …) — legitimate spellings,
- the structural `ref` prefix,
- `<>[],.*` punctuation,
- already-`@`-escaped segments.

The reference now matches the escaped declaration.

## Validation

- `FidelityGateTests`, `LoweredFidelityGateTests`, `ClusterCaptureTests` all green
  (re-run on top of current `main`, which includes #1540).
- Harness-only change (one helper + a one-line `Clean()` routing); no product
  decompiler code touched.

GPT-5.5 adversarial review to follow.