### PR TITLE
Don't loop-promote box-value-type on a throw path

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -554,6 +554,18 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_BoxOnThrowPathInLoop_NotPromoted()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // A box that feeds an exception message only allocates on the throw path, so even inside
+        // a loop it is not hot pay-dirt: reported, but medium and not loop-promoted.
+        var row = Assert.Single(BoxRows(index, nameof(OptimizationOpportunityFixtures.BoxesIntoThrowMessage)));
+        Assert.Equal("medium", row.Confidence);
+        Assert.False(row.InLoop);
+    }
+
+    [Fact]
     public void OptimizationOpportunities_GenericParameterBox_NotReported()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -726,6 +738,19 @@ public class OptimizationOpportunityFixtures
         foreach (int v in values)
         {
             sink.Add(v);
+        }
+    }
+
+    // Boxes a value into an exception message on a throw path inside a loop -> the box only
+    // allocates when throwing, so it is NOT hot pay-dirt: reported, but medium (not loop-promoted).
+    public static void BoxesIntoThrowMessage(int code, int count)
+    {
+        for (int i = 0; i < count; i++)
+        {
+            if (code == i)
+            {
+                throw new System.InvalidOperationException(string.Format("dup {0}", code));
+            }
         }
     }
 

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1036,7 +1036,11 @@ public sealed class LibraryBodyIndex
                         var allocating = IsAllocatingValueTypeBox(token, boxed);
                         pendingBoxOffset = allocating ? offset : null;
                         pendingBoxType = allocating ? boxed : null;
-                        pendingBoxInLoop = allocating && IsInLoopRegion(offset, loopRegions);
+                        // A box on a throw path executes at most once before unwinding, so it is
+                        // not a repeated/hot allocation even inside a loop region.
+                        pendingBoxInLoop = allocating
+                            && IsInLoopRegion(offset, loopRegions)
+                            && !BoxFeedsThrowSoon(il, position);
                         break;
                     }
                     default:
@@ -1096,6 +1100,37 @@ public sealed class LibraryBodyIndex
         static bool IsEscapingBoxConsumer(ILOpCode op)
             => op is ILOpCode.Stelem_ref or ILOpCode.Call or ILOpCode.Callvirt
                 or ILOpCode.Newobj or ILOpCode.Stfld or ILOpCode.Stsfld or ILOpCode.Ret;
+
+        // True when a boxed value flows straight into a throw within a short window — the classic
+        // `box <enum>; call Format; newobj <Exception>; throw` exception-message pattern. Such a
+        // box only allocates on the error path, so it is not hot pay-dirt and is not loop-promoted.
+        bool BoxFeedsThrowSoon(byte[] il, int position)
+        {
+            for (int steps = 0; steps < 6 && position < il.Length; steps++)
+            {
+                int probeOffset = position;
+                var op = ReadOpcode(il, ref position);
+                if (op is ILOpCode.Throw or ILOpCode.Rethrow)
+                    return true;
+                if (IsControlFlowDivergent(op))
+                    return false;
+                SkipOperand(il, op, ref position, probeOffset);
+            }
+            return false;
+        }
+
+        // Opcodes after which straight-line flow no longer reliably reaches the next instruction
+        // (branches, switch, returns, leave/endfinally), so a forward throw-probe must stop.
+        static bool IsControlFlowDivergent(ILOpCode op)
+            => op is ILOpCode.Br or ILOpCode.Br_s or ILOpCode.Brtrue or ILOpCode.Brtrue_s
+                or ILOpCode.Brfalse or ILOpCode.Brfalse_s or ILOpCode.Beq or ILOpCode.Beq_s
+                or ILOpCode.Bne_un or ILOpCode.Bne_un_s or ILOpCode.Bge or ILOpCode.Bge_s
+                or ILOpCode.Bgt or ILOpCode.Bgt_s or ILOpCode.Ble or ILOpCode.Ble_s
+                or ILOpCode.Blt or ILOpCode.Blt_s or ILOpCode.Bge_un or ILOpCode.Bge_un_s
+                or ILOpCode.Bgt_un or ILOpCode.Bgt_un_s or ILOpCode.Ble_un or ILOpCode.Ble_un_s
+                or ILOpCode.Blt_un or ILOpCode.Blt_un_s or ILOpCode.Switch
+                or ILOpCode.Ret or ILOpCode.Leave or ILOpCode.Leave_s
+                or ILOpCode.Endfinally or ILOpCode.Endfilter;
 
         // True only when a `box` operand is positively identified as a value type that
         // unconditionally allocates. ECMA-335 allows `box` on reference types (no allocation),


### PR DESCRIPTION
## Summary

Refines the `box-value-type` confidence signal so cold exception-message boxing doesn't pollute the top of the (now triage-ranked) Performance Triage section.

A box that feeds an exception message — the classic `box <enum>; call Format; newobj <Exception>; throw` pattern — only allocates when the exception is thrown, i.e. on the error path. It is **not** a repeated/hot allocation, even when it sits inside a loop region. After #1545 (triage ranking ranks in-loop + high-confidence first), such boxes could otherwise rank at the very top.

## Change

At a `box`, a bounded forward probe (`BoxFeedsThrowSoon`) walks straight-line from the box up to 6 instructions; if it reaches `throw`/`rethrow` before any control-flow divergence (branch/switch/return/leave), the box is **not loop-promoted** — it stays medium confidence and `InLoop` is false, so it ranks below genuine hot allocations.

The probe is deliberately **conservative**: a longer window or an intervening branch leaves the box unchanged, so no genuine hot box is demoted (no regression — worst case a throw-path box stays as it was).

## Effect

On Newtonsoft.Json, high-confidence `box-value-type` rows drop **14 → 7**, removing exception-message boxes from the high band.

## Tests

- New `OptimizationOpportunities_BoxOnThrowPathInLoop_NotPromoted` fixture/test: a box feeding `throw new InvalidOperationException(string.Format(...))` inside a `for` loop is reported but medium and not in-loop.
- The existing in-loop-`Add` box still asserts high/in-loop (genuine hot box unaffected).
- `ILInspector.Analysis.Tests` 73 pass; `dotnet-inspect.Tests` 1321 pass (9 ilasm-skipped).

## Note

This is a confidence/ranking refinement, not a detection change — throw-path boxes are still reported (they do allocate when thrown), just not prioritized as hot pay-dirt.
