### PR TITLE
Cast mismatched pointer assignment values

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PointerAssignmentCastTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PointerAssignmentCastTests.cs
@@ -52,6 +52,16 @@ public class PointerAssignmentCastTests
         Assert.DoesNotContain("return V_0;", output);
     }
 
+    [Fact]
+    public void MismatchedPointerPropertyAssignment_RendersExplicitCast()
+    {
+        var output = Print(PointerPropertyStoreFunction());
+
+        Assert.Contains("byte* V_0 = null;", output);
+        Assert.Contains("owner.Pointer = (int*)V_0;", output);
+        Assert.DoesNotContain("owner.Pointer = V_0;", output);
+    }
+
     static string Print(IrFunction function)
     {
         function.CheckInvariant();
@@ -102,6 +112,27 @@ public class PointerAssignmentCastTests
             "M",
             Owner,
             new MethodSignature(IntPointer, [], HasThis: false, GenericParameterCount: 0),
+            [BytePointer],
+            body);
+    }
+
+    static IrFunction PointerPropertyStoreFunction()
+    {
+        var setter = new MethodRef(Owner, "set_Pointer", Void, [IntPointer], HasThis: true);
+        var block = new Block();
+        block.Add(new StoreLocal(0, BytePointer, new Constant(null, BytePointer)));
+        block.Add(new StoreProperty(
+            setter,
+            new LoadArgument(0, "owner", Owner),
+            [],
+            new LoadLocal(0, BytePointer)));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            Owner,
+            new MethodSignature(Void, [new Parameter("owner", Owner)], HasThis: false, GenericParameterCount: 0),
             [BytePointer],
             body);
     }

--- a/src/ILInspector.Decompiler.Tests/PointerAssignmentCastTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PointerAssignmentCastTests.cs
@@ -1,0 +1,108 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class PointerAssignmentCastTests
+{
+    static readonly TypeRef Byte = TypeRef.CoreLib("System", "Byte");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef BytePointer = TypeRef.Pointer(Byte);
+    static readonly TypeRef IntPointer = TypeRef.Pointer(Int32);
+    static readonly TypeRef Owner = TypeRef.Definition("Synthetic", "Samples", "PointerSamples");
+
+    [Fact]
+    public void MismatchedPointerLocalInitialization_RendersExplicitCast()
+    {
+        var output = Print(PointerStoreFunction(BytePointer, IntPointer));
+
+        Assert.Contains("byte* V_1 = null;", output);
+        Assert.Contains("int* V_0 = (int*)V_1;", output);
+        Assert.DoesNotContain("int* V_0 = V_1;", output);
+    }
+
+    [Fact]
+    public void SamePointerLocalInitialization_RendersWithoutCast()
+    {
+        var output = Print(PointerStoreFunction(IntPointer, IntPointer));
+
+        Assert.Contains("int* V_1 = null;", output);
+        Assert.Contains("int* V_0 = V_1;", output);
+        Assert.DoesNotContain("int* V_0 = (int*)V_1;", output);
+    }
+
+    [Fact]
+    public void MismatchedPointerAssignment_RendersExplicitCast()
+    {
+        var output = Print(PointerAssignmentFunction());
+
+        Assert.Contains("int* V_0 = null;", output);
+        Assert.Contains("byte* V_1 = null;", output);
+        Assert.Contains("V_0 = (int*)V_1;", output);
+        Assert.DoesNotContain("V_0 = V_1;", output);
+    }
+
+    [Fact]
+    public void MismatchedPointerReturn_RendersExplicitCast()
+    {
+        var output = Print(PointerReturnFunction());
+
+        Assert.Contains("byte* V_0 = null;", output);
+        Assert.Contains("return (int*)V_0;", output);
+        Assert.DoesNotContain("return V_0;", output);
+    }
+
+    static string Print(IrFunction function)
+    {
+        function.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+    }
+
+    static IrFunction PointerStoreFunction(TypeRef sourcePointer, TypeRef targetPointer)
+    {
+        var block = new Block();
+        block.Add(new StoreLocal(1, sourcePointer, new Constant(null, sourcePointer)));
+        block.Add(new StoreLocal(0, targetPointer, new LoadLocal(1, sourcePointer)));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            Owner,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [targetPointer, sourcePointer],
+            body);
+    }
+
+    static IrFunction PointerAssignmentFunction()
+    {
+        var block = new Block();
+        block.Add(new StoreLocal(0, IntPointer, new Constant(null, IntPointer)));
+        block.Add(new StoreLocal(1, BytePointer, new Constant(null, BytePointer)));
+        block.Add(new StoreLocal(0, IntPointer, new LoadLocal(1, BytePointer)));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            Owner,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [IntPointer, BytePointer],
+            body);
+    }
+
+    static IrFunction PointerReturnFunction()
+    {
+        var block = new Block();
+        block.Add(new StoreLocal(0, BytePointer, new Constant(null, BytePointer)));
+        block.Add(new Return(new LoadLocal(0, BytePointer)));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            Owner,
+            new MethodSignature(IntPointer, [], HasThis: false, GenericParameterCount: 0),
+            [BytePointer],
+            body);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -402,6 +402,13 @@ public sealed partial class CSharpPrinter
         {
             return $"({TypeText(target)}){LocalName(pinnedLoad.Index)}";
         }
+        if (target is { Kind: TypeRefKind.Pointer }
+            && EffectiveType(value) is { Kind: TypeRefKind.Pointer } pointerSource
+            && value is not Constant { Value: null }
+            && !target.Equals(pointerSource))
+        {
+            return $"({TypeText(target)}){Operand(value)}";
+        }
         // An integer flowing into an enum-typed position — a comparison kind, a
         // flags value computed at run time — needs an explicit (Enum)x cast: C#
         // converts int→enum implicitly only for the literal 0. The cast is always

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1335,7 +1335,8 @@ public sealed partial class CSharpPrinter
                 && load.PropertyName == s.PropertyName
                 && Equals(load.Accessor.DeclaringType, s.Accessor.DeclaringType)
                 && SameLValue(load.Instance, s.Instance)
-                && PlaceIdentity.SameOperands(load.IndexArguments, s.IndexArguments)),
+                && PlaceIdentity.SameOperands(load.IndexArguments, s.IndexArguments),
+            StorePropertyTargetType(s)),
         EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {CastValue(e.Value, e.Accessor.ParameterTypes[0])};",
         StoreElement s => $"{Operand(s.Array)}[{Expression(s.Index)}] = {CastValue(s.Value, s.ElementType)};",
         StoreIndirect s => AssignmentText(
@@ -1381,6 +1382,9 @@ public sealed partial class CSharpPrinter
             target.IsThisInstance ? new LoadArgument(0, "this", target.Field!.DeclaringType) : null),
         _ => $"/* {target.Describe()} */",
     };
+
+    static TypeRef? StorePropertyTargetType(StoreProperty store)
+        => store.Accessor.ParameterTypes.Length > 0 ? store.Accessor.ParameterTypes[^1] : null;
 
     string Expression(IrExpression node) => node switch
     {


### PR DESCRIPTION
## Summary

Fixes #1458 by making `CastValue` emit an explicit target pointer cast when a pointer expression flows into a differently typed pointer target.

This covers local initialization, later assignment, call/argument boundaries that already use `CastValue`, and returns. Same-typed pointer flows and pointer null literals remain unchanged.

## Evidence

Shape proof:

- Adversarial synthetic fixtures:
  - `byte*` local into `int*` declaration renders `int* V_0 = (int*)V_1;`.
  - later assignment renders `V_0 = (int*)V_1;`.
  - return renders `return (int*)V_0;`.
- Positive canary: same-typed `int*` to `int*` initialization renders without a cast.
- Real importer canary: `System.Array.CreateInstance` now contains `int* V_1 = (int*)S_257;`.

Validation:

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.PointerAssignmentCastTests`
- `dotnet build src/dotnet-inspect -c Release -v:q`
- Full `src/ILInspector.Decompiler.Tests` is currently blocked by unrelated calli baseline failures on current main:
  - `LoweringCoverageTests.EveryPipelinePassType_IsClassified_ByOneRegister` (`CallIndirectSpellabilityPass` classification)
  - `IrImporterTests.UnmanagedCallersOnly_StdcallMethodAddress_PreservesFunctionPointerWitness`
  These failures were also observed on current main in recent validation passes.

Generated quality card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,295 methods
Correctness coverage: validity sampled 350 / 88,295 (0.40%); fidelity sampled 22 / 88,295 (0.02%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,295 (+925)
- dotnet-inspect: 11,710 -> 12,238 methods (+528)
- ILInspector.Analysis: 500 -> 665 methods (+165)
- ILInspector.Decompiler: 5,004 -> 5,227 methods (+223)
- ILInspector.Metadata: 1,824 -> 1,833 methods (+9)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,613 (87.90%) | +719 |
| Conditional-branch residual | 2,290 (2.62%) | 2,316 (2.62%) | +26 |
| Forward-merge stops | 2,284 (2.61%) | 2,306 (2.61%) | +22 |
| Full malformed | 33 | 32 | -1 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,295 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 4/22, exact 18, recompile-failed 0, context-failed 0; sampled 22 / 88,295 (0.02%) | +3 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (count regressions evaluated here): Full malformed 32 -> 32 (0); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Verdict: corpus sensor reported regressions; review before merging.
```

Local main control produced the same quality card, so the aggregate fully-raised rate warning is baseline/current-main drift, not this branch. The branch improves `Full malformed` aggregate by 1 and leaves the pinned-subset gate clean.
