### PR TITLE
Count value-type boxing in the allocations signal

### DIFF
--- a/docs/design/graph-signal-annotations.md
+++ b/docs/design/graph-signal-annotations.md
@@ -44,7 +44,7 @@ regions) are folded in from the body scan during index build.
 
 | Field | Means | Derivation |
 | --- | --- | --- |
-| `Alloc` / `Allocations` | heap allocations in the body | `newobj` call edges (`CallKind.NewObject`) plus `newarr` array allocations |
+| `Alloc` / `Allocations` | heap allocations in the body | `newobj` call edges (`CallKind.NewObject`), `newarr` array allocations, plus `box` of value types |
 | `Copy` / `Copies` | copy/materialize calls | callees in a curated set (`ToArray`, `ToList`, `CopyTo`, `GetSubArray`, `Substring`, `Concat`, `Join`) |
 | `Unsafe` | method has unsafe evidence | any `UnsafeEvidence` for the method |
 | `Reflection` | dynamic / metadata work | callees under `System.Reflection*`, `System.Linq.Expressions`, or `System.Activator` |
@@ -62,7 +62,7 @@ regions) are folded in from the body scan during index build.
 
 | Field | Means | Derivation |
 | --- | --- | --- |
-| `EvidenceIL` / `Evidence` / `IL` | IL offsets of the signal sites | sorted offsets of the signal-bearing instructions (`newobj`/`newarr`/`throw`/`ldftn`/reflection calls), capped for compactness |
+| `EvidenceIL` / `Evidence` / `IL` | IL offsets of the signal sites | sorted offsets of the signal-bearing instructions (`newobj`/`newarr`/`box`/`throw`/`ldftn`/reflection calls), capped for compactness |
 
 A node renders a signal only when its count is non-zero (or, for `EvidenceIL`, when
 offsets exist), so requesting `--fields Alloc` annotates only the allocating nodes.

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -609,6 +609,16 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_GenericStructBox_IsBoxValueType()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // A constructed generic struct boxes via a TypeSpec; value-type-ness is read from the
+        // signature blob, so it is reported (not missed for lacking a well-known name).
+        Assert.Single(BoxRows(index, nameof(OptimizationOpportunityFixtures.BoxesGenericStruct)));
+    }
+
+    [Fact]
     public void OptimizationOpportunities_BitConverterGetBytes_IsTemporaryByteArrayCopy()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -792,11 +802,23 @@ public class OptimizationOpportunityFixtures
     {
         return System.BitConverter.GetBytes(value)[0];
     }
+
+    // Boxing a constructed in-assembly generic STRUCT (a TypeSpec) -> reported: value-type-ness
+    // comes from the TypeSpec signature blob (ELEMENT_TYPE_VALUETYPE), not the well-known list.
+    public static object BoxesGenericStruct(BoxFixtureStruct<int> value)
+    {
+        return value;
+    }
 }
 
 public struct BoxFixtureStruct
 {
     public int X;
+}
+
+public struct BoxFixtureStruct<T>
+{
+    public T Value;
 }
 
 // A source-generated type (mirrors the [GeneratedCode] System.Text.Json source generator

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -554,6 +554,20 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void MethodSignals_Allocations_CountBoxing()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+
+        // A method that boxes a value type but performs no newobj/newarr must still report a
+        // heap allocation in its signals (box allocates, like newobj/newarr).
+        var method = Assert.Single(index.Methods.Where(m =>
+            m.Name == nameof(OptimizationOpportunityFixtures.BoxesIntoStringFormat)));
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
+        Assert.True(s.Allocations >= 1, $"expected boxing to count as an allocation, got {s.Allocations}");
+    }
+
+    [Fact]
     public void OptimizationOpportunities_BoxOnThrowPathInLoop_NotPromoted()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1150,6 +1150,12 @@ public sealed class LibraryBodyIndex
                 var handle = MetadataTokens.EntityHandle(token);
                 if (handle.Kind == HandleKind.TypeDefinition)
                     return IsValueTypeDefinition((TypeDefinitionHandle)handle);
+                // A constructed generic type (e.g. Box<int>) is a TypeSpec whose signature blob
+                // directly encodes value-type-ness (ELEMENT_TYPE_VALUETYPE vs ELEMENT_TYPE_CLASS),
+                // so we don't need to resolve the definition. Covers in-assembly and external
+                // generic structs alike; Nullable<T> is already excluded above.
+                if (handle.Kind == HandleKind.TypeSpecification)
+                    return IsValueTypeSpec((TypeSpecificationHandle)handle);
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
             {
@@ -1157,6 +1163,27 @@ public sealed class LibraryBodyIndex
             }
 
             return leaf.Kind == TypeRefKind.Definition && IsWellKnownValueType(leaf.Namespace, leaf.Name);
+        }
+
+        // Reads a TypeSpec signature blob to decide value-type-ness directly from metadata. The
+        // signature is an ELEMENT_TYPE_* stream; a generic instance is GENERICINST followed by
+        // VALUETYPE (0x11) or CLASS (0x12), and a bare value/class spec starts with that byte.
+        bool IsValueTypeSpec(TypeSpecificationHandle handle)
+        {
+            const byte ElementTypeValueType = 0x11;
+            const byte ElementTypeGenericInst = 0x15;
+            var blob = _reader.GetBlobReader(_reader.GetTypeSpecification(handle).Signature);
+            if (blob.RemainingBytes == 0)
+                return false;
+            byte code = blob.ReadByte();
+            if (code == ElementTypeGenericInst)
+            {
+                if (blob.RemainingBytes == 0)
+                    return false;
+                code = blob.ReadByte();
+            }
+            // VALUETYPE (0x11) is a value type; CLASS (0x12) and everything else is not.
+            return code == ElementTypeValueType;
         }
 
         // Authoritative in-assembly check: a value type extends System.ValueType or System.Enum.

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -653,8 +653,8 @@ public sealed class LibraryBodyIndex
                             && !HasGeneratedCodeAttribute(methodAttributes)
                             && !HasCompilerGeneratedAttribute(methodAttributes))
                             optimizationOpportunities.AddRange(CollectOptimizationOpportunities(il, caller, scope, loopRegions));
-                        var signals = CollectBodySignals(il, body);
-                        if (signals.Newarr > 0 || signals.Throws > 0 || signals.Catches > 0 || signals.Finallys > 0)
+                        var signals = CollectBodySignals(il, body, scope);
+                        if (signals.Newarr > 0 || signals.Throws > 0 || signals.Catches > 0 || signals.Finallys > 0 || signals.Boxes > 0)
                             bodySignals[caller.MetadataToken] = signals;
                         ScanBody(il, caller, scope, calls, unsafeEvidence,
                             includeIndirectOpcodes: hasUnsafeApiMember || hasUnsafeSignature || hasUnsafeLocals,
@@ -1490,11 +1490,12 @@ public sealed class LibraryBodyIndex
         // throw/rethrow sites, and exception-handling clauses. Mirrors the loop-region
         // scan's defensive structure — a malformed body yields empty signals, never a
         // failed index build.
-        BodySignals CollectBodySignals(byte[] il, MethodBodyBlock body)
+        BodySignals CollectBodySignals(byte[] il, MethodBodyBlock body, GenericScope scope)
         {
-            int newarr = 0, throws = 0;
+            int newarr = 0, throws = 0, boxes = 0;
             var arrayOffsets = ImmutableArray.CreateBuilder<int>();
             var throwOffsets = ImmutableArray.CreateBuilder<int>();
+            var boxOffsets = ImmutableArray.CreateBuilder<int>();
             try
             {
                 int position = 0;
@@ -1512,6 +1513,21 @@ public sealed class LibraryBodyIndex
                             throws++;
                             throwOffsets.Add(offset);
                             break;
+                        case ILOpCode.Box:
+                        {
+                            // Boxing a genuinely-allocating value type is a heap allocation, like
+                            // newobj/newarr. Counted unconditionally (the box-value-type opportunity
+                            // adds the escape gate separately for actionable triage).
+                            int boxStart = position;
+                            int token = ReadInt32(il, ref position, offset);
+                            if (IsAllocatingValueTypeBox(token, ResolveTypeToken(token, scope)))
+                            {
+                                boxes++;
+                                boxOffsets.Add(offset);
+                            }
+                            position = boxStart; // let the shared SkipOperand advance past the token
+                            break;
+                        }
                     }
                     SkipOperand(il, opcode, ref position, offset);
                 }
@@ -1535,7 +1551,7 @@ public sealed class LibraryBodyIndex
                 }
             }
 
-            return new BodySignals(newarr, throws, catches, finallys, arrayOffsets.ToImmutable(), throwOffsets.ToImmutable());
+            return new BodySignals(newarr, throws, catches, finallys, arrayOffsets.ToImmutable(), throwOffsets.ToImmutable(), boxes, boxOffsets.ToImmutable());
         }
 
         bool TryReadBranchTarget(ILOpCode opcode, byte[] il, ref int position, int offset, out int target)

--- a/src/ILInspector.Analysis/MethodSignals.cs
+++ b/src/ILInspector.Analysis/MethodSignals.cs
@@ -9,7 +9,7 @@ namespace ILInspector.Analysis;
 /// throws, exception regions) are folded in from the body scan. The vocabulary
 /// grows additively — each new field is a signal plus a projection case.
 /// </summary>
-/// <param name="Allocations">Heap allocations in the body: <c>newobj</c> plus <c>newarr</c>.</param>
+/// <param name="Allocations">Heap allocations in the body: <c>newobj</c>, <c>newarr</c>, plus <c>box</c> of value types.</param>
 /// <param name="Copies">Calls to well-known copy/materialize APIs (ToArray, Substring, …).</param>
 /// <param name="Unsafe">The method has any unsafe evidence.</param>
 /// <param name="Reflection">Calls into reflection-style APIs (System.Reflection, Activator, System.Linq.Expressions).</param>
@@ -50,7 +50,9 @@ public readonly record struct BodySignals(
     int Catches,
     int Finallys,
     ImmutableArray<int> ArrayAllocOffsets,
-    ImmutableArray<int> ThrowOffsets);
+    ImmutableArray<int> ThrowOffsets,
+    int Boxes = 0,
+    ImmutableArray<int> BoxOffsets = default);
 
 public static class MethodSignalAnalysis
 {
@@ -135,6 +137,8 @@ public static class MethodSignalAnalysis
                 AddEvidence(token, offset);
             foreach (var offset in NormalizeOffsets(body.ThrowOffsets))
                 AddEvidence(token, offset);
+            foreach (var offset in NormalizeOffsets(body.BoxOffsets))
+                AddEvidence(token, offset);
 
             var offsets = evidence.TryGetValue(token, out var set)
                 ? [.. set.Take(MaxEvidenceOffsets)]
@@ -144,7 +148,7 @@ public static class MethodSignalAnalysis
                 : ImmutableArray<string>.Empty;
 
             result[token] = new MethodSignals(
-                allocations.GetValueOrDefault(token) + body.Newarr,
+                allocations.GetValueOrDefault(token) + body.Newarr + body.Boxes,
                 copies.GetValueOrDefault(token),
                 unsafeMethods.Contains(token),
                 reflection.GetValueOrDefault(token),


### PR DESCRIPTION
## Summary

Closes a consistency gap exposed by the `box-value-type` shape: the per-method **`allocations` signal** counted only `newobj` + `newarr`, **not `box`**. So a method whose heap allocations come from boxing showed `Alloc 0` on the Call Graph / Caller Graph and contributed nothing to the diff Analysis Diff's allocations delta — even though `box-value-type` flags it as an allocation.

Boxing a genuinely-allocating value type **is** a heap allocation, so it should count toward the allocation signal alongside `newobj`/`newarr`.

## Change

- `BodySignals` gains `Boxes` + `BoxOffsets`, collected during the IL body scan using the **same** value-type identification as the `box-value-type` shape (concrete value types only; reference types, generic parameters, and `Nullable<T>` excluded).
- Counted **unconditionally** — the escape gate stays specific to the actionable *opportunity* shape, while the *signal* reflects every box that allocates, consistent with how `newobj`/`newarr` are counted.
- `MethodSignalAnalysis.Collect` folds `body.Boxes` into `Allocations` and adds the box offsets to the evidence (`EvidenceIL`) receipts.

## Why it matters

The `Alloc` field on Call Graph / Caller Graph and the diff's allocations delta are now honest about boxing — the single most common "hidden" allocation in value-heavy code (serializers, formatters). Previously these undercounted, which is misleading for the exact perf-triage workflows the section is for.

## Implementation note

Found and fixed a self-introduced bug during development: the `BodySignals` constructor call wasn't initially updated to pass the new `Boxes`/`BoxOffsets` (they default to 0), so the count was silently dropped — caught by the new signal test before commit.

## Tests

- New `MethodSignals_Allocations_CountBoxing`: a method whose only heap allocation is a box reports `Allocations >= 1`.
- `ILInspector.Analysis.Tests` 74 pass; `dotnet-inspect.Tests` 1321 pass (9 ilasm-skipped); markdownlint clean.
- Doc updated: `graph-signal-annotations.md` (`Alloc` and `EvidenceIL` derivations now list `box`).
