### PR TITLE
Decline structuring when a Leave targets into a proposed arm (#1551)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StructuringGotoScopeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringGotoScopeTests.cs
@@ -108,4 +108,37 @@ public class StructuringGotoScopeTests
         Assert.Empty(function.Descendants.OfType<IfStatement>());
         Assert.NotEmpty(function.Descendants.OfType<Leave>());
     }
+
+    [Fact]
+    public void LeaveTargetInsideArmFromNestedEh_StaysFlat()
+    {
+        // #1551 (adversarial review): the surviving Leave into the true-arm head is
+        // nested inside a TryCatch in an out-of-range block. EhStructuringPass runs
+        // before StructuringPass, so a leave can already sit inside an EH shell; the
+        // scope guard must scan descendants, not just direct children, or it strands
+        // the nested leave's `goto IL_0018; // leave` inside the arm braces (CS0159).
+        var tryInner = new Block(0);
+        tryInner.Add(new Leave(24));                    // leave into trueArm head, nested in try
+        var tryBody = new BlockContainer();
+        tryBody.Add(tryInner);
+        var catchInner = new Block(4);
+        catchInner.Add(new Leave(8));                   // catch exits the region to b1
+        var catchBody = new BlockContainer();
+        catchBody.Add(catchInner);
+        var eh = new Block(0);
+        eh.Add(new TryCatch(tryBody, [new CatchClause(TypeRef.CoreLib("System", "Exception"), catchBody)]));
+        var b1 = new Block(8);
+        b1.Add(new ConditionalBranch(Cond(), 24));      // diamond conditional -> trueArm
+        var b2 = new Block(16);                          // false arm
+        b2.Add(new Branch(32));                          // -> join
+        var b3 = new Block(24);                          // true arm head, ALSO a leave target
+        b3.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        var b4 = new Block(32);                          // join
+        b4.Add(new Return(new LoadLocal(0, Int32)));
+
+        var function = Structured([eh, b1, b2, b3, b4]);
+
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+        Assert.NotEmpty(function.Descendants.OfType<Leave>());
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/StructuringGotoScopeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StructuringGotoScopeTests.cs
@@ -81,4 +81,31 @@ public class StructuringGotoScopeTests
         Assert.Empty(function.Descendants.OfType<IfStatement>());
         Assert.NotEmpty(function.Descendants.OfType<SwitchBranch>());
     }
+
+    [Fact]
+    public void LeaveTargetInsideArm_StaysFlat()
+    {
+        // #1551: the same scope violation as SwitchTargetInsideArm, but the outside
+        // transfer is a surviving Leave instead of a SwitchBranch. A leading leave
+        // also targets the true-arm head (b3 @ 24); wrapping b3 in the else arm
+        // would strand the leave's `goto IL_0018; // leave` inside the braces
+        // (CS0159), so the pass must keep the whole container flat.
+        var lv = new Block(0);
+        lv.Add(new Leave(24));                          // surviving leave -> trueArm head
+        var b1 = new Block(8);
+        b1.Add(new ConditionalBranch(Cond(), 24));      // diamond conditional -> trueArm
+        var b2 = new Block(16);                          // false arm
+        b2.Add(new Branch(32));                          // -> join
+        var b3 = new Block(24);                          // true arm head, ALSO a leave target
+        b3.Add(new StoreLocal(0, Int32, new Constant(1, Int32)));
+        var b4 = new Block(32);                          // join
+        b4.Add(new Return(new LoadLocal(0, Int32)));
+
+        var function = Structured([lv, b1, b2, b3, b4]);
+
+        // Declined: no diamond raised, so the leave target keeps a container-level
+        // label and the Leave survives at top level (legal goto).
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+        Assert.NotEmpty(function.Descendants.OfType<Leave>());
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -524,14 +524,16 @@ public sealed class StructuringPass : IIrPass
 
     /// <summary>
     /// True when a block inside the arm range <c>[start, stop)</c> is the target
-    /// of an unraised <see cref="SwitchBranch"/> dispatch located <em>outside</em>
-    /// that range. <see cref="Validate"/> treats a surviving SwitchBranch as
-    /// fallthrough (it raises no switch here), so the dispatch is printed as a
-    /// chain of <c>goto</c>s that nothing dissolves. Wrapping one of its targets
-    /// inside an arm's braces would strand those gotos as jumps <em>into</em> the
-    /// braced scope (CS0159), so the region must stay flat. Conditional/unconditional
-    /// guards are not checked: they are either consumed by the if/diamond shape or
-    /// inlined as shared terminators, so they leave no surviving label.
+    /// of a control transfer located <em>outside</em> that range that survives to
+    /// print as a label-stranding <c>goto</c> — an unraised <see cref="SwitchBranch"/>
+    /// dispatch or a surviving <see cref="Leave"/> (printed <c>goto IL_xxxx; // leave</c>).
+    /// <see cref="Validate"/> treats a surviving SwitchBranch as fallthrough and a
+    /// surviving in-container leave as a kept goto, so either prints a jump that
+    /// nothing dissolves. Wrapping one of its targets inside an arm's braces would
+    /// strand that jump as one <em>into</em> the braced scope (CS0159), so the
+    /// region must stay flat. Conditional/unconditional guards are not checked:
+    /// they are either consumed by the if/diamond shape or inlined as shared
+    /// terminators, so they leave no surviving label.
     /// </summary>
     static bool RegionExternallyEntered(Ctx ctx, int start, int stop)
     {
@@ -542,13 +544,24 @@ public sealed class StructuringPass : IIrPass
                 continue;  // an internal jump stays inside the arm — legal
             foreach (var child in blocks[source].Children)
             {
-                if (child is not SwitchBranch switchBranch || IsStateMachineDispatch(switchBranch))
-                    continue;
-                foreach (int targetOffset in switchBranch.TargetOffsets)
+                switch (child)
                 {
-                    if (ctx.OffsetToIndex.TryGetValue(targetOffset, out int target)
-                        && target >= start && target < stop)
-                        return true;  // switch dispatches into this arm
+                    case SwitchBranch switchBranch when !IsStateMachineDispatch(switchBranch):
+                        foreach (int targetOffset in switchBranch.TargetOffsets)
+                        {
+                            if (ctx.OffsetToIndex.TryGetValue(targetOffset, out int target)
+                                && target >= start && target < stop)
+                                return true;  // switch dispatches into this arm
+                        }
+                        break;
+
+                    // A surviving leave whose target stays inside this container
+                    // keeps its label and prints `goto IL_xxxx; // leave`; if that
+                    // target is inside the arm, nesting it would jump into scope.
+                    case Leave leave
+                        when ctx.OffsetToIndex.TryGetValue(leave.TargetOffset, out int leaveTarget)
+                            && leaveTarget >= start && leaveTarget < stop:
+                        return true;
                 }
             }
         }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -544,25 +544,27 @@ public sealed class StructuringPass : IIrPass
                 continue;  // an internal jump stays inside the arm — legal
             foreach (var child in blocks[source].Children)
             {
-                switch (child)
+                if (child is SwitchBranch switchBranch && !IsStateMachineDispatch(switchBranch))
                 {
-                    case SwitchBranch switchBranch when !IsStateMachineDispatch(switchBranch):
-                        foreach (int targetOffset in switchBranch.TargetOffsets)
-                        {
-                            if (ctx.OffsetToIndex.TryGetValue(targetOffset, out int target)
-                                && target >= start && target < stop)
-                                return true;  // switch dispatches into this arm
-                        }
-                        break;
-
-                    // A surviving leave whose target stays inside this container
-                    // keeps its label and prints `goto IL_xxxx; // leave`; if that
-                    // target is inside the arm, nesting it would jump into scope.
-                    case Leave leave
-                        when ctx.OffsetToIndex.TryGetValue(leave.TargetOffset, out int leaveTarget)
-                            && leaveTarget >= start && leaveTarget < stop:
-                        return true;
+                    foreach (int targetOffset in switchBranch.TargetOffsets)
+                    {
+                        if (ctx.OffsetToIndex.TryGetValue(targetOffset, out int target)
+                            && target >= start && target < stop)
+                            return true;  // switch dispatches into this arm
+                    }
                 }
+            }
+
+            // A surviving leave whose target stays inside this container keeps its
+            // label and prints `goto IL_xxxx; // leave`; if that target is inside the
+            // arm, nesting it would jump into scope. EhStructuringPass runs before
+            // this pass, so a leave may already be nested inside a TryCatch/TryFinally
+            // shell in this source block — scan descendants, not just children.
+            foreach (var leave in blocks[source].Descendants.OfType<Leave>())
+            {
+                if (ctx.OffsetToIndex.TryGetValue(leave.TargetOffset, out int leaveTarget)
+                    && leaveTarget >= start && leaveTarget < stop)
+                    return true;
             }
         }
         return false;


### PR DESCRIPTION
Closes #1551 (the one open row of #1524, the control-flow / side-effect-drop over-raise burndown).

## Over-raise being narrowed

`StructuringPass.RegionExternallyEntered` (added in #1538) declines wrapping a forward diamond/guard arm around a block that an **out-of-range `SwitchBranch`** dispatches into — nesting the target inside the arm braces would strand the switch's `goto IL_xxxx` as a jump *into* the braced scope (CS0159). A surviving **`Leave`** is the uncovered analog: an out-of-range leave whose in-container target lands inside the arm prints `goto IL_xxxx; // leave` into the braces — the same CS0159 scope violation, while still reporting `Full`.

## Fix

Extend `RegionExternallyEntered` to treat such a leave as an external entry, mirroring the `SwitchBranch` guard. Narrowest possible gate: an out-of-range leave whose `TargetOffset` maps to a block index inside `[start, stop)` → decline. It only declines more (an over-raise becomes an honest flat `goto`), never raises something new. Same leave-target soundness family as #1354/#1398/#1415/#1469/#1517.

## Evidence

- **Adversarial fixture:** `StructuringGotoScopeTests.LeaveTargetInsideArm_StaysFlat` — the #1538 `SwitchTargetInsideArm` shape with the leading `SwitchBranch` replaced by `new Leave(24)` into the true-arm head. Asserts no `IfStatement` raised and the `Leave` survives flat. **Verified it fails without the gate** (the diamond raises and strands the leave) and passes with it.
- **Positive canary:** `CleanDiamond_RaisesToIfElse` still raises; the #1538 `SwitchTargetInsideArm_StaysFlat` negative stays green.
- **Full `src/ILInspector.Decompiler.Tests`: 1337 tests, 0 failures.**
- **Corpus quality card:** decline-only structuring change; no live CoreLib method has this shape (per #1551), so zero corpus delta expected. A/B card to follow as a comment.

Cross-model adversarial review (GPT-5.5) to follow.

Closes #1551. Related: #1524, #1538, #1517.