### PR TITLE
Wrap overflowing unsigned constant arithmetic

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MixedSignArithmeticConstantTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignArithmeticConstantTests.cs
@@ -13,8 +13,9 @@ public class MixedSignArithmeticConstantTests
 {
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef s_uint = TypeRef.CoreLib("System", "UInt32");
+    static readonly TypeRef s_ulong = TypeRef.CoreLib("System", "UInt64");
 
-    static string Render(IrExpression value)
+    static string Render(IrExpression value, TypeRef? returnType = null)
     {
         var block = new Block(0);
         block.Add(new Return(value));
@@ -23,7 +24,7 @@ public class MixedSignArithmeticConstantTests
         var function = new IrFunction(
             "M",
             TypeRef.Definition("Synthetic", "", "T"),
-            new MethodSignature(s_uint, [new Parameter("x", s_uint)], HasThis: false, GenericParameterCount: 0),
+            new MethodSignature(returnType ?? s_uint, [new Parameter("x", s_uint)], HasThis: false, GenericParameterCount: 0),
             ImmutableArray<TypeRef>.Empty,
             body);
         return CSharpPrinter.Print(function).Output!.Trim();
@@ -91,4 +92,28 @@ public class MixedSignArithmeticConstantTests
         Assert.StartsWith("return unchecked(", output);
         Assert.Contains("(uint)", output);
     }
+
+    [Fact]
+    public void PureUnsignedOverflowingAdd_WrapsWholeBinaryInUnchecked()
+        => Assert.Equal(
+            "return unchecked(4294967295u + 1u);",
+            Render(Arith(BinaryKind.Add, new Constant(uint.MaxValue, s_uint), new Constant(1u, s_uint))));
+
+    [Fact]
+    public void PureUnsignedOverflowingSubtract_WrapsWholeBinaryInUnchecked()
+        => Assert.Equal(
+            "return unchecked(0u - 1u);",
+            Render(Arith(BinaryKind.Subtract, new Constant(0u, s_uint), new Constant(1u, s_uint))));
+
+    [Fact]
+    public void PureUnsignedNonOverflowingAdd_StaysPlain()
+        => Assert.Equal(
+            "return 4294967295 + 0;",
+            Render(Arith(BinaryKind.Add, new Constant(uint.MaxValue, s_uint), new Constant(0u, s_uint))));
+
+    [Fact]
+    public void PureULongOverflowingAdd_WrapsWholeBinaryInUnchecked()
+        => Assert.Equal(
+            "return unchecked(18446744073709551615UL + 1UL);",
+            Render(Arith(BinaryKind.Add, new Constant(ulong.MaxValue, s_ulong), new Constant(1UL, s_ulong)), s_ulong));
 }

--- a/src/ILInspector.Decompiler.Tests/MixedSignArithmeticConstantTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignArithmeticConstantTests.cs
@@ -112,6 +112,12 @@ public class MixedSignArithmeticConstantTests
             Render(Arith(BinaryKind.Add, new Constant(uint.MaxValue, s_uint), new Constant(0u, s_uint))));
 
     [Fact]
+    public void PureSignedOverflowingAdd_WrapsWholeBinaryInUnchecked()
+        => Assert.Equal(
+            "return unchecked(2147483647 + 1);",
+            Render(Arith(BinaryKind.Add, new Constant(int.MaxValue, s_int), new Constant(1, s_int)), s_int));
+
+    [Fact]
     public void PureULongOverflowingAdd_WrapsWholeBinaryInUnchecked()
         => Assert.Equal(
             "return unchecked(18446744073709551615UL + 1UL);",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -95,15 +95,24 @@ public sealed partial class CSharpPrinter
         // *outermost* such constant binary once and drop the inner/per-operand
         // `unchecked` so the whole expression is covered without nesting.
         bool parentWraps = binary.Parent is Binary parent && IsUncheckedConstantArithmetic(parent);
+        bool fixedWidthConstantOverflow = SubtreeOverflowsFixedWidthConstantArithmetic(binary);
         bool uncheckedConstant = !wrap && !parentWraps && IsUncheckedConstantArithmetic(binary);
         bool covered = uncheckedConstant || parentWraps;
+        bool preserveUnsignedConstants = fixedWidthConstantOverflow
+            && !SubtreeReinterpretsOutOfRangeConstant(binary)
+            && covered
+            && IsIntegerConstantExpression(binary)
+            && IsUnsignedFixedWidthInteger(EffectiveType(binary))
+            && !mixedSign;
         string left = mixedSign ? BitwiseUnsignedOperand(binary.Left, wrapConstantCast: !covered)
             : castLeft ? UnsignedOperand(binary.Left)
+            : preserveUnsignedConstants ? UnsignedConstantArithmeticOperand(binary.Left, EffectiveType(binary))
             : Operand(binary.Left);
         bool isShift = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight;
         string right = isShift ? ShiftCount(binary)
             : mixedSign ? BitwiseUnsignedOperand(binary.Right, wrapConstantCast: !covered)
             : castBoth ? UnsignedOperand(binary.Right)
+            : preserveUnsignedConstants ? UnsignedConstantArithmeticOperand(binary.Right, EffectiveType(binary))
             : Operand(binary.Right);
         string text = $"{left} {BinaryOperator(binary)} {right}";
         // add.ovf/sub.ovf/mul.ovf (and their .un forms) carry an overflow check
@@ -117,16 +126,18 @@ public sealed partial class CSharpPrinter
 
     /// <summary>
     /// An unchecked <c>+</c>/<c>-</c>/<c>*</c> that is a C# integer constant
-    /// expression whose subtree reinterprets an out-of-range signed constant as
-    /// unsigned. Such an expression is evaluated in a checked constant context and
-    /// must sit inside an <c>unchecked(...)</c> to compile. Used to wrap the
-    /// outermost such binary (and detect that a parent already wraps it).
+    /// expression whose subtree either reinterprets an out-of-range signed constant
+    /// as unsigned or overflows its fixed-width integer result. Such an expression
+    /// is evaluated in a checked constant context and must sit inside an
+    /// <c>unchecked(...)</c> to compile. Used to wrap the outermost such binary
+    /// (and detect that a parent already wraps it).
     /// </summary>
     bool IsUncheckedConstantArithmetic(Binary binary)
         => !binary.IsChecked
             && binary.Kind is BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply
             && IsIntegerConstantExpression(binary)
-            && SubtreeReinterpretsOutOfRangeConstant(binary);
+            && (SubtreeReinterpretsOutOfRangeConstant(binary)
+                || SubtreeOverflowsFixedWidthConstantArithmetic(binary));
 
     /// <summary>Whether a mixed-sign arithmetic reconciliation or an explicit cast anywhere in the constant subtree reinterprets an out-of-range signed constant as unsigned — the cast that needs <c>unchecked</c>.</summary>
     bool SubtreeReinterpretsOutOfRangeConstant(IrExpression expression)
@@ -150,6 +161,123 @@ public sealed partial class CSharpPrinter
                 return false;
         }
     }
+
+    /// <summary>Whether any unchecked fixed-width integer constant arithmetic in the subtree overflows the type it renders as.</summary>
+    bool SubtreeOverflowsFixedWidthConstantArithmetic(IrExpression expression)
+    {
+        switch (expression)
+        {
+            case Convert { IsChecked: false } convert:
+                return SubtreeOverflowsFixedWidthConstantArithmetic(convert.Operand);
+            case Binary binary:
+                return TryEvaluateIntegerConstantExpression(binary, out _, out bool overflow) && overflow
+                    || SubtreeOverflowsFixedWidthConstantArithmetic(binary.Left)
+                    || SubtreeOverflowsFixedWidthConstantArithmetic(binary.Right);
+            default:
+                return false;
+        }
+    }
+
+    bool TryEvaluateIntegerConstantExpression(IrExpression expression, out System.Numerics.BigInteger value, out bool overflow)
+    {
+        switch (expression)
+        {
+            case Convert { IsChecked: false } convert:
+                return TryEvaluateIntegerConstantExpression(convert.Operand, out value, out overflow);
+            case Constant constant:
+                return TryReadIntegerConstant(constant, out value, out overflow);
+            case Binary { IsChecked: false, Kind: BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply } binary:
+            {
+                if (!TryEvaluateIntegerConstantExpression(binary.Left, out var left, out var leftOverflow)
+                    || !TryEvaluateIntegerConstantExpression(binary.Right, out var right, out var rightOverflow)
+                    || !TryGetIntegerRange(EffectiveType(binary), out var min, out var max))
+                {
+                    value = default;
+                    overflow = false;
+                    return false;
+                }
+
+                value = binary.Kind switch
+                {
+                    BinaryKind.Add => left + right,
+                    BinaryKind.Subtract => left - right,
+                    _ => left * right,
+                };
+                overflow = leftOverflow || rightOverflow || value < min || value > max;
+                return true;
+            }
+            default:
+                value = default;
+                overflow = false;
+                return false;
+        }
+    }
+
+    static bool TryReadIntegerConstant(Constant constant, out System.Numerics.BigInteger value, out bool overflow)
+    {
+        value = constant.Value switch
+        {
+            sbyte v => v,
+            byte v => v,
+            short v => v,
+            ushort v => v,
+            int v => v,
+            uint v => v,
+            long v => v,
+            ulong v => v,
+            _ => default,
+        };
+        overflow = false;
+        return constant.Value is sbyte or byte or short or ushort or int or uint or long or ulong;
+    }
+
+    static bool TryGetIntegerRange(TypeRef? type, out System.Numerics.BigInteger min, out System.Numerics.BigInteger max)
+    {
+        if (type is not { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" })
+        {
+            min = max = default;
+            return false;
+        }
+
+        switch (type.Name)
+        {
+            case "SByte":
+                min = sbyte.MinValue; max = sbyte.MaxValue; return true;
+            case "Byte":
+                min = byte.MinValue; max = byte.MaxValue; return true;
+            case "Int16":
+                min = short.MinValue; max = short.MaxValue; return true;
+            case "UInt16" or "Char":
+                min = ushort.MinValue; max = ushort.MaxValue; return true;
+            case "Int32":
+                min = int.MinValue; max = int.MaxValue; return true;
+            case "UInt32":
+                min = uint.MinValue; max = uint.MaxValue; return true;
+            case "Int64":
+                min = long.MinValue; max = long.MaxValue; return true;
+            case "UInt64":
+                min = ulong.MinValue; max = ulong.MaxValue; return true;
+            default:
+                min = max = default;
+                return false;
+        }
+    }
+
+    string UnsignedConstantArithmeticOperand(IrExpression operand, TypeRef? target)
+        => operand is Constant constant && target is not null && EffectiveType(constant)?.Equals(target) == true
+            ? UnsignedConstantText(constant, target)
+            : Operand(operand);
+
+    static string UnsignedConstantText(Constant constant, TypeRef target)
+        => target.Name switch
+        {
+            "UInt32" => $"{System.Convert.ToUInt32(constant.Value, System.Globalization.CultureInfo.InvariantCulture).ToString(System.Globalization.CultureInfo.InvariantCulture)}u",
+            "UInt64" => $"{System.Convert.ToUInt64(constant.Value, System.Globalization.CultureInfo.InvariantCulture).ToString(System.Globalization.CultureInfo.InvariantCulture)}UL",
+            _ => ConstantText(constant),
+        };
+
+    static bool IsUnsignedFixedWidthInteger(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "UInt32" or "UInt64" };
 
     /// <summary>
     /// True when a bitwise <c>&amp;</c>/<c>|</c>/<c>^</c> has one signed and one


### PR DESCRIPTION
## Summary

Fixes #1522. Extends numeric printer unchecked wrapping from out-of-range unsigned casts to pure fixed-width integer constant arithmetic overflow.

Behavior:

- `uint.MaxValue + 1u`, `0u - 1u`, and `ulong.MaxValue + 1UL` render inside `unchecked(...)`;
- unsigned literal suffixes are preserved inside pure unsigned overflow wrappers so the expression remains unsigned arithmetic;
- non-overflowing constant arithmetic does not gain `unchecked`;
- existing #1467 mixed-sign/out-of-range cast rendering is preserved.

## Tests

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/MixedSignArithmeticConstantTests/*"`
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`

## Quality card

Branch-vs-current-main card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,367 methods
Correctness coverage: validity sampled 350 / 88,367 (0.40%); fidelity sampled 36 / 88,367 (0.04%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 88,360 -> 88,367 (+7)
- ILInspector.Decompiler: 5,285 -> 5,292 methods (+7)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,672 (87.90%) | 77,675 (87.90%) | +3 |
| Conditional-branch residual | 2,404 (2.72%) | 2,408 (2.72%) | +4 |
| Forward-merge stops | 2,140 (2.42%) | 2,144 (2.43%) | +4 |
| Full malformed | 32 | 32 | 0 |
| Semantic defects | 4/350 — sampled 350 / 88,360 (0.40%) | 4/350 — sampled 350 / 88,367 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 88,360 (0.04%) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 88,367 (0.04%) | 0 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (count regressions evaluated here): Full malformed 32 -> 32 (0); opcode diffs 1 -> 1 (0).

Verdict: corpus sensor matched baseline tolerances.

Per-method delta artifact: `/tmp/corpus-delta-1522.json`
```

Delta summary: `changedMethods=75`, `sourceChanged=0`, `passBugChanged=0`.

## Adversarial review

Requested Opus 4.8 review. It is still running unusually long; I opened this PR with local evidence and will post the review result as soon as it completes.
