### PR TITLE
Turn 'dotnet-inspect skill' into a skill router with focused sub-skills

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Markout" Version="0.13.7" />
+    <PackageVersion Include="Markout" Version="0.14.0" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />
     <PackageVersion Include="ShellComplete" Version="0.1.0" />

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Bare names are routed automatically: platform-looking names (`System.*`, `Micros
 | `implements X` | Find concrete implementors or subclasses. |
 | `depends X` | Walk type, package, or library dependency graphs; emits Mermaid diagrams. |
 | `cache` | Inspect or clear dotnet-inspect caches. |
-| `skill` | Print the embedded LLM skill definition. |
+| `skill` | Print the base LLM skill; routes to focused skills (`skill list`, `skill source`, `skill performance`). |
 
 Single-type `type X` output is tree-shaped by default. Use `-v:n` or `-v:d`
 to grow that tree to overload leaves; use `--markdown -v:q` when you want the

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,141 +1,50 @@
 ---
 name: dotnet-inspect
 version: 0.14.0
-description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, and API version diffs. Router to focused source and performance skills.
+description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, and version-to-version API changes.
 ---
 
 # dotnet-inspect
 
-Use dotnet-inspect when you need evidence instead of guesses for .NET packages,
-platform libraries, local assemblies, APIs, dependencies, or version-to-version
-API changes.
+Use dotnet-inspect for evidence instead of guesses about .NET packages, platform
+libraries, assemblies, APIs, dependencies, or API version diffs. Focused skills
+are listed at the end.
 
 ```bash
 dnx dotnet-inspect -y -- <command>
 ```
-
-## Skills
-
-This is the base skill: the everyday lookup, query, and output workflows. Deeper
-topics live in focused skills you can print on demand:
-
-| Skill | Print it with | Use it for |
-| ----- | ------------- | ---------- |
-| source | `dotnet-inspect skill source` | Decompiled C#, IL, `@Source`/`Annotated Source`, SourceLink original source, unsafe/IL audits. |
-| performance | `dotnet-inspect skill performance` | Whole-assembly call-graph leverage ranking and performance triage (experimental). |
-
-Run `dotnet-inspect skill list` to list available skills. Load a focused skill
-only when the task needs it; keep this base skill for routine lookups.
 
 ## Common starts
 
 | Goal | Command |
 | ---- | ------- |
 | Find an API | `find Pattern`, then reuse the reported `--platform`, `--package`, or `--library`. |
+| Inspect a type | `type Type --package Foo`; add `--all` for non-public/hidden members. |
 | Inspect overloads | `member Type --platform Lib -m Name -S "Member Index"` |
 | Select an overload | `member Type --platform Lib Name:1` or `Name~digest` |
-| Inspect a type | `type Type --package Foo`; add `--all` for non-public/hidden/extra members. |
-| Compare APIs | `diff --package Foo@old..new --breaking`; use `--additive` for new APIs. |
-| Inspect packages | `package Foo -S Signals`, `-S "Library Files"`, `--library` |
-| Inspect libraries | `library Foo` or `library path/to.dll`; add `--platform`, `--package`, `-S Signals`. |
-| Relationships | `depends Type`, `extensions Type`, `implements Interface`; add package/platform/project scope. |
-| Source or IL | see `dotnet-inspect skill source`. |
+| Compare APIs | `diff --package Foo@old..new --breaking`; `--additive` for new APIs. |
+| Inspect packages | `package Foo -S Signals`, `--library`, `--path @readme --content`. |
+| Inspect libraries | `library Foo` or `library path/to.dll`; add `--platform`, `-S Signals`. |
+| Relationships | `depends Type`, `extensions Type`, `implements Interface`. |
 
-## Member lookup workflow
+## Member lookup
 
-Member lookup is a common flow. Use `find` when scope is unknown, then inspect
-the type, then use `Member Index` to find the overload to select. The bare router
-also accepts source-qualified member syntax when the source is obvious.
+Run `find Name` when scope is unknown, inspect the type, then `-S "Member Index"`
+to list overloads. Select with `Name:N` (1-based, current index) or `Name~digest`
+(stable); prefer `Name~digest` for notes and scripts. A selected overload
+defaults to `Signature`.
 
 ```bash
 dnx dotnet-inspect -y -- find JsonSerializer
 dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Serialize -S "Member Index"
-dnx dotnet-inspect -y -- System.Text.Json.JsonSerializer.Serialize:1 -S Signature
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json Serialize:1 -S Signature
 ```
 
-Selector syntax: first run `member Type --platform Lib -m Name -S "Member Index"`
-(or the package/library source `find` reported). Then pass either `Name:N`
-(1-based, for the current index) or `Name~digest` (stable, from the `Stable`
-column) as the positional member selector. `Canonical Signature` is the printed
-digest input. Prefer `Name~digest` in notes, scripts, issues, and handoffs; use
-`Name:N` for immediate drill-in. `--show-index` is an alias for
-`-S "Member Index"`.
+## Tips
 
-A selected overload defaults to `Signature`. For decompiled source, IL,
-annotated source, and SourceLink evidence (`-S @Source`, `-S "Source
-Locations"`, `Annotated Source`, `IL`), use `dotnet-inspect skill source`.
-
-## Query and output
-
-Default output is Markdown. Use `--table` for compact aligned rows, `--tsv` for
-stable snake_case headers with no embedded tabs/newlines, `--jsonl` for one JSON
-object per row, `--json` for structured documents, `--bare` for one undecorated
-payload or URL list, `--count` for a bare row count, and `--mermaid` for
-graph-shaped output.
-
-Use `-D` to discover sections/columns, `-S Section` to select sections by name or
-wildcard, and `--columns`/`--fields` to project values. Discover first instead of
-guessing names.
-
-```bash
-dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -D --tsv
-dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Serialize -D "Member Index" --tsv
-dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Serialize -S "Member Index" --columns "Selector;Stable;Canonical Signature" --tsv
-```
-
-`@` names a category: `-S @All`, `-S @Source`, `-S @Audit`, `-S @Integrations`,
-`-S @Switches`. Row formats (`--tsv`/`--jsonl`/`--table`) work best with one
-concrete section, not a category.
-
-## Limits
-
-Prefer built-in limits to shell pipes. `-n N` and numeric shorthand like `-6`
-cap output lines; `--tail N` shows the end; `--rows` makes `-n` cap Markdown
-table data rows; `--count` counts rows in one selected table. Command-specific
-caps: `-t N` for type/find rows, `-m N` for members, and `--versions N` for
-package versions.
-
-## Package docs, libraries, and signals
-
-For agent-readable package docs, use `--path @readme --content`; the resolver
-exposes the best README content for agents, preferring `AGENTS.md` over
-`README.md` when present. For multi-package doc surveys, pass multiple package
-IDs with `--path @readme --jsonl` for metadata rows or `--path @readme --content
---jsonl` for content rows. Add `--frontmatter`/`--yaml-header` or `--body` with
-`--content`; keep `--readme` for single-package reads.
-
-```bash
-dnx dotnet-inspect -y -- package Microsoft.Extensions.AI -S Signals
-dnx dotnet-inspect -y -- package Microsoft.Extensions.AI --path @readme --content --frontmatter
-dnx dotnet-inspect -y -- package Microsoft.Extensions.AI Microsoft.Extensions.AI.OpenAI --path @readme --content --jsonl
-dnx dotnet-inspect -y -- project ./App --agents-index --jsonl
-dnx dotnet-inspect -y -- package Microsoft.Extensions.AI --library -S @Integrations
-```
-
-Use `package Foo --library` for the primary DLL when unambiguous; add a DLL name
-or use `--all-libraries` for multi-library packages. `Signals` reports
-observations, not trust: SourceLink, determinism, trim/AOT, memory-safety
-metadata, unsafe/PInvoke, references, TFMs, manifest/docs, license,
-vulnerabilities, package age, and dependency risk.
-
-## Other workflows
-
-Use `diff --package Foo@old..new --breaking` for migration work, `--additive`
-for release-note work, and `-t Type` to narrow. For platform APIs, compare
-individual libraries: `diff --platform System.Runtime@9.0.0..10.0.0 --additive`.
-
-Use `--bare` to extract one undecorated payload: `package Foo --readme --bare` or
-`type Name -S Signature --bare`. For decompiled source, IL, SourceLink, and
-unsafe audits, load `dotnet-inspect skill source`. For call-graph leverage and
-performance triage, load `dotnet-inspect skill performance`.
-
-## General tips
-
-- Built-in aliases and common BCL types resolve without scope: `type string`, `type 'List<T>'`.
-- Quote generic type names and shell patterns: `member 'Dictionary<TKey,TValue>'`, `-S "Async*"`.
-- After `find`, reuse the package/library it reports; add `--library` for multi-library packages.
-- `type` uses `-t` for type filters; `member` uses `-m` for member filters.
+- Default output is Markdown; for formats, `-D`/`-S` discovery, projection, and
+  limits, load `dotnet-inspect skill query`.
+- Common BCL types resolve without scope: `type string`, `type 'List<T>'`. Quote
+  generics and patterns: `member 'Dictionary<TKey,TValue>'`, `-S "Async*"`.
 - Unpinned packages use latest stable; add `--preview` for prerelease APIs.
-- If behavior is surprising, rerun with `--trace-mermaid` and include stderr in bug reports.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,16 +1,31 @@
 ---
 name: dotnet-inspect
-version: 0.13.0
-description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/source, and API version diffs.
+version: 0.14.0
+description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, and API version diffs. Router to focused source and performance skills.
 ---
 
 # dotnet-inspect
 
-Use dotnet-inspect when you need evidence instead of guesses for .NET packages, platform libraries, local assemblies, APIs, dependencies, SourceLink/source, or version-to-version API changes.
+Use dotnet-inspect when you need evidence instead of guesses for .NET packages,
+platform libraries, local assemblies, APIs, dependencies, or version-to-version
+API changes.
 
 ```bash
 dnx dotnet-inspect -y -- <command>
 ```
+
+## Skills
+
+This is the base skill: the everyday lookup, query, and output workflows. Deeper
+topics live in focused skills you can print on demand:
+
+| Skill | Print it with | Use it for |
+| ----- | ------------- | ---------- |
+| source | `dotnet-inspect skill source` | Decompiled C#, IL, `@Source`/`Annotated Source`, SourceLink original source, unsafe/IL audits. |
+| performance | `dotnet-inspect skill performance` | Whole-assembly call-graph leverage ranking and performance triage (experimental). |
+
+Run `dotnet-inspect skill list` to list available skills. Load a focused skill
+only when the task needs it; keep this base skill for routine lookups.
 
 ## Common starts
 
@@ -19,16 +34,18 @@ dnx dotnet-inspect -y -- <command>
 | Find an API | `find Pattern`, then reuse the reported `--platform`, `--package`, or `--library`. |
 | Inspect overloads | `member Type --platform Lib -m Name -S "Member Index"` |
 | Select an overload | `member Type --platform Lib Name:1` or `Name~digest` |
-| Source/implementation | `type Type -S "Source Files"`; `member Type -m Name -S "Source Locations"`; `member Type Name:1 -S @Source`; `library/package Foo -S "Source Files"` |
 | Inspect a type | `type Type --package Foo`; add `--all` for non-public/hidden/extra members. |
 | Compare APIs | `diff --package Foo@old..new --breaking`; use `--additive` for new APIs. |
 | Inspect packages | `package Foo -S Signals`, `-S "Library Files"`, `--library` |
 | Inspect libraries | `library Foo` or `library path/to.dll`; add `--platform`, `--package`, `-S Signals`. |
 | Relationships | `depends Type`, `extensions Type`, `implements Interface`; add package/platform/project scope. |
+| Source or IL | see `dotnet-inspect skill source`. |
 
 ## Member lookup workflow
 
-Member lookup is a common flow. Use `find` when scope is unknown, then inspect the type, then use `Member Index` to find the overload to select. The bare router also accepts source-qualified member syntax when the source is obvious.
+Member lookup is a common flow. Use `find` when scope is unknown, then inspect
+the type, then use `Member Index` to find the overload to select. The bare router
+also accepts source-qualified member syntax when the source is obvious.
 
 ```bash
 dnx dotnet-inspect -y -- find JsonSerializer
@@ -36,22 +53,31 @@ dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Serialize -S "Member Index"
 dnx dotnet-inspect -y -- System.Text.Json.JsonSerializer.Serialize:1 -S Signature
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json Serialize:1 -S Signature
-dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json Serialize~1dc14dd1fb -S @Source
-dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json Serialize:1 -S Calls
-dnx dotnet-inspect -y -- member string IndexOf:7 -S Callers --caller-package System.Text.Json@9.0.0 --tfm net9.0
 ```
 
-Selector syntax: first run `member Type --platform Lib -m Name -S "Member Index"` (or the package/library source `find` reported). Then pass either `Name:N` (1-based, for the current index) or `Name~digest` (stable, from the `Stable` column) as the positional member selector. `Canonical Signature` is the printed digest input. Prefer `Name~digest` in notes, scripts, issues, and handoffs; use `Name:N` for immediate drill-in. `--show-index` is an alias for `-S "Member Index"`.
+Selector syntax: first run `member Type --platform Lib -m Name -S "Member Index"`
+(or the package/library source `find` reported). Then pass either `Name:N`
+(1-based, for the current index) or `Name~digest` (stable, from the `Stable`
+column) as the positional member selector. `Canonical Signature` is the printed
+digest input. Prefer `Name~digest` in notes, scripts, issues, and handoffs; use
+`Name:N` for immediate drill-in. `--show-index` is an alias for
+`-S "Member Index"`.
 
-A selected overload defaults to `Signature`; bare `-S` adds `Decompiled Source`. Use `-S "Source Locations"` for member file/line URLs without fetching source bodies. Use `-S @Source` for source and IL evidence: `Decompiled Source` (raised C#), `Annotated Source` (C# with hidden-fact comments and interleaved IL), `Original Source`, and `IL`. Use `Annotated Source` or `IL` when exact opcodes, offsets, branches, tokens, or calls matter.
-
-Use `-S Calls` for direct call-site evidence, `-S Callers` for reverse edges (widen with `--bin`, `--project`, or `--caller-package`), `-S "Unsafe Operations"` for unsafe evidence, and `-S Facts --tsv` for structured hidden facts.
+A selected overload defaults to `Signature`. For decompiled source, IL,
+annotated source, and SourceLink evidence (`-S @Source`, `-S "Source
+Locations"`, `Annotated Source`, `IL`), use `dotnet-inspect skill source`.
 
 ## Query and output
 
-Default output is Markdown. Use `--table` for compact aligned rows, `--tsv` for stable snake_case headers with no embedded tabs/newlines, `--jsonl` for one JSON object per row, `--json` for structured documents, `--bare` for one undecorated payload or URL list, `--count` for a bare row count, and `--mermaid` for graph-shaped output.
+Default output is Markdown. Use `--table` for compact aligned rows, `--tsv` for
+stable snake_case headers with no embedded tabs/newlines, `--jsonl` for one JSON
+object per row, `--json` for structured documents, `--bare` for one undecorated
+payload or URL list, `--count` for a bare row count, and `--mermaid` for
+graph-shaped output.
 
-Use `-D` to discover sections/columns, `-S Section` to select sections by name or wildcard, and `--columns`/`--fields` to project values. Discover first instead of guessing names.
+Use `-D` to discover sections/columns, `-S Section` to select sections by name or
+wildcard, and `--columns`/`--fields` to project values. Discover first instead of
+guessing names.
 
 ```bash
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -D --tsv
@@ -59,15 +85,26 @@ dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Se
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Serialize -S "Member Index" --columns "Selector;Stable;Canonical Signature" --tsv
 ```
 
-`@` names a category: `-S @All`, `-S @Source`, `-S @Audit`, `-S @Integrations`, `-S @Switches`. Row formats (`--tsv`/`--jsonl`/`--table`) work best with one concrete section, not a category.
+`@` names a category: `-S @All`, `-S @Source`, `-S @Audit`, `-S @Integrations`,
+`-S @Switches`. Row formats (`--tsv`/`--jsonl`/`--table`) work best with one
+concrete section, not a category.
 
 ## Limits
 
-Prefer built-in limits to shell pipes. `-n N` and numeric shorthand like `-6` cap output lines; `--tail N` shows the end; `--rows` makes `-n` cap Markdown table data rows; `--count` counts rows in one selected table. Command-specific caps: `-t N` for type/find rows, `-m N` for members, and `--versions N` for package versions.
+Prefer built-in limits to shell pipes. `-n N` and numeric shorthand like `-6`
+cap output lines; `--tail N` shows the end; `--rows` makes `-n` cap Markdown
+table data rows; `--count` counts rows in one selected table. Command-specific
+caps: `-t N` for type/find rows, `-m N` for members, and `--versions N` for
+package versions.
 
 ## Package docs, libraries, and signals
 
-For agent-readable package docs, use `--path @readme --content`; the resolver exposes the best README content for agents, preferring `AGENTS.md` over `README.md` when present. For multi-package doc surveys, pass multiple package IDs with `--path @readme --jsonl` for metadata rows or `--path @readme --content --jsonl` for content rows. Add `--frontmatter`/`--yaml-header` or `--body` with `--content`; keep `--readme` for single-package reads.
+For agent-readable package docs, use `--path @readme --content`; the resolver
+exposes the best README content for agents, preferring `AGENTS.md` over
+`README.md` when present. For multi-package doc surveys, pass multiple package
+IDs with `--path @readme --jsonl` for metadata rows or `--path @readme --content
+--jsonl` for content rows. Add `--frontmatter`/`--yaml-header` or `--body` with
+`--content`; keep `--readme` for single-package reads.
 
 ```bash
 dnx dotnet-inspect -y -- package Microsoft.Extensions.AI -S Signals
@@ -75,18 +112,24 @@ dnx dotnet-inspect -y -- package Microsoft.Extensions.AI --path @readme --conten
 dnx dotnet-inspect -y -- package Microsoft.Extensions.AI Microsoft.Extensions.AI.OpenAI --path @readme --content --jsonl
 dnx dotnet-inspect -y -- project ./App --agents-index --jsonl
 dnx dotnet-inspect -y -- package Microsoft.Extensions.AI --library -S @Integrations
-dnx dotnet-inspect -y -- library System.Text.Json -S "Source Files"
 ```
 
-Use `package Foo --library` for the primary DLL when unambiguous; add a DLL name or use `--all-libraries` for multi-library packages. Use `-S "Source Files"` for SourceLink type-to-URL rows. `Signals` reports observations, not trust: SourceLink, determinism, trim/AOT, memory-safety metadata, unsafe/PInvoke, references, TFMs, manifest/docs, license, vulnerabilities, package age, and dependency risk.
+Use `package Foo --library` for the primary DLL when unambiguous; add a DLL name
+or use `--all-libraries` for multi-library packages. `Signals` reports
+observations, not trust: SourceLink, determinism, trim/AOT, memory-safety
+metadata, unsafe/PInvoke, references, TFMs, manifest/docs, license,
+vulnerabilities, package age, and dependency risk.
 
 ## Other workflows
 
-Use `diff --package Foo@old..new --breaking` for migration work, `--additive` for release-note work, and `-t Type` to narrow. For platform APIs, compare individual libraries: `diff --platform System.Runtime@9.0.0..10.0.0 --additive`.
+Use `diff --package Foo@old..new --breaking` for migration work, `--additive`
+for release-note work, and `-t Type` to narrow. For platform APIs, compare
+individual libraries: `diff --platform System.Runtime@9.0.0..10.0.0 --additive`.
 
-For unsafe audits, start with `library MyLib.dll -S @Audit`, then drill into `member Type Method:1 --library MyLib.dll -S "Unsafe Operations,IL"`.
-
-Use `--bare` to extract one undecorated payload: `type Name -S "Decompiled Source" --bare`, `member Type Method:1 -S "Source Locations" --bare`, or `package Foo --readme --bare`. SourceLink URLs default to raw/fetchable form; add `--blob` for browser URLs. Use `library Foo --il-offset 0x06000001+0x5` for crash diagnostics with MethodDef token plus IL offset. If decompiled output looks wrong, capture `Decompiled Source`, `Annotated Source`, `Original Source`, and `IL`; maintainers diagnose pipeline state with DecompilerHarness.
+Use `--bare` to extract one undecorated payload: `package Foo --readme --bare` or
+`type Name -S Signature --bare`. For decompiled source, IL, SourceLink, and
+unsafe audits, load `dotnet-inspect skill source`. For call-graph leverage and
+performance triage, load `dotnet-inspect skill performance`.
 
 ## General tips
 

--- a/skills/dotnet-inspect/performance.md
+++ b/skills/dotnet-inspect/performance.md
@@ -1,0 +1,54 @@
+---
+name: dotnet-inspect-performance
+version: 0.1.0
+description: Whole-assembly call-graph leverage ranking and performance triage for .NET libraries (experimental).
+---
+
+# dotnet-inspect: performance analysis and triage
+
+Use this skill to find the members worth optimizing or hardening first in a .NET
+assembly, and to triage them against actionable rewrite shapes. This analysis is
+experimental; section names and signal sets may change between releases.
+
+```bash
+dnx dotnet-inspect -y -- <command>
+```
+
+## Rank by leverage first
+
+`Top Leverage` ranks members by call-graph leverage: direct callers, `Root
+Reach` (distinct entry points that transitively reach a member), fanout, depth,
+and loop calls. Start here on a whole library, then narrow to a type.
+
+```bash
+dnx dotnet-inspect -y -- library MyLib.dll -S "Top Leverage"
+dnx dotnet-inspect -y -- type MyType --library MyLib.dll --all -S "Top Leverage"
+```
+
+Ranking rows carry a copyable `Stable` selector, `Visibility`, and `Selector`.
+Add `--all` to include non-public members.
+
+## Triage against rewrite shapes
+
+`Performance Triage` re-ranks the same leverage against actionable rewrite
+shapes — small non-escaping arrays, temporary or span-to-array copies, capturing
+delegates, stateless instance methods — so hot, fixable members surface first.
+
+```bash
+dnx dotnet-inspect -y -- library MyLib.dll -S "Performance Triage"
+```
+
+Target IL-visible costs (allocations: box, newarr, delegate newobj,
+ToArray/ToList/Concat), not JIT-handled concerns (isinst/castclass folding,
+devirtualization, bounds-check elimination, null-check folding).
+
+## Drill a candidate
+
+`Call Graph` is a bounded outbound tree; `Caller Graph` is a bounded reverse
+tree to entry points. Project per-node cost with `--fields` (alloc, copy,
+unsafe, reflection, throw/exception, catch/finally).
+
+```bash
+dnx dotnet-inspect -y -- member MyType Method:1 --library MyLib.dll -S "Call Graph,Facts"
+dnx dotnet-inspect -y -- member MyType Method:1 --library MyLib.dll -S "Caller Graph" --fields "Throw,Catch,Finally"
+```

--- a/skills/dotnet-inspect/query.md
+++ b/skills/dotnet-inspect/query.md
@@ -1,0 +1,55 @@
+---
+name: dotnet-inspect-query
+version: 0.1.0
+description: Output formats, section discovery and selection (-D/-S), value projection, and output limits shared across all dotnet-inspect commands.
+---
+
+# dotnet-inspect: query and output system
+
+These flags are cross-command: the same output formats, discovery, projection,
+and limits work on `find`, `type`, `member`, `package`, `library`, `diff`, and
+the relationship commands. Discover the shape first, then select and project.
+
+```bash
+dnx dotnet-inspect -y -- <command>
+```
+
+## Output formats
+
+Default output is Markdown. Pick a machine or compact shape when you need one:
+
+- `--table` — compact aligned rows.
+- `--tsv` — stable snake_case headers, no embedded tabs/newlines.
+- `--jsonl` — one JSON object per row.
+- `--json` — structured documents.
+- `--bare` — one undecorated payload or URL list.
+- `--count` — a bare row count.
+- `--mermaid` — graph-shaped output.
+
+## Discover and select sections
+
+Use `-D` to discover the sections and columns a command can emit, `-S Section` to
+select sections by name or wildcard, and `--columns`/`--fields` to project
+values. Discover first instead of guessing names.
+
+```bash
+dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -D --tsv
+dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Serialize -D "Member Index" --tsv
+dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Serialize -S "Member Index" --columns "Selector;Stable;Canonical Signature" --tsv
+```
+
+`@` names a category of sections: `-S @All`, `-S @Source`, `-S @Audit`,
+`-S @Integrations`, `-S @Switches`. Row formats (`--tsv`/`--jsonl`/`--table`)
+work best with one concrete section, not a category.
+
+## Limit output
+
+Prefer built-in limits to shell pipes:
+
+- `-n N` and numeric shorthand like `-6` cap output lines, like `head`.
+- `--tail N` shows the end, like `tail`.
+- `--rows` makes `-n` cap Markdown table data rows instead of output lines.
+- `--count` counts rows in one selected table.
+
+Command-specific caps: `-t N` for type/find rows, `-m N` for members, and
+`--versions N` for package versions.

--- a/skills/dotnet-inspect/source.md
+++ b/skills/dotnet-inspect/source.md
@@ -1,0 +1,74 @@
+---
+name: dotnet-inspect-source
+version: 0.1.0
+description: Decompiled C#, IL, and SourceLink-backed original source evidence for .NET members, types, and libraries.
+---
+
+# dotnet-inspect: source and decompiler
+
+Use this skill when you need source-level evidence for a .NET API: raised C#,
+exact IL, SourceLink-backed original source, or unsafe-operation audits.
+
+```bash
+dnx dotnet-inspect -y -- <command>
+```
+
+## Source evidence for a member
+
+A selected overload defaults to `Signature`; bare `-S` adds `Decompiled Source`.
+Use `-S "Source Locations"` for member file/line URLs without fetching bodies.
+Use `-S @Source` for the full source-and-IL evidence set:
+
+- `Decompiled Source` — raised, lowered C# (readable best-effort).
+- `Annotated Source` — C# with hidden-fact comments and interleaved IL.
+- `Original Source` — SourceLink-backed original source when available.
+- `IL` — raw IL, the highest-fidelity view.
+
+Use `Annotated Source` or `IL` when exact opcodes, offsets, branches, tokens, or
+calls matter.
+
+```bash
+dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json Serialize:1 -S @Source
+dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json Serialize:1 -S "Annotated Source"
+dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Source Files"
+dnx dotnet-inspect -y -- library System.Text.Json -S "Source Files"
+```
+
+## Fidelity model
+
+The decompiler degrades honestly: IL with no faithful C# spelling renders as a
+visible comment and lowers the result's fidelity level
+(`Full` -> `Partial` -> `StructuredOnly` -> `IlOnly` -> `Failed`) instead of
+emitting plausible-but-wrong source, with a stable `DEC####` diagnostic on every
+degradation. `Original Source` is original source; `Decompiled Source` is lowered
+C#; raw/annotated `IL` is highest fidelity.
+
+If decompiled output looks wrong, capture `Decompiled Source`, `Annotated
+Source`, `Original Source`, and `IL` together; maintainers diagnose pipeline
+state with DecompilerHarness.
+
+## SourceLink
+
+PDBs carry SourceLink data; they are not SourceLink themselves. Use
+`-S "Source Files"` for SourceLink type-to-URL rows. SourceLink URLs default to
+raw/fetchable form; add `--blob` for browser URLs.
+
+```bash
+dnx dotnet-inspect -y -- library System.Text.Json -S "Source Files"
+dnx dotnet-inspect -y -- member Type Method:1 -S "Source Locations" --bare
+```
+
+## Unsafe and IL audits
+
+```bash
+dnx dotnet-inspect -y -- library MyLib.dll -S @Audit
+dnx dotnet-inspect -y -- member Type Method:1 --library MyLib.dll -S "Unsafe Operations,IL"
+dnx dotnet-inspect -y -- member Type Method:1 -S Facts --tsv
+dnx dotnet-inspect -y -- library Foo --il-offset 0x06000001+0x5
+```
+
+Use `-S Calls` for direct call-site evidence, `-S Callers` for reverse edges
+(widen with `--bin`, `--project`, or `--caller-package`), `-S "Unsafe
+Operations"` for unsafe evidence, and `-S Facts --tsv` for structured hidden
+facts. Use `library Foo --il-offset 0x06000001+0x5` (MethodDef token plus IL
+offset) for crash diagnostics.

--- a/src/dotnet-inspect.Tests/SkillCommandTests.cs
+++ b/src/dotnet-inspect.Tests/SkillCommandTests.cs
@@ -1,0 +1,64 @@
+using DotnetInspector.Commands;
+
+namespace DotnetInspector.Tests;
+
+public class SkillCommandTests
+{
+    [Fact]
+    public async Task Execute_PrintsRouterSkill()
+    {
+        var (exitCode, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(SkillCommand.Execute()));
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("name: dotnet-inspect", output);
+        Assert.Contains("## Skills", output);
+    }
+
+    [Fact]
+    public async Task ExecuteList_ListsEveryRegisteredSkill()
+    {
+        var (exitCode, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(SkillCommand.ExecuteList()));
+
+        Assert.Equal(0, exitCode);
+        foreach (var skill in SkillCommand.Skills)
+        {
+            Assert.Contains(skill.Name, output);
+        }
+    }
+
+    [Theory]
+    [InlineData("source")]
+    [InlineData("performance")]
+    public async Task ExecuteSkill_PrintsRegisteredFocusedSkill(string name)
+    {
+        var (exitCode, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(SkillCommand.ExecuteSkill(name)));
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains($"name: dotnet-inspect-{name}", output);
+    }
+
+    [Fact]
+    public async Task ExecuteSkill_UnknownName_FailsWithGuidance()
+    {
+        var (exitCode, _, error) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(SkillCommand.ExecuteSkill("does-not-exist")));
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown skill", error);
+        Assert.Contains("skill list", error);
+    }
+
+    [Fact]
+    public async Task EveryRegisteredSkillResourceResolves()
+    {
+        foreach (var skill in SkillCommand.Skills)
+        {
+            var (exitCode, _, _) = await ConsoleCapture.RunAsync(
+                () => Task.FromResult(SkillCommand.ExecuteSkill(skill.Name)));
+            Assert.Equal(0, exitCode);
+        }
+    }
+}

--- a/src/dotnet-inspect.Tests/SkillCommandTests.cs
+++ b/src/dotnet-inspect.Tests/SkillCommandTests.cs
@@ -47,12 +47,15 @@ public class SkillCommandTests
     }
 
     [Fact]
-    public async Task ExecuteList_ListsEveryRegisteredSkill()
+    public async Task ExecuteList_ListsEverySkillAsMarkdownH1()
     {
         var (exitCode, output, _) = await ConsoleCapture.RunAsync(
             () => Task.FromResult(SkillCommand.ExecuteList()));
 
         Assert.Equal(0, exitCode);
+        Assert.Contains("# Skills", output);
+        Assert.DoesNotContain("## Skills", output); // standalone document => H1, not H2
+        Assert.Contains("| Skill | Use it for |", output);
         foreach (var skill in SkillCommand.Skills)
         {
             Assert.Contains(skill.Name, output);

--- a/src/dotnet-inspect.Tests/SkillCommandTests.cs
+++ b/src/dotnet-inspect.Tests/SkillCommandTests.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Commands;
+using DotnetInspector.Options;
 
 namespace DotnetInspector.Tests;
 
@@ -60,6 +61,48 @@ public class SkillCommandTests
         {
             Assert.Contains(skill.Name, output);
         }
+    }
+
+    [Fact]
+    public async Task ExecuteList_Tsv_EmitsStableHeadersAndRows()
+    {
+        var (exitCode, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(SkillCommand.ExecuteList(OutputFormat.Tsv)));
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("skill\tuse_for", output);
+        Assert.DoesNotContain("# Skills", output); // no markdown heading
+        Assert.DoesNotContain("|", output);        // no markdown table
+        foreach (var skill in SkillCommand.Skills)
+        {
+            Assert.Contains(skill.Name, output);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteList_Json_EmitsStructuredRows()
+    {
+        var (exitCode, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(SkillCommand.ExecuteList(OutputFormat.Json)));
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("\"skill\":", output.Replace(" ", ""));
+        Assert.Contains("\"use_for\":", output.Replace(" ", ""));
+        foreach (var skill in SkillCommand.Skills)
+        {
+            Assert.Contains(skill.Name, output);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteList_NoHeaders_OmitsHeaderRow()
+    {
+        var (exitCode, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(SkillCommand.ExecuteList(OutputFormat.Tsv, noHeader: true)));
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain("skill\tuse_for", output);
+        Assert.Contains("query", output);
     }
 
     public static IEnumerable<object[]> RegisteredSkills()

--- a/src/dotnet-inspect.Tests/SkillCommandTests.cs
+++ b/src/dotnet-inspect.Tests/SkillCommandTests.cs
@@ -16,6 +16,37 @@ public class SkillCommandTests
     }
 
     [Fact]
+    public async Task Execute_AppendsSkillsSectionAfterBaseline()
+    {
+        var (_, output, _) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(SkillCommand.Execute()));
+
+        // The generated skill list must come last so a head -n filter keeps the
+        // high-value baseline content.
+        var skillsIndex = output.IndexOf("## Skills", StringComparison.Ordinal);
+        var commonStartsIndex = output.IndexOf("## Common starts", StringComparison.Ordinal);
+        Assert.True(commonStartsIndex >= 0, "baseline content missing");
+        Assert.True(skillsIndex > commonStartsIndex, "Skills section must follow baseline");
+
+        // Every focused skill is listed in the generated section.
+        foreach (var skill in SkillCommand.Skills)
+        {
+            Assert.Contains(skill.Name, output[skillsIndex..]);
+        }
+    }
+
+    [Fact]
+    public void BaselineSkill_IsAtMostFiftyLines()
+    {
+        var assembly = typeof(SkillCommand).Assembly;
+        using var stream = assembly.GetManifestResourceStream(SkillCommand.RouterResourceName);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream!);
+        var lineCount = reader.ReadToEnd().TrimEnd('\n').Split('\n').Length;
+        Assert.True(lineCount <= 50, $"baseline SKILL.md is {lineCount} lines (limit 50)");
+    }
+
+    [Fact]
     public async Task ExecuteList_ListsEveryRegisteredSkill()
     {
         var (exitCode, output, _) = await ConsoleCapture.RunAsync(
@@ -28,9 +59,11 @@ public class SkillCommandTests
         }
     }
 
+    public static IEnumerable<object[]> RegisteredSkills()
+        => SkillCommand.Skills.Select(s => new object[] { s.Name });
+
     [Theory]
-    [InlineData("source")]
-    [InlineData("performance")]
+    [MemberData(nameof(RegisteredSkills))]
     public async Task ExecuteSkill_PrintsRegisteredFocusedSkill(string name)
     {
         var (exitCode, output, _) = await ConsoleCapture.RunAsync(

--- a/src/dotnet-inspect/CommandLine/Commands/UtilityCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/UtilityCommandDefinitions.cs
@@ -57,9 +57,17 @@ public static class UtilityCommandDefinitions
         skillCommand.Options.Add(opts.Limit);
         skillCommand.SetAction((parseResult) => SkillCommand.Execute());
 
-        // Subcommand: list
+        // Subcommand: list (supports the standard output formats)
         var listCommand = new Command("list", "List available focused skills");
-        listCommand.SetAction((parseResult) => SkillCommand.ExecuteList());
+        listCommand.Options.Add(opts.Json);
+        opts.AddTableOptionsTo(listCommand);
+        listCommand.Options.Add(opts.Limit);
+        listCommand.SetAction((parseResult) =>
+        {
+            var format = opts.ResolveFormat(parseResult);
+            var noHeader = parseResult.GetValue(opts.NoHeaders);
+            return SkillCommand.ExecuteList(format, noHeader);
+        });
         skillCommand.Subcommands.Add(listCommand);
 
         // Subcommand per registered focused skill (e.g. source, performance)

--- a/src/dotnet-inspect/CommandLine/Commands/UtilityCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/UtilityCommandDefinitions.cs
@@ -53,9 +53,25 @@ public static class UtilityCommandDefinitions
 
     public static Command CreateSkillCommand(SharedOptions opts)
     {
-        var skillCommand = new Command("skill", "Show skill definition");
+        var skillCommand = new Command("skill", "Show skill definition (router to focused skills)");
         skillCommand.Options.Add(opts.Limit);
         skillCommand.SetAction((parseResult) => SkillCommand.Execute());
+
+        // Subcommand: list
+        var listCommand = new Command("list", "List available focused skills");
+        listCommand.SetAction((parseResult) => SkillCommand.ExecuteList());
+        skillCommand.Subcommands.Add(listCommand);
+
+        // Subcommand per registered focused skill (e.g. source, performance)
+        foreach (var skill in SkillCommand.Skills)
+        {
+            var name = skill.Name;
+            var focusedCommand = new Command(name, skill.Description);
+            focusedCommand.Options.Add(opts.Limit);
+            focusedCommand.SetAction((parseResult) => SkillCommand.ExecuteSkill(name));
+            skillCommand.Subcommands.Add(focusedCommand);
+        }
+
         return skillCommand;
     }
 }

--- a/src/dotnet-inspect/Commands/SkillCommand.cs
+++ b/src/dotnet-inspect/Commands/SkillCommand.cs
@@ -1,4 +1,8 @@
 using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DotnetInspector.Options;
+using DotnetInspector.Output;
 using DotnetInspector.Views;
 using Markout;
 
@@ -100,9 +104,41 @@ public class SkillCommand
     /// as the trailing Skills section of the base skill, but rendered at H1
     /// (default heading level) since it is the whole document here.
     /// </summary>
-    public static int ExecuteList()
+    /// <summary>
+    /// Lists the focused skills in the requested output format. Markdown (the
+    /// default) renders the same Skills view as the trailing section of the base
+    /// skill, at H1 since it is the whole document here. Table/TSV/JSONL render
+    /// just the rows; JSON emits structured rows.
+    /// </summary>
+    public static int ExecuteList(OutputFormat format = OutputFormat.Markdown, bool noHeader = false)
     {
-        MarkoutSerializer.Serialize(BuildSkillsView(), Console.Out, SkillsViewContext.Default);
+        if (format == OutputFormat.Json)
+        {
+            var rows = Skills.Select(s => new SkillListJsonRow(s.Name, s.Description)).ToList();
+            Console.WriteLine(JsonSerializer.Serialize(rows, SkillListJsonContext.Default.ListSkillListJsonRow));
+            return 0;
+        }
+
+        var view = BuildSkillsView();
+        switch (format)
+        {
+            case OutputFormat.Table:
+            case OutputFormat.Tsv:
+            case OutputFormat.Jsonl:
+                var options = OutputFormatter.CreateTableWriterOptions(
+                    tsv: format == OutputFormat.Tsv,
+                    jsonl: format == OutputFormat.Jsonl);
+                MarkoutSerializer.Serialize(
+                    view, Console.Out, new TableFormatter(!noHeader), SkillsViewContext.Default, options);
+                break;
+            case OutputFormat.PlainText:
+                MarkoutSerializer.Serialize(view, Console.Out, new PlainTextFormatter(), SkillsViewContext.Default);
+                break;
+            default:
+                MarkoutSerializer.Serialize(view, Console.Out, SkillsViewContext.Default);
+                break;
+        }
+
         return 0;
     }
 
@@ -112,7 +148,7 @@ public class SkillCommand
             .Select(s => new SkillRow
             {
                 Skill = s.Name,
-                Description = s.Description,
+                UseFor = s.Description,
             })
             .ToList(),
     };
@@ -142,4 +178,17 @@ public class SkillCommand
         using var reader = new StreamReader(stream);
         return reader.ReadToEnd();
     }
+}
+
+/// <summary>
+/// One row of <c>skill list --json</c> output.
+/// </summary>
+public record SkillListJsonRow(
+    [property: JsonPropertyName("skill")] string Skill,
+    [property: JsonPropertyName("use_for")] string UseFor);
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(List<SkillListJsonRow>))]
+internal partial class SkillListJsonContext : JsonSerializerContext
+{
 }

--- a/src/dotnet-inspect/Commands/SkillCommand.cs
+++ b/src/dotnet-inspect/Commands/SkillCommand.cs
@@ -1,4 +1,7 @@
 using System.Reflection;
+using DotnetInspector.Output;
+using DotnetInspector.Views;
+using Markout;
 
 namespace DotnetInspector.Commands;
 
@@ -28,6 +31,10 @@ public class SkillCommand
     public static readonly IReadOnlyList<SkillEntry> Skills =
     [
         new SkillEntry(
+            "query",
+            "Output formats, -D/-S discovery, value projection, @ categories, and output limits shared across commands.",
+            "dotnet-inspect.skills.query.md"),
+        new SkillEntry(
             "source",
             "Decompiled C#, IL, annotated source, SourceLink original source, and unsafe/IL audits.",
             "dotnet-inspect.skills.source.md"),
@@ -38,9 +45,39 @@ public class SkillCommand
     ];
 
     /// <summary>
-    /// Prints the base router skill.
+    /// Prints the base router skill: the baseline skill text followed by a
+    /// generated <c>## Skills</c> section listing the focused skills. The skill
+    /// list is appended last (after the baseline) so a <c>head -n</c> filter on
+    /// the output keeps the high-value baseline content.
     /// </summary>
-    public static int Execute() => PrintResource(RouterResourceName);
+    public static int Execute()
+    {
+        var baseline = ReadResource(RouterResourceName);
+        if (baseline is null)
+        {
+            Console.Error.WriteLine($"Error: skill resource '{RouterResourceName}' not found.");
+            return 1;
+        }
+
+        Console.Write(baseline.TrimEnd('\n'));
+        Console.WriteLine();
+        Console.WriteLine();
+
+        var view = new SkillsView
+        {
+            Skills = Skills
+                .Select(s => new SkillRow
+                {
+                    Skill = s.Name,
+                    Command = MarkoutInline.Code($"{Name} {s.Name}"),
+                    Description = s.Description,
+                })
+                .ToList(),
+        };
+        MarkoutSerializer.Serialize(view, Console.Out, SkillsViewContext.Default);
+
+        return 0;
+    }
 
     /// <summary>
     /// Prints a focused skill by name.
@@ -86,18 +123,27 @@ public class SkillCommand
 
     private static int PrintResource(string resourceName)
     {
-        var assembly = Assembly.GetExecutingAssembly();
-        using var stream = assembly.GetManifestResourceStream(resourceName);
-
-        if (stream is null)
+        var content = ReadResource(resourceName);
+        if (content is null)
         {
             Console.Error.WriteLine($"Error: skill resource '{resourceName}' not found.");
             return 1;
         }
 
-        using var reader = new StreamReader(stream);
-        Console.WriteLine(reader.ReadToEnd());
-
+        Console.WriteLine(content);
         return 0;
+    }
+
+    private static string? ReadResource(string resourceName)
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        using var stream = assembly.GetManifestResourceStream(resourceName);
+        if (stream is null)
+        {
+            return null;
+        }
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
     }
 }

--- a/src/dotnet-inspect/Commands/SkillCommand.cs
+++ b/src/dotnet-inspect/Commands/SkillCommand.cs
@@ -62,21 +62,10 @@ public class SkillCommand
         Console.WriteLine();
         Console.WriteLine();
 
-        var view = new SkillsView
-        {
-            Skills = Skills
-                .Select(s => new SkillRow
-                {
-                    Skill = s.Name,
-                    Description = s.Description,
-                })
-                .ToList(),
-        };
-
         // HeadingLevelOffset = 1 renders the view's H1 title as an H2 section so
         // it appends cleanly under the baseline skill without a second H1.
         var options = new MarkoutWriterOptions { HeadingLevelOffset = 1 };
-        MarkoutSerializer.Serialize(view, Console.Out, SkillsViewContext.Default, options);
+        MarkoutSerializer.Serialize(BuildSkillsView(), Console.Out, SkillsViewContext.Default, options);
 
         return 0;
     }
@@ -107,21 +96,26 @@ public class SkillCommand
     }
 
     /// <summary>
-    /// Lists the focused skills available beyond the base skill.
+    /// Lists the focused skills as a standalone Markdown document. Same content
+    /// as the trailing Skills section of the base skill, but rendered at H1
+    /// (default heading level) since it is the whole document here.
     /// </summary>
     public static int ExecuteList()
     {
-        Console.WriteLine("Available dotnet-inspect skills:");
-        Console.WriteLine();
-        Console.WriteLine("  (base)        Print with 'dotnet-inspect skill'. Everyday lookup, query, and output workflows.");
-        foreach (var skill in Skills)
-        {
-            Console.WriteLine($"  {skill.Name,-12}  {skill.Description}");
-        }
-        Console.WriteLine();
-        Console.WriteLine("Print a focused skill with 'dotnet-inspect skill <name>'.");
+        MarkoutSerializer.Serialize(BuildSkillsView(), Console.Out, SkillsViewContext.Default);
         return 0;
     }
+
+    private static SkillsView BuildSkillsView() => new()
+    {
+        Skills = Skills
+            .Select(s => new SkillRow
+            {
+                Skill = s.Name,
+                Description = s.Description,
+            })
+            .ToList(),
+    };
 
     private static int PrintResource(string resourceName)
     {

--- a/src/dotnet-inspect/Commands/SkillCommand.cs
+++ b/src/dotnet-inspect/Commands/SkillCommand.cs
@@ -3,19 +3,95 @@ using System.Reflection;
 namespace DotnetInspector.Commands;
 
 /// <summary>
-/// Prints the SKILL.md file for LLM consumption.
+/// Prints embedded skill documents for LLM consumption. The base skill acts as a
+/// router that lists focused topical skills (source, performance, ...). Each
+/// focused skill is an embedded resource printed on demand.
 /// </summary>
 public class SkillCommand
 {
     public const string Name = "skill";
-    public static int Execute()
+
+    /// <summary>
+    /// A focused skill that can be printed with <c>dotnet-inspect skill &lt;name&gt;</c>.
+    /// </summary>
+    public sealed record SkillEntry(string Name, string Description, string ResourceName);
+
+    /// <summary>
+    /// The base/router skill, printed by bare <c>dotnet-inspect skill</c>.
+    /// </summary>
+    public const string RouterResourceName = "dotnet-inspect.SKILL.md";
+
+    /// <summary>
+    /// Registry of focused skills. Add an entry plus its embedded resource to
+    /// expose a new <c>dotnet-inspect skill &lt;name&gt;</c> subcommand.
+    /// </summary>
+    public static readonly IReadOnlyList<SkillEntry> Skills =
+    [
+        new SkillEntry(
+            "source",
+            "Decompiled C#, IL, annotated source, SourceLink original source, and unsafe/IL audits.",
+            "dotnet-inspect.skills.source.md"),
+        new SkillEntry(
+            "performance",
+            "Whole-assembly call-graph leverage ranking and performance triage (experimental).",
+            "dotnet-inspect.skills.performance.md"),
+    ];
+
+    /// <summary>
+    /// Prints the base router skill.
+    /// </summary>
+    public static int Execute() => PrintResource(RouterResourceName);
+
+    /// <summary>
+    /// Prints a focused skill by name.
+    /// </summary>
+    public static int ExecuteSkill(string name)
+    {
+        var entry = Skills.FirstOrDefault(
+            s => string.Equals(s.Name, name, StringComparison.OrdinalIgnoreCase));
+
+        if (entry is null)
+        {
+            Console.Error.WriteLine($"Error: Unknown skill '{name}'.");
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Available skills:");
+            foreach (var s in Skills)
+            {
+                Console.Error.WriteLine($"  {s.Name}");
+            }
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Run 'dotnet-inspect skill list' for descriptions.");
+            return 1;
+        }
+
+        return PrintResource(entry.ResourceName);
+    }
+
+    /// <summary>
+    /// Lists the focused skills available beyond the base skill.
+    /// </summary>
+    public static int ExecuteList()
+    {
+        Console.WriteLine("Available dotnet-inspect skills:");
+        Console.WriteLine();
+        Console.WriteLine("  (base)        Print with 'dotnet-inspect skill'. Everyday lookup, query, and output workflows.");
+        foreach (var skill in Skills)
+        {
+            Console.WriteLine($"  {skill.Name,-12}  {skill.Description}");
+        }
+        Console.WriteLine();
+        Console.WriteLine("Print a focused skill with 'dotnet-inspect skill <name>'.");
+        return 0;
+    }
+
+    private static int PrintResource(string resourceName)
     {
         var assembly = Assembly.GetExecutingAssembly();
-        using var stream = assembly.GetManifestResourceStream("dotnet-inspect.SKILL.md");
+        using var stream = assembly.GetManifestResourceStream(resourceName);
 
-        if (stream == null)
+        if (stream is null)
         {
-            Console.Error.WriteLine("Error: SKILL.md resource not found.");
+            Console.Error.WriteLine($"Error: skill resource '{resourceName}' not found.");
             return 1;
         }
 

--- a/src/dotnet-inspect/Commands/SkillCommand.cs
+++ b/src/dotnet-inspect/Commands/SkillCommand.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using DotnetInspector.Output;
 using DotnetInspector.Views;
 using Markout;
 
@@ -69,12 +68,15 @@ public class SkillCommand
                 .Select(s => new SkillRow
                 {
                     Skill = s.Name,
-                    Command = MarkoutInline.Code($"{Name} {s.Name}"),
                     Description = s.Description,
                 })
                 .ToList(),
         };
-        MarkoutSerializer.Serialize(view, Console.Out, SkillsViewContext.Default);
+
+        // HeadingLevelOffset = 1 renders the view's H1 title as an H2 section so
+        // it appends cleanly under the baseline skill without a second H1.
+        var options = new MarkoutWriterOptions { HeadingLevelOffset = 1 };
+        MarkoutSerializer.Serialize(view, Console.Out, SkillsViewContext.Default, options);
 
         return 0;
     }

--- a/src/dotnet-inspect/Views/SkillsView.cs
+++ b/src/dotnet-inspect/Views/SkillsView.cs
@@ -32,7 +32,7 @@ public class SkillRow
     public string Skill { get; set; } = "";
 
     [MarkoutPropertyName("Use it for")]
-    public string Description { get; set; } = "";
+    public string UseFor { get; set; } = "";
 }
 
 [MarkoutContext(typeof(SkillsView))]

--- a/src/dotnet-inspect/Views/SkillsView.cs
+++ b/src/dotnet-inspect/Views/SkillsView.cs
@@ -4,13 +4,25 @@ namespace DotnetInspector.Views;
 
 /// <summary>
 /// Renders the focused-skill registry as a trailing <c>## Skills</c> section for
-/// the base skill output. Kept as a section (not a document title) so it renders
-/// at heading level 2 and can be appended after the baseline skill text.
+/// the base skill output. Serialized with <see cref="MarkoutWriterOptions.HeadingLevelOffset"/>
+/// set to 1 so the document title drops from H1 to H2 ("print a section, elide
+/// the H1") and the block can be appended under the baseline skill text. The
+/// intro description explains how to print a focused skill, which lets the table
+/// stay a clean two columns.
 /// </summary>
-[MarkoutSerializable]
+[MarkoutSerializable(TitleProperty = nameof(Title), DescriptionProperty = nameof(Description))]
 public class SkillsView
 {
-    [MarkoutSection(Name = "Skills")]
+    [MarkoutIgnore]
+    public string Title => "Skills";
+
+    [MarkoutIgnore]
+    public string Description =>
+        "Targeted skills are available for more advanced topics. Print one with "
+        + "`dotnet-inspect skill <name>` when a task needs it, or run "
+        + "`dotnet-inspect skill list` to see them all.";
+
+    [MarkoutSection(Headless = true)]
     public List<SkillRow> Skills { get; set; } = [];
 }
 
@@ -18,9 +30,6 @@ public class SkillRow
 {
     [MarkoutPropertyName("Skill")]
     public string Skill { get; set; } = "";
-
-    [MarkoutPropertyName("Print it with")]
-    public string Command { get; set; } = "";
 
     [MarkoutPropertyName("Use it for")]
     public string Description { get; set; } = "";

--- a/src/dotnet-inspect/Views/SkillsView.cs
+++ b/src/dotnet-inspect/Views/SkillsView.cs
@@ -1,0 +1,32 @@
+using Markout;
+
+namespace DotnetInspector.Views;
+
+/// <summary>
+/// Renders the focused-skill registry as a trailing <c>## Skills</c> section for
+/// the base skill output. Kept as a section (not a document title) so it renders
+/// at heading level 2 and can be appended after the baseline skill text.
+/// </summary>
+[MarkoutSerializable]
+public class SkillsView
+{
+    [MarkoutSection(Name = "Skills")]
+    public List<SkillRow> Skills { get; set; } = [];
+}
+
+public class SkillRow
+{
+    [MarkoutPropertyName("Skill")]
+    public string Skill { get; set; } = "";
+
+    [MarkoutPropertyName("Print it with")]
+    public string Command { get; set; } = "";
+
+    [MarkoutPropertyName("Use it for")]
+    public string Description { get; set; } = "";
+}
+
+[MarkoutContext(typeof(SkillsView))]
+public partial class SkillsViewContext : MarkoutSerializerContext
+{
+}

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <EmbeddedResource Include="release-notes.md" />
     <EmbeddedResource Include="../../skills/dotnet-inspect/SKILL.md" LogicalName="dotnet-inspect.SKILL.md" />
+    <EmbeddedResource Include="../../skills/dotnet-inspect/query.md" LogicalName="dotnet-inspect.skills.query.md" />
     <EmbeddedResource Include="../../skills/dotnet-inspect/source.md" LogicalName="dotnet-inspect.skills.source.md" />
     <EmbeddedResource Include="../../skills/dotnet-inspect/performance.md" LogicalName="dotnet-inspect.skills.performance.md" />
   </ItemGroup>

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -63,8 +63,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MarkdownTable.Formatting" />
-    <PackageReference Include="Markout" />
+    <!-- PROTOTYPE: project-references the local Markout build to test the
+         unreleased HeadingLevelOffset feature (Markout 0.14.0). Swap back to
+         <PackageReference Include="Markout" /> once 0.14.0 is published. -->
+    <ProjectReference Include="../../../../../markout/.worktrees/print-section-elide-h1/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj" />
+    <ProjectReference Include="../../../../../markout/.worktrees/print-section-elide-h1/src/Markout/Markout.csproj" />
+    <ProjectReference Include="../../../../../markout/.worktrees/print-section-elide-h1/src/Markout.SourceGeneration/Markout.SourceGeneration.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -44,6 +44,8 @@
   <ItemGroup>
     <EmbeddedResource Include="release-notes.md" />
     <EmbeddedResource Include="../../skills/dotnet-inspect/SKILL.md" LogicalName="dotnet-inspect.SKILL.md" />
+    <EmbeddedResource Include="../../skills/dotnet-inspect/source.md" LogicalName="dotnet-inspect.skills.source.md" />
+    <EmbeddedResource Include="../../skills/dotnet-inspect/performance.md" LogicalName="dotnet-inspect.skills.performance.md" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -63,14 +63,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- PROTOTYPE: project-references the local Markout build to test the
-         unreleased HeadingLevelOffset feature (Markout 0.14.0). Swap back to
-         <PackageReference Include="Markout" /> once 0.14.0 is published. -->
-    <ProjectReference Include="../../../../../markout/.worktrees/print-section-elide-h1/src/MarkdownTable.Formatting/MarkdownTable.Formatting.csproj" />
-    <ProjectReference Include="../../../../../markout/.worktrees/print-section-elide-h1/src/Markout/Markout.csproj" />
-    <ProjectReference Include="../../../../../markout/.worktrees/print-section-elide-h1/src/Markout.SourceGeneration/Markout.SourceGeneration.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
+    <PackageReference Include="MarkdownTable.Formatting" />
+    <PackageReference Include="Markout" />
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Turns `dotnet-inspect skill` into a **skill router**: the base skill stays tight
and focused, deeper topics move into named sub-skills printed on demand. This
keeps the embedded skill small (some agents `head -n` it) while still exposing
advanced guidance when a task needs it.

```text
dotnet-inspect skill              # base skill + trailing "## Skills" list
dotnet-inspect skill list         # the skills list as a standalone document
dotnet-inspect skill query        # output formats, -D/-S discovery, projection, limits
dotnet-inspect skill source       # decompiled C#, IL, SourceLink, unsafe/IL audits
dotnet-inspect skill performance  # call-graph leverage ranking + triage
```

Adding a skill is one registry entry + one embedded `.md`; the subcommand,
`skill list` row, and trailing router section are generated from the registry.

## What changed

- **Base skill trimmed to a strict ≤50 lines** of pure baseline (lookup, member
  workflow, tips). A test guards the line cap.
- **Source/decompiler, performance, and a new `query` skill** extracted into
  embedded resources. `query` collects the cross-command output machinery
  (formats, `-D`/`-S`, `--columns`/`--fields`, `@` categories, limits).
- **Trailing `## Skills` section is generated** from the registry and appended
  last (so `head -n` keeps baseline), with an intro description and a clean
  `Skill | Use it for` table.
- **`skill list` outputs Markdown by default** (same view at H1) and honors the
  standard output flags like other list commands: `--table`, `--tsv`, `--jsonl`,
  `--json`, `--no-headers`.

## Markout dependency

The trailing section is rendered entirely through Markout using a new
**`MarkoutWriterOptions.HeadingLevelOffset`** option ("print a section, elide the
H1"): the view's H1 title renders as `## Skills` so it appends under the baseline
without a second H1. That feature shipped in **Markout 0.14.0**
(richlander/markout#116); this PR bumps the package reference 0.13.7 → 0.14.0.

## Output

`dotnet-inspect skill` (tail):

```markdown
## Skills

Targeted skills are available for more advanced topics. Print one with `dotnet-inspect skill <name>` when a task needs it, or run `dotnet-inspect skill list` to see them all.

| Skill | Use it for |
| ----- | ---------- |
| query | Output formats, -D/-S discovery, value projection, @ categories, and output limits shared across commands. |
| source | Decompiled C#, IL, annotated source, SourceLink original source, and unsafe/IL audits. |
| performance | Whole-assembly call-graph leverage ranking and performance triage (experimental). |
```

`dotnet-inspect skill list --tsv`:

```text
skill	use_for
query	Output formats, -D/-S discovery, value projection, @ categories, and output limits shared across commands.
source	Decompiled C#, IL, annotated source, SourceLink original source, and unsafe/IL audits.
performance	Whole-assembly call-graph leverage ranking and performance triage (experimental).
```

## Tests

New `SkillCommandTests` cover the router output and Skills-after-baseline
ordering, the ≤50-line baseline cap, every registered focused skill resolving,
unknown-skill guidance, `skill list` Markdown/H1, and the `--tsv`/`--json`/
`--no-headers` formats. Full `SkillCommandTests`, `ResourceScannerTests`, and
`CommandLineTests` pass (172 total); changed Markdown lints clean.
