### PR TITLE
Anchor local function demangling after enclosing name

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpNamingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpNamingTests.cs
@@ -1,0 +1,14 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class CSharpNamingTests
+{
+    [Theory]
+    [InlineData("<M>g__Local|0_0", "Local")]
+    [InlineData("<Ag__B>g__Local|0_0", "Local")]
+    [InlineData("<Ag__B>g__Local", "Local")]
+    [InlineData("<Ag__B>b__0_0", "<Ag__B>b__0_0")]
+    public void MethodName_DemanglesLocalFunctionAfterEnclosingName(string metadataName, string expected)
+        => Assert.Equal(expected, CSharpNaming.MethodName(metadataName));
+}

--- a/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
@@ -131,6 +131,40 @@ public class LocalFunctionRaisingPassTests
     }
 
     [Fact]
+    public void EnclosingMethodNameContainingGMarker_DemanglesLocalFunctionName()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var method = new MethodRef(
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            "<Ag__B>g__Local|0_0",
+            intType,
+            [intType],
+            HasThis: false)
+        {
+            CompilerGenerated = MetadataFactState.Yes,
+        };
+        var function = FunctionReturningCall(method, intType);
+        var body = LocalFunctionBody(method, intType);
+        var context = new PassContext(
+            new Stepper(enabled: false),
+            importMethodBody: m => m == method ? body : null);
+
+        new LocalFunctionRaisingPass().Run(function, context);
+
+        var invocation = Assert.Single(function.Descendants.OfType<LocalFunctionInvocation>());
+        Assert.Equal("Local", invocation.Name);
+        var declaration = Assert.Single(function.Descendants.OfType<LocalFunctionStatement>());
+        Assert.Equal("Local", declaration.Name);
+
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.Contains("return Local(x);", output);
+        Assert.Contains("static int Local(int x)", output);
+        Assert.DoesNotContain("B>g__Local", output);
+        function.CheckInvariant();
+    }
+
+    [Fact]
     public void LambdaLocalFunctionImportCycle_DeclinesInsteadOfReenteringPipeline()
     {
         var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -64,16 +64,16 @@ internal static class CSharpNaming
     /// The source name of a call target. A compiler-generated local function
     /// carries the metadata name <c>&lt;Enclosing&gt;g__Local|N_M</c>, which is
     /// not a valid C# identifier; the source name is the segment between
-    /// <c>g__</c> and the <c>|</c> ordinal suffix.
+    /// <c>&gt;g__</c> and the <c>|</c> ordinal suffix.
     /// </summary>
     public static string MethodName(string name)
     {
         if (!name.StartsWith('<'))
             return name;
-        int marker = name.IndexOf("g__", StringComparison.Ordinal);
+        int marker = name.IndexOf(">g__", StringComparison.Ordinal);
         if (marker < 0)
             return name;
-        int start = marker + 3;
+        int start = marker + 4;
         int bar = name.IndexOf('|', start);
         return bar > start ? name[start..bar] : name[start..];
     }


### PR DESCRIPTION
## Summary

Fixes #1549 by anchoring local-function metadata-name demangling on the `>g__` marker after the enclosing method name, instead of the first `g__` anywhere in the metadata name.

This keeps enclosing method names like `Ag__B` from corrupting recovered local-function names: `<Ag__B>g__Local|0_0` now demangles to `Local`.

## Evidence

- Added direct `CSharpNaming.MethodName` cases for ordinary local functions, enclosing names containing `g__`, no ordinal suffix, and non-local-function generated names.
- Added a `LocalFunctionRaisingPass`/printer regression: synthetic local function `<Ag__B>g__Local|0_0` raises to declaration/invocation named `Local`, and output contains `Local(x)` / `static int Local(...)` with no `B>g__Local` fragment.

Validation:

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.CSharpNamingTests -class ILInspector.Decompiler.Tests.LocalFunctionRaisingPassTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` — 1341/1341 passed.
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -v:q`

Quality card matches current main control exactly; remaining warning is baseline/current-main drift, not this branch.
