### PR TITLE
Escape await identifiers in generated C#

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -63,6 +63,8 @@ public class CfgSampleClass
     // CS1001 "Identifier expected". Exercises the LoadArgument render path.
     public static int KeywordParam(int @delegate) => @delegate + 1;
 
+    public static int ContextualKeywordParam(int @await) => @await + 1;
+
     // A reference inequality against null: csc lowers `o != null` to
     // `ldnull; cgt.un` (an unsigned ordering), so the IR is GreaterThan-unsigned
     // with a null operand. The printer must spell it `o is not null`, not the

--- a/src/ILInspector.Decompiler.Tests/KeywordIdentifierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/KeywordIdentifierTests.cs
@@ -26,4 +26,13 @@ public class KeywordIdentifierTests
         Assert.Contains("@delegate + 1", output);
         Assert.DoesNotContain(" delegate", output);
     }
+
+    [Fact]
+    public void ContextualKeywordParameter_IsEscaped()
+    {
+        var output = Render(nameof(CfgSampleClass.ContextualKeywordParam));
+
+        Assert.Contains("@await + 1", output);
+        Assert.DoesNotContain(" await", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/KeywordIdentifierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/KeywordIdentifierTests.cs
@@ -8,6 +8,8 @@ namespace ILInspector.Decompiler.Tests;
 // filtered, so the live case is parameter names.
 public class KeywordIdentifierTests
 {
+    static readonly TypeRef AwaitType = TypeRef.Definition("Synthetic", "", "Await");
+
     static string Render(string methodName)
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
@@ -33,6 +35,27 @@ public class KeywordIdentifierTests
         var output = Render(nameof(CfgSampleClass.ContextualKeywordParam));
 
         Assert.Contains("@await + 1", output);
+        Assert.DoesNotContain(" await", output);
+    }
+
+    [Fact]
+    public void ReadableLocalName_DoesNotEmitBareAwait()
+    {
+        var body = new BlockContainer();
+        var block = new Block();
+        block.Add(new StoreLocal(0, AwaitType, new Constant(null, AwaitType)));
+        block.Add(new ExpressionStatement(new LoadLocal(0, AwaitType)));
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0),
+            [AwaitType],
+            body);
+
+        var output = CSharpPrinter.Print(function, new PrinterOptions { ReadableLocalNames = true }).Output!;
+
+        Assert.Contains("V_0", output);
         Assert.DoesNotContain(" await", output);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/LocalFunctionKeywordEscapeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionKeywordEscapeTests.cs
@@ -1,4 +1,6 @@
 using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -42,6 +44,31 @@ public class LocalFunctionKeywordEscapeTests
         Assert.Contains("return @return();", output);   // invocation escaped
         Assert.DoesNotContain("int return(", output);   // header not emitted raw
         Assert.DoesNotContain("return return()", output);
+    }
+
+    [Fact]
+    public void ContextualKeywordLocalFunctionName_IsEscapedAtDeclarationAndInvocation()
+    {
+        var output = PrintWithLocalFunction("await");
+
+        Assert.Contains("@await(", output);
+        Assert.Contains("return @await();", output);
+        Assert.DoesNotContain("int await(", output);
+        Assert.DoesNotContain("return await()", output);
+
+        string shell = $$"""
+            using System.Threading.Tasks;
+            class C
+            {
+                async Task<int> M()
+                {
+            {{output}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(shell, cancellationToken: TestContext.Current.CancellationToken);
+        Assert.DoesNotContain(tree.GetDiagnostics(TestContext.Current.CancellationToken),
+            diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -33,10 +33,12 @@ internal static class CSharpNaming
     }
 
     /// <summary>An identifier safe to emit in C# source: a reserved keyword is
-    /// <c>@</c>-escaped (a parameter named <c>delegate</c> becomes <c>@delegate</c>,
-    /// which would otherwise be CS1001); any other name is returned unchanged.</summary>
+    /// <c>@</c>-escaped (a parameter named <c>delegate</c> becomes
+    /// <c>@delegate</c>). The contextual <c>await</c> keyword is escaped too: it
+    /// is illegal as a bare identifier inside async methods, which is where
+    /// recovered local functions and parameter references can appear.</summary>
     public static string EscapeIdentifier(string name)
-        => ReservedKeywords.Contains(name) ? "@" + name : name;
+        => ReservedKeywords.Contains(name) || name == "await" ? "@" + name : name;
 
     static readonly HashSet<string> ReservedKeywords = new(StringComparer.Ordinal)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -11,7 +11,7 @@ internal static class CSharpNaming
 {
     /// <summary>A name safe to emit bare as a C# identifier: letters/digits/underscore, no leading digit, and not a reserved keyword (which would need an <c>@</c> escape).</summary>
     public static bool IsUsableIdentifier(string name)
-        => IsEscapableIdentifier(name) && !ReservedKeywords.Contains(name);
+        => IsEscapableIdentifier(name) && !RequiresEscape(name);
 
     /// <summary>
     /// A name C# can emit as an identifier, possibly via an <c>@</c> escape: valid
@@ -38,7 +38,10 @@ internal static class CSharpNaming
     /// is illegal as a bare identifier inside async methods, which is where
     /// recovered local functions and parameter references can appear.</summary>
     public static string EscapeIdentifier(string name)
-        => ReservedKeywords.Contains(name) || name == "await" ? "@" + name : name;
+        => RequiresEscape(name) ? "@" + name : name;
+
+    static bool RequiresEscape(string name)
+        => ReservedKeywords.Contains(name) || name == "await";
 
     static readonly HashSet<string> ReservedKeywords = new(StringComparer.Ordinal)
     {


### PR DESCRIPTION
## Summary

- Escape the contextual `await` keyword through `CSharpNaming.EscapeIdentifier`, since bare `await` is invalid as a recovered identifier inside async method bodies.
- Add a compiled parameter fixture for `@await` and assert body references render as `@await`.
- Add a local-function fixture for a recovered local function named `await`, including a Roslyn parse check inside an async shell.

Fixes #1494.

## Evidence

Focused/regression validation:

```bash
dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- \
  -class ILInspector.Decompiler.Tests.KeywordIdentifierTests \
  -class ILInspector.Decompiler.Tests.LocalFunctionKeywordEscapeTests \
  -class ILInspector.Decompiler.Tests.IrImporterTests \
  -class ILInspector.Decompiler.Tests.StringInterpolationPassTests \
  -class ILInspector.Decompiler.Tests.UsingStatementPassTests \
  -class ILInspector.Decompiler.Tests.InlineArrayElementRefPassTests \
  -class ILInspector.Decompiler.Tests.TypeSourceCheckTests
# 145 passed

dotnet run --project src/ILInspector.Decompiler.Tests -c Release
# 1338 passed

dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet
```

Corpus card on the integrated branch:

```text
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,365 methods
Correctness coverage: validity sampled 350 / 88,365 (0.40%); fidelity sampled 36 / 88,365 (0.04%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-23). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 87,370 -> 88,365 (+995)
- dotnet-inspect: 11,710 -> 12,243 methods (+533)
- ILInspector.Analysis: 500 -> 672 methods (+172)
- ILInspector.Decompiler: 5,004 -> 5,285 methods (+281)
- ILInspector.Metadata: 1,824 -> 1,833 methods (+9)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 76,894 (88.01%) | 77,677 (87.90%) | +783 |
| Conditional-branch residual | 2,290 (2.62%) | 2,404 (2.72%) | +114 |
| Forward-merge stops | 2,284 (2.61%) | 2,140 (2.42%) | -144 |
| Full malformed | 33 | 32 | -1 |
| Semantic defects | 4/350 — sampled 350 / 87,370 (0.40%) | 4/350 — sampled 350 / 88,365 (0.40%) | 0 |
| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,370 (0.01%) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 88,365 (0.04%) | +4 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (count regressions evaluated here): Full malformed 32 -> 32 (0); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- fully-raised rate dropped 11 bps (baseline 88.01%, current 87.90%, tolerance 10 bps)

Caveat: the corpus drifted from the baseline. The aggregate count rows above mix the PR with that drift, but count-based regressions are gated on the pinned-NuGet subset; no pinned count regression is reported here.
```
