### PR TITLE
Cap volatile. ldind/stind at Partial fidelity (#1434)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/NullConditionalCoalescePassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullConditionalCoalescePassTests.cs
@@ -1,3 +1,4 @@
+using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
@@ -26,7 +27,8 @@ public class NullConditionalCoalescePassTests
         IrExpression? receiver = null,
         int guardBTarget = 30,
         bool entryIntoGuardB = false,
-        bool tempUsedAfterMerge = false)
+        bool tempUsedAfterMerge = false,
+        bool volatileReload = false)
     {
         const int vk = 0, sj = 1, sr = 2;
         receiver ??= new LoadArgumentAddress(0, "value", s_tk);
@@ -38,7 +40,7 @@ public class NullConditionalCoalescePassTests
         a.Add(new ConditionalBranch(new Box(s_tk, new LoadLocal(vk, s_tk)), 30));
 
         var b = new Block(10);
-        b.Add(new StoreLocal(vk, s_tk, new LoadIndirect(s_tk, new LoadStackSlot(sj, TypeRef.ByRef(s_tk)))));
+        b.Add(new StoreLocal(vk, s_tk, new LoadIndirect(s_tk, new LoadStackSlot(sj, TypeRef.ByRef(s_tk))) { IsVolatile = volatileReload }));
         b.Add(new StoreStackSlot(sj, new LoadLocalAddress(vk, s_tk)));
         b.Add(new ConditionalBranch(new Box(s_tk, new LoadLocal(vk, s_tk)), guardBTarget));
 
@@ -103,6 +105,26 @@ public class NullConditionalCoalescePassTests
         new NullConditionalCoalescePass().Run(function, PassContext.None);
         var nc = Assert.Single(function.Descendants.OfType<NullConditional>());
         Assert.Empty(function.Descendants.OfType<Coalesce>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void VolatileReload_StaysFlat_AndCapsFidelity()
+    {
+        // The reload `Vk = *Sj` carries a `volatile.` prefix. Folding it into a
+        // null-conditional would erase the LoadIndirect — dropping the
+        // acquire/release ordering and bypassing the fidelity cap (no faithful
+        // spelling, #1434). The fold must refuse so the volatile load survives and
+        // fidelity stays Partial.
+        var function = Build(new Constant(0, s_int), s_int, volatileReload: true);
+
+        new NullConditionalCoalescePass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NullConditional>());
+        Assert.Empty(function.Descendants.OfType<Coalesce>());
+        var load = Assert.Single(function.Descendants.OfType<LoadIndirect>());
+        Assert.True(load.IsVolatile);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
         function.CheckInvariant();
     }
 

--- a/src/ILInspector.Decompiler.Tests/VolatileIndirectFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/VolatileIndirectFidelityTests.cs
@@ -90,4 +90,83 @@ public class VolatileIndirectFidelityTests
         Assert.Contains("*p", volatileOutput);
         Assert.Equal(plainOutput, volatileOutput);
     }
+
+    // --- Pass-erasure guards: a volatile indirect node must not be folded away by
+    // a raising pass before the final-tree fidelity check runs (else the cap is
+    // bypassed). The fold must decline, leaving the volatile node flat. ---
+
+    static readonly TypeRef InlineArray2 =
+        TypeRef.Definition("UserAssembly", "Samples", "InlineArray2", ValueTypeHint.ValueType, MetadataFactState.Yes);
+    static readonly TypeRef SpanInt = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Span`1"), [IntType]);
+
+    static MethodRef PrivateImplHelper(string name, TypeRef returnType)
+        => new(
+            TypeRef.Definition(TypeRef.CoreLibrary, "", "<PrivateImplementationDetails>"),
+            name,
+            returnType,
+            [TypeRef.ByRef(InlineArray2), IntType],
+            HasThis: false)
+        {
+            TypeArguments = [InlineArray2, IntType],
+            DeclaringTypeCompilerGenerated = MetadataFactState.Yes,
+        };
+
+    // csc lowers `[a, b]` to: default-init a synthesized InlineArray2 local, store
+    // each slot through <PrivateImplementationDetails>.InlineArrayElementRef, then
+    // expose it via InlineArrayAsReadOnlySpan. InlineArrayCollectionPass folds that
+    // into `[a, b]`, detaching the element stores. With volatile stores it must not.
+    static IrFunction InlineArrayCollection(bool isVolatile)
+    {
+        var block = new Block();
+        block.Add(new InitObject(InlineArray2, new LoadLocalAddress(0, InlineArray2)));
+        block.Add(new StoreIndirect(
+            IntType,
+            new Call(PrivateImplHelper("InlineArrayElementRef", TypeRef.ByRef(IntType)), isVirtual: false,
+                [new LoadLocalAddress(0, InlineArray2), new Constant(0, IntType)]),
+            new LoadArgument(0, "a", IntType)) { IsVolatile = isVolatile });
+        block.Add(new StoreIndirect(
+            IntType,
+            new Call(PrivateImplHelper("InlineArrayElementRef", TypeRef.ByRef(IntType)), isVirtual: false,
+                [new LoadLocalAddress(0, InlineArray2), new Constant(1, IntType)]),
+            new LoadArgument(1, "b", IntType)) { IsVolatile = isVolatile });
+        block.Add(new StoreLocal(1, SpanInt, new Call(
+            PrivateImplHelper("InlineArrayAsReadOnlySpan", SpanInt), isVirtual: false,
+            [new LoadLocalAddress(0, InlineArray2), new Constant(2, IntType)])));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var signature = new MethodSignature(
+            VoidType,
+            [new Parameter("a", IntType), new Parameter("b", IntType)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        return new IrFunction("M", TypeRef.Definition("Synthetic", "", "T"), signature, [InlineArray2, SpanInt], body);
+    }
+
+    [Fact]
+    public void PlainInlineArrayStores_FoldToCollectionExpression()
+    {
+        // Positive canary: without the volatile prefix the pass raises the literal,
+        // so the test below proves the volatile prefix is the only discriminator.
+        var function = InlineArrayCollection(isVolatile: false);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<CollectionExpression>());
+        Assert.Empty(function.Descendants.OfType<StoreIndirect>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void VolatileInlineArrayStores_StayFlat_AndCapFidelity()
+    {
+        var function = InlineArrayCollection(isVolatile: true);
+
+        new InlineArrayCollectionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<CollectionExpression>());
+        Assert.Equal(2, function.Descendants.OfType<StoreIndirect>().Count(s => s.IsVolatile));
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        function.CheckInvariant();
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/VolatileIndirectFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/VolatileIndirectFidelityTests.cs
@@ -1,0 +1,93 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Over-raise honesty gate for issue #1434: a <c>volatile.</c>-prefixed indirect
+/// access (<c>volatile. ldind</c>/<c>volatile. stind</c>) decompiles to a bare
+/// <c>*p</c> that drops the acquire/release ordering, and must not be reported
+/// <see cref="DecompilationFidelity.Full"/>. csc never emits <c>volatile.</c> on a
+/// bare deref, so the counterexample is a synthetic IR fixture; the non-volatile
+/// twin is the built-in near-miss negative — identical <c>*p</c> output, but it
+/// stays <c>Full</c>.
+/// </summary>
+public class VolatileIndirectFidelityTests
+{
+    static readonly TypeRef IntType = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef IntPtr = TypeRef.Pointer(IntType);
+    static readonly TypeRef VoidType = TypeRef.CoreLib("System", "Void");
+
+    static IrFunction ReadVolatile(bool isVolatile)
+    {
+        var load = new LoadIndirect(IntType, new LoadArgument(0, "p", IntPtr)) { IsVolatile = isVolatile };
+        var container = new BlockContainer();
+        var entry = new Block(0x00);
+        entry.Add(new Return(load));
+        container.Add(entry);
+        var signature = new MethodSignature(IntType, [new Parameter("p", IntPtr)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("ReadVolatile", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+    }
+
+    static IrFunction WriteVolatile(bool isVolatile)
+    {
+        var store = new StoreIndirect(IntType, new LoadArgument(0, "p", IntPtr), new Constant(1, IntType)) { IsVolatile = isVolatile };
+        var container = new BlockContainer();
+        var entry = new Block(0x00);
+        entry.Add(store);
+        entry.Add(new Return(null));
+        container.Add(entry);
+        var signature = new MethodSignature(VoidType, [new Parameter("p", IntPtr)], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("WriteVolatile", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+    }
+
+    [Fact]
+    public void VolatileLoadIndirect_IsPartial_WithRemark()
+    {
+        var function = ReadVolatile(isVolatile: true);
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        var remark = Assert.Single(FidelityRemarks.Collect(function));
+        Assert.Equal(DiagnosticIds.VolatileIndirectAccess, remark.Code);  // DEC0012
+    }
+
+    [Fact]
+    public void VolatileStoreIndirect_IsPartial_WithRemark()
+    {
+        var function = WriteVolatile(isVolatile: true);
+
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+        var remark = Assert.Single(FidelityRemarks.Collect(function));
+        Assert.Equal(DiagnosticIds.VolatileIndirectAccess, remark.Code);  // DEC0012
+    }
+
+    [Fact]
+    public void PlainLoadIndirect_StaysFull_NoRemark()
+    {
+        var function = ReadVolatile(isVolatile: false);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(FidelityRemarks.Collect(function));
+    }
+
+    [Fact]
+    public void PlainStoreIndirect_StaysFull_NoRemark()
+    {
+        var function = WriteVolatile(isVolatile: false);
+
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Empty(FidelityRemarks.Collect(function));
+    }
+
+    [Fact]
+    public void VolatileAndPlainLoad_PrintIdentically_SoFidelityIsTheOnlyDiscriminator()
+    {
+        // The near-miss negative: the printer still emits a bare `*p` for both, so
+        // the only thing distinguishing the volatile read is the lowered fidelity.
+        var volatileOutput = CSharpPrinter.Print(ReadVolatile(isVolatile: true)).Output;
+        var plainOutput = CSharpPrinter.Print(ReadVolatile(isVolatile: false)).Output;
+
+        Assert.Contains("*p", volatileOutput);
+        Assert.Equal(plainOutput, volatileOutput);
+    }
+}

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -113,6 +113,17 @@ public static class DiagnosticIds
     /// comments/gotos and must not claim Full fidelity.
     /// </summary>
     public const string UnsupportedExceptionFilter = "DEC0011";
+
+    /// <summary>
+    /// A <c>volatile.</c>-prefixed indirect access (<c>volatile. ldind</c>/
+    /// <c>volatile. stind</c>) survived raising. The acquire/release ordering is
+    /// real, but a bare <c>*p</c> dereference drops it and has no faithful
+    /// plain-C# spelling (a volatile read/write through a pointer or by-ref is not
+    /// expressible without <c>Volatile.Read</c>/<c>Volatile.Write</c>), so it must
+    /// not claim Full fidelity. <c>volatile.</c> on a <em>field</em> access stays
+    /// faithful — the volatility lives on the field declaration.
+    /// </summary>
+    public const string VolatileIndirectAccess = "DEC0012";
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
+++ b/src/ILInspector.Decompiler/Pipeline/FidelityRemarks.cs
@@ -47,6 +47,11 @@ public static class FidelityRemarks
                     Add(remarks, DiagnosticIds.UnsupportedExceptionFilter, OffsetOf(node), node,
                         "residual exception filter boundary (endfilter) with no standalone C# spelling");
                     break;
+                case LoadIndirect { IsVolatile: true }:
+                case StoreIndirect { IsVolatile: true }:
+                    Add(remarks, DiagnosticIds.VolatileIndirectAccess, OffsetOf(node), node,
+                        "volatile. indirect access (volatile. ldind/stind) renders as a bare *p, dropping the acquire/release ordering — no faithful plain-C# spelling");
+                    break;
             }
 
             var unsupportedType = node.DirectTypes.FirstOrDefault(t => t.ContainsUnsupported)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -320,8 +320,10 @@ public sealed class IrFunction : IrNode
     /// expression spelling, any residual exception-filter boundary, any
     /// expression whose result type the pipeline does not know (null — e.g. a
     /// join slot merged from conflicting types), an EH-retry <c>continue</c>
-    /// whose source-like spelling is not currently opcode-exact, or an un-raised
-    /// <c>pinned</c> T&amp; local (no faithful C# spelling) ⇒ at most
+    /// whose source-like spelling is not currently opcode-exact, a
+    /// <c>volatile.</c>-prefixed indirect access (the bare <c>*p</c> deref drops
+    /// the acquire/release ordering and has no faithful plain-C# spelling), or an
+    /// un-raised <c>pinned</c> T&amp; local (no faithful C# spelling) ⇒ at most
     /// <see cref="DecompilationFidelity.Partial"/>.
     /// </summary>
     public DecompilationFidelity Fidelity
@@ -333,6 +335,8 @@ public sealed class IrFunction : IrNode
             || n is LoadToken { Kind: not RuntimeTokenKind.Type }
             || n is EndFilter
             || n is Continue
+            || n is LoadIndirect { IsVolatile: true }
+            || n is StoreIndirect { IsVolatile: true }
             || n.DirectTypes.Any(t => t.ContainsUnsupported)
             || CSharpSpellability.HasUnrepresentableMetadataName(n)
             || n is IrExpression { ResultType: null }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -315,6 +315,7 @@ public sealed class InlineArrayCollectionPass : IIrPass
         {
             if (statements[index + 5 + i] is not StoreIndirect
                 {
+                    IsVolatile: false,
                     Type: var storeType,
                     Address: LoadProperty item,
                 } store
@@ -605,6 +606,10 @@ public sealed class InlineArrayCollectionPass : IIrPass
         var byIndex = new SortedDictionary<int, StoreIndirect>();
         foreach (var store in function.Descendants.OfType<StoreIndirect>())
         {
+            // A volatile. stind has no faithful spelling inside a collection
+            // expression; leave it flat so fidelity caps (issue #1434).
+            if (store.IsVolatile)
+                continue;
             if (store.Address is not Call elementRef || !IsPrivateImpl(elementRef.Callee, "InlineArrayElementRef"))
                 continue;
             if (elementRef.Arguments is not [LoadLocalAddress { Index: var refLocal }, Constant { Value: int slot }] || refLocal != local)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalCoalescePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalCoalescePass.cs
@@ -111,7 +111,7 @@ public sealed class NullConditionalCoalescePass : IIrPass
         // B: Vk = *Sj; Sj = &Vk; if ((object)Vk != null) goto TRUE
         if (blockB.Children is not
             [
-                StoreLocal { Index: var vkB, Value: LoadIndirect { Address: LoadStackSlot { Slot: var sjReadB } } },
+                StoreLocal { Index: var vkB, Value: LoadIndirect { IsVolatile: false, Address: LoadStackSlot { Slot: var sjReadB } } },
                 StoreStackSlot { Slot: var sjB, Value: LoadLocalAddress { Index: var vkAddrB } },
                 ConditionalBranch { TargetOffset: var trueOffB } condB,
             ]


### PR DESCRIPTION
Fixes #1434.

### Fidelity model over-raise: `volatile. ldind`/`volatile. stind` reported `Full` with a bare `*p`

**Discriminator (shape):** `LoadIndirect`/`StoreIndirect` with `IsVolatile == true` (set by the importer from the `volatile.` prefix). Previously nothing read `IsVolatile` outside the importer and `Describe()`, so the printer emitted a plain `*p` and the fidelity model had no clause — a volatile read/write was indistinguishable from a non-volatile one at `Full`.

**Narrowest gate added:** an `IsVolatile`-true clause for `LoadIndirect`/`StoreIndirect` in `IrFunction.Fidelity` (caps at `Partial`) and a matching `FidelityRemarks.Collect` clause emitting the new stable code `DEC0012 VolatileIndirectAccess`. A `volatile.` indirect access has no faithful plain-C# spelling, so it must degrade honestly rather than claim `Full`.

**Field volatility unaffected:** csc only emits `volatile.` on a *field* access when the field is declared `volatile`, so that volatility lives on the declaration and stays `Full`. Only the indirect `ldind`/`stind` form is gated.

Positive fixture (still `Full`): a plain (non-volatile) `ldind`/`stind` still prints `*p` at `Full` with no remark.
Decline (adversarial near miss): the synthetic `volatile. ldind`/`stind` twin — identical `*p` output — is now `Partial` + `DEC0012`. csc cannot emit `volatile.` on a bare deref, so the counterexample is synthetic IR (matching the #1356 realism note).

Proof level: shape proof (pass fixtures + adversarial negative). Output text is unchanged, so no validity/corpus movement.

Evidence:

- `src/ILInspector.Decompiler.Tests/VolatileIndirectFidelityTests.cs`: 4 fidelity assertions (2 volatile→Partial+DEC0012, 2 plain→Full) + 1 printer near-miss canary proving both render identical `*p` so fidelity is the only discriminator — all green.
- Full `ILInspector.Decompiler.Tests` suite: **1341 passed, 0 failed** (includes `FidelityGateTests`/`FidelityRemarksTests`; no corpus-fidelity baseline regressions).

Honesty note: invalid `Full` → `Partial` is an honesty improvement, not a regression.

Per AGENTS.md I'll request adversarial review from GPT-5.5 after opening.
