### PR TITLE
Harden TypedConstantsPass against degenerate callee/target shapes (#1489)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypedConstantsPassRobustnessTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypedConstantsPassRobustnessTests.cs
@@ -1,0 +1,49 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// TypedConstantsPass must be total over any IR shape: it retypes the constants it
+// understands and leaves the rest, never throwing (issue #1489). A callee that
+// reaches the pass with an uninitialized parameter list — possible through an
+// unusual reconstruction seam — must not crash `.Length`; a constant argument is
+// simply left untyped.
+public class TypedConstantsPassRobustnessTests
+{
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    static IrFunction FunctionWith(IrNode statement)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(statement);
+        var signature = new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Void, signature, [], container);
+    }
+
+    [Fact]
+    public void CallWithDefaultParameterTypes_DoesNotThrow_AndLeavesConstant()
+    {
+        // A MethodRef whose ParameterTypes is a default (uninitialized)
+        // ImmutableArray — `.Length` on it would throw NullReferenceException.
+        var callee = new MethodRef(
+            DeclaringType: TypeRef.CoreLib("System", "Object"),
+            Name: "Consume",
+            ReturnType: Void,
+            ParameterTypes: default,
+            HasThis: false);
+        var argument = new Constant(5, Int32);
+        var call = new Call(callee, isVirtual: false, [argument]);
+
+        var function = FunctionWith(new ExpressionStatement(call));
+
+        var ex = Record.Exception(() => new TypedConstantsPass().Run(function, PassContext.None));
+
+        Assert.Null(ex);
+        // Nothing to retype against: the constant is left exactly as it was.
+        var survivor = Assert.Single(function.Descendants.OfType<Constant>());
+        Assert.Equal(5, survivor.Value);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -88,6 +88,12 @@ public sealed class TypedConstantsPass : IIrPass
 
     static void RetypeArguments(MethodRef callee, IReadOnlyList<IrExpression> arguments, int receiverOffset, IReadOnlyDictionary<TypeRef, TypeShape> shapes, Stepper stepper)
     {
+        // A callee resolved through an unusual seam (e.g. a reconstructed
+        // state-machine MoveNext) can carry an uninitialized parameter list;
+        // `.Length` on a default ImmutableArray throws. Retype only against a
+        // materialized signature — leave the rest, don't crash the pass.
+        if (callee.ParameterTypes.IsDefault)
+            return;
         for (int i = 0; i < callee.ParameterTypes.Length && i + receiverOffset < arguments.Count; i++)
         {
             if (arguments[i + receiverOffset] is Constant constant)
@@ -97,6 +103,10 @@ public sealed class TypedConstantsPass : IIrPass
 
     static void Retype(Constant constant, TypeRef target, IReadOnlyDictionary<TypeRef, TypeShape> shapes, Stepper stepper)
     {
+        // A retype position whose target type did not resolve carries no
+        // identity to recover; skip it rather than dereference a null target.
+        if (target is null)
+            return;
         if (constant.Value is not int value)
             return;
         if (target is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" })


### PR DESCRIPTION
Fixes #1489.

## What

`TypedConstantsPass` should be total over any IR shape — retype the constants it understands and leave the rest, never throwing. A callee that reaches the pass with an **uninitialized parameter list** (a `default` `ImmutableArray<TypeRef>`) made `RetypeArguments` throw `NullReferenceException` on `.Length`. That is the exact crash in #1489, reached through the `Call` case and inlined onto `TypedConstantsPass.Run` in Release builds (the issue's reported "line 15" is the Release inlining attribution; the real site is `RetypeArguments` `.Length`).

Every one of the pass's switch arms funnels through two helpers, so the fix is centralized there — matching the existing **match-and-skip** convention (the pipeline runner deliberately does not swallow; passes are expected to be robust):

- `RetypeArguments`: no-op when `ParameterTypes.IsDefault`.
- `Retype`: no-op on a null `target` (defense in depth).

## Behavior impact

None on well-formed IR. Both guarded conditions are unreachable for a materialized callee/target, so no constant that was retyped before is skipped now. This is a robustness/defensive change, not a raise/structuring/printer-semantics change — **no quality-card movement is expected**.

## Reproduction note

The repro shapes documented in #1489 (`foreach` over a pattern enumerator with a user `finally`, manual-enumerator `Dispose`) do **not** crash on pristine `main`: verified at HEAD and at the issue-time commit `85ff58cd`, across every method including all compiler-generated `MoveNext` bodies (`ImportAssembly` → `IrPasses.Default`). On pristine main #1474 declines that reconstruction, so the malformed `MoveNext` never reaches the pass — the NRE was observed against in-progress #1429 disposal-gate work. The fix is the defensive hardening the issue explicitly asks for, with a faithful regression that reproduces the precise NRE by construction.

## Tests

- New `TypedConstantsPassRobustnessTests`: builds a `Call` whose `MethodRef` carries a `default` `ParameterTypes` and asserts the pass leaves the constant untyped without throwing. **Red before the guard** (`ImmutableArray.get_Length` NRE), green after.
- Focused suites pass: `TypedConstantsPassTests`, `IteratorReconstructionPassTests`, `TypedConstantsPassRobustnessTests` (42 tests).

## Evidence stage

Stage 0 entry gate: builds clean; focused xUnit executable tests green; no Markdown changed. Behavior-neutral guard, so no corpus/fidelity movement expected.
