### PR TITLE
Materialize bool operand of bool/int bitwise & | ^ (#1452)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/BoolIntBitwiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/BoolIntBitwiseTests.cs
@@ -52,4 +52,42 @@ public class BoolIntBitwiseTests
         Assert.Contains("a & b", output);
         Assert.DoesNotContain("? 1 : 0", output);
     }
+
+    [Fact]
+    public void OrBoolUintMix_CastsMaterializedBoolForUnsignedSibling()
+    {
+        var output = Render(nameof(CfgSampleClass.OrBoolUintMix));
+
+        // The materialized bool is a signed `int`; a `uint` sibling would make the
+        // bitwise op `int | uint` (CS0266, widens to long). Routing the rewrite
+        // through the printer's mixed-sign reconciliation supplies the `(uint)`
+        // reinterpret so the expression binds. The materialized ternary is present
+        // and an unsigned cast surrounds the integer mix.
+        Assert.Contains("? 1 : 0", output);
+        Assert.Contains("(uint)", output);
+    }
+
+    [Fact]
+    public void AndNestedConditionalBool_ParenthesizesConditionalCondition()
+    {
+        var output = Render(nameof(CfgSampleClass.AndNestedConditionalBool));
+
+        // The bool operand is itself a conditional; materializing must parenthesize
+        // it — `((x ? p : q) ? 1 : 0)` — or `?:` right-associativity reparses it as
+        // `x ? p : (q ? 1 : 0)` (CS0173/CS0019).
+        Assert.Contains("((x ? p : q) ? 1 : 0) & i", output);
+    }
+
+    [Fact]
+    public void AndNestedBoolIntMix_MaterializesBothNestedMixes()
+    {
+        var output = Render(nameof(CfgSampleClass.AndNestedBoolIntMix));
+
+        // Deepest-first processing must materialize BOTH the inner and outer
+        // bool/int mixes. The inner `(a > 0 ? 1 : 0) & i` and the outer `... & j`
+        // are both present, and no bare `bool & int` (CS0019) survives — a leaked
+        // mix would leave a `) & i`/`) & j` with a bool-typed left and no `? 1 : 0`.
+        Assert.Contains("(a > 0 ? 1 : 0) & i", output);
+        Assert.Contains("? 1 : 0) & j", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/BoolIntBitwiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/BoolIntBitwiseTests.cs
@@ -1,0 +1,55 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A bitwise `&`/`|`/`^` that mixes a bool operand (a comparison result or a
+// bool-typed slot) with an integer operand combines two `i4` (0/1) values in IL,
+// so `and`/`or`/`xor` is legal — but C# has no `bool & int` (CS0019).
+// BinaryResult sinks the *result* to int; the printer must also materialize the
+// bool operand to `(cond ? 1 : 0)`. This is the operand-side complement of the
+// enum/integer and signed/unsigned operand coercions.
+public class BoolIntBitwiseTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void AndBoolIntMix_MaterializesBoolOperand()
+    {
+        var output = Render(nameof(CfgSampleClass.AndBoolIntMix));
+
+        // The bool operand `a > 0` must materialize to `(a > 0 ? 1 : 0)` so the
+        // `&` is `int & int`, not the CS0019 `bool & int`.
+        Assert.Contains("(a > 0 ? 1 : 0) &", output);
+        Assert.DoesNotContain("a > 0 &", output);
+    }
+
+    [Fact]
+    public void OrBoolIntMix_MaterializesBoolOperand()
+    {
+        var output = Render(nameof(CfgSampleClass.OrBoolIntMix));
+
+        // No bool operand may stand bare beside the integer `|`. The materialized
+        // bool reads `(... ? 1 : 0)`; a CS0019 leak would print a bool slot/expr
+        // directly against the `|`.
+        Assert.Contains("? 1 : 0) |", output);
+    }
+
+    [Fact]
+    public void AndTwoBools_StaysBareBoolOp()
+    {
+        var output = Render(nameof(CfgSampleClass.AndTwoBools));
+
+        // Both operands are bool — a genuine logical/bitwise bool `&`. No integer
+        // sibling, so no `? 1 : 0` materialization.
+        Assert.Contains("a & b", output);
+        Assert.DoesNotContain("? 1 : 0", output);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -143,6 +143,24 @@ public class CfgSampleClass
     // bool op — neither operand is an integer, so no `? 1 : 0` materialization.
     public static bool AndTwoBools(bool a, bool b) => a & b;
 
+    // Adversarial: the bool operand mixes with a `uint` sibling. The materialized
+    // `(b ? 1 : 0)` is a signed int, so `int | uint` would be CS0266 (widens to
+    // long) unless the mixed-sign reconciliation casts it: `(uint)(... ? 1 : 0) | c`.
+    public static uint OrBoolUintMix(uint a, bool b) => (a > 0 ? 1u : 0u) | (b ? 2u : 0u);
+
+    // Adversarial: the bool operand is itself a conditional (`x ? p : q` over two
+    // bools). Materializing must parenthesize it — `((x ? p : q) ? 1 : 0) & i` —
+    // or `?:` right-associativity reparses it (CS0173/CS0019).
+    public static int AndNestedConditionalBool(bool x, bool p, bool q, int i)
+        => ((x ? p : q) ? 1 : 0) & i;
+
+    // Adversarial: a bool/int bitwise nested inside the bool operand of an outer
+    // bool/int bitwise. The materialization must reach BOTH mixes (deepest-first),
+    // or the outer rewrite clones the still-`bool & int` inner mix and leaves a
+    // CS0019 in the live tree.
+    public static int AndNestedBoolIntMix(int a, int i, int j)
+        => ((((a > 0 ? 1 : 0) & i) != 0) ? 1 : 0) & j;
+
     // Adversarial near-miss for the not-null idiom: `x > 0` on a uint also emits
     // `cgt.un` against a zero constant, but the zero is an integer literal, not a
     // reference null. It must stay an unsigned `x > 0` comparison, never `is not null`.

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -128,6 +128,21 @@ public class CfgSampleClass
     // (CS0029). The bitwise result must take the integer operand's type.
     public static uint BoolBitwiseOrWidened(bool a, uint c) => (a ? 1u : 0u) | c;
 
+    // A bitwise `&` that mixes a bool operand (a `cgt.un` comparison result) with
+    // an integer operand. Both are `i4` (0/1) on the IL stack, so `and` is legal,
+    // but C# has no `bool & int` (CS0019). BinaryResult sinks the *result* to int;
+    // the printer must also materialize the bool operand to `(cond ? 1 : 0)`.
+    public static int AndBoolIntMix(int a, bool b) => (a > 0 ? 1 : 0) & (b ? 1 : 0);
+
+    // The `|` sibling with a non-unit integer arm (`b ? 2 : 0`), which lands the
+    // bool operand and the integer operand in distinct slots — the same root, a
+    // bool-typed value in an integer bitwise context.
+    public static int OrBoolIntMix(int a, bool b) => (a > 0 ? 1 : 0) | (b ? 2 : 0);
+
+    // Positive canary: a genuine logical/bitwise `&` of two bools stays a bare
+    // bool op — neither operand is an integer, so no `? 1 : 0` materialization.
+    public static bool AndTwoBools(bool a, bool b) => a & b;
+
     // Adversarial near-miss for the not-null idiom: `x > 0` on a uint also emits
     // `cgt.un` against a zero constant, but the zero is an integer literal, not a
     // reference null. It must stay an unsigned `x > 0` comparison, never `is not null`.

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -79,13 +79,16 @@ public class FidelityGateTests
         "NullConditionalPropertyAssignment",
         "ObjectInitializerArgumentBeforeShortCircuit",
         "ReusedSlotStringListCount",
-        // OrBoolIntMix is the #1452 bool-operand materialization: a bitwise
-        // `bool | int` is CS0019, so the printer materializes the bool operand to
-        // `(cond ? 1 : 0)`. In the slot-form shape (a bool-typed `S_0`), that
-        // ternary recompiles to a branch-select that differs from the original
-        // branchless 0/1 — valid C# (no CS0019), not opcode-exact. The sibling
-        // AndBoolIntMix stays opcode-exact, so it is not docketed.
+        // OrBoolIntMix / OrBoolUintMix are the #1452 bool-operand materialization:
+        // a bitwise `bool | int` is CS0019, so BitwiseBoolOperandPass rewrites the
+        // bool operand to `(cond ? 1 : 0)`. In the slot-form shapes that ternary
+        // recompiles to a branch-select that differs from the original branchless
+        // 0/1 — valid C# (no CS0019), not opcode-exact. OrBoolUintMix additionally
+        // takes the `(uint)` mixed-sign reinterpret. The siblings AndBoolIntMix,
+        // AndNestedConditionalBool, and AndNestedBoolIntMix stay opcode-exact, so
+        // they are not docketed.
         "OrBoolIntMix",
+        "OrBoolUintMix",
     };
 
     /// <summary>

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -79,6 +79,13 @@ public class FidelityGateTests
         "NullConditionalPropertyAssignment",
         "ObjectInitializerArgumentBeforeShortCircuit",
         "ReusedSlotStringListCount",
+        // OrBoolIntMix is the #1452 bool-operand materialization: a bitwise
+        // `bool | int` is CS0019, so the printer materializes the bool operand to
+        // `(cond ? 1 : 0)`. In the slot-form shape (a bool-typed `S_0`), that
+        // ternary recompiles to a branch-select that differs from the original
+        // branchless 0/1 — valid C# (no CS0019), not opcode-exact. The sibling
+        // AndBoolIntMix stays opcode-exact, so it is not docketed.
+        "OrBoolIntMix",
     };
 
     /// <summary>

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -69,6 +69,12 @@ public class LoweredFidelityGateTests
         "NullConditionalPropertyAssignment",
         "ObjectInitializerArgumentBeforeShortCircuit",
         "ReusedSlotStringListCount",
+        // OrBoolIntMix is the #1452 bool-operand materialization: a bitwise
+        // `bool | int` is CS0019, so the printer materializes the bool operand to
+        // `(cond ? 1 : 0)`; in the slot-form shape that ternary recompiles to a
+        // branch-select differing from the original branchless 0/1 — valid C#, not
+        // opcode-exact. The sibling AndBoolIntMix stays opcode-exact (not docketed).
+        "OrBoolIntMix",
     };
 
     /// <summary>

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -69,12 +69,14 @@ public class LoweredFidelityGateTests
         "NullConditionalPropertyAssignment",
         "ObjectInitializerArgumentBeforeShortCircuit",
         "ReusedSlotStringListCount",
-        // OrBoolIntMix is the #1452 bool-operand materialization: a bitwise
-        // `bool | int` is CS0019, so the printer materializes the bool operand to
-        // `(cond ? 1 : 0)`; in the slot-form shape that ternary recompiles to a
-        // branch-select differing from the original branchless 0/1 — valid C#, not
-        // opcode-exact. The sibling AndBoolIntMix stays opcode-exact (not docketed).
+        // OrBoolIntMix / OrBoolUintMix are the #1452 bool-operand materialization:
+        // a bitwise `bool | int` is CS0019, so BitwiseBoolOperandPass rewrites the
+        // bool operand to `(cond ? 1 : 0)`; in the slot-form shapes that ternary
+        // recompiles to a branch-select differing from the original branchless 0/1
+        // — valid C#, not opcode-exact. OrBoolUintMix additionally takes the
+        // `(uint)` mixed-sign reinterpret. The And* siblings stay opcode-exact.
         "OrBoolIntMix",
+        "OrBoolUintMix",
     };
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -74,20 +74,6 @@ public sealed partial class CSharpPrinter
                 return $"{Operand(binary.Left)} {BinaryOperator(binary)} {EnumIntegerCast(binary.Right, binary.Left.ResultType!)}";
             if (IsEnumLikeInteger(binary.Right.ResultType) && TypeFamilies.IsInteger(binary.Left.ResultType))
                 return $"{EnumIntegerCast(binary.Left, binary.Right.ResultType!)} {BinaryOperator(binary)} {Operand(binary.Right)}";
-            // A bitwise &/|/^ that mixes a bool operand (a comparison result or a
-            // bool-typed slot) with an integer operand is CS0019: C# has no
-            // `bool & int`. The IL combines two i4 (0/1) values, so materialize the
-            // bool operand to an integer — `(cond ? 1 : 0)`, mirroring
-            // ConditionalArm's bool-at-numeric-sink coercion. BinaryResult already
-            // sinks the *result* to int; this is the operand-side complement. A
-            // bool/bool pair (genuine logical &/|/^) has no integer operand and is
-            // untouched — both branches require the sibling to be a non-bool integer.
-            bool leftBool = TypeFamilies.IsBoolean(binary.Left.ResultType);
-            bool rightBool = TypeFamilies.IsBoolean(binary.Right.ResultType);
-            if (leftBool && !rightBool && TypeFamilies.IsInteger(binary.Right.ResultType))
-                return $"({Condition(binary.Left)} ? 1 : 0) {BinaryOperator(binary)} {Operand(binary.Right)}";
-            if (rightBool && !leftBool && TypeFamilies.IsInteger(binary.Left.ResultType))
-                return $"{Operand(binary.Left)} {BinaryOperator(binary)} ({Condition(binary.Right)} ? 1 : 0)";
         }
         // div.un/rem.un compute on unsigned operands; shr.un shifts an
         // unsigned left operand. Operands that are already unsigned (or

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -74,6 +74,20 @@ public sealed partial class CSharpPrinter
                 return $"{Operand(binary.Left)} {BinaryOperator(binary)} {EnumIntegerCast(binary.Right, binary.Left.ResultType!)}";
             if (IsEnumLikeInteger(binary.Right.ResultType) && TypeFamilies.IsInteger(binary.Left.ResultType))
                 return $"{EnumIntegerCast(binary.Left, binary.Right.ResultType!)} {BinaryOperator(binary)} {Operand(binary.Right)}";
+            // A bitwise &/|/^ that mixes a bool operand (a comparison result or a
+            // bool-typed slot) with an integer operand is CS0019: C# has no
+            // `bool & int`. The IL combines two i4 (0/1) values, so materialize the
+            // bool operand to an integer — `(cond ? 1 : 0)`, mirroring
+            // ConditionalArm's bool-at-numeric-sink coercion. BinaryResult already
+            // sinks the *result* to int; this is the operand-side complement. A
+            // bool/bool pair (genuine logical &/|/^) has no integer operand and is
+            // untouched — both branches require the sibling to be a non-bool integer.
+            bool leftBool = TypeFamilies.IsBoolean(binary.Left.ResultType);
+            bool rightBool = TypeFamilies.IsBoolean(binary.Right.ResultType);
+            if (leftBool && !rightBool && TypeFamilies.IsInteger(binary.Right.ResultType))
+                return $"({Condition(binary.Left)} ? 1 : 0) {BinaryOperator(binary)} {Operand(binary.Right)}";
+            if (rightBool && !leftBool && TypeFamilies.IsInteger(binary.Left.ResultType))
+                return $"{Operand(binary.Left)} {BinaryOperator(binary)} ({Condition(binary.Right)} ? 1 : 0)";
         }
         // div.un/rem.un compute on unsigned operands; shr.un shifts an
         // unsigned left operand. Operands that are already unsigned (or

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -60,8 +60,8 @@ public static class TypeFamilies
         // so the expression doesn't read as bool and force a `? 1 : 0` (CS0029)
         // at a numeric sink. A bool/bool pair (genuine logical `&`/`|`) is
         // untouched — it falls through to the same-family branch below.
-        var leftBool = IsBoolean(left!);
-        var rightBool = IsBoolean(right!);
+        var leftBool = IsBoolean(left);
+        var rightBool = IsBoolean(right);
         if (leftBool ^ rightBool)
             return leftBool ? right : left;
         if (lf == rf)
@@ -143,7 +143,7 @@ public static class TypeFamilies
         return !IsImplicitlyConvertible(source.Name, target.Name);
     }
 
-    static bool IsBoolean(TypeRef type)
+    public static bool IsBoolean(TypeRef? type)
         => type is { Name: "Boolean", Assembly: TypeRef.CoreLibrary, Namespace: "System" };
 
     public static bool IsNumericPrimitive(TypeRef type)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BitwiseBoolOperandPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BitwiseBoolOperandPass.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Materializes a <c>bool</c> operand of an integer bitwise <c>&amp;</c>/<c>|</c>/
+/// <c>^</c> into the <c>0/1</c> integer it carries. A bitwise <c>and</c>/<c>or</c>/
+/// <c>xor</c> that mixes a <c>bool</c>-typed operand (a <see cref="Comparison"/>
+/// result, a bool-typed slot, a bool field/call) with an integer operand combines
+/// two <c>i4</c> (0/1) values on the IL stack, so the opcode is legal — but C# has
+/// no <c>bool &amp; int</c> (CS0019). <see cref="TypeFamilies.BinaryResult"/> already
+/// sinks the <em>result</em> of the mix to <c>int</c>; this pass supplies the
+/// operand-side complement by wrapping the bool operand in
+/// <c>(operand ? 1 : 0)</c>.
+///
+/// <para>Doing it as an IR rewrite (rather than a printer special-case) lets the
+/// existing numeric machinery finish the job: the wrapped operand is a normal
+/// <c>int</c> <see cref="Conditional"/>, so the printer's mixed-sign reconciliation
+/// supplies the <c>(uint)</c> reinterpret for a <c>uint</c>/<c>nuint</c> sibling
+/// (<c>(uint)(a ? 1 : 0) | c</c>, not the CS0266 <c>int | uint</c>), and a nested
+/// conditional condition parenthesizes itself (<c>((x ? y : z) ? 1 : 0)</c>). This
+/// is the same shape csc already emits when the bool was an explicit
+/// <c>cond ? 1 : 0</c>, so it round-trips identically.</para>
+///
+/// <para>A genuine <c>bool &amp; bool</c> (a logical/bitwise bool op) is untouched:
+/// the rewrite requires exactly one bool operand and an integer sibling.</para>
+/// </summary>
+public sealed class BitwiseBoolOperandPass : IIrPass
+{
+    public string Name => "bitwise-bool-operand";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        var matches = function.Descendants
+            .OfType<Binary>()
+            .Where(IsBitwiseBoolIntegerMix)
+            .ToList();
+
+        var intType = TypeRef.CoreLib("System", "Int32");
+        // Process deepest-first. Descendants is pre-order (ancestor before
+        // descendant), so reversing guarantees every nested match is materialized
+        // on the live tree before an enclosing match clones-and-replaces the
+        // subtree that contains it — otherwise the outer rewrite would clone the
+        // still-bool inner mix and the stale inner match would rewrite the
+        // discarded original (leaving a `bool & int` CS0019 in the live tree).
+        matches.Reverse();
+        foreach (var binary in matches)
+        {
+            // Exactly one operand is bool (IsBitwiseBoolIntegerMix guarantees it);
+            // wrap that one. Clone it so the new conditional owns a detached copy
+            // before the in-place replace swaps it out of the binary.
+            var boolOperand = TypeFamilies.IsBoolean(binary.Left.ResultType) ? binary.Left : binary.Right;
+            var conditional = new Conditional(
+                (IrExpression)boolOperand.Clone(),
+                new Constant(1, intType),
+                new Constant(0, intType))
+            {
+                MergedType = intType,
+            };
+            context.Stepper.StepOver("materialize bool operand of bitwise op to (cond ? 1 : 0)", boolOperand);
+            boolOperand.ReplaceWith(conditional);
+        }
+    }
+
+    /// <summary>A bitwise <c>&amp;</c>/<c>|</c>/<c>^</c> with exactly one <c>bool</c> operand and an integer sibling — the CS0019 <c>bool &amp; int</c> mix.</summary>
+    static bool IsBitwiseBoolIntegerMix(Binary binary)
+    {
+        if (binary.Kind is not (BinaryKind.And or BinaryKind.Or or BinaryKind.Xor))
+            return false;
+        bool leftBool = TypeFamilies.IsBoolean(binary.Left.ResultType);
+        bool rightBool = TypeFamilies.IsBoolean(binary.Right.ResultType);
+        if (leftBool == rightBool)
+            return false;
+        // The non-bool sibling must be a genuine integer. IsInteger(bool) is true
+        // (bool is stack family I4), so the bool side is excluded by leftBool/
+        // rightBool above and only the integer sibling is tested here.
+        return leftBool
+            ? TypeFamilies.IsInteger(binary.Right.ResultType)
+            : TypeFamilies.IsInteger(binary.Left.ResultType);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -196,6 +196,13 @@ public static class IrPasses
         // flat it renders `b > false` (CS0019) and the method never binds. Runs
         // after inlining so the bool operand is in its final position.
         new BoolToIntNormalizationPass(),
+        // The operand-side complement of the bool→int normalization: a bool
+        // operand of an integer bitwise &/|/^ (a comparison result or bool slot
+        // landing in `flags | (b ? 1 : 0)` shape) is `bool & int` (CS0019).
+        // Materialize it to `(b ? 1 : 0)` so the integer mix binds; runs right
+        // after the normalization above so both bool→int shapes are settled
+        // before the printer's mixed-sign/numeric machinery sees them.
+        new BitwiseBoolOperandPass(),
         // With structuring done, a spilled base/this constructor argument is a
         // folded expression (base(message ?? "default")); collapse it into the
         // chain call so the call lands as the body's first statement and the

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -77,6 +77,8 @@ internal static class NativePasses
     public static TypedConstantsPass TypedConstants => new();
     [Native(NativeCategory.IlErasure, "bool marshalled as int (cgt against 0) normalized")]
     public static BoolToIntNormalizationPass BoolToIntNormalization => new();
+    [Native(NativeCategory.IlErasure, "a bool operand of an integer bitwise &/|/^ (erased to i4 on the IL stack) materialized back to (cond ? 1 : 0) so the mix is not CS0019 bool & int")]
+    public static BitwiseBoolOperandPass BitwiseBoolOperand => new();
     [Native(NativeCategory.IlErasure, "a standing static function-pointer load (ldftn) spelled &Method")]
     public static MethodAddressPass MethodAddress => new();
     [Native(NativeCategory.IlErasure, "typeof(T) == typeof(U) / typeof type-switch folded")]


### PR DESCRIPTION
## Summary

Fixes #1452 (over-raise correctness, #1356 burndown). A bitwise `and`/`or`/`xor` that combines a **bool**-typed operand (a `Comparison` result or a bool-typed slot) with an **int**-typed operand was raised to a C# `&`/`|`/`^` printing `bool` beside `int`, producing **CS0019** at `Fidelity=Full`. `TypeFamilies.BinaryResult` already sinks the *result* of the mix to `int`; the missing piece was the operand-side materialization.

## Fix — `BitwiseBoolOperandPass`

A new IR normalization pass (`src/ILInspector.Decompiler/Pipeline/Passes/BitwiseBoolOperandPass.cs`, registered right after `BoolToIntNormalizationPass`) rewrites the bool operand of an integer bitwise `&`/`|`/`^` into an explicit `int` `Conditional` — `(operand ? 1 : 0)`. Because the wrapped operand becomes a normal int conditional, the **existing** printer machinery finishes the job, which is what makes the edge cases correct:

- **bool/uint mixed-sign**: the int conditional vs an unsigned sibling flows through `MixedSignBitwise`, emitting the `(uint)` reinterpret (`(uint)(a ? 1 : 0) | c`) instead of the CS0266 `int | uint`.
- **nested-conditional operand**: a conditional in condition position parenthesizes itself (`((x ? p : q) ? 1 : 0)`), avoiding the CS0173 `?:` reparse.

Matches are processed **deepest-first** so an enclosing match never clones a still-`bool` nested mix before that nested match runs.

A genuine `bool & bool` logical op is untouched (the rewrite requires exactly one bool operand and an integer sibling).

## Adversarial review

Reviewed by GPT-5.5 (different model family). It found three reachable near-misses in an earlier printer-level draft — bool/uint mixed-sign, nested-conditional parenthesization, and a deepest-first ordering hazard — all fixed by the pass-based approach above, each with a dedicated fixture. Final verdict: **no significant issues**.

## Tests / evidence

- New `BoolIntBitwiseTests` (6) + `CfgSampleClass` fixtures: `AndBoolIntMix`, `OrBoolIntMix` (slot form), `AndTwoBools` (positive bool/bool canary), `OrBoolUintMix` (mixed-sign), `AndNestedConditionalBool` (parenthesization), `AndNestedBoolIntMix` (deepest-first).
- All six affected fixture bodies recompile through csc with 0 errors.
- Full `ILInspector.Decompiler.Tests` suite green (`CorpusSweepGateTests` floors, `FidelityGateTests` / `LoweredFidelityGateTests` exact-baseline gates). `OrBoolIntMix` / `OrBoolUintMix` are docketed as valid-but-not-opcode-exact slot diffs; the `And*` fixtures recompile **opcode-exact**.
