### PR TITLE
Constrain analysis copy signals to framework APIs

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -583,6 +583,7 @@ public class LibraryBodyIndexTests
 
     [Theory]
     [InlineData(nameof(OptimizationOpportunityFixtures.EnumerableToArrayCopy))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ListToArrayNotFlagged))]
     [InlineData(nameof(OptimizationOpportunityFixtures.StringConcatCopy))]
     [InlineData(nameof(OptimizationOpportunityFixtures.StringJoinCopy))]
     [InlineData(nameof(OptimizationOpportunityFixtures.StringSubstringCopy))]

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -567,6 +567,35 @@ public class LibraryBodyIndexTests
         Assert.True(s.Allocations >= 1, $"expected boxing to count as an allocation, got {s.Allocations}");
     }
 
+    [Theory]
+    [InlineData(nameof(OptimizationOpportunityFixtures.UserJoinLookalike))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.UserConcatLookalike))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.UserSubstringLookalike))]
+    public void MethodSignals_UserCopyNameLookalikes_DoNotCountCopies(string methodName)
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+        var method = Assert.Single(index.Methods.Where(m => m.Name == methodName));
+
+        int copies = signals.TryGetValue(method.MetadataToken, out var s) ? s.Copies : 0;
+        Assert.Equal(0, copies);
+    }
+
+    [Theory]
+    [InlineData(nameof(OptimizationOpportunityFixtures.EnumerableToArrayCopy))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.StringConcatCopy))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.StringJoinCopy))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.StringSubstringCopy))]
+    public void MethodSignals_FrameworkCopyApis_CountCopies(string methodName)
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+        var method = Assert.Single(index.Methods.Where(m => m.Name == methodName));
+
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s), $"expected copy signal for {methodName}");
+        Assert.True(s.Copies >= 1, $"expected at least one copy for {methodName}, got {s.Copies}");
+    }
+
     [Fact]
     public void OptimizationOpportunities_BoxOnThrowPathInLoop_NotPromoted()
     {
@@ -697,6 +726,27 @@ public class OptimizationOpportunityFixtures
     // as span-to-array-copy (kept out to avoid flooding the section).
     public static int[] ListToArrayNotFlagged(System.Collections.Generic.List<int> list) => list.ToArray();
 
+    public static int[] EnumerableToArrayCopy(System.Collections.Generic.IEnumerable<int> values)
+        => values.ToArray();
+
+    public static string StringConcatCopy(string left, string right)
+        => string.Concat(left, right);
+
+    public static string StringJoinCopy(string[] values)
+        => string.Join(",", values);
+
+    public static string StringSubstringCopy(string value)
+        => value.Substring(1);
+
+    public static string UserJoinLookalike(int a, int b)
+        => UserCopyLookalikes.Join(a, b);
+
+    public static string UserConcatLookalike(int a, int b)
+        => UserCopyLookalikes.Concat(a, b);
+
+    public static string UserSubstringLookalike(string value)
+        => UserCopyLookalikes.Substring(value);
+
     // Stored to a field -> escapes.
     public void StoresArrayToField() => _arrayField = new int[4];
 
@@ -763,6 +813,13 @@ public class OptimizationOpportunityFixtures
         {
             sink.Add(v);
         }
+    }
+
+    public static class UserCopyLookalikes
+    {
+        public static string Join(int a, int b) => $"{a}:{b}";
+        public static string Concat(int a, int b) => $"{a}{b}";
+        public static string Substring(string value) => value;
     }
 
     // Boxes a value into an exception message on a throw path inside a loop -> the box only

--- a/src/ILInspector.Analysis/MethodSignals.cs
+++ b/src/ILInspector.Analysis/MethodSignals.cs
@@ -178,7 +178,7 @@ public static class MethodSignalAnalysis
 
         if (callee.Name == "ToArray"
             && (IsSpanLike(callee.DeclaringType)
-                || IsFrameworkType(callee.DeclaringType, TypeRef.CoreLibrary, "System.Collections.Generic", "List`1")))
+                || IsFrameworkType(callee.DeclaringType, "System.Collections", "System.Collections.Generic", "List`1")))
             return true;
 
         if (callee.Name == "CopyTo"
@@ -212,10 +212,13 @@ public static class MethodSignalAnalysis
         => IsFrameworkType(type, TypeRef.CoreLibrary, ns, name);
 
     static bool IsFrameworkType(TypeRef? type, string assembly, string ns, string name)
-        => type is { Kind: TypeRefKind.Definition, Assembly: var typeAssembly, Namespace: var typeNamespace, Name: var typeName }
+    {
+        var definition = type is { Kind: TypeRefKind.GenericInstance } ? type.ElementType : type;
+        return definition is { Kind: TypeRefKind.Definition, Assembly: var typeAssembly, Namespace: var typeNamespace, Name: var typeName }
             && typeAssembly == assembly
             && typeNamespace == ns
             && typeName == name;
+    }
 
     // A constructed type is treated as an exception when its simple name ends with
     // "Exception" — the universal BCL/user convention (InvalidOperationException,

--- a/src/ILInspector.Analysis/MethodSignals.cs
+++ b/src/ILInspector.Analysis/MethodSignals.cs
@@ -164,13 +164,58 @@ public static class MethodSignalAnalysis
     static ImmutableArray<int> NormalizeOffsets(ImmutableArray<int> offsets)
         => offsets.IsDefault ? [] : offsets;
 
-    // Well-known copy/materialize APIs. Name-based, high-confidence members whose
-    // dominant effect is producing a copy of existing data. Intentionally small;
-    // grow deliberately to keep false positives low.
+    // Well-known copy/materialize APIs. Exact framework identities whose dominant
+    // effect is producing a copy of existing data. Intentionally small; grow
+    // deliberately to keep false positives low.
     static bool IsCopyApi(MemberRef callee)
-        => callee.Kind != MemberKind.Unsupported
-           && callee.Name is "ToArray" or "ToList" or "CopyTo" or "GetSubArray"
-               or "Substring" or "Concat" or "Join";
+    {
+        if (callee.Kind == MemberKind.Unsupported)
+            return false;
+
+        if (callee.Name is "ToArray" or "ToList"
+            && IsFrameworkType(callee.DeclaringType, "System.Linq", "System.Linq", "Enumerable"))
+            return true;
+
+        if (callee.Name == "ToArray"
+            && (IsSpanLike(callee.DeclaringType)
+                || IsFrameworkType(callee.DeclaringType, TypeRef.CoreLibrary, "System.Collections.Generic", "List`1")))
+            return true;
+
+        if (callee.Name == "CopyTo"
+            && (IsSpanLike(callee.DeclaringType)
+                || IsFrameworkType(callee.DeclaringType, TypeRef.CoreLibrary, "System", "Array")))
+            return true;
+
+        if (callee.Name == "GetSubArray"
+            && IsCoreLibraryType(callee.DeclaringType, "System.Runtime.CompilerServices", "RuntimeHelpers"))
+            return true;
+
+        if (callee.Name == "Substring"
+            && IsCoreLibraryType(callee.DeclaringType, "System", "String"))
+            return true;
+
+        if (callee.Name is "Concat" or "Join"
+            && IsCoreLibraryType(callee.DeclaringType, "System", "String"))
+            return true;
+
+        return false;
+    }
+
+    static bool IsSpanLike(TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        return IsFrameworkType(definition, TypeRef.CoreLibrary, "System", "Span`1")
+            || IsFrameworkType(definition, TypeRef.CoreLibrary, "System", "ReadOnlySpan`1");
+    }
+
+    static bool IsCoreLibraryType(TypeRef? type, string ns, string name)
+        => IsFrameworkType(type, TypeRef.CoreLibrary, ns, name);
+
+    static bool IsFrameworkType(TypeRef? type, string assembly, string ns, string name)
+        => type is { Kind: TypeRefKind.Definition, Assembly: var typeAssembly, Namespace: var typeNamespace, Name: var typeName }
+            && typeAssembly == assembly
+            && typeNamespace == ns
+            && typeName == name;
 
     // A constructed type is treated as an exception when its simple name ends with
     // "Exception" — the universal BCL/user convention (InvalidOperationException,


### PR DESCRIPTION
## Summary

Fixes #1553 by replacing name-only copy/materialize signal matching with curated framework declaring-type identities.

User-defined `Join` / `Concat` / `Substring` methods no longer increment `MethodSignals.Copies`, while intended framework copy APIs such as `Enumerable.ToArray`, `string.Concat`, `string.Join`, and `string.Substring` still signal.

## Evidence

Shape proof:

- Adversarial negatives: user-defined `Join`, `Concat`, and `Substring` lookalikes report `Copies == 0`.
- Positive canaries: framework `Enumerable.ToArray`, `string.Concat`, `string.Join`, and `string.Substring` report copy signals.
- Existing call-tree allocation/copy signal coverage remains green.

Validation:

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` — 82/82 passed.
- `dotnet build src/dotnet-inspect -c Release -v:q` — passed.
