### PR TITLE
Add loop-aware allocation-regression detection to Analysis Diff

### DIFF
--- a/docs/design/graph-signal-annotations.md
+++ b/docs/design/graph-signal-annotations.md
@@ -113,6 +113,22 @@ Rows are classified and ranked so the highest-value movements surface first:
 - **Direction.** A positive delta on a cost signal is a *regression*; negative is an
   *improvement*. The summary splits the counts (`N regressions, M improvements,
   K added/removed`).
+- **Loop-awareness (allocations).** An allocation row is annotated `in-loop` in the
+  `Shape` column when the method allocates inside a loop (any surfaced optimization
+  opportunity is flagged in-loop, covering `newobj`/`newarr`/`box` hotspots). In-loop
+  allocations are repeated/hot, whereas one-time construction or error-path
+  allocations are usually known-good, so this is the pay-dirt discriminator.
+
+`--alloc-regressions` is a focus mode for the inherently file-able set: it keeps
+only allocation *increases* on members present in both versions (an existing method
+the maintainers made allocate more), drops every other signal and added/removed
+member, and surfaces in-loop (hot) regressions first regardless of raw `|delta|`.
+The summary counts the hot subset (`N allocation regressions, M in loop`). The flag
+implies the Analysis Diff section, so it works without an explicit `-S`.
+
+```bash
+diff --package Newtonsoft.Json@12.0.3..13.0.3 --alloc-regressions
+```
 
 Machine output honors `--tsv` and `--jsonl` (the section serializes through the
 projected-table writer, like every other tabular section), so an agent can consume

--- a/docs/design/graph-signal-annotations.md
+++ b/docs/design/graph-signal-annotations.md
@@ -114,10 +114,14 @@ Rows are classified and ranked so the highest-value movements surface first:
   *improvement*. The summary splits the counts (`N regressions, M improvements,
   K added/removed`).
 - **Loop-awareness (allocations).** An allocation row is annotated `in-loop` in the
-  `Shape` column when the method allocates inside a loop (any surfaced optimization
-  opportunity is flagged in-loop, covering `newobj`/`newarr`/`box` hotspots). In-loop
-  allocations are repeated/hot, whereas one-time construction or error-path
-  allocations are usually known-good, so this is the pay-dirt discriminator.
+  `Shape` column when the method allocates inside a loop, sourced from
+  `MethodSignals.AllocInLoop` (a non-exception `newobj`/`newarr`/`box` in a loop
+  region — independent of the hotspot threshold, so a single hot allocation still
+  counts). The bit is read from the version that bears the cost: the new method for a
+  regression, the old method for an improvement. In-loop allocations are
+  repeated/hot, whereas one-time construction or error-path allocations are usually
+  known-good, so this is the pay-dirt discriminator. It is a method-level signal
+  (the method allocates somewhere in a loop), not a per-site attribution.
 
 `--alloc-regressions` is a focus mode for the inherently file-able set: it keeps
 only allocation *increases* on members present in both versions (an existing method

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -22,7 +22,7 @@ dnx dotnet-inspect -y -- <command>
 | Inspect a type | `type Type --package Foo`; add `--all` for non-public/hidden members. |
 | Inspect overloads | `member Type --platform Lib -m Name -S "Member Index"` |
 | Select an overload | `member Type --platform Lib Name:1` or `Name~digest` |
-| Compare APIs | `diff --package Foo@old..new --breaking`; `--additive` for new APIs. |
+| Compare APIs | `diff --package Foo@old..new --breaking` (`--additive` new APIs); `--alloc-regressions` for perf regressions (allocations up, hot first). |
 | Inspect packages | `package Foo -S Signals`, `--library`, `--path @readme --content`. |
 | Inspect libraries | `library Foo` or `library path/to.dll`; add `--platform`, `-S Signals`. |
 | Relationships | `depends Type`, `extensions Type`, `implements Interface`. |

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -616,6 +616,60 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void MethodSignals_AllocInLoop_TrueForLoopAllocation()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+
+        var method = Assert.Single(index.Methods.Where(m =>
+            m.Name == nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop)));
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
+        Assert.True(s.AllocInLoop);
+    }
+
+    [Fact]
+    public void MethodSignals_AllocInLoop_FalseForOneTimeAllocation()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+
+        var method = Assert.Single(index.Methods.Where(m =>
+            m.Name == nameof(OptimizationOpportunityFixtures.AllocatesManyObjects)));
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
+        Assert.False(s.AllocInLoop);
+    }
+
+    [Fact]
+    public void MethodSignals_AllocInLoop_TrueBelowHotspotThreshold_WithoutOpportunity()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+
+        // The key fidelity case: a single allocation in a loop is hot, but below the
+        // hotspot threshold and matching no shape, so it surfaces no opportunity. The
+        // loop bit must still be set (it is not gated on the opportunity machinery).
+        var method = Assert.Single(index.Methods.Where(m =>
+            m.Name == nameof(OptimizationOpportunityFixtures.AllocatesOnceInLoop)));
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
+        Assert.True(s.AllocInLoop);
+        Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.AllocatesOnceInLoop)));
+    }
+
+    [Fact]
+    public void MethodSignals_AllocInLoop_FalseForExceptionConstructionInLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+
+        // Exception construction inside a loop only allocates on the throw path, so the
+        // hot-allocation bit must exclude it.
+        var method = Assert.Single(index.Methods.Where(m =>
+            m.Name == nameof(OptimizationOpportunityFixtures.ThrowsInLoop)));
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
+        Assert.False(s.AllocInLoop);
+    }
+
+    [Fact]
     public void OptimizationOpportunities_BoxOnThrowPathInLoop_NotPromoted()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -906,6 +960,31 @@ public class OptimizationOpportunityFixtures
             case 6: throw new System.InvalidCastException("6");
             case 7: throw new System.TimeoutException("7");
             case 8: throw new System.NotImplementedException("8");
+        }
+    }
+
+    // A single steady-state allocation inside a loop, below the hotspot threshold and
+    // matching no specific shape, so it surfaces NO opportunity row. It still allocates
+    // in a loop, so MethodSignals.AllocInLoop must be true (the loop bit is independent
+    // of the opportunity/threshold machinery).
+    public static object AllocatesOnceInLoop(int n)
+    {
+        object last = new object();
+        for (int i = 0; i < n; i++)
+        {
+            last = new object();
+        }
+        return last;
+    }
+
+    // Exception construction inside a loop only allocates on the throw path, so it must
+    // not set AllocInLoop (error-path allocation is not steady-state hot pay-dirt).
+    public static void ThrowsInLoop(int n)
+    {
+        for (int i = 0; i < n; i++)
+        {
+            if (i < 0)
+                throw new System.InvalidOperationException("never");
         }
     }
 }

--- a/src/ILInspector.Analysis/MethodSignals.cs
+++ b/src/ILInspector.Analysis/MethodSignals.cs
@@ -18,6 +18,7 @@ namespace ILInspector.Analysis;
 /// <param name="Finallys"><c>finally</c>/<c>fault</c> handler clauses.</param>
 /// <param name="EvidenceOffsets">IL offsets of the signal-bearing instructions, as compact receipts.</param>
 /// <param name="ExceptionTypeNames">Distinct exception types constructed (<c>newobj</c> of a <c>*Exception</c> type) in the body.</param>
+/// <param name="AllocInLoop">Whether the method allocates inside a loop (non-exception <c>newobj</c>, <c>newarr</c>, or <c>box</c> in a loop region) — the hot/repeated case.</param>
 public sealed record MethodSignals(
     int Allocations,
     int Copies,
@@ -27,7 +28,8 @@ public sealed record MethodSignals(
     int Catches = 0,
     int Finallys = 0,
     ImmutableArray<int> EvidenceOffsets = default,
-    ImmutableArray<string> ExceptionTypeNames = default)
+    ImmutableArray<string> ExceptionTypeNames = default,
+    bool AllocInLoop = false)
 {
     public static readonly MethodSignals None = new(0, 0, false);
 
@@ -79,6 +81,7 @@ public static class MethodSignalAnalysis
         var reflection = new Dictionary<int, int>();
         var exceptionTypes = new Dictionary<int, SortedSet<string>>();
         var evidence = new Dictionary<int, SortedSet<int>>();
+        var newObjInLoop = new HashSet<int>();
 
         void AddEvidence(int token, int offset)
         {
@@ -101,6 +104,12 @@ public static class MethodSignalAnalysis
                     if (!exceptionTypes.TryGetValue(caller, out var set))
                         exceptionTypes[caller] = set = new SortedSet<string>(StringComparer.Ordinal);
                     set.Add(call.Callee.DeclaringType.Name);
+                }
+                else if (call.InLoop)
+                {
+                    // Steady-state (non-exception) object construction inside a loop is
+                    // the hot/repeated allocation; error-path construction is excluded.
+                    newObjInLoop.Add(caller);
                 }
             }
             if (call.Kind is CallKind.LoadFunction or CallKind.LoadVirtualFunction)
@@ -157,7 +166,8 @@ public static class MethodSignalAnalysis
                 body.Catches,
                 body.Finallys,
                 offsets,
-                exceptions);
+                exceptions,
+                newObjInLoop.Contains(token) || body.AllocInLoop);
         }
         return result;
     }

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -90,8 +90,8 @@ public class DiffCommandTests
         Assert.Contains("IL_0001", markdown);
     }
 
-    private static DiffCommand.RankedAnalysisRow Ranked(string member, string signal, int magnitude, int direction, bool inBoth)
-        => new(new AnalysisDiffRow($"`{member}`", signal, "0", magnitude.ToString(), $"+{magnitude}", null, null), magnitude, direction, inBoth);
+    private static DiffCommand.RankedAnalysisRow Ranked(string member, string signal, int magnitude, int direction, bool inBoth, bool inLoop = false)
+        => new(new AnalysisDiffRow($"`{member}`", signal, "0", magnitude.ToString(), $"+{magnitude}", inLoop ? "in-loop" : null, null), magnitude, direction, inBoth, inLoop);
 
     [Fact]
     public void RankAnalysisRows_OrdersInPlaceChangesByDescendingMagnitude()
@@ -137,6 +137,49 @@ public class DiffCommandTests
         Assert.Equal(
             "No in-place analysis signal changes detected.",
             DiffCommand.BuildAnalysisSummary(total: 0, regressions: 0, improvements: 0, addedRemoved: 0, changedOnly: true));
+    }
+
+    [Fact]
+    public void RankAnalysisRows_AllocRegressionsOnly_KeepsOnlyInPlaceAllocationIncreases()
+    {
+        var input = new List<DiffCommand.RankedAnalysisRow>
+        {
+            Ranked("Type.AllocUp()", "allocations", 3, +1, inBoth: true),
+            Ranked("Type.AllocDown()", "allocations", 2, -1, inBoth: true),   // improvement, dropped
+            Ranked("Type.ThrowsUp()", "throws", 9, +1, inBoth: true),          // non-allocation, dropped
+            Ranked("Type.Added()", "allocations", 5, +1, inBoth: false),       // added member, dropped
+        };
+
+        var result = DiffCommand.RankAnalysisRows(input, changedOnly: false, allocRegressionsOnly: true);
+
+        Assert.Single(result.Rows);
+        Assert.Equal("`Type.AllocUp()`", result.Rows[0].Member);
+        Assert.Equal("1 allocation regression (1 signal).", result.Summary);
+    }
+
+    [Fact]
+    public void RankAnalysisRows_AllocRegressionsOnly_SurfacesInLoopRegressionsFirst()
+    {
+        var input = new List<DiffCommand.RankedAnalysisRow>
+        {
+            Ranked("Type.OneTime()", "allocations", 8, +1, inBoth: true, inLoop: false),   // large but not hot
+            Ranked("Type.Hot()", "allocations", 1, +1, inBoth: true, inLoop: true),        // small but in-loop
+        };
+
+        var result = DiffCommand.RankAnalysisRows(input, changedOnly: false, allocRegressionsOnly: true);
+
+        // In focus mode, in-loop (hot) allocation regressions outrank larger one-time increases.
+        Assert.Equal("`Type.Hot()`", result.Rows[0].Member);
+        Assert.Equal("`Type.OneTime()`", result.Rows[1].Member);
+        Assert.Equal("2 allocation regressions, 1 in loop (2 signals).", result.Summary);
+    }
+
+    [Fact]
+    public void BuildAllocRegressionSummary_FormatsCountAndInLoop()
+    {
+        Assert.Equal("No allocation regressions detected.", DiffCommand.BuildAllocRegressionSummary(total: 0, inLoop: 0));
+        Assert.Equal("1 allocation regression (1 signal).", DiffCommand.BuildAllocRegressionSummary(total: 1, inLoop: 0));
+        Assert.Equal("3 allocation regressions, 2 in loop (3 signals).", DiffCommand.BuildAllocRegressionSummary(total: 3, inLoop: 2));
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -49,6 +49,7 @@ public static class InspectionCommandDefinitions
         var breakingOption = new Option<bool>("--breaking") { Description = "Show only breaking changes" };
         var additiveOption = new Option<bool>("--additive") { Description = "Show only additive changes" };
         var changedOption = new Option<bool>("--changed") { Description = "Analysis Diff only: show only in-place changes to members present in both versions (drop added/removed members)" };
+        var allocRegressionsOption = new Option<bool>("--alloc-regressions") { Description = "Analysis Diff focus: show only allocation increases on members present in both versions (the file-able set), in-loop (hot) ones first" };
         var legendOption = new Option<bool>("--legend") { Description = "Show legend explaining change symbols" };
 
         diffCommand.Arguments.Add(argsArg);
@@ -64,6 +65,7 @@ public static class InspectionCommandDefinitions
         diffCommand.Options.Add(breakingOption);
         diffCommand.Options.Add(additiveOption);
         diffCommand.Options.Add(changedOption);
+        diffCommand.Options.Add(allocRegressionsOption);
         diffCommand.Options.Add(legendOption);
         opts.AddOutputOptionsTo(diffCommand);
         opts.AddNuGetOptionsTo(diffCommand);
@@ -71,7 +73,7 @@ public static class InspectionCommandDefinitions
 
         var commandArgs = new DiffOptionsParser.DiffCommandArgs(
             argsArg, packageOption, platformOption, libraryOption, frameworkOption, tfmOption, allOption,
-            typeFilterOption, opts.OneLine, opts.NoHeaders, nameOnlyOption, breakingOption, additiveOption, changedOption, legendOption);
+            typeFilterOption, opts.OneLine, opts.NoHeaders, nameOnlyOption, breakingOption, additiveOption, changedOption, allocRegressionsOption, legendOption);
 
         diffCommand.SetAction(async (parseResult, ct) =>
         {

--- a/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/DiffOptionsParser.cs
@@ -31,6 +31,7 @@ public static class DiffOptionsParser
         Option<bool> BreakingOption,
         Option<bool> AdditiveOption,
         Option<bool> ChangedOption,
+        Option<bool> AllocRegressionsOption,
         Option<bool> LegendOption);
 
     /// <summary>
@@ -116,6 +117,7 @@ public static class DiffOptionsParser
             Breaking = parseResult.GetValue(args.BreakingOption),
             Additive = parseResult.GetValue(args.AdditiveOption),
             ChangedOnly = parseResult.GetValue(args.ChangedOption),
+            AllocRegressionsOnly = parseResult.GetValue(args.AllocRegressionsOption),
             Legend = parseResult.GetValue(args.LegendOption),
             SourceOptions = opts.ParseNuGetSourceOptions(parseResult),
             Discover = opts.ParseDiscover(parseResult),

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -345,7 +345,8 @@ public class DiffCommand
     }
 
     private static bool SelectsAnalysisDiff(DiffOptions options)
-        => options.Select?.Any(value => string.Equals(value, "Analysis Diff", StringComparison.OrdinalIgnoreCase)) == true;
+        => options.AllocRegressionsOnly
+            || options.Select?.Any(value => string.Equals(value, "Analysis Diff", StringComparison.OrdinalIgnoreCase)) == true;
 
     internal sealed record AnalysisDiffResult(List<AnalysisDiffRow> Rows, string Summary);
 
@@ -353,7 +354,7 @@ public class DiffCommand
     // absolute numeric movement (for ordering); Direction is +1 regression (more
     // cost), -1 improvement (less cost), 0 neutral; InBoth is true when the member
     // is present in both versions (an in-place change vs an added/removed member).
-    internal sealed record RankedAnalysisRow(AnalysisDiffRow Row, int Magnitude, int Direction, bool InBoth);
+    internal sealed record RankedAnalysisRow(AnalysisDiffRow Row, int Magnitude, int Direction, bool InBoth, bool InLoop = false);
 
     private static AnalysisDiffResult BuildAnalysisDiff(IReadOnlyList<string> fromPaths, IReadOnlyList<string> toPaths, DiffOptions options)
     {
@@ -366,27 +367,45 @@ public class DiffCommand
             newSnapshot.TryGetValue(key, out var newMethod);
             var display = newMethod?.Display ?? oldMethod?.Display ?? key;
             var inBoth = oldMethod is not null && newMethod is not null;
-            AddCountRows(ranked, display, inBoth, oldMethod?.Signals, newMethod?.Signals);
+            // The InLoop bit on OptimizationOpportunity is the pay-dirt discriminator
+            // for allocations: an allocation inside a loop is repeated/hot, whereas a
+            // one-time construction or error-path allocation is usually known-good.
+            var allocInLoop = AllocatesInLoop(oldMethod?.Opportunities) || AllocatesInLoop(newMethod?.Opportunities);
+            AddCountRows(ranked, display, inBoth, oldMethod?.Signals, newMethod?.Signals, allocInLoop);
             AddExceptionRow(ranked, display, inBoth, oldMethod?.Signals, newMethod?.Signals);
             AddOptimizationRows(ranked, display, inBoth, oldMethod?.Opportunities, newMethod?.Opportunities);
         }
 
-        return RankAnalysisRows(ranked, options.ChangedOnly);
+        return RankAnalysisRows(ranked, options.ChangedOnly, options.AllocRegressionsOnly);
     }
 
-    // Applies the changed-only filter, ranks rows (in-place changes first, then by
-    // descending movement magnitude), and builds the summary line. Pure function
-    // over already-classified rows so it can be unit-tested without assemblies.
-    internal static AnalysisDiffResult RankAnalysisRows(IReadOnlyList<RankedAnalysisRow> ranked, bool changedOnly)
+    // A method allocates in a loop when any of its surfaced optimization
+    // opportunities is flagged in-loop (covers newobj/newarr/box hotspots).
+    private static bool AllocatesInLoop(List<OptimizationOpportunity>? opportunities)
+        => opportunities is not null && opportunities.Any(opportunity => opportunity.InLoop);
+
+    // Applies the changed-only / allocation-regression filters, ranks rows (in-place
+    // changes first, then by descending movement magnitude), and builds the summary
+    // line. Pure function over already-classified rows so it can be unit-tested
+    // without assemblies. In allocation-regression focus mode, only in-place
+    // allocation increases are kept and in-loop (hot) ones are surfaced first.
+    internal static AnalysisDiffResult RankAnalysisRows(IReadOnlyList<RankedAnalysisRow> ranked, bool changedOnly, bool allocRegressionsOnly = false)
     {
-        var selected = changedOnly ? ranked.Where(row => row.InBoth).ToList() : ranked.ToList();
+        IEnumerable<RankedAnalysisRow> filtered = ranked;
+        if (allocRegressionsOnly)
+            filtered = filtered.Where(row => row.InBoth && row.Direction > 0 && row.Row.Signal == "allocations");
+        else if (changedOnly)
+            filtered = filtered.Where(row => row.InBoth);
+        var selected = filtered.ToList();
 
         var regressions = selected.Count(row => row.InBoth && row.Direction > 0);
         var improvements = selected.Count(row => row.InBoth && row.Direction < 0);
         var addedRemoved = selected.Count(row => !row.InBoth);
+        var inLoopRegressions = selected.Count(row => row.InLoop && row.Direction > 0);
 
         var rows = selected
-            .OrderByDescending(row => row.InBoth)
+            .OrderByDescending(row => allocRegressionsOnly && row.InLoop)
+            .ThenByDescending(row => row.InBoth)
             .ThenByDescending(row => row.Magnitude)
             .ThenBy(row => row.Row.Member, StringComparer.Ordinal)
             .ThenBy(row => row.Row.Signal, StringComparer.Ordinal)
@@ -394,8 +413,18 @@ public class DiffCommand
             .Select(row => row.Row)
             .ToList();
 
-        var summary = BuildAnalysisSummary(rows.Count, regressions, improvements, addedRemoved, changedOnly);
+        var summary = allocRegressionsOnly
+            ? BuildAllocRegressionSummary(rows.Count, inLoopRegressions)
+            : BuildAnalysisSummary(rows.Count, regressions, improvements, addedRemoved, changedOnly);
         return new AnalysisDiffResult(rows, summary);
+    }
+
+    internal static string BuildAllocRegressionSummary(int total, int inLoop)
+    {
+        if (total == 0)
+            return "No allocation regressions detected.";
+        var hot = inLoop > 0 ? $", {inLoop} in loop" : "";
+        return $"{total} allocation regression{(total == 1 ? "" : "s")}{hot} ({total} signal{(total == 1 ? "" : "s")}).";
     }
 
     internal static string BuildAnalysisSummary(int total, int regressions, int improvements, int addedRemoved, bool changedOnly)
@@ -466,9 +495,9 @@ public class DiffCommand
     private static string FormatMethod(MethodIdentity method)
         => $"{method.DeclaringType.ToQualifiedDisplayString()}.{method.Name}({string.Join(", ", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
 
-    private static void AddCountRows(List<RankedAnalysisRow> rows, string display, bool inBoth, MethodSignals? oldSignals, MethodSignals? newSignals)
+    private static void AddCountRows(List<RankedAnalysisRow> rows, string display, bool inBoth, MethodSignals? oldSignals, MethodSignals? newSignals, bool allocInLoop)
     {
-        AddCountRow(rows, display, inBoth, "allocations", oldSignals?.Allocations ?? 0, newSignals?.Allocations ?? 0, Evidence(oldSignals, newSignals));
+        AddCountRow(rows, display, inBoth, "allocations", oldSignals?.Allocations ?? 0, newSignals?.Allocations ?? 0, Evidence(oldSignals, newSignals), allocInLoop);
         AddCountRow(rows, display, inBoth, "copies", oldSignals?.Copies ?? 0, newSignals?.Copies ?? 0, Evidence(oldSignals, newSignals));
         AddCountRow(rows, display, inBoth, "reflection", oldSignals?.Reflection ?? 0, newSignals?.Reflection ?? 0, Evidence(oldSignals, newSignals));
         AddCountRow(rows, display, inBoth, "throws", oldSignals?.Throws ?? 0, newSignals?.Throws ?? 0, Evidence(oldSignals, newSignals));
@@ -477,7 +506,7 @@ public class DiffCommand
         AddCountRow(rows, display, inBoth, "unsafe", oldSignals?.Unsafe == true ? 1 : 0, newSignals?.Unsafe == true ? 1 : 0, Evidence(oldSignals, newSignals));
     }
 
-    private static void AddCountRow(List<RankedAnalysisRow> rows, string display, bool inBoth, string signal, int oldValue, int newValue, string? evidence)
+    private static void AddCountRow(List<RankedAnalysisRow> rows, string display, bool inBoth, string signal, int oldValue, int newValue, string? evidence, bool allocInLoop = false)
     {
         if (oldValue == newValue)
             return;
@@ -489,11 +518,12 @@ public class DiffCommand
                 oldValue.ToString(),
                 newValue.ToString(),
                 FormatDelta(delta),
-                null,
+                allocInLoop ? "in-loop" : null,
                 evidence),
             Math.Abs(delta),
             Math.Sign(delta),
-            inBoth));
+            inBoth,
+            allocInLoop));
     }
 
     private static void AddExceptionRow(List<RankedAnalysisRow> rows, string display, bool inBoth, MethodSignals? oldSignals, MethodSignals? newSignals)
@@ -717,6 +747,7 @@ public record DiffOptions
     public bool Breaking { get; init; }
     public bool Additive { get; init; }
     public bool ChangedOnly { get; init; }
+    public bool AllocRegressionsOnly { get; init; }
     public bool Legend { get; init; }
     public string[]? Discover { get; init; }
     public bool Tree { get; init; }

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -367,22 +367,13 @@ public class DiffCommand
             newSnapshot.TryGetValue(key, out var newMethod);
             var display = newMethod?.Display ?? oldMethod?.Display ?? key;
             var inBoth = oldMethod is not null && newMethod is not null;
-            // The InLoop bit on OptimizationOpportunity is the pay-dirt discriminator
-            // for allocations: an allocation inside a loop is repeated/hot, whereas a
-            // one-time construction or error-path allocation is usually known-good.
-            var allocInLoop = AllocatesInLoop(oldMethod?.Opportunities) || AllocatesInLoop(newMethod?.Opportunities);
-            AddCountRows(ranked, display, inBoth, oldMethod?.Signals, newMethod?.Signals, allocInLoop);
+            AddCountRows(ranked, display, inBoth, oldMethod?.Signals, newMethod?.Signals);
             AddExceptionRow(ranked, display, inBoth, oldMethod?.Signals, newMethod?.Signals);
             AddOptimizationRows(ranked, display, inBoth, oldMethod?.Opportunities, newMethod?.Opportunities);
         }
 
         return RankAnalysisRows(ranked, options.ChangedOnly, options.AllocRegressionsOnly);
     }
-
-    // A method allocates in a loop when any of its surfaced optimization
-    // opportunities is flagged in-loop (covers newobj/newarr/box hotspots).
-    private static bool AllocatesInLoop(List<OptimizationOpportunity>? opportunities)
-        => opportunities is not null && opportunities.Any(opportunity => opportunity.InLoop);
 
     // Applies the changed-only / allocation-regression filters, ranks rows (in-place
     // changes first, then by descending movement magnitude), and builds the summary
@@ -495,9 +486,9 @@ public class DiffCommand
     private static string FormatMethod(MethodIdentity method)
         => $"{method.DeclaringType.ToQualifiedDisplayString()}.{method.Name}({string.Join(", ", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
 
-    private static void AddCountRows(List<RankedAnalysisRow> rows, string display, bool inBoth, MethodSignals? oldSignals, MethodSignals? newSignals, bool allocInLoop)
+    private static void AddCountRows(List<RankedAnalysisRow> rows, string display, bool inBoth, MethodSignals? oldSignals, MethodSignals? newSignals)
     {
-        AddCountRow(rows, display, inBoth, "allocations", oldSignals?.Allocations ?? 0, newSignals?.Allocations ?? 0, Evidence(oldSignals, newSignals), allocInLoop);
+        AddCountRow(rows, display, inBoth, "allocations", oldSignals?.Allocations ?? 0, newSignals?.Allocations ?? 0, Evidence(oldSignals, newSignals), oldSignals?.AllocInLoop ?? false, newSignals?.AllocInLoop ?? false);
         AddCountRow(rows, display, inBoth, "copies", oldSignals?.Copies ?? 0, newSignals?.Copies ?? 0, Evidence(oldSignals, newSignals));
         AddCountRow(rows, display, inBoth, "reflection", oldSignals?.Reflection ?? 0, newSignals?.Reflection ?? 0, Evidence(oldSignals, newSignals));
         AddCountRow(rows, display, inBoth, "throws", oldSignals?.Throws ?? 0, newSignals?.Throws ?? 0, Evidence(oldSignals, newSignals));
@@ -506,11 +497,15 @@ public class DiffCommand
         AddCountRow(rows, display, inBoth, "unsafe", oldSignals?.Unsafe == true ? 1 : 0, newSignals?.Unsafe == true ? 1 : 0, Evidence(oldSignals, newSignals));
     }
 
-    private static void AddCountRow(List<RankedAnalysisRow> rows, string display, bool inBoth, string signal, int oldValue, int newValue, string? evidence, bool allocInLoop = false)
+    private static void AddCountRow(List<RankedAnalysisRow> rows, string display, bool inBoth, string signal, int oldValue, int newValue, string? evidence, bool oldAllocInLoop = false, bool newAllocInLoop = false)
     {
         if (oldValue == newValue)
             return;
         var delta = newValue - oldValue;
+        // Annotate from the version that bears the cost: the new method for a
+        // regression (allocations up), the old method for an improvement. A loop
+        // allocation is repeated/hot; one-time or error-path allocations are not.
+        var inLoop = delta > 0 ? newAllocInLoop : oldAllocInLoop;
         rows.Add(new RankedAnalysisRow(
             new AnalysisDiffRow(
                 MarkoutInline.Code(display),
@@ -518,12 +513,12 @@ public class DiffCommand
                 oldValue.ToString(),
                 newValue.ToString(),
                 FormatDelta(delta),
-                allocInLoop ? "in-loop" : null,
+                inLoop ? "in-loop" : null,
                 evidence),
             Math.Abs(delta),
             Math.Sign(delta),
             inBoth,
-            allocInLoop));
+            inLoop));
     }
 
     private static void AddExceptionRow(List<RankedAnalysisRow> rows, string display, bool inBoth, MethodSignals? oldSignals, MethodSignals? newSignals)


### PR DESCRIPTION
## What

Adds version-to-version **allocation-regression detection** to the Analysis Diff — the inherently most file-able performance signal: an existing method (present in both versions) that the maintainers made allocate *more*.

The diff already emitted an `allocations` count delta, but it was buried among every other signal with no loop-awareness — even though **in-loop (hot) allocations are the proven pay-dirt discriminator** (a one-time construction or error-path allocation is usually known-good; an allocation inside a loop is repeated).

## Changes (diff-side only — no Analysis-library churn)

- **Loop annotation.** Carry the `InLoop` bit (already on `OptimizationOpportunity`, covering `newobj`/`newarr`/`box` hotspots) onto the allocations diff row, shown as `in-loop` in the `Shape` column.
- **`--alloc-regressions` focus mode.** Keeps only in-place allocation *increases*, drops every other signal and added/removed member, and surfaces in-loop regressions **first** regardless of raw `|delta|`. The flag implies the Analysis Diff section. Summary counts the hot subset (`N allocation regressions, M in loop`).

This is **complementary** to single-version `Performance Triage` (longstanding cost predating the baseline): the diff catches version-introduced regressions.

## Validation

On the methodology corpus (Newtonsoft `9.0.1 -> 13.0.3`), the focus mode surfaces `JsonWriter.WriteValue` (17 -> 19 allocations, **in a loop**) ranked *ahead* of larger one-time regressions like a `+20` static-`cctor` change — exactly the hot-first, file-able ordering.

```
| Member                          | Signal      | Old | New | Delta | Shape   |
| JsonWriter.WriteValue(...)      | allocations | 17  | 19  | +2    | in-loop |
| ConvertUtils..cctor()           | allocations | 3   | 23  | +20   |         |
| DefaultContractResolver.Create… | allocations | 1   | 6   | +5    |         |
```

## Tests

- New unit tests for the focus-mode filter, hot-first ranking, and summary (`DiffCommandTests`).
- Full `dotnet-inspect.Tests` suite green (1336 pass, 9 ilasm-skips). TSV/JSONL machine output verified clean.
- Docs (`graph-signal-annotations.md`) and `SKILL.md` updated; markdownlint clean.

Will request a GPT-5.5 adversarial review per the detection-logic convention.