### PR TITLE
Fix analysis framework API lookalike signals

### DIFF
--- a/src/ILInspector.Analysis.LookalikeFixtures/ILInspector.Analysis.LookalikeFixtures.csproj
+++ b/src/ILInspector.Analysis.LookalikeFixtures/ILInspector.Analysis.LookalikeFixtures.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <NoWarn>$(NoWarn);CS0436</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.LookalikeFixtures/LookalikeSignalFixtures.cs
+++ b/src/ILInspector.Analysis.LookalikeFixtures/LookalikeSignalFixtures.cs
@@ -1,0 +1,35 @@
+namespace ILInspector.Analysis.LookalikeFixtures
+{
+    public static class LookalikeSignalFixtures
+    {
+        public static int CallsFakeReflection() => System.Reflection.UserReflector.GetMethods();
+
+        public static int CallsFakeUnsafe() => System.Runtime.CompilerServices.Unsafe.As(41);
+
+        public static byte CallsFakeBitConverter() => System.BitConverter.GetBytes(1)[0];
+    }
+}
+
+namespace System.Reflection
+{
+    public static class UserReflector
+    {
+        public static int GetMethods() => 42;
+    }
+}
+
+namespace System.Runtime.CompilerServices
+{
+    public static class Unsafe
+    {
+        public static int As(int value) => value + 1;
+    }
+}
+
+namespace System
+{
+    public static class BitConverter
+    {
+        public static byte[] GetBytes(int value) => [(byte)value];
+    }
+}

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Analysis.LookalikeFixtures\ILInspector.Analysis.LookalikeFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
   </ItemGroup>
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -678,6 +678,61 @@ public class LibraryBodyIndexTests
             && o.Shape == "temporary-byte-array-copy");
     }
 
+    [Fact]
+    public void FrameworkApiPredicates_AcceptRealFrameworkApis()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var signals = index.GetMethodSignals();
+        var reflects = Assert.Single(index.Methods.Where(method =>
+            method.Name == nameof(CallTreeFixtures.Reflects)));
+        Assert.True(signals.TryGetValue(reflects.MetadataToken, out var reflectSignals));
+        Assert.Equal(2, reflectSignals.Reflection);
+
+        Assert.Contains(index.UnsafeEvidence, evidence =>
+            evidence.Member.Name == nameof(UnsafeEvidenceFixtures.CallsUnsafeAs)
+            && evidence.Reason == "Unsafe call"
+            && evidence.Detail.Contains("System.Runtime.CompilerServices.Unsafe.As<int, uint>", StringComparison.Ordinal));
+
+        Assert.Contains(index.OptimizationOpportunities, opportunity =>
+            opportunity.Method.Name == nameof(OptimizationOpportunityFixtures.FirstValueByte)
+            && opportunity.Shape == "temporary-byte-array-copy");
+    }
+
+    [Fact]
+    public void FrameworkApiPredicates_IgnoreUserDefinedLookalikes()
+    {
+        var index = LibraryBodyIndex.Open(LookalikeFixturePath());
+        var signals = index.GetMethodSignals();
+
+        var fakeReflection = Assert.Single(index.Methods.Where(method =>
+            method.Name == "CallsFakeReflection"));
+        signals.TryGetValue(fakeReflection.MetadataToken, out var fakeReflectionSignals);
+        Assert.Equal(0, fakeReflectionSignals?.Reflection ?? 0);
+
+        Assert.DoesNotContain(index.UnsafeEvidence, evidence =>
+            evidence.Member.Name == "CallsFakeUnsafe"
+            && evidence.Reason == "Unsafe call");
+
+        Assert.DoesNotContain(index.OptimizationOpportunities, opportunity =>
+            opportunity.Method.Name == "CallsFakeBitConverter"
+            && opportunity.Shape == "temporary-byte-array-copy");
+    }
+
+    static string LookalikeFixturePath()
+    {
+        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string path = Path.GetFullPath(Path.Combine(
+            outputDirectory.FullName,
+            "..",
+            "..",
+            "ILInspector.Analysis.LookalikeFixtures",
+            outputDirectory.Name,
+            "ILInspector.Analysis.LookalikeFixtures.dll"));
+        Assert.True(File.Exists(path), $"Expected lookalike fixture assembly at {path}");
+        return path;
+    }
+
 
     [Fact]
     public void TopUnsafeLeverage_RanksRequiresUnsafeMethodsByCallers()

--- a/src/ILInspector.Analysis/FrameworkIdentity.cs
+++ b/src/ILInspector.Analysis/FrameworkIdentity.cs
@@ -1,0 +1,47 @@
+namespace ILInspector.Analysis;
+
+internal static class FrameworkIdentity
+{
+    public static bool IsCoreLibraryType(TypeRef type, string ns, string name)
+    {
+        var definition = NamedDefinition(type);
+        return definition.Kind != TypeRefKind.Unsupported
+            && definition.Assembly == TypeRef.CoreLibrary
+            && definition.Namespace == ns
+            && definition.Name == name;
+    }
+
+    public static bool IsKnownFrameworkType(TypeRef type, string assembly, string ns, string name)
+    {
+        var definition = NamedDefinition(type);
+        return definition.Kind != TypeRefKind.Unsupported
+            && definition.Assembly == assembly
+            && definition.Namespace == ns
+            && definition.Name == name;
+    }
+
+    public static bool IsKnownFrameworkNamespace(TypeRef type, string ns)
+    {
+        var definition = NamedDefinition(type);
+        return definition.Kind != TypeRefKind.Unsupported
+            && definition.Namespace == ns
+            && IsFrameworkAssembly(definition.Assembly);
+    }
+
+    public static bool IsKnownFrameworkNamespacePrefix(TypeRef type, string nsPrefix)
+    {
+        var definition = NamedDefinition(type);
+        return definition.Kind != TypeRefKind.Unsupported
+            && (definition.Namespace == nsPrefix || definition.Namespace.StartsWith(nsPrefix + ".", StringComparison.Ordinal))
+            && IsFrameworkAssembly(definition.Assembly);
+    }
+
+    static TypeRef NamedDefinition(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+
+    static bool IsFrameworkAssembly(string assembly)
+        => assembly == TypeRef.CoreLibrary
+            || assembly == "System"
+            || assembly.StartsWith("System.", StringComparison.Ordinal)
+            || assembly == "Microsoft.CSharp";
+}

--- a/src/ILInspector.Analysis/FrameworkIdentity.cs
+++ b/src/ILInspector.Analysis/FrameworkIdentity.cs
@@ -20,28 +20,27 @@ internal static class FrameworkIdentity
             && definition.Name == name;
     }
 
-    public static bool IsKnownFrameworkNamespace(TypeRef type, string ns)
+    public static bool IsKnownFrameworkNamespace(TypeRef type, string assembly, string ns)
     {
         var definition = NamedDefinition(type);
         return definition.Kind != TypeRefKind.Unsupported
             && definition.Namespace == ns
-            && IsFrameworkAssembly(definition.Assembly);
+            && IsCoreLibraryOrAssembly(definition.Assembly, assembly);
     }
 
-    public static bool IsKnownFrameworkNamespacePrefix(TypeRef type, string nsPrefix)
+    public static bool IsKnownFrameworkNamespacePrefix(TypeRef type, string assemblyPrefix, string nsPrefix)
     {
         var definition = NamedDefinition(type);
         return definition.Kind != TypeRefKind.Unsupported
             && (definition.Namespace == nsPrefix || definition.Namespace.StartsWith(nsPrefix + ".", StringComparison.Ordinal))
-            && IsFrameworkAssembly(definition.Assembly);
+            && (definition.Assembly == TypeRef.CoreLibrary
+                || definition.Assembly == assemblyPrefix
+                || definition.Assembly.StartsWith(assemblyPrefix + ".", StringComparison.Ordinal));
     }
 
     static TypeRef NamedDefinition(TypeRef type)
         => type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
 
-    static bool IsFrameworkAssembly(string assembly)
-        => assembly == TypeRef.CoreLibrary
-            || assembly == "System"
-            || assembly.StartsWith("System.", StringComparison.Ordinal)
-            || assembly == "Microsoft.CSharp";
+    static bool IsCoreLibraryOrAssembly(string actual, string expected)
+        => actual == TypeRef.CoreLibrary || actual == expected;
 }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1678,8 +1678,7 @@ public sealed class LibraryBodyIndex
 
         static bool IsBitConverterGetBytes(MemberRef member)
             => member.Kind != MemberKind.Unsupported
-                && member.DeclaringType.Namespace == "System"
-                && member.DeclaringType.Name == "BitConverter"
+                && FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "BitConverter")
                 && member.Name == "GetBytes";
 
         // A `ToArray()` call that copies a span into a freshly allocated array. ReadOnlySpan<T>
@@ -1722,7 +1721,8 @@ public sealed class LibraryBodyIndex
         static bool IsUnsafeApi(MemberRef member) => IsUnsafeApi(member.DeclaringType);
 
         static bool IsUnsafeApi(TypeRef type)
-            => type is { Namespace: "System.Runtime.CompilerServices", Name: "Unsafe" };
+            => FrameworkIdentity.IsCoreLibraryType(type, "System.Runtime.CompilerServices", "Unsafe")
+                || FrameworkIdentity.IsKnownFrameworkType(type, "System.Runtime.CompilerServices.Unsafe", "System.Runtime.CompilerServices", "Unsafe");
 
         static bool ContainsUnsafeType(TypeRef type)
         {

--- a/src/ILInspector.Analysis/MethodSignals.cs
+++ b/src/ILInspector.Analysis/MethodSignals.cs
@@ -181,7 +181,7 @@ public static class MethodSignalAnalysis
         => type.Kind != TypeRefKind.Unsupported
            && type.Name.EndsWith("Exception", StringComparison.Ordinal);
 
-    // Reflection-style APIs, identified by the callee's declaring namespace (and, for
+    // Reflection-style APIs, identified by framework declaring-type identity (and, for
     // System.Type, a curated member set). These are runtime metadata / dynamic-invocation
     // surfaces (System.Reflection), dynamic construction (System.Activator), expression
     // trees (System.Linq.Expressions), and the reflective members on System.Type — all
@@ -190,11 +190,11 @@ public static class MethodSignalAnalysis
     {
         if (callee.Kind == MemberKind.Unsupported)
             return false;
-        var ns = callee.DeclaringType.Namespace;
-        if (ns is "System.Reflection" || ns.StartsWith("System.Reflection.", StringComparison.Ordinal)
-            || ns is "System.Linq.Expressions")
+        if (FrameworkIdentity.IsKnownFrameworkNamespacePrefix(callee.DeclaringType, "System.Reflection")
+            || FrameworkIdentity.IsKnownFrameworkNamespace(callee.DeclaringType, "System.Linq.Expressions"))
             return true;
-        if (ns != "System")
+        if (!FrameworkIdentity.IsCoreLibraryType(callee.DeclaringType, "System", "Activator")
+            && !FrameworkIdentity.IsCoreLibraryType(callee.DeclaringType, "System", "Type"))
             return false;
         return callee.DeclaringType.Name switch
         {

--- a/src/ILInspector.Analysis/MethodSignals.cs
+++ b/src/ILInspector.Analysis/MethodSignals.cs
@@ -238,8 +238,8 @@ public static class MethodSignalAnalysis
     {
         if (callee.Kind == MemberKind.Unsupported)
             return false;
-        if (FrameworkIdentity.IsKnownFrameworkNamespacePrefix(callee.DeclaringType, "System.Reflection")
-            || FrameworkIdentity.IsKnownFrameworkNamespace(callee.DeclaringType, "System.Linq.Expressions"))
+        if (FrameworkIdentity.IsKnownFrameworkNamespacePrefix(callee.DeclaringType, "System.Reflection", "System.Reflection")
+            || FrameworkIdentity.IsKnownFrameworkNamespace(callee.DeclaringType, "System.Linq.Expressions", "System.Linq.Expressions"))
             return true;
         if (!FrameworkIdentity.IsCoreLibraryType(callee.DeclaringType, "System", "Activator")
             && !FrameworkIdentity.IsCoreLibraryType(callee.DeclaringType, "System", "Type"))


### PR DESCRIPTION
## Summary

Fixes #1571 by requiring framework declaring-type identity before analysis predicates report framework API semantics:

- reflection signals now require real framework `System.Reflection*`, `System.Linq.Expressions`, `System.Type`, or `System.Activator` identities;
- unsafe API evidence now requires real `System.Runtime.CompilerServices.Unsafe` identity;
- `temporary-byte-array-copy` now requires real corelib `System.BitConverter.GetBytes`.

Adds a separate build-only lookalike fixture assembly so user-defined `System.Reflection.UserReflector`, `System.Runtime.CompilerServices.Unsafe`, and `System.BitConverter` types are tested through the real SRM importer without leaking duplicate `System.*` types into the test compile.

## Evidence

```text
lookalike reflection=0
lookalike unsafeCall=False
lookalike temporaryByteArray=False
real reflection=2
real unsafeCall=True
real temporaryByteArray=True
```

Validation:

```text
dotnet run --project src/ILInspector.Analysis.Tests -c Release
ILInspector.Analysis.Tests  Total: 89, Errors: 0, Failed: 0, Skipped: 0

dotnet build src/dotnet-inspect -c Release
Build succeeded. 0 Warning(s), 0 Error(s)
```

Adversarial review: Opus 4.8 reviewed the branch diff and found no high-confidence issues. No follow-up changes were required after review.
