### PR TITLE
Require Grpc.Core structural tie for gRPC generated classification (#1574)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -377,6 +377,14 @@ public class LibraryBodyIndexTests
         // Hand-written gRPC registration calling ServerServiceDefinition.CreateBuilder (without
         // generated __* members) must not be flagged — gRPC calls alone are not a signal.
         Assert.DoesNotContain(typeof(HandWrittenGrpcRegistration).FullName!, generated);
+        // A user type with a generated-looking __Helper_* member but no Grpc.Core call must not
+        // be flagged — a generated member name alone is not enough (#1574).
+        Assert.DoesNotContain(typeof(GeneratedLookalike).FullName!, generated);
+        // Because it is not classified as generated, its optimization opportunity stays visible
+        // (Performance Triage suppresses opportunities only for generated-framework types).
+        Assert.Contains(index.OptimizationOpportunities, opportunity =>
+            opportunity.Method.DeclaringType.Name == nameof(GeneratedLookalike)
+            && opportunity.Method.Name == nameof(GeneratedLookalike.MakesLocalArrayUnsuppressed));
     }
 
     [Fact]

--- a/src/ILInspector.Analysis.Tests/ProtobufGrpcGeneratedFixtures.cs
+++ b/src/ILInspector.Analysis.Tests/ProtobufGrpcGeneratedFixtures.cs
@@ -84,4 +84,19 @@ namespace ILInspector.Analysis.Tests
         public static Grpc.Core.ServerServiceDefinition.Builder Register()
             => Grpc.Core.ServerServiceDefinition.CreateBuilder();
     }
+
+    // A user type that declares a generated-looking __Helper_* member but makes no gRPC call.
+    // A member name alone must NOT classify it as generated (#1574), otherwise its real
+    // optimization opportunities would be suppressed from Performance Triage.
+    public static class GeneratedLookalike
+    {
+        public static int __Helper_NotGenerated() => 1;
+
+        public static int MakesLocalArrayUnsuppressed()
+        {
+            var a = new int[4];
+            a[0] = 1;
+            return a[0];
+        }
+    }
 }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -159,13 +159,17 @@ public sealed class LibraryBodyIndex
     /// any of its methods bootstraps protobuf generated infrastructure — calling
     /// <c>Google.Protobuf.Reflection.FileDescriptor.FromGeneratedCode</c>, constructing
     /// <c>Google.Protobuf.Reflection.GeneratedClrTypeInfo</c>, or constructing the
-    /// per-message <c>Google.Protobuf.MessageParser&lt;T&gt;</c> — or declares gRPC stub
-    /// infrastructure members whose names are codegen-only (<c>__ServiceName</c>,
-    /// <c>__Helper_*</c>, <c>__Marshaller_*</c>, <c>__Method_*</c>). gRPC binding calls
-    /// (<c>ServerServiceDefinition</c>/<c>Marshallers</c>) are intentionally not a signal,
-    /// since hand-written registration uses them too. These signals appear in generated
-    /// protobuf/gRPC code, so perf triage can mark them in Top Leverage and suppress them
-    /// from Performance Triage like other generated detail.
+    /// per-message <c>Google.Protobuf.MessageParser&lt;T&gt;</c> — or is a gRPC stub that both
+    /// declares infrastructure members whose names are codegen-only (<c>__ServiceName</c>,
+    /// <c>__Helper_*</c>, <c>__Marshaller_*</c>, <c>__Method_*</c>) <em>and</em> calls into
+    /// <c>Grpc.Core</c> (the binding/marshalling APIs a generated stub uses). A generated
+    /// member name alone is not sufficient — an ordinary user type can declare a
+    /// <c>__Helper_*</c> method — so the structural <c>Grpc.Core</c> tie is required to avoid
+    /// classifying user lookalikes as generated. gRPC binding calls
+    /// (<c>ServerServiceDefinition</c>/<c>Marshallers</c>) are still not a signal on their own,
+    /// since hand-written registration uses them without the generated members. These signals
+    /// appear in generated protobuf/gRPC code, so perf triage can mark them in Top Leverage and
+    /// suppress them from Performance Triage like other generated detail.
     /// </summary>
     public IReadOnlySet<string> GeneratedFrameworkTypeNames => _generatedFrameworkTypes ??= ComputeGeneratedFrameworkTypes();
 
@@ -197,7 +201,22 @@ public sealed class LibraryBodyIndex
                 generated.Add(call.Caller.DeclaringType.ToQualifiedDisplayString());
         }
 
-        // gRPC service stubs declare marshaller/serialization-helper infrastructure members.
+        // gRPC service stubs declare marshaller/serialization-helper infrastructure members
+        // whose names are codegen-only. A generated-looking member name is not enough on its
+        // own — an ordinary user type can declare a __Helper_* method — so require a structural
+        // tie to gRPC: the same type must also call into Grpc.Core (the binding/marshalling
+        // APIs a generated stub uses). This keeps hand-written gRPC registration (Grpc.Core
+        // calls but no __* members) and user lookalikes (__* members but no Grpc.Core calls)
+        // out of the generated set.
+        var typesCallingGrpcCore = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var call in DirectCalls)
+        {
+            if (call.Callee.Kind == MemberKind.Unsupported)
+                continue;
+            if (IsGrpcCoreNamespace(NamedDefinition(call.Callee.DeclaringType).Namespace))
+                typesCallingGrpcCore.Add(call.Caller.DeclaringType.ToQualifiedDisplayString());
+        }
+
         foreach (var method in Methods)
         {
             if (method.Name == "__ServiceName"
@@ -205,12 +224,21 @@ public sealed class LibraryBodyIndex
                 || method.Name.StartsWith("__Marshaller_", StringComparison.Ordinal)
                 || method.Name.StartsWith("__Method_", StringComparison.Ordinal))
             {
-                generated.Add(method.DeclaringType.ToQualifiedDisplayString());
+                var typeName = method.DeclaringType.ToQualifiedDisplayString();
+                if (typesCallingGrpcCore.Contains(typeName))
+                    generated.Add(typeName);
             }
         }
 
         return generated;
     }
+
+    static TypeRef NamedDefinition(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance && type.ElementType is { } element ? element : type;
+
+    static bool IsGrpcCoreNamespace(string? ns)
+        => ns is not null
+            && (ns == "Grpc.Core" || ns.StartsWith("Grpc.Core.", StringComparison.Ordinal));
 
     static bool IsType(TypeRef type, string ns, string name)
     {


### PR DESCRIPTION
## Row

Burndown row #1574 from #1555 (analysis adversarial bug burndown). Advances the **generated-code classification false positives** cluster.

## Proof gap closed

`LibraryBodyIndex.GeneratedFrameworkTypeNames` classified a type as protobuf/gRPC generated when it merely declared a method named `__ServiceName`, `__Helper_*`, `__Marshaller_*`, or `__Method_*`. A generated-looking member name alone flagged ordinary user types as generated, which marks them in `Top Leverage` and suppresses their optimization opportunities from `Performance Triage` (via `LibraryMetadataService.IsGeneratedMethod`).

## Fix

Require a structural tie to gRPC in addition to the codegen-only member name: the same type must also call into `Grpc.Core` (the binding/marshalling APIs a generated stub uses — `Method<,>`, `Marshallers`, `ServerServiceDefinition`). Narrow, SRM-only, no behavior added to other surfaces.

This preserves the three discriminator cases:

- **Real gRPC stub positive** stays classified: `__Helper_*` member **and** a `Grpc.Core` call.
- **Hand-written gRPC registration** stays negative: `Grpc.Core` call but no `__*` member.
- **User lookalike** now stays negative: `__*` member but no `Grpc.Core` call.

## Evidence

Adversarial negative fixture `GeneratedLookalike` (declares `__Helper_NotGenerated`, no gRPC call) plus a positive canary that its array opportunity remains visible. Existing protobuf/gRPC positives and the hand-written-registration negative are unchanged.

`dotnet run --project src/ILInspector.Analysis.Tests -c Release` — **87 passed, 0 failed**.

Affected surface: `Performance Triage` / `Top Leverage` generated-type suppression.

Closes #1574.