### PR TITLE
Type-check sidecar fact primitives against a canonical registry (#1285)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
@@ -66,6 +66,67 @@ public class LoweringFactCatalogTests
                 + string.Join(", ", duplicates));
     }
 
+    [Fact]
+    public void PrimitiveIdsUseRegisteredNamespaces()
+    {
+        var unknown = AllPrimitives()
+            .Select(fact => fact.Id)
+            .Distinct(StringComparer.Ordinal)
+            .Where(id => !FactPrimitiveCatalog.IsRegistered(id))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(unknown.Length == 0,
+            "Fact primitive ids must use a registered namespace (FactPrimitiveCatalog.Namespaces) "
+                + "or an allow-listed shape primitive (FactPrimitiveCatalog.ShapePrimitives). "
+                + "Add the new primitive to the registry intentionally, or fix the typo: "
+                + string.Join(", ", unknown));
+    }
+
+    [Fact]
+    public void PrimitiveIdsHaveNoCaseVariantAliases()
+    {
+        var aliases = AllPrimitives()
+            .Select(fact => fact.Id)
+            .Distinct(StringComparer.Ordinal)
+            .GroupBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .Where(group => group.Count() > 1)
+            .Select(group => "{" + string.Join(" | ", group.Order(StringComparer.Ordinal)) + "}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(aliases.Length == 0,
+            "Fact primitive ids that differ only by case are duplicate aliases for the same predicate; "
+                + "unify them to one canonical spelling: " + string.Join(", ", aliases));
+    }
+
+    [Fact]
+    public void SubstrateEvidenceReferencesStillBind()
+    {
+        var stale = new List<string>();
+
+        foreach (var fact in AllPrimitives())
+        {
+            foreach (var (typeName, member) in FactPrimitiveCatalog.SubstrateReferences(fact.Evidence))
+            {
+                var type = FactPrimitiveCatalog.SubstratePredicateTypes.First(t => t.Name == typeName);
+                var bound = type.GetMember(member,
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+
+                if (bound.Length == 0)
+                    stale.Add($"{fact.Id}: evidence references missing {typeName}.{member}");
+            }
+        }
+
+        Assert.True(stale.Count == 0,
+            "Fact primitive evidence references a substrate predicate that no longer exists; "
+                + "update the evidence to a real method or remove the stale reference: "
+                + string.Join("; ", stale));
+    }
+
+    static IEnumerable<FactPrimitive> AllPrimitives()
+        => DiscoverFactEntries().Cast<LoweringFactEntry>().SelectMany(entry => entry.RequiredFacts);
+
     static Dictionary<string, Type> CoverageRows()
     {
         var rows = new Dictionary<string, Type>(StringComparer.Ordinal);

--- a/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
@@ -111,7 +111,7 @@ public class LoweringFactCatalogTests
             {
                 var type = FactPrimitiveCatalog.SubstratePredicateTypes.First(t => t.Name == typeName);
                 var bound = type.GetMember(member,
-                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance);
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
 
                 if (bound.Length == 0)
                     stale.Add($"{fact.Id}: evidence references missing {typeName}.{member}");

--- a/src/ILInspector.Decompiler/Pipeline/Facts/FactPrimitiveCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/FactPrimitiveCatalog.cs
@@ -1,0 +1,99 @@
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Canonical registry for <see cref="FactPrimitive"/> identifiers used by lowering
+/// fact sidecars.
+/// </summary>
+/// <remarks>
+/// Sidecar primitive ids and evidence are free-form strings, so a refactor can rename
+/// or move a predicate while the catalog still passes, leaving stale metadata that
+/// looks authoritative but no longer points at an executable guard. This registry lets
+/// catalog tests reject the three drift shapes called out in issue #1285: unknown
+/// primitive namespaces, case-variant duplicate aliases, and substrate evidence
+/// references that no longer bind to a real method.
+/// </remarks>
+internal static class FactPrimitiveCatalog
+{
+    static readonly char[] NamespaceSeparators = ['.', ':'];
+
+    /// <summary>
+    /// Canonical namespace tokens. A namespaced primitive id is written as
+    /// "&lt;namespace&gt;.detail" or "&lt;namespace&gt;:detail"; its leading token must be
+    /// one of these.
+    /// </summary>
+    public static readonly ImmutableHashSet<string> Namespaces = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        "member",
+        "place",
+        "pdb",
+        "dataflow",
+        "generated",
+        "generated-type",
+        "generated-method",
+        "state-machine",
+        "metadata",
+        "ir",
+        "deconstruction");
+
+    /// <summary>
+    /// Pass-specific shape primitives that are intentionally un-namespaced. These are
+    /// allow-listed explicitly so a new bare primitive id is forced through review
+    /// instead of drifting in silently.
+    /// </summary>
+    public static readonly ImmutableHashSet<string> ShapePrimitives = ImmutableHashSet.Create(
+        StringComparer.Ordinal,
+        "property-subpattern-comparison",
+        "property-declaration-pattern-guard",
+        "no-generated-closure-method",
+        "manual-factory-lookalike",
+        "mdarray-bounds-and-get-shape",
+        "enumerator-call-shape",
+        "cross-method-import");
+
+    /// <summary>
+    /// Substrate predicate types whose "&lt;Type&gt;.&lt;Member&gt;" evidence references
+    /// must continue to bind to a real member after refactors.
+    /// </summary>
+    public static readonly ImmutableArray<Type> SubstratePredicateTypes = ImmutableArray.Create(
+        typeof(MemberIdentity),
+        typeof(PlaceIdentity),
+        typeof(GeneratedCodeIdentity),
+        typeof(ReferenceOwnership));
+
+    static readonly Regex SubstrateReferencePattern = new(
+        @"\b(" + string.Join("|", SubstratePredicateTypes.Select(t => Regex.Escape(t.Name)))
+            + @")\.([A-Za-z_][A-Za-z0-9_]*)",
+        RegexOptions.Compiled);
+
+    /// <summary>Returns the leading namespace token of a primitive id, or null when the id is bare.</summary>
+    public static string? NamespaceOf(string id)
+    {
+        int cut = id.IndexOfAny(NamespaceSeparators);
+        return cut < 0 ? null : id[..cut];
+    }
+
+    /// <summary>
+    /// True when the id uses a registered namespace or is an allow-listed bare shape primitive.
+    /// </summary>
+    public static bool IsRegistered(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return false;
+
+        string? ns = NamespaceOf(id);
+        return ns is null ? ShapePrimitives.Contains(id) : Namespaces.Contains(ns);
+    }
+
+    /// <summary>
+    /// Extracts "&lt;Type&gt;.&lt;Member&gt;" substrate references from a free-form evidence
+    /// string. Prose that merely names a substrate type without a "." member access is ignored.
+    /// </summary>
+    public static IEnumerable<(string Type, string Member)> SubstrateReferences(string evidence)
+    {
+        foreach (Match match in SubstrateReferencePattern.Matches(evidence))
+            yield return (match.Groups[1].Value, match.Groups[2].Value);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Facts/FactPrimitiveCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/FactPrimitiveCatalog.cs
@@ -65,7 +65,7 @@ internal static class FactPrimitiveCatalog
 
     static readonly Regex SubstrateReferencePattern = new(
         @"\b(" + string.Join("|", SubstratePredicateTypes.Select(t => Regex.Escape(t.Name)))
-            + @")\.([A-Za-z_][A-Za-z0-9_]*)",
+            + @")\.([A-Za-z_][A-Za-z0-9_]*(?:/[A-Za-z_][A-Za-z0-9_]*)*)",
         RegexOptions.Compiled);
 
     /// <summary>Returns the leading namespace token of a primitive id, or null when the id is bare.</summary>
@@ -89,11 +89,17 @@ internal static class FactPrimitiveCatalog
 
     /// <summary>
     /// Extracts "&lt;Type&gt;.&lt;Member&gt;" substrate references from a free-form evidence
-    /// string. Prose that merely names a substrate type without a "." member access is ignored.
+    /// string. A same-type slash-abbreviated member list ("&lt;Type&gt;.A/B") yields one
+    /// reference per member. Prose that merely names a substrate type without a "."
+    /// member access is ignored.
     /// </summary>
     public static IEnumerable<(string Type, string Member)> SubstrateReferences(string evidence)
     {
         foreach (Match match in SubstrateReferencePattern.Matches(evidence))
-            yield return (match.Groups[1].Value, match.Groups[2].Value);
+        {
+            string typeName = match.Groups[1].Value;
+            foreach (string member in match.Groups[2].Value.Split('/'))
+                yield return (typeName, member);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes the curator-approved **registry-only slice** of #1285 (row 3 of the #1565 proof-visibility burndown).

Lowering fact sidecar primitive ids and evidence are free-form strings, so a refactor can rename or move a predicate while `LoweringFactCatalogTests` still passes, leaving stale metadata that looks authoritative but no longer points at an executable guard.

This PR adds `FactPrimitiveCatalog` (a canonical registry) plus three catalog tests that reject the three drift shapes named in #1285:

- **Unknown / typo primitive namespaces** — `PrimitiveIdsUseRegisteredNamespaces` requires every `FactPrimitive.Id` to use a registered namespace (`member`, `place`, `pdb`, `dataflow`, `generated`, `generated-type`, `generated-method`, `state-machine`, `metadata`, `ir`, `deconstruction`) or an explicitly allow-listed bare shape primitive.
- **Case-variant duplicate aliases** — `PrimitiveIdsHaveNoCaseVariantAliases` fails when two ids differ only by case (e.g. `Place.Stack-Slot` vs `place.stack-slot`).
- **Stale substrate evidence** — `SubstrateEvidenceReferencesStillBind` extracts `<Type>.<Member>` references to the substrate predicate types (`MemberIdentity`, `PlaceIdentity`, `GeneratedCodeIdentity`, `ReferenceOwnership`) from evidence strings and reflects to confirm each still binds; prose without a `.`-member access is ignored.

## Scope / non-goals

- **Metadata + tests only.** No decompiler behavior, structuring, printer, or fidelity change.
- Independent of #1284 (sidecar completeness) — this hardens existing sidecar primitives rather than adding new rows.
- Existing ids are intentionally accepted as-is by the registry; the gate catches *future* drift. Sub-parsing the `corelib-identity:` payload to unify `string`/`String` type-token casing is left as a documented follow-up.

## Evidence

- Build: `dotnet build src/ILInspector.Decompiler -c Release` — succeeded, 0 warnings.
- Focused: `LoweringFactCatalogTests` — 6/6 pass (3 existing + 3 new).
- Teeth check: temporarily injected a bad-namespace primitive, a case-variant alias, and a stale `MemberIdentity.IsTotallyGone` evidence reference; all three new tests failed with the expected messages, then reverted.
- Full fast unit suite: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"` — **1351 passed, 0 failed**.

Burndown: #1565 row 3.
