### PR TITLE
Fix analysis generic declaring type call identity

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -242,6 +242,63 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void TopLeverage_CountsCallerOfConstructedGenericDeclaringType()
+    {
+        var index = LibraryBodyIndex.Open(typeof(GenericDeclaringCallers).Assembly.Location);
+
+        var ranked = index.TopLeverage(count: 200,
+            scope: method => method.DeclaringType.Name == "GenericDeclaringTarget`1");
+
+        var target = Assert.Single(ranked.Where(entry => entry.Method.Name == nameof(GenericDeclaringTarget<int>.Target)));
+        Assert.Equal(1, target.DirectCallerCount);
+        Assert.Equal(1, target.RootReach);
+
+        var targetWithParameter = Assert.Single(ranked.Where(entry => entry.Method.Name == nameof(GenericDeclaringTarget<int>.TargetWithParameter)));
+        Assert.Equal(1, targetWithParameter.DirectCallerCount);
+    }
+
+    [Fact]
+    public void BuildCallerTree_LinksConstructedGenericDeclaringTypeCaller()
+    {
+        var index = LibraryBodyIndex.Open(typeof(GenericDeclaringCallers).Assembly.Location);
+        var target = Assert.Single(index.Methods.Where(method =>
+            method.DeclaringType.Name == "GenericDeclaringTarget`1"
+            && method.Name == nameof(GenericDeclaringTarget<int>.Target)));
+
+        var tree = index.BuildCallerTree(target.MetadataToken, maxDepth: 2, maxNodes: 20);
+
+        Assert.Contains(tree.Children, child =>
+            child.Member.Name == nameof(GenericDeclaringCallers.CallGenericTarget));
+    }
+
+    [Fact]
+    public void BuildCallTree_LinksConstructedGenericDeclaringTypeCallee()
+    {
+        var index = LibraryBodyIndex.Open(typeof(GenericDeclaringCallers).Assembly.Location);
+        var caller = Assert.Single(index.Methods.Where(method =>
+            method.Name == nameof(GenericDeclaringCallers.CallGenericTarget)));
+
+        var tree = index.BuildCallTree(caller.MetadataToken, maxDepth: 2, maxNodes: 20);
+
+        var child = Assert.Single(tree.Children.Where(node =>
+            node.Member.Name == nameof(GenericDeclaringTarget<int>.Target)));
+        Assert.Equal(CallTreeStatus.Leaf, child.Status);
+        Assert.Equal("ILInspector.Analysis.Tests.GenericDeclaringTarget<int>", child.Member.DeclaringType.ToQualifiedDisplayString());
+    }
+
+    [Fact]
+    public void TopUnsafeLeverage_CountsCallerOfConstructedGenericDeclaringType()
+    {
+        var index = LibraryBodyIndex.Open(typeof(GenericDeclaringCallers).Assembly.Location);
+
+        var unsafeTarget = Assert.Single(index.TopUnsafeLeverage(count: 100).Where(entry =>
+            entry.Method.DeclaringType.Name == "GenericUnsafeTarget`1"
+            && entry.Method.Name == nameof(GenericUnsafeTarget<int>.UnsafeTarget)));
+
+        Assert.Equal(1, unsafeTarget.DirectCallerCount);
+    }
+
+    [Fact]
     public void MemberReferences_InstantiateGenericDeclaringTypeArguments()
     {
         var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);
@@ -1438,6 +1495,27 @@ public static class CallSiteFixtures
     public static T GenericEcho<T>(T value) => value;
 
     public static int CallsGenericEcho() => GenericEcho(42);
+}
+
+public static class GenericDeclaringCallers
+{
+    public static int CallGenericTarget() => GenericDeclaringTarget<int>.Target();
+
+    public static int CallGenericTargetWithParameter() => GenericDeclaringTarget<int>.TargetWithParameter(41);
+
+    public static unsafe int CallUnsafeGenericTarget(int* value) => GenericUnsafeTarget<int>.UnsafeTarget(value);
+}
+
+public static class GenericDeclaringTarget<T>
+{
+    public static int Target() => 42;
+
+    public static T TargetWithParameter(T value) => value;
+}
+
+public static class GenericUnsafeTarget<T>
+{
+    public static unsafe int UnsafeTarget(int* value) => *value;
 }
 
 public interface ICallerGraphTarget

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -296,28 +296,14 @@ public sealed class LibraryBodyIndex
             .GroupBy(call => call.Caller.MetadataToken)
             .ToDictionary(group => group.Key, group => group.ToList());
 
-        var tokenByKey = new Dictionary<string, int>(StringComparer.Ordinal);
-        var methodTokens = new HashSet<int>();
-        foreach (var method in Methods)
-        {
-            methodTokens.Add(method.MetadataToken);
-            tokenByKey.TryAdd(MethodKey(method.DeclaringType, method.Name, method.ParameterTypes), method.MetadataToken);
-        }
+        var methodMap = MethodDefinitionMap.Create(Methods);
 
         int budget = Math.Max(1, maxNodes);
         int created = 1;
         var expanded = new HashSet<int>();
 
         int ResolveCallee(DirectCall call)
-        {
-            if (methodTokens.Contains(call.CalleeDefinitionToken))
-                return call.CalleeDefinitionToken;
-            if (call.Callee.Kind == MemberKind.Unsupported)
-                return 0;
-            return tokenByKey.TryGetValue(MethodKey(call.Callee.DeclaringType, call.Callee.Name, call.Callee.ParameterTypes), out int token)
-                ? token
-                : 0;
-        }
+            => methodMap.Resolve(call);
 
         var incomingCounts = DirectCalls
             .GroupBy(call => ResolveCallee(call))
@@ -387,13 +373,7 @@ public sealed class LibraryBodyIndex
                 ? resolvedCallee
                 : MemberRef.Unsupported($"method token 0x{rootMethodToken:X8}");
 
-        var tokenByKey = new Dictionary<string, int>(StringComparer.Ordinal);
-        var methodTokens = new HashSet<int>();
-        foreach (var method in Methods)
-        {
-            methodTokens.Add(method.MetadataToken);
-            tokenByKey.TryAdd(MethodKey(method.DeclaringType, method.Name, method.ParameterTypes), method.MetadataToken);
-        }
+        var methodMap = MethodDefinitionMap.Create(Methods);
 
         int ResolveCalleeToken(DirectCall call)
         {
@@ -404,13 +384,9 @@ public sealed class LibraryBodyIndex
             // surfaces its real inbound callers.
             if (call.CalleeDefinitionToken == rootMethodToken)
                 return rootMethodToken;
-            if (methodTokens.Contains(call.CalleeDefinitionToken))
+            if (methodMap.ContainsToken(call.CalleeDefinitionToken))
                 return call.CalleeDefinitionToken;
-            if (call.Callee.Kind == MemberKind.Unsupported)
-                return 0;
-            return tokenByKey.TryGetValue(MethodKey(call.Callee.DeclaringType, call.Callee.Name, call.Callee.ParameterTypes), out int token)
-                ? token
-                : 0;
+            return methodMap.Resolve(call);
         }
 
         // Group inbound call edges by callee, then collapse to one edge per distinct caller
@@ -625,9 +601,6 @@ public sealed class LibraryBodyIndex
     // normalize generic member identity for both Callers and Caller Graph.
     static string CallerGraphKey(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes, TypeRef returnType)
         => $"{declaringType.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{string.Join(",", parameterTypes.Select(type => type.ToQualifiedDisplayString()))}|{returnType.ToQualifiedDisplayString()}";
-
-    static string MethodKey(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes)
-        => $"{declaringType.ToQualifiedDisplayString()}|{name}|{string.Join(",", parameterTypes.Select(type => type.ToQualifiedDisplayString()))}";
 
     sealed class IndexBuilder
     {

--- a/src/ILInspector.Analysis/MethodDefinitionMap.cs
+++ b/src/ILInspector.Analysis/MethodDefinitionMap.cs
@@ -1,0 +1,82 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Analysis;
+
+internal sealed class MethodDefinitionMap
+{
+    readonly HashSet<int> _methodTokens = [];
+    readonly Dictionary<string, int> _tokenByKey = new(StringComparer.Ordinal);
+    readonly Dictionary<string, List<MethodIdentity>> _methodsByDeclaringTypeAndName = new(StringComparer.Ordinal);
+
+    MethodDefinitionMap(ImmutableArray<MethodIdentity> methods)
+    {
+        foreach (var method in methods)
+        {
+            _methodTokens.Add(method.MetadataToken);
+            _tokenByKey.TryAdd(Key(method.DeclaringType, method.Name, method.ParameterTypes), method.MetadataToken);
+
+            var groupKey = DeclaringTypeAndNameKey(method.DeclaringType, method.Name);
+            if (_methodsByDeclaringTypeAndName.TryGetValue(groupKey, out var list))
+                list.Add(method);
+            else
+                _methodsByDeclaringTypeAndName[groupKey] = [method];
+        }
+    }
+
+    public static MethodDefinitionMap Create(ImmutableArray<MethodIdentity> methods) => new(methods);
+
+    public bool ContainsToken(int token) => _methodTokens.Contains(token);
+
+    public int Resolve(DirectCall call)
+    {
+        if (_methodTokens.Contains(call.CalleeDefinitionToken))
+            return call.CalleeDefinitionToken;
+        if (call.Callee.Kind == MemberKind.Unsupported)
+            return 0;
+        if (_tokenByKey.TryGetValue(Key(call.Callee.DeclaringType, call.Callee.Name, call.Callee.ParameterTypes), out int token))
+            return token;
+        return ResolveConstructedGenericDeclaringType(call.Callee);
+    }
+
+    int ResolveConstructedGenericDeclaringType(MemberRef callee)
+    {
+        var declaring = callee.DeclaringType;
+        if (declaring.Kind != TypeRefKind.GenericInstance || declaring.ElementType is not { } definition)
+            return 0;
+        if (!_methodsByDeclaringTypeAndName.TryGetValue(DeclaringTypeAndNameKey(definition, callee.Name), out var candidates))
+            return 0;
+
+        foreach (var candidate in candidates)
+        {
+            if (!definition.Equals(candidate.DeclaringType))
+                continue;
+            if (SignatureMatches(candidate, declaring.TypeArguments, callee.TypeArguments, callee.ParameterTypes, callee.ReturnType))
+                return candidate.MetadataToken;
+        }
+
+        return 0;
+    }
+
+    static bool SignatureMatches(
+        MethodIdentity candidate,
+        ImmutableArray<TypeRef> typeArguments,
+        ImmutableArray<TypeRef> methodArguments,
+        ImmutableArray<TypeRef> parameterTypes,
+        TypeRef returnType)
+    {
+        if (candidate.ParameterTypes.Length != parameterTypes.Length)
+            return false;
+        for (int i = 0; i < parameterTypes.Length; i++)
+        {
+            if (!candidate.ParameterTypes[i].Instantiate(typeArguments, methodArguments).Equals(parameterTypes[i]))
+                return false;
+        }
+        return candidate.ReturnType.Instantiate(typeArguments, methodArguments).Equals(returnType);
+    }
+
+    static string DeclaringTypeAndNameKey(TypeRef declaringType, string name)
+        => $"{declaringType.Assembly}|{declaringType.Namespace}|{declaringType.Name}|{name}";
+
+    static string Key(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes)
+        => $"{declaringType.ToQualifiedDisplayString()}|{name}|{string.Join(",", parameterTypes.Select(type => type.ToQualifiedDisplayString()))}";
+}

--- a/src/ILInspector.Analysis/MethodLeverage.cs
+++ b/src/ILInspector.Analysis/MethodLeverage.cs
@@ -42,24 +42,8 @@ public static class MethodLeverageRanking
         if (count <= 0)
             return [];
 
-        var methodTokens = new HashSet<int>();
-        var tokenByKey = new Dictionary<string, int>(StringComparer.Ordinal);
-        foreach (var method in methods)
-        {
-            methodTokens.Add(method.MetadataToken);
-            tokenByKey.TryAdd(Key(method.DeclaringType, method.Name, method.ParameterTypes), method.MetadataToken);
-        }
-
-        int Resolve(DirectCall call)
-        {
-            if (methodTokens.Contains(call.CalleeDefinitionToken))
-                return call.CalleeDefinitionToken;
-            if (call.Callee.Kind == MemberKind.Unsupported)
-                return 0;
-            return tokenByKey.TryGetValue(Key(call.Callee.DeclaringType, call.Callee.Name, call.Callee.ParameterTypes), out int token)
-                ? token
-                : 0;
-        }
+        var methodTokens = methods.Select(method => method.MetadataToken).ToHashSet();
+        var methodMap = MethodDefinitionMap.Create(methods);
 
         // Distinct direct callers per callee token (fanin).
         var directCallers = new Dictionary<int, HashSet<int>>();
@@ -72,7 +56,7 @@ public static class MethodLeverageRanking
         foreach (var call in directCalls)
         {
             int caller = call.Caller.MetadataToken;
-            int callee = Resolve(call);
+            int callee = methodMap.Resolve(call);
 
             fanout[caller] = fanout.GetValueOrDefault(caller) + 1;
             if (call.InLoop)
@@ -196,7 +180,4 @@ public static class MethodLeverageRanking
 
         return rootReach;
     }
-
-    static string Key(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes)
-        => $"{declaringType.ToQualifiedDisplayString()}|{name}|{string.Join(",", parameterTypes.Select(type => type.ToQualifiedDisplayString()))}";
 }

--- a/src/ILInspector.Analysis/UnsafeLeverage.cs
+++ b/src/ILInspector.Analysis/UnsafeLeverage.cs
@@ -24,11 +24,13 @@ public static class UnsafeLeverage
         ImmutableArray<MethodIdentity> methods,
         int count)
     {
-        // Distinct direct callers per callee, keyed by the targeted MethodDef token. An
-        // intra-assembly call references that method's own token (peeled from a MethodSpec
-        // for generic-method calls), so this matches a method's MetadataToken to its callers.
+        // Distinct direct callers per callee, keyed by the targeted MethodDef token. Generic
+        // method calls carry a MethodSpec operand, and calls through a constructed generic
+        // declaring type carry a MemberRef operand; normalize both back to the open definition.
+        var methodMap = MethodDefinitionMap.Create(methods);
         var callersByToken = directCalls
-            .GroupBy(call => call.CalleeDefinitionToken)
+            .GroupBy(methodMap.Resolve)
+            .Where(group => group.Key != 0)
             .ToDictionary(group => group.Key, group => group.Select(c => c.Caller.MetadataToken).Distinct().Count());
 
         return methods


### PR DESCRIPTION
## Summary

Fixes #1570 by normalizing same-assembly calls through constructed generic declaring types back to the open `MethodDef` identity.

- Adds a shared `MethodDefinitionMap` used by `BuildCallTree`, `BuildCallerTree`, `TopLeverage`, and `TopUnsafeLeverage`.
- Matches `G<int>.M()` and signatures that contain declaring-type generic parameters (for example `G<int>.M(int)`) against the open `G<T>.M(T)` method definition.
- Preserves existing generic-method `MethodSpec` peeling by returning the direct `CalleeDefinitionToken` first when it already resolves.

## Evidence

```text
TopLeverage Target directCallers=1 rootReach=1
TopLeverage TargetWithParameter directCallers=1
CallerGraph Target children=CallGenericTarget
CallGraph CallGenericTarget child=ILInspector.Analysis.Tests.GenericDeclaringTarget<int>.Target status=Leaf
TopUnsafeLeverage UnsafeTarget directCallers=1
```

Validation:

```text
dotnet run --project src/ILInspector.Analysis.Tests -c Release
ILInspector.Analysis.Tests  Total: 91, Errors: 0, Failed: 0, Skipped: 0

dotnet build src/dotnet-inspect -c Release
Build succeeded. 0 Warning(s), 0 Error(s)
```

Adversarial review: Opus 4.8 reviewed the synced branch diff and found no high-confidence issues. No follow-up code changes were required after review.
