### PR TITLE
Add sidecar guardrail for substrate rows

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweringFactCatalogTests.cs
@@ -15,6 +15,9 @@ public class LoweringFactCatalogTests
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.ForEachStatement");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Index");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.IsPatternOperator");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.ConditionalAccess");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.LockStatement");
+        Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.NullCoalescingAssignmentOperator");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.ObjectOrCollectionInitializerExpression");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.PatternSwitchStatement");
         Assert.Contains(entries, e => e.Key.ToString() == "LocalRewriter.Range");
@@ -52,6 +55,25 @@ public class LoweringFactCatalogTests
     }
 
     [Fact]
+    public void KnownSubstrateDependentCoverageRowsHaveSidecarEntries()
+    {
+        var entries = DiscoverFactEntries().Cast<LoweringFactEntry>()
+            .ToDictionary(e => e.Key);
+
+        foreach (var requirement in SubstrateDependentCoverageRows())
+        {
+            Assert.True(entries.TryGetValue(requirement.Key, out var entry),
+                $"{requirement.Key}: {requirement.Reason} Add a fact sidecar entry or record an explicit exemption in this test.");
+            Assert.Equal(requirement.Mechanism, entry.Mechanism);
+
+            foreach (var primitive in requirement.RequiredPrimitiveIds)
+            {
+                Assert.Contains(entry.RequiredFacts, fact => fact.Id == primitive);
+            }
+        }
+    }
+
+    [Fact]
     public void EntriesAreUniquePerCoverageRow()
     {
         var duplicates = DiscoverFactEntries().Cast<LoweringFactEntry>()
@@ -73,6 +95,45 @@ public class LoweringFactCatalogTests
         AddRows(rows, typeof(ClosureCoverage), "ClosureConversion");
         return rows;
     }
+
+    static IEnumerable<SidecarRequirement> SubstrateDependentCoverageRows() =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.LockStatement)),
+            typeof(LockSugarPass),
+            [
+                "member.corelib-identity:Monitor.Enter",
+                "member.corelib-identity:Monitor.Exit",
+                "ownership.local-references-only-within",
+            ],
+            "LockSugarPass composes exact Monitor member identity and ReferenceOwnership proofs."),
+
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.ConditionalAccess)),
+            typeof(NullConditionalPass),
+            [
+                "place.variable",
+                "type-shape.non-nullable-value",
+            ],
+            "NullConditionalPass composes PlaceIdentity and type-shape proofs."),
+
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.NullCoalescingAssignmentOperator)),
+            typeof(NullCoalescingAssignmentPass),
+            [
+                "place.variable",
+                "place.operands",
+                "type-shape.non-nullable-value",
+                "dataflow.stack-slot-single-assignment",
+            ],
+            "NullCoalescingAssignmentPass composes PlaceIdentity, value-type, and spill-confinement proofs."),
+    ];
+
+    sealed record SidecarRequirement(
+        LoweringFactKey Key,
+        Type Mechanism,
+        string[] RequiredPrimitiveIds,
+        string Reason);
 
     static void AddRows(Dictionary<string, Type> rows, Type register, string name)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Facts/LockAndNullRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/LockAndNullRecoveryFacts.cs
@@ -1,0 +1,43 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+internal sealed class LockAndNullRecoveryFacts : ILoweringFactProvider
+{
+    public IEnumerable<LoweringFactEntry> Entries =>
+    [
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.LockStatement)),
+            typeof(LockSugarPass),
+            [
+                new FactPrimitive("member.corelib-identity:Monitor.Enter", "MemberIdentity.IsMonitorEnter"),
+                new FactPrimitive("member.corelib-identity:Monitor.Exit", "MemberIdentity.IsMonitorExit"),
+                new FactPrimitive("ownership.local-references-only-within", "ReferenceOwnership.LocalReferencesOnlyWithin"),
+            ],
+            PositiveCoverage: "IrImporterTests VoidLock/parameter/static-field lock fixtures and LockSugarSoundnessTests clean synthetic lock shape",
+            AdversarialCoverage: "LockSugarSoundnessTests lockTaken external read, user Monitor lookalike, wrong Enter signature, extra finally work, and mismatched Exit object negatives",
+            MissingDiscriminator: "static-field receivers intentionally preserve the copied receiver local instead of spelling the field in the lock header"),
+
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.ConditionalAccess)),
+            typeof(NullConditionalPass),
+            [
+                new FactPrimitive("place.variable", "PlaceIdentity.SameVariable"),
+                new FactPrimitive("type-shape.non-nullable-value", "TypeFamilies.IsKnownNonNullableValueType"),
+            ],
+            PositiveCoverage: "IrImporterTests NullConditional_RaisesQuestionDot_AndSoundlyTypesSlot and IdiomShapeScorecardTests NullConditionalPass conditional-access fixture",
+            AdversarialCoverage: "NullValueTypeGuardTests re-evaluable and spilled value-type receiver negatives; PlaceIdentityTests SameVariable atom negatives",
+            MissingDiscriminator: "nullable value-type ?. forms lower through Nullable<T> and are not represented by the bare null arm this pass raises"),
+
+        new(
+            new LoweringFactKey(LoweringFactRegister.LocalRewriter, nameof(LoweringCoverage.NullCoalescingAssignmentOperator)),
+            typeof(NullCoalescingAssignmentPass),
+            [
+                new FactPrimitive("place.variable", "PlaceIdentity.SameVariable"),
+                new FactPrimitive("place.operands", "PlaceIdentity.SameOperands"),
+                new FactPrimitive("type-shape.non-nullable-value", "TypeFamilies.IsKnownNonNullableValueType"),
+                new FactPrimitive("dataflow.stack-slot-single-assignment", "NullCoalescingAssignmentPass.RecoverSpilledValue slot confinement checks"),
+            ],
+            PositiveCoverage: "NullCoalescingAssignmentPassTests local, field, property, indexer, constant-index, and dictionary-indexer ??= fixtures",
+            AdversarialCoverage: "NullCoalescingAssignmentPassTests extra-then, incompatible accessor, mismatched index type/value, and different constant-index negatives; NullValueTypeGuardTests value-type local negative",
+            MissingDiscriminator: "nested-struct compound null-coalescing assignment remains outside this pass"),
+    ];
+}


### PR DESCRIPTION
## Summary

Closes #1284. Adds explicit lowering fact sidecar entries for the substrate-dependent rows that were missing from the catalog:

- `LockStatement` / `LockSugarPass`
- `ConditionalAccess` / `NullConditionalPass`
- `NullCoalescingAssignmentOperator` / `NullCoalescingAssignmentPass`

Also adds `LoweringFactCatalogTests.KnownSubstrateDependentCoverageRowsHaveSidecarEntries`, an explicit guardrail registry for these rows. The test requires each row to have a sidecar with the expected primitive IDs, so future sidecar drops or primitive drift fail locally instead of silently under-reporting proof dependencies.

## Evidence

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringFactCatalogTests/*"` — 4 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"` — 1349 passed
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` — 89 passed

This is metadata/test-only; it does not change decompiler behavior, so no corpus quality card was generated. I also started the full unfiltered `ILInspector.Decompiler.Tests` executable, but stopped it after an extended CPU-bound run with no final output on the shared machine; the documented fast PR-gate subset above completed green after rebasing onto current `origin/main`.

## Adversarial review

Requested cross-model review from Opus 4.8. Result: no blocking findings. The reviewer checked that the metadata points at real pass predicates/tests, the mechanism types match `LoweringCoverage`, and the guardrail pins the intended row/primitive set.
