### PR TITLE
Add decompiler predicate census guardrail

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
@@ -1,0 +1,130 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class SubstratePredicateCensusTests
+{
+    static readonly Dictionary<PredicateKey, string> ApprovedLocalPredicates = new()
+    {
+        [new("BooleanFoldingPass.cs", "SameNullTestedLoad")] =
+            "Pass-local composition of PlaceIdentity.SameVariable and SameStackSlot for the null-tested value accepted by boolean folding.",
+        [new("ConstructorCallDiagnosticsPass.cs", "SameDefinition")] =
+            "Constructor diagnostics compare the declaring type with the current/base type; this is diagnostic routing, not a reusable rewrite gate.",
+        [new("EhStructuringPass.cs", "SameZone")] =
+            "Control-flow legality check over EH constructs and branch offsets, not a place/member identity predicate.",
+        [new("ExpressionInliningPass.cs", "IsInsideCatchFilter")] =
+            "Inlining-specific EH guard that first finds the containing catch clause before using ReferenceOwnership.IsInside on its filter.",
+        [new("ExpressionInliningPass.cs", "SameRegions")] =
+            "Inlining-specific EH range equality for candidate movement; the predicate is over function region spans, not IR identity.",
+        [new("NullCoalescingAssignmentPass.cs", "SameField")] =
+            "FieldRef equality paired with pass-owned receiver/index-shape checks for null-coalescing assignment.",
+        [new("NullCoalescingAssignmentPass.cs", "SameReceiver")] =
+            "Pass-local receiver admissibility: null static receiver or PlaceIdentity.SameVariable only.",
+        [new("StructuringPass.cs", "IsInsideFinallyBody")] =
+            "Structuring-specific leave-target guard for finally bodies, not a general ancestor/location helper.",
+    };
+
+    [Fact]
+    public void PassLocalPredicateHelpers_AreClassified()
+    {
+        var actual = EnumeratePassLocalPredicates().ToArray();
+        var actualKeys = actual.Select(p => p.Key).ToHashSet();
+        var approvedKeys = ApprovedLocalPredicates.Keys.ToHashSet();
+
+        var unclassified = actual
+            .Where(p => !approvedKeys.Contains(p.Key))
+            .OrderBy(p => p.Key.File, StringComparer.Ordinal)
+            .ThenBy(p => p.Key.Method, StringComparer.Ordinal)
+            .Select(p => $"{p.Key.File}:{p.Line}: {p.Key.Method}")
+            .ToArray();
+        var staleApprovals = approvedKeys
+            .Where(key => !actualKeys.Contains(key))
+            .OrderBy(key => key.File, StringComparer.Ordinal)
+            .ThenBy(key => key.Method, StringComparer.Ordinal)
+            .Select(key => $"{key.File}: {key.Method}")
+            .ToArray();
+        var missingRationale = ApprovedLocalPredicates
+            .Where(kvp => string.IsNullOrWhiteSpace(kvp.Value))
+            .Select(kvp => $"{kvp.Key.File}: {kvp.Key.Method}")
+            .ToArray();
+
+        Assert.True(unclassified.Length == 0,
+            "Pass-local predicate-shaped helpers must be migrated to substrate atoms or approved with a rationale: "
+            + string.Join(", ", unclassified));
+        Assert.True(staleApprovals.Length == 0,
+            "Approved pass-local predicate helpers no longer found; remove stale approvals: "
+            + string.Join(", ", staleApprovals));
+        Assert.True(missingRationale.Length == 0,
+            "Approved pass-local predicate helpers must carry a rationale: "
+            + string.Join(", ", missingRationale));
+    }
+
+    static IEnumerable<PredicateHit> EnumeratePassLocalPredicates()
+    {
+        string passesDirectory = Path.Combine(FindRepositoryRoot(), "src", "ILInspector.Decompiler", "Pipeline", "Passes");
+        foreach (string path in Directory.EnumerateFiles(passesDirectory, "*.cs").OrderBy(static p => p, StringComparer.Ordinal))
+        {
+            string text = File.ReadAllText(path);
+            var tree = CSharpSyntaxTree.ParseText(text, path: path, cancellationToken: TestContext.Current.CancellationToken);
+            var root = tree.GetCompilationUnitRoot(TestContext.Current.CancellationToken);
+
+            foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+            {
+                string methodName = method.Identifier.ValueText;
+                if (!IsStaticBoolCensusPredicate(method.Modifiers, method.ReturnType, methodName))
+                {
+                    continue;
+                }
+
+                int line = method.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                yield return new PredicateHit(new PredicateKey(Path.GetFileName(path), methodName), line);
+            }
+
+            foreach (var localFunction in root.DescendantNodes().OfType<LocalFunctionStatementSyntax>())
+            {
+                string methodName = localFunction.Identifier.ValueText;
+                if (!IsStaticBoolCensusPredicate(localFunction.Modifiers, localFunction.ReturnType, methodName))
+                {
+                    continue;
+                }
+
+                int line = localFunction.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                yield return new PredicateHit(new PredicateKey(Path.GetFileName(path), methodName), line);
+            }
+        }
+    }
+
+    static bool IsStaticBoolCensusPredicate(SyntaxTokenList modifiers, TypeSyntax returnType, string name)
+        => modifiers.Any(SyntaxKind.StaticKeyword)
+            && ReturnsBool(returnType)
+            && IsCensusPredicateName(name);
+
+    static bool IsCensusPredicateName(string name)
+        => name.StartsWith("Same", StringComparison.Ordinal)
+            || name.StartsWith("IsInside", StringComparison.Ordinal);
+
+    static bool ReturnsBool(TypeSyntax returnType)
+        => returnType switch
+        {
+            PredefinedTypeSyntax predefined => predefined.Keyword.IsKind(SyntaxKind.BoolKeyword),
+            IdentifierNameSyntax identifier => identifier.Identifier.ValueText == nameof(Boolean),
+            _ => false,
+        };
+
+    static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            string passesDirectory = Path.Combine(directory.FullName, "src", "ILInspector.Decompiler", "Pipeline", "Passes");
+            if (Directory.Exists(passesDirectory))
+                return directory.FullName;
+        }
+
+        throw new DirectoryNotFoundException("Could not find repository root containing src/ILInspector.Decompiler/Pipeline/Passes.");
+    }
+
+    readonly record struct PredicateKey(string File, string Method);
+    readonly record struct PredicateHit(PredicateKey Key, int Line);
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainArgumentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainArgumentPass.cs
@@ -84,7 +84,7 @@ public sealed class ConstructorChainArgumentPass : IIrPass
         }
 
         var load = record.Loads[0];
-        if (!IsInside(load, call))
+        if (!ReferenceOwnership.IsInside(load, call))
             return false;
 
         var value = (IrExpression)previous.DetachChildren()[0];
@@ -118,17 +118,6 @@ public sealed class ConstructorChainArgumentPass : IIrPass
         }
         return places;
     }
-
-    static bool IsInside(IrNode node, IrNode root)
-    {
-        for (var current = node; current is not null; current = current.Parent)
-        {
-            if (ReferenceEquals(current, root))
-                return true;
-        }
-        return false;
-    }
-
     sealed class Place
     {
         public List<IrNode> Loads { get; } = [];

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainPass.cs
@@ -91,7 +91,7 @@ public sealed class ConstructorChainPass : IIrPass
             return false;
 
         foreach (var load in source.Loads)
-            if (!receiverStores.Any(store => IsInside(load, store)))
+            if (!receiverStores.Any(store => ReferenceOwnership.IsInside(load, store)))
                 return false;
 
         sourceStore = source.Stores[0];
@@ -113,17 +113,6 @@ public sealed class ConstructorChainPass : IIrPass
     };
 
     static bool StoreIsThis(IrNode store) => StoreValue(store) is LoadArgument { Index: 0 };
-
-    static bool IsInside(IrNode node, IrNode root)
-    {
-        for (var current = node; current is not null; current = current.Parent)
-        {
-            if (ReferenceEquals(current, root))
-                return true;
-        }
-        return false;
-    }
-
     static Place CountUsage(IrFunction function, (bool IsSlot, int Index) place)
     {
         var result = new Place();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
@@ -377,7 +377,7 @@ public sealed class DeconstructionAssignmentPass : IIrPass
     static bool ReferencedOnlyWithin(IrFunction function, TupleSeed seed, IReadOnlyList<IrNode> allowed)
     {
         foreach (var reference in function.Descendants.Where(seed.IsReference))
-            if (!allowed.Any(allowedNode => IsInside(reference, allowedNode)))
+            if (!allowed.Any(allowedNode => ReferenceOwnership.IsInside(reference, allowedNode)))
                 return false;
         return true;
     }
@@ -399,16 +399,6 @@ public sealed class DeconstructionAssignmentPass : IIrPass
             {
                 return false;
             }
-        }
-        return false;
-    }
-
-    static bool IsInside(IrNode node, IrNode root)
-    {
-        for (var current = node; current is not null; current = current.Parent)
-        {
-            if (ReferenceEquals(current, root))
-                return true;
         }
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -84,7 +84,7 @@ public sealed class ExpressionInliningPass : IIrPass
             {
                 continue;
             }
-            if (!IsInside(load, next))
+            if (!ReferenceOwnership.IsInside(load, next))
                 continue;
             if (store is StoreLocal { Value: LoadField { Instance: null } } && IsLockObject(load))
                 continue;  // keep copied static lock receivers; inlining can fail to bind in reconstructed shells
@@ -387,22 +387,12 @@ public sealed class ExpressionInliningPass : IIrPass
         static bool Inside(int offset, int start, int length) => offset >= start && offset < start + length;
     }
 
-    static bool IsInside(IrNode node, IrNode root)
-    {
-        for (var current = node; current is not null; current = current.Parent)
-        {
-            if (ReferenceEquals(current, root))
-                return true;
-        }
-        return false;
-    }
-
     static bool IsInsideCatchFilter(IrNode node)
     {
         for (var current = node.Parent; current is not null; current = current.Parent)
         {
             if (current is CatchClause clause)
-                return clause.Filter is { } filter && IsInside(node, filter);
+                return clause.Filter is { } filter && ReferenceOwnership.IsInside(node, filter);
         }
         return false;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedArrayRaising.cs
@@ -87,7 +87,7 @@ internal static class FixedArrayRaising
         // the element-address arm) — never the body — so dropping it orphans nothing.
         foreach (var load in function.Descendants.OfType<LoadLocal>())
         {
-            if (load.Index == pin && !IsInside(load, guard))
+            if (load.Index == pin && !ReferenceOwnership.IsInside(load, guard))
                 return;
         }
 
@@ -111,7 +111,7 @@ internal static class FixedArrayRaising
         {
             if (reference is StoreLocal store && (store == zeroStore || store == addressStore))
                 continue;
-            if (!bodyStmts.Any(stmt => IsInside(reference, stmt)))
+            if (!bodyStmts.Any(stmt => ReferenceOwnership.IsInside(reference, stmt)))
                 return;
         }
 
@@ -169,13 +169,5 @@ internal static class FixedArrayRaising
         while (value is Convert convert)
             value = convert.Operand;
         return value;
-    }
-
-    static bool IsInside(IrNode node, IrNode root)
-    {
-        for (var current = node; current is not null; current = current.Parent)
-            if (ReferenceEquals(current, root))
-                return true;
-        return false;
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/FixedStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/FixedStatementPass.cs
@@ -168,7 +168,7 @@ public sealed class FixedStatementPass : IIrPass
         foreach (var node in function.Descendants)
         {
             if (node is LoadLocal l && pinnedSlots.Contains(l.Index)
-                && !bodyStmts.Any(stmt => IsInside(node, stmt)))
+                && !bodyStmts.Any(stmt => ReferenceOwnership.IsInside(node, stmt)))
             {
                 return;
             }
@@ -311,15 +311,5 @@ public sealed class FixedStatementPass : IIrPass
         while (value is Convert convert)
             value = convert.Operand;
         return value is Constant { Value: null or 0 or 0L };
-    }
-
-    static bool IsInside(IrNode node, IrNode root)
-    {
-        for (var current = node; current is not null; current = current.Parent)
-        {
-            if (ReferenceEquals(current, root))
-                return true;
-        }
-        return false;
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -94,9 +94,9 @@ public sealed class IncrementDecrementPass : IIrPass
         var loads = function.Descendants.OfType<LoadStackSlot>().Where(l => l.Slot == slot).ToList();
         if (function.Descendants.OfType<StoreStackSlot>().Count(s => s.Slot == slot) != 1)
             return false;
-        if (loads.Count != 2 || loads.Count(l => IsInside(l, update)) != 1)
+        if (loads.Count != 2 || loads.Count(l => ReferenceOwnership.IsInside(l, update)) != 1)
             return false;
-        if (loads.FirstOrDefault(l => !IsInside(l, update)) is not { } useLoad)
+        if (loads.FirstOrDefault(l => !ReferenceOwnership.IsInside(l, update)) is not { } useLoad)
             return false;
 
         // The consumer must be a later statement in this same block.
@@ -187,7 +187,7 @@ public sealed class IncrementDecrementPass : IIrPass
         if (function.Descendants.OfType<StoreStackSlot>().Count(s => s.Slot == slot) != 1)
             return false;
         var loads = function.Descendants.OfType<LoadStackSlot>().Where(l => l.Slot == slot).ToList();
-        if (loads.Count != 2 || !loads.All(l => IsInside(l, store)))
+        if (loads.Count != 2 || !loads.All(l => ReferenceOwnership.IsInside(l, store)))
             return false;
 
         stepper.StepOver("inline captured address into compound assignment", store);
@@ -454,15 +454,5 @@ public sealed class IncrementDecrementPass : IIrPass
                 return current;
         }
         return null;
-    }
-
-    static bool IsInside(IrNode node, IrNode root)
-    {
-        for (var current = node; current is not null; current = current.Parent)
-        {
-            if (ReferenceEquals(current, root))
-                return true;
-        }
-        return false;
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/InlineArrayCollectionPass.cs
@@ -389,7 +389,7 @@ public sealed class InlineArrayCollectionPass : IIrPass
                 LoadLocalAddress address => address.Index == local,
                 _ => false,
             })
-            .All(node => IsInsideAny(node, allowed));
+            .All(node => ReferenceOwnership.IsInsideAny(node, allowed));
 
     static bool ReferencesStackSlotOnlyWithin(IrFunction function, int stackSlot, IReadOnlyCollection<IrNode> allowed)
         => function.Descendants
@@ -399,23 +399,12 @@ public sealed class InlineArrayCollectionPass : IIrPass
                 StoreStackSlot store => store.Slot == stackSlot,
                 _ => false,
             })
-            .All(node => IsInsideAny(node, allowed));
+            .All(node => ReferenceOwnership.IsInsideAny(node, allowed));
 
     static bool HasKnownHiddenLocal(IrFunction function, int index)
         => index >= 0
             && index < function.LocalNames.Length
             && string.IsNullOrWhiteSpace(function.LocalNames[index]);
-
-    static bool IsInsideAny(IrNode node, IReadOnlyCollection<IrNode> roots)
-        => roots.Any(root => IsInside(node, root));
-
-    static bool IsInside(IrNode node, IrNode root)
-    {
-        for (var current = node; current is not null; current = current.Parent)
-            if (ReferenceEquals(current, root))
-                return true;
-        return false;
-    }
 
     /// <summary>
     /// Raises a direct inline-array span conversion — an

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LambdaCachePass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LambdaCachePass.cs
@@ -257,7 +257,7 @@ public sealed class LambdaCachePass : IIrPass
     static bool FieldReferencesOnlyWithin(IrFunction function, FieldRef field, IReadOnlyCollection<IrNode> allowed)
         => function.Descendants
             .Where(node => ReferencesField(node, field))
-            .All(node => allowed.Any(root => IsInside(node, root)));
+            .All(node => allowed.Any(root => ReferenceOwnership.IsInside(node, root)));
 
     static bool ReferencesField(IrNode node, FieldRef field) => node switch
     {
@@ -266,15 +266,6 @@ public sealed class LambdaCachePass : IIrPass
         LoadFieldAddress address => address.Field.Equals(field),
         _ => false,
     };
-
-    static bool IsInside(IrNode node, IrNode root)
-    {
-        for (var current = node; current is not null; current = current.Parent)
-            if (ReferenceEquals(current, root))
-                return true;
-        return false;
-    }
-
     // Whether the statement reads or writes the given stack slot anywhere in its
     // subtree — the guard for what may be interleaved ahead of the cache load.
     static bool ReferencesSlot(IrNode node, int slot)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ReturnDispatchPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ReturnDispatchPass.cs
@@ -120,7 +120,7 @@ public sealed class ReturnDispatchPass : IIrPass
         var hiddenOffsets = blocks.Skip(1).Select(block => block.StartOffset).ToHashSet();
         foreach (var node in function.Descendants)
         {
-            if (IsInside(node, container))
+            if (ReferenceOwnership.IsInside(node, container))
                 continue;
             foreach (int target in Targets(node))
                 if (hiddenOffsets.Contains(target))
@@ -137,12 +137,4 @@ public sealed class ReturnDispatchPass : IIrPass
         Leave leave => [leave.TargetOffset],
         _ => [],
     };
-
-    static bool IsInside(IrNode node, IrNode root)
-    {
-        for (var current = node; current is not null; current = current.Parent)
-            if (ReferenceEquals(current, root))
-                return true;
-        return false;
-    }
 }


### PR DESCRIPTION
## Summary

Closes #1283.

- Adds `SubstratePredicateCensusTests` to inventory pass-local `static bool Same*` / `IsInside*` predicate helpers under `Pipeline/Passes`.
- Requires every found helper to be either migrated to substrate atoms or listed with an explicit local-by-design rationale.
- Migrates mechanical duplicate ancestor checks to `ReferenceOwnership.IsInside` / `IsInsideAny` in the affected passes.

## Evidence

- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity minimal`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -noLogo -class ILInspector.Decompiler.Tests.SubstratePredicateCensusTests -class ILInspector.Decompiler.Tests.ReturnDispatchPassTests -class ILInspector.Decompiler.Tests.ExpressionInliningPassTests -class ILInspector.Decompiler.Tests.LambdaCachePassTests -class ILInspector.Decompiler.Tests.ConstructorChainRenderingTests -class ILInspector.Decompiler.Tests.DeconstructionAssignmentPassTests -class ILInspector.Decompiler.Tests.FixedArrayStatementTests -class ILInspector.Decompiler.Tests.IncrementDecrementPassTests -class ILInspector.Decompiler.Tests.InlineArrayElementRefPassTests -class ILInspector.Decompiler.Tests.VolatileIndirectFidelityTests`
- `git diff --check`

A full `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` run was attempted before final sync, but it remained active without completion after an extended wait and was stopped; the focused census plus affected pass tests above are the closest row-specific coverage.

## Adversarial review

Requested Opus 4.8 review. It found one guardrail gap: the census missed static local functions. This PR now includes local-function scanning; no remaining high-signal issues were reported.
