### PR TITLE
Document Ladder tester role

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Decompiler Correctness Pipeline](decompiler-correctness-pipeline.md) | The staged gauntlet of decompiler checks, from entry gates to changed-method fidelity. |
 | [Adversarial Defect Discovery](adversarial-defect-discovery.md) | Role protocol for finding high-confidence defects in decompiler and analysis-library surfaces before they become burndown rows. |
 | [Decompiler Burndown Curator](decompiler-burndown-curator.md) | Operating protocol for decompiler burndown queue hygiene, the curator rollup, stale PRs, CI breaks, and agent delegation. |
+| [Ladder Tester](decompiler-burndown-curator.md#ladder-tester) | How the product quality ladder is measured one leg at a time, and when to file issues or spawn a linked burndown. |
 | [Burndown Runner](decompiler-burndown-curator.md#burndown-runner) | How agents use burndown lists as hot-start queues, avoid double claims, and reduce merge conflicts before review. |
 
 ### Contributor docs

--- a/docs/decompiler-burndown-curator.md
+++ b/docs/decompiler-burndown-curator.md
@@ -93,6 +93,42 @@ Maintainers should use the curator rollup as the dashboard: merge clean PRs,
 assign the next open row, ask for rebaseline when a list closes, and stop agents
 from creating motion when the next measured lane is not clear.
 
+## Ladder tester
+
+**Ladder testers** are the agents who advance the product quality ladder
+(currently #1599). The ladder is the user-visible bring-up sequence; it is not a
+parallel bug queue. Use one Ladder tester at a time unless a maintainer
+explicitly splits independent preparation work.
+
+The Ladder tester should:
+
+1. start from the curator rollup (#1568) and confirm the active ladder issue;
+2. choose the current ladder leg, not an arbitrary later one;
+3. define or refresh that leg's fixture/corpus, current score, scoped success
+   bar, and regression guard;
+4. run the current decompiler against the leg's fixture/corpus;
+5. either **claim success** on the ladder issue when the leg already meets its
+   bar and has a guard, or create focused issues for the failures that block it;
+6. prefer creating a leg-specific burndown list when a non-success leg exposes
+   multiple independent failures;
+7. link any leg-specific burndown from the primary curator rollup (#1568), so
+   maintainers and runners can find it without reading the whole ladder issue.
+
+The Ladder tester should not implement broad fixes directly by default. Its job
+is to keep the ladder objective: define the target, prove current state, file or
+cluster the blocking work, and verify that landed fixes move the leg to its
+scoped 100% bar. If a single small fix is obviously enough to complete the leg,
+ask before switching from tester to implementer.
+
+When a ladder leg is not successful, the preferred flow is:
+
+1. Post the measured failure summary on the ladder issue.
+2. File focused issues for each independent failure pattern.
+3. If there is more than one issue, create a small burndown list for that leg.
+4. Add that burndown to #1568 with open row count and next action.
+5. When the burndown closes, re-run the ladder leg and either claim success or
+   file the next blocking pattern.
+
 ## Burndown runner
 
 **Burndown runners** are the agents who act on burndown lists. A runner owns one


### PR DESCRIPTION
## Summary

Adds the **Ladder tester** role to the decompiler burndown curator guide and links it from the docs index.

The role guidance says the Ladder tester:

- advances the product quality ladder one leg at a time;
- claims success on a ladder leg only when the scoped bar and guard are met;
- files focused issues for failures;
- prefers creating a leg-specific burndown when a non-success leg exposes multiple independent failures;
- links those burndowns from the primary curator rollup (#1568).

## Evidence

- `npx markdownlint-cli --fix docs/decompiler-burndown-curator.md docs/README.md`
- `npx markdownlint-cli docs/decompiler-burndown-curator.md docs/README.md`

Docs-only; no product behavior change.
