### PR TITLE
Register ownership and type-shape fact primitive namespaces (unblock main)

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Facts/FactPrimitiveCatalog.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/FactPrimitiveCatalog.cs
@@ -36,7 +36,9 @@ internal static class FactPrimitiveCatalog
         "state-machine",
         "metadata",
         "ir",
-        "deconstruction");
+        "deconstruction",
+        "ownership",
+        "type-shape");
 
     /// <summary>
     /// Pass-specific shape primitives that are intentionally un-namespaced. These are


### PR DESCRIPTION
## main is red — two-PR interaction

`main` currently fails `ILInspector.Decompiler.Tests.LoweringFactCatalogTests.PrimitiveIdsUseRegisteredNamespaces` deterministically (confirmed on pure `origin/main`), blocking all PRs.

**Cause:** a semantic interaction between two PRs that were each green in isolation:

- **#1590** added `FactPrimitiveCatalog` + the test enforcing that every fact primitive id uses a registered namespace. Its `Namespaces` set does not include `ownership` or `type-shape`.
- **#1595** added `LockAndNullRecoveryFacts` with primitives `ownership.local-references-only-within` and `type-shape.non-nullable-value`.

Merged together, the registry rejects the new ids → red main.

## Fix

Register `ownership` and `type-shape` in `FactPrimitiveCatalog.Namespaces`. The backing predicates are real and public:

- `ownership.local-references-only-within` → `ReferenceOwnership.LocalReferencesOnlyWithin` (`src/ILInspector.Decompiler/Pipeline/ReferenceOwnership.cs:45`)
- `type-shape.non-nullable-value` → `TypeFamilies.IsKnownNonNullableValueType` (`src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs:90`)

So these are intentional new primitives, registered as such.

## Evidence

`ILInspector.Decompiler.Tests` `LoweringFactCatalogTests` 7/7 pass on this branch (failed before). Two-line registry change; no behavior change to lowering/structuring.

cc the #1595 / #1590 authors — flagging since this resolves the namespace decision their interaction surfaced.