### PR TITLE
Add ReturnSinkingPass adversarial near-miss coverage (#1289)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnSinkingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnSinkingPassTests.cs
@@ -149,6 +149,34 @@ public class ReturnSinkingPassTests
         Assert.Equal(0, StoreCount(function, 0));
         var ret = Assert.Single(tryBody.Blocks[0].Children.OfType<Return>());
         Assert.IsType<LoadArgument>(ret.Value);
+        // The trailing `return V_0` must be gone: no load of the accumulator may
+        // survive (this also guards Apply still detaching plan.Returns).
+        Assert.DoesNotContain(function.Descendants.OfType<LoadLocal>(), l => l.Index == 0);
+        Assert.Empty(entry.Children.OfType<Return>());
+        function.CheckInvariant();
+    }
+
+    // Positive control isolating the switch-statement exclusion to statement
+    // kind: the same per-arm-store-then-trailing-return shape, but with a
+    // *supported* statement (if/else with non-bool arms), sinks into per-arm
+    // returns. The matching switch fixture below keeps its temp only because the
+    // pass deliberately excludes switch, not because the arm shape is unhandled.
+    [Fact]
+    public void IfElseArmsAccumulator_Sinks()
+    {
+        var thenArm = Block(new StoreLocal(0, Int32, new Constant(10, Int32)));
+        var elseArm = Block(new StoreLocal(0, Int32, new Constant(20, Int32)));
+        var entry = Block(
+            new IfStatement(new LoadArgument(0, "x", Int32), thenArm, elseArm),
+            new Return(new LoadLocal(0, Int32)));
+        var function = Function(Container(entry), Int32);
+
+        new ReturnSinkingPass().Run(function, PassContext.None);
+
+        Assert.Equal(0, StoreCount(function, 0));
+        Assert.DoesNotContain(function.Descendants.OfType<LoadLocal>(), l => l.Index == 0);
+        Assert.Contains(function.Descendants.OfType<Return>(), r => r.Value is Constant { Value: 10 });
+        Assert.Contains(function.Descendants.OfType<Return>(), r => r.Value is Constant { Value: 20 });
         function.CheckInvariant();
     }
 
@@ -244,7 +272,9 @@ public class ReturnSinkingPassTests
 
     // Switch statement tail: a trailing return after a switch statement whose
     // arms store the accumulator must not be sunk into per-arm returns, because
-    // csc lowers switch expressions through their own result accumulator.
+    // csc lowers switch expressions through their own result accumulator. The
+    // if/else positive control above proves this arm shape is otherwise
+    // sinkable, so the temp survives here only due to the switch exclusion.
     [Fact]
     public void SwitchStatementArms_StayAccumulator()
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnSinkingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnSinkingPassTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
@@ -5,6 +6,9 @@ namespace ILInspector.Decompiler.Tests;
 public class ReturnSinkingPassTests
 {
     static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
 
     [Fact]
     public void ExplicitElseBoolAccumulator_StaysAccumulatorForFidelity()
@@ -93,4 +97,184 @@ public class ReturnSinkingPassTests
         Assert.Contains(function.Descendants.OfType<Return>(), r => r.Value is Constant { Value: true });
         function.CheckInvariant();
     }
+
+    // --- Adversarial near-miss coverage (issue #1289) -----------------------
+    //
+    // The pass is sound by construction only when it consumes every store and
+    // every load of an accumulator local (all-or-nothing). The fixtures below
+    // pin the documented decline families — escaping (non-return) load,
+    // partial-store consumption, address-taken, branch-target store, and the two
+    // switch forms — and a positive control proves the negatives are not passing
+    // vacuously. If any "stays" fixture begins to sink, the all-or-nothing
+    // guarantee has regressed.
+
+    static IrFunction Function(BlockContainer body, params TypeRef[] locals) =>
+        new(
+            "M",
+            Object,
+            new MethodSignature(Int32, [new Parameter("x", Int32)], HasThis: false, GenericParameterCount: 0),
+            [.. locals],
+            body);
+
+    static BlockContainer Container(params Block[] blocks)
+    {
+        var container = new BlockContainer();
+        foreach (var block in blocks)
+            container.Add(block);
+        return container;
+    }
+
+    static ExpressionStatement Use(IrExpression value) =>
+        new(new Call(
+            new MethodRef(TypeRef.CoreLib("System", "GC"), "KeepAlive", Void, [Object], HasThis: false),
+            isVirtual: false,
+            [value]));
+
+    static int StoreCount(IrFunction function, int index) =>
+        function.Descendants.OfType<StoreLocal>().Count(s => s.Index == index);
+
+    // Positive control: a pure return accumulator spilled across a try/finally is
+    // sunk — the store becomes the try body's return and the trailing temp load
+    // disappears. This is the shape every negative below perturbs by one feature.
+    [Fact]
+    public void TryFinallyAccumulator_Sinks()
+    {
+        var tryBody = Container(Block(new StoreLocal(0, Int32, new LoadArgument(0, "x", Int32))));
+        var finallyBody = Container(Block(Use(new Constant(null, Object))));
+        var entry = Block(new TryFinally(tryBody, finallyBody), new Return(new LoadLocal(0, Int32)));
+        var function = Function(Container(entry), Int32);
+
+        new ReturnSinkingPass().Run(function, PassContext.None);
+
+        Assert.Equal(0, StoreCount(function, 0));
+        var ret = Assert.Single(tryBody.Blocks[0].Children.OfType<Return>());
+        Assert.IsType<LoadArgument>(ret.Value);
+        function.CheckInvariant();
+    }
+
+    // Escaping load: the accumulator's value is also read inside the finally, so
+    // sinking the store would leave that read bound to an undefined local. The
+    // non-return load must keep the whole candidate standing.
+    [Fact]
+    public void NonReturnLoadInFinally_StaysAccumulator()
+    {
+        var tryBody = Container(Block(new StoreLocal(0, Int32, new LoadArgument(0, "x", Int32))));
+        var finallyBody = Container(Block(Use(new LoadLocal(0, Int32))));
+        var entry = Block(new TryFinally(tryBody, finallyBody), new Return(new LoadLocal(0, Int32)));
+        var function = Function(Container(entry), Int32);
+
+        new ReturnSinkingPass().Run(function, PassContext.None);
+
+        Assert.Equal(1, StoreCount(function, 0));
+        var ret = Assert.Single(entry.Children.OfType<Return>());
+        Assert.IsType<LoadLocal>(ret.Value);
+        function.CheckInvariant();
+    }
+
+    // Partial consumption: a second, non-tail store of the same local cannot be
+    // folded, so the plan does not consume every store and must decline rather
+    // than sink only the adjacent one (which would strand the other store).
+    [Fact]
+    public void UnconsumedSecondStore_StaysAccumulator()
+    {
+        var entry = Block(
+            new StoreLocal(0, Int32, new Constant(1, Int32)),
+            Use(new Constant(null, Object)),
+            new StoreLocal(0, Int32, new LoadArgument(0, "x", Int32)),
+            new Return(new LoadLocal(0, Int32)));
+        var function = Function(Container(entry), Int32);
+
+        new ReturnSinkingPass().Run(function, PassContext.None);
+
+        Assert.Equal(2, StoreCount(function, 0));
+        var ret = Assert.Single(entry.Children.OfType<Return>());
+        Assert.IsType<LoadLocal>(ret.Value);
+        function.CheckInvariant();
+    }
+
+    // Address-taken: the accumulator's address escapes into the finally, so the
+    // store is not safely removable even though every load is a return.
+    [Fact]
+    public void AddressTakenLocal_StaysAccumulator()
+    {
+        var tryBody = Container(Block(new StoreLocal(0, Int32, new LoadArgument(0, "x", Int32))));
+        var finallyBody = Container(Block(Use(new LoadLocalAddress(0, Int32))));
+        var entry = Block(new TryFinally(tryBody, finallyBody), new Return(new LoadLocal(0, Int32)));
+        var function = Function(Container(entry), Int32);
+
+        new ReturnSinkingPass().Run(function, PassContext.None);
+
+        Assert.Equal(1, StoreCount(function, 0));
+        function.CheckInvariant();
+    }
+
+    // Branch-target store: a residual branch jumps to the block that holds the
+    // fold store, so rewriting that store into a return would change which code
+    // the branch reaches. The branch-target guard must keep it standing.
+    [Fact]
+    public void BranchTargetStoreBlock_StaysAccumulator()
+    {
+        const int targetOffset = 0x20;
+        var tryBody = Container(Block(targetOffset, new StoreLocal(0, Int32, new LoadArgument(0, "x", Int32))));
+        var finallyBody = Container(Block(new Branch(targetOffset)));
+        var entry = Block(new TryFinally(tryBody, finallyBody), new Return(new LoadLocal(0, Int32)));
+        var function = Function(Container(entry), Int32);
+
+        new ReturnSinkingPass().Run(function, PassContext.None);
+
+        Assert.Equal(1, StoreCount(function, 0));
+    }
+
+    // SwitchBranch present: a value-producing jump table elsewhere in the method
+    // means a switch expression's own accumulator may be in play, so the pass
+    // bails entirely rather than risk sinking it.
+    [Fact]
+    public void SwitchBranchInMethod_DisablesSinking()
+    {
+        var entry = Block(
+            new StoreLocal(0, Int32, new LoadArgument(0, "x", Int32)),
+            new Return(new LoadLocal(0, Int32)));
+        var dispatch = Block(new SwitchBranch(new LoadArgument(0, "x", Int32), ImmutableArray.Create(0x10)));
+        var function = Function(Container(entry, dispatch), Int32);
+
+        new ReturnSinkingPass().Run(function, PassContext.None);
+
+        Assert.Equal(1, StoreCount(function, 0));
+    }
+
+    // Switch statement tail: a trailing return after a switch statement whose
+    // arms store the accumulator must not be sunk into per-arm returns, because
+    // csc lowers switch expressions through their own result accumulator.
+    [Fact]
+    public void SwitchStatementArms_StayAccumulator()
+    {
+        var case0 = new SwitchSection(
+            ImmutableArray.Create(new Constant(0, Int32)),
+            isDefault: false,
+            Container(Block(new StoreLocal(0, Int32, new Constant(10, Int32)), new Break())));
+        var defaultSection = new SwitchSection(
+            ImmutableArray<Constant>.Empty,
+            isDefault: true,
+            Container(Block(new StoreLocal(0, Int32, new Constant(20, Int32)), new Break())));
+        var entry = Block(
+            new Switch(new LoadArgument(0, "x", Int32), [case0, defaultSection]),
+            new Return(new LoadLocal(0, Int32)));
+        var function = Function(Container(entry), Int32);
+
+        new ReturnSinkingPass().Run(function, PassContext.None);
+
+        Assert.Equal(2, StoreCount(function, 0));
+        var ret = Assert.Single(entry.Children.OfType<Return>());
+        Assert.IsType<LoadLocal>(ret.Value);
+    }
+
+    static Block Block(int startOffset, params IrNode[] statements)
+    {
+        var block = new Block(startOffset);
+        foreach (var statement in statements)
+            block.Add(statement);
+        return block;
+    }
+
+    static Block Block(params IrNode[] statements) => Block(0, statements);
 }


### PR DESCRIPTION
## Summary

Adds a pass-level **adversarial near-miss coverage packet** for `ReturnSinkingPass`, advancing row #1289 in the proof-visibility burndown (#1565). Test-only; no production change.

`ReturnSinkingPass` is sound by construction only when it consumes **every** store and **every** load of an accumulator local (all-or-nothing). The existing tests only covered the explicit-else bool-accumulator decline. This pins the remaining documented decline families and adds a positive control so the negatives cannot pass vacuously.

## What this proves

Each negative is the positive control's shape perturbed by exactly one feature, so a decline isolates the named guard:

| Fixture | Family | Discriminator |
| --- | --- | --- |
| `TryFinallyAccumulator_Sinks` | positive control | sinks the try-body store into a return |
| `NonReturnLoadInFinally_StaysAccumulator` | escaping load | a non-return load in the finally |
| `UnconsumedSecondStore_StaysAccumulator` | partial consumption | a second, non-tail store |
| `AddressTakenLocal_StaysAccumulator` | address-taken | `LoadLocalAddress` in the finally |
| `BranchTargetStoreBlock_StaysAccumulator` | branch-target store | a residual `Branch` into the fold-store block |
| `SwitchBranchInMethod_DisablesSinking` | value-table dispatch | a `SwitchBranch` elsewhere in the method |
| `SwitchStatementArms_StayAccumulator` | switch-statement tail | a `switch` statement before the trailing return |

If any "stays" fixture starts to sink, the all-or-nothing guarantee has regressed.

## Adversarial-discovery result

I first tried to **falsify** the invariant with each near-miss before locking it in. The pass correctly declines on all of them — no over-raise/miscompile found — so this lands as hardening coverage rather than a behavior fix.

## Evidence

- Build: clean.
- Focused: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ...ReturnSinkingPassTests` → **10/10 pass**.
- Fast subset (PR gate, `-notrait "Speed=Slow"`): **1355/1355 pass** (10.2s).
- IR invariants: fixtures call `function.CheckInvariant()` where the resulting tree is well-formed.
- No production code changed, so no quality-diff card / per-method delta applies. The slow compile-back/corpus suite stays nightly/manual per #1584; the local full run was CPU-starved by concurrent sibling suites and was not completed.
- No Markdown changed.

Closes #1289.
