### PR TITLE
Add rung 1 fixture and fast guard for decompiler product ladder (#1603)

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung1/ILInspector.Decompiler.Fixtures.LadderRung1.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung1/ILInspector.Decompiler.Fixtures.LadderRung1.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Rung 1 of the decompiler product quality ladder (#1599): Hello World / C# 1
+    core. A small, durable fixture covering the rung 1 constructs — methods,
+    locals, calls, fields, explicit and getter-only properties, and simple
+    if/else branches — that the rung 1 fast guard (LadderRung1GateTests) measures.
+
+    Referenced by the test project so the DLL is built and locatable via
+    typeof(LadderRung1.Program).Assembly.Location. Keep the shapes ordinary C# 1
+    core: this fixture is the scoped completion bar for rung 1, not a place to add
+    newer-language idioms.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Decompiler.Fixtures.LadderRung1/LadderRung1.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung1/LadderRung1.cs
@@ -1,0 +1,92 @@
+using System;
+
+namespace LadderRung1;
+
+// Rung 1 of the decompiler product quality ladder (#1599): Hello World / C# 1
+// core. Every member here is deliberately ordinary C# 1: methods, locals, calls,
+// fields, properties (explicit get/set and getter-only), and simple if/else
+// branches. LadderRung1GateTests decompiles this assembly and pins the rung 1
+// completion bar (all members import + render Full, fully raised with zero gaps,
+// zero malformed Full / semantic-binding defects, accessors included).
+public class Program
+{
+    int _count;
+
+    // Explicit get/set property backed by a field, with a setter branch.
+    public int Count
+    {
+        get
+        {
+            return _count;
+        }
+        set
+        {
+            if (value < 0)
+            {
+                _count = 0;
+                return;
+            }
+            _count = value;
+        }
+    }
+
+    // Getter-only property.
+    public string Prefix
+    {
+        get
+        {
+            return "Hello";
+        }
+    }
+
+    // Object construction, local assignment, field/property interaction, a call,
+    // Console.WriteLine, and a simple if/else branch.
+    public static void Main(string[] args)
+    {
+        Program program = new Program();
+        program.Count = args.Length;
+        string message = program.Greet("world");
+        if (program.IsPositive(program.Count))
+        {
+            Console.WriteLine(message);
+        }
+        else
+        {
+            Console.WriteLine(program.Prefix);
+        }
+    }
+
+    // String concatenation / call spelling, plus a field mutation.
+    public string Greet(string name)
+    {
+        string result = string.Concat(Prefix, ", ", name);
+        _count++;
+        return result;
+    }
+
+    // Multi-return branch classification.
+    public int Classify(int value)
+    {
+        if (value == 0)
+        {
+            return 0;
+        }
+        if (value < 3)
+        {
+            return 1;
+        }
+        return 2;
+    }
+
+    // Simple arithmetic.
+    public int Add(int left, int right)
+    {
+        return left + right;
+    }
+
+    // Boolean branch / result.
+    public bool IsPositive(int value)
+    {
+        return value > 0;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -28,6 +28,7 @@
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainA\ILInspector.Decompiler.Fixtures.UnsafeChainA.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainB\ILInspector.Decompiler.Fixtures.UnsafeChainB.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainC\ILInspector.Decompiler.Fixtures.UnsafeChainC.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung1\ILInspector.Decompiler.Fixtures.LadderRung1.csproj" />
   </ItemGroup>
 
   <!--
@@ -62,6 +63,10 @@
              Link="TypeSourceCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\TypeBindCheck.cs"
              Link="TypeBindCheck.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\ShellConstraints.cs"
+             Link="ShellConstraints.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\ValidityCheck.cs"
+             Link="ValidityCheck.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/ILInspector.Decompiler.Tests/LadderRung1GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1GateTests.cs
@@ -1,0 +1,100 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The rung 1 completion guard for the decompiler product quality ladder (#1599 /
+/// #1603): Hello World / C# 1 core. It decompiles the in-repo
+/// <see cref="LadderRung1.Program"/> fixture and pins the scoped rung 1 bar so a
+/// regression below it fails fast in PR CI:
+/// <list type="bullet">
+/// <item>every fixture member (including property accessors and the constructor)
+/// imports and renders as <c>Full</c>;</item>
+/// <item>every member is fully raised — <c>--gaps</c> sees zero residual control
+/// flow;</item>
+/// <item><c>--validity-check</c> sees zero malformed <c>Full</c> methods and zero
+/// non-noise semantic-binding defects.</item>
+/// </list>
+/// This is the depth-scoped completion bar for rung 1, deliberately fast (not a
+/// corpus sweep): compile-back opcode exactness is evidence elsewhere
+/// (<see cref="FidelityGateTests"/>), not the rung 1 bar — <c>IsPositive</c>
+/// recompiles its branch as <c>cgt</c> while still rendering valid C#.
+/// </summary>
+public class LadderRung1GateTests
+{
+    static string FixturePath => typeof(LadderRung1.Program).Assembly.Location;
+    static readonly string FixtureType = typeof(LadderRung1.Program).FullName!;
+
+    [Fact]
+    public void Rung1Fixture_AllMembersImportRenderFullAndFullyRaised()
+    {
+        var members = new List<(string Name, IrFunction Function)>();
+        using (var source = MetadataSource.Open(FixturePath))
+        {
+            foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+            {
+                if (typeName != FixtureType)
+                    continue;
+                IrPasses.Run(function);
+                members.Add((methodName, function));
+            }
+        }
+
+        Assert.NotEmpty(members);
+
+        // Property accessors must be included, not only ordinary method groups.
+        Assert.Contains(members, m => m.Name == "get_Count");
+        Assert.Contains(members, m => m.Name == "set_Count");
+        Assert.Contains(members, m => m.Name == "get_Prefix");
+
+        var notFull = members
+            .Where(m => m.Function.Fidelity != DecompilationFidelity.Full)
+            .Select(m => m.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(notFull.Length == 0,
+            "Rung 1 requires every fixture member to render Full; not Full: " + string.Join(", ", notFull));
+
+        var gaps = members
+            .Where(m => Completeness.Residual(m.Function) is not null)
+            .Select(m => m.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(gaps.Length == 0,
+            "Rung 1 requires every fixture member to be fully raised (zero residual gaps); gaps: " + string.Join(", ", gaps));
+    }
+
+    [Fact]
+    public void Rung1Fixture_HasNoMalformedOrSemanticDefects()
+    {
+        var results = ValidityCheck.Evaluate(FixturePath)
+            .Where(r => r.TypeName == FixtureType)
+            .ToList();
+
+        Assert.NotEmpty(results);
+
+        var malformed = results
+            .Where(r => r.IsFull && r.IsMalformed)
+            .Select(r => $"{r.MethodName}: {r.MalformedDiagnostics[0].Id} {r.MalformedDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(malformed.Length == 0,
+            "Rung 1 requires zero malformed Full methods; malformed: " + string.Join("; ", malformed));
+
+        var semantic = results
+            .Where(r => r.HasSemanticDefect)
+            .Select(r => $"{r.MethodName}: {r.SemanticDiagnostics[0].Id} {r.SemanticDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(semantic.Length == 0,
+            "Rung 1 requires zero semantic-binding defects; defects: " + string.Join("; ", semantic));
+
+        // Guard against a vacuous pass: every Full member must actually have been
+        // bound (not skipped by the cap), so the semantic assertion has teeth.
+        Assert.All(
+            results.Where(r => r.IsFull),
+            r => Assert.True(r.SemanticChecked, $"Full method {r.MethodName} was not semantically bound."));
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/LadderRung1GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1GateTests.cs
@@ -45,19 +45,23 @@ public class LadderRung1GateTests
     {
         var members = LoadRaisedMembers();
 
-        Assert.Equal(ExpectedMembers, members.Keys.Order(StringComparer.Ordinal).ToArray());
+        // Compare the full name list (duplicates included), so an added overload —
+        // which a name-keyed dictionary would silently collapse — also fails.
+        Assert.Equal(
+            ExpectedMembers,
+            members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
 
         var notFull = members
-            .Where(m => m.Value.Fidelity != DecompilationFidelity.Full)
-            .Select(m => m.Key)
+            .Where(m => m.Function.Fidelity != DecompilationFidelity.Full)
+            .Select(m => m.Name)
             .Order(StringComparer.Ordinal)
             .ToArray();
         Assert.True(notFull.Length == 0,
             "Rung 1 requires every fixture member to render Full; not Full: " + string.Join(", ", notFull));
 
         var gaps = members
-            .Where(m => Completeness.Residual(m.Value) is not null)
-            .Select(m => m.Key)
+            .Where(m => Completeness.Residual(m.Function) is not null)
+            .Select(m => m.Name)
             .Order(StringComparer.Ordinal)
             .ToArray();
         Assert.True(gaps.Length == 0,
@@ -68,7 +72,9 @@ public class LadderRung1GateTests
     public void Rung1Fixture_RendersRecognizableConstructs()
     {
         var members = LoadRaisedMembers();
-        string Body(string name) => CSharpPrinter.PrintRaised(members[name]).Output?.Trim() ?? "";
+        // Single() also fails loudly on an unexpected duplicate-named member.
+        string Body(string name) =>
+            CSharpPrinter.PrintRaised(members.Single(m => m.Name == name).Function).Output?.Trim() ?? "";
 
         // Exact small bodies: field reads/writes, literals, and arithmetic must
         // render verbatim. These catch intra-fixture member/field misrenders
@@ -138,16 +144,16 @@ public class LadderRung1GateTests
             r => Assert.True(r.SemanticChecked, $"Full method {r.MethodName} was not semantically bound."));
     }
 
-    static Dictionary<string, IrFunction> LoadRaisedMembers()
+    static List<(string Name, IrFunction Function)> LoadRaisedMembers()
     {
-        var members = new Dictionary<string, IrFunction>(StringComparer.Ordinal);
+        var members = new List<(string Name, IrFunction Function)>();
         using var source = MetadataSource.Open(FixturePath);
         foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
         {
             if (typeName != FixtureType)
                 continue;
             IrPasses.Run(function);
-            members[methodName] = function;
+            members.Add((methodName, function));
         }
         return members;
     }

--- a/src/ILInspector.Decompiler.Tests/LadderRung1GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1GateTests.cs
@@ -10,10 +10,14 @@ namespace ILInspector.Decompiler.Tests;
 /// <see cref="LadderRung1.Program"/> fixture and pins the scoped rung 1 bar so a
 /// regression below it fails fast in PR CI:
 /// <list type="bullet">
-/// <item>every fixture member (including property accessors and the constructor)
-/// imports and renders as <c>Full</c>;</item>
+/// <item>the fixture exposes exactly the rung 1 member set (incl. property
+/// accessors and the constructor) — no construct is silently dropped;</item>
+/// <item>every member imports and renders as <c>Full</c>;</item>
 /// <item>every member is fully raised — <c>--gaps</c> sees zero residual control
 /// flow;</item>
+/// <item>the rendered C# is recognizable for the rung 1 constructs (fields,
+/// property/method calls, branches) — this catches intra-fixture misrenders that
+/// the validity shell filters as member-resolution noise;</item>
 /// <item><c>--validity-check</c> sees zero malformed <c>Full</c> methods and zero
 /// non-noise semantic-binding defects.</item>
 /// </list>
@@ -27,43 +31,79 @@ public class LadderRung1GateTests
     static string FixturePath => typeof(LadderRung1.Program).Assembly.Location;
     static readonly string FixtureType = typeof(LadderRung1.Program).FullName!;
 
+    // The exact rung 1 construct set. Locked so a future fixture edit that drops a
+    // construct (e.g. removing the multi-return Classify, or an accessor) fails
+    // loudly instead of silently shrinking the measured scope.
+    static readonly string[] ExpectedMembers =
+    [
+        ".ctor", "Add", "Classify", "Greet", "IsPositive", "Main",
+        "get_Count", "get_Prefix", "set_Count",
+    ];
+
     [Fact]
-    public void Rung1Fixture_AllMembersImportRenderFullAndFullyRaised()
+    public void Rung1Fixture_ExposesExactMemberSet_AllFullAndFullyRaised()
     {
-        var members = new List<(string Name, IrFunction Function)>();
-        using (var source = MetadataSource.Open(FixturePath))
-        {
-            foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
-            {
-                if (typeName != FixtureType)
-                    continue;
-                IrPasses.Run(function);
-                members.Add((methodName, function));
-            }
-        }
+        var members = LoadRaisedMembers();
 
-        Assert.NotEmpty(members);
-
-        // Property accessors must be included, not only ordinary method groups.
-        Assert.Contains(members, m => m.Name == "get_Count");
-        Assert.Contains(members, m => m.Name == "set_Count");
-        Assert.Contains(members, m => m.Name == "get_Prefix");
+        Assert.Equal(ExpectedMembers, members.Keys.Order(StringComparer.Ordinal).ToArray());
 
         var notFull = members
-            .Where(m => m.Function.Fidelity != DecompilationFidelity.Full)
-            .Select(m => m.Name)
+            .Where(m => m.Value.Fidelity != DecompilationFidelity.Full)
+            .Select(m => m.Key)
             .Order(StringComparer.Ordinal)
             .ToArray();
         Assert.True(notFull.Length == 0,
             "Rung 1 requires every fixture member to render Full; not Full: " + string.Join(", ", notFull));
 
         var gaps = members
-            .Where(m => Completeness.Residual(m.Function) is not null)
-            .Select(m => m.Name)
+            .Where(m => Completeness.Residual(m.Value) is not null)
+            .Select(m => m.Key)
             .Order(StringComparer.Ordinal)
             .ToArray();
         Assert.True(gaps.Length == 0,
             "Rung 1 requires every fixture member to be fully raised (zero residual gaps); gaps: " + string.Join(", ", gaps));
+    }
+
+    [Fact]
+    public void Rung1Fixture_RendersRecognizableConstructs()
+    {
+        var members = LoadRaisedMembers();
+        string Body(string name) => CSharpPrinter.PrintRaised(members[name]).Output?.Trim() ?? "";
+
+        // Exact small bodies: field reads/writes, literals, and arithmetic must
+        // render verbatim. These catch intra-fixture member/field misrenders
+        // (e.g. `_count` -> `_count_BROKEN`) that ValidityCheck's external shell
+        // filters as CS0103/CS1061 member-resolution noise.
+        Assert.Equal("return _count;", Body("get_Count"));
+        Assert.Equal("return \"Hello\";", Body("get_Prefix"));
+        Assert.Equal("return left + right;", Body("Add"));
+        Assert.Equal("return value > 0;", Body("IsPositive"));
+
+        // Setter branch writes the backing field on both arms.
+        var setCount = Body("set_Count");
+        Assert.Contains("if (value < 0)", setCount);
+        Assert.Contains("_count = 0;", setCount);
+        Assert.Contains("_count = value;", setCount);
+
+        // String concat / call spelling reads the getter-only property and mutates
+        // the field.
+        var greet = Body("Greet");
+        Assert.Contains("string.Concat(Prefix, \", \", name)", greet);
+        Assert.Contains("_count++;", greet);
+
+        // Multi-return branch classification.
+        var classify = Body("Classify");
+        Assert.Contains("if (value == 0)", classify);
+        Assert.Contains("if (value < 3)", classify);
+        Assert.Contains("return 0;", classify);
+        Assert.Contains("return 2;", classify);
+
+        // Object construction, property/method calls, Console.WriteLine, branch.
+        var main = Body("Main");
+        Assert.Contains("new Program()", main);
+        Assert.Contains("program.Greet(\"world\")", main);
+        Assert.Contains("program.IsPositive(program.Count)", main);
+        Assert.Contains("Console.WriteLine(", main);
     }
 
     [Fact]
@@ -96,5 +136,19 @@ public class LadderRung1GateTests
         Assert.All(
             results.Where(r => r.IsFull),
             r => Assert.True(r.SemanticChecked, $"Full method {r.MethodName} was not semantically bound."));
+    }
+
+    static Dictionary<string, IrFunction> LoadRaisedMembers()
+    {
+        var members = new Dictionary<string, IrFunction>(StringComparer.Ordinal);
+        using var source = MetadataSource.Open(FixturePath);
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (typeName != FixtureType)
+                continue;
+            IrPasses.Run(function);
+            members[methodName] = function;
+        }
+        return members;
     }
 }


### PR DESCRIPTION
Closes #1603. Advances #1599 rung 1 (Decompiler product quality ladder) — the first implementation queue item per the #1568 rollup.

## What

#1599 rung 1 (Hello World / C# 1 core) measured green on main but had **no durable fast PR guard**, so rung 1 could not be marked complete. This adds the missing fixture + guard.

- **New fixture assembly** `ILInspector.Decompiler.Fixtures.LadderRung1` with `LadderRung1.Program`, covering the rung 1 constructs from the issue: a `Main` (object construction, locals, a call, `Console.WriteLine`, if/else), an explicit `Count` get/set property (field-backed, with a setter branch), a getter-only `Prefix`, `Greet` (string concat/call spelling + field mutation), `Classify` (multi-return branch), `Add` (arithmetic), `IsPositive` (boolean branch).
- **`LadderRung1GateTests`** (3 tests) decompiles the fixture and pins the scoped rung 1 bar:
  - the fixture exposes the **exact** rung 1 member set (`.ctor, Add, Classify, Greet, IsPositive, Main, get_Count, get_Prefix, set_Count`) — dropping a construct fails loudly;
  - every member imports and renders `Full`;
  - every member is fully raised (`Completeness.Residual` is null → zero `--gaps`);
  - the rendered C# is **recognizable** — exact bodies for the trivial members (`return _count;`, `return "Hello";`, …) plus targeted substrings for the field writes, `string.Concat` call spelling, branches, and `Main`'s construction/calls;
  - zero malformed `Full` and zero non-noise semantic-binding defects (via the canonical `ValidityCheck`), with a vacuity guard that every `Full` member was actually bound.
- **Reuse over reimplementation:** linked `ValidityCheck.cs` + `ShellConstraints.cs` into the test project, mirroring the already-linked `FidelityCheck.cs` pattern, so the guard uses the same `--validity-check` logic the harness uses.

## Scope discipline

Compile-back opcode exactness is **not** the rung 1 bar (per the issue): `IsPositive` recompiles its branch as `cgt` while still rendering valid, recognizable C#. Fidelity exactness stays in `FidelityGateTests`. The guard is fast (not `Speed=Slow`) and runs in PR CI.

## Validation

- `dotnet build src/ILInspector.Decompiler.Tests -c Release` — clean (fixture builds transitively via ProjectReference; linked sources compile).
- `LadderRung1GateTests` — 3 passed (<1s).
- Probe (reverted) confirmed the guard sees the exact issue measurement: **9 members** (`.ctor, Add, Classify, Greet, IsPositive, Main, get_Count, get_Prefix, set_Count`), **9/9 Full, 9/9 fully raised**, all semantically bound.
- Fast decompiler subset (`-notrait Speed=Slow`) — 1370 total, 0 failed.
- Branch is current with `origin/main` (includes the #1601 registry fix, so the prior unrelated red is gone).

## Follow-up

On merge, #1599 rung 1 can be marked complete with the guard path `src/ILInspector.Decompiler.Tests/LadderRung1GateTests.cs` (commented on #1599), unless a re-measure exposes a new blocker.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
