### PR TITLE
Fix analysis pseudo-exception hotspot suppression

### DIFF
--- a/src/ILInspector.Analysis.ExceptionBaseFixtures/ExternalFixtureException.cs
+++ b/src/ILInspector.Analysis.ExceptionBaseFixtures/ExternalFixtureException.cs
@@ -1,0 +1,8 @@
+namespace ILInspector.Analysis.ExceptionBaseFixtures;
+
+public class ExternalFixtureException : Exception
+{
+    public ExternalFixtureException(string message) : base(message)
+    {
+    }
+}

--- a/src/ILInspector.Analysis.ExceptionBaseFixtures/ILInspector.Analysis.ExceptionBaseFixtures.csproj
+++ b/src/ILInspector.Analysis.ExceptionBaseFixtures/ILInspector.Analysis.ExceptionBaseFixtures.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Analysis.ExceptionBaseFixtures\ILInspector.Analysis.ExceptionBaseFixtures.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis.LookalikeFixtures\ILInspector.Analysis.LookalikeFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
   </ItemGroup>

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -645,6 +645,40 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_PseudoExceptionAllocations_AreAllocationHotspot()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+
+        var method = Assert.Single(index.Methods.Where(m =>
+            m.Name == nameof(OptimizationOpportunityFixtures.AllocatesManyPseudoExceptions)));
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
+        Assert.True(s.Allocations >= 8, $"expected >= 8 allocations, got {s.Allocations}");
+
+        var row = Assert.Single(HotspotRows(index, nameof(OptimizationOpportunityFixtures.AllocatesManyPseudoExceptions)));
+        Assert.Equal("medium", row.Confidence);
+        Assert.False(row.InLoop);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_PlainObjectAllocations_RemainAllocationHotspot()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var row = Assert.Single(HotspotRows(index, nameof(OptimizationOpportunityFixtures.AllocatesManyPlainObjects)));
+        Assert.Equal("medium", row.Confidence);
+        Assert.False(row.InLoop);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_CustomExceptionThrowArms_AreNotHotspot()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.ManyCustomThrowArms)));
+    }
+
+    [Fact]
     public void OptimizationOpportunities_BoxIntoObjectApi_IsBoxValueType()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -1141,6 +1175,47 @@ public class OptimizationOpportunityFixtures
         }
     }
 
+    public static int AllocatesManyPseudoExceptions()
+    {
+        var a0 = new PseudoException(0);
+        var a1 = new PseudoException(1);
+        var a2 = new PseudoException(2);
+        var a3 = new PseudoException(3);
+        var a4 = new PseudoException(4);
+        var a5 = new PseudoException(5);
+        var a6 = new PseudoException(6);
+        var a7 = new PseudoException(7);
+        return a0.Value + a1.Value + a2.Value + a3.Value + a4.Value + a5.Value + a6.Value + a7.Value;
+    }
+
+    public static int AllocatesManyPlainObjects()
+    {
+        var a0 = new PlainObject(0);
+        var a1 = new PlainObject(1);
+        var a2 = new PlainObject(2);
+        var a3 = new PlainObject(3);
+        var a4 = new PlainObject(4);
+        var a5 = new PlainObject(5);
+        var a6 = new PlainObject(6);
+        var a7 = new PlainObject(7);
+        return a0.Value + a1.Value + a2.Value + a3.Value + a4.Value + a5.Value + a6.Value + a7.Value;
+    }
+
+    public static void ManyCustomThrowArms(int code)
+    {
+        switch (code)
+        {
+            case 0: throw new FixtureException("0");
+            case 1: throw new FixtureException("1");
+            case 2: throw new FixtureException("2");
+            case 3: throw new FixtureException("3");
+            case 4: throw new FixtureException("4");
+            case 5: throw new FixtureException("5");
+            case 6: throw new FixtureException("6");
+            case 7: throw new FixtureException("7");
+        }
+    }
+
     // A single steady-state allocation inside a loop, below the hotspot threshold and
     // matching no specific shape, so it surfaces NO opportunity row. It still allocates
     // in a loop, so MethodSignals.AllocInLoop must be true (the loop bit is independent
@@ -1164,6 +1239,27 @@ public class OptimizationOpportunityFixtures
             if (i < 0)
                 throw new System.InvalidOperationException("never");
         }
+    }
+}
+
+public sealed class PseudoException
+{
+    public PseudoException(int value) => Value = value;
+
+    public int Value { get; }
+}
+
+public sealed class PlainObject
+{
+    public PlainObject(int value) => Value = value;
+
+    public int Value { get; }
+}
+
+public sealed class FixtureException : Exception
+{
+    public FixtureException(string message) : base(message)
+    {
     }
 }
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -726,6 +726,7 @@ public class LibraryBodyIndexTests
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 
         Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.ManyCustomThrowArms)));
+        Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.ManyDerivedCustomThrowArms)));
     }
 
     [Fact]
@@ -1266,6 +1267,21 @@ public class OptimizationOpportunityFixtures
         }
     }
 
+    public static void ManyDerivedCustomThrowArms(int code)
+    {
+        switch (code)
+        {
+            case 0: throw new DerivedFixtureException("0");
+            case 1: throw new DerivedFixtureException("1");
+            case 2: throw new DerivedFixtureException("2");
+            case 3: throw new DerivedFixtureException("3");
+            case 4: throw new DerivedFixtureException("4");
+            case 5: throw new DerivedFixtureException("5");
+            case 6: throw new DerivedFixtureException("6");
+            case 7: throw new DerivedFixtureException("7");
+        }
+    }
+
     // A single steady-state allocation inside a loop, below the hotspot threshold and
     // matching no specific shape, so it surfaces NO opportunity row. It still allocates
     // in a loop, so MethodSignals.AllocInLoop must be true (the loop bit is independent
@@ -1309,6 +1325,13 @@ public sealed class PlainObject
 public sealed class FixtureException : Exception
 {
     public FixtureException(string message) : base(message)
+    {
+    }
+}
+
+public sealed class DerivedFixtureException : InvalidOperationException
+{
+    public DerivedFixtureException(string message) : base(message)
     {
     }
 }

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -727,6 +727,7 @@ public class LibraryBodyIndexTests
 
         Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.ManyCustomThrowArms)));
         Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.ManyDerivedCustomThrowArms)));
+        Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.ManyCrossAssemblyCustomThrowArms)));
     }
 
     [Fact]
@@ -1282,6 +1283,21 @@ public class OptimizationOpportunityFixtures
         }
     }
 
+    public static void ManyCrossAssemblyCustomThrowArms(int code)
+    {
+        switch (code)
+        {
+            case 0: throw new CrossAssemblyDerivedFixtureException("0");
+            case 1: throw new CrossAssemblyDerivedFixtureException("1");
+            case 2: throw new CrossAssemblyDerivedFixtureException("2");
+            case 3: throw new CrossAssemblyDerivedFixtureException("3");
+            case 4: throw new CrossAssemblyDerivedFixtureException("4");
+            case 5: throw new CrossAssemblyDerivedFixtureException("5");
+            case 6: throw new CrossAssemblyDerivedFixtureException("6");
+            case 7: throw new CrossAssemblyDerivedFixtureException("7");
+        }
+    }
+
     // A single steady-state allocation inside a loop, below the hotspot threshold and
     // matching no specific shape, so it surfaces NO opportunity row. It still allocates
     // in a loop, so MethodSignals.AllocInLoop must be true (the loop bit is independent
@@ -1332,6 +1348,13 @@ public sealed class FixtureException : Exception
 public sealed class DerivedFixtureException : InvalidOperationException
 {
     public DerivedFixtureException(string message) : base(message)
+    {
+    }
+}
+
+public sealed class CrossAssemblyDerivedFixtureException : ExceptionBaseFixtures.ExternalFixtureException
+{
+    public CrossAssemblyDerivedFixtureException(string message) : base(message)
     {
     }
 }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -787,14 +787,8 @@ public sealed class LibraryBodyIndex
         bool IsExceptionReference(TypeReferenceHandle handle)
         {
             var type = TypeRefDecoder.Instance.GetTypeFromReference(_reader, handle, 0);
-            return IsFrameworkAssembly(type.Assembly)
-                && type.Name.EndsWith("Exception", StringComparison.Ordinal);
+            return type.Name.EndsWith("Exception", StringComparison.Ordinal);
         }
-
-        static bool IsFrameworkAssembly(string assembly)
-            => assembly == TypeRef.CoreLibrary
-                || assembly == "System"
-                || assembly.StartsWith("System.", StringComparison.Ordinal);
 
         MethodIdentity CreateMethodIdentity(TypeDefinitionHandle typeHandle, MethodDefinitionHandle methodHandle, MethodDefinition methodDef, GenericScope scope)
         {

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -776,7 +776,7 @@ public sealed class LibraryBodyIndex
             }
             bool result = baseHandle.Kind switch
             {
-                HandleKind.TypeReference => IsSystemExceptionReference(MetadataTokens.TypeReferenceHandle(MetadataTokens.GetRowNumber(baseHandle))),
+                HandleKind.TypeReference => IsExceptionReference(MetadataTokens.TypeReferenceHandle(MetadataTokens.GetRowNumber(baseHandle))),
                 HandleKind.TypeDefinition => IsExceptionTypeDefinition(MetadataTokens.TypeDefinitionHandle(MetadataTokens.GetRowNumber(baseHandle)), cache),
                 _ => false,
             };
@@ -784,12 +784,17 @@ public sealed class LibraryBodyIndex
             return result;
         }
 
-        bool IsSystemExceptionReference(TypeReferenceHandle handle)
+        bool IsExceptionReference(TypeReferenceHandle handle)
         {
-            var typeRef = _reader.GetTypeReference(handle);
-            return _reader.GetString(typeRef.Namespace) == "System"
-                && _reader.GetString(typeRef.Name) == "Exception";
+            var type = TypeRefDecoder.Instance.GetTypeFromReference(_reader, handle, 0);
+            return IsFrameworkAssembly(type.Assembly)
+                && type.Name.EndsWith("Exception", StringComparison.Ordinal);
         }
+
+        static bool IsFrameworkAssembly(string assembly)
+            => assembly == TypeRef.CoreLibrary
+                || assembly == "System"
+                || assembly.StartsWith("System.", StringComparison.Ordinal);
 
         MethodIdentity CreateMethodIdentity(TypeDefinitionHandle typeHandle, MethodDefinitionHandle methodHandle, MethodDefinition methodDef, GenericScope scope)
         {

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -20,7 +20,8 @@ public sealed class LibraryBodyIndex
         bool memorySafetyRulesEnabled,
         UnsafeModeBreakdown unsafeModes,
         IReadOnlyDictionary<int, BodySignals> bodySignals,
-        IReadOnlySet<int> suppressedOpportunityTokens)
+        IReadOnlySet<int> suppressedOpportunityTokens,
+        IReadOnlySet<string> exceptionTypeNames)
     {
         Path = path;
         Methods = methods;
@@ -32,6 +33,7 @@ public sealed class LibraryBodyIndex
         UnsafeModes = unsafeModes;
         _bodySignals = bodySignals;
         _suppressedOpportunityTokens = suppressedOpportunityTokens;
+        _exceptionTypeNames = exceptionTypeNames;
     }
 
     public string Path { get; }
@@ -71,6 +73,17 @@ public sealed class LibraryBodyIndex
         }
     }
 
+    bool IsExceptionConstruction(TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+        if (_exceptionTypeNames.Contains(definition.ToQualifiedDisplayString()))
+            return true;
+        if (Methods.Length > 0
+            && definition.Assembly == Methods[0].AssemblyName)
+            return false;
+        return definition.Name.EndsWith("Exception", StringComparison.Ordinal);
+    }
+
     // Methods that allocate heavily but match no specific rewrite shape are the most
     // commonly-missed real perf issues (e.g. a number parser doing many small allocations).
     // The steady-state allocation count is itself a file-able signal — "reduce allocations in
@@ -95,7 +108,7 @@ public sealed class LibraryBodyIndex
             if (call.Kind != CallKind.NewObject)
                 continue;
             if (call.Callee.Kind != MemberKind.Unsupported
-                && call.Callee.DeclaringType.Name.EndsWith("Exception", StringComparison.Ordinal))
+                && IsExceptionConstruction(call.Callee.DeclaringType))
                 continue;
             int token = call.Caller.MetadataToken;
             steadyNewobj[token] = steadyNewobj.GetValueOrDefault(token) + 1;
@@ -138,6 +151,7 @@ public sealed class LibraryBodyIndex
     Dictionary<int, MethodSignals>? _signals;
     readonly IReadOnlyDictionary<int, BodySignals> _bodySignals;
     readonly IReadOnlySet<int> _suppressedOpportunityTokens;
+    readonly IReadOnlySet<string> _exceptionTypeNames;
 
     /// <summary>
     /// Per-method analysis signals (allocations, copies, unsafe, reflection,
@@ -266,7 +280,7 @@ public sealed class LibraryBodyIndex
         return new LibraryBodyIndex(
             path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
             index.OptimizationOpportunities, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
-            index.BodySignals, index.SuppressedOpportunityTokens);
+            index.BodySignals, index.SuppressedOpportunityTokens, index.ExceptionTypeNames);
     }
 
     public ImmutableArray<DirectCall> FindCalls(MemberPattern pattern)
@@ -665,7 +679,7 @@ public sealed class LibraryBodyIndex
                 && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
         }
 
-        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlySet<int> SuppressedOpportunityTokens) Build()
+        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames) Build()
         {
             var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var calls = ImmutableArray.CreateBuilder<DirectCall>();
@@ -674,6 +688,7 @@ public sealed class LibraryBodyIndex
             var optimizationOpportunities = ImmutableArray.CreateBuilder<OptimizationOpportunity>();
             var bodySignals = new Dictionary<int, BodySignals>();
             var suppressedOpportunityTokens = new HashSet<int>();
+            var exceptionTypeNames = ComputeExceptionTypeNames();
             int none = 0, impl = 0, expl = 0;
 
             foreach (var typeHandle in _reader.TypeDefinitions)
@@ -733,7 +748,47 @@ public sealed class LibraryBodyIndex
             }
 
             return (methods.ToImmutable(), calls.ToImmutable(), unsafeEvidence.ToImmutable(), diagnostics.ToImmutable(),
-                optimizationOpportunities.ToImmutable(), new UnsafeModeBreakdown(none, impl, expl), bodySignals, suppressedOpportunityTokens);
+                optimizationOpportunities.ToImmutable(), new UnsafeModeBreakdown(none, impl, expl), bodySignals, suppressedOpportunityTokens, exceptionTypeNames);
+        }
+
+        IReadOnlySet<string> ComputeExceptionTypeNames()
+        {
+            var cache = new Dictionary<TypeDefinitionHandle, bool>();
+            var names = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var typeHandle in _reader.TypeDefinitions)
+            {
+                if (IsExceptionTypeDefinition(typeHandle, cache))
+                    names.Add(TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, typeHandle, 0).ToQualifiedDisplayString());
+            }
+            return names;
+        }
+
+        bool IsExceptionTypeDefinition(TypeDefinitionHandle typeHandle, Dictionary<TypeDefinitionHandle, bool> cache)
+        {
+            if (cache.TryGetValue(typeHandle, out bool cached))
+                return cached;
+
+            var baseHandle = _reader.GetTypeDefinition(typeHandle).BaseType;
+            if (baseHandle.IsNil)
+            {
+                cache[typeHandle] = false;
+                return false;
+            }
+            bool result = baseHandle.Kind switch
+            {
+                HandleKind.TypeReference => IsSystemExceptionReference(MetadataTokens.TypeReferenceHandle(MetadataTokens.GetRowNumber(baseHandle))),
+                HandleKind.TypeDefinition => IsExceptionTypeDefinition(MetadataTokens.TypeDefinitionHandle(MetadataTokens.GetRowNumber(baseHandle)), cache),
+                _ => false,
+            };
+            cache[typeHandle] = result;
+            return result;
+        }
+
+        bool IsSystemExceptionReference(TypeReferenceHandle handle)
+        {
+            var typeRef = _reader.GetTypeReference(handle);
+            return _reader.GetString(typeRef.Namespace) == "System"
+                && _reader.GetString(typeRef.Name) == "Exception";
         }
 
         MethodIdentity CreateMethodIdentity(TypeDefinitionHandle typeHandle, MethodDefinitionHandle methodHandle, MethodDefinition methodDef, GenericScope scope)


### PR DESCRIPTION
## Summary

Fixes #1588 by classifying exception construction for `allocation-hotspot` suppression using in-assembly inheritance evidence instead of a raw `*Exception` constructed-type suffix.

- In-assembly non-exception `PseudoException` allocations now contribute to `allocation-hotspot`.
- Real exception construction remains excluded for framework exceptions, direct custom exceptions, derived custom exceptions, and custom exceptions whose base lives in another assembly.
- External constructed types keep the existing conservative `*Exception` fallback because cross-assembly base resolution remains out of scope for `ILInspector.Analysis`.

## Evidence

```text
PseudoException alloc-signal=8 hotspots=1
PlainObject alloc-signal=8 hotspots=1
ManyThrowArms hotspots=0
ManyCustomThrowArms hotspots=0
ManyDerivedCustomThrowArms hotspots=0
ManyCrossAssemblyCustomThrowArms hotspots=0
```

Validation:

```text
dotnet run --project src/ILInspector.Analysis.Tests -c Release
ILInspector.Analysis.Tests  Total: 103, Errors: 0, Failed: 0, Skipped: 0

dotnet build src/dotnet-inspect -c Release
Build succeeded. 0 Warning(s), 0 Error(s)
```

Adversarial review: Opus 4.8 found two classifier gaps during review (framework exception subclass bases and first-party cross-assembly exception bases). Both were fixed with canaries. Final Opus 4.8 review found no high-confidence issues.
