### PR TITLE
Render non-finite float constants as valid C#

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2625,6 +2625,36 @@ public class CfgSampleClass
         return double.PositiveInfinity;
     }
 
+    public static double DoubleNegativeInfinity()
+    {
+        return double.NegativeInfinity;
+    }
+
+    public static float FloatNaN()
+    {
+        return float.NaN;
+    }
+
+    public static float FloatPositiveInfinity()
+    {
+        return float.PositiveInfinity;
+    }
+
+    public static float FloatNegativeInfinity()
+    {
+        return float.NegativeInfinity;
+    }
+
+    public static bool DoubleNaNComparison(double x)
+    {
+        return x == double.NaN;
+    }
+
+    public static double DoublePositiveInfinityAdd(double x)
+    {
+        return x + double.PositiveInfinity;
+    }
+
     public static int? NullableReturn(bool flag)
     {
         if (flag) return 42;

--- a/src/ILInspector.Decompiler.Tests/NonFiniteConstantPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NonFiniteConstantPrinterTests.cs
@@ -1,0 +1,148 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class NonFiniteConstantPrinterTests
+{
+    static readonly TypeRef Double = TypeRef.CoreLib("System", "Double");
+    static readonly TypeRef Single = TypeRef.CoreLib("System", "Single");
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+
+    [Fact]
+    public void NonFiniteFloatAndDoubleConstants_RenderAsFrameworkConstants_AndCompile()
+    {
+        AssertRenderAndCompile(Double, new Constant(double.NaN, Double), "public static double M()", "return double.NaN;");
+        AssertRenderAndCompile(Double, new Constant(double.PositiveInfinity, Double), "public static double M()", "return double.PositiveInfinity;");
+        AssertRenderAndCompile(Double, new Constant(double.NegativeInfinity, Double), "public static double M()", "return double.NegativeInfinity;");
+        AssertRenderAndCompile(Single, new Constant(float.NaN, Single), "public static float M()", "return float.NaN;");
+        AssertRenderAndCompile(Single, new Constant(float.PositiveInfinity, Single), "public static float M()", "return float.PositiveInfinity;");
+        AssertRenderAndCompile(Single, new Constant(float.NegativeInfinity, Single), "public static float M()", "return float.NegativeInfinity;");
+    }
+
+    [Fact]
+    public void ImportedNonFiniteFloatAndDoubleConstants_RenderAsFrameworkConstants_AndCompile()
+    {
+        AssertImportedFixture(nameof(CfgSampleClass.DoubleNaN), "public static double M()", "return double.NaN;");
+        AssertImportedFixture(nameof(CfgSampleClass.DoublePositiveInfinity), "public static double M()", "return double.PositiveInfinity;");
+        AssertImportedFixture(nameof(CfgSampleClass.DoubleNegativeInfinity), "public static double M()", "return double.NegativeInfinity;");
+        AssertImportedFixture(nameof(CfgSampleClass.FloatNaN), "public static float M()", "return float.NaN;");
+        AssertImportedFixture(nameof(CfgSampleClass.FloatPositiveInfinity), "public static float M()", "return float.PositiveInfinity;");
+        AssertImportedFixture(nameof(CfgSampleClass.FloatNegativeInfinity), "public static float M()", "return float.NegativeInfinity;");
+        AssertImportedFixture(nameof(CfgSampleClass.DoubleNaNComparison), "public static bool M(double x)", "return x == double.NaN;");
+        AssertImportedFixture(nameof(CfgSampleClass.DoublePositiveInfinityAdd), "public static double M(double x)", "return x + double.PositiveInfinity;");
+    }
+
+    [Fact]
+    public void InlineNonFiniteFloatAndDoubleConstants_RenderAsFrameworkConstants_AndCompile()
+    {
+        AssertRenderAndCompile(
+            Bool,
+            new Comparison(ComparisonKind.Equal, isUnsigned: false, new LoadArgument(0, "x", Double), new Constant(double.NaN, Double)),
+            "public static bool M(double x)",
+            "return x == double.NaN;",
+            new Parameter("x", Double));
+
+        AssertRenderAndCompile(
+            Double,
+            new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadArgument(0, "x", Double), new Constant(double.PositiveInfinity, Double)),
+            "public static double M(double x)",
+            "return x + double.PositiveInfinity;",
+            new Parameter("x", Double));
+    }
+
+    [Fact]
+    public void FiniteFloatAndDoubleConstants_KeepLiteralSpelling_AndCompile()
+    {
+        AssertRenderAndCompile(Double, new Constant(double.MaxValue, Double), "public static double M()", "return 1.7976931348623157E+308d;");
+        AssertRenderAndCompile(Single, new Constant(float.MaxValue, Single), "public static float M()", "return 3.4028235E+38f;");
+        AssertRenderAndCompile(Single, new Constant(-0.0f, Single), "public static float M()", "return -0f;");
+        AssertRenderAndCompile(Double, new Constant(1.5d, Double), "public static double M()", "return 1.5d;");
+    }
+
+    static void AssertRenderAndCompile(TypeRef returnType, IrExpression expression, string methodHeader, string expected, params Parameter[] parameters)
+    {
+        string body = Render(returnType, expression, parameters.ToImmutableArray()).Trim();
+        AssertBodyAndCompile(methodHeader, expected, body);
+    }
+
+    static void AssertImportedFixture(string methodName, string methodHeader, string expected)
+    {
+        string body = RenderFixture(methodName).Trim();
+        AssertBodyAndCompile(methodHeader, expected, body);
+    }
+
+    static void AssertBodyAndCompile(string methodHeader, string expected, string body)
+    {
+        Assert.Equal(expected, body);
+
+        var errors = Recompile(methodHeader, body)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToArray();
+        Assert.True(errors.Length == 0, "Rendered body must compile, got:\n  " + string.Join("\n  ", errors) + "\n--- body ---\n" + body);
+    }
+
+    static string RenderFixture(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
+        Assert.NotNull(result.Output);
+        return result.Output!;
+    }
+
+    static string Render(TypeRef returnType, IrExpression expression, ImmutableArray<Parameter> parameters)
+    {
+        var block = new Block(0);
+        block.Add(new Return(expression));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "", "T"),
+            new MethodSignature(returnType, parameters, HasThis: false, GenericParameterCount: 0),
+            ImmutableArray<TypeRef>.Empty,
+            body);
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    static ImmutableArray<Diagnostic> Recompile(string methodHeader, string body)
+    {
+        string source = $$"""
+            using System;
+            static class __Gate
+            {
+                {{methodHeader}}
+                {
+            {{body}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "__gate",
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        return compilation.GetDiagnostics();
+    }
+
+    static ImmutableArray<MetadataReference> RuntimeReferences()
+    {
+        var references = ImmutableArray.CreateBuilder<MetadataReference>();
+        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+            try { references.Add(MetadataReference.CreateFromFile(path)); }
+            catch { }
+        }
+        return references.ToImmutable();
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2369,10 +2369,32 @@ public sealed partial class CSharpPrinter
         char c => CharText(c),
         int i => i.ToString(CultureInfo.InvariantCulture),
         long l => l.ToString(CultureInfo.InvariantCulture),
-        float f => $"{f.ToString("R", CultureInfo.InvariantCulture)}f",
-        double d => $"{d.ToString("R", CultureInfo.InvariantCulture)}d",
+        float f => SingleText(f),
+        double d => DoubleText(d),
         _ => constant.Value.ToString() ?? "?",
     };
+
+    static string SingleText(float value)
+    {
+        if (float.IsNaN(value))
+            return "float.NaN";
+        if (float.IsPositiveInfinity(value))
+            return "float.PositiveInfinity";
+        if (float.IsNegativeInfinity(value))
+            return "float.NegativeInfinity";
+        return $"{value.ToString("R", CultureInfo.InvariantCulture)}f";
+    }
+
+    static string DoubleText(double value)
+    {
+        if (double.IsNaN(value))
+            return "double.NaN";
+        if (double.IsPositiveInfinity(value))
+            return "double.PositiveInfinity";
+        if (double.IsNegativeInfinity(value))
+            return "double.NegativeInfinity";
+        return $"{value.ToString("R", CultureInfo.InvariantCulture)}d";
+    }
 
     static string CharText(char c) => $"'{EscapeChar(c, inString: false)}'";
 


### PR DESCRIPTION
## Summary

Closes #1583.

- Spells float/double NaN and infinities as valid C# framework constants (`float.NaN`, `double.PositiveInfinity`, etc.) instead of invalid `NaNf` / `Infinityd` identifiers.
- Keeps finite float/double literal spelling on the existing round-trip format path.
- Adds synthetic printer tests, real importer-backed fixture canaries, inline expression cases, compile checks, and finite literal regressions.

## Evidence

- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity minimal`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.NonFiniteConstantPrinterTests -noLogo`
- `git diff --check`

I attempted a full `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` run, but it was still active with no result after 20 minutes and was stopped. The focused subset above covers the changed printer path, real importer fixtures, inline uses, and finite canaries.

## Adversarial review

Requested Opus 4.8 review. It reported no blocking issues. One non-blocking observation: relational patterns against `NaN` are still illegal C# (`x is > double.NaN`), but the prior spelling was already invalid (`> NaNd`) and this slice strictly improves all reachable constant contexts.
