### PR TITLE
Cast mixed-sign compound rhs to resolved lvalue type (#1459)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MixedSignCompoundTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignCompoundTests.cs
@@ -12,6 +12,8 @@ public class MixedSignCompoundTests
     static readonly TypeRef ULong = TypeRef.CoreLib("System", "UInt64");
     static readonly TypeRef Long = TypeRef.CoreLib("System", "Int64");
     static readonly TypeRef Int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef NUInt = TypeRef.CoreLib("System", "UIntPtr");
+    static readonly TypeRef NInt = TypeRef.CoreLib("System", "IntPtr");
 
     // ulong V_0 = arg; V_0 = V_0 - (long)1; return V_0;  →  the second store folds
     // to a compound assignment whose right operand is a signed (long) 1.
@@ -56,13 +58,111 @@ public class MixedSignCompoundTests
     }
 
     [Fact]
-    public void DivideCompound_MixedSign_KeepsSignednessSensitiveOpUnreconciled()
+    public void DivideCompound_MixedSign_SignedOpUnsignedTarget_StaysUnreconciled()
     {
-        // Divide is sign-sensitive (`/` vs `div.un`), so the mixed-sign RHS cast is
-        // NOT applied — casting the operand to the unsigned target type would flip
-        // the opcode. The operand keeps its signed `(long)` form instead.
+        // Divide is sign-sensitive (`/` vs `div.un`). This synthetic shape is a
+        // SIGNED divide (isUnsigned: false) over an UNSIGNED target — the opcode
+        // signedness does not match the lvalue, so casting the operand to the
+        // unsigned target type would flip the opcode. The reconciliation gate
+        // (NeedsCompoundSignCast) therefore declines it and the operand keeps its
+        // signed `(long)` form. (A faithful `div.un` over an unsigned target IS
+        // reconciled — see NuintDivideUnsigned_Faithful_BindsToTargetType.)
         var output = Render(BinaryKind.Divide);
 
         Assert.Contains("(long)", output);
+    }
+
+    // ── Native-int (#1459): nuint/nint are wide same-width like ulong/long, so the
+    // same CS0034 mix arises; the indirect (`ref nuint`) form additionally loses
+    // the unsigned lvalue type through ldind.i. ──────────────────────────────────
+
+    // arg/local nuint compound with a signed (nint) right operand.
+    static string RenderLocal(BinaryKind kind, TypeRef target, TypeRef rhsType, bool isUnsigned)
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var binary = new Binary(kind, isChecked: false, isUnsigned, new LoadLocal(0, target), new LoadArgument(1, "b", rhsType));
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, target, new LoadArgument(0, "arg", target)));
+        block.Add(new StoreLocal(0, target, binary));
+        block.Add(new Return(new LoadLocal(0, target)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M", owner,
+            new MethodSignature(target, [new Parameter("arg", target), new Parameter("b", rhsType)], HasThis: false, GenericParameterCount: 0),
+            [target],
+            body);
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    // `ref nuint x; x op= b` — the target is read through a LoadIndirect the
+    // importer types as the SIGNED native `IntPtr` (ldind.i), even though the
+    // StoreIndirect's resolved pointee type is `nuint`. The compound cast must use
+    // the resolved pointee type, not the bare target-read type.
+    static string RenderIndirect(BinaryKind kind, bool isUnsigned)
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var refParam = TypeRef.ByRef(NUInt);
+        var read = new LoadIndirect(NInt, new LoadArgument(0, "x", refParam));
+        var binary = new Binary(kind, isChecked: false, isUnsigned, read, new LoadArgument(1, "b", NInt));
+        var block = new Block(0);
+        block.Add(new StoreIndirect(NInt, new LoadArgument(0, "x", refParam), binary));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M", owner,
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [new Parameter("x", refParam), new Parameter("b", NInt)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void NuintSubtractNint_BindsToTargetType()
+    {
+        var output = RenderLocal(BinaryKind.Subtract, NUInt, NInt, isUnsigned: false);
+
+        Assert.Contains("V_0 -= (nuint)", output);
+        // `nuint -= nint` is CS0034; the right operand must not stay bare nint.
+        Assert.DoesNotContain("-= b", output);
+    }
+
+    [Fact]
+    public void NuintDivideUnsigned_Faithful_BindsToTargetType()
+    {
+        // A `div.un` (isUnsigned: true) over an unsigned target: the opcode
+        // signedness matches the lvalue, so casting the right operand to `nuint`
+        // does not flip the opcode and removes the CS0034 — unlike the signed
+        // divide over an unsigned target, which stays unreconciled.
+        var output = RenderLocal(BinaryKind.Divide, NUInt, NInt, isUnsigned: true);
+
+        Assert.Contains("V_0 /= (nuint)", output);
+        Assert.DoesNotContain("/= b", output);
+    }
+
+    [Fact]
+    public void IndirectNuintSubtract_UsesResolvedPointeeType()
+    {
+        // The ldind.i target read is typed `nint`; without using the resolved
+        // `nuint` pointee type the reconciliation would see nint/nint (not mixed)
+        // and emit the CS0034 `x -= b`.
+        var output = RenderIndirect(BinaryKind.Subtract, isUnsigned: false);
+
+        Assert.Contains("x -= (nuint)", output);
+        Assert.DoesNotContain("-= b", output);
+    }
+
+    [Fact]
+    public void NintTarget_SameSign_NotReconciled()
+    {
+        // A signed nint target with a signed nint operand is not a mixed-sign pair,
+        // so no cast is inserted — the canary that the reconciliation is gated on
+        // an actual signedness mismatch.
+        var output = RenderLocal(BinaryKind.Subtract, NInt, NInt, isUnsigned: false);
+
+        Assert.Contains("V_0 -= b", output);
+        Assert.DoesNotContain("(nuint)", output);
+        Assert.DoesNotContain("(nint)", output);
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -354,6 +354,27 @@ public sealed partial class CSharpPrinter
             && MixedSignSameWidthIntegers(binary);
 
     /// <summary>
+    /// Whether a compound assignment's right operand must be cast to the lvalue
+    /// type to bind. True when the lvalue and the right operand are a mixed-sign
+    /// same-width integer pair (e.g. <c>nuint -= nint</c>, <c>ulong /= long</c>) —
+    /// which has no C# common type (CS0034) — for an operator whose compound form
+    /// is faithful under the cast: the sign-neutral unchecked <c>+</c>/<c>-</c>/
+    /// <c>*</c> and bitwise <c>&amp;</c>/<c>|</c>/<c>^</c>, plus <c>/</c>/<c>%</c>
+    /// when the IL opcode's signedness already matches the lvalue (the compound
+    /// runs in the lvalue's type, so casting the right operand cannot flip
+    /// <c>div</c>↔<c>div.un</c>). Checked <c>.ovf</c> compounds stay plain.
+    /// </summary>
+    bool NeedsCompoundSignCast(Binary binary, TypeRef? lvalueType)
+    {
+        bool signNeutral = (!binary.IsChecked && binary.Kind is BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply)
+            || binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor;
+        bool divRemFaithful = binary.Kind is BinaryKind.Divide or BinaryKind.Remainder
+            && binary.IsUnsigned == TypeFamilies.IsUnsignedIntegerPrimitive(lvalueType);
+        return (signNeutral || divRemFaithful)
+            && MixedSignSameWidthIntegers(lvalueType, EffectiveType(binary.Right));
+    }
+
+    /// <summary>
     /// True when an integer arithmetic (unchecked <c>+</c>/<c>-</c>/<c>*</c>) or
     /// bitwise (<c>&amp;</c>/<c>|</c>/<c>^</c>) binary <em>renders</em> unsigned:
     /// both operands are the same-width <em>wide</em> integer (int/uint, long/ulong,
@@ -400,9 +421,16 @@ public sealed partial class CSharpPrinter
     /// compound-assignment paths.
     /// </summary>
     static bool MixedSignSameWidthIntegers(IrExpression leftOperand, IrExpression rightOperand)
+        => MixedSignSameWidthIntegers(EffectiveType(leftOperand), EffectiveType(rightOperand));
+
+    /// <summary>
+    /// The type-level core of the mixed-sign same-width test: one signed and one
+    /// unsigned wide integer of the same stack width. The compound-assignment path
+    /// uses this directly with the resolved lvalue type, which an indirect store's
+    /// <c>ldind.i</c>-typed target read does not carry.
+    /// </summary>
+    static bool MixedSignSameWidthIntegers(TypeRef? left, TypeRef? right)
     {
-        var left = EffectiveType(leftOperand);
-        var right = EffectiveType(rightOperand);
         // Both operands must be WIDE integers: a sub-int (byte/short/ushort/char)
         // promotes to int in C#, so `ushort - int` is already `int - int` and
         // needs no reconciliation — treating the sub-int as the unsigned partner

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1939,7 +1939,7 @@ public sealed partial class CSharpPrinter
             // A compound assignment only forms when the value reads the target
             // in same-type arithmetic, so the result already matches the target
             // — no conversion is involved on this path.
-            string statement = CompoundStatement(target, binary);
+            string statement = CompoundStatement(target, binary, targetType);
             // A checked compound (add.ovf/sub.ovf/mul.ovf) cannot be spelled as a
             // statement-level `checked(x += v)` (CS0201), so the overflow context
             // is restored with a single-statement checked block. Only the
@@ -1955,21 +1955,29 @@ public sealed partial class CSharpPrinter
     /// the compiler's implicit width mask; strip it exactly as the expression form
     /// does so <c>x &lt;&lt;= n</c> does not re-mask on recompile (see ShiftCount).
     /// </summary>
-    string CompoundStatement(string target, Binary binary)
+    string CompoundStatement(string target, Binary binary, TypeRef? targetType = null)
     {
         if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract && binary.Right is Constant { Value: 1 })
             return $"{target}{(binary.Kind == BinaryKind.Add ? "++" : "--")};";
+        // The compound runs in the lvalue's type. Prefer the resolved store type
+        // (`targetType`) over `binary.Left.ResultType`: an indirect store reads its
+        // target through `ldind.i`, which the importer types as the signed native
+        // `IntPtr` even for a `ref nuint`, so the bare `binary.Left` type loses the
+        // lvalue's real signedness.
+        var lvalueType = targetType ?? binary.Left.ResultType;
         string rightText = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight
             ? ShiftCount(binary)
-            // A mixed-sign same-width binary (`ulong -= (long)1`) has no C# common
-            // type, so `target op= right` is CS0034. For the sign-NEUTRAL operators
-            // (unchecked +/-/*, bitwise &/|/^) the bit operation is identical either
-            // way, so cast the right operand to the target lvalue type — the type
-            // `binary.Left` (the target read) carries — to make it bind. Sign-sensitive
-            // ops (/, %, checked .ovf, where the cast would flip div/div.un or the
-            // overflow domain) are deliberately excluded and keep their plain form.
-            : MixedSignArithmetic(binary) || MixedSignBitwise(binary)
-                ? CastValue(binary.Right, binary.Left.ResultType)
+            // A mixed-sign same-width compound (`nuint -= nint`, `ulong /= long`)
+            // has no C# common type, so `target op= right` is CS0034. For the
+            // sign-NEUTRAL operators (unchecked +/-/*, bitwise &/|/^) the bit
+            // operation is identical either way, so cast the right operand to the
+            // lvalue type to make it bind. Sign-sensitive /, % are excluded in the
+            // plain binary form (an operand cast flips div/div.un), but a COMPOUND
+            // runs in the lvalue's type, so the opcode signedness is already the
+            // lvalue's: casting only the right operand is faithful when the opcode
+            // signedness matches the lvalue. Checked .ovf compounds stay plain.
+            : NeedsCompoundSignCast(binary, lvalueType)
+                ? CastValue(binary.Right, lvalueType)
                 : Operand(binary.Right);
         return $"{target} {BinaryOperator(binary)}= {rightText};";
     }


### PR DESCRIPTION
## Summary

Burndown row from #1598 (Cluster A, #1459). A compound assignment whose operands are a mixed-sign same-width integer pair (`nuint -= nint`, `ulong /= long`) has no C# common type, so `target op= rhs` is **CS0034** at `Full`.

The original issue's measured cases — the constant `byteCount -= (nint)16384` shape in `Buffer::BulkMoveWithWriteBarrierBatch` — were **already fixed** by the mixed-sign arithmetic work: a fresh `--validity-check` sweep of `System.Private.CoreLib` reports **0 CS0034**, and that method now recompiles as `byteCount -= (nuint)((nint)16384)`. But two reachable holes remained, found by probing the native-int compound shapes:

| shape | before (CS0034) | after |
| --- | --- | --- |
| `ref nuint x; x -= b` (nint) | `x -= b;` | `x -= (nuint)b;` |
| `ref nuint x; x += b` | `x += b;` | `x += (nuint)b;` |
| `nuint x; x /= (nuint)b` | `x /= b;` | `x /= (nuint)b;` |
| `ref nuint x; x %= 100` | `x %= ((nint)100);` | `x %= (nuint)((nint)100);` |

## Root causes / fix

1. **Sign-sensitive `/=` / `%=` were excluded** from compound reconciliation (a plain-binary operand cast flips `div`↔`div.un`). But a *compound* runs in the lvalue's type, so the IL opcode signedness is already the lvalue's — casting only the right operand cannot flip the opcode. `NeedsCompoundSignCast` now reconciles div/rem when the opcode signedness matches the lvalue (gated; a mismatch degrades to the plain form rather than flipping the op).
2. **The cast keyed on `binary.Left.ResultType`**, but an indirect store (`ref nuint x`) reads its target through `ldind.i`, which the importer types as the signed native `IntPtr` — losing the `nuint` signedness, so reconciliation never fired. `CompoundStatement` now threads the resolved store/pointee type (`targetType`, already computed by `AssignmentText`) and keys the mixed-sign decision on it.

Adds a `TypeRef`-level `MixedSignSameWidthIntegers` overload. No printer widening; same-sign and fixed-width compounds are unchanged.

## Tests / evidence

- `MixedSignCompoundTests`: 4 new synthetic-IR tests (native-int local subtract, faithful `div.un`, indirect-store `ref nuint`, same-sign canary) + refined the divide test to assert the signed-op/unsigned-target *mismatch* stays unreconciled. 7/7 pass.
- Real-csc verification via a `nuint` probe library: all affected bodies recompile with 0 errors; same-sign (`nint`/`int`) and `nuint /= nuint` canaries unchanged.
- **CoreLib `--validity-check` sweep: 0 CS0034, defect set byte-identical before/after** (zero corpus delta — the fix targets shapes absent from CoreLib's importable methods).
- Related groups green: MixedSign (30), Compound (10), IncrementDecrement (18), ShiftCount, PointerAssignment, PrinterPrecedence. Full decompiler suite run in progress.
