### PR TITLE
Tighten display class delegate classification

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -603,6 +603,15 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_UserDisplayClassName_IsInstanceMethodGroupDelegate()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var shape = Assert.Single(DelegateShapes(index, nameof(OptimizationOpportunityFixtures.UserTypeNameContainsDisplayClass)));
+        Assert.Equal("instance-method-group-delegate", shape);
+    }
+
+    [Fact]
     public void OptimizationOpportunities_CarryContainingMethodRootReach()
     {
         var index = LibraryBodyIndex.Open(typeof(OpportunityLeverageFixtures).Assembly.Location);
@@ -950,6 +959,7 @@ public class LibraryBodyIndexTests
 public class OptimizationOpportunityFixtures
 {
     private readonly int _field = 3;
+    private readonly UserDisplayClassTarget _displayClassTarget = new();
     private int[]? _arrayField;
 
     public int[] MakesArrayAfterFieldAccess()
@@ -1071,6 +1081,11 @@ public class OptimizationOpportunityFixtures
 
     public virtual int VirtualHelper() => _field;
 
+    public Func<int> UserTypeNameContainsDisplayClass()
+    {
+        return _displayClassTarget.GetValue;
+    }
+
     // --- Boxing (box-value-type) ---
 
     // Boxes an int into an object-typed API argument -> escapes via call.
@@ -1093,6 +1108,11 @@ public class OptimizationOpportunityFixtures
         public static string Join(int a, int b) => $"{a}:{b}";
         public static string Concat(int a, int b) => $"{a}{b}";
         public static string Substring(string value) => value;
+    }
+
+    public sealed class UserDisplayClassTarget
+    {
+        public int GetValue() => 42;
     }
 
     // Boxes a value into an exception message on a throw path inside a loop -> the box only

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1149,11 +1149,19 @@ public sealed class LibraryBodyIndex
 
         // True when a delegate's target method is a closure body emitted on a compiler-
         // generated display class (it closes over captured locals/parameters). The
-        // non-capturing lambda cache type is named exactly <>c (no "DisplayClass"), and
-        // static/instance method groups live on ordinary types, so none of those match.
+        // non-capturing lambda cache type is named exactly <>c, and static/instance
+        // method groups live on ordinary types, so none of those match.
         static bool IsClosureTarget(MemberRef target)
             => target.Kind != MemberKind.Unsupported
-               && target.DeclaringType.Name.Contains("DisplayClass", StringComparison.Ordinal);
+               && DeclaringTypeLeafName(target.DeclaringType)
+                   .StartsWith("<>c__DisplayClass", StringComparison.Ordinal);
+
+        static string DeclaringTypeLeafName(TypeRef type)
+        {
+            string name = type.Kind == TypeRefKind.GenericInstance ? type.ElementType?.Name ?? "" : type.Name;
+            int nested = name.LastIndexOf('+');
+            return nested < 0 ? name : name[(nested + 1)..];
+        }
 
         // Opcodes that consume a boxed value in a way that makes it escape (so the box is a
         // real heap allocation): stored into a reference array, passed to a call/ctor, written


### PR DESCRIPTION
## Summary

Closes #1587.

- Tightens capturing-delegate detection to the compiler display-class leaf-name shape (`<>c__DisplayClass*`) instead of any type name containing `DisplayClass`.
- Keeps real capturing lambdas classified as `capturing-delegate`.
- Adds a user `DisplayClass` lookalike fixture that must classify as `instance-method-group-delegate`.

## Evidence

- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity minimal`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`
- `git diff --check`

## Adversarial review

Requested Opus 4.8 review. It reported no significant issues. It verified real compiler display-class leaf names, nested/generic declaring type handling, and the non-capturing/static/instance delegate canaries.
