### PR TITLE
Include bodiless unsafe methods in leverage ranking

### DIFF
--- a/src/ILInspector.Analysis.App/Program.cs
+++ b/src/ILInspector.Analysis.App/Program.cs
@@ -64,7 +64,7 @@ static int RunUnsafeReport(string[] args)
     Console.WriteLine($"  Implicit (requires-unsafe, module not opted in): {modes.Implicit:N0}");
     Console.WriteLine($"  Explicit (requires-unsafe, module opted in):     {modes.Explicit:N0}");
     Console.WriteLine();
-    Console.WriteLine($"Top {top.Length} requires-unsafe methods by direct callers (with an IL body):");
+    Console.WriteLine($"Top {top.Length} requires-unsafe methods by direct callers:");
     Console.WriteLine();
     int rank = 1;
     foreach (var entry in top)

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -943,6 +943,10 @@ public class LibraryBodyIndexTests
         Assert.Contains(top, e =>
             e.Method.Name == nameof(UnsafeEvidenceFixtures.UnsafePointerRead)
             && e.Mode == CallerUnsafeMode.Implicit);
+        var pointerExtern = Assert.Single(top.Where(e =>
+            e.Method.Name == nameof(UnsafeEvidenceFixtures.PointerExtern)));
+        Assert.Equal(2, pointerExtern.DirectCallerCount);
+        Assert.Equal(CallerUnsafeMode.Implicit, pointerExtern.Mode);
         Assert.DoesNotContain(top, e => e.Method.Name == nameof(UnsafeEvidenceFixtures.CallsUnsafeAs));
     }
 }
@@ -1788,6 +1792,13 @@ public static partial class UnsafeEvidenceFixtures
 
     [DllImport("kernel32.dll")]
     public static extern int PInvokeOnly();
+
+    [DllImport("kernel32.dll")]
+    public static unsafe extern int PointerExtern(int* value);
+
+    public static unsafe int PointerExternCallerA(int* value) => PointerExtern(value);
+
+    public static unsafe int PointerExternCallerB(int* value) => PointerExtern(value);
 }
 
 // Two independent containing types that each nest a type with the same simple name

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -17,6 +17,7 @@ public sealed class LibraryBodyIndex
         ImmutableArray<UnsafeEvidence> unsafeEvidence,
         ImmutableArray<AnalysisDiagnostic> diagnostics,
         ImmutableArray<OptimizationOpportunity> optimizationOpportunities,
+        ImmutableArray<MethodIdentity> unsafeLeverageMethods,
         bool memorySafetyRulesEnabled,
         UnsafeModeBreakdown unsafeModes,
         IReadOnlyDictionary<int, BodySignals> bodySignals,
@@ -28,6 +29,7 @@ public sealed class LibraryBodyIndex
         UnsafeEvidence = unsafeEvidence;
         Diagnostics = diagnostics;
         _rawOpportunities = optimizationOpportunities;
+        _unsafeLeverageMethods = unsafeLeverageMethods;
         MemorySafetyRulesEnabled = memorySafetyRulesEnabled;
         UnsafeModes = unsafeModes;
         _bodySignals = bodySignals;
@@ -41,6 +43,7 @@ public sealed class LibraryBodyIndex
     public ImmutableArray<AnalysisDiagnostic> Diagnostics { get; }
 
     readonly ImmutableArray<OptimizationOpportunity> _rawOpportunities;
+    readonly ImmutableArray<MethodIdentity> _unsafeLeverageMethods;
     ImmutableArray<OptimizationOpportunity> _opportunities;
 
     /// <summary>
@@ -265,7 +268,7 @@ public sealed class LibraryBodyIndex
         var index = builder.Build();
         return new LibraryBodyIndex(
             path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
-            index.OptimizationOpportunities, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
+            index.OptimizationOpportunities, index.UnsafeLeverageMethods, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
             index.BodySignals, index.SuppressedOpportunityTokens);
     }
 
@@ -278,7 +281,7 @@ public sealed class LibraryBodyIndex
     /// them propagates the requirement to the most callers.
     /// </summary>
     public ImmutableArray<UnsafeMethodLeverage> TopUnsafeLeverage(int count = 6)
-        => UnsafeLeverage.Top(DirectCalls, Methods, count);
+        => UnsafeLeverage.Top(DirectCalls, _unsafeLeverageMethods, count);
 
     /// <summary>
     /// The most-leveraged methods in this assembly, ranked by distinct direct
@@ -665,9 +668,10 @@ public sealed class LibraryBodyIndex
                 && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
         }
 
-        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlySet<int> SuppressedOpportunityTokens) Build()
+        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlySet<int> SuppressedOpportunityTokens) Build()
         {
             var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
+            var unsafeLeverageMethods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var calls = ImmutableArray.CreateBuilder<DirectCall>();
             var unsafeEvidence = ImmutableArray.CreateBuilder<UnsafeEvidence>();
             var diagnostics = ImmutableArray.CreateBuilder<AnalysisDiagnostic>();
@@ -700,6 +704,8 @@ public sealed class LibraryBodyIndex
                         }
                         bool hasUnsafeApiMember = AddUnsafeApiMemberEvidence(caller, unsafeEvidence);
                         bool hasUnsafeSignature = AddUnsafeSignatureEvidence(caller, unsafeEvidence);
+                        if (caller.CallerUnsafeMode != CallerUnsafeMode.None || hasUnsafeApiMember)
+                            unsafeLeverageMethods.Add(caller);
                         if (methodDef.RelativeVirtualAddress == 0)
                             continue;
 
@@ -733,7 +739,7 @@ public sealed class LibraryBodyIndex
             }
 
             return (methods.ToImmutable(), calls.ToImmutable(), unsafeEvidence.ToImmutable(), diagnostics.ToImmutable(),
-                optimizationOpportunities.ToImmutable(), new UnsafeModeBreakdown(none, impl, expl), bodySignals, suppressedOpportunityTokens);
+                optimizationOpportunities.ToImmutable(), unsafeLeverageMethods.ToImmutable(), new UnsafeModeBreakdown(none, impl, expl), bodySignals, suppressedOpportunityTokens);
         }
 
         MethodIdentity CreateMethodIdentity(TypeDefinitionHandle typeHandle, MethodDefinitionHandle methodHandle, MethodDefinition methodDef, GenericScope scope)


### PR DESCRIPTION
## Summary

Fixes #1589 by letting `TopUnsafeLeverage` rank requires-unsafe methods that do not have IL bodies, such as extern/PInvoke pointer-signature sinks.

- Keeps `LibraryBodyIndex.Methods` body-only for body-derived analysis.
- Adds a separate unsafe-leverage target population populated before the `RelativeVirtualAddress == 0` skip.
- Updates the analysis-app header so the report no longer claims all ranked rows have IL bodies.
- Adds a `PointerExtern(int*)` canary with two direct callers.

## Evidence

```text
UnsafeModes total=422 unsafe=6 implicit=6 explicit=0
PointerExtern callers=2 mode=Implicit
UnsafePointerRead callers=0 mode=Implicit
CallsUnsafeAs ranked=False
```

Validation:

```text
dotnet run --project src/ILInspector.Analysis.Tests -c Release
ILInspector.Analysis.Tests  Total: 103, Errors: 0, Failed: 0, Skipped: 0

dotnet build src/dotnet-inspect -c Release
Build succeeded. 0 Warning(s), 0 Error(s)
```

Adversarial review: Opus 4.8 found one stale analysis-app report header that still said ranked methods had IL bodies. Fixed by removing the stale qualifier; reran validation successfully.
