### PR TITLE
Include next sweep timing in curator output

### DIFF
--- a/docs/decompiler-burndown-curator.md
+++ b/docs/decompiler-burndown-curator.md
@@ -585,7 +585,8 @@ End each sweep with:
 - mergeable PRs ready for maintainer action;
 - rows that require human escalation;
 - whether a rebaseline is needed before new work;
-- the single next recommended action.
+- the single next recommended action;
+- when the next sweep or action is expected.
 
 If the best result is "do not start new work yet," say that. A good curator
 compresses backlog; it does not create motion for motion's sake.


### PR DESCRIPTION
## Summary
- update the curator sweep output checklist to include when the next sweep or action is expected

## Validation
- npx markdownlint-cli docs/decompiler-burndown-curator.md