### PR TITLE
Require Google.Protobuf assembly identity for generated detection (#1580)

### DIFF
--- a/src/ILInspector.Analysis.LookalikeFixtures/LookalikeSignalFixtures.cs
+++ b/src/ILInspector.Analysis.LookalikeFixtures/LookalikeSignalFixtures.cs
@@ -8,6 +8,22 @@ namespace ILInspector.Analysis.LookalikeFixtures
 
         public static byte CallsFakeBitConverter() => System.BitConverter.GetBytes(1)[0];
     }
+
+    // Calls user-defined Google.Protobuf.* lookalike types declared in THIS assembly
+    // (named ILInspector.Analysis.LookalikeFixtures, not Google.Protobuf). The protobuf
+    // generated-bootstrap predicates require real Google.Protobuf assembly identity, so
+    // this product type must NOT be classified as generated and its optimization
+    // opportunities must stay actionable (#1580).
+    public sealed class ProtobufBootstrapLookalike
+    {
+        public static object CallsLookalikeDescriptor()
+            => Google.Protobuf.Reflection.FileDescriptor.FromGeneratedCode([], [], new Google.Protobuf.Reflection.GeneratedClrTypeInfo());
+
+        public static object CallsLookalikeMessageParser()
+            => new Google.Protobuf.MessageParser<ProtobufBootstrapLookalike>(() => new ProtobufBootstrapLookalike());
+
+        public static int[] ShouldStillBeActionable() => new int[4];
+    }
 }
 
 namespace System.Reflection
@@ -31,5 +47,30 @@ namespace System
     public static class BitConverter
     {
         public static byte[] GetBytes(int value) => [(byte)value];
+    }
+}
+
+// User-defined Google.Protobuf.* lookalikes declared in a user assembly (not the real
+// Google.Protobuf runtime). Structurally identical to the protobuf bootstrap shapes, so
+// name/namespace-only matching would misclassify their callers as generated (#1580).
+namespace Google.Protobuf.Reflection
+{
+    public sealed class FileDescriptor
+    {
+        public static FileDescriptor FromGeneratedCode(byte[] descriptorData, FileDescriptor[] dependencies, GeneratedClrTypeInfo info) => new();
+    }
+
+    public sealed class GeneratedClrTypeInfo
+    {
+    }
+}
+
+namespace Google.Protobuf
+{
+    public sealed class MessageParser<T>
+    {
+        public MessageParser(Func<T> factory)
+        {
+        }
     }
 }

--- a/src/ILInspector.Analysis.ProtobufFixtures/ILInspector.Analysis.ProtobufFixtures.csproj
+++ b/src/ILInspector.Analysis.ProtobufFixtures/ILInspector.Analysis.ProtobufFixtures.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Minimal stand-ins for the protobuf runtime, compiled into an assembly literally
+    named Google.Protobuf so that LibraryBodyIndex.GeneratedFrameworkTypeNames can
+    require real protobuf assembly identity (#1580). Test consumers that reference
+    this assembly model real generated code calling into the protobuf runtime; a
+    user assembly that defines its own Google.Protobuf.* lookalikes does not match.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>Google.Protobuf</AssemblyName>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.ProtobufFixtures/ProtobufRuntimeStandins.cs
+++ b/src/ILInspector.Analysis.ProtobufFixtures/ProtobufRuntimeStandins.cs
@@ -1,0 +1,28 @@
+// Minimal stand-ins for the protobuf runtime infrastructure that real generated code
+// calls. These are compiled into an assembly named Google.Protobuf (see the .csproj
+// AssemblyName) so that the protobuf generated-bootstrap predicates in
+// LibraryBodyIndex.GeneratedFrameworkTypeNames can require real protobuf assembly
+// identity rather than namespace/name shape alone (#1580). Signatures mirror the
+// shapes that generated code actually calls.
+
+namespace Google.Protobuf.Reflection
+{
+    public sealed class FileDescriptor
+    {
+        public static FileDescriptor FromGeneratedCode(byte[] descriptorData, FileDescriptor[] dependencies, GeneratedClrTypeInfo info) => new();
+    }
+
+    public sealed class GeneratedClrTypeInfo
+    {
+    }
+}
+
+namespace Google.Protobuf
+{
+    public sealed class MessageParser<T>
+    {
+        public MessageParser(Func<T> factory)
+        {
+        }
+    }
+}

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ILInspector.Analysis.ExceptionBaseFixtures\ILInspector.Analysis.ExceptionBaseFixtures.csproj" />
+    <ProjectReference Include="..\ILInspector.Analysis.ProtobufFixtures\ILInspector.Analysis.ProtobufFixtures.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis.LookalikeFixtures\ILInspector.Analysis.LookalikeFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
   </ItemGroup>

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -495,6 +495,26 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void GeneratedFrameworkTypeNames_IgnoresUserDefinedProtobufLookalikes()
+    {
+        // The lookalike fixture assembly is NOT named Google.Protobuf; it declares its own
+        // Google.Protobuf.* bootstrap-shaped types and calls them from product code. The
+        // protobuf generated-bootstrap predicates require real Google.Protobuf assembly
+        // identity, so the calling product type must not be classified as generated (#1580).
+        var index = LibraryBodyIndex.Open(LookalikeFixturePath());
+        var generated = index.GeneratedFrameworkTypeNames;
+
+        const string lookalikeType = "ILInspector.Analysis.LookalikeFixtures.ProtobufBootstrapLookalike";
+        Assert.DoesNotContain(lookalikeType, generated);
+
+        // Because it is not classified as generated, its optimization opportunity stays
+        // visible — Performance Triage suppresses opportunities only for generated types.
+        Assert.Contains(index.OptimizationOpportunities, opportunity =>
+            opportunity.Method.DeclaringType.Name == "ProtobufBootstrapLookalike"
+            && opportunity.Method.Name == "ShouldStillBeActionable");
+    }
+
+    [Fact]
     public void OptimizationOpportunities_SuppressesSourceGeneratedTypes()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);

--- a/src/ILInspector.Analysis.Tests/ProtobufGrpcGeneratedFixtures.cs
+++ b/src/ILInspector.Analysis.Tests/ProtobufGrpcGeneratedFixtures.cs
@@ -1,29 +1,10 @@
-// Minimal stand-ins for the protobuf/gRPC infrastructure that real generated code calls.
-// LibraryBodyIndex.GeneratedFrameworkTypeNames matches structurally by namespace/type/method
-// name, so these reproduce the bootstrap signals without a dependency on Google.Protobuf or
-// Grpc.Core. Block namespaces are required because the stubs live in foreign namespaces.
-
-namespace Google.Protobuf.Reflection
-{
-    public sealed class FileDescriptor
-    {
-        public static FileDescriptor FromGeneratedCode(byte[] descriptorData, FileDescriptor[] dependencies, GeneratedClrTypeInfo info) => new();
-    }
-
-    public sealed class GeneratedClrTypeInfo
-    {
-    }
-}
-
-namespace Google.Protobuf
-{
-    public sealed class MessageParser<T>
-    {
-        public MessageParser(Func<T> factory)
-        {
-        }
-    }
-}
+// Minimal stand-ins for the gRPC infrastructure that real generated code calls, plus
+// protobuf/gRPC consumer fixtures. The protobuf runtime stand-ins (FileDescriptor,
+// GeneratedClrTypeInfo, MessageParser<T>) live in the separate ILInspector.Analysis.ProtobufFixtures
+// project, which compiles to an assembly named Google.Protobuf; the consumers below bind to
+// those external types so the generated-bootstrap predicates see real Google.Protobuf assembly
+// identity (#1580). The gRPC stand-in is matched by namespace + generated __* members, not by
+// assembly, so it stays local.
 
 namespace Grpc.Core
 {

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -173,7 +173,10 @@ public sealed class LibraryBodyIndex
     /// any of its methods bootstraps protobuf generated infrastructure — calling
     /// <c>Google.Protobuf.Reflection.FileDescriptor.FromGeneratedCode</c>, constructing
     /// <c>Google.Protobuf.Reflection.GeneratedClrTypeInfo</c>, or constructing the
-    /// per-message <c>Google.Protobuf.MessageParser&lt;T&gt;</c> — or is a gRPC stub that both
+    /// per-message <c>Google.Protobuf.MessageParser&lt;T&gt;</c> — where the bootstrap type
+    /// comes from the real <c>Google.Protobuf</c> assembly (a user assembly can declare
+    /// <c>Google.Protobuf.*</c> lookalikes, so namespace/name alone is not sufficient,
+    /// #1580) — or is a gRPC stub that both
     /// declares infrastructure members whose names are codegen-only (<c>__ServiceName</c>,
     /// <c>__Helper_*</c>, <c>__Marshaller_*</c>, <c>__Method_*</c>) <em>and</em> calls into
     /// <c>Grpc.Core</c> (the binding/marshalling APIs a generated stub uses). A generated
@@ -197,16 +200,18 @@ public sealed class LibraryBodyIndex
             if (callee.Kind == MemberKind.Unsupported)
                 continue;
             bool protobufBootstrap =
-                (callee.DeclaringType.Namespace == "Google.Protobuf.Reflection"
-                    && callee.DeclaringType.Name == "FileDescriptor"
+                (IsProtobufType(callee.DeclaringType, "Google.Protobuf.Reflection", "FileDescriptor")
                     && callee.Name == "FromGeneratedCode")
-                || (callee.DeclaringType.Namespace == "Google.Protobuf.Reflection"
-                    && callee.DeclaringType.Name == "GeneratedClrTypeInfo"
+                || (IsProtobufType(callee.DeclaringType, "Google.Protobuf.Reflection", "GeneratedClrTypeInfo")
                     && callee.Name == ".ctor")
-                || (IsType(callee.DeclaringType, "Google.Protobuf", "MessageParser")
+                || (IsProtobufType(callee.DeclaringType, "Google.Protobuf", "MessageParser")
                     && callee.Name == ".ctor");
             // Only protobuf generated bootstraps are matched by call: FromGeneratedCode,
             // GeneratedClrTypeInfo, and MessageParser<T> construction are codegen signals.
+            // The bootstrap type must come from the real Google.Protobuf assembly: a user
+            // assembly can declare Google.Protobuf.* lookalike types and call them from
+            // ordinary product code, and name/namespace-only matching would misclassify
+            // that product type as generated (#1580).
             // gRPC binding APIs (ServerServiceDefinition/Marshallers) are deliberately NOT
             // matched by call, since hand-written low-level gRPC registration legitimately
             // calls them; gRPC stubs are instead recognized by their generated __*
@@ -254,10 +259,11 @@ public sealed class LibraryBodyIndex
         => ns is not null
             && (ns == "Grpc.Core" || ns.StartsWith("Grpc.Core.", StringComparison.Ordinal));
 
-    static bool IsType(TypeRef type, string ns, string name)
+    static bool IsProtobufType(TypeRef type, string ns, string name)
     {
         var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
         return definition is not null
+            && definition.Assembly == "Google.Protobuf"
             && definition.Namespace == ns
             && StripGenericArity(definition.Name) == name;
     }


### PR DESCRIPTION
## Summary

Closes #1580 (row 10 of the #1555 Analysis adversarial bug burndown, Cluster C).

`LibraryBodyIndex.GeneratedFrameworkTypeNames` classified a type as protobuf *generated* when it called members shaped like protobuf bootstraps — `Google.Protobuf.Reflection.FileDescriptor.FromGeneratedCode`, `Google.Protobuf.Reflection.GeneratedClrTypeInfo..ctor`, or `Google.Protobuf.MessageParser<T>..ctor` — by namespace/type/member **name only**. A user assembly can declare its own `Google.Protobuf.*` lookalike types and call them from ordinary product code; the analyzer then marked that product type as generated, tagged it in `Top Leverage`, and suppressed its real optimization opportunities from `Performance Triage`.

## Fix

Gate the three protobuf bootstrap predicates on the bootstrap type's declaring **assembly** being the real `Google.Protobuf` assembly (`IsProtobufType` now checks `Assembly == "Google.Protobuf"`), mirroring the framework-identity gating from #1571/#1574. The gRPC stub branch is intentionally unchanged — it is matched by `Grpc.Core` namespace **plus** generated `__*` members, not by assembly — so #1574 coverage stays independent.

## Test infrastructure

The existing positive fixtures defined the protobuf types in the test assembly itself, which is now (correctly) indistinguishable from a lookalike. To represent real protobuf assembly identity:

- New `ILInspector.Analysis.ProtobufFixtures` project compiled as assembly **`Google.Protobuf`** holding the runtime stand-ins; the existing positive consumers (`FakeProtobufReflection`, `FakeProtobufMessage`) bind those external types and **still classify** as generated.
- New negative fixture `ProtobufBootstrapLookalike` declares `Google.Protobuf.*` lookalikes in the (non-`Google.Protobuf`) `LookalikeFixtures` assembly and is asserted to **stay unclassified**, with its `small-array` opportunity preserved.

## Evidence

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` — **104 passed, 0 failed** (clean rebuild).
- New `GeneratedFrameworkTypeNames_IgnoresUserDefinedProtobufLookalikes` test; teeth verified by removing the assembly gate (the lookalike is then classified and the test fails).
- End-to-end CLI against the lookalike fixture assembly:
  - `Top Leverage`: `ProtobufBootstrapLookalike.CallsLookalikeDescriptor()/CallsLookalikeMessageParser()` are **not** marked `generated`.
  - `Performance Triage`: `ProtobufBootstrapLookalike.ShouldStillBeActionable()` is visible with its `small-array` opportunity — the exact #1580 done signal.

## Done signal

- User-defined `Google.Protobuf.*` lookalike calls no longer add the caller type to `GeneratedFrameworkTypeNames`. ✅
- The repro's `ShouldStillBeActionable` row remains visible in `Performance Triage`. ✅
- Real protobuf generated fixtures still classify as generated. ✅
- Existing #1574 gRPC generated-name near-miss coverage remains independent. ✅
