### PR TITLE
Qualify foreign nested type definitions through their declaring chain (#1581)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ForeignNestedFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeignNestedFixture.cs
@@ -1,0 +1,23 @@
+namespace Repro;
+
+// Fixture for #1581: a non-generic nested type referenced from inside its
+// enclosing scope (Outer.InScope) and from a foreign scope (Other.ForeignReturn).
+// The in-scope body may render the bare innermost name `Inner`; the foreign body
+// must qualify through the declaring chain (`Outer.Inner`), or `Inner` is not in
+// scope inside `Repro.Other` and the Full-looking body is invalid C#.
+public sealed class Outer
+{
+    public sealed class Inner
+    {
+        public int Value;
+    }
+
+    public static Inner InScope()
+        => new Inner { Value = 1 };
+}
+
+public sealed class Other
+{
+    public static Outer.Inner ForeignReturn()
+        => new Outer.Inner { Value = 2 };
+}

--- a/src/ILInspector.Decompiler.Tests/ForeignNestedTypeSpellingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeignNestedTypeSpellingTests.cs
@@ -1,0 +1,55 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// #1581: a non-generic nested type referenced from a foreign scope must be
+// spelled through its declaring chain (`Outer.Inner`); the bare innermost name
+// `Inner` only binds inside the enclosing type. The body printer previously
+// rendered every nested definition as its innermost name, emitting invalid C#
+// from a foreign scope while still claiming Full fidelity.
+public class ForeignNestedTypeSpellingTests
+{
+    static string RenderBody(string typeFullName, string method)
+    {
+        using var source = MetadataSource.Open(typeof(Repro.Outer).Assembly.Location);
+        var function = IrImporter.Import(source, typeFullName, method);
+        Assert.NotNull(function);
+        var result = CSharpPrinter.PrintRaised(function!, m => IrImporter.Import(source, m));
+        Assert.NotNull(result.Output);
+        return result.Output!.ReplaceLineEndings("\n").Trim();
+    }
+
+    [Fact]
+    public void ForeignNestedType_QualifiesThroughDeclaringChain()
+    {
+        string body = RenderBody("Repro.Other", nameof(Repro.Other.ForeignReturn));
+
+        // From `Repro.Other`, `Inner` is not in scope: the body must qualify it.
+        Assert.Equal("return new Outer.Inner { Value = 2 };", body);
+        Assert.DoesNotContain("new Inner", body);
+    }
+
+    [Fact]
+    public void InScopeNestedType_KeepsBareInnermostName()
+    {
+        string body = RenderBody("Repro.Outer", nameof(Repro.Outer.InScope));
+
+        // Inside `Repro.Outer`, the bare innermost name binds and stays idiomatic.
+        Assert.Equal("return new Inner { Value = 1 };", body);
+        Assert.DoesNotContain("Outer.Inner", body);
+    }
+
+    [Fact]
+    public void Spellability_ValidatesEveryNestedSegment_NotJustTheLeaf()
+    {
+        // A valid declaring chain has a C# spelling for every segment.
+        var valid = TypeRef.Definition("Asm", "N", "Outer+Inner");
+        Assert.False(CSharpSpellability.HasUnrepresentableMetadataName(new LoadArgument(0, "x", valid)));
+
+        // An unspellable outer segment (compiler-generated `<>`-shaped name) with a
+        // valid leaf must still be flagged: the foreign-scope spelling would emit
+        // the whole chain, so `Outer.Inner` is not Full-fidelity C#.
+        var invalidOuter = TypeRef.Definition("Asm", "N", "<>c__Outer+Inner");
+        Assert.True(CSharpSpellability.HasUnrepresentableMetadataName(new LoadArgument(0, "x", invalidOuter)));
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ForeignNestedTypeSpellingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeignNestedTypeSpellingTests.cs
@@ -52,4 +52,24 @@ public class ForeignNestedTypeSpellingTests
         var invalidOuter = TypeRef.Definition("Asm", "N", "<>c__Outer+Inner");
         Assert.True(CSharpSpellability.HasUnrepresentableMetadataName(new LoadArgument(0, "x", invalidOuter)));
     }
+
+    [Fact]
+    public void GenericOuterNestedDefinition_SpellsUnboundArityPerSegment()
+    {
+        var foreignScope = TypeRef.Definition("Asm", "N", "Other");
+
+        // An open generic outer must be spelled unbound (Outer<>.Inner); a bare
+        // `Outer.Inner` fails CS0305 in e.g. typeof(Outer<>.Inner).
+        var genericOuter = TypeRef.Definition("Asm", "N", "Outer`1+Inner");
+        Assert.Equal("Outer<>.Inner", genericOuter.ToDisplayString(foreignScope));
+
+        var twoParamOuterGenericInner = TypeRef.Definition("Asm", "N", "Outer`2+Inner`1");
+        Assert.Equal("Outer<,>.Inner<>", twoParamOuterGenericInner.ToDisplayString(foreignScope));
+
+        // A non-generic chain is unchanged, and the bare innermost name is kept
+        // when the enclosing type is the printing scope.
+        var plain = TypeRef.Definition("Asm", "N", "Outer+Inner");
+        Assert.Equal("Outer.Inner", plain.ToDisplayString(foreignScope));
+        Assert.Equal("Inner", plain.ToDisplayString(TypeRef.Definition("Asm", "N", "Outer")));
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
@@ -140,10 +140,17 @@ internal static class CSharpSpellability
             case TypeRefKind.Definition:
                 if (IsCoreLibPrimitive(type))
                     return null;
-                string simpleName = StripArity(InnermostName(type.Name));
-                return CSharpNaming.IsUsableIdentifier(simpleName)
-                    ? null
-                    : $"type name '{simpleName}' has no C# spelling";
+                // Validate every nested segment, not just the leaf: a foreign
+                // nested type is spelled through its declaring chain
+                // (`Outer.Inner`), so an unspellable outer segment also has no
+                // valid C# spelling even when the innermost name is fine.
+                foreach (var segment in type.Name.Split('+'))
+                {
+                    string simpleSegment = StripArity(segment);
+                    if (!CSharpNaming.IsUsableIdentifier(simpleSegment))
+                        return $"type name '{simpleSegment}' has no C# spelling";
+                }
+                return null;
 
             case TypeRefKind.GenericInstance:
                 if (type.ElementType is { } definition && TypeReason(definition) is { } definitionReason)
@@ -183,12 +190,6 @@ internal static class CSharpSpellability
         => type.Assembly == TypeRef.CoreLibrary
             && type.Namespace == "System"
             && s_coreLibPrimitiveNames.Contains(type.Name);
-
-    static string InnermostName(string metadataName)
-    {
-        int nested = metadataName.LastIndexOf('+');
-        return nested < 0 ? metadataName : metadataName[(nested + 1)..];
-    }
 
     static string StripArity(string name)
     {

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -518,10 +518,24 @@ public sealed class TypeRef : IEquatable<TypeRef>
 
     /// <summary>
     /// Renders a nested type definition through its declaring chain
-    /// (<c>Outer.Inner</c>), stripping each <c>+</c>-separated segment's arity.
+    /// (<c>Outer.Inner</c>). A generic segment of an open definition has no type
+    /// arguments, so it is spelled unbound (<c>Outer&lt;&gt;.Inner</c>,
+    /// <c>Outer&lt;,&gt;.Inner</c>) — the only valid C# for an open generic
+    /// declaring type, e.g. inside <c>typeof(Outer&lt;&gt;.Inner)</c>.
     /// </summary>
     string RenderNestedDefinition()
-        => string.Join(".", Array.ConvertAll(Name.Split('+'), StripArity));
+    {
+        var parts = new List<string>();
+        foreach (var segment in Name.Split('+'))
+        {
+            string name = StripArity(segment);
+            int arity = ArityOf(segment);
+            if (arity > 0)
+                name = $"{name}<{new string(',', arity - 1)}>";
+            parts.Add(name);
+        }
+        return string.Join(".", parts);
+    }
 
     /// <summary>
     /// A generic instance shows only the innermost segment's own type

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -446,7 +446,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
     /// </summary>
     public string ToDisplayString(TypeRef? scope) => Kind switch
     {
-        TypeRefKind.Definition => DisplayName(),
+        TypeRefKind.Definition => RenderDefinition(scope),
         TypeRefKind.GenericInstance => RenderGenericInstance(scope),
         TypeRefKind.SzArray => $"{ElementType!.ToDisplayString(scope)}[]",
         TypeRefKind.Array => $"{ElementType!.ToDisplayString(scope)}[{new string(',', Rank - 1)}]",
@@ -477,6 +477,51 @@ public sealed class TypeRef : IEquatable<TypeRef>
         string innermost = nested < 0 ? Name : Name[(nested + 1)..];
         return StripArity(innermost);
     }
+
+    /// <summary>
+    /// Scope-aware rendering for a type definition. The innermost simple name is
+    /// only in scope when the printing context is inside the enclosing type; from
+    /// a foreign scope a bare nested name (<c>Inner</c>) fails CS0246, so the
+    /// reference is qualified through its declaring chain (<c>Outer.Inner</c>),
+    /// mirroring <see cref="RenderGenericInstance"/>. A null scope keeps the bare
+    /// innermost spelling used by diagnostics and tests.
+    /// </summary>
+    string RenderDefinition(TypeRef? scope)
+    {
+        if (scope is not null
+            && Name.Contains('+')
+            && !IsPrivateImplementationDetails
+            && !DefinitionEnclosingInScope(scope))
+        {
+            return RenderNestedDefinition();
+        }
+        return DisplayName();
+    }
+
+    /// <summary>
+    /// True when this nested definition's enclosing type is the printing scope
+    /// (or contains it), so the bare innermost name binds. A non-nested
+    /// definition is always "in scope" — its name has no declaring chain to lose.
+    /// </summary>
+    bool DefinitionEnclosingInScope(TypeRef scope)
+    {
+        int lastPlus = Name.LastIndexOf('+');
+        if (lastPlus < 0)
+            return true;
+        var scopeDefinition = scope.Kind == TypeRefKind.GenericInstance ? scope.ElementType! : scope;
+        string enclosing = Name[..lastPlus];
+        return Assembly == scopeDefinition.Assembly
+            && Namespace == scopeDefinition.Namespace
+            && (enclosing == scopeDefinition.Name
+                || scopeDefinition.Name.StartsWith(enclosing + "+", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Renders a nested type definition through its declaring chain
+    /// (<c>Outer.Inner</c>), stripping each <c>+</c>-separated segment's arity.
+    /// </summary>
+    string RenderNestedDefinition()
+        => string.Join(".", Array.ConvertAll(Name.Split('+'), StripArity));
 
     /// <summary>
     /// A generic instance shows only the innermost segment's own type


### PR DESCRIPTION
## Row

Burndown row #1581 from #1598 (decompiler printer and semantics correctness), Cluster A — printer validity and type spelling.

## Invalid-output claim being narrowed

The decompiler body printer rendered every nested type **definition** through `TypeRef.DisplayName()`, which strips the declaring chain to the innermost segment. That spelling only binds when the printing scope is inside the enclosing type. From a foreign scope a bare `Inner` is not in scope (CS0246), yet the body still reported `Full`. `CSharpSpellability.TypeReason` had the same leaf-only blind spot, so an unspellable outer segment could not force honest degradation.

## Fix (narrow)

- `TypeRef.ToDisplayString(scope)` — the `Definition` case now qualifies a foreign nested type through its declaring chain (`Outer.Inner`), mirroring the existing `RenderGenericInstance` behavior. The bare innermost name is kept when in scope (`new Inner` inside `Outer`) and for a null scope (diagnostics/tests). `<PrivateImplementationDetails>` keeps its prior innermost spelling.
- `CSharpSpellability.TypeReason` — validates every `+`-separated nested segment, not just the leaf.

No printer/pass behavior widened; this removes invalid `Full` output (it becomes valid output or honest `Partial`).

## Evidence

Real-importer fixture (`ForeignNestedFixture`) plus focused tests:

- `ForeignNestedType_QualifiesThroughDeclaringChain`: `Repro.Other.ForeignReturn` body renders `return new Outer.Inner { Value = 2 };` (was `new Inner`, invalid from `Repro.Other`).
- `InScopeNestedType_KeepsBareInnermostName`: `Repro.Outer.InScope` still renders `return new Inner { Value = 1 };` (positive canary).
- `Spellability_ValidatesEveryNestedSegment_NotJustTheLeaf`: a nested definition with an unspellable outer segment but valid leaf is now flagged unspellable.

`dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ...ForeignNestedTypeSpellingTests` — 3/3 pass. Full suite runs in CI (local run is slow under heavy parallel machine load).

Closes #1581.
