### PR TITLE
Add rung 4 C# 7 ladder guard

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung4/ILInspector.Decompiler.Fixtures.LadderRung4.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung4/ILInspector.Decompiler.Fixtures.LadderRung4.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Decompiler.Fixtures.LadderRung4/LadderRung4.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung4/LadderRung4.cs
@@ -1,0 +1,106 @@
+namespace LadderRung4;
+
+// Rung 4 of the decompiler product quality ladder (#1599): C# 7 local syntax.
+// This fixture is deliberately scoped to ordinary source shapes that should
+// either decompile to valid C# or degrade honestly rather than claiming invalid
+// Full output: tuples, deconstruction, local functions, simple patterns, and ref
+// locals/returns.
+public static class CSharp7LocalSyntax
+{
+    public static (int Sum, int Product) TupleReturn(int left, int right)
+    {
+        return (left + right, left * right);
+    }
+
+    public static int TupleUse((int Left, int Right) pair)
+    {
+        return pair.Left + pair.Right;
+    }
+
+    public static int DeconstructPoint(Point point)
+    {
+        var (x, y) = point;
+        return x + y;
+    }
+
+    public static int LocalFunctionNonCapturing(int value)
+    {
+        int Double(int item)
+        {
+            return item * 2;
+        }
+
+        return Double(value);
+    }
+
+    public static int LocalFunctionCapturing(int value)
+    {
+        int AddSeed(int item) => item + value;
+
+        return AddSeed(3);
+    }
+
+    public static int LocalFunctionCapturingWithLocal(int value)
+    {
+        int AddSquare(int item)
+        {
+            int y = item + value;
+            return y * y;
+        }
+
+        return AddSquare(3);
+    }
+
+    public static int SimplePattern(object value)
+    {
+        if (value is int number)
+        {
+            return number;
+        }
+
+        if (value is string text)
+        {
+            return text.Length;
+        }
+
+        return 0;
+    }
+
+    public static int RefLocalUpdate(bool useLeft)
+    {
+        int left = 1;
+        int right = 2;
+        ref int target = ref SelectRef(useLeft, ref left, ref right);
+        target += 10;
+        return left + right;
+    }
+
+    public static ref int SelectRef(bool useLeft, ref int left, ref int right)
+    {
+        if (useLeft)
+        {
+            return ref left;
+        }
+
+        return ref right;
+    }
+}
+
+public readonly struct Point
+{
+    public Point(int x, int y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public int X { get; }
+
+    public int Y { get; }
+
+    public void Deconstruct(out int x, out int y)
+    {
+        x = X;
+        y = Y;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainB\ILInspector.Decompiler.Fixtures.UnsafeChainB.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainC\ILInspector.Decompiler.Fixtures.UnsafeChainC.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung1\ILInspector.Decompiler.Fixtures.LadderRung1.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung4\ILInspector.Decompiler.Fixtures.LadderRung4.csproj" />
   </ItemGroup>
 
   <!--

--- a/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
@@ -106,7 +106,7 @@ public class LadderRung4GateTests
     [Fact]
     public void Rung4Fixture_HasNoMalformedOrSemanticDefectiveFullOutput()
     {
-        var results = ValidityCheck.Evaluate(FixturePath)
+        var results = ValidityCheck.Evaluate(FixturePath, importSiblingBodies: true)
             .Where(r => r.TypeName == FixtureType)
             .ToList();
 

--- a/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
@@ -1,0 +1,150 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The rung 4 guard for the decompiler product quality ladder (#1599): C# 7
+/// local syntax. This is a scoped capability gate, not a broad C# 7 claim. It
+/// pins tuples, deconstruction, local functions, simple patterns, and ref
+/// locals/returns so they keep rendering as valid or honestly degraded output in
+/// the fast PR gate.
+/// </summary>
+public class LadderRung4GateTests
+{
+    static string FixturePath => typeof(LadderRung4.CSharp7LocalSyntax).Assembly.Location;
+    static readonly string FixtureType = typeof(LadderRung4.CSharp7LocalSyntax).FullName!;
+
+    static readonly string[] ExpectedMembers =
+    [
+        "<LocalFunctionCapturing>g__AddSeed|4_0",
+        "<LocalFunctionCapturingWithLocal>g__AddSquare|5_0",
+        "<LocalFunctionNonCapturing>g__Double|3_0",
+        "DeconstructPoint",
+        "LocalFunctionCapturing",
+        "LocalFunctionCapturingWithLocal",
+        "LocalFunctionNonCapturing",
+        "RefLocalUpdate",
+        "SelectRef",
+        "SimplePattern",
+        "TupleReturn",
+        "TupleUse",
+    ];
+
+    [Fact]
+    public void Rung4Fixture_ExposesExactMemberSet_AndHasNoResidualGaps()
+    {
+        var members = LoadRaisedMembers();
+
+        Assert.Equal(
+            ExpectedMembers,
+            members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
+
+        var failed = members
+            .Where(m => !m.Result.Succeeded)
+            .Select(m => $"{m.Name}: {string.Join(", ", m.Result.Diagnostics.Select(d => d.Message))}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(failed.Length == 0,
+            "Rung 4 product printing must not fail; failures: " + string.Join("; ", failed));
+
+        var gaps = members
+            .Where(m => Completeness.Residual(m.Function) is not null)
+            .Select(m => $"{m.Name}: {Completeness.Residual(m.Function)}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(gaps.Length == 0,
+            "Rung 4 fixture members must be fully structured (zero residual gaps); gaps: " + string.Join("; ", gaps));
+    }
+
+    [Fact]
+    public void Rung4Fixture_RendersRecognizableCSharp7LocalSyntax()
+    {
+        var members = LoadRaisedMembers();
+        string Body(string name) => members.Single(m => m.Name == name).Body.Trim();
+        DecompilationFidelity Fidelity(string name) => members.Single(m => m.Name == name).Function.Fidelity;
+
+        Assert.Equal("return (left + right, left * right);", Body("TupleReturn"));
+        Assert.Equal("return pair.Item1 + pair.Item2;", Body("TupleUse"));
+
+        var deconstruct = Body("DeconstructPoint");
+        Assert.Contains("(int ", deconstruct);
+        Assert.Contains(") = point;", deconstruct);
+        Assert.Contains("return ", deconstruct);
+
+        var staticLocal = Body("LocalFunctionNonCapturing");
+        Assert.Contains("return Double(value);", staticLocal);
+        Assert.Contains("static int Double(int item) => item * 2;", staticLocal);
+        Assert.DoesNotContain("g__", staticLocal);
+
+        var capturingLocal = Body("LocalFunctionCapturing");
+        Assert.Contains("return AddSeed(3);", capturingLocal);
+        Assert.Contains("int AddSeed(int item) => item + value;", capturingLocal);
+        Assert.DoesNotContain("DisplayClass", capturingLocal);
+
+        var localBodyCapture = Body("LocalFunctionCapturingWithLocal");
+        Assert.Equal(DecompilationFidelity.Partial, Fidelity("LocalFunctionCapturingWithLocal"));
+        Assert.Contains("DisplayClass", localBodyCapture);
+        Assert.Contains("AddSquare(3", localBodyCapture);
+
+        var pattern = Body("SimplePattern");
+        Assert.Contains("value is int", pattern);
+        Assert.Contains("value is string text", pattern);
+        Assert.Contains("return text.Length;", pattern);
+
+        var refLocal = Body("RefLocalUpdate");
+        Assert.Contains("ref int ", refLocal);
+        Assert.Contains(" = ref CSharp7LocalSyntax.SelectRef(useLeft, ref left, ref right);", refLocal);
+        Assert.Contains("+ 10;", refLocal);
+
+        var refReturn = Body("SelectRef");
+        Assert.Contains("return ref left;", refReturn);
+        Assert.Contains("return ref right;", refReturn);
+    }
+
+    [Fact]
+    public void Rung4Fixture_HasNoMalformedOrSemanticDefectiveFullOutput()
+    {
+        var results = ValidityCheck.Evaluate(FixturePath)
+            .Where(r => r.TypeName == FixtureType)
+            .ToList();
+
+        Assert.NotEmpty(results);
+
+        var malformedFull = results
+            .Where(r => r.IsFull && r.IsMalformed)
+            .Select(r => $"{r.MethodName}: {r.MalformedDiagnostics[0].Id} {r.MalformedDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(malformedFull.Length == 0,
+            "Rung 4 requires zero malformed Full methods; malformed: " + string.Join("; ", malformedFull));
+
+        var semanticFull = results
+            .Where(r => r.IsFull && r.HasSemanticDefect)
+            .Select(r => $"{r.MethodName}: {r.SemanticDiagnostics[0].Id} {r.SemanticDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(semanticFull.Length == 0,
+            "Rung 4 requires zero non-noise semantic defects on Full methods; defects: " + string.Join("; ", semanticFull));
+
+        Assert.All(
+            results.Where(r => r.IsFull),
+            r => Assert.True(r.SemanticChecked, $"Full method {r.MethodName} was not semantically bound."));
+    }
+
+    static List<(string Name, IrFunction Function, DecompilerResult Result, string Body)> LoadRaisedMembers()
+    {
+        var members = new List<(string Name, IrFunction Function, DecompilerResult Result, string Body)>();
+        using var source = MetadataSource.Open(FixturePath);
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (typeName != FixtureType)
+                continue;
+
+            var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+            members.Add((methodName, function, result, result.Output ?? ""));
+        }
+        return members;
+    }
+}

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -129,10 +129,10 @@ static class ValidityCheck
         return 0;
     }
 
-    internal static IReadOnlyList<MethodResult> Evaluate(string assemblyPath, int cap = int.MaxValue, bool lowered = false)
-        => Evaluate([assemblyPath], cap, lowered);
+    internal static IReadOnlyList<MethodResult> Evaluate(string assemblyPath, int cap = int.MaxValue, bool lowered = false, bool importSiblingBodies = false)
+        => Evaluate([assemblyPath], cap, lowered, importSiblingBodies);
 
-    internal static IReadOnlyList<MethodResult> Evaluate(IReadOnlyList<string> assemblies, int cap = int.MaxValue, bool lowered = false)
+    internal static IReadOnlyList<MethodResult> Evaluate(IReadOnlyList<string> assemblies, int cap = int.MaxValue, bool lowered = false, bool importSiblingBodies = false)
     {
         var references = RuntimeReferences();
         var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
@@ -180,7 +180,12 @@ static class ValidityCheck
                     // shell with identifier-syntax errors. Skip them.
                     if (typeName.Contains('<') || methodName.Contains('<'))
                         continue;
-                    var rendered = (lowered ? CSharpPrinter.PrintLowered(function) : CSharpPrinter.PrintRaised(function)).Output;
+                    Func<MethodRef, IrFunction?>? importMethodBody = importSiblingBodies
+                        ? method => IrImporter.Import(source, method)
+                        : null;
+                    var rendered = (lowered
+                        ? CSharpPrinter.PrintLowered(function, importMethodBody)
+                        : CSharpPrinter.PrintRaised(function, importMethodBody)).Output;
                     if (rendered is null)
                         continue;
                     bool full = function.Fidelity == DecompilationFidelity.Full;


### PR DESCRIPTION
## Summary

Part of #1599 row 4.

- add `ILInspector.Decompiler.Fixtures.LadderRung4` with a scoped C# 7 local-syntax fixture
- cover tuples, tuple member use, deconstruction, static and capturing local functions, simple patterns, and ref locals/returns
- add a fast PR-gate guard that checks exact fixture scope, product-path printing with the cross-method import seam, zero residual gaps, recognizable C# 7 syntax, and no malformed/non-noise semantic defects on Full output

## Scope / ladder status

This creates the rung 4 fixture and fast guard. It intentionally keeps the completion claim scoped: the fixture has a known honest-degrade frontier for local-bodied capturing local functions (`Partial` with display-class residue), while the simpler capturing local-function shape is recovered.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LadderRung4GateTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`