### PR TITLE
Escape keyword identifiers in decompiler output

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpNamingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpNamingTests.cs
@@ -11,4 +11,19 @@ public class CSharpNamingTests
     [InlineData("<Ag__B>b__0_0", "<Ag__B>b__0_0")]
     public void MethodName_DemanglesLocalFunctionAfterEnclosingName(string metadataName, string expected)
         => Assert.Equal(expected, CSharpNaming.MethodName(metadataName));
+
+    [Theory]
+    [InlineData("return", "@return")]
+    [InlineData("event", "@event")]
+    [InlineData("<M>g__return|0_0", "@return")]
+    [InlineData("Normal", "Normal")]
+    public void SourceMethodName_EscapesKeywordsAfterDemangling(string metadataName, string expected)
+        => Assert.Equal(expected, CSharpNaming.SourceMethodName(metadataName));
+
+    [Theory]
+    [InlineData("class", "@class")]
+    [InlineData("class`1", "@class")]
+    [InlineData("Normal`1", "Normal")]
+    public void TypeNameSegment_StripsArityAndEscapesKeywords(string metadataName, string expected)
+        => Assert.Equal(expected, CSharpNaming.TypeNameSegment(metadataName));
 }

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -65,6 +65,23 @@ public class CfgSampleClass
 
     public static int ContextualKeywordParam(int @await) => @await + 1;
 
+    public static int @return(int value) => value + 1;
+
+    public static int CallsKeywordStaticMethod(int value) => @return(value);
+
+    public int @event(int value) => value + 2;
+
+    public int CallsKeywordInstanceMethod(int value) => @event(value);
+
+    public Func<int, int> KeywordInstanceMethodGroup() => @event;
+
+    public static @class CreateKeywordType() => new @class();
+
+    public sealed class @class
+    {
+        public int Value => 42;
+    }
+
     // A reference inequality against null: csc lowers `o != null` to
     // `ldnull; cgt.un` (an unsigned ordering), so the IR is GreaterThan-unsigned
     // with a null operand. The printer must spell it `o is not null`, not the

--- a/src/ILInspector.Decompiler.Tests/KeywordIdentifierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/KeywordIdentifierTests.cs
@@ -1,3 +1,4 @@
+using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
@@ -17,6 +18,7 @@ public class KeywordIdentifierTests
         Assert.NotNull(function);
         IrPasses.Run(function!);
         function!.CheckInvariant();
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
         return CSharpPrinter.Print(function).Output!;
     }
 
@@ -36,6 +38,42 @@ public class KeywordIdentifierTests
 
         Assert.Contains("@await + 1", output);
         Assert.DoesNotContain(" await", output);
+    }
+
+    [Fact]
+    public void KeywordStaticMethodName_IsEscaped()
+    {
+        var output = Render(nameof(CfgSampleClass.CallsKeywordStaticMethod));
+
+        Assert.Contains("CfgSampleClass.@return(value)", output);
+        Assert.DoesNotContain("CfgSampleClass.return(value)", output);
+    }
+
+    [Fact]
+    public void KeywordInstanceMethodName_IsEscaped()
+    {
+        var output = Render(nameof(CfgSampleClass.CallsKeywordInstanceMethod));
+
+        Assert.Contains("@event(value)", output);
+        Assert.DoesNotContain(" event(value)", output);
+    }
+
+    [Fact]
+    public void KeywordMethodGroupName_IsEscaped()
+    {
+        var output = Render(nameof(CfgSampleClass.KeywordInstanceMethodGroup));
+
+        Assert.Contains("new Func<int, int>(@event)", output);
+        Assert.DoesNotContain("new Func<int, int>(event)", output);
+    }
+
+    [Fact]
+    public void KeywordTypeName_IsEscaped()
+    {
+        var output = Render(nameof(CfgSampleClass.CreateKeywordType));
+
+        Assert.Contains("new @class()", output);
+        Assert.DoesNotContain("new class()", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
@@ -85,7 +85,7 @@ internal static class CSharpSpellability
             return null;
 
         string name = CSharpNaming.MethodName(method.Name);
-        return CSharpNaming.IsUsableIdentifier(name)
+        return CSharpNaming.IsEscapableIdentifier(name)
             ? null
             : $"method name '{method.Name}' has no C# spelling";
     }
@@ -141,7 +141,7 @@ internal static class CSharpSpellability
                 if (IsCoreLibPrimitive(type))
                     return null;
                 string simpleName = StripArity(InnermostName(type.Name));
-                return CSharpNaming.IsUsableIdentifier(simpleName)
+                return CSharpNaming.IsEscapableIdentifier(simpleName)
                     ? null
                     : $"type name '{simpleName}' has no C# spelling";
 
@@ -162,7 +162,7 @@ internal static class CSharpSpellability
 
             case TypeRefKind.GenericParameter:
             case TypeRefKind.MethodGenericParameter:
-                return type.GenericParameterName.Length == 0 || CSharpNaming.IsUsableIdentifier(type.GenericParameterName)
+                return type.GenericParameterName.Length == 0 || CSharpNaming.IsEscapableIdentifier(type.GenericParameterName)
                     ? null
                     : $"generic parameter name '{type.GenericParameterName}' has no C# spelling";
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -40,6 +40,12 @@ internal static class CSharpNaming
     public static string EscapeIdentifier(string name)
         => RequiresEscape(name) ? "@" + name : name;
 
+    public static string SourceMethodName(string metadataName)
+        => EscapeIdentifier(MethodName(metadataName));
+
+    public static string TypeNameSegment(string metadataName)
+        => EscapeIdentifier(StripArity(metadataName));
+
     static bool RequiresEscape(string name)
         => ReservedKeywords.Contains(name) || name == "await";
 
@@ -81,5 +87,11 @@ internal static class CSharpNaming
         int start = marker + 4;
         int bar = name.IndexOf('|', start);
         return bar > start ? name[start..bar] : name[start..];
+    }
+
+    static string StripArity(string name)
+    {
+        int tick = name.IndexOf('`');
+        return tick < 0 ? name : name[..tick];
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -84,7 +84,7 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string MethodGroupText(MethodRef method, IrExpression target)
     {
-        string name = CSharpNaming.MethodName(method.Name);
+        string name = CSharpNaming.SourceMethodName(method.Name);
         if (target is Constant { Value: null })
             return $"{TypeText(method.DeclaringType)}.{name}";
         if (target is LoadArgument { Index: 0, Name: "this" })
@@ -104,7 +104,7 @@ public sealed partial class CSharpPrinter
         string typeArguments = method.TypeArguments.IsEmpty
             ? ""
             : $"<{string.Join(", ", method.TypeArguments.Select(TypeText))}>";
-        string name = $"{CSharpNaming.MethodName(method.Name)}{typeArguments}";
+        string name = $"{CSharpNaming.SourceMethodName(method.Name)}{typeArguments}";
         return IsCrossType(method.DeclaringType)
             ? $"&{TypeText(method.DeclaringType)}.{name}"
             : $"&{name}";
@@ -134,7 +134,7 @@ public sealed partial class CSharpPrinter
                     ? call.Callee.ParameterRefKinds
                     : [.. call.Callee.ParameterRefKinds.Skip(1)];
                 string extensionArgs = Arguments(arguments.Skip(1), restTypes, restRefKinds);
-                return $"{ReceiverText(arguments[0])}.{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({extensionArgs})";
+                return $"{ReceiverText(arguments[0])}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({extensionArgs})";
             }
             // A static abstract/virtual interface member invoked through a type
             // parameter compiles to `constrained. T; call IInterface<…>::Method`.
@@ -143,8 +143,8 @@ public sealed partial class CSharpPrinter
             // static abstract member: CS0119/CS0314). The constrained type is the
             // receiver, and the spelling recompiles to the same constrained call.
             if (call.ConstrainedTo is { } staticReceiver)
-                return $"{TypeText(staticReceiver)}.{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
-            return $"{TypeText(call.Callee.DeclaringType)}.{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
+                return $"{TypeText(staticReceiver)}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
+            return $"{TypeText(call.Callee.DeclaringType)}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
         }
         var receiver = arguments[0];
         string rest = Arguments(arguments.Skip(1), call.Callee.ParameterTypes, call.Callee.ParameterRefKinds);
@@ -163,10 +163,10 @@ public sealed partial class CSharpPrinter
             // Non-virtual this-receiver call to a base-declared method is
             // C#'s base.M() — the call opcode deliberately skips dispatch.
             return !call.IsVirtual && IsCrossType(call.Callee.DeclaringType)
-                ? $"base.{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({rest})"
-                : $"{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({rest})";
+                ? $"base.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})"
+                : $"{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
         }
-        return $"{ReceiverText(receiver)}.{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({rest})";
+        return $"{ReceiverText(receiver)}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
     }
 
     string Arguments(IEnumerable<IrExpression> arguments)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -250,6 +250,6 @@ public sealed partial class CSharpPrinter
         string typeArguments = call.Callee.TypeArguments.IsEmpty
             ? ""
             : $"<{string.Join(", ", call.Callee.TypeArguments.Select(TypeText))}>";
-        return $".{CSharpNaming.MethodName(call.Callee.Name)}{typeArguments}({Arguments(call.Arguments.Skip(1), call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
+        return $".{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({Arguments(call.Arguments.Skip(1), call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
+++ b/src/ILInspector.Decompiler/Pipeline/TypeRef.cs
@@ -454,7 +454,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
         TypeRefKind.Pointer => $"{ElementType!.ToDisplayString(scope)}*",
         TypeRefKind.Pinned => $"pinned {ElementType!.ToDisplayString(scope)}",
         TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter =>
-            GenericParameterName.Length > 0 ? GenericParameterName : $"!{GenericParameterIndex}",
+            GenericParameterName.Length > 0 ? CSharpNaming.EscapeIdentifier(GenericParameterName) : $"!{GenericParameterIndex}",
         TypeRefKind.FunctionPointer => RenderFunctionPointer(scope),
         _ => $"<unsupported: {UnsupportedReason}>",
     };
@@ -475,7 +475,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
         // convention extended inward), so `Interop+Error` renders `Error`.
         int nested = Name.LastIndexOf('+');
         string innermost = nested < 0 ? Name : Name[(nested + 1)..];
-        return StripArity(innermost);
+        return CSharpNaming.TypeNameSegment(innermost);
     }
 
     /// <summary>
@@ -566,7 +566,7 @@ public sealed class TypeRef : IEquatable<TypeRef>
         int argIndex = 0;
         for (int i = 0; i < segments.Length; i++)
         {
-            string name = StripArity(segments[i]);
+            string name = CSharpNaming.TypeNameSegment(segments[i]);
             int arity = arities[i];
             if (arity > 0)
             {

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -357,17 +357,31 @@ public class OutputFormatterTests
                 new ApiMember { Kind = "method", Name = "CreateKeywordType", Signature = "Probe.class CreateKeywordType()" },
             ]
         };
+        var defaultStringLiteral = new ApiType
+        {
+            Namespace = "Probe",
+            Name = "KeywordMethods",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember { Kind = "method", Name = "DefaultPath", Signature = "void DefaultPath(string value = \"config.in.txt\")" },
+            ]
+        };
         var options = new ApiOptions { Verbosity = Verbosity.Normal };
         var methodView = new TypeView();
         var returnTypeView = new TypeView();
+        var defaultStringView = new TypeView();
 
         ApiOutputFormatter.PopulateMemberSignature(methodView, keywordMethodType, options);
         ApiOutputFormatter.PopulateMemberSignature(returnTypeView, keywordTypeReturn, options);
+        ApiOutputFormatter.PopulateMemberSignature(defaultStringView, defaultStringLiteral, options);
 
         var methodSignature = Assert.Single(Assert.IsType<List<MemberSignatureRow>>(methodView.SignatureRows));
         var returnTypeSignature = Assert.Single(Assert.IsType<List<MemberSignatureRow>>(returnTypeView.SignatureRows));
+        var defaultStringSignature = Assert.Single(Assert.IsType<List<MemberSignatureRow>>(defaultStringView.SignatureRows));
         Assert.Equal("<code>public int @return(int value)</code>", methodSignature.Signature);
         Assert.Equal("<code>public Probe.@class CreateKeywordType()</code>", returnTypeSignature.Signature);
+        Assert.Equal("<code>public void DefaultPath(string value = \"config.in.txt\")</code>", defaultStringSignature.Signature);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -335,6 +335,42 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public void PopulateMemberSignature_EscapesKeywordMethodAndQualifiedTypeNames()
+    {
+        var keywordMethodType = new ApiType
+        {
+            Namespace = "Probe",
+            Name = "KeywordMethods",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember { Kind = "method", Name = "return", Signature = "int return(int value)" },
+            ]
+        };
+        var keywordTypeReturn = new ApiType
+        {
+            Namespace = "Probe",
+            Name = "KeywordMethods",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember { Kind = "method", Name = "CreateKeywordType", Signature = "Probe.class CreateKeywordType()" },
+            ]
+        };
+        var options = new ApiOptions { Verbosity = Verbosity.Normal };
+        var methodView = new TypeView();
+        var returnTypeView = new TypeView();
+
+        ApiOutputFormatter.PopulateMemberSignature(methodView, keywordMethodType, options);
+        ApiOutputFormatter.PopulateMemberSignature(returnTypeView, keywordTypeReturn, options);
+
+        var methodSignature = Assert.Single(Assert.IsType<List<MemberSignatureRow>>(methodView.SignatureRows));
+        var returnTypeSignature = Assert.Single(Assert.IsType<List<MemberSignatureRow>>(returnTypeView.SignatureRows));
+        Assert.Equal("<code>public int @return(int value)</code>", methodSignature.Signature);
+        Assert.Equal("<code>public Probe.@class CreateKeywordType()</code>", returnTypeSignature.Signature);
+    }
+
+    [Fact]
     public void TypeViewSchema_DoesNotOwnFirstClassMemberRows()
     {
         var schema = ApiViewContext.Default.GetSchemaInfo<TypeView>()!.ToDocumentSchema();

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1906,10 +1906,41 @@ public static class ApiOutputFormatter
     private static string EscapeQualifiedKeywordSegments(string signature)
     {
         var sb = new StringBuilder(signature.Length);
+        bool inString = false;
+        bool inChar = false;
+        bool escapedChar = false;
         for (int i = 0; i < signature.Length; i++)
         {
             char c = signature[i];
             sb.Append(c);
+            if (inString || inChar)
+            {
+                if (escapedChar)
+                {
+                    escapedChar = false;
+                    continue;
+                }
+                if (c == '\\')
+                {
+                    escapedChar = true;
+                    continue;
+                }
+                if (inString && c == '"')
+                    inString = false;
+                else if (inChar && c == '\'')
+                    inChar = false;
+                continue;
+            }
+            if (c == '"')
+            {
+                inString = true;
+                continue;
+            }
+            if (c == '\'')
+            {
+                inChar = true;
+                continue;
+            }
             if (c != '.' || i + 1 >= signature.Length || signature[i + 1] == '@' || !IsIdentifierStart(signature[i + 1]))
                 continue;
 

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1796,11 +1796,14 @@ public static class ApiOutputFormatter
                 signature = AddMethodGenericParameters(signature, member.Name, methodParameters);
             if (member.IsExtension)
                 signature = AddExtensionThisModifier(signature);
+            signature = EscapeMemberNameInSignature(signature, member.Name);
         }
         else if (member.Kind == "event" && !signature.StartsWith("event ", StringComparison.Ordinal))
         {
             signature = $"event {signature}";
         }
+
+        signature = EscapeQualifiedKeywordSegments(signature);
 
         List<string> parts = [];
         if (member.IsObsolete)
@@ -1877,8 +1880,74 @@ public static class ApiOutputFormatter
     private static string FormatConstructorTypeName(string name)
     {
         var arityIndex = name.IndexOf('`');
-        return arityIndex < 0 ? name : name[..arityIndex];
+        var typeName = arityIndex < 0 ? name : name[..arityIndex];
+        return EscapeCSharpIdentifier(typeName);
     }
+
+    private static string EscapeMemberNameInSignature(string signature, string memberName)
+    {
+        if (string.IsNullOrEmpty(memberName))
+            return signature;
+
+        int parenStart = signature.IndexOf('(');
+        if (parenStart <= 0)
+            return signature;
+
+        int nameIndex = signature.LastIndexOf(memberName, parenStart - 1, StringComparison.Ordinal);
+        if (nameIndex < 0)
+            return signature;
+
+        string escaped = EscapeCSharpIdentifier(memberName);
+        return escaped == memberName
+            ? signature
+            : string.Concat(signature.AsSpan(0, nameIndex), escaped, signature.AsSpan(nameIndex + memberName.Length));
+    }
+
+    private static string EscapeQualifiedKeywordSegments(string signature)
+    {
+        var sb = new StringBuilder(signature.Length);
+        for (int i = 0; i < signature.Length; i++)
+        {
+            char c = signature[i];
+            sb.Append(c);
+            if (c != '.' || i + 1 >= signature.Length || signature[i + 1] == '@' || !IsIdentifierStart(signature[i + 1]))
+                continue;
+
+            int start = i + 1;
+            int end = start + 1;
+            while (end < signature.Length && IsIdentifierPart(signature[end]))
+                end++;
+
+            string segment = signature[start..end];
+            string escaped = EscapeCSharpIdentifier(segment);
+            if (escaped != segment)
+            {
+                sb.Append(escaped);
+                i = end - 1;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string EscapeCSharpIdentifier(string name)
+        => s_csharpReservedKeywords.Contains(name) || name == "await" ? "@" + name : name;
+
+    private static bool IsIdentifierStart(char c) => char.IsLetter(c) || c == '_';
+
+    private static bool IsIdentifierPart(char c) => char.IsLetterOrDigit(c) || c == '_';
+
+    static readonly HashSet<string> s_csharpReservedKeywords = new(StringComparer.Ordinal)
+    {
+        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
+        "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else",
+        "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
+        "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
+        "long", "namespace", "new", "null", "object", "operator", "out", "override", "params",
+        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
+        "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
+        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
+        "void", "volatile", "while",
+    };
 
     private static string AddMethodGenericParameters(string signature, string methodName, IReadOnlyList<string> methodParameters)
     {


### PR DESCRIPTION
## Summary

Fixes #1613.

Escapes C# keyword identifiers in decompiler output instead of treating them as bare or unspellable:

- method calls, method groups, address-of methods, null-conditional call suffixes
- type-name segments and generic parameter names in decompiler type rendering
- member declarations rendered by `dotnet-inspect member -S "Decompiled Source"`
- spellability now treats keyword identifiers as escapable and still degrades truly invalid names

## Evidence

Focused and affected tests:

```text
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded.

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/KeywordIdentifierTests/*"
Total: 7, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CSharpNamingTests/*"
Total: 11, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/UnspeakableNameFidelityTests/*"
Total: 2, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/UnspellableTypeFidelityTests/*"
Total: 3, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeOfRenderingTests/*"
Total: 20, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/OutputFormatterTests/PopulateMemberSignature_EscapesKeywordMethodAndQualifiedTypeNames"
Total: 1, Errors: 0, Failed: 0, Skipped: 0
```

Broader product suite:

```text
dotnet run --project src/dotnet-inspect.Tests -c Release
Total: 1344, Errors: 0, Failed: 0, Skipped: 9
```

The full `ILInspector.Decompiler.Tests` executable was started but did not complete after an extended wait; I stopped it and ran the closest affected decompiler subsets above instead.

Manual product repro after source build:

```csharp
public static int @return(int value) => value + 1;
public static int CallsKeywordStatic(int value) => KeywordMethods.@return(value);
public int CallsKeywordInstance(int value) => @event(value);
public System.Func<int, int> KeywordMethodGroup() => new Func<int, int>(@event);
public static Probe.@class CreateKeywordType() => new @class();
```
