### PR TITLE
Add rung 5 fixture and measurement guard for decompiler product ladder (#1599)

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung5/ILInspector.Decompiler.Fixtures.LadderRung5.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung5/ILInspector.Decompiler.Fixtures.LadderRung5.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Rung 5 of the decompiler product quality ladder (#1599): C# 8-9 syntax
+    surface. A small, durable fixture covering the rung 5 constructs — index/range
+    operators, using declarations, switch expressions, expanded patterns
+    (relational/logical/property/tuple), and records with init-only members — that
+    the rung 5 fast guard (LadderRung5GateTests) measures.
+
+    Referenced by the test project so the DLL is built and locatable via
+    typeof(LadderRung5.Program).Assembly.Location. Keep the shapes ordinary C# 8-9:
+    this fixture is the scoped completion bar for rung 5, not a place to add
+    C# 10+ idioms (those are rung 6) or boss-rung constructs.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+
+namespace LadderRung5;
+
+// Rung 5 of the decompiler product quality ladder (#1599): C# 8-9 syntax surface.
+// Every member here exercises one rung 5 construct — index/range operators,
+// using declarations, switch expressions, expanded patterns
+// (relational/logical/property/tuple/type), and records with init-only members.
+// LadderRung5GateTests decompiles this assembly and measures the rung 5 bar:
+// fixture members render valid C# with no invalid Full, and source concepts the
+// IL erases degrade with owned residuals rather than wrong source truth.
+public class Program
+{
+    // Index-from-end operator (^1).
+    public int LastElement(int[] values)
+    {
+        return values[^1];
+    }
+
+    // Index-from-end with a computed offset.
+    public int FromEnd(int[] values, int offset)
+    {
+        return values[^offset];
+    }
+
+    // Range operator producing a slice (1..^1).
+    public int[] MiddleSlice(int[] values)
+    {
+        return values[1..^1];
+    }
+
+    // Range with an open end (..2).
+    public int[] Prefix(int[] values)
+    {
+        return values[..2];
+    }
+
+    // Switch expression with relational and logical (and) patterns.
+    public string Size(int value)
+    {
+        return value switch
+        {
+            < 0 => "negative",
+            0 => "zero",
+            > 0 and < 10 => "small",
+            _ => "big",
+        };
+    }
+
+    // Switch expression over a tuple with nested relational patterns.
+    public string Quadrant(int x, int y)
+    {
+        return (x, y) switch
+        {
+            ( > 0, > 0) => "I",
+            ( < 0, > 0) => "II",
+            ( < 0, < 0) => "III",
+            ( > 0, < 0) => "IV",
+            _ => "axis",
+        };
+    }
+
+    // Property pattern.
+    public bool IsOrigin(Point point)
+    {
+        return point is { X: 0, Y: 0 };
+    }
+
+    // Type pattern with a logical-not pattern.
+    public bool IsRealString(object value)
+    {
+        return value is string and not "";
+    }
+
+    // Switch expression mixing type, constant, and discard patterns.
+    public string Describe(object value)
+    {
+        return value switch
+        {
+            null => "null",
+            string s => s,
+            int n and > 0 => "positive int",
+            _ => "other",
+        };
+    }
+
+    // using declaration over a disposable local.
+    public long UsingDeclaration(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes);
+        stream.ReadByte();
+        return stream.Length;
+    }
+
+    // Object initializer assigning an init-only property on a record.
+    public Point MakeScaled(int x, int y)
+    {
+        return new Point(x, y) { Magnitude = x + y };
+    }
+
+    // Nondestructive mutation (with-expression) on a record.
+    public Point Shift(Point point, int dx)
+    {
+        return point with { X = point.X + dx };
+    }
+}
+
+// Positional record with an extra init-only property: rung 5 "records/init where
+// visible". The compiler-synthesized members (Equals, ==, GetHashCode, ToString,
+// Deconstruct, copy-constructor, Clone, EqualityContract) are part of what the
+// decompiler must render validly or degrade honestly.
+public record Point(int X, int Y)
+{
+    public int Magnitude { get; init; }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainB\ILInspector.Decompiler.Fixtures.UnsafeChainB.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainC\ILInspector.Decompiler.Fixtures.UnsafeChainC.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung1\ILInspector.Decompiler.Fixtures.LadderRung1.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung5\ILInspector.Decompiler.Fixtures.LadderRung5.csproj" />
   </ItemGroup>
 
   <!--

--- a/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
@@ -39,6 +39,7 @@ public class LadderRung5GateTests
 {
     static string FixturePath => typeof(LadderRung5.Program).Assembly.Location;
     static readonly string ProgramType = typeof(LadderRung5.Program).FullName!;
+    static readonly string RecordType = typeof(LadderRung5.Point).FullName!;
 
     // The exact rung 5 source-visible Program member set. Locked so a future
     // fixture edit that drops a construct fails loudly instead of silently
@@ -50,12 +51,35 @@ public class LadderRung5GateTests
         "UsingDeclaration",
     ];
 
+    // The record's compiler-synthesized member set (primary + copy ctor, Clone,
+    // Deconstruct, the two Equals overloads, GetHashCode, PrintMembers, ToString,
+    // EqualityContract, accessors, equality operators). Locked because rung 5
+    // ("records/init where visible") measures these, and a gap issue (#1632)
+    // depends on Point.Deconstruct: a future importer/printer change that drops a
+    // synthesized member must fail here rather than silently shrink the scope.
+    static readonly string[] ExpectedRecordMembers =
+    [
+        ".ctor", ".ctor", "<Clone>$", "Deconstruct", "Equals", "Equals",
+        "GetHashCode", "PrintMembers", "ToString", "get_EqualityContract",
+        "get_Magnitude", "get_X", "get_Y", "op_Equality", "op_Inequality",
+        "set_Magnitude", "set_X", "set_Y",
+    ];
+
     [Fact]
     public void Rung5Fixture_ExposesExactProgramMemberSet()
     {
         var members = LoadRaisedMembers().Where(m => m.Type == ProgramType).ToList();
         Assert.Equal(
             ExpectedProgramMembers,
+            members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
+    }
+
+    [Fact]
+    public void Rung5Fixture_ExposesExactRecordMemberSet()
+    {
+        var members = LoadRaisedMembers().Where(m => m.Type == RecordType).ToList();
+        Assert.Equal(
+            ExpectedRecordMembers,
             members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
     }
 
@@ -115,10 +139,13 @@ public class LadderRung5GateTests
         // Property pattern.
         Assert.Contains("point is not null && point.X == 0 && point.Y == 0", Body("IsOrigin"));
 
-        // Type pattern with a negated constant pattern.
+        // Type pattern with a negated constant pattern. Pin the negation, not just
+        // the `is string` test and the `""` literal: a decompile that dropped the
+        // `not ""` (e.g. `value is string s && s == ""`) reverses the semantics and
+        // must fail here.
         var isRealString = Body("IsRealString");
         Assert.Contains("value is string", isRealString);
-        Assert.Contains("== \"\"", isRealString);
+        Assert.Matches(@"!\(\s*\w+ == """"\s*\)|!= """"", isRealString);
 
         // Scalar relational/type switch expressions lower to recognizable
         // branches with the right arms.

--- a/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
@@ -1,0 +1,155 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The rung 5 guard for the decompiler product quality ladder (#1599): C# 8-9
+/// syntax surface. It decompiles the in-repo <see cref="LadderRung5.Program"/>
+/// fixture and pins the scoped rung 5 bar that already holds, so a regression
+/// below it fails fast in PR CI:
+/// <list type="bullet">
+/// <item>the fixture exposes exactly the rung 5 source-visible member set — no
+/// construct is silently dropped;</item>
+/// <item><b>no invalid <c>Full</c></b>: every member that imports as <c>Full</c>
+/// renders as valid C# — zero malformed <c>Full</c> methods and zero non-noise
+/// semantic-binding defects (the core ladder bar);</item>
+/// <item>the constructs that already meet the rung 5 bar — index/range operators,
+/// <c>using</c> declarations, property/type patterns, scalar relational switch
+/// expressions, and init-only object initializers — render recognizably.</item>
+/// </list>
+///
+/// Rung 5 is <b>not complete</b>: three source-visible constructs still fall short
+/// of the bar and are tracked as focused issues. They are deliberately NOT
+/// asserted green here; this guard locks the invariant and the working surface so
+/// those fixes can be verified against a stable baseline:
+/// <list type="bullet">
+/// <item>#1630 — <c>with</c>-expression (<see cref="LadderRung5.Program.Shift"/>)
+/// is not raised and renders the invalid <c>&lt;Clone&gt;$</c> identifier (CS1001);
+/// it stays <c>Partial</c>, so it does not breach the no-invalid-<c>Full</c>
+/// bar.</item>
+/// <item>#1631 — tuple-pattern switch expression
+/// (<see cref="LadderRung5.Program.Quadrant"/>) decompiles to a goto ladder.</item>
+/// <item>#1632 — record <c>Deconstruct</c> drops the receiver and renders
+/// <c>X = X;</c>.</item>
+/// </list>
+/// </summary>
+public class LadderRung5GateTests
+{
+    static string FixturePath => typeof(LadderRung5.Program).Assembly.Location;
+    static readonly string ProgramType = typeof(LadderRung5.Program).FullName!;
+
+    // The exact rung 5 source-visible Program member set. Locked so a future
+    // fixture edit that drops a construct fails loudly instead of silently
+    // shrinking the measured scope.
+    static readonly string[] ExpectedProgramMembers =
+    [
+        ".ctor", "Describe", "FromEnd", "IsOrigin", "IsRealString", "LastElement",
+        "MakeScaled", "MiddleSlice", "Prefix", "Quadrant", "Shift", "Size",
+        "UsingDeclaration",
+    ];
+
+    [Fact]
+    public void Rung5Fixture_ExposesExactProgramMemberSet()
+    {
+        var members = LoadRaisedMembers().Where(m => m.Type == ProgramType).ToList();
+        Assert.Equal(
+            ExpectedProgramMembers,
+            members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
+    }
+
+    // The core ladder bar for rung 5: every member that imports as Full must
+    // render valid C#. This holds across the whole fixture today (the only
+    // malformed member, Shift / #1630, imports as Partial), so a future change
+    // that promotes a malformed body to Full — or introduces any malformed Full —
+    // fails here.
+    [Fact]
+    public void Rung5Fixture_HasNoInvalidFull()
+    {
+        var results = ValidityCheck.Evaluate(FixturePath)
+            .Where(r => r.TypeName.StartsWith("LadderRung5.", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.NotEmpty(results);
+
+        var malformedFull = results
+            .Where(r => r.IsFull && r.IsMalformed)
+            .Select(r => $"{r.Id}: {r.MalformedDiagnostics[0].Id} {r.MalformedDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(malformedFull.Length == 0,
+            "Rung 5 requires no invalid Full; malformed Full: " + string.Join("; ", malformedFull));
+
+        var semantic = results
+            .Where(r => r.HasSemanticDefect)
+            .Select(r => $"{r.Id}: {r.SemanticDiagnostics[0].Id} {r.SemanticDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(semantic.Length == 0,
+            "Rung 5 requires zero semantic-binding defects; defects: " + string.Join("; ", semantic));
+
+        // Teeth: every Full member must actually have been bound (not skipped by
+        // the cap), so the malformed/semantic assertions are not vacuous.
+        Assert.All(
+            results.Where(r => r.IsFull),
+            r => Assert.True(r.SemanticChecked, $"Full method {r.Id} was not semantically bound."));
+    }
+
+    // The rung 5 constructs that already meet the bar render recognizably. These
+    // catch intra-fixture misrenders that the validity shell filters as
+    // member-resolution noise.
+    [Fact]
+    public void Rung5Fixture_RendersWorkingConstructs()
+    {
+        var members = LoadRaisedMembers().Where(m => m.Type == ProgramType).ToList();
+        string Body(string name) =>
+            CSharpPrinter.PrintRaised(members.Single(m => m.Name == name).Function).Output?.Trim() ?? "";
+
+        // Index-from-end and range operators.
+        Assert.Equal("return values[^1];", Body("LastElement"));
+        Assert.Equal("return values[^offset];", Body("FromEnd"));
+        Assert.Equal("return values[1..^1];", Body("MiddleSlice"));
+        Assert.Equal("return values[..2];", Body("Prefix"));
+
+        // Property pattern.
+        Assert.Contains("point is not null && point.X == 0 && point.Y == 0", Body("IsOrigin"));
+
+        // Type pattern with a negated constant pattern.
+        var isRealString = Body("IsRealString");
+        Assert.Contains("value is string", isRealString);
+        Assert.Contains("== \"\"", isRealString);
+
+        // Scalar relational/type switch expressions lower to recognizable
+        // branches with the right arms.
+        var size = Body("Size");
+        Assert.Contains("return \"negative\";", size);
+        Assert.Contains("return \"small\";", size);
+        Assert.Contains("return \"big\";", size);
+
+        var describe = Body("Describe");
+        Assert.Contains("return s;", describe);
+        Assert.Contains("\"positive int\"", describe);
+        Assert.Contains("\"null\"", describe);
+
+        // using declaration over a disposable local.
+        Assert.Contains("using (MemoryStream stream = new MemoryStream(bytes))", Body("UsingDeclaration"));
+
+        // init-only property set through an object initializer on a record.
+        Assert.Contains("new Point(x, y) { Magnitude = x + y }", Body("MakeScaled"));
+    }
+
+    static List<(string Type, string Name, IrFunction Function)> LoadRaisedMembers()
+    {
+        var members = new List<(string Type, string Name, IrFunction Function)>();
+        using var source = MetadataSource.Open(FixturePath);
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (!typeName.StartsWith("LadderRung5.", StringComparison.Ordinal))
+                continue;
+            IrPasses.Run(function);
+            members.Add((typeName, methodName, function));
+        }
+        return members;
+    }
+}


### PR DESCRIPTION
## Summary

Rung 5 (C# 8–9 syntax surface) of the decompiler product quality ladder (#1599). Adds a durable `LadderRung5` fixture and a fast PR guard (`LadderRung5GateTests`), and measures current decompiler status against the rung. Mirrors the rung 1 pattern (#1609).

This is Ladder-tester measurement work: it establishes the fixture, locks the bar that already holds, and files focused issues for the failing patterns — it does **not** implement the fixes. Rung 5 is **not** marked complete.

## Rung 5 status (measured)

**Meets the bar (Full + valid):**

- Index/range operators: `values[^1]`, `values[^offset]`, `values[1..^1]`, `values[..2]`
- `using` declaration → `using (MemoryStream stream = ...)`
- Property pattern → `point is not null && point.X == 0 && point.Y == 0`
- Type + negated-constant pattern → `value is string ... && !(... == "")`
- Scalar relational/type switch expressions (`Size`, `Describe`) → recognizable nested branches
- init-only object initializer on a record → `new Point(x, y) { Magnitude = x + y }`
- Record core members (`Equals`, `==`, `GetHashCode`, `ToString`, `PrintMembers`, accessors)

**Falls short (tracked, not asserted green):**

- **#1630** — `with`-expression (`Program.Shift`) is not raised and renders the invalid `<Clone>$` identifier (CS1001). Stays `Partial`, so it does not breach the no-invalid-`Full` bar.
- **#1631** — tuple-pattern switch expression (`Program.Quadrant`) decompiles to a `goto` ladder.
- **#1632** — record `Deconstruct` drops the receiver, renders `X = X;`.

## Guard

`LadderRung5GateTests` (fast PR gate, no `Speed=Slow` trait):

1. locks the source-visible `Program` member set (a dropped construct fails loudly);
2. pins **no invalid `Full`** across the fixture (zero malformed `Full`, zero semantic-binding defects, every `Full` actually bound — teeth);
3. asserts recognizable rendering for the working constructs above.

The three gap members are deliberately not asserted green; the guard gives those fixes a stable baseline to verify against.

## Evidence

- Build clean. Files mirror rung 1's PR #1609 (fixture csproj + cs, test csproj ref, gate test).
- Focused: `LadderRung5GateTests` → 3/3 pass.
- Fast subset (`-notrait "Speed=Slow"`) → **1413/1413 pass** (15s).
- No Markdown changed. No production decompiler code changed (fixture + test only).

Advances #1599 rung 5. Gaps: #1630, #1631, #1632.
