### PR TITLE
Add rung 3 C# 6 sugar ladder guard

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung3/ILInspector.Decompiler.Fixtures.LadderRung3.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung3/ILInspector.Decompiler.Fixtures.LadderRung3.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Rung 3 of the decompiler product quality ladder (#1599): C# 6 sugar.
+    This fixture is intentionally small and source-recognizable: expression-bodied
+    members, null propagation, and simple interpolation.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Decompiler.Fixtures.LadderRung3/LadderRung3.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung3/LadderRung3.cs
@@ -3,8 +3,10 @@ using System;
 namespace LadderRung3;
 
 // Rung 3 of the decompiler product quality ladder (#1599): C# 6 sugar.
-// LadderRung3GateTests pins expression-bodied type-source output, null
-// propagation, and simple interpolation.
+// LadderRung3GateTests pins null propagation and simple interpolation as
+// recoverable method-body sugar. Expression-bodied members are IL-identical to
+// block-bodied members, so their arrow spelling is pinned only as a type-source
+// rendering preference for applicable single-expression bodies.
 public class Program
 {
     public string Prefix => "Hello";

--- a/src/ILInspector.Decompiler.Fixtures.LadderRung3/LadderRung3.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung3/LadderRung3.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace LadderRung3;
+
+// Rung 3 of the decompiler product quality ladder (#1599): C# 6 sugar.
+// LadderRung3GateTests pins expression-bodied type-source output, null
+// propagation, and simple interpolation.
+public class Program
+{
+    public string Prefix => "Hello";
+
+    public static void Main(string[] args)
+    {
+        var node = args.Length == 0 ? null : new Node(args[0]);
+        Console.WriteLine(Describe(node));
+        Console.WriteLine(Format(args.Length, Describe(node)));
+    }
+
+    public static string Describe(Node node) => node?.Label ?? "none";
+
+    public static string Format(int count, string label) => $"Count={count}; Label={label}";
+
+    public string Greet(Node node) => $"{Prefix}, {node?.Label ?? "guest"}";
+}
+
+public class Node
+{
+    public Node(string label)
+    {
+        Label = label;
+    }
+
+    public string Label { get; }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainB\ILInspector.Decompiler.Fixtures.UnsafeChainB.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainC\ILInspector.Decompiler.Fixtures.UnsafeChainC.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung1\ILInspector.Decompiler.Fixtures.LadderRung1.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung3\ILInspector.Decompiler.Fixtures.LadderRung3.csproj" />
   </ItemGroup>
 
   <!--

--- a/src/ILInspector.Decompiler.Tests/LadderRung3GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung3GateTests.cs
@@ -10,8 +10,10 @@ namespace ILInspector.Decompiler.Tests;
 /// <summary>
 /// The rung 3 completion guard for the decompiler product quality ladder (#1599):
 /// C# 6 sugar. The scoped bar is deliberately explicit:
-/// expression-bodied declarations are a whole-type source responsibility, while
-/// null propagation and simple interpolation are method-body responsibilities.
+/// null propagation and simple interpolation are measured as method-body
+/// recoveries. Expression-bodied declarations are IL-identical to block-bodied
+/// members, so this guard treats their arrow spelling as a whole-type
+/// type-source rendering preference, not as independent source recovery proof.
 /// </summary>
 public class LadderRung3GateTests
 {
@@ -72,9 +74,12 @@ public class LadderRung3GateTests
     }
 
     [Fact]
-    public void Rung3Fixture_RendersExpressionBodiedTypeSource()
+    public void Rung3Fixture_RendersExpressionBodiedTypeSourceStyle()
     {
-        string source = ComposeFixtureType();
+        var (type, source) = ComposeFixtureType();
+
+        var deltas = TypeSourceCheck.CompareType(type, source);
+        Assert.DoesNotContain(deltas, d => d.Kind == TypeSourceCheck.Deltas.MemberMissing);
 
         Assert.Contains("public string Prefix => \"Hello\";", source);
         Assert.Contains("public static string Describe(Node node) => node?.Label ?? \"none\";", source);
@@ -111,14 +116,14 @@ public class LadderRung3GateTests
             r => Assert.True(r.SemanticChecked, $"Full method {r.MethodName} was not semantically bound."));
     }
 
-    static string ComposeFixtureType()
+    static (ApiType Type, string Source) ComposeFixtureType()
     {
         using var pe = new PEReader(File.OpenRead(FixturePath));
         var api = ApiSurfaceExtractor.Extract(pe);
         var type = Assert.Single(api.Types, t => t.FullName == FixtureType);
         var source = TypeSourceComposer.Compose(type, FixturePath, pdbPath: null);
         Assert.NotNull(source);
-        return source;
+        return (type, source);
     }
 
     static List<(string Name, IrFunction Function)> LoadRaisedMembers()

--- a/src/ILInspector.Decompiler.Tests/LadderRung3GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung3GateTests.cs
@@ -1,0 +1,137 @@
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The rung 3 completion guard for the decompiler product quality ladder (#1599):
+/// C# 6 sugar. The scoped bar is deliberately explicit:
+/// expression-bodied declarations are a whole-type source responsibility, while
+/// null propagation and simple interpolation are method-body responsibilities.
+/// </summary>
+public class LadderRung3GateTests
+{
+    static string FixturePath => typeof(LadderRung3.Program).Assembly.Location;
+    static readonly string FixtureType = typeof(LadderRung3.Program).FullName!;
+
+    static readonly string[] ExpectedMembers =
+    [
+        ".ctor", "Describe", "Format", "Greet", "Main", "get_Prefix",
+    ];
+
+    [Fact]
+    public void Rung3Fixture_ExposesExactMemberSet_AllFullAndFullyRaised()
+    {
+        var members = LoadRaisedMembers();
+
+        Assert.Equal(
+            ExpectedMembers,
+            members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
+
+        var notFull = members
+            .Where(m => m.Function.Fidelity != DecompilationFidelity.Full)
+            .Select(m => m.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(notFull.Length == 0,
+            "Rung 3 requires every scoped fixture member to render Full; not Full: " + string.Join(", ", notFull));
+
+        var gaps = members
+            .Where(m => Completeness.Residual(m.Function) is not null)
+            .Select(m => m.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(gaps.Length == 0,
+            "Rung 3 requires every scoped fixture member to be fully raised (zero residual gaps); gaps: " + string.Join(", ", gaps));
+    }
+
+    [Fact]
+    public void Rung3Fixture_RendersCSharp6MethodBodySugar()
+    {
+        var members = LoadRaisedMembers();
+        string Body(string name) =>
+            CSharpPrinter.PrintRaised(members.Single(m => m.Name == name).Function).Output?.Trim() ?? "";
+
+        Assert.Equal("return \"Hello\";", Body("get_Prefix"));
+
+        var describe = Body("Describe");
+        Assert.Contains("node?.Label ?? \"none\"", describe);
+        Assert.DoesNotContain("goto", describe);
+
+        var format = Body("Format");
+        Assert.Contains("return $\"Count={count}; Label={label}\";", format);
+        Assert.DoesNotContain("DefaultInterpolatedStringHandler", format);
+
+        var greet = Body("Greet");
+        Assert.Contains("Prefix", greet);
+        Assert.Contains("node?.Label ?? \"guest\"", greet);
+    }
+
+    [Fact]
+    public void Rung3Fixture_RendersExpressionBodiedTypeSource()
+    {
+        string source = ComposeFixtureType();
+
+        Assert.Contains("public string Prefix => \"Hello\";", source);
+        Assert.Contains("public static string Describe(Node node) => node?.Label ?? \"none\";", source);
+        Assert.Contains("public static string Format(int count, string label) => $\"Count={count}; Label={label}\";", source);
+    }
+
+    [Fact]
+    public void Rung3Fixture_HasNoMalformedOrSemanticDefects()
+    {
+        var results = ValidityCheck.Evaluate(FixturePath)
+            .Where(r => r.TypeName == FixtureType)
+            .ToList();
+
+        Assert.NotEmpty(results);
+
+        var malformed = results
+            .Where(r => r.IsFull && r.IsMalformed)
+            .Select(r => $"{r.MethodName}: {r.MalformedDiagnostics[0].Id} {r.MalformedDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(malformed.Length == 0,
+            "Rung 3 requires zero malformed Full methods; malformed: " + string.Join("; ", malformed));
+
+        var semantic = results
+            .Where(r => r.HasSemanticDefect)
+            .Select(r => $"{r.MethodName}: {r.SemanticDiagnostics[0].Id} {r.SemanticDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(semantic.Length == 0,
+            "Rung 3 requires zero semantic-binding defects; defects: " + string.Join("; ", semantic));
+
+        Assert.All(
+            results.Where(r => r.IsFull),
+            r => Assert.True(r.SemanticChecked, $"Full method {r.MethodName} was not semantically bound."));
+    }
+
+    static string ComposeFixtureType()
+    {
+        using var pe = new PEReader(File.OpenRead(FixturePath));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(api.Types, t => t.FullName == FixtureType);
+        var source = TypeSourceComposer.Compose(type, FixturePath, pdbPath: null);
+        Assert.NotNull(source);
+        return source;
+    }
+
+    static List<(string Name, IrFunction Function)> LoadRaisedMembers()
+    {
+        var members = new List<(string Name, IrFunction Function)>();
+        using var source = MetadataSource.Open(FixturePath);
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (typeName != FixtureType)
+                continue;
+            IrPasses.Run(function);
+            members.Add((methodName, function));
+        }
+        return members;
+    }
+}


### PR DESCRIPTION
## Summary

PTAL #1599 row 3. This adds a durable fast guard for the C# 6 sugar rung, scoped to what the current decompiler can honestly prove:

- adds `ILInspector.Decompiler.Fixtures.LadderRung3` with expression-bodied source members, null propagation, and simple interpolation;
- adds `LadderRung3GateTests` to pin the exact fixture member set, `Full` fidelity, zero residual gaps, zero malformed/semantic defects, method-body null propagation, and simple interpolation;
- pins expression-bodied declarations as a `TypeSourceComposer` rendering preference, not as independent source-recovery proof, because expression-bodied and block-bodied members are IL-identical;
- adds a `TypeSourceCheck` member-missing guard for the composed rung 3 type.

The guard intentionally does **not** claim nested interpolation containing null propagation is fully recovered as interpolation; the scoped bar measures null propagation and simple interpolation separately.

## Evidence

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LadderRung3GateTests/*"
ILInspector.Decompiler.Tests  Total: 4, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
ILInspector.Decompiler.Tests  Total: 1422, Errors: 0, Failed: 0, Skipped: 0

dotnet build src/dotnet-inspect -c Release
Build succeeded. 0 Warning(s), 0 Error(s)
```

Note: I also attempted the full unfiltered decompiler suite earlier; it did not complete in the shared environment after an extended wait, so I stopped it and used the fast PR-gate subset plus the focused rung guard.

## Adversarial review

Opus 4.8 reviewed the rung bar/guard and found one success-claim issue: expression-bodied output was initially framed as a C# 6 recovery even though it is IL-identical rendering style. I narrowed the comments/test claim to treat it as type-source rendering preference and added a `TypeSourceCheck` member-missing guard. Final Opus 4.8 review found no high-confidence remaining issues.
