### PR TITLE
Carry assembly identity through cross-assembly caller graph keys (#1579)

### DIFF
--- a/src/ILInspector.Analysis.CallerGraphCaller/ILInspector.Analysis.CallerGraphCaller.csproj
+++ b/src/ILInspector.Analysis.CallerGraphCaller/ILInspector.Analysis.CallerGraphCaller.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Caller-graph cross-assembly fixture (#1579): a real caller. References the real target
+    and calls Target.Api.Ping, so a caller graph rooted at the real target must report this
+    assembly's Shared.Entry.Run as a direct caller.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Analysis.CallerGraphTarget\ILInspector.Analysis.CallerGraphTarget.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
+++ b/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
@@ -1,0 +1,10 @@
+// Caller-graph cross-assembly fixture (#1579): a real caller. Shared.Entry.Run calls the
+// real Target.Api.Ping. Its caller signature is intentionally identical to the twin caller
+// assembly to exercise the caller-collapse case.
+namespace Shared
+{
+    public static class Entry
+    {
+        public static void Run() => Target.Api.Ping();
+    }
+}

--- a/src/ILInspector.Analysis.CallerGraphCallerTwin/ILInspector.Analysis.CallerGraphCallerTwin.csproj
+++ b/src/ILInspector.Analysis.CallerGraphCallerTwin/ILInspector.Analysis.CallerGraphCallerTwin.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Caller-graph cross-assembly fixture (#1579): a second real caller (the twin). Declares the
+    same Shared.Entry.Run signature as ILInspector.Analysis.CallerGraphCaller and also calls the
+    real Target.Api.Ping. The two assemblies must remain two distinct direct caller nodes; a key
+    that omits the caller source assembly collapses them into one.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Analysis.CallerGraphTarget\ILInspector.Analysis.CallerGraphTarget.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.CallerGraphCallerTwin/SharedEntry.cs
+++ b/src/ILInspector.Analysis.CallerGraphCallerTwin/SharedEntry.cs
@@ -1,0 +1,9 @@
+// Caller-graph cross-assembly fixture (#1579): the twin real caller. Same Shared.Entry.Run
+// signature as ILInspector.Analysis.CallerGraphCaller, also calling the real Target.Api.Ping.
+namespace Shared
+{
+    public static class Entry
+    {
+        public static void Run() => Target.Api.Ping();
+    }
+}

--- a/src/ILInspector.Analysis.CallerGraphLookalikeCaller/ILInspector.Analysis.CallerGraphLookalikeCaller.csproj
+++ b/src/ILInspector.Analysis.CallerGraphLookalikeCaller/ILInspector.Analysis.CallerGraphLookalikeCaller.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Caller-graph cross-assembly fixture (#1579): the lookalike caller. Declares its OWN
+    Target.Api.Ping (same fully-qualified name as the real target, different assembly) and calls
+    it from Shared.Entry.Run. A caller graph rooted at the real target must NOT report this
+    assembly, because its calls resolve to the in-assembly lookalike, not the real target.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.CallerGraphLookalikeCaller/LookalikeTargetAndCaller.cs
+++ b/src/ILInspector.Analysis.CallerGraphLookalikeCaller/LookalikeTargetAndCaller.cs
@@ -1,0 +1,21 @@
+// Caller-graph cross-assembly fixture (#1579): the lookalike caller. Declares its own
+// Target.Api.Ping (same FQN as the real target, different assembly) and calls it. Its calls
+// resolve to the in-assembly lookalike, so a graph rooted at the real target must not report
+// Consumer.Entry.Run as a caller; name-only callee matching would misattribute it.
+namespace Target
+{
+    public static class Api
+    {
+        public static void Ping()
+        {
+        }
+    }
+}
+
+namespace Consumer
+{
+    public static class Entry
+    {
+        public static void Run() => Target.Api.Ping();
+    }
+}

--- a/src/ILInspector.Analysis.CallerGraphTarget/ILInspector.Analysis.CallerGraphTarget.csproj
+++ b/src/ILInspector.Analysis.CallerGraphTarget/ILInspector.Analysis.CallerGraphTarget.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Caller-graph cross-assembly fixture (#1579): the real target assembly. Declares
+    Target.Api.Ping, which the caller-graph negative tests root at while a same-FQN
+    lookalike in a different assembly must not be reported as a caller.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.CallerGraphTarget/TargetApi.cs
+++ b/src/ILInspector.Analysis.CallerGraphTarget/TargetApi.cs
@@ -1,0 +1,11 @@
+// Caller-graph cross-assembly fixture (#1579): the real target. The negative tests root
+// the caller graph at Target.Api.Ping in this assembly.
+namespace Target
+{
+    public static class Api
+    {
+        public static void Ping()
+        {
+        }
+    }
+}

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -23,6 +23,10 @@
     <ProjectReference Include="..\ILInspector.Analysis.ExceptionBaseFixtures\ILInspector.Analysis.ExceptionBaseFixtures.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis.ProtobufFixtures\ILInspector.Analysis.ProtobufFixtures.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis.LookalikeFixtures\ILInspector.Analysis.LookalikeFixtures.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ILInspector.Analysis.CallerGraphTarget\ILInspector.Analysis.CallerGraphTarget.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCaller\ILInspector.Analysis.CallerGraphCaller.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCallerTwin\ILInspector.Analysis.CallerGraphCallerTwin.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ILInspector.Analysis.CallerGraphLookalikeCaller\ILInspector.Analysis.CallerGraphLookalikeCaller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
   </ItemGroup>
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -130,6 +130,59 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void BuildCallerTree_WithScope_OmitsCallersOfSameNameMemberInAnotherAssembly()
+    {
+        // Root the caller graph at the real Target.Api.Ping. One scope (CallerGraphCaller) calls
+        // the real target; the other (CallerGraphLookalikeCaller) calls its own in-assembly
+        // Target.Api.Ping lookalike with the same fully-qualified name. Only the real caller may
+        // be reported — the cross-assembly key must carry callee assembly identity (#1579).
+        var targetIndex = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphTarget"));
+        var realCaller = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphCaller"));
+        var lookalikeCaller = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphLookalikeCaller"));
+
+        var ping = targetIndex.Methods.First(method => method.DeclaringType.Name == "Api" && method.Name == "Ping");
+        var tree = targetIndex.BuildCallerTree(ping.MetadataToken, new[] { realCaller, lookalikeCaller }, maxDepth: 2, maxNodes: 50);
+
+        var sources = tree.Children.Select(child => child.Perf?.Source).ToList();
+        Assert.Contains("ILInspector.Analysis.CallerGraphCaller", sources);
+        Assert.DoesNotContain("ILInspector.Analysis.CallerGraphLookalikeCaller", sources);
+        Assert.Single(tree.Children);
+    }
+
+    [Fact]
+    public void BuildCallerTree_WithScope_KeepsSameSignatureCallersFromDifferentAssembliesDistinct()
+    {
+        // Two caller assemblies declare the identical Shared.Entry.Run signature and both call the
+        // real Target.Api.Ping. They must remain two distinct direct caller nodes; a key that omits
+        // the caller source assembly collapses them into one (#1579).
+        var targetIndex = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphTarget"));
+        var caller = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphCaller"));
+        var twin = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphCallerTwin"));
+
+        var ping = targetIndex.Methods.First(method => method.DeclaringType.Name == "Api" && method.Name == "Ping");
+        var tree = targetIndex.BuildCallerTree(ping.MetadataToken, new[] { caller, twin }, maxDepth: 2, maxNodes: 50);
+
+        var sources = tree.Children.Select(child => child.Perf?.Source).ToList();
+        Assert.Equal(2, tree.Children.Length);
+        Assert.Contains("ILInspector.Analysis.CallerGraphCaller", sources);
+        Assert.Contains("ILInspector.Analysis.CallerGraphCallerTwin", sources);
+    }
+
+    static string CallerGraphFixturePath(string projectName)
+    {
+        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string path = Path.GetFullPath(Path.Combine(
+            outputDirectory.FullName,
+            "..",
+            "..",
+            projectName,
+            outputDirectory.Name,
+            projectName + ".dll"));
+        Assert.True(File.Exists(path), $"Expected caller-graph fixture assembly at {path}");
+        return path;
+    }
+
+    [Fact]
     public void TopLeverage_RanksMostCalledMethodFirst()
     {
         var index = LibraryBodyIndex.Open(typeof(LeverageFixtures).Assembly.Location);

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -647,14 +647,17 @@ public sealed class LibraryBodyIndex
     }
 
     // Cross-assembly caller-graph identity key. The multi-assembly reverse map matches members
-    // structurally (tokens are assembly-local), so the key adds parameter arity and the return
-    // type to the qualified declaring type, name, and parameters to reduce the chance of
-    // distinct overloads colliding. Generic members remain a known limitation shared with the
-    // Callers table: a constructed call site (e.g. List<int>.Add / Id<int>) is keyed on its
-    // instantiation and will not match an open-definition target — tracked as a follow-up to
-    // normalize generic member identity for both Callers and Caller Graph.
+    // structurally (tokens are assembly-local), so the key leads with the declaring type's
+    // assembly and adds parameter arity and the return type to the qualified declaring type,
+    // name, and parameters. The assembly prefix is required so that same-namespace/type/member
+    // members in different assemblies do not match the selected target (callee side) and so that
+    // identically-signed callers from different caller scopes are not collapsed into one node
+    // (caller side) (#1579). Generic members remain a known limitation shared with the Callers
+    // table: a constructed call site (e.g. List<int>.Add / Id<int>) is keyed on its instantiation
+    // and will not match an open-definition target — tracked as a follow-up to normalize generic
+    // member identity for both Callers and Caller Graph.
     static string CallerGraphKey(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes, TypeRef returnType)
-        => $"{declaringType.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{string.Join(",", parameterTypes.Select(type => type.ToQualifiedDisplayString()))}|{returnType.ToQualifiedDisplayString()}";
+        => $"{declaringType.Assembly}|{declaringType.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{string.Join(",", parameterTypes.Select(type => type.ToQualifiedDisplayString()))}|{returnType.ToQualifiedDisplayString()}";
 
     sealed class IndexBuilder
     {

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -652,10 +652,16 @@ public sealed class LibraryBodyIndex
     // name, and parameters. The assembly prefix is required so that same-namespace/type/member
     // members in different assemblies do not match the selected target (callee side) and so that
     // identically-signed callers from different caller scopes are not collapsed into one node
-    // (caller side) (#1579). Generic members remain a known limitation shared with the Callers
-    // table: a constructed call site (e.g. List<int>.Add / Id<int>) is keyed on its instantiation
-    // and will not match an open-definition target — tracked as a follow-up to normalize generic
-    // member identity for both Callers and Caller Graph.
+    // (caller side) (#1579). Known limitations, both shared with the Callers table:
+    //   - Generic members: a constructed call site (e.g. List<int>.Add / Id<int>) is keyed on its
+    //     instantiation and will not match an open-definition target.
+    //   - Type forwarding beyond the corelib facade canonicalization (TypeRef.CanonicalAssembly):
+    //     a type physically defined in assembly B but referenced through a [TypeForwardedTo]
+    //     facade A keys as B on the definition side and A at the referencing call site, so such a
+    //     forwarded member may not link its callers. This is an honest missed edge, preferred over
+    //     the prior false positive of attributing unrelated same-FQN callers to the target.
+    // Tracked as a follow-up to normalize member identity (generic + forwarded) for both Callers
+    // and Caller Graph.
     static string CallerGraphKey(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes, TypeRef returnType)
         => $"{declaringType.Assembly}|{declaringType.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{string.Join(",", parameterTypes.Select(type => type.ToQualifiedDisplayString()))}|{returnType.ToQualifiedDisplayString()}";
 


### PR DESCRIPTION
## Summary

Closes #1579 (last open row of the #1555 Analysis adversarial bug burndown, Cluster B).

`LibraryBodyIndex.BuildCallerTree`'s multi-assembly reverse map keyed callees and callers by **structural member identity only** (`CallerGraphKey`: qualified declaring type, name, parameter types, return type), omitting assembly identity. Two failures followed:

- **Callee false match:** a caller that calls a same-namespace/type/member member in a *different* assembly was reported as a caller of the selected target.
- **Caller-source collapse:** two identically-signed callers from different caller scopes collapsed into one direct caller node.

## Fix

Lead `CallerGraphKey` with the declaring type's assembly. The key is used **symmetrically** — for the callee side (reverse-map key) and the caller side (child lookup + dedupe grouping) — so the single prefix fixes both bugs: a cross-assembly lookalike callee no longer matches the root, and same-signature callers from different assemblies stay distinct.

A TypeDef's own assembly (`GetTypeFromDefinition` → `AssemblyDefinition.Name`) and a cross-assembly `TypeRef`'s `AssemblyReference.Name` resolve to the same simple name, and `MethodIdentity.AssemblyName` equals both, so root and caller edges still align. The single-assembly `BuildCallerTree` path is token-based and unaffected.

## Tests

Four cross-assembly fixture assemblies:

- `CallerGraphTarget` — `Target.Api.Ping` (the real root).
- `CallerGraphCaller` / `CallerGraphCallerTwin` — both declare the identical `Shared.Entry.Run` and call the real `Target.Api.Ping` (the collision pair).
- `CallerGraphLookalikeCaller` — declares its **own** same-FQN `Target.Api.Ping` and calls it from `Consumer.Entry.Run`.

New tests:

- `BuildCallerTree_WithScope_OmitsCallersOfSameNameMemberInAnotherAssembly` — the lookalike caller is not reported; the real caller is.
- `BuildCallerTree_WithScope_KeepsSameSignatureCallersFromDifferentAssembliesDistinct` — the two same-signature real callers stay two distinct nodes.

## Evidence

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` — **113 passed, 0 failed** (clean rebuild).
- CLI rendering layer: `MemberCallGraphSectionTests` + `MemberCallersSectionTests` — **20 passed**.
- Teeth verified by reverting the assembly prefix: both new tests fail (lookalike reported; collision collapses to one).

## Done signal

- Negative: a caller referencing a same-FQN member in a different assembly is not reported. ✅
- Positive: the real caller is still reported. ✅
- Negative: same-signature callers from different assemblies produce two distinct nodes, not one. ✅
- Existing cross-assembly caller graph tests still pass. ✅
