### PR TITLE
Non-vacuous cross-assembly overload guard (analysis ladder rung 1)

### DIFF
--- a/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
+++ b/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
@@ -6,5 +6,12 @@ namespace Shared
     public static class Entry
     {
         public static void Run() => Target.Api.Ping();
+
+        // Distinct callers of the int and string Ping overloads. A caller graph rooted at one
+        // overload must report only its own caller; a CallerGraphKey that drops parameter
+        // types would collapse these onto Ping and cross-link them (#1623 rung 1).
+        public static void RunInt() => Target.Api.Ping(1);
+
+        public static void RunString() => Target.Api.Ping("x");
     }
 }

--- a/src/ILInspector.Analysis.CallerGraphTarget/TargetApi.cs
+++ b/src/ILInspector.Analysis.CallerGraphTarget/TargetApi.cs
@@ -7,5 +7,16 @@ namespace Target
         public static void Ping()
         {
         }
+
+        // Overloads sharing the simple name Ping. A cross-assembly caller graph rooted at one
+        // overload must not pull in callers of the other; that requires the param-bearing
+        // CallerGraphKey, which is only exercised across assemblies (#1623 rung 1).
+        public static void Ping(int value)
+        {
+        }
+
+        public static void Ping(string value)
+        {
+        }
     }
 }

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -168,6 +168,29 @@ public class LibraryBodyIndexTests
         Assert.Contains("ILInspector.Analysis.CallerGraphCallerTwin", sources);
     }
 
+    [Fact]
+    public void BuildCallerTree_WithScope_KeepsTargetOverloadsDistinct()
+    {
+        // Root the caller graph at the int overload of Target.Api.Ping. The caller assembly
+        // invokes the int and string overloads from separate methods (RunInt/RunString). Only
+        // RunInt may be reported: the cross-assembly reverse map keys on CallerGraphKey, which
+        // must carry parameter types, or the two overloads collapse and cross-link callers
+        // (#1623 rung 1; non-vacuous because same-assembly resolution is token-based).
+        var targetIndex = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphTarget"));
+        var caller = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphCaller"));
+
+        var intOverload = targetIndex.Methods.Single(method =>
+            method.DeclaringType.Name == "Api" && method.Name == "Ping"
+            && method.ParameterTypes.Length == 1 && method.ParameterTypes[0].Equals(TypeRef.CoreLib("System", "Int32")));
+
+        var tree = targetIndex.BuildCallerTree(intOverload.MetadataToken, new[] { caller }, maxDepth: 2, maxNodes: 50);
+
+        var callerNames = tree.Children.Select(child => child.Member.Name).ToList();
+        Assert.Contains("RunInt", callerNames);
+        Assert.DoesNotContain("RunString", callerNames);
+        Assert.DoesNotContain("Run", callerNames);
+    }
+
     static string CallerGraphFixturePath(string projectName)
     {
         var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
@@ -462,6 +485,9 @@ public class LibraryBodyIndexTests
     {
         var index = LibraryBodyIndex.Open(typeof(OverloadTargets).Assembly.Location);
 
+        // Same-assembly calls resolve by MethodDef token, so this guards token-based
+        // overload distinctness. The param-bearing key collapse is exercised separately
+        // by BuildCallerTree_WithScope_KeepsTargetOverloadsDistinct (cross-assembly).
         var overloads = index.TopLeverage(count: 200,
                 scope: method => method.DeclaringType.Name == nameof(OverloadTargets) && method.Name == nameof(OverloadTargets.M))
             .Where(entry => entry.Method.Name == nameof(OverloadTargets.M))


### PR DESCRIPTION
Completes **rung 1 (identity exactness)** on the analysis quality ladder (#1623), replacing a guard the adversarial review proved vacuous.

## Why

GPT-5.5 adversarial review found the #1644 same-assembly overload guards **vacuous** for the regression they claim to catch: `MethodDefinitionMap.Resolve` returns `CalleeDefinitionToken` for same-assembly calls *before* the parameter-bearing key is consulted (`MethodDefinitionMap.cs:30-37`). So dropping parameter types from `CallerGraphKey` / `MethodDefinitionMap.Key` would not fail `TopLeverage_KeepsOverloadsDistinct`. Verified in source.

The param-bearing `CallerGraphKey` is only exercised **across assemblies** (the scoped reverse caller graph, `LibraryBodyIndex.cs:570`).

## Change (test-only)

Extends the existing cross-assembly caller-graph harness:
- `CallerGraphTarget`: add `Ping(int)` / `Ping(string)` overloads.
- `CallerGraphCaller`: add `RunInt`/`RunString` calling each overload.
- New guard `BuildCallerTree_WithScope_KeepsTargetOverloadsDistinct`: roots the scoped caller graph at the `int` overload and asserts only `RunInt` is reported — not `RunString`, not the no-arg `Run`.

## Proven non-vacuous

Injected a `CallerGraphKey` that drops parameter types → the new test **fails** (`Assert.DoesNotContain() Failure: Item found in collection`); reverting restores green. The prior same-assembly `TopLeverage_KeepsOverloadsDistinct` is annotated as a token-resolution guard (still valid, just not the key-collapse detector).

No product code changes. `ILInspector.Analysis.Tests` 117/117.

On merge I'll mark ladder #1623 rung 1 `Complete` with this PR + the guard test + commit. Adversarial review already informed this change; happy to get a second pass.