### PR TITLE
Preserve enum underlying casts in decompiled output

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -873,6 +873,8 @@ public class CfgSampleClass
     public static void CallWithPriorityInt(CfgPriority priority) => TakesPriorityInt((int)priority);
     public static long LongPriorityToLong(CfgLongPriority priority) => (long)priority;
     public static long PriorityToLong(CfgPriority priority) => (long)priority;
+    public static CfgPriority NextPriority(CfgPriority priority) => priority + 1;
+    public static CfgPriority PreviousPriority(CfgPriority priority) => priority - 1;
 
     // --- Cross-assembly enum vs integer (CS0019) ---
     // System.DayOfWeek / System.AttributeTargets live in CoreLib, not this test

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -875,6 +875,7 @@ public class CfgSampleClass
     public static long PriorityToLong(CfgPriority priority) => (long)priority;
     public static CfgPriority NextPriority(CfgPriority priority) => priority + 1;
     public static CfgPriority PreviousPriority(CfgPriority priority) => priority - 1;
+    public static int CheckedPriorityPlusOne(CfgPriority priority) => checked((int)priority + 1);
 
     // --- Cross-assembly enum vs integer (CS0019) ---
     // System.DayOfWeek / System.AttributeTargets live in CoreLib, not this test

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -863,6 +863,17 @@ public class CfgSampleClass
     // (CfgPriority)value cast — C# converts int->enum implicitly only for 0.
     public static CfgPriority ToPriority(int value) => (CfgPriority)value;
 
+    // Enum-to-underlying conversions also carry no conv when the widths match.
+    // C# still requires the explicit enum->integer cast, and overload resolution
+    // changes without it (an enum argument binds differently from an int).
+    public static int PriorityToInt(CfgPriority priority) => (int)priority;
+    public static int PriorityPlusOne(CfgPriority priority) => (int)priority + 1;
+    public static int PrioritySum(CfgPriority left, CfgPriority right) => (int)left + (int)right;
+    public static void TakesPriorityInt(int value) { _ = value; }
+    public static void CallWithPriorityInt(CfgPriority priority) => TakesPriorityInt((int)priority);
+    public static long LongPriorityToLong(CfgLongPriority priority) => (long)priority;
+    public static long PriorityToLong(CfgPriority priority) => (long)priority;
+
     // --- Cross-assembly enum vs integer (CS0019) ---
     // System.DayOfWeek / System.AttributeTargets live in CoreLib, not this test
     // assembly, so on decompile ResolveShape returns Unknown — the enum loses its
@@ -3787,6 +3798,8 @@ public sealed class JoinTypeProvider
 }
 
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }
+
+public enum CfgLongPriority : long { Low = 0, High = 2 }
 
 // uint-underlying with a high-bit member: the value 0x80000000 emits as the
 // signed int -2147483648, the case the member-map key must agree on.

--- a/src/ILInspector.Decompiler.Tests/EnumUnderlyingCastTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumUnderlyingCastTests.cs
@@ -84,4 +84,12 @@ public class EnumUnderlyingCastTests
         Assert.Contains("return priority - 1;", output);
         Assert.DoesNotContain("return (int)priority - 1;", output);
     }
+
+    [Fact]
+    public void CheckedEnumArithmeticToUnderlyingInt_PreservesCheckedContext()
+    {
+        var output = Render(nameof(CfgSampleClass.CheckedPriorityPlusOne));
+
+        Assert.Contains("return checked((int)priority + 1);", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/EnumUnderlyingCastTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumUnderlyingCastTests.cs
@@ -66,4 +66,22 @@ public class EnumUnderlyingCastTests
 
         Assert.Contains("return (long)priority;", output);
     }
+
+    [Fact]
+    public void EnumPlusIntReturnedAsEnum_StaysEnumTyped()
+    {
+        var output = Render(nameof(CfgSampleClass.NextPriority));
+
+        Assert.Contains("return priority + 1;", output);
+        Assert.DoesNotContain("return (int)priority + 1;", output);
+    }
+
+    [Fact]
+    public void EnumMinusIntReturnedAsEnum_StaysEnumTyped()
+    {
+        var output = Render(nameof(CfgSampleClass.PreviousPriority));
+
+        Assert.Contains("return priority - 1;", output);
+        Assert.DoesNotContain("return (int)priority - 1;", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/EnumUnderlyingCastTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumUnderlyingCastTests.cs
@@ -1,0 +1,69 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class EnumUnderlyingCastTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void EnumReturnedAsUnderlyingInt_RendersExplicitCast()
+    {
+        var output = Render(nameof(CfgSampleClass.PriorityToInt));
+
+        Assert.Contains("return (int)priority;", output);
+        Assert.DoesNotContain("return priority;", output);
+    }
+
+    [Fact]
+    public void EnumArithmetic_RendersOperandCasts()
+    {
+        var output = Render(nameof(CfgSampleClass.PriorityPlusOne));
+
+        Assert.Contains("return (int)priority + 1;", output);
+        Assert.DoesNotContain("return priority + 1;", output);
+    }
+
+    [Fact]
+    public void EnumEnumArithmetic_RendersBothOperandCasts()
+    {
+        var output = Render(nameof(CfgSampleClass.PrioritySum));
+
+        Assert.Contains("return (int)left + (int)right;", output);
+        Assert.DoesNotContain("return left + right;", output);
+    }
+
+    [Fact]
+    public void EnumCallArgumentToUnderlyingInt_RendersExplicitCast()
+    {
+        var output = Render(nameof(CfgSampleClass.CallWithPriorityInt));
+
+        Assert.Contains("TakesPriorityInt((int)priority);", output);
+        Assert.DoesNotContain("TakesPriorityInt(priority);", output);
+    }
+
+    [Fact]
+    public void LongEnumReturnedAsUnderlyingLong_RendersExplicitCast()
+    {
+        var output = Render(nameof(CfgSampleClass.LongPriorityToLong));
+
+        Assert.Contains("return (long)priority;", output);
+        Assert.DoesNotContain("return priority;", output);
+    }
+
+    [Fact]
+    public void EnumToWiderPrimitive_KeepsExistingConvert()
+    {
+        var output = Render(nameof(CfgSampleClass.PriorityToLong));
+
+        Assert.Contains("return (long)priority;", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -117,14 +117,6 @@ public sealed partial class CSharpPrinter
             if (IsEnumLikeInteger(binary.Right.ResultType) && TypeFamilies.IsInteger(binary.Left.ResultType))
                 return $"{EnumIntegerCast(binary.Left, binary.Right.ResultType!)} {BinaryOperator(binary)} {Operand(binary.Right)}";
         }
-        if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply
-                or BinaryKind.Divide or BinaryKind.Remainder
-            && EnumArithmeticText(binary) is { } enumArithmetic)
-        {
-            if (wrap)
-                return $"checked({enumArithmetic})";
-            return uncheckedOverflow ? $"unchecked({enumArithmetic})" : enumArithmetic;
-        }
         // div.un/rem.un compute on unsigned operands; shr.un shifts an
         // unsigned left operand. Operands that are already unsigned (or
         // float, where .un means unordered, not unsigned) print plain.
@@ -751,7 +743,7 @@ public sealed partial class CSharpPrinter
             && target is { } enumArithmeticTarget
             && EnumArithmeticUnderlyingType(enumArithmetic)?.Equals(enumArithmeticTarget) == true)
         {
-            return Expression(value);
+            return EnumArithmeticText(enumArithmetic) ?? Expression(value);
         }
         if (target is { } primitiveTarget
             && TypeFamilies.IsIntegerLike(primitiveTarget)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -743,7 +743,7 @@ public sealed partial class CSharpPrinter
             && target is { } enumArithmeticTarget
             && EnumArithmeticUnderlyingType(enumArithmetic)?.Equals(enumArithmeticTarget) == true)
         {
-            return EnumArithmeticText(enumArithmetic) ?? Expression(value);
+            return EnumArithmeticValueText(enumArithmetic) ?? Expression(value);
         }
         if (target is { } primitiveTarget
             && TypeFamilies.IsIntegerLike(primitiveTarget)
@@ -892,6 +892,40 @@ public sealed partial class CSharpPrinter
         => type is not null && _function.EnumUnderlyingTypes.TryGetValue(type, out var underlying)
             ? underlying
             : null;
+
+    string? EnumArithmeticValueText(Binary binary)
+    {
+        bool enclosingChecked = _checkedContext;
+        if (binary.IsChecked)
+        {
+            _checkedContext = true;
+            try
+            {
+                var text = EnumArithmeticText(binary);
+                return text is not null && !enclosingChecked ? $"checked({text})" : text;
+            }
+            finally
+            {
+                _checkedContext = enclosingChecked;
+            }
+        }
+
+        bool uncheckedOverflow = enclosingChecked && EnumArithmeticCanOverflow(binary);
+        if (uncheckedOverflow)
+            _checkedContext = false;
+        try
+        {
+            var text = EnumArithmeticText(binary);
+            return text is not null && uncheckedOverflow ? $"unchecked({text})" : text;
+        }
+        finally
+        {
+            _checkedContext = enclosingChecked;
+        }
+    }
+
+    static bool EnumArithmeticCanOverflow(Binary binary)
+        => binary.Kind is BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply;
 
     /// <summary>A sub-int integer (byte/sbyte/short/ushort/char) — the primitives C# promotes to int in any binary numeric/bitwise/shift expression.</summary>
     static bool IsSubIntInteger(TypeRef? type)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -117,6 +117,14 @@ public sealed partial class CSharpPrinter
             if (IsEnumLikeInteger(binary.Right.ResultType) && TypeFamilies.IsInteger(binary.Left.ResultType))
                 return $"{EnumIntegerCast(binary.Left, binary.Right.ResultType!)} {BinaryOperator(binary)} {Operand(binary.Right)}";
         }
+        if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply
+                or BinaryKind.Divide or BinaryKind.Remainder
+            && EnumArithmeticText(binary) is { } enumArithmetic)
+        {
+            if (wrap)
+                return $"checked({enumArithmetic})";
+            return uncheckedOverflow ? $"unchecked({enumArithmetic})" : enumArithmetic;
+        }
         // div.un/rem.un compute on unsigned operands; shr.un shifts an
         // unsigned left operand. Operands that are already unsigned (or
         // float, where .un means unordered, not unsigned) print plain.
@@ -164,6 +172,34 @@ public sealed partial class CSharpPrinter
         if (wrap)
             return $"checked({text})";
         return uncheckedConstant || uncheckedOverflow ? $"unchecked({text})" : text;
+    }
+
+    string? EnumArithmeticText(Binary binary)
+    {
+        if (EnumArithmeticUnderlyingType(binary) is not { } target)
+            return null;
+
+        var leftEnumUnderlying = EnumUnderlyingType(binary.Left.ResultType);
+        var rightEnumUnderlying = EnumUnderlyingType(binary.Right.ResultType);
+        string left = leftEnumUnderlying is not null ? CastValue(binary.Left, target) : Operand(binary.Left);
+        string right = rightEnumUnderlying is not null ? CastValue(binary.Right, target) : Operand(binary.Right);
+        return $"{left} {BinaryOperator(binary)} {right}";
+    }
+
+    TypeRef? EnumArithmeticUnderlyingType(Binary binary)
+    {
+        if (binary.Kind is not (BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Multiply
+            or BinaryKind.Divide or BinaryKind.Remainder))
+        {
+            return null;
+        }
+
+        var leftEnumUnderlying = EnumUnderlyingType(binary.Left.ResultType);
+        var rightEnumUnderlying = EnumUnderlyingType(binary.Right.ResultType);
+        if (leftEnumUnderlying is null && rightEnumUnderlying is null)
+            return null;
+        var target = leftEnumUnderlying ?? rightEnumUnderlying;
+        return target is not null && TypeFamilies.IsIntegerLike(target) ? target : null;
     }
 
     /// <summary>
@@ -711,6 +747,19 @@ public sealed partial class CSharpPrinter
                 || value is Constant { Value: long lv } && lv < 0;
             return $"({TypeText(enumTarget)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}";
         }
+        if (value is Binary enumArithmetic
+            && target is { } enumArithmeticTarget
+            && EnumArithmeticUnderlyingType(enumArithmetic)?.Equals(enumArithmeticTarget) == true)
+        {
+            return Expression(value);
+        }
+        if (target is { } primitiveTarget
+            && TypeFamilies.IsIntegerLike(primitiveTarget)
+            && EnumUnderlyingType(EffectiveType(value)) is { } underlying
+            && underlying.Equals(primitiveTarget))
+        {
+            return $"({TypeText(primitiveTarget)}){Operand(value)}";
+        }
         // The same cast, for a cross-assembly enum. ClassifyShape only sees types
         // defined in the inspected assembly, so a framework enum like
         // StringComparison resolves to Unknown rather than Enum and the branch
@@ -846,6 +895,11 @@ public sealed partial class CSharpPrinter
         }
         return value.ResultType;
     }
+
+    TypeRef? EnumUnderlyingType(TypeRef? type)
+        => type is not null && _function.EnumUnderlyingTypes.TryGetValue(type, out var underlying)
+            ? underlying
+            : null;
 
     /// <summary>A sub-int integer (byte/sbyte/short/ushort/char) — the primitives C# promotes to int in any binary numeric/bitwise/shift expression.</summary>
     static bool IsSubIntInteger(TypeRef? type)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -401,6 +401,7 @@ public static class IrImporter
     {
         var shapes = new Dictionary<TypeRef, TypeShape>();
         Dictionary<TypeRef, IReadOnlyDictionary<long, string>>? enums = null;
+        Dictionary<TypeRef, TypeRef>? enumUnderlyingTypes = null;
         var collectionInitializerTypes = ImmutableHashSet.CreateBuilder<TypeRef>();
 
         void Consider(TypeRef? type)
@@ -428,6 +429,11 @@ public static class IrImporter
             {
                 enums ??= [];
                 enums[type] = members;
+                if (source.ResolveEnumUnderlyingType(type) is { } underlying)
+                {
+                    enumUnderlyingTypes ??= [];
+                    enumUnderlyingTypes[type] = underlying;
+                }
             }
         }
 
@@ -463,6 +469,8 @@ public static class IrImporter
             function.TypeShapes = shapes;
         if (enums is not null)
             function.EnumMembers = enums;
+        if (enumUnderlyingTypes is not null)
+            function.EnumUnderlyingTypes = enumUnderlyingTypes;
         if (collectionInitializerTypes.Count > 0)
             function.CollectionInitializerTypes = collectionInitializerTypes.ToImmutable();
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -300,6 +300,14 @@ public sealed class IrFunction : IrNode
         = ImmutableDictionary<TypeRef, IReadOnlyDictionary<long, string>>.Empty;
 
     /// <summary>
+    /// Underlying primitive type of the same-assembly enum types this function
+    /// references, materialized while metadata is live. Lets the printer preserve
+    /// enum-to-underlying casts that IL does not encode when widths match.
+    /// </summary>
+    public IReadOnlyDictionary<TypeRef, TypeRef> EnumUnderlyingTypes { get; set; }
+        = ImmutableDictionary<TypeRef, TypeRef>.Empty;
+
+    /// <summary>
     /// Types proven, while metadata was live, to satisfy C# collection-initializer
     /// receiver rules. `ObjectInitializerPass` consumes this so an arbitrary
     /// method named `Add` is not enough to raise `new C { ... }`.

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -168,6 +168,7 @@ public sealed class MetadataSource : IDisposable
 
     Dictionary<TypeRef, TypeShape>? _shapes;
     Dictionary<TypeRef, IReadOnlyDictionary<long, string>>? _enumMembers;
+    Dictionary<TypeRef, TypeRef>? _enumUnderlyingTypes;
     Dictionary<TypeRef, TypeRef?>? _baseTypes;
     HashSet<TypeRef>? _interfaces;
     Dictionary<TypeRef, ImmutableArray<TypeRef>>? _interfaceImpls;
@@ -201,12 +202,21 @@ public sealed class MetadataSource : IDisposable
         return _enumMembers!.GetValueOrDefault(type);
     }
 
+    internal TypeRef? ResolveEnumUnderlyingType(TypeRef type)
+    {
+        if (type.Kind != TypeRefKind.Definition)
+            return null;
+        EnsureTypeMaps();
+        return _enumUnderlyingTypes!.GetValueOrDefault(type);
+    }
+
     void EnsureTypeMaps()
     {
         if (_shapes is not null)
             return;
         var shapes = new Dictionary<TypeRef, TypeShape>();
         var enums = new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>();
+        var enumUnderlyingTypes = new Dictionary<TypeRef, TypeRef>();
         var bases = new Dictionary<TypeRef, TypeRef?>();
         var interfaces = new HashSet<TypeRef>();
         var interfaceImpls = new Dictionary<TypeRef, ImmutableArray<TypeRef>>();
@@ -228,9 +238,14 @@ public sealed class MetadataSource : IDisposable
                 interfaces.Add(key);
             interfaceImpls[key] = DecodeInterfaces(typeDef, scope);
             if (shape == TypeShape.Enum)
+            {
                 enums[key] = BuildEnumMembers(typeDef);
+                if (ResolveEnumUnderlyingType(typeDef, scope) is { } underlying)
+                    enumUnderlyingTypes[key] = underlying;
+            }
         }
         _enumMembers = enums;
+        _enumUnderlyingTypes = enumUnderlyingTypes;
         _baseTypes = bases;
         _interfaces = interfaces;
         _interfaceImpls = interfaceImpls;
@@ -428,6 +443,17 @@ public sealed class MetadataSource : IDisposable
                 members.TryAdd(value, Reader.GetString(field.Name));
         }
         return members;
+    }
+
+    TypeRef? ResolveEnumUnderlyingType(TypeDefinition enumType, GenericScope scope)
+    {
+        foreach (var fieldHandle in enumType.GetFields())
+        {
+            var field = Reader.GetFieldDefinition(fieldHandle);
+            if (Reader.GetString(field.Name) == "value__")
+                return field.DecodeSignature(TypeRefDecoder.Instance, scope);
+        }
+        return null;
     }
 
     long? ReadConstant(ConstantHandle handle)


### PR DESCRIPTION
## Summary

Closes #1592. Preserves required same-width enum-to-underlying casts that IL does not encode as `conv` instructions, so decompiled `Full` output remains valid C# and does not change overload binding.

Changes:

- materialize same-assembly enum underlying primitive types during import, next to the existing enum member map;
- use that metadata in `CSharpPrinter` to render enum values as `(int)enumValue` / `(long)enumValue` at underlying-typed return/store/call boundaries;
- render enum arithmetic as underlying-typed only when the sink is the underlying primitive;
- preserve enum-typed `enum +/- int` expressions for enum sinks;
- preserve checked/unchecked context for checked enum-underlying arithmetic.

## Evidence

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/EnumUnderlyingCastTests/*"` — 9 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CrossAssemblyEnumIntegerTests/*"` — 4 passed locally before latest main merge; after merging latest main, the reviewer observed one pre-existing `origin/main` failure in `EnumSwitchLabels_CastIntegerToEnum` due to switch-expression spelling, unrelated to this diff
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/ShiftCountRenderingTests/*"` — 3 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"` — 1441 passed
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` — 111 passed

I attempted the documented corpus quality-diff-card run twice. Both runs remained CPU-bound for an extended period with no card output, and `origin/main` advanced while they were running; I stopped the stale runs, merged latest main, and reran the fast gates above on the final branch.

## Adversarial review

Requested cross-model Opus 4.8 review. Two blocking findings were fixed before opening this PR:

1. enum `+/- int` flowing back to an enum sink must remain enum-typed, not `(int)enum + n`;
2. checked enum-underlying arithmetic must preserve `checked(...)` context.

Final merged-branch review reported no blocking findings in the scoped diff. A PR comment with the final review summary is posted separately.
