### PR TITLE
Spell value-position LogicalNot of a non-bool operand as a truthiness test (#1657)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LogicalNotValuePositionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LogicalNotValuePositionTests.cs
@@ -1,0 +1,64 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A LogicalNot in VALUE position (a `return`/assign, not a branch condition) over
+// a NON-bool operand is the truthiness test C# spells with `is null` / `== 0`,
+// not a literal `!operand`. It arises when a `brfalse x; ldc.0/ldc.1` select that
+// computes `x == null` folds to `return LogicalNot(x)` (e.g.
+// System.Collections.StructuralEqualityComparer.Equals returns `!y` for an
+// `object y`). The condition path already spells this; the expression path did
+// not, emitting `!y` — CS0023 (`!` is not defined on `object`). csc emits the
+// folded shape from its own structuring, so it is constructed at the IR level.
+public class LogicalNotValuePositionTests
+{
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
+    static readonly TypeRef Int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+
+    // bool M(<argType> a) => return !a;   (a LogicalNot of the single argument)
+    static string Render(TypeRef argType)
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Return(new LogicalNot(new LoadArgument(0, "a", argType))));
+        body.Add(block);
+        var function = new IrFunction(
+            "M", owner,
+            new MethodSignature(Bool, [new Parameter("a", argType)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void ReferenceOperand_SpellsIsNull_NotBang()
+    {
+        var output = Render(Object);
+
+        // `!a` on an object is CS0023; the faithful truthiness form is `a is null`.
+        Assert.Contains("return a is null;", output);
+        Assert.DoesNotContain("!a", output);
+    }
+
+    [Fact]
+    public void IntegerOperand_SpellsEqualsZero_NotBang()
+    {
+        var output = Render(Int);
+
+        // `!a` on an int is CS0023; the truthiness form is `a == 0`.
+        Assert.Contains("return a == 0;", output);
+        Assert.DoesNotContain("!a", output);
+    }
+
+    [Fact]
+    public void BooleanOperand_StaysBang()
+    {
+        var output = Render(Bool);
+
+        // A genuine bool operand is its own truth value — the bare `!a` is correct
+        // and must be preserved (Truthiness returns null for bool).
+        Assert.Contains("return !a;", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1403,6 +1403,12 @@ public sealed partial class CSharpPrinter
         LoadField f => FieldTarget(f.Field, f.Instance),
         Binary b => BinaryText(b),
         Comparison c => ComparisonText(c),
+        // A LogicalNot in value position (a folded `brfalse x; ldc.0/ldc.1` select,
+        // e.g. `return y == null`) over a NON-bool operand is the same truthiness
+        // test the condition path spells: `!y` on an object is CS0023, the faithful
+        // form is `y is null` (and `x == 0` for an integer). A bool operand returns
+        // null from Truthiness and keeps the bare `!operand`.
+        LogicalNot { Operand: { } operand } when Truthiness(operand) is { } negated => negated.Inverted,
         LogicalNot n => $"!{Operand(n.Operand)}",
         LogicalBinary l => LogicalText(l),
         Conditional t => ConditionalText(t),


### PR DESCRIPTION
## Summary

Fixes #1657. A `LogicalNot` that survives into **value position** (a `return`/assignment, not a branch condition) over a **non-bool** operand printed the bare `!operand` — **CS0023** (`operator '!' cannot be applied to operand of type 'object'`/`int`).

Found by a `--validity-check` sweep. Real corpus case — `System.Collections.StructuralEqualityComparer::Equals(object, object)`:

```diff
-    return !y;          // CS0023 — '!' is not defined on 'object'
+    return y is null;
```

The IL is the `brfalse y; ldc.i4.0/ldc.i4.1` select computing `y == null`, which a return-select fold raises to `return LogicalNot(y)`.

## Fix

The condition path (`Condition`) already spells a `LogicalNot` over a non-bool operand via `Truthiness(operand).Inverted` (`y is null`, `x == 0`). The expression path (`Expression`) did not. This adds the same `Truthiness` case to the `Expression` switch before the bare-`!` fallback. A genuine `bool` operand keeps `!operand` (`Truthiness` returns null for bool), so the change is scoped to exactly the CS0023 non-bool cases.

## Tests / evidence

- New `LogicalNotValuePositionTests` (synthetic IR): reference operand → `a is null`, integer → `a == 0`, bool canary → `!a` preserved. 3/3 pass. (csc does not emit this folded shape from ordinary source — the established synthetic-IR pattern, as in `MixedSignCompoundTests`.)
- Real corpus verification: `StructuralEqualityComparer::Equals` went `CS0023,CS0176` → `CS0176` (the CS0023 is gone; the unrelated CS0176 is a separate pre-existing defect). Defect-set method counts are unchanged across System.Linq/Collections/RegularExpressions/Linq.Expressions — **zero new defects**.
- Related groups green: ReferenceNull, PointerNullComparison, NullValueTypeGuard, BoolToInt, LoadIndirectBool, ComparisonTreeBoolArm, ElseReturnFold, ReturnDispatch, RefBoolBranch. Full decompiler suite running.

## Scope note

The condition-position `if (!interfaceSlot)` case (an interface-typed stack slot that `Truthiness` does not classify as a reference) is a **distinct** root cause and is intentionally out of scope here.
