### PR TITLE
Make constructor-chain order-barrier a deny-list (#1421 follow-up)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ConstructorChainArgumentOrderTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConstructorChainArgumentOrderTests.cs
@@ -12,6 +12,7 @@ public class ConstructorChainArgumentOrderTests
     static readonly TypeRef Base = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
     static readonly FieldRef StaticField = new(Derived, "F", Int32);
 
     static MethodRef Effect(string name) => new(Derived, name, Int32, [], HasThis: false);
@@ -216,6 +217,24 @@ public class ConstructorChainArgumentOrderTests
         var function = BuildCtor(
             2,
             new StoreStackSlot(0, new Call(Effect("MutateF"), isVirtual: false, [])),
+            new ExpressionStatement(call));
+
+        RunPass(function);
+
+        Assert.Equal(1, StackStores(function));
+        function.CheckInvariant();
+    }
+
+    // A potentially-throwing inline cast left of an effectful spill is a barrier:
+    // inlining would let the cast throw before the spill's effect runs.
+    [Fact]
+    public void InlineThrowingCastLeftOfEffectfulSpill_DoesNotInline()
+    {
+        var stringType = TypeRef.CoreLib("System", "String");
+        var call = ChainCall(2, new CastClass(stringType, new LoadArgument(1, "o", Object)), new LoadStackSlot(0, Int32));
+        var function = BuildCtor(
+            2,
+            new StoreStackSlot(0, new Call(Effect("Mutate"), isVirtual: false, [])),
             new ExpressionStatement(call));
 
         RunPass(function);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainArgumentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorChainArgumentPass.cs
@@ -196,19 +196,15 @@ public sealed class ConstructorChainArgumentPass : IIrPass
     }
 
     /// <summary>
-    /// Nodes whose evaluation reads a place or produces an effect, so their order
-    /// relative to a moved value matters: place reads and addresses, calls and
-    /// object/delegate creation, stores, throw, and the raised effectful expression
-    /// forms (property getter, await, increment/decrement) earlier passes leave in
-    /// place. Pure leaves (constants, sizeof, ldtoken, argument/receiver loads) are
-    /// not barriers.
+    /// True unless <paramref name="node"/> is provably reorder-pure — i.e. anything
+    /// other than a constant, <c>sizeof</c>, <c>ldtoken</c>, or an argument/receiver
+    /// load. Everything else (place reads, calls, stores, allocations, casts and
+    /// other potentially-throwing or order-sensitive operations) is treated as a
+    /// barrier, so a moved value can never cross it. Deny-list by design: an
+    /// unrecognized node is conservatively a barrier rather than silently reorderable.
     /// </summary>
     static bool IsOrderSensitive(IrNode node)
-        => node is LoadField or LoadLocal or LoadStackSlot or LoadElement or LoadIndirect
-            or LoadProperty or LoadFieldAddress or LoadElementAddress
-            or Call or CallIndirect or NewObject or DelegateCreation
-            or StoreField or StoreProperty or StoreElement or StoreIndirect
-            or Throw or AwaitExpression or IncrementDecrement;
+        => node is not (Constant or SizeOf or LoadToken or LoadArgument);
 
     static Dictionary<(bool IsSlot, int Index), Place> CountPlaces(IrFunction function)
     {


### PR DESCRIPTION
## Follow-up to #1652 (merged)

#1652 fixed the constructor-chain argument effect-order over-raise (#1421) and merged. During its adversarial review one **medium** finding landed without its fix: the merged `IsOrderSensitive` is an *allowlist* of place-reads/effects that still omits potentially-throwing/allocating inline nodes — `CastClass`, `IsInstance`, `ArrayLength`, checked `Convert`/`Binary`, `NewArray`, `Box`, `UnboxAny`, etc.

## Wrong-semantics claim being narrowed

Because those nodes are not barriers, an effectful spill can be reordered after one:

```text
S0 = Mutate();
base((string)o, S0)   ->   base((string)o, Mutate())
```

If `o` is not a `string`, the emitted form throws **before** `Mutate()` runs; the original IR ran `Mutate()` (the pre-call store) first.

## Fix

Invert `IsOrderSensitive` from an allowlist to a deny-list: every node is an ordering barrier **except** provably-pure leaves (`Constant`, `SizeOf`, `LoadToken`, `LoadArgument` — covers the `this` receiver and plain parameter args). An unrecognized node is conservatively a barrier rather than silently reorderable.

Normal csc shapes are unaffected: csc spills every argument ahead of a control-flow argument, so no inline non-pure node precedes a spilled one. All existing constructor-chain fixtures still pass.

## Evidence

`ConstructorChainArgumentOrderTests` — 11/11 pass, including the new `InlineThrowingCastLeftOfEffectfulSpill_DoesNotInline`. Full `ILInspector.Decompiler.Tests` runs in CI.

Refs #1421.
