### PR TITLE
Add pseudo-exception loop hotness guard

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1009,6 +1009,7 @@ public class LibraryBodyIndexTests
             m.Name == nameof(OptimizationOpportunityFixtures.AllocatesPseudoExceptionOnceInLoop)));
         Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
         Assert.True(s.AllocInLoop);
+        Assert.DoesNotContain(nameof(PseudoException), s.ExceptionTypes);
         Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.AllocatesPseudoExceptionOnceInLoop)));
     }
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -998,6 +998,21 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void MethodSignals_AllocInLoop_TrueForInAssemblyPseudoExceptionLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+
+        // #1607: a same-assembly type whose name ends with Exception is not an
+        // exception unless the metadata base chain proves it derives from System.Exception.
+        var method = Assert.Single(index.Methods.Where(m =>
+            m.Name == nameof(OptimizationOpportunityFixtures.AllocatesPseudoExceptionOnceInLoop)));
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
+        Assert.True(s.AllocInLoop);
+        Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.AllocatesPseudoExceptionOnceInLoop)));
+    }
+
+    [Fact]
     public void MethodSignals_AllocInLoop_FalseForExceptionConstructionInLoop()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -1484,6 +1499,16 @@ public class OptimizationOpportunityFixtures
         for (int i = 0; i < n; i++)
         {
             last = new object();
+        }
+        return last;
+    }
+
+    public static object AllocatesPseudoExceptionOnceInLoop(int n)
+    {
+        object last = new PseudoException(0);
+        for (int i = 0; i < n; i++)
+        {
+            last = new PseudoException(i);
         }
         return last;
     }


### PR DESCRIPTION
## Summary

Adds a regression guard for #1607 so an in-assembly non-exception type whose name ends with `Exception` still reports `MethodSignals.AllocInLoop` when allocated in a loop.

Current `origin/main` already routes MethodSignals through the in-assembly exception map; this PR locks the #1607 Analysis Diff behavior so future suffix-only exception checks cannot regress it.

## Evidence

```text
dotnet run --project src/ILInspector.Analysis.Tests -c Release

Total: 118, Errors: 0, Failed: 0, Skipped: 0
```

Source-built CLI repro:

```text
Summary | 2 allocation regressions, 2 in loop (2 signals).

Probe.LoopAllocationProbe.PlainObjectLoop(int)        allocations  0  1  +1  in-loop
Probe.LoopAllocationProbe.PseudoExceptionLoop(int)    allocations  0  1  +1  in-loop
```

This preserves the existing throw-path canary: `ThrowsInLoop` remains non-hot.

Adversarial review requested separately before merge.

Fixes #1607
