### PR TITLE
Parse YAML block-scalar frontmatter (fixes #1647; phase 1 of #1659)

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -6044,6 +6044,41 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Project_AgentsIndex_FoldsBlockScalarDescription()
+    {
+        var agents = """
+            ---
+            name: markout
+            description: >-
+              Source-generated .NET serializer that renders objects as Markdown.
+              Reach for it when a CLI needs structured, agent-readable output
+              instead of hand-built strings.
+            ---
+            # Body
+            """;
+        var (projectPath, tempDir) = CreateProjectWithPackageDocs(
+            new ProjectDocPackage("Test.Project.Folded", "1.0.0", "README.md", "readme", agents));
+
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "project", projectPath, "--agents-index", "--jsonl");
+
+            Assert.True(exit == 0, $"exit={exit}\nstdout:\n{output}\nstderr:\n{error}");
+            Assert.Empty(error);
+            using var document = JsonDocument.Parse(output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Single());
+            Assert.Equal("markout", document.RootElement.GetProperty("name").GetString());
+            Assert.Equal(
+                "Source-generated .NET serializer that renders objects as Markdown. Reach for it when a CLI needs structured, agent-readable output instead of hand-built strings.",
+                document.RootElement.GetProperty("description").GetString());
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Project_Readme_UsesProjectResolvedDependencyVersion()
     {
         var agents = """

--- a/src/dotnet-inspect/Services/MarkdownContent.cs
+++ b/src/dotnet-inspect/Services/MarkdownContent.cs
@@ -30,6 +30,7 @@ public static class MarkdownContent
         while (lineStart < frontmatterEnd)
         {
             var lineEnd = FindLineEnd(content, lineStart);
+            var indent = CountIndent(content, lineStart, lineEnd);
             var line = content[lineStart..lineEnd].Trim();
             if (line.Length > 0 && !line.StartsWith('#'))
             {
@@ -37,9 +38,18 @@ public static class MarkdownContent
                 if (colon > 0)
                 {
                     var key = line[..colon].Trim();
-                    var value = TrimYamlScalar(line[(colon + 1)..].Trim());
+                    var rawValue = line[(colon + 1)..].Trim();
                     if (key.Length > 0)
-                        values[key] = value;
+                    {
+                        if (TryGetBlockScalarStyle(rawValue, out var folded))
+                        {
+                            var blockStart = NextLineStart(content, lineEnd);
+                            values[key] = ReadBlockScalar(content, frontmatterEnd, blockStart, indent, folded, out lineStart);
+                            continue;
+                        }
+
+                        values[key] = TrimYamlScalar(rawValue);
+                    }
                 }
             }
 
@@ -47,6 +57,118 @@ public static class MarkdownContent
         }
 
         return values;
+    }
+
+    /// <summary>
+    /// Recognizes a YAML block scalar header (<c>|</c> literal or <c>&gt;</c> folded), optionally with
+    /// chomping/indentation indicators (e.g. <c>|-</c>, <c>&gt;-</c>, <c>|+</c>, <c>&gt;2</c>). Returns true
+    /// for both styles; <paramref name="folded"/> is true for <c>&gt;</c>.
+    /// </summary>
+    private static bool TryGetBlockScalarStyle(string value, out bool folded)
+    {
+        folded = false;
+        if (value.Length == 0 || (value[0] != '|' && value[0] != '>'))
+            return false;
+
+        // Everything after the indicator must be chomping/indent indicators (-, +, digits) only,
+        // ignoring a trailing comment.
+        var rest = value[1..];
+        var commentStart = rest.IndexOf('#');
+        if (commentStart >= 0)
+            rest = rest[..commentStart];
+        foreach (var ch in rest.Trim())
+        {
+            if (ch is not ('-' or '+') && !char.IsDigit(ch))
+                return false;
+        }
+
+        folded = value[0] == '>';
+        return true;
+    }
+
+    /// <summary>
+    /// Reads the body of a YAML block scalar. Lines indented more than <paramref name="parentIndent"/>
+    /// (and blank lines) belong to the block; the first line at or below the parent indent ends it.
+    /// Folded blocks join wrapped text lines with a single space and blank lines with a newline; literal
+    /// blocks preserve newlines. Trailing whitespace is trimmed (sufficient for the table/field consumers).
+    /// <paramref name="next"/> receives the line start where parsing should resume.
+    /// </summary>
+    private static string ReadBlockScalar(string content, int end, int start, int parentIndent, bool folded, out int next)
+    {
+        var lines = new List<string>();
+        var blockIndent = -1;
+        var lineStart = start;
+        while (lineStart < end)
+        {
+            var lineEnd = FindLineEnd(content, lineStart);
+            var rawEnd = lineEnd > lineStart && content[lineEnd - 1] == '\r' ? lineEnd - 1 : lineEnd;
+            var isBlank = IsBlank(content, lineStart, rawEnd);
+            if (!isBlank)
+            {
+                var indent = CountIndent(content, lineStart, rawEnd);
+                if (indent <= parentIndent)
+                    break;
+
+                if (blockIndent < 0)
+                    blockIndent = indent;
+
+                var stripStart = lineStart + Math.Min(blockIndent, indent);
+                lines.Add(content[stripStart..rawEnd]);
+            }
+            else
+            {
+                lines.Add("");
+            }
+
+            lineStart = NextLineStart(content, lineEnd);
+        }
+
+        next = lineStart;
+
+        // Drop trailing blank lines.
+        while (lines.Count > 0 && lines[^1].Length == 0)
+            lines.RemoveAt(lines.Count - 1);
+
+        if (folded)
+        {
+            var builder = new System.Text.StringBuilder();
+            for (var i = 0; i < lines.Count; i++)
+            {
+                if (lines[i].Length == 0)
+                {
+                    builder.Append('\n');
+                }
+                else
+                {
+                    if (builder.Length > 0 && builder[^1] != '\n')
+                        builder.Append(' ');
+                    builder.Append(lines[i]);
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        return string.Join('\n', lines);
+    }
+
+    private static int CountIndent(string content, int start, int end)
+    {
+        var i = start;
+        while (i < end && content[i] == ' ')
+            i++;
+        return i - start;
+    }
+
+    private static bool IsBlank(string content, int start, int end)
+    {
+        for (var i = start; i < end; i++)
+        {
+            if (content[i] is not (' ' or '\t'))
+                return false;
+        }
+
+        return true;
     }
 
     private static string TrimYamlScalar(string value)


### PR DESCRIPTION
## Summary

First phase of the grounding/`--print` redesign (#1659): fix the YAML frontmatter
parser so block-scalar descriptions are read correctly. Closes #1647.

`MarkdownContent.ParseYamlFrontmatter` was a naive line-by-line `key: value` reader
with no support for YAML block scalars (`>-`, `>`, `|`, `|-`). A package whose
frontmatter used a folded/literal `description` (a very common style for long text)
yielded `description = ">-"`, breaking `project --agents-index`. The repo's own
**Markout** dependency triggers it.

## Behavior

Block scalars are now consumed:
- **Folded (`>`)** — wrapped lines join with a space; blank lines become newlines.
- **Literal (`|`)** — newlines preserved.
- Chomping/indent indicators (`-`, `+`, digits) are accepted.
- The block ends at the first line at or below the key's indent, so a following key
  is never swallowed.

## Before / After

```
# before
dotnet-inspect project src/dotnet-inspect --agents-index
| Markout | 0.14.0 | markout | >- |

# after
| Markout | 0.14.0 | markout | Source-generated .NET serializer that renders objects as Markdown ... |
```

## Tests

- New E2E test `Project_AgentsIndex_FoldsBlockScalarDescription` (folded `>-`).
- Verified edge cases via a direct probe: key-after-block (not swallowed), literal
  `|` newline preservation, folded blank-line → newline, plain scalars unchanged.
- `dotnet build src/dotnet-inspect -c Release` clean; targeted suites green
  (`*AgentsIndex*`, `*Frontmatter*`, `*Readme*`, `*Project_*` — 35 tests, 0 failures).

## Why this first

The planned `Grounding` section (#1659) surfaces each dependency's `name`/`description`
from frontmatter, so correct block-scalar parsing is a prerequisite. Remaining #1659
phases (shared-option binding per #1649, the `Grounding` section, and the `--print`
flag superseding `--agents-index`/`--readme`) follow in later PRs.
