### PR TITLE
Count root reach from entry SCCs

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -305,6 +305,20 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void TopLeverage_TreatsMutuallyRecursiveEntryComponentAsRoot()
+    {
+        var index = LibraryBodyIndex.Open(typeof(LeverageDepthFixtures).Assembly.Location);
+
+        var ranked = index.TopLeverage(count: 100, scope: method => method.DeclaringType.Name == nameof(LeverageDepthFixtures));
+        var byName = ranked.ToDictionary(entry => entry.Method.Name);
+
+        Assert.Equal(1, byName[nameof(LeverageDepthFixtures.Ping)].RootReach);
+        Assert.Equal(1, byName[nameof(LeverageDepthFixtures.Pong)].RootReach);
+        Assert.Equal(1, byName[nameof(LeverageDepthFixtures.ChainTop)].RootReach);
+        Assert.Equal(1, byName[nameof(LeverageDepthFixtures.ChainLeaf)].RootReach);
+    }
+
+    [Fact]
     public void TopLeverage_CountsCallerOfIntraAssemblyGenericMethod()
     {
         var index = LibraryBodyIndex.Open(typeof(CallSiteFixtures).Assembly.Location);

--- a/src/ILInspector.Analysis/MethodLeverage.cs
+++ b/src/ILInspector.Analysis/MethodLeverage.cs
@@ -198,64 +198,84 @@ public static class MethodLeverageRanking
         HashSet<int> methodTokens,
         IReadOnlyDictionary<int, HashSet<int>> adjacency)
     {
+        var reverse = new Dictionary<int, List<int>>();
+        foreach (var (caller, callees) in adjacency)
+        {
+            if (!methodTokens.Contains(caller))
+                continue;
+            foreach (int callee in callees)
+            {
+                if (!methodTokens.Contains(callee))
+                    continue;
+                (reverse.TryGetValue(callee, out var callers)
+                    ? callers
+                    : reverse[callee] = []).Add(caller);
+            }
+        }
+
+        foreach (var callers in reverse.Values)
+            callers.Sort();
+
+        var visited = new HashSet<int>();
+        var finishOrder = new List<int>(methodTokens.Count);
+        var visitStack = new Stack<(int Token, bool Exit)>();
+
+        foreach (int token in methodTokens.OrderBy(t => t))
+        {
+            if (!visited.Add(token))
+                continue;
+            visitStack.Push((token, Exit: false));
+            while (visitStack.Count > 0)
+            {
+                var (current, exit) = visitStack.Pop();
+                if (exit)
+                {
+                    finishOrder.Add(current);
+                    continue;
+                }
+
+                visitStack.Push((current, Exit: true));
+                if (!adjacency.TryGetValue(current, out var callees))
+                    continue;
+                foreach (int callee in callees.OrderByDescending(t => t))
+                {
+                    if (methodTokens.Contains(callee) && visited.Add(callee))
+                        visitStack.Push((callee, Exit: false));
+                }
+            }
+        }
+
         var components = new List<int[]>();
         var componentByToken = new Dictionary<int, int>();
-        var indexByToken = new Dictionary<int, int>();
-        var lowLinkByToken = new Dictionary<int, int>();
-        var stack = new Stack<int>();
-        var onStack = new HashSet<int>();
-        int nextIndex = 0;
 
-        void Visit(int token)
+        foreach (int root in finishOrder.AsEnumerable().Reverse())
         {
-            indexByToken[token] = nextIndex;
-            lowLinkByToken[token] = nextIndex;
-            nextIndex++;
-            stack.Push(token);
-            onStack.Add(token);
+            if (componentByToken.ContainsKey(root))
+                continue;
 
-            if (adjacency.TryGetValue(token, out var callees))
+            var component = new List<int>();
+            var stack = new Stack<int>();
+            stack.Push(root);
+            componentByToken[root] = components.Count;
+            while (stack.Count > 0)
             {
-                foreach (int callee in callees)
+                int current = stack.Pop();
+                component.Add(current);
+                if (!reverse.TryGetValue(current, out var callers))
+                    continue;
+                for (int i = callers.Count - 1; i >= 0; i--)
                 {
-                    if (!methodTokens.Contains(callee))
-                        continue;
-                    if (!indexByToken.ContainsKey(callee))
+                    int caller = callers[i];
+                    if (!componentByToken.ContainsKey(caller))
                     {
-                        Visit(callee);
-                        lowLinkByToken[token] = Math.Min(lowLinkByToken[token], lowLinkByToken[callee]);
-                    }
-                    else if (onStack.Contains(callee))
-                    {
-                        lowLinkByToken[token] = Math.Min(lowLinkByToken[token], indexByToken[callee]);
+                        componentByToken[caller] = components.Count;
+                        stack.Push(caller);
                     }
                 }
             }
 
-            if (lowLinkByToken[token] != indexByToken[token])
-                return;
-
-            var component = new List<int>();
-            int member;
-            do
-            {
-                member = stack.Pop();
-                onStack.Remove(member);
-                component.Add(member);
-            }
-            while (member != token);
-
             component.Sort();
-            int componentIndex = components.Count;
-            foreach (int item in component)
-                componentByToken[item] = componentIndex;
             components.Add(component.ToArray());
-        }
-
-        foreach (int token in methodTokens.OrderBy(t => t))
-        {
-            if (!indexByToken.ContainsKey(token))
-                Visit(token);
         }
 
         return (components, componentByToken);

--- a/src/ILInspector.Analysis/MethodLeverage.cs
+++ b/src/ILInspector.Analysis/MethodLeverage.cs
@@ -110,7 +110,7 @@ public static class MethodLeverageRanking
             return (best, cut);
         }
 
-        var rootReach = ComputeRootReach(methodTokens, directCallers, adjacency);
+        var rootReach = ComputeRootReach(methodTokens, adjacency);
 
         return methods
             .Where(method => scope is null || scope(method))
@@ -138,7 +138,6 @@ public static class MethodLeverageRanking
     // large assemblies (where the count degrades to a lower bound).
     static Dictionary<int, int> ComputeRootReach(
         HashSet<int> methodTokens,
-        IReadOnlyDictionary<int, HashSet<int>> directCallers,
         IReadOnlyDictionary<int, HashSet<int>> adjacency)
     {
         const long VisitBudget = 6_000_000;
@@ -147,22 +146,36 @@ public static class MethodLeverageRanking
         var queue = new Queue<int>();
         long budget = VisitBudget;
 
-        // A root has no in-assembly caller other than itself. Self-recursion contributes
-        // a self-edge to directCallers, so a self-recursive entry point would otherwise be
-        // misclassified as non-root (dropping it and its descendants from root reach).
-        static bool IsRoot(int token, IReadOnlyDictionary<int, HashSet<int>> directCallers)
-            => !directCallers.TryGetValue(token, out var callers)
-                || (callers.Count == 1 && callers.Contains(token));
+        var (components, componentByToken) = StronglyConnectedComponents(methodTokens, adjacency);
+        var hasExternalIncoming = new bool[components.Count];
+        foreach (var (caller, callees) in adjacency)
+        {
+            if (!componentByToken.TryGetValue(caller, out int callerComponent))
+                continue;
+            foreach (int callee in callees)
+            {
+                if (componentByToken.TryGetValue(callee, out int calleeComponent)
+                    && callerComponent != calleeComponent)
+                {
+                    hasExternalIncoming[calleeComponent] = true;
+                }
+            }
+        }
 
         // Deterministic order so a budget cut-off is reproducible.
-        foreach (var root in methodTokens.Where(t => IsRoot(t, directCallers)).OrderBy(t => t))
+        foreach (var componentIndex in Enumerable.Range(0, components.Count)
+            .Where(i => !hasExternalIncoming[i])
+            .OrderBy(i => components[i][0]))
         {
             if (budget <= 0)
                 break;
             reached.Clear();
             queue.Clear();
-            reached.Add(root);
-            queue.Enqueue(root);
+            foreach (int root in components[componentIndex])
+            {
+                reached.Add(root);
+                queue.Enqueue(root);
+            }
             while (queue.Count > 0)
             {
                 int node = queue.Dequeue();
@@ -179,5 +192,72 @@ public static class MethodLeverageRanking
         }
 
         return rootReach;
+    }
+
+    static (List<int[]> Components, Dictionary<int, int> ComponentByToken) StronglyConnectedComponents(
+        HashSet<int> methodTokens,
+        IReadOnlyDictionary<int, HashSet<int>> adjacency)
+    {
+        var components = new List<int[]>();
+        var componentByToken = new Dictionary<int, int>();
+        var indexByToken = new Dictionary<int, int>();
+        var lowLinkByToken = new Dictionary<int, int>();
+        var stack = new Stack<int>();
+        var onStack = new HashSet<int>();
+        int nextIndex = 0;
+
+        void Visit(int token)
+        {
+            indexByToken[token] = nextIndex;
+            lowLinkByToken[token] = nextIndex;
+            nextIndex++;
+            stack.Push(token);
+            onStack.Add(token);
+
+            if (adjacency.TryGetValue(token, out var callees))
+            {
+                foreach (int callee in callees)
+                {
+                    if (!methodTokens.Contains(callee))
+                        continue;
+                    if (!indexByToken.ContainsKey(callee))
+                    {
+                        Visit(callee);
+                        lowLinkByToken[token] = Math.Min(lowLinkByToken[token], lowLinkByToken[callee]);
+                    }
+                    else if (onStack.Contains(callee))
+                    {
+                        lowLinkByToken[token] = Math.Min(lowLinkByToken[token], indexByToken[callee]);
+                    }
+                }
+            }
+
+            if (lowLinkByToken[token] != indexByToken[token])
+                return;
+
+            var component = new List<int>();
+            int member;
+            do
+            {
+                member = stack.Pop();
+                onStack.Remove(member);
+                component.Add(member);
+            }
+            while (member != token);
+
+            component.Sort();
+            int componentIndex = components.Count;
+            foreach (int item in component)
+                componentByToken[item] = componentIndex;
+            components.Add(component.ToArray());
+        }
+
+        foreach (int token in methodTokens.OrderBy(t => t))
+        {
+            if (!indexByToken.ContainsKey(token))
+                Visit(token);
+        }
+
+        return (components, componentByToken);
     }
 }

--- a/src/ILInspector.Analysis/MethodLeverage.cs
+++ b/src/ILInspector.Analysis/MethodLeverage.cs
@@ -216,13 +216,14 @@ public static class MethodLeverageRanking
         foreach (var callers in reverse.Values)
             callers.Sort();
 
-        var visited = new HashSet<int>();
+        var entered = new HashSet<int>();
+        var exited = new HashSet<int>();
         var finishOrder = new List<int>(methodTokens.Count);
         var visitStack = new Stack<(int Token, bool Exit)>();
 
         foreach (int token in methodTokens.OrderBy(t => t))
         {
-            if (!visited.Add(token))
+            if (entered.Contains(token))
                 continue;
             visitStack.Push((token, Exit: false));
             while (visitStack.Count > 0)
@@ -230,16 +231,19 @@ public static class MethodLeverageRanking
                 var (current, exit) = visitStack.Pop();
                 if (exit)
                 {
-                    finishOrder.Add(current);
+                    if (exited.Add(current))
+                        finishOrder.Add(current);
                     continue;
                 }
+                if (!entered.Add(current))
+                    continue;
 
                 visitStack.Push((current, Exit: true));
                 if (!adjacency.TryGetValue(current, out var callees))
                     continue;
                 foreach (int callee in callees.OrderByDescending(t => t))
                 {
-                    if (methodTokens.Contains(callee) && visited.Add(callee))
+                    if (methodTokens.Contains(callee) && !entered.Contains(callee))
                         visitStack.Push((callee, Exit: false));
                 }
             }


### PR DESCRIPTION
## Summary

Closes #1611. Computes `RootReach` from root strongly-connected components instead of only individual root methods, so a mutually-recursive entry component with no incoming external callers contributes one root source.

Changes:

- builds SCCs over the in-assembly call graph before root-reach BFS;
- treats SCCs with no incoming edge from another SCC as root components;
- seeds BFS with all members of a root SCC while counting the component as one root source;
- uses an iterative SCC implementation to avoid stack-overflow risk on deep call graphs;
- adds a regression for `LeverageDepthFixtures.Ping/Pong` and their downstream callees.

## Evidence

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` — 119 passed
- Product surface check:

```text
dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll \
  library artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tests.dll \
  -S "Top Leverage" --fields "Member,Callers,Root Reach" --table --rows -n 200

ILInspector.Analysis.Tests.LeverageDepthFixtures.Pong()       Callers 1  Root Reach 1
ILInspector.Analysis.Tests.LeverageDepthFixtures.ChainTop()   Callers 1  Root Reach 1
ILInspector.Analysis.Tests.LeverageDepthFixtures.ChainLeaf()  Callers 1  Root Reach 1
ILInspector.Analysis.Tests.LeverageDepthFixtures.Ping()       Callers 1  Root Reach 1
```

## Adversarial review

Requested cross-model Opus 4.8 review. Initial review found the recursive Tarjan SCC implementation was semantically correct for #1611 but had an unbounded recursion risk; I replaced it with an iterative two-pass SCC. Final review reported no blocking findings.
