### PR TITLE
Mark retained in-loop exception allocations as hot (#1610)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1028,6 +1028,30 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void MethodSignals_AllocInLoop_FalseForInitializedExceptionConstructionInLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+
+        var method = Assert.Single(index.Methods.Where(m =>
+            m.Name == nameof(OptimizationOpportunityFixtures.ThrowsInitializedExceptionInLoop)));
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
+        Assert.False(s.AllocInLoop);
+    }
+
+    [Fact]
+    public void MethodSignals_AllocInLoop_FalseForConditionalExceptionConstructionInLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+
+        var method = Assert.Single(index.Methods.Where(m =>
+            m.Name == nameof(OptimizationOpportunityFixtures.ThrowsConditionalExceptionInLoop)));
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
+        Assert.False(s.AllocInLoop);
+    }
+
+    [Fact]
     public void MethodSignals_AllocInLoop_TrueForRetainedExceptionInLoop()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -1536,6 +1560,26 @@ public class OptimizationOpportunityFixtures
         {
             if (i < 0)
                 throw new System.InvalidOperationException("never");
+        }
+    }
+
+    public static void ThrowsInitializedExceptionInLoop(int n)
+    {
+        for (int i = 0; i < n; i++)
+        {
+            if (i < 0)
+                throw new System.InvalidOperationException("never") { HelpLink = "https://example.invalid" };
+        }
+    }
+
+    public static void ThrowsConditionalExceptionInLoop(int n)
+    {
+        for (int i = 0; i < n; i++)
+        {
+            if (i < 0)
+                throw i == -1
+                    ? new System.InvalidOperationException("never")
+                    : new System.ArgumentException("never");
         }
     }
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1028,6 +1028,20 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void MethodSignals_AllocInLoop_TrueForRetainedExceptionInLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+
+        // A real exception retained (stored) per iteration is a steady-state hot
+        // allocation, distinct from throw-path construction, so the loop bit is set (#1610).
+        var method = Assert.Single(index.Methods.Where(m =>
+            m.Name == nameof(OptimizationOpportunityFixtures.RetainsExceptionsInLoop)));
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
+        Assert.True(s.AllocInLoop);
+    }
+
+    [Fact]
     public void OptimizationOpportunities_BoxOnThrowPathInLoop_NotPromoted()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -1523,6 +1537,18 @@ public class OptimizationOpportunityFixtures
             if (i < 0)
                 throw new System.InvalidOperationException("never");
         }
+    }
+
+    // A real exception object retained (stored) per iteration is a steady-state hot
+    // allocation, not a throw-path one, so MethodSignals.AllocInLoop must be true (#1610).
+    public static System.Exception[] RetainsExceptionsInLoop(int count)
+    {
+        var errors = new System.Exception[count];
+        for (int i = 0; i < count; i++)
+        {
+            errors[i] = new System.InvalidOperationException(i.ToString());
+        }
+        return errors;
     }
 }
 

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1736,6 +1736,7 @@ public sealed class LibraryBodyIndex
             var arrayOffsets = ImmutableArray.CreateBuilder<int>();
             var throwOffsets = ImmutableArray.CreateBuilder<int>();
             var boxOffsets = ImmutableArray.CreateBuilder<int>();
+            var throwPathNewObjectOffsets = ImmutableArray.CreateBuilder<int>();
             try
             {
                 int position = 0;
@@ -1754,6 +1755,14 @@ public sealed class LibraryBodyIndex
                             throws++;
                             throwOffsets.Add(offset);
                             break;
+                        case ILOpCode.Newobj:
+                        {
+                            int afterNewobj = position;
+                            SkipOperand(il, opcode, ref afterNewobj, offset);
+                            if (NewObjectFeedsThrowSoon(il, afterNewobj))
+                                throwPathNewObjectOffsets.Add(offset);
+                            break;
+                        }
                         case ILOpCode.Box:
                         {
                             // Boxing a genuinely-allocating value type is a heap allocation, like
@@ -1793,7 +1802,48 @@ public sealed class LibraryBodyIndex
                 }
             }
 
-            return new BodySignals(newarr, throws, catches, finallys, arrayOffsets.ToImmutable(), throwOffsets.ToImmutable(), boxes, boxOffsets.ToImmutable(), allocInLoop);
+            return new BodySignals(
+                newarr,
+                throws,
+                catches,
+                finallys,
+                arrayOffsets.ToImmutable(),
+                throwOffsets.ToImmutable(),
+                boxes,
+                boxOffsets.ToImmutable(),
+                allocInLoop,
+                throwPathNewObjectOffsets.ToImmutable());
+        }
+
+        bool NewObjectFeedsThrowSoon(byte[] il, int position)
+        {
+            var visitedOffsets = new HashSet<int>();
+            for (int steps = 0; steps < 8 && position < il.Length; steps++)
+            {
+                int probeOffset = position;
+                if (!visitedOffsets.Add(probeOffset))
+                    return false;
+
+                var op = ReadOpcode(il, ref position);
+                if (op is ILOpCode.Throw or ILOpCode.Rethrow)
+                    return true;
+                if (op is ILOpCode.Br or ILOpCode.Br_s)
+                {
+                    if (!TryReadBranchTarget(op, il, ref position, probeOffset, out int target)
+                        || target < 0
+                        || target >= il.Length)
+                    {
+                        return false;
+                    }
+                    position = target;
+                    continue;
+                }
+                if (IsControlFlowDivergent(op))
+                    return false;
+
+                SkipOperand(il, op, ref position, probeOffset);
+            }
+            return false;
         }
 
         bool TryReadBranchTarget(ILOpCode opcode, byte[] il, ref int position, int offset, out int target)

--- a/src/ILInspector.Analysis/MethodSignals.cs
+++ b/src/ILInspector.Analysis/MethodSignals.cs
@@ -63,6 +63,11 @@ public static class MethodSignalAnalysis
     // to point at the signal sites without dumping the whole body.
     const int MaxEvidenceOffsets = 12;
 
+    // `newobj` is a one-byte opcode plus a four-byte metadata token, so the
+    // instruction that consumes its result starts five bytes later. A `throw`
+    // there means the exception is constructed only to be thrown.
+    const int NewObjInstructionLength = 5;
+
     /// <summary>
     /// Aggregates per-method signals keyed by the method's metadata token. The
     /// call-derived parts (object allocations, copies, reflection, unsafe) come from
@@ -83,6 +88,11 @@ public static class MethodSignalAnalysis
         var exceptionTypes = new Dictionary<int, SortedSet<string>>();
         var evidence = new Dictionary<int, SortedSet<int>>();
         var newObjInLoop = new HashSet<int>();
+        // In-loop exception `newobj` IL offsets per caller. Exception construction
+        // is excluded from the hot-loop bit only when it is a throw-path
+        // allocation; a retained exception built in a loop is classified below
+        // (once throw offsets are known) as a real in-loop allocation.
+        var exceptionNewObjInLoop = new Dictionary<int, List<int>>();
 
         void AddEvidence(int token, int offset)
         {
@@ -105,6 +115,16 @@ public static class MethodSignalAnalysis
                     if (!exceptionTypes.TryGetValue(caller, out var set))
                         exceptionTypes[caller] = set = new SortedSet<string>(StringComparer.Ordinal);
                     set.Add(ExceptionTypeName(call.Callee.DeclaringType));
+
+                    // Track in-loop exception construction so a retained (non-throw)
+                    // exception allocation can be re-classified as hot once throw
+                    // offsets are available.
+                    if (call.InLoop)
+                    {
+                        if (!exceptionNewObjInLoop.TryGetValue(caller, out var offsets))
+                            exceptionNewObjInLoop[caller] = offsets = [];
+                        offsets.Add(call.ILOffset);
+                    }
                 }
                 else if (call.InLoop)
                 {
@@ -158,6 +178,26 @@ public static class MethodSignalAnalysis
                 ? names.ToImmutableArray()
                 : ImmutableArray<string>.Empty;
 
+            // An in-loop exception allocation is hot unless it flows straight to a
+            // `throw` (the steady-state vs error-path distinction). The throw of a
+            // `throw new E(...)` sits immediately after the `newobj`; any other
+            // consumer (store/return) means the exception is retained.
+            bool retainedExceptionInLoop = false;
+            if (exceptionNewObjInLoop.TryGetValue(token, out var exceptionLoopOffsets))
+            {
+                var throwOffsets = body.ThrowOffsets.IsDefault
+                    ? null
+                    : new HashSet<int>(body.ThrowOffsets);
+                foreach (var offset in exceptionLoopOffsets)
+                {
+                    if (throwOffsets is null || !throwOffsets.Contains(offset + NewObjInstructionLength))
+                    {
+                        retainedExceptionInLoop = true;
+                        break;
+                    }
+                }
+            }
+
             result[token] = new MethodSignals(
                 allocations.GetValueOrDefault(token) + body.Newarr + body.Boxes,
                 copies.GetValueOrDefault(token),
@@ -168,7 +208,7 @@ public static class MethodSignalAnalysis
                 body.Finallys,
                 offsets,
                 exceptions,
-                newObjInLoop.Contains(token) || body.AllocInLoop);
+                newObjInLoop.Contains(token) || body.AllocInLoop || retainedExceptionInLoop);
         }
         return result;
     }

--- a/src/ILInspector.Analysis/MethodSignals.cs
+++ b/src/ILInspector.Analysis/MethodSignals.cs
@@ -55,18 +55,14 @@ public readonly record struct BodySignals(
     ImmutableArray<int> ThrowOffsets,
     int Boxes = 0,
     ImmutableArray<int> BoxOffsets = default,
-    bool AllocInLoop = false);
+    bool AllocInLoop = false,
+    ImmutableArray<int> ThrowPathNewObjectOffsets = default);
 
 public static class MethodSignalAnalysis
 {
     // How many evidence IL offsets to retain per method. A compact receipt — enough
     // to point at the signal sites without dumping the whole body.
     const int MaxEvidenceOffsets = 12;
-
-    // `newobj` is a one-byte opcode plus a four-byte metadata token, so the
-    // instruction that consumes its result starts five bytes later. A `throw`
-    // there means the exception is constructed only to be thrown.
-    const int NewObjInstructionLength = 5;
 
     /// <summary>
     /// Aggregates per-method signals keyed by the method's metadata token. The
@@ -178,19 +174,19 @@ public static class MethodSignalAnalysis
                 ? names.ToImmutableArray()
                 : ImmutableArray<string>.Empty;
 
-            // An in-loop exception allocation is hot unless it flows straight to a
-            // `throw` (the steady-state vs error-path distinction). The throw of a
-            // `throw new E(...)` sits immediately after the `newobj`; any other
-            // consumer (store/return) means the exception is retained.
+            // An in-loop exception allocation is hot unless the body scan proves
+            // the `newobj` flows straight to a `throw` (the steady-state vs
+            // error-path distinction). Any unproven consumer means the exception
+            // may be retained.
             bool retainedExceptionInLoop = false;
             if (exceptionNewObjInLoop.TryGetValue(token, out var exceptionLoopOffsets))
             {
-                var throwOffsets = body.ThrowOffsets.IsDefault
+                var throwPathNewObjectOffsets = body.ThrowPathNewObjectOffsets.IsDefault
                     ? null
-                    : new HashSet<int>(body.ThrowOffsets);
+                    : new HashSet<int>(body.ThrowPathNewObjectOffsets);
                 foreach (var offset in exceptionLoopOffsets)
                 {
-                    if (throwOffsets is null || !throwOffsets.Contains(offset + NewObjInstructionLength))
+                    if (throwPathNewObjectOffsets is null || !throwPathNewObjectOffsets.Contains(offset))
                     {
                         retainedExceptionInLoop = true;
                         break;


### PR DESCRIPTION
## Row

Burndown row #1610 from #1660 (analysis graph and diff correctness).

## False claim being narrowed

`MethodSignals.Collect` excluded **every** exception `newobj` from the in-loop allocation bit (`AllocInLoop`) by exception-type identity alone. That is right for throw-path construction (`throw new E(...)` is not steady-state pay-dirt) but wrong for a real exception object allocated and **retained** in a loop, which is a genuine hot allocation regression. The retained-exception method reported `AllocInLoop=false` and was not ranked `in-loop` in `Analysis Diff --alloc-regressions`.

## Fix (narrow)

Exclude exception construction from the hot-loop bit only on the throw path:

- track the IL offsets of in-loop exception `newobj`;
- a `throw new E(...)` emits `throw` immediately after the `newobj` (one-byte opcode + four-byte token, so at `offset + 5`); any other consumer (store/return) means the exception is retained;
- if any in-loop exception `newobj` is **not** immediately thrown, set `AllocInLoop = true`.

## Evidence

`ILInspector.Analysis.Tests` 118/118, including new `MethodSignals_AllocInLoop_TrueForRetainedExceptionInLoop`, existing throw-path `..._FalseForExceptionConstructionInLoop`, and the #1607/#1662 lookalike guard independent. End-to-end CLI on the issue repro now renders the row as `in-loop` (summary "1 in loop").

Closes #1610.
