### PR TITLE
Normalize generic member identity for cross-assembly matching (#1339)

### DIFF
--- a/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
+++ b/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
@@ -13,5 +13,13 @@ namespace Shared
         public static void RunInt() => Target.Api.Ping(1);
 
         public static void RunString() => Target.Api.Ping("x");
+
+        // Constructed-generic callers (#1339). A caller graph rooted at the open target
+        // definition must report these once generic identity is normalized: UseBox invokes
+        // Box<int>.Store (a member on a constructed generic type) and UseEcho invokes Echo<int>
+        // (a constructed generic method via a MethodSpec).
+        public static void UseBox() => new Target.Box<int>().Store(1);
+
+        public static void UseEcho() => Target.GenericApi.Echo(1);
     }
 }

--- a/src/ILInspector.Analysis.CallerGraphTarget/TargetApi.cs
+++ b/src/ILInspector.Analysis.CallerGraphTarget/TargetApi.cs
@@ -19,4 +19,24 @@ namespace Target
         {
         }
     }
+
+    // Generic target surfaces (#1339). A cross-assembly caller graph rooted at the open
+    // definition must report constructed-instantiation callers in another assembly, which it
+    // can only do once generic member identity is normalized to the open definition.
+
+    // Member on a generic type: a caller invokes Store on a constructed Box<int>, keyed on the
+    // instantiation, which must match the open Box<T>.Store(T) target.
+    public sealed class Box<T>
+    {
+        public void Store(T value)
+        {
+        }
+    }
+
+    // Generic method on a non-generic type: a caller invokes Echo<int>, a MethodSpec keyed on
+    // the instantiation, which must match the open Echo<T>(T) target.
+    public static class GenericApi
+    {
+        public static T Echo<T>(T value) => value;
+    }
 }

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -191,6 +191,79 @@ public class LibraryBodyIndexTests
         Assert.DoesNotContain("Run", callerNames);
     }
 
+    [Fact]
+    public void BuildCallerTree_WithScope_LinksConstructedGenericTypeMemberCaller()
+    {
+        // Root the caller graph at the open Box<T>.Store(T). Another assembly calls
+        // Box<int>.Store(1) — a member reference keyed on the List<int>-style instantiation. The
+        // cross-assembly reverse map must normalize that constructed declaring type to its open
+        // definition so the caller is reported (#1339); before, it under-reported as zero.
+        var targetIndex = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphTarget"));
+        var caller = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphCaller"));
+
+        var store = targetIndex.Methods.First(method =>
+            method.DeclaringType.Name == "Box`1" && method.Name == "Store");
+        var tree = targetIndex.BuildCallerTree(store.MetadataToken, new[] { caller }, maxDepth: 2, maxNodes: 50);
+
+        var callerNames = tree.Children.Select(child => child.Member.Name).ToList();
+        Assert.Contains("UseBox", callerNames);
+        Assert.Contains("ILInspector.Analysis.CallerGraphCaller", tree.Children.Select(child => child.Perf?.Source));
+    }
+
+    [Fact]
+    public void BuildCallerTree_WithScope_LinksConstructedGenericMethodCaller()
+    {
+        // Root the caller graph at the open Echo<T>(T). Another assembly calls Echo<int>(1) — a
+        // MethodSpec keyed on the instantiation. Normalizing generic method identity to the open
+        // definition + parameter arity links the caller across assemblies (#1339).
+        var targetIndex = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphTarget"));
+        var caller = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphCaller"));
+
+        var echo = targetIndex.Methods.First(method =>
+            method.DeclaringType.Name == "GenericApi" && method.Name == "Echo");
+        var tree = targetIndex.BuildCallerTree(echo.MetadataToken, new[] { caller }, maxDepth: 2, maxNodes: 50);
+
+        var callerNames = tree.Children.Select(child => child.Member.Name).ToList();
+        Assert.Contains("UseEcho", callerNames);
+    }
+
+    [Fact]
+    public void MatchesCrossAssembly_MatchesConstructedGenericMemberAgainstOpenTarget()
+    {
+        // Open target Box<T>.Store(T): declaring type is the open List`1-style definition, the
+        // parameter is the type parameter T.
+        var openBox = TypeRef.Definition("Lib", "N", "Box`1");
+        var pattern = MemberPattern.Method(openBox, "Store", [TypeRef.GenericParameter(0, "T")]);
+
+        // Constructed call site Box<int>.Store(int): declaring type is the instantiation, the
+        // parameter is the concrete int.
+        var constructedBox = TypeRef.GenericInstance(openBox, [TypeRef.CoreLib("System", "Int32")]);
+        var callSite = new MemberRef(constructedBox, "Store", [TypeRef.CoreLib("System", "Int32")], TypeRef.CoreLib("System", "Void"), MemberKind.Method);
+
+        Assert.True(pattern.MatchesCrossAssembly(callSite));
+        // The exact same-assembly matcher cannot bridge the open/closed spelling gap.
+        Assert.False(pattern.Matches(callSite));
+    }
+
+    [Fact]
+    public void MatchesCrossAssembly_StillDiscriminatesGenericMembersByArity()
+    {
+        // A generic member is erased to arity, not dropped entirely: a one-parameter target must
+        // not absorb a two-parameter call site on the same generic type.
+        var openBox = TypeRef.Definition("Lib", "N", "Box`1");
+        var pattern = MemberPattern.Method(openBox, "Store", [TypeRef.GenericParameter(0, "T")]);
+
+        var constructedBox = TypeRef.GenericInstance(openBox, [TypeRef.CoreLib("System", "Int32")]);
+        var twoArg = new MemberRef(
+            constructedBox,
+            "Store",
+            [TypeRef.CoreLib("System", "Int32"), TypeRef.CoreLib("System", "Int32")],
+            TypeRef.CoreLib("System", "Void"),
+            MemberKind.Method);
+
+        Assert.False(pattern.MatchesCrossAssembly(twoArg));
+    }
+
     static string CallerGraphFixturePath(string projectName)
     {
         var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));

--- a/src/ILInspector.Analysis/GenericMemberIdentity.cs
+++ b/src/ILInspector.Analysis/GenericMemberIdentity.cs
@@ -1,0 +1,82 @@
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// Canonicalizes generic member identity for <em>cross-assembly</em> structural
+/// matching (the <c>Callers</c> table and the cross-assembly <c>Caller Graph</c>).
+///
+/// Same-assembly matching resolves through metadata tokens
+/// (<see cref="DirectCall.CalleeDefinitionToken"/>), so it sees a constructed call
+/// site and its open definition as the same member already. Cross-assembly matching
+/// has no shared token space and must compare structurally, where the two sides
+/// disagree on generics: a call site keys on its instantiation
+/// (<c>List&lt;int&gt;.Add(int)</c> / <c>Id&lt;int&gt;(int)</c>) while the selected
+/// target keys on the open definition (<c>List&lt;T&gt;.Add(T)</c> /
+/// <c>Id&lt;T&gt;(T)</c>), so they never match and the target under-reports external
+/// callers (#1339).
+///
+/// The normalization reduces a generic member to its open declaring definition plus
+/// name plus parameter arity ("arity + erased shape"). It is deliberately symmetric:
+/// the open-definition side and the constructed-call-site side each compute the same
+/// erased identity from the data they carry, so they collapse onto one key. Distinct
+/// generic overloads that share a name and parameter arity on the same generic type
+/// are an accepted coarsening, far preferable to the prior zero-match under-report.
+/// Non-generic members are left on their exact instantiated signature.
+/// </summary>
+internal static class GenericMemberIdentity
+{
+    /// <summary>
+    /// The open named definition of a (possibly constructed) declaring type, so a
+    /// constructed generic type matches its open definition. A non-generic or
+    /// already-open declaring type is returned unchanged.
+    /// </summary>
+    public static TypeRef OpenDeclaringType(TypeRef declaringType)
+        => declaringType.Kind == TypeRefKind.GenericInstance && declaringType.ElementType is { } element
+            ? element
+            : declaringType;
+
+    /// <summary>
+    /// Whether a declaring type is generic — either a constructed instantiation
+    /// (call site) or an open generic definition (target side, whose metadata name
+    /// carries an arity backtick).
+    /// </summary>
+    public static bool IsGenericType(TypeRef type)
+        => type.Kind == TypeRefKind.GenericInstance
+            || (type.Kind == TypeRefKind.Definition && HasArity(type.Name));
+
+    /// <summary>A metadata type name carries a generic arity suffix (e.g. <c>List`1</c>).</summary>
+    public static bool HasArity(string name) => name.IndexOf('`') >= 0;
+
+    /// <summary>
+    /// Whether a type mentions a generic parameter anywhere — the open-definition
+    /// marker for a generic method (its signature still references <c>!T</c>/<c>!!T</c>
+    /// where the call site carries concrete instantiations).
+    /// </summary>
+    public static bool ContainsGenericParameter(TypeRef type)
+    {
+        if (type.Kind is TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter)
+            return true;
+        if (type.ElementType is { } element && ContainsGenericParameter(element))
+            return true;
+        return type.TypeArguments.Any(ContainsGenericParameter);
+    }
+
+    /// <summary>
+    /// Whether a member should be matched on erased generic shape rather than its
+    /// exact instantiated signature. True when the declaring type is generic (open or
+    /// constructed), the member carries method type arguments (a constructed generic
+    /// method call), or its signature mentions a generic parameter (an open generic
+    /// method definition).
+    /// </summary>
+    public static bool ShouldErase(
+        TypeRef declaringType,
+        ImmutableArray<TypeRef> parameterTypes,
+        TypeRef returnType,
+        ImmutableArray<TypeRef> typeArguments)
+        => IsGenericType(declaringType)
+            || typeArguments.Length > 0
+            || ContainsGenericParameter(returnType)
+            || parameterTypes.Any(ContainsGenericParameter);
+}

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -537,7 +537,7 @@ public sealed class LibraryBodyIndex
         if (rootIdentity is { } identity)
         {
             rootMember = new MemberRef(identity.DeclaringType, identity.Name, identity.ParameterTypes, identity.ReturnType, MemberKind.Method);
-            rootKey = CallerGraphKey(identity.DeclaringType, identity.Name, identity.ParameterTypes, identity.ReturnType);
+            rootKey = CallerGraphKey(identity);
         }
         else
         {
@@ -548,7 +548,7 @@ public sealed class LibraryBodyIndex
                 ? resolved
                 : MemberRef.Unsupported($"method token 0x{rootMethodToken:X8}");
             rootKey = rootMember.Kind != MemberKind.Unsupported
-                ? CallerGraphKey(rootMember.DeclaringType, rootMember.Name, rootMember.ParameterTypes, rootMember.ReturnType)
+                ? CallerGraphKey(rootMember)
                 : "";
         }
 
@@ -567,9 +567,9 @@ public sealed class LibraryBodyIndex
             {
                 if (call.Callee.Kind == MemberKind.Unsupported)
                     continue;
-                var calleeKey = CallerGraphKey(call.Callee.DeclaringType, call.Callee.Name, call.Callee.ParameterTypes, call.Callee.ReturnType);
+                var calleeKey = CallerGraphKey(call.Callee);
                 var caller = call.Caller;
-                var callerKey = CallerGraphKey(caller.DeclaringType, caller.Name, caller.ParameterTypes, caller.ReturnType);
+                var callerKey = CallerGraphKey(caller);
                 var edge = new ReverseCallerEdge(caller, callerKey, signals.GetValueOrDefault(caller.MetadataToken, MethodSignals.None), call.InLoop);
                 if (reverse.TryGetValue(calleeKey, out var list))
                     list.Add(edge);
@@ -652,18 +652,44 @@ public sealed class LibraryBodyIndex
     // name, and parameters. The assembly prefix is required so that same-namespace/type/member
     // members in different assemblies do not match the selected target (callee side) and so that
     // identically-signed callers from different caller scopes are not collapsed into one node
-    // (caller side) (#1579). Known limitations, both shared with the Callers table:
-    //   - Generic members: a constructed call site (e.g. List<int>.Add / Id<int>) is keyed on its
-    //     instantiation and will not match an open-definition target.
-    //   - Type forwarding beyond the corelib facade canonicalization (TypeRef.CanonicalAssembly):
-    //     a type physically defined in assembly B but referenced through a [TypeForwardedTo]
-    //     facade A keys as B on the definition side and A at the referencing call site, so such a
-    //     forwarded member may not link its callers. This is an honest missed edge, preferred over
-    //     the prior false positive of attributing unrelated same-FQN callers to the target.
-    // Tracked as a follow-up to normalize member identity (generic + forwarded) for both Callers
-    // and Caller Graph.
-    static string CallerGraphKey(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes, TypeRef returnType)
-        => $"{declaringType.Assembly}|{declaringType.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{string.Join(",", parameterTypes.Select(type => type.ToQualifiedDisplayString()))}|{returnType.ToQualifiedDisplayString()}";
+    // (caller side) (#1579).
+    //
+    // Generic members are normalized to their open declaring definition + name + parameter arity
+    // (#1339): a constructed call site (e.g. List<int>.Add / Id<int>) keys identically to its
+    // open-definition target (List<T>.Add / Id<T>) instead of on the instantiation, so generic
+    // dependency members surface their external callers. Both sides compute the same erased
+    // identity from the data they carry — the open definition (MethodIdentity, whose signature
+    // still mentions generic parameters) and the constructed call site (MemberRef, whose declaring
+    // type is a GenericInstance or which carries method type arguments). See GenericMemberIdentity.
+    //
+    // Remaining limitation: type forwarding beyond the corelib facade canonicalization
+    // (TypeRef.CanonicalAssembly): a type physically defined in assembly B but referenced through a
+    // [TypeForwardedTo] facade A keys as B on the definition side and A at the referencing call
+    // site, so such a forwarded member may not link its callers. This is an honest missed edge,
+    // preferred over the prior false positive of attributing unrelated same-FQN callers.
+    static string CallerGraphKey(MethodIdentity member)
+        => CallerGraphKey(
+            member.DeclaringType,
+            member.Name,
+            member.ParameterTypes,
+            member.ReturnType,
+            GenericMemberIdentity.ShouldErase(member.DeclaringType, member.ParameterTypes, member.ReturnType, []));
+
+    static string CallerGraphKey(MemberRef member)
+        => CallerGraphKey(
+            member.DeclaringType,
+            member.Name,
+            member.ParameterTypes,
+            member.ReturnType,
+            GenericMemberIdentity.ShouldErase(member.DeclaringType, member.ParameterTypes, member.ReturnType, member.TypeArguments));
+
+    static string CallerGraphKey(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes, TypeRef returnType, bool eraseGenericSignature)
+    {
+        var openDeclaring = GenericMemberIdentity.OpenDeclaringType(declaringType);
+        return eraseGenericSignature
+            ? $"{openDeclaring.Assembly}|{openDeclaring.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|<generic>"
+            : $"{openDeclaring.Assembly}|{openDeclaring.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{string.Join(",", parameterTypes.Select(type => type.ToQualifiedDisplayString()))}|{returnType.ToQualifiedDisplayString()}";
+    }
 
     sealed class IndexBuilder
     {

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -111,15 +111,25 @@ public sealed record UnsafeEvidence(
 public sealed class MemberPattern
 {
     readonly TypeRef? _declaringType;
+    readonly TypeRef? _openDeclaringType;
     readonly string? _declaringTypeName;
+    readonly bool _eraseGenericSignature;
 
     MemberPattern(TypeRef? declaringType, string? declaringTypeName, string name, ImmutableArray<TypeRef> parameterTypes, bool matchParameterTypes)
     {
         _declaringType = declaringType;
+        _openDeclaringType = declaringType is null ? null : GenericMemberIdentity.OpenDeclaringType(declaringType);
         _declaringTypeName = declaringTypeName;
         Name = name;
         ParameterTypes = parameterTypes;
         MatchParameterTypes = matchParameterTypes;
+        // A generic target matches cross-assembly on its open declaring type + name +
+        // parameter arity, because a constructed caller spells the instantiated
+        // signature the open definition never matches (#1339).
+        _eraseGenericSignature = matchParameterTypes
+            && (declaringType is not null
+                ? GenericMemberIdentity.IsGenericType(declaringType) || parameterTypes.Any(GenericMemberIdentity.ContainsGenericParameter)
+                : (declaringTypeName is not null && GenericMemberIdentity.HasArity(declaringTypeName)) || parameterTypes.Any(GenericMemberIdentity.ContainsGenericParameter));
     }
 
     public string Name { get; }
@@ -148,5 +158,32 @@ public sealed class MemberPattern
             return false;
         }
         return !MatchParameterTypes || member.ParameterTypes.SequenceEqual(ParameterTypes);
+    }
+
+    /// <summary>
+    /// Structural match for <em>cross-assembly</em> callers, where a constructed call
+    /// site and the open-definition target disagree on generic spelling. The candidate
+    /// declaring type is reduced to its open definition so a constructed generic type
+    /// matches its open definition, and a generic target is compared on parameter arity
+    /// rather than exact instantiated signature (#1339). Non-generic members fall back
+    /// to the same exact comparison as <see cref="Matches"/>.
+    /// </summary>
+    public bool MatchesCrossAssembly(MemberRef member)
+    {
+        var candidateDeclaring = GenericMemberIdentity.OpenDeclaringType(member.DeclaringType);
+        bool declaringMatches = _openDeclaringType is not null
+            ? candidateDeclaring.Equals(_openDeclaringType)
+            : string.Equals(candidateDeclaring.ToQualifiedDisplayString(), _declaringTypeName, StringComparison.Ordinal);
+        if (!declaringMatches || !string.Equals(member.Name, Name, StringComparison.Ordinal))
+        {
+            return false;
+        }
+        if (!MatchParameterTypes)
+        {
+            return true;
+        }
+        return _eraseGenericSignature
+            ? member.ParameterTypes.Length == ParameterTypes.Length
+            : member.ParameterTypes.SequenceEqual(ParameterTypes);
     }
 }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1128,9 +1128,13 @@ public static class ApiOutputFormatter
                             continue;
                         }
 
+                        // Cross-assembly matching must normalize generic member identity: a
+                        // constructed call site (List<int>.Add / Id<int>) matches the open
+                        // target definition (List<T>.Add / Id<T>) it could never match exactly
+                        // (#1339). Same-assembly matching above stays exact, token-driven.
                         var scopeSource = Path.GetFileNameWithoutExtension(scopePath);
                         rows.AddRange(scopeIndex.DirectCalls
-                            .Where(call => pattern.Matches(call.Callee))
+                            .Where(call => pattern.MatchesCrossAssembly(call.Callee))
                             .Select(call => CreateCallerRow(scopeSource, call)));
                     }
                 }


### PR DESCRIPTION
## Row

Burndown #1660 (Analysis graph and diff correctness), Cluster A row #1339.

## False claim being narrowed

Both the cross-assembly `Callers` table (`MemberPattern`) and the cross-assembly `Caller Graph` (`LibraryBodyIndex.CallerGraphKey`) matched members on exact structural identity. A constructed call site keys on its **instantiation** (`List<int>.Add(int)`, `Id<int>(int)`) while the selected target keys on the **open definition** (`List<T>.Add(T)`, `Id<T>(T)`), so they never matched — a generic dependency member, or a member on a generic type, **under-reported its external callers as zero**.

Same-assembly matching was never affected because it resolves through `CalleeDefinitionToken` (the MethodSpec/TypeSpec is peeled to its definition).

## Fix

Normalize generic members to their **open declaring definition + name + parameter arity** ("arity + erased shape", as the issue allows) for cross-assembly matching only. New shared helper `GenericMemberIdentity`:

- `OpenDeclaringType` reduces a constructed `GenericInstance` declaring type to its open definition, so `List<int>` matches `List<T>`.
- `ShouldErase` detects a generic member symmetrically: the open side (`MethodIdentity`, signature still mentions generic parameters) and the constructed-call-site side (`MemberRef`, declaring type is a `GenericInstance` or carries method type arguments) each compute the same erased identity, so they collapse onto one key/match.

Applied uniformly to both surfaces required by the issue:

- `LibraryBodyIndex.CallerGraphKey` — type-aware overloads for `MethodIdentity` (target/caller side) and `MemberRef` (call-site side); generic members key as `assembly|openDeclaring|name|arity|<generic>`.
- `MemberPattern.MatchesCrossAssembly` — new method that normalizes the candidate declaring type and compares generic targets on arity; `MemberPattern.Matches` (same-assembly path) is left exactly as-is. `ApiOutputFormatter`'s cross-assembly Callers scan switches to `MatchesCrossAssembly`; the same-assembly scan is unchanged.

Non-generic members keep their exact instantiated signature, so the #1579 overload-distinctness guarantees (e.g. `Ping(int)` vs `Ping(string)` stay distinct) are preserved.

### Accepted coarsening

Two distinct generic overloads sharing a name **and** parameter arity on the same generic type/generic method collapse to one key — an honest coarsening, far preferable to the prior zero-match under-report, and exactly the "arity + erased shape" trade the issue calls out. Type-forwarding beyond the corelib facade remains the one documented missed edge.

## Done signal

> constructed generic call sites match open generic targets across assemblies; same-assembly token matching remains unchanged ✓

## Evidence

New cross-assembly fixtures in the existing caller-graph fixture assemblies:
- `Target.Box<T>.Store(T)` + caller `Shared.Entry.UseBox` calling `Box<int>.Store(1)` (member on a constructed generic type).
- `Target.GenericApi.Echo<T>(T)` + caller `Shared.Entry.UseEcho` calling `Echo<int>(1)` (constructed generic method / MethodSpec).

Tests (`LibraryBodyIndexTests`):
- `BuildCallerTree_WithScope_LinksConstructedGenericTypeMemberCaller`
- `BuildCallerTree_WithScope_LinksConstructedGenericMethodCaller`
- `MatchesCrossAssembly_MatchesConstructedGenericMemberAgainstOpenTarget` (asserts old `Matches` returns false and new `MatchesCrossAssembly` returns true on the same input — before/after in one test)
- `MatchesCrossAssembly_StillDiscriminatesGenericMembersByArity` (one-param target does not absorb a two-param call site)

**Non-vacuity check**: with the erase temporarily disabled, both graph tests fail (caller graph reports zero generic callers); restored, they pass — this is the before/after on the Caller Graph surface.

```
ILInspector.Analysis.Tests  Total: 122, Errors: 0, Failed: 0, Skipped: 0
dotnet-inspect.Tests        Total: 1344, Errors: 0, Failed: 0, Skipped: 9
```

Branch synced with latest `origin/main` (merge, clean) before final validation.

## Adversarial review

Will request cross-model adversarial review (GPT-5.5 per the current pairing) and post the result as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
