### PR TITLE
Add rung 9 dynamic expression honesty guard

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung9/ILInspector.Decompiler.Fixtures.LadderRung9.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung9/ILInspector.Decompiler.Fixtures.LadderRung9.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Rung 9 of the decompiler product quality ladder (#1599): dynamic and
+    expression-tree honesty. This fixture is intentionally small and focused on
+    compiler-generated call-site / expression-builder lowering shapes that must
+    not be rendered as source syntax unless a future raise proves that recovery.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq.Expressions;
+
+namespace LadderRung9;
+
+// Rung 9 of the decompiler product quality ladder (#1599): dynamic and
+// expression-tree honesty. These constructs are source-visible but lower through
+// compiler-generated scaffolding; the rung guard requires the decompiler to
+// either keep that scaffolding explicit/honestly Partial or recover source syntax
+// only after a future proof-backed raise changes the guard.
+public class DynamicAndExpressionTrees
+{
+    public object DynamicAdd(dynamic left, dynamic right)
+    {
+        return left + right;
+    }
+
+    public object DynamicGetLength(dynamic value)
+    {
+        return value.Length;
+    }
+
+    public object DynamicInvoke(dynamic function, int value)
+    {
+        return function(value);
+    }
+
+    public object DynamicInvokeMember(dynamic value, int start, int length)
+    {
+        return value.Substring(start, length);
+    }
+
+    public Expression<Func<int, int>> SimpleExpressionTree()
+    {
+        return x => x + 1;
+    }
+
+    public Expression<Func<int, bool>> CapturedExpressionTree(int threshold)
+    {
+        return x => x > threshold;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -32,6 +32,7 @@
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung3\ILInspector.Decompiler.Fixtures.LadderRung3.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung4\ILInspector.Decompiler.Fixtures.LadderRung4.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung5\ILInspector.Decompiler.Fixtures.LadderRung5.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung9\ILInspector.Decompiler.Fixtures.LadderRung9.csproj" />
   </ItemGroup>
 
   <!--

--- a/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
@@ -1,0 +1,130 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The rung 9 guard for the decompiler product quality ladder (#1599): dynamic
+/// and expression-tree honesty. It does not claim dynamic or expression-tree
+/// source-syntax recovery. It locks the current safe boundary: dynamic call-site
+/// scaffolding and captured expression trees degrade honestly, while simple
+/// expression-tree builders render as explicit <c>Expression.*</c> calls rather
+/// than unsupported fake source lambdas.
+/// </summary>
+public class LadderRung9GateTests
+{
+    static string FixturePath => typeof(LadderRung9.DynamicAndExpressionTrees).Assembly.Location;
+    static readonly string FixtureType = typeof(LadderRung9.DynamicAndExpressionTrees).FullName!;
+
+    static readonly string[] ExpectedMembers =
+    [
+        ".ctor",
+        "CapturedExpressionTree",
+        "DynamicAdd",
+        "DynamicGetLength",
+        "DynamicInvoke",
+        "DynamicInvokeMember",
+        "SimpleExpressionTree",
+    ];
+
+    [Fact]
+    public void Rung9Fixture_ExposesExactMemberSet()
+    {
+        var members = LoadRaisedMembers();
+
+        Assert.Equal(
+            ExpectedMembers,
+            members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
+    }
+
+    [Fact]
+    public void Rung9Fixture_HasNoInvalidFull()
+    {
+        var results = ValidityCheck.Evaluate(FixturePath, importSiblingBodies: true)
+            .Where(r => r.TypeName == FixtureType)
+            .ToList();
+
+        Assert.NotEmpty(results);
+
+        var malformedFull = results
+            .Where(r => r.IsFull && r.IsMalformed)
+            .Select(r => $"{r.MethodName}: {r.MalformedDiagnostics[0].Id} {r.MalformedDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(malformedFull.Length == 0,
+            "Rung 9 requires no invalid Full; malformed Full: " + string.Join("; ", malformedFull));
+
+        var semanticFull = results
+            .Where(r => r.IsFull && r.HasSemanticDefect)
+            .Select(r => $"{r.MethodName}: {r.SemanticDiagnostics[0].Id} {r.SemanticDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(semanticFull.Length == 0,
+            "Rung 9 requires zero non-noise semantic defects on Full methods; defects: " + string.Join("; ", semanticFull));
+
+        Assert.All(
+            results.Where(r => r.IsFull),
+            r => Assert.True(r.SemanticChecked, $"Full method {r.MethodName} was not semantically bound."));
+    }
+
+    [Fact]
+    public void Rung9Fixture_DegradesDynamicCallSitesHonestly()
+    {
+        var members = LoadRaisedMembers();
+
+        AssertDynamicPartial(members, "DynamicAdd", "Binder.BinaryOperation", "CallSite<Func<CallSite, object, object, object>>");
+        AssertDynamicPartial(members, "DynamicGetLength", "Binder.GetMember", "CallSite<Func<CallSite, object, object>>");
+        AssertDynamicPartial(members, "DynamicInvoke", "Binder.Invoke", "CallSite<Func<CallSite, object, int, object>>");
+        AssertDynamicPartial(members, "DynamicInvokeMember", "Binder.InvokeMember", "CallSite<Func<CallSite, object, int, int, object>>");
+    }
+
+    [Fact]
+    public void Rung9Fixture_RendersExpressionTreesWithoutFakeSourceLambdas()
+    {
+        var members = LoadRaisedMembers();
+
+        var simple = members.Single(m => m.Name == "SimpleExpressionTree");
+        Assert.Equal(DecompilationFidelity.Full, simple.Function.Fidelity);
+        Assert.Contains("Expression.Parameter(typeof(int), \"x\")", simple.Body);
+        Assert.Contains("Expression.Add(", simple.Body);
+        Assert.Contains("Expression.Lambda<Func<int, int>>", simple.Body);
+        Assert.DoesNotContain("=>", simple.Body);
+
+        var captured = members.Single(m => m.Name == "CapturedExpressionTree");
+        Assert.Equal(DecompilationFidelity.Partial, captured.Function.Fidelity);
+        Assert.Contains("Expression.GreaterThan(", captured.Body);
+        Assert.Contains("FieldInfo.GetFieldFromHandle", captured.Body);
+        Assert.Contains("LoadToken Field", captured.Body);
+        Assert.DoesNotContain("=>", captured.Body);
+    }
+
+    static void AssertDynamicPartial(
+        List<(string Name, IrFunction Function, DecompilerResult Result, string Body)> members,
+        string name,
+        string expectedBinder,
+        string expectedCallSite)
+    {
+        var member = members.Single(m => m.Name == name);
+        Assert.Equal(DecompilationFidelity.Partial, member.Function.Fidelity);
+        Assert.Contains(expectedBinder, member.Body);
+        Assert.Contains(expectedCallSite, member.Body);
+        Assert.DoesNotContain("dynamic", member.Body);
+    }
+
+    static List<(string Name, IrFunction Function, DecompilerResult Result, string Body)> LoadRaisedMembers()
+    {
+        var members = new List<(string Name, IrFunction Function, DecompilerResult Result, string Body)>();
+        using var source = MetadataSource.Open(FixturePath);
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (typeName != FixtureType)
+                continue;
+
+            var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+            members.Add((methodName, function, result, result.Output ?? ""));
+        }
+
+        return members;
+    }
+}


### PR DESCRIPTION
## Summary

Adds the row/rung 9 fixture and fast honesty guard for #1599 dynamic / expression-tree behavior.

- Adds `ILInspector.Decompiler.Fixtures.LadderRung9` with dynamic binary/get/invoke/invoke-member shapes plus simple and captured expression trees.
- Adds `LadderRung9GateTests` to pin the row's current safe boundary: no invalid `Full`; dynamic call-site scaffolding remains explicit and `Partial`; simple expression trees render as explicit `Expression.*` calls, not fake source lambdas; captured expression trees degrade honestly.
- Wires the fixture into the decompiler test project.

This is a guard PR, not a source-syntax recovery claim for dynamic or expression trees.

## Evidence

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LadderRung9GateTests
ILInspector.Decompiler.Tests  Total: 4, Errors: 0, Failed: 0, Skipped: 0

dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded. 0 Warning(s), 0 Error(s)

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
ILInspector.Decompiler.Tests  Total: 1467, Errors: 0, Failed: 0, Skipped: 0
```

Fixture measurement:

```text
COMPILE-CHECK over 7 rendered methods (2 Full, 5 Partial)
Full malformed: 0
Semantic binding defects among Full: 0

GAPS over 10 methods (0 pass bugs)
fully raised: 2 (20.00%)
real gaps: 8 (80.00%) — expected dynamic/captured-expression honesty boundary
```

## Adversarial review

Opus 4.8 found no blockers. It suggested adding dynamic `Binder.InvokeMember` coverage; this PR now includes that case. A final focused Opus review of the added case found no significant issues and confirmed the guard remains non-overclaiming.
