### PR TITLE
Materialize delayed initializer chains at seed

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerContiguityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerContiguityTests.cs
@@ -1,13 +1,14 @@
 using ILInspector.Decompiler.Pipeline;
+using System.Collections.Immutable;
 
 namespace ILInspector.Decompiler.Tests;
 
 // Adversarial guard for ObjectInitializerPass stack-slot contiguity (issue #1408).
-// The stack-slot form folds member-store values into `new T { ... }` at the single
-// downstream escape. If a non-consumed (side-effecting) statement sits between the
-// member stores and the escape, folding moves the member-value computations after
-// it — reordering observable side effects. This pins the minimal IR near-miss;
-// ObjectInitializerPassTests covers the csc-emitted short-circuit argument shape.
+// If a non-consumed side-effecting statement sits between the member stores and
+// the single downstream escape, the pass must materialize the initializer at the
+// seed rather than move it to the escape; otherwise member-value computations
+// would be reordered after the gap. ObjectInitializerPassTests covers the
+// csc-emitted short-circuit argument shape.
 public class ObjectInitializerContiguityTests
 {
     static readonly TypeRef Type = TypeRef.Definition("Synthetic", "Samples", "InitTarget");
@@ -48,12 +49,57 @@ public class ObjectInitializerContiguityTests
     }
 
     [Fact]
-    public void StatementBetweenStoresAndEscape_IsNotFolded()
+    public void StatementBetweenStoresAndEscape_FoldsAtSeedWithoutReordering()
     {
         var function = Build(interveningStatement: true);
-        Assert.Empty(function.Descendants.OfType<ObjectInitializerExpression>());
-        // The member store and the intervening call keep their original order.
-        Assert.Single(function.Descendants.OfType<StoreProperty>());
-        Assert.Equal(2, function.Descendants.OfType<Call>().Count());
+        Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.Empty(function.Descendants.OfType<StoreProperty>());
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("new InitTarget { X = Owner.Log() }", output);
+        Assert.True(
+            output.IndexOf("new InitTarget { X = Owner.Log() }", StringComparison.Ordinal)
+                < output.IndexOf("Other();", StringComparison.Ordinal),
+            output);
+    }
+
+    [Fact]
+    public void CollectionStatementBetweenAddsAndEscape_FoldsAtSeedWithoutReordering()
+    {
+        var function = CollectionWithInterveningStatement();
+        Assert.Single(function.Descendants.OfType<ObjectInitializerExpression>());
+        Assert.DoesNotContain(function.Descendants.OfType<Call>(), call => call.Callee.Name == "Add");
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("new InitTarget { 1, 2 }", output);
+        Assert.True(
+            output.IndexOf("new InitTarget { 1, 2 }", StringComparison.Ordinal)
+                < output.IndexOf("Other();", StringComparison.Ordinal),
+            output);
+    }
+
+    static IrFunction CollectionWithInterveningStatement()
+    {
+        var ctor = new MethodRef(Type, ".ctor", Void, [], HasThis: true);
+        var add = new MethodRef(Type, "Add", Void, [Int32], HasThis: true);
+        var other = new MethodRef(Owner, "Other", Void, [], HasThis: false);
+
+        var block = new Block();
+        block.Add(new StoreStackSlot(Slot, new NewObject(ctor, [])));
+        block.Add(new ExpressionStatement(new Call(add, isVirtual: false, [new LoadStackSlot(Slot, Type), new Constant(1, Int32)])));
+        block.Add(new StoreStackSlot(Slot + 1, new LoadStackSlot(Slot, Type)));
+        block.Add(new ExpressionStatement(new Call(add, isVirtual: false, [new LoadStackSlot(Slot + 1, Type), new Constant(2, Int32)])));
+        block.Add(new ExpressionStatement(new Call(other, isVirtual: false, [])));
+        block.Add(new Return(new LoadStackSlot(Slot + 1, Type)));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction("M", Owner, new MethodSignature(Type, [], HasThis: false, GenericParameterCount: 0), [], body)
+        {
+            CollectionInitializerTypes = ImmutableHashSet.Create(Type),
+        };
+        new ObjectInitializerPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+        return function;
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ObjectInitializerPass.cs
@@ -7,8 +7,9 @@ namespace ILInspector.Decompiler.Pipeline;
 /// stack slots — or a fresh local, applying a contiguous run of member stores
 /// (object form) or single-argument <c>Add</c> calls (collection form) to the
 /// threaded reference, then consuming it exactly once downstream. This pass folds
-/// that run into an initializer at the single use site and removes the now-dead
-/// chain.
+/// that run into an initializer at the single use site when the escape is
+/// contiguous, or at the original seed when a later single escape would otherwise
+/// reorder intervening side effects, and removes the now-dead chain.
 ///
 /// <para>Slice scope: the stack-slot dup form, which is what the compiler emits
 /// in expression position (a <c>return</c>/argument initializer), plus the
@@ -68,6 +69,7 @@ public sealed class ObjectInitializerPass : IIrPass
 
     abstract record InitializerTarget;
     sealed record StackSlotTarget(LoadStackSlot Use) : InitializerTarget;
+    sealed record StackSlotSeedTarget(StoreStackSlot Seed, LoadStackSlot Use) : InitializerTarget;
     sealed record LocalSeedTarget(StoreLocal Seed) : InitializerTarget;
 
     sealed record Plan(
@@ -212,22 +214,34 @@ public sealed class ObjectInitializerPass : IIrPass
         if (outsideUses.Count != 1)
             return null;
 
-        // The escape must immediately follow the consumed run: every statement between
-        // the seed and the statement that consumes the reference must itself be consumed.
-        // Otherwise a non-consumed (side-effecting) statement sits between the member
-        // stores and the escape, and folding the member values into the initializer at
-        // the escape would move them after that statement — reordering observable side
-        // effects. csc emits the dup-chain use contiguously, so a gap is hand-written IL.
+        // When the escape immediately follows the consumed run, the initializer can be
+        // moved to that use site (return/call argument position). When unrelated
+        // statements sit between the run and the escape, materialize the initializer at
+        // the original seed instead: that keeps member-value side effects before the
+        // gap and still collapses the compiler temp chain into one initialized value.
         IrNode escapeStatement = outsideUses[0];
         while (escapeStatement.Parent is { } parent && !ReferenceEquals(parent, seed.Parent))
             escapeStatement = parent;
         if (!ReferenceEquals(escapeStatement.Parent, seed.Parent))
             return null;   // the reference escapes in another block — not a contiguous run
+        bool contiguousEscape = true;
         for (int i = seed.ChildIndex + 1; i < escapeStatement.ChildIndex; i++)
+        {
             if (!consumedSet.Contains(statements[i]))
-                return null;
+            {
+                contiguousEscape = false;
+                break;
+            }
+        }
 
-        return new Plan(consumed, creation, isCollection ?? false, entries, new StackSlotTarget(outsideUses[0]));
+        return new Plan(
+            consumed,
+            creation,
+            isCollection ?? false,
+            entries,
+            contiguousEscape
+                ? new StackSlotTarget(outsideUses[0])
+                : new StackSlotSeedTarget(seed, outsideUses[0]));
     }
 
     static Plan? TryBuild(IrFunction function, StoreLocal seed, NewObject creation)
@@ -555,7 +569,11 @@ public sealed class ObjectInitializerPass : IIrPass
         // arguments out of those now-detached statements before reparenting them
         // into the new initializer tree.
         foreach (var statement in plan.Consumed)
+        {
+            if (plan.Target is StackSlotSeedTarget target && ReferenceEquals(statement, target.Seed))
+                continue;
             statement.Detach();
+        }
 
         foreach (var leaf in LeafArguments(plan.Entries))
             leaf.Detach();
@@ -569,6 +587,17 @@ public sealed class ObjectInitializerPass : IIrPass
                 var initializer = new ObjectInitializerExpression(plan.Creation, plan.IsCollection, entries);
                 initializer.InheritSourceOffset(plan.Creation);
                 stackSlot.Use.ReplaceWith(initializer);
+                break;
+            }
+
+            case StackSlotSeedTarget stackSlotSeed:
+            {
+                var creation = (NewObject)plan.Creation.Clone();
+                var initializer = new ObjectInitializerExpression(creation, plan.IsCollection, entries);
+                initializer.InheritSourceOffset(plan.Creation);
+                plan.Creation.ReplaceWith(initializer);
+                if (stackSlotSeed.Use.Slot != stackSlotSeed.Seed.Slot)
+                    stackSlotSeed.Use.ReplaceWith(new LoadStackSlot(stackSlotSeed.Seed.Slot, stackSlotSeed.Use.Type));
                 break;
             }
 


### PR DESCRIPTION
## Summary

Closes #1624.

- Lets `ObjectInitializerPass` collapse stack-slot object/collection initializer runs even when the single later use is separated by unrelated statements.
- Keeps the existing contiguous escape behavior unchanged: direct return/call-argument initializer runs still fold at the escape site.
- For non-contiguous runs, materializes the initializer at the original seed so member/Add side effects stay before the intervening statement, then rewrites the later alias-slot use back to the seed slot.
- Updates the contiguity guard with object and collection initializer canaries that prove side-effect ordering is preserved.

## Evidence

- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity minimal`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ObjectInitializerPassTests -class ILInspector.Decompiler.Tests.ObjectInitializerContiguityTests -noLogo`
- `git diff --check`

## Adversarial review

Requested Opus 4.8 review. It reported no significant correctness/soundness issues. It specifically checked side-effect ordering, alias-use replacement, cross-block/multiple-use rejection, IR parenting/invariants, and unchanged direct-return/named-local behavior.
