### PR TITLE
Add --print flag and rename Package README section to Grounding (#1659)

### DIFF
--- a/docs/design/rendering-model.md
+++ b/docs/design/rendering-model.md
@@ -61,7 +61,7 @@ The `package` command inspects a NuGet package. Its default view is *package ide
 
 Each lens is self-contained. `--files` shows a file tree and exits. It does not also show metadata or dependencies -- those belong to the identity view.
 
-`Files`, `Package README`, `Library Files`, and `Markdown Files` all use the same row schema: package-relative `Path` and uncompressed byte `Size`. `Files` is explicit-only and renders the full package depth; `Package README` is explicit-only and returns the best README candidate (`AGENTS.md` > `README.md` > `PACKAGE.md` > declared readme); `Markdown Files` is explicit-only and renders all `.md` files; `Library Files` is the default library asset slice over the same schema.
+`Files`, `Grounding`, `Library Files`, and `Markdown Files` all use the same row schema: package-relative `Path` and uncompressed byte `Size`. `Files` is explicit-only and renders the full package depth; `Grounding` is explicit-only and returns the best grounding candidate (`AGENTS.md` > `README.md` > `PACKAGE.md` > declared readme); `Markdown Files` is explicit-only and renders all `.md` files; `Library Files` is the default library asset slice over the same schema.
 
 **Why Files is not in `-v:d`:** Files are structural layout data (what the package contains on disk), not identity metadata (what the package is). Mixing structural content into the identity view conflates two different concerns. The `--path`/`-S Files` file-resolution view is the correct entry point for structural exploration.
 

--- a/docs/design/schema-query.md
+++ b/docs/design/schema-query.md
@@ -65,7 +65,7 @@ Two paths:
 ```csharp
 var schema = new DocumentSchema()
     .Add("Package Info", "field", "Version", "Type", "Size", "Highest TFM", "TFM Count", "Built", ...)
-    .Add("Package README", "column", "Path", "Size")
+    .Add("Grounding", "column", "Path", "Size")
     .Add("Target Frameworks", "column", "TFM")
     .Add("Library Files", "column", "Path", "Size")
     .Add("Markdown Files", "column", "Path", "Size")

--- a/docs/design/section-pipeline.md
+++ b/docs/design/section-pipeline.md
@@ -175,7 +175,7 @@ The package command has 14 registered sections:
 | Markdown Files | Explicit | — | Full-depth `.md` file listing with `Path` and `Size` |
 | Manifest | Minimal | — | Basic package manifest rows, with extra tool manifest rows when present |
 | Package Info | Minimal | — | Full metadata field table |
-| Package README | Explicit | — | Best README candidate with `Path` and `Size`; at most one row |
+| Grounding | Explicit | — | Best grounding candidate with `Path` and `Size`; at most one row |
 | Runtime Dependencies | Minimal | — | Only when runtime deps present |
 | Signals | Explicit | — | Opt-in package metadata/assets, dependency, provenance, and NuGet registry observations |
 | Signature | Normal | — | Only when signature information is available |

--- a/docs/workflows/core/package-inspection.md
+++ b/docs/workflows/core/package-inspection.md
@@ -205,7 +205,8 @@ to print selected file bodies. Markdown content can be scoped to the YAML header
 or body:
 
 ```bash
-dotnet-inspect package Markout -S "Package README"
+dotnet-inspect package Markout -S "Grounding"
+dotnet-inspect package Markout --print
 dotnet-inspect package Markout -S "Markdown Files"
 dotnet-inspect package Markout --path @agents --content --frontmatter
 dotnet-inspect package Markout Polly --path @agents --path @readme --match first --content --jsonl

--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -26,6 +26,7 @@ Default output is Markdown. Pick a machine or compact shape when you need one:
 - `--json` — structured documents.
 - `--bare` — one undecorated payload or URL list.
 - `--count` — a bare row count.
+- `--print` — print the document behind a selected section's first row (e.g. `package X -S Grounding --print` prints the best grounding doc).
 - `--mermaid` — graph-shaped output.
 
 ## Discover and select sections

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -5310,14 +5310,51 @@ public class CommandExecutionTests
         var (packagePath, tempDir) = CreateLocalReadmePackage("Test.BestReadme.Section", "README.md", "readme", "agents");
         try
         {
-            var (exit, output, error) = await RunAppAsync("package", packagePath, "-S", "Package README");
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "-S", "Grounding");
 
             Assert.Equal(0, exit);
-            Assert.Contains("## Package README", output);
+            Assert.Contains("## Grounding", output);
             Assert.Contains("| Path | Size |", output);
             Assert.Contains("| AGENTS.md | 6 |", output);
             Assert.DoesNotContain("| README.md | 6 |", output);
             Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_GroundingSection_LegacyReadmeSelectorStillResolves()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.Grounding.Alias", "README.md", "readme", "agents");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "-S", "Package README");
+
+            Assert.Equal(0, exit);
+            Assert.Contains("## Grounding", output);
+            Assert.Contains("| AGENTS.md | 6 |", output);
+            Assert.DoesNotContain("Tip:", error);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_Print_PrintsBestGroundingContent()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage("Test.Print.Grounding", "README.md", "readme", "agents");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "--print", "--bare");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.Equal("agents\n", output.ReplaceLineEndings("\n"));
         }
         finally
         {
@@ -5368,7 +5405,7 @@ public class CommandExecutionTests
         var (packagePath, tempDir) = CreateLocalReadmePackage("Test.PackageReadme.Bare", "PACKAGE.md", "package docs");
         try
         {
-            var (exit, output, error) = await RunAppAsync("package", packagePath, "-S", "Package README", "--bare", "--tips", "q");
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "-S", "Grounding", "--bare", "--tips", "q");
 
             Assert.Equal(0, exit);
             Assert.Empty(error);

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -926,7 +926,7 @@ public class SectionPipelineTests
 
         Assert.Contains("Summary", names);
         Assert.Contains("Package Info", names);
-        Assert.Contains("Package README", names);
+        Assert.Contains("Grounding", names);
         Assert.Contains("Signals", names);
         Assert.Contains("Target Frameworks", names);
         Assert.Contains("Library Files", names);

--- a/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
@@ -93,6 +93,7 @@ public static class PackageCommandDefinitions
         opts.AddOutputOptionsTo(packageCommand);
         opts.AddSectionOptionsTo(packageCommand);
         opts.AddCountOptionTo(packageCommand);
+        opts.AddPrintOptionTo(packageCommand);
         opts.AddNuGetOptionsTo(packageCommand);
 
         // Search subcommand

--- a/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
@@ -136,7 +136,7 @@ public static class PackageOptionsParser
             ScopeTools = parseResult.GetValue(args.ToolsOption),
             ListVersions = showVersions,
             IncludePrerelease = parseResult.GetValue(args.PrereleaseOption),
-            ShowReadme = parseResult.GetValue(args.ReadmeOption),
+            ShowReadme = parseResult.GetValue(args.ReadmeOption) || parseResult.GetValue(opts.Print),
             ShowContent = parseResult.GetValue(args.ContentOption),
             ContentScope = contentScope,
             FrontmatterRequested = frontmatterRequested,

--- a/src/dotnet-inspect/Output/SelectResolver.cs
+++ b/src/dotnet-inspect/Output/SelectResolver.cs
@@ -32,6 +32,7 @@ public static class SelectResolver
     static readonly Dictionary<string, string> LegacySectionAliases = new(StringComparer.OrdinalIgnoreCase)
     {
         ["Optimization Opportunities"] = SectionNames.PerformanceTriage,
+        ["Package README"] = DotnetInspector.Views.PackageSections.PackageReadme,
     };
 
     public static bool IsAllSelector(string[]? select)

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -36,6 +36,7 @@ public class SharedOptions
     public Option<bool> Rows { get; } = new("--rows") { Description = "Interpret -n/-N as data rows per rendered table instead of output lines" };
     public Option<int?> Tail { get; }
     public Option<bool> Count { get; } = new("--count") { Description = "Reduce a selected table/vector to a single row count" };
+    public Option<bool> Print { get; } = new("--print") { Description = "Print the document behind the selected section's first row (currently the Grounding doc); errors if it is not a printable text file" };
     public Option<bool> Info { get; } = new("--info") { Description = "Show operational metrics (output, time, HTTP, cache) on stderr" };
     public Option<string?> Tips { get; }
 
@@ -161,6 +162,14 @@ public class SharedOptions
     public void AddCountOptionTo(Command command)
     {
         command.Options.Add(Count);
+    }
+
+    /// <summary>
+    /// Adds the print output option to commands that can render a printable document section.
+    /// </summary>
+    public void AddPrintOptionTo(Command command)
+    {
+        command.Options.Add(Print);
     }
 
     public int? ParseRows(ParseResult parseResult)

--- a/src/dotnet-inspect/Views/PackageSections.cs
+++ b/src/dotnet-inspect/Views/PackageSections.cs
@@ -8,7 +8,7 @@ public static class PackageSections
 {
     public const string Summary = "Summary";
     public const string PackageInfo = "Package Info";
-    public const string PackageReadme = "Package README";
+    public const string PackageReadme = "Grounding";
     public const string Signals = "Signals";
     public const string Statistics = "Statistics";
     public const string TargetFrameworks = "Target Frameworks";


### PR DESCRIPTION
First slice of #1659 (unify grounding/readme into a Grounding section + a `--print` row-projection flag).

## What this does

- **Rename `Package README` → `Grounding`.** The package section that surfaces the best grounding doc is now named `Grounding`, matching what it already resolves (`AGENTS.md` > `README.md` > `PACKAGE.md` > declared `<PackageReadmeFile>`). The old `Package README` name was misleading because it could silently return `AGENTS.md` content under a "readme" label.
  - A legacy selector alias keeps `-S "Package README"` working (resolves to `Grounding`).
- **Add a global `--print` flag** (sibling of `--count`/`--bare`) wired into the `package` command. Same shape as `--count`, but instead of reducing the selected table to a row count, it resolves and prints the document behind the section's first row — currently the best `Grounding` doc.

## Examples

```bash
dotnet-inspect package System.Text.Json -S Grounding   # metadata row (PACKAGE.md, 8582)
dotnet-inspect package System.Text.Json --print        # prints the grounding doc body
```

## Scope / not yet done

This is the **core slice**. Still outstanding per #1659:

- The `-D`-discoverable Grounding section at **`project` scope** (one row per direct dependency), superseding `--agents-index`.
- Future `-n N` row selection for `--print` (`--print` currently always targets the first row).

## Validation

- `dotnet build src/dotnet-inspect -c Release` → 0 warnings / 0 errors.
- `dotnet run --project src/dotnet-inspect.Tests -c Release` → **1347 total, 0 failed**, 9 skipped (ildasm/ilasm env skips only). Includes 2 new tests: `Package_GroundingSection_LegacyReadmeSelectorStillResolves` and `Package_Print_PrintsBestGroundingContent`.
- `markdownlint` clean on all 5 changed Markdown files.
- Manual smoke test of `-S Grounding` and `--print --bare` against System.Text.Json.

Refs #1659
