### PR TITLE
Add rung 2 initializer fixture gate

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung2/ILInspector.Decompiler.Fixtures.LadderRung2.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung2/ILInspector.Decompiler.Fixtures.LadderRung2.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Rung 2 of the decompiler product quality ladder (#1599): C# 2-3 structural
+    basics. This fixture keeps the measured slice small: ordinary object and
+    collection initializer lowerings that flow through compiler temporaries into
+    a local, a later use, or a return value.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Decompiler.Fixtures.LadderRung2/LadderRung2.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung2/LadderRung2.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace LadderRung2;
+
+// Rung 2 of the decompiler product quality ladder (#1599): C# 2-3 structural
+// basics. The initializer shapes here are intentionally ordinary C# 3 source:
+// an object initializer whose constructed value is used after another initializer
+// chain, a collection initializer assigned to a local, a collection initializer
+// returned directly, and the already-supported direct-return object initializer.
+public static class Program
+{
+    public static void Main()
+    {
+        Box<int> item = new Box<int> { Value = 3, Label = "three" };
+        List<int> values = new List<int> { 1, 2, 3 };
+        Console.WriteLine(item.FormatWith(values.FirstOrZero()));
+    }
+
+    public static List<int> MakeCollectionInitializer()
+    {
+        return new List<int> { 1, 2, 3 };
+    }
+
+    public static Box<string> MakeDirectReturn(string text)
+        => new Box<string> { Value = text, Label = text.OrFallback("empty") };
+}
+
+public sealed class Box<T>
+{
+    public T Value { get; set; }
+    public string Label { get; set; }
+
+    public string FormatWith(int value) => string.Concat(Label, ":", Value, ":", value);
+}
+
+public static class LadderRung2Extensions
+{
+    public static int FirstOrZero(this List<int> values) => values.Count == 0 ? 0 : values[0];
+
+    public static string OrFallback(this string value, string fallback)
+        => string.IsNullOrEmpty(value) ? fallback : value;
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainB\ILInspector.Decompiler.Fixtures.UnsafeChainB.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainC\ILInspector.Decompiler.Fixtures.UnsafeChainC.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung1\ILInspector.Decompiler.Fixtures.LadderRung1.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung2\ILInspector.Decompiler.Fixtures.LadderRung2.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung3\ILInspector.Decompiler.Fixtures.LadderRung3.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung4\ILInspector.Decompiler.Fixtures.LadderRung4.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung5\ILInspector.Decompiler.Fixtures.LadderRung5.csproj" />

--- a/src/ILInspector.Decompiler.Tests/LadderRung2GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung2GateTests.cs
@@ -1,0 +1,101 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Narrow rung 2 guard for #1624: C# 3 object/collection initializer lowerings
+/// flowing through compiler temporaries must render as initializer syntax rather
+/// than explicit property-set/Add temp chains.
+/// </summary>
+public class LadderRung2GateTests
+{
+    static string FixturePath => typeof(LadderRung2.Program).Assembly.Location;
+    static readonly string FixtureType = typeof(LadderRung2.Program).FullName!;
+
+    static readonly Lazy<IReadOnlyDictionary<string, string>> s_runtimeAssemblies = new(() =>
+        (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+        .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+        .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+        .GroupBy(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase)
+        .ToDictionary(group => group.Key!, group => group.First(), StringComparer.OrdinalIgnoreCase));
+
+    static readonly AssemblyLocator RuntimeLocator = (name, trust) =>
+        trust == AssemblyTrust.Platform && s_runtimeAssemblies.Value.TryGetValue(name, out var path)
+            ? path
+            : null;
+
+    static readonly string[] ExpectedMembers =
+    [
+        "Main", "MakeCollectionInitializer", "MakeDirectReturn",
+    ];
+
+    [Fact]
+    public void Rung2Fixture_ExposesExactScopedMemberSet_AllFull()
+    {
+        var members = LoadRaisedMembers();
+
+        Assert.Equal(
+            ExpectedMembers,
+            members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
+
+        var notFull = members
+            .Where(m => m.Function.Fidelity != DecompilationFidelity.Full)
+            .Select(m => m.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(notFull.Length == 0,
+            "Rung 2 initializer slice requires every scoped fixture member to render Full; not Full: " + string.Join(", ", notFull));
+    }
+
+    [Fact]
+    public void Rung2Fixture_RendersInitializerChainsRecognizably()
+    {
+        var members = LoadRaisedMembers();
+        string Body(string name) =>
+            CSharpPrinter.PrintRaised(members.Single(m => m.Name == name).Function).Output?.Trim() ?? "";
+
+        var main = Body("Main");
+        Assert.Contains("new Box<int> { Value = 3, Label = \"three\" }", main);
+        Assert.Contains("new List<int> { 1, 2, 3 }", main);
+        Assert.DoesNotContain(".Value = 3;", main);
+        Assert.DoesNotContain(".Label = \"three\";", main);
+        Assert.DoesNotContain(".Add(1);", main);
+
+        Assert.Contains(
+            "return new List<int> { 1, 2, 3 };",
+            Body("MakeCollectionInitializer"));
+        Assert.Contains(
+            "return new Box<string> { Value = text, Label = text.OrFallback(\"empty\") };",
+            Body("MakeDirectReturn"));
+    }
+
+    [Fact]
+    public void Rung2Fixture_HasNoMalformedFullMethods()
+    {
+        var malformed = ValidityCheck.Evaluate(FixturePath)
+            .Where(r => r.TypeName == FixtureType && r.IsFull && r.IsMalformed)
+            .Select(r => $"{r.MethodName}: {r.MalformedDiagnostics[0].Id} {r.MalformedDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(malformed.Length == 0,
+            "Rung 2 initializer slice requires zero malformed Full methods; malformed: " + string.Join("; ", malformed));
+    }
+
+    static List<(string Name, IrFunction Function)> LoadRaisedMembers()
+    {
+        var members = new List<(string Name, IrFunction Function)>();
+        using var source = MetadataSource.Open(FixturePath, locator: RuntimeLocator);
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (typeName != FixtureType)
+                continue;
+            IrPasses.Run(function);
+            members.Add((methodName, function));
+        }
+        return members;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Facts/ObjectInitializerFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/ObjectInitializerFacts.cs
@@ -13,7 +13,7 @@ internal sealed class ObjectInitializerFacts : ILoweringFactProvider
                 new FactPrimitive("metadata.collection-initializer-receiver", "IEnumerable receiver proof for Add-based collection entries"),
                 new FactPrimitive("ir.initializer-entry-shape", "InitializerEntry member/indexer/Add argument model"),
             ],
-            PositiveCoverage: "ObjectInitializerPassTests property, field, indexer, list, dictionary, nested object/collection, nested-reassign (Inner = new U { ... }, folded inner-first), and named-local object/collection fixtures",
+            PositiveCoverage: "ObjectInitializerPassTests property, field, indexer, list, dictionary, nested object/collection, nested-reassign (Inner = new U { ... }, folded inner-first), named-local object/collection fixtures, ObjectInitializerContiguityTests gap-before-single-escape seed materialization, and LadderRung2GateTests compiler-temp local/return initializer chains",
             AdversarialCoverage: "ObjectInitializerPassTests extra outside use remains lowered; self-reference and mixed member/collection shapes stay flat; non-IEnumerable Add lookalikes stay lowered; named-local nested mutation stays lowered; nested-mutate (Inner = { ... }) stays distinct from nested-reassign (Inner = new U { ... }); a receiver slot re-stored (clobbered) between the run and its escape stays lowered",
             MissingDiscriminator: "named locals with extra outside uses remain lowered"),
     ];


### PR DESCRIPTION
## Summary

Follow-up to #1671 / #1624: add the explicit rung 2 fixture and gate that pins object/collection initializer chains flowing through compiler temporaries. The production behavior fix is already merged; this PR adds the upstream-facing guard and sidecar coverage text.

## Evidence

- `dotnet build src/dotnet-inspect -c Release --nologo -v q`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.LadderRung2GateTests"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/ObjectInitializer*/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`

## Adversarial review

Requested Opus 4.8 adversarial review. Result: no findings; reviewer confirmed the gate fails against pre-#1671 `ObjectInitializerPass` behavior and passes on current branch.