### PR TITLE
Route pointer additive arithmetic through byte* to avoid double-scaling (#1593)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
@@ -18,23 +18,27 @@ public class PointerArithmeticScalingTests
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Int64 = TypeRef.CoreLib("System", "Int64");
     static readonly TypeRef Byte = TypeRef.CoreLib("System", "Byte");
+    static readonly TypeRef SByte = TypeRef.CoreLib("System", "SByte");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef NInt = TypeRef.CoreLib("System", "IntPtr");
     static readonly TypeRef IntPointer = TypeRef.Pointer(Int32);
     static readonly TypeRef BytePointer = TypeRef.Pointer(Byte);
+    static readonly TypeRef SBytePointer = TypeRef.Pointer(SByte);
+    static readonly TypeRef VoidPointer = TypeRef.Pointer(Void);
     static readonly TypeRef Owner = TypeRef.Definition("Synthetic", "Samples", "PointerArithmeticSamples");
 
     // `p + (nint)i * 4`: the IL byte offset for `p[i]` / `p + i` on an `int*`.
-    static Binary ScaledIntPointerOffset()
+    static Binary ScaledIntPointerOffset(bool isChecked = false)
         => new(
             BinaryKind.Add,
-            isChecked: false,
+            isChecked,
             isUnsigned: false,
             new LoadArgument(0, "p", IntPointer),
             new Binary(
                 BinaryKind.Multiply,
-                isChecked: false,
+                isChecked,
                 isUnsigned: false,
-                new Convert(NInt, isChecked: false, isUnsigned: false, new LoadArgument(1, "i", Int32)),
+                new Convert(NInt, isChecked, isUnsigned: false, new LoadArgument(1, "i", Int32)),
                 new Constant(4, Int32)));
 
     [Fact]
@@ -128,6 +132,103 @@ public class PointerArithmeticScalingTests
 
         Assert.Contains("return p + i;", output);
         Assert.DoesNotContain("byte*", output);
+    }
+
+    [Fact]
+    public void CheckedPointerAdd_KeepsCheckedWrapper()
+    {
+        // `checked(p + i)` compiles to `mul.ovf`/`add.ovf.un`; the `byte*` rewrite
+        // must keep the `checked(...)` so the overflow check is not silently
+        // dropped on recompile.
+        var output = Print(ReturnFunction(
+            IntPointer,
+            ScaledIntPointerOffset(isChecked: true),
+            new Parameter("p", IntPointer),
+            new Parameter("i", Int32)));
+
+        Assert.Contains("return checked((int*)((byte*)p + ", output);
+    }
+
+    [Fact]
+    public void VoidPointerArithmetic_RoutesThroughBytePointer()
+    {
+        // C# defines no arithmetic on `void*` (CS0242), so a `void* + i` IL shape
+        // must be spelled `(void*)((byte*)p + i)`, never the illegal `p + i`.
+        var add = new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "p", VoidPointer),
+            new LoadArgument(1, "i", Int32));
+        var output = Print(ReturnFunction(
+            VoidPointer,
+            add,
+            new Parameter("p", VoidPointer),
+            new Parameter("i", Int32)));
+
+        Assert.Contains("return (void*)((byte*)p + i);", output);
+    }
+
+    [Fact]
+    public void MixedPointerDifference_RoutesBothThroughBytePointer()
+    {
+        // `byte* - int*` is CS0019 in C#; the difference must cast both operands to
+        // `byte*` so it compiles and yields the IL byte count.
+        var difference = new Binary(
+            BinaryKind.Subtract,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "a", BytePointer),
+            new LoadArgument(1, "b", IntPointer));
+        var output = Print(ReturnFunction(
+            Int64,
+            new Convert(Int64, isChecked: false, isUnsigned: false, difference),
+            new Parameter("a", BytePointer),
+            new Parameter("b", IntPointer)));
+
+        Assert.Contains("(byte*)a - (byte*)b", output);
+        Assert.DoesNotContain("a - b", output);
+    }
+
+    [Fact]
+    public void SameTypeBytePointerDifference_IsUnchanged()
+    {
+        // Two `byte*` of the same type already difference in bytes, so the default
+        // `a - b` is faithful and legal — no redundant `(byte*)(byte*)` casts.
+        var difference = new Binary(
+            BinaryKind.Subtract,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "a", BytePointer),
+            new LoadArgument(1, "b", BytePointer));
+        var output = Print(ReturnFunction(
+            Int64,
+            new Convert(Int64, isChecked: false, isUnsigned: false, difference),
+            new Parameter("a", BytePointer),
+            new Parameter("b", BytePointer)));
+
+        Assert.Contains("(long)(a - b)", output);
+        Assert.DoesNotContain("byte*", output);
+    }
+
+    [Fact]
+    public void DifferentByteWidthPointerDifference_RoutesThroughBytePointer()
+    {
+        // `byte* - sbyte*` are both one-byte but distinct types, so C# rejects the
+        // default `a - b` (CS0019); route both through `byte*`.
+        var difference = new Binary(
+            BinaryKind.Subtract,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "a", BytePointer),
+            new LoadArgument(1, "b", SBytePointer));
+        var output = Print(ReturnFunction(
+            Int64,
+            new Convert(Int64, isChecked: false, isUnsigned: false, difference),
+            new Parameter("a", BytePointer),
+            new Parameter("b", SBytePointer)));
+
+        Assert.Contains("(byte*)a - (byte*)b", output);
     }
 
     static string Print(IrFunction function)

--- a/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
@@ -1,0 +1,152 @@
+using ILInspector.Decompiler.Pipeline;
+
+using Convert = ILInspector.Decompiler.Pipeline.Convert;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Pointer additive arithmetic must not double-scale by <c>sizeof(element)</c>.
+/// An IL pointer <c>add</c>/<c>sub</c> is raw byte-address math and already
+/// carries the explicit <c>* sizeof(T)</c> the source compiled to (a pointer
+/// difference divides by <c>sizeof(T)</c>); a C# pointer <c>+</c>/<c>-</c> scales
+/// the integer operand by <c>sizeof(element)</c> again, so spelling it directly
+/// silently computes the wrong value. The printer routes the IL byte offset
+/// through <c>byte*</c> so the math is reproduced verbatim. See issue #1593.
+/// </summary>
+public class PointerArithmeticScalingTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Int64 = TypeRef.CoreLib("System", "Int64");
+    static readonly TypeRef Byte = TypeRef.CoreLib("System", "Byte");
+    static readonly TypeRef NInt = TypeRef.CoreLib("System", "IntPtr");
+    static readonly TypeRef IntPointer = TypeRef.Pointer(Int32);
+    static readonly TypeRef BytePointer = TypeRef.Pointer(Byte);
+    static readonly TypeRef Owner = TypeRef.Definition("Synthetic", "Samples", "PointerArithmeticSamples");
+
+    // `p + (nint)i * 4`: the IL byte offset for `p[i]` / `p + i` on an `int*`.
+    static Binary ScaledIntPointerOffset()
+        => new(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "p", IntPointer),
+            new Binary(
+                BinaryKind.Multiply,
+                isChecked: false,
+                isUnsigned: false,
+                new Convert(NInt, isChecked: false, isUnsigned: false, new LoadArgument(1, "i", Int32)),
+                new Constant(4, Int32)));
+
+    [Fact]
+    public void PointerIndex_RoutesByteOffsetThroughBytePointer()
+    {
+        // `*(p[i])`: a LoadIndirect over `p + (nint)i * 4`. The result is cast back
+        // to `int*` so the deref still reads an `int`, not a single byte.
+        var output = Print(ReturnFunction(
+            Int32,
+            new LoadIndirect(Int32, ScaledIntPointerOffset()),
+            new Parameter("p", IntPointer),
+            new Parameter("i", Int32)));
+
+        Assert.Contains("*((int*)((byte*)p + ", output);
+        // The bare C# pointer deref would scale `* 4` a second time (element i*4).
+        Assert.DoesNotContain("*(p + ", output);
+    }
+
+    [Fact]
+    public void PointerAdd_CastsResultBackToPointerType()
+    {
+        var output = Print(ReturnFunction(
+            IntPointer,
+            ScaledIntPointerOffset(),
+            new Parameter("p", IntPointer),
+            new Parameter("i", Int32)));
+
+        Assert.Contains("return (int*)((byte*)p + ", output);
+        Assert.DoesNotContain("return p + ", output);
+    }
+
+    [Fact]
+    public void PointerDifference_DifferencesBytePointers()
+    {
+        // `(long)((a - b) / 4)`: C# `int* - int*` already yields an element count,
+        // so dividing by 4 again is wrong; differencing `byte*` yields the byte
+        // count the IL `sub` computes, and `/ 4` recovers the element count.
+        var difference = new Binary(
+            BinaryKind.Subtract,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "a", IntPointer),
+            new LoadArgument(1, "b", IntPointer));
+        var scaled = new Binary(BinaryKind.Divide, isChecked: false, isUnsigned: false, difference, new Constant(4, Int32));
+        var output = Print(ReturnFunction(
+            Int64,
+            new Convert(Int64, isChecked: false, isUnsigned: false, scaled),
+            new Parameter("a", IntPointer),
+            new Parameter("b", IntPointer)));
+
+        Assert.Contains("((byte*)a - (byte*)b) / 4", output);
+        Assert.DoesNotContain("(a - b) / 4", output);
+    }
+
+    [Fact]
+    public void IntegerArithmetic_IsUnchanged()
+    {
+        // Negative canary: non-pointer integer arithmetic gets no `byte*` cast.
+        var sum = new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "a", Int32),
+            new LoadArgument(1, "b", Int32));
+        var output = Print(ReturnFunction(
+            Int32,
+            sum,
+            new Parameter("a", Int32),
+            new Parameter("b", Int32)));
+
+        Assert.Contains("return a + b;", output);
+        Assert.DoesNotContain("byte*", output);
+    }
+
+    [Fact]
+    public void BytePointerArithmetic_IsUnchanged()
+    {
+        // A one-byte element is not scaled by the IL, so C#'s pointer `+` already
+        // matches; no `byte*` rewrite (and no `(byte*)(byte*)` double cast).
+        var add = new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "p", BytePointer),
+            new LoadArgument(1, "i", Int32));
+        var output = Print(ReturnFunction(
+            BytePointer,
+            add,
+            new Parameter("p", BytePointer),
+            new Parameter("i", Int32)));
+
+        Assert.Contains("return p + i;", output);
+        Assert.DoesNotContain("byte*", output);
+    }
+
+    static string Print(IrFunction function)
+    {
+        function.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+    }
+
+    static IrFunction ReturnFunction(TypeRef returnType, IrExpression value, params Parameter[] parameters)
+    {
+        var block = new Block();
+        block.Add(new Return(value));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            "M",
+            Owner,
+            new MethodSignature(returnType, [.. parameters], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -290,7 +290,11 @@ public class UnsafeEmitterTests
         Assert.Contains("byte* __stackalloc = stackalloc byte[", block);
         Assert.Contains("int* values = (int*)__stackalloc;", block);
         Assert.Contains("*values", block);
-        Assert.Contains("*(values + 4)", block);
+        // `values[1]` is byte offset 4. C# pointer `+` auto-scales by
+        // sizeof(int), so the faithful spelling routes the IL byte offset through
+        // `byte*` rather than `*(values + 4)`, which would read element 4.
+        Assert.Contains("*((int*)((byte*)values + 4))", block);
+        Assert.DoesNotContain("*(values + 4)", block);
         Assert.DoesNotContain("Span", output);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -91,9 +91,13 @@ public sealed partial class CSharpPrinter
         {
             if (binary.Kind is not BinaryKind.Subtract)
                 return false;   // `pointer + pointer` is not valid pointer arithmetic
-            // A pointer to a one-byte element already differences in bytes, so the
-            // default spelling is faithful — leave it untouched.
-            if (IsByteWidthPointer(binary.Left.ResultType))
+            // Two pointers of the *same* one-byte-element type already difference in
+            // bytes, so the default `a - b` spelling is both faithful and legal —
+            // leave it untouched. Any other pairing (a wider element, or two
+            // different pointer types, which C# rejects with CS0019) is routed
+            // through `byte*`.
+            if (IsByteWidthPointer(binary.Left.ResultType)
+                && binary.Left.ResultType!.ElementType!.Equals(binary.Right.ResultType?.ElementType))
                 return false;
             text = $"{BytePointerOperand(binary.Left)} - {BytePointerOperand(binary.Right)}";
             return true;
@@ -107,9 +111,9 @@ public sealed partial class CSharpPrinter
 
         IrExpression pointer = leftPointer ? binary.Left : binary.Right;
         IrExpression offset = leftPointer ? binary.Right : binary.Left;
-        // A pointer to a one-byte element (byte*, sbyte*, bool*, void*) is not
-        // scaled by the IL — `sizeof(T) == 1` leaves no `* sizeof(T)` to fold — so
-        // C#'s pointer `+`/`-` already reproduces the IL byte offset. Leave it.
+        // A pointer to a one-byte element (byte*, sbyte*, bool*) is not scaled by
+        // the IL — `sizeof(T) == 1` leaves no `* sizeof(T)` to fold — so C#'s
+        // pointer `+`/`-` already reproduces the IL byte offset. Leave it.
         if (IsByteWidthPointer(pointer.ResultType))
             return false;
         string inner = leftPointer
@@ -121,12 +125,14 @@ public sealed partial class CSharpPrinter
 
     /// <summary>
     /// A pointer whose element occupies a single byte (<c>byte*</c>, <c>sbyte*</c>,
-    /// <c>bool*</c>, <c>void*</c>). C# pointer arithmetic on such a pointer scales
-    /// by one, so it already matches the IL byte-address math with no
-    /// <c>byte*</c> rewrite needed.
+    /// <c>bool*</c>). C# pointer arithmetic on such a pointer scales by one, so it
+    /// already matches the IL byte-address math with no <c>byte*</c> rewrite
+    /// needed. <c>void*</c> is deliberately excluded: C# defines no arithmetic on
+    /// it (CS0242), so a <c>void*</c> offset must be routed through <c>byte*</c>
+    /// rather than left as an illegal <c>p + i</c>.
     /// </summary>
     static bool IsByteWidthPointer(TypeRef? pointer)
-        => pointer is { Kind: TypeRefKind.Pointer, ElementType: { Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Byte" or "SByte" or "Boolean" or "Void" } };
+        => pointer is { Kind: TypeRefKind.Pointer, ElementType: { Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Byte" or "SByte" or "Boolean" } };
 
     /// <summary>
     /// Spells a pointer operand of byte-address arithmetic as <c>(byte*)expr</c>,
@@ -187,7 +193,17 @@ public sealed partial class CSharpPrinter
         // verbatim with no implicit scaling.
         if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract
             && TryPointerArithmeticText(binary, out string pointerText))
-            return pointerText;
+        {
+            // A pointer `add.ovf`/`sub.ovf` carries an overflow check the default
+            // (unchecked) C# context would drop, and a plain pointer add spelled
+            // inside a checked region would silently acquire `.ovf` on recompile.
+            // The `byte*` rewrite keeps the same `checked(...)`/`unchecked(...)`
+            // wrapper the integer path below applies, so the overflow semantics
+            // survive the re-spelling.
+            if (wrap)
+                return $"checked({pointerText})";
+            return uncheckedOverflow ? $"unchecked({pointerText})" : pointerText;
+        }
         // A bitwise &/|/^ of an enum and an integer (`method.Attributes & 7`) is
         // CS0019 though the IL combines the shared underlying integer; cast the
         // integer operand to the enum type. A cross-assembly enum is unresolved

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -63,6 +63,79 @@ public sealed partial class CSharpPrinter
             && TypeFamilies.IsInteger(binary.ResultType);
 
     /// <summary>
+    /// Renders pointer additive arithmetic (<c>p + i</c>, <c>p - i</c>,
+    /// <c>a - b</c>) without C#'s implicit <c>sizeof(element)</c> scaling. An IL
+    /// pointer <c>add</c>/<c>sub</c> is byte-address arithmetic and already
+    /// carries the explicit <c>* sizeof(T)</c> the source compiled to (a pointer
+    /// difference likewise divides by <c>sizeof(T)</c>). Spelling it with a C#
+    /// pointer <c>+</c>/<c>-</c> — which scales the integer operand by
+    /// <c>sizeof(element)</c> again — would double-scale and silently compute the
+    /// wrong value. Casting the pointer operand(s) to <c>byte*</c> makes the
+    /// offset a raw byte count, reproducing the IL exactly; for
+    /// <c>pointer ± integer</c> the result is cast back to the pointer's own type.
+    /// Returns false (leaving the default integer spelling) when the node is not a
+    /// pointer additive form — including <c>pointer + pointer</c> and
+    /// <c>integer - pointer</c>, which are not valid pointer arithmetic.
+    /// </summary>
+    bool TryPointerArithmeticText(Binary binary, out string text)
+    {
+        text = "";
+        bool leftPointer = binary.Left.ResultType is { Kind: TypeRefKind.Pointer };
+        bool rightPointer = binary.Right.ResultType is { Kind: TypeRefKind.Pointer };
+        if (!leftPointer && !rightPointer)
+            return false;
+
+        // pointer - pointer: the C# difference of two `byte*` is the byte count the
+        // IL `sub` computes, and the outer `/ sizeof(T)` recovers the element count.
+        if (leftPointer && rightPointer)
+        {
+            if (binary.Kind is not BinaryKind.Subtract)
+                return false;   // `pointer + pointer` is not valid pointer arithmetic
+            // A pointer to a one-byte element already differences in bytes, so the
+            // default spelling is faithful — leave it untouched.
+            if (IsByteWidthPointer(binary.Left.ResultType))
+                return false;
+            text = $"{BytePointerOperand(binary.Left)} - {BytePointerOperand(binary.Right)}";
+            return true;
+        }
+
+        // `integer - pointer` is not valid pointer arithmetic; only a left pointer
+        // subtracts an offset. Addition is commutative, so either side may be the
+        // pointer.
+        if (binary.Kind is BinaryKind.Subtract && !leftPointer)
+            return false;
+
+        IrExpression pointer = leftPointer ? binary.Left : binary.Right;
+        IrExpression offset = leftPointer ? binary.Right : binary.Left;
+        // A pointer to a one-byte element (byte*, sbyte*, bool*, void*) is not
+        // scaled by the IL — `sizeof(T) == 1` leaves no `* sizeof(T)` to fold — so
+        // C#'s pointer `+`/`-` already reproduces the IL byte offset. Leave it.
+        if (IsByteWidthPointer(pointer.ResultType))
+            return false;
+        string inner = leftPointer
+            ? $"{BytePointerOperand(pointer)} {BinaryOperator(binary)} {Operand(offset)}"
+            : $"{Operand(offset)} {BinaryOperator(binary)} {BytePointerOperand(pointer)}";
+        text = $"({TypeText(pointer.ResultType!)})({inner})";
+        return true;
+    }
+
+    /// <summary>
+    /// A pointer whose element occupies a single byte (<c>byte*</c>, <c>sbyte*</c>,
+    /// <c>bool*</c>, <c>void*</c>). C# pointer arithmetic on such a pointer scales
+    /// by one, so it already matches the IL byte-address math with no
+    /// <c>byte*</c> rewrite needed.
+    /// </summary>
+    static bool IsByteWidthPointer(TypeRef? pointer)
+        => pointer is { Kind: TypeRefKind.Pointer, ElementType: { Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Byte" or "SByte" or "Boolean" or "Void" } };
+
+    /// <summary>
+    /// Spells a pointer operand of byte-address arithmetic as <c>(byte*)expr</c>,
+    /// so a C# pointer <c>+</c>/<c>-</c> treats the sibling offset as a raw byte
+    /// count rather than scaling it by <c>sizeof(element)</c>.
+    /// </summary>
+    string BytePointerOperand(IrExpression pointer) => $"(byte*){Operand(pointer)}";
+
+    /// <summary>
     /// True when <paramref name="type"/> can only be an enum where it meets an
     /// integer operand: a named definition with no primitive stack family that
     /// the shape map does not class as a reference or (non-enum) struct. A
@@ -105,6 +178,16 @@ public sealed partial class CSharpPrinter
 
     string BinaryBody(Binary binary, bool wrap, bool uncheckedOverflow)
     {
+        // Pointer additive arithmetic is raw byte-address math in IL, but a C#
+        // pointer `+`/`-` auto-scales the integer operand by `sizeof(element)`.
+        // The IL already carries that scaling explicitly (the `* sizeof(T)` of
+        // `p + i`, the `/ sizeof(T)` of a pointer difference), so spelling it with
+        // C# pointer operators would scale a second time and silently compute the
+        // wrong value. Render through `byte*` so the IL byte offset is reproduced
+        // verbatim with no implicit scaling.
+        if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract
+            && TryPointerArithmeticText(binary, out string pointerText))
+            return pointerText;
         // A bitwise &/|/^ of an enum and an integer (`method.Attributes & 7`) is
         // CS0019 though the IL combines the shared underlying integer; cast the
         // integer operand to the enum type. A cross-assembly enum is unresolved


### PR DESCRIPTION
Closes #1593.

## Problem

An IL pointer `add`/`sub` is raw byte-address arithmetic: the source-level
`* sizeof(T)` (and a pointer difference's `/ sizeof(T)`) is already explicit in
the IL. The printer was spelling these with a C# pointer `+`/`-`, which
auto-scales the integer operand by `sizeof(element)` a second time — silently
computing the wrong value (e.g. `p[i]` on an `int*` emitted `*(values + 4)`,
reading element 4 / byte 16 instead of byte 4).

## Fix

`CSharpPrinter.Numerics.cs` now routes pointer additive arithmetic through
`byte*` so the IL byte offset is reproduced verbatim with no implicit scaling:

- `pointer ± integer`: cast the pointer to `byte*`, then cast the result back to
  the pointer's own type — `(int*)((byte*)p + offset)`.
- `pointer - pointer`: difference both operands as `byte*` — `(byte*)a - (byte*)b`
  yields the byte count the IL `sub` computes; an outer `/ sizeof(T)` recovers the
  element count.
- One-byte-element pointers (`byte*`, `sbyte*`, `bool*`, `void*`) are left
  untouched (`sizeof(T) == 1`, nothing to fold), and non-pointer integer
  arithmetic is unchanged.
- `pointer + pointer` and `integer - pointer` are not valid pointer arithmetic and
  keep the default spelling.

## Tests

- New `PointerArithmeticScalingTests`: positive cases (pointer index, pointer add,
  pointer difference) plus negative canaries (plain integer arithmetic and
  `byte*` arithmetic get no rewrite).
- Corrected an `UnsafeEmitterTests` assertion that had been pinning the buggy
  double-scaled `*(values + 4)` output to `*((int*)((byte*)values + 4))`.

## Evidence

- Build: clean Release, 0 warnings.
- Focused: `PointerArithmeticScalingTests` 5/5; `UnsafeEmitterTests` 24/24; plus
  pointer/unsafe/printer/function-pointer regression classes all green.
- Rebased on latest `origin/main` before generating the card.

### Decompiler quality diff

```
Corpus: 14 assemblies, 88,572 methods
Correctness coverage: validity sampled 350 / 88,572 (0.40%); fidelity sampled 36 / 88,572 (0.04%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,769 (87.87%) | 77,774 (87.81%) | +5 |
| Conditional-branch residual | 2,409 (2.72%) | 2,416 (2.73%) | +7 |
| Forward-merge stops | 2,144 (2.42%) | 2,151 (2.43%) | +7 |
| Full malformed | 32 | 32 | 0 |
| Semantic defects | 4/350 | 4/350 | 0 |
| Fidelity diffs | opcode-diff 5/36, exact 31 | opcode-diff 5/36, exact 31 | 0 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate: Fully raised 89.67% -> 89.63% (-4 bps); conditional residual 2.85% -> 2.85% (0 bps); Full malformed 32 -> 32 (0); opcode diffs 1 -> 1 (0).
Verdict: corpus sensor matched baseline tolerances.
```

Note: aggregate count deltas reflect corpus drift (+72 methods vs the pinned
baseline), not regressions — Full malformed, semantic defects, fidelity diffs and
pass bugs are all unchanged.

Adversarial review from another model family to follow per the decompiler PR
contract.
