### PR TITLE
Suppress cached generic delegate triage false positives

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -851,6 +851,17 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_GenericCachedLambda_NotReported()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures.GenericOptimizationOpportunityFixtures<>).Assembly.Location);
+
+        Assert.Empty(index.OptimizationOpportunities
+            .Where(o => o.Method.DeclaringType.Name.EndsWith("+GenericOptimizationOpportunityFixtures`1", StringComparison.Ordinal)
+                && o.Method.Name == nameof(OptimizationOpportunityFixtures.GenericOptimizationOpportunityFixtures<int>.NonCapturingLambda)
+                && o.Shape is "delegate-allocation" or "capturing-delegate" or "instance-method-group-delegate"));
+    }
+
+    [Fact]
     public void OptimizationOpportunities_CarryContainingMethodRootReach()
     {
         var index = LibraryBodyIndex.Open(typeof(OpportunityLeverageFixtures).Assembly.Location);
@@ -1403,6 +1414,14 @@ public class OptimizationOpportunityFixtures
         public static string Join(int a, int b) => $"{a}:{b}";
         public static string Concat(int a, int b) => $"{a}{b}";
         public static string Substring(string value) => value;
+    }
+
+    public class GenericOptimizationOpportunityFixtures<T>
+    {
+        public Func<T, T> NonCapturingLambda()
+        {
+            return value => value;
+        }
     }
 
     public sealed class UserDisplayClassTarget

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1232,7 +1232,7 @@ public sealed class LibraryBodyIndex
                         pendingDelegateCapturing = IsClosureTarget(ftnTarget);
                         pendingDelegateInstanceGroup = !pendingDelegateCapturing
                             && ftnTarget.Kind != MemberKind.Unsupported
-                            && !ftnTarget.DeclaringType.Name.Contains("<>", StringComparison.Ordinal)
+                            && !DeclaringTypeLeafName(ftnTarget.DeclaringType).Contains("<>", StringComparison.Ordinal)
                             && previousOpcode != ILOpCode.Ldnull;
                         break;
                     }


### PR DESCRIPTION
## Summary

- fix Performance Triage delegate classification to unwrap generic declaring-type leaves before checking for compiler-generated `<>` cache holders
- add a regression fixture for generic non-capturing lambdas so cached `<>c` delegates do not surface as per-call `instance-method-group-delegate` rows

Fixes the highest-priority cached-once delegate false positive from #1670.

## Validation

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -method "*GenericCachedLambda*"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -class "ILInspector.Analysis.Tests.LibraryBodyIndexTests"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release --nologo -v q`
- `dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll library artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tests.dll -S "Performance Triage" --jsonl | grep -F "GenericOptimizationOpportunityFixtures" || true`

## Adversarial review

Requested Opus 4.8 review of the unstaged fix before commit. It found no significant correctness issues, verified the old code reproduces the false positive, and confirmed the regression test fails without the source fix and passes with it.