### PR TITLE
Recover recursive local functions

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung4/LadderRung4.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung4/LadderRung4.cs
@@ -84,6 +84,21 @@ public static class CSharp7LocalSyntax
 
         return ref right;
     }
+
+    public static int RecursiveLocalFunction(int value)
+    {
+        return Fact(value);
+
+        static int Fact(int n)
+        {
+            if (n <= 1)
+            {
+                return 1;
+            }
+
+            return n * Fact(n - 1);
+        }
+    }
 }
 
 public readonly struct Point

--- a/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
@@ -21,10 +21,12 @@ public class LadderRung4GateTests
         "<LocalFunctionCapturing>g__AddSeed|4_0",
         "<LocalFunctionCapturingWithLocal>g__AddSquare|5_0",
         "<LocalFunctionNonCapturing>g__Double|3_0",
+        "<RecursiveLocalFunction>g__Fact|9_0",
         "DeconstructPoint",
         "LocalFunctionCapturing",
         "LocalFunctionCapturingWithLocal",
         "LocalFunctionNonCapturing",
+        "RecursiveLocalFunction",
         "RefLocalUpdate",
         "SelectRef",
         "SimplePattern",
@@ -87,6 +89,13 @@ public class LadderRung4GateTests
         Assert.Equal(DecompilationFidelity.Partial, Fidelity("LocalFunctionCapturingWithLocal"));
         Assert.Contains("DisplayClass", localBodyCapture);
         Assert.Contains("AddSquare(3", localBodyCapture);
+
+        var recursiveLocal = Body("RecursiveLocalFunction");
+        Assert.Contains("return Fact(value);", recursiveLocal);
+        Assert.Contains("static int Fact(int n)", recursiveLocal);
+        Assert.Contains("return n * (Fact(n - 1));", recursiveLocal);
+        Assert.DoesNotContain("CSharp7LocalSyntax.Fact", recursiveLocal);
+        Assert.DoesNotContain("g__", recursiveLocal);
 
         var pattern = Body("SimplePattern");
         Assert.Contains("value is int", pattern);

--- a/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
@@ -83,13 +83,15 @@ public class LocalFunctionRaisingPassTests
     }
 
     [Fact]
-    public void RecursiveLocalFunction_StaysLowered()
+    public void RecursiveLocalFunction_RaisesSelfCallableDeclaration()
     {
-        // The body calls itself; keeping the import non-recursive bars recovery.
         string output = PrintRaised(nameof(CfgSampleClass.RecursiveLocalFunction));
 
-        Assert.DoesNotContain("int Fact(int v) =>", output);     // no recovered declaration
-        Assert.Contains("Fact(n)", output);                      // call left as the lowered invocation
+        Assert.Contains("return Fact(n);", output);
+        Assert.Contains("static int Fact(int v)", output);
+        Assert.Contains("return v * (Fact(v - 1));", output);
+        Assert.DoesNotContain("CfgSampleClass.Fact", output);
+        Assert.DoesNotContain("g__", output);
     }
 
     [Fact]
@@ -211,6 +213,48 @@ public class LocalFunctionRaisingPassTests
 
         Assert.Equal(1, localImports);
         Assert.Equal(1, lambdaImports);
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void LocalFunctionBodyCallingDifferentLocalFunction_StaysLowered()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var first = new MethodRef(
+            owner,
+            "<M>g__First|0_0",
+            s_int,
+            [s_int],
+            HasThis: false)
+        {
+            CompilerGenerated = MetadataFactState.Yes,
+        };
+        var second = new MethodRef(
+            owner,
+            "<M>g__Second|0_1",
+            s_int,
+            [s_int],
+            HasThis: false)
+        {
+            CompilerGenerated = MetadataFactState.Yes,
+        };
+        var function = FunctionReturningCall(first, s_int);
+        var context = new PassContext(
+            new Stepper(enabled: false),
+            importMethodBody: method =>
+            {
+                if (method == first)
+                    return LocalFunctionBodyCalling(first, second);
+                if (method == second)
+                    return LocalFunctionBody(second, s_int);
+                return null;
+            });
+
+        new LocalFunctionRaisingPass().Run(function, context);
+
+        Assert.Empty(function.Descendants.OfType<LocalFunctionStatement>());
+        Assert.Empty(function.Descendants.OfType<LocalFunctionInvocation>());
+        Assert.Single(function.Descendants.OfType<Call>(), call => call.Callee == first);
         function.CheckInvariant();
     }
 
@@ -376,6 +420,23 @@ public class LocalFunctionRaisingPassTests
             isVirtual: false,
             new Constant(null, TypeRef.CoreLib("System", "Object")))));
         block.Add(new Return(new LoadArgument(0, "x", s_int)));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            localMethod.Name,
+            localMethod.DeclaringType,
+            new MethodSignature(s_int, [new Parameter("x", s_int)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+
+    static IrFunction LocalFunctionBodyCalling(MethodRef localMethod, MethodRef calledMethod)
+    {
+        var block = new Block();
+        block.Add(new Return(new Call(
+            calledMethod,
+            isVirtual: false,
+            [new LoadArgument(0, "x", s_int)])));
         var body = new BlockContainer();
         body.Add(block);
         return new IrFunction(

--- a/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
@@ -18,6 +18,8 @@ public class SubstratePredicateCensusTests
             "Inlining-specific EH guard that first finds the containing catch clause before using ReferenceOwnership.IsInside on its filter.",
         [new("ExpressionInliningPass.cs", "SameRegions")] =
             "Inlining-specific EH range equality for candidate movement; the predicate is over function region spans, not IR identity.",
+        [new("LocalFunctionRaisingPass.cs", "SameLocalFunctionMethod")] =
+            "Local-function mangled names are unique within the declaring type; this pass-local check distinguishes self-recursion from nested or mutual local-function calls.",
         [new("NullCoalescingAssignmentPass.cs", "SameField")] =
             "FieldRef equality paired with pass-owned receiver/index-shape checks for null-coalescing assignment.",
         [new("NullCoalescingAssignmentPass.cs", "SameReceiver")] =

--- a/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/LocalFunctionRaisingPass.cs
@@ -67,13 +67,17 @@ public sealed class LocalFunctionRaisingPass : IIrPass
                 var body = importScope.Import();
                 if (body is null)
                     continue;
-                // Keep the import non-recursive: a body that calls a local function
-                // (itself, mutually, or nested) is out of this slice.
-                if (body.Descendants.OfType<Call>().Any(c => GeneratedCodeIdentity.IsLocalFunctionMethod(c.Callee)))
+                // Mutual or nested local-function calls are still out of this slice.
+                // A self-call is recoverable: rewrite it to the same local-function
+                // invocation used by the host call sites after the nested pipeline
+                // has run without re-entering this method's import.
+                if (HasOtherLocalFunctionCall(body, method))
                     continue;
 
                 IrPasses.Run(body, IrPasses.Default, context);
 
+                if (HasOtherLocalFunctionCall(body, method))
+                    continue;
                 if (environment is not null && !SubstituteEnvironment(body, environment))
                     continue;
                 bool allowLocals = environment is null;
@@ -83,6 +87,7 @@ public sealed class LocalFunctionRaisingPass : IIrPass
                     continue;
 
                 string name = CSharpNaming.MethodName(method.Name);
+                RewriteSelfCalls(body, method, name);
                 // The environment parameter is the last one; drop it from the source signature.
                 var parameters = environment is null
                     ? body.Signature.Parameters
@@ -243,6 +248,27 @@ public sealed class LocalFunctionRaisingPass : IIrPass
         return true;
     }
 
+    static bool HasOtherLocalFunctionCall(IrFunction body, MethodRef method)
+        => body.Descendants.OfType<Call>()
+            .Any(c => GeneratedCodeIdentity.IsLocalFunctionMethod(c.Callee)
+                && !SameLocalFunctionMethod(c.Callee, method));
+
+    static void RewriteSelfCalls(IrFunction body, MethodRef method, string name)
+    {
+        foreach (var call in body.Descendants.OfType<Call>().ToList())
+        {
+            if (!SameLocalFunctionMethod(call.Callee, method))
+                continue;
+
+            var arguments = call.DetachChildren().Cast<IrExpression>().ToList();
+            call.ReplaceWith(new LocalFunctionInvocation(name, method.ReturnType, arguments));
+        }
+    }
+
+    static bool SameLocalFunctionMethod(MethodRef left, MethodRef right)
+        => left.Name == right.Name
+            && Equals(left.DeclaringType, right.DeclaringType);
+
     static bool IsCaptureValue(IrExpression value, IrFunction function) => value switch
     {
         LoadArgument => true,
@@ -268,6 +294,8 @@ public sealed class LocalFunctionRaisingPass : IIrPass
             if (allowLocalStatements && statement is StoreLocal)
                 continue;
             if (allowLocalStatements && statement is StoreStackSlot)
+                continue;
+            if (statement is IfStatement)
                 continue;
             if (statement is not ExpressionStatement)
                 return false;


### PR DESCRIPTION
## Summary

Fixes #1640 by recovering self-recursive local functions as valid local-function declarations instead of printing calls to nonexistent ordinary helper members such as `CSharp7LocalSyntax.Fact(value)`.

The local-function pass now treats calls back to the same synthesized local-function method as self-recursion, rewrites those calls to `LocalFunctionInvocation`, and still declines nested or mutual local-function calls. The rung 4 fixture now includes a recursive local function and the gate asserts the valid recovered shape.

## Before / after

Before:

```csharp
public static int RecursiveLocalFunction(int value) => CSharp7LocalSyntax.Fact(value);
```

After:

```csharp
public static int RecursiveLocalFunction(int value)
{
    return Fact(value);
    static int Fact(int n)
    {
        if (n <= 1)
        {
            return 1;
        }
        return n * (Fact(n - 1));
    }
}
```

## Evidence

```text
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded. 0 Warning(s), 0 Error(s)

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LocalFunctionRaisingPassTests
Total: 19, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LadderRung4GateTests
Total: 3, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
Total: 1486, Errors: 0, Failed: 0, Skipped: 0
```

Full `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` did not complete in this shared environment after ~30 minutes and was stopped; the focused tests, rung gate, and PR-fast subset above passed after rebasing onto current `origin/main`.

## Quality diff card

```text
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,633 methods
Correctness coverage: validity sampled 350 / 88,633 (0.39%); fidelity sampled 36 / 88,633 (0.04%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 88,500 -> 88,633 (+133)
- dotnet-inspect: 12,358 -> 12,380 methods (+22)
- ILInspector.Analysis: 684 -> 725 methods (+41)
- ILInspector.Decompiler: 5,293 -> 5,363 methods (+70)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,769 (87.87%) | 77,821 (87.80%) | +52 |
| Conditional-branch residual | 2,409 (2.72%) | 2,421 (2.73%) | +12 |
| Forward-merge stops | 2,144 (2.42%) | 2,156 (2.43%) | +12 |
| Full malformed | 32 | 32 | 0 |
| Semantic defects | 4/350 — sampled 350 / 88,500 (0.40%) | 4/350 — sampled 350 / 88,633 (0.39%) | 0 |
| Fidelity diffs | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 88,500 (0.04%) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 88,633 (0.04%) | 0 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 89.67% -> 89.63% (-4 bps); conditional residual 2.85% -> 2.85% (0 bps); Full malformed 32 -> 32 (0); opcode diffs 1 -> 1 (0).

Verdict: corpus sensor matched baseline tolerances.
```

## Adversarial review

Cross-family adversarial review requested from Opus 4.8. I will post the review result as a PR comment.
