### PR TITLE
ci: cut Actions cost and per-PR runner contention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,14 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
+# Cancel superseded PR runs (e.g. when an agent pushes again to the same branch)
+# so only the latest commit of a PR consumes a full CI run. Pushes to main are
+# NOT cancelled: release.yml publishes from a main-push CI run's package
+# artifacts, so those runs must always complete.
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # Detect what changed to determine which jobs to run
   changes:
@@ -18,6 +26,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
       ilroundtrip: ${{ steps.filter.outputs.ilroundtrip }}
+      packaging: ${{ steps.filter.outputs.packaging }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -38,6 +47,7 @@ jobs:
           CODE=false
           DOCS=false
           ILROUNDTRIP=false
+          PACKAGING=false
           while IFS= read -r file; do
             case "$file" in
               src/*) CODE=true ;;
@@ -62,13 +72,24 @@ jobs:
               src/DotnetInspector.Core/*) ILROUNDTRIP=true ;;
               *.props|*.sln) ILROUNDTRIP=true ;;
             esac
+            # Packaging/pack-smoke validation only needs to run when build or
+            # packaging configuration changes. Most PRs (e.g. decompiler raises)
+            # don't touch these, so gating pack/pack-rid here keeps them off the
+            # hot PR path. On push to main, pack still runs (see job `if`s) to
+            # produce the artifacts release.yml publishes.
+            case "$file" in
+              *.csproj|*.props|*.targets|*.sln) PACKAGING=true ;;
+              global.json|nuget.config|NuGet.config) PACKAGING=true ;;
+              .github/workflows/*) PACKAGING=true ;;
+            esac
           done <<< "$FILES"
           echo "code=$CODE" >> "$GITHUB_OUTPUT"
           echo "docs=$DOCS" >> "$GITHUB_OUTPUT"
           echo "ilroundtrip=$ILROUNDTRIP" >> "$GITHUB_OUTPUT"
+          echo "packaging=$PACKAGING" >> "$GITHUB_OUTPUT"
           echo "Changed files:"
           echo "$FILES"
-          echo "code=$CODE docs=$DOCS ilroundtrip=$ILROUNDTRIP"
+          echo "code=$CODE docs=$DOCS ilroundtrip=$ILROUNDTRIP packaging=$PACKAGING"
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -88,9 +109,16 @@ jobs:
   # Build and test on Ubuntu only. Windows/macOS coverage was moved to the
   # Publish workflow to cut Actions minutes (those runners bill at higher
   # multipliers). This trades per-PR cross-platform test coverage for cost.
+  #
+  # Runs on PRs only. A pull_request build validates the PR merged into the
+  # current base, so re-running the full test suite on the push to main is
+  # redundant; we skip it there to cut Actions minutes (the test job is the
+  # most expensive leg) and to reduce queued-job contention when many agents
+  # have PRs in flight at once. Release packages are built by release.yml at
+  # publish time, not here.
   test:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true' && github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -108,6 +136,14 @@ jobs:
         with:
           dotnet-version: '11.0.x'
           dotnet-quality: 'preview'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Build
         run: dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
@@ -205,10 +241,15 @@ jobs:
         if: matrix.rid == 'linux-x64' && needs.changes.outputs.ilroundtrip == 'true'
         run: dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
 
-  # Pack and smoke test on Ubuntu
+  # Pack and smoke test on Ubuntu. This is a packaging smoke test only: it
+  # validates that the tool still packs and installs. It is NOT the source of
+  # release artifacts (release.yml builds those itself at publish time), so it
+  # runs only on PRs that touch build/packaging configuration. Most PRs (e.g.
+  # decompiler raises) skip it, which removes two jobs from the per-PR runner
+  # demand and shortens queue times under concurrent-agent load.
   pack:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.packaging == 'true'
     runs-on: ubuntu-26.04
     env:
       DOTNET_INSPECT_TIPS: q
@@ -327,12 +368,13 @@ jobs:
       - name: Uninstall tool
         run: dotnet tool uninstall --global dotnet-inspect
 
-  # Build RID-specific Native AOT packages built on Linux runners. The
-  # win-x64, win-arm64, and osx-arm64 AOT packages are built in the Publish
-  # workflow instead, so Windows/macOS runners are only used at release time.
+  # Linux-arm64 AOT pack smoke test. Like the `pack` job, this only verifies
+  # that the RID-specific AOT package builds; it is not a release artifact
+  # source (release.yml builds all RID packages at publish time). Gated to PRs
+  # that touch build/packaging configuration so it stays off the hot PR path.
   pack-rid:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.packaging == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: 'CI workflow run ID to publish from'
+        description: 'CI run ID identifying the commit to publish (used only to resolve the SHA; all packages are built fresh in this workflow)'
         required: true
       confirm:
         description: 'Type "publish" to confirm NuGet release'
@@ -15,8 +15,8 @@ permissions:
   id-token: write
 
 jobs:
-  # Resolve the exact commit the CI run was built from so the Windows/macOS
-  # packages we build here match the Linux packages produced by that run.
+  # Resolve the exact commit to publish from the given CI run, so every package
+  # built below (Windows/macOS/Linux RIDs + portable) comes from one commit.
   resolve:
     runs-on: ubuntu-26.04
     if: github.event.inputs.confirm == 'publish'
@@ -33,8 +33,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Build the RID-specific Native AOT packages that used to be built in CI.
-  # These run only at publish time to keep Windows/macOS off the per-PR path.
+  # Build the RID-specific Native AOT packages. These run only at publish time
+  # so per-PR/per-merge CI never has to build or upload release artifacts.
+  # Windows/macOS build on their native runners; the Linux RIDs build here too
+  # (they used to be produced by CI's pack/pack-rid jobs).
   build-native:
     needs: resolve
     strategy:
@@ -47,6 +49,10 @@ jobs:
             os: windows-latest
           - rid: osx-arm64
             os: macos-latest
+          - rid: linux-x64
+            os: ubuntu-26.04
+          - rid: linux-arm64
+            os: ubuntu-26.04-arm
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -69,8 +75,50 @@ jobs:
           path: artifacts/package/release/*.nupkg
           if-no-files-found: error
 
+  # Build the RID-neutral packages: the non-AOT "any" fallback and the
+  # TFM-agnostic pointer. These used to come from CI's pack job; they are now
+  # built here at publish time so CI never produces release artifacts.
+  build-portable:
+    needs: resolve
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Pack pointer package
+        # SelfContained=true forces the pack TFM segment to 'any', so the pointer
+        # manifest lands at tools/any/any/DotnetToolSettings.xml. The pointer
+        # carries no implementation, so SelfContained pulls in no runtime.
+        run: dotnet pack src/dotnet-inspect -c Release -p:SelfContained=true -p:OfficialBuild=true
+
+      - name: Upload pointer package
+        uses: actions/upload-artifact@v7
+        with:
+          name: package-pointer
+          path: artifacts/package/release/*.nupkg
+          if-no-files-found: error
+
+      - name: Pack any (non-AOT) package
+        # TFM is pinned to net10.0 structurally via Directory.Build.props so this
+        # fallback stays installable on the LTS runtime. See issue #240.
+        run: dotnet pack src/dotnet-inspect -c Release -r any -p:PublishAot=false -p:OfficialBuild=true
+
+      - name: Upload any package
+        uses: actions/upload-artifact@v7
+        with:
+          name: package-any
+          path: artifacts/package/release/*.nupkg
+          if-no-files-found: error
+
   publish:
-    needs: [resolve, build-native]
+    needs: [resolve, build-native, build-portable]
     runs-on: ubuntu-26.04
     if: github.event.inputs.confirm == 'publish'
     environment: nuget
@@ -82,16 +130,7 @@ jobs:
         with:
           ref: ${{ needs.resolve.outputs.sha }}
       
-      - name: Download Linux/any/pointer packages from CI run
-        uses: actions/download-artifact@v8
-        with:
-          path: packages
-          pattern: package-*
-          merge-multiple: true
-          run-id: ${{ github.event.inputs.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download Windows/macOS packages built in this run
+      - name: Download all packages built in this run
         uses: actions/download-artifact@v8
         with:
           path: packages


### PR DESCRIPTION
## Problem

GitHub Actions spend is growing with PR volume (~100 PRs/week, ~3 CI runs/PR plus a redundant push-to-main run each merge). Long PR cycles also raise contention when many agents have PRs in flight (the GitHub concurrent-runner cap queues jobs).

Two angles, both addressed here: **do less per PR** and **build packages only at publish time** (they're not needed before).

## Changes

**`ci.yml`**
- **Concurrency cancel-in-progress for PRs** (main pushes still run to completion, since releases resolve a commit from a main run). Superseded PR pushes free runner slots instead of finishing.
- **`test` runs on PRs only.** A `pull_request` build validates the PR merged into the current base, so re-running the full suite on push-to-main is redundant. Push-to-main now runs ~just the `changes` job.
- **`pack`/`pack-rid` gated to PRs that touch build/packaging config** via a new `packaging` changes output (`*.csproj`/`*.props`/`*.targets`/`*.sln`/`global.json`/`nuget.config`/`.github/workflows/*`). Most PRs now run only `changes` + `test`, ~halving in-flight jobs and reducing queue contention.
- **NuGet cache** added to `test`.

**`release.yml`**
- Builds **all** packages at publish time: 5 RID AOT (win-x64/arm64, osx-arm64, linux-x64, linux-arm64) + a new `build-portable` job for the pointer and `any` packages. Previously these came from a CI run's artifacts.
- Drops the "download from CI run" step; publish consumes only this run's artifacts. `run_id` now only resolves the commit SHA.

## Effect

| | Before | After |
|---|---|---|
| Typical PR | 4 jobs (changes, test, pack, pack-rid) | 2 jobs (changes, test) |
| Push to main | 4 jobs | ~1 job (changes) |
| Superseded PR pushes | run to completion | cancelled |
| Release artifacts | built in every CI run | built only at publish |

## Trade-offs

- No post-merge validation job on `main` (the merge commit is tested in the PR; `decompiler-daily.yml` remains the daily safety net).
- Packaging regressions surface on packaging-touching PRs or at publish (`release.yml` still runs reach-validation).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
