### PR TITLE
Recover nullable coalesce for rung 2

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung2/LadderRung2.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung2/LadderRung2.cs
@@ -7,8 +7,8 @@ namespace LadderRung2;
 // basics. The initializer shapes here are intentionally ordinary C# 3 source:
 // an object initializer whose constructed value is used after another initializer
 // chain, a collection initializer assigned to a local, a collection initializer
-// returned directly, the already-supported direct-return object initializer, and
-// an anonymous type local.
+// returned directly, the already-supported direct-return object initializer, an
+// anonymous type local, and nullable value-type coalescing.
 public static class Program
 {
     public static void Main()
@@ -25,6 +25,9 @@ public static class Program
 
     public static Box<string> MakeDirectReturn(string text)
         => new Box<string> { Value = text, Label = text.OrFallback("empty") };
+
+    public static int NullableOrDefault(int? value)
+        => value ?? 42;
 
     public static string AnonymousSummary(string name, int count)
     {

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2722,6 +2722,32 @@ public class CfgSampleClass
         return a ?? b;
     }
 
+    public static int NullableValueCoalesce(int? value)
+    {
+        return value ?? 42;
+    }
+
+    public static int NullableValueParameterlessGetValueOrDefault(int? value)
+    {
+        return value.GetValueOrDefault();
+    }
+
+    public static void NullableValueGetValueOrDefaultStatement(int? value)
+    {
+        value.GetValueOrDefault(42);
+    }
+
+    public static int NullableValueGetValueOrDefaultSideEffect(int? value)
+    {
+        return value.GetValueOrDefault(NullableFallbackWithSideEffect());
+    }
+
+    static int NullableFallbackWithSideEffect()
+    {
+        LastValue++;
+        return 42;
+    }
+
     public static string NullCoalescingAssignLocal(string? input, string fallback)
     {
         string? value = input;

--- a/src/ILInspector.Decompiler.Tests/LadderRung2GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung2GateTests.cs
@@ -6,10 +6,11 @@ using ILInspector.Metadata;
 namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
-/// Narrow rung 2 guard for #1624/#1625: C# 3 object/collection initializer
+/// Narrow rung 2 guard for #1624/#1625/#1626: C# 3 object/collection initializer
 /// lowerings flowing through compiler temporaries must render as initializer
 /// syntax, and anonymous type locals must use source-level local spelling rather
-/// than generated metadata type names.
+/// than generated metadata type names, and nullable value-type coalesce must use
+/// source-level ?? syntax.
 /// </summary>
 public class LadderRung2GateTests
 {
@@ -30,12 +31,12 @@ public class LadderRung2GateTests
 
     static readonly string[] ExpectedMembers =
     [
-        "AnonymousSummary", "Main", "MakeCollectionInitializer", "MakeDirectReturn",
+        "AnonymousSummary", "Main", "MakeCollectionInitializer", "MakeDirectReturn", "NullableOrDefault",
     ];
 
     static readonly string[] ExpectedFullMembers =
     [
-        "Main", "MakeCollectionInitializer", "MakeDirectReturn",
+        "Main", "MakeCollectionInitializer", "MakeDirectReturn", "NullableOrDefault",
     ];
 
     [Fact]
@@ -82,6 +83,10 @@ public class LadderRung2GateTests
         Assert.Contains("info.Name", anonymous);
         Assert.Contains("info.Count", anonymous);
         Assert.DoesNotContain("AnonymousType", anonymous);
+
+        var nullable = Body("NullableOrDefault");
+        Assert.Contains("return value ?? 42;", nullable);
+        Assert.DoesNotContain("GetValueOrDefault", nullable);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
@@ -25,6 +25,7 @@ public class MemberIdentityTests
     static readonly TypeRef s_readOnlySpanInt = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [s_int]);
     static readonly TypeRef s_exception = TypeRef.CoreLib("System", "Exception");
     static readonly TypeRef s_exceptionDispatchInfo = TypeRef.CoreLib("System.Runtime.ExceptionServices", "ExceptionDispatchInfo");
+    static readonly TypeRef s_nullableInt = TypeRef.GenericInstance(TypeRef.CoreLib("System", "Nullable`1"), [s_int]);
 
     [Fact]
     public void IsCoreLibraryType_RequiresCoreLibraryIdentity()
@@ -101,6 +102,26 @@ public class MemberIdentityTests
             StringSubstringMethod(s_string, parameterCount: 2),
             isVirtual: true,
             [new LoadArgument(0, "s", s_string), new LoadArgument(1, "i", s_int)])));
+    }
+
+    [Fact]
+    public void IsNullableGetValueOrDefault_RequiresExactCorelibFallbackSignature()
+    {
+        Assert.True(MemberIdentity.IsNullableGetValueOrDefault(NullableGetValueOrDefault(s_nullableInt), out var valueType));
+        Assert.Equal(s_int, valueType);
+
+        Assert.False(MemberIdentity.IsNullableGetValueOrDefault(new Call(
+            NullableGetValueOrDefaultMethod(s_nullableInt) with
+            {
+                ParameterTypes = [],
+            },
+            isVirtual: false,
+            [new LoadArgumentAddress(0, "value", s_nullableInt)]), out _));
+
+        var lookalike = TypeRef.GenericInstance(
+            TypeRef.Definition("UserAssembly", "System", "Nullable`1"),
+            [s_int]);
+        Assert.False(MemberIdentity.IsNullableGetValueOrDefault(NullableGetValueOrDefault(lookalike), out _));
     }
 
     [Fact]
@@ -513,6 +534,15 @@ public class MemberIdentityTests
             StringSubstringMethod(declaringType, parameterCount),
             isVirtual: true,
             [(IrExpression)new LoadArgument(0, "s", s_string), .. Enumerable.Range(0, parameterCount).Select(i => new LoadArgument(i + 1, $"p{i}", s_int))]);
+
+    static MethodRef NullableGetValueOrDefaultMethod(TypeRef declaringType)
+        => new(declaringType, "GetValueOrDefault", s_int, [s_int], HasThis: true);
+
+    static Call NullableGetValueOrDefault(TypeRef declaringType)
+        => new(
+            NullableGetValueOrDefaultMethod(declaringType),
+            isVirtual: false,
+            [new LoadArgumentAddress(0, "value", declaringType), new LoadArgument(1, "fallback", s_int)]);
 
     static MethodRef SpanSliceMethod(TypeRef declaringType, int parameterCount)
         => new(declaringType, "Slice", declaringType, [.. Enumerable.Repeat(s_int, parameterCount)], HasThis: true);

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -58,6 +58,59 @@ public class NullCoalescingAssignmentPassTests
     }
 
     [Fact]
+    public void NullableGetValueOrDefault_WithFallback_RaisesToCoalesce()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullableValueCoalesce));
+
+        var coalesce = Assert.Single(function.Descendants.OfType<Coalesce>());
+        Assert.Equal("int", coalesce.ResultType?.ToDisplayString());
+        var output = CSharpPrinter.Print(function).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("return value ?? 42;", output);
+        Assert.DoesNotContain("GetValueOrDefault", output);
+    }
+
+    [Fact]
+    public void NullableGetValueOrDefault_Parameterless_StaysCall()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullableValueParameterlessGetValueOrDefault));
+
+        Assert.Empty(function.Descendants.OfType<Coalesce>());
+        var output = CSharpPrinter.Print(function).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("return value.GetValueOrDefault();", output);
+        Assert.DoesNotContain("??", output);
+    }
+
+    [Fact]
+    public void NullableGetValueOrDefault_StatementContext_RendersValidDiscard()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullableValueGetValueOrDefaultStatement));
+
+        Assert.Single(function.Descendants.OfType<Coalesce>());
+        var output = CSharpPrinter.Print(function).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("_ = value ?? 42;", output);
+        Assert.DoesNotContain("GetValueOrDefault", output);
+    }
+
+    [Fact]
+    public void NullableGetValueOrDefault_SideEffectingFallback_StaysCall()
+    {
+        var function = Raised(nameof(CfgSampleClass.NullableValueGetValueOrDefaultSideEffect));
+
+        Assert.Empty(function.Descendants.OfType<Coalesce>());
+        var output = CSharpPrinter.Print(function).Output;
+
+        Assert.NotNull(output);
+        Assert.Contains("return value.GetValueOrDefault(CfgSampleClass.NullableFallbackWithSideEffect());", output);
+        Assert.DoesNotContain("??", output);
+    }
+
+    [Fact]
     public void StaticFieldNullAssignmentDiamond_RaisesToNullCoalescingFieldAssignment()
     {
         var function = Raised(nameof(CfgSampleClass.NullCoalescingAssignStaticField));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1413,7 +1413,7 @@ public sealed partial class CSharpPrinter
         LogicalBinary l => LogicalText(l),
         Conditional t => ConditionalText(t),
         SwitchExpression se => SwitchExpressionInline(se),
-        Coalesce co => $"{Operand(co.Left)} ?? {Operand(co.Right)}",
+        Coalesce co => CoalesceText(co),
         NullConditional nc => NullConditionalText(nc),
         Unary { Kind: UnaryKind.Negate } u => $"-{Operand(u.Operand)}",
         Unary u => $"~{Operand(u.Operand)}",
@@ -1480,6 +1480,22 @@ public sealed partial class CSharpPrinter
         UnsupportedNode u => $"/* {u.Describe()} */",
         _ => $"/* {node.Describe()} */",
     };
+
+    string CoalesceText(Coalesce co)
+        => $"{CoalesceOperand(co.Left)} ?? {Operand(co.Right)}";
+
+    string CoalesceOperand(IrExpression expression)
+        => expression is LoadIndirect
+        {
+            Type:
+            {
+                Kind: TypeRefKind.GenericInstance,
+                ElementType: { Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Nullable`1" },
+            },
+            Address.ResultType.Kind: TypeRefKind.ByRef,
+        } load
+            ? DerefLoad(load)
+            : Operand(expression);
 
     /// <summary>Conditions render brtrue's raw value as-is; LogicalNot over a comparison folds via the shared type-aware duals (float folds flip the unordered flag).</summary>
     string Condition(IrExpression condition) => condition switch

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -890,9 +890,19 @@ public sealed class Coalesce : IrExpression
 
     public IrExpression Left => (IrExpression)Children[0];
     public IrExpression Right => (IrExpression)Children[1];
-    public override TypeRef? ResultType => Left.ResultType ?? Right.ResultType;
+    public override TypeRef? ResultType => NullableValueCoalesceResult(Left.ResultType, Right.ResultType) ?? Left.ResultType ?? Right.ResultType;
 
     public override string Describe() => "Coalesce";
+
+    static TypeRef? NullableValueCoalesceResult(TypeRef? left, TypeRef? right)
+        => left is
+        {
+            Kind: TypeRefKind.GenericInstance,
+            ElementType: { Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Nullable`1" },
+            TypeArguments: [var value],
+        } && right?.Equals(value) == true
+            ? value
+            : null;
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -162,6 +162,38 @@ public static class MemberIdentity
             && call.Callee.ParameterTypes.Length is 1 or 2
             && call.Arguments.Count == call.Callee.ParameterTypes.Length + 1;
 
+    public static bool IsNullableGetValueOrDefault(Call call, out TypeRef valueType)
+    {
+        valueType = TypeRef.Unsupported("unmatched nullable GetValueOrDefault");
+        if (call.IsVirtual
+            || call.Callee is not
+            {
+                HasThis: true,
+                Name: "GetValueOrDefault",
+                TypeArguments.IsEmpty: true,
+                DeclaringType:
+                {
+                    Kind: TypeRefKind.GenericInstance,
+                    ElementType: { } definition,
+                    TypeArguments: [var nullableValue],
+                } declaringType,
+                ReturnType: var returnType,
+                ParameterTypes: [var fallback],
+            }
+            || !IsCoreLibraryType(definition, "System", "Nullable`1")
+            || call.Arguments.Count != 2
+            || call.Arguments[0].ResultType is not { Kind: TypeRefKind.ByRef, ElementType: { } receiver }
+            || !receiver.Equals(declaringType)
+            || !returnType.Equals(nullableValue)
+            || !fallback.Equals(nullableValue))
+        {
+            return false;
+        }
+
+        valueType = nullableValue;
+        return true;
+    }
+
     public static bool IsSpanSlice(Call call)
     {
         if (call.IsVirtual

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -1,9 +1,9 @@
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Folds structured shapes into short-circuit boolean expressions and
-/// ternaries — the inverse of the compiler's condition lowering, running
-/// after structuring so the shapes are tree nodes:
+/// Folds structured shapes into short-circuit boolean expressions, ternaries, and
+/// value-typed nullable coalesce calls — the inverse of the compiler's condition
+/// lowering, running after structuring so the shapes are tree nodes:
 ///
 /// 1. Nested guards: <c>if (a) { if (b) { T } }</c> → <c>if (a &amp;&amp; b) { T }</c>.
 /// 2. Guard-return chains: <c>if (c) return A; return true;</c> →
@@ -241,6 +241,7 @@ public sealed class BooleanFoldingPass : IIrPass
                     || FoldElseReturn(function, statement, stepper)
                     || FoldTernaryReturn(statement, stepper)
                     || FoldSlotDiamond(function, statement, stepper) || FoldCoalesce(function, statement, stepper),
+                Call call => FoldNullableGetValueOrDefault(call, stepper),
                 Comparison comparison => FoldBoolConstantComparison(comparison, stepper),
                 Conditional conditional => MaterializeBoolConditional(function, conditional, stepper),
                 _ => false,
@@ -250,6 +251,31 @@ public sealed class BooleanFoldingPass : IIrPass
         }
         return false;
     }
+
+    static bool FoldNullableGetValueOrDefault(Call call, Stepper stepper)
+    {
+        if (!IsNullableCoalesceExpressionContext(call)
+            || !MemberIdentity.IsNullableGetValueOrDefault(call, out _))
+            return false;
+        if (call.Arguments[1] is not Constant)
+            return false;
+
+        var parts = call.DetachChildren();
+        var receiver = (IrExpression)parts[0];
+        var fallback = (IrExpression)parts[1];
+        var nullableValue = new LoadIndirect(call.Callee.DeclaringType, receiver);
+        stepper.StepOver("fold nullable GetValueOrDefault into ?? coalesce", call);
+        call.ReplaceWith(new Coalesce(nullableValue, fallback));
+        return true;
+    }
+
+    static bool IsNullableCoalesceExpressionContext(Call call)
+        => call.Parent switch
+        {
+            Block => false,
+            ForLoop loop when ReferenceEquals(loop.Initializer, call) || ReferenceEquals(loop.Increment, call) => false,
+            _ => true,
+        };
 
     /// <summary>
     /// <c>cond ? 0 : boolExpr</c> (and nested 0/1/bool conditionals) →


### PR DESCRIPTION
## Summary

Closes #1626. Progresses #1599 rung 2 / #1627.

- recovers exact corelib `Nullable<T>.GetValueOrDefault(constant)` calls as `value ?? constant`
- keeps parameterless and side-effecting fallback `GetValueOrDefault(...)` calls as calls
- extends the rung 2 fixture/gate with `NullableOrDefault(int? value) => value ?? 42`

## Shape proof

Positive output:

```csharp
public static int NullableOrDefault(System.Nullable<int> value) => value ?? 42;
```

Near miss still flat:

```csharp
public static int NullableValueGetValueOrDefaultSideEffect(System.Nullable<int> value) => value.GetValueOrDefault(CfgSampleClass.NullableFallbackWithSideEffect());
```

Opus 4.8 adversarial review found one high-severity issue in the first version: folding side-effecting fallbacks into `??` would make fallback evaluation conditional. Fixed by narrowing the fold to constant fallbacks and adding the side-effecting negative above. No remaining blocking issue from that review after the fix.

## Validation

```text
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded. 0 Warning(s), 0 Error(s)

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/NullCoalescingAssignmentPassTests/*"
ILInspector.Decompiler.Tests  Total: 30, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LadderRung2GateTests/*"
ILInspector.Decompiler.Tests  Total: 3, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/MemberIdentityTests/*"
ILInspector.Decompiler.Tests  Total: 17, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
ILInspector.Decompiler.Tests  Total: 1512, Errors: 0, Failed: 0, Skipped: 0
```

Rung 2 fixture harness:

```text
COMPILE-CHECK over 13 rendered methods (12 Full, 1 Partial)
Full malformed   : 0 (0.00% of Full)
Partial malformed: 0 (0.00% of Partial)
Semantic binding non-noise errors among Full: 0

GAPS over 21 methods (0 pass bugs)
fully raised : 14 (66.67%)
real gaps    : 7 (33.33%)
dominant residual: fidelity:(typed) on anonymous-type generated members
```

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,719 methods
Correctness coverage: validity sampled 350 / 88,719 (0.39%); fidelity sampled 36 / 88,719 (0.04%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (`--emit-corpus-baseline`) before trusting count-based regressions.

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,769 (87.87%) | 77,908 (87.81%) | +139 |
| Conditional-branch residual | 2,409 (2.72%) | 2,423 (2.73%) | +14 |
| Forward-merge stops | 2,144 (2.42%) | 2,158 (2.43%) | +14 |
| Full malformed | 32 | 32 | 0 |
| Semantic defects | 4/350 — sampled 350 / 88,500 (0.40%) | 4/350 — sampled 350 / 88,719 (0.39%) | 0 |
| Fidelity diffs | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 88,500 (0.04%) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 88,719 (0.04%) | 0 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate: Fully raised 89.67% -> 89.64% (-3 bps); conditional residual 2.85% -> 2.85% (0 bps); Full malformed 32 -> 32 (0); opcode diffs 1 -> 1 (0).

Verdict: corpus sensor matched baseline tolerances.
