### PR TITLE
Complete decompiler ladder rung 2 with a full-surface gate

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LadderRung2GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung2GateTests.cs
@@ -145,10 +145,13 @@ public class LadderRung2GateTests
         Assert.Equal("return this.Label;", Body(members, "Box`1::get_Label"));
         Assert.Equal("this.Label = value;", Body(members, "Box`1::set_Label"));
 
-        var formatWith = Body(members, "Box`1::FormatWith");
-        Assert.Contains("string.Concat(", formatWith);
-        Assert.Contains("Label", formatWith);
-        Assert.Contains("Value", formatWith);
+        // FormatWith binds to the ReadOnlySpan<object?> params overload (Value is the
+        // generic T), so the faithful, valid rendering is a C# 12 params collection
+        // expression. Pin it exactly so the guard fails on any other rendering rather
+        // than masking a regression behind a loose contains-check.
+        Assert.Equal(
+            "return string.Concat([Label, \":\", Value, \":\", value]);",
+            Body(members, "Box`1::FormatWith"));
 
         // Extension method definitions raise to recognizable bodies.
         var firstOrZero = Body(members, "LadderRung2Extensions::FirstOrZero");

--- a/src/ILInspector.Decompiler.Tests/LadderRung2GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung2GateTests.cs
@@ -6,16 +6,37 @@ using ILInspector.Metadata;
 namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
-/// Narrow rung 2 guard for #1624/#1625/#1626: C# 3 object/collection initializer
-/// lowerings flowing through compiler temporaries must render as initializer
-/// syntax, and anonymous type locals must use source-level local spelling rather
-/// than generated metadata type names, and nullable value-type coalesce must use
-/// source-level ?? syntax.
+/// The rung 2 completion guard for the decompiler product quality ladder (#1599):
+/// C# 2-3 structural basics. It decompiles the in-repo <see cref="LadderRung2"/>
+/// fixture and pins the scoped rung 2 bar across the full capability surface so a
+/// regression below it fails fast in PR CI:
+/// <list type="bullet">
+/// <item>the fixture exposes exactly the rung 2 member set across all three
+/// user-authored types — the <c>Program</c> driver, the generic <c>Box&lt;T&gt;</c>,
+/// and the extension class — so no construct is silently dropped;</item>
+/// <item>every member except the anonymous-type frontier renders <c>Full</c>;</item>
+/// <item>every member is fully raised — zero residual control flow;</item>
+/// <item>the rendered C# is recognizable for the rung 2 constructs: object and
+/// collection initializers (#1624), anonymous-type locals (#1625), nullable
+/// value-type coalesce (#1626), generic property/method bodies, and instance-style
+/// extension-call spelling;</item>
+/// <item><c>--validity-check</c> sees zero malformed <c>Full</c> methods and zero
+/// non-noise semantic-binding defects across the fixture.</item>
+/// </list>
+/// <c>AnonymousSummary</c> is pinned as the rung 2 honest-degrade frontier: the
+/// method body raises to a recognizable <c>var info = new { ... }</c> local, but the
+/// member stays <c>Partial</c> because the compiler-generated anonymous type is not
+/// source-recoverable at the type-declaration level. A future change that recovers it
+/// to <c>Full</c> should update this guard deliberately.
 /// </summary>
 public class LadderRung2GateTests
 {
     static string FixturePath => typeof(LadderRung2.Program).Assembly.Location;
-    static readonly string FixtureType = typeof(LadderRung2.Program).FullName!;
+
+    static readonly string ProgramType = typeof(LadderRung2.Program).FullName!;
+    static readonly string BoxType = typeof(LadderRung2.Box<>).FullName!;
+    static readonly string ExtensionsType = typeof(LadderRung2.LadderRung2Extensions).FullName!;
+    static readonly HashSet<string> FixtureTypes = [ProgramType, BoxType, ExtensionsType];
 
     static readonly Lazy<IReadOnlyDictionary<string, string>> s_runtimeAssemblies = new(() =>
         (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
@@ -29,42 +50,64 @@ public class LadderRung2GateTests
             ? path
             : null;
 
+    // The exact rung 2 construct set across every user-authored fixture type. Locked
+    // (type-qualified, duplicates included) so a future fixture edit that drops a
+    // construct or adds an overload fails loudly instead of silently shrinking scope.
     static readonly string[] ExpectedMembers =
     [
-        "AnonymousSummary", "Main", "MakeCollectionInitializer", "MakeDirectReturn", "NullableOrDefault",
+        // LadderRung2.Box`1 — generics.
+        "Box`1::.ctor", "Box`1::FormatWith",
+        "Box`1::get_Label", "Box`1::get_Value",
+        "Box`1::set_Label", "Box`1::set_Value",
+        // LadderRung2.LadderRung2Extensions — extension-call spelling.
+        "LadderRung2Extensions::FirstOrZero", "LadderRung2Extensions::OrFallback",
+        // LadderRung2.Program — initializers, anonymous types, nullable coalesce.
+        "Program::AnonymousSummary", "Program::Main",
+        "Program::MakeCollectionInitializer", "Program::MakeDirectReturn",
+        "Program::NullableOrDefault",
     ];
 
-    static readonly string[] ExpectedFullMembers =
-    [
-        "Main", "MakeCollectionInitializer", "MakeDirectReturn", "NullableOrDefault",
-    ];
+    // The anonymous-type local is the honest-degrade frontier: recognizable body, but
+    // the member stays Partial because the generated type is not source-recoverable.
+    const string AnonymousFrontier = "Program::AnonymousSummary";
 
     [Fact]
-    public void Rung2Fixture_ExposesExactScopedMemberSet_InitializerMembersAllFull()
+    public void Rung2Fixture_ExposesExactMemberSet_AllFullExceptAnonymousFrontier_AndFullyRaised()
     {
         var members = LoadRaisedMembers();
 
         Assert.Equal(
             ExpectedMembers,
-            members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
+            members.Select(m => m.Key).Order(StringComparer.Ordinal).ToArray());
 
         var notFull = members
-            .Where(m => ExpectedFullMembers.Contains(m.Name) && m.Function.Fidelity != DecompilationFidelity.Full)
-            .Select(m => m.Name)
+            .Where(m => m.Key != AnonymousFrontier && m.Function.Fidelity != DecompilationFidelity.Full)
+            .Select(m => m.Key)
             .Order(StringComparer.Ordinal)
             .ToArray();
         Assert.True(notFull.Length == 0,
-            "Rung 2 initializer slice requires every initializer fixture member to render Full; not Full: " + string.Join(", ", notFull));
+            "Rung 2 requires every fixture member except the anonymous-type frontier to render Full; not Full: " + string.Join(", ", notFull));
+
+        // The anonymous-type local is pinned Partial: an honest, owned residual. If
+        // this ever becomes Full, update the guard deliberately rather than silently.
+        var anonymous = members.Single(m => m.Key == AnonymousFrontier).Function;
+        Assert.Equal(DecompilationFidelity.Partial, anonymous.Fidelity);
+
+        var gaps = members
+            .Where(m => Completeness.Residual(m.Function) is not null)
+            .Select(m => m.Key)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(gaps.Length == 0,
+            "Rung 2 requires every fixture member to be fully raised (zero residual gaps); gaps: " + string.Join(", ", gaps));
     }
 
     [Fact]
     public void Rung2Fixture_RendersInitializerChainsRecognizably()
     {
         var members = LoadRaisedMembers();
-        string Body(string name) =>
-            CSharpPrinter.PrintRaised(members.Single(m => m.Name == name).Function).Output?.Trim() ?? "";
 
-        var main = Body("Main");
+        var main = Body(members, "Program::Main");
         Assert.Contains("new Box<int> { Value = 3, Label = \"three\" }", main);
         Assert.Contains("new List<int> { 1, 2, 3 }", main);
         Assert.DoesNotContain(".Value = 3;", main);
@@ -73,45 +116,112 @@ public class LadderRung2GateTests
 
         Assert.Contains(
             "return new List<int> { 1, 2, 3 };",
-            Body("MakeCollectionInitializer"));
+            Body(members, "Program::MakeCollectionInitializer"));
         Assert.Contains(
             "return new Box<string> { Value = text, Label = text.OrFallback(\"empty\") };",
-            Body("MakeDirectReturn"));
+            Body(members, "Program::MakeDirectReturn"));
 
-        var anonymous = Body("AnonymousSummary");
+        var anonymous = Body(members, "Program::AnonymousSummary");
         Assert.Contains("var info = new { Name = name, Count = count };", anonymous);
         Assert.Contains("info.Name", anonymous);
         Assert.Contains("info.Count", anonymous);
         Assert.DoesNotContain("AnonymousType", anonymous);
 
-        var nullable = Body("NullableOrDefault");
+        var nullable = Body(members, "Program::NullableOrDefault");
         Assert.Contains("return value ?? 42;", nullable);
         Assert.DoesNotContain("GetValueOrDefault", nullable);
     }
 
     [Fact]
-    public void Rung2Fixture_HasNoMalformedScopedMethods()
+    public void Rung2Fixture_RendersGenericsAndExtensionCallsRecognizably()
     {
-        var malformed = ValidityCheck.Evaluate(FixturePath)
-            .Where(r => r.TypeName == FixtureType && ExpectedMembers.Contains(r.MethodName) && r.IsMalformed)
-            .Select(r => $"{r.MethodName}: {r.MalformedDiagnostics[0].Id} {r.MalformedDiagnostics[0].Message}")
-            .Order(StringComparer.Ordinal)
-            .ToArray();
+        var members = LoadRaisedMembers();
 
-        Assert.True(malformed.Length == 0,
-            "Rung 2 fixture slice requires zero malformed scoped methods; malformed: " + string.Join("; ", malformed));
+        // Generic Box<T> property/method bodies render with ordinary field/member
+        // access — this catches intra-fixture misrenders the validity shell filters
+        // as member-resolution noise.
+        Assert.Equal("return this.Value;", Body(members, "Box`1::get_Value"));
+        Assert.Equal("this.Value = value;", Body(members, "Box`1::set_Value"));
+        Assert.Equal("return this.Label;", Body(members, "Box`1::get_Label"));
+        Assert.Equal("this.Label = value;", Body(members, "Box`1::set_Label"));
+
+        var formatWith = Body(members, "Box`1::FormatWith");
+        Assert.Contains("string.Concat(", formatWith);
+        Assert.Contains("Label", formatWith);
+        Assert.Contains("Value", formatWith);
+
+        // Extension method definitions raise to recognizable bodies.
+        var firstOrZero = Body(members, "LadderRung2Extensions::FirstOrZero");
+        Assert.Contains("values.Count", firstOrZero);
+        Assert.Contains("return values[0];", firstOrZero);
+        Assert.Contains("return 0;", firstOrZero);
+
+        var orFallback = Body(members, "LadderRung2Extensions::OrFallback");
+        Assert.Contains("string.IsNullOrEmpty(value)", orFallback);
+        Assert.Contains("return value;", orFallback);
+        Assert.Contains("return fallback;", orFallback);
+
+        // Extension calls render in instance form at the call site, not as static
+        // helper calls on the extension class.
+        var main = Body(members, "Program::Main");
+        Assert.Contains("values.FirstOrZero()", main);
+        Assert.DoesNotContain("LadderRung2Extensions.FirstOrZero", main);
+        Assert.DoesNotContain("LadderRung2Extensions.OrFallback", Body(members, "Program::MakeDirectReturn"));
     }
 
-    static List<(string Name, IrFunction Function)> LoadRaisedMembers()
+    [Fact]
+    public void Rung2Fixture_HasNoMalformedOrSemanticDefects()
     {
-        var members = new List<(string Name, IrFunction Function)>();
+        var results = ValidityCheck.Evaluate(FixturePath)
+            .Where(r => FixtureTypes.Contains(r.TypeName))
+            .ToList();
+
+        Assert.NotEmpty(results);
+
+        var malformed = results
+            .Where(r => r.IsFull && r.IsMalformed)
+            .Select(r => $"{r.TypeName}::{r.MethodName}: {r.MalformedDiagnostics[0].Id} {r.MalformedDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(malformed.Length == 0,
+            "Rung 2 requires zero malformed Full methods; malformed: " + string.Join("; ", malformed));
+
+        var semantic = results
+            .Where(r => r.HasSemanticDefect)
+            .Select(r => $"{r.TypeName}::{r.MethodName}: {r.SemanticDiagnostics[0].Id} {r.SemanticDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(semantic.Length == 0,
+            "Rung 2 requires zero semantic-binding defects; defects: " + string.Join("; ", semantic));
+
+        // Guard against a vacuous pass: every Full member must actually have been
+        // bound (not skipped by the cap), so the semantic assertion has teeth.
+        Assert.All(
+            results.Where(r => r.IsFull),
+            r => Assert.True(r.SemanticChecked, $"Full method {r.TypeName}::{r.MethodName} was not semantically bound."));
+    }
+
+    static string Body(List<(string Key, IrFunction Function)> members, string key) =>
+        CSharpPrinter.PrintRaised(members.Single(m => m.Key == key).Function).Output?.Trim() ?? "";
+
+    // ImportAssembly yields metadata type names (e.g. LadderRung2.Box`1). Build a
+    // stable, namespace-stripped member key so the locked member set stays readable.
+    static string Simple(string typeName)
+    {
+        var dot = typeName.LastIndexOf('.');
+        return dot >= 0 ? typeName[(dot + 1)..] : typeName;
+    }
+
+    static List<(string Key, IrFunction Function)> LoadRaisedMembers()
+    {
+        var members = new List<(string Key, IrFunction Function)>();
         using var source = MetadataSource.Open(FixturePath, locator: RuntimeLocator);
         foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
         {
-            if (typeName != FixtureType)
+            if (!FixtureTypes.Contains(typeName))
                 continue;
             IrPasses.Run(function);
-            members.Add((methodName, function));
+            members.Add(($"{Simple(typeName)}::{methodName}", function));
         }
         return members;
     }


### PR DESCRIPTION
## Summary

Completes #1599 rung 2 (C# 2-3 structural basics). The three rung 2 blockers already merged — #1624 (initializer chains) -> #1671, #1625 (anonymous-type locals) -> #1680, #1626 (nullable coalesce) -> #1686 — but `LadderRung2GateTests` was only scoped to `LadderRung2.Program`. It never guarded two explicit rung 2 capability targets (**generics** and **extension-call spelling**) and, unlike the rung 1/3 completion gates, never asserted **zero residual gaps**. So row 2 was effectively "blockers burned down" but not "rung complete".

This PR turns the gate into a true completion guard over the full rung 2 surface — **test-only, no product or central-file churn.**

## What the gate now pins

Across all three user-authored fixture types (`Program`, the generic `Box<T>`, and the extension class):

- **Exact type-qualified member set** (13 members) — drops/overloads fail loudly.
- **Every member `Full`** except the pinned anonymous-type honest-degrade frontier: `AnonymousSummary` stays `Partial` because the compiler-generated anonymous type is not source-recoverable; its body still raises to `var info = new { ... }`.
- **Zero residual gaps** for every member.
- **Recognizable C#**: object/collection initializers, anonymous local, nullable coalesce (`value ?? 42`), generic `Box<T>` property/method bodies (`return this.Value;`, `string.Concat(...)`), and instance-style extension calls (`values.FirstOrZero()`, not the static helper spelling).
- **Zero malformed `Full` / non-noise semantic defects** across the fixture, with a non-vacuous `SemanticChecked` guard. The validity filter shares `IrImporter` type names, so the generic `Box` type is genuinely covered (the anonymous type is excluded by the harness angle-bracket skip).

## Validation

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LadderRung2GateTests
  Total: 4, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
  Total: 1513, Errors: 0, Failed: 0, Skipped: 0

dotnet build src/dotnet-inspect -c Release
  Build succeeded. 0 Warning(s), 0 Error(s)
```

Measured fixture state (product import path): generic `Box<T>` members and both extension methods render `Full` and clean; `AnonymousSummary` is honest `Partial`; all members have zero residual.

Adversarial review to follow per the rung workflow.
