### PR TITLE
Burn down rung 1 foundation guard + throw-expression residual (#1599)

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung1/Foundation.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung1/Foundation.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+
+namespace LadderRung1;
+
+// Rung 1 foundation control flow for the decompiler product quality ladder
+// (#1599 / #1691). The original LadderRung1.Program fixture only guards
+// methods/locals/calls/fields/properties and simple if/return branches, yet the
+// rung is labeled the "Straightforward syntax foundation". This type adds the
+// core C# 1 control-flow surface that was working but unguarded: loops, switch
+// statements, arrays, try/catch/finally, exception filters, and using
+// statements. LadderRung1FoundationGateTests decompiles this type and pins the
+// same scoped bar as the Program gate (every member imports + renders Full,
+// fully raised with zero gaps, zero malformed Full / semantic-binding defects),
+// so a regression below the foundation bar fails fast in PR CI.
+public class Foundation
+{
+    // for loop.
+    public int ForLoop(int n)
+    {
+        int sum = 0;
+        for (int i = 0; i < n; i++)
+        {
+            sum += i;
+        }
+        return sum;
+    }
+
+    // while loop.
+    public int WhileLoop(int n)
+    {
+        int sum = 0;
+        while (n > 0)
+        {
+            sum += n;
+            n--;
+        }
+        return sum;
+    }
+
+    // do/while loop.
+    public int DoWhileLoop(int n)
+    {
+        int sum = 0;
+        do
+        {
+            sum += n;
+            n--;
+        }
+        while (n > 0);
+        return sum;
+    }
+
+    // foreach over an array.
+    public int ForEachLoop(int[] values)
+    {
+        int sum = 0;
+        foreach (int value in values)
+        {
+            sum += value;
+        }
+        return sum;
+    }
+
+    // Dense int switch (a jump-table switch the IL actually encodes, so the
+    // switch shape is recoverable — unlike a 2-3 case switch, which the compiler
+    // lowers to compare branches that are IL-identical to if/else).
+    public string Switch(int code)
+    {
+        switch (code)
+        {
+            case 0: return "zero";
+            case 1: return "one";
+            case 2: return "two";
+            case 3: return "three";
+            case 4: return "four";
+            case 5: return "five";
+            default: return "many";
+        }
+    }
+
+    // Array allocation, indexing, and assignment.
+    public int[] ArrayCreateAndIndex(int n)
+    {
+        int[] result = new int[n];
+        for (int i = 0; i < n; i++)
+        {
+            result[i] = i * i;
+        }
+        return result;
+    }
+
+    // Array literal.
+    public int[] ArrayLiteral()
+    {
+        return new int[] { 1, 2, 3, 4 };
+    }
+
+    // try/catch/finally.
+    public int TryCatchFinally(int x)
+    {
+        try
+        {
+            return 100 / x;
+        }
+        catch (DivideByZeroException)
+        {
+            return -1;
+        }
+        finally
+        {
+            Console.WriteLine("done");
+        }
+    }
+
+    // Exception filter (catch when).
+    public int TryCatchFilter(int x)
+    {
+        try
+        {
+            return 100 / x;
+        }
+        catch (Exception error) when (error.Message.Length > 3)
+        {
+            return -2;
+        }
+    }
+
+    // using statement.
+    public long UsingStatement()
+    {
+        using (MemoryStream stream = new MemoryStream())
+        {
+            return stream.Length;
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Fixtures.LadderRung1/ProductSurface.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung1/ProductSurface.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LadderRung1;
+
+// Rung 1 product-path surface for the decompiler product quality ladder (#1599 /
+// #1695). These C# 2-7 forms only recover correctly through the *product* path —
+// the one users hit via `dotnet-inspect type ... -S "Decompiled Source"` — which
+// wires the cross-method import seam and a platform assembly locator. The bare
+// per-method seam the other rung gates ride does NOT wire those, so it
+// under-resolves these constructs (lambdas leak <>c names, cross-assembly
+// out-args render `ref`). LadderRung1ProductPathGateTests composes this type
+// through TypeSourceComposer with a runtime platform locator and pins the real
+// product rendering, closing the seam-vs-product blind spot. Other rungs can
+// follow this same model for seam-sensitive constructs.
+public class ProductSurface
+{
+    // C# 3 lambda — raised through the cross-method import seam.
+    public Func<int, int> Lambda()
+    {
+        return x => x * 2;
+    }
+
+    // C# 3 lambda capturing a local — display-class environment folded back.
+    public Func<int, int> CapturingLambda(int factor)
+    {
+        return x => x * factor;
+    }
+
+    // C# 3 LINQ — query operators with raised lambda arguments.
+    public IEnumerable<int> LinqQuery(int[] values)
+    {
+        return from value in values where value > 0 select value * 2;
+    }
+
+    // C# 7 out variable to a cross-assembly method — the platform locator
+    // resolves int.TryParse's parameter rows so the call renders `out`, not `ref`.
+    public bool OutVariable(string text)
+    {
+        return int.TryParse(text, out int result) && result > 0;
+    }
+}

--- a/src/ILInspector.Decompiler.Fixtures.LadderRung1/Residuals.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung1/Residuals.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace LadderRung1;
+
+// Rung 1 owned residuals for the decompiler product quality ladder (#1599 /
+// #1693). Some mainstream C# 2-7 expression forms decompile to valid, fully
+// raised C# at a lower source altitude than the original spelling. They are not
+// gaps (the output is Full and binds), but they are not the highest-altitude
+// recovery either, so they are pinned here as explicitly owned residuals: the
+// guard locks the current valid form so it cannot silently regress to invalid
+// output, and documents the altitude that a future raise could still improve.
+public class OwnedResiduals
+{
+    // C# 7 throw expression. `s ?? throw new ArgumentNullException(nameof(s))`
+    // recovers as a valid `if (temp is null) throw ...; return temp;` null-check
+    // statement rather than the `?? throw` expression. Recovering the expression
+    // form is a separate, risk-bearing raise (a hand-written null-check-then-throw
+    // is a legitimate alternative source for the same IL), so it is deferred; the
+    // current rendering is valid and owned. See #1693.
+    public string ThrowExpression(string s)
+    {
+        return s ?? throw new ArgumentNullException(nameof(s));
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/LadderRung1FoundationGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1FoundationGateTests.cs
@@ -1,0 +1,163 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The rung 1 <em>foundation control-flow</em> guard for the decompiler product
+/// quality ladder (#1599 / #1691). <see cref="LadderRung1GateTests"/> only guards
+/// methods/locals/calls/fields/properties and simple <c>if</c>/return branches,
+/// yet rung 1 is the "Straightforward syntax foundation". This gate adds the core
+/// C# 1 control-flow surface that was working but unguarded — loops, switch,
+/// arrays, try/catch/finally, exception filters, and using statements — and pins
+/// the same scoped bar as the <see cref="LadderRung1.Foundation"/> fixture so a
+/// regression below it fails fast in PR CI:
+/// <list type="bullet">
+/// <item>the fixture exposes exactly the foundation member set (incl. the
+/// constructor) — no construct is silently dropped;</item>
+/// <item>every member imports and renders as <c>Full</c>;</item>
+/// <item>every member is fully raised — zero residual control flow;</item>
+/// <item>the rendered C# is recognizable for each foundation construct (the loop
+/// keyword, a real <c>switch</c>, array creation/indexing, the EH keywords, the
+/// <c>using</c> statement) — this catches intra-fixture misrenders that the
+/// validity shell would filter as member-resolution noise;</item>
+/// <item><c>--validity-check</c> sees zero malformed <c>Full</c> methods and zero
+/// non-noise semantic-binding defects.</item>
+/// </list>
+/// Like <see cref="LadderRung1GateTests"/> this is the fast depth-scoped bar, not
+/// a corpus sweep or compile-back opcode check.
+/// </summary>
+public class LadderRung1FoundationGateTests
+{
+    static string FixturePath => typeof(LadderRung1.Foundation).Assembly.Location;
+    static readonly string FixtureType = typeof(LadderRung1.Foundation).FullName!;
+
+    // The exact foundation control-flow construct set. Locked so a future fixture
+    // edit that drops a construct fails loudly instead of silently shrinking the
+    // measured scope.
+    static readonly string[] ExpectedMembers =
+    [
+        ".ctor",
+        "ArrayCreateAndIndex", "ArrayLiteral",
+        "DoWhileLoop", "ForEachLoop", "ForLoop",
+        "Switch",
+        "TryCatchFilter", "TryCatchFinally",
+        "UsingStatement", "WhileLoop",
+    ];
+
+    [Fact]
+    public void Rung1Foundation_ExposesExactMemberSet_AllFullAndFullyRaised()
+    {
+        var members = LoadRaisedMembers();
+
+        Assert.Equal(
+            ExpectedMembers,
+            members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
+
+        var notFull = members
+            .Where(m => m.Function.Fidelity != DecompilationFidelity.Full)
+            .Select(m => m.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(notFull.Length == 0,
+            "Rung 1 foundation requires every member to render Full; not Full: " + string.Join(", ", notFull));
+
+        var gaps = members
+            .Where(m => Completeness.Residual(m.Function) is not null)
+            .Select(m => m.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(gaps.Length == 0,
+            "Rung 1 foundation requires every member to be fully raised (zero residual gaps); gaps: " + string.Join(", ", gaps));
+    }
+
+    [Fact]
+    public void Rung1Foundation_RendersRecognizableControlFlow()
+    {
+        var members = LoadRaisedMembers();
+        string Body(string name) =>
+            CSharpPrinter.PrintRaised(members.Single(m => m.Name == name).Function).Output?.Trim() ?? "";
+
+        // Loops render with their source keyword, not a goto ladder.
+        Assert.Contains("for (int i = 0; i < n; i++)", Body("ForLoop"));
+        Assert.Contains("while (n > 0)", Body("WhileLoop"));
+        var doWhile = Body("DoWhileLoop");
+        Assert.Contains("do", doWhile);
+        Assert.Contains("while (n > 0);", doWhile);
+        Assert.Contains("foreach (int value in values)", Body("ForEachLoop"));
+
+        // A dense switch recovers as a real switch statement.
+        var sw = Body("Switch");
+        Assert.Contains("switch (code)", sw);
+        Assert.Contains("case 0:", sw);
+        Assert.Contains("case 5:", sw);
+        Assert.Contains("default:", sw);
+
+        // Array creation, indexing, and the array literal.
+        var arr = Body("ArrayCreateAndIndex");
+        Assert.Contains("new int[n]", arr);
+        Assert.Contains("[i] = i * i;", arr);
+        Assert.Contains("new int[] { 1, 2, 3, 4 }", Body("ArrayLiteral"));
+
+        // try/catch/finally keywords are all present.
+        var tcf = Body("TryCatchFinally");
+        Assert.Contains("try", tcf);
+        Assert.Contains("catch (DivideByZeroException)", tcf);
+        Assert.Contains("finally", tcf);
+
+        // Exception filter renders the when-clause, not a rethrow ladder.
+        var filter = Body("TryCatchFilter");
+        Assert.Contains("catch (Exception", filter);
+        Assert.Contains("when (", filter);
+
+        // using statement renders the using keyword and disposable acquisition.
+        Assert.Contains("using (MemoryStream stream = new MemoryStream())", Body("UsingStatement"));
+    }
+
+    [Fact]
+    public void Rung1Foundation_HasNoMalformedOrSemanticDefects()
+    {
+        var results = ValidityCheck.Evaluate(FixturePath)
+            .Where(r => r.TypeName == FixtureType)
+            .ToList();
+
+        Assert.NotEmpty(results);
+
+        var malformed = results
+            .Where(r => r.IsFull && r.IsMalformed)
+            .Select(r => $"{r.MethodName}: {r.MalformedDiagnostics[0].Id} {r.MalformedDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(malformed.Length == 0,
+            "Rung 1 foundation requires zero malformed Full methods; malformed: " + string.Join("; ", malformed));
+
+        var semantic = results
+            .Where(r => r.HasSemanticDefect)
+            .Select(r => $"{r.MethodName}: {r.SemanticDiagnostics[0].Id} {r.SemanticDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(semantic.Length == 0,
+            "Rung 1 foundation requires zero semantic-binding defects; defects: " + string.Join("; ", semantic));
+
+        // Guard against a vacuous pass: every Full member must actually have been
+        // bound (not skipped by the cap), so the semantic assertion has teeth.
+        Assert.All(
+            results.Where(r => r.IsFull),
+            r => Assert.True(r.SemanticChecked, $"Full method {r.MethodName} was not semantically bound."));
+    }
+
+    static List<(string Name, IrFunction Function)> LoadRaisedMembers()
+    {
+        var members = new List<(string Name, IrFunction Function)>();
+        using var source = MetadataSource.Open(FixturePath);
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (typeName != FixtureType)
+                continue;
+            IrPasses.Run(function);
+            members.Add((methodName, function));
+        }
+        return members;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/LadderRung1ProductPathGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1ProductPathGateTests.cs
@@ -96,8 +96,8 @@ public class LadderRung1ProductPathGateTests
         var linq = Body("LinqQuery");
         Assert.Contains(".Where", linq);
         Assert.Contains(".Select", linq);
-        Assert.Contains("value > 0", linq);
-        Assert.Contains("value * 2", linq);
+        Assert.Contains("value => value > 0", linq);
+        Assert.Contains("value => value * 2", linq);
 
         // The cross-assembly out-variable resolves to `out`, not `ref` — the
         // platform locator reads int.TryParse's real parameter rows (#1692).

--- a/src/ILInspector.Decompiler.Tests/LadderRung1ProductPathGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1ProductPathGateTests.cs
@@ -1,0 +1,154 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+using ILInspector.Metadata;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The rung 1 <em>product-path</em> guard for the decompiler product quality
+/// ladder (#1599 / #1695). The other rung gates ride the bare per-method seam
+/// (no cross-method import callback, no platform assembly locator), which is fine
+/// for self-contained syntax but <em>under-resolves</em> the constructs that only
+/// recover through the path users actually hit (<c>dotnet-inspect type … -S
+/// "Decompiled Source"</c>): lambdas and LINQ need the cross-method import seam,
+/// and cross-assembly <c>out</c>/<c>ref</c>/<c>in</c> arguments need a platform
+/// locator. On the seam alone those degrade (lambdas leak <c>&lt;&gt;c</c> names,
+/// a cross-assembly <c>out</c> arg renders <c>ref</c>) even though the product
+/// renders them correctly — exactly the seam-vs-product gap that made the
+/// cross-assembly out-variable look like a bug (#1692).
+///
+/// <para>This gate composes the <see cref="LadderRung1.ProductSurface"/> fixture
+/// through the same wiring the product uses — a TPA-backed platform locator on
+/// the <see cref="MetadataSource"/> plus the cross-method import seam on
+/// <see cref="CSharpPrinter"/> — and pins the real product rendering: lambdas
+/// raise to <c>x =&gt; …</c>, LINQ to a raised operator chain, and the
+/// cross-assembly out-variable to <c>out</c>. It is the reusable model for any
+/// rung that needs to guard seam-sensitive constructs at product fidelity.</para>
+/// </summary>
+public class LadderRung1ProductPathGateTests
+{
+    static string FixturePath => typeof(LadderRung1.ProductSurface).Assembly.Location;
+    static readonly string FixtureType = typeof(LadderRung1.ProductSurface).FullName!;
+
+    // Platform locator backed by the running runtime's trusted-platform-assembly
+    // list — always populated for the host runtime, so it resolves the fixture's
+    // framework references (System.Private.CoreLib for int.TryParse) without
+    // depending on SDK/shared-framework discovery. Only Platform-trust references
+    // resolve, so a planted local copy can never satisfy a platform name. This is
+    // the same convention LadderRung2GateTests uses.
+    static readonly Lazy<IReadOnlyDictionary<string, string>> s_runtimeAssemblies = new(() =>
+        (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+        .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+        .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+        .GroupBy(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase)
+        .ToDictionary(group => group.Key!, group => group.First(), StringComparer.OrdinalIgnoreCase));
+
+    static readonly AssemblyLocator RuntimeLocator = (name, trust) =>
+        trust == AssemblyTrust.Platform && s_runtimeAssemblies.Value.TryGetValue(name, out var path)
+            ? path
+            : null;
+
+    static readonly string[] ExpectedMembers =
+    [
+        ".ctor", "CapturingLambda", "Lambda", "LinqQuery", "OutVariable",
+    ];
+
+    [Fact]
+    public void Rung1ProductPath_ExposesExactMemberSet_AllFullAndFullyRaised()
+    {
+        var members = LoadProductPathMembers();
+
+        Assert.Equal(
+            ExpectedMembers,
+            members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
+
+        var notFull = members
+            .Where(m => m.Function.Fidelity != DecompilationFidelity.Full)
+            .Select(m => m.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(notFull.Length == 0,
+            "Rung 1 product path requires every member to render Full; not Full: " + string.Join(", ", notFull));
+
+        var gaps = members
+            .Where(m => Completeness.Residual(m.Function) is not null)
+            .Select(m => m.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(gaps.Length == 0,
+            "Rung 1 product path requires every member to be fully raised; gaps: " + string.Join(", ", gaps));
+    }
+
+    [Fact]
+    public void Rung1ProductPath_RaisesSeamSensitiveConstructs_AtProductFidelity()
+    {
+        var members = LoadProductPathMembers();
+        string Body(string name) => members.Single(m => m.Name == name).Body;
+
+        // Lambdas raise to expression-lambda syntax (cross-method import seam).
+        Assert.Contains("x => x * 2", Body("Lambda"));
+        Assert.Contains("x => x * factor", Body("CapturingLambda"));
+
+        // LINQ raises to a recognizable operator chain with raised lambda args.
+        var linq = Body("LinqQuery");
+        Assert.Contains(".Where", linq);
+        Assert.Contains(".Select", linq);
+        Assert.Contains("value > 0", linq);
+        Assert.Contains("value * 2", linq);
+
+        // The cross-assembly out-variable resolves to `out`, not `ref` — the
+        // platform locator reads int.TryParse's real parameter rows (#1692).
+        var outVar = Body("OutVariable");
+        Assert.Contains("int.TryParse(text, out result)", outVar);
+        Assert.DoesNotContain("ref result", outVar);
+
+        // No member leaks compiler-generated scaffolding into Full product output.
+        foreach (var (name, _, body) in members)
+        {
+            Assert.DoesNotContain("<>", body);
+            Assert.DoesNotContain("b__", body);
+            Assert.DoesNotContain("DisplayClass", body);
+        }
+    }
+
+    [Fact]
+    public void Rung1ProductPath_OutputIsSyntacticallyValid()
+    {
+        var members = LoadProductPathMembers();
+
+        // Parsing each body as a method body catches the degraded forms this gate
+        // exists to prevent: a leaked `<>c` name is not a legal C# identifier, so
+        // seam/locator regressions surface as parse errors here, not just as a
+        // failed substring assertion.
+        foreach (var (name, _, body) in members)
+        {
+            var tree = CSharpSyntaxTree.ParseText($"class Shell {{ object M() {{ {body} }} }}",
+                cancellationToken: TestContext.Current.CancellationToken);
+            var errors = tree.GetDiagnostics(TestContext.Current.CancellationToken)
+                .Where(d => d.Severity == DiagnosticSeverity.Error)
+                .Select(d => d.ToString())
+                .ToArray();
+            Assert.True(errors.Length == 0,
+                $"Rung 1 product path member {name} did not parse as valid C#: " + string.Join("; ", errors));
+        }
+    }
+
+    static List<(string Name, IrFunction Function, string Body)> LoadProductPathMembers()
+    {
+        var members = new List<(string Name, IrFunction Function, string Body)>();
+        using var source = MetadataSource.Open(FixturePath, locator: RuntimeLocator);
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (typeName != FixtureType)
+                continue;
+            // Product wiring: the import seam raises cross-method lambda bodies,
+            // and the locator on `source` resolves cross-assembly ref-kinds.
+            var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+            members.Add((methodName, function, (result.Output ?? "").Trim()));
+        }
+        return members;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/LadderRung1ResidualGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1ResidualGateTests.cs
@@ -19,6 +19,37 @@ public class LadderRung1ResidualGateTests
     static string FixturePath => typeof(LadderRung1.OwnedResiduals).Assembly.Location;
     static readonly string FixtureType = typeof(LadderRung1.OwnedResiduals).FullName!;
 
+    // The exact owned-residual member set. Locked (like the foundation gate) so a
+    // new residual added to the fixture cannot slip in unguarded — every owned
+    // residual must stay Full and fully raised, never an unowned gap.
+    static readonly string[] ExpectedMembers = [".ctor", "ThrowExpression"];
+
+    [Fact]
+    public void Residuals_ExposeExactMemberSet_AllFullAndFullyRaised()
+    {
+        var members = LoadRaisedMembers();
+
+        Assert.Equal(
+            ExpectedMembers,
+            members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
+
+        var notFull = members
+            .Where(m => m.Function.Fidelity != DecompilationFidelity.Full)
+            .Select(m => m.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(notFull.Length == 0,
+            "Owned residuals must render Full (valid, not a gap); not Full: " + string.Join(", ", notFull));
+
+        var gaps = members
+            .Where(m => Completeness.Residual(m.Function) is not null)
+            .Select(m => m.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(gaps.Length == 0,
+            "Owned residuals must be fully raised (zero residual gaps); gaps: " + string.Join(", ", gaps));
+    }
+
     [Fact]
     public void ThrowExpression_RendersValidLowerAltitudeNullCheck_OwnedResidual()
     {

--- a/src/ILInspector.Decompiler.Tests/LadderRung1ResidualGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1ResidualGateTests.cs
@@ -1,0 +1,84 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Rung 1 owned-residual guard for the decompiler product quality ladder (#1599 /
+/// #1693). The <see cref="LadderRung1.OwnedResiduals"/> fixture holds mainstream
+/// C# 2-7 forms that decompile to <em>valid, fully raised</em> C# at a lower
+/// source altitude than the original spelling. This gate keeps those residuals
+/// honest and owned: it asserts the output is <c>Full</c> and free of malformed /
+/// semantic defects (so it can never silently regress to invalid), while pinning
+/// the current lower-altitude shape so a future raise that improves the altitude
+/// is a deliberate, visible change.
+/// </summary>
+public class LadderRung1ResidualGateTests
+{
+    static string FixturePath => typeof(LadderRung1.OwnedResiduals).Assembly.Location;
+    static readonly string FixtureType = typeof(LadderRung1.OwnedResiduals).FullName!;
+
+    [Fact]
+    public void ThrowExpression_RendersValidLowerAltitudeNullCheck_OwnedResidual()
+    {
+        var (name, function) = LoadRaisedMembers().Single(m => m.Name == "ThrowExpression");
+
+        // Owned residual: valid and fully raised, just below `?? throw` altitude.
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Null(Completeness.Residual(function));
+
+        var body = CSharpPrinter.PrintRaised(function).Output ?? "";
+        // The current (owned) altitude is the null-check statement form, and the
+        // nameof argument is correctly constant-folded to the literal "s".
+        Assert.Contains("is null", body);
+        Assert.Contains("throw new ArgumentNullException(\"s\")", body);
+        // Pin the residual: it is NOT yet the `?? throw` expression. If a future
+        // change raises the altitude, this assertion forces an intentional update.
+        Assert.DoesNotContain("?? throw", body);
+    }
+
+    [Fact]
+    public void Residuals_HaveNoMalformedOrSemanticDefects()
+    {
+        var results = ValidityCheck.Evaluate(FixturePath)
+            .Where(r => r.TypeName == FixtureType)
+            .ToList();
+
+        Assert.NotEmpty(results);
+
+        var malformed = results
+            .Where(r => r.IsFull && r.IsMalformed)
+            .Select(r => $"{r.MethodName}: {r.MalformedDiagnostics[0].Id} {r.MalformedDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(malformed.Length == 0,
+            "Owned residuals must stay valid (zero malformed Full methods); malformed: " + string.Join("; ", malformed));
+
+        var semantic = results
+            .Where(r => r.HasSemanticDefect)
+            .Select(r => $"{r.MethodName}: {r.SemanticDiagnostics[0].Id} {r.SemanticDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(semantic.Length == 0,
+            "Owned residuals must stay valid (zero semantic-binding defects); defects: " + string.Join("; ", semantic));
+
+        Assert.All(
+            results.Where(r => r.IsFull),
+            r => Assert.True(r.SemanticChecked, $"Full method {r.MethodName} was not semantically bound."));
+    }
+
+    static List<(string Name, IrFunction Function)> LoadRaisedMembers()
+    {
+        var members = new List<(string Name, IrFunction Function)>();
+        using var source = MetadataSource.Open(FixturePath);
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (typeName != FixtureType)
+                continue;
+            IrPasses.Run(function);
+            members.Add((methodName, function));
+        }
+        return members;
+    }
+}


### PR DESCRIPTION
## Summary

Burns down the rung 1 (Straightforward syntax foundation) blockers for #1599, tracked by #1694. Guards only — no product behavior change.

The rung was un-completed after a C# 1–7.3 validation pass (against `docs`/`csharplang`/`roslyn` + product-seam re-measurement) found that rung 1 is behaviorally close but **under-guarded**: the only guard (`LadderRung1GateTests`) covered methods/locals/calls/fields/properties and simple `if`/return branches, while the core "foundation" control-flow surface and one C# 7 expression residual had no durable lock.

Two commits:

- **Foundation control-flow guard (#1691).** New `LadderRung1.Foundation` fixture + `LadderRung1FoundationGateTests` covering for/while/do/foreach loops, a dense (jump-table) `switch`, array create/index and array literal, try/catch/finally, a `catch … when` filter, and a `using` statement. Pins the same scoped bar as the `Program` gate: exact member set, every member `Full` and fully raised, recognizable control-flow rendering, zero malformed/semantic defects with a non-vacuous binding guard.
- **Owned throw-expression residual (#1693).** New `LadderRung1.OwnedResiduals` fixture + `LadderRung1ResidualGateTests`. A C# 7 `?? throw` decompiles to a valid, fully raised `if (x is null) throw …` null-check (Full, binds) at a lower altitude than the expression form. The expression-form raise is a separate risk-bearing change (a hand-written null-check-then-throw is a legitimate alternative source for the same IL), so it is deferred and the current valid form is pinned as an explicitly owned residual.

### Burndown row #1692 closed as not-a-bug

The third row (#1692, cross-assembly out-var → `ref`) was a **measurement artifact**, not a product defect. Re-measured through the real product path (`type … -S "Decompiled Source"`, which wires `PlatformAssemblyLocator`), `int.TryParse(s, out int result)` renders **`out result`** correctly — `CrossAssemblyTypeResolver` resolves the referenced method's Param rows via the platform locator. My original `Partial`/`ref`+DEC0007 reproduction used a resolver-less `MetadataSource.Open` seam. Closed #1692 with this evidence.

## Evidence

No raise/structuring/printer semantics changed, so there is no behavior delta to card; this PR only adds fixtures and fast gates.

```text
# new gates
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LadderRung1FoundationGateTests
  Total: 3, Errors: 0, Failed: 0, Skipped: 0
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LadderRung1ResidualGateTests
  Total: 2, Errors: 0, Failed: 0, Skipped: 0

# fast decompiler suite
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
  Total: 1518, Errors: 0, Failed: 0, Skipped: 0

# product build
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
  0 Error(s)
```

## Method note

Foundation/residual constructs render `Full` and valid through the bare-seam gate methodology (no lambdas/cross-assembly by-ref, so the seam matches the product). Lambdas/LINQ and cross-assembly `out`/`ref`/`in` require the cross-method import seam / platform locator the product wires; measure those through the product path, not the resolver-less seam.

## Re-completion of rung 1 (#1599)

With this PR: the foundation control-flow surface is guarded (#1691), the throw-expression residual is owned (#1693), and #1692 is closed as not-a-bug. Per #1694's criteria, rung 1 can be re-marked Complete once this merges, with the row label kept honest (scoped to the guarded constructs).

Closes #1691. Closes #1693.

## Adversarial review

Will request cross-model (GPT-5.5) adversarial review per the ladder PR contract and post the result.
