### PR TITLE
Release 0.14.0: version bump and CLI usability fixes (#1690)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -485,5 +485,8 @@ $RECYCLE.BIN/
 docs/field-parser.md
 .claude/worktrees/
 
+# Local development worktrees (AGENTS.md: all work happens in worktrees)
+.worktrees/
+
 # Vendored ILAssembler worktree (restore with eng/restore-ilassembler.sh)
 external/

--- a/docs/design/scope-simplification.md
+++ b/docs/design/scope-simplification.md
@@ -51,9 +51,15 @@ Earlier iterations had a `--dotnet` flag meaning "search everything Microsoft sh
 
 ### Tips on no-arg invocations
 
-When `find`, `extensions`, or `implements` are invoked with no arguments, show tips that teach the scoping system:
+When `find`, `extensions`, or `implements` are invoked with no arguments, the
+command reports a missing required argument the Unix way — a concise error and
+the scoping tips on stderr, with a non-zero exit code (help itself is reserved
+for explicit `--help`):
 
 ```text
+Error: Search pattern required.
+Run 'dotnet-inspect find --help' for usage.
+
 Tips:
 find Chat*                                # search default scope
 find Chat* --platform                     # platform libraries only

--- a/src/dotnet-inspect.Tests/ApiTypeLookupServiceTests.cs
+++ b/src/dotnet-inspect.Tests/ApiTypeLookupServiceTests.cs
@@ -15,6 +15,57 @@ public class ApiTypeLookupServiceTests
         Assert.True(result.Found);
         Assert.Equal("System.Text.Json.JsonSerializer", result.Match);
         Assert.Same(api.Types[0], result.Type);
+        Assert.Null(result.ImpliedMember);
+    }
+
+    [Fact]
+    public void LookupType_NamespaceQualifiedType_ResolvesWithoutPeelingMember()
+    {
+        // Regression for issue #1690: "System.Text.Json.JsonSerializer" is a type, not a
+        // Type.Member pair, so it must resolve directly with no implied member.
+        var api = CreateSurface();
+
+        var result = ApiTypeLookupService.LookupType(api, "System.Text.Json.JsonSerializer");
+
+        Assert.True(result.Found);
+        Assert.Equal("System.Text.Json.JsonSerializer", result.Match);
+        Assert.Null(result.ImpliedMember);
+    }
+
+    [Fact]
+    public void LookupType_FullyQualifiedTypeMember_PeelsTrailingMember()
+    {
+        // Regression for issue #1690: "System.Text.Json.JsonSerializer.Serialize" must resolve
+        // to the JsonSerializer type with "Serialize" surfaced as an implied member filter,
+        // rather than failing because "System" was mistaken for the type.
+        var api = CreateSurface();
+
+        var result = ApiTypeLookupService.LookupType(api, "System.Text.Json.JsonSerializer.Serialize");
+
+        Assert.True(result.Found);
+        Assert.Equal("System.Text.Json.JsonSerializer", result.Match);
+        Assert.Equal("Serialize", result.ImpliedMember);
+    }
+
+    [Fact]
+    public void LookupType_SimpleTypeMember_PeelsTrailingMember()
+    {
+        var api = CreateSurface();
+
+        var result = ApiTypeLookupService.LookupType(api, "JsonSerializer.Serialize");
+
+        Assert.True(result.Found);
+        Assert.Equal("System.Text.Json.JsonSerializer", result.Match);
+        Assert.Equal("Serialize", result.ImpliedMember);
+    }
+
+    [Fact]
+    public void LookupType_UnresolvableDottedName_DoesNotPeel()
+    {
+        var result = ApiTypeLookupService.LookupType(CreateSurface(), "System.Nonexistent");
+
+        Assert.False(result.Found);
+        Assert.Null(result.ImpliedMember);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3552,6 +3552,35 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task NoArguments_Commands_ReportMissingInputConsistently()
+    {
+        // Issue #1690: every command reports a missing required argument the Unix way —
+        // a concise error on stderr with a non-zero exit, not full help with exit 0.
+        foreach (var command in new[] { "type", "member", "find", "depends", "extensions", "implements" })
+        {
+            var (exit, output, error) = await RunAppAsync(command, "--tips", "q");
+
+            Assert.Equal(1, exit);
+            Assert.Empty(output);
+            Assert.Contains("Error:", error);
+            Assert.Contains($"dotnet-inspect {command} --help", error);
+        }
+    }
+
+    [Fact]
+    public async Task LibraryCommand_NonexistentLibraryPath_ReportsFileNotFound()
+    {
+        // Regression for issue #1690: a missing local library path must report a file error,
+        // not be misclassified as a NuGet package.
+        var (exit, output, error) = await RunAppAsync("library", "./does-not-exist/MyLib.dll");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("File not found: ./does-not-exist/MyLib.dll", error);
+        Assert.DoesNotContain("Package", error);
+    }
+
+    [Fact]
     public async Task LibraryCommand_BareSelect_RendersInfoPreset()
     {
         var (exit, output, _) = await RunAppAsync("library", "System.Text.Json", "-S");

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -544,12 +544,15 @@ public class MemberOptionsParserTests
     }
 
     [Fact]
-    public async Task ExplicitPackage_PositionalDottedMember_SplitsTypeAndMember()
+    public async Task ExplicitPackage_PositionalDottedMember_DefersBoundaryToLookup()
     {
+        // The parser leaves an explicit-source dotted name whole; the type/member boundary
+        // (e.g. JsonSerializer.Serialize vs the type System.String) is resolved against real
+        // metadata in ApiTypeLookupService, covered by ApiTypeLookupServiceTests. See #1690.
         var options = await ParseSuccessAsync("member", "JsonSerializer.Serialize", "--package", "System.Text.Json");
 
-        Assert.Equal("JsonSerializer", options.TypeName);
-        Assert.Contains("Serialize", options.MemberFilter);
+        Assert.Equal("JsonSerializer.Serialize", options.TypeName);
+        Assert.Empty(options.MemberFilter);
     }
 
     // ── Overload shorthand (Name:N) ──────────────────────────────────────

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -555,6 +555,29 @@ public class MemberOptionsParserTests
         Assert.Empty(options.MemberFilter);
     }
 
+    [Fact]
+    public async Task ExplicitPackage_PositionalDottedMemberWithOverloadSelector_Splits()
+    {
+        // A ":N" overload selector is unambiguously a member (a type name cannot contain ':'),
+        // so the parser splits it even for an explicit source. See #1690 / PR #1697 review.
+        var options = await ParseSuccessAsync("member", "JsonSerializer.Serialize:2", "--package", "System.Text.Json");
+
+        Assert.Equal("JsonSerializer", options.TypeName);
+        Assert.Contains("Serialize", options.MemberFilter);
+        Assert.Equal(2, options.OverloadIndex);
+    }
+
+    [Fact]
+    public async Task ExplicitPackage_PositionalDottedMemberWithDigest_Splits()
+    {
+        // A "~hash" digest selector is likewise unambiguously a member.
+        var options = await ParseSuccessAsync("member", "JsonSerializer.Serialize~abc123", "--package", "System.Text.Json");
+
+        Assert.Equal("JsonSerializer", options.TypeName);
+        Assert.Contains("Serialize", options.MemberFilter);
+        Assert.Equal("abc123", options.MemberDigest);
+    }
+
     // ── Overload shorthand (Name:N) ──────────────────────────────────────
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -123,8 +123,9 @@ public static class ApiCommandDefinitions
                         sectionCategories: typePipeline.GetCategoryMap());
 
                 case TypeOptionsParser.ShowHelp:
-                    HelpWriter.WriteHelp(typeCommand);
-                    return 0;
+                    Console.Error.WriteLine("Error: Type name, pattern, or source required.");
+                    Console.Error.WriteLine("Run 'dotnet-inspect type --help' for usage.");
+                    return 1;
 
                 case TypeOptionsParser.VersionError error:
                     Console.Error.WriteLine(error.Message);
@@ -254,8 +255,9 @@ public static class ApiCommandDefinitions
                         sectionCategories: memberPipeline.GetCategoryMap());
 
                 case MemberOptionsParser.ShowHelp:
-                    HelpWriter.WriteHelp(memberCommand);
-                    return 0;
+                    Console.Error.WriteLine("Error: Type name or source required.");
+                    Console.Error.WriteLine("Run 'dotnet-inspect member --help' for usage.");
+                    return 1;
 
                 case MemberOptionsParser.VersionError error:
                     Console.Error.WriteLine(error.Message);

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -168,6 +168,16 @@ public static class InspectionCommandDefinitions
             {
                 if (File.Exists(source))
                     assemblyPath = source;
+                else if (source.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                    || source.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+                    || source.Contains('/')
+                    || source.Contains('\\'))
+                {
+                    // A non-existent value that looks like a local library path (has a file
+                    // extension or directory separator) is reported as a missing file rather
+                    // than misclassified as a NuGet package. See #1690.
+                    assemblyPath = source;
+                }
                 else if (!source.Contains('@') && PlatformResolver.IsPlatformCandidate(source))
                 {
                     // Platform-preferred routing for System.*/Microsoft.* bare names

--- a/src/dotnet-inspect/CommandLine/Commands/SearchCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/SearchCommandDefinitions.cs
@@ -90,7 +90,8 @@ public static class SearchCommandDefinitions
             switch (result)
             {
                 case FindOptionsParser.ShowHelpWithTips:
-                    return TipWriter.ShowHelpWithTips(findCommand,
+                    return TipWriter.MissingArgumentWithTips(findCommand,
+                        "Search pattern required.",
                         "find Chat*                                # search default scope",
                         "find Chat* --platform                     # platform libraries only",
                         "find Chat* --extensions                   # Microsoft.Extensions packages",
@@ -176,7 +177,8 @@ public static class SearchCommandDefinitions
 
             if (string.IsNullOrEmpty(targetType))
             {
-                return TipWriter.ShowHelpWithTips(implCommand,
+                return TipWriter.MissingArgumentWithTips(implCommand,
+                    "Type name required.",
                     "implements Stream                         # search default scope",
                     "implements Stream --platform              # platform libraries only",
                     "implements Stream --extensions             # Microsoft.Extensions packages",
@@ -302,7 +304,8 @@ public static class SearchCommandDefinitions
 
             if (string.IsNullOrEmpty(targetType))
             {
-                return TipWriter.ShowHelpWithTips(extCommand,
+                return TipWriter.MissingArgumentWithTips(extCommand,
+                    "Type name required.",
                     "extensions HttpClient                     # search default scope",
                     "extensions HttpClient --platform          # platform libraries only",
                     "extensions HttpClient --extensions         # Microsoft.Extensions packages",
@@ -429,7 +432,8 @@ public static class SearchCommandDefinitions
                 if (packages.Length == 1 && assemblies.Length == 0)
                     return await DependsCommand.ExecutePackageDependsAsync(commonOptions with { PackageName = packages[0] });
 
-                return TipWriter.ShowHelpWithTips(dependsCommand,
+                return TipWriter.MissingArgumentWithTips(dependsCommand,
+                    "Type, package, or library required.",
                     "depends IFloatingPointIeee754 --platform   # type hierarchy",
                     "depends --library Microsoft.Extensions.AI   # assembly references",
                     "depends --package System.Text.Json          # NuGet dependencies");

--- a/src/dotnet-inspect/CommandLine/Helpers/TipWriter.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/TipWriter.cs
@@ -11,16 +11,21 @@ namespace DotnetInspector.CommandLine;
 public static class TipWriter
 {
     /// <summary>
-    /// Shows help followed by command-specific tips.
+    /// Reports a missing required argument the Unix way: a concise error and the example
+    /// tips on stderr, with a non-zero exit code. Help is reserved for explicit --help.
     /// </summary>
-    public static int ShowHelpWithTips(Command command, params string[] tips)
+    public static int MissingArgumentWithTips(Command command, string message, params string[] tips)
     {
-        HelpWriter.WriteHelp(command);
-        Console.Error.WriteLine();
-        Console.Error.WriteLine("Tips:");
-        foreach (var tip in tips)
-            Console.Error.WriteLine($"  {tip}");
-        return 0;
+        Console.Error.WriteLine($"Error: {message}");
+        Console.Error.WriteLine($"Run 'dotnet-inspect {command.Name} --help' for usage.");
+        if (tips.Length > 0)
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Tips:");
+            foreach (var tip in tips)
+                Console.Error.WriteLine($"  {tip}");
+        }
+        return 1;
     }
 
     /// <summary>

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -160,18 +160,24 @@ public static class MemberOptionsParser
 
         var typeName = source.TypeName;
 
-        // If the type name contains a dot and no member filters were provided, split at the
-        // last dot: the right part is a member filter. This applies only to the non-explicit
-        // multi-arg form (e.g. member System.Text.Json JsonSerializer.Serialize), where the
-        // source has already been resolved from the first argument. For the explicit-source
-        // form (--package/--library/--platform), the dotted name is left whole and the
-        // type/member boundary is resolved against real metadata in ApiTypeLookupService,
-        // because "System.String" is a type while "System" is only a namespace.
+        // Split a dotted name into Type + member at the last top-level dot when:
+        //  - non-explicit multi-arg form (e.g. member System.Text.Json JsonSerializer.Serialize),
+        //    where the source was already resolved from the first argument; or
+        //  - explicit-source form whose trailing segment is unambiguously a member because it
+        //    carries an overload (":N") or digest ("~hash") selector, which a type name can
+        //    never contain (e.g. member JsonSerializer.Serialize:2 --platform System.Text.Json).
+        // Plain explicit-source dotted names are left whole so the type/member boundary is
+        // resolved against real metadata in ApiTypeLookupService, because "System.String" is a
+        // type while "System" is only a namespace.
         // Skip if the right part contains '<' — that's a generic type name (e.g., Generic.List<T>),
         // not a type.member pair.
+        bool explicitSourceSelectorSplit = sourceInputs.HasExplicitSource
+            && sourceInputs.Args.Length == 1
+            && typeName != null
+            && HasMemberSelectorSuffix(typeName);
         if (typeName != null
-            && !sourceInputs.HasExplicitSource
-            && sourceInputs.Args.Length > 1
+            && (((!sourceInputs.HasExplicitSource && sourceInputs.Args.Length > 1)
+                    || explicitSourceSelectorSplit))
             && typeName.Contains('.')
             && positionalMembers.Count == 0
             && optionMembers.Length == 0)
@@ -268,6 +274,19 @@ public static class MemberOptionsParser
         };
 
         return new Success(options);
+    }
+
+    /// <summary>
+    /// True when the trailing segment of a dotted name (after the last top-level dot) carries an
+    /// overload (":N") or digest ("~hash") selector. Such a suffix is unambiguously a member,
+    /// since a type name can contain neither character.
+    /// </summary>
+    private static bool HasMemberSelectorSuffix(string typeName)
+    {
+        var (splitTypeName, splitMemberName) = SharedParsers.SplitTrailingMember(typeName);
+        return splitTypeName != null
+            && splitMemberName != null
+            && (splitMemberName.Contains(':') || splitMemberName.Contains('~'));
     }
 
     private static (HashSet<string> Filter, int? Limit) BuildMemberFilter(string[] allMembers, bool ctorOnly, out bool clearShorthand)

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -160,18 +160,18 @@ public static class MemberOptionsParser
 
         var typeName = source.TypeName;
 
-        // If the type name contains a dot and no member filters were provided,
-        // split at the last dot: the right part is a member filter.
-        // Handles: member System.Text.Json.JsonDocument.Parse
-        //      and: member JsonSerializer.Serialize --package System.Text.Json
-        //   → source=System.Text.Json, type=JsonDocument, member=Parse
+        // If the type name contains a dot and no member filters were provided, split at the
+        // last dot: the right part is a member filter. This applies only to the non-explicit
+        // multi-arg form (e.g. member System.Text.Json JsonSerializer.Serialize), where the
+        // source has already been resolved from the first argument. For the explicit-source
+        // form (--package/--library/--platform), the dotted name is left whole and the
+        // type/member boundary is resolved against real metadata in ApiTypeLookupService,
+        // because "System.String" is a type while "System" is only a namespace.
         // Skip if the right part contains '<' — that's a generic type name (e.g., Generic.List<T>),
         // not a type.member pair.
         if (typeName != null
-            && ((!sourceInputs.HasExplicitSource && sourceInputs.Args.Length > 1)
-                || (sourceInputs.HasExplicitSource
-                    && sourceInputs.Args.Length == 1
-                    && IsLocalDottedMemberWithExplicitSource(typeName)))
+            && !sourceInputs.HasExplicitSource
+            && sourceInputs.Args.Length > 1
             && typeName.Contains('.')
             && positionalMembers.Count == 0
             && optionMembers.Length == 0)
@@ -268,12 +268,6 @@ public static class MemberOptionsParser
         };
 
         return new Success(options);
-    }
-
-    private static bool IsLocalDottedMemberWithExplicitSource(string typeName)
-    {
-        var (splitTypeName, splitMemberName) = SharedParsers.SplitTrailingMember(typeName);
-        return splitMemberName != null && splitTypeName != null && !splitTypeName.Contains('.');
     }
 
     private static (HashSet<string> Filter, int? Limit) BuildMemberFilter(string[] allMembers, bool ctorOnly, out bool clearShorthand)

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -81,9 +81,17 @@ public static class MemberCommand
 
             // If the type resolved by peeling a trailing Type.Member suffix (e.g.
             // "System.String.Length" -> type System.String + member Length), apply the peeled
-            // segment as a member filter when the user gave no explicit member filter.
-            if (lookupResult.ImpliedMember is { } impliedMember && options.MemberFilter.Count == 0)
-                options = options with { MemberFilter = [impliedMember] };
+            // segment as a member filter. The peeled suffix is always a plain member name
+            // (selector-bearing suffixes like ":N"/"~hash" are split in the parser), so it is
+            // combined with any explicit -m filters rather than replacing or being dropped.
+            if (lookupResult.ImpliedMember is { } impliedMember)
+            {
+                var mergedFilter = new HashSet<string>(options.MemberFilter, StringComparer.OrdinalIgnoreCase)
+                {
+                    impliedMember
+                };
+                options = options with { MemberFilter = mergedFilter };
+            }
 
             // Check each member filter before producing output
             if (options.MemberFilter.Count > 0)

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -79,6 +79,12 @@ public static class MemberCommand
 
             var apiType = lookupResult.Type!;
 
+            // If the type resolved by peeling a trailing Type.Member suffix (e.g.
+            // "System.String.Length" -> type System.String + member Length), apply the peeled
+            // segment as a member filter when the user gave no explicit member filter.
+            if (lookupResult.ImpliedMember is { } impliedMember && options.MemberFilter.Count == 0)
+                options = options with { MemberFilter = [impliedMember] };
+
             // Check each member filter before producing output
             if (options.MemberFilter.Count > 0)
             {

--- a/src/dotnet-inspect/Inspectors/ApiTypeLookupService.cs
+++ b/src/dotnet-inspect/Inspectors/ApiTypeLookupService.cs
@@ -2,7 +2,7 @@ using ILInspector.Metadata;
 
 namespace DotnetInspector.Inspectors;
 
-internal sealed record ApiTypeLookupResult(string Query, LookupResult Lookup, ApiType? Type)
+internal sealed record ApiTypeLookupResult(string Query, LookupResult Lookup, ApiType? Type, string? ImpliedMember = null)
 {
     public bool Found => Type != null;
     public string? Match => Lookup.Match;
@@ -65,10 +65,33 @@ internal static class ApiTypeLookupService
     public static ApiTypeLookupResult LookupType(ApiSurface api, string typeName)
     {
         var lookup = TypeMatcher.Lookup(api.Types.Select(t => t.FullName), typeName);
-        var type = lookup.Match == null
-            ? null
-            : api.Types.First(t => t.FullName == lookup.Match);
-        return new ApiTypeLookupResult(typeName, lookup, type);
+        if (lookup.Match != null)
+            return new ApiTypeLookupResult(typeName, lookup, api.Types.First(t => t.FullName == lookup.Match));
+
+        // The query may be a Type.Member where the type portion is itself namespace-qualified
+        // (e.g. "System.String.Length" or "System.Text.Json.JsonSerializer.Serialize"). The type
+        // and member boundary is not knowable syntactically — "System.String" is a type while
+        // "System" is a namespace — so it is resolved here against real metadata: peel the
+        // trailing segment and retry the prefix as a type. If the prefix resolves, the peeled
+        // suffix is surfaced as an implied member filter.
+        var dot = FqnParser.LastTopLevelDot(typeName);
+        if (dot > 0)
+        {
+            var member = typeName[(dot + 1)..];
+            var typeCandidate = typeName[..dot];
+            if (!member.Contains('<'))
+            {
+                var prefixLookup = TypeMatcher.Lookup(api.Types.Select(t => t.FullName), typeCandidate);
+                if (prefixLookup.Match != null)
+                    return new ApiTypeLookupResult(
+                        typeName,
+                        prefixLookup,
+                        api.Types.First(t => t.FullName == prefixLookup.Match),
+                        member);
+            }
+        }
+
+        return new ApiTypeLookupResult(typeName, lookup, null);
     }
 
     public static MemberFilterValidationResult ValidateMemberFilters(

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -24,7 +24,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.13.0</VersionPrefix>
+    <VersionPrefix>0.14.0</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,36 @@
 # Release Notes
 
+## v0.14.0
+
+### Grounding and skill workflow
+
+- Renames the `package` README section to `Grounding` and adds a `--print`
+  flag for emitting grounding/content payloads directly (#1659, #1672).
+- Turns `dotnet-inspect skill` into a router to focused scenario sub-skills
+  (`skill list`, `skill source`, `skill performance`, and more), with
+  one-line descriptions sourced from each skill's YAML frontmatter
+  (#1559, #1577).
+
+### Performance analysis (experimental)
+
+- Renames the `Optimization Opportunities` section to `Performance Triage`
+  and ranks rows by triage priority (hot pay-dirt first) (#1530, #1545).
+- Adds allocation-hotspot rows to `Performance Triage` and loop-aware
+  allocation-regression detection to Analysis Diff (#1558, #1582).
+
+### Decompiler (experimental)
+
+- Large body of method-body raise, structuring, and printer fidelity
+  improvements across the C# decompiler, plus honest `DEC####` degradation
+  rather than plausible-but-wrong output. These remain experimental and are
+  surfaced through `member -S @Source`.
+
+### CLI fixes
+
+- Fixes CLI batch processing bugs (#1679).
+- Preserves `ref readonly` return signatures and function-pointer signature
+  modifiers in rendered API surfaces (#1678, #1537).
+
 ## v0.13.0
 
 ### SourceLink section consolidation

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -31,6 +31,18 @@
 - Preserves `ref readonly` return signatures and function-pointer signature
   modifiers in rendered API surfaces (#1678, #1537).
 
+### Usability fixes (#1690)
+
+- `member` now accepts fully-qualified type names such as
+  `System.String` and `System.String.Length`; the type/member boundary is
+  resolved against real metadata instead of a fragile dotted-name heuristic.
+- `library <path>` reports a missing local file as a file error rather than
+  misclassifying the path as a NuGet package.
+- All commands now report a missing required argument consistently — a concise
+  error on stderr with a non-zero exit code — instead of some printing full
+  help with a zero exit. Help and discovery remain available via `--help` and
+  `-D`.
+
 ## v0.13.0
 
 ### SourceLink section consolidation


### PR DESCRIPTION
## Summary

Prepares the **0.14.0** publish and fixes the usability defects found in an adversarial usability test of the CLI. Closes #1690.

The tool version was still `0.13.0` — identical to the latest on nuget.org — while the skill frontmatter already declared `0.14.0`, so a publish would have collided. This bumps the tool to `0.14.0` and resolves three usability findings, each with tests.

## Changes

### Release readiness
- Bump `VersionPrefix` to `0.14.0` (matches the `skill` frontmatter; `--version` and the skill now agree) and add a `v0.14.0` release-notes section.
- Ignore the top-level `.worktrees/` development directory (AGENTS.md mandates worktree-based development; only `.claude/worktrees/` was ignored before).

### Usability fixes (#1690)
1. **`member` rejected fully-qualified type names.** `member System.String` failed with `Type 'System' not found` because a fragile dotted-name heuristic split `Namespace.Type` as `Type.Member`, and `System.String.Length` was not split at all. The explicit-source split is removed from `MemberOptionsParser`; `ApiTypeLookupService.LookupType` now resolves the type/member boundary against real metadata — if the full dotted name is not a type, it peels the trailing segment and retries the prefix, surfacing the suffix as an implied member filter.
   - `member System.String`, `member System.String.Length`, `member System.Text.Json.JsonSerializer.Serialize` all work now.
   - Existing forms (`String.Length`, `JsonSerializer.Serialize`, etc.) are unchanged.
2. **`library <path>` mislabeled a missing file as a package.** A non-existent value that looks like a library path (file extension or directory separator) now routes to the assembly branch and reports `File not found:` instead of `Package '...' not found`.
3. **Inconsistent empty-argument behavior.** `package`/`library`/`diff` errored with a non-zero exit while `type`/`member`/`find`/`depends`/`extensions`/`implements` printed full help with exit 0. All commands now follow the Unix convention for a missing required argument — a concise error on stderr with a non-zero exit; help and discovery remain available via `--help` and `-D`.

## Tests

- `ApiTypeLookupServiceTests`: 5 new cases for namespace-qualified types and trailing-member peeling.
- `CommandExecutionTests.NoArguments_Commands_ReportMissingInputConsistently`
- `CommandExecutionTests.LibraryCommand_NonexistentLibraryPath_ReportsFileNotFound`
- Updated `MemberOptionsParserTests` to reflect the boundary moving to the lookup layer.
- Full `dotnet-inspect.Tests` suite: **1373 passed, 9 skipped, 0 failed**; `markdownlint` clean on changed docs.

## Notes

This is a CLI usability change set, not a decompiler-affecting PR, so the decompiler harness/quality-card evidence does not apply.
