### PR TITLE
Add iterator ladder gate

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderIterator/ILInspector.Decompiler.Fixtures.LadderIterator.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.LadderIterator/ILInspector.Decompiler.Fixtures.LadderIterator.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Iterator semantic boss for the decompiler product quality ladder (#1599 row 3).
+    The fixture is intentionally source-recognizable: common iterator recovery
+    shapes plus explicit honest-degrade frontiers for user cleanup / captured
+    side effects that must not be silently erased.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Decompiler.Fixtures.LadderIterator/LadderIterator.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderIterator/LadderIterator.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+
+namespace LadderIterator;
+
+// Iterator semantic boss for the decompiler product quality ladder (#1599 row 3).
+// This fixture is not a complete C# iterator catalog. It pins the mainstream
+// state-machine shapes the product currently recovers and the owned residuals
+// that must degrade honestly rather than drop cleanup or captured side effects.
+public static class IteratorSamples
+{
+    public static IEnumerable<int> Linear()
+    {
+        yield return 1;
+        yield return 2;
+    }
+
+    public static IEnumerable<int> Counting(int n)
+    {
+        for (int i = 0; i < n; i++)
+        {
+            yield return i;
+        }
+    }
+
+    public static IEnumerable<int> Conditional(bool flag)
+    {
+        if (flag)
+        {
+            yield return 1;
+        }
+
+        yield return 2;
+    }
+
+    public static IEnumerable<int> MultiYieldLoop(int n)
+    {
+        for (int i = 0; i < n; i++)
+        {
+            yield return i;
+            yield return -i;
+        }
+    }
+
+    public static IEnumerable<int> NestedLoops()
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            for (int j = 0; j < 2; j++)
+            {
+                yield return i + j;
+            }
+        }
+    }
+
+    public static IEnumerable<int> ForeachDelegation(IEnumerable<int> source)
+    {
+        foreach (int value in source)
+        {
+            yield return value;
+        }
+    }
+
+    public static IEnumerator<int> EnumeratorReturn()
+    {
+        yield return 7;
+        yield return 8;
+    }
+
+    public static IEnumerable<int> Empty()
+    {
+        yield break;
+    }
+
+    public static IEnumerable<int> SideEffectThenBreak()
+    {
+        Console.WriteLine("side effect");
+        yield break;
+    }
+
+    public static IEnumerable<int> CapturedParameterSideEffectThenBreak(int value)
+    {
+        Console.WriteLine(value);
+        yield break;
+    }
+
+    public static IEnumerable<int> UserFinally(IEnumerable<int> source)
+    {
+        try
+        {
+            foreach (int value in source)
+            {
+                yield return value;
+            }
+        }
+        finally
+        {
+            Console.WriteLine("cleanup");
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -34,6 +34,7 @@
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung4\ILInspector.Decompiler.Fixtures.LadderRung4.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung5\ILInspector.Decompiler.Fixtures.LadderRung5.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung9\ILInspector.Decompiler.Fixtures.LadderRung9.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderIterator\ILInspector.Decompiler.Fixtures.LadderIterator.csproj" />
   </ItemGroup>
 
   <!--

--- a/src/ILInspector.Decompiler.Tests/LadderIteratorGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderIteratorGateTests.cs
@@ -1,0 +1,235 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Iterator semantic boss guard for the decompiler product quality ladder (#1599
+/// row 3). It locks a scoped matrix of common iterator state-machine shapes and
+/// explicit honest-degrade frontiers:
+/// <list type="bullet">
+/// <item>linear, counting-loop, conditional, multi-yield loop, nested-loop,
+/// foreach-delegation, IEnumerator-returning, and empty iterators render as
+/// recognizable <c>yield</c> C# at <c>Full</c> fidelity;</item>
+/// <item>side effects before <c>yield break</c> survive rather than being collapsed
+/// into a bare break;</item>
+/// <item>captured-parameter side effects and user <c>finally</c> cleanup remain
+/// owned residuals, not fake <c>Full</c> source;</item>
+/// <item><c>--validity-check</c> sees no malformed or semantic-defective
+/// <c>Full</c> output for the fixture.</item>
+/// </list>
+/// </summary>
+public class LadderIteratorGateTests
+{
+    static string FixturePath => typeof(LadderIterator.IteratorSamples).Assembly.Location;
+    static readonly string FixtureType = typeof(LadderIterator.IteratorSamples).FullName!;
+
+    static readonly string[] ExpectedMembers =
+    [
+        "CapturedParameterSideEffectThenBreak",
+        "Conditional",
+        "Counting",
+        "Empty",
+        "EnumeratorReturn",
+        "ForeachDelegation",
+        "Linear",
+        "MultiYieldLoop",
+        "NestedLoops",
+        "SideEffectThenBreak",
+        "UserFinally",
+    ];
+
+    static readonly string[] FullRecoveredMembers =
+    [
+        "Conditional",
+        "Counting",
+        "Empty",
+        "EnumeratorReturn",
+        "ForeachDelegation",
+        "Linear",
+        "MultiYieldLoop",
+        "NestedLoops",
+        "SideEffectThenBreak",
+    ];
+
+    static readonly string[] HonestResidualMembers =
+    [
+        "CapturedParameterSideEffectThenBreak",
+        "UserFinally",
+    ];
+
+    [Fact]
+    public void IteratorFixture_ExposesExactMemberSet_WithRecoveredAndOwnedResidualRows()
+    {
+        var members = LoadRaisedMembers();
+
+        Assert.Equal(
+            ExpectedMembers,
+            members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
+
+        var notFull = members
+            .Where(m => FullRecoveredMembers.Contains(m.Name, StringComparer.Ordinal)
+                && m.Function.Fidelity != DecompilationFidelity.Full)
+            .Select(m => m.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(notFull.Length == 0,
+            "Iterator rung recovered rows must render Full; not Full: " + string.Join(", ", notFull));
+
+        var unexpectedlyFullResiduals = members
+            .Where(m => HonestResidualMembers.Contains(m.Name, StringComparer.Ordinal)
+                && m.Function.Fidelity == DecompilationFidelity.Full)
+            .Select(m => m.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(unexpectedlyFullResiduals.Length == 0,
+            "Iterator rung residual rows must stay honest until reconstructed: " + string.Join(", ", unexpectedlyFullResiduals));
+
+        var gaps = members
+            .Where(m => FullRecoveredMembers.Contains(m.Name, StringComparer.Ordinal)
+                && Completeness.Residual(m.Function) is not null)
+            .Select(m => $"{m.Name}: {Completeness.Residual(m.Function)}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(gaps.Length == 0,
+            "Iterator rung recovered rows must be fully raised (zero residual gaps); gaps: " + string.Join("; ", gaps));
+
+        foreach (var member in members.Where(m => HonestResidualMembers.Contains(m.Name, StringComparer.Ordinal)))
+        {
+            var marker = Assert.Single(member.Function.Descendants.OfType<UnsupportedNode>(), node => node.Opcode == "iterator");
+            Assert.Contains("not reconstructed", marker.Reason);
+        }
+    }
+
+    [Fact]
+    public void IteratorFixture_RendersRecognizableRecoveredYields()
+    {
+        var members = LoadRaisedMembers();
+        string Body(string name) => members.Single(m => m.Name == name).Body.Trim();
+
+        Assert.Contains("yield return 1;", Body("Linear"));
+        Assert.Contains("yield return 2;", Body("Linear"));
+
+        var counting = Body("Counting");
+        Assert.Contains("int i = 0;", counting);
+        Assert.Contains("while (i < n)", counting);
+        Assert.Contains("yield return i;", counting);
+
+        var conditional = Body("Conditional");
+        Assert.Contains("if (flag)", conditional);
+        Assert.Contains("yield return 1;", conditional);
+        Assert.Contains("yield return 2;", conditional);
+
+        var multi = Body("MultiYieldLoop");
+        Assert.Contains("while (i < n)", multi);
+        Assert.Contains("yield return i;", multi);
+        Assert.Contains("yield return -i;", multi);
+
+        var nested = Body("NestedLoops");
+        Assert.Contains("for (int i = 0; i < 2; i++)", nested);
+        Assert.Contains("for (int j = 0; j < 2; j++)", nested);
+        Assert.Contains("yield return i + j;", nested);
+
+        var foreachDelegation = Body("ForeachDelegation");
+        Assert.Contains("foreach (", foreachDelegation);
+        Assert.Contains("in source)", foreachDelegation);
+        Assert.Contains("yield return", foreachDelegation);
+        Assert.DoesNotContain("GetEnumerator", foreachDelegation);
+        Assert.DoesNotContain("Finally", foreachDelegation);
+
+        Assert.Contains("yield return 7;", Body("EnumeratorReturn"));
+        Assert.Contains("yield return 8;", Body("EnumeratorReturn"));
+        Assert.Contains("yield break;", Body("Empty"));
+    }
+
+    [Fact]
+    public void IteratorFixture_PreservesSideEffectsOrDegradesHonestly()
+    {
+        var members = LoadRaisedMembers();
+        string Body(string name) => members.Single(m => m.Name == name).Body.Trim();
+
+        var sideEffectBreak = Body("SideEffectThenBreak");
+        Assert.Contains("Console.WriteLine(\"side effect\");", sideEffectBreak);
+        Assert.Contains("yield break;", sideEffectBreak);
+
+        foreach (var name in HonestResidualMembers)
+        {
+            var member = members.Single(m => m.Name == name);
+            Assert.NotEqual(DecompilationFidelity.Full, member.Function.Fidelity);
+            Assert.Contains("iterator", member.Body);
+            Assert.Contains("not reconstructed", member.Body);
+        }
+    }
+
+    [Fact]
+    public void IteratorFixture_HasNoMalformedOrSemanticDefectiveFullOutput()
+    {
+        var results = ValidityCheck.Evaluate(FixturePath, importSiblingBodies: true)
+            .Where(r => r.TypeName == FixtureType)
+            .ToList();
+
+        Assert.NotEmpty(results);
+
+        var malformedFull = results
+            .Where(r => r.IsFull && r.IsMalformed)
+            .Select(r => $"{r.MethodName}: {r.MalformedDiagnostics[0].Id} {r.MalformedDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(malformedFull.Length == 0,
+            "Iterator rung requires zero malformed Full methods; malformed: " + string.Join("; ", malformedFull));
+
+        var semanticFull = results
+            .Where(r => r.IsFull && r.HasSemanticDefect)
+            .Select(r => $"{r.MethodName}: {r.SemanticDiagnostics[0].Id} {r.SemanticDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(semanticFull.Length == 0,
+            "Iterator rung requires zero non-noise semantic defects on Full methods; defects: " + string.Join("; ", semanticFull));
+
+        Assert.All(
+            results.Where(r => r.IsFull),
+            r => Assert.True(r.SemanticChecked, $"Full method {r.MethodName} was not semantically bound."));
+    }
+
+    [Fact]
+    [Trait("Speed", "Slow")]
+    public void IteratorFixture_RecoveredRowsCompileBackOpcodeExact()
+    {
+        var results = FidelityCheck.Evaluate(FixturePath)
+            .Where(r => r.Type == FixtureType)
+            .ToList();
+
+        Assert.NotEmpty(results);
+
+        foreach (var name in FullRecoveredMembers)
+        {
+            var result = Assert.Single(results, r => r.Method == name);
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+        }
+
+        var diffs = results
+            .Where(r => r.Status == FidelityCheck.CompileBackStatus.OpcodeDiff)
+            .Select(r => r.Method)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(diffs.Length == 0,
+            "Iterator rung targeted fidelity requires zero opcode diffs; diffs: " + string.Join(", ", diffs));
+    }
+
+    static List<(string Name, IrFunction Function, string Body)> LoadRaisedMembers()
+    {
+        var members = new List<(string Name, IrFunction Function, string Body)>();
+        using var source = MetadataSource.Open(FixturePath);
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (typeName != FixtureType)
+                continue;
+
+            var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+            Assert.True(result.Succeeded, $"{methodName}: {string.Join(", ", result.Diagnostics.Select(d => d.Message))}");
+            members.Add((methodName, function, result.Output ?? ""));
+        }
+        return members;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Facts/IteratorRecoveryFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Facts/IteratorRecoveryFacts.cs
@@ -10,7 +10,7 @@ internal sealed class IteratorRecoveryFacts : ILoweringFactProvider
             [
                 new FactPrimitive("generated.iterator-state-machine", "GeneratedCodeIdentity.IsIteratorStateMachineConstructor"),
             ],
-            PositiveCoverage: "IteratorReconstructionPassTests linear, yield-nothing, counting-loop, conditional, multi-yield, nested-loop, and foreach-delegation iterator fixtures",
+            PositiveCoverage: "IteratorReconstructionPassTests linear, yield-nothing, counting-loop, conditional, multi-yield, nested-loop, and foreach-delegation iterator fixtures; LadderIteratorGateTests product-ladder iterator matrix",
             AdversarialCoverage: "IteratorReconstructionPassTests parameter-referencing empty iterator, state-machine-name lookalike (IteratorAcknowledgmentPassTests), and collection-spread yield body that reconstructs the iterator while leaving the spread lowered (CollectionExpressionSpreadIterator_ReconstructsYieldButNotSpread)",
             MissingDiscriminator: "captured iterator shapes and deeper state-machine/PDB correlation remain owed; a reconstructed iterator can still contain lowered scaffolding from an unraised inner frontier — e.g. a yielded spread collection expression (`yield return [.. arch, true];`) keeps its inline-array/CopyTo/Slice lowering because the spread collection-target frontier is unraised (see CollectionExpression)"),
     ];


### PR DESCRIPTION
## Summary

Adds a dedicated product-ladder gate for #1599 row 3, the iterator semantic boss:

- new `ILInspector.Decompiler.Fixtures.LadderIterator` fixture with recovered iterator shapes and honest residual frontiers
- new `LadderIteratorGateTests` covering exact member scope, recognizable `yield` output, side-effect preservation / honest degradation, validity, and targeted compile-back fidelity for recovered rows
- updates iterator sidecar facts to name the product-ladder matrix coverage

This is a guard/measurement PR, not a product behavior change. The scoped matrix pins 9 recovered rows as Full/zero-residual/compile-back Exact and 2 residual rows (`CapturedParameterSideEffectThenBreak`, `UserFinally`) as honest non-Full iterator markers.

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LadderIteratorGateTests/*"`
- `dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class "*IteratorReconstructionPassTests" -class "*IteratorAcknowledgmentPassTests" -class "*IteratorUserFinallyTests"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Fixtures.LadderIterator/release/ILInspector.Decompiler.Fixtures.LadderIterator.dll --fidelity-check --max-examples 20`
  - `COMPILE-BACK over 11 rendered methods (9 Full)`
  - `exact opcode match : 9 (81.82%)`
  - `opcode diff (Full) : 0`
  - `recompile fail     : 2` (the two pinned non-Full residual rows)

I also attempted the full unfiltered `src/ILInspector.Decompiler.Tests` Release suite; it was stopped after ~28 minutes on this shared host with no completion output. The PR-gate fast subset and the new targeted slow fidelity gate both pass.

## Adversarial review

Requested cross-model review from Opus 4.8. Result: no significant correctness issues found. It confirmed the fixture/gate partition is complete and self-consistent, the 9 recovered rows compile back Exact, and the only caveat is the expected repo convention that these decompiler gates run in Release rather than Debug.
