### PR TITLE
Expand row 5 dynamic expression honesty guard

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung9/LadderRung9.cs
@@ -30,6 +30,72 @@ public class DynamicAndExpressionTrees
         return value.Substring(start, length);
     }
 
+    public int DynamicConvert(dynamic value)
+    {
+        return (int)value;
+    }
+
+    public object DynamicNegate(dynamic value)
+    {
+        return -value;
+    }
+
+    public object DynamicConstruct(dynamic value)
+    {
+        return new DynamicConstructTarget(value);
+    }
+
+    public object DynamicSetMember(dynamic value, string name)
+    {
+        value.Name = name;
+        return value;
+    }
+
+    public object DynamicGetIndex(dynamic value, int index)
+    {
+        return value[index];
+    }
+
+    public object DynamicSetIndex(dynamic value, int index, object next)
+    {
+        value[index] = next;
+        return value;
+    }
+
+    public object DynamicCompoundMember(dynamic value, int delta)
+    {
+        value.Count += delta;
+        return value;
+    }
+
+    public void DynamicResultDiscarded(dynamic value)
+    {
+        value.Reset();
+    }
+
+    public void DynamicEventAdd(dynamic value, EventHandler handler)
+    {
+        value.Changed += handler;
+    }
+
+    public void DynamicEventRemove(dynamic value, EventHandler handler)
+    {
+        value.Changed -= handler;
+    }
+
+    public object DynamicNamedOut(dynamic value, string key)
+    {
+        object result;
+        value.TryGet(name: key, result: out result);
+        return result;
+    }
+
+    public int DynamicRefArgument(dynamic value, int input)
+    {
+        value.Mutate(ref input);
+        return input;
+    }
+
     public Expression<Func<int, int>> SimpleExpressionTree()
     {
         return x => x + 1;
@@ -39,4 +105,14 @@ public class DynamicAndExpressionTrees
     {
         return x => x > threshold;
     }
+}
+
+public sealed class DynamicConstructTarget
+{
+    public DynamicConstructTarget(int value)
+    {
+        Value = value;
+    }
+
+    public int Value { get; }
 }

--- a/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
@@ -99,8 +99,8 @@ public class LadderRung9GateTests
         AssertDynamicPartial(members, "DynamicSetMember", "Binder.SetMember");
         AssertDynamicPartial(members, "DynamicGetIndex", "Binder.GetIndex");
         AssertDynamicPartial(members, "DynamicSetIndex", "Binder.SetIndex");
-        AssertDynamicPartial(members, "DynamicCompoundMember", "Binder.SetMember");
-        AssertDynamicPartial(members, "DynamicResultDiscarded", "Binder.InvokeMember");
+        AssertDynamicPartial(members, "DynamicCompoundMember", "Binder.SetMember((CSharpBinderFlags)128", "Binder.GetMember", "Binder.BinaryOperation");
+        AssertDynamicPartial(members, "DynamicResultDiscarded", "Binder.InvokeMember((CSharpBinderFlags)256", "CallSite<Action<CallSite, object>>");
         AssertDynamicPartial(members, "DynamicEventAdd", "Binder.IsEvent", "add_Changed");
         AssertDynamicPartial(members, "DynamicEventRemove", "Binder.IsEvent", "remove_Changed");
     }

--- a/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
@@ -1,6 +1,9 @@
+using System.Collections.Immutable;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.DecompilerHarness;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -8,9 +11,10 @@ namespace ILInspector.Decompiler.Tests;
 /// The rung 9 guard for the decompiler product quality ladder (#1599): dynamic
 /// and expression-tree honesty. It does not claim dynamic or expression-tree
 /// source-syntax recovery. It locks the current safe boundary: dynamic call-site
-/// scaffolding and captured expression trees degrade honestly, while simple
-/// expression-tree builders render as explicit <c>Expression.*</c> calls rather
-/// than unsupported fake source lambdas.
+/// scaffolding degrades honestly across the Roslyn binder families this row owns,
+/// expression-tree builders render as explicit <c>Expression.*</c> calls where
+/// supported, and prohibited expression-tree forms stay documented as the row's
+/// honesty frontier.
 /// </summary>
 public class LadderRung9GateTests
 {
@@ -22,9 +26,21 @@ public class LadderRung9GateTests
         ".ctor",
         "CapturedExpressionTree",
         "DynamicAdd",
+        "DynamicCompoundMember",
+        "DynamicConstruct",
+        "DynamicConvert",
+        "DynamicEventAdd",
+        "DynamicEventRemove",
+        "DynamicGetIndex",
         "DynamicGetLength",
         "DynamicInvoke",
         "DynamicInvokeMember",
+        "DynamicNamedOut",
+        "DynamicNegate",
+        "DynamicRefArgument",
+        "DynamicResultDiscarded",
+        "DynamicSetIndex",
+        "DynamicSetMember",
         "SimpleExpressionTree",
     ];
 
@@ -77,6 +93,35 @@ public class LadderRung9GateTests
         AssertDynamicPartial(members, "DynamicGetLength", "Binder.GetMember", "CallSite<Func<CallSite, object, object>>");
         AssertDynamicPartial(members, "DynamicInvoke", "Binder.Invoke", "CallSite<Func<CallSite, object, int, object>>");
         AssertDynamicPartial(members, "DynamicInvokeMember", "Binder.InvokeMember", "CallSite<Func<CallSite, object, int, int, object>>");
+        AssertDynamicPartial(members, "DynamicConvert", "Binder.Convert", "CallSite<Func<CallSite, object, int>>");
+        AssertDynamicPartial(members, "DynamicNegate", "Binder.UnaryOperation", "CallSite<Func<CallSite, object, object>>");
+        AssertDynamicPartial(members, "DynamicConstruct", "Binder.InvokeConstructor", "CallSite<Func<CallSite, Type, object, DynamicConstructTarget>>");
+        AssertDynamicPartial(members, "DynamicSetMember", "Binder.SetMember");
+        AssertDynamicPartial(members, "DynamicGetIndex", "Binder.GetIndex");
+        AssertDynamicPartial(members, "DynamicSetIndex", "Binder.SetIndex");
+        AssertDynamicPartial(members, "DynamicCompoundMember", "Binder.SetMember");
+        AssertDynamicPartial(members, "DynamicResultDiscarded", "Binder.InvokeMember");
+        AssertDynamicPartial(members, "DynamicEventAdd", "Binder.IsEvent", "add_Changed");
+        AssertDynamicPartial(members, "DynamicEventRemove", "Binder.IsEvent", "remove_Changed");
+    }
+
+    [Fact]
+    public void Rung9Fixture_DegradesDynamicArgumentMetadataHonestly()
+    {
+        var members = LoadRaisedMembers();
+
+        AssertDynamicPartial(
+            members,
+            "DynamicNamedOut",
+            "Binder.InvokeMember",
+            "CSharpArgumentInfo.Create",
+            "\"name\"",
+            "\"result\"");
+        AssertDynamicPartial(
+            members,
+            "DynamicRefArgument",
+            "Binder.InvokeMember",
+            "CSharpArgumentInfo.Create");
     }
 
     [Fact]
@@ -99,16 +144,35 @@ public class LadderRung9GateTests
         Assert.DoesNotContain("=>", captured.Body);
     }
 
+    [Theory]
+    [InlineData("Expression<Func<dynamic, object>> e = x => x.Value;", "CS1963")]
+    [InlineData("Expression<Func<int, int>> e = x => x = 1;", "CS0832")]
+    [InlineData("Expression<Action> e = () => { };", "CS0834")]
+    [InlineData("Expression<Func<System.Threading.Tasks.Task>> e = async () => await System.Threading.Tasks.Task.CompletedTask;", "CS1989")]
+    [InlineData("Expression<Func<object, bool>> e = x => x is string s;", "CS8122")]
+    [InlineData("Expression<Func<(int, int)>> e = () => (1, 2);", "CS8143")]
+    [InlineData("Expression<Func<int[], int>> e = x => x[^1];", "CS8791")]
+    [InlineData("Expression<Func<int[], int[]>> e = x => x[1..];", "CS8792")]
+    [InlineData("Expression<Func<RecordSample, RecordSample>> e = x => x with { X = 1 };", "CS8849")]
+    [InlineData("Expression<Func<int[]>> e = () => [1, 2];", "CS9175")]
+    [InlineData("Expression<Func<int, int>> e = x => Optional(x);", "CS0854")]
+    [InlineData("Expression<Func<int, int>> e = x => Optional(value: x, delta: 1);", "CS0853")]
+    public void Rung9ExpressionTreeRestrictions_AreTrackedAsHonestyFrontier(string statement, string expectedDiagnostic)
+    {
+        var diagnostics = CompileExpressionTreeStatement(statement);
+
+        Assert.Contains(expectedDiagnostic, diagnostics);
+    }
+
     static void AssertDynamicPartial(
         List<(string Name, IrFunction Function, DecompilerResult Result, string Body)> members,
         string name,
-        string expectedBinder,
-        string expectedCallSite)
+        params string[] expectedFragments)
     {
         var member = members.Single(m => m.Name == name);
         Assert.Equal(DecompilationFidelity.Partial, member.Function.Fidelity);
-        Assert.Contains(expectedBinder, member.Body);
-        Assert.Contains(expectedCallSite, member.Body);
+        foreach (string fragment in expectedFragments)
+            Assert.Contains(fragment, member.Body);
         Assert.DoesNotContain("dynamic", member.Body);
     }
 
@@ -126,5 +190,52 @@ public class LadderRung9GateTests
         }
 
         return members;
+    }
+
+    static string[] CompileExpressionTreeStatement(string statement)
+    {
+        string source = $$"""
+            using System;
+            using System.Linq.Expressions;
+
+            public record RecordSample(int X);
+
+            public static class ExpressionTreeRestrictionShell
+            {
+                static int Optional(int value, int delta = 1) => value + delta;
+
+                public static void Check(dynamic dynamicValue)
+                {
+                    {{statement}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "expression-tree-restriction-shell",
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        return compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => d.Id)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    static ImmutableArray<MetadataReference> RuntimeReferences()
+    {
+        var references = ImmutableArray.CreateBuilder<MetadataReference>();
+        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+            try { references.Add(MetadataReference.CreateFromFile(path)); }
+            catch { }
+        }
+
+        return references.ToImmutable();
     }
 }


### PR DESCRIPTION
## Summary

Expands the #1599 row 5 / #1696 dynamic-expression honesty guard so the completion claim covers the upstream audit surface more faithfully.

- Adds fixture methods for dynamic conversion, unary operation, constructor invocation, set/get index, set member, compound member assignment, result-discarded invocation, event add/remove, and named/ref/out argument metadata.
- Extends `LadderRung9GateTests` to require those dynamic shapes to remain honest `Partial` scaffolding rather than fake `dynamic` source recovery.
- Adds Roslyn-backed expression-tree restriction checks for dynamic operations, assignment, statement/async lambdas, declaration patterns, tuples, index/range, with-expressions, collection expressions, and named/optional argument restrictions.

This is a guard/measurement PR, not a source-syntax recovery claim.

## Evidence

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LadderRung9GateTests
ILInspector.Decompiler.Tests  Total: 17, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
ILInspector.Decompiler.Tests  Total: 1545, Errors: 0, Failed: 0, Skipped: 0

dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded. 0 Warning(s), 0 Error(s)
```

Fixes #1696.
