### PR TITLE
Fix record Deconstruct receiver and primary-ctor base residual (#1632, #1639)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ConstructorCallDiagnosticsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConstructorCallDiagnosticsPassTests.cs
@@ -7,6 +7,7 @@ public class ConstructorCallDiagnosticsPassTests
 {
     static readonly TypeRef Owner = TypeRef.CoreLib("Synthetic", "Owner");
     static readonly TypeRef Base = TypeRef.CoreLib("Synthetic", "Base");
+    static readonly TypeRef ObjectType = TypeRef.CoreLib("System", "Object");
     static readonly TypeRef Unrelated = TypeRef.CoreLib("Synthetic", "Unrelated");
     static readonly TypeRef StructType = TypeRef.CoreLib("Synthetic", "StructType");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
@@ -42,13 +43,33 @@ public class ConstructorCallDiagnosticsPassTests
     }
 
     [Fact]
-    public void Run_LeavesParameterStoreBeforeParameterlessBaseCallLiftable()
+    public void Run_LeavesParameterStoreBeforeParameterlessObjectBaseCallLiftable()
     {
         // The record / primary-constructor shape: the synthesized ctor stores its
         // parameters into the backing fields and then calls the implicit
-        // parameterless base ctor. The parameterless base call is C#'s implicit
-        // : base() and must stay liftable (Full), not become an owned residual —
-        // see #1639. The param-storing field assignments render as body statements.
+        // parameterless object..ctor. object's ctor is a guaranteed no-op, so the
+        // base call stays liftable (Full), not an owned residual — see #1639. The
+        // param-storing field assignments render as body statements.
+        var field = new FieldRef(Owner, "_value", Int32);
+        var store = new StoreField(field, new LoadArgument(0, "this", Owner), new LoadArgument(1, "value", Int32));
+        var ctor = new MethodRef(ObjectType, ".ctor", Void, [], HasThis: true);
+        var call = new Call(ctor, isVirtual: false, [new LoadArgument(0, "this", Owner)]);
+        var function = Function(".ctor", [store, new ExpressionStatement(call)], baseType: ObjectType);
+
+        new ConstructorCallDiagnosticsPass().Run(function, PassContext.None);
+
+        var statement = Assert.IsType<ExpressionStatement>(function.Body.Blocks[0].Children[1]);
+        Assert.Same(call, statement.Expression);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void Run_MarksParameterStoreBeforeNonObjectBaseCallUnsupported()
+    {
+        // A parameterless base call to a NON-object base type is not provably a
+        // no-op: eliding it would reorder the preceding param stores after a base
+        // ctor that could observe pre-base state (e.g. via a virtual the derived
+        // type overrides). It must stay an explicit residual, not silently Full.
         var field = new FieldRef(Owner, "_value", Int32);
         var store = new StoreField(field, new LoadArgument(0, "this", Owner), new LoadArgument(1, "value", Int32));
         var ctor = new MethodRef(Base, ".ctor", Void, [], HasThis: true);
@@ -58,8 +79,8 @@ public class ConstructorCallDiagnosticsPassTests
         new ConstructorCallDiagnosticsPass().Run(function, PassContext.None);
 
         var statement = Assert.IsType<ExpressionStatement>(function.Body.Blocks[0].Children[1]);
-        Assert.Same(call, statement.Expression);
-        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.IsType<UnsupportedNode>(statement.Expression);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ConstructorCallDiagnosticsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConstructorCallDiagnosticsPassTests.cs
@@ -42,12 +42,36 @@ public class ConstructorCallDiagnosticsPassTests
     }
 
     [Fact]
-    public void Run_MarksConstructorChainWithParameterStoreBeforeCallUnsupported()
+    public void Run_LeavesParameterStoreBeforeParameterlessBaseCallLiftable()
     {
+        // The record / primary-constructor shape: the synthesized ctor stores its
+        // parameters into the backing fields and then calls the implicit
+        // parameterless base ctor. The parameterless base call is C#'s implicit
+        // : base() and must stay liftable (Full), not become an owned residual —
+        // see #1639. The param-storing field assignments render as body statements.
         var field = new FieldRef(Owner, "_value", Int32);
         var store = new StoreField(field, new LoadArgument(0, "this", Owner), new LoadArgument(1, "value", Int32));
         var ctor = new MethodRef(Base, ".ctor", Void, [], HasThis: true);
         var call = new Call(ctor, isVirtual: false, [new LoadArgument(0, "this", Owner)]);
+        var function = Function(".ctor", [store, new ExpressionStatement(call)], baseType: Base);
+
+        new ConstructorCallDiagnosticsPass().Run(function, PassContext.None);
+
+        var statement = Assert.IsType<ExpressionStatement>(function.Body.Blocks[0].Children[1]);
+        Assert.Same(call, statement.Expression);
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void Run_MarksParameterStoreBeforeParameterizedBaseCallUnsupported()
+    {
+        // A non-parameterless base call preceded by a parameter store is NOT the
+        // elidable implicit : base(); it carries arguments and has no faithful
+        // statement spelling, so it must remain an explicit residual.
+        var field = new FieldRef(Owner, "_value", Int32);
+        var store = new StoreField(field, new LoadArgument(0, "this", Owner), new LoadArgument(1, "value", Int32));
+        var ctor = new MethodRef(Base, ".ctor", Void, [Int32], HasThis: true);
+        var call = new Call(ctor, isVirtual: false, [new LoadArgument(0, "this", Owner), new Constant(5, Int32)]);
         var function = Function(".ctor", [store, new ExpressionStatement(call)], baseType: Base);
 
         new ConstructorCallDiagnosticsPass().Run(function, PassContext.None);

--- a/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
@@ -17,16 +17,12 @@ namespace ILInspector.Decompiler.Tests;
 /// semantic-binding defects (the core ladder bar);</item>
 /// <item>the constructs that already meet the rung 5 bar — index/range operators,
 /// <c>using</c> declarations, property/type patterns, scalar relational switch
-/// expressions, and init-only object initializers — render recognizably.</item>
-/// </list>
-///
-/// Rung 5 is <b>not complete</b>: one source-visible construct still falls short
-/// of the bar and is tracked as a focused issue. It is deliberately NOT asserted
-/// green here; this guard locks the invariant and the working surface so that fix
-/// can be verified against a stable baseline:
-/// <list type="bullet">
-/// <item>#1632 — record <c>Deconstruct</c> drops the receiver and renders
-/// <c>X = X;</c>.</item>
+/// expressions, and init-only object initializers — render recognizably;</item>
+/// <item>the compiler-synthesized record members render at the rung 5 bar:
+/// <c>Deconstruct</c> qualifies its shadowed instance reads (<c>X = this.X;</c>,
+/// #1632) and the positional-record primary constructor renders valid
+/// <c>Full</c> with the implicit base call elided (no owned base-ctor residual,
+/// #1639).</item>
 /// </list>
 /// </summary>
 public class LadderRung5GateTests
@@ -48,9 +44,10 @@ public class LadderRung5GateTests
     // The record's compiler-synthesized member set (primary + copy ctor, Clone,
     // Deconstruct, the two Equals overloads, GetHashCode, PrintMembers, ToString,
     // EqualityContract, accessors, equality operators). Locked because rung 5
-    // ("records/init where visible") measures these, and a gap issue (#1632)
-    // depends on Point.Deconstruct: a future importer/printer change that drops a
-    // synthesized member must fail here rather than silently shrink the scope.
+    // ("records/init where visible") measures these — Point.Deconstruct (#1632)
+    // and the positional primary constructor (#1639) are asserted green in
+    // Rung5Fixture_RendersRecordMembers — so a future importer/printer change that
+    // drops a synthesized member must fail here rather than silently shrink scope.
     static readonly string[] ExpectedRecordMembers =
     [
         ".ctor", ".ctor", "<Clone>$", "Deconstruct", "Equals", "Equals",
@@ -179,6 +176,50 @@ public class LadderRung5GateTests
 
         // nondestructive mutation (with-expression) on a record.
         Assert.Contains("return point with { X = point.X + dx };", Body("Shift"));
+    }
+
+    // The compiler-synthesized record members render at the rung 5 bar. These pin
+    // the two fixes that closed the modern-syntax burndown rows (#1632, #1639) so
+    // they cannot silently regress.
+    [Fact]
+    public void Rung5Fixture_RendersRecordMembers()
+    {
+        var members = LoadRaisedMembers().Where(m => m.Type == RecordType).ToList();
+        string Body(IrFunction function) =>
+            CSharpPrinter.PrintRaised(function).Output?.Trim() ?? "";
+
+        // #1632: Deconstruct(out int X, out int Y) reads this.X/this.Y. The out
+        // parameters shadow the X/Y properties, so the receiver must be qualified;
+        // a dropped receiver renders the self-assigning no-op `X = X;`.
+        var deconstruct = Body(members.Single(m => m.Name == "Deconstruct").Function);
+        Assert.Contains("X = this.X;", deconstruct);
+        Assert.Contains("Y = this.Y;", deconstruct);
+        Assert.DoesNotContain("X = X;", deconstruct);
+        Assert.DoesNotContain("Y = Y;", deconstruct);
+
+        // #1639: the positional-record primary constructor stores its parameters
+        // into the backing fields and then calls the implicit parameterless base
+        // constructor. It must render valid Full with the base call elided — no
+        // owned base-ctor residual.
+        var primaryCtor = members
+            .Where(m => m.Name == ".ctor" && m.Function.Signature.Parameters.Length == 2)
+            .Select(m => m.Function)
+            .Single();
+        var primaryBody = Body(primaryCtor);
+        Assert.Contains("this.X = X;", primaryBody);
+        Assert.Contains("this.Y = Y;", primaryBody);
+        Assert.DoesNotContain("Unsupported", primaryBody);
+        Assert.DoesNotContain("/*", primaryBody);
+
+        // The copy constructor stays clean: instance reads from the source record,
+        // base call elided.
+        var copyCtor = members
+            .Where(m => m.Name == ".ctor" && m.Function.Signature.Parameters.Length == 1)
+            .Select(m => m.Function)
+            .Single();
+        var copyBody = Body(copyCtor);
+        Assert.Contains("this.X = original.X;", copyBody);
+        Assert.DoesNotContain("Unsupported", copyBody);
     }
 
     static List<(string Type, string Name, IrFunction Function)> LoadRaisedMembers()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -38,7 +38,12 @@ public sealed partial class CSharpPrinter
             // C#'s base. — the call opcode deliberately skips dispatch.
             LoadArgument { Index: 0, Name: "this" } when !isVirtual && IsCrossType(accessor.DeclaringType) => "base",
             null => TypeText(accessor.DeclaringType),
-            LoadArgument { Index: 0, Name: "this" } => "",
+            // A parameter or local with the same name shadows the property, so a
+            // bare read binds to it, not the property (e.g. the synthesized record
+            // Deconstruct(out int X, ...) whose body reads this.X). Qualify with
+            // this. to reach the property; an unshadowed instance property stays
+            // bare per the taste convention, matching FieldTarget.
+            LoadArgument { Index: 0, Name: "this" } => IsShadowedByLocal(name) ? "this" : "",
             _ => ReceiverText(instance),
         };
         // An instance property accessor with index arguments IS an indexer,

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorCallDiagnosticsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorCallDiagnosticsPass.cs
@@ -68,10 +68,10 @@ public sealed class ConstructorCallDiagnosticsPass : IIrPass
             && prologue.All(IsInstanceFieldStore);
     }
 
-    /// <summary>A no-argument <c>call instance .ctor</c> on <c>this</c> to <see cref="object"/> — the one base ctor whose no-op body makes eliding it (and thus reordering preceding field stores after it) observably safe.</summary>
+    /// <summary>A no-argument <c>call instance .ctor</c> on <c>this</c> to corelib <see cref="object"/> — the one base ctor whose no-op body makes eliding it (and thus reordering preceding field stores after it) observably safe.</summary>
     static bool IsElidableObjectBaseCall(IrFunction function, Call call)
         => call.Arguments is [LoadArgument { Index: 0 }]
-            && call.Callee.DeclaringType is { Namespace: "System", Name: "Object" }
+            && call.Callee.DeclaringType is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Object" }
             && function.BaseType is { } baseType
             && SameDefinition(call.Callee.DeclaringType, baseType);
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorCallDiagnosticsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorCallDiagnosticsPass.cs
@@ -54,18 +54,24 @@ public sealed class ConstructorCallDiagnosticsPass : IIrPass
 
         // Record / primary-constructor prologue: the synthesized constructor
         // stores its parameters into the backing fields (this.<X>k__BackingField
-        // = X) and THEN calls the implicit parameterless base constructor. A
-        // parameterless call to the base type is always C#'s implicit : base()
-        // and is elidable; the param-storing field assignments render as ordinary
-        // body statements, so the constructor stays valid Full instead of leaking
-        // an owned base-ctor residual. See #1639.
-        return IsImplicitParameterlessBaseCall(function, call)
+        // = X) and THEN calls the implicit parameterless object..ctor. The printer
+        // does NOT lift these param-dependent stores into pre-base position — it
+        // emits them as body statements and suppresses the parameterless base call
+        // — so the stores effectively run AFTER the implicit base ctor in the
+        // rendered C#. That reordering is only observably safe when the base ctor
+        // does nothing: System.Object's parameterless ctor is a guaranteed no-op,
+        // so eliding it keeps the constructor valid Full instead of leaking an
+        // owned base-ctor residual. A non-trivial base ctor (e.g. one calling a
+        // virtual the derived type overrides to read the field) must stay a
+        // residual. See #1639.
+        return IsElidableObjectBaseCall(function, call)
             && prologue.All(IsInstanceFieldStore);
     }
 
-    /// <summary>A no-argument <c>call instance .ctor</c> on <c>this</c> to the direct base type: C#'s implicit <c>: base()</c>.</summary>
-    static bool IsImplicitParameterlessBaseCall(IrFunction function, Call call)
+    /// <summary>A no-argument <c>call instance .ctor</c> on <c>this</c> to <see cref="object"/> — the one base ctor whose no-op body makes eliding it (and thus reordering preceding field stores after it) observably safe.</summary>
+    static bool IsElidableObjectBaseCall(IrFunction function, Call call)
         => call.Arguments is [LoadArgument { Index: 0 }]
+            && call.Callee.DeclaringType is { Namespace: "System", Name: "Object" }
             && function.BaseType is { } baseType
             && SameDefinition(call.Callee.DeclaringType, baseType);
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorCallDiagnosticsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConstructorCallDiagnosticsPass.cs
@@ -43,9 +43,35 @@ public sealed class ConstructorCallDiagnosticsPass : IIrPass
         }
 
         int chainIndex = ChildIndexOf(entry, statement);
-        return chainIndex >= 0
-            && entry.Children.Take(chainIndex).All(IsFieldInitializerStore);
+        if (chainIndex < 0)
+            return false;
+
+        var prologue = entry.Children.Take(chainIndex);
+        // Standard prologue: constant field initializers (no place loads) precede
+        // the chain call, so they re-express as field declarations + : base().
+        if (prologue.All(IsFieldInitializerStore))
+            return true;
+
+        // Record / primary-constructor prologue: the synthesized constructor
+        // stores its parameters into the backing fields (this.<X>k__BackingField
+        // = X) and THEN calls the implicit parameterless base constructor. A
+        // parameterless call to the base type is always C#'s implicit : base()
+        // and is elidable; the param-storing field assignments render as ordinary
+        // body statements, so the constructor stays valid Full instead of leaking
+        // an owned base-ctor residual. See #1639.
+        return IsImplicitParameterlessBaseCall(function, call)
+            && prologue.All(IsInstanceFieldStore);
     }
+
+    /// <summary>A no-argument <c>call instance .ctor</c> on <c>this</c> to the direct base type: C#'s implicit <c>: base()</c>.</summary>
+    static bool IsImplicitParameterlessBaseCall(IrFunction function, Call call)
+        => call.Arguments is [LoadArgument { Index: 0 }]
+            && function.BaseType is { } baseType
+            && SameDefinition(call.Callee.DeclaringType, baseType);
+
+    /// <summary>A <c>this.field = value</c> store, regardless of whether the value reads constructor parameters (the record primary-constructor shape).</summary>
+    static bool IsInstanceFieldStore(IrNode node)
+        => node is StoreField { HasInstance: true, Instance: LoadArgument { Index: 0 } };
 
     static bool IsConstructorChainTarget(IrFunction function, TypeRef declaringType)
         => SameDefinition(declaringType, function.DeclaringType)


### PR DESCRIPTION
## Summary

Burns down both open rows of the #1599 row 2 (modern straightforward syntax / rung 5) burndown #1643 — two positional-record rendering defects — in one PR.

### #1632 — record `Deconstruct` drops receiver, renders `X = X`

The synthesized `Deconstruct(out int X, out int Y)` body reads `this.X`/`this.Y`, but `PropertyTarget` always rendered a `this` receiver as the empty string, so the property read collided with the same-named `out` parameter and printed the self-assigning no-op `X = X;` (a fidelity misrender — the body no longer reflected the IL's instance reads).

Fix: qualify the receiver as `this.` when a parameter/local shadows the property name, mirroring `FieldTarget`'s existing `IsShadowedByLocal` handling. Unshadowed instance properties stay bare per the taste convention.

```
Before: X = X;          After: X = this.X;
        Y = Y;                 Y = this.Y;
```

### #1639 — record primary constructor retains unsupported base-ctor residual

The positional-record primary constructor stores its parameters into the backing fields and *then* calls the implicit parameterless base ctor — a fields-before-base ordering `IsLiftableConstructorChain` did not recognize (its field-initializer guard bans place loads). The base call leaked an owned `/* Unsupported ... direct constructor call to object ... */` residual and the ctor degraded to `Partial`.

Fix: treat a parameterless call to the base type preceded by `this`-field stores as the elidable implicit `: base()`. The param-storing assignments render as ordinary body statements, and the printer already elides a surviving parameterless base call, so the ctor is now valid `Full`.

```
Before: this.X = X;     After: this.X = X;
        this.Y = Y;            this.Y = Y;
        /* Unsupported IL_000F call .ctor: ... */
```

The rung 5 fixture is now **30 Full / 0 Partial** (the primary ctor moved Partial -> Full). The copy constructor and ordinary constructors remain valid.

## Guard

`LadderRung5GateTests` gains `Rung5Fixture_RendersRecordMembers`, pinning both fixes green (Deconstruct receiver-qualified, primary ctor Full with no residual, copy ctor still clean). The docstring/member comments drop the "#1632 not asserted green" note. The `ConstructorCallDiagnosticsPassTests` case that asserted the old residual behavior is updated to the new lifted-Full shape, with a companion test keeping a *parameterized* base call an explicit residual.

## Evidence

- `LadderRung5GateTests` 5/5
- Fast decompiler subset (`-trait- "Speed=Slow"`) 1515/1515
- `CorpusSweepGateTests`, `FidelityGateTests`, `LoweredFidelityGateTests` green
- `dotnet build src/dotnet-inspect -c Release` clean
- Corpus quality-diff card: **matched baseline tolerances** — Full malformed 32 -> 32, semantic defects 0 delta, pass bugs 0, pinned-subset opcode diffs 1 -> 1 (aggregate count/sample deltas are baseline-drift noise flagged by the tool, not a clean PR signal)

Adversarial cross-family review (GPT-5.5) requested per the decompiler PR contract.

Closes #1632, closes #1639. Advances #1599 row 2 / #1643.
