### PR TITLE
Improve row 6 function-pointer fidelity coverage

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -182,6 +182,13 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6FunctionPointerInvocation_RecompilesThroughFidelityHarness()
+    {
+        AssertExactCompileBack(NewUnsafePath, NewUnsafeType, "InvokeFunctionPointer");
+        AssertExactCompileBack(LegacyUnsafePath, LegacyUnsafeType, "InvokeFunctionPointer");
+    }
+
+    [Fact]
     public void Rung6UnspellableVolatileAndPinnedShapes_DegradeHonestly()
     {
         var volatileLoad = VolatileIndirectRead(isVolatile: true);
@@ -200,6 +207,15 @@ public class LadderRung6GateTests
         var raisedPinnedOutput = CSharpPrinter.Print(raisedPinned).Output;
         Assert.Contains("fixed (int* V_0 = ", raisedPinnedOutput);
         Assert.DoesNotContain("pinned", raisedPinnedOutput);
+    }
+
+    static void AssertExactCompileBack(string assemblyPath, string typeName, string methodName)
+    {
+        var result = Assert.Single(
+            FidelityCheck.Evaluate(assemblyPath),
+            r => r.Type == typeName && r.Method == methodName);
+
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
     }
 
     static List<(string Name, IrFunction Function, DecompilerResult Result, string Body)> LoadRaisedMembers(

--- a/src/ILInspector.Metadata/TypeNode.cs
+++ b/src/ILInspector.Metadata/TypeNode.cs
@@ -188,9 +188,9 @@ internal sealed class FunctionPointerTypeNode(MethodSignature<TypeNode> signatur
     public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
     {
         ConsumeByte(bytes, ref position, defaultByte);
+        signature.ReturnType.ApplyNullability(bytes, ref position, defaultByte);
         foreach (var parameter in signature.ParameterTypes)
             parameter.ApplyNullability(bytes, ref position, defaultByte);
-        signature.ReturnType.ApplyNullability(bytes, ref position, defaultByte);
     }
 
     static string ConventionText(SignatureCallingConvention convention) => convention switch

--- a/src/ILInspector.Metadata/TypeNode.cs
+++ b/src/ILInspector.Metadata/TypeNode.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Reflection.Metadata;
 
 namespace ILInspector.Metadata;
 
@@ -169,17 +170,38 @@ internal sealed class GenericParameterNode(string name) : TypeNode
     }
 }
 
-/// <summary>Function pointer types (delegate*).</summary>
-internal sealed class FunctionPointerTypeNode : TypeNode
+/// <summary>Function pointer types (delegate*&lt;...&gt;).</summary>
+internal sealed class FunctionPointerTypeNode(MethodSignature<TypeNode> signature) : TypeNode
 {
     public override bool IsReferenceType => false;
 
-    public override string Render() => "delegate*";
+    public override string Render()
+    {
+        var types = signature.ParameterTypes.Select(t => t.Render()).Append(signature.ReturnType.Render());
+        string arguments = string.Join(", ", types);
+        string convention = ConventionText(signature.Header.CallingConvention);
+        return convention.Length == 0
+            ? $"delegate*<{arguments}>"
+            : $"delegate* {convention}<{arguments}>";
+    }
 
     public override void ApplyNullability(byte[]? bytes, ref int position, byte defaultByte)
     {
         ConsumeByte(bytes, ref position, defaultByte);
+        foreach (var parameter in signature.ParameterTypes)
+            parameter.ApplyNullability(bytes, ref position, defaultByte);
+        signature.ReturnType.ApplyNullability(bytes, ref position, defaultByte);
     }
+
+    static string ConventionText(SignatureCallingConvention convention) => convention switch
+    {
+        SignatureCallingConvention.Default => "",
+        SignatureCallingConvention.CDecl => "unmanaged[Cdecl]",
+        SignatureCallingConvention.StdCall => "unmanaged[Stdcall]",
+        SignatureCallingConvention.ThisCall => "unmanaged[Thiscall]",
+        SignatureCallingConvention.FastCall => "unmanaged[Fastcall]",
+        _ => "unmanaged",
+    };
 }
 
 /// <summary>Modified or pinned types—pass through to the underlying type.</summary>

--- a/src/ILInspector.Metadata/TypeNodeProvider.cs
+++ b/src/ILInspector.Metadata/TypeNodeProvider.cs
@@ -80,7 +80,7 @@ internal sealed class TypeNodeProvider : ISignatureTypeProvider<TypeNode, Generi
         return new GenericParameterNode(name);
     }
 
-    public TypeNode GetFunctionPointerType(MethodSignature<TypeNode> signature) => new FunctionPointerTypeNode();
+    public TypeNode GetFunctionPointerType(MethodSignature<TypeNode> signature) => new FunctionPointerTypeNode(signature);
 
     public TypeNode GetModifiedType(TypeNode modifier, TypeNode unmodifiedType, bool isRequired) => new ModifiedTypeNode(modifier, unmodifiedType, isRequired);
 

--- a/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
+++ b/src/ILInspector.MetadataPrimitives/SignatureDecoder.cs
@@ -75,7 +75,25 @@ public class SignatureDecoder : ISignatureTypeProvider<string, GenericContext?>
         return $"T{index}";
     }
 
-    public string GetFunctionPointerType(MethodSignature<string> signature) => "delegate*";
+    public string GetFunctionPointerType(MethodSignature<string> signature)
+    {
+        var types = signature.ParameterTypes.Add(signature.ReturnType);
+        string arguments = string.Join(", ", types);
+        string convention = ConventionText(signature.Header.CallingConvention);
+        return convention.Length == 0
+            ? $"delegate*<{arguments}>"
+            : $"delegate* {convention}<{arguments}>";
+    }
+
+    static string ConventionText(SignatureCallingConvention convention) => convention switch
+    {
+        SignatureCallingConvention.Default => "",
+        SignatureCallingConvention.CDecl => "unmanaged[Cdecl]",
+        SignatureCallingConvention.StdCall => "unmanaged[Stdcall]",
+        SignatureCallingConvention.ThisCall => "unmanaged[Thiscall]",
+        SignatureCallingConvention.FastCall => "unmanaged[Fastcall]",
+        _ => "unmanaged",
+    };
     
     public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
     

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceUnsafeTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceUnsafeTests.cs
@@ -44,6 +44,14 @@ public sealed class ApiSurfaceUnsafeTests
     }
 
     [Fact]
+    public void FunctionPointerSignature_PreservesDelegatePointerShape()
+    {
+        Assert.Equal(
+            "int InvokeFunctionPointer(delegate*<int, int> callback, int x)",
+            Method(nameof(NewFixtures.InvokeFunctionPointer)).Signature);
+    }
+
+    [Fact]
     public void SafeMember_IsNotUnsafe()
     {
         // No pointer and not declared unsafe at the member level.

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceUnsafeTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceUnsafeTests.cs
@@ -15,17 +15,21 @@ namespace ILInspector.Metadata.Tests;
 /// </summary>
 public sealed class ApiSurfaceUnsafeTests
 {
+    private static ApiType Type(Type type)
+    {
+        using var stream = File.OpenRead(type.Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+        return surface.Types.First(t => t.FullName == type.FullName);
+    }
+
     private static ApiMember Method(string name)
     {
         // ApiSurfaceExtractor materializes the surface into lists, so the reader
         // can be disposed once Extract returns. typeof(...).Name is the simple
         // type name ("UnsafeFixtures"); nameof on the using-alias would yield the
         // alias identifier instead.
-        using var stream = File.OpenRead(typeof(NewFixtures).Assembly.Location);
-        using var peReader = new PEReader(stream);
-        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
-        return surface.Types.First(t => t.Name == typeof(NewFixtures).Name)
-            .Members.First(m => m.Name == name && m.Kind == "method");
+        return Type(typeof(NewFixtures)).Members.First(m => m.Name == name && m.Kind == "method");
     }
 
     [Fact]
@@ -52,9 +56,28 @@ public sealed class ApiSurfaceUnsafeTests
     }
 
     [Fact]
+    public void FunctionPointerSignature_AppliesNullabilityInMetadataOrder()
+    {
+        var members = Type(typeof(FunctionPointerNullabilityFixture)).Members;
+
+        Assert.Equal(
+            "delegate*<string, string?>",
+            members.Single(m => m.Name == nameof(FunctionPointerNullabilityFixture.ReturnsNullable)).ReturnType);
+        Assert.Equal(
+            "delegate*<string?, string>",
+            members.Single(m => m.Name == nameof(FunctionPointerNullabilityFixture.ParameterNullable)).ReturnType);
+    }
+
+    [Fact]
     public void SafeMember_IsNotUnsafe()
     {
         // No pointer and not declared unsafe at the member level.
         Assert.False(Method(nameof(NewFixtures.StackAllocDefault)).IsUnsafe);
     }
+}
+
+public unsafe class FunctionPointerNullabilityFixture
+{
+    public delegate*<string, string?> ReturnsNullable;
+    public delegate*<string?, string> ParameterNullable;
 }

--- a/tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj
+++ b/tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsAotCompatible>false</IsAotCompatible>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2286,7 +2286,8 @@ static class FidelityCheck
             return "object";
         if (type == "delegate*")
             return "void*"; // a pointer-sized stand-in; calls through it are rare
-        if (type.StartsWith("delegate*", StringComparison.Ordinal))
+        if (type.StartsWith("delegate*", StringComparison.Ordinal)
+            || type.StartsWith("ref delegate*", StringComparison.Ordinal))
             return type;
         return EscapeTypeKeywords(type);
     }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2272,19 +2272,22 @@ static class FidelityCheck
     }
 
     /// <summary>
-    /// The lightweight <see cref="SignatureDecoder"/> renders some shapes as
-    /// invalid C#: function pointers as a bare <c>delegate*</c> (no signature),
-    /// and unresolved generic parameters as <c>!n</c>/<c>!!n</c>. A single such
-    /// member would sink the whole single-unit skeleton, so spellings are
-    /// repaired to the nearest compiling form. The target body rarely touches
-    /// these; when it does the diff is honestly attributable to the gap.
+    /// The lightweight <see cref="SignatureDecoder"/> can render some unresolved
+    /// shapes as invalid C#: unresolved generic parameters as <c>!n</c>/<c>!!n</c>,
+    /// and older function-pointer decoders as a bare <c>delegate*</c> (no
+    /// signature). A single such member would sink the whole single-unit skeleton,
+    /// so spellings are repaired to the nearest compiling form. The target body
+    /// rarely touches these; when it does the diff is honestly attributable to the
+    /// gap.
     /// </summary>
     static string Clean(string type)
     {
         if (type.Contains('!'))
             return "object";
-        if (type.Contains("delegate*"))
+        if (type == "delegate*")
             return "void*"; // a pointer-sized stand-in; calls through it are rare
+        if (type.StartsWith("delegate*", StringComparison.Ordinal))
+            return type;
         return EscapeTypeKeywords(type);
     }
 


### PR DESCRIPTION
## Summary

Refs #1599 row 6.

Burns down the row-6 function-pointer compile-back residual from #1700. The unsafe fixture methods already rendered valid product C#, but the fidelity harness reconstructed function-pointer signatures as `void*`, so `callback(x)` failed with CS0149 and the row reported two recompile failures.

- Preserve function-pointer parameter/return shapes in metadata signature rendering (`delegate*<...>` / `delegate* unmanaged[...]<...>`).
- Keep the fidelity skeleton from escaping the structural `delegate*` keyword as an identifier.
- Add API-surface coverage for function-pointer signatures.
- Add a rung-6 fidelity guard proving both new-rules and legacy fixture `InvokeFunctionPointer` methods compile back exactly.

This is a row-6 burndown slice, not a row-completion claim. The remaining measured unsafe fixture residual is the `SumPinned` pointer-arithmetic opcode diff.

## Evidence

Before this change, unsafe fixture fidelity showed 18 exact, 2 opcode diffs, and 2 recompile failures (CS0149). After this change:

```text
dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Fixtures.NewUnsafe/release/ILInspector.Decompiler.Fixtures.NewUnsafe.dll artifacts/bin/ILInspector.Decompiler.Fixtures.LegacyUnsafe/release/ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll --fidelity-check --max-examples 10
COMPILE-BACK over 22 rendered methods (22 Full)
exact opcode match : 20 (90.91%)
opcode diff (Full) : 2
context-build fail : 0
recompile fail     : 0
```

Additional validation:

```text
dotnet run --project tests/ILInspector.Metadata.Tests -c Release
ILInspector.Metadata.Tests  Total: 227, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LadderRung6GateTests/*"
ILInspector.Decompiler.Tests  Total: 7, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.CallIndirectSpellabilityPassTests -class ILInspector.Decompiler.Tests.FunctionPointerDiagnosticsPassTests -class ILInspector.Decompiler.Tests.RefArgumentRenderingTests -class ILInspector.Decompiler.Tests.PointerAssignmentCastTests -class ILInspector.Decompiler.Tests.PointerArithmeticScalingTests
ILInspector.Decompiler.Tests  Total: 37, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
ILInspector.Decompiler.Tests  Total: 1549, Errors: 0, Failed: 0, Skipped: 0

dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded. 0 Warning(s), 0 Error(s)
```
