### PR TITLE
Render checked user-defined operators with checked(...) not op_Checked* call (#1706)

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung5/ILInspector.Decompiler.Fixtures.LadderRung5.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung5/ILInspector.Decompiler.Fixtures.LadderRung5.csproj
@@ -1,16 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!--
-    Rung 5 of the decompiler product quality ladder (#1599): C# 8-9 syntax
-    surface. A small, durable fixture covering the rung 5 constructs — index/range
-    operators, using declarations, switch expressions, expanded patterns
-    (relational/logical/property/tuple), and records with init-only members — that
-    the rung 5 fast guard (LadderRung5GateTests) measures.
+    Rung 5 of the decompiler product quality ladder (#1599): the straightforward
+    modern-syntax row (row 2). A small, durable fixture covering the rung 5
+    constructs — index/range operators, using declarations, switch expressions,
+    expanded patterns (relational/logical/property/tuple), records with init-only
+    members, and C# 11 checked user-defined operators (#1706) — that the rung 5
+    fast guard (LadderRung5GateTests) measures.
 
     Referenced by the test project so the DLL is built and locatable via
-    typeof(LadderRung5.Program).Assembly.Location. Keep the shapes ordinary C# 8-9:
-    this fixture is the scoped completion bar for rung 5, not a place to add
-    C# 10+ idioms (those are rung 6) or boss-rung constructs.
+    typeof(LadderRung5.Program).Assembly.Location. Keep the shapes ordinary
+    straightforward modern syntax: this fixture is the scoped completion bar for
+    the modern-syntax row, not a place for boss-rung constructs (iterators, async,
+    dynamic, unsafe/native).
   -->
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>

--- a/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
@@ -3,10 +3,12 @@ using System.IO;
 
 namespace LadderRung5;
 
-// Rung 5 of the decompiler product quality ladder (#1599): C# 8-9 syntax surface.
-// Every member here exercises one rung 5 construct — index/range operators,
-// using declarations, switch expressions, expanded patterns
-// (relational/logical/property/tuple/type), and records with init-only members.
+// Rung 5 of the decompiler product quality ladder (#1599): the straightforward
+// modern-syntax row (row 2). Most members exercise one C# 8-9 construct —
+// index/range operators, using declarations, switch expressions, expanded
+// patterns (relational/logical/property/tuple/type), and records with init-only
+// members — plus C# 11 checked user-defined operators (#1706), whose USE must
+// render with a checked(...) context rather than an explicit op_Checked* call.
 // LadderRung5GateTests decompiles this assembly and measures the rung 5 bar:
 // fixture members render valid C# with no invalid Full, and source concepts the
 // IL erases degrade with owned residuals rather than wrong source truth.
@@ -113,4 +115,31 @@ public class Program
 public record Point(int X, int Y)
 {
     public int Magnitude { get; init; }
+}
+
+// C# 11 checked user-defined operators (#1706): a modern-syntax construct whose
+// USE must render with a checked(...) context, not an explicit op_Checked* method
+// call (which is CS0571 "cannot explicitly call operator" — invalid Full). The
+// checked and unchecked operators are both exercised so the gate pins the
+// distinction: AddChecked renders `checked(a + b)`, AddUnchecked renders `a + b`.
+public readonly struct CheckedMeters
+{
+    public CheckedMeters(int value)
+    {
+        Value = value;
+    }
+
+    public int Value { get; }
+
+    public static CheckedMeters operator +(CheckedMeters a, CheckedMeters b)
+        => new CheckedMeters(a.Value + b.Value);
+
+    public static CheckedMeters operator checked +(CheckedMeters a, CheckedMeters b)
+        => checked(new CheckedMeters(a.Value + b.Value));
+
+    // The decompiler renders these uses (not the operator declarations above):
+    // the checked use must force the checked overload with checked(...).
+    public static CheckedMeters AddChecked(CheckedMeters a, CheckedMeters b) => checked(a + b);
+
+    public static CheckedMeters AddUnchecked(CheckedMeters a, CheckedMeters b) => a + b;
 }

--- a/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
@@ -23,6 +23,9 @@ namespace ILInspector.Decompiler.Tests;
 /// #1632) and the positional-record primary constructor renders valid
 /// <c>Full</c> with the implicit base call elided (no owned base-ctor residual,
 /// #1639).</item>
+/// <item>C# 11 checked user-defined operators render their use with a
+/// <c>checked(...)</c> context (<c>checked(a + b)</c>) rather than an explicit
+/// <c>op_Checked*</c> method call, which is CS0571 invalid <c>Full</c> (#1706).</item>
 /// </list>
 /// </summary>
 public class LadderRung5GateTests
@@ -30,6 +33,7 @@ public class LadderRung5GateTests
     static string FixturePath => typeof(LadderRung5.Program).Assembly.Location;
     static readonly string ProgramType = typeof(LadderRung5.Program).FullName!;
     static readonly string RecordType = typeof(LadderRung5.Point).FullName!;
+    static readonly string CheckedOperatorType = typeof(LadderRung5.CheckedMeters).FullName!;
 
     // The exact rung 5 source-visible Program member set. Locked so a future
     // fixture edit that drops a construct fails loudly instead of silently
@@ -220,6 +224,28 @@ public class LadderRung5GateTests
         var copyBody = Body(copyCtor);
         Assert.Contains("this.X = original.X;", copyBody);
         Assert.DoesNotContain("Unsupported", copyBody);
+    }
+
+    // C# 11 checked user-defined operators (#1706). The USE of a checked operator
+    // must force the checked overload with a checked(...) context; a bare method
+    // spelling (CheckedMeters.op_CheckedAddition(a, b)) is CS0571 invalid Full.
+    [Fact]
+    public void Rung5Fixture_RendersCheckedOperators()
+    {
+        var members = LoadRaisedMembers().Where(m => m.Type == CheckedOperatorType).ToList();
+        string Body(string name) =>
+            CSharpPrinter.PrintRaised(members.Single(m => m.Name == name).Function).Output?.Trim() ?? "";
+
+        // The checked use renders checked(a + b), NOT an explicit op_Checked* call.
+        var addChecked = Body("AddChecked");
+        Assert.Equal("return checked(a + b);", addChecked);
+        Assert.DoesNotContain("op_Checked", addChecked);
+
+        // The unchecked sibling stays a bare operator with no checked wrapper.
+        var addUnchecked = Body("AddUnchecked");
+        Assert.Equal("return a + b;", addUnchecked);
+        Assert.DoesNotContain("checked", addUnchecked);
+        Assert.DoesNotContain("op_Addition", addUnchecked);
     }
 
     static List<(string Type, string Name, IrFunction Function)> LoadRaisedMembers()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Text;
+using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Pipeline;
 
@@ -2076,6 +2077,17 @@ public sealed partial class CSharpPrinter
     string? OperatorSpelling(Call call)
     {
         var arguments = call.Arguments;
+
+        // User-defined checked operators (C# 11). The metadata name encodes the
+        // checked overload (op_CheckedAddition, op_CheckedSubtraction, ...); the
+        // faithful spelling wraps the operator form in checked(...) so the same
+        // overload is selected, collapsing the wrapper inside an enclosing checked
+        // context. Without this the call falls through to a method spelling
+        // (T.op_CheckedAddition(a, b)) that is CS0571 "cannot explicitly call
+        // operator" — invalid Full. See #1706.
+        if (call.Callee.Name.StartsWith("op_Checked", StringComparison.Ordinal))
+            return CheckedOperatorSpelling(call);
+
         if (arguments.Count == 2)
         {
             string? op = call.Callee.Name switch
@@ -2104,6 +2116,46 @@ public sealed partial class CSharpPrinter
             };
         }
         return null;
+    }
+
+    /// <summary>The checked-context spelling of a user-defined checked operator call (op_Checked*), or null when the name has no faithful operator form.</summary>
+    string? CheckedOperatorSpelling(Call call)
+    {
+        var arguments = call.Arguments;
+
+        // checked explicit conversion: checked((T)x).
+        if (call.Callee.Name == "op_CheckedExplicit" && arguments.Count == 1)
+            return WrapChecked(() => $"({TypeText(call.Callee.ReturnType)}){Operand(arguments[0])}");
+
+        // The remaining checked operators share their symbol with the unchecked
+        // form (op_CheckedAddition → "+"); reuse the single mapping the signature
+        // renderer uses. Increment/decrement have no faithful functional call
+        // spelling, so they fall through to null (a method call) like op_Increment.
+        string? symbol = OperatorNames.MapBinaryOrUnary(call.Callee.Name["op_Checked".Length..]);
+        return (symbol, arguments.Count) switch
+        {
+            ("+" or "-" or "*" or "/", 2)
+                => WrapChecked(() => $"{Operand(arguments[0])} {symbol} {Operand(arguments[1])}"),
+            ("-", 1) // op_CheckedUnaryNegation
+                => WrapChecked(() => $"-{Operand(arguments[0])}"),
+            _ => null,
+        };
+    }
+
+    /// <summary>Wraps an operator spelling in <c>checked(...)</c>, rendering its operands in a checked context so nested checked operators collapse; an enclosing checked context drops the redundant wrapper.</summary>
+    string WrapChecked(Func<string> render)
+    {
+        if (_checkedContext)
+            return render();
+        _checkedContext = true;
+        try
+        {
+            return $"checked({render()})";
+        }
+        finally
+        {
+            _checkedContext = false;
+        }
     }
 
     HashSet<string>? _localScopeNames;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2130,7 +2130,9 @@ public sealed partial class CSharpPrinter
         // The remaining checked operators share their symbol with the unchecked
         // form (op_CheckedAddition → "+"); reuse the single mapping the signature
         // renderer uses. Increment/decrement have no faithful functional call
-        // spelling, so they fall through to null (a method call) like op_Increment.
+        // spelling and share the pre-existing op_Increment/op_Decrement invalid
+        // residual (#1712 — needs ++/-- raising, not a printer change), so they
+        // fall through to null (a method call) here.
         string? symbol = OperatorNames.MapBinaryOrUnary(call.Callee.Name["op_Checked".Length..]);
         return (symbol, arguments.Count) switch
         {


### PR DESCRIPTION
## Summary

Fixes #1706 — an **invalid-`Full`** blocker surfaced by the GPT-5.5 adversarial **completeness** review of #1599 row 2 (straightforward modern syntax). C# 11 user-defined **checked operators** decompiled to an explicit operator-method call the compiler rejects with **CS0571**.

```csharp
// before                                          // after
return CheckedNumber.op_CheckedAddition(l, r);     return checked(l + r);     // CS0571 → valid
```

## Root cause

`CSharpPrinter.OperatorSpelling` mapped `op_Addition` etc. to `+` but had **no `op_Checked*` cases**, so a checked-operator call fell through to the raw method-name spelling (CS0571), reported as `Full`. The **declaration** side already handled `op_Checked*` (`TypeSourceComposer` via `OperatorNames.MapBinaryOrUnary`) — an asymmetry between rendering a checked operator's declaration and its use. The defect even slipped past `--validity-check` (its synthetic member resolution filters the explicit call as binding-noise); only compile-back `--fidelity-check` caught it.

## Fix

Render a checked-operator **use** with a `checked(...)` context that forces the checked overload, reusing the single `OperatorNames` symbol map:

| Name | Render |
| --- | --- |
| `op_CheckedAddition/Subtraction/Multiply/Division` | `checked(a + b)` |
| `op_CheckedUnaryNegation` | `checked(-a)` |
| `op_CheckedExplicit` | `checked((T)a)` |

An enclosing checked context collapses the wrapper, so nested checked operators render `checked(a + b - c)` without redundant wrappers. Unchecked operators are unchanged. `op_CheckedIncrement`/`Decrement` have no faithful functional-call spelling and keep the pre-existing `op_Increment`/`Decrement` method-call parity (out of scope, noted in #1706).

## Guard

The rung 5 modern-syntax fixture (which **is** the #1599 row 2 fixture) gains a `CheckedMeters` struct with a checked `+` operator plus `AddChecked`/`AddUnchecked` uses, and `LadderRung5GateTests.Rung5Fixture_RendersCheckedOperators` pins `checked(a + b)` vs `a + b` and the absence of `op_Checked*`. The existing `Rung5Fixture_HasNoInvalidFull` now also covers the new type.

While here, the fixture's **stale** "C# 8-9 only / C# 10+ is rung 6" comments are corrected: rung 6 is the unsafe/native/byref boss, not a C# 10+ syntax rung — there is no separate modern-syntax fixture, so checked operators belong on the modern-syntax (rung 5 / row 2) fixture.

## Evidence

- `LadderRung5GateTests` 6/6 (new checked-operator guard)
- Fast decompiler subset (`-trait- "Speed=Slow"`) 1550/1550
- `CorpusSweepGateTests` green (CoreLib `Int128`/`UInt128` etc. define checked operators)
- Checked-operator probe compile-back: CS0571 eliminated (remaining recompile-fails are CS1061 harness skeleton limitations, not decompiler defects)
- Corpus quality-diff card: _posted as a follow-up comment_

> Note: this is the **first failing pattern** from the row 2 completeness review; the review also found that the C# 10-13 modern-syntax surface is otherwise unmeasured by the rung 5 guard (it was C# 8-9-scoped). That broader guard-coverage gap is a ladder-structure question for the maintainer and is not resolved here.

Cross-family adversarial review (GPT-5.5) requested per the decompiler PR contract.

Closes #1706. Advances #1599 row 2 / #1643.
