### PR TITLE
Pin cross-assembly exception boundary (analysis ladder #1623 rung 2)

### DIFF
--- a/src/ILInspector.Analysis.ExceptionBaseFixtures/ExternalFixtureException.cs
+++ b/src/ILInspector.Analysis.ExceptionBaseFixtures/ExternalFixtureException.cs
@@ -6,3 +6,30 @@ public class ExternalFixtureException : Exception
     {
     }
 }
+
+// Cross-assembly boundary pins (analysis ladder #1623 rung 2). The product is
+// SRM-direct and does NOT load referenced assemblies, so the base chain of a type
+// defined in THIS assembly cannot be walked from the inspected assembly. Exception
+// classification therefore falls back to the conservative "*Exception" name suffix
+// for external types. These two types make that documented heuristic explicit (and
+// adversarial) rather than silent:
+//
+//   * ExternalPseudoException ends with "Exception" but does NOT derive from
+//     System.Exception — the suffix fallback over-accepts it (a pinned false
+//     positive boundary).
+//   * ExternalErrorState DOES derive from System.Exception but does not end with
+//     "Exception" — the suffix fallback misses it (a pinned false negative
+//     boundary).
+
+// Name ends with "Exception" but is a plain reference type, not an exception.
+public class ExternalPseudoException
+{
+}
+
+// A real exception whose simple name does not end with "Exception".
+public class ExternalErrorState : Exception
+{
+    public ExternalErrorState(string message) : base(message)
+    {
+    }
+}

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -2119,6 +2119,38 @@ public class CallTreeTests
         Assert.Contains(nameof(CustomDomainException), signals!.ExceptionTypes);
     }
 
+    [Fact]
+    public void ConstructedExceptionTypes_ExternalSuffixLookalike_PinsSuffixFallbackBoundary()
+    {
+        // #1623 rung 2 boundary pin. The product is SRM-direct and does not load the
+        // referenced assembly, so it cannot prove that ExternalPseudoException does NOT
+        // derive from System.Exception. The documented fallback is the "*Exception"
+        // name suffix, so this cross-assembly non-exception lookalike IS counted. This
+        // is a deliberately-owned false positive at the no-referenced-assembly-loading
+        // boundary (Invariant 1) — pinned so the heuristic is explicit, not silent. If
+        // referenced-assembly base resolution is ever added, this assertion flips to
+        // DoesNotContain.
+        var signals = SignalsForMethod(nameof(CallTreeFixtures.ConstructsExternalSuffixLookalike));
+
+        Assert.True(signals.Allocations >= 1, "the cross-assembly newobj is still an allocation");
+        Assert.Contains(nameof(ExceptionBaseFixtures.ExternalPseudoException), signals.ExceptionTypes);
+    }
+
+    [Fact]
+    public void ConstructedExceptionTypes_ExternalUnsuffixedException_PinsSuffixFallbackBoundary()
+    {
+        // #1623 rung 2 boundary pin (the dual of the test above). ExternalErrorState
+        // really derives from System.Exception, but its name does not end with
+        // "Exception" and its base chain is in a referenced assembly the SRM-direct
+        // product does not load, so the suffix fallback misses it. This is a
+        // deliberately-owned false negative at the same boundary — the allocation is
+        // still counted, only the exception-type classification degrades.
+        var signals = SignalsForMethod(nameof(CallTreeFixtures.ConstructsExternalUnsuffixedException));
+
+        Assert.True(signals.Allocations >= 1, "the cross-assembly newobj is still an allocation");
+        Assert.DoesNotContain(nameof(ExceptionBaseFixtures.ExternalErrorState), signals.ExceptionTypes);
+    }
+
     static MethodSignals SignalsForMethod(string methodName)
     {
         int token = Index.Methods.First(method => method.Name == methodName).MetadataToken;
@@ -2377,6 +2409,15 @@ public static class CallTreeFixtures
     // Constructs an in-assembly type that actually derives from System.Exception; it
     // must still be reported as a constructed exception.
     public static object ConstructsCustomException() => new CustomDomainException();
+
+    // Cross-assembly boundary pins (#1623 rung 2). These construct types defined in a
+    // referenced assembly whose base chain the SRM-direct product cannot walk, so
+    // exception classification falls back to the documented "*Exception" suffix.
+    public static object ConstructsExternalSuffixLookalike()
+        => new ExceptionBaseFixtures.ExternalPseudoException();
+
+    public static object ConstructsExternalUnsuffixedException()
+        => new ExceptionBaseFixtures.ExternalErrorState("external");
 }
 
 // An in-assembly custom exception that derives from System.Exception.


### PR DESCRIPTION
## Analysis quality ladder (#1623) — rung 2 (signal precision)

Skeptical measurement pass on rung 2, mirroring the #1599 rework: validate the
rung's guards are non-vacuous, pin the silent boundary, and file owned residuals
instead of leaving the rung over-claimed as "largely covered."

### What this changes (test-only)

The GPT-5.5 adversarial review of rung 2 found the SRM-direct cross-assembly
exception boundary was **silent**. `MethodSignalAnalysis.IsExceptionType` can only
walk an in-assembly base chain, so for external types it falls back to the
`*Exception` name suffix. That fallback over-accepts a cross-assembly
non-exception lookalike and misses a real cross-assembly exception without the
suffix — both unguarded.

This pins **both directions** with adversarial cross-assembly fixtures
(`ILInspector.Analysis.ExceptionBaseFixtures`), so the documented heuristic
(Invariant 1's no-referenced-assembly-loading boundary) is explicit, not silent:

- `ExternalPseudoException` — ends in `Exception`, not an exception → **counted**
  (owned false positive).
- `ExternalErrorState` — a real exception without the suffix → **missed** (owned
  false negative). The allocation is still counted in both cases.

### Non-vacuity

The **FP pin** is the non-vacuous suffix-fallback guard: forcing the suffix
fallback to `return false` fails
`ConstructedExceptionTypes_ExternalSuffixLookalike_PinsSuffixFallbackBoundary`
(and 5 sibling suffix-dependent tests); reverting restores green. It asserts a
cross-assembly type that is only classifiable via the suffix fallback.

The **FN pin** is a current-boundary characterization pin, not a "suffix is
active" guard — `ExternalErrorState` does not end in `Exception`, so its
`DoesNotContain` assertion would also hold under that mutation. Its guard value is
that it flips to a failure (Contains) only if external base-chain resolution is
ever added, flagging that the boundary moved.

### Remaining rung-2 gaps filed

The other GPT-5.5 gaps are genuinely owned residuals, not silent, so they are
tracked in **#1708** (rung-2 cross-assembly identity burndown):

- framework / well-known-value-type identity gated by simple assembly name (no
  public-key-token);
- net48 `System.Core` facade false negatives (LINQ / Expressions recall).

### Evidence

- `ILInspector.Analysis.Tests` 129/129 (127 + 2 new pins).
- Non-vacuity probe: 6 failures when the suffix fallback is broken; 0 after revert.
- No product code changes.

On merge I'll mark #1623 rung 2 `Burndown — #1708` with Row C (this boundary)
pinned.

