### PR TITLE
Own the rung 1 combined-code structuring frontier (#1599)

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung1/CombinedFrontier.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung1/CombinedFrontier.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace LadderRung1;
@@ -14,16 +13,24 @@ namespace LadderRung1;
 // Full), but it is not recognizable C# — so these realistic shapes are an
 // explicitly OWNED frontier, not a silent gap.
 //
+// This fixture deliberately has NO field initializer: a field initializer is
+// dropped by the whole-type composer (a separate defect, #1713), which would
+// make the constructor a misleading "clean Full" control. The default
+// constructor here is genuinely empty, so it is honestly Full.
+//
 // LadderRung1CombinedFrontierGateTests pins these as honest-degrade Partial
 // frontiers: it proves the degradation is honest (no malformed Full) and locks
 // the frontier so that (a) it can never regress into an invalid Full claim and
 // (b) when the structuring pass is improved to raise them, the "is Partial"
 // assertion flips and forces an intentional promotion to a positive guard.
-public class CombinedFrontier<T>
+public class CombinedFrontier
 {
-    private readonly List<T> _items = new List<T>();
-
-    public int Count => _items.Count;
+    // A trivial member that genuinely raises to Full — the control that proves
+    // the gate's "simple members stay Full" assertion is not vacuous.
+    public int Echo(int value)
+    {
+        return value;
+    }
 
     // Realistic combination: foreach + switch + LINQ + interpolation + tuple in
     // one method. Currently degrades to a whole-method goto ladder with a leaked

--- a/src/ILInspector.Decompiler.Fixtures.LadderRung1/CombinedFrontier.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung1/CombinedFrontier.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LadderRung1;
+
+// Rung 1 combined-code frontier for the decompiler product quality ladder (#1599
+// / #1710). The other rung 1 fixtures exercise each construct in ISOLATION in a
+// tiny method, and all raise to Full. But realistic code combines them, and the
+// structuring pass is fragile to those combinations: a method that mixes a
+// foreach loop, a switch, and a LINQ/lambda can tip the whole method into a
+// goto-ladder fallback, which also defeats lambda raising (the delegate target
+// leaks a `<>c` name). The output is honestly classified Partial (never a lying
+// Full), but it is not recognizable C# — so these realistic shapes are an
+// explicitly OWNED frontier, not a silent gap.
+//
+// LadderRung1CombinedFrontierGateTests pins these as honest-degrade Partial
+// frontiers: it proves the degradation is honest (no malformed Full) and locks
+// the frontier so that (a) it can never regress into an invalid Full claim and
+// (b) when the structuring pass is improved to raise them, the "is Partial"
+// assertion flips and forces an intentional promotion to a positive guard.
+public class CombinedFrontier<T>
+{
+    private readonly List<T> _items = new List<T>();
+
+    public int Count => _items.Count;
+
+    // Realistic combination: foreach + switch + LINQ + interpolation + tuple in
+    // one method. Currently degrades to a whole-method goto ladder with a leaked
+    // `<>c` lambda target.
+    public (int Count, decimal Total) Summarize(decimal[] prices, string label)
+    {
+        decimal total = 0m;
+        foreach (decimal price in prices)
+        {
+            total += price;
+        }
+
+        int bucket;
+        switch (prices.Length)
+        {
+            case 0: bucket = 0; break;
+            case 1: bucket = 1; break;
+            default: bucket = 2; break;
+        }
+
+        decimal[] positives = prices.Where(price => price > 0m).ToArray();
+        string tag = label ?? "untitled";
+        Console.WriteLine($"{tag}: {positives.Length} positive, bucket {bucket}");
+        return (positives.Length, total);
+    }
+
+    // Minimal trigger isolated from the realistic method: an assign-and-break
+    // switch followed by a LINQ/lambda in the same method is enough to collapse
+    // the switch into a goto ladder.
+    public int SwitchThenLinq(int[] values)
+    {
+        int bucket;
+        switch (values.Length)
+        {
+            case 0: bucket = 10; break;
+            case 1: bucket = 20; break;
+            default: bucket = 30; break;
+        }
+
+        int[] positives = values.Where(value => value > 0).ToArray();
+        return bucket + positives.Length;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/LadderRung1CombinedFrontierGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1CombinedFrontierGateTests.cs
@@ -1,0 +1,113 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The rung 1 <em>combined-code frontier</em> guard for the decompiler product
+/// quality ladder (#1599 / #1710). The other rung 1 gates exercise each construct
+/// in isolation in a tiny method, and all raise to <c>Full</c>. But realistic
+/// code combines them, and the structuring pass is fragile to those combinations:
+/// a method mixing a <c>foreach</c> loop, a <c>switch</c>, and a LINQ/lambda can
+/// tip the whole method into a goto-ladder fallback, which also defeats lambda
+/// raising (the delegate target leaks a <c>&lt;&gt;c</c> name). The
+/// <see cref="LadderRung1.CombinedFrontier{T}"/> fixture captures that.
+///
+/// <para>This gate owns the frontier honestly. It pins that the combined methods
+/// degrade to <c>Partial</c> (never a lying <c>Full</c>) while the simple members
+/// stay <c>Full</c>, and that the user type has <b>zero malformed <c>Full</c></b>
+/// output — the degradation is honest, not invalid C# claimed as good. It is the
+/// inverse of a positive guard: when the structuring pass is improved to raise
+/// these shapes, the <c>Partial</c> assertions flip and force an intentional
+/// promotion to a recognizable-output guard. Until then, rung 1 is NOT complete
+/// for realistic combined code — this is the blocking row.</para>
+/// </summary>
+public class LadderRung1CombinedFrontierGateTests
+{
+    static string FixturePath => typeof(LadderRung1.CombinedFrontier<>).Assembly.Location;
+    static readonly string FixtureType = typeof(LadderRung1.CombinedFrontier<>).FullName!;
+
+    // Methods that currently degrade — the frontier. Locked so a structuring
+    // improvement that raises them flips this gate and forces a promotion.
+    static readonly string[] FrontierMembers = ["Summarize", "SwitchThenLinq"];
+
+    // Simple members that are unaffected by the combination and stay Full.
+    static readonly string[] RaisedMembers = [".ctor", "get_Count"];
+
+    [Fact]
+    public void Rung1CombinedFrontier_DegradesHonestly_FrontierPartial_SimpleFull()
+    {
+        var members = LoadProductPathMembers();
+
+        Assert.Equal(
+            RaisedMembers.Concat(FrontierMembers).Order(StringComparer.Ordinal).ToArray(),
+            members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
+
+        // The frontier methods degrade — honestly classified Partial, with a
+        // residual — they are NOT recognizable C#. When structuring is improved
+        // to raise them, these assertions flip and force an intentional promotion.
+        foreach (var name in FrontierMembers)
+        {
+            var m = members.Single(x => x.Name == name);
+            Assert.Equal(DecompilationFidelity.Partial, m.Function.Fidelity);
+            Assert.NotNull(Completeness.Residual(m.Function));
+        }
+
+        // The simple members are unaffected by the combination.
+        foreach (var name in RaisedMembers)
+        {
+            var m = members.Single(x => x.Name == name);
+            Assert.Equal(DecompilationFidelity.Full, m.Function.Fidelity);
+            Assert.Null(Completeness.Residual(m.Function));
+        }
+    }
+
+    [Fact]
+    public void Rung1CombinedFrontier_DegradationIsHonest_NoMalformedFull()
+    {
+        var results = ValidityCheck.Evaluate(FixturePath)
+            .Where(r => r.TypeName == FixtureType)
+            .ToList();
+
+        Assert.NotEmpty(results);
+
+        // The core honesty invariant: the decompiler never claims Full on output
+        // that does not parse. The combined frontier degrades to Partial instead
+        // of leaking its goto/`<>c` rendering under a Full claim.
+        var malformedFull = results
+            .Where(r => r.IsFull && r.IsMalformed)
+            .Select(r => $"{r.MethodName}: {r.MalformedDiagnostics[0].Id} {r.MalformedDiagnostics[0].Message}")
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.True(malformedFull.Length == 0,
+            "Rung 1 combined frontier must degrade honestly (zero malformed Full); malformed Full: "
+                + string.Join("; ", malformedFull));
+
+        // Non-vacuous: the frontier methods must actually be present and at least
+        // one must be malformed-but-Partial, proving this gate is measuring the
+        // real degradation and not an empty/relabeled result.
+        var partialMalformed = results
+            .Where(r => !r.IsFull && r.IsMalformed)
+            .Select(r => r.MethodName)
+            .ToArray();
+        Assert.Contains("Summarize", partialMalformed);
+    }
+
+    static List<(string Name, IrFunction Function)> LoadProductPathMembers()
+    {
+        var members = new List<(string Name, IrFunction Function)>();
+        using var source = MetadataSource.Open(FixturePath);
+        foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+        {
+            if (typeName != FixtureType)
+                continue;
+            // The structuring degradation is locator-independent (it is the loop /
+            // switch raising that fails, not cross-assembly resolution), so the
+            // proven bare-seam pass run establishes the frontier fidelity.
+            IrPasses.Run(function);
+            members.Add((methodName, function));
+        }
+        return members;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/LadderRung1CombinedFrontierGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1CombinedFrontierGateTests.cs
@@ -25,15 +25,17 @@ namespace ILInspector.Decompiler.Tests;
 /// </summary>
 public class LadderRung1CombinedFrontierGateTests
 {
-    static string FixturePath => typeof(LadderRung1.CombinedFrontier<>).Assembly.Location;
-    static readonly string FixtureType = typeof(LadderRung1.CombinedFrontier<>).FullName!;
+    static string FixturePath => typeof(LadderRung1.CombinedFrontier).Assembly.Location;
+    static readonly string FixtureType = typeof(LadderRung1.CombinedFrontier).FullName!;
 
     // Methods that currently degrade — the frontier. Locked so a structuring
     // improvement that raises them flips this gate and forces a promotion.
     static readonly string[] FrontierMembers = ["Summarize", "SwitchThenLinq"];
 
-    // Simple members that are unaffected by the combination and stay Full.
-    static readonly string[] RaisedMembers = [".ctor", "get_Count"];
+    // Simple members that are unaffected by the combination and stay Full. The
+    // constructor is a genuinely empty default ctor (the fixture has no field
+    // initializer, which the composer would otherwise drop — see #1713).
+    static readonly string[] RaisedMembers = [".ctor", "Echo"];
 
     [Fact]
     public void Rung1CombinedFrontier_DegradesHonestly_FrontierPartial_SimpleFull()


### PR DESCRIPTION
## Summary

Surfaces and **owns** the real gap behind the rung 1 (#1599) completeness question: the rung gates exercise each construct in isolation and are all green, but the structuring pass is fragile to realistic **combinations**. Guards only — no product code change.

A method mixing a `foreach` loop, a `switch`, and a LINQ/lambda tips the whole method into a goto-ladder fallback, which also defeats lambda raising (the delegate target leaks a `<>c` name). The output is honestly `Partial` (no malformed `Full`, so the "no invalid Full" invariant holds), but it is **not recognizable C#**.

This was found by decompiling a realistic, idiomatic row-1 helper — exactly the kind of code that "logically fits row 1" but is not actually addressed.

## What this adds

- `LadderRung1.CombinedFrontier` fixture: a realistic `foreach`+`switch`+LINQ+interpolation+tuple method (`Summarize`) plus the minimal `switch`+LINQ trigger (`SwitchThenLinq`).
- `LadderRung1CombinedFrontierGateTests`: pins the **honest degradation** — frontier methods `Partial` with a `structuring: conditional-branch` residual, simple members (`get_Count`, `.ctor`) `Full`, and **zero malformed `Full`** for the type. It is the inverse of a positive guard: when the structuring pass is improved (#1710), the `Partial` assertions flip and force an intentional promotion to a recognizable-output guard.

## Why it matters for rung 1

Individual constructs and small pairs raise cleanly (`foreach` alone, `foreach`+LINQ, `switch` alone, `foreach`+`switch`+tuple). The failure is specific to the combination. So **rung 1 is not complete for realistic combined code** — it should stay in burndown (or have its claim scoped to isolated constructs) until #1710 is fixed. This gate makes the gap an owned, tracked frontier instead of a silent one.

Filed **#1710** for the structuring fix.

## Evidence

No raise/structuring/printer change — fixtures + one gate only.

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LadderRung1CombinedFrontierGateTests
  Total: 2, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
  Total: 1551, Errors: 0, Failed: 0, Skipped: 0

dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
  0 Error(s)
```

Refs #1599, #1694. Filed #1710.
