### PR TITLE
Consolidated signal-recall scorecard + copy-variant gap (analysis ladder #1623 rung 3)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1000,6 +1000,22 @@ public class LibraryBodyIndexTests
         Assert.False(row.InLoop);
     }
 
+    [Theory]
+    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesDateTimeValue))]
+    public void OptimizationOpportunities_ExternalWellKnownValueTypeBox_IsBoxValueType(string methodName)
+    {
+        // #1623 rung 3: boxing a referenced (TypeReference) framework struct is recognized
+        // only via IsWellKnownValueType's curated set, since the SRM-direct product cannot
+        // resolve the external type definition. Recall the curated external value types so
+        // dropping one is not silent.
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var row = Assert.Single(BoxRows(index, methodName));
+        Assert.Equal("medium", row.Confidence);
+        Assert.False(row.InLoop);
+    }
+
     [Fact]
     public void OptimizationOpportunities_BoxInLoop_IsHighConfidence()
     {
@@ -1048,6 +1064,9 @@ public class LibraryBodyIndexTests
     [InlineData(nameof(OptimizationOpportunityFixtures.EnumerableToListCopy))]
     [InlineData(nameof(OptimizationOpportunityFixtures.ArrayCopyToCopy))]
     [InlineData(nameof(OptimizationOpportunityFixtures.SpanCopyToCopy))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.MutableSpanCopyToCopy))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.SpanToArrayCopy))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.MutableSpanToArrayCopy))]
     [InlineData(nameof(OptimizationOpportunityFixtures.RangeSubArrayCopy))]
     public void MethodSignals_FrameworkCopyApis_CountCopies(string methodName)
     {
@@ -1057,6 +1076,24 @@ public class LibraryBodyIndexTests
 
         Assert.True(signals.TryGetValue(method.MetadataToken, out var s), $"expected copy signal for {methodName}");
         Assert.True(s.Copies >= 1, $"expected at least one copy for {methodName}, got {s.Copies}");
+    }
+
+    // #1623 rung 3 / #1715: reflection recall per IsReflectionApi branch. Without these,
+    // a regression removing the System.Reflection.* namespace path, the Expressions
+    // path, or a System.Type curated-set member would not fail any recall gate.
+    [Theory]
+    [InlineData(nameof(ReflectionRecallFixtures.InvokesViaReflection), 1)]
+    [InlineData(nameof(ReflectionRecallFixtures.EnumeratesAssemblyTypes), 1)]
+    [InlineData(nameof(ReflectionRecallFixtures.BuildsExpression), 1)]
+    [InlineData(nameof(ReflectionRecallFixtures.CallsTypeMemberSet), 4)]
+    public void MethodSignals_ReflectionApis_CountReflection(string methodName, int expected)
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+        var method = Assert.Single(index.Methods.Where(m => m.Name == methodName));
+
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s), $"expected reflection signal for {methodName}");
+        Assert.True(s.Reflection >= expected, $"expected >= {expected} reflection for {methodName}, got {s.Reflection}");
     }
 
     // #1623 rung 3 (signal recall): one consolidated per-signal recall scorecard over a
@@ -1090,8 +1127,13 @@ public class LibraryBodyIndexTests
         Assert.True(Signal(nameof(CallTreeFixtures.AllocatesArray)).Allocations >= 1, "array allocation (newarr)");
         Assert.True(Signal(nameof(OptimizationOpportunityFixtures.BoxesIntoStringFormat)).Allocations >= 1, "boxing allocation (box)");
         Assert.True(Signal(nameof(CallTreeFixtures.AllocatesAndCopies)).Copies >= 1, "copy signal");
+        Assert.True(Signal(nameof(OptimizationOpportunityFixtures.SpanToArrayCopy)).Copies >= 1, "copy: span ToArray");
         Assert.Equal(2, Signal(nameof(CallTreeFixtures.Reflects)).Reflection); // seeded: Type.GetMethods + Activator.CreateInstance
-        Assert.True(HasUnsafe(nameof(UnsafeEvidenceFixtures.CallsUnsafeAs)), "unsafe signal");
+        Assert.True(Signal(nameof(ReflectionRecallFixtures.EnumeratesAssemblyTypes)).Reflection >= 1, "reflection: System.Reflection.* namespace");
+        Assert.True(Signal(nameof(ReflectionRecallFixtures.BuildsExpression)).Reflection >= 1, "reflection: System.Linq.Expressions");
+        Assert.True(Signal(nameof(ReflectionRecallFixtures.CallsTypeMemberSet)).Reflection >= 4, "reflection: System.Type curated member set");
+        Assert.True(HasUnsafe(nameof(UnsafeEvidenceFixtures.CallsUnsafeAs)), "unsafe evidence");
+        Assert.True(Signal(nameof(UnsafeEvidenceFixtures.CallsUnsafeAs)).Unsafe, "unsafe signal (folded MethodSignals.Unsafe field)");
         Assert.True(Signal(nameof(CallTreeFixtures.Throws)).Throws >= 1, "throw signal");
         Assert.True(Signal(nameof(CallTreeFixtures.TryCatchFinally)).Catches >= 1, "catch signal");
         Assert.True(Signal(nameof(CallTreeFixtures.TryCatchFinally)).Finallys >= 1, "finally signal");
@@ -1104,6 +1146,7 @@ public class LibraryBodyIndexTests
         Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.SpanToArrayCopy), "span-to-array-copy"), "span-to-array-copy");
         Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.FirstValueByte), "temporary-byte-array-copy"), "temporary-byte-array-copy");
         Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.BoxesIntoStringFormat), "box-value-type"), "box-value-type");
+        Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), "box-value-type"), "box: external well-known value type (Guid)");
 
         // High-confidence (in-loop) promotion of an allocation hotspot is itself a recalled signal.
         Assert.Contains(index.OptimizationOpportunities, o =>
@@ -1434,6 +1477,9 @@ public class OptimizationOpportunityFixtures
     public static void SpanCopyToCopy(System.ReadOnlySpan<int> source, System.Span<int> destination)
         => source.CopyTo(destination);
 
+    public static void MutableSpanCopyToCopy(System.Span<int> source, System.Span<int> destination)
+        => source.CopyTo(destination);
+
     public static int[] RangeSubArrayCopy(int[] values)
         => values[1..];
 
@@ -1518,6 +1564,15 @@ public class OptimizationOpportunityFixtures
             sink.Add(v);
         }
     }
+
+    // External well-known value-type box recall (#1623 rung 3). Boxing a referenced
+    // (TypeReference) framework struct is recognized only via IsWellKnownValueType's
+    // curated (namespace, name) set, since the SRM-direct product cannot resolve the
+    // external type definition. Canary representative members of that set so dropping
+    // one is not silent; the boxed value escapes via the return.
+    public static object BoxesGuidValue(System.Guid value) => value;
+
+    public static object BoxesDateTimeValue(System.DateTime value) => value;
 
     public static class UserCopyLookalikes
     {
@@ -2490,6 +2545,35 @@ public static class CallTreeFixtures
 
     public static object ConstructsExternalUnsuffixedException()
         => new ExceptionBaseFixtures.ExternalErrorState("external");
+}
+
+// Reflection-signal recall fixtures (#1623 rung 3 / #1715). One canary per
+// IsReflectionApi branch so a regression removing any branch fails recall:
+//   - System.Reflection.* namespace prefix (MethodInfo.Invoke, Assembly.GetTypes)
+//   - System.Linq.Expressions namespace
+//   - System.Type curated member set, beyond the GetMethods covered by Reflects
+// System.Activator is already covered by CallTreeFixtures.Reflects.
+public static class ReflectionRecallFixtures
+{
+    public static object? InvokesViaReflection(System.Reflection.MethodInfo method, object target)
+        => method.Invoke(target, null);
+
+    public static System.Type[] EnumeratesAssemblyTypes(System.Reflection.Assembly assembly)
+        => assembly.GetTypes();
+
+    public static System.Linq.Expressions.ConstantExpression BuildsExpression()
+        => System.Linq.Expressions.Expression.Constant(42);
+
+    // Four distinct System.Type curated-set members -> Reflection count 4.
+    public static int CallsTypeMemberSet(System.Type type)
+    {
+        int found = 0;
+        if (type.GetProperty("Length") is not null) found++;
+        if (type.GetField("value") is not null) found++;
+        if (type.GetConstructor(System.Type.EmptyTypes) is not null) found++;
+        if (type.MakeArrayType() is not null) found++;
+        return found;
+    }
 }
 
 // An in-assembly custom exception that derives from System.Exception.

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1045,6 +1045,10 @@ public class LibraryBodyIndexTests
     [InlineData(nameof(OptimizationOpportunityFixtures.StringConcatCopy))]
     [InlineData(nameof(OptimizationOpportunityFixtures.StringJoinCopy))]
     [InlineData(nameof(OptimizationOpportunityFixtures.StringSubstringCopy))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.EnumerableToListCopy))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ArrayCopyToCopy))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.SpanCopyToCopy))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.RangeSubArrayCopy))]
     public void MethodSignals_FrameworkCopyApis_CountCopies(string methodName)
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -1053,6 +1057,58 @@ public class LibraryBodyIndexTests
 
         Assert.True(signals.TryGetValue(method.MetadataToken, out var s), $"expected copy signal for {methodName}");
         Assert.True(s.Copies >= 1, $"expected at least one copy for {methodName}, got {s.Copies}");
+    }
+
+    // #1623 rung 3 (signal recall): one consolidated per-signal recall scorecard over a
+    // labeled in-assembly fixture. Each row names a method seeded with a known signal and
+    // asserts the analysis detects it, so a whole signal family (or one recognized
+    // framework-API variant) silently going dark fails here in one place rather than only
+    // in a single distant test. Recall is measured on hand-seeded in-assembly fixtures
+    // (the SRM-direct no-referenced-assembly-loading boundary applies, per #1623
+    // Invariant 1); real-world / corpus recall is rungs 8-10, not this rung.
+    [Fact]
+    public void Rung3_SignalRecall_DetectsEverySeededSignalFamily()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
+
+        MethodSignals Signal(string method)
+        {
+            var m = Assert.Single(index.Methods.Where(x => x.Name == method));
+            Assert.True(signals.TryGetValue(m.MetadataToken, out var s), $"no signals computed for {method}");
+            return s!;
+        }
+
+        bool HasOpportunity(string method, string shape)
+            => index.OptimizationOpportunities.Any(o => o.Method.Name == method && o.Shape == shape);
+
+        bool HasUnsafe(string method)
+            => index.UnsafeEvidence.Any(e => e.Member.Name == method);
+
+        // --- MethodSignals families ---
+        Assert.True(Signal(nameof(CallTreeFixtures.AllocatesAndCopies)).Allocations >= 2, "object allocation (newobj)");
+        Assert.True(Signal(nameof(CallTreeFixtures.AllocatesArray)).Allocations >= 1, "array allocation (newarr)");
+        Assert.True(Signal(nameof(OptimizationOpportunityFixtures.BoxesIntoStringFormat)).Allocations >= 1, "boxing allocation (box)");
+        Assert.True(Signal(nameof(CallTreeFixtures.AllocatesAndCopies)).Copies >= 1, "copy signal");
+        Assert.Equal(2, Signal(nameof(CallTreeFixtures.Reflects)).Reflection); // seeded: Type.GetMethods + Activator.CreateInstance
+        Assert.True(HasUnsafe(nameof(UnsafeEvidenceFixtures.CallsUnsafeAs)), "unsafe signal");
+        Assert.True(Signal(nameof(CallTreeFixtures.Throws)).Throws >= 1, "throw signal");
+        Assert.True(Signal(nameof(CallTreeFixtures.TryCatchFinally)).Catches >= 1, "catch signal");
+        Assert.True(Signal(nameof(CallTreeFixtures.TryCatchFinally)).Finallys >= 1, "finally signal");
+        Assert.Contains("InvalidOperationException", Signal(nameof(CallTreeFixtures.Throws)).ExceptionTypes);
+        Assert.True(Signal(nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop)).AllocInLoop, "alloc-in-loop hot path");
+
+        // --- OptimizationOpportunity shapes ---
+        Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.AllocatesManyObjects), "allocation-hotspot"), "allocation-hotspot");
+        Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), "stackalloc-candidate"), "stackalloc-candidate");
+        Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.SpanToArrayCopy), "span-to-array-copy"), "span-to-array-copy");
+        Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.FirstValueByte), "temporary-byte-array-copy"), "temporary-byte-array-copy");
+        Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.BoxesIntoStringFormat), "box-value-type"), "box-value-type");
+
+        // High-confidence (in-loop) promotion of an allocation hotspot is itself a recalled signal.
+        Assert.Contains(index.OptimizationOpportunities, o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop)
+            && o.Shape == "allocation-hotspot" && o.InLoop && o.Confidence == "high");
     }
 
     [Fact]
@@ -1364,6 +1420,22 @@ public class OptimizationOpportunityFixtures
 
     public static string StringSubstringCopy(string value)
         => value.Substring(1);
+
+    // Copy-signal variant recall (#1623 rung 3). IsCopyApi recognizes ToList, CopyTo
+    // (span/array), and RuntimeHelpers.GetSubArray (range slicing) in addition to the
+    // ToArray/Substring/Concat/Join forms above, but those variants had no recall
+    // guard — a regression dropping any of them would have been silent.
+    public static System.Collections.Generic.List<int> EnumerableToListCopy(System.Collections.Generic.IEnumerable<int> values)
+        => System.Linq.Enumerable.ToList(values);
+
+    public static void ArrayCopyToCopy(int[] source, int[] destination)
+        => source.CopyTo(destination, 0);
+
+    public static void SpanCopyToCopy(System.ReadOnlySpan<int> source, System.Span<int> destination)
+        => source.CopyTo(destination);
+
+    public static int[] RangeSubArrayCopy(int[] values)
+        => values[1..];
 
     public static string UserJoinLookalike(int a, int b)
         => UserCopyLookalikes.Join(a, b);


### PR DESCRIPTION
## Analysis quality ladder (#1623) — rung 3 (signal recall)

Skeptical measurement of rung 3, same lens as the rung-2 pass (#1709): the rung's
done-signal is "per-signal recall on a labeled fixture," but recall was only
covered by ~20 scattered positive tests with **no consolidated scorecard**, and
the measurement surfaced a real **silent recall gap**.

### Finding — copy-signal variant gap (silent)

`MethodSignalAnalysis.IsCopyApi` recognizes seven framework copy forms, but three
recognized variants had **no recall test** — a regression dropping any would have
been silent:

- `Enumerable.ToList`
- span/array `CopyTo`
- `RuntimeHelpers.GetSubArray` (range slicing, `arr[1..]`)

Closed by adding labeled fixtures and extending
`MethodSignals_FrameworkCopyApis_CountCopies` to cover them.

### Consolidated recall scorecard (the rung's guard)

New `Rung3_SignalRecall_DetectsEverySeededSignalFamily` is a single per-signal
recall scorecard over the labeled in-assembly fixture, so a whole family (or one
recognized API variant) going dark fails in one place: allocations
(newobj/newarr/box), copies, reflection, unsafe, throw/catch/finally, constructed
exception type, alloc-in-loop, and the allocation-hotspot / stackalloc /
span-to-array / temporary-byte-array / box-value-type opportunity shapes.

Recall is measured on **hand-seeded in-assembly fixtures** (the SRM-direct
no-referenced-assembly-loading boundary applies, #1623 Invariant 1); real-world /
corpus recall remains rungs 8-10, not this rung.

### Honest residual

Reflection recall is not yet exhaustive: the `System.Reflection.*` namespace path,
`System.Linq.Expressions`, and most of the `System.Type` curated member set are
not individually recall-guarded. Filed as **#1715** so rung 3 is not over-claimed.

### Non-vacuity

Disabling the `GetSubArray` copy branch fails the `RangeSubArrayCopy` recall row;
reverting restores green.

### Evidence

- `ILInspector.Analysis.Tests` 134/134.
- Test-only; no product code changes.

On merge I'll set #1623 rung 3 to record the consolidated scorecard guard, the
closed copy-variant gap, and residual #1715.


---

## Update — closing rung-3 recall residuals (folds in #1715)

After a GPT-5.5 adversarial pass, expanded the change so the per-signal recall
claim is honest across every recognized predicate branch:

- **Reflection (#1715):** `ReflectionRecallFixtures` canaries each `IsReflectionApi`
  branch — `System.Reflection.*` namespace, `System.Linq.Expressions`, and
  `System.Type` curated members beyond `GetMethods` — plus a focused theory and
  scorecard rows. Activator stays covered by `Reflects`.
- **Span copy variants:** span `ToArray` (Span/ReadOnlySpan) and mutable
  `Span<T>.CopyTo` had no `Copies`-signal recall (only opportunity tests); added.
- **External well-known value-type box:** boxing a referenced framework struct is
  recognized only via `IsWellKnownValueType`'s curated set; added Guid/DateTime
  recall, proven non-vacuous (dropping `Guid` fails the row and the scorecard).
- **Unsafe:** scorecard now asserts the folded `MethodSignals.Unsafe` field, not
  only `UnsafeEvidence`.

`ILInspector.Analysis.Tests` 143/143.

Closes #1715.
