### PR TITLE
Recover scaled pointer element loads

### DIFF
--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -134,7 +134,7 @@ public class LadderRung6GateTests
 
         var pinned = NewBody("SumPinned");
         Assert.Contains("fixed (int* p = ", pinned);
-        Assert.Contains("sum +=", FirstUnsafeBlockBody(pinned));
+        Assert.Contains("sum += p[i];", FirstUnsafeBlockBody(pinned));
         Assert.DoesNotContain("pinned", pinned);
 
         Assert.All(ExpectedUnsafeMembers, name =>
@@ -186,6 +186,13 @@ public class LadderRung6GateTests
     {
         AssertExactCompileBack(NewUnsafePath, NewUnsafeType, "InvokeFunctionPointer");
         AssertExactCompileBack(LegacyUnsafePath, LegacyUnsafeType, "InvokeFunctionPointer");
+    }
+
+    [Fact]
+    public void Rung6PinnedPointerElementAccess_RecompilesThroughFidelityHarness()
+    {
+        AssertExactCompileBack(NewUnsafePath, NewUnsafeType, "SumPinned");
+        AssertExactCompileBack(LegacyUnsafePath, LegacyUnsafeType, "SumPinned");
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
@@ -10,8 +10,10 @@ namespace ILInspector.Decompiler.Tests;
 /// carries the explicit <c>* sizeof(T)</c> the source compiled to (a pointer
 /// difference divides by <c>sizeof(T)</c>); a C# pointer <c>+</c>/<c>-</c> scales
 /// the integer operand by <c>sizeof(element)</c> again, so spelling it directly
-/// silently computes the wrong value. The printer routes the IL byte offset
-/// through <c>byte*</c> so the math is reproduced verbatim. See issue #1593.
+/// silently computes the wrong value. A dereference of the canonical scaled form
+/// can climb back to <c>p[i]</c>; other pointer arithmetic routes the IL byte
+/// offset through <c>byte*</c> so the math is reproduced verbatim. See issue
+/// #1593.
 /// </summary>
 public class PointerArithmeticScalingTests
 {
@@ -42,18 +44,19 @@ public class PointerArithmeticScalingTests
                 new Constant(4, Int32)));
 
     [Fact]
-    public void PointerIndex_RoutesByteOffsetThroughBytePointer()
+    public void PointerIndex_RendersElementAccess()
     {
-        // `*(p[i])`: a LoadIndirect over `p + (nint)i * 4`. The result is cast back
-        // to `int*` so the deref still reads an `int`, not a single byte.
+        // A LoadIndirect over `p + (nint)i * 4` is the canonical IL shape for
+        // `p[i]`. Rendering the element access avoids C# re-emitting extra native
+        // conversions around the byte offset.
         var output = Print(ReturnFunction(
             Int32,
             new LoadIndirect(Int32, ScaledIntPointerOffset()),
             new Parameter("p", IntPointer),
             new Parameter("i", Int32)));
 
-        Assert.Contains("*((int*)((byte*)p + ", output);
-        // The bare C# pointer deref would scale `* 4` a second time (element i*4).
+        Assert.Contains("return p[i];", output);
+        Assert.DoesNotContain("byte*", output);
         Assert.DoesNotContain("*(p + ", output);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1637,6 +1637,7 @@ public sealed partial class CSharpPrinter
             // bracketing the whole expression, and dropping its parens would misbind.
             || node is Binary or Convert
                 && (IsWholeExpressionWrapper(text, "checked(") || IsWholeExpressionWrapper(text, "unchecked("));
+        atomic = atomic || node is LoadIndirect load && PointerElementAccessText(load) is not null;
         return atomic ? text : $"({text})";
     }
 
@@ -1728,6 +1729,8 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string DerefLoad(LoadIndirect load)
     {
+        if (PointerElementAccessText(load) is { } indexed)
+            return indexed;
         if (load.Type is { } element
             && load.Address is Convert { Target: { Namespace: "System", Assembly: TypeRef.CoreLibrary, Name: "IntPtr" or "UIntPtr" } } conv)
         {
@@ -1742,6 +1745,94 @@ public sealed partial class CSharpPrinter
             return NativeIntPointerDeref(load.Address, nativeElement);
         return Deref(load.Address);
     }
+
+    string? PointerElementAccessText(LoadIndirect load)
+    {
+        if (load.Type is not { } element
+            || load.Address is not Binary { Kind: BinaryKind.Add } address
+            || !TrySplitPointerAdd(address, out var pointer, out var offset)
+            || pointer.ResultType is not { Kind: TypeRefKind.Pointer, ElementType: { } pointerElement }
+            || !pointerElement.Equals(element)
+            || !TryScaledPointerIndex(offset, pointerElement, out var index))
+        {
+            return null;
+        }
+
+        return $"{Operand(pointer)}[{Expression(index)}]";
+    }
+
+    static bool TrySplitPointerAdd(Binary add, out IrExpression pointer, out IrExpression offset)
+    {
+        if (add.Left.ResultType is { Kind: TypeRefKind.Pointer } && add.Right.ResultType is not { Kind: TypeRefKind.Pointer })
+        {
+            pointer = add.Left;
+            offset = add.Right;
+            return true;
+        }
+        if (add.Right.ResultType is { Kind: TypeRefKind.Pointer } && add.Left.ResultType is not { Kind: TypeRefKind.Pointer })
+        {
+            pointer = add.Right;
+            offset = add.Left;
+            return true;
+        }
+
+        pointer = add.Left;
+        offset = add.Right;
+        return false;
+    }
+
+    static bool TryScaledPointerIndex(IrExpression offset, TypeRef elementType, out IrExpression index)
+    {
+        if (ByteSize(elementType) is not { } elementSize)
+        {
+            index = offset;
+            return false;
+        }
+
+        if (offset is Binary { Kind: BinaryKind.Multiply } multiply)
+        {
+            if (IsConstant(multiply.Left, elementSize))
+            {
+                index = NativeIntegerOperand(multiply.Right);
+                return true;
+            }
+            if (IsConstant(multiply.Right, elementSize))
+            {
+                index = NativeIntegerOperand(multiply.Left);
+                return true;
+            }
+        }
+
+        if (elementSize == 1)
+        {
+            index = NativeIntegerOperand(offset);
+            return true;
+        }
+
+        index = offset;
+        return false;
+    }
+
+    static IrExpression NativeIntegerOperand(IrExpression expression)
+        => expression is Convert { Target: { Namespace: "System", Assembly: TypeRef.CoreLibrary, Name: "IntPtr" or "UIntPtr" }, Operand: { } operand }
+            ? operand
+            : expression;
+
+    static bool IsConstant(IrExpression expression, int value)
+        => expression is Constant { Value: int i } && i == value
+            || expression is Constant { Value: long l } && l == value;
+
+    static int? ByteSize(TypeRef type)
+        => type is { Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+            ? type.Name switch
+            {
+                "Boolean" or "Byte" or "SByte" => 1,
+                "Char" or "Int16" or "UInt16" => 2,
+                "Int32" or "UInt32" or "Single" => 4,
+                "Int64" or "UInt64" or "Double" => 8,
+                _ => null,
+            }
+            : null;
 
     string IndirectTarget(IrExpression address, TypeRef? elementType)
         => elementType is not null && IsNativeInteger(address.ResultType)


### PR DESCRIPTION
## Summary

Refs #1599 row 6.

Burns down the remaining measured unsafe fixture fidelity residual from #1700/#1704: `SumPinned` recompiled with an opcode diff because the decompiler rendered the pointer element read as byte-address arithmetic (`*((int*)((byte*)p + ((nint)i) * 4))`). That is valid, but Roslyn recompiles it with extra native-int conversions.

- Recognizes `ldind T` over `T* + ((nint)index * sizeof(T))` and renders it as `p[index]`.
- Keeps the existing byte-pointer rewrite for non-deref pointer arithmetic.
- Pins the row-6 guard so both NewUnsafe and LegacyUnsafe `SumPinned` compile back exactly.

This is a row-6 burndown slice, not a row-completion claim.

## Evidence

Unsafe fixture fidelity is now exact across the full row-6 fixture pair:

```text
dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Fixtures.NewUnsafe/release/ILInspector.Decompiler.Fixtures.NewUnsafe.dll artifacts/bin/ILInspector.Decompiler.Fixtures.LegacyUnsafe/release/ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll --fidelity-check --max-examples 10
COMPILE-BACK over 22 rendered methods (22 Full)
exact opcode match : 22 (100.00%)
opcode diff (Full) : 0
context-build fail : 0
recompile fail     : 0
```

Additional validation:

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.LadderRung6GateTests -class ILInspector.Decompiler.Tests.PointerArithmeticScalingTests -class ILInspector.Decompiler.Tests.UnsafeEmitterTests -class ILInspector.Decompiler.Tests.PinnedLocalFidelityTests
ILInspector.Decompiler.Tests  Total: 45, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
ILInspector.Decompiler.Tests  Total: 1553, Errors: 0, Failed: 0, Skipped: 0

dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded. 0 Warning(s), 0 Error(s)
```

Quality diff card:

```text
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,773 methods
Correctness coverage: validity sampled 350 / 88,773 (0.39%); fidelity sampled 36 / 88,773 (0.04%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 88,500 -> 88,773 (+273)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,769 (87.87%) | 78,192 (88.08%) | +423 |
| Conditional-branch residual | 2,409 (2.72%) | 2,427 (2.73%) | +18 |
| Forward-merge stops | 2,144 (2.42%) | 2,163 (2.44%) | +19 |
| Full malformed | 32 | 32 | 0 |
| Semantic defects | 4/350 — sampled 350 / 88,500 (0.40%) | 4/350 — sampled 350 / 88,773 (0.39%) | 0 |
| Fidelity diffs | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 88,500 (0.04%) | opcode-diff 9/36, exact 27, recompile-failed 0, context-failed 0; sampled 36 / 88,773 (0.04%) | +4 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 89.67% -> 89.66% (-1 bps); conditional residual 2.85% -> 2.85% (0 bps); Full malformed 32 -> 32 (0); opcode diffs 1 -> 1 (0).

Verdict: corpus sensor matched baseline tolerances.
```
