### PR TITLE
Render field initializers in decompiled type listings (#1713)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
@@ -466,6 +466,21 @@ public class TypeSourceCheckTests
         Assert.Contains("Configured = configured", source);
     }
 
+    [Fact]
+    public void Evaluate_OnPrivateConstructorFixture_RendersInitializer()
+    {
+        // The only constructor is private, so it is absent from the public API
+        // surface; the initializer must still be collected from metadata (#1713).
+        string path = typeof(TypeSourcePrivateCtorInitFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(api.Types, t => t.FullName == typeof(TypeSourcePrivateCtorInitFixture).FullName);
+        var source = TypeSourceComposer.Compose(type, path, pdbPath: null);
+        Assert.NotNull(source);
+
+        Assert.Contains("public readonly int Seed = 5;", source);
+    }
+
 }
 
 public class TypeSourceNullableConstraintMatrix<TNotNull, TClassNullable, TUnmanaged, TNullableInterface>
@@ -510,4 +525,13 @@ public class TypeSourceFieldInitializerFixture
     {
         Configured = configured;
     }
+}
+
+public sealed class TypeSourcePrivateCtorInitFixture
+{
+    public readonly int Seed = 5;
+
+    private TypeSourcePrivateCtorInitFixture() { }
+
+    public static TypeSourcePrivateCtorInitFixture Create() => new();
 }

--- a/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
@@ -442,6 +442,30 @@ public class TypeSourceCheckTests
         var deltas = TypeSourceCheck.Evaluate(path);
         Assert.NotNull(deltas);
     }
+    [Fact]
+    public void Evaluate_OnFieldInitializerFixture_RendersInitializersOnDeclarations()
+    {
+        string path = typeof(TypeSourceFieldInitializerFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(api.Types, t => t.FullName == typeof(TypeSourceFieldInitializerFixture).FullName);
+        var source = TypeSourceComposer.Compose(type, path, pdbPath: null);
+        Assert.NotNull(source);
+
+        // Field initializers (this.f = value before the base call) are lifted out
+        // of the constructor body by the printer and rendered on the declaration,
+        // not dropped (#1713).
+        Assert.Contains("public readonly int Seed = 5;", source);
+        Assert.Contains("public readonly string Label = \"hello\";", source);
+
+        // A field assigned from a constructor parameter is NOT a field initializer
+        // (it reads a parameter), so its declaration has no initializer and the
+        // assignment stays in the constructor body.
+        Assert.Contains("public int Configured;", source);
+        Assert.DoesNotContain("public int Configured =", source);
+        Assert.Contains("Configured = configured", source);
+    }
+
 }
 
 public class TypeSourceNullableConstraintMatrix<TNotNull, TClassNullable, TUnmanaged, TNullableInterface>
@@ -474,4 +498,16 @@ public class @class<@event>
     public int @int { get; set; }
 
     public int @void() => @delegate;
+}
+
+public class TypeSourceFieldInitializerFixture
+{
+    public readonly int Seed = 5;
+    public readonly string Label = "hello";
+    public int Configured;
+
+    public TypeSourceFieldInitializerFixture(int configured)
+    {
+        Configured = configured;
+    }
 }

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -89,7 +89,7 @@ public static class TypeSourceComposer
             else
             {
                 ComposeFields(sb, reader, typeHandle, bodyNamespaces,
-                    CollectFieldInitializers(pipelineSource, type), ref any);
+                    CollectFieldInitializers(pipelineSource, type.FullName, reader, typeHandle), ref any);
                 ComposeMembers(sb, type, pipelineSource, reader, typeHandle, bodyNamespaces, ref any);
             }
 
@@ -761,34 +761,35 @@ public static class TypeSourceComposer
     /// <summary>
     /// Gathers field initializers (<c>this.f = value</c> stores the printer lifts
     /// out of a constructor body to the field declarations) so
-    /// <see cref="ComposeFields"/> can render them. Constructors are imported here
-    /// only to read <see cref="DecompilerResult.FieldInitializers"/>;
+    /// <see cref="ComposeFields"/> can render them. Instance constructors are
+    /// enumerated straight from metadata — not from <see cref="ApiType.Members"/>,
+    /// which omits non-public constructors, so a factory type whose only
+    /// constructor is private still recovers its initializers. Each constructor is
+    /// imported only to read <see cref="DecompilerResult.FieldInitializers"/>;
     /// <see cref="ComposeMembers"/> renders the (now initializer-free) bodies
-    /// separately. Initializers are identical across base-chaining constructors,
-    /// so the first one seen for a field wins. The overload-index derivation
-    /// mirrors <see cref="ComposeMembers"/> so the correct constructor is imported.
+    /// separately. Initializers are identical across base-chaining constructors, so
+    /// the first one seen for a field wins. The static constructor (<c>.cctor</c>)
+    /// is skipped: its stores are not lifted (no base chain, no <c>this</c>).
     /// </summary>
     static Dictionary<string, string> CollectFieldInitializers(
-        Pipeline.MetadataSource pipelineSource, ApiType type)
+        Pipeline.MetadataSource pipelineSource, string typeFullName,
+        MetadataReader reader, TypeDefinitionHandle typeHandle)
     {
         var initializers = new Dictionary<string, string>(StringComparer.Ordinal);
-        var overloadIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+        var typeDef = reader.GetTypeDefinition(typeHandle);
 
-        foreach (var member in type.Members)
+        // The overload index counts every '.ctor' in metadata order at
+        // publicOnly: false — the same order this loop walks — so it selects the
+        // matching constructor regardless of accessibility.
+        int constructorIndex = 0;
+        foreach (var methodHandle in typeDef.GetMethods())
         {
-            if (member.Kind != "constructor")
+            if (reader.GetString(reader.GetMethodDefinition(methodHandle).Name) != ".ctor")
                 continue;
-
-            int runningIndex = overloadIndex.GetValueOrDefault(member.Name);
-            overloadIndex[member.Name] = runningIndex + 1;
-            if (member.IsAbstract)
-                continue;
-            int index = member.DeclaringOverloadIndex is { } declaringIndex
-                ? declaringIndex - 1
-                : runningIndex;
 
             var function = Pipeline.IrImporter.Import(
-                pipelineSource, member.DeclaringType ?? type.FullName, member.Name, index, publicOnly: true);
+                pipelineSource, typeFullName, ".ctor", constructorIndex, publicOnly: false);
+            constructorIndex++;
             if (function is null)
                 continue;
 

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -88,7 +88,8 @@ public static class TypeSourceComposer
             }
             else
             {
-                ComposeFields(sb, reader, typeHandle, bodyNamespaces, ref any);
+                ComposeFields(sb, reader, typeHandle, bodyNamespaces,
+                    CollectFieldInitializers(pipelineSource, type), ref any);
                 ComposeMembers(sb, type, pipelineSource, reader, typeHandle, bodyNamespaces, ref any);
             }
 
@@ -200,7 +201,8 @@ public static class TypeSourceComposer
         _ => null,
     };
 
-    static void ComposeFields(StringBuilder sb, MetadataReader reader, TypeDefinitionHandle typeHandle, SortedSet<string> namespaces, ref bool any)
+    static void ComposeFields(StringBuilder sb, MetadataReader reader, TypeDefinitionHandle typeHandle,
+        SortedSet<string> namespaces, IReadOnlyDictionary<string, string> fieldInitializers, ref bool any)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
         var genericContext = GenericContext.ForType(reader, typeDef);
@@ -247,7 +249,14 @@ public static class TypeSourceComposer
                 if (field.Attributes.HasFlag(FieldAttributes.InitOnly))
                     decl.Append("readonly ");
             }
-            decl.Append($"{EscapeKnownIdentifiers(Shorten(fieldType), genericContext.TypeParameters)} {EscapeIdentifier(name)};");
+            // A field initializer (this.f = value) is lifted out of the
+            // constructor body by the printer; render it back on the declaration.
+            // const fields carry their value in metadata, not a ctor store.
+            string typeAndName = $"{EscapeKnownIdentifiers(Shorten(fieldType), genericContext.TypeParameters)} {EscapeIdentifier(name)}";
+            decl.Append(!field.Attributes.HasFlag(FieldAttributes.Literal)
+                    && fieldInitializers.TryGetValue(name, out var initializer)
+                ? $"{typeAndName} = {initializer};"
+                : $"{typeAndName};");
             sb.AppendLine(decl.ToString());
             wrote = true;
             any = true;
@@ -749,6 +758,49 @@ public static class TypeSourceComposer
     /// The expression of a single-statement body suitable for '=>':
     /// 'return X;' yields X; a lone statement yields itself without ';'.
     /// </summary>
+    /// <summary>
+    /// Gathers field initializers (<c>this.f = value</c> stores the printer lifts
+    /// out of a constructor body to the field declarations) so
+    /// <see cref="ComposeFields"/> can render them. Constructors are imported here
+    /// only to read <see cref="DecompilerResult.FieldInitializers"/>;
+    /// <see cref="ComposeMembers"/> renders the (now initializer-free) bodies
+    /// separately. Initializers are identical across base-chaining constructors,
+    /// so the first one seen for a field wins. The overload-index derivation
+    /// mirrors <see cref="ComposeMembers"/> so the correct constructor is imported.
+    /// </summary>
+    static Dictionary<string, string> CollectFieldInitializers(
+        Pipeline.MetadataSource pipelineSource, ApiType type)
+    {
+        var initializers = new Dictionary<string, string>(StringComparer.Ordinal);
+        var overloadIndex = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var member in type.Members)
+        {
+            if (member.Kind != "constructor")
+                continue;
+
+            int runningIndex = overloadIndex.GetValueOrDefault(member.Name);
+            overloadIndex[member.Name] = runningIndex + 1;
+            if (member.IsAbstract)
+                continue;
+            int index = member.DeclaringOverloadIndex is { } declaringIndex
+                ? declaringIndex - 1
+                : runningIndex;
+
+            var function = Pipeline.IrImporter.Import(
+                pipelineSource, member.DeclaringType ?? type.FullName, member.Name, index, publicOnly: true);
+            if (function is null)
+                continue;
+
+            var result = Pipeline.CSharpPrinter.PrintRaised(
+                function, importMethodBody: method => Pipeline.IrImporter.Import(pipelineSource, method));
+            foreach (var (field, value) in result.FieldInitializers)
+                initializers.TryAdd(field, value);
+        }
+
+        return initializers;
+    }
+
     static string? DecompileBody(
         Pipeline.MetadataSource pipelineSource, string typeFullName, ApiMember member, int overloadIndex,
         SortedSet<string> bodyNamespaces, out string? constructorChain, out bool requiresAsync)


### PR DESCRIPTION
## Summary

Fixes #1713: `TypeSourceComposer` dropped every field initializer from decompiled type listings. `private readonly int _x = 5;` decompiled to `private readonly int _x;` with an empty constructor — semantically misleading (uninitialized fields), and it would not recompile to the same type behavior.

## Root cause

The information was already there. `CSharpPrinter` lifts genuine field-initializer stores (`this.f = value` preceding the base call, with no parameter/local/`this` reads) out of the constructor body into `DecompilerResult.FieldInitializers`. `TypeSourceComposer` simply never read that list when rendering field declarations — so the ctor body printer elided the stores (correctly, expecting hoisting) but nothing hoisted them.

Method-level fidelity was always intact (harness compile-back is exact), so this was purely the whole-type composition gap.

## Fix

- `CollectFieldInitializers` decompiles the type's constructors (mirroring `ComposeMembers`' overload-index derivation) and collects their `FieldInitializers`.
- `ComposeFields` renders `= value` on matching field declarations.
- A field assigned from a constructor parameter is **not** a field initializer (it reads a place), so it is not lifted and correctly stays in the constructor body. `const` fields keep their metadata value and are unaffected.

## Before / after

```csharp
// before
private readonly int _x;
private readonly string _name;
public A(int seed) => _counter = seed;

// after
private readonly int _x = 5;
private readonly string _name = "hello";
public int _counter;            // assigned from a param -> stays in ctor
public A(int seed) => _counter = seed;
```

## Evidence

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.TypeSourceCheckTests
  Total: 28, 0 failed   (incl. new Evaluate_OnFieldInitializerFixture_RendersInitializersOnDeclarations)

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.TypeBindGateTests
  Total: 1, 0 failed    (500+ CoreLib types compose + bind)

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
  Total: 1552, 0 failed
```

## Out of scope (pre-existing)

Collection-typed fields (e.g. `List<int>`) render without a `using System.Collections.Generic;` — a pre-existing `TypeSourceComposer` namespace-collection gap (present on `origin/main` for the field type itself), independent of initializers. Not addressed here.

One of the two row 1 (#1599) blockers. Closes #1713.
