### PR TITLE
Render C# 12 primary-constructor captures validly + broaden row 2 modern-syntax guard (#1719)

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
@@ -143,3 +143,34 @@ public readonly struct CheckedMeters
 
     public static CheckedMeters AddUnchecked(CheckedMeters a, CheckedMeters b) => a + b;
 }
+
+// C# 12 primary constructor on a class. The captured parameters lift into
+// unspeakable <param>P fields; the decompiler must render them as the parameter
+// name (a real lowered field + this.-qualified constructor stores), never the raw
+// <seed>P, which is invalid Full (#1719). Rung 5 modern-syntax surface (#1599 row 2).
+public class PrimaryCounter(int seed, int step)
+{
+    public int Next() => seed + step;
+
+    public int SeedPlus(int extra) => seed + extra;
+}
+
+// Other straightforward C# 11-12 modern-syntax shapes the rung 5 bar covers: each
+// must render valid C# or honestly degrade (HasNoInvalidFull guards the whole
+// LadderRung5 surface). A collection-expression spread recovers to [..head, tail];
+// a list pattern and a required-member object initializer render recognizably.
+public class ModernSyntax
+{
+    public int[] Spread(int[] head, int tail) => [.. head, tail];
+
+    public bool IsOneTwoThree(int[] xs) => xs is [1, 2, 3];
+
+    public ModernHolder MakeHolder() => new ModernHolder { Name = "n", Count = 3 };
+}
+
+public class ModernHolder
+{
+    public required string Name { get; set; }
+
+    public required int Count { get; init; }
+}

--- a/src/ILInspector.Decompiler.Tests/CSharpNamingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpNamingTests.cs
@@ -26,4 +26,18 @@ public class CSharpNamingTests
     [InlineData("Normal`1", "Normal")]
     public void TypeNameSegment_StripsArityAndEscapesKeywords(string metadataName, string expected)
         => Assert.Equal(expected, CSharpNaming.TypeNameSegment(metadataName));
+
+    [Theory]
+    [InlineData("<seed>P", "seed")]                 // C# 12 primary-ctor capture
+    [InlineData("<value>P", "value")]
+    [InlineData("<\u00e9>P", "\u00e9")]             // precomposed Unicode letter
+    [InlineData("<e\u0301>P", "e\u0301")]           // letter + combining mark
+    [InlineData("<seed>k__BackingField", null)]     // auto-property backing field
+    [InlineData("<>c", null)]                       // display class
+    [InlineData("<M>g__Local|0_0", null)]           // local function
+    [InlineData("ordinary", null)]                  // ordinary field
+    [InlineData("<>P", null)]                        // empty inner name
+    [InlineData("<<x>g__>P", null)]                 // nested mangle, not an identifier
+    public void PrimaryConstructorCaptureName_DemanglesCaptureFields(string fieldName, string? expected)
+        => Assert.Equal(expected, CSharpNaming.PrimaryConstructorCaptureName(fieldName));
 }

--- a/src/ILInspector.Decompiler.Tests/CSharpNamingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpNamingTests.cs
@@ -32,6 +32,8 @@ public class CSharpNamingTests
     [InlineData("<value>P", "value")]
     [InlineData("<\u00e9>P", "\u00e9")]             // precomposed Unicode letter
     [InlineData("<e\u0301>P", "e\u0301")]           // letter + combining mark
+    [InlineData("<\u216b>P", "\u216b")]             // letter-number start (Roman numeral)
+    [InlineData("<\U0001d4cd>P", "\U0001d4cd")]    // astral-plane letter (surrogate pair)
     [InlineData("<seed>k__BackingField", null)]     // auto-property backing field
     [InlineData("<>c", null)]                       // display class
     [InlineData("<M>g__Local|0_0", null)]           // local function

--- a/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
@@ -1,6 +1,8 @@
+using System.Reflection.PortableExecutable;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.DecompilerHarness;
+using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -34,6 +36,8 @@ public class LadderRung5GateTests
     static readonly string ProgramType = typeof(LadderRung5.Program).FullName!;
     static readonly string RecordType = typeof(LadderRung5.Point).FullName!;
     static readonly string CheckedOperatorType = typeof(LadderRung5.CheckedMeters).FullName!;
+    static readonly string PrimaryCtorType = typeof(LadderRung5.PrimaryCounter).FullName!;
+    static readonly string ModernSyntaxType = typeof(LadderRung5.ModernSyntax).FullName!;
 
     // The exact rung 5 source-visible Program member set. Locked so a future
     // fixture edit that drops a construct fails loudly instead of silently
@@ -246,6 +250,62 @@ public class LadderRung5GateTests
         Assert.Equal("return a + b;", addUnchecked);
         Assert.DoesNotContain("checked", addUnchecked);
         Assert.DoesNotContain("op_Addition", addUnchecked);
+    }
+
+    // C# 12 primary constructor on a class. The captured parameters lift into
+    // unspeakable <param>P fields; the decompiler must render them as the
+    // parameter name — a declared lowered field plus this.-qualified constructor
+    // stores and bare reads — never the raw <seed>P, which is invalid Full.
+    [Fact]
+    public void Rung5Fixture_RendersPrimaryConstructorCaptures()
+    {
+        var members = LoadRaisedMembers().Where(m => m.Type == PrimaryCtorType).ToList();
+        string Body(string name) =>
+            CSharpPrinter.PrintRaised(members.Single(m => m.Name == name).Function).Output?.Trim() ?? "";
+
+        // Capture reads de-mangle to the parameter name, never the <seed>P field.
+        Assert.Equal("return seed + step;", Body("Next"));
+        Assert.Equal("return seed + extra;", Body("SeedPlus"));
+
+        // The constructor stores the captured parameters into the de-mangled
+        // fields with this.-qualification (the parameter shadows the field).
+        var ctor = Body(".ctor");
+        Assert.Contains("this.seed = seed;", ctor);
+        Assert.Contains("this.step = step;", ctor);
+
+        // The composed type declares the capture fields under the parameter name,
+        // so the bodies' reads bind. No leftover unspeakable <…>P leaks.
+        var source = ComposeType(PrimaryCtorType);
+        Assert.Contains("private int seed;", source);
+        Assert.Contains("private int step;", source);
+        Assert.DoesNotContain(">P", source);
+        Assert.DoesNotContain("<seed>", source);
+    }
+
+    // Other straightforward C# 11-12 modern-syntax shapes render recognizably: a
+    // collection-expression spread recovers to [..head, tail]; a list pattern and
+    // a required-member object initializer render as recognizable C#.
+    [Fact]
+    public void Rung5Fixture_RendersModernSyntaxConstructs()
+    {
+        var members = LoadRaisedMembers().Where(m => m.Type == ModernSyntaxType).ToList();
+        string Body(string name) =>
+            CSharpPrinter.PrintRaised(members.Single(m => m.Name == name).Function).Output?.Trim() ?? "";
+
+        Assert.Equal("return [..head, tail];", Body("Spread"));
+        Assert.Contains("xs.Length == 3", Body("IsOneTwoThree"));
+        Assert.Contains("xs[0] == 1", Body("IsOneTwoThree"));
+        Assert.Contains("new ModernHolder { Name = \"n\", Count = 3 }", Body("MakeHolder"));
+    }
+
+    static string ComposeType(string fullName)
+    {
+        using var pe = new PEReader(File.OpenRead(FixturePath));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(api.Types, t => t.FullName == fullName);
+        var source = TypeSourceComposer.Compose(type, FixturePath, pdbPath: null);
+        Assert.NotNull(source);
+        return source!;
     }
 
     static List<(string Type, string Name, IrFunction Function)> LoadRaisedMembers()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -72,6 +72,24 @@ internal static class CSharpNaming
     }
 
     /// <summary>
+    /// The primary-constructor parameter a capture field <c>&lt;param&gt;P</c>
+    /// stores, or null for an ordinary field. C# 12 lifts a primary-constructor
+    /// parameter that an instance member reads into this unspeakable field; the
+    /// source spelling — at both the declaration and every read — is the parameter
+    /// name itself, which is in scope across the whole type.
+    /// </summary>
+    public static string? PrimaryConstructorCaptureName(string fieldName)
+    {
+        const string suffix = ">P";
+        return fieldName.Length > suffix.Length + 1
+            && fieldName[0] == '<'
+            && fieldName.EndsWith(suffix, StringComparison.Ordinal)
+            && IsEscapableIdentifier(fieldName[1..^suffix.Length])
+            ? fieldName[1..^suffix.Length]
+            : null;
+    }
+
+    /// <summary>
     /// The source name of a call target. A compiler-generated local function
     /// carries the metadata name <c>&lt;Enclosing&gt;g__Local|N_M</c>, which is
     /// not a valid C# identifier; the source name is the segment between

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -84,9 +84,37 @@ internal static class CSharpNaming
         return fieldName.Length > suffix.Length + 1
             && fieldName[0] == '<'
             && fieldName.EndsWith(suffix, StringComparison.Ordinal)
-            && IsEscapableIdentifier(fieldName[1..^suffix.Length])
+            && IsIdentifierLike(fieldName[1..^suffix.Length])
             ? fieldName[1..^suffix.Length]
             : null;
+    }
+
+    /// <summary>
+    /// A Unicode-aware C# identifier shape: a letter or <c>_</c> start, then
+    /// letters, digits, connectors, or combining marks. Looser than
+    /// <see cref="IsEscapableIdentifier"/> (which is ASCII-ish) so a recovered
+    /// metadata name whose source identifier uses a valid Unicode character — a
+    /// combining mark, a connector — is still recognized rather than leaking the
+    /// raw unspeakable name.
+    /// </summary>
+    static bool IsIdentifierLike(string name)
+    {
+        if (name.Length == 0 || !(char.IsLetter(name[0]) || name[0] == '_'))
+            return false;
+        foreach (char c in name)
+        {
+            if (char.IsLetterOrDigit(c) || c == '_')
+                continue;
+            if (char.GetUnicodeCategory(c) is
+                System.Globalization.UnicodeCategory.NonSpacingMark
+                or System.Globalization.UnicodeCategory.SpacingCombiningMark
+                or System.Globalization.UnicodeCategory.ConnectorPunctuation
+                or System.Globalization.UnicodeCategory.Format
+                or System.Globalization.UnicodeCategory.LetterNumber)
+                continue;
+            return false;
+        }
+        return true;
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpNaming.cs
@@ -90,32 +90,49 @@ internal static class CSharpNaming
     }
 
     /// <summary>
-    /// A Unicode-aware C# identifier shape: a letter or <c>_</c> start, then
-    /// letters, digits, connectors, or combining marks. Looser than
-    /// <see cref="IsEscapableIdentifier"/> (which is ASCII-ish) so a recovered
-    /// metadata name whose source identifier uses a valid Unicode character — a
-    /// combining mark, a connector — is still recognized rather than leaking the
-    /// raw unspeakable name.
+    /// A Unicode-aware C# identifier shape, evaluated per Rune so astral-plane
+    /// (surrogate-pair) characters classify correctly. Looser than
+    /// <see cref="IsEscapableIdentifier"/> (which is ASCII-ish): the start is a
+    /// letter, letter-number, or <c>_</c>, and each part adds digits, combining
+    /// marks, connectors, and format characters — the C# identifier rule. So a
+    /// recovered metadata name whose source identifier uses a valid Unicode
+    /// character is recognized rather than leaking the raw unspeakable name.
     /// </summary>
     static bool IsIdentifierLike(string name)
     {
-        if (name.Length == 0 || !(char.IsLetter(name[0]) || name[0] == '_'))
+        if (name.Length == 0)
             return false;
-        foreach (char c in name)
+        bool first = true;
+        foreach (var rune in name.EnumerateRunes())
         {
-            if (char.IsLetterOrDigit(c) || c == '_')
-                continue;
-            if (char.GetUnicodeCategory(c) is
-                System.Globalization.UnicodeCategory.NonSpacingMark
-                or System.Globalization.UnicodeCategory.SpacingCombiningMark
-                or System.Globalization.UnicodeCategory.ConnectorPunctuation
-                or System.Globalization.UnicodeCategory.Format
-                or System.Globalization.UnicodeCategory.LetterNumber)
-                continue;
-            return false;
+            if (first)
+            {
+                if (!IsIdentifierStartRune(rune))
+                    return false;
+                first = false;
+            }
+            else if (!IsIdentifierPartRune(rune))
+            {
+                return false;
+            }
         }
         return true;
     }
+
+    static bool IsIdentifierStartRune(System.Text.Rune rune)
+        => rune.Value == '_'
+            || System.Text.Rune.IsLetter(rune)
+            || System.Text.Rune.GetUnicodeCategory(rune) == System.Globalization.UnicodeCategory.LetterNumber;
+
+    static bool IsIdentifierPartRune(System.Text.Rune rune)
+        => rune.Value == '_'
+            || System.Text.Rune.IsLetterOrDigit(rune)
+            || System.Text.Rune.GetUnicodeCategory(rune) is
+                System.Globalization.UnicodeCategory.LetterNumber
+                or System.Globalization.UnicodeCategory.NonSpacingMark
+                or System.Globalization.UnicodeCategory.SpacingCombiningMark
+                or System.Globalization.UnicodeCategory.ConnectorPunctuation
+                or System.Globalization.UnicodeCategory.Format;
 
     /// <summary>
     /// The source name of a call target. A compiler-generated local function

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -17,6 +17,21 @@ public sealed partial class CSharpPrinter
                 LoadArgument { Index: 0, Name: "this" } => $"this.{CSharpNaming.EscapeIdentifier(property)}",
                 _ => $"{ReceiverText(instance)}.{CSharpNaming.EscapeIdentifier(property)}",
             };
+        // A C# 12 primary-constructor capture field, <param>P, has no spellable C#
+        // name; its source spelling is the primary-constructor parameter, which is
+        // in scope across the whole type. Render it as an ordinary field named for
+        // the parameter, with the same shadow qualification (the constructor's own
+        // parameter shadows it, so `this.` reaches the field).
+        if (CSharpNaming.PrimaryConstructorCaptureName(field.Name) is { } capture)
+        {
+            string captured = CSharpNaming.EscapeIdentifier(capture);
+            return instance switch
+            {
+                null => $"{TypeText(field.DeclaringType)}.{captured}",
+                LoadArgument { Index: 0, Name: "this" } => IsShadowedByLocal(capture) ? $"this.{captured}" : captured,
+                _ => $"{ReceiverText(instance)}.{captured}",
+            };
+        }
         string fieldName = CSharpNaming.EscapeIdentifier(field.Name);
         return instance switch
         {

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -210,8 +210,15 @@ public static class TypeSourceComposer
         {
             var field = reader.GetFieldDefinition(fieldHandle);
             string name = reader.GetString(field.Name);
-            if (name.Contains('<'))
+            // A C# 12 primary-constructor capture field, <param>P, is referenced by
+            // instance members under the parameter's source name, so it must be
+            // declared (unlike auto-property backing fields, which the property
+            // declaration covers). Emit it as an ordinary field named for the
+            // parameter; skip the other compiler-generated <...> fields.
+            string? captureName = Pipeline.CSharpNaming.PrimaryConstructorCaptureName(name);
+            if (name.Contains('<') && captureName is null)
                 continue; // compiler-generated backing fields
+            string displayName = captureName ?? name;
 
             string access = (field.Attributes & FieldAttributes.FieldAccessMask) switch
             {
@@ -247,7 +254,7 @@ public static class TypeSourceComposer
                 if (field.Attributes.HasFlag(FieldAttributes.InitOnly))
                     decl.Append("readonly ");
             }
-            decl.Append($"{EscapeKnownIdentifiers(Shorten(fieldType), genericContext.TypeParameters)} {EscapeIdentifier(name)};");
+            decl.Append($"{EscapeKnownIdentifiers(Shorten(fieldType), genericContext.TypeParameters)} {EscapeIdentifier(displayName)};");
             sb.AppendLine(decl.ToString());
             wrote = true;
             any = true;


### PR DESCRIPTION
## Summary

Continues the #1599 **row 2 (straightforward modern syntax)** completeness work: **measures the C# 10-13 surface** the rung 5 guard didn't cover and **fixes the invalid-`Full` blocker** that measurement found.

### Fix — C# 12 primary-constructor capture fields (#1719)

A primary constructor on a class decompiled to invalid C#: the captured parameters lift into unspeakable `<param>P` fields that the decompiler emitted raw and never declared.

```csharp
// before (invalid Full)                       // after (valid)
public class PrimaryCounter {                   public class PrimaryCounter {
    public PrimaryCounter(int seed, int step){      private int seed;
        <seed>P = seed;   // CS1525/CS0103           private int step;
        <step>P = step;                             public PrimaryCounter(int seed, int step) {
    }                                                   this.seed = seed;
    public int Next() => <seed>P + 1;                   this.step = step;
}                                                   }
                                                    public int Next() => seed + step;
                                                }
```

Root cause: `TypeSourceComposer.ComposeFields` skipped every `<`-named field as a compiler-generated backing field (dropping the capture-field declaration), and `CSharpPrinter.FieldTarget` rendered references with the raw `<param>P` name. Unlike an auto-property backing field, a capture field has no property to cover it.

Fix (consistent with the decompiler's no-sugar lowering — records render as plain types): render the capture as a real lowered field named for the parameter, and de-mangle every reference. Added `CSharpNaming.PrimaryConstructorCaptureName` (mirrors `BackingFieldProperty`), emit the declaration in the composer, and de-mangle reads in `FieldTarget` with the existing shadow qualification.

### Measure + guard — broaden rung 5 to the C# 10-13 surface

The rung 5 fixture/guard (which **is** the #1599 row 2 fixture) was C# 8-9-scoped. This adds:
- `PrimaryCounter` — primary-ctor class (the fix above), guarded by `Rung5Fixture_RendersPrimaryConstructorCaptures` (asserts composed field declarations + de-mangled bodies, no `>P` leak).
- `ModernSyntax`/`ModernHolder` — collection-expression spread (`[..head, tail]`), list pattern, and required-member initializer, guarded by `Rung5Fixture_RendersModernSyntaxConstructs`. The existing `HasNoInvalidFull` now also covers these.

### What the measurement found (full row 2 picture)

| Construct | C# | Result |
| --- | --- | --- |
| Primary ctor on class | 12 | **was invalid Full → fixed here (#1719)** |
| Collection expr (`[a,b]`, `[..a, b]`) | 12 | valid (recovered or honest lowered) |
| List/slice patterns | 11 | valid (lowered guards) |
| Required members | 11 | valid |
| Record struct / `with` | 10 | valid (lowered, no `record` sugar) |
| Raw / u8 strings | 11 | valid (lowered to regular string / byte[]) |
| User-defined `++`/`--` | — | invalid Full — **filed #1712** (needs `++`/`--` raising, out of scope) |

So after this PR the only known row 2 invalid-`Full` is #1712. Lower-altitude renders (lowered collection-expr scaffolding, list-pattern guards) are honest and mostly docketed in `LoweringCoverage`.

## Evidence

- `LadderRung5GateTests` 8/8 (2 new guards)
- Fast decompiler subset (`-trait- "Speed=Slow"`) 1554/1554
- `CorpusSweepGateTests` + CoreLib `TypeBindCheckTests` green (composer change handles CoreLib `<param>P` fields without breaking binding)
- Fidelity gates + corpus quality-diff card: _posted as follow-up comments_

Cross-family adversarial review (GPT-5.5) requested per the decompiler PR contract.

Closes #1719. Advances #1599 row 2.
