### PR TITLE
Fix row 6 function-pointer and native-int gaps

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MixedSignCompoundTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignCompoundTests.cs
@@ -95,6 +95,25 @@ public class MixedSignCompoundTests
         return CSharpPrinter.Print(function).Output!;
     }
 
+    static string RenderLocalConstant(BinaryKind kind, TypeRef target, TypeRef rhsType, bool isUnsigned, int value)
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var rhs = new ILInspector.Decompiler.Pipeline.Convert(rhsType, isChecked: false, isUnsigned: false, new Constant(value, Int));
+        var binary = new Binary(kind, isChecked: false, isUnsigned, new LoadLocal(0, target), rhs);
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, target, new LoadArgument(0, "arg", target)));
+        block.Add(new StoreLocal(0, target, binary));
+        block.Add(new Return(new LoadLocal(0, target)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M", owner,
+            new MethodSignature(target, [new Parameter("arg", target)], HasThis: false, GenericParameterCount: 0),
+            [target],
+            body);
+        return CSharpPrinter.Print(function).Output!;
+    }
+
     // `ref nuint x; x op= b` — the target is read through a LoadIndirect the
     // importer types as the SIGNED native `IntPtr` (ldind.i), even though the
     // StoreIndirect's resolved pointee type is `nuint`. The compound cast must use
@@ -126,6 +145,15 @@ public class MixedSignCompoundTests
         Assert.Contains("V_0 -= (nuint)", output);
         // `nuint -= nint` is CS0034; the right operand must not stay bare nint.
         Assert.DoesNotContain("-= b", output);
+    }
+
+    [Fact]
+    public void NuintSubtractNintConstant_DoesNotCastToSignedNativeInt()
+    {
+        var output = RenderLocalConstant(BinaryKind.Subtract, NUInt, NInt, isUnsigned: false, 16384);
+
+        Assert.Contains("V_0 -= ", output);
+        Assert.DoesNotContain("(nint)", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -942,12 +942,16 @@ public sealed partial class CSharpPrinter
         // char slot) is subsumed by the boundary cast: emit one cast to the
         // target on the conversion's operand, not (char)((ushort)x). An
         // out-of-range constant operand still needs the unchecked spelling.
-        if (value is Convert { IsChecked: false, IsUnsigned: false } conv && TypeFamilies.SameWidth(conv.Target, target))
+        if (value is Convert { IsChecked: false, IsUnsigned: false } conv && SameNumericSlotWidth(conv.Target, target))
             return conv.Operand is Constant { Value: int or long } convConst
                 ? NumericConstant(convConst, target!)
                 : $"({TypeText(target!)}){Operand(conv.Operand)}";
         return $"({TypeText(target!)}){Operand(value)}";
     }
+
+    static bool SameNumericSlotWidth(TypeRef? a, TypeRef? b)
+        => TypeFamilies.SameWidth(a, b)
+            || TypeFamilies.Of(a) == StackFamily.I && TypeFamilies.Of(b) == StackFamily.I;
 
     string ConditionalText(Conditional conditional)
     {

--- a/tests/ILInspector.Metadata.Tests/ApiSurfaceUnsafeTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSurfaceUnsafeTests.cs
@@ -56,6 +56,28 @@ public sealed class ApiSurfaceUnsafeTests
     }
 
     [Fact]
+    public void FunctionPointerSignature_PreservesDistinctFieldShapes()
+    {
+        var members = Type(typeof(FunctionPointerShapeFixture)).Members;
+
+        Assert.Equal(
+            "delegate*<int, int>",
+            members.Single(m => m.Name == nameof(FunctionPointerShapeFixture.Field)).ReturnType);
+        Assert.Equal(
+            "delegate*<string, bool>",
+            members.Single(m => m.Name == nameof(FunctionPointerShapeFixture.Other)).ReturnType);
+        Assert.Equal(
+            "delegate* unmanaged[Cdecl]<int, void>",
+            members.Single(m => m.Name == nameof(FunctionPointerShapeFixture.Unmanaged)).ReturnType);
+        Assert.Equal(
+            "delegate*<int, int>[]",
+            members.Single(m => m.Name == nameof(FunctionPointerShapeFixture.ArrayOf)).ReturnType);
+        Assert.Equal(
+            "delegate*<int, int> Ret(delegate*<int, int> f)",
+            members.Single(m => m.Name == nameof(FunctionPointerShapeFixture.Ret)).Signature);
+    }
+
+    [Fact]
     public void FunctionPointerSignature_AppliesNullabilityInMetadataOrder()
     {
         var members = Type(typeof(FunctionPointerNullabilityFixture)).Members;
@@ -80,4 +102,14 @@ public unsafe class FunctionPointerNullabilityFixture
 {
     public delegate*<string, string?> ReturnsNullable;
     public delegate*<string?, string> ParameterNullable;
+}
+
+public unsafe class FunctionPointerShapeFixture
+{
+    public delegate*<int, int> Field;
+    public delegate*<string, bool> Other;
+    public delegate* unmanaged[Cdecl]<int, void> Unmanaged;
+    public delegate*<int, int>[] ArrayOf = [];
+
+    public delegate*<int, int> Ret(delegate*<int, int> f) => f;
 }


### PR DESCRIPTION
## Summary

Closes #1665.
Closes #1459.

Addresses the first two direct row-6 issues:

- adds regression coverage that function-pointer metadata signatures render distinct, complete C# shapes (`delegate*<int, int>`, `delegate*<string, bool>`, `delegate* unmanaged[Cdecl]<int, void>`, arrays, and function-pointer returns);
- fixes native-int same-slot conversion folding so a `nuint` compound operation does not retain a signed `nint` constant and trip CS0034.

`#1665` was already fixed in production on current `origin/main`; this PR adds the missing done-signal canaries. `#1459` still failed for a literal `Convert(nint, ldc.i4 16384)` shape before this change and is fixed by treating `nint`/`nuint` as same numeric slot width for boundary-cast subsumption.

## Evidence

```text
dotnet run --project tests/ILInspector.Metadata.Tests -c Release
ILInspector.Metadata.Tests  Total: 229, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/MixedSignCompoundTests/*"
ILInspector.Decompiler.Tests  Total: 8, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.MixedSignCompoundTests -class ILInspector.Decompiler.Tests.MixedSignArithmeticConstantTests -class ILInspector.Decompiler.Tests.MixedSignComparisonTests -class ILInspector.Decompiler.Tests.MixedSignBitwiseTests -class ILInspector.Decompiler.Tests.CheckedUncheckedInsertTests -class ILInspector.Decompiler.Tests.NegativeCastParenthesizationTests
ILInspector.Decompiler.Tests  Total: 46, Errors: 0, Failed: 0, Skipped: 0

dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded. 0 Warning(s), 0 Error(s)

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
ILInspector.Decompiler.Tests  Total: 1553, Errors: 0, Failed: 0, Skipped: 0
```

CoreLib validity sample:

```text
dotnet run --project tools/DecompilerHarness -c Release -- <active System.Private.CoreLib.dll> --validity-check --compile-cap 2000 --max-examples 10
COMPILE-CHECK over 38350 rendered methods (37985 Full, 365 Partial)
Semantic binding (Full + syntactically-valid, capped at 2000 bound):
  with a non-binding-noise error: 38 (1.90%)
  by code ... no CS0034 bucket
```

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 15 assemblies, 1,462 methods
Sample: hash-stable 100 methods per assembly
Correctness coverage: validity not run; fidelity not run

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (`--emit-corpus-baseline`) before trusting count-based regressions.

- total methods 1,461 -> 1,462 (+1)
- ILInspector.MetadataPrimitives: 61 -> 62 methods (+1)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 1,213 (83.03%) | 1,222 (83.58%) | +9 |
| Conditional-branch residual | 35 (2.40%) | 33 (2.26%) | -2 |
| Forward-merge stops | 27 (1.85%) | 27 (1.85%) | 0 |
| Full malformed | not run | not run | - |
| Semantic defects | not run | not run | - |
| Fidelity diffs | not run | not run | - |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 82.17% -> 82.17% (0 bps); conditional residual 3.00% -> 3.00% (0 bps); Full malformed 0 -> 0 (0); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Verdict: corpus sensor matched baseline tolerances.

Per-method delta artifact: `/tmp/row6-direct-corpus-delta.json`

## Adversarial review

Opus 4.8 reviewed the diff and found no blockers. It verified the native-int fold is bit-exact for the platform-sized family, the #1459 test is revert-sensitive, the #1665 canaries are non-vacuous, and the production change is narrow (`StackFamily.I` only). Non-blocking note: multi-convention function pointers are not added here because #1665’s requested done signal only named the Cdecl shape.
