### PR TITLE
Recognize legacy-TFM facade assemblies in signal predicates (#1708 Row B)

### DIFF
--- a/src/ILInspector.Analysis.FacadeFixtures/FacadeSignalFixtures.cs
+++ b/src/ILInspector.Analysis.FacadeFixtures/FacadeSignalFixtures.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace ILInspector.Analysis.FacadeFixtures
+{
+    // Real framework positives whose declaring assembly is a legacy facade
+    // (netstandard here; System.Core on net48), not the modern split assembly.
+    // The signal predicates must still recognize them (#1708 Row B).
+    public static class FacadeSignalFixtures
+    {
+        // System.Linq.Enumerable.ToArray -> copy signal.
+        public static int[] EnumerableToArrayCopy(IEnumerable<int> values)
+            => values.ToArray();
+
+        // System.Linq.Enumerable.ToList -> copy signal.
+        public static List<int> EnumerableToListCopy(IEnumerable<int> values)
+            => values.ToList();
+
+        // System.Linq.Expressions.* -> reflection signal.
+        public static Expression BuildsExpression()
+            => Expression.Constant(42);
+    }
+}

--- a/src/ILInspector.Analysis.FacadeFixtures/ILInspector.Analysis.FacadeFixtures.csproj
+++ b/src/ILInspector.Analysis.FacadeFixtures/ILInspector.Analysis.FacadeFixtures.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Targets netstandard2.0 on purpose: its BCL type references resolve through a
+    facade assembly (netstandard) rather than the modern split assemblies
+    (System.Linq, System.Linq.Expressions). This reproduces the legacy-TFM facade
+    recall gap (#1708 Row B) where framework-identity predicates that expect the
+    modern assembly name miss real positives. Loaded by path, not compiled against.
+  -->
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\ILInspector.Analysis.ExceptionBaseFixtures\ILInspector.Analysis.ExceptionBaseFixtures.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis.ProtobufFixtures\ILInspector.Analysis.ProtobufFixtures.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis.LookalikeFixtures\ILInspector.Analysis.LookalikeFixtures.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ILInspector.Analysis.FacadeFixtures\ILInspector.Analysis.FacadeFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphTarget\ILInspector.Analysis.CallerGraphTarget.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCaller\ILInspector.Analysis.CallerGraphCaller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCallerTwin\ILInspector.Analysis.CallerGraphCallerTwin.csproj" ReferenceOutputAssembly="false" />

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1380,6 +1380,115 @@ public class LibraryBodyIndexTests
         return path;
     }
 
+    static string FacadeFixturePath()
+    {
+        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string path = Path.GetFullPath(Path.Combine(
+            outputDirectory.FullName,
+            "..",
+            "..",
+            "ILInspector.Analysis.FacadeFixtures",
+            outputDirectory.Name,
+            "ILInspector.Analysis.FacadeFixtures.dll"));
+        Assert.True(File.Exists(path), $"Expected facade fixture assembly at {path}");
+        return path;
+    }
+
+    // #1708 Row B: a netstandard2.0 fixture references BCL types through the
+    // netstandard facade (assembly canonicalizes to corelib), reproducing the
+    // legacy-TFM recall gap where copy predicates expected the modern split assembly.
+    [Theory]
+    [InlineData("EnumerableToArrayCopy")]
+    [InlineData("EnumerableToListCopy")]
+    public void MethodSignals_CopyApis_RecognizeLegacyFacadeAssemblies(string methodName)
+    {
+        var index = LibraryBodyIndex.Open(FacadeFixturePath());
+        var signals = index.GetMethodSignals();
+        var method = Assert.Single(index.Methods.Where(m => m.Name == methodName));
+
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s), $"no signals for {methodName}");
+        Assert.True(s.Copies >= 1, $"expected copy on facade assembly for {methodName}, got {s.Copies}");
+    }
+
+    [Fact]
+    public void MethodSignals_Reflection_RecognizesLegacyFacadeExpressions()
+    {
+        var index = LibraryBodyIndex.Open(FacadeFixturePath());
+        var signals = index.GetMethodSignals();
+        var method = Assert.Single(index.Methods.Where(m => m.Name == "BuildsExpression"));
+
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
+        Assert.True(s.Reflection >= 1, $"expected reflection on facade assembly, got {s.Reflection}");
+    }
+
+    // #1708 Row B (.NET Framework path). Real net48 assemblies cannot be built on this
+    // host, so exercise the predicate directly: Enumerable lives in System.Core on net48
+    // and in the netstandard/corelib facade bucket on netstandard, yet a same-named user
+    // assembly must still be rejected (precision preserved).
+    [Theory]
+    [InlineData("System.Linq", 1)]   // modern split assembly
+    [InlineData("System.Core", 1)]   // .NET Framework facade
+    [InlineData("netstandard", 1)]   // canonicalizes to corelib
+    [InlineData("Contoso.Data", 0)]  // user assembly lookalike -> not a copy
+    public void Collect_CopyApiRecall_HonorsFrameworkFacadesButNotUserLookalikes(string calleeAssembly, int expectedCopies)
+    {
+        const int callerToken = 0x06000123;
+        var calls = ImmutableArray.Create(EnumerableToArrayCall(calleeAssembly, callerToken));
+
+        var signals = MethodSignalAnalysis.Collect(calls, ImmutableArray<UnsafeEvidence>.Empty);
+
+        int copies = signals.TryGetValue(callerToken, out var s) ? s.Copies : 0;
+        Assert.Equal(expectedCopies, copies);
+    }
+
+    static DirectCall EnumerableToArrayCall(string calleeAssembly, int callerToken)
+    {
+        var enumerable = TypeRef.Definition(calleeAssembly, "System.Linq", "Enumerable");
+        var callee = new MemberRef(enumerable, "ToArray", [], TypeRef.Unsupported("ret"), MemberKind.Method);
+        return FrameworkCall(callee, callerToken);
+    }
+
+    // #1708 Row B reflection path. Expression trees live in System.Core on net48 and in
+    // the netstandard/corelib facade bucket on netstandard, but a same-named user
+    // assembly must not be classified as reflection.
+    [Theory]
+    [InlineData("System.Linq.Expressions", 1)] // modern split assembly
+    [InlineData("System.Core", 1)]             // .NET Framework facade
+    [InlineData("netstandard", 1)]             // canonicalizes to corelib
+    [InlineData("Contoso.Expr", 0)]            // user assembly lookalike -> not reflection
+    public void Collect_ReflectionRecall_HonorsFrameworkFacadesButNotUserLookalikes(string calleeAssembly, int expectedReflection)
+    {
+        const int callerToken = 0x06000124;
+        var calls = ImmutableArray.Create(ExpressionConstantCall(calleeAssembly, callerToken));
+
+        var signals = MethodSignalAnalysis.Collect(calls, ImmutableArray<UnsafeEvidence>.Empty);
+
+        int reflection = signals.TryGetValue(callerToken, out var s) ? s.Reflection : 0;
+        Assert.Equal(expectedReflection, reflection);
+    }
+
+    static DirectCall ExpressionConstantCall(string calleeAssembly, int callerToken)
+    {
+        var expression = TypeRef.Definition(calleeAssembly, "System.Linq.Expressions", "Expression");
+        var callee = new MemberRef(expression, "Constant", [], TypeRef.Unsupported("ret"), MemberKind.Method);
+        return FrameworkCall(callee, callerToken);
+    }
+
+    static DirectCall FrameworkCall(MemberRef callee, int callerToken)
+    {
+        var callerType = TypeRef.Definition("Caller.Assembly", "Caller.Ns", "CallerType");
+        var caller = new MethodIdentity(
+            "Caller.Assembly",
+            Guid.Empty,
+            callerType,
+            "Caller",
+            [],
+            TypeRef.CoreLib("System", "Void"),
+            callerToken,
+            IsStatic: true);
+        return new DirectCall(caller, callee, ILOffset: 0, OperandToken: 0, CalleeDefinitionToken: 0, CallKind.Call);
+    }
+
 
     [Fact]
     public void TopUnsafeLeverage_RanksRequiresUnsafeMethodsByCallers()

--- a/src/ILInspector.Analysis/FrameworkIdentity.cs
+++ b/src/ILInspector.Analysis/FrameworkIdentity.cs
@@ -2,6 +2,12 @@ namespace ILInspector.Analysis;
 
 internal static class FrameworkIdentity
 {
+    // Legacy-TFM facade for the modern split assemblies (#1708 Row B). On .NET
+    // Framework, namespaces that modern .NET ships as separate assemblies
+    // (System.Linq, System.Linq.Expressions, System.Collections, ...) live in
+    // System.Core, so a real framework type can carry that assembly identity.
+    internal const string LegacyCombinedFacadeAssembly = "System.Core";
+
     public static bool IsCoreLibraryType(TypeRef type, string ns, string name)
     {
         var definition = NamedDefinition(type);
@@ -15,7 +21,7 @@ internal static class FrameworkIdentity
     {
         var definition = NamedDefinition(type);
         return definition.Kind != TypeRefKind.Unsupported
-            && definition.Assembly == assembly
+            && MatchesFrameworkAssembly(definition.Assembly, assembly)
             && definition.Namespace == ns
             && definition.Name == name;
     }
@@ -25,7 +31,7 @@ internal static class FrameworkIdentity
         var definition = NamedDefinition(type);
         return definition.Kind != TypeRefKind.Unsupported
             && definition.Namespace == ns
-            && IsCoreLibraryOrAssembly(definition.Assembly, assembly);
+            && MatchesFrameworkAssembly(definition.Assembly, assembly);
     }
 
     public static bool IsKnownFrameworkNamespacePrefix(TypeRef type, string assemblyPrefix, string nsPrefix)
@@ -35,12 +41,22 @@ internal static class FrameworkIdentity
             && (definition.Namespace == nsPrefix || definition.Namespace.StartsWith(nsPrefix + ".", StringComparison.Ordinal))
             && (definition.Assembly == TypeRef.CoreLibrary
                 || definition.Assembly == assemblyPrefix
-                || definition.Assembly.StartsWith(assemblyPrefix + ".", StringComparison.Ordinal));
+                || definition.Assembly.StartsWith(assemblyPrefix + ".", StringComparison.Ordinal)
+                || definition.Assembly == LegacyCombinedFacadeAssembly);
     }
 
     static TypeRef NamedDefinition(TypeRef type)
         => type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
 
-    static bool IsCoreLibraryOrAssembly(string actual, string expected)
-        => actual == TypeRef.CoreLibrary || actual == expected;
+    // True when an actual declaring-assembly identity matches an expected framework
+    // assembly, tolerating legacy-TFM facades (#1708 Row B). A non-corelib framework
+    // type can surface as corelib (netstandard / mscorlib / System.Runtime facades
+    // canonicalize to corelib in TypeRef.CanonicalAssembly) or as System.Core (.NET
+    // Framework). Namespace and name still guard against user lookalikes, and the
+    // facades only widen matching for non-corelib expectations so corelib checks stay
+    // exact.
+    internal static bool MatchesFrameworkAssembly(string actual, string expected)
+        => actual == expected
+            || actual == TypeRef.CoreLibrary
+            || (expected != TypeRef.CoreLibrary && actual == LegacyCombinedFacadeAssembly);
 }

--- a/src/ILInspector.Analysis/MethodSignals.cs
+++ b/src/ILInspector.Analysis/MethodSignals.cs
@@ -263,7 +263,7 @@ public static class MethodSignalAnalysis
     {
         var definition = type is { Kind: TypeRefKind.GenericInstance } ? type.ElementType : type;
         return definition is { Kind: TypeRefKind.Definition, Assembly: var typeAssembly, Namespace: var typeNamespace, Name: var typeName }
-            && typeAssembly == assembly
+            && FrameworkIdentity.MatchesFrameworkAssembly(typeAssembly, assembly)
             && typeNamespace == ns
             && typeName == name;
     }


### PR DESCRIPTION
## Analysis ladder #1623 rung 2 — #1708 Row B (legacy-TFM facade recall)

Addresses **#1708 Row B**: framework-identity signal predicates matched the modern
split-assembly name exactly, so real positives were missed on legacy TFMs.

### Root cause

A non-corelib framework type can surface under a facade assembly:
- **netstandard** references canonicalize to `corelib` (`TypeRef.CanonicalAssembly`);
- **.NET Framework** ships `System.Linq` / `System.Linq.Expressions` in `System.Core`.

The reflection predicate already tolerated the corelib facade (via
`IsCoreLibraryOrAssembly`), but the copy predicate
(`MethodSignals.IsFrameworkType`) used exact assembly equality — so e.g.
`Enumerable.ToArray` / `ToList` copies went **uncounted** on netstandard/net48,
while `Expression.*` reflection (corelib-tolerant) still worked. net48 was worse:
even Expressions (`System.Core`) was missed.

### Fix

`FrameworkIdentity.MatchesFrameworkAssembly(actual, expected)` accepts the modern
name, the corelib facade bucket, and `System.Core`. Facade tolerance only widens
**non-corelib** expectations, so corelib checks stay exact and namespace+name still
guard against user lookalikes. `IsKnownFrameworkType` / `IsKnownFrameworkNamespace(Prefix)`
and `MethodSignals.IsFrameworkType` route through it.

### Tests

- **netstandard2.0 `FacadeFixtures`** assembly (BCL refs resolve via the netstandard
  facade) + integration tests: `Enumerable.ToArray`/`ToList` copies and
  `Expression` reflection now recognized.
- **Synthetic `Collect` theories** pin copy and reflection recall across
  `System.Linq` (modern), `System.Core` (net48), `netstandard` (corelib) — while a
  same-named user assembly (`Contoso.*`) stays uncounted (precision preserved).

### Evidence

- Repro probe: facade `Enumerable` copies `0 -> 1` after the fix.
- `ILInspector.Analysis.Tests` 154/154; `dotnet-inspect.Tests` 1375 passed / 9
  env-skipped — no regressions.

### Remaining on #1708

Row A (framework identity gated by *simple name*; strong identity via
public-key-token) is the deeper remaining item and is intentionally **not** in this
PR — this fix keeps namespace+name guards and does not widen the simple-name
spoofing surface beyond the documented SRM-direct boundary. Row C (external
`*Exception` suffix) stays pinned (merged #1709).
