### PR TITLE
Gate framework signal identity on public-key-token (#1708 Row A)

### DIFF
--- a/src/ILInspector.Analysis.SpoofFixtures/ILInspector.Analysis.SpoofFixtures.csproj
+++ b/src/ILInspector.Analysis.SpoofFixtures/ILInspector.Analysis.SpoofFixtures.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    A user assembly literally named "System.Linq" (unsigned, so no framework
+    public-key-token) exposing a System.Linq.Enumerable lookalike. This is the
+    adversarial fixture for #1708 Row A: simple-name matching would accept its
+    Enumerable.ToArray as a framework copy, but strong (public-key-token) identity
+    must reject it. Loaded by path; never referenced for compilation.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>System.Linq</AssemblyName>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <SignAssembly>false</SignAssembly>
+    <!-- CS0436: our System.Linq.Enumerable intentionally shadows the real one. -->
+    <NoWarn>$(NoWarn);CS0436</NoWarn>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.SpoofFixtures/SpoofFixtures.cs
+++ b/src/ILInspector.Analysis.SpoofFixtures/SpoofFixtures.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+// Declared in namespace System.Linq inside an assembly named System.Linq, but
+// unsigned -> no framework public-key-token. Strong identity (#1708 Row A) must not
+// classify a call to this Enumerable.ToArray lookalike as a framework copy.
+namespace System.Linq
+{
+    public static class Enumerable
+    {
+        public static int[] ToArray(IEnumerable<int> values) => new int[0];
+    }
+
+    public static class Spoofer
+    {
+        public static int[] CallsFakeEnumerableToArray(IEnumerable<int> values)
+            => Enumerable.ToArray(values);
+    }
+}

--- a/src/ILInspector.Analysis.SpoofRuntimeFixtures/ILInspector.Analysis.SpoofRuntimeFixtures.csproj
+++ b/src/ILInspector.Analysis.SpoofRuntimeFixtures/ILInspector.Analysis.SpoofRuntimeFixtures.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    A user assembly literally named "System.Runtime" (unsigned, no framework
+    public-key-token, canonicalizes to corelib) exposing a System.Span<T> lookalike.
+    Adversarial fixture for #1708 Row A's span-to-array opportunity path: simple-name
+    identity would report its Span<T>.ToArray() as a span-to-array-copy, but strong
+    (public-key-token) identity must reject it. Loaded by path; never referenced.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>System.Runtime</AssemblyName>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <SignAssembly>false</SignAssembly>
+    <NoWarn>$(NoWarn);CS0436</NoWarn>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.SpoofRuntimeFixtures/SpanSpoofFixtures.cs
+++ b/src/ILInspector.Analysis.SpoofRuntimeFixtures/SpanSpoofFixtures.cs
@@ -1,0 +1,15 @@
+// Declared in namespace System inside an assembly named System.Runtime (unsigned,
+// canonicalizes to corelib) -> no framework public-key-token. Strong identity
+// (#1708 Row A) must not report this Span<T>.ToArray lookalike as a span-to-array-copy.
+namespace System
+{
+    public readonly struct Span<T>
+    {
+        public T[] ToArray() => new T[0];
+    }
+
+    public static class SpanSpoofer
+    {
+        public static int[] CallsFakeSpanToArray(Span<int> span) => span.ToArray();
+    }
+}

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\ILInspector.Analysis.LookalikeFixtures\ILInspector.Analysis.LookalikeFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.FacadeFixtures\ILInspector.Analysis.FacadeFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.SpoofFixtures\ILInspector.Analysis.SpoofFixtures.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ILInspector.Analysis.SpoofRuntimeFixtures\ILInspector.Analysis.SpoofRuntimeFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphTarget\ILInspector.Analysis.CallerGraphTarget.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCaller\ILInspector.Analysis.CallerGraphCaller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCallerTwin\ILInspector.Analysis.CallerGraphCallerTwin.csproj" ReferenceOutputAssembly="false" />

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\ILInspector.Analysis.ProtobufFixtures\ILInspector.Analysis.ProtobufFixtures.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis.LookalikeFixtures\ILInspector.Analysis.LookalikeFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.FacadeFixtures\ILInspector.Analysis.FacadeFixtures.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ILInspector.Analysis.SpoofFixtures\ILInspector.Analysis.SpoofFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphTarget\ILInspector.Analysis.CallerGraphTarget.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCaller\ILInspector.Analysis.CallerGraphCaller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCallerTwin\ILInspector.Analysis.CallerGraphCallerTwin.csproj" ReferenceOutputAssembly="false" />

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1423,6 +1423,33 @@ public class LibraryBodyIndexTests
         int copies = signals.TryGetValue(method.MetadataToken, out var s) ? s.Copies : 0;
         Assert.Equal(0, copies);
     }
+
+    static string SpoofRuntimeFixturePath()
+    {
+        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string path = Path.GetFullPath(Path.Combine(
+            outputDirectory.FullName,
+            "..",
+            "..",
+            "ILInspector.Analysis.SpoofRuntimeFixtures",
+            outputDirectory.Name,
+            "System.Runtime.dll"));
+        Assert.True(File.Exists(path), $"Expected runtime spoof fixture assembly at {path}");
+        return path;
+    }
+
+    // #1708 Row A, span-to-array opportunity path. An assembly named "System.Runtime"
+    // (unsigned -> canonicalizes to corelib, no framework key) exposes a System.Span<T>
+    // lookalike. The span-to-array-copy opportunity must require a trusted framework key,
+    // not just the corelib-canonical name.
+    [Fact]
+    public void OptimizationOpportunities_SpanToArray_RejectSimpleNameSpoofWithoutFrameworkKey()
+    {
+        var index = LibraryBodyIndex.Open(SpoofRuntimeFixturePath());
+
+        Assert.DoesNotContain(index.OptimizationOpportunities, o =>
+            o.Method.Name == "CallsFakeSpanToArray" && o.Shape == "span-to-array-copy");
+    }
     // netstandard facade (assembly canonicalizes to corelib), reproducing the
     // legacy-TFM recall gap where copy predicates expected the modern split assembly.
     [Theory]

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1394,7 +1394,35 @@ public class LibraryBodyIndexTests
         return path;
     }
 
-    // #1708 Row B: a netstandard2.0 fixture references BCL types through the
+    static string SpoofFixturePath()
+    {
+        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string path = Path.GetFullPath(Path.Combine(
+            outputDirectory.FullName,
+            "..",
+            "..",
+            "ILInspector.Analysis.SpoofFixtures",
+            outputDirectory.Name,
+            "System.Linq.dll"));
+        Assert.True(File.Exists(path), $"Expected spoof fixture assembly at {path}");
+        return path;
+    }
+
+    // #1708 Row A end-to-end. A real assembly literally named "System.Linq" (unsigned,
+    // so no framework public-key-token) exposes a System.Linq.Enumerable.ToArray
+    // lookalike. Simple-name identity accepted it as a framework copy; strong
+    // (public-key-token) identity must reject it. The decoder lowers
+    // TrustedFrameworkAssembly from the AssemblyDefinition's (empty) key.
+    [Fact]
+    public void MethodSignals_CopyApis_RejectSimpleNameSpoofWithoutFrameworkKey()
+    {
+        var index = LibraryBodyIndex.Open(SpoofFixturePath());
+        var signals = index.GetMethodSignals();
+        var method = Assert.Single(index.Methods.Where(m => m.Name == "CallsFakeEnumerableToArray"));
+
+        int copies = signals.TryGetValue(method.MetadataToken, out var s) ? s.Copies : 0;
+        Assert.Equal(0, copies);
+    }
     // netstandard facade (assembly canonicalizes to corelib), reproducing the
     // legacy-TFM recall gap where copy predicates expected the modern split assembly.
     [Theory]
@@ -1472,6 +1500,41 @@ public class LibraryBodyIndexTests
         var expression = TypeRef.Definition(calleeAssembly, "System.Linq.Expressions", "Expression");
         var callee = new MemberRef(expression, "Constant", [], TypeRef.Unsupported("ret"), MemberKind.Method);
         return FrameworkCall(callee, callerToken);
+    }
+
+    // #1708 Row A. The same framework-named assembly is accepted only when it carries a
+    // known framework public-key-token (TrustedFrameworkAssembly). A simple-name match
+    // alone (trusted = false) must not fire the copy or reflection signal.
+    [Theory]
+    [InlineData(true, 1)]
+    [InlineData(false, 0)]
+    public void Collect_CopyApi_RequiresTrustedFrameworkAssembly(bool trusted, int expectedCopies)
+    {
+        const int callerToken = 0x06000201;
+        var enumerable = TypeRef.Definition("System.Linq", "System.Linq", "Enumerable", trustedFrameworkAssembly: trusted);
+        var callee = new MemberRef(enumerable, "ToArray", [], TypeRef.Unsupported("ret"), MemberKind.Method);
+        var calls = ImmutableArray.Create(FrameworkCall(callee, callerToken));
+
+        var signals = MethodSignalAnalysis.Collect(calls, ImmutableArray<UnsafeEvidence>.Empty);
+
+        int copies = signals.TryGetValue(callerToken, out var s) ? s.Copies : 0;
+        Assert.Equal(expectedCopies, copies);
+    }
+
+    [Theory]
+    [InlineData(true, 1)]
+    [InlineData(false, 0)]
+    public void Collect_ReflectionApi_RequiresTrustedFrameworkAssembly(bool trusted, int expectedReflection)
+    {
+        const int callerToken = 0x06000202;
+        var expression = TypeRef.Definition("System.Linq.Expressions", "System.Linq.Expressions", "Expression", trustedFrameworkAssembly: trusted);
+        var callee = new MemberRef(expression, "Constant", [], TypeRef.Unsupported("ret"), MemberKind.Method);
+        var calls = ImmutableArray.Create(FrameworkCall(callee, callerToken));
+
+        var signals = MethodSignalAnalysis.Collect(calls, ImmutableArray<UnsafeEvidence>.Empty);
+
+        int reflection = signals.TryGetValue(callerToken, out var s) ? s.Reflection : 0;
+        Assert.Equal(expectedReflection, reflection);
     }
 
     static DirectCall FrameworkCall(MemberRef callee, int callerToken)

--- a/src/ILInspector.Analysis/FrameworkAssemblyKeys.cs
+++ b/src/ILInspector.Analysis/FrameworkAssemblyKeys.cs
@@ -1,0 +1,63 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Security.Cryptography;
+
+namespace ILInspector.Analysis;
+
+/// <summary>
+/// Recognizes Microsoft framework assembly identity by public-key-token (#1708 Row A).
+/// The product is SRM-direct and does not load referenced assemblies, but the
+/// public-key-token travels in metadata (AssemblyReference / AssemblyDefinition), so a
+/// framework signal predicate can require strong identity instead of trusting a simple
+/// assembly name. This rejects spoofs such as a user assembly named <c>System.Linq</c>
+/// exposing a <c>System.Linq.Enumerable</c> lookalike.
+/// </summary>
+internal static class FrameworkAssemblyKeys
+{
+    // Public-key-tokens used by the .NET frameworks (lowercase hex).
+    static readonly HashSet<string> s_frameworkTokens = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "b77a5c561934e089", // ECMA / .NET Framework: mscorlib, System, System.Core, System.Xml, ...
+        "b03f5f7f11d50a3a", // Microsoft .NET ref assemblies / contracts: System.*, System.Linq, ...
+        "7cec85d7bea7798e", // System.Private.CoreLib (and the Silverlight key)
+        "cc7b13ffcd2ddd51", // netstandard and several System.* packages
+        "31bf3856ad364e35", // Microsoft key: WindowsBase, System.ValueTuple, ...
+        "adb9793829ddae60", // assorted System.* packages
+    };
+
+    public static bool IsFrameworkReference(MetadataReader reader, AssemblyReferenceHandle handle)
+    {
+        var reference = reader.GetAssemblyReference(handle);
+        return IsFrameworkKeyOrToken(
+            reader.GetBlobBytes(reference.PublicKeyOrToken),
+            isFullKey: (reference.Flags & AssemblyFlags.PublicKey) != 0);
+    }
+
+    public static bool IsFrameworkDefinition(MetadataReader reader)
+    {
+        if (!reader.IsAssembly)
+            return false;
+        // The AssemblyDefinition row stores the full public key, never the token.
+        return IsFrameworkKeyOrToken(reader.GetBlobBytes(reader.GetAssemblyDefinition().PublicKey), isFullKey: true);
+    }
+
+    static bool IsFrameworkKeyOrToken(byte[] keyOrToken, bool isFullKey)
+    {
+        if (keyOrToken.Length == 0)
+            return false;
+        byte[] token = isFullKey ? ComputeToken(keyOrToken) : keyOrToken;
+        return token.Length == 8 && s_frameworkTokens.Contains(Convert.ToHexString(token));
+    }
+
+    // The public-key-token is the low 8 bytes of the SHA-1 hash of the public key,
+    // emitted in reverse order (ECMA-335 II.6.3).
+    static byte[] ComputeToken(byte[] publicKey)
+    {
+        Span<byte> hash = stackalloc byte[20];
+        SHA1.HashData(publicKey, hash);
+        var token = new byte[8];
+        for (int i = 0; i < token.Length; i++)
+            token[i] = hash[hash.Length - 1 - i];
+        return token;
+    }
+}

--- a/src/ILInspector.Analysis/FrameworkIdentity.cs
+++ b/src/ILInspector.Analysis/FrameworkIdentity.cs
@@ -12,6 +12,7 @@ internal static class FrameworkIdentity
     {
         var definition = NamedDefinition(type);
         return definition.Kind != TypeRefKind.Unsupported
+            && definition.TrustedFrameworkAssembly
             && definition.Assembly == TypeRef.CoreLibrary
             && definition.Namespace == ns
             && definition.Name == name;
@@ -21,6 +22,7 @@ internal static class FrameworkIdentity
     {
         var definition = NamedDefinition(type);
         return definition.Kind != TypeRefKind.Unsupported
+            && definition.TrustedFrameworkAssembly
             && MatchesFrameworkAssembly(definition.Assembly, assembly)
             && definition.Namespace == ns
             && definition.Name == name;
@@ -30,6 +32,7 @@ internal static class FrameworkIdentity
     {
         var definition = NamedDefinition(type);
         return definition.Kind != TypeRefKind.Unsupported
+            && definition.TrustedFrameworkAssembly
             && definition.Namespace == ns
             && MatchesFrameworkAssembly(definition.Assembly, assembly);
     }
@@ -38,6 +41,7 @@ internal static class FrameworkIdentity
     {
         var definition = NamedDefinition(type);
         return definition.Kind != TypeRefKind.Unsupported
+            && definition.TrustedFrameworkAssembly
             && (definition.Namespace == nsPrefix || definition.Namespace.StartsWith(nsPrefix + ".", StringComparison.Ordinal))
             && (definition.Assembly == TypeRef.CoreLibrary
                 || definition.Assembly == assemblyPrefix

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1931,6 +1931,7 @@ public sealed class LibraryBodyIndex
                 return false;
             var definition = declaring.ElementType;
             if (definition is null
+                || !definition.TrustedFrameworkAssembly
                 || definition.Assembly != TypeRef.CoreLibrary
                 || definition.Namespace != "System")
                 return false;

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1400,7 +1400,9 @@ public sealed class LibraryBodyIndex
                 return false;
             }
 
-            return leaf.Kind == TypeRefKind.Definition && IsWellKnownValueType(leaf.Namespace, leaf.Name);
+            return leaf.Kind == TypeRefKind.Definition
+                && leaf.TrustedFrameworkAssembly
+                && IsWellKnownValueType(leaf.Namespace, leaf.Name);
         }
 
         // Reads a TypeSpec signature blob to decide value-type-ness directly from metadata. The

--- a/src/ILInspector.Analysis/MethodSignals.cs
+++ b/src/ILInspector.Analysis/MethodSignals.cs
@@ -263,6 +263,7 @@ public static class MethodSignalAnalysis
     {
         var definition = type is { Kind: TypeRefKind.GenericInstance } ? type.ElementType : type;
         return definition is { Kind: TypeRefKind.Definition, Assembly: var typeAssembly, Namespace: var typeNamespace, Name: var typeName }
+            && definition.TrustedFrameworkAssembly
             && FrameworkIdentity.MatchesFrameworkAssembly(typeAssembly, assembly)
             && typeNamespace == ns
             && typeName == name;

--- a/src/ILInspector.Analysis/TypeRef.cs
+++ b/src/ILInspector.Analysis/TypeRef.cs
@@ -46,8 +46,23 @@ public sealed class TypeRef : IEquatable<TypeRef>
     public string GenericParameterName { get; private init; } = "";
     public string UnsupportedReason { get; private init; } = "";
 
-    public static TypeRef Definition(string assembly, string ns, string name)
-        => new(TypeRefKind.Definition) { Assembly = CanonicalAssembly(assembly), Namespace = ns, Name = name };
+    // Whether this type's declaring assembly carries a known Microsoft framework
+    // public-key-token (#1708 Row A). Advisory classification used by the framework
+    // signal predicates to reject simple-name spoofs (a user assembly named
+    // "System.Linq" exposing System.Linq.Enumerable). Defaults to true so synthetic
+    // and corelib refs stay trusted; only the decoder lowers it for a decoded
+    // reference whose assembly is not framework-signed. Excluded from equality/hash:
+    // it is derived metadata, not part of structural type identity.
+    public bool TrustedFrameworkAssembly { get; private init; } = true;
+
+    public static TypeRef Definition(string assembly, string ns, string name, bool trustedFrameworkAssembly = true)
+        => new(TypeRefKind.Definition)
+        {
+            Assembly = CanonicalAssembly(assembly),
+            Namespace = ns,
+            Name = name,
+            TrustedFrameworkAssembly = trustedFrameworkAssembly,
+        };
 
     public static TypeRef CoreLib(string ns, string name) => Definition(CoreLibrary, ns, name);
 

--- a/src/ILInspector.Analysis/TypeRefDecoder.cs
+++ b/src/ILInspector.Analysis/TypeRefDecoder.cs
@@ -44,12 +44,12 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         if (typeDef.IsNested)
         {
             var declaring = GetTypeFromDefinition(reader, typeDef.GetDeclaringType(), 0);
-            return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{name}");
+            return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{name}", declaring.TrustedFrameworkAssembly);
         }
         string assembly = reader.IsAssembly
             ? reader.GetString(reader.GetAssemblyDefinition().Name)
             : "";
-        return TypeRef.Definition(assembly, ns, name);
+        return TypeRef.Definition(assembly, ns, name, FrameworkAssemblyKeys.IsFrameworkDefinition(reader));
     }
 
     public TypeRef GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
@@ -60,9 +60,12 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         return typeRef.ResolutionScope.Kind switch
         {
             HandleKind.AssemblyReference => TypeRef.Definition(
-                reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)typeRef.ResolutionScope).Name), ns, name),
+                reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)typeRef.ResolutionScope).Name),
+                ns,
+                name,
+                FrameworkAssemblyKeys.IsFrameworkReference(reader, (AssemblyReferenceHandle)typeRef.ResolutionScope)),
             HandleKind.TypeReference => NestedReference(reader, (TypeReferenceHandle)typeRef.ResolutionScope, name),
-            _ => TypeRef.Definition("", ns, name),
+            _ => TypeRef.Definition("", ns, name, FrameworkAssemblyKeys.IsFrameworkDefinition(reader)),
         };
     }
 
@@ -87,7 +90,7 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
     static TypeRef NestedReference(MetadataReader reader, TypeReferenceHandle declaringHandle, string nestedName)
     {
         var declaring = Instance.GetTypeFromReference(reader, declaringHandle, 0);
-        return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{nestedName}");
+        return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{nestedName}", declaring.TrustedFrameworkAssembly);
     }
 
     static string NameAt(ImmutableArray<string> names, int index)


### PR DESCRIPTION
## Analysis ladder #1623 rung 2 — #1708 Row A (strong framework identity via public-key-token)

Closes the simple-name spoofing hole behind #1708 Row A (and gaps 2/3 from the
rung-2 adversarial review): framework/value-type signal predicates trusted the
simple assembly **name**, so a user assembly literally named `System.Linq`
exposing `System.Linq.Enumerable` was accepted as a framework copy/reflection/box.

### Approach

Gate framework identity on the referenced assembly's **public-key-token** — strong
identity the SRM-direct product reads straight from metadata, no assembly loading.

- `TypeRef.TrustedFrameworkAssembly` (default **true**, excluded from equality/hash).
  The decoder lowers it for a decoded reference/definition whose assembly is not
  framework-signed (`AssemblyReference` token / `AssemblyDefinition` key).
- `FrameworkAssemblyKeys`: the known Microsoft framework public-key-tokens; handles
  the 8-byte reference token and the full `AssemblyDefinition` key (SHA-1 token).
- Gate `FrameworkIdentity.{IsCoreLibraryType, IsKnownFrameworkType,
  IsKnownFrameworkNamespace, IsKnownFrameworkNamespacePrefix}`,
  `MethodSignals.IsFrameworkType`, and the external well-known value-type box check.

PKT is an **additional** gate on top of the existing name/facade match, so Row B's
legacy-TFM facades still resolve (netstandard / System.Core carry Microsoft keys)
while unsigned / user-keyed lookalikes are rejected. Default-true keeps
synthetic/corelib refs trusted, so only decoded non-framework refs change behavior.

### Tests

- **Real adversarial fixture**: an assembly literally named `System.Linq` (unsigned,
  no framework key) whose `Enumerable.ToArray` lookalike is no longer counted as a
  copy. Proven non-vacuous: removing the gate makes it count (`0 -> 1`).
- **Synthetic trust theories** for copy and reflection (trusted → fires, untrusted → quiet).
- Row B facade recall preserved (netstandard fixture, real Microsoft key).

### Evidence

- `ILInspector.Analysis.Tests` 159/159.
- `dotnet-inspect.Tests` 1375 passed / 9 env-skipped — **no recall regression** on the
  real-assembly corpus.
- `DotnetInspector.Services.Tests` 159/159.

### #1708

This completes #1708: Row A (this PR), Row B (#1722, merged), Row C (external
`*Exception` suffix, pinned by #1709). A GPT-5.5 adversarial review is requested,
focused on PKT-set completeness / false-negative risk.

Closes #1708.
