### PR TITLE
Performance Triage: detect repeated-scan / O(n·m) patterns (#1714)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -961,6 +961,32 @@ public class LibraryBodyIndexTests
         Assert.Equal("capturing-delegate", shape);
     }
 
+    [Fact]
+    public void OptimizationOpportunities_DelegateConsumedByLazyLinq_FixDescribesMovedAllocation()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.CapturingLambdaConsumedByWhere)
+            && o.Shape == "capturing-delegate"));
+        // The surfaced Fix text (not just the dropped Caveat) must convey that a lambda
+        // rewrite only moves the allocation and indexing is the real elimination.
+        Assert.Contains("MOVES the allocation", op.SafeFixDirection, StringComparison.Ordinal);
+        Assert.Contains("indexing", op.SafeFixDirection, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_DelegateNotConsumedByLinq_KeepsDefaultFix()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.CapturingLambdaConsumedByNonLinq)
+            && o.Shape == "capturing-delegate"));
+        Assert.DoesNotContain("MOVES the allocation", op.SafeFixDirection, StringComparison.Ordinal);
+        Assert.Null(op.Caveat);
+    }
+
     [Theory]
     [InlineData(nameof(OptimizationOpportunityFixtures.NonCapturingLambda))]
     [InlineData(nameof(OptimizationOpportunityFixtures.StaticMethodGroup))]
@@ -1638,6 +1664,21 @@ public class OptimizationOpportunityFixtures
     public static Func<int> CapturingLambda(int seed)
     {
         return () => seed + 1;
+    }
+
+    // A capturing lambda consumed by a lazy LINQ operator (Where). Rewriting the lambda as
+    // an iterator/local function only MOVES the allocation to the state machine, so the
+    // capturing-delegate row carries a "moved allocation" caveat.
+    public static System.Collections.Generic.IEnumerable<int> CapturingLambdaConsumedByWhere(
+        System.Collections.Generic.IEnumerable<int> source, int threshold)
+        => System.Linq.Enumerable.Where(source, x => x > threshold);
+
+    // A capturing lambda NOT consumed by a LINQ operator: ordinary use, no moved-allocation
+    // caveat (the local-function rewrite genuinely removes the allocation here).
+    public static int CapturingLambdaConsumedByNonLinq(int threshold)
+    {
+        Func<int, bool> predicate = x => x > threshold;
+        return predicate(5) ? 1 : 0;
     }
 
     // Non-capturing lambda -> compiler-cached delegate (one row, not capturing).

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -808,6 +808,41 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_FlagsLinqMembershipScanInsideLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.LinqScanInLoop)
+            && o.Shape == "linq-scan-in-loop"));
+        Assert.True(op.InLoop);
+        Assert.Equal("medium", op.Confidence);
+        Assert.Contains("Any", op.Evidence, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_DoesNotFlagLinqScanOutsideLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.DoesNotContain(index.OptimizationOpportunities, o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.LinqScanOutsideLoop)
+            && o.Shape == "linq-scan-in-loop");
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_DoesNotFlagLazyWhereInLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // Enumerable.Where is lazy: calling it in a loop does not enumerate, so it is
+        // not a repeated scan and must not be flagged.
+        Assert.DoesNotContain(index.OptimizationOpportunities, o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.LazyWhereInLoopNotFlagged)
+            && o.Shape == "linq-scan-in-loop");
+    }
+
+    [Fact]
     public void OptimizationOpportunities_CapturingLambdaIsCapturingDelegate_SingleRow()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -1355,6 +1390,41 @@ public class OptimizationOpportunityFixtures
 
     public static int[] EnumerableToArrayCopy(System.Collections.Generic.IEnumerable<int> values)
         => values.ToArray();
+
+    // --- Repeated LINQ scan inside a loop (linq-scan-in-loop) ---
+
+    // A membership LINQ scan (Enumerable.Any) runs once per loop iteration over a
+    // sequence whose size scales with the input -> O(n*m). The canonical fix is to
+    // build a HashSet once outside the loop.
+    public static int LinqScanInLoop(System.Collections.Generic.IEnumerable<int> source, int[] keys)
+    {
+        var count = 0;
+        foreach (var key in keys)
+        {
+            if (System.Linq.Enumerable.Any(source, x => x == key))
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    // The same membership scan, but not inside any loop -> not a repeated scan.
+    public static bool LinqScanOutsideLoop(System.Collections.Generic.IEnumerable<int> source, int key)
+        => System.Linq.Enumerable.Any(source, x => x == key);
+
+    // A lazy operator (Enumerable.Where) called in a loop does not itself enumerate,
+    // so it is not a terminal scan and must not be flagged.
+    public static int LazyWhereInLoopNotFlagged(System.Collections.Generic.IEnumerable<int> source, int[] keys)
+    {
+        var seen = 0;
+        foreach (var key in keys)
+        {
+            var filtered = System.Linq.Enumerable.Where(source, x => x == key);
+            seen += filtered is null ? 0 : 1;
+        }
+        return seen;
+    }
 
     public static string StringConcatCopy(string left, string right)
         => string.Concat(left, right);

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -843,6 +843,29 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_FlagsScanMethodInvokedInCallerLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.ContainsKey)
+            && o.Shape == "scan-method-in-loop-call"));
+        Assert.True(op.InLoop);
+        Assert.Equal("low", op.Confidence);
+        Assert.Contains(nameof(OptimizationOpportunityFixtures.CallsScanHelperInLoop), op.Evidence, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_DoesNotFlagScanMethodInvokedOnlyOutsideLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.DoesNotContain(index.OptimizationOpportunities, o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.ContainsKeyNeverLooped)
+            && o.Shape == "scan-method-in-loop-call");
+    }
+
+    [Fact]
     public void OptimizationOpportunities_CapturingLambdaIsCapturingDelegate_SingleRow()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -1425,6 +1448,33 @@ public class OptimizationOpportunityFixtures
         }
         return seen;
     }
+
+    // --- Cross-method repeated scan (scan-method-in-loop-call) ---
+
+    // A scanning helper: contains a membership scan but no loop in its own body.
+    public static bool ContainsKey(System.Collections.Generic.IEnumerable<int> source, int key)
+        => System.Linq.Enumerable.Any(source, x => x == key);
+
+    // Invokes the scanning helper once per loop iteration -> the scan runs O(m) times.
+    public static int CallsScanHelperInLoop(System.Collections.Generic.IEnumerable<int> source, int[] keys)
+    {
+        var n = 0;
+        foreach (var key in keys)
+        {
+            if (ContainsKey(source, key))
+            {
+                n++;
+            }
+        }
+        return n;
+    }
+
+    // A scanning helper that is only ever invoked outside any loop -> not a repeated scan.
+    public static bool ContainsKeyNeverLooped(System.Collections.Generic.IEnumerable<int> source, int key)
+        => System.Linq.Enumerable.Any(source, x => x == key);
+
+    public static bool CallsScanHelperOnceNoLoop(System.Collections.Generic.IEnumerable<int> source, int key)
+        => ContainsKeyNeverLooped(source, key);
 
     public static string StringConcatCopy(string left, string right)
         => string.Concat(left, right);

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -969,10 +969,10 @@ public class LibraryBodyIndexTests
         var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
             o.Method.Name == nameof(OptimizationOpportunityFixtures.CapturingLambdaConsumedByWhere)
             && o.Shape == "capturing-delegate"));
-        // The surfaced Fix text (not just the dropped Caveat) must convey that a lambda
-        // rewrite only moves the allocation and indexing is the real elimination.
-        Assert.Contains("MOVES the allocation", op.SafeFixDirection, StringComparison.Ordinal);
-        Assert.Contains("indexing", op.SafeFixDirection, StringComparison.OrdinalIgnoreCase);
+        // The surfaced Fix text (not just the dropped Caveat) must convey that the closure
+        // rewrite reduces but does not eliminate the allocation (the lazy iterator remains).
+        Assert.Contains("reduced, not eliminated", op.SafeFixDirection, StringComparison.Ordinal);
+        Assert.Contains("iterator", op.SafeFixDirection, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -983,7 +983,22 @@ public class LibraryBodyIndexTests
         var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
             o.Method.Name == nameof(OptimizationOpportunityFixtures.CapturingLambdaConsumedByNonLinq)
             && o.Shape == "capturing-delegate"));
-        Assert.DoesNotContain("MOVES the allocation", op.SafeFixDirection, StringComparison.Ordinal);
+        Assert.DoesNotContain("iterator", op.SafeFixDirection, StringComparison.OrdinalIgnoreCase);
+        Assert.Null(op.Caveat);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_DelegateConsumedByMembershipTerminal_NotGivenLazyIteratorFix()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // A predicate consumed by an EAGER membership terminal (Any) allocates no iterator,
+        // so it must NOT receive the lazy/iterator "moved allocation" wording. The repeated
+        // scan itself is covered separately by the linq-scan-in-loop shape.
+        var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.LinqScanInLoop)
+            && o.Shape == "capturing-delegate"));
+        Assert.DoesNotContain("iterator", op.SafeFixDirection, StringComparison.OrdinalIgnoreCase);
         Assert.Null(op.Caveat);
     }
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -866,6 +866,93 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_FlagsLazyReturningScanMethodInvokedInCallerLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // A helper that returns a deferred Where query, enumerated once per caller-loop
+        // iteration, is the cross-method shape of a repeated scan (e.g. Aspire's
+        // GetChildSpans().Any()). Flagged at low confidence against the helper.
+        var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.FilterLazy)
+            && o.Shape == "scan-method-in-loop-call"));
+        Assert.Equal("low", op.Confidence);
+        Assert.Contains("Where", op.Evidence, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_DoesNotFlagParameterlessTerminalsInLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // First()/Any()/Count() with no predicate are O(1) (positional read or the
+        // ICollection.Count fast path), so neither shape may flag them in a loop.
+        Assert.DoesNotContain(index.OptimizationOpportunities, o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.ParameterlessTerminalsInLoopNotFlagged)
+            && (o.Shape == "linq-scan-in-loop" || o.Shape == "scan-method-in-loop-call"));
+    }
+
+    [Theory]
+    [InlineData("System.Linq")]   // .NET 5+ reference assemblies
+    [InlineData("System.Core")]   // .NET Framework
+    [InlineData("netstandard")]   // canonicalizes to the core library
+    public void IsLinqMembershipScan_MatchesPredicateOverloadAcrossTargetFrameworks(string assembly)
+    {
+        var enumerable = TypeRef.Definition(assembly, "System.Linq", "Enumerable");
+        var anyPredicate = new MemberRef(
+            enumerable,
+            "Any",
+            [TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"), TypeRef.CoreLib("System", "Func`2")],
+            TypeRef.CoreLib("System", "Boolean"),
+            MemberKind.Method);
+
+        Assert.True(LibraryBodyIndex.IsLinqMembershipScan(anyPredicate, out var op));
+        Assert.Equal("Any", op);
+    }
+
+    [Theory]
+    [InlineData("Any")]
+    [InlineData("First")]
+    [InlineData("Single")]
+    [InlineData("Count")]
+    [InlineData("Last")]
+    public void IsLinqMembershipScan_RejectsParameterlessOverload(string name)
+    {
+        var enumerable = TypeRef.Definition("System.Linq", "System.Linq", "Enumerable");
+        var parameterless = new MemberRef(
+            enumerable,
+            name,
+            [TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1")],
+            TypeRef.CoreLib("System", "Boolean"),
+            MemberKind.Method);
+
+        Assert.False(LibraryBodyIndex.IsLinqMembershipScan(parameterless, out _));
+    }
+
+    [Fact]
+    public void IsLinqMembershipScan_RejectsLazyOperatorAndUserTypeLookalike()
+    {
+        var enumerable = TypeRef.Definition("System.Linq", "System.Linq", "Enumerable");
+        var where = new MemberRef(
+            enumerable,
+            "Where",
+            [TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"), TypeRef.CoreLib("System", "Func`2")],
+            TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"),
+            MemberKind.Method);
+        Assert.False(LibraryBodyIndex.IsLinqMembershipScan(where, out _));
+
+        // A user-defined Enumerable in a different namespace/assembly must not match.
+        var userEnumerable = TypeRef.Definition("MyLib", "My.Linq", "Enumerable");
+        var userAny = new MemberRef(
+            userEnumerable,
+            "Any",
+            [TypeRef.CoreLib("System", "Object"), TypeRef.CoreLib("System", "Object")],
+            TypeRef.CoreLib("System", "Boolean"),
+            MemberKind.Method);
+        Assert.False(LibraryBodyIndex.IsLinqMembershipScan(userAny, out _));
+    }
+
+    [Fact]
     public void OptimizationOpportunities_CapturingLambdaIsCapturingDelegate_SingleRow()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -1475,6 +1562,44 @@ public class OptimizationOpportunityFixtures
 
     public static bool CallsScanHelperOnceNoLoop(System.Collections.Generic.IEnumerable<int> source, int key)
         => ContainsKeyNeverLooped(source, key);
+
+    // Parameterless positional/aggregate terminals are O(1) (a positional read or the
+    // ICollection.Count fast path), so they must NOT be flagged even inside a loop.
+    public static int ParameterlessTerminalsInLoopNotFlagged(System.Collections.Generic.List<int> list, int[] keys)
+    {
+        var n = 0;
+        foreach (var key in keys)
+        {
+            if (System.Linq.Enumerable.Any(list))
+            {
+                n += System.Linq.Enumerable.Count(list);
+            }
+            if (System.Linq.Enumerable.First(list) == key)
+            {
+                n++;
+            }
+        }
+        return n;
+    }
+
+    // A lazy-returning helper: hands back a deferred Where query without enumerating it.
+    public static System.Collections.Generic.IEnumerable<int> FilterLazy(System.Collections.Generic.IEnumerable<int> source, int key)
+        => System.Linq.Enumerable.Where(source, x => x == key);
+
+    // Enumerates the lazy helper's result once per loop iteration -> the deferred linear
+    // scan runs O(m) times across the call boundary.
+    public static int CallsLazyHelperInLoop(System.Collections.Generic.IEnumerable<int> source, int[] keys)
+    {
+        var n = 0;
+        foreach (var key in keys)
+        {
+            foreach (var _ in FilterLazy(source, key))
+            {
+                n++;
+            }
+        }
+        return n;
+    }
 
     public static string StringConcatCopy(string left, string right)
         => string.Concat(left, right);

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -148,14 +148,21 @@ public sealed class LibraryBodyIndex
     // sequence to answer a lookup/membership question and whose canonical fix is an
     // indexed lookup (HashSet/Dictionary). Lazy operators (Where/Select/OrderBy) are
     // excluded — they do not enumerate at the call site — as are materializers
-    // (ToArray/ToList) and numeric aggregates, which have a different fix shape and are
-    // left to a follow-up to keep this signal high-precision.
-    internal static bool IsLinqMembershipScan(MemberRef member, out string op)
+    // (ToArray/ToList), which have a different fix shape.
+    //
+    // Only the predicate/value overloads do real O(n) work. The parameterless positional
+    // and aggregate overloads (First(), Single(), Count(), Any()) are O(1) — a positional
+    // read, or the ICollection.Count fast path — so they are NOT scans and must not be
+    // flagged. Every scanning overload takes the source plus a predicate/value, so it has
+    // at least two parameters in Enumerable's static signature; gate on that arity.
+    public static bool IsLinqMembershipScan(MemberRef member, out string op)
     {
         op = "";
         if (member.Kind == MemberKind.Unsupported)
             return false;
-        if (!FrameworkIdentity.IsKnownFrameworkType(member.DeclaringType, "System.Linq", "System.Linq", "Enumerable"))
+        if (!IsEnumerableDefinition(member.DeclaringType))
+            return false;
+        if (member.ParameterTypes.Length < 2)
             return false;
         switch (member.Name)
         {
@@ -177,11 +184,59 @@ public sealed class LibraryBodyIndex
         }
     }
 
-    // Cross-method repeated scan: an in-assembly method whose body performs a membership
-    // LINQ scan (see IsLinqMembershipScan) is itself invoked at a call site inside a loop.
-    // The scan then runs on every loop iteration even though the scan and the loop live in
-    // different methods — the same O(n*m) shape as linq-scan-in-loop, but split across a
-    // call boundary where a single-method scan would miss it. Reported once per scanning
+    // System.Linq.Enumerable across target frameworks: the type lives in System.Linq on
+    // .NET 5+ reference assemblies, in System.Core on .NET Framework, and canonicalizes to
+    // the core library on netstandard. Match all three so the heuristic is not silently
+    // inert on the most common library target (netstandard2.0).
+    static bool IsEnumerableDefinition(TypeRef type)
+    {
+        var def = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+        return def.Kind != TypeRefKind.Unsupported
+            && def.Namespace == "System.Linq"
+            && def.Name == "Enumerable"
+            && (def.Assembly == TypeRef.CoreLibrary || def.Assembly == "System.Linq" || def.Assembly == "System.Core");
+    }
+
+    // A lazy/deferred Enumerable operator (Where/Select/…): it returns an iterator without
+    // enumerating at the call site. A helper that returns such a query is itself a deferred
+    // linear scan — the scan runs when the caller enumerates the result.
+    static bool IsLinqLazyProducer(MemberRef member, out string op)
+    {
+        op = "";
+        if (member.Kind == MemberKind.Unsupported || !IsEnumerableDefinition(member.DeclaringType))
+            return false;
+        switch (member.Name)
+        {
+            case "Where":
+            case "Select":
+            case "SelectMany":
+            case "OfType":
+            case "Cast":
+                op = member.Name;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    // The method's return type is an enumerable sequence (IEnumerable / IEnumerable<T>),
+    // i.e. it can hand back a deferred query for the caller to enumerate.
+    static bool ReturnsEnumerableSequence(TypeRef returnType)
+    {
+        var def = returnType.Kind == TypeRefKind.GenericInstance ? returnType.ElementType ?? returnType : returnType;
+        if (def.Kind == TypeRefKind.Unsupported)
+            return false;
+        return (def.Namespace == "System.Collections.Generic" && def.Name == "IEnumerable`1")
+            || (def.Namespace == "System.Collections" && def.Name == "IEnumerable");
+    }
+
+    // Cross-method repeated scan: an in-assembly method that linearly scans a sequence is
+    // itself invoked at a call site inside a loop, so the scan runs on every iteration even
+    // though the scan and the loop live in different methods — the same O(n*m) shape as
+    // linq-scan-in-loop, split across a call boundary where a single-method scan would miss
+    // it. "Scans a sequence" covers both a method that performs a membership terminal
+    // (IsLinqMembershipScan) and a method that returns a deferred Where/Select query the
+    // caller enumerates (a lazy producer returning IEnumerable). Reported once per scanning
     // method, naming a representative looping caller.
     IEnumerable<OptimizationOpportunity> ScanMethodsInvokedInLoops(Dictionary<int, int> reachByToken)
     {
@@ -189,12 +244,68 @@ public sealed class LibraryBodyIndex
         foreach (var method in Methods)
             methodByToken[method.MetadataToken] = method;
 
-        // Methods that contain at least one membership scan, keyed by the containing
-        // (caller) method token. The recorded op is a representative for the evidence string.
+        // Methods that linearly scan a sequence, keyed by the containing (caller) method
+        // token. The recorded op is a representative for the evidence string. Two kinds:
+        // a membership terminal in the body, or a deferred query returned for the caller to
+        // enumerate (lazy producer whose return type is an enumerable sequence).
         var scanningMethods = new Dictionary<int, string>();
+        var inAssemblyCallees = new Dictionary<int, HashSet<int>>();
+        var lazyReturning = new Dictionary<int, string>();
         foreach (var call in DirectCalls)
-            if (IsLinqMembershipScan(call.Callee, out var op))
-                scanningMethods.TryAdd(call.Caller.MetadataToken, op);
+        {
+            if (IsLinqMembershipScan(call.Callee, out var membershipOp))
+            {
+                scanningMethods.TryAdd(call.Caller.MetadataToken, membershipOp);
+            }
+            else if (IsLinqLazyProducer(call.Callee, out var lazyOp)
+                && methodByToken.TryGetValue(call.Caller.MetadataToken, out var producer)
+                && ReturnsEnumerableSequence(producer.ReturnType))
+            {
+                lazyReturning.TryAdd(call.Caller.MetadataToken, lazyOp);
+            }
+
+            // Record in-assembly call edges for transitive lazy-producer propagation.
+            if (methodByToken.ContainsKey(call.CalleeDefinitionToken))
+            {
+                if (!inAssemblyCallees.TryGetValue(call.Caller.MetadataToken, out var callees))
+                    inAssemblyCallees[call.Caller.MetadataToken] = callees = [];
+                callees.Add(call.CalleeDefinitionToken);
+            }
+        }
+
+        // Transitive closure: a sequence-returning method that calls a known lazy-returning
+        // method is itself treated as lazy-returning (e.g. an instance overload delegating to
+        // a static Where helper, as in Aspire's OtlpSpan.GetChildSpans()).
+        for (var changed = true; changed;)
+        {
+            changed = false;
+            foreach (var (callerToken, callees) in inAssemblyCallees)
+            {
+                if (lazyReturning.ContainsKey(callerToken))
+                    continue;
+                if (!methodByToken.TryGetValue(callerToken, out var m) || !ReturnsEnumerableSequence(m.ReturnType))
+                    continue;
+                foreach (var callee in callees)
+                {
+                    if (lazyReturning.TryGetValue(callee, out var op))
+                    {
+                        lazyReturning[callerToken] = op;
+                        changed = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        foreach (var (token, op) in lazyReturning)
+            scanningMethods.TryAdd(token, op);
+
+        // Methods already reported by the in-method linq-scan-in-loop shape: do not also
+        // emit a (weaker, low-confidence) cross-method row for the same method.
+        var inMethodScanLoopTokens = new HashSet<int>();
+        foreach (var opportunity in _rawOpportunities)
+            if (opportunity.Shape == "linq-scan-in-loop")
+                inMethodScanLoopTokens.Add(opportunity.Method.MetadataToken);
 
         var emitted = new HashSet<int>();
         foreach (var call in DirectCalls)
@@ -208,6 +319,8 @@ public sealed class LibraryBodyIndex
                 continue;
             if (_suppressedOpportunityTokens.Contains(calleeToken))
                 continue;
+            if (inMethodScanLoopTokens.Contains(calleeToken))
+                continue;
             // A method that scans itself in a loop is already reported as linq-scan-in-loop;
             // and a method invoking itself recursively is not a caller-loop in the O(n*m) sense.
             if (call.Caller.MetadataToken == calleeToken)
@@ -218,8 +331,8 @@ public sealed class LibraryBodyIndex
             yield return new OptimizationOpportunity(
                 method,
                 "scan-method-in-loop-call",
-                $"Performs Enumerable.{op}(...); invoked inside a loop by {call.Caller.DeclaringType.ToQualifiedDisplayString()}::{call.Caller.Name}",
-                "A method that linearly scans a sequence is called on every iteration of a caller's loop; hoist the scan or build a set/dictionary index the caller can reuse for O(1) lookups.",
+                $"Linearly scans a sequence (Enumerable.{op}); invoked inside a loop by {call.Caller.DeclaringType.ToQualifiedDisplayString()}::{call.Caller.Name}",
+                "A method that linearly scans a sequence is called on every iteration of a caller's loop; precompute an index the caller can reuse, or hoist the scan out of the loop.",
                 "low",
                 true,
                 null,
@@ -1306,7 +1419,7 @@ public sealed class LibraryBodyIndex
                                 caller,
                                 "linq-scan-in-loop",
                                 $"Enumerable.{scanOp}(...) inside a loop",
-                                "Linear LINQ scan per iteration; build a HashSet/Dictionary index once outside the loop for O(1) lookups.",
+                                "Linear LINQ scan per iteration; precompute a set/dictionary index (or hoist the result) once outside the loop.",
                                 "medium",
                                 true,
                                 offset,

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1391,19 +1391,21 @@ public sealed class LibraryBodyIndex
                         pendingConstant = null;
                         int token = ReadInt32(il, ref position, offset);
                         var callee = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
-                        // If the delegate just allocated flows straight into a lazy LINQ
-                        // operator (Where/Select/…), the obvious "rewrite the lambda as an
-                        // iterator/local function" fix only MOVES the allocation to the
-                        // iterator state machine rather than removing it. Annotate the
-                        // delegate row so a cleared shape is not read as a free win.
+                        // When the delegate just allocated flows straight into a lazy LINQ
+                        // operator (Where/Select/…), a static-local-function rewrite removes the
+                        // closure but the LINQ call still allocates a deferred-query iterator per
+                        // call — the allocation is reduced, not eliminated. Annotate the surfaced
+                        // fix so a cleared closure shape is not read as a free win. (Eager
+                        // membership terminals — Any/Count/… — allocate no iterator and are
+                        // handled by the linq-scan-in-loop shape, so they are not annotated here.)
                         if (pendingDelegateOpportunityIndex is { } moveIndex
-                            && (LibraryBodyIndex.IsLinqLazyProducer(callee, out _) || LibraryBodyIndex.IsLinqMembershipScan(callee, out _)))
+                            && LibraryBodyIndex.IsLinqLazyProducer(callee, out _))
                         {
                             var row = opportunities[moveIndex];
                             opportunities[moveIndex] = row with
                             {
-                                SafeFixDirection = "Consumed by a lazy LINQ operator: a local-function/iterator rewrite only MOVES the allocation to the iterator state machine. Eliminate it by indexing the sequence (HashSet/Dictionary) so no per-element delegate is needed.",
-                                Caveat = "Rewriting the delegate alone does not remove the allocation; the LINQ scan still allocates an iterator.",
+                                SafeFixDirection = "Consumed by a lazy LINQ operator (Where/Select/…): a static local function removes this closure, but the LINQ call still allocates a deferred-query iterator per call — reduced, not eliminated. Replace the query with an explicit loop (or a precomputed index when used for lookups) to remove both.",
+                                Caveat = "A delegate-only rewrite does not remove the allocation; the lazy LINQ call still allocates an iterator.",
                             };
                         }
                         if (IsBitConverterGetBytes(callee))

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1211,6 +1211,22 @@ public sealed class LibraryBodyIndex
                                 offset,
                                 "The copy is required if the array escapes (returned, stored, or passed to an array-typed API)."));
                         }
+                        else if (IsLinqMembershipScan(callee, out var scanOp) && IsInLoopRegion(offset, loopRegions))
+                        {
+                            // A membership/search LINQ terminal (Any, First, Count, Contains, …)
+                            // that runs inside a loop re-scans its sequence on every iteration.
+                            // If the scanned sequence scales with the loop this is O(n*m) — the
+                            // canonical fix is to build a set/dictionary index once outside the loop.
+                            opportunities.Add(new OptimizationOpportunity(
+                                caller,
+                                "linq-scan-in-loop",
+                                $"Enumerable.{scanOp}(...) inside a loop",
+                                "Linear LINQ scan per iteration; build a HashSet/Dictionary index once outside the loop for O(1) lookups.",
+                                "medium",
+                                true,
+                                offset,
+                                "Quadratic only if the scanned sequence grows with the loop; a small or constant sequence is fine."));
+                        }
                         break;
                     }
                     case ILOpCode.Ldftn:
@@ -1937,6 +1953,39 @@ public sealed class LibraryBodyIndex
                 return false;
             receiver = $"System.{name}<T>::ToArray";
             return true;
+        }
+
+        // A membership/search LINQ terminal on System.Linq.Enumerable: one that walks the
+        // sequence to answer a lookup/aggregate question and whose canonical fix is an
+        // indexed lookup (HashSet/Dictionary). Lazy operators (Where/Select/OrderBy) are
+        // excluded — they do not enumerate at the call site — as are materializers
+        // (ToArray/ToList) and numeric aggregates, which have a different fix shape and are
+        // left to a follow-up to keep this signal high-precision.
+        static bool IsLinqMembershipScan(MemberRef member, out string op)
+        {
+            op = "";
+            if (member.Kind == MemberKind.Unsupported)
+                return false;
+            if (!FrameworkIdentity.IsKnownFrameworkType(member.DeclaringType, "System.Linq", "System.Linq", "Enumerable"))
+                return false;
+            switch (member.Name)
+            {
+                case "Any":
+                case "All":
+                case "First":
+                case "FirstOrDefault":
+                case "Last":
+                case "LastOrDefault":
+                case "Single":
+                case "SingleOrDefault":
+                case "Count":
+                case "LongCount":
+                case "Contains":
+                    op = member.Name;
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         static string StripGenericArity(string name)

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -72,6 +72,7 @@ public sealed class LibraryBodyIndex
                             ? opportunity with { RootReach = reach }
                             : opportunity),
                     .. AllocationHotspots(reachByToken),
+                    .. ScanMethodsInvokedInLoops(reachByToken),
                 ];
             }
             return _opportunities;
@@ -140,6 +141,90 @@ public sealed class LibraryBodyIndex
                 null,
                 "Aggregate allocation density (excludes exception construction); review the method's hot paths.",
                 reachByToken.GetValueOrDefault(token));
+        }
+    }
+
+    // A membership/search LINQ terminal on System.Linq.Enumerable: one that walks the
+    // sequence to answer a lookup/membership question and whose canonical fix is an
+    // indexed lookup (HashSet/Dictionary). Lazy operators (Where/Select/OrderBy) are
+    // excluded — they do not enumerate at the call site — as are materializers
+    // (ToArray/ToList) and numeric aggregates, which have a different fix shape and are
+    // left to a follow-up to keep this signal high-precision.
+    internal static bool IsLinqMembershipScan(MemberRef member, out string op)
+    {
+        op = "";
+        if (member.Kind == MemberKind.Unsupported)
+            return false;
+        if (!FrameworkIdentity.IsKnownFrameworkType(member.DeclaringType, "System.Linq", "System.Linq", "Enumerable"))
+            return false;
+        switch (member.Name)
+        {
+            case "Any":
+            case "All":
+            case "First":
+            case "FirstOrDefault":
+            case "Last":
+            case "LastOrDefault":
+            case "Single":
+            case "SingleOrDefault":
+            case "Count":
+            case "LongCount":
+            case "Contains":
+                op = member.Name;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    // Cross-method repeated scan: an in-assembly method whose body performs a membership
+    // LINQ scan (see IsLinqMembershipScan) is itself invoked at a call site inside a loop.
+    // The scan then runs on every loop iteration even though the scan and the loop live in
+    // different methods — the same O(n*m) shape as linq-scan-in-loop, but split across a
+    // call boundary where a single-method scan would miss it. Reported once per scanning
+    // method, naming a representative looping caller.
+    IEnumerable<OptimizationOpportunity> ScanMethodsInvokedInLoops(Dictionary<int, int> reachByToken)
+    {
+        var methodByToken = new Dictionary<int, MethodIdentity>(Methods.Length);
+        foreach (var method in Methods)
+            methodByToken[method.MetadataToken] = method;
+
+        // Methods that contain at least one membership scan, keyed by the containing
+        // (caller) method token. The recorded op is a representative for the evidence string.
+        var scanningMethods = new Dictionary<int, string>();
+        foreach (var call in DirectCalls)
+            if (IsLinqMembershipScan(call.Callee, out var op))
+                scanningMethods.TryAdd(call.Caller.MetadataToken, op);
+
+        var emitted = new HashSet<int>();
+        foreach (var call in DirectCalls)
+        {
+            if (!call.InLoop)
+                continue;
+            int calleeToken = call.CalleeDefinitionToken;
+            if (!scanningMethods.TryGetValue(calleeToken, out var op))
+                continue;
+            if (!methodByToken.TryGetValue(calleeToken, out var method))
+                continue;
+            if (_suppressedOpportunityTokens.Contains(calleeToken))
+                continue;
+            // A method that scans itself in a loop is already reported as linq-scan-in-loop;
+            // and a method invoking itself recursively is not a caller-loop in the O(n*m) sense.
+            if (call.Caller.MetadataToken == calleeToken)
+                continue;
+            if (!emitted.Add(calleeToken))
+                continue;
+
+            yield return new OptimizationOpportunity(
+                method,
+                "scan-method-in-loop-call",
+                $"Performs Enumerable.{op}(...); invoked inside a loop by {call.Caller.DeclaringType.ToQualifiedDisplayString()}::{call.Caller.Name}",
+                "A method that linearly scans a sequence is called on every iteration of a caller's loop; hoist the scan or build a set/dictionary index the caller can reuse for O(1) lookups.",
+                "low",
+                true,
+                null,
+                "Quadratic only if the scanned sequence grows with the caller's loop; confirm the sequence is the loop-variant collection and not small/constant.",
+                reachByToken.GetValueOrDefault(calleeToken));
         }
     }
 
@@ -1953,39 +2038,6 @@ public sealed class LibraryBodyIndex
                 return false;
             receiver = $"System.{name}<T>::ToArray";
             return true;
-        }
-
-        // A membership/search LINQ terminal on System.Linq.Enumerable: one that walks the
-        // sequence to answer a lookup/aggregate question and whose canonical fix is an
-        // indexed lookup (HashSet/Dictionary). Lazy operators (Where/Select/OrderBy) are
-        // excluded — they do not enumerate at the call site — as are materializers
-        // (ToArray/ToList) and numeric aggregates, which have a different fix shape and are
-        // left to a follow-up to keep this signal high-precision.
-        static bool IsLinqMembershipScan(MemberRef member, out string op)
-        {
-            op = "";
-            if (member.Kind == MemberKind.Unsupported)
-                return false;
-            if (!FrameworkIdentity.IsKnownFrameworkType(member.DeclaringType, "System.Linq", "System.Linq", "Enumerable"))
-                return false;
-            switch (member.Name)
-            {
-                case "Any":
-                case "All":
-                case "First":
-                case "FirstOrDefault":
-                case "Last":
-                case "LastOrDefault":
-                case "Single":
-                case "SingleOrDefault":
-                case "Count":
-                case "LongCount":
-                case "Contains":
-                    op = member.Name;
-                    return true;
-                default:
-                    return false;
-            }
         }
 
         static string StripGenericArity(string name)

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1269,6 +1269,10 @@ public sealed class LibraryBodyIndex
             int? pendingBoxOffset = null;
             TypeRef? pendingBoxType = null;
             bool pendingBoxInLoop = false;
+            // Index (into opportunities) of a just-emitted delegate row awaiting its consumer:
+            // if the delegate flows straight into a lazy LINQ operator, the obvious iterator
+            // rewrite only moves the allocation, so we annotate that on the row.
+            int? pendingDelegateOpportunityIndex = null;
             int position = 0;
             while (position < il.Length)
             {
@@ -1353,6 +1357,7 @@ public sealed class LibraryBodyIndex
                             // method groups are compiler-cached, so they are not reported.
                             if (pendingDelegateCapturing)
                             {
+                                pendingDelegateOpportunityIndex = opportunities.Count;
                                 opportunities.Add(new OptimizationOpportunity(
                                     caller,
                                     "capturing-delegate",
@@ -1365,6 +1370,7 @@ public sealed class LibraryBodyIndex
                             }
                             else if (pendingDelegateInstanceGroup)
                             {
+                                pendingDelegateOpportunityIndex = opportunities.Count;
                                 opportunities.Add(new OptimizationOpportunity(
                                     caller,
                                     "instance-method-group-delegate",
@@ -1385,6 +1391,21 @@ public sealed class LibraryBodyIndex
                         pendingConstant = null;
                         int token = ReadInt32(il, ref position, offset);
                         var callee = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
+                        // If the delegate just allocated flows straight into a lazy LINQ
+                        // operator (Where/Select/…), the obvious "rewrite the lambda as an
+                        // iterator/local function" fix only MOVES the allocation to the
+                        // iterator state machine rather than removing it. Annotate the
+                        // delegate row so a cleared shape is not read as a free win.
+                        if (pendingDelegateOpportunityIndex is { } moveIndex
+                            && (LibraryBodyIndex.IsLinqLazyProducer(callee, out _) || LibraryBodyIndex.IsLinqMembershipScan(callee, out _)))
+                        {
+                            var row = opportunities[moveIndex];
+                            opportunities[moveIndex] = row with
+                            {
+                                SafeFixDirection = "Consumed by a lazy LINQ operator: a local-function/iterator rewrite only MOVES the allocation to the iterator state machine. Eliminate it by indexing the sequence (HashSet/Dictionary) so no per-element delegate is needed.",
+                                Caveat = "Rewriting the delegate alone does not remove the allocation; the LINQ scan still allocates an iterator.",
+                            };
+                        }
                         if (IsBitConverterGetBytes(callee))
                         {
                             opportunities.Add(new OptimizationOpportunity(
@@ -1497,6 +1518,13 @@ public sealed class LibraryBodyIndex
                 // Stack-neutral nops between the ldftn and newobj (e.g. Debug IL) are skipped.
                 if (opcode is not (ILOpCode.Ldftn or ILOpCode.Ldvirtftn or ILOpCode.Newobj or ILOpCode.Nop))
                     pendingDelegateOffset = null;
+
+                // The "moved allocation" annotation only applies when the delegate flows
+                // directly into its consuming call. Keep the pending index alive across the
+                // delegate newobj and intervening nops; clear it once any other instruction
+                // (including the consuming call, already handled above) is processed.
+                if (opcode is not (ILOpCode.Newobj or ILOpCode.Nop))
+                    pendingDelegateOpportunityIndex = null;
 
                 // A boxed concrete value type that flows straight into an escaping consumer
                 // (stored into a reference array, passed to a call/ctor, written to a field, or


### PR DESCRIPTION
## Summary

Adds three repeated-scan / O(n·m) detections to `Performance Triage`, closing the top-down gap documented in #1714: static triage flagged per-call delegate allocations but missed the *compounding* repeated-scan cost (the original Aspire.Dashboard finding was an O(n²) span-tree scan that triage walked right past). This is the bottom-up tool-accuracy work that #1714 sequences first and that aligns with the analysis quality ladder (#1623).

Two rounds of adversarial review are folded in (see commit history); every finding was either fixed or investigated and cleared.

## New shapes / signals

- **`linq-scan-in-loop`** (in-method): a membership/search LINQ terminal (`Any`/`All`/`First`/`Single`/`Count`/`Contains` + `*OrDefault`, predicate overload) invoked inside a loop region — a linear re-scan per iteration. Confidence `medium`, with a size caveat.
- **`scan-method-in-loop-call`** (cross-method): an in-assembly method that linearly scans a sequence — either a membership terminal in its body, or a lazy producer (`Where`/`Select`/…) returning an enumerable — is itself invoked from a caller's loop. A bounded transitive fixpoint propagates the lazy-producer property across delegating overloads. Confidence `low` (the dataflow proving the sequence scales with the loop is not established), deduped against the in-method shape.
- **Eliminated-vs-moved Fix guidance**: when a capturing / instance-method-group delegate is consumed by a lazy LINQ operator, the surfaced `Fix` text is corrected to say a static-local-function rewrite *reduces but does not eliminate* the allocation (the deferred-query iterator remains) — so a cleared closure shape is not read as a free win. Surfaced in `Fix` (a rendered column) because the library/member projections drop `Caveat`.

## Precision

The membership shape is deliberately narrow: only eager terminals on `System.Linq.Enumerable`, gated to the **predicate/value overload** (`ParameterTypes.Length >= 2`) so the O(1) parameterless overloads (`First()`/`Count()`/`Any()`) are not mislabeled. Lazy operators and materializers (`ToArray`/`ToList`) are excluded. `Enumerable` is matched across `System.Linq` / `System.Core` / corelib so the heuristic is not silently inert on netstandard2.0 / .NET Framework.

## Validation against the motivating case

Verified end-to-end on `Aspire.Dashboard.dll` (built from current `main`):

- On the **unpatched** build the heuristics catch the original O(n²): `TelemetryRepository.CalculateTraceUninstrumentedPeers` (`Enumerable.Any` in a loop) and `OtlpSpan.GetChildSpans()` (a lazy `Where` query enumerated in `CalculateTraceUninstrumentedPeers`'s loop, surfaced transitively). Both disappear once the scan is replaced by a set — i.e. the tool now finds, by itself, the issue that was originally found by hand.
- Volume is controlled: `linq-scan-in-loop` 10 rows, `scan-method-in-loop-call` ~2 rows on Aspire after the precision fixes (down from 17 / 5 before the arity gate).

## Adversarial review (two rounds)

- Round 1 found the headline defect — name-only matching mislabeled parameterless O(1) overloads as scans (~6/17 Aspire rows were false positives). Fixed via the arity gate; also fixed a netstandard/netfx recall hole and a `Count` fix-message mismatch. Because the arity gate correctly excludes a bare `.Any()`, the motivating case (a parameterless `Any` over a lazy `Where`) was recovered via the lazy-producer + transitive-fixpoint path.
- Round 2 found the eliminated-vs-moved wording was lazy/iterator-specific but applied to eager membership terminals (and not loop-gated). Fixed by restricting the annotation to lazy consumers. All other round-2 hypotheses (index lifetime tracking, arity-gate receiver counting, token-space soundness, fixpoint termination) were investigated and cleared.

## Tests

- `ILInspector.Analysis.Tests`: 148 (was 129) — new fixtures/tests for each shape, the parameterless-not-flagged guard, a TFM-identity theory, the lazy-producer recovery, and the membership-not-given-iterator-wording pin.
- `dotnet-inspect.Tests`: 1375 pass (9 env-skipped), no snapshot regressions.

## Notes / follow-ups

- `scan-method-in-loop-call` is intentionally `low` confidence: it is a candidate to confirm, not a verdict. Whether the scanned sequence actually scales with the caller's loop is not proven statically — a natural rung/guard for #1623's measured precision/recall ladder.
- Skill/doc updates (`skills/performance/SKILL.md`) are intentionally **not** in this PR; per #1714 they land after the tool work is in and accurate.

Refs #1714, #1623.
