### PR TITLE
Labeled Performance Triage ranking guard (analysis ladder #1623 rung 5)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -953,6 +953,24 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void IsLinqMembershipScan_RejectsSameNameAssemblyWithoutFrameworkKey()
+    {
+        // #1708 Row A: an assembly literally named System.Linq but without a framework
+        // public-key-token (trusted = false) must not be classified as real LINQ for the
+        // #1725 repeated-scan shapes — the matcher must honor the trust gate, not just the
+        // simple name.
+        var spoof = TypeRef.Definition("System.Linq", "System.Linq", "Enumerable", trustedFrameworkAssembly: false);
+        var anyPredicate = new MemberRef(
+            spoof,
+            "Any",
+            [TypeRef.CoreLib("System.Collections.Generic", "IEnumerable`1"), TypeRef.CoreLib("System", "Func`2")],
+            TypeRef.CoreLib("System", "Boolean"),
+            MemberKind.Method);
+
+        Assert.False(LibraryBodyIndex.IsLinqMembershipScan(anyPredicate, out _));
+    }
+
+    [Fact]
     public void OptimizationOpportunities_CapturingLambdaIsCapturingDelegate_SingleRow()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -186,16 +186,11 @@ public sealed class LibraryBodyIndex
 
     // System.Linq.Enumerable across target frameworks: the type lives in System.Linq on
     // .NET 5+ reference assemblies, in System.Core on .NET Framework, and canonicalizes to
-    // the core library on netstandard. Match all three so the heuristic is not silently
-    // inert on the most common library target (netstandard2.0).
+    // the core library on netstandard. IsKnownFrameworkType matches all three facades and
+    // also enforces the public-key-token trust gate (#1708 Row A), so a user assembly named
+    // System.Linq exposing an Enumerable lookalike is not mistaken for real LINQ.
     static bool IsEnumerableDefinition(TypeRef type)
-    {
-        var def = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
-        return def.Kind != TypeRefKind.Unsupported
-            && def.Namespace == "System.Linq"
-            && def.Name == "Enumerable"
-            && (def.Assembly == TypeRef.CoreLibrary || def.Assembly == "System.Linq" || def.Assembly == "System.Core");
-    }
+        => FrameworkIdentity.IsKnownFrameworkType(type, "System.Linq", "System.Linq", "Enumerable");
 
     // A lazy/deferred Enumerable operator (Where/Select/…): it returns an iterator without
     // enumerating at the call site. A helper that returns such a query is itself a deferred

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -258,6 +258,63 @@ public class OutputFormatterTests
         }
     }
 
+    // #1623 rung 5: a labeled, non-vacuous ranking guard for the Performance Triage
+    // model. Unlike the monotonicity check above (which re-derives the production key and
+    // only proves self-consistency), this asserts the model's intended priority on seeded
+    // opportunities: in-loop and confidence dominate raw root-reach, so pay-dirt outranks
+    // higher-reach known-good, and within a tier reach is the tie-break. Reordering the
+    // key (e.g. ranking reach above loop/confidence) fails here.
+    [Fact]
+    public void OrderByTriagePriority_RanksSeededPayDirtAboveKnownGood()
+    {
+        var opportunities = new[]
+        {
+            Opp("KnownGoodHighReach", inLoop: false, confidence: "low", rootReach: 999, shape: "small-array"),
+            Opp("KnownGoodHighConfNoLoop", inLoop: false, confidence: "high", rootReach: 5, shape: "allocation-hotspot"),
+            Opp("PayDirtLinqScanInLoop", inLoop: true, confidence: "medium", rootReach: 1, shape: "linq-scan-in-loop"),
+            Opp("PayDirtLoopHigh", inLoop: true, confidence: "high", rootReach: 1, shape: "allocation-hotspot"),
+            Opp("KnownGoodReachLow", inLoop: false, confidence: "low", rootReach: 7, shape: "small-array"),
+        };
+
+        var ordered = LibraryMetadataService.OrderByTriagePriority(opportunities)
+            .Select(o => o.Method.Name)
+            .ToList();
+
+        int payDirtHigh = ordered.IndexOf("PayDirtLoopHigh");
+        int payDirtScan = ordered.IndexOf("PayDirtLinqScanInLoop");
+        int knownHighConf = ordered.IndexOf("KnownGoodHighConfNoLoop");
+        int knownHighReach = ordered.IndexOf("KnownGoodHighReach");
+        int knownReachLow = ordered.IndexOf("KnownGoodReachLow");
+
+        // In-loop pay-dirt (even at reach 1, incl. the #1725 linq-scan-in-loop shape)
+        // outranks every not-in-loop row, even one with reach 999 or high confidence.
+        Assert.True(payDirtHigh < knownHighConf, "in-loop high must precede not-loop high");
+        Assert.True(payDirtScan < knownHighConf, "in-loop medium must precede not-loop high");
+        Assert.True(payDirtScan < knownHighReach, "in-loop must precede higher-reach not-loop");
+        // Within the in-loop tier, higher confidence first.
+        Assert.True(payDirtHigh < payDirtScan, "in-loop high must precede in-loop medium");
+        // Within not-in-loop, higher confidence beats higher reach.
+        Assert.True(knownHighConf < knownHighReach, "high confidence must precede higher-reach low");
+        // Within the same (loop, confidence) tier, higher reach is the tie-break.
+        Assert.True(knownHighReach < knownReachLow, "higher reach must precede lower reach at equal tier");
+    }
+
+    static ILInspector.Analysis.OptimizationOpportunity Opp(string name, bool inLoop, string confidence, int rootReach, string shape)
+    {
+        var declaring = ILInspector.Analysis.TypeRef.Definition("Asm", "Ns", "Type");
+        var method = new ILInspector.Analysis.MethodIdentity(
+            "Asm",
+            System.Guid.Empty,
+            declaring,
+            name,
+            [],
+            ILInspector.Analysis.TypeRef.CoreLib("System", "Void"),
+            MetadataToken: 0x06000001,
+            IsStatic: true);
+        return new ILInspector.Analysis.OptimizationOpportunity(
+            method, shape, "evidence", "fix", confidence, inLoop, ILOffset: null, Caveat: null, RootReach: rootReach);
+    }
+
     [Fact]
     public void ScanOptimizationOpportunities_SuppressesGeneratedMethods()
     {

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -716,18 +716,9 @@ internal static class LibraryMetadataService
         {
             var index = Analysis.LibraryBodyIndex.Open(path);
             var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
-            var rows = index.OptimizationOpportunities
-                .Where(opportunity => !IsGeneratedMethod(opportunity.Method, generatedFrameworkTypes))
-                // Performance Triage ordering: surface pay-dirt first. In-loop (repeated, hot)
-                // allocations lead, then by confidence, then by call-graph leverage (root reach).
-                // This is distinct from Top Leverage, which ranks purely by reach.
-                .OrderByDescending(opportunity => opportunity.InLoop)
-                .ThenByDescending(opportunity => ConfidenceRank(opportunity.Confidence))
-                .ThenByDescending(opportunity => opportunity.RootReach)
-                .ThenBy(opportunity => opportunity.Method.DeclaringType.ToQualifiedDisplayString(), StringComparer.Ordinal)
-                .ThenBy(opportunity => opportunity.Method.Name, StringComparer.Ordinal)
-                .ThenBy(opportunity => opportunity.ILOffset ?? -1)
-                .ThenBy(opportunity => opportunity.Shape, StringComparer.Ordinal)
+            var rows = OrderByTriagePriority(
+                    index.OptimizationOpportunities
+                        .Where(opportunity => !IsGeneratedMethod(opportunity.Method, generatedFrameworkTypes)))
                 .Select(opportunity => new OptimizationOpportunitySummary
                 {
                     Member = FormatMethod(opportunity.Method),
@@ -748,6 +739,21 @@ internal static class LibraryMetadataService
             return null;
         }
     }
+
+    // Performance Triage ordering: surface pay-dirt first. In-loop (repeated, hot)
+    // allocations lead, then by confidence, then by call-graph leverage (root reach),
+    // then a stable structural tie-break. This is distinct from Top Leverage, which ranks
+    // purely by reach. Extracted so the ranking model is guarded by a labeled, non-vacuous
+    // test (analysis quality ladder #1623 rung 5), not only by self-consistent monotonicity.
+    internal static IEnumerable<Analysis.OptimizationOpportunity> OrderByTriagePriority(IEnumerable<Analysis.OptimizationOpportunity> opportunities)
+        => opportunities
+            .OrderByDescending(opportunity => opportunity.InLoop)
+            .ThenByDescending(opportunity => ConfidenceRank(opportunity.Confidence))
+            .ThenByDescending(opportunity => opportunity.RootReach)
+            .ThenBy(opportunity => opportunity.Method.DeclaringType.ToQualifiedDisplayString(), StringComparer.Ordinal)
+            .ThenBy(opportunity => opportunity.Method.Name, StringComparer.Ordinal)
+            .ThenBy(opportunity => opportunity.ILOffset ?? -1)
+            .ThenBy(opportunity => opportunity.Shape, StringComparer.Ordinal);
 
     // Triage ordering weight for a confidence label (high allocations are the surest pay-dirt).
     static int ConfidenceRank(string confidence) => confidence switch


### PR DESCRIPTION
## Analysis quality ladder (#1623) — rung 5 (Performance Triage ranking quality)

Skeptical measurement of rung 5, prompted by #1725 (merged), which added the
repeated-scan shapes `linq-scan-in-loop` / `scan-method-in-loop-call` and itself
noted the low-confidence cross-method shape is "a natural rung/guard for #1623's
measured precision/recall ladder."

### Altitude

- **Ranking model** exists: the library-scope Performance Triage scan orders by
  `InLoop` desc → confidence desc → `RootReach` desc → stable tie-break (distinct
  from Top Leverage, which ranks purely by reach).
- **Generated-code suppression**: honestly guarded
  (`ScanOptimizationOpportunities_SuppressesGeneratedMethods`,
  `RenderOptimizationOpportunities_SuppressesGeneratedMethods`, and analysis-level
  source-generated/record suppression tests).
- **#1725 shapes**: detection + precision well-guarded (loop-gating, the arity gate
  for parameterless O(1) overloads, TFM identity, lazy-producer recovery, lazy-vs-
  eager fix wording).
- **Gap**: the ranking *guard* (`ScanOptimizationOpportunities_OrdersByTriagePriority`)
  re-derives the production sort key and only checks monotonicity — it cannot catch a
  wrong ranking model or prove pay-dirt actually outranks known-good.

### Change

- Extract the ordering into `LibraryMetadataService.OrderByTriagePriority` so the
  model is independently testable (production calls it; behavior unchanged).
- Add `OrderByTriagePriority_RanksSeededPayDirtAboveKnownGood`: a labeled guard that
  seeds opportunities with discriminating `(InLoop, Confidence, RootReach)` and
  asserts the *semantic* priority — in-loop and confidence dominate raw reach (so
  pay-dirt at reach 1 outranks known-good at reach 999), reach tie-breaks within a
  tier, and the #1725 `linq-scan-in-loop` shape lands in the in-loop pay-dirt tier.

### Non-vacuity

Reordering the key to rank reach first fails the new guard (the prior monotonicity
test could not assert this semantic).

### Evidence

- `dotnet-inspect.Tests` 1376 (was 1375); `ILInspector.Analysis.Tests` 179 — no
  regressions; refactor is behavior-preserving.

GPT-5.5 adversarial review requested (refactor equivalence, guard non-vacuity,
rung-5 completeness). Refs #1623, #1725, #1714.
