### PR TITLE
Recover user-defined increment operators (#1712)

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
@@ -117,11 +117,8 @@ public record Point(int X, int Y)
     public int Magnitude { get; init; }
 }
 
-// C# 11 checked user-defined operators (#1706): a modern-syntax construct whose
-// USE must render with a checked(...) context, not an explicit op_Checked* method
-// call (which is CS0571 "cannot explicitly call operator" — invalid Full). The
-// checked and unchecked operators are both exercised so the gate pins the
-// distinction: AddChecked renders `checked(a + b)`, AddUnchecked renders `a + b`.
+// C# 11 checked user-defined operators (#1706) and user-defined ++/-- (#1712):
+// uses must render as source operators, not explicit op_* method calls (CS0571).
 public readonly struct CheckedMeters
 {
     public CheckedMeters(int value)
@@ -137,11 +134,35 @@ public readonly struct CheckedMeters
     public static CheckedMeters operator checked +(CheckedMeters a, CheckedMeters b)
         => checked(new CheckedMeters(a.Value + b.Value));
 
+    public static CheckedMeters operator ++(CheckedMeters value)
+        => new CheckedMeters(value.Value + 1);
+
+    public static CheckedMeters operator --(CheckedMeters value)
+        => new CheckedMeters(value.Value - 1);
+
+    public static CheckedMeters operator checked ++(CheckedMeters value)
+        => checked(new CheckedMeters(value.Value + 1));
+
+    public static CheckedMeters operator checked --(CheckedMeters value)
+        => checked(new CheckedMeters(value.Value - 1));
+
     // The decompiler renders these uses (not the operator declarations above):
     // the checked use must force the checked overload with checked(...).
     public static CheckedMeters AddChecked(CheckedMeters a, CheckedMeters b) => checked(a + b);
 
     public static CheckedMeters AddUnchecked(CheckedMeters a, CheckedMeters b) => a + b;
+
+    public static CheckedMeters PreIncrement(CheckedMeters value) => ++value;
+
+    public static CheckedMeters PostIncrement(CheckedMeters value) => value++;
+
+    public static CheckedMeters PreDecrement(CheckedMeters value) => --value;
+
+    public static CheckedMeters PostDecrement(CheckedMeters value) => value--;
+
+    public static CheckedMeters CheckedPreIncrement(CheckedMeters value) => checked(++value);
+
+    public static CheckedMeters CheckedPreDecrement(CheckedMeters value) => checked(--value);
 }
 
 // C# 12 primary constructor on a class. The captured parameters lift into

--- a/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
@@ -9,6 +9,7 @@ public class IncrementDecrementPassTests
     static readonly TypeRef Boolean = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef EnumType = TypeRef.Definition("Test", "Synthetic", "Mode", ValueTypeHint.ValueType);
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef OperatorType = TypeRef.Definition("Test", "Synthetic", "Counter", ValueTypeHint.ValueType);
     static readonly TypeRef UnknownValueType = TypeRef.Definition("External", "Synthetic", "Mode", ValueTypeHint.ValueType);
     static readonly TypeRef ValueType = TypeRef.Definition("Test", "Synthetic", "StructLike", ValueTypeHint.ValueType);
 
@@ -58,6 +59,16 @@ public class IncrementDecrementPassTests
 
     static StoreLocal ValueTypeUpdateFromTemp() =>
         new(0, ValueType, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false, new LoadLocal(1, ValueType), new Constant(1, Int32)));
+
+    static MethodRef OperatorMethod(string name, MetadataFactState isOperator = MetadataFactState.Yes)
+        => new(OperatorType, name, OperatorType, [OperatorType], HasThis: false)
+        {
+            IsSpecialName = true,
+            IsOperator = isOperator,
+        };
+
+    static Call OperatorCall(string name, IrExpression argument, MetadataFactState isOperator = MetadataFactState.Yes)
+        => new(OperatorMethod(name, isOperator), isVirtual: false, [argument]);
 
     [Fact]
     public void DeadTempPostIncrement_FoldsToOperator()
@@ -117,6 +128,71 @@ public class IncrementDecrementPassTests
 
         var unsupported = Assert.IsType<UnsupportedNode>(Assert.IsType<ExpressionStatement>(Assert.Single(statements)).Expression);
         Assert.Contains("++", unsupported.Reason);
+    }
+
+    [Fact]
+    public void UserDefinedPostIncrementCall_FoldsToOperator()
+    {
+        // S = x; x = op_Increment(S); return S;  ->  return x++;
+        var statements = Run(FunctionWithSignature(OperatorType, [OperatorType],
+            new StoreStackSlot(0, new LoadLocal(0, OperatorType)),
+            new StoreLocal(0, OperatorType, OperatorCall("op_Increment", new LoadStackSlot(0, OperatorType))),
+            new Return(new LoadStackSlot(0, OperatorType))));
+
+        var increment = Assert.IsType<IncrementDecrement>(Assert.IsType<Return>(Assert.Single(statements)).Value);
+        Assert.True(increment.IsIncrement);
+        Assert.False(increment.IsPrefix);
+        Assert.False(increment.IsChecked);
+    }
+
+    [Fact]
+    public void UserDefinedPrefixIncrementCall_FoldsToOperator()
+    {
+        // S = op_Increment(x); x = S; return S;  ->  return ++x;
+        var statements = Run(FunctionWithSignature(OperatorType, [OperatorType],
+            new StoreStackSlot(0, OperatorCall("op_Increment", new LoadLocal(0, OperatorType))),
+            new StoreLocal(0, OperatorType, new LoadStackSlot(0, OperatorType)),
+            new Return(new LoadStackSlot(0, OperatorType))));
+
+        var increment = Assert.IsType<IncrementDecrement>(Assert.IsType<Return>(Assert.Single(statements)).Value);
+        Assert.True(increment.IsIncrement);
+        Assert.True(increment.IsPrefix);
+        Assert.False(increment.IsChecked);
+    }
+
+    [Fact]
+    public void UserDefinedCheckedPrefixIncrementCall_FoldsToCheckedOperator()
+    {
+        var statements = Run(FunctionWithSignature(OperatorType, [OperatorType],
+            new StoreStackSlot(0, OperatorCall("op_CheckedIncrement", new LoadLocal(0, OperatorType))),
+            new StoreLocal(0, OperatorType, new LoadStackSlot(0, OperatorType)),
+            new Return(new LoadStackSlot(0, OperatorType))));
+
+        var increment = Assert.IsType<IncrementDecrement>(Assert.IsType<Return>(Assert.Single(statements)).Value);
+        Assert.True(increment.IsIncrement);
+        Assert.True(increment.IsPrefix);
+        Assert.True(increment.IsChecked);
+    }
+
+    [Fact]
+    public void UserDefinedDirectDecrementStatement_FoldsToOperator()
+    {
+        var statements = Run(FunctionWithSignature(TypeRef.CoreLib("System", "Void"), [OperatorType],
+            new StoreLocal(0, OperatorType, OperatorCall("op_Decrement", new LoadLocal(0, OperatorType)))));
+
+        var increment = Assert.IsType<IncrementDecrement>(Assert.IsType<ExpressionStatement>(Assert.Single(statements)).Expression);
+        Assert.False(increment.IsIncrement);
+        Assert.False(increment.IsPrefix);
+        Assert.False(increment.IsChecked);
+    }
+
+    [Fact]
+    public void NonOperatorLookalike_IsNotFolded()
+    {
+        var statements = Run(FunctionWithSignature(TypeRef.CoreLib("System", "Void"), [OperatorType],
+            new StoreLocal(0, OperatorType, OperatorCall("op_Increment", new LoadLocal(0, OperatorType), MetadataFactState.No))));
+
+        Assert.IsType<StoreLocal>(Assert.Single(statements));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
@@ -25,9 +25,10 @@ namespace ILInspector.Decompiler.Tests;
 /// #1632) and the positional-record primary constructor renders valid
 /// <c>Full</c> with the implicit base call elided (no owned base-ctor residual,
 /// #1639).</item>
-/// <item>C# 11 checked user-defined operators render their use with a
-/// <c>checked(...)</c> context (<c>checked(a + b)</c>) rather than an explicit
-/// <c>op_Checked*</c> method call, which is CS0571 invalid <c>Full</c> (#1706).</item>
+/// <item>C# 11 checked user-defined operators and user-defined
+/// <c>++</c>/<c>--</c> render as source operators rather than explicit
+/// <c>op_*</c> method calls, which are CS0571 invalid <c>Full</c>
+/// (#1706, #1712).</item>
 /// </list>
 /// </summary>
 public class LadderRung5GateTests
@@ -230,9 +231,9 @@ public class LadderRung5GateTests
         Assert.DoesNotContain("Unsupported", copyBody);
     }
 
-    // C# 11 checked user-defined operators (#1706). The USE of a checked operator
-    // must force the checked overload with a checked(...) context; a bare method
-    // spelling (CheckedMeters.op_CheckedAddition(a, b)) is CS0571 invalid Full.
+    // C# 11 checked user-defined operators (#1706) and user-defined ++/-- (#1712).
+    // Uses must render as source operators; bare op_* method spellings are CS0571
+    // invalid Full.
     [Fact]
     public void Rung5Fixture_RendersCheckedOperators()
     {
@@ -250,6 +251,26 @@ public class LadderRung5GateTests
         Assert.Equal("return a + b;", addUnchecked);
         Assert.DoesNotContain("checked", addUnchecked);
         Assert.DoesNotContain("op_Addition", addUnchecked);
+
+        Assert.Equal("return ++value;", Body("PreIncrement"));
+        Assert.Equal("return value++;", Body("PostIncrement"));
+        Assert.Equal("return --value;", Body("PreDecrement"));
+        Assert.Equal("return value--;", Body("PostDecrement"));
+        Assert.Equal("return checked(++value);", Body("CheckedPreIncrement"));
+        Assert.Equal("return checked(--value);", Body("CheckedPreDecrement"));
+
+        foreach (var name in new[]
+        {
+            "PreIncrement",
+            "PostIncrement",
+            "PreDecrement",
+            "PostDecrement",
+            "CheckedPreIncrement",
+            "CheckedPreDecrement",
+        })
+        {
+            Assert.DoesNotContain("op_", Body(name));
+        }
     }
 
     // C# 12 primary constructor on a class. The captured parameters lift into

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2354,6 +2354,15 @@ public sealed partial class CSharpPrinter
 
     string IncrementDecrementText(IncrementDecrement id)
     {
+        string Render()
+        {
+            string op = id.IsIncrement ? "++" : "--";
+            return id.IsPrefix ? $"{op}{Operand(id.Target)}" : $"{Operand(id.Target)}{op}";
+        }
+
+        if (id.IsChecked)
+            return WrapChecked(Render);
+
         // ++/-- is a hidden `x = x + 1`; on an integer place inside a checked
         // region that add recompiles as `add.ovf`, an overflow check the original
         // plain increment never had. Wrap in `unchecked(...)` and clear the context
@@ -2364,8 +2373,7 @@ public sealed partial class CSharpPrinter
             _checkedContext = false;
         try
         {
-            string op = id.IsIncrement ? "++" : "--";
-            string text = id.IsPrefix ? $"{op}{Operand(id.Target)}" : $"{Operand(id.Target)}{op}";
+            string text = Render();
             return wrapUnchecked ? $"unchecked({text})" : text;
         }
         finally

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1104,15 +1104,17 @@ public sealed class AwaitExpression : IrExpression
 /// </summary>
 public sealed class IncrementDecrement : IrExpression
 {
-    public IncrementDecrement(IrExpression target, bool isIncrement, bool isPrefix)
+    public IncrementDecrement(IrExpression target, bool isIncrement, bool isPrefix, bool isChecked = false)
     {
         IsIncrement = isIncrement;
         IsPrefix = isPrefix;
+        IsChecked = isChecked;
         AddChild(target);
     }
 
     public bool IsIncrement { get; }
     public bool IsPrefix { get; }
+    public bool IsChecked { get; }
     /// <summary>The incremented place — a local or argument load.</summary>
     public IrExpression Target => (IrExpression)Children[0];
     public override TypeRef? ResultType => Target.ResultType;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -38,13 +38,18 @@ public sealed class IncrementDecrementPass : IIrPass
     {
         foreach (var block in function.Descendants.OfType<Block>())
         {
-            for (int i = 0; i + 1 < block.Children.Count; i++)
+            for (int i = 0; i < block.Children.Count; i++)
             {
-                if (TryFold(function, block, i, stepper))
-                    return true;
-                if (TryFoldAddressCompound(function, block, i, stepper))
-                    return true;
-                if (TryFoldStatementIncrement(function, block, i, stepper))
+                if (i + 1 < block.Children.Count)
+                {
+                    if (TryFold(function, block, i, stepper))
+                        return true;
+                    if (TryFoldAddressCompound(function, block, i, stepper))
+                        return true;
+                    if (TryFoldStatementIncrement(function, block, i, stepper))
+                        return true;
+                }
+                if (TryFoldDirectOperatorStatement(block, i, stepper))
                     return true;
             }
         }
@@ -64,6 +69,8 @@ public sealed class IncrementDecrementPass : IIrPass
         int slot = slotStore.Slot;
         bool isIncrement;
         bool isPrefix;
+        bool isChecked = false;
+        bool isUserDefinedOperator = false;
 
         if (IsPlaceLoad(slotStore.Value, place)
             && updateValue is Binary { IsChecked: false, Kind: var postKind } post
@@ -75,6 +82,13 @@ public sealed class IncrementDecrementPass : IIrPass
             isPrefix = false;
             isIncrement = postKind is BinaryKind.Add;
         }
+        else if (IsPlaceLoad(slotStore.Value, place)
+            && TryOperatorIncrementCall(updateValue, argument => argument is LoadStackSlot load && load.Slot == slot, place.Type, out isIncrement, out isChecked))
+        {
+            // S = x; x = op_Increment(S);  ->  x++ (old value consumed downstream)
+            isPrefix = false;
+            isUserDefinedOperator = true;
+        }
         else if (slotStore.Value is Binary { IsChecked: false, Kind: var preKind } pre
             && IsPlaceLoad(pre.Left, place)
             && pre.Right is Constant { Value: 1 }
@@ -84,6 +98,13 @@ public sealed class IncrementDecrementPass : IIrPass
             // S = x ± 1; x = S;  →  ++x / --x
             isPrefix = true;
             isIncrement = preKind is BinaryKind.Add;
+        }
+        else if (TryOperatorIncrementCall(slotStore.Value, argument => IsPlaceLoad(argument, place), place.Type, out isIncrement, out isChecked)
+            && updateValue is LoadStackSlot checkedPreLoad && checkedPreLoad.Slot == slot)
+        {
+            // S = op_Increment(x); x = S;  ->  ++x (updated value consumed downstream)
+            isPrefix = true;
+            isUserDefinedOperator = true;
         }
         else
         {
@@ -114,14 +135,14 @@ public sealed class IncrementDecrementPass : IIrPass
             if (ReferencesPlace(block.Children[k], place))
                 return false;
         }
-        if (!IsIncrementable(place.Type, function))
+        if (!isUserDefinedOperator && !IsIncrementable(place.Type, function))
         {
             MarkUnsupportedIncrementExpression(isPrefix ? slotStore.Value : updateValue, place, isIncrement ? BinaryKind.Add : BinaryKind.Subtract, stepper);
             return true;
         }
 
         stepper.StepOver($"fold dup {(isIncrement ? "++" : "--")} idiom into operator", useLoad);
-        useLoad.ReplaceWith(new IncrementDecrement(ClonePlace(place), isIncrement, isPrefix));
+        useLoad.ReplaceWith(new IncrementDecrement(ClonePlace(place), isIncrement, isPrefix, isChecked));
         update.Detach();
         slotStore.Detach();
         return true;
@@ -273,6 +294,20 @@ public sealed class IncrementDecrementPass : IIrPass
         return true;
     }
 
+    static bool TryFoldDirectOperatorStatement(Block block, int i, Stepper stepper)
+    {
+        var store = block.Children[i];
+        if (PlaceOf(store) is not { } place || StoreValue(store) is not { } value)
+            return false;
+        if (!TryOperatorIncrementCall(value, argument => IsPlaceLoad(argument, place), place.Type, out bool isIncrement, out bool isChecked))
+            return false;
+
+        var increment = new IncrementDecrement(ClonePlace(place), isIncrement, isPrefix: false, isChecked);
+        stepper.StepOver($"fold direct operator {(isIncrement ? "++" : "--")} statement", store);
+        store.ReplaceWith(new ExpressionStatement(increment));
+        return true;
+    }
+
     readonly record struct ForLoopIncrement(ForLoop Loop, int TempIndex, PlaceRef Place, StoreLocal Capture, LoadLocal IncrementRead, BinaryKind Kind, bool IsIncrementable);
 
     /// <summary>
@@ -383,6 +418,39 @@ public sealed class IncrementDecrementPass : IIrPass
     static IrExpression ClonePlace(PlaceRef place) => place.IsLocal
         ? new LoadLocal(place.Index, place.Type)
         : new LoadArgument(place.Index, place.Name, place.Type);
+
+    static bool TryOperatorIncrementCall(
+        IrExpression expression,
+        Func<IrExpression, bool> argumentMatches,
+        TypeRef targetType,
+        out bool isIncrement,
+        out bool isChecked)
+    {
+        isIncrement = false;
+        isChecked = false;
+        if (expression is not Call { Callee.HasThis: false, Arguments.Count: 1 } call)
+            return false;
+        if (!argumentMatches(call.Arguments[0]))
+            return false;
+        if (!Equals(call.Callee.ReturnType, targetType)
+            || call.Callee.ParameterTypes.Length != 1
+            || !Equals(call.Callee.ParameterTypes[0], targetType))
+        {
+            return false;
+        }
+        if (call.Callee.IsOperator == MetadataFactState.No || !call.Callee.IsSpecialName)
+            return false;
+
+        (isIncrement, isChecked) = call.Callee.Name switch
+        {
+            "op_Increment" => (true, false),
+            "op_Decrement" => (false, false),
+            "op_CheckedIncrement" => (true, true),
+            "op_CheckedDecrement" => (false, true),
+            _ => (false, false),
+        };
+        return call.Callee.Name is "op_Increment" or "op_Decrement" or "op_CheckedIncrement" or "op_CheckedDecrement";
+    }
 
     static bool IsIncrementable(TypeRef type, IrFunction function)
         => TypeFamilies.IsNumericPrimitive(type)


### PR DESCRIPTION
## Summary

Closes #1712.

Fixes the #1599 row 2 invalid-Full gap where user-defined `++`/`--` uses rendered as explicit `op_Increment` / `op_Decrement` / `op_CheckedIncrement` / `op_CheckedDecrement` calls, which are CS0571 invalid C#.

Changes:
- extends `IncrementDecrementPass` to fold csc's user-defined operator call/store/dup shapes back into prefix/postfix `++`/`--`;
- carries checked operator evidence on `IncrementDecrement` so checked variants render as `checked(++value)` / `checked(--value)`;
- broadens the LadderRung5 `CheckedMeters` fixture and gate to cover unchecked and checked increment/decrement uses;
- adds pass-level positive and near-miss coverage, including an `IsOperator == No` lookalike decline.

## Evidence

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.IncrementDecrementPassTests -class ILInspector.Decompiler.Tests.LadderRung5GateTests
ILInspector.Decompiler.Tests  Total: 31, Errors: 0, Failed: 0, Skipped: 0

 dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
ILInspector.Decompiler.Tests  Total: 1575, Errors: 0, Failed: 0, Skipped: 0

dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded. 0 Warning(s), 0 Error(s)
```

Unfiltered `src/ILInspector.Decompiler.Tests` was attempted but did not complete after a long wait and was stopped after producing only runner startup output; the focused real-fixture gate and fast decompiler suite above are green.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 88,790 methods
Correctness coverage: validity sampled 350 / 88,790 (0.39%); fidelity sampled 36 / 88,790 (0.04%)

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 88,500 -> 88,790 (+290)
- dotnet-inspect: 12,358 -> 12,414 methods (+56)
- DotnetInspector.Core: 282 -> 283 methods (+1)
- ILInspector.Analysis: 684 -> 725 methods (+41)
- ILInspector.Decompiler: 5,293 -> 5,471 methods (+178)
- ILInspector.Metadata: 1,833 -> 1,846 methods (+13)
- ILInspector.MetadataPrimitives: 61 -> 62 methods (+1)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 77,769 (87.87%) | 78,196 (88.07%) | +427 |
| Conditional-branch residual | 2,409 (2.72%) | 2,429 (2.74%) | +20 |
| Forward-merge stops | 2,144 (2.42%) | 2,165 (2.44%) | +21 |
| Full malformed | 32 | 32 | 0 |
| Semantic defects | 4/350 — sampled 350 / 88,500 (0.40%) | 4/350 — sampled 350 / 88,790 (0.39%) | 0 |
| Fidelity diffs | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 88,500 (0.04%) | opcode-diff 9/36, exact 27, recompile-failed 0, context-failed 0; sampled 36 / 88,790 (0.04%) | +4 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 89.67% -> 89.66% (-1 bps); conditional residual 2.85% -> 2.85% (0 bps); Full malformed 32 -> 32 (0); opcode diffs 1 -> 1 (0).

Verdict: corpus sensor matched baseline tolerances.

## Adversarial review

Opus 4.8 reviewed the working-tree diff and found no significant issues. It specifically checked false-positive rewrites, ordering/side-effect safety, checked semantics, printer validity, and test non-vacuity.