### PR TITLE
Fold N-way switch-store dispatch so combined switch code structures (#1710)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ConditionalStoreChainPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConditionalStoreChainPassTests.cs
@@ -1,0 +1,122 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ConditionalStoreChainPassTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    // The dispatch-first switch-store shape csc emits for
+    //   switch (n) { case 0: x = 10; break; case 1: x = 20; break; default: x = 30; break; }
+    //   <continuation that reads x>
+    // Guards first (each tests n and jumps to a separated arm), then the arms
+    // (each `x = const; goto MERGE`), then the merge.
+    static IrFunction BuildThreeWaySwitchStore(int armBlockStatements = 1)
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var body = new BlockContainer();
+
+        var d0 = new Block(0);
+        d0.Add(new ConditionalBranch(Eq(0), 12));          // case 0 -> arm0
+        var d1 = new Block(4);
+        d1.Add(new ConditionalBranch(Eq(1), 16));          // case 1 -> arm1
+        var d2 = new Block(8);
+        d2.Add(new Branch(20));                             // default -> arm2
+
+        var arm0 = new Block(12);
+        arm0.Add(new StoreLocal(0, Int32, new Constant(10, Int32)));
+        if (armBlockStatements > 1)
+            arm0.Add(new StoreLocal(1, Int32, new Constant(99, Int32)));  // extra statement
+        arm0.Add(new Branch(24));
+        var arm1 = new Block(16);
+        arm1.Add(new StoreLocal(0, Int32, new Constant(20, Int32)));
+        arm1.Add(new Branch(24));
+        var arm2 = new Block(20);
+        arm2.Add(new StoreLocal(0, Int32, new Constant(30, Int32)));      // last arm falls into the merge
+
+        var merge = new Block(24);
+        merge.Add(new Return(new LoadLocal(0, Int32)));
+
+        foreach (var block in (Block[])[d0, d1, d2, arm0, arm1, arm2, merge])
+            body.Add(block);
+
+        return Function(owner, body);
+    }
+
+    // A two-arm if/else store: csc interleaves guard+arm and the structurer already
+    // recovers it as if/else, so this pass must leave it untouched (no ternary).
+    static IrFunction BuildTwoWayStore()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var body = new BlockContainer();
+
+        var d0 = new Block(0);
+        d0.Add(new ConditionalBranch(Eq(0), 8));           // case 0 -> arm0
+        var arm1 = new Block(4);
+        arm1.Add(new StoreLocal(0, Int32, new Constant(20, Int32)));
+        arm1.Add(new Branch(12));
+        var arm0 = new Block(8);
+        arm0.Add(new StoreLocal(0, Int32, new Constant(10, Int32)));
+        var merge = new Block(12);
+        merge.Add(new Return(new LoadLocal(0, Int32)));
+
+        foreach (var block in (Block[])[d0, arm1, arm0, merge])
+            body.Add(block);
+
+        return Function(owner, body);
+    }
+
+    [Fact]
+    public void FoldsThreeWaySwitchStoreIntoNestedConditional()
+    {
+        var function = BuildThreeWaySwitchStore();
+
+        new ConditionalStoreChainPass().Run(function, PassContext.None);
+
+        // The dispatch and arm blocks collapse into the head; only the head and the
+        // merge survive, and the store value is a nested conditional.
+        Assert.Equal(2, function.Body.Blocks.Count);
+        Assert.Equal(2, function.Descendants.OfType<Conditional>().Count());
+        var store = Assert.Single(
+            function.Descendants.OfType<StoreLocal>(),
+            s => s.Index == 0 && s.Value is Conditional);
+        Assert.IsType<Conditional>(store.Value);
+        // No residual goto ladder.
+        Assert.Empty(function.Descendants.OfType<Branch>());
+    }
+
+    [Fact]
+    public void DeclinesTwoArmStore()
+    {
+        var function = BuildTwoWayStore();
+
+        new ConditionalStoreChainPass().Run(function, PassContext.None);
+
+        // Fewer than three arms: leave it for the structurer's if/else recovery.
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+        Assert.Equal(4, function.Body.Blocks.Count);
+    }
+
+    [Fact]
+    public void DeclinesWhenArmDoesMoreThanStore()
+    {
+        var function = BuildThreeWaySwitchStore(armBlockStatements: 2);
+
+        new ConditionalStoreChainPass().Run(function, PassContext.None);
+
+        // An arm that carries a second store is not a clean value select; decline.
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+        Assert.Equal(7, function.Body.Blocks.Count);
+    }
+
+    static IrExpression Eq(int constant)
+        => new Comparison(ComparisonKind.Equal, isUnsigned: false, new LoadLocal(2, Int32), new Constant(constant, Int32));
+
+    static IrFunction Function(TypeRef owner, BlockContainer body)
+        => new(
+            "M",
+            owner,
+            new MethodSignature(Int32, [new Parameter("n", Int32)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+}

--- a/src/ILInspector.Decompiler.Tests/ConditionalStoreChainPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ConditionalStoreChainPassTests.cs
@@ -109,6 +109,52 @@ public class ConditionalStoreChainPassTests
         Assert.Equal(7, function.Body.Blocks.Count);
     }
 
+    [Fact]
+    public void DeclinesBackwardMerge()
+    {
+        // Arms that branch BACK to the dispatch head form a loop. Folding them and
+        // letting control fall through would turn the loop into straight-line code
+        // (a miscompile) — the pass must decline a non-forward merge.
+        var function = BuildThreeWaySwitchStoreBackwardMerge();
+
+        new ConditionalStoreChainPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+        // The loop back-edges survive (nothing folded or dropped).
+        Assert.Equal(3, function.Descendants.OfType<Branch>().Count(b => b.TargetOffset == 0));
+    }
+
+    // The dispatch lives after the entry; each arm stores then branches BACK to the
+    // dispatch head (offset 0) — a re-dispatch loop. The merge is therefore the
+    // head (a backward edge), which must not fold.
+    static IrFunction BuildThreeWaySwitchStoreBackwardMerge()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var body = new BlockContainer();
+
+        var d0 = new Block(0);
+        d0.Add(new ConditionalBranch(Eq(0), 12));
+        var d1 = new Block(4);
+        d1.Add(new ConditionalBranch(Eq(1), 16));
+        var d2 = new Block(8);
+        d2.Add(new Branch(20));
+
+        var arm0 = new Block(12);
+        arm0.Add(new StoreLocal(0, Int32, new Constant(10, Int32)));
+        arm0.Add(new Branch(0));                 // back-edge to the dispatch head
+        var arm1 = new Block(16);
+        arm1.Add(new StoreLocal(0, Int32, new Constant(20, Int32)));
+        arm1.Add(new Branch(0));
+        var arm2 = new Block(20);
+        arm2.Add(new StoreLocal(0, Int32, new Constant(30, Int32)));
+        arm2.Add(new Branch(0));
+
+        foreach (var block in (Block[])[d0, d1, d2, arm0, arm1, arm2])
+            body.Add(block);
+
+        return Function(owner, body);
+    }
+
     static IrExpression Eq(int constant)
         => new Comparison(ComparisonKind.Equal, isUnsigned: false, new LoadLocal(2, Int32), new Constant(constant, Int32));
 

--- a/src/ILInspector.Decompiler.Tests/LadderRung1CombinedFrontierGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1CombinedFrontierGateTests.cs
@@ -57,10 +57,11 @@ public class LadderRung1CombinedFrontierGateTests
         {
             var m = members.Single(x => x.Name == name);
             Assert.Null(Completeness.Residual(m.Function));
+            // Assert on the IR shape (the switch dispatch folded to a Conditional
+            // store of the bucket local) rather than printer substrings, plus the
+            // absence of a goto ladder in the rendered output.
+            Assert.NotEmpty(m.Function.Descendants.OfType<Conditional>());
             var body = CSharpPrinter.PrintRaised(m.Function).Output ?? "";
-            // The switch raised to a nested conditional store, not a goto ladder.
-            Assert.Contains("bucket = ", body);
-            Assert.Contains(" ? ", body);
             Assert.DoesNotContain("goto IL_", body);
         }
 

--- a/src/ILInspector.Decompiler.Tests/LadderRung1CombinedFrontierGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1CombinedFrontierGateTests.cs
@@ -5,31 +5,32 @@ using ILInspector.DecompilerHarness;
 namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
-/// The rung 1 <em>combined-code frontier</em> guard for the decompiler product
+/// The rung 1 <em>combined-code recovery</em> guard for the decompiler product
 /// quality ladder (#1599 / #1710). The other rung 1 gates exercise each construct
-/// in isolation in a tiny method, and all raise to <c>Full</c>. But realistic
-/// code combines them, and the structuring pass is fragile to those combinations:
-/// a method mixing a <c>foreach</c> loop, a <c>switch</c>, and a LINQ/lambda can
-/// tip the whole method into a goto-ladder fallback, which also defeats lambda
-/// raising (the delegate target leaks a <c>&lt;&gt;c</c> name). The
-/// <see cref="LadderRung1.CombinedFrontier{T}"/> fixture captures that.
+/// in isolation in a tiny method. This one exercises a realistic combination — a
+/// method mixing a <c>foreach</c> loop, a <c>switch</c> that assigns a local, and
+/// a LINQ/lambda continuation — which used to tip the whole method into a
+/// goto-ladder fallback (issue #1710). The
+/// <see cref="LadderRung1.CombinedFrontier"/> fixture captures that shape.
 ///
-/// <para>This gate owns the frontier honestly. It pins that the combined methods
-/// degrade to <c>Partial</c> (never a lying <c>Full</c>) while the simple members
-/// stay <c>Full</c>, and that the user type has <b>zero malformed <c>Full</c></b>
-/// output — the degradation is honest, not invalid C# claimed as good. It is the
-/// inverse of a positive guard: when the structuring pass is improved to raise
-/// these shapes, the <c>Partial</c> assertions flip and force an intentional
-/// promotion to a recognizable-output guard. Until then, rung 1 is NOT complete
-/// for realistic combined code — this is the blocking row.</para>
+/// <para>The fold of an N-way switch-store dispatch into a nested conditional
+/// store (<c>ConditionalStoreChainPass</c>) now lets these methods structure: the
+/// goto-ladder <em>structuring residual is gone</em> and the body is recognizable
+/// C# (the switch renders as a nested <c>?:</c> store). This gate pins that
+/// recovery — zero structuring residual, the dispatch raised, no goto ladder —
+/// and the standing honesty invariant that the type has zero malformed
+/// <c>Full</c> output. (Through this bare seam the combined methods still report
+/// <c>Partial</c> because it does not raise the cross-method lambda; the product
+/// path raises it, guarded by <see cref="LadderRung1ProductPathGateTests"/>. That
+/// remaining residual is the lambda, not structuring.)</para>
 /// </summary>
 public class LadderRung1CombinedFrontierGateTests
 {
     static string FixturePath => typeof(LadderRung1.CombinedFrontier).Assembly.Location;
     static readonly string FixtureType = typeof(LadderRung1.CombinedFrontier).FullName!;
 
-    // Methods that currently degrade — the frontier. Locked so a structuring
-    // improvement that raises them flips this gate and forces a promotion.
+    // The combined switch-store methods that #1710 recovered: their switch
+    // dispatch now folds to a nested conditional store and structures cleanly.
     static readonly string[] FrontierMembers = ["Summarize", "SwitchThenLinq"];
 
     // Simple members that are unaffected by the combination and stay Full. The
@@ -38,7 +39,7 @@ public class LadderRung1CombinedFrontierGateTests
     static readonly string[] RaisedMembers = [".ctor", "Echo"];
 
     [Fact]
-    public void Rung1CombinedFrontier_DegradesHonestly_FrontierPartial_SimpleFull()
+    public void Rung1CombinedSwitch_RaisesDispatch_NoStructuringResidual()
     {
         var members = LoadProductPathMembers();
 
@@ -46,17 +47,24 @@ public class LadderRung1CombinedFrontierGateTests
             RaisedMembers.Concat(FrontierMembers).Order(StringComparer.Ordinal).ToArray(),
             members.Select(m => m.Name).Order(StringComparer.Ordinal).ToArray());
 
-        // The frontier methods degrade — honestly classified Partial, with a
-        // residual — they are NOT recognizable C#. When structuring is improved
-        // to raise them, these assertions flip and force an intentional promotion.
+        // The combined switch-store methods now structure: the N-way switch
+        // dispatch folds to a nested conditional store (#1710), so the
+        // goto-ladder structuring residual is gone and the body is recognizable
+        // C#. (They render Partial only via this bare seam, which does not raise
+        // the cross-method lambda; the product path raises it — see
+        // LadderRung1ProductPathGateTests. That residual is not structuring.)
         foreach (var name in FrontierMembers)
         {
             var m = members.Single(x => x.Name == name);
-            Assert.Equal(DecompilationFidelity.Partial, m.Function.Fidelity);
-            Assert.NotNull(Completeness.Residual(m.Function));
+            Assert.Null(Completeness.Residual(m.Function));
+            var body = CSharpPrinter.PrintRaised(m.Function).Output ?? "";
+            // The switch raised to a nested conditional store, not a goto ladder.
+            Assert.Contains("bucket = ", body);
+            Assert.Contains(" ? ", body);
+            Assert.DoesNotContain("goto IL_", body);
         }
 
-        // The simple members are unaffected by the combination.
+        // The simple members are unaffected.
         foreach (var name in RaisedMembers)
         {
             var m = members.Single(x => x.Name == name);
@@ -66,7 +74,7 @@ public class LadderRung1CombinedFrontierGateTests
     }
 
     [Fact]
-    public void Rung1CombinedFrontier_DegradationIsHonest_NoMalformedFull()
+    public void Rung1CombinedSwitch_HasNoMalformedFull()
     {
         var results = ValidityCheck.Evaluate(FixturePath)
             .Where(r => r.TypeName == FixtureType)
@@ -75,25 +83,20 @@ public class LadderRung1CombinedFrontierGateTests
         Assert.NotEmpty(results);
 
         // The core honesty invariant: the decompiler never claims Full on output
-        // that does not parse. The combined frontier degrades to Partial instead
-        // of leaking its goto/`<>c` rendering under a Full claim.
+        // that does not parse.
         var malformedFull = results
             .Where(r => r.IsFull && r.IsMalformed)
             .Select(r => $"{r.MethodName}: {r.MalformedDiagnostics[0].Id} {r.MalformedDiagnostics[0].Message}")
             .Order(StringComparer.Ordinal)
             .ToArray();
         Assert.True(malformedFull.Length == 0,
-            "Rung 1 combined frontier must degrade honestly (zero malformed Full); malformed Full: "
+            "Rung 1 combined switch must stay honest (zero malformed Full); malformed Full: "
                 + string.Join("; ", malformedFull));
 
-        // Non-vacuous: the frontier methods must actually be present and at least
-        // one must be malformed-but-Partial, proving this gate is measuring the
-        // real degradation and not an empty/relabeled result.
-        var partialMalformed = results
-            .Where(r => !r.IsFull && r.IsMalformed)
-            .Select(r => r.MethodName)
-            .ToArray();
-        Assert.Contains("Summarize", partialMalformed);
+        // Non-vacuous: the combined methods must actually be present in the
+        // evaluated set, so the no-malformed-Full assertion has teeth.
+        Assert.Contains("Summarize", results.Select(r => r.MethodName));
+        Assert.Contains("SwitchThenLinq", results.Select(r => r.MethodName));
     }
 
     static List<(string Name, IrFunction Function)> LoadProductPathMembers()

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConditionalStoreChainPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConditionalStoreChainPass.cs
@@ -1,0 +1,336 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Folds an N-way (≥3 arm) conditional-store dispatch into one nested
+/// conditional store, before structuring. This is the multi-arm sibling of
+/// <see cref="SlotStoreDiamondPass"/> over a local: csc lowers a C#
+/// <c>switch (v) { case k0: x = a0; break; … default: x = aN; break; }</c>
+/// followed by a live continuation as a <em>dispatch-first</em> shape — a run of
+/// guard blocks that each test <c>v</c> and jump to a separated arm block, then
+/// the arms (each <c>x = aJ; goto MERGE;</c>), then the merge:
+/// <code>
+///   D0: if (v == k0) goto A0;     // dispatch chain (each falls into the next)
+///   D1: if (v == k1) goto A1;
+///   D2: goto A2;                  // default
+///   A0: x = a0; goto MERGE;       // arms (separated from their guard)
+///   A1: x = a1; goto MERGE;
+///   A2: x = a2;                   // last arm falls into the merge
+///   MERGE: …continuation…         // a live successor uses x
+/// </code>
+/// The arms are physically non-contiguous with their guards, so the index-range
+/// <see cref="StructuringPass"/> cannot name the merge join and leaves the whole
+/// method flat (<c>cond-target-past-region</c>). The equivalent <c>if/else if</c>
+/// chain interleaves guard+arm and already structures; only this switch lowering
+/// is stranded. Folding the arms into one
+/// <c>x = c0 ? a0 : (c1 ? a1 : a2)</c> store eliminates the merge, so structuring
+/// (and the lambda/continuation raising it gates) then succeeds.
+///
+/// <para>Strictly gated to the provably safe shape: every guard tests with a
+/// straight-line condition and selects a distinct arm; every arm is exactly one
+/// store of the <em>same</em> local followed by a branch to one common merge (the
+/// last may fall through); arm values carry no control flow; and no block outside
+/// the dispatch reaches an arm or an inner guard. Anything else declines and
+/// stays flat — never a guess. Requires ≥2 guards (≥3 arms) so the two-arm
+/// <c>if/else</c> store, which already structures cleanly, is left untouched.</para>
+/// </summary>
+public sealed class ConditionalStoreChainPass : IIrPass
+{
+    public string Name => "conditional-store-chain";
+
+    /// <summary>Cap on arms folded into one nested conditional: a small value
+    /// selection stays readable; a larger table is left flat for switch raising.</summary>
+    const int MaxArms = 8;
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        while (FoldOne(function, context.Stepper))
+        {
+        }
+    }
+
+    static bool FoldOne(IrFunction function, Stepper stepper)
+    {
+        foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
+        {
+            var blocks = container.Blocks;
+            var offsetToIndex = new Dictionary<int, int>();
+            for (int i = 0; i < blocks.Count; i++)
+                offsetToIndex[blocks[i].StartOffset] = i;
+
+            for (int head = 0; head < blocks.Count; head++)
+            {
+                if (Match(function, blocks, offsetToIndex, head) is { } shape)
+                {
+                    Fold(container, blocks, shape, stepper);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    sealed record Arm(int BlockIndex, IrExpression Value);
+
+    sealed record Shape(
+        int HeadIndex,
+        IReadOnlyList<int> GuardIndices,
+        IReadOnlyList<Arm> Arms,
+        int StoreLocalIndex,
+        TypeRef StoreType,
+        int MergeOffset,
+        IReadOnlyList<IrExpression> Conditions,
+        IReadOnlyList<int> RemovedIndices);
+
+    static Shape? Match(IrFunction function, IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int head)
+    {
+        // 1. Walk the dispatch chain: consecutive blocks each ending in a
+        //    ConditionalBranch (the head may carry a straight-line prologue), the
+        //    chain ending in a block whose last statement is an unconditional
+        //    Branch (the default arm). Each guard's fallthrough is the next guard.
+        var guardIndices = new List<int>();
+        var conditions = new List<IrExpression>();
+        var armTargets = new List<int>();
+        int terminalIndex = -1;
+        int cursor = head;
+        while (true)
+        {
+            if (cursor >= blocks.Count)
+                return null;
+            var children = blocks[cursor].Children;
+            if (children.Count == 0)
+                return null;
+            var last = children[^1];
+
+            // Only the head may carry leading statements (the switch-value
+            // prologue); inner guards must be a pure single conditional so no
+            // observable work is hoisted across the short-circuit dispatch order.
+            bool pureGuard = children.Count == 1
+                || (cursor == head && children.Take(children.Count - 1).All(c => !IsControlFlow(c)));
+
+            if (last is ConditionalBranch conditional)
+            {
+                if (!pureGuard)
+                    return null;
+                if (cursor != head && children.Count != 1)
+                    return null;
+                guardIndices.Add(cursor);
+                conditions.Add(conditional.Condition);
+                armTargets.Add(conditional.TargetOffset);
+                cursor++;
+                continue;
+            }
+            if (last is Branch branch)
+            {
+                // Only the head may carry a prologue ahead of the terminal branch;
+                // an inner default block must be just the branch.
+                if (cursor != head && children.Count != 1)
+                    return null;
+                if (cursor == head && children.Count > 1 && !children.Take(children.Count - 1).All(c => !IsControlFlow(c)))
+                    return null;
+                armTargets.Add(branch.TargetOffset);  // the default arm
+                terminalIndex = cursor;
+                break;
+            }
+            return null;
+        }
+        if (terminalIndex < 0)
+            return null;
+
+        // Need at least two guards (so at least three arms): the two-arm store
+        // already structures as if/else and must not be reshaped into a ternary.
+        if (guardIndices.Count < 2)
+            return null;
+        if (armTargets.Count > MaxArms)
+            return null;
+
+        // 2. Resolve and validate the arms. Each arm block must be exactly
+        //    `StoreLocal target = value; (Branch merge)` — the last arm may fall
+        //    through to the merge — with every arm storing the same local and
+        //    converging on one merge. Arm targets must be distinct blocks.
+        var armIndexSet = new HashSet<int>();
+        var arms = new List<Arm>();
+        int? storeLocalIndex = null;
+        TypeRef? storeType = null;
+        int? mergeOffset = null;
+
+        for (int a = 0; a < armTargets.Count; a++)
+        {
+            if (!offsetToIndex.TryGetValue(armTargets[a], out int armIndex))
+                return null;
+            if (!armIndexSet.Add(armIndex))
+                return null;  // two guards select the same arm — not a clean dispatch
+            var children = blocks[armIndex].Children;
+            if (children.Count is < 1 or > 2)
+                return null;
+
+            IrExpression? exit = null;
+            int storeCount = children.Count;
+            if (children[^1] is Branch armBranch)
+            {
+                storeCount--;
+                exit = null;
+                if (!RegisterMerge(armBranch.TargetOffset, ref mergeOffset))
+                    return null;
+            }
+            else
+            {
+                // No trailing branch: the arm falls into the next block, which
+                // must be the merge. Record the fallthrough successor's offset.
+                if (armIndex + 1 >= blocks.Count)
+                    return null;
+                if (!RegisterMerge(blocks[armIndex + 1].StartOffset, ref mergeOffset))
+                    return null;
+            }
+            _ = exit;
+
+            if (storeCount != 1 || children[0] is not StoreLocal store)
+                return null;
+            if (ContainsControlFlow(store.Value))
+                return null;
+            if (storeLocalIndex is { } existing && existing != store.Index)
+                return null;
+            storeLocalIndex ??= store.Index;
+            storeType ??= store.Type;
+            arms.Add(new Arm(armIndex, store.Value));
+        }
+
+        if (storeLocalIndex is not { } localIndex || storeType is not { } type || mergeOffset is not { } merge)
+            return null;
+        if (!offsetToIndex.ContainsKey(merge))
+            return null;
+
+        // 3. No external entry: every dispatch/arm block other than the head must
+        //    be reached only from inside this dispatch (so removing them is safe).
+        //    The dispatch blocks are the conditional guards plus the terminal
+        //    (default) branch block.
+        var dispatchBlocks = new List<int>(guardIndices) { terminalIndex };
+        var interior = new HashSet<int>();
+        foreach (int d in dispatchBlocks)
+            if (d != head)
+                interior.Add(d);
+        foreach (var arm in arms)
+            interior.Add(arm.BlockIndex);
+        var interiorOffsets = interior.Select(i => blocks[i].StartOffset).ToHashSet();
+        var allowedSources = new HashSet<int>(dispatchBlocks) { head };
+        foreach (var (blockIndex, target) in AllBranchTargets(blocks))
+        {
+            if (interiorOffsets.Contains(target) && !allowedSources.Contains(blockIndex))
+                return null;
+        }
+        // The dispatch blocks must be physically consecutive: each guard falls
+        // through to the next dispatch block (guard or terminal), so the chain is
+        // a contiguous short-circuit run with no interleaved foreign block.
+        for (int g = 0; g < dispatchBlocks.Count - 1; g++)
+            if (dispatchBlocks[g] + 1 != dispatchBlocks[g + 1])
+                return null;
+
+        var removed = interior.OrderBy(i => i).ToList();
+        return new Shape(head, guardIndices, arms, localIndex, type, merge, conditions, removed);
+    }
+
+    static bool RegisterMerge(int offset, ref int? mergeOffset)
+    {
+        if (mergeOffset is { } existing)
+            return existing == offset;
+        mergeOffset = offset;
+        return true;
+    }
+
+    static void Fold(BlockContainer container, IReadOnlyList<Block> blocks, Shape shape, Stepper stepper)
+    {
+        var ordered = container.Blocks.ToList();
+
+        // Build the nested conditional right-to-left: the last arm is the final
+        // else, each guard's condition selecting its arm over the rest.
+        // Arms[j] aligns with Conditions[j]; the final arm is the default.
+        IrExpression value = (IrExpression)shape.Arms[^1].Value.Clone();
+        for (int j = shape.Conditions.Count - 1; j >= 0; j--)
+        {
+            var conditional = new Conditional(
+                (IrExpression)shape.Conditions[j].Clone(),
+                (IrExpression)shape.Arms[j].Value.Clone(),
+                value)
+            {
+                MergedType = shape.StoreType,
+            };
+            value = conditional;
+        }
+
+        var folded = new Block(ordered[shape.HeadIndex].StartOffset);
+        var headChildren = ordered[shape.HeadIndex].DetachChildren();
+        // Keep the head's prologue (everything before its terminal branch); the
+        // conditions still load whatever the prologue computed.
+        for (int k = 0; k < headChildren.Count - 1; k++)
+            folded.Add(headChildren[k]);
+        folded.Add(new StoreLocal(shape.StoreLocalIndex, shape.StoreType, value));
+
+        var removedSet = shape.RemovedIndices.ToHashSet();
+        // The merge is reached by fall-through when it is the next surviving block
+        // after the folded head (every dispatch/arm block between them is removed);
+        // only emit an explicit branch when something else survives in between.
+        int mergeIndex = ordered.FindIndex(b => b.StartOffset == shape.MergeOffset);
+        bool mergeFallsThrough = true;
+        for (int i = shape.HeadIndex + 1; i < mergeIndex; i++)
+        {
+            if (!removedSet.Contains(i))
+            {
+                mergeFallsThrough = false;
+                break;
+            }
+        }
+        if (!mergeFallsThrough)
+            folded.Add(new Branch(shape.MergeOffset));
+
+        foreach (var block in ordered)
+            block.Detach();
+
+        var rebuilt = new BlockContainer();
+        for (int i = 0; i < ordered.Count; i++)
+        {
+            if (i == shape.HeadIndex)
+            {
+                rebuilt.Add(folded);
+                continue;
+            }
+            if (removedSet.Contains(i))
+                continue;
+            rebuilt.Add(ordered[i]);
+        }
+
+        stepper.StepOver(
+            $"fold {shape.Arms.Count}-way conditional store of local {shape.StoreLocalIndex} into a nested conditional",
+            container);
+        container.ReplaceWith(rebuilt);
+    }
+
+    static IEnumerable<(int BlockIndex, int Target)> AllBranchTargets(IReadOnlyList<Block> blocks)
+    {
+        for (int i = 0; i < blocks.Count; i++)
+            foreach (var node in blocks[i].Descendants)
+                switch (node)
+                {
+                    case Branch branch:
+                        yield return (i, branch.TargetOffset);
+                        break;
+                    case ConditionalBranch conditional:
+                        yield return (i, conditional.TargetOffset);
+                        break;
+                    case SwitchBranch sw:
+                        foreach (int target in sw.TargetOffsets)
+                            yield return (i, target);
+                        break;
+                    case Leave leave:
+                        yield return (i, leave.TargetOffset);
+                        break;
+                }
+    }
+
+    static bool ContainsControlFlow(IrExpression value)
+        => value.Descendants.Prepend(value).Any(IsControlFlow);
+
+    static bool IsControlFlow(IrNode node)
+        => node is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter;
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ConditionalStoreChainPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ConditionalStoreChainPass.cs
@@ -199,7 +199,19 @@ public sealed class ConditionalStoreChainPass : IIrPass
 
         if (storeLocalIndex is not { } localIndex || storeType is not { } type || mergeOffset is not { } merge)
             return null;
-        if (!offsetToIndex.ContainsKey(merge))
+        if (!offsetToIndex.TryGetValue(merge, out int mergeIndex))
+            return null;
+        // The merge must be strictly forward of the whole dispatch — after every
+        // guard and arm block. A backward/self merge (arms that branch back to the
+        // dispatch, i.e. a loop) must never fold: removing the arms and falling
+        // through would turn the loop into straight-line code (a miscompile).
+        int maxDispatchOrArm = head;
+        foreach (int g in guardIndices)
+            maxDispatchOrArm = System.Math.Max(maxDispatchOrArm, g);
+        maxDispatchOrArm = System.Math.Max(maxDispatchOrArm, terminalIndex);
+        foreach (var arm in arms)
+            maxDispatchOrArm = System.Math.Max(maxDispatchOrArm, arm.BlockIndex);
+        if (mergeIndex <= maxDispatchOrArm)
             return null;
 
         // 3. No external entry: every dispatch/arm block other than the head must

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -143,6 +143,10 @@ public static class IrPasses
         // Fold shared-forward slot diamonds into one conditional store so a
         // later merge can structure instead of carrying the slot through gotos.
         new SlotStoreDiamondPass(),
+        // Fold an N-way (≥3 arm) switch-store dispatch into one nested
+        // conditional store — the multi-arm sibling of the slot-store diamond
+        // over a local — so its merge structures instead of staying flat.
+        new ConditionalStoreChainPass(),
         new StructuringPass(),
         // Recover a destructor: a Finalize override's try/finally + base.Finalize()
         // scaffold, structured just above, collapses to the ~T() body.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -57,6 +57,8 @@ internal static class NativePasses
     public static ComparisonTreeBoolArmPass ComparisonTreeBoolArm => new();
     [Native(NativeCategory.EmitArtifact, "a shared-forward slot-store diamond folded to one conditional store so structuring can consume the surrounding merge")]
     public static SlotStoreDiamondPass SlotStoreDiamond => new();
+    [Native(NativeCategory.EmitArtifact, "an N-way (>=3 arm) switch-store dispatch folded to one nested conditional store so structuring can consume the surrounding merge")]
+    public static ConditionalStoreChainPass ConditionalStoreChain => new();
     [Native(NativeCategory.EmitArtifact, "generic null-conditional invocation (recv?.M() ?? x — the default(T)-box two-stage null test) folded so structuring can consume it")]
     public static NullConditionalCoalescePass NullConditionalCoalesce => new();
     [Native(NativeCategory.EmitArtifact, "branch-to-adjacent / dead branches removed before structuring")]


### PR DESCRIPTION
## Summary

Fixes #1710: a realistic method mixing a `foreach` loop, a `switch` that assigns a local, and a LINQ/lambda continuation decompiled to a whole-method **goto ladder** (`structuring: cond-target-past-region`).

```csharp
// before
int V_2 = values.Length;
if (V_2 == 0) goto IL_000D;
if (V_2 == 1) goto IL_0012;
goto IL_0017;
IL_000D: bucket = 10; goto IL_001A;
...
S_1 = new Func<int, bool>(<>c.<>9.<…>b__0_0);   // lambda also stranded
...

// after
int bucket = values.Length == 0 ? 10 : (values.Length == 1 ? 20 : 30);
int[] positives = values.Where(v => v > 0).ToArray();
```

## Root cause (narrowed by prototype)

The `<>c` leak was a `--dump` seam artifact; the product raises the lambda. The equivalent `if/else-if` chain **already structures**. Only csc's `switch` lowering fails: it emits **dispatch-first** (all guard conditions), then the **separated arms**, then the merge — so the arms sit physically apart from their guards and the index-range `StructuringPass` cannot name the merge join.

## Fix

`ConditionalStoreChainPass` — the N-way (≥3 arm) sibling of `SlotStoreDiamondPass` over a local. It recognizes the dispatch chain whose arms each store the **same** local with a self-contained value and converge on one merge, and folds them into a single nested conditional store. That eliminates the merge, so structuring (and the lambda/continuation raising it gates) succeeds.

Strictly gated, declines on anything else: ≥2 guards (the two-arm `if/else` already structures and is left untouched); each arm exactly one store + branch to the common merge; no external entry into the dispatch/arms; arm values free of control flow. Anything ambiguous stays flat — never a guess.

This is the architecturally-blessed value-flow store-diamond lane (PR #1150 review: these folds "move data across a join… and they're the highest-impact ones"), not a control-flow normalizer — so it is consistent with `SlotStoreDiamondPass`. The broader multi-merge `cond-target-past-region` population is the larger post-dominator structuring work (#1175), unchanged here.

## Promotes the rung 1 combined-frontier gate (#1711)

The `CombinedFrontier` switch-store methods now structure (no goto ladder, no structuring residual). `LadderRung1CombinedFrontierGateTests` flips from asserting the `Partial` frontier to asserting the recovery — the intentional promotion the frontier was designed to force.

## Evidence (14-assembly real-world corpus, 88,840 methods)

```text
# validity A/B defect diff (the authority bar: zero new invalid)
--validity-check --diff-validity-defects   (66,648 methods in both)
  REGRESSED: (none)   IMPROVED: (none)

# blast radius
--pass-impact conditional-store-chain
  changed 4/88,840 methods (0.00%); 0 pass bugs

# tool-generated quality-diff card (baseline noted stale; clean signal is the A/B above)
  Full malformed 32 -> 32 (0) | Pass bugs 0 -> 0 | Semantic defects 0 delta
  Verdict: corpus sensor matched baseline tolerances
  (+4 fidelity opcode-diffs = the expected valid ternary re-lowering)

# fast decompiler suite (incl. #640 short-circuit canaries, FidelityGateTests, LoweringCoverage)
  Total: 1555, 0 failed
```

New `ConditionalStoreChainPassTests` lock the boundaries (folds 3-way; declines 2-way; declines an arm that does more than store). The `CombinedFrontier` compiled fixture is the real-importer canary.

## Scope (honest)

Narrow and safe: it recovers the value-select-switch shape (the #1710 repro and 4 corpus methods) with zero regressions. It does not move the bulk `conditional-branch` residual, which needs the #1175 post-dominator structuring.

Closes #1710. Refs #1599, #1694.

Cross-model (GPT-5.5) adversarial review requested.
