### PR TITLE
End-to-end Analysis Diff version-pair + identity guards (analysis ladder #1623 rung 6)

### DIFF
--- a/src/DiffFixtures.V1/DiffFixtures.V1.csproj
+++ b/src/DiffFixtures.V1/DiffFixtures.V1.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Versioned analysis-diff fixture (#1623 rung 6). V1 and V2 share AssemblyName
+    DiffFixtureSample and method signatures so the diff matches them in-place; only
+    the bodies differ (seeded allocation regression / improvement / stable). Loaded
+    by path; never referenced for compilation.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>DiffFixtureSample</AssemblyName>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace DiffFixtureSample
+{
+    public static class DiffSample
+    {
+        // V1: a single allocation, not in a loop (1 allocation).
+        public static void RegressesAllocInLoop(int n, List<object> sink)
+        {
+            sink.Add(new object());
+        }
+
+        // V1: three allocations.
+        public static void ImprovesAlloc(List<object> sink)
+        {
+            sink.Add(new object());
+            sink.Add(new object());
+            sink.Add(new object());
+        }
+
+        // Identical in both versions -> no diff row.
+        public static int Stable() => 42;
+    }
+}

--- a/src/DiffFixtures.V2/DiffFixtures.V2.csproj
+++ b/src/DiffFixtures.V2/DiffFixtures.V2.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Versioned analysis-diff fixture (#1623 rung 6). V1 and V2 share AssemblyName
+    DiffFixtureSample and method signatures so the diff matches them in-place; only
+    the bodies differ (seeded allocation regression / improvement / stable). Loaded
+    by path; never referenced for compilation.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>DiffFixtureSample</AssemblyName>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace DiffFixtureSample
+{
+    public static class DiffSample
+    {
+        // V2: the allocation moved into a loop and gained a second site (2 allocations,
+        // in-loop) -> an allocation regression that is hot.
+        public static void RegressesAllocInLoop(int n, List<object> sink)
+        {
+            sink.Add(new object());
+            for (int i = 0; i < n; i++)
+                sink.Add(new object());
+        }
+
+        // V2: a single allocation -> an improvement vs V1's three.
+        public static void ImprovesAlloc(List<object> sink)
+        {
+            sink.Add(new object());
+        }
+
+        // Identical in both versions -> no diff row.
+        public static int Stable() => 42;
+    }
+}

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -248,10 +248,16 @@ public class DiffCommandTests
     {
         var v1 = DiffFixturePath("DiffFixtures.V1");
 
-        var result = DiffCommand.BuildAnalysisDiff([v1], [v1], new DiffOptions { ChangedOnly = true });
+        // Full diff: self-diff must have neither in-place deltas nor spurious
+        // added/removed rows.
+        var full = DiffCommand.BuildAnalysisDiff([v1], [v1], new DiffOptions());
+        Assert.Empty(full.Rows);
+        Assert.Equal("No analysis signal changes detected.", full.Summary);
 
-        Assert.Empty(result.Rows);
-        Assert.Equal("No in-place analysis signal changes detected.", result.Summary);
+        // Changed-only view agrees.
+        var changedOnly = DiffCommand.BuildAnalysisDiff([v1], [v1], new DiffOptions { ChangedOnly = true });
+        Assert.Empty(changedOnly.Rows);
+        Assert.Equal("No in-place analysis signal changes detected.", changedOnly.Summary);
     }
 
     static string DiffFixturePath(string project)

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -213,4 +213,54 @@ public class DiffCommandTests
         Assert.Contains("No in-place analysis signal changes detected.", markdown);
         Assert.DoesNotContain("No analysis signal changes detected.", markdown);
     }
+
+    // #1623 rung 6: end-to-end version-pair diff. V1/V2 share AssemblyName and method
+    // signatures (matched in-place); only bodies differ. A seeded in-loop allocation
+    // regression and an allocation improvement must surface, and an unchanged method
+    // must not produce a row.
+    [Fact]
+    public void BuildAnalysisDiff_VersionPair_SurfacesSeededRegressionAndImprovement()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var result = DiffCommand.BuildAnalysisDiff([v1], [v2], new DiffOptions { ChangedOnly = true });
+
+        var regression = Assert.Single(result.Rows, r =>
+            r.Member.Contains("RegressesAllocInLoop") && r.Signal == "allocations");
+        Assert.Equal("1", regression.Old);
+        Assert.Equal("2", regression.New);
+        Assert.Equal("in-loop", regression.Shape);
+
+        var improvement = Assert.Single(result.Rows, r =>
+            r.Member.Contains("ImprovesAlloc") && r.Signal == "allocations");
+        Assert.Equal("3", improvement.Old);
+        Assert.Equal("1", improvement.New);
+
+        Assert.DoesNotContain(result.Rows, r => r.Member.Contains("Stable"));
+    }
+
+    // #1623 rung 6: identity / no spurious deltas. Diffing a build against itself must
+    // produce zero in-place signal changes (guards signal determinism across two opens
+    // and the zero-delta filter).
+    [Fact]
+    public void BuildAnalysisDiff_Identity_SelfDiffHasNoSpuriousDeltas()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+
+        var result = DiffCommand.BuildAnalysisDiff([v1], [v1], new DiffOptions { ChangedOnly = true });
+
+        Assert.Empty(result.Rows);
+        Assert.Equal("No in-place analysis signal changes detected.", result.Summary);
+    }
+
+    static string DiffFixturePath(string project)
+    {
+        var outputDirectory = new System.IO.DirectoryInfo(
+            System.AppContext.BaseDirectory.TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar));
+        string path = System.IO.Path.GetFullPath(System.IO.Path.Combine(
+            outputDirectory.FullName, "..", "..", project, outputDirectory.Name, "DiffFixtureSample.dll"));
+        Assert.True(System.IO.File.Exists(path), $"Expected diff fixture assembly at {path}");
+        return path;
+    }
 }

--- a/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
+++ b/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
@@ -22,6 +22,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\dotnet-inspect\dotnet-inspect.csproj" />
+    <ProjectReference Include="..\DiffFixtures.V1\DiffFixtures.V1.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\DiffFixtures.V2\DiffFixtures.V2.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -356,7 +356,7 @@ public class DiffCommand
     // is present in both versions (an in-place change vs an added/removed member).
     internal sealed record RankedAnalysisRow(AnalysisDiffRow Row, int Magnitude, int Direction, bool InBoth, bool InLoop = false);
 
-    private static AnalysisDiffResult BuildAnalysisDiff(IReadOnlyList<string> fromPaths, IReadOnlyList<string> toPaths, DiffOptions options)
+    internal static AnalysisDiffResult BuildAnalysisDiff(IReadOnlyList<string> fromPaths, IReadOnlyList<string> toPaths, DiffOptions options)
     {
         var oldSnapshot = BuildAnalysisSnapshot(fromPaths, options);
         var newSnapshot = BuildAnalysisSnapshot(toPaths, options);


### PR DESCRIPTION
## Analysis quality ladder (#1623) — rung 6 (Analysis Diff correctness)

Skeptical measurement of rung 6. Its burndown (#1660: #1607 in-loop marker, #1610
retained-exceptions-hot) is closed, so this is the measure-and-consolidate pass.

### Altitude

The diff ranking/classification logic is well unit-tested — but only on **synthetic
`RankedAnalysisRow` inputs** (`RankAnalysisRows_*`, `BuildAnalysisSummary_*`). The
rung's done-signal is "diff **fixture pairs** match expected regressions /
improvements / identity," and **nothing diffed two real assembly versions
end-to-end**, nor pinned **identity (no spurious deltas)**.

### Change

- Add a versioned fixture pair (`DiffFixtures.V1` / `.V2`, shared
  `AssemblyName=DiffFixtureSample` and method signatures so the diff matches them
  in-place; only bodies differ): a seeded in-loop allocation regression, an
  allocation improvement, and a stable method.
- `BuildAnalysisDiff_VersionPair_SurfacesSeededRegressionAndImprovement`: asserts the
  exact deltas — allocations `1 -> 2` **in-loop** regression, `3 -> 1` improvement —
  and that the unchanged method yields **no** row.
- `BuildAnalysisDiff_Identity_SelfDiffHasNoSpuriousDeltas`: diffing a build against
  itself produces zero in-place changes (guards signal determinism + the zero-delta
  filter).
- Make `BuildAnalysisDiff` internal so the end-to-end path is testable (no behavior
  change).

### Evidence

`dotnet-inspect.Tests` 1378 (was 1376), no regressions. GPT-5.5 adversarial review
requested (fixture count soundness, in-place key matching, identity strength).
Refs #1623, #1660.
