### PR TITLE
Distinguish same-arity generic overloads in cross-assembly caller graph (#1731)

### DIFF
--- a/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
+++ b/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
@@ -20,6 +20,10 @@ namespace Shared
         // (a constructed generic method via a MethodSpec).
         public static void UseBox() => new Target.Box<int>().Store(1);
 
+        // #1731: calls the same-arity List<T> overload of Store on the same Box<int>. A
+        // caller graph rooted at Store(List<T>) must report this and not UseBox.
+        public static void UseBoxList() => new Target.Box<int>().Store(new System.Collections.Generic.List<int>());
+
         public static void UseEcho() => Target.GenericApi.Echo(1);
     }
 }

--- a/src/ILInspector.Analysis.CallerGraphTarget/TargetApi.cs
+++ b/src/ILInspector.Analysis.CallerGraphTarget/TargetApi.cs
@@ -31,6 +31,13 @@ namespace Target
         public void Store(T value)
         {
         }
+
+        // #1731: a same-arity overload on the same generic declaring type. The
+        // cross-assembly caller graph must keep Store(T) and Store(List<T>) distinct;
+        // the prior arity-only erasure collapsed them.
+        public void Store(System.Collections.Generic.List<T> values)
+        {
+        }
     }
 
     // Generic method on a non-generic type: a caller invokes Echo<int>, a MethodSpec keyed on

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -202,12 +202,42 @@ public class LibraryBodyIndexTests
         var caller = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphCaller"));
 
         var store = targetIndex.Methods.First(method =>
-            method.DeclaringType.Name == "Box`1" && method.Name == "Store");
+            method.DeclaringType.Name == "Box`1" && method.Name == "Store"
+            && method.ParameterTypes[0].Kind == TypeRefKind.GenericParameter);
         var tree = targetIndex.BuildCallerTree(store.MetadataToken, new[] { caller }, maxDepth: 2, maxNodes: 50);
 
         var callerNames = tree.Children.Select(child => child.Member.Name).ToList();
         Assert.Contains("UseBox", callerNames);
         Assert.Contains("ILInspector.Analysis.CallerGraphCaller", tree.Children.Select(child => child.Perf?.Source));
+    }
+
+    // #1731: Box<T>.Store(T) and Box<T>.Store(List<T>) share name and arity on the same
+    // generic declaring type. Cross-assembly caller graph identity must keep them distinct
+    // — rooting at one overload reports only its own constructed caller, not the other's.
+    // The prior arity-only erasure (open declaring + name + parameter count) collapsed them
+    // and cross-linked the callers, which de-verified #1623 rung 1.
+    [Fact]
+    public void BuildCallerTree_WithScope_KeepsSameArityGenericOverloadsDistinct()
+    {
+        var targetIndex = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphTarget"));
+        var caller = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphCaller"));
+
+        var storeValue = targetIndex.Methods.First(method =>
+            method.DeclaringType.Name == "Box`1" && method.Name == "Store"
+            && method.ParameterTypes[0].Kind == TypeRefKind.GenericParameter);
+        var storeList = targetIndex.Methods.First(method =>
+            method.DeclaringType.Name == "Box`1" && method.Name == "Store"
+            && method.ParameterTypes[0].Kind == TypeRefKind.GenericInstance);
+
+        var valueCallers = targetIndex.BuildCallerTree(storeValue.MetadataToken, new[] { caller }, maxDepth: 2, maxNodes: 50)
+            .Children.Select(child => child.Member.Name).ToList();
+        var listCallers = targetIndex.BuildCallerTree(storeList.MetadataToken, new[] { caller }, maxDepth: 2, maxNodes: 50)
+            .Children.Select(child => child.Member.Name).ToList();
+
+        Assert.Contains("UseBox", valueCallers);
+        Assert.DoesNotContain("UseBoxList", valueCallers);
+        Assert.Contains("UseBoxList", listCallers);
+        Assert.DoesNotContain("UseBox", listCallers);
     }
 
     [Fact]

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -240,6 +240,39 @@ public class LibraryBodyIndexTests
         Assert.DoesNotContain("UseBox", listCallers);
     }
 
+    // #1731 (adversarial review): the cross-assembly caller-graph shape keys on the OPEN
+    // signature (VAR/MVAR markers), not the substituted concrete types. A constructed
+    // Box<int>.Store(T) call carries a concrete int as its instantiated parameter, but the
+    // open signature retains the type-parameter marker — so a type-parameter instantiation
+    // stays distinct from a literal of the same type, and the shape matches the open target.
+    [Fact]
+    public void ResolvedCall_PreservesOpenGenericMarker_DistinctFromInstantiatedParameter()
+    {
+        var caller = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphCaller"));
+
+        var storeValueCall = caller.DirectCalls.First(call =>
+            call.Callee.Name == "Store" && call.Callee.ParameterTypes[0].Kind == TypeRefKind.Definition);
+
+        // Instantiated parameter is the concrete int; the open signature keeps the marker.
+        Assert.Equal(TypeRefKind.Definition, storeValueCall.Callee.ParameterTypes[0].Kind);
+        Assert.Equal(TypeRefKind.GenericParameter, storeValueCall.Callee.OpenSignatureParameters[0].Kind);
+    }
+
+    // #1731 (adversarial review, finding B): the erased generic shape qualifies a generic
+    // instance by namespace, so N1.Foo<T> and N2.Foo<T> (same metadata name, different
+    // namespace) do not collapse.
+    [Fact]
+    public void ErasedParameterShape_QualifiesGenericInstanceByNamespace()
+    {
+        var typeParameter = TypeRef.GenericParameter(0, "T");
+        var foo1 = TypeRef.GenericInstance(TypeRef.Definition("AsmA", "N1", "Foo`1"), [typeParameter]);
+        var foo2 = TypeRef.GenericInstance(TypeRef.Definition("AsmB", "N2", "Foo`1"), [typeParameter]);
+
+        Assert.NotEqual(
+            GenericMemberIdentity.ErasedParameterShape([foo1]),
+            GenericMemberIdentity.ErasedParameterShape([foo2]));
+    }
+
     [Fact]
     public void BuildCallerTree_WithScope_LinksConstructedGenericMethodCaller()
     {

--- a/src/ILInspector.Analysis/GenericMemberIdentity.cs
+++ b/src/ILInspector.Analysis/GenericMemberIdentity.cs
@@ -25,7 +25,7 @@ namespace ILInspector.Analysis;
 /// are an accepted coarsening, far preferable to the prior zero-match under-report.
 /// Non-generic members are left on their exact instantiated signature.
 /// </summary>
-internal static class GenericMemberIdentity
+public static class GenericMemberIdentity
 {
     /// <summary>
     /// The open named definition of a (possibly constructed) declaring type, so a
@@ -81,61 +81,34 @@ internal static class GenericMemberIdentity
             || parameterTypes.Any(ContainsGenericParameter);
 
     /// <summary>
-    /// A cross-assembly-stable parameter shape for an erased generic member. Each
-    /// declaring-type generic argument is mapped to a positional marker
-    /// (<c>!0</c>, <c>!1</c>, …) so the open definition (whose parameters reference the
-    /// type parameters as <c>!i</c>) and a constructed call site (whose parameters carry
-    /// the instantiation) collapse onto the same shape, while same-arity overloads with
-    /// a different parameter structure — <c>Box&lt;T&gt;.Store(T)</c> vs
-    /// <c>Box&lt;T&gt;.Store(List&lt;T&gt;)</c> — stay distinct (#1731). The earlier
-    /// erasure kept only the parameter count, collapsing such overloads.
+    /// A cross-assembly-stable parameter shape for an erased generic member, computed
+    /// from the <em>open</em> signature (VAR/MVAR markers preserved): a type generic
+    /// parameter renders as <c>!i</c>, a method generic parameter as <c>!!i</c>, generic
+    /// instances and array/byref/pointer wrappers recurse, and any other type uses its
+    /// namespace-qualified display. The open definition and a constructed call site both
+    /// carry the same markers, so they collapse onto one key, while same-arity overloads
+    /// with a different parameter structure — <c>Box&lt;T&gt;.Store(T)</c> vs
+    /// <c>Box&lt;T&gt;.Store(List&lt;T&gt;)</c>, or a type-parameter vs a literal of the
+    /// same instantiated type — stay distinct (#1731). The earlier erasure kept only the
+    /// parameter count.
     /// </summary>
-    public static string ErasedParameterShape(TypeRef declaringType, ImmutableArray<TypeRef> methodTypeArguments, ImmutableArray<TypeRef> parameterTypes)
+    public static string ErasedParameterShape(ImmutableArray<TypeRef> openParameterTypes)
+        => string.Join(",", openParameterTypes.Select(NormalizeShape));
+
+    static string NormalizeShape(TypeRef type) => type.Kind switch
     {
-        var declaringArguments = declaringType.Kind == TypeRefKind.GenericInstance
-            ? declaringType.TypeArguments
-            : [];
-        return string.Join(",", parameterTypes.Select(parameter => NormalizeShape(parameter, declaringArguments, methodTypeArguments)));
-    }
-
-    static string NormalizeShape(TypeRef type, ImmutableArray<TypeRef> declaringArguments, ImmutableArray<TypeRef> methodArguments)
-    {
-        // Open-definition side: a type/method generic parameter is a positional marker.
-        if (type.Kind == TypeRefKind.GenericParameter)
-            return $"!{type.GenericParameterIndex}";
-        if (type.Kind == TypeRefKind.MethodGenericParameter)
-            return $"!!{type.GenericParameterIndex}";
-
-        // Constructed-call-site side: a type equal to a declaring-type argument maps to
-        // the matching type marker (!i), and one equal to a method type argument maps to
-        // the method marker (!!i) — so List<int> under Box<int> reads as List<!0>
-        // (matching open List<T> under Box<T>), and Id<int>(int) reads as !!0 (matching
-        // open Id<T>(T)). Declaring args take precedence so the markers line up with the
-        // open definition's parameter kinds.
-        for (int i = 0; i < declaringArguments.Length; i++)
-        {
-            if (declaringArguments[i].Equals(type))
-                return $"!{i}";
-        }
-        for (int i = 0; i < methodArguments.Length; i++)
-        {
-            if (methodArguments[i].Equals(type))
-                return $"!!{i}";
-        }
-
-        return type.Kind switch
-        {
-            TypeRefKind.GenericInstance when type.ElementType is { } definition
-                => $"{definition.Name}<{string.Join(",", type.TypeArguments.Select(argument => NormalizeShape(argument, declaringArguments, methodArguments)))}>",
-            TypeRefKind.SzArray when type.ElementType is { } element
-                => $"{NormalizeShape(element, declaringArguments, methodArguments)}[]",
-            TypeRefKind.Array when type.ElementType is { } element
-                => $"{NormalizeShape(element, declaringArguments, methodArguments)}[{new string(',', type.Rank > 0 ? type.Rank - 1 : 0)}]",
-            TypeRefKind.ByRef when type.ElementType is { } element
-                => $"ref {NormalizeShape(element, declaringArguments, methodArguments)}",
-            TypeRefKind.Pointer when type.ElementType is { } element
-                => $"{NormalizeShape(element, declaringArguments, methodArguments)}*",
-            _ => type.ToQualifiedDisplayString(),
-        };
-    }
+        TypeRefKind.GenericParameter => $"!{type.GenericParameterIndex}",
+        TypeRefKind.MethodGenericParameter => $"!!{type.GenericParameterIndex}",
+        TypeRefKind.GenericInstance when type.ElementType is { } definition
+            => $"{definition.ToQualifiedDisplayString()}<{string.Join(",", type.TypeArguments.Select(NormalizeShape))}>",
+        TypeRefKind.SzArray when type.ElementType is { } element
+            => $"{NormalizeShape(element)}[]",
+        TypeRefKind.Array when type.ElementType is { } element
+            => $"{NormalizeShape(element)}[{new string(',', type.Rank > 0 ? type.Rank - 1 : 0)}]",
+        TypeRefKind.ByRef when type.ElementType is { } element
+            => $"ref {NormalizeShape(element)}",
+        TypeRefKind.Pointer when type.ElementType is { } element
+            => $"{NormalizeShape(element)}*",
+        _ => type.ToQualifiedDisplayString(),
+    };
 }

--- a/src/ILInspector.Analysis/GenericMemberIdentity.cs
+++ b/src/ILInspector.Analysis/GenericMemberIdentity.cs
@@ -79,4 +79,63 @@ internal static class GenericMemberIdentity
             || typeArguments.Length > 0
             || ContainsGenericParameter(returnType)
             || parameterTypes.Any(ContainsGenericParameter);
+
+    /// <summary>
+    /// A cross-assembly-stable parameter shape for an erased generic member. Each
+    /// declaring-type generic argument is mapped to a positional marker
+    /// (<c>!0</c>, <c>!1</c>, …) so the open definition (whose parameters reference the
+    /// type parameters as <c>!i</c>) and a constructed call site (whose parameters carry
+    /// the instantiation) collapse onto the same shape, while same-arity overloads with
+    /// a different parameter structure — <c>Box&lt;T&gt;.Store(T)</c> vs
+    /// <c>Box&lt;T&gt;.Store(List&lt;T&gt;)</c> — stay distinct (#1731). The earlier
+    /// erasure kept only the parameter count, collapsing such overloads.
+    /// </summary>
+    public static string ErasedParameterShape(TypeRef declaringType, ImmutableArray<TypeRef> methodTypeArguments, ImmutableArray<TypeRef> parameterTypes)
+    {
+        var declaringArguments = declaringType.Kind == TypeRefKind.GenericInstance
+            ? declaringType.TypeArguments
+            : [];
+        return string.Join(",", parameterTypes.Select(parameter => NormalizeShape(parameter, declaringArguments, methodTypeArguments)));
+    }
+
+    static string NormalizeShape(TypeRef type, ImmutableArray<TypeRef> declaringArguments, ImmutableArray<TypeRef> methodArguments)
+    {
+        // Open-definition side: a type/method generic parameter is a positional marker.
+        if (type.Kind == TypeRefKind.GenericParameter)
+            return $"!{type.GenericParameterIndex}";
+        if (type.Kind == TypeRefKind.MethodGenericParameter)
+            return $"!!{type.GenericParameterIndex}";
+
+        // Constructed-call-site side: a type equal to a declaring-type argument maps to
+        // the matching type marker (!i), and one equal to a method type argument maps to
+        // the method marker (!!i) — so List<int> under Box<int> reads as List<!0>
+        // (matching open List<T> under Box<T>), and Id<int>(int) reads as !!0 (matching
+        // open Id<T>(T)). Declaring args take precedence so the markers line up with the
+        // open definition's parameter kinds.
+        for (int i = 0; i < declaringArguments.Length; i++)
+        {
+            if (declaringArguments[i].Equals(type))
+                return $"!{i}";
+        }
+        for (int i = 0; i < methodArguments.Length; i++)
+        {
+            if (methodArguments[i].Equals(type))
+                return $"!!{i}";
+        }
+
+        return type.Kind switch
+        {
+            TypeRefKind.GenericInstance when type.ElementType is { } definition
+                => $"{definition.Name}<{string.Join(",", type.TypeArguments.Select(argument => NormalizeShape(argument, declaringArguments, methodArguments)))}>",
+            TypeRefKind.SzArray when type.ElementType is { } element
+                => $"{NormalizeShape(element, declaringArguments, methodArguments)}[]",
+            TypeRefKind.Array when type.ElementType is { } element
+                => $"{NormalizeShape(element, declaringArguments, methodArguments)}[{new string(',', type.Rank > 0 ? type.Rank - 1 : 0)}]",
+            TypeRefKind.ByRef when type.ElementType is { } element
+                => $"ref {NormalizeShape(element, declaringArguments, methodArguments)}",
+            TypeRefKind.Pointer when type.ElementType is { } element
+                => $"{NormalizeShape(element, declaringArguments, methodArguments)}*",
+            _ => type.ToQualifiedDisplayString(),
+        };
+    }
 }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -886,8 +886,8 @@ public sealed class LibraryBodyIndex
             member.DeclaringType,
             member.Name,
             member.ParameterTypes,
+            member.ParameterTypes,
             member.ReturnType,
-            [],
             GenericMemberIdentity.ShouldErase(member.DeclaringType, member.ParameterTypes, member.ReturnType, []));
 
     static string CallerGraphKey(MemberRef member)
@@ -895,15 +895,15 @@ public sealed class LibraryBodyIndex
             member.DeclaringType,
             member.Name,
             member.ParameterTypes,
+            member.OpenSignatureParameters,
             member.ReturnType,
-            member.TypeArguments,
             GenericMemberIdentity.ShouldErase(member.DeclaringType, member.ParameterTypes, member.ReturnType, member.TypeArguments));
 
-    static string CallerGraphKey(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes, TypeRef returnType, ImmutableArray<TypeRef> methodTypeArguments, bool eraseGenericSignature)
+    static string CallerGraphKey(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes, ImmutableArray<TypeRef> openParameterTypes, TypeRef returnType, bool eraseGenericSignature)
     {
         var openDeclaring = GenericMemberIdentity.OpenDeclaringType(declaringType);
         return eraseGenericSignature
-            ? $"{openDeclaring.Assembly}|{openDeclaring.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{GenericMemberIdentity.ErasedParameterShape(declaringType, methodTypeArguments, parameterTypes)}"
+            ? $"{openDeclaring.Assembly}|{openDeclaring.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{GenericMemberIdentity.ErasedParameterShape(openParameterTypes)}"
             : $"{openDeclaring.Assembly}|{openDeclaring.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{string.Join(",", parameterTypes.Select(type => type.ToQualifiedDisplayString()))}|{returnType.ToQualifiedDisplayString()}";
     }
 

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -887,6 +887,7 @@ public sealed class LibraryBodyIndex
             member.Name,
             member.ParameterTypes,
             member.ReturnType,
+            [],
             GenericMemberIdentity.ShouldErase(member.DeclaringType, member.ParameterTypes, member.ReturnType, []));
 
     static string CallerGraphKey(MemberRef member)
@@ -895,13 +896,14 @@ public sealed class LibraryBodyIndex
             member.Name,
             member.ParameterTypes,
             member.ReturnType,
+            member.TypeArguments,
             GenericMemberIdentity.ShouldErase(member.DeclaringType, member.ParameterTypes, member.ReturnType, member.TypeArguments));
 
-    static string CallerGraphKey(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes, TypeRef returnType, bool eraseGenericSignature)
+    static string CallerGraphKey(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes, TypeRef returnType, ImmutableArray<TypeRef> methodTypeArguments, bool eraseGenericSignature)
     {
         var openDeclaring = GenericMemberIdentity.OpenDeclaringType(declaringType);
         return eraseGenericSignature
-            ? $"{openDeclaring.Assembly}|{openDeclaring.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|<generic>"
+            ? $"{openDeclaring.Assembly}|{openDeclaring.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{GenericMemberIdentity.ErasedParameterShape(declaringType, methodTypeArguments, parameterTypes)}"
             : $"{openDeclaring.Assembly}|{openDeclaring.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{string.Join(",", parameterTypes.Select(type => type.ToQualifiedDisplayString()))}|{returnType.ToQualifiedDisplayString()}";
     }
 

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -79,6 +79,20 @@ public sealed record MemberRef(
 {
     public ImmutableArray<TypeRef> TypeArguments { get; init; } = [];
 
+    /// <summary>
+    /// The parameter signature with generic markers (VAR/MVAR) preserved — i.e. before
+    /// the declaring-type / method-type instantiation that <see cref="ParameterTypes"/>
+    /// carries. Cross-assembly caller-graph identity keys on this so a constructed call
+    /// site and the open definition reduce to the same generic shape, and a literal type
+    /// stays distinct from a type-parameter instantiation (#1731). Empty when not
+    /// separately captured, in which case <see cref="OpenSignatureParameters"/> falls
+    /// back to <see cref="ParameterTypes"/>.
+    /// </summary>
+    public ImmutableArray<TypeRef> OpenParameterTypes { get; init; } = [];
+
+    public ImmutableArray<TypeRef> OpenSignatureParameters
+        => OpenParameterTypes.IsDefaultOrEmpty ? ParameterTypes : OpenParameterTypes;
+
     public static MemberRef Unsupported(string reason)
         => new(TypeRef.Unsupported(reason), "?", [], TypeRef.Unsupported("unknown return"), MemberKind.Unsupported);
 }

--- a/src/ILInspector.Analysis/MemberResolver.cs
+++ b/src/ILInspector.Analysis/MemberResolver.cs
@@ -20,7 +20,10 @@ internal static class MemberResolver
                     GenericParameterNames(reader, method.GetGenericParameters()));
                 var signature = method.DecodeSignature(TypeRefDecoder.Instance, typeScope);
                 string name = reader.GetString(method.Name);
-                return new MemberRef(declaring, name, signature.ParameterTypes, signature.ReturnType, KindFor(name));
+                return new MemberRef(declaring, name, signature.ParameterTypes, signature.ReturnType, KindFor(name))
+                {
+                    OpenParameterTypes = signature.ParameterTypes,
+                };
             }
             case HandleKind.MemberReference:
             {
@@ -34,7 +37,11 @@ internal static class MemberResolver
                     name,
                     [.. signature.ParameterTypes.Select(p => p.Instantiate(typeArguments, []))],
                     signature.ReturnType.Instantiate(typeArguments, []),
-                    KindFor(name));
+                    KindFor(name))
+                {
+                    // Raw signature with VAR/MVAR markers, before instantiation (#1731).
+                    OpenParameterTypes = signature.ParameterTypes,
+                };
             }
             case HandleKind.MethodSpecification:
             {
@@ -46,6 +53,8 @@ internal static class MemberResolver
                     TypeArguments = methodArguments,
                     ReturnType = generic.ReturnType.Instantiate([], methodArguments),
                     ParameterTypes = [.. generic.ParameterTypes.Select(p => p.Instantiate([], methodArguments))],
+                    // OpenParameterTypes is inherited from `generic` (raw markers), not
+                    // instantiated, so the open generic-method shape is preserved (#1731).
                 };
             }
             default:


### PR DESCRIPTION
## #1731 — cross-assembly caller graph collapsed same-arity generic overloads (de-verified #1623 rung 1)

The cross-assembly caller-graph key erased a generic member to
`openDeclaring|name|parameterCount|<generic>`, dropping the parameter shape. Two
overloads on the same generic type with the same arity — `Box<T>.Store(T)` vs
`Box<T>.Store(List<T>)` — collapsed onto one key, so rooting the caller graph at
either overload reported **both** callers. That is the exactness gap that
de-verified #1623 row 1.

### Fix

`GenericMemberIdentity.ErasedParameterShape(declaringType, methodTypeArguments,
parameterTypes)` builds a **cross-assembly-stable parameter shape**: each
declaring-type generic argument maps to a positional marker `!i`, each method type
argument to `!!i`, open generic parameters to the same `!i`/`!!i`, and compound
types (generic instances, arrays, byref, pointer) recurse.

This is symmetric by construction:

- open `Box<T>.Store(List<T>)` → param `List<!0>`; constructed `Box<int>.Store(List<int>)`
  → `int` equals declaring arg 0 → `List<!0>`. **Match.**
- open `Box<T>.Store(T)` → `!0`; constructed `Box<int>.Store(1)` → `!0`. **Match.**
- `!0` ≠ `List<!0>`, so the two overloads stay **distinct**.
- generic methods stay intact: open `Echo<T>(T)` → `!!0`; constructed `Echo<int>(1)`
  (member type args `[int]`) → `!!0`. **Match** (#1339 preserved).

`CallerGraphKey` emits the shape instead of `<generic>` and threads the member's
method type arguments. Arity (`parameterTypes.Length`) still participates.

### Tests

- Fixtures: `Box<T>.Store(List<T>)` + a `UseBoxList` caller.
- `BuildCallerTree_WithScope_KeepsSameArityGenericOverloadsDistinct`: rooting at each
  overload reports only its own constructed caller. **Proven non-vacuous** — the old
  arity-only key fails it.
- The existing generic-member test was disambiguated to the `Store(T)` overload.

### Evidence

`ILInspector.Analysis.Tests` 191/191; `dotnet-inspect.Tests` 1378 — no regressions
(#1339 constructed/open matching intact). GPT-5.5 adversarial review requested.

On merge, re-verify #1623 rung 1. Closes #1731.
