### PR TITLE
Gate allocation-hotspot: dedup + loop-only + raised threshold (#1714)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1232,27 +1232,38 @@ public class LibraryBodyIndexTests
             .ToList();
 
     [Fact]
-    public void OptimizationOpportunities_AllocationDenseMethod_IsAllocationHotspot()
+    public void OptimizationOpportunities_AllocationDenseNonLoopMethod_IsNotHotspot()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 
-        // A method that allocates many objects but matches no specific shape still surfaces as
-        // an allocation-hotspot (the count itself is the file-able signal). Not in a loop -> medium.
-        var row = Assert.Single(HotspotRows(index, nameof(OptimizationOpportunityFixtures.AllocatesManyObjects)));
-        Assert.Equal("medium", row.Confidence);
-        Assert.False(row.InLoop);
-        Assert.Contains("heap allocations", row.Evidence);
+        // A dense but NON-loop method is usually intrinsic one-shot construction, not
+        // reducible repeated waste -> no hotspot row (avoids flooding allocation-heavy code).
+        Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.AllocatesManyObjects)));
     }
 
     [Fact]
-    public void OptimizationOpportunities_AllocationDenseLoop_IsHighConfidenceHotspot()
+    public void OptimizationOpportunities_AllocationDenseLoop_IsMediumHotspot()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 
-        // Allocating in a loop is repeated cost -> the hotspot is promoted to high confidence.
+        // Dense allocation inside a loop, matching no specific shape -> a medium hotspot.
         var row = Assert.Single(HotspotRows(index, nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop)));
-        Assert.Equal("high", row.Confidence);
+        Assert.Equal("medium", row.Confidence);
         Assert.True(row.InLoop);
+        Assert.Contains("in a loop", row.Evidence);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_AllocationDenseLoopWithSpecificShape_IsDeduped()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // The method is dense-in-loop but already has a specific (capturing-delegate) row, so
+        // the vague aggregate hotspot row is deduped away.
+        Assert.NotEmpty(index.OptimizationOpportunities.Where(o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.AllocatesDenselyInLoopWithDelegate)
+            && o.Shape == "capturing-delegate"));
+        Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.AllocatesDenselyInLoopWithDelegate)));
     }
 
     [Fact]
@@ -1275,29 +1286,37 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
-    public void OptimizationOpportunities_PseudoExceptionAllocations_AreAllocationHotspot()
+    public void OptimizationOpportunities_PseudoExceptionAllocationsInLoop_AreAllocationHotspot()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
         var signals = index.GetMethodSignals();
 
+        // Pseudo-exceptions (non-Exception types named like exceptions) are real steady-state
+        // allocations and must not be excluded as exception construction.
         var method = Assert.Single(index.Methods.Where(m =>
-            m.Name == nameof(OptimizationOpportunityFixtures.AllocatesManyPseudoExceptions)));
+            m.Name == nameof(OptimizationOpportunityFixtures.AllocatesManyPseudoExceptionsInLoop)));
         Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
-        Assert.True(s.Allocations >= 8, $"expected >= 8 allocations, got {s.Allocations}");
+        Assert.True(s.Allocations >= 16, $"expected >= 16 allocations, got {s.Allocations}");
 
-        var row = Assert.Single(HotspotRows(index, nameof(OptimizationOpportunityFixtures.AllocatesManyPseudoExceptions)));
+        var row = Assert.Single(HotspotRows(index, nameof(OptimizationOpportunityFixtures.AllocatesManyPseudoExceptionsInLoop)));
         Assert.Equal("medium", row.Confidence);
-        Assert.False(row.InLoop);
+        Assert.True(row.InLoop);
     }
 
     [Fact]
-    public void OptimizationOpportunities_PlainObjectAllocations_RemainAllocationHotspot()
+    public void OptimizationOpportunities_PlainObjectAllocationsNonLoop_AreNotHotspot()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+        var signals = index.GetMethodSignals();
 
-        var row = Assert.Single(HotspotRows(index, nameof(OptimizationOpportunityFixtures.AllocatesManyPlainObjects)));
-        Assert.Equal("medium", row.Confidence);
-        Assert.False(row.InLoop);
+        // Plain custom objects are counted as allocations (not excluded), but a non-loop
+        // dense method is no longer flagged as a hotspot.
+        var method = Assert.Single(index.Methods.Where(m =>
+            m.Name == nameof(OptimizationOpportunityFixtures.AllocatesManyPlainObjects)));
+        Assert.True(signals.TryGetValue(method.MetadataToken, out var s));
+        Assert.True(s.Allocations >= 8, $"expected >= 8 allocations, got {s.Allocations}");
+
+        Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.AllocatesManyPlainObjects)));
     }
 
     [Fact]
@@ -1462,17 +1481,17 @@ public class LibraryBodyIndexTests
         Assert.True(Signal(nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop)).AllocInLoop, "alloc-in-loop hot path");
 
         // --- OptimizationOpportunity shapes ---
-        Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.AllocatesManyObjects), "allocation-hotspot"), "allocation-hotspot");
+        Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop), "allocation-hotspot"), "allocation-hotspot");
         Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), "stackalloc-candidate"), "stackalloc-candidate");
         Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.SpanToArrayCopy), "span-to-array-copy"), "span-to-array-copy");
         Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.FirstValueByte), "temporary-byte-array-copy"), "temporary-byte-array-copy");
         Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.BoxesIntoStringFormat), "box-value-type"), "box-value-type");
         Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), "box-value-type"), "box: external well-known value type (Guid)");
 
-        // High-confidence (in-loop) promotion of an allocation hotspot is itself a recalled signal.
+        // A dense in-loop allocation hotspot (matching no specific shape) is recalled at medium.
         Assert.Contains(index.OptimizationOpportunities, o =>
             o.Method.Name == nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop)
-            && o.Shape == "allocation-hotspot" && o.InLoop && o.Confidence == "high");
+            && o.Shape == "allocation-hotspot" && o.InLoop && o.Confidence == "medium");
     }
 
     [Fact]
@@ -2309,20 +2328,39 @@ public class OptimizationOpportunityFixtures
         return items;
     }
 
-    // >= threshold heap allocations with allocations inside a loop -> a high allocation-hotspot.
+    // >= threshold heap allocations inside a loop, matching no specific shape -> a medium
+    // allocation-hotspot (repeated, dense, not otherwise pinpointed).
     public static object AllocatesManyObjectsInLoop(int n)
     {
         var items = new System.Collections.Generic.List<object>();
         for (int i = 0; i < n; i++)
         {
-            items.Add(new object());
-            items.Add(new object());
-            items.Add(new object());
-            items.Add(new object());
-            items.Add(new object());
-            items.Add(new object());
-            items.Add(new object());
-            items.Add(new object());
+            items.Add(new object()); items.Add(new object()); items.Add(new object());
+            items.Add(new object()); items.Add(new object()); items.Add(new object());
+            items.Add(new object()); items.Add(new object()); items.Add(new object());
+            items.Add(new object()); items.Add(new object()); items.Add(new object());
+            items.Add(new object()); items.Add(new object()); items.Add(new object());
+            items.Add(new object()); items.Add(new object()); items.Add(new object());
+        }
+        return items;
+    }
+
+    // Dense allocations inside a loop, but the method ALSO allocates a capturing delegate (a
+    // specific shape). The hotspot row is deduped away so it doesn't double-count the
+    // already-pinpointed method.
+    public static object AllocatesDenselyInLoopWithDelegate(int n)
+    {
+        var items = new System.Collections.Generic.List<object>();
+        System.Func<int> captured = () => n + 1;
+        items.Add(captured());
+        for (int i = 0; i < n; i++)
+        {
+            items.Add(new object()); items.Add(new object()); items.Add(new object());
+            items.Add(new object()); items.Add(new object()); items.Add(new object());
+            items.Add(new object()); items.Add(new object()); items.Add(new object());
+            items.Add(new object()); items.Add(new object()); items.Add(new object());
+            items.Add(new object()); items.Add(new object()); items.Add(new object());
+            items.Add(new object()); items.Add(new object()); items.Add(new object());
         }
         return items;
     }
@@ -2356,6 +2394,24 @@ public class OptimizationOpportunityFixtures
         var a6 = new PseudoException(6);
         var a7 = new PseudoException(7);
         return a0.Value + a1.Value + a2.Value + a3.Value + a4.Value + a5.Value + a6.Value + a7.Value;
+    }
+
+    // Pseudo-exceptions (non-Exception types named like exceptions) are real steady-state
+    // allocations, so a loop densely constructing them is a hotspot (confirms they are not
+    // wrongly excluded as exception construction).
+    public static int AllocatesManyPseudoExceptionsInLoop(int n)
+    {
+        var total = 0;
+        for (int i = 0; i < n; i++)
+        {
+            total += new PseudoException(0).Value + new PseudoException(1).Value + new PseudoException(2).Value
+                + new PseudoException(3).Value + new PseudoException(4).Value + new PseudoException(5).Value
+                + new PseudoException(6).Value + new PseudoException(7).Value + new PseudoException(8).Value
+                + new PseudoException(9).Value + new PseudoException(10).Value + new PseudoException(11).Value
+                + new PseudoException(12).Value + new PseudoException(13).Value + new PseudoException(14).Value
+                + new PseudoException(15).Value + new PseudoException(16).Value + new PseudoException(17).Value;
+        }
+        return total;
     }
 
     public static int AllocatesManyPlainObjects()

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1267,6 +1267,16 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_ValueTypeConstructionInLoop_IsNotHotspot()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // A loop densely constructing VALUE types (Nullable + an in-assembly struct) clears the
+        // >= 16 newobj count but allocates nothing on the heap -> must not be a hotspot.
+        Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.ConstructsManyValueTypesInLoop)));
+    }
+
+    [Fact]
     public void OptimizationOpportunities_LowAllocationMethod_IsNotHotspot()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -2414,6 +2424,28 @@ public class OptimizationOpportunityFixtures
         return total;
     }
 
+    // Densely constructs VALUE types in a loop (Nullable + an in-assembly struct). None of
+    // these `newobj` allocate on the heap, so the method must NOT be an allocation-hotspot
+    // even though it clears the >= 16 newobj count.
+    public static int ConstructsManyValueTypesInLoop(int n)
+    {
+        var total = 0;
+        for (int i = 0; i < n; i++)
+        {
+            System.Nullable<int> n0 = new System.Nullable<int>(0); System.Nullable<int> n1 = new System.Nullable<int>(1);
+            System.Nullable<int> n2 = new System.Nullable<int>(2); System.Nullable<int> n3 = new System.Nullable<int>(3);
+            System.Nullable<int> n4 = new System.Nullable<int>(4); System.Nullable<int> n5 = new System.Nullable<int>(5);
+            System.Nullable<int> n6 = new System.Nullable<int>(6); System.Nullable<int> n7 = new System.Nullable<int>(7);
+            System.Nullable<int> n8 = new System.Nullable<int>(8); System.Nullable<int> n9 = new System.Nullable<int>(9);
+            var p0 = new PlainValue(0); var p1 = new PlainValue(1); var p2 = new PlainValue(2);
+            var p3 = new PlainValue(3); var p4 = new PlainValue(4); var p5 = new PlainValue(5);
+            var p6 = new PlainValue(6); var p7 = new PlainValue(7);
+            total += (n0 ?? 0) + (n1 ?? 0) + (n2 ?? 0) + (n3 ?? 0) + (n4 ?? 0) + (n5 ?? 0) + (n6 ?? 0)
+                + (n7 ?? 0) + (n8 ?? 0) + (n9 ?? 0) + p0.V + p1.V + p2.V + p3.V + p4.V + p5.V + p6.V + p7.V;
+        }
+        return total;
+    }
+
     public static int AllocatesManyPlainObjects()
     {
         var a0 = new PlainObject(0);
@@ -2552,6 +2584,15 @@ public sealed class PlainObject
     public PlainObject(int value) => Value = value;
 
     public int Value { get; }
+}
+
+// An in-assembly value type: `new PlainValue(...)` does not allocate on the heap, so it must
+// not count toward allocation-hotspot density.
+public struct PlainValue
+{
+    public PlainValue(int v) => V = v;
+
+    public int V { get; }
 }
 
 public sealed class FixtureException : Exception

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -74,7 +74,7 @@ public sealed class LibraryBodyIndex
                         var confidence = AdjustDelegateConfidenceForReach(adjusted.Shape, adjusted.InLoop, adjusted.Confidence, reach);
                         return confidence != adjusted.Confidence ? adjusted with { Confidence = confidence } : adjusted;
                     }),
-                    .. AllocationHotspots(reachByToken),
+                    .. AllocationHotspots(reachByToken, new HashSet<int>(_rawOpportunities.Select(o => o.Method.MetadataToken))),
                     .. ScanMethodsInvokedInLoops(reachByToken),
                 ];
             }
@@ -93,14 +93,15 @@ public sealed class LibraryBodyIndex
         return definition.Name.EndsWith("Exception", StringComparison.Ordinal);
     }
 
-    // Methods that allocate heavily but match no specific rewrite shape are the most
-    // commonly-missed real perf issues (e.g. a number parser doing many small allocations).
-    // The steady-state allocation count is itself a file-able signal — "reduce allocations in
-    // this hot method" — so surface allocation-dense methods as their own opportunity, ranked
-    // by the same loop/leverage priority as shaped rows. Exception-construction allocations are
-    // excluded (they only allocate on throw paths, not steady state), and source-/compiler-
-    // generated methods are suppressed just as for shaped opportunities.
-    const int AllocationHotspotThreshold = 8;
+    // A method that allocates densely is a real perf signal only when the allocations are
+    // both REPEATED (in a loop) and not already pinpointed by a specific shape — otherwise
+    // the count is dominated by intrinsic, non-reducible construction (e.g. a serializer
+    // building its output model), which floods the section on allocation-heavy assemblies.
+    // So allocation-hotspot fires only for a method that (1) is not already covered by a
+    // specific-shape row, (2) allocates inside a loop, and (3) clears a high density bar.
+    // Exception-construction allocations are excluded (throw-path only), and source-/
+    // compiler-generated methods are suppressed just as for shaped opportunities.
+    const int AllocationHotspotThreshold = 16;
 
     // A non-loop delegate is allocated once per call, so it is low-value in a cold method —
     // but on a high-reach (widely-reached, hot) method it is a real per-call heap allocation
@@ -120,7 +121,7 @@ public sealed class LibraryBodyIndex
             ? "medium"
             : confidence;
 
-    IEnumerable<OptimizationOpportunity> AllocationHotspots(Dictionary<int, int> reachByToken)
+    IEnumerable<OptimizationOpportunity> AllocationHotspots(Dictionary<int, int> reachByToken, IReadOnlySet<int> methodsWithSpecificShape)
     {
         var methodByToken = new Dictionary<int, MethodIdentity>(Methods.Length);
         foreach (var method in Methods)
@@ -147,20 +148,29 @@ public sealed class LibraryBodyIndex
         {
             if (_suppressedOpportunityTokens.Contains(token))
                 continue;
+            // Dedup: a method already pinpointed by a specific shape (delegate/box/array/…)
+            // doesn't also need a vague aggregate-density row; that only double-counts and
+            // drowns the actionable specific rows.
+            if (methodsWithSpecificShape.Contains(token))
+                continue;
             _bodySignals.TryGetValue(token, out var body);
+            // Only loop allocations are repeated; a once-per-call dense method is usually
+            // intrinsic construction (e.g. building an output object), not reducible waste.
+            bool inLoop = steadyNewobjLoop.Contains(token) || body.AllocInLoop;
+            if (!inLoop)
+                continue;
             int allocations = steadyNewobj.GetValueOrDefault(token) + body.Newarr + body.Boxes;
             if (allocations < AllocationHotspotThreshold)
                 continue;
-            bool inLoop = steadyNewobjLoop.Contains(token) || body.AllocInLoop;
             yield return new OptimizationOpportunity(
                 method,
                 "allocation-hotspot",
-                $"{allocations} heap allocations (newobj/newarr/box)",
-                "Many allocations in one method are often reducible: pool or cache reused objects, use spans/stackalloc for transient buffers, and avoid intermediate collections on hot paths.",
-                inLoop ? "high" : "medium",
-                inLoop,
+                $"{allocations} heap allocations in a loop (newobj/newarr/box)",
+                "Many allocations in one loop are often reducible: pool or cache reused objects, use spans/stackalloc for transient buffers, and avoid intermediate collections on hot paths.",
+                "medium",
+                true,
                 null,
-                "Aggregate allocation density (excludes exception construction); review the method's hot paths.",
+                "Aggregate loop-allocation density (excludes exception construction); some may be intrinsic object construction. Review the loop body for reducible temporaries.",
                 reachByToken.GetValueOrDefault(token));
         }
     }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -23,7 +23,8 @@ public sealed class LibraryBodyIndex
         IReadOnlyDictionary<int, BodySignals> bodySignals,
         IReadOnlyDictionary<(string Namespace, string Name), bool> inAssemblyTypeIsException,
         IReadOnlySet<int> suppressedOpportunityTokens,
-        IReadOnlySet<string> exceptionTypeNames)
+        IReadOnlySet<string> exceptionTypeNames,
+        IReadOnlySet<string> inAssemblyValueTypeNames)
     {
         Path = path;
         Methods = methods;
@@ -38,6 +39,7 @@ public sealed class LibraryBodyIndex
         _inAssemblyTypeIsException = inAssemblyTypeIsException;
         _suppressedOpportunityTokens = suppressedOpportunityTokens;
         _exceptionTypeNames = exceptionTypeNames;
+        _inAssemblyValueTypeNames = inAssemblyValueTypeNames;
     }
 
     public string Path { get; }
@@ -93,6 +95,25 @@ public sealed class LibraryBodyIndex
         return definition.Name.EndsWith("Exception", StringComparison.Ordinal);
     }
 
+    // True when a `newobj` of this type does NOT allocate on the heap: a value type (struct/
+    // enum). The common framework value types constructed in hot loops (Span/ReadOnlySpan/
+    // Memory/Nullable/ValueTuple) are matched by identity; in-assembly structs/enums are
+    // matched via the value-type name set resolved from metadata. Counting these as heap
+    // allocations would inflate allocation-hotspot density (e.g. generated JSON parse loops
+    // are full of ReadOnlySpan<byte>/Nullable<T> constructors that allocate nothing).
+    bool IsNonHeapConstruction(TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+        if (definition.Kind == TypeRefKind.Unsupported)
+            return false;
+        if (definition.Namespace == "System" && definition.Name is
+                "Span`1" or "ReadOnlySpan`1" or "Memory`1" or "ReadOnlyMemory`1" or "Nullable`1"
+                or "ValueTuple" or "ValueTuple`1" or "ValueTuple`2" or "ValueTuple`3" or "ValueTuple`4"
+                or "ValueTuple`5" or "ValueTuple`6" or "ValueTuple`7" or "ValueTuple`8")
+            return true;
+        return _inAssemblyValueTypeNames.Contains(definition.ToQualifiedDisplayString());
+    }
+
     // A method that allocates densely is a real perf signal only when the allocations are
     // both REPEATED (in a loop) and not already pinpointed by a specific shape — otherwise
     // the count is dominated by intrinsic, non-reducible construction (e.g. a serializer
@@ -137,6 +158,11 @@ public sealed class LibraryBodyIndex
                 continue;
             if (call.Callee.Kind != MemberKind.Unsupported
                 && IsExceptionConstruction(call.Callee.DeclaringType))
+                continue;
+            // A `newobj` of a value type (Span/Nullable/ValueTuple/in-assembly struct) does not
+            // allocate on the heap, so it must not count toward allocation density.
+            if (call.Callee.Kind != MemberKind.Unsupported
+                && IsNonHeapConstruction(call.Callee.DeclaringType))
                 continue;
             int token = call.Caller.MetadataToken;
             steadyNewobj[token] = steadyNewobj.GetValueOrDefault(token) + 1;
@@ -382,6 +408,7 @@ public sealed class LibraryBodyIndex
     readonly IReadOnlyDictionary<(string Namespace, string Name), bool> _inAssemblyTypeIsException;
     readonly IReadOnlySet<int> _suppressedOpportunityTokens;
     readonly IReadOnlySet<string> _exceptionTypeNames;
+    readonly IReadOnlySet<string> _inAssemblyValueTypeNames;
 
     /// <summary>
     /// Per-method analysis signals (allocations, copies, unsafe, reflection,
@@ -516,7 +543,8 @@ public sealed class LibraryBodyIndex
         return new LibraryBodyIndex(
             path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
             index.OptimizationOpportunities, index.UnsafeLeverageMethods, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
-            index.BodySignals, index.InAssemblyTypeIsException, index.SuppressedOpportunityTokens, index.ExceptionTypeNames);
+            index.BodySignals, index.InAssemblyTypeIsException, index.SuppressedOpportunityTokens, index.ExceptionTypeNames,
+            index.InAssemblyValueTypeNames);
     }
 
     public ImmutableArray<DirectCall> FindCalls(MemberPattern pattern)
@@ -950,7 +978,7 @@ public sealed class LibraryBodyIndex
                 && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
         }
 
-        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames) Build()
+        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames, IReadOnlySet<string> InAssemblyValueTypeNames) Build()
         {
             var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var unsafeLeverageMethods = ImmutableArray.CreateBuilder<MethodIdentity>();
@@ -961,6 +989,7 @@ public sealed class LibraryBodyIndex
             var bodySignals = new Dictionary<int, BodySignals>();
             var suppressedOpportunityTokens = new HashSet<int>();
             var exceptionTypeNames = ComputeExceptionTypeNames();
+            var inAssemblyValueTypeNames = ComputeInAssemblyValueTypeNames();
             int none = 0, impl = 0, expl = 0;
 
             foreach (var typeHandle in _reader.TypeDefinitions)
@@ -1024,7 +1053,7 @@ public sealed class LibraryBodyIndex
 
             return (methods.ToImmutable(), calls.ToImmutable(), unsafeEvidence.ToImmutable(), diagnostics.ToImmutable(),
                 optimizationOpportunities.ToImmutable(), unsafeLeverageMethods.ToImmutable(), new UnsafeModeBreakdown(none, impl, expl), bodySignals,
-                BuildInAssemblyExceptionMap(), suppressedOpportunityTokens, exceptionTypeNames);
+                BuildInAssemblyExceptionMap(), suppressedOpportunityTokens, exceptionTypeNames, inAssemblyValueTypeNames);
         }
 
         // Classifies in-assembly types by whether they derive from System.Exception,
@@ -1088,6 +1117,26 @@ public sealed class LibraryBodyIndex
                 }
                 return false;
             }
+        }
+
+        // In-assembly value types (struct/enum) by qualified name. A `newobj` of one of these
+        // does NOT allocate on the heap, so it must not be counted toward allocation density.
+        IReadOnlySet<string> ComputeInAssemblyValueTypeNames()
+        {
+            var names = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var typeHandle in _reader.TypeDefinitions)
+            {
+                var baseHandle = _reader.GetTypeDefinition(typeHandle).BaseType;
+                if (baseHandle.Kind != HandleKind.TypeReference)
+                    continue;
+                var baseRef = _reader.GetTypeReference((TypeReferenceHandle)baseHandle);
+                if (_reader.GetString(baseRef.Namespace) == "System"
+                    && _reader.GetString(baseRef.Name) is "ValueType" or "Enum")
+                {
+                    names.Add(TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, typeHandle, 0).ToQualifiedDisplayString());
+                }
+            }
+            return names;
         }
 
         IReadOnlySet<string> ComputeExceptionTypeNames()


### PR DESCRIPTION
## Summary

`allocation-hotspot` was the single largest noise source on allocation-heavy assemblies — **791 rows (69% of output) on the OpenAI SDK**, and 75 on Aspire.Dashboard of which **59% duplicated a specific shape**. The `>=8` catch-all had no actionability filter: it double-counted the specific shapes, drowned the actionable rows, and fired on intrinsic one-shot construction (serializers building their output model — median 12, up to 851 allocations, none reducible).

Per the shape-set review (#1714), tighten the shape so a row means something. It now fires only when a method:

1. is **not already pinpointed by a specific shape** (dedup — stops double-counting/drowning),
2. allocates **inside a loop** (repeated cost, not one-shot intrinsic construction), and
3. clears a **raised density bar** (threshold `8 → 16`).

Confidence is now a flat **medium** (an aggregate-density heuristic, not a specific actionable site), with a caveat noting some density may be intrinsic object construction.

## Evidence (chosen against real corpora)

| DLL | total rows | allocation-hotspot |
| --- | ---: | ---: |
| OpenAI | 1131 → **428** | 791 → **88** (69% → 20% of output) |
| Aspire.Dashboard | 572 → **497** | 75 → **0** |

The surviving 88 OpenAI rows are genuinely dense (≥16) in-loop serializer loops not otherwise covered — an honest "this hot loop allocates heavily" signal. Aspire's 75 (44 redundant + 30 cold one-shots) are gone; the actionable Aspire allocations remain covered by the specific shapes.

## Design note

Pure-serializer assemblies are inherently hard for a static scan: the counted allocations are the constructed output objects (the method's purpose), not reducible waste, and they're hot by nature — so hotness-gating alone can't separate them without dataflow. This PR takes the review's "raise the threshold + require in-loop + dedup" option. A per-assembly **summary** surface (one line: "N allocation-dense methods") is a reasonable further step but needs new output plumbing and has member-scope wrinkles; tracked as a follow-up on #1623.

## Tests

- `ILInspector.Analysis.Tests`: 191 — fixtures/tests reworked for the loop-only + dedup + threshold-16 semantics (dense-in-loop → medium; non-loop dense → not flagged; dense-in-loop-with-a-specific-shape → deduped; pseudo-exceptions-in-loop still counted). The #1623 rung-3 recall guard was updated to recall the in-loop hotspot at medium.
- `dotnet-inspect.Tests`: 1378 green.

Refs #1714, #1623.
