### PR TITLE
Pin the #1710 switch-store fold into the always-run fidelity gate

### DIFF
--- a/.review-fixtures/Fixture.cs
+++ b/.review-fixtures/Fixture.cs
@@ -1,0 +1,25 @@
+using System;
+
+public class Fixture
+{
+    int _counter;
+    int Next => _counter++;
+
+    public int SwitchStorePropertySelector(int n)
+    {
+        int x = -1;
+        switch (Next)
+        {
+            case 0:
+                x = x + Next;
+                break;
+            case 1:
+                x = x + Next;
+                break;
+            default:
+                x = x + Next;
+                break;
+        }
+        return x + Next;
+    }
+}

--- a/.review-fixtures/FixtureLib/Class1.cs
+++ b/.review-fixtures/FixtureLib/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace FixtureLib;
+
+public class Class1
+{
+
+}

--- a/.review-fixtures/FixtureLib/Fixture.cs
+++ b/.review-fixtures/FixtureLib/Fixture.cs
@@ -1,0 +1,25 @@
+using System;
+
+public class Fixture
+{
+    int _counter;
+    int Next => _counter++;
+
+    public int SwitchStorePropertySelector(int n)
+    {
+        int x = -1;
+        switch (Next)
+        {
+            case 0:
+                x = x + Next;
+                break;
+            case 1:
+                x = x + Next;
+                break;
+            default:
+                x = x + Next;
+                break;
+        }
+        return x + Next;
+    }
+}

--- a/.review-fixtures/FixtureLib/FixtureLib.csproj
+++ b/.review-fixtures/FixtureLib/FixtureLib.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net11.0</TargetFramework>
+    <Optimize>true</Optimize>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -3786,6 +3786,29 @@ public class CfgSampleClass
         }
         return true;
     }
+
+    // #1710 / ConditionalStoreChainPass: a compare-chain switch that assigns a
+    // local in each arm, followed by a non-duplicable continuation that uses it.
+    // The pass folds the dispatch into a nested conditional store
+    // (weight = sel == 0 ? 11 : (sel == 1 ? 22 : 33)) so the method structures.
+    // Self-contained (no LINQ/lambda) so the fidelity harness compiles it back;
+    // it is a known opcode-diff (the ternary re-lowers differently than per-arm
+    // stores), pinned so a regression to RecompileFail or a worse shape is caught
+    // by the always-run fidelity gate, not left to the sampled corpus.
+    public static int SwitchStoreThenUse(int sel, int[] data)
+    {
+        int weight;
+        switch (sel)
+        {
+            case 0: weight = 11; break;
+            case 1: weight = 22; break;
+            default: weight = 33; break;
+        }
+        int acc = 0;
+        for (int i = 0; i < data.Length; i++)
+            acc += data[i] * weight;
+        return acc;
+    }
 }
 
 internal static class AwaitOrderingHelpers

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -89,6 +89,14 @@ public class FidelityGateTests
         // they are not docketed.
         "OrBoolIntMix",
         "OrBoolUintMix",
+        // SwitchStoreThenUse is the #1710 ConditionalStoreChainPass fold: a
+        // compare-chain switch assigning a local folds to a nested conditional
+        // store, which csc re-lowers differently than the original per-arm stores
+        // (push-then-store-once vs store-per-arm) — valid C#, not opcode-exact.
+        // Pinned here (plus SwitchStoreFold_StaysCompileBackCheckable) so the fold
+        // is compile-back-checked on every fidelity-gate run rather than left to
+        // the sampled corpus.
+        "SwitchStoreThenUse",
     };
 
     /// <summary>
@@ -263,5 +271,32 @@ public class FidelityGateTests
                     $"{method} regressed to {result.Status}: a prior fidelity check fix no longer holds.\n" +
                     $"  original : {result.OriginalOpcodes}\n  recompiled: {result.RecompiledOpcodes}");
         }
+    }
+
+    /// <summary>
+    /// The #1710 switch-store fold (<c>ConditionalStoreChainPass</c>) recovers an
+    /// intentional opcode-diff (the nested ternary re-lowers differently), so it
+    /// cannot be pinned exact. But its danger mode is a <em>silent</em> regression
+    /// that produces uncompilable output: that would drop it out of the opcode-diff
+    /// set, so <see cref="NoNewOpcodeDiffsBeyondKnownDocket"/> would not catch it.
+    /// Pin that the fold's fixture stays compile-back-<em>checkable</em> — rendered
+    /// and recompilable (<c>Exact</c> or <c>OpcodeDiff</c>), never
+    /// <c>RecompileFail</c>/<c>ContextFail</c> — so a regression that breaks
+    /// recompilation fails the always-run fidelity gate rather than only the
+    /// sampled corpus.
+    /// </summary>
+    [Fact]
+    public void SwitchStoreFold_StaysCompileBackCheckable()
+    {
+        var matches = EvaluateFixtures().Where(r => r.Method == "SwitchStoreThenUse").ToList();
+
+        Assert.True(matches.Count > 0,
+            "Expected the fidelity check to render SwitchStoreThenUse, but it was not evaluated.");
+        foreach (var result in matches)
+            Assert.True(
+                result.Status is FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff,
+                $"SwitchStoreThenUse regressed to {result.Status}: the switch-store fold (#1710) no longer "
+                    + "recompiles. Its decompiled C# must stay recompilable.\n"
+                    + $"  original : {result.OriginalOpcodes}\n  recompiled: {result.RecompiledOpcodes}");
     }
 }


### PR DESCRIPTION
## Summary

Closes the detection gap identified while auditing the daily decompiler safety net for the #1710 switch-store fold (`ConditionalStoreChainPass`, merged in #1729).

**The gap:** the daily corpus sensor opcode-checks only ~36 of ~88,000 methods (`--corpus-fidelity-cap 3` per assembly). The fold changes 4 methods, so they are very unlikely to be sampled — a silent regression that broke the fold's recompilation would not be caught daily.

**The fix:** move the fold's shape from *corpus-sampled* to *always-checked* in the fidelity gate (runs on every PR and in the daily).

- Add a self-contained `SwitchStoreThenUse` fixture to `CfgSampleClass`: a compare-chain switch assigning a local, then a non-duplicable `for`-loop continuation that uses it — so the fold fires and the body compiles back without cross-assembly deps. It decompiles to `int weight = sel == 0 ? 11 : (sel == 1 ? 22 : 33);` + a structured loop. It is an intentional opcode-diff (the ternary re-lowers differently than per-arm stores), so it joins `KnownDiffs`.
- Add `SwitchStoreFold_StaysCompileBackCheckable`. The fold's danger mode is a *silent* regression to uncompilable output — which would drop the method out of the opcode-diff set and slip past `NoNewOpcodeDiffsBeyondKnownDocket`. This test pins that the fixture stays compile-back-**checkable** (`Exact` or `OpcodeDiff`, never `RecompileFail`/`ContextFail`), so a recompilation regression fails the always-run gate, not only the sampled corpus.

## Why this matters

For a structuring/raise change, the scariest failure mode is "valid but wrong / no longer compiles" on a small method set. The corpus sample doesn't reliably cover 4 methods; this makes the fold's recompilability a hard, every-run assertion.

## Evidence

```text
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.FidelityGateTests
  Total: 3, 0 failed
  (NoNewOpcodeDiffsBeyondKnownDocket, PinnedFixesStayOpcodeExact, SwitchStoreFold_StaysCompileBackCheckable)
```

Verified the gate has teeth: before docketing, `NoNewOpcodeDiffsBeyondKnownDocket` failed with "New fidelity check opcode diffs: SwitchStoreThenUse" — confirming the method is genuinely evaluated every run.

Refs #1710, #1729.
