### PR TITLE
Include parameter-type assembly identity in caller-graph keys (#1741)

### DIFF
--- a/src/DiffAsmFixtures.Caller/DiffAsmFixtures.Caller.csproj
+++ b/src/DiffAsmFixtures.Caller/DiffAsmFixtures.Caller.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>DiffAsmCaller</AssemblyName>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DiffAsmFixtures.Target\DiffAsmFixtures.Target.csproj" />
+    <ProjectReference Include="..\DiffAsmFixtures.LibA\DiffAsmFixtures.LibA.csproj"><Aliases>LibA</Aliases></ProjectReference>
+    <ProjectReference Include="..\DiffAsmFixtures.LibB\DiffAsmFixtures.LibB.csproj"><Aliases>LibB</Aliases></ProjectReference>
+  </ItemGroup>
+</Project>

--- a/src/DiffAsmFixtures.Caller/Use.cs
+++ b/src/DiffAsmFixtures.Caller/Use.cs
@@ -1,0 +1,12 @@
+extern alias LibA;
+extern alias LibB;
+
+namespace DiffAsmCaller
+{
+    public static class Use
+    {
+        public static void UseA() => DiffAsmTarget.Api.Ping(new LibA::Shared.Token());
+
+        public static void UseB() => DiffAsmTarget.Api.Ping(new LibB::Shared.Token());
+    }
+}

--- a/src/DiffAsmFixtures.LibA/DiffAsmFixtures.LibA.csproj
+++ b/src/DiffAsmFixtures.LibA/DiffAsmFixtures.LibA.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>DiffAsmLibA</AssemblyName>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/DiffAsmFixtures.LibA/Token.cs
+++ b/src/DiffAsmFixtures.LibA/Token.cs
@@ -1,0 +1,5 @@
+// libA
+namespace Shared
+{
+    public sealed class Token { }
+}

--- a/src/DiffAsmFixtures.LibB/DiffAsmFixtures.LibB.csproj
+++ b/src/DiffAsmFixtures.LibB/DiffAsmFixtures.LibB.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>DiffAsmLibB</AssemblyName>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/DiffAsmFixtures.LibB/Token.cs
+++ b/src/DiffAsmFixtures.LibB/Token.cs
@@ -1,0 +1,5 @@
+// libB
+namespace Shared
+{
+    public sealed class Token { }
+}

--- a/src/DiffAsmFixtures.Target/Api.cs
+++ b/src/DiffAsmFixtures.Target/Api.cs
@@ -1,0 +1,19 @@
+extern alias LibA;
+extern alias LibB;
+
+// #1741: two overloads whose parameter types share the FQN Shared.Token but come from
+// different assemblies (LibA vs LibB). The cross-assembly caller graph must keep them
+// distinct, which requires parameter-type assembly identity in the key.
+namespace DiffAsmTarget
+{
+    public static class Api
+    {
+        public static void Ping(LibA::Shared.Token value)
+        {
+        }
+
+        public static void Ping(LibB::Shared.Token value)
+        {
+        }
+    }
+}

--- a/src/DiffAsmFixtures.Target/DiffAsmFixtures.Target.csproj
+++ b/src/DiffAsmFixtures.Target/DiffAsmFixtures.Target.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <AssemblyName>DiffAsmTarget</AssemblyName>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DiffAsmFixtures.LibA\DiffAsmFixtures.LibA.csproj"><Aliases>LibA</Aliases></ProjectReference>
+    <ProjectReference Include="..\DiffAsmFixtures.LibB\DiffAsmFixtures.LibB.csproj"><Aliases>LibB</Aliases></ProjectReference>
+  </ItemGroup>
+</Project>

--- a/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
+++ b/src/ILInspector.Analysis.CallerGraphCaller/SharedEntry.cs
@@ -24,6 +24,10 @@ namespace Shared
         // caller graph rooted at Store(List<T>) must report this and not UseBox.
         public static void UseBoxList() => new Target.Box<int>().Store(new System.Collections.Generic.List<int>());
 
+        // #1741 (review): calls Store on the different-arity Box<int, string> (Box`2). A
+        // caller graph rooted at Box`1.Store must not report this, and vice versa.
+        public static void UseBox2() => new Target.Box<int, string>().Store(1);
+
         public static void UseEcho() => Target.GenericApi.Echo(1);
     }
 }

--- a/src/ILInspector.Analysis.CallerGraphTarget/TargetApi.cs
+++ b/src/ILInspector.Analysis.CallerGraphTarget/TargetApi.cs
@@ -40,6 +40,16 @@ namespace Target
         }
     }
 
+    // #1741 (review): a different-arity generic type with the SAME simple name (Box`2)
+    // and a same-name/same-arity method. The declaring-type portion of the caller-graph
+    // key must preserve generic arity so Box`1.Store and Box`2.Store stay distinct.
+    public sealed class Box<T1, T2>
+    {
+        public void Store(T1 value)
+        {
+        }
+    }
+
     // Generic method on a non-generic type: a caller invokes Echo<int>, a MethodSpec keyed on
     // the instantiation, which must match the open Echo<T>(T) target.
     public static class GenericApi

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -30,6 +30,8 @@
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCaller\ILInspector.Analysis.CallerGraphCaller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCallerTwin\ILInspector.Analysis.CallerGraphCallerTwin.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphLookalikeCaller\ILInspector.Analysis.CallerGraphLookalikeCaller.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\DiffAsmFixtures.Target\DiffAsmFixtures.Target.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\DiffAsmFixtures.Caller\DiffAsmFixtures.Caller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
   </ItemGroup>
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -341,6 +341,58 @@ public class LibraryBodyIndexTests
         return path;
     }
 
+    static string NamedFixturePath(string projectName, string assemblyName)
+    {
+        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string path = Path.GetFullPath(Path.Combine(
+            outputDirectory.FullName,
+            "..",
+            "..",
+            projectName,
+            outputDirectory.Name,
+            assemblyName + ".dll"));
+        Assert.True(File.Exists(path), $"Expected fixture assembly at {path}");
+        return path;
+    }
+
+    // #1741: two Ping overloads whose parameter types share the FQN Shared.Token but come
+    // from different assemblies (DiffAsmLibA vs DiffAsmLibB). The cross-assembly caller
+    // graph must keep them distinct — rooting at one overload reports only its own caller.
+    // The prior key rendered parameter types with ToQualifiedDisplayString(), which omits
+    // assembly, so both collapsed and cross-linked the callers (de-verified #1623 rung 1).
+    [Fact]
+    public void BuildCallerTree_WithScope_KeepsSameFqnParametersFromDifferentAssembliesDistinct()
+    {
+        var target = LibraryBodyIndex.Open(NamedFixturePath("DiffAsmFixtures.Target", "DiffAsmTarget"));
+        var caller = LibraryBodyIndex.Open(NamedFixturePath("DiffAsmFixtures.Caller", "DiffAsmCaller"));
+
+        var pingA = target.Methods.First(method =>
+            method.Name == "Ping" && method.ParameterTypes[0].Assembly == "DiffAsmLibA");
+        var pingB = target.Methods.First(method =>
+            method.Name == "Ping" && method.ParameterTypes[0].Assembly == "DiffAsmLibB");
+
+        var aCallers = target.BuildCallerTree(pingA.MetadataToken, new[] { caller }, maxDepth: 2, maxNodes: 50)
+            .Children.Select(child => child.Member.Name).ToList();
+        var bCallers = target.BuildCallerTree(pingB.MetadataToken, new[] { caller }, maxDepth: 2, maxNodes: 50)
+            .Children.Select(child => child.Member.Name).ToList();
+
+        Assert.Contains("UseA", aCallers);
+        Assert.DoesNotContain("UseB", aCallers);
+        Assert.Contains("UseB", bCallers);
+        Assert.DoesNotContain("UseA", bCallers);
+    }
+
+    // #1741 (unit): the key fragment for a type includes its assembly, so same-FQN types
+    // from different assemblies do not collapse.
+    [Fact]
+    public void KeyFragment_QualifiesNamedTypeByAssembly()
+    {
+        var tokenA = TypeRef.Definition("LibA", "Shared", "Token");
+        var tokenB = TypeRef.Definition("LibB", "Shared", "Token");
+
+        Assert.NotEqual(GenericMemberIdentity.KeyFragment(tokenA), GenericMemberIdentity.KeyFragment(tokenB));
+    }
+
     [Fact]
     public void TopLeverage_RanksMostCalledMethodFirst()
     {

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -240,6 +240,32 @@ public class LibraryBodyIndexTests
         Assert.DoesNotContain("UseBox", listCallers);
     }
 
+    // #1741 (review): Box<T> (Box`1) and Box<T1,T2> (Box`2) share a simple name but have
+    // different generic arity, each with a same-name/same-arity Store. The declaring-type
+    // portion of the caller-graph key must preserve arity so the two Stores stay distinct.
+    [Fact]
+    public void BuildCallerTree_WithScope_KeepsSameNameGenericTypesOfDifferentArityDistinct()
+    {
+        var targetIndex = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphTarget"));
+        var caller = LibraryBodyIndex.Open(CallerGraphFixturePath("ILInspector.Analysis.CallerGraphCaller"));
+
+        var box1Store = targetIndex.Methods.First(method =>
+            method.DeclaringType.Name == "Box`1" && method.Name == "Store"
+            && method.ParameterTypes[0].Kind == TypeRefKind.GenericParameter);
+        var box2Store = targetIndex.Methods.First(method =>
+            method.DeclaringType.Name == "Box`2" && method.Name == "Store");
+
+        var box1Callers = targetIndex.BuildCallerTree(box1Store.MetadataToken, new[] { caller }, maxDepth: 2, maxNodes: 50)
+            .Children.Select(child => child.Member.Name).ToList();
+        var box2Callers = targetIndex.BuildCallerTree(box2Store.MetadataToken, new[] { caller }, maxDepth: 2, maxNodes: 50)
+            .Children.Select(child => child.Member.Name).ToList();
+
+        Assert.Contains("UseBox", box1Callers);
+        Assert.DoesNotContain("UseBox2", box1Callers);
+        Assert.Contains("UseBox2", box2Callers);
+        Assert.DoesNotContain("UseBox", box2Callers);
+    }
+
     // #1731 (adversarial review): the cross-assembly caller-graph shape keys on the OPEN
     // signature (VAR/MVAR markers), not the substituted concrete types. A constructed
     // Box<int>.Store(T) call carries a concrete int as its instantiated parameter, but the

--- a/src/ILInspector.Analysis/GenericMemberIdentity.cs
+++ b/src/ILInspector.Analysis/GenericMemberIdentity.cs
@@ -93,22 +93,32 @@ public static class GenericMemberIdentity
     /// parameter count.
     /// </summary>
     public static string ErasedParameterShape(ImmutableArray<TypeRef> openParameterTypes)
-        => string.Join(",", openParameterTypes.Select(NormalizeShape));
+        => string.Join(",", openParameterTypes.Select(KeyFragment));
 
-    static string NormalizeShape(TypeRef type) => type.Kind switch
+    /// <summary>
+    /// An assembly-qualified, cross-assembly-stable key fragment for a type. Generic
+    /// parameters render as <c>!i</c>/<c>!!i</c>; generic instances and
+    /// array/byref/pointer wrappers recurse; a named type renders as
+    /// <c>assembly|namespace.name</c>. Including the assembly keeps same-FQN types from
+    /// different assemblies distinct in string keys (<see cref="TypeRef.Equals"/> already
+    /// distinguishes them, but the display strings did not) (#1741), and the namespace
+    /// keeps same-name types from different namespaces distinct (#1731).
+    /// </summary>
+    public static string KeyFragment(TypeRef type) => type.Kind switch
     {
         TypeRefKind.GenericParameter => $"!{type.GenericParameterIndex}",
         TypeRefKind.MethodGenericParameter => $"!!{type.GenericParameterIndex}",
         TypeRefKind.GenericInstance when type.ElementType is { } definition
-            => $"{definition.ToQualifiedDisplayString()}<{string.Join(",", type.TypeArguments.Select(NormalizeShape))}>",
+            => $"{KeyFragment(definition)}<{string.Join(",", type.TypeArguments.Select(KeyFragment))}>",
         TypeRefKind.SzArray when type.ElementType is { } element
-            => $"{NormalizeShape(element)}[]",
+            => $"{KeyFragment(element)}[]",
         TypeRefKind.Array when type.ElementType is { } element
-            => $"{NormalizeShape(element)}[{new string(',', type.Rank > 0 ? type.Rank - 1 : 0)}]",
+            => $"{KeyFragment(element)}[{new string(',', type.Rank > 0 ? type.Rank - 1 : 0)}]",
         TypeRefKind.ByRef when type.ElementType is { } element
-            => $"ref {NormalizeShape(element)}",
+            => $"ref {KeyFragment(element)}",
         TypeRefKind.Pointer when type.ElementType is { } element
-            => $"{NormalizeShape(element)}*",
+            => $"{KeyFragment(element)}*",
+        TypeRefKind.Definition => $"{type.Assembly}|{type.Namespace}.{type.Name}",
         _ => type.ToQualifiedDisplayString(),
     };
 }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -896,15 +896,15 @@ public sealed class LibraryBodyIndex
             member.Name,
             member.ParameterTypes,
             member.OpenSignatureParameters,
-            member.ReturnType,
+            member.OpenSignatureReturn,
             GenericMemberIdentity.ShouldErase(member.DeclaringType, member.ParameterTypes, member.ReturnType, member.TypeArguments));
 
-    static string CallerGraphKey(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes, ImmutableArray<TypeRef> openParameterTypes, TypeRef returnType, bool eraseGenericSignature)
+    static string CallerGraphKey(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes, ImmutableArray<TypeRef> openParameterTypes, TypeRef openReturnType, bool eraseGenericSignature)
     {
         var openDeclaring = GenericMemberIdentity.OpenDeclaringType(declaringType);
         return eraseGenericSignature
-            ? $"{openDeclaring.Assembly}|{openDeclaring.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{GenericMemberIdentity.ErasedParameterShape(openParameterTypes)}"
-            : $"{openDeclaring.Assembly}|{openDeclaring.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{string.Join(",", parameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(returnType)}";
+            ? $"{GenericMemberIdentity.KeyFragment(openDeclaring)}|{name}|{parameterTypes.Length}|{GenericMemberIdentity.ErasedParameterShape(openParameterTypes)}|{GenericMemberIdentity.KeyFragment(openReturnType)}"
+            : $"{GenericMemberIdentity.KeyFragment(openDeclaring)}|{name}|{parameterTypes.Length}|{string.Join(",", parameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(openReturnType)}";
     }
 
     sealed class IndexBuilder

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -904,7 +904,7 @@ public sealed class LibraryBodyIndex
         var openDeclaring = GenericMemberIdentity.OpenDeclaringType(declaringType);
         return eraseGenericSignature
             ? $"{openDeclaring.Assembly}|{openDeclaring.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{GenericMemberIdentity.ErasedParameterShape(openParameterTypes)}"
-            : $"{openDeclaring.Assembly}|{openDeclaring.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{string.Join(",", parameterTypes.Select(type => type.ToQualifiedDisplayString()))}|{returnType.ToQualifiedDisplayString()}";
+            : $"{openDeclaring.Assembly}|{openDeclaring.ToQualifiedDisplayString()}|{name}|{parameterTypes.Length}|{string.Join(",", parameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(returnType)}";
     }
 
     sealed class IndexBuilder

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -93,6 +93,16 @@ public sealed record MemberRef(
     public ImmutableArray<TypeRef> OpenSignatureParameters
         => OpenParameterTypes.IsDefaultOrEmpty ? ParameterTypes : OpenParameterTypes;
 
+    /// <summary>
+    /// The return type with generic markers preserved (before instantiation), for the
+    /// same cross-assembly keying reason as <see cref="OpenParameterTypes"/> (#1741).
+    /// Null when not separately captured, in which case <see cref="OpenSignatureReturn"/>
+    /// falls back to <see cref="ReturnType"/>.
+    /// </summary>
+    public TypeRef? OpenReturnType { get; init; }
+
+    public TypeRef OpenSignatureReturn => OpenReturnType ?? ReturnType;
+
     public static MemberRef Unsupported(string reason)
         => new(TypeRef.Unsupported(reason), "?", [], TypeRef.Unsupported("unknown return"), MemberKind.Unsupported);
 }

--- a/src/ILInspector.Analysis/MemberResolver.cs
+++ b/src/ILInspector.Analysis/MemberResolver.cs
@@ -23,6 +23,7 @@ internal static class MemberResolver
                 return new MemberRef(declaring, name, signature.ParameterTypes, signature.ReturnType, KindFor(name))
                 {
                     OpenParameterTypes = signature.ParameterTypes,
+                    OpenReturnType = signature.ReturnType,
                 };
             }
             case HandleKind.MemberReference:
@@ -41,6 +42,7 @@ internal static class MemberResolver
                 {
                     // Raw signature with VAR/MVAR markers, before instantiation (#1731).
                     OpenParameterTypes = signature.ParameterTypes,
+                    OpenReturnType = signature.ReturnType,
                 };
             }
             case HandleKind.MethodSpecification:
@@ -53,8 +55,9 @@ internal static class MemberResolver
                     TypeArguments = methodArguments,
                     ReturnType = generic.ReturnType.Instantiate([], methodArguments),
                     ParameterTypes = [.. generic.ParameterTypes.Select(p => p.Instantiate([], methodArguments))],
-                    // OpenParameterTypes is inherited from `generic` (raw markers), not
-                    // instantiated, so the open generic-method shape is preserved (#1731).
+                    // OpenParameterTypes / OpenReturnType are inherited from `generic` (raw
+                    // markers), not instantiated, so the open generic-method shape is
+                    // preserved (#1731, #1741).
                 };
             }
             default:


### PR DESCRIPTION
## #1741 — caller-graph keys omitted parameter-type assembly identity (de-verified #1623 rung 1, again)

The cross-assembly caller-graph key rendered parameter (and return) types with
`TypeRef.ToQualifiedDisplayString()`, which omits the assembly. Two overloads whose
parameter types share an FQN but come from different assemblies —
`Ping(LibA::Shared.Token)` vs `Ping(LibB::Shared.Token)` — collapsed onto one key, so
rooting the caller graph at either reported **both** callers. Independent of the
#1731 generic shape; it affects **non-generic** overloads too.

### Fix

`GenericMemberIdentity.KeyFragment(TypeRef)` — an assembly-qualified, cross-assembly-
stable type key fragment:

- generic parameters → `!i` / `!!i`;
- a named type → `assembly|namespace.name`;
- generic instances / arrays / byref / pointer recurse.

`CallerGraphKey` uses it for params **and** return in both the erased (generic) and
non-erased branches, so non-generic overloads are fixed too. `TypeRef.Equals` already
distinguished assembly; the string key now does as well. (`TypeRef.Assembly` is
canonicalized — facades → `corelib` — so a framework param keys identically from the
open target and the constructed call site.)

### Tests

- **End-to-end** extern-alias fixtures: `DiffAsmFixtures.LibA`/`LibB` (same
  `Shared.Token` FQN), `Target` (the two overloads), `Caller`. Guard
  `BuildCallerTree_WithScope_KeepsSameFqnParametersFromDifferentAssembliesDistinct` —
  each overload reports only its own caller.
- **Unit** `KeyFragment_QualifiesNamedTypeByAssembly`.
- Both **proven non-vacuous** — dropping the assembly qualification fails both.

### Evidence

`ILInspector.Analysis.Tests` 195/195; `dotnet-inspect.Tests` 1378 — no regressions
(#1731 / #1339 constructed-open matching intact). Dual adversarial review (GPT-5.5 +
MAI) requested, focused on open/constructed symmetry (false-split risk).

Closes #1741. Re-verify #1623 rung 1 on merge.
