### PR TITLE
Suppress throw-path boxes from box-value-type (#1714)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1413,6 +1413,16 @@ public class LibraryBodyIndexTests
         Assert.False(row.InLoop);
     }
 
+    [Fact]
+    public void OptimizationOpportunities_BoxFeedingThrow_IsNotBoxValueType()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // A value boxed into an exception message that is thrown is an error-path allocation,
+        // not steady-state pay-dirt, so it is suppressed (not just demoted off the loop bit).
+        Assert.Empty(BoxRows(index, nameof(OptimizationOpportunityFixtures.ThrowsWithBoxedValue)));
+    }
+
     [Theory]
     [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue))]
     [InlineData(nameof(OptimizationOpportunityFixtures.BoxesDateTimeValue))]
@@ -1676,15 +1686,14 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
-    public void OptimizationOpportunities_BoxOnThrowPathInLoop_NotPromoted()
+    public void OptimizationOpportunities_BoxOnThrowPathInLoop_IsSuppressed()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 
-        // A box that feeds an exception message only allocates on the throw path, so even inside
-        // a loop it is not hot pay-dirt: reported, but medium and not loop-promoted.
-        var row = Assert.Single(BoxRows(index, nameof(OptimizationOpportunityFixtures.BoxesIntoThrowMessage)));
-        Assert.Equal("medium", row.Confidence);
-        Assert.False(row.InLoop);
+        // A box that feeds an exception message only allocates on the throw path, so it is not
+        // steady-state pay-dirt even inside a loop -> suppressed entirely (the throw-probe now
+        // gates emission, not just the loop bit).
+        Assert.Empty(BoxRows(index, nameof(OptimizationOpportunityFixtures.BoxesIntoThrowMessage)));
     }
 
     [Fact]
@@ -2301,6 +2310,17 @@ public class OptimizationOpportunityFixtures
     public static string BoxesIntoStringFormat(int value)
     {
         return string.Format("v={0}", value);
+    }
+
+    // Boxes a value into an exception message that is thrown immediately. The box is an
+    // error-path allocation (executes at most once before unwinding), so it must NOT be
+    // flagged as a box-value-type opportunity.
+    public static void ThrowsWithBoxedValue(int value)
+    {
+        if (value < 0)
+        {
+            throw new System.ArgumentException(string.Format("bad {0}", value));
+        }
     }
 
     // Boxes a value type per iteration into a non-generic collection -> in a loop (high).

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1605,13 +1605,18 @@ public sealed class LibraryBodyIndex
                         // unconditionally-allocating value type. Escape is decided at the
                         // consumer below.
                         var allocating = IsAllocatingValueTypeBox(token, boxed);
-                        pendingBoxOffset = allocating ? offset : null;
-                        pendingBoxType = allocating ? boxed : null;
-                        // A box on a throw path executes at most once before unwinding, so it is
-                        // not a repeated/hot allocation even inside a loop region.
-                        pendingBoxInLoop = allocating
-                            && IsInLoopRegion(offset, loopRegions)
-                            && !BoxFeedsThrowSoon(il, position);
+                        // A box that flows into a throw within a few instructions is an
+                        // error-path allocation (an exception message: `throw new
+                        // ArgumentException($"bad {x}")` lowers to box; Format; newobj; throw).
+                        // It executes at most once before unwinding, not in steady state, so it
+                        // is not pay-dirt — suppress it entirely (mirrors excluding exception
+                        // construction from allocation density), not merely demote it off the
+                        // hot-loop bit.
+                        var feedsThrow = allocating && BoxFeedsThrowSoon(il, position);
+                        pendingBoxOffset = allocating && !feedsThrow ? offset : null;
+                        pendingBoxType = allocating && !feedsThrow ? boxed : null;
+                        pendingBoxInLoop = pendingBoxOffset is not null
+                            && IsInLoopRegion(offset, loopRegions);
                         break;
                     }
                     default:


### PR DESCRIPTION
## Summary

The shape-set review (#1714) found a real `box-value-type` false positive: a value boxed into an exception message — `throw new ArgumentException(string.Format("bad {0}", x))` lowers to `box; Format; newobj; throw` — was still emitted at medium, because `BoxFeedsThrowSoon` only gated the loop-promotion bit (`pendingBoxInLoop`), not emission, and was only evaluated when already in a loop region.

A box that flows into a throw within a few instructions is an **error-path allocation**: it executes at most once before unwinding, not in steady state, so it isn't pay-dirt (the same reason exception construction is excluded from allocation density). The throw-probe now gates **emission** — when a box feeds a throw soon, no pending box is set, so no row is emitted (loop or not).

## Impact

- **System.Text.Json: box-value-type 58 → 51** (7 throw-path `ThrowHelper`-style FPs removed).
- **Aspire.Dashboard: unchanged** — modern interpolated exception messages use the generic `DefaultInterpolatedStringHandler` and don't box; the FP is specific to `string.Format` / explicit `object`-param throws.

## Tests

- A non-loop (`ThrowsWithBoxedValue`) and an in-loop (`BoxesIntoThrowMessage`) throw-path box fixture both assert **no** `box-value-type` row (the prior 'reported but not loop-promoted' assertion is updated to 'suppressed'). `BoxesIntoStringFormat` (a non-throw box) still emits, confirming normal boxes are unaffected.
- `ILInspector.Analysis.Tests` 196; `dotnet-inspect.Tests` 1378 — green.

Refs #1714, #1623.