### PR TITLE
Add generated decompiler fixture catalogue

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1,0 +1,77 @@
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// The seed generated-fixture catalogue for #1742: compile small source-shape
+/// entries into a temporary library, run the existing compile-back oracle, and
+/// report by stable fixture ID instead of only by metadata method name.
+/// </summary>
+[Trait("Speed", "Slow")]
+public class GeneratedFixtureCatalogTests
+{
+    [Fact]
+    public void MinimalCompileBackRungs_ReportExpectedOutcomesByFixtureId()
+    {
+        var run = GeneratedFixtureRunner.Run(GeneratedFixtureCatalog.MinimalCompileBackRungs);
+        string report = GeneratedFixtureRunner.FormatReport(run);
+
+        Assert.True(run.Passed, report);
+
+        AssertTarget(
+            run,
+            "minimal.property.literal",
+            "GeneratedFixtures.MinimalPropertyLiteral.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.property.literal",
+            "GeneratedFixtures.MinimalPropertyLiteral.Class1",
+            "get_Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+
+        AssertTarget(
+            run,
+            "minimal.primary-ctor.field-init",
+            "GeneratedFixtures.MinimalPrimaryCtorFieldInit.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.OpcodeDiff,
+            frontier: true);
+        AssertTarget(
+            run,
+            "minimal.primary-ctor.field-init",
+            "GeneratedFixtures.MinimalPrimaryCtorFieldInit.Class1",
+            "get_Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+
+        Assert.Contains("minimal.property.literal", report);
+        Assert.Contains("minimal.primary-ctor.field-init", report);
+        Assert.Contains("PASS frontier", report);
+        Assert.Contains("decompiler=Full", report);
+        Assert.Contains("compile-back=OpcodeDiff", report);
+    }
+
+    static void AssertTarget(
+        GeneratedFixtureRunResult run,
+        string fixtureId,
+        string type,
+        string method,
+        FidelityCheck.CompileBackStatus expectedStatus,
+        bool frontier)
+    {
+        var result = Assert.Single(run.Results, r =>
+            r.FixtureId == fixtureId &&
+            r.Type == type &&
+            r.Method == method);
+
+        Assert.Equal(expectedStatus, result.ExpectedStatus);
+        Assert.Equal(expectedStatus, result.ActualStatus);
+        Assert.Equal(frontier, result.IsFrontier);
+        Assert.Equal("Full", result.DecompilerFidelity);
+        Assert.True(result.Passed);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -55,6 +55,8 @@
              Link="CorpusSensor.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\FidelityCheck.cs"
              Link="FidelityCheck.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\GeneratedFixtures.cs"
+             Link="GeneratedFixtures.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ValidityCheck.cs"
              Link="ValidityCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AnnotationCheck.cs"

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -1,0 +1,293 @@
+using System.Diagnostics;
+using System.Runtime.Versioning;
+using System.Text;
+
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Addressable generated C# fixtures for progressive compile-back checks. The
+/// catalogue names the source shape, expected target methods, and expected
+/// compile-back outcome; the runner materializes those entries as a temporary
+/// class library and grades them with <see cref="FidelityCheck.Evaluate(string)"/>.
+/// </summary>
+internal static class GeneratedFixtureCatalog
+{
+    public static readonly GeneratedFixtureDefinition MinimalPropertyLiteral = new(
+        "minimal.property.literal",
+        """
+        namespace GeneratedFixtures.MinimalPropertyLiteral;
+
+        public class Class1
+        {
+            public string Method1 => "Hello World";
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalPropertyLiteral.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalPropertyLiteral.Class1", "get_Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "property", "literal"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalPrimaryCtorFieldInit = new(
+        "minimal.primary-ctor.field-init",
+        """
+        namespace GeneratedFixtures.MinimalPrimaryCtorFieldInit;
+
+        public class Class1(string message)
+        {
+            private readonly string _message = message;
+
+            public string Method1 => _message;
+        }
+        """,
+        [
+            new(
+                "GeneratedFixtures.MinimalPrimaryCtorFieldInit.Class1",
+                ".ctor",
+                FidelityCheck.CompileBackStatus.OpcodeDiff,
+                IsFrontier: true,
+                Note: "Primary-constructor field initializer stores before base(); reconstructed constructor body stores after base()."),
+            new("GeneratedFixtures.MinimalPrimaryCtorFieldInit.Class1", "get_Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "primary-constructor", "field-initializer"]);
+
+    public static IReadOnlyList<GeneratedFixtureDefinition> MinimalCompileBackRungs { get; } =
+    [
+        MinimalPropertyLiteral,
+        MinimalPrimaryCtorFieldInit,
+    ];
+}
+
+internal sealed record GeneratedFixtureDefinition(
+    string Id,
+    string Source,
+    IReadOnlyList<GeneratedFixtureTarget> Targets,
+    IReadOnlyList<string> Tags);
+
+internal sealed record GeneratedFixtureTarget(
+    string Type,
+    string Method,
+    FidelityCheck.CompileBackStatus ExpectedStatus,
+    int Overload = 0,
+    bool IsFrontier = false,
+    string? Note = null)
+{
+    public string DisplayMember => $"{Type}::{Method}#{Overload}";
+}
+
+internal sealed record GeneratedFixtureRunOptions(
+    string? TargetFramework = null,
+    bool KeepArtifacts = false)
+{
+    public static GeneratedFixtureRunOptions Default { get; } = new();
+}
+
+internal sealed record GeneratedFixtureRunResult(
+    string ProjectDirectory,
+    string AssemblyPath,
+    IReadOnlyList<GeneratedFixtureResult> Results)
+{
+    public bool Passed => Results.All(result => result.Passed);
+}
+
+internal sealed record GeneratedFixtureResult(
+    string FixtureId,
+    string Type,
+    string Method,
+    int Overload,
+    string DecompilerFidelity,
+    FidelityCheck.CompileBackStatus? ActualStatus,
+    FidelityCheck.CompileBackStatus ExpectedStatus,
+    bool IsFrontier,
+    string? Detail,
+    string? Note)
+{
+    public bool Passed => ActualStatus == ExpectedStatus;
+    public string DisplayMember => $"{Type}::{Method}#{Overload}";
+}
+
+internal static class GeneratedFixtureRunner
+{
+    public static GeneratedFixtureRunResult Run(
+        IReadOnlyList<GeneratedFixtureDefinition> fixtures,
+        GeneratedFixtureRunOptions? options = null)
+    {
+        if (fixtures.Count == 0)
+            throw new ArgumentException("At least one generated fixture is required.", nameof(fixtures));
+
+        options ??= GeneratedFixtureRunOptions.Default;
+        var root = Path.Combine(Path.GetTempPath(), "dotnet-inspect-generated-fixtures", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            string projectPath = Path.Combine(root, "GeneratedDecompilerFixtures.csproj");
+            File.WriteAllText(projectPath, ProjectFile(options.TargetFramework ?? CurrentTargetFramework()));
+
+            for (int i = 0; i < fixtures.Count; i++)
+            {
+                string sourcePath = Path.Combine(root, $"{i:000}_{SafeFileName(fixtures[i].Id)}.cs");
+                File.WriteAllText(sourcePath, fixtures[i].Source);
+            }
+
+            Build(root);
+            string assemblyPath = Path.Combine(root, "bin", "Release",
+                options.TargetFramework ?? CurrentTargetFramework(), "GeneratedDecompilerFixtures.dll");
+            if (!File.Exists(assemblyPath))
+                throw new InvalidOperationException($"Generated fixture assembly was not produced: {assemblyPath}");
+
+            var compileBack = FidelityCheck.Evaluate(assemblyPath)
+                .ToDictionary(result => Key(result.Type, result.Method, result.Overload), StringComparer.Ordinal);
+            var decompilerFidelity = DecompilerFidelity(assemblyPath, fixtures);
+            var results = new List<GeneratedFixtureResult>();
+            foreach (var fixture in fixtures)
+            {
+                foreach (var target in fixture.Targets)
+                {
+                    compileBack.TryGetValue(Key(target.Type, target.Method, target.Overload), out var actual);
+                    results.Add(new GeneratedFixtureResult(
+                        fixture.Id,
+                        target.Type,
+                        target.Method,
+                        target.Overload,
+                        decompilerFidelity.GetValueOrDefault(Key(target.Type, target.Method, target.Overload), "Unknown"),
+                        actual?.Status,
+                        target.ExpectedStatus,
+                        target.IsFrontier,
+                        actual?.Detail ?? (actual is null ? "target-method-not-found" : null),
+                        target.Note));
+                }
+            }
+
+            return new GeneratedFixtureRunResult(root, assemblyPath, results);
+        }
+        finally
+        {
+            if (!options.KeepArtifacts)
+                TryDelete(root);
+        }
+    }
+
+    public static string FormatReport(GeneratedFixtureRunResult run)
+    {
+        var sb = new StringBuilder();
+        int fixtureCount = run.Results.Select(r => r.FixtureId).Distinct(StringComparer.Ordinal).Count();
+        sb.AppendLine(
+            $"GENERATED FIXTURE COMPILE-BACK over {fixtureCount} fixture(s), {run.Results.Count} target method(s)");
+        foreach (var result in run.Results.OrderBy(r => r.FixtureId, StringComparer.Ordinal).ThenBy(r => r.DisplayMember, StringComparer.Ordinal))
+        {
+            string actual = result.ActualStatus?.ToString() ?? "Missing";
+            string frontier = result.IsFrontier ? " frontier" : "";
+            string status = result.Passed ? "PASS" : "FAIL";
+            sb.AppendLine(
+                $"  {status}{frontier}  {result.FixtureId}  {result.DisplayMember}  " +
+                $"decompiler={result.DecompilerFidelity}  compile-back={actual}  expected={result.ExpectedStatus}");
+            if (!string.IsNullOrWhiteSpace(result.Detail))
+                sb.AppendLine($"      detail: {result.Detail}");
+            if (!string.IsNullOrWhiteSpace(result.Note))
+                sb.AppendLine($"      note: {result.Note}");
+        }
+        return sb.ToString();
+    }
+
+    static string Key(string type, string method, int overload) => $"{type}::{method}#{overload}";
+
+    static string ProjectFile(string targetFramework) =>
+        $$"""
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>{{targetFramework}}</TargetFramework>
+            <ImplicitUsings>disable</ImplicitUsings>
+            <Nullable>disable</Nullable>
+            <LangVersion>preview</LangVersion>
+            <IsPackable>false</IsPackable>
+            <IsAotCompatible>false</IsAotCompatible>
+            <AssemblyName>GeneratedDecompilerFixtures</AssemblyName>
+          </PropertyGroup>
+        </Project>
+        """;
+
+    static string CurrentTargetFramework()
+    {
+        var frameworkName = typeof(GeneratedFixtureRunner).Assembly
+            .GetCustomAttributes(typeof(TargetFrameworkAttribute), inherit: false)
+            .OfType<TargetFrameworkAttribute>()
+            .FirstOrDefault()
+            ?.FrameworkName;
+        if (frameworkName is null)
+            return "net11.0";
+
+        const string prefix = ".NETCoreApp,Version=v";
+        return frameworkName.StartsWith(prefix, StringComparison.Ordinal)
+            ? "net" + frameworkName[prefix.Length..]
+            : "net11.0";
+    }
+
+    static string SafeFileName(string id)
+    {
+        var chars = id.Select(ch => char.IsLetterOrDigit(ch) ? ch : '_').ToArray();
+        return new string(chars);
+    }
+
+    static Dictionary<string, string> DecompilerFidelity(
+        string assemblyPath,
+        IReadOnlyList<GeneratedFixtureDefinition> fixtures)
+    {
+        var fidelities = new Dictionary<string, string>(StringComparer.Ordinal);
+        using var source = MetadataSource.Open(assemblyPath);
+        foreach (var target in fixtures.SelectMany(fixture => fixture.Targets))
+        {
+            var function = IrImporter.Import(source, target.Type, target.Method, target.Overload);
+            if (function is null)
+                continue;
+
+            _ = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+            fidelities[Key(target.Type, target.Method, target.Overload)] = function.Fidelity.ToString();
+        }
+
+        return fidelities;
+    }
+
+    static void Build(string workingDirectory)
+    {
+        using var process = new Process();
+        process.StartInfo.FileName = "dotnet";
+        process.StartInfo.WorkingDirectory = workingDirectory;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+        process.StartInfo.ArgumentList.Add("build");
+        process.StartInfo.ArgumentList.Add("-c");
+        process.StartInfo.ArgumentList.Add("Release");
+        process.StartInfo.ArgumentList.Add("--nologo");
+        process.StartInfo.ArgumentList.Add("--verbosity");
+        process.StartInfo.ArgumentList.Add("quiet");
+        if (!process.Start())
+            throw new InvalidOperationException("Could not start dotnet build for generated fixtures.");
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(milliseconds: 120_000))
+        {
+            try { process.Kill(entireProcessTree: true); }
+            catch (InvalidOperationException) { }
+            throw new TimeoutException("Generated fixture build timed out.");
+        }
+
+        string stdout = stdoutTask.GetAwaiter().GetResult();
+        string stderr = stderrTask.GetAwaiter().GetResult();
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"Generated fixture build failed with exit code {process.ExitCode}.\n{stdout}\n{stderr}");
+    }
+
+    static void TryDelete(string path)
+    {
+        try { Directory.Delete(path, recursive: true); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -55,6 +55,8 @@ static class Program
         bool typeCheck = false;
         bool bindCheck = false;
         bool classifyDec0009 = false;
+        bool generatedFixtures = false;
+        bool keepGeneratedFixtures = false;
         string? emitCorpusSnapshot = null;
         string? diffCorpusBaseline = null;
         string? emitCorpusDelta = null;
@@ -112,6 +114,8 @@ static class Program
                 case "--bind-check": bindCheck = true; break;
                 case "--classify-dec0009": classifyDec0009 = true; break;
                 case "--dec0009-shapes": classifyDec0009 = true; break;
+                case "--generated-fixtures": generatedFixtures = true; break;
+                case "--keep-generated-fixtures": keepGeneratedFixtures = true; break;
                 case "--emit-corpus-baseline": emitCorpusSnapshot = args[++i]; break;
                 case "--emit-corpus-snapshot": emitCorpusSnapshot = args[++i]; break;
                 case "--diff-corpus-baseline": diffCorpusBaseline = args[++i]; break;
@@ -135,6 +139,13 @@ static class Program
                 case "--help" or "-h": PrintUsage(); return 0;
                 default: inputs.Add(args[i]); break;
             }
+        }
+
+        if (generatedFixtures)
+        {
+            if (inputs.Count > 0)
+                return Fail("--generated-fixtures generates its own temporary input assembly; do not pass assembly paths.");
+            return GeneratedFixtures(keepGeneratedFixtures);
         }
 
         var assemblies = ResolveAssemblies(inputs);
@@ -212,6 +223,21 @@ static class Program
 
         // Default: the pipeline's fidelity/stop-reason inventory.
         return Inventory(assemblies);
+    }
+
+    static int GeneratedFixtures(bool keepArtifacts)
+    {
+        var run = GeneratedFixtureRunner.Run(
+            GeneratedFixtureCatalog.MinimalCompileBackRungs,
+            new GeneratedFixtureRunOptions(KeepArtifacts: keepArtifacts));
+        Console.Write(GeneratedFixtureRunner.FormatReport(run));
+        if (keepArtifacts)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"Generated fixture project: {run.ProjectDirectory}");
+            Console.WriteLine($"Generated fixture assembly: {run.AssemblyPath}");
+        }
+        return run.Passed ? 0 : 1;
     }
 
     /// <summary>
@@ -1126,6 +1152,12 @@ static class Program
                                 remarks by generated-name family. Use --json for
                                 machine-readable output.
           --dec0009-shapes       alias for --classify-dec0009.
+          --generated-fixtures   generate the seed fixture catalogue into a
+                                temporary class library, run compile-back, and
+                                report by fixture ID and target method.
+          --keep-generated-fixtures
+                                with --generated-fixtures: keep the temporary
+                                project and print its paths.
           --emit-corpus-baseline <f>     run the real-world corpus sensor and write
                                 the current JSON baseline to <f>.
           --emit-corpus-snapshot <f>     alias for --emit-corpus-baseline; intended

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -8,6 +8,14 @@ The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — t
 
 **Gaps** (`--gaps`): the completeness view — see below.
 
+**Generated fixtures** (`--generated-fixtures`): builds the seed generated-fixture
+catalogue into a temporary class library, runs the compile-back oracle, and prints
+results by stable fixture ID plus target method. This is the first step toward an
+addressable progressive fixture ladder: `minimal.property.literal` is expected
+`Exact`, while `minimal.primary-ctor.field-init` records the current constructor
+`OpcodeDiff` frontier and the exact getter. Add `--keep-generated-fixtures` to
+preserve the generated project for drill-down.
+
 **Library report** (`--library-report`): a portfolio view. It combines the IR
 residual buckets from `--gaps` with the Roslyn-backed validity oracle from
 `--validity-check`, then prints a global top-pattern section and one section per
@@ -440,6 +448,11 @@ dotnet run --project tools/DecompilerHarness -c Release -- --fidelity-check \
 # Focus one type, dump the units that fail to recompile:
 CB_TYPE=CfgSampleClass CB_DUMP=1 dotnet run --project tools/DecompilerHarness -c Release -- \
   --fidelity-check artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll
+
+# Generated progressive fixture catalogue: build source snippets, then compile-back.
+dotnet run --project tools/DecompilerHarness -c Release -- --generated-fixtures
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  --generated-fixtures --keep-generated-fixtures
 
 # Stage-by-stage dump of one method (metadata type name)
 dotnet run --project tools/DecompilerHarness -c Release -- \


### PR DESCRIPTION
## Summary

Fixes #1742.

Adds the first generated decompiler fixture catalogue and a standalone DecompilerHarness entry point:

- defines seed fixture IDs for `minimal.property.literal` and `minimal.primary-ctor.field-init`
- generates a temporary class library from catalogue source snippets
- runs the existing compile-back oracle over the generated DLL
- reports by fixture ID, target method, decompiler fidelity, actual compile-back result, and expected result
- exposes the runner via `--generated-fixtures` plus `--keep-generated-fixtures`

The primary-constructor field initializer is intentionally recorded as the first frontier: the generated constructor currently compile-backs as `OpcodeDiff` because the original stores the field before `base()`, while reconstructed C# stores after `base()`.

## Evidence

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures
npx markdownlint-cli tools/DecompilerHarness/README.md
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
```

Generated fixture smoke:

```text
GENERATED FIXTURE COMPILE-BACK over 2 fixture(s), 4 target method(s)
  PASS frontier  minimal.primary-ctor.field-init  GeneratedFixtures.MinimalPrimaryCtorFieldInit.Class1::.ctor#0  decompiler=Full  compile-back=OpcodeDiff  expected=OpcodeDiff
      note: Primary-constructor field initializer stores before base(); reconstructed constructor body stores after base().
  PASS  minimal.primary-ctor.field-init  GeneratedFixtures.MinimalPrimaryCtorFieldInit.Class1::get_Method1#0  decompiler=Full  compile-back=Exact  expected=Exact
  PASS  minimal.property.literal  GeneratedFixtures.MinimalPropertyLiteral.Class1::.ctor#0  decompiler=Full  compile-back=Exact  expected=Exact
  PASS  minimal.property.literal  GeneratedFixtures.MinimalPropertyLiteral.Class1::get_Method1#0  decompiler=Full  compile-back=Exact  expected=Exact
```
