### PR TITLE
Fix invalid checked(i++) for-header from user-defined checked increment (#1712)

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
@@ -213,3 +213,28 @@ public class ModernHolder
 
     public required int Count { get; init; }
 }
+
+// A class user type with a checked ++ operator. A checked for-loop over a class
+// loop variable raises to a `for` whose header increment is checked, which has no
+// valid for-header spelling (checked(i++) is CS0201). The decompiler keeps such a
+// loop as a while so the checked increment localizes to a checked { i++; } body
+// statement (#1712).
+public class CheckedStep
+{
+    public int Value;
+
+    public static CheckedStep operator ++(CheckedStep c) => new CheckedStep { Value = c.Value + 1 };
+
+    public static CheckedStep operator checked ++(CheckedStep c) => checked(new CheckedStep { Value = c.Value + 1 });
+
+    public static int CheckedForLoop(CheckedStep start, int n)
+    {
+        checked
+        {
+            for (CheckedStep i = start; i.Value < n; i++)
+            {
+            }
+        }
+        return n;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ForLoopPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForLoopPassTests.cs
@@ -45,6 +45,44 @@ public class ForLoopPassTests
         Assert.Single(outer.Body.Descendants.OfType<Continue>());
     }
 
+    [Fact]
+    public void CheckedUserIncrement_StaysWhileLoop()
+    {
+        var function = FunctionWithCheckedUserIncrement();
+
+        new ForLoopPass().Run(function, PassContext.None);
+
+        // A checked user-defined increment has no for-header spelling, so the loop
+        // must stay a while loop (#1712).
+        Assert.Single(function.Descendants.OfType<WhileLoop>());
+        Assert.Empty(function.Descendants.OfType<ForLoop>());
+    }
+
+    static IrFunction FunctionWithCheckedUserIncrement()
+    {
+        var userType = TypeRef.Definition("Test", "Synthetic", "Stepper", ValueTypeHint.ValueType);
+        var op = new MethodRef(userType, "op_CheckedIncrement", userType, [userType], HasThis: false)
+        {
+            IsSpecialName = true,
+            IsOperator = MetadataFactState.Yes,
+        };
+
+        var container = new BlockContainer();
+        var block = new Block();
+        block.Add(new StoreLocal(0, userType, new Constant(0, Int32)));
+
+        var loopBody = new Block();
+        loopBody.Add(new StoreLocal(0, userType, new Call(op, isVirtual: false, [new LoadLocal(0, userType)])));
+        block.Add(new WhileLoop(
+            new Comparison(ComparisonKind.LessThan, isUnsigned: false, new LoadLocal(0, Int32), new Constant(10, Int32)),
+            loopBody));
+        block.Add(new Return(new LoadLocal(0, Int32)));
+        container.Add(block);
+
+        var signature = new MethodSignature(Int32, [], HasThis: false, GenericParameterCount: 0);
+        return new IrFunction("M", Owner, signature, [userType], container);
+    }
+
     static IrFunction FunctionWithLoop(bool hasContinueBeforeIncrement)
     {
         var container = new BlockContainer();

--- a/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
@@ -268,6 +268,18 @@ public class LadderRung5GateTests
         var stmtChecked = Body("StatementIncrementChecked");
         Assert.Contains("checked { a++; }", stmtChecked);
         Assert.DoesNotContain("op_", stmtChecked);
+
+        // #1712 follow-up: a checked for-loop over a class loop variable has no
+        // valid for-header spelling for the checked increment (checked(i++) is
+        // CS0201), so it stays a while loop with the increment localized to a
+        // checked { i++; } body block.
+        var classLoop = CSharpPrinter.PrintRaised(
+            LoadRaisedMembers().Single(m => m.Type == typeof(LadderRung5.CheckedStep).FullName && m.Name == "CheckedForLoop").Function)
+            .Output ?? "";
+        Assert.Contains("while (", classLoop);
+        Assert.Contains("checked { i++; }", classLoop);
+        Assert.DoesNotContain("checked(i++)", classLoop);
+        Assert.DoesNotContain("op_", classLoop);
     }
 
     // C# 12 primary constructor on a class. The captured parameters lift into

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForLoopPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForLoopPass.cs
@@ -28,6 +28,14 @@ public sealed class ForLoopPass : IIrPass
             {
                 continue;
             }
+            // A checked user-defined increment (i = op_CheckedIncrement(i)) has no
+            // for-header spelling that preserves the checked overload: a `checked
+            // { i++; }` block is invalid in a for header, and a bare `checked(i++)`
+            // expression is CS0201 there. Keep such loops as while (in either the
+            // initializer or increment slot) so the checked increment localizes to
+            // a `checked { i++; }` statement. See #1712.
+            if (IsCheckedUserIncrement(increment.Value) || IsCheckedUserIncrement(initializer.Value))
+                continue;
             if (!ConditionReads(loop.Condition, initializer.Index))
                 continue;
             if (ContainsCurrentLoopContinue(loop.Body))
@@ -40,6 +48,10 @@ public sealed class ForLoopPass : IIrPass
             loop.ReplaceWith(new ForLoop(initializer, (IrExpression)parts[0], increment, (Block)parts[1]));
         }
     }
+
+    /// <summary>True when a loop increment store value is a user-defined <c>op_CheckedIncrement</c>/<c>op_CheckedDecrement</c> call — a checked increment that has no for-header spelling.</summary>
+    static bool IsCheckedUserIncrement(IrExpression value)
+        => value is Call { Callee: { HasThis: false, Name: "op_CheckedIncrement" or "op_CheckedDecrement" } };
 
     static bool ConditionReads(IrExpression condition, int localIndex)
     {


### PR DESCRIPTION
## Summary

Follow-up to the merged #1712 work (#1723 / #1728). A checked user-defined increment over a **class** loop variable raised to a `for` whose header increment is checked, rendered as an **invalid `Full`**:

```csharp
// before (CS0201 — checked(i++) is not a valid for-increment)
for (C i = start; i.V < n; checked(i++)) { }
```

A checked user increment has no valid for-header spelling: a `checked { i++; }` block is illegal in a header, and a bare `checked(i++)` expression is CS0201.

## Fix

`ForLoopPass` now declines raising a `while`→`for` when either the **increment** or the **initializer** slot is a checked user-defined increment (`op_CheckedIncrement`/`op_CheckedDecrement`). The loop stays a `while`, so the checked increment localizes to a `checked { i++; }` body statement and the rest of the body keeps its own context:

```csharp
// after
C i = start;
while (i.V < n)
{
    checked { i++; }
}
```

An unchecked class loop still raises to the idiomatic `for (C i = start; i.V < n; i++)`.

## Background

This case surfaced in a deep cross-family adversarial review of #1723. The fix landed on that PR's branch after it had already squash-merged, so it's carried here as a focused follow-up.

## Evidence

- Verified through the decompiler: class checked for-loop → `while (...) { checked { i++; } }`, **0 opcode diff / 0 recompile fail**; unchecked class loop still `for (...; i++)`.
- Guards: rung 5 fixture gains `CheckedStep` (class + checked `++` + checked for-loop) with a gate assertion; `ForLoopPassTests.CheckedUserIncrement_StaysWhileLoop`.
- Fast subset 1587/1587, `ForLoopPassTests` 4, `LadderRung5GateTests` 8/8, `CorpusSweepGateTests` green.

Advances #1712 / #1599 row 2.
