### PR TITLE
Document adversarial review resolution links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,8 @@ For decompiler-affecting PRs, follow this evidence and review contract:
   open the PR before the reviews finish, and may request earlier if progress
   slows.
 - Always post a PR comment summarizing the adversarial review results and any
-  follow-up changes or explicit non-actions.
+  follow-up changes or explicit non-actions. Include references or links to the
+  commit(s) that resolved actionable review guidance.
 
 See `docs/decompiler-quality.md` and `tools/DecompilerHarness/README.md` for the
 broader workflow and command details.
@@ -209,8 +210,10 @@ Rules:
 - **Reconcile and surface the results on the PR**: post a PR review/comment
   summarizing both reviews (attributed by model), where they agreed or diverged,
   which findings you verified vs dismissed, and the follow-up changes or explicit
-  non-actions. Do not merely summarize reviews back to the requester — they must
-  be visible on the PR.
+  non-actions. Include references or links to the commit(s) that resolved
+  actionable review guidance; for dismissed or non-actioned guidance, state why
+  no resolution commit applies. Do not merely summarize reviews back to the
+  requester — they must be visible on the PR.
 - Simple/docs-only PRs do not need this; state that the change is low-risk.
 
 ## PR Strategy and CI Cost

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -164,7 +164,7 @@ Report:
 1. focused tests;
 2. `src/ILInspector.Decompiler.Tests`;
 3. generated quality card showing no unexpected corpus movement;
-4. adversarial review summary.
+4. adversarial review summary with resolution commit links.
 
 ### Bug fixes
 
@@ -188,7 +188,7 @@ Report:
 4. per-method delta artifact;
 5. changed-method fidelity result, or a clear statement that changed methods are
    not currently checkable;
-6. cross-model adversarial review summary.
+6. cross-model adversarial review summary with resolution commit links.
 
 For #1175-class retained-label work, the changed-method population must include
 the forward-merge / structuring-residual methods the PR changes. A green global
@@ -453,6 +453,7 @@ Corpus/structure evidence:
 
 Review:
 - Cross-model adversarial review: <summary/link>
+- Resolution commits: <links for addressed guidance, or "none" with rationale>
 - Follow-ups: <issues for remaining buckets>
 
 Why this is enough:

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -345,6 +345,11 @@ The useful output is one of three things:
 - a pattern-pivoted issue with minimized examples when the bug or gap is larger
   than one safe PR.
 
+When the review is posted to a PR, include links to the commit(s) that resolved
+actionable review guidance. If guidance is dismissed or left for a follow-up,
+state why no resolution commit applies and link the follow-up issue when one
+exists.
+
 **When to run this role.** It is a targeted review lane, not a universal CI
 gate, so spend it where a raise's breadth is least proven:
 
@@ -650,7 +655,8 @@ match without changing the implementation first. The useful output is concrete:
 a source-shaped negative fixture, the exact discriminator it toggles, and the
 test that proves the pass does not raise it. When the pass is too broad, add the
 negative fixture first so it fails for the current implementation, then narrow
-the matcher.
+the matcher. In the PR-visible review summary, link the commit(s) that resolved
+the actionable review guidance.
 
 Adversarial research has three useful modes. Use the cheapest one that can
 answer the question, and escalate when the pass is broad, recent, or tied to an


### PR DESCRIPTION
## Summary
- Require PR-visible adversarial review summaries to link the commit(s) that resolved actionable guidance
- Update decompiler PR reporting guidance and final-boss template with resolution commit links
- Clarify that dismissed or deferred guidance should explain why no resolution commit applies

## Validation
- `npx markdownlint-cli AGENTS.md docs/decompiler-correctness-pipeline.md docs/decompiler-quality.md`

Docs-only change; no adversarial review required.