### PR TITLE
Pin the decompiler self-corpus to a published package version (kill drift)

### DIFF
--- a/eng/prepare-decompiler-corpus.sh
+++ b/eng/prepare-decompiler-corpus.sh
@@ -1,15 +1,28 @@
 #!/usr/bin/env bash
 # Restores the fixed real-world decompiler corpus from #1166 and emits one
-# managed assembly path per line. Run after `dotnet build src/dotnet-inspect -c
-# Release` when the dotnet-inspect self corpus should be included.
+# managed assembly path per line.
+#
+# Every assembly is a PINNED published package version, so the corpus is a
+# stable target: the only thing that varies across a decompiler change is the
+# tool, never the input. The dotnet-inspect self-assemblies come from the
+# published, non-AOT `dotnet-inspect.any` package (its managed IL under
+# tools/net10.0/any/) rather than the local `artifacts/bin` build — that removes
+# corpus drift (#1404) and breaks the circularity where a decompiler change
+# rebuilt both the tool and its own corpus at once. Bump SELF_VERSION (and
+# re-emit the baseline) to advance the self-corpus deliberately.
 set -euo pipefail
 
-root="$(git rev-parse --show-toplevel)"
+# Pinned dotnet-inspect.any version supplying the self-corpus managed assemblies.
+SELF_VERSION="0.14.0"
+# The TFM folder the non-AOT tool package ships its managed assemblies under
+# (the release "reach" floor; see release.yml validate-reach-packaging).
+SELF_TFM="net10.0"
+
 out="${1:-}"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-cat > "$tmp/corpus.csproj" <<'EOF'
+cat > "$tmp/corpus.csproj" <<EOF
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net11.0</TargetFramework>
@@ -22,6 +35,7 @@ cat > "$tmp/corpus.csproj" <<'EOF'
     <PackageReference Include="System.CommandLine" Version="3.0.0-preview.5.26302.115" />
     <PackageReference Include="NuGet.Versioning" Version="7.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
+    <PackageReference Include="dotnet-inspect.any" Version="$SELF_VERSION" />
   </ItemGroup>
 </Project>
 EOF
@@ -29,6 +43,8 @@ EOF
 dotnet restore "$tmp/corpus.csproj" --verbosity quiet >/dev/null
 
 packages="${NUGET_PACKAGES:-$HOME/.nuget/packages}"
+self="$packages/dotnet-inspect.any/$SELF_VERSION/tools/$SELF_TFM/any"
+
 declare -a assemblies=(
   "$packages/newtonsoft.json/13.0.4/lib/net6.0/Newtonsoft.Json.dll"
   "$packages/microsoft.codeanalysis.common/5.0.0/lib/net9.0/Microsoft.CodeAnalysis.dll"
@@ -36,23 +52,16 @@ declare -a assemblies=(
   "$packages/system.commandline/3.0.0-preview.5.26302.115/lib/net10.0/System.CommandLine.dll"
   "$packages/nuget.versioning/7.3.0/lib/net8.0/NuGet.Versioning.dll"
   "$packages/microsoft.applicationinsights/2.23.0/lib/netstandard2.0/Microsoft.ApplicationInsights.dll"
+  # dotnet-inspect self-corpus, from the pinned published `any` package.
+  "$self/DotnetInspector.Core.dll"
+  "$self/DotnetInspector.Packages.dll"
+  "$self/DotnetInspector.Services.dll"
+  "$self/ILInspector.Metadata.dll"
+  "$self/ILInspector.MetadataPrimitives.dll"
+  "$self/dotnet-inspect.dll"
+  "$self/ILInspector.Analysis.dll"
+  "$self/ILInspector.Decompiler.dll"
 )
-
-declare -a self_assemblies=(
-  "$root/artifacts/bin/DotnetInspector.Core/release/DotnetInspector.Core.dll"
-  "$root/artifacts/bin/DotnetInspector.Packages/release/DotnetInspector.Packages.dll"
-  "$root/artifacts/bin/DotnetInspector.Services/release/DotnetInspector.Services.dll"
-  "$root/artifacts/bin/DotnetInspector.Services/release/ILInspector.Metadata.dll"
-  "$root/artifacts/bin/DotnetInspector.Services/release/ILInspector.MetadataPrimitives.dll"
-  "$root/artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll"
-  "$root/artifacts/bin/dotnet-inspect/release/ILInspector.Analysis.dll"
-  "$root/artifacts/bin/dotnet-inspect/release/ILInspector.Decompiler.dll"
-)
-for assembly in "${self_assemblies[@]}"; do
-  if [ -f "$assembly" ]; then
-    assemblies+=("$assembly")
-  fi
-done
 
 for assembly in "${assemblies[@]}"; do
   if [ ! -f "$assembly" ]; then


### PR DESCRIPTION
## Summary

Kills decompiler-corpus drift by pinning the self-corpus to a published package version — your suggestion. The corpus sensor's count-delta metrics (`fully-raised`, `conditional-branch`) had become untrustworthy because the corpus moved under its own baseline.

## Root cause

`eng/prepare-decompiler-corpus.sh` built the corpus from **6 pinned third-party packages** (immutable) **+ 8 locally-built self assemblies** (`artifacts/bin/.../release/*.dll`). The self assemblies were the *entire* drift source:

- every decompiler change rebuilt them, so the method population shifted under the pinned baseline → count deltas became uninterpretable (the "baseline stale, corpus drifted +340" note on recent quality cards; cf. stale-baseline detection #1404);
- it also created a **circularity**: a change altered both the tool *and* its own corpus at once, so deltas couldn't be cleanly attributed.

## Fix

Source the self-corpus from the pinned, published **non-AOT `dotnet-inspect.any`** package (`0.14.0`) — its managed IL ships under `tools/net10.0/any/` and contains exactly the same 8 assemblies (plus a few bonus ones: `Markout`, `SourceLinkFetch`, `NuGetFetch`). Now **every** corpus assembly is an immutable published version, so the corpus is a fixed target: only the tool varies across a decompiler change, restoring count-delta regressions as a trustworthy signal.

`SELF_VERSION` is a single variable at the top of the script — bump it (and re-emit the baseline) to advance the self-corpus deliberately, the same cadence as the third-party pins.

Note: must be the `.any` package — the RID-specific AOT packages are native single-file with no separable managed IL.

## Rebaseline (accompanies the pin)

Re-emitted `real-world-baseline.json` against the pinned corpus. The new baseline is a clean known-good state, and the sensor matches it exactly:

```text
Corpus sensor matched baseline
Assemblies: 14   Methods: 89,065
Fully raised: 78,394 (88.02%)
Conditional-branch residual: 2,408 (2.70%)
Full malformed: 32   (the established floor)
Pass bugs: 0
```

The large `real-world-baseline.json` diff is the expected per-method snapshot recomposed from the pinned package (machine-managed; reviewed via the summary metrics above).

Refs #1404. Two cross-model adversarial reviews requested per #1734.
