### PR TITLE
Document PR ready-to-merge signal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,11 @@ Before opening a PR, fetch `origin/main` and update the feature branch with the
 latest main using either merge or rebase. Resolve conflicts locally and rerun
 relevant checks so the PR does not start from a stale base.
 
+When all merge-blocking validation, CI, and required review are complete, post a
+clear PR comment that says the PR is `Ready to merge`. If you continue running
+extra tests or review after that point, label them as non-blocking follow-up work
+so maintainers do not mistake the PR for still being in progress.
+
 After fetching, rebasing, merging `origin/main`, or resolving conflicts from
 main, re-read `AGENTS.md` and any task-relevant docs it points to before
 continuing. If instructions changed, treat the refreshed instructions as

--- a/agents/burndown-curator.md
+++ b/agents/burndown-curator.md
@@ -50,6 +50,11 @@ issue.
 - Unresolved adversarial feedback: take over after `60m`.
 - Maintainer notification: every active sweep reports mergeable PRs.
 
+Runners must post an explicit `Ready to merge` PR comment after all
+merge-blocking validation, CI, and required review are complete. If an agent keeps
+running extra tests or review after that point, the PR comment or follow-up
+status must label that work as non-blocking.
+
 For every open PR mentioned in a report, state either:
 
 - `Ready to merge` with evidence: clean branch, green checks, review

--- a/agents/burndown-runner.md
+++ b/agents/burndown-runner.md
@@ -30,7 +30,10 @@ row at a time and drives it to a PR, explicit blocker, or pivot issue.
    and merge or rebase the latest main into the branch.
 5. Rerun row validation after syncing.
 6. Open a PR and update the row to `In review — #PR`.
-7. When merged, the curator or runner updates the row to `Done — #PR`.
+7. When all merge-blocking validation, CI, and required review are complete,
+   post a PR comment that clearly says `Ready to merge`. Label any later tests
+   or review as non-blocking follow-up work.
+8. When merged, the curator or runner updates the row to `Done — #PR`.
 
 ## If blocked
 

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -456,6 +456,9 @@ Review:
 - Resolution commits: <links for addressed guidance, or "none" with rationale>
 - Follow-ups: <issues for remaining buckets>
 
+Merge readiness:
+Ready to merge / Blocked by <concrete blocker>
+
 Why this is enough:
 <one paragraph tying the evidence to the decision>
 ```
@@ -467,6 +470,11 @@ boss prevents a meaningful safety claim (for example, changed-method rows are
 mostly uncheckable for unknown reasons). Choose **Pivot** when the evidence says
 the next useful work is a different boss or a measurement issue rather than more
 raise code.
+
+When the decision is **Go** and all merge-blocking validation, CI, and required
+review are complete, post a PR comment that clearly says `Ready to merge`. If
+extra tests or review continue after that point, mark them as non-blocking
+follow-up work so the PR state remains unambiguous.
 
 ## Naming the harnesses by role
 


### PR DESCRIPTION
## Summary
- Require agents to post an explicit `Ready to merge` PR comment once all merge-blocking validation, CI, and required review are complete
- Clarify that extra tests or review after that point must be labeled non-blocking
- Update burndown runner/curator guidance and the decompiler final-boss template

## Validation
- `npx markdownlint-cli AGENTS.md agents/burndown-runner.md agents/burndown-curator.md docs/decompiler-correctness-pipeline.md`

Docs-only change; no adversarial review required.