### PR TITLE
Audit + fix sibling key paths for assembly/arity identity loss (key-path audit)

### DIFF
--- a/src/ILInspector.Analysis/MethodDefinitionMap.cs
+++ b/src/ILInspector.Analysis/MethodDefinitionMap.cs
@@ -78,5 +78,5 @@ internal sealed class MethodDefinitionMap
         => $"{declaringType.Assembly}|{declaringType.Namespace}|{declaringType.Name}|{name}";
 
     static string Key(TypeRef declaringType, string name, ImmutableArray<TypeRef> parameterTypes)
-        => $"{declaringType.ToQualifiedDisplayString()}|{name}|{string.Join(",", parameterTypes.Select(type => type.ToQualifiedDisplayString()))}";
+        => $"{GenericMemberIdentity.KeyFragment(declaringType)}|{name}|{string.Join(",", parameterTypes.Select(GenericMemberIdentity.KeyFragment))}";
 }

--- a/src/ILInspector.Analysis/TypeRefDecoder.cs
+++ b/src/ILInspector.Analysis/TypeRefDecoder.cs
@@ -65,7 +65,16 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
                 name,
                 FrameworkAssemblyKeys.IsFrameworkReference(reader, (AssemblyReferenceHandle)typeRef.ResolutionScope)),
             HandleKind.TypeReference => NestedReference(reader, (TypeReferenceHandle)typeRef.ResolutionScope, name),
-            _ => TypeRef.Definition("", ns, name, FrameworkAssemblyKeys.IsFrameworkDefinition(reader)),
+            // ModuleReference / nil scope: the type is in the current assembly (another
+            // module of it, or an exported/forwarded type resolved in this manifest), so
+            // stamp the current assembly name — matching GetTypeFromDefinition — rather than
+            // an empty string, so assembly-qualified identity keys are symmetric between a
+            // definition and a same-assembly reference to it.
+            _ => TypeRef.Definition(
+                reader.IsAssembly ? reader.GetString(reader.GetAssemblyDefinition().Name) : "",
+                ns,
+                name,
+                FrameworkAssemblyKeys.IsFrameworkDefinition(reader)),
         };
     }
 

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -269,4 +269,38 @@ public class DiffCommandTests
         Assert.True(System.IO.File.Exists(path), $"Expected diff fixture assembly at {path}");
         return path;
     }
+
+    // Key-path audit: the analysis-diff member key must distinguish members that
+    // TypeRef.Equals distinguishes but display strings do not — same-name/different-arity
+    // generic declaring types, and same-FQN parameter types from different assemblies —
+    // otherwise the snapshot merges them and the diff misses a member (sibling of #1741).
+    [Fact]
+    public void MethodKey_DistinguishesSameNameDifferentArityDeclaringTypes()
+    {
+        var box1 = DiffMethod(ILInspector.Analysis.TypeRef.Definition("Asm", "Ns", "Box`1"), "Store");
+        var box2 = DiffMethod(ILInspector.Analysis.TypeRef.Definition("Asm", "Ns", "Box`2"), "Store");
+
+        Assert.NotEqual(DiffCommand.MethodKey(box1), DiffCommand.MethodKey(box2));
+    }
+
+    [Fact]
+    public void MethodKey_DistinguishesSameFqnParametersFromDifferentAssemblies()
+    {
+        var declaring = ILInspector.Analysis.TypeRef.Definition("Asm", "Ns", "Api");
+        var pingA = DiffMethod(declaring, "Ping", ILInspector.Analysis.TypeRef.Definition("LibA", "Shared", "Token"));
+        var pingB = DiffMethod(declaring, "Ping", ILInspector.Analysis.TypeRef.Definition("LibB", "Shared", "Token"));
+
+        Assert.NotEqual(DiffCommand.MethodKey(pingA), DiffCommand.MethodKey(pingB));
+    }
+
+    static ILInspector.Analysis.MethodIdentity DiffMethod(ILInspector.Analysis.TypeRef declaring, string name, params ILInspector.Analysis.TypeRef[] parameterTypes)
+        => new(
+            "Asm",
+            System.Guid.Empty,
+            declaring,
+            name,
+            [.. parameterTypes],
+            ILInspector.Analysis.TypeRef.CoreLib("System", "Void"),
+            MetadataToken: 0x06000001,
+            IsStatic: true);
 }

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -480,8 +480,8 @@ public class DiffCommand
     private static bool MatchesTypeFilters(string typeFullName, HashSet<string> filters)
         => filters.Count == 0 || filters.Any(filter => MatchesDiffTypeFilter(typeFullName, filter));
 
-    private static string MethodKey(MethodIdentity method)
-        => $"{method.AssemblyName}|{method.DeclaringType.ToQualifiedDisplayString()}|{method.Name}|{string.Join(",", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))}|{method.ReturnType.ToQualifiedDisplayString()}";
+    internal static string MethodKey(MethodIdentity method)
+        => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
 
     private static string FormatMethod(MethodIdentity method)
         => $"{method.DeclaringType.ToQualifiedDisplayString()}.{method.Name}({string.Join(", ", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";


### PR DESCRIPTION
## Key-path audit — close the "display-string-loses-assembly/arity" class of identity bugs

Follow-up to the #1741 fix. The cross-assembly caller-graph key was fixed by keying
on the assembly+arity-qualified `GenericMemberIdentity.KeyFragment`. This audit found
**two sibling key paths** with the same weakness and routes them through the same
helper.

### Findings

- **`MethodDefinitionMap.Key`** (same-assembly call resolution fallback): rendered
  the declaring type and parameters with `ToQualifiedDisplayString()`, which drops
  assembly and strips generic arity. So `Box\`1.Store` / `Box\`2.Store`, or same-FQN
  params from different assemblies, could collide in the in-assembly resolution map.
  (`DeclaringTypeAndNameKey` was already assembly+raw-name qualified; only the
  param-bearing `Key` was weak.) The swap to `KeyFragment` is behavior-preserving for
  the open/constructed dimension and adds assembly+arity precision.
- **`DiffCommand.MethodKey`** (analysis-diff version-pair matching): same loss, so a
  snapshot could merge two distinct members and the diff miss one. Now uses
  `KeyFragment` for declaring/params/return; made `internal` for testing.

The display/format helpers (`FormatMethod`) were correctly **excluded** — they are
output, not identity.

### Guards (proven non-vacuous)

`MethodKey_DistinguishesSameNameDifferentArityDeclaringTypes` and
`MethodKey_DistinguishesSameFqnParametersFromDifferentAssemblies` — both fail under
the old `ToQualifiedDisplayString` rendering. `MethodDefinitionMap.Key` is
defense-in-depth, covered by the full suite (its open/constructed behavior is
unchanged).

### Evidence

`ILInspector.Analysis.Tests` 199/199; `dotnet-inspect.Tests` 1380 — no regressions.
This consolidates every analysis member/identity string key onto one
assembly+arity-qualified renderer, closing the class of bug that recurred across
#1731 / #1741.
