### PR TITLE
Add string-build-in-loop shape: O(n^2) string accumulation (#1714)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1436,6 +1436,35 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_PrependStringInLoop_IsHighStringBuild()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // The accumulator as the LAST concat argument (`s = x + sep + s`) is still O(n^2).
+        Assert.Single(StringBuildRows(index, nameof(OptimizationOpportunityFixtures.PrependsStringInLoop)));
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_ReassignUnrelatedSlotInLoop_IsNotStringBuild()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // `Foo(s); s = a + b;` — `s` is loaded only for the unrelated call, not as a concat
+        // argument. The stack-aware check must not misread this as accumulation.
+        Assert.Empty(StringBuildRows(index, nameof(OptimizationOpportunityFixtures.ReassignsUnrelatedSlotInLoop)));
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_DerivedAccumulatorInLoop_IsNotStringBuild()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // The accumulator flows through `s.Trim()` before the concat -> conservatively not
+        // matched (the bare-load bit does not survive the intermediate call).
+        Assert.Empty(StringBuildRows(index, nameof(OptimizationOpportunityFixtures.DerivedAccumulatorInLoop)));
+    }
+
+    [Fact]
     public void OptimizationOpportunities_AllocationDenseNonLoopMethod_IsNotHotspot()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -2279,6 +2308,39 @@ public class OptimizationOpportunityFixtures
     {
         var s = a;
         s += b;
+        return s;
+    }
+
+    // Accumulator is the LAST concat argument (prepend): `s = x + sep + s` is still O(n^2).
+    public static string PrependsStringInLoop(string[] items)
+    {
+        var s = "";
+        foreach (var x in items)
+            s = x + " " + s;
+        return s;
+    }
+
+    // NOT accumulation by the stack-aware check: the destination slot is loaded only to pass
+    // to an unrelated call, then reassigned from operands that do not include it
+    // (`Foo(s); s = a + b;`). The bare load is popped by Foo before the concat, so `s` is not a
+    // concat argument -> must NOT be flagged. (Adversarial-review regression guard.)
+    public static string ReassignsUnrelatedSlotInLoop(string seed, string a, string b, string[] items)
+    {
+        foreach (var x in items)
+        {
+            System.Console.WriteLine(seed);
+            seed = a + b;
+        }
+        return seed;
+    }
+
+    // Conservatively NOT flagged: the accumulator flows through a call (`s.Trim()`) before the
+    // concat, so the bare-load bit does not survive. Documents the precision/recall tradeoff.
+    public static string DerivedAccumulatorInLoop(string[] items)
+    {
+        var s = "";
+        foreach (var x in items)
+            s = x + " " + s.Trim();
         return s;
     }
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1372,6 +1372,69 @@ public class LibraryBodyIndexTests
             .Where(o => o.Method.Name == methodName && o.Shape == "allocation-hotspot")
             .ToList();
 
+    static System.Collections.Generic.List<OptimizationOpportunity> StringBuildRows(LibraryBodyIndex index, string methodName)
+        => index.OptimizationOpportunities
+            .Where(o => o.Method.Name == methodName && o.Shape == "string-build-in-loop")
+            .ToList();
+
+    [Fact]
+    public void OptimizationOpportunities_StringAppendInLoop_IsHighStringBuild()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // `s += x` inside a loop is the O(n^2) growing-accumulator anti-pattern.
+        var row = Assert.Single(StringBuildRows(index, nameof(OptimizationOpportunityFixtures.AppendsStringInLoop)));
+        Assert.Equal("high", row.Confidence);
+        Assert.True(row.InLoop);
+        Assert.Contains("StringBuilder", row.SafeFixDirection);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_StringAppendOfPropertyInLoop_IsHighStringBuild()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // An intervening sub-expression call (indexer / property get) between the accumulator
+        // load and the Concat must not hide the self-accumulation.
+        Assert.Single(StringBuildRows(index, nameof(OptimizationOpportunityFixtures.AppendsStringPropertyInLoop)));
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_StringAppendToParameterInLoop_IsHighStringBuild()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // Accumulation into a parameter slot is the same shape as into a local.
+        Assert.Single(StringBuildRows(index, nameof(OptimizationOpportunityFixtures.AppendsToParameterInLoop)));
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_ConcatIntoListInLoop_IsNotStringBuild()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // A per-iteration string added to a list is not accumulation -> no StringBuilder fix.
+        Assert.Empty(StringBuildRows(index, nameof(OptimizationOpportunityFixtures.ConcatsIntoListInLoop)));
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_ReturnConcatInLoop_IsNotStringBuild()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // A one-time concat on a return path inside a loop is not a repeated copy.
+        Assert.Empty(StringBuildRows(index, nameof(OptimizationOpportunityFixtures.ReturnsConcatInLoop)));
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_StringAppendOutsideLoop_IsNotStringBuild()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // `s += x` outside any loop allocates once -> not the StringBuilder anti-pattern.
+        Assert.Empty(StringBuildRows(index, nameof(OptimizationOpportunityFixtures.AppendsStringOnce)));
+    }
+
     [Fact]
     public void OptimizationOpportunities_AllocationDenseNonLoopMethod_IsNotHotspot()
     {
@@ -2158,6 +2221,66 @@ public class OptimizationOpportunityFixtures
 
     // Returned -> escapes.
     public static int[] ReturnsSmallArray() => new int[4];
+
+    // --- String accumulation (string-build-in-loop) ---
+
+    // `s += x` inside a foreach: String.Concat(s, x) stored back to the same local each
+    // iteration -> O(n^2) growing-accumulator copy. The canonical StringBuilder case (HIGH).
+    public static string AppendsStringInLoop(string[] items)
+    {
+        var s = "";
+        foreach (var x in items)
+            s += x;
+        return s;
+    }
+
+    // `s += item.Property` inside a loop: an instance-call (get_Property) sits between the
+    // accumulator load and the Concat, so it exercises the not-clearing-on-calls path.
+    public static string AppendsStringPropertyInLoop(System.Collections.Generic.List<string> items)
+    {
+        var s = "";
+        for (int i = 0; i < items.Count; i++)
+            s = s + items[i] + ",";
+        return s;
+    }
+
+    // Accumulation into a parameter slot rather than a local (`seed += x`).
+    public static string AppendsToParameterInLoop(string seed, string[] items)
+    {
+        foreach (var x in items)
+            seed += x;
+        return seed;
+    }
+
+    // NOT accumulation: each iteration builds a fresh string added to a list. The concat
+    // result is never stored back into one of its inputs -> no StringBuilder rewrite, so it
+    // must NOT be flagged (this was the noisy tier measured to be ~all false positives).
+    public static System.Collections.Generic.List<string> ConcatsIntoListInLoop(System.Collections.Generic.Dictionary<string, string> pairs)
+    {
+        var parts = new System.Collections.Generic.List<string>();
+        foreach (var kv in pairs)
+            parts.Add(kv.Key + "=" + kv.Value);
+        return parts;
+    }
+
+    // NOT accumulation: a one-time concat on a return path inside a loop -> not flagged.
+    public static string ReturnsConcatInLoop(string[] items)
+    {
+        foreach (var x in items)
+        {
+            if (x.Length > 3)
+                return x + "-found";
+        }
+        return "";
+    }
+
+    // NOT accumulation: `s += x` but OUTSIDE any loop -> not flagged (no repeated copy).
+    public static string AppendsStringOnce(string a, string b)
+    {
+        var s = a;
+        s += b;
+        return s;
+    }
 
     // --- Copy allocation (span-to-array) ---
 

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1562,7 +1562,7 @@ public sealed class LibraryBodyIndex
                                 "Quadratic only if the scanned sequence grows with the loop; a small or constant sequence is fine."));
                         }
                         else if (IsStringConcat(callee) && IsInLoopRegion(offset, loopRegions)
-                            && ConcatAccumulatesIntoSource(il, position))
+                            && ConcatAccumulatesIntoSource(il, offset, position, callee.ParameterTypes.Length, callerScope))
                         {
                             // `s += …` inside a loop lowers to String.Concat(s, …) stored back to
                             // the same local/parameter. Each iteration copies the whole growing
@@ -2495,43 +2495,186 @@ public sealed class LibraryBodyIndex
             position = (int)targetPosition;
         }
 
-        // True when the String.Concat call ending at `storeOffset` accumulates into one of its
-        // own inputs: the instruction immediately after the call stores to a local/parameter
-        // slot that the same call also loaded as an argument (`s = String.Concat(s, …)`, the
-        // `s += …` lowering). Repeated copying of the growing accumulator is the canonical
-        // O(n^2) StringBuilder anti-pattern. The check is value-specific (the stored slot must
-        // be one of the call's argument loads), so an unrelated in-loop concat into a fresh
-        // local is not misread as accumulation. Argument slots are namespaced apart from local
-        // slots so a local index and a parameter index with the same number do not collide.
-        public static bool ConcatAccumulatesIntoSource(byte[] il, int storeOffset)
+        // True when the String.Concat at `concatOffset` — whose result is stored by the
+        // instruction at `storeOffset` — accumulates into one of its own arguments, i.e.
+        // `s = String.Concat(s, …)` (the `s += …` lowering). Each iteration copies the whole
+        // growing accumulator: the canonical O(n^2) StringBuilder anti-pattern.
+        //
+        // Soundness is by stack-aware simulation, not a flat load window. It replays the eval
+        // stack across the basic block that produces the concat's arguments, tagging each stack
+        // slot with one bit — "produced by a bare load of the destination slot" — and reports
+        // accumulation only when a value actually consumed by the concat carries that bit. So a
+        // prior unrelated use of the slot (`Foo(s); s = a + b;`) is not misread: that load is
+        // popped by its own consumer before the concat. A derived accumulator
+        // (`s = s.Substring(..) + x`) is conservatively not matched (the bit does not survive the
+        // intermediate call). Anything the small stack model does not understand makes the probe
+        // bail, so it never reports a false positive on unmodeled IL.
+        public bool ConcatAccumulatesIntoSource(byte[] il, int concatOffset, int storeOffset, int concatArgCount, GenericScope callerScope)
         {
             const int ArgSlotBias = 1 << 20;
-            if (storeOffset < 0 || storeOffset >= il.Length)
-                return false;
-            int sp = storeOffset;
-            var storeOp = ReadOpcode(il, ref sp);
-            if (!TryReadLocalSlot(il, storeOp, ref sp, storeOffset, out bool storeIsStore, out bool storeIsArg, out int storeSlot)
-                || !storeIsStore)
-                return false;
-            int storeKey = (storeIsArg ? ArgSlotBias : 0) | storeSlot;
-
-            int position = 0;
-            var argLoads = new List<int>();
-            while (position < storeOffset)
+            try
             {
-                int offset = position;
-                var opcode = ReadOpcode(il, ref position);
-                bool isLocalOp = TryReadLocalSlot(il, opcode, ref position, offset, out bool isStore, out bool isArg, out int slot);
-                if (!isLocalOp)
-                    SkipOperandStatic(il, opcode, ref position, offset);
-                if (position >= storeOffset)
-                    break; // this is the Concat call itself; preserve its argument loads
-                if (isLocalOp && !isStore)
-                    argLoads.Add((isArg ? ArgSlotBias : 0) | slot);
-                else if (ClearsAccumulatorWindow(opcode))
-                    argLoads.Clear();
+                if (storeOffset < 0 || storeOffset >= il.Length || concatOffset < 0 || concatArgCount <= 0)
+                    return false;
+
+                // The concat result must be stored straight back into a local/parameter slot.
+                int sp = storeOffset;
+                var storeOp = ReadOpcode(il, ref sp);
+                if (!TryReadLocalSlot(il, storeOp, ref sp, storeOffset, out bool storeIsStore, out bool storeIsArg, out int storeSlot)
+                    || !storeIsStore)
+                    return false;
+                int storeKey = (storeIsArg ? ArgSlotBias : 0) | storeSlot;
+
+                // Pass 1: find the start of the basic block that feeds the concat — the point
+                // after the most recent store/branch/terminator before it. (Calls are not block
+                // boundaries.)
+                int blockStart = 0;
+                int p = 0;
+                while (p < concatOffset)
+                {
+                    int o = p;
+                    var op = ReadOpcode(il, ref p);
+                    bool isLocal = TryReadLocalSlot(il, op, ref p, o, out bool localStore, out _, out _);
+                    if (!isLocal)
+                        SkipOperandStatic(il, op, ref p, o);
+                    if (p <= concatOffset && ((isLocal && localStore) || EndsConcatArgumentBlock(op)))
+                        blockStart = p;
+                }
+
+                // Pass 2: simulate the eval stack from the block start to the concat. Each slot
+                // carries a bit: was it produced by a bare load of the destination slot?
+                var stack = new List<bool>();
+                p = blockStart;
+                while (p < concatOffset)
+                {
+                    int o = p;
+                    var op = ReadOpcode(il, ref p);
+                    if (TryReadLocalSlot(il, op, ref p, o, out bool isStore, out bool isArg, out int slot))
+                    {
+                        if (isStore)
+                            return false; // a store starts a new block; model desync -> bail
+                        int key = (isArg ? ArgSlotBias : 0) | slot;
+                        stack.Add(key == storeKey);
+                        continue;
+                    }
+                    if (!ApplyConcatBlockStackEffect(il, op, ref p, o, stack, callerScope))
+                        return false; // unmodeled opcode or stack underflow -> conservative bail
+                }
+
+                // The concat's arguments are the top `concatArgCount` slots. Accumulation iff any
+                // of them came from a bare load of the destination slot.
+                if (stack.Count < concatArgCount)
+                    return false;
+                for (int i = stack.Count - concatArgCount; i < stack.Count; i++)
+                    if (stack[i])
+                        return true;
+                return false;
             }
-            return argLoads.Contains(storeKey);
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
+            {
+                return false;
+            }
+        }
+
+        // Applies one instruction's eval-stack effect during the concat-argument replay, pushing
+        // `false` for any value that is not a bare load of the accumulator slot. Returns false to
+        // bail the whole probe on a stack underflow or any opcode the model does not cover, so an
+        // incomplete model can only lose a detection, never invent one.
+        bool ApplyConcatBlockStackEffect(byte[] il, ILOpCode opcode, ref int position, int offset, List<bool> stack, GenericScope callerScope)
+        {
+            switch (opcode)
+            {
+                case ILOpCode.Nop:
+                    return true;
+                // Pure pushes of a non-accumulator value.
+                case ILOpCode.Ldc_i4_m1 or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1 or ILOpCode.Ldc_i4_2
+                    or ILOpCode.Ldc_i4_3 or ILOpCode.Ldc_i4_4 or ILOpCode.Ldc_i4_5 or ILOpCode.Ldc_i4_6
+                    or ILOpCode.Ldc_i4_7 or ILOpCode.Ldc_i4_8 or ILOpCode.Ldnull:
+                    stack.Add(false);
+                    return true;
+                case ILOpCode.Ldc_i4_s:
+                    Advance(il, ref position, 1, offset);
+                    stack.Add(false);
+                    return true;
+                case ILOpCode.Ldc_i4 or ILOpCode.Ldc_r4 or ILOpCode.Ldstr or ILOpCode.Ldsfld
+                    or ILOpCode.Ldsflda or ILOpCode.Ldtoken or ILOpCode.Ldftn or ILOpCode.Sizeof:
+                    Advance(il, ref position, 4, offset);
+                    stack.Add(false);
+                    return true;
+                case ILOpCode.Ldc_i8 or ILOpCode.Ldc_r8:
+                    Advance(il, ref position, 8, offset);
+                    stack.Add(false);
+                    return true;
+                case ILOpCode.Ldloca_s or ILOpCode.Ldarga_s:
+                    Advance(il, ref position, 1, offset);
+                    stack.Add(false);
+                    return true;
+                case ILOpCode.Ldloca or ILOpCode.Ldarga:
+                    Advance(il, ref position, 2, offset);
+                    stack.Add(false);
+                    return true;
+                // pop 1, push 1 (a derived value — never the bare accumulator).
+                case ILOpCode.Conv_i1 or ILOpCode.Conv_i2 or ILOpCode.Conv_i4 or ILOpCode.Conv_i8
+                    or ILOpCode.Conv_r4 or ILOpCode.Conv_r8 or ILOpCode.Conv_u4 or ILOpCode.Conv_u8
+                    or ILOpCode.Conv_u2 or ILOpCode.Conv_u1 or ILOpCode.Conv_i or ILOpCode.Conv_u
+                    or ILOpCode.Conv_r_un or ILOpCode.Neg or ILOpCode.Not or ILOpCode.Ldlen
+                    or ILOpCode.Ldind_i1 or ILOpCode.Ldind_u1 or ILOpCode.Ldind_i2 or ILOpCode.Ldind_u2
+                    or ILOpCode.Ldind_i4 or ILOpCode.Ldind_u4 or ILOpCode.Ldind_i8 or ILOpCode.Ldind_i
+                    or ILOpCode.Ldind_r4 or ILOpCode.Ldind_r8 or ILOpCode.Ldind_ref:
+                    return Pop(stack, 1) && Push(stack);
+                case ILOpCode.Ldfld or ILOpCode.Ldflda or ILOpCode.Ldobj or ILOpCode.Castclass
+                    or ILOpCode.Isinst or ILOpCode.Unbox or ILOpCode.Unbox_any or ILOpCode.Box:
+                    Advance(il, ref position, 4, offset);
+                    return Pop(stack, 1) && Push(stack);
+                // pop 2, push 1.
+                case ILOpCode.Add or ILOpCode.Sub or ILOpCode.Mul or ILOpCode.Div or ILOpCode.Div_un
+                    or ILOpCode.Rem or ILOpCode.Rem_un or ILOpCode.And or ILOpCode.Or or ILOpCode.Xor
+                    or ILOpCode.Shl or ILOpCode.Shr or ILOpCode.Shr_un or ILOpCode.Ceq or ILOpCode.Cgt
+                    or ILOpCode.Cgt_un or ILOpCode.Clt or ILOpCode.Clt_un or ILOpCode.Ldelem_i1
+                    or ILOpCode.Ldelem_u1 or ILOpCode.Ldelem_i2 or ILOpCode.Ldelem_u2 or ILOpCode.Ldelem_i4
+                    or ILOpCode.Ldelem_u4 or ILOpCode.Ldelem_i8 or ILOpCode.Ldelem_i or ILOpCode.Ldelem_r4
+                    or ILOpCode.Ldelem_r8 or ILOpCode.Ldelem_ref:
+                    return Pop(stack, 2) && Push(stack);
+                case ILOpCode.Ldelem or ILOpCode.Ldelema:
+                    Advance(il, ref position, 4, offset);
+                    return Pop(stack, 2) && Push(stack);
+                case ILOpCode.Dup:
+                    if (stack.Count == 0)
+                        return false;
+                    stack.Add(stack[^1]);
+                    return true;
+                case ILOpCode.Pop:
+                    return Pop(stack, 1);
+                case ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj:
+                {
+                    int token = ReadInt32(il, ref position, offset);
+                    var callee = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
+                    if (callee.Kind == MemberKind.Unsupported)
+                        return false;
+                    int pops = callee.ParameterTypes.Length + (opcode != ILOpCode.Newobj && callee.HasThis ? 1 : 0);
+                    if (!Pop(stack, pops))
+                        return false;
+                    if (opcode == ILOpCode.Newobj || callee.ReturnType.Name != "Void")
+                        stack.Add(false);
+                    return true;
+                }
+                default:
+                    return false; // unmodeled opcode -> bail (no false positive)
+            }
+        }
+
+        static bool Pop(List<bool> stack, int count)
+        {
+            if (stack.Count < count)
+                return false;
+            stack.RemoveRange(stack.Count - count, count);
+            return true;
+        }
+
+        static bool Push(List<bool> stack)
+        {
+            stack.Add(false);
+            return true;
         }
 
         // Decodes a load/store of a local or argument slot, advancing past any inline operand.
@@ -2568,14 +2711,12 @@ public sealed class LibraryBodyIndex
             }
         }
 
-        // A value-sink that ends the run of argument loads feeding the next concat: a store
-        // (the value is consumed into a slot/field/element), a branch, or block-terminator.
-        // Calls are deliberately NOT boundaries: a sub-expression call (e.g. `s += x.Name`,
-        // `s = s + list[i]`) consumes only its own arguments and leaves the earlier accumulator
-        // load live beneath them on the eval stack, so it must stay in the window. The
-        // store-immediately-after-concat requirement already excludes list/return uses whose
-        // concat result is not stored back, so not clearing on calls does not admit those.
-        static bool ClearsAccumulatorWindow(ILOpCode opcode)
+        // A store/branch/terminator that ends the basic block feeding a concat: it bounds the
+        // straight-line region whose eval-stack the accumulation probe replays. Calls are NOT
+        // boundaries — a sub-expression call (`s += x.Name`, `s = s + list[i]`) leaves the
+        // earlier accumulator value live beneath its arguments. (Store-to-local/parameter is
+        // handled separately by the caller via the local-slot decoder.)
+        static bool EndsConcatArgumentBlock(ILOpCode opcode)
             => opcode is ILOpCode.Stfld or ILOpCode.Stsfld or ILOpCode.Stobj
                 or ILOpCode.Stelem or ILOpCode.Stelem_i or ILOpCode.Stelem_i1 or ILOpCode.Stelem_i2
                 or ILOpCode.Stelem_i4 or ILOpCode.Stelem_i8 or ILOpCode.Stelem_r4 or ILOpCode.Stelem_r8

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -249,6 +249,15 @@ public sealed class LibraryBodyIndex
     static bool IsEnumerableDefinition(TypeRef type)
         => FrameworkIdentity.IsKnownFrameworkType(type, "System.Linq", "System.Linq", "Enumerable");
 
+    // System.String.Concat — the lowering of the `+` / `+=` string operators (and of simple
+    // interpolations like `$"{a}-{b}"`). Each call allocates a fresh string. Inside a loop,
+    // when the result is stored back into one of its own inputs, it is the StringBuilder
+    // anti-pattern: `s += …` repeatedly copies the growing accumulator (O(n^2)).
+    public static bool IsStringConcat(MemberRef member)
+        => member.Kind != MemberKind.Unsupported
+            && member.Name == "Concat"
+            && FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "String");
+
     // A lazy/deferred Enumerable operator (Where/Select/…): it returns an iterator without
     // enumerating at the call site. A helper that returns such a query is itself a deferred
     // linear scan — the scan runs when the caller enumerates the result.
@@ -1552,6 +1561,28 @@ public sealed class LibraryBodyIndex
                                 offset,
                                 "Quadratic only if the scanned sequence grows with the loop; a small or constant sequence is fine."));
                         }
+                        else if (IsStringConcat(callee) && IsInLoopRegion(offset, loopRegions)
+                            && ConcatAccumulatesIntoSource(il, position))
+                        {
+                            // `s += …` inside a loop lowers to String.Concat(s, …) stored back to
+                            // the same local/parameter. Each iteration copies the whole growing
+                            // accumulator, so the loop is O(n^2) in the final length — the
+                            // canonical StringBuilder fix. Only this self-accumulation shape is
+                            // reported: a non-accumulating String.Concat/Format/Join in a loop
+                            // (e.g. `list.Add($"{k}={v}")`, `return $"{a}-{b}"`) allocates one
+                            // transient per iteration with no StringBuilder rewrite, so it is not
+                            // flagged — that tier was measured to be essentially all false
+                            // positives on real assemblies.
+                            opportunities.Add(new OptimizationOpportunity(
+                                caller,
+                                "string-build-in-loop",
+                                "string += in a loop (String.Concat onto a growing accumulator)",
+                                "Repeated concatenation copies the whole accumulator each iteration (O(n^2)); build with a StringBuilder hoisted outside the loop and ToString() once after.",
+                                "high",
+                                true,
+                                offset,
+                                null));
+                        }
                         break;
                     }
                     case ILOpCode.Ldftn:
@@ -2462,6 +2493,155 @@ public sealed class LibraryBodyIndex
             if (targetPosition < position || targetPosition > il.Length)
                 throw new BadImageFormatException($"Malformed IL operand at IL_{offset:X4}");
             position = (int)targetPosition;
+        }
+
+        // True when the String.Concat call ending at `storeOffset` accumulates into one of its
+        // own inputs: the instruction immediately after the call stores to a local/parameter
+        // slot that the same call also loaded as an argument (`s = String.Concat(s, …)`, the
+        // `s += …` lowering). Repeated copying of the growing accumulator is the canonical
+        // O(n^2) StringBuilder anti-pattern. The check is value-specific (the stored slot must
+        // be one of the call's argument loads), so an unrelated in-loop concat into a fresh
+        // local is not misread as accumulation. Argument slots are namespaced apart from local
+        // slots so a local index and a parameter index with the same number do not collide.
+        public static bool ConcatAccumulatesIntoSource(byte[] il, int storeOffset)
+        {
+            const int ArgSlotBias = 1 << 20;
+            if (storeOffset < 0 || storeOffset >= il.Length)
+                return false;
+            int sp = storeOffset;
+            var storeOp = ReadOpcode(il, ref sp);
+            if (!TryReadLocalSlot(il, storeOp, ref sp, storeOffset, out bool storeIsStore, out bool storeIsArg, out int storeSlot)
+                || !storeIsStore)
+                return false;
+            int storeKey = (storeIsArg ? ArgSlotBias : 0) | storeSlot;
+
+            int position = 0;
+            var argLoads = new List<int>();
+            while (position < storeOffset)
+            {
+                int offset = position;
+                var opcode = ReadOpcode(il, ref position);
+                bool isLocalOp = TryReadLocalSlot(il, opcode, ref position, offset, out bool isStore, out bool isArg, out int slot);
+                if (!isLocalOp)
+                    SkipOperandStatic(il, opcode, ref position, offset);
+                if (position >= storeOffset)
+                    break; // this is the Concat call itself; preserve its argument loads
+                if (isLocalOp && !isStore)
+                    argLoads.Add((isArg ? ArgSlotBias : 0) | slot);
+                else if (ClearsAccumulatorWindow(opcode))
+                    argLoads.Clear();
+            }
+            return argLoads.Contains(storeKey);
+        }
+
+        // Decodes a load/store of a local or argument slot, advancing past any inline operand.
+        // Returns false for any other opcode (operand left for the caller to skip).
+        static bool TryReadLocalSlot(byte[] il, ILOpCode opcode, ref int position, int offset, out bool isStore, out bool isArg, out int slot)
+        {
+            isStore = false;
+            isArg = false;
+            slot = -1;
+            switch (opcode)
+            {
+                case ILOpCode.Ldloc_0: slot = 0; return true;
+                case ILOpCode.Ldloc_1: slot = 1; return true;
+                case ILOpCode.Ldloc_2: slot = 2; return true;
+                case ILOpCode.Ldloc_3: slot = 3; return true;
+                case ILOpCode.Ldloc_s: slot = ReadByte(il, ref position, offset); return true;
+                case ILOpCode.Ldloc: slot = (ushort)ReadInt16(il, ref position, offset); return true;
+                case ILOpCode.Stloc_0: isStore = true; slot = 0; return true;
+                case ILOpCode.Stloc_1: isStore = true; slot = 1; return true;
+                case ILOpCode.Stloc_2: isStore = true; slot = 2; return true;
+                case ILOpCode.Stloc_3: isStore = true; slot = 3; return true;
+                case ILOpCode.Stloc_s: isStore = true; slot = ReadByte(il, ref position, offset); return true;
+                case ILOpCode.Stloc: isStore = true; slot = (ushort)ReadInt16(il, ref position, offset); return true;
+                case ILOpCode.Ldarg_0: isArg = true; slot = 0; return true;
+                case ILOpCode.Ldarg_1: isArg = true; slot = 1; return true;
+                case ILOpCode.Ldarg_2: isArg = true; slot = 2; return true;
+                case ILOpCode.Ldarg_3: isArg = true; slot = 3; return true;
+                case ILOpCode.Ldarg_s: isArg = true; slot = ReadByte(il, ref position, offset); return true;
+                case ILOpCode.Ldarg: isArg = true; slot = (ushort)ReadInt16(il, ref position, offset); return true;
+                case ILOpCode.Starg_s: isStore = true; isArg = true; slot = ReadByte(il, ref position, offset); return true;
+                case ILOpCode.Starg: isStore = true; isArg = true; slot = (ushort)ReadInt16(il, ref position, offset); return true;
+                default:
+                    return false;
+            }
+        }
+
+        // A value-sink that ends the run of argument loads feeding the next concat: a store
+        // (the value is consumed into a slot/field/element), a branch, or block-terminator.
+        // Calls are deliberately NOT boundaries: a sub-expression call (e.g. `s += x.Name`,
+        // `s = s + list[i]`) consumes only its own arguments and leaves the earlier accumulator
+        // load live beneath them on the eval stack, so it must stay in the window. The
+        // store-immediately-after-concat requirement already excludes list/return uses whose
+        // concat result is not stored back, so not clearing on calls does not admit those.
+        static bool ClearsAccumulatorWindow(ILOpCode opcode)
+            => opcode is ILOpCode.Stfld or ILOpCode.Stsfld or ILOpCode.Stobj
+                or ILOpCode.Stelem or ILOpCode.Stelem_i or ILOpCode.Stelem_i1 or ILOpCode.Stelem_i2
+                or ILOpCode.Stelem_i4 or ILOpCode.Stelem_i8 or ILOpCode.Stelem_r4 or ILOpCode.Stelem_r8
+                or ILOpCode.Stelem_ref or ILOpCode.Stind_i or ILOpCode.Stind_i1 or ILOpCode.Stind_i2
+                or ILOpCode.Stind_i4 or ILOpCode.Stind_i8 or ILOpCode.Stind_r4 or ILOpCode.Stind_r8
+                or ILOpCode.Stind_ref
+                or ILOpCode.Ret or ILOpCode.Throw or ILOpCode.Rethrow or ILOpCode.Leave or ILOpCode.Leave_s
+                or ILOpCode.Br or ILOpCode.Br_s or ILOpCode.Brtrue or ILOpCode.Brtrue_s
+                or ILOpCode.Brfalse or ILOpCode.Brfalse_s or ILOpCode.Beq or ILOpCode.Beq_s
+                or ILOpCode.Bne_un or ILOpCode.Bne_un_s or ILOpCode.Bge or ILOpCode.Bge_s
+                or ILOpCode.Bgt or ILOpCode.Bgt_s or ILOpCode.Ble or ILOpCode.Ble_s
+                or ILOpCode.Blt or ILOpCode.Blt_s or ILOpCode.Bge_un or ILOpCode.Bge_un_s
+                or ILOpCode.Bgt_un or ILOpCode.Bgt_un_s or ILOpCode.Ble_un or ILOpCode.Ble_un_s
+                or ILOpCode.Blt_un or ILOpCode.Blt_un_s or ILOpCode.Switch;
+
+        // Operand-length skip for opcodes other than the local load/store ops handled by
+        // TryReadLocalSlot. Mirrors SkipOperand but is static and self-contained so the
+        // accumulation probe needs no instance state.
+        static void SkipOperandStatic(byte[] il, ILOpCode opcode, ref int position, int offset)
+        {
+            switch (opcode)
+            {
+                case ILOpCode.Switch:
+                {
+                    int count = ReadInt32(il, ref position, offset);
+                    if (count < 0)
+                        throw new BadImageFormatException($"Malformed switch at IL_{offset:X4}");
+                    long target = (long)position + (long)count * 4;
+                    if (target < position || target > il.Length)
+                        throw new BadImageFormatException($"Malformed switch at IL_{offset:X4}");
+                    position = (int)target;
+                    break;
+                }
+                case ILOpCode.Br_s or ILOpCode.Brfalse_s or ILOpCode.Brtrue_s or ILOpCode.Beq_s
+                    or ILOpCode.Bge_s or ILOpCode.Bgt_s or ILOpCode.Ble_s or ILOpCode.Blt_s
+                    or ILOpCode.Bne_un_s or ILOpCode.Bge_un_s or ILOpCode.Bgt_un_s
+                    or ILOpCode.Ble_un_s or ILOpCode.Blt_un_s or ILOpCode.Leave_s
+                    or ILOpCode.Ldarga_s or ILOpCode.Ldloca_s
+                    or ILOpCode.Ldc_i4_s or ILOpCode.Unaligned:
+                    Advance(il, ref position, 1, offset);
+                    break;
+                case ILOpCode.Ldarga or ILOpCode.Ldloca:
+                    Advance(il, ref position, 2, offset);
+                    break;
+                case ILOpCode.Br or ILOpCode.Brfalse or ILOpCode.Brtrue or ILOpCode.Beq
+                    or ILOpCode.Bge or ILOpCode.Bgt or ILOpCode.Ble or ILOpCode.Blt
+                    or ILOpCode.Bne_un or ILOpCode.Bge_un or ILOpCode.Bgt_un
+                    or ILOpCode.Ble_un or ILOpCode.Blt_un or ILOpCode.Leave
+                    or ILOpCode.Ldc_i4 or ILOpCode.Ldc_r4
+                    or ILOpCode.Jmp or ILOpCode.Ldstr
+                    or ILOpCode.Call or ILOpCode.Calli or ILOpCode.Callvirt or ILOpCode.Newobj
+                    or ILOpCode.Ldftn or ILOpCode.Ldvirtftn
+                    or ILOpCode.Ldfld or ILOpCode.Ldflda or ILOpCode.Stfld
+                    or ILOpCode.Ldsfld or ILOpCode.Ldsflda or ILOpCode.Stsfld
+                    or ILOpCode.Cpobj or ILOpCode.Ldobj or ILOpCode.Castclass
+                    or ILOpCode.Isinst or ILOpCode.Unbox or ILOpCode.Stobj
+                    or ILOpCode.Box or ILOpCode.Newarr or ILOpCode.Ldelema
+                    or ILOpCode.Ldelem or ILOpCode.Stelem or ILOpCode.Unbox_any
+                    or ILOpCode.Refanyval or ILOpCode.Mkrefany or ILOpCode.Initobj
+                    or ILOpCode.Constrained or ILOpCode.Sizeof or ILOpCode.Ldtoken:
+                    Advance(il, ref position, 4, offset);
+                    break;
+                case ILOpCode.Ldc_i8 or ILOpCode.Ldc_r8:
+                    Advance(il, ref position, 8, offset);
+                    break;
+            }
         }
 
         static byte ReadByte(byte[] il, ref int position, int offset)

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -80,6 +80,13 @@ public sealed record MemberRef(
     public ImmutableArray<TypeRef> TypeArguments { get; init; } = [];
 
     /// <summary>
+    /// True when the method has a `this` parameter (instance call), so a call site pops one
+    /// extra value (the receiver) beyond <see cref="ParameterTypes"/>. Used by stack-effect
+    /// reasoning over call sites.
+    /// </summary>
+    public bool HasThis { get; init; }
+
+    /// <summary>
     /// The parameter signature with generic markers (VAR/MVAR) preserved — i.e. before
     /// the declaring-type / method-type instantiation that <see cref="ParameterTypes"/>
     /// carries. Cross-assembly caller-graph identity keys on this so a constructed call

--- a/src/ILInspector.Analysis/MemberResolver.cs
+++ b/src/ILInspector.Analysis/MemberResolver.cs
@@ -24,6 +24,7 @@ internal static class MemberResolver
                 {
                     OpenParameterTypes = signature.ParameterTypes,
                     OpenReturnType = signature.ReturnType,
+                    HasThis = signature.Header.IsInstance,
                 };
             }
             case HandleKind.MemberReference:
@@ -43,6 +44,7 @@ internal static class MemberResolver
                     // Raw signature with VAR/MVAR markers, before instantiation (#1731).
                     OpenParameterTypes = signature.ParameterTypes,
                     OpenReturnType = signature.ReturnType,
+                    HasThis = signature.Header.IsInstance,
                 };
             }
             case HandleKind.MethodSpecification:


### PR DESCRIPTION
## What

Adds a new Performance Triage shape, **`string-build-in-loop`**, that flags the classic O(n²) string-accumulation anti-pattern: `s += …` (or `s = s + … `) inside a loop, where each iteration copies the whole growing accumulator. The fix is a `StringBuilder` hoisted outside the loop.

Part of #1714.

## Precision-first design

A naive "any `String.Concat`/`Format`/`Join` in a loop" detector is almost pure noise — measured directly: on Aspire.Dashboard the broad version produced 13 hits, **every one a false positive** (e.g. `list.Add($"{k}={v}")`, `return $"{a}-{b}"` inside a loop, both lowered to `String.Concat` but neither a `StringBuilder` opportunity). So this shape emits **only** the self-accumulation case:

- The call is `System.String.Concat` (trust-gated framework identity), and
- it sits in a loop region, and
- the concat result is stored straight back into a local/parameter slot, and
- a value **actually consumed by that concat** originated from a bare load of that same slot (`s = Concat(s, …)`).

The accumulation check (`ConcatAccumulatesIntoSource`) is **stack-aware**: it replays the eval stack across the basic block feeding the concat, tagging each stack slot with a "produced by a bare load of the destination slot" bit, and reports accumulation only when one of the concat's actual arguments carries that bit. This recognizes `s += x`, `s = s + a + list[i]`, `s += item.Name`, `s += Method(x)`, and the accumulator-as-last-arg prepend (`s = x + sep + s`), while rejecting a prior unrelated use of the slot (`Foo(s); s = a + b;`). `MemberRef.HasThis` was added so call sites pop the receiver correctly; any unmodeled opcode or stack underflow makes the probe bail (never a false positive).

## Evidence (production `dotnet-inspect`)

Verified end-to-end with the built CLI and confirmed each hit by decompilation (ilspycmd):

- **0 hits** on well-written modern code: Aspire.Dashboard, OpenAI, and 46 other assemblies in the Aspire bin folder.
- **20 hits** in `Humanizer.dll` across 4 number-to-words converters — all genuine, e.g. `text += fact.Postfix`, `text += UnitsMap[num]`, `text += ConvertToOrdinal(number)` inside `foreach`/`for`.

Controlled fixtures confirm the true/false split: `s += x`, `s += x.Prop`, `s = s + a + list[i]`, `s = x + sep + s`, and parameter accumulation all flag HIGH; per-item list-building, return-in-loop concats, the `Foo(s); s = a + b;` non-accumulation, and derived accumulators do not flag.

## Conservative by design

A **derived** accumulator — where the value flows through a call before the concat (`s = s.Trim() + x`, `path = path.Substring(..) + path.Substring(..)`) — is intentionally not matched: the bare-load bit does not survive the intermediate call. This is the precision/recall tradeoff that keeps the false-positive rate at zero (it costs ~2 Humanizer rows and 1 Microsoft.OpenApi row that are genuine but derived). Broadening to derived accumulators and to `Format`/`Join`/interpolation is tracked as a follow-up on #1714.

## Tests

10 fixtures + tests in `LibraryBodyIndexTests`, including adversarial-review regression guards for the false-positive and derived-accumulator cases. Full suite green: ILInspector.Analysis.Tests 208, dotnet-inspect.Tests 1378 (9 ildasm skips).
