### PR TITLE
Add generated fixture selection and JSON

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 using ILInspector.DecompilerHarness;
 
 namespace ILInspector.Decompiler.Tests;
@@ -53,6 +55,55 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("PASS frontier", report);
         Assert.Contains("decompiler=Full", report);
         Assert.Contains("compile-back=OpcodeDiff", report);
+    }
+
+    [Fact]
+    public void CatalogueSelection_MatchesExactIdOrPrefix()
+    {
+        Assert.Equal(
+            ["minimal.property.literal"],
+            GeneratedFixtureCatalog.Select("minimal.property.literal").Select(fixture => fixture.Id).ToArray());
+
+        Assert.Equal(
+            ["minimal.primary-ctor.field-init", "minimal.property.literal"],
+            GeneratedFixtureCatalog.Select("minimal").Select(fixture => fixture.Id).Order(StringComparer.Ordinal).ToArray());
+
+        Assert.Empty(GeneratedFixtureCatalog.Select("missing"));
+    }
+
+    [Fact]
+    public void CatalogueListJson_ContainsFixtureIdsAndExpectedStatuses()
+    {
+        string json = GeneratedFixtureRunner.FormatListJson(GeneratedFixtureCatalog.All);
+
+        using var document = JsonDocument.Parse(json);
+        var fixtures = document.RootElement.EnumerateArray().ToArray();
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.property.literal");
+
+        var primaryCtor = Assert.Single(fixtures,
+            fixture => fixture.GetProperty("Id").GetString() == "minimal.primary-ctor.field-init");
+        var ctor = Assert.Single(primaryCtor.GetProperty("Targets").EnumerateArray(),
+            target => target.GetProperty("Method").GetString() == ".ctor");
+        Assert.Equal("OpcodeDiff", ctor.GetProperty("ExpectedStatus").GetString());
+        Assert.True(ctor.GetProperty("IsFrontier").GetBoolean());
+    }
+
+    [Fact]
+    public void SelectedFixtureRunJson_ContainsOnlySelectedFixtureResults()
+    {
+        var selected = GeneratedFixtureCatalog.Select("minimal.property.literal");
+        var run = GeneratedFixtureRunner.Run(selected);
+        string json = GeneratedFixtureRunner.FormatJson(run);
+
+        using var document = JsonDocument.Parse(json);
+        var results = document.RootElement.GetProperty("Results").EnumerateArray().ToArray();
+
+        Assert.Equal(2, results.Length);
+        Assert.All(results, result =>
+        {
+            Assert.Equal("minimal.property.literal", result.GetProperty("FixtureId").GetString());
+            Assert.Equal("Exact", result.GetProperty("ActualStatus").GetString());
+        });
     }
 
     static void AssertTarget(

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
 using System.Runtime.Versioning;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 using ILInspector.Decompiler.Pipeline;
 
@@ -56,11 +58,24 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "primary-constructor", "field-initializer"]);
 
-    public static IReadOnlyList<GeneratedFixtureDefinition> MinimalCompileBackRungs { get; } =
+    public static IReadOnlyList<GeneratedFixtureDefinition> All { get; } =
     [
         MinimalPropertyLiteral,
         MinimalPrimaryCtorFieldInit,
     ];
+
+    public static IReadOnlyList<GeneratedFixtureDefinition> MinimalCompileBackRungs => All;
+
+    public static IReadOnlyList<GeneratedFixtureDefinition> Select(string? selector)
+    {
+        if (string.IsNullOrWhiteSpace(selector))
+            return All;
+
+        return All
+            .Where(fixture => fixture.Id.Equals(selector, StringComparison.Ordinal)
+                || fixture.Id.StartsWith(selector, StringComparison.Ordinal))
+            .ToArray();
+    }
 }
 
 internal sealed record GeneratedFixtureDefinition(
@@ -113,6 +128,12 @@ internal sealed record GeneratedFixtureResult(
 
 internal static class GeneratedFixtureRunner
 {
+    static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
     public static GeneratedFixtureRunResult Run(
         IReadOnlyList<GeneratedFixtureDefinition> fixtures,
         GeneratedFixtureRunOptions? options = null)
@@ -192,6 +213,56 @@ internal static class GeneratedFixtureRunner
                 sb.AppendLine($"      note: {result.Note}");
         }
         return sb.ToString();
+    }
+
+    public static string FormatJson(GeneratedFixtureRunResult run)
+    {
+        var payload = new
+        {
+            ProjectDirectory = Directory.Exists(run.ProjectDirectory) ? run.ProjectDirectory : null,
+            AssemblyPath = File.Exists(run.AssemblyPath) ? run.AssemblyPath : null,
+            run.Results,
+            run.Passed,
+        };
+        return JsonSerializer.Serialize(payload, s_jsonOptions);
+    }
+
+    public static string FormatList(IReadOnlyList<GeneratedFixtureDefinition> fixtures)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"GENERATED FIXTURE CATALOG ({fixtures.Count} fixture(s))");
+        foreach (var fixture in fixtures.OrderBy(fixture => fixture.Id, StringComparer.Ordinal))
+        {
+            sb.AppendLine($"  {fixture.Id}  [{string.Join(", ", fixture.Tags)}]");
+            foreach (var target in fixture.Targets)
+            {
+                string frontier = target.IsFrontier ? " frontier" : "";
+                sb.AppendLine(
+                    $"      {target.DisplayMember}  expected={target.ExpectedStatus}{frontier}");
+            }
+        }
+        return sb.ToString();
+    }
+
+    public static string FormatListJson(IReadOnlyList<GeneratedFixtureDefinition> fixtures)
+    {
+        var items = fixtures
+            .OrderBy(fixture => fixture.Id, StringComparer.Ordinal)
+            .Select(fixture => new
+            {
+                fixture.Id,
+                fixture.Tags,
+                Targets = fixture.Targets.Select(target => new
+                {
+                    target.Type,
+                    target.Method,
+                    target.Overload,
+                    ExpectedStatus = target.ExpectedStatus.ToString(),
+                    target.IsFrontier,
+                    target.Note,
+                }),
+            });
+        return JsonSerializer.Serialize(items, s_jsonOptions);
     }
 
     static string Key(string type, string method, int overload) => $"{type}::{method}#{overload}";

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -56,6 +56,7 @@ static class Program
         bool bindCheck = false;
         bool classifyDec0009 = false;
         bool generatedFixtures = false;
+        string? generatedFixtureSelector = null;
         bool keepGeneratedFixtures = false;
         string? emitCorpusSnapshot = null;
         string? diffCorpusBaseline = null;
@@ -114,7 +115,13 @@ static class Program
                 case "--bind-check": bindCheck = true; break;
                 case "--classify-dec0009": classifyDec0009 = true; break;
                 case "--dec0009-shapes": classifyDec0009 = true; break;
-                case "--generated-fixtures": generatedFixtures = true; break;
+                case "--generated-fixtures":
+                    generatedFixtures = true;
+                    if (i + 1 < args.Length && !args[i + 1].StartsWith('-')
+                        && !File.Exists(args[i + 1]) && !Directory.Exists(args[i + 1])
+                        && !LooksLikePath(args[i + 1]))
+                        generatedFixtureSelector = args[++i];
+                    break;
                 case "--keep-generated-fixtures": keepGeneratedFixtures = true; break;
                 case "--emit-corpus-baseline": emitCorpusSnapshot = args[++i]; break;
                 case "--emit-corpus-snapshot": emitCorpusSnapshot = args[++i]; break;
@@ -145,7 +152,7 @@ static class Program
         {
             if (inputs.Count > 0)
                 return Fail("--generated-fixtures generates its own temporary input assembly; do not pass assembly paths.");
-            return GeneratedFixtures(keepGeneratedFixtures);
+            return GeneratedFixtures(generatedFixtureSelector, keepGeneratedFixtures, json);
         }
 
         var assemblies = ResolveAssemblies(inputs);
@@ -225,13 +232,33 @@ static class Program
         return Inventory(assemblies);
     }
 
-    static int GeneratedFixtures(bool keepArtifacts)
+    static int GeneratedFixtures(string? selector, bool keepArtifacts, bool json)
     {
+        var fixtures = GeneratedFixtureCatalog.Select(selector);
+        if (selector == "list")
+        {
+            if (json)
+                Console.WriteLine(GeneratedFixtureRunner.FormatListJson(GeneratedFixtureCatalog.All));
+            else
+                Console.Write(GeneratedFixtureRunner.FormatList(GeneratedFixtureCatalog.All));
+            return 0;
+        }
+
+        if (fixtures.Count == 0)
+            return Fail($"No generated fixture IDs match '{selector}'. Use '--generated-fixtures list'.");
+
         var run = GeneratedFixtureRunner.Run(
-            GeneratedFixtureCatalog.MinimalCompileBackRungs,
+            fixtures,
             new GeneratedFixtureRunOptions(KeepArtifacts: keepArtifacts));
-        Console.Write(GeneratedFixtureRunner.FormatReport(run));
-        if (keepArtifacts)
+        if (json)
+        {
+            Console.WriteLine(GeneratedFixtureRunner.FormatJson(run));
+        }
+        else
+        {
+            Console.Write(GeneratedFixtureRunner.FormatReport(run));
+        }
+        if (keepArtifacts && !json)
         {
             Console.WriteLine();
             Console.WriteLine($"Generated fixture project: {run.ProjectDirectory}");
@@ -239,6 +266,14 @@ static class Program
         }
         return run.Passed ? 0 : 1;
     }
+
+    static bool LooksLikePath(string value) =>
+        value.Contains(Path.DirectorySeparatorChar)
+        || value.Contains(Path.AltDirectorySeparatorChar)
+        || value.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+        || value.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+        || value.EndsWith(".so", StringComparison.OrdinalIgnoreCase)
+        || value.EndsWith(".dylib", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// The self-contained real-gap view. It inspects only the raised tree:
@@ -1152,9 +1187,13 @@ static class Program
                                 remarks by generated-name family. Use --json for
                                 machine-readable output.
           --dec0009-shapes       alias for --classify-dec0009.
-          --generated-fixtures   generate the seed fixture catalogue into a
+          --generated-fixtures [id|prefix|list]
+                                generate selected fixture catalogue entries into a
                                 temporary class library, run compile-back, and
-                                report by fixture ID and target method.
+                                report by fixture ID and target method. With no
+                                selector, run all generated fixtures. Use
+                                "list" to list fixture IDs. Add --json for
+                                machine-readable list/results.
           --keep-generated-fixtures
                                 with --generated-fixtures: keep the temporary
                                 project and print its paths.

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -8,13 +8,15 @@ The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — t
 
 **Gaps** (`--gaps`): the completeness view — see below.
 
-**Generated fixtures** (`--generated-fixtures`): builds the seed generated-fixture
-catalogue into a temporary class library, runs the compile-back oracle, and prints
-results by stable fixture ID plus target method. This is the first step toward an
-addressable progressive fixture ladder: `minimal.property.literal` is expected
-`Exact`, while `minimal.primary-ctor.field-init` records the current constructor
-`OpcodeDiff` frontier and the exact getter. Add `--keep-generated-fixtures` to
-preserve the generated project for drill-down.
+**Generated fixtures** (`--generated-fixtures [id|prefix|list]`): builds selected
+generated-fixture catalogue entries into a temporary class library, runs the
+compile-back oracle, and prints results by stable fixture ID plus target method.
+This is the first step toward an addressable progressive fixture ladder:
+`minimal.property.literal` is expected `Exact`, while
+`minimal.primary-ctor.field-init` records the current constructor `OpcodeDiff`
+frontier and the exact getter. With no selector, all generated fixtures run; use
+`list` to list fixture IDs, `--json` for machine-readable list/results, and
+`--keep-generated-fixtures` to preserve the generated project for drill-down.
 
 **Library report** (`--library-report`): a portfolio view. It combines the IR
 residual buckets from `--gaps` with the Roslyn-backed validity oracle from
@@ -451,6 +453,9 @@ CB_TYPE=CfgSampleClass CB_DUMP=1 dotnet run --project tools/DecompilerHarness -c
 
 # Generated progressive fixture catalogue: build source snippets, then compile-back.
 dotnet run --project tools/DecompilerHarness -c Release -- --generated-fixtures
+dotnet run --project tools/DecompilerHarness -c Release -- --generated-fixtures list
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  --generated-fixtures minimal.property.literal --json
 dotnet run --project tools/DecompilerHarness -c Release -- \
   --generated-fixtures --keep-generated-fixtures
 


### PR DESCRIPTION
## Summary

Follow-up for #1742.

Extends the generated decompiler fixture catalogue runner with scalable addressing and machine-readable output:

- `--generated-fixtures list` lists fixture IDs and expected target outcomes without building a temp assembly
- `--generated-fixtures <id-or-prefix>` runs only selected fixture entries
- `--json` emits machine-readable catalogue lists or run results with enum statuses serialized as strings
- path-like positional inputs after `--generated-fixtures` are rejected as unsupported assembly inputs instead of misread as selectors

## Evidence

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures list
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.property.literal --json
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures missing # expected exit 1
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
```

Selected fixture JSON smoke:

```json
{
  "ProjectDirectory": null,
  "AssemblyPath": null,
  "Results": [
    {
      "FixtureId": "minimal.property.literal",
      "ActualStatus": "Exact",
      "ExpectedStatus": "Exact",
      "Passed": true
    }
  ],
  "Passed": true
}
```

## Adversarial review

Requested Opus 4.8 and MAI-Code-1-Flash reviews before opening. They found two actionable issues:

- `--json --keep-generated-fixtures` appended human path lines after the JSON payload, making stdout invalid JSON.
- Nonexistent path-like tokens after `--generated-fixtures` could be interpreted as fixture selectors instead of rejected as unsupported assembly inputs.

Both were fixed in commit d04581ed before this PR was opened. Final Opus and MAI reviews reported no significant issues.
