### PR TITLE
Fix unchecked unsigned ordering constants (#1750)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MixedSignComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignComparisonTests.cs
@@ -1,4 +1,7 @@
+using System.Collections.Immutable;
 using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -13,6 +16,8 @@ namespace ILInspector.Decompiler.Tests;
 // to preserve the signed comparison (#1476).
 public class MixedSignComparisonTests
 {
+    static readonly TypeRef UInt = TypeRef.CoreLib("System", "UInt32");
+    static readonly TypeRef Int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef ULong = TypeRef.CoreLib("System", "UInt64");
     static readonly TypeRef Long = TypeRef.CoreLib("System", "Int64");
     static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
@@ -32,6 +37,32 @@ public class MixedSignComparisonTests
                 [new Parameter("a", leftType), new Parameter("b", rightType)],
                 HasThis: false, GenericParameterCount: 0),
             [], body);
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    static string RenderComparison(ComparisonKind kind, bool isUnsigned, IrExpression left, IrExpression right)
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Return(new Comparison(kind, isUnsigned, left, right)));
+        body.Add(block);
+        var function = new IrFunction(
+            "M", owner,
+            new MethodSignature(Bool,
+                [new Parameter("i", left.ResultType ?? UInt)],
+                HasThis: false, GenericParameterCount: 0),
+            [], body);
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    static string RenderImported(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(UnsignedComparisonSpecimens).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(UnsignedComparisonSpecimens).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
         return CSharpPrinter.Print(function).Output!;
     }
 
@@ -111,4 +142,121 @@ public class MixedSignComparisonTests
         var output = CSharpPrinter.Print(function).Output!;
         Assert.Contains("(long)((ulong)a + b) < c", output);
     }
+
+    [Fact]
+    public void UnsignedOrdering_UIntOutOfRangeConstant_WrapsCastInUnchecked()
+    {
+        var output = RenderComparison(ComparisonKind.GreaterThanOrEqual, isUnsigned: true,
+            new LoadArgument(0, "i", UInt),
+            new Constant(-294967296, Int));
+
+        Assert.Contains("i >= unchecked((uint)-294967296)", output);
+        AssertBodyCompiles("public static bool M(uint i)", output);
+    }
+
+    [Fact]
+    public void UnsignedOrdering_ULongOutOfRangeConstant_WrapsCastInUnchecked()
+    {
+        var output = RenderComparison(ComparisonKind.GreaterThanOrEqual, isUnsigned: true,
+            new LoadArgument(0, "i", ULong),
+            new Constant(-8446744073709551616L, Long));
+
+        Assert.Contains("i >= unchecked((ulong)-8446744073709551616)", output);
+        AssertBodyCompiles("public static bool M(ulong i)", output);
+    }
+
+    [Fact]
+    public void UnsignedOrdering_ULongNegativeLongConstant_WrapsCastInUnchecked()
+    {
+        var output = RenderComparison(ComparisonKind.LessThan, isUnsigned: true,
+            new LoadArgument(0, "i", ULong),
+            new Constant(-16L, Long));
+
+        Assert.Contains("i < unchecked((ulong)-16)", output);
+        AssertBodyCompiles("public static bool M(ulong i)", output);
+    }
+
+    [Fact]
+    public void UnsignedEquality_OutOfRangeConstant_StillWrapsCastInUnchecked()
+    {
+        var output = RenderComparison(ComparisonKind.Equal, isUnsigned: false,
+            new LoadArgument(0, "i", ULong),
+            new Constant(-1L, Long));
+
+        Assert.Contains("i == unchecked((ulong)-1)", output);
+        AssertBodyCompiles("public static bool M(ulong i)", output);
+    }
+
+    [Fact]
+    public void ImportedUnsignedOrderingOutOfRangeConstants_RenderUncheckedCasts()
+    {
+        AssertContainsAndCompiles("public static bool M(ulong i)",
+            "i >= unchecked((ulong)-8446744073709551616)",
+            RenderImported(nameof(UnsignedComparisonSpecimens.GeUlongHighBit)));
+        AssertContainsAndCompiles("public static bool M(uint i)",
+            "i >= unchecked((uint)-294967296)",
+            RenderImported(nameof(UnsignedComparisonSpecimens.UintGe)));
+        AssertContainsAndCompiles("public static bool M(ulong i)",
+            "i < unchecked((ulong)((long)-16))",
+            RenderImported(nameof(UnsignedComparisonSpecimens.UlongLt)));
+        AssertContainsAndCompiles("public static bool M(ulong i)",
+            "i == unchecked((ulong)((long)-1))",
+            RenderImported(nameof(UnsignedComparisonSpecimens.UlongEq)));
+    }
+
+    static void AssertContainsAndCompiles(string methodHeader, string expected, string body)
+    {
+        Assert.Contains(expected, body);
+        AssertBodyCompiles(methodHeader, body);
+    }
+
+    static void AssertBodyCompiles(string methodHeader, string body)
+    {
+        var errors = Recompile(methodHeader, body)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToArray();
+        Assert.True(errors.Length == 0, "Rendered body must compile, got:\n  " + string.Join("\n  ", errors) + "\n--- body ---\n" + body);
+    }
+
+    static ImmutableArray<Diagnostic> Recompile(string methodHeader, string body)
+    {
+        string source = $$"""
+            static class __Gate
+            {
+                {{methodHeader}}
+                {
+            {{body}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "__gate",
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        return compilation.GetDiagnostics();
+    }
+
+    static ImmutableArray<MetadataReference> RuntimeReferences()
+    {
+        var references = ImmutableArray.CreateBuilder<MetadataReference>();
+        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+            references.Add(MetadataReference.CreateFromFile(path));
+        }
+        return references.ToImmutable();
+    }
+}
+
+public static class UnsignedComparisonSpecimens
+{
+    public static bool GeUlongHighBit(ulong i) => i >= 10000000000000000000UL;
+    public static bool UintGe(uint i) => i >= 4000000000U;
+    public static bool UlongLt(ulong i) => i < 0xFFFFFFFFFFFFFFF0UL;
+    public static bool UlongEq(ulong i) => i == ulong.MaxValue;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -784,14 +784,19 @@ public sealed partial class CSharpPrinter
         return expression is Constant { Value: 0 or 0L or 0u or 0UL or (short)0 or (sbyte)0 or (byte)0 or (ushort)0 };
     }
 
-    /// <summary>Casts a signed-integer operand to its unsigned counterpart; already-unsigned, float (.un = unordered), and unknown-typed operands print plain.</summary>
+    /// <summary>
+    /// Casts a signed-integer operand to its unsigned counterpart; already-unsigned,
+    /// float (.un = unordered), and unknown-typed operands print plain. A signed
+    /// constant outside the unsigned target's range takes the <c>unchecked</c>
+    /// spelling so the out-of-range cast is legal (CS0221).
+    /// </summary>
     string UnsignedOperand(IrExpression operand, bool checkedSafe = true)
     {
         string? cast = TypeFamilies.UnsignedCastKeyword(operand.ResultType);
         if (cast is null)
             return Operand(operand);
         string text = $"({cast}){Operand(operand)}";
-        return checkedSafe ? CheckedSafeCast(text) : text;
+        return checkedSafe ? CheckedSafeCast(text, force: IsOutOfRangeUnsignedConstant(operand)) : text;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes #1750 by making unsigned ordering comparisons use the same `unchecked(...)` protection already used by equality/bitwise reinterprets when a signed integer constant is outside the unsigned target range.

This narrows the false `Full` claim where output such as `i >= (ulong)-8446744073709551616` and `i >= (uint)-294967296` did not bind (`CS0221`). The fixed output is valid C#, for example:

```csharp
public static bool GeUlongHighBit(ulong i) => i >= unchecked((ulong)-8446744073709551616);
public static bool UintGe(uint i) => i >= unchecked((uint)-294967296);
public static bool UlongLt(ulong i) => i < unchecked((ulong)((long)-16));
public static bool UlongEq(ulong i) => i == unchecked((ulong)((long)-1));
```

## Evidence

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/MixedSignComparisonTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- `dotnet run --project tools/DecompilerHarness -c Release -- /tmp/unsigned-comparison-specimens/bin/Release/net11.0/unsigned-comparison-specimens.dll --validity-check --compile-cap 20 --max-examples 20`

Harness result:

```text
COMPILE-CHECK over 4 rendered methods (4 Full, 0 Partial)

Syntactic validity (parse + statement legality — false-positive-free):
  Full malformed   : 0 (0.00% of Full) — the "claimed good but won't parse" set
  Partial malformed: 0 (0 of Partial) — expected: the diagnosed unsupported bits

Semantic binding (Full + syntactically-valid, capped at 4 bound):
  with a non-binding-noise error: 0 (0.00%)
```

The full slow `src/ILInspector.Decompiler.Tests` suite was attempted locally but did not complete under machine contention; this PR includes the closest focused importer-backed compile checks plus the fast PR decompiler gate.

## Review

Adversarial review is required before merge; I will post the reconciled results here.
