### PR TITLE
Fix boxed generic reference equality decompile

### DIFF
--- a/src/ILInspector.Decompiler.Tests/BoxedReferenceEqualityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/BoxedReferenceEqualityTests.cs
@@ -1,0 +1,68 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class BoxedReferenceEqualityTests
+{
+    [Fact]
+    public void BoxedGenericEquality_PreservesObjectCasts()
+    {
+        using var source = MetadataSource.Open(typeof(BoxedReferenceEqualitySpecimens).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(BoxedReferenceEqualitySpecimens).FullName!,
+            nameof(BoxedReferenceEqualitySpecimens.IndexOfReference));
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("if ((object)item == (object)list[i])", output);
+        Assert.DoesNotContain("if ((item) == (list[i]))", output);
+    }
+
+    [Fact]
+    public void BoxedGenericInequality_PreservesObjectCasts()
+    {
+        var generic = TypeRef.MethodGenericParameter(0, "T");
+        var comparison = new Comparison(
+            ComparisonKind.NotEqual,
+            isUnsigned: false,
+            new Box(generic, new LoadArgument(0, "left", generic)),
+            new Box(generic, new LoadArgument(1, "right", generic)));
+        var block = new Block();
+        block.Add(new Return(comparison));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(
+                TypeRef.CoreLib("System", "Boolean"),
+                [new Parameter("left", generic), new Parameter("right", generic)],
+                HasThis: false,
+                GenericParameterCount: 1),
+            [],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("return (object)left != (object)right;", output);
+        Assert.DoesNotContain("return left != right;", output);
+    }
+}
+
+public static class BoxedReferenceEqualitySpecimens
+{
+    public static int IndexOfReference<T>(System.Collections.Generic.List<T> list, T item)
+    {
+        for (int i = 0; i < list.Count; i++)
+        {
+            if ((object?)item == (object?)list[i])
+                return i;
+        }
+
+        return -1;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -694,6 +694,14 @@ public sealed partial class CSharpPrinter
                 ? $"{Operand(operand)} is null"
                 : $"{Operand(operand)} is not null";
         }
+        // Equality over an explicitly boxed operand is reference identity over the
+        // boxed object. Dropping the box evidence turns unconstrained generic
+        // operands into `T == T` (CS0019) and can also bind overloaded operators.
+        if (kind is ComparisonKind.Equal or ComparisonKind.NotEqual
+            && (left is Box || right is Box))
+        {
+            return $"{BoxedReferenceOperand(left)} {ComparisonOperator(kind)} {BoxedReferenceOperand(right)}";
+        }
         // The `cgt.un`/`clt.un` against null idiom csc emits for a reference
         // inequality (`ldnull; cgt.un` = `obj != null`): an unsigned ordering of a
         // reference against null tests non-nullness (null is 0, so `x > 0` / `0 <
@@ -765,6 +773,9 @@ public sealed partial class CSharpPrinter
             ? $"{UnsignedOperand(left)} {ComparisonOperator(kind)} {UnsignedOperand(right)}"
             : $"{Operand(left)} {ComparisonOperator(kind)} {Operand(right)}";
     }
+
+    string BoxedReferenceOperand(IrExpression operand)
+        => operand is Box box ? $"(object){Operand(box.Operand)}" : Operand(operand);
 
     static bool IsFloatComparison(IrExpression left, IrExpression right)
         => TypeFamilies.IsFloat(left.ResultType) || TypeFamilies.IsFloat(right.ResultType);


### PR DESCRIPTION
## Summary

Fixes #1758 by preserving explicit `(object)` casts when IL compares boxed operands for equality/inequality. This keeps boxed generic reference-identity checks valid instead of dropping the box evidence and rendering invalid `T == T`.

## Evidence

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/BoxedReferenceEqualityTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- `dotnet run --project tools/DecompilerHarness -c Release -- /tmp/dvReferenceEquality/bin/Release/net11.0/dvReferenceEquality.dll --validity-check --compile-cap 20 --max-examples 20`
- `dotnet run --project tools/DecompilerHarness -c Release -- /tmp/dvReferenceEquality/bin/Release/net11.0/dvReferenceEquality.dll --fidelity-check --compile-cap 20 --max-examples 20`

The reduced fixture now renders `if ((object)item == (object)list[i])` and passes validity plus compile-back fidelity. A full slow `src/ILInspector.Decompiler.Tests` run was also started, but was stopped after ~23 minutes without progress output; the fast PR-gate subset and focused regression coverage passed.

## Adversarial review

Requested cross-model adversarial review from Claude Opus 4.8 and MAI-Code-1-Flash; summary comment to follow on this PR.
