### PR TITLE
Fix jagged array creation rendering (#1654)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4027,6 +4027,22 @@ public static class RectangularArraySamples
     public static int Jagged(int[][] a, int i, int j) => a[i][j];
 }
 
+// Issue #1654: ordinary newarr over an array-typed element must put the new
+// length in the outer rank, e.g. new int[n][] rather than new int[][n].
+public static class JaggedArrayCreationSamples
+{
+    public static int[][] J2() => new int[3][];
+    public static int[][][] J3() => new int[3][][];
+    public static string[][] JStr() => new string[5][];
+    public static int[][] JVar(int n) => new int[n][];
+    public static int[][,] JMdElement() => new int[2][,];
+    public static int[][][,] JSzThenMdElement() => new int[2][][,];
+    public static int[][,][] JMdThenSzElement() => new int[2][,][];
+
+    public static int[] SingleDimNew(int n) => new int[n];
+    public static int[] ArrayLiteral() => new[] { 1, 2, 3 };
+}
+
 // Canary: a user type declaring its own Get/Set must NOT be rewritten as an
 // indexer — only TypeRefKind.Array receivers are the rectangular pseudo-members.
 public sealed class UserGridSample

--- a/src/ILInspector.Decompiler.Tests/MultiDimensionalArrayPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MultiDimensionalArrayPrinterTests.cs
@@ -19,6 +19,31 @@ public class MultiDimensionalArrayPrinterTests
     public void RectangularElementAndCreationOps_LowerToIndexerSyntax_AndCompile(string methodName, string header, string expected)
         => AssertImportedBodyAndCompile(methodName, header, expected);
 
+    [Theory]
+    [InlineData(nameof(JaggedArrayCreationSamples.J2), "public static int[][] M()", "return new int[3][];")]
+    [InlineData(nameof(JaggedArrayCreationSamples.J3), "public static int[][][] M()", "return new int[3][][];")]
+    [InlineData(nameof(JaggedArrayCreationSamples.JStr), "public static string[][] M()", "return new string[5][];")]
+    [InlineData(nameof(JaggedArrayCreationSamples.JVar), "public static int[][] M(int n)", "return new int[n][];")]
+    [InlineData(nameof(JaggedArrayCreationSamples.JMdElement), "public static int[][,] M()", "return new int[2][,];")]
+    [InlineData(nameof(JaggedArrayCreationSamples.JSzThenMdElement), "public static int[][][,] M()", "return new int[2][][,];")]
+    [InlineData(nameof(JaggedArrayCreationSamples.JMdThenSzElement), "public static int[][,][] M()", "return new int[2][,][];")]
+    public void JaggedNewArray_PlacesBoundOnOuterRank_AndCompiles(string methodName, string header, string expected)
+    {
+        string body = RenderFixture(methodName, typeof(JaggedArrayCreationSamples).FullName!).Trim();
+        Assert.Equal(expected, body);
+        AssertCompiles(header, body);
+    }
+
+    [Theory]
+    [InlineData(nameof(JaggedArrayCreationSamples.SingleDimNew), "public static int[] M(int n)", "return new int[n];")]
+    [InlineData(nameof(JaggedArrayCreationSamples.ArrayLiteral), "public static int[] M()", "new int[] { 1, 2, 3 }")]
+    public void SingleDimensionalCreationCanaries_StayValid(string methodName, string header, string expected)
+    {
+        string body = RenderFixture(methodName, typeof(JaggedArrayCreationSamples).FullName!).Trim();
+        Assert.Contains(expected, body);
+        AssertCompiles(header, body);
+    }
+
     [Fact]
     public void RectangularSet_LowersToIndexerAssignment_AndCompiles()
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -282,7 +282,7 @@ public sealed partial class CSharpPrinter
     {
         if (!IsMultiDimArrayType(node.Constructor.DeclaringType) || node.Arguments.Count != node.Constructor.DeclaringType.Rank)
             return null;
-        return $"new {ArrayCreationElementText(node.Constructor.DeclaringType.ElementType!)}[{string.Join(", ", node.Arguments.Select(Expression))}]{ArrayCreationSuffix(node.Constructor.DeclaringType.ElementType!)}";
+        return ArrayCreationText(node.Constructor.DeclaringType.ElementType!, node.Arguments);
     }
 
     static bool HasRepeatedStackSlot(IEnumerable<IrExpression> expressions)
@@ -317,6 +317,9 @@ public sealed partial class CSharpPrinter
             current = element;
         return TypeText(current);
     }
+
+    string ArrayCreationText(TypeRef elementType, IEnumerable<IrExpression> lengths)
+        => $"new {ArrayCreationElementText(elementType)}[{string.Join(", ", lengths.Select(Expression))}]{ArrayCreationSuffix(elementType)}";
 
     string ArrayCreationSuffix(TypeRef type)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1458,7 +1458,7 @@ public sealed partial class CSharpPrinter
         IndexFromEnd i => $"^{Operand(i.Offset)}",
         LoadElement e when MultiDimArrayElementText(e) is { } text => text,
         LoadElement e => $"{Operand(e.Array)}[{Expression(e.Index)}]",
-        NewArray n => $"new {TypeText(n.ElementType)}[{Expression(n.Length)}]",
+        NewArray n => ArrayCreationText(n.ElementType, [n.Length]),
         SpanLiteral s => $"new {TypeText(s.ElementType)}[] {{ {string.Join(", ", s.Elements.Select(Expression))} }}",
         ArrayLiteral a => $"new {TypeText(a.ElementType)}[] {{ {string.Join(", ", a.Elements.Select(Expression))} }}",
         CollectionExpression c => $"[{string.Join(", ", c.Elements.Select(CollectionElementText))}]",


### PR DESCRIPTION
## Summary

Fixes #1654 by routing ordinary `newarr` rendering through the array-creation formatter so array-typed elements place the allocation bound in the outer rank: `new int[n][]` instead of invalid `new int[][n]`.

Added focused importer-backed canaries for plain jagged arrays, variable lengths, string arrays, mixed jagged/rectangular element suffixes (`new int[2][][,]`, `new int[2][,][]`), and single-dimensional creation/initializer canaries.

## Validation

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/MultiDimensionalArrayPrinterTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- `dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet`
- Targeted harness dumps show `// fidelity: Full` with `return new int[3][];`, `return new int[3][][];`, `return new int[n][];`, `return new int[2][][,];`, and `return new int[2][,][];`.
- PR quick corpus card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 15 assemblies, 1,462 methods
Sample: hash-stable 100 methods per assembly
Correctness coverage: validity not run; fidelity not run

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 1,461 -> 1,462 (+1)
- ILInspector.MetadataPrimitives: 61 -> 62 methods (+1)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 1,213 (83.03%) | 1,220 (83.45%) | +7 |
| Conditional-branch residual | 35 (2.40%) | 32 (2.19%) | -3 |
| Forward-merge stops | 27 (1.85%) | 26 (1.78%) | -1 |
| Full malformed | not run | not run | - |
| Semantic defects | not run | not run | - |
| Fidelity diffs | not run | not run | - |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 82.17% -> 82.17% (0 bps); conditional residual 3.00% -> 3.00% (0 bps); Full malformed 0 -> 0 (0); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Verdict: corpus sensor matched baseline tolerances.
```

Limit: the unfiltered slow `src/ILInspector.Decompiler.Tests` executable was attempted twice but did not complete after long waits on the shared host, so the PR relies on the focused class, fast PR-gate subset, targeted harness dumps, and PR quick corpus evidence.

## Adversarial review

Requested cross-model adversarial review from Claude Opus 4.8 and MAI-Code-1-Flash. Summary will be posted as a PR comment with resolution details.