### PR TITLE
Fix System.Memory stackalloc span raise (#1761)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackAllocSpanPassTests.cs
@@ -1,4 +1,5 @@
 using ILInspector.Decompiler.Pipeline;
+using IrConvert = ILInspector.Decompiler.Pipeline.Convert;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -8,6 +9,7 @@ public class StackAllocSpanPassTests
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef Byte = TypeRef.CoreLib("System", "Byte");
+    static readonly TypeRef VoidPointer = TypeRef.Pointer(Void);
 
     [Fact]
     public void CorelibSpanDirectStackalloc_Raises()
@@ -36,6 +38,68 @@ public class StackAllocSpanPassTests
         var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
         Assert.Equal("int", raised.ElementType.ToDisplayString());
         Assert.Empty(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SystemMemorySpanDirectStackalloc_Raises()
+    {
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.Definition("System.Memory", "System", "Span`1"),
+            new StackAllocate(new Constant(4, Int32))));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal("int", raised.ElementType.ToDisplayString());
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void SystemMemoryReadOnlySpanDirectStackalloc_Raises()
+    {
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.Definition("System.Memory", "System", "ReadOnlySpan`1"),
+            new StackAllocate(new Constant(4, Int32))));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal("int", raised.ElementType.ToDisplayString());
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void ConvertWrappedStackallocPointer_Raises()
+    {
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new IrConvert(VoidPointer, isChecked: false, isUnsigned: false, new StackAllocate(new Constant(4, Int32)))));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        var raised = Assert.Single(function.Descendants.OfType<StackAllocArray>());
+        Assert.Equal("int", raised.ElementType.ToDisplayString());
+        Assert.Empty(function.Descendants.OfType<NewObject>());
+        Assert.Empty(function.Descendants.OfType<IrConvert>());
+        function.CheckInvariant();
+    }
+
+    [Fact]
+    public void CheckedConvertWrappedStackallocPointer_DoesNotRaise()
+    {
+        var function = Build(StackAllocSpanConstructor(
+            TypeRef.CoreLib("System", "Span`1"),
+            new IrConvert(VoidPointer, isChecked: true, isUnsigned: false, new StackAllocate(new Constant(4, Int32)))));
+
+        new StackAllocSpanPass().Run(function, PassContext.None);
+
+        Assert.Single(function.Descendants.OfType<NewObject>());
+        Assert.Single(function.Descendants.OfType<IrConvert>());
+        Assert.Single(function.Descendants.OfType<StackAllocate>());
+        Assert.Empty(function.Descendants.OfType<StackAllocArray>());
         function.CheckInvariant();
     }
 
@@ -75,7 +139,7 @@ public class StackAllocSpanPassTests
     static NewObject StackAllocSpanConstructor(TypeRef spanDefinition, IrExpression pointer)
     {
         var span = TypeRef.GenericInstance(spanDefinition, [Int32]);
-        var ctor = new MethodRef(span, ".ctor", Void, [TypeRef.Pointer(Void), Int32], HasThis: true);
+        var ctor = new MethodRef(span, ".ctor", Void, [VoidPointer, Int32], HasThis: true);
         return new NewObject(ctor, [pointer, new Constant(1, Int32)]);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -820,8 +820,8 @@ public static class MemberIdentity
         => type is { Kind: TypeRefKind.GenericInstance } ? type.ElementType : type;
 
     static bool IsSpanLikeType(TypeRef type)
-        => IsCoreLibraryType(type, "System", "Span`1")
-            || IsCoreLibraryType(type, "System", "ReadOnlySpan`1");
+        => IsCoreLibraryOrFacadeType(type, "System", "Span`1", "System.Memory")
+            || IsCoreLibraryOrFacadeType(type, "System", "ReadOnlySpan`1", "System.Memory");
 
     static bool IsCollectionsMarshalType(TypeRef type)
         => IsCoreLibraryOrFacadeType(type, "System.Runtime.InteropServices", "CollectionsMarshal", "System.Runtime.InteropServices");

--- a/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StackAllocSpanPass.cs
@@ -33,7 +33,7 @@ public sealed class StackAllocSpanPass : IIrPass
             // Span<T>(void* pointer, int length): the pointer is the stackalloc,
             // the length is the logical element count.
             if (newObject.Arguments is not [{ } pointer, var count]
-                || pointer is not StackAllocate)
+                || !IsStackAllocPointer(pointer))
                 continue;
 
             count.Detach();
@@ -43,4 +43,21 @@ public sealed class StackAllocSpanPass : IIrPass
             newObject.ReplaceWith(raised);
         }
     }
+
+    static bool IsStackAllocPointer(IrExpression pointer)
+    {
+        if (pointer is StackAllocate)
+            return true;
+
+        return pointer is Convert
+        {
+            IsChecked: false,
+            Operand: StackAllocate,
+            Target: { } target,
+        } && IsPointerLikeTarget(target);
+    }
+
+    static bool IsPointerLikeTarget(TypeRef target)
+        => target.Kind == TypeRefKind.Pointer
+            || target is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "IntPtr" or "UIntPtr" };
 }


### PR DESCRIPTION
## Summary

Fixes #1761 by broadening the stackalloc-span raise to cover the real Markdig shape:

- System.Span<T> / ReadOnlySpan<T> constructors from the System.Memory facade are now treated as the same span identity as corelib for span-like rewrite gates.
- StackAllocSpanPass now also accepts a narrow non-checked pointer/native-int conversion wrapped directly around StackAllocate, while still declining arbitrary wrapper calls and checked conversions.

This narrows the false Full claim where Markdig LeafBlock.AppendLine emitted invalid source like new Span<char>((void*)(stackalloc byte[128]), 64). The fixed output raises to:

    V_1 = new ValueStringBuilder(stackalloc char[64]);

## Evidence

- dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/StackAllocSpanPassTests/*"
- dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
- dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll member Markdig.Syntax.LeafBlock AppendLine --library ~/.nuget/packages/markdig/1.2.0/lib/netstandard2.0/Markdig.dll --all -S "Decompiled Source" --bare
- dotnet run --project tools/DecompilerHarness -c Release -- ~/.nuget/packages/markdig/1.2.0/lib/netstandard2.0/Markdig.dll --validity-check --compile-cap 3000 --max-examples 80

Harness result for Markdig after the fix:

    COMPILE-CHECK over 2101 rendered methods (2068 Full, 33 Partial)

    Syntactic validity (parse + statement legality — false-positive-free):
      Full malformed   : 0 (0.00% of Full) — the "claimed good but won't parse" set
      Partial malformed: 23 (69.70% of Partial) — expected: the diagnosed unsupported bits

    Semantic binding (Full + syntactically-valid, capped at 2068 bound):
      with a non-binding-noise error: 30 (1.45%)

The prior CS8346 stackalloc-span example is gone from the Markdig validity examples.

## Review

Adversarial review is required before merge; I will post the reconciled results here.
