### PR TITLE
Fix generic isinst null-test rendering

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GenericIsInstanceNullTestTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GenericIsInstanceNullTestTests.cs
@@ -1,0 +1,58 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class GenericIsInstanceNullTestTests
+{
+    [Fact]
+    public void ValueContextGenericIsInstanceNotNull_RendersAsTypeTest()
+    {
+        using var source = MetadataSource.Open(typeof(GenericIsInstanceSpecimens<>).Assembly.Location);
+        var function = IrImporter.Import(
+            source,
+            typeof(GenericIsInstanceSpecimens<>).FullName!,
+            nameof(GenericIsInstanceSpecimens<object>.DirectIs));
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("value is T", output);
+        Assert.DoesNotContain("value as T", output);
+    }
+
+    [Fact]
+    public void ValueContextGenericIsInstanceNull_RendersAsNegatedTypeTest()
+    {
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var generic = TypeRef.GenericParameter(0, "T");
+        var comparison = new Comparison(
+            ComparisonKind.Equal,
+            isUnsigned: false,
+            new IsInstance(generic, new LoadArgument(0, "value", objectType)),
+            new Constant(null, objectType));
+        var block = new Block();
+        block.Add(new Return(comparison));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(boolType, [new Parameter("value", objectType)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        var output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("return value is not T;", output);
+        Assert.DoesNotContain("value as T", output);
+    }
+}
+
+public abstract class GenericIsInstanceSpecimens<T>
+{
+    public bool DirectIs(object value) => value is T;
+    public string Ternary(object value) => value is T ? "y" : "n";
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -690,6 +690,9 @@ public sealed partial class CSharpPrinter
             && (left is Constant { Value: null } || right is Constant { Value: null }))
         {
             var operand = right is Constant { Value: null } ? left : right;
+            if (IsInstanceNullTestText(operand, isNotNull: kind == ComparisonKind.NotEqual) is { } typeTest)
+                return typeTest;
+
             return kind == ComparisonKind.Equal
                 ? $"{Operand(operand)} is null"
                 : $"{Operand(operand)} is not null";
@@ -713,6 +716,9 @@ public sealed partial class CSharpPrinter
                 || (kind == ComparisonKind.LessThan && left is Constant { Value: null })))
         {
             var operand = kind == ComparisonKind.GreaterThan ? left : right;
+            if (IsInstanceNullTestText(operand, isNotNull: true) is { } typeTest)
+                return typeTest;
+
             return operand.ResultType is { Kind: TypeRefKind.Pointer }
                 ? $"{Operand(operand)} != null"
                 : $"{Operand(operand)} is not null";
@@ -776,6 +782,15 @@ public sealed partial class CSharpPrinter
 
     string BoxedReferenceOperand(IrExpression operand)
         => operand is Box box ? $"(object){Operand(box.Operand)}" : Operand(operand);
+
+    string? IsInstanceNullTestText(IrExpression operand, bool isNotNull)
+    {
+        if (operand is not IsInstance ii)
+            return null;
+
+        string test = $"{Operand(ii.Operand)} is {TypeText(ii.Type)}";
+        return isNotNull ? test : $"{Operand(ii.Operand)} is not {TypeText(ii.Type)}";
+    }
 
     static bool IsFloatComparison(IrExpression left, IrExpression right)
         => TypeFamilies.IsFloat(left.ResultType) || TypeFamilies.IsFloat(right.ResultType);


### PR DESCRIPTION
## Summary

Fixes #1752 by rendering value-context `IsInstance` null tests as C# type tests:

- not-null checks render as `value is T`
- null checks render as `value is not T`

This avoids invalid unconstrained-generic `as T` output such as `(value as T) is not null` while leaving ordinary reference null checks, pointer null checks, and boxed equality handling on their existing paths.

## Evidence

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/GenericIsInstanceNullTestTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- `dotnet run --project tools/DecompilerHarness -c Release -- /tmp/dvGenericIs/bin/Release/net11.0/dvGenericIs.dll --validity-check --compile-cap 20 --max-examples 20`
- `dotnet run --project tools/DecompilerHarness -c Release -- /tmp/dvGenericIs/bin/Release/net11.0/dvGenericIs.dll --fidelity-check --compile-cap 20 --max-examples 20`

The reduced fixture now renders `public bool DirectIs(object value) => value is T;`, passes validity, and compile-back reports 3/3 exact opcode matches.

## Adversarial review

Requested cross-model adversarial review from Claude Opus 4.8 and MAI-Code-1-Flash; summary comment to follow on this PR.
