### PR TITLE
Add minimal generated fixture rungs

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -49,9 +49,61 @@ public class GeneratedFixtureCatalogTests
             "get_Method1",
             FidelityCheck.CompileBackStatus.Exact,
             frontier: false);
+        AssertTarget(
+            run,
+            "minimal.ctor-field.getter",
+            "GeneratedFixtures.MinimalCtorFieldGetter.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.ctor-field.getter",
+            "GeneratedFixtures.MinimalCtorFieldGetter.Class1",
+            "get_Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.auto-property.getter",
+            "GeneratedFixtures.MinimalAutoPropertyGetter.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.RecompileFail,
+            frontier: true);
+        AssertTarget(
+            run,
+            "minimal.auto-property.getter",
+            "GeneratedFixtures.MinimalAutoPropertyGetter.Class1",
+            "get_Method1",
+            FidelityCheck.CompileBackStatus.RecompileFail,
+            frontier: true);
+        AssertTarget(
+            run,
+            "minimal.method-call.same-type",
+            "GeneratedFixtures.MinimalMethodCallSameType.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.method-call.same-type",
+            "GeneratedFixtures.MinimalMethodCallSameType.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.method-call.same-type",
+            "GeneratedFixtures.MinimalMethodCallSameType.Class1",
+            "Method2",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
 
         Assert.Contains("minimal.property.literal", report);
         Assert.Contains("minimal.primary-ctor.field-init", report);
+        Assert.Contains("minimal.ctor-field.getter", report);
+        Assert.Contains("minimal.auto-property.getter", report);
+        Assert.Contains("minimal.method-call.same-type", report);
         Assert.Contains("PASS frontier", report);
         Assert.Contains("decompiler=Full", report);
         Assert.Contains("compile-back=OpcodeDiff", report);
@@ -65,7 +117,13 @@ public class GeneratedFixtureCatalogTests
             GeneratedFixtureCatalog.Select("minimal.property.literal").Select(fixture => fixture.Id).ToArray());
 
         Assert.Equal(
-            ["minimal.primary-ctor.field-init", "minimal.property.literal"],
+            [
+                "minimal.auto-property.getter",
+                "minimal.ctor-field.getter",
+                "minimal.method-call.same-type",
+                "minimal.primary-ctor.field-init",
+                "minimal.property.literal",
+            ],
             GeneratedFixtureCatalog.Select("minimal").Select(fixture => fixture.Id).Order(StringComparer.Ordinal).ToArray());
 
         Assert.Empty(GeneratedFixtureCatalog.Select("missing"));
@@ -79,6 +137,9 @@ public class GeneratedFixtureCatalogTests
         using var document = JsonDocument.Parse(json);
         var fixtures = document.RootElement.EnumerateArray().ToArray();
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.property.literal");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.ctor-field.getter");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.auto-property.getter");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.method-call.same-type");
 
         var primaryCtor = Assert.Single(fixtures,
             fixture => fixture.GetProperty("Id").GetString() == "minimal.primary-ctor.field-init");

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -58,10 +58,85 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "primary-constructor", "field-initializer"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalCtorFieldGetter = new(
+        "minimal.ctor-field.getter",
+        """
+        namespace GeneratedFixtures.MinimalCtorFieldGetter;
+
+        public class Class1
+        {
+            private readonly string _message;
+
+            public Class1(string message)
+            {
+                _message = message;
+            }
+
+            public string Method1 => _message;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalCtorFieldGetter.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalCtorFieldGetter.Class1", "get_Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "constructor", "field", "property"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalAutoPropertyGetter = new(
+        "minimal.auto-property.getter",
+        """
+        namespace GeneratedFixtures.MinimalAutoPropertyGetter;
+
+        public class Class1
+        {
+            public Class1(string message)
+            {
+                Method1 = message;
+            }
+
+            public string Method1 { get; }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalAutoPropertyGetter.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.RecompileFail, IsFrontier: true,
+                Note: "Compile-back skeleton does not reconstruct the get-only auto-property surface yet."),
+            new("GeneratedFixtures.MinimalAutoPropertyGetter.Class1", "get_Method1",
+                FidelityCheck.CompileBackStatus.RecompileFail, IsFrontier: true,
+                Note: "Compile-back skeleton does not reconstruct the get-only auto-property surface yet."),
+        ],
+        ["minimal", "constructor", "auto-property"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalMethodCallSameType = new(
+        "minimal.method-call.same-type",
+        """
+        namespace GeneratedFixtures.MinimalMethodCallSameType;
+
+        public class Class1
+        {
+            public string Method1() => Method2();
+
+            private string Method2() => "Hello World";
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalMethodCallSameType.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalMethodCallSameType.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalMethodCallSameType.Class1", "Method2",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "method-call"]);
+
     public static IReadOnlyList<GeneratedFixtureDefinition> All { get; } =
     [
         MinimalPropertyLiteral,
         MinimalPrimaryCtorFieldInit,
+        MinimalCtorFieldGetter,
+        MinimalAutoPropertyGetter,
+        MinimalMethodCallSameType,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> MinimalCompileBackRungs => All;

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -12,7 +12,10 @@ The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — t
 generated-fixture catalogue entries into a temporary class library, runs the
 compile-back oracle, and prints results by stable fixture ID plus target method.
 This is the first step toward an addressable progressive fixture ladder:
-`minimal.property.literal` is expected `Exact`, while
+`minimal.property.literal`, `minimal.ctor-field.getter`,
+and `minimal.method-call.same-type` are expected `Exact`, while
+`minimal.auto-property.getter` records the current get-only auto-property
+`RecompileFail` frontier and
 `minimal.primary-ctor.field-init` records the current constructor `OpcodeDiff`
 frontier and the exact getter. With no selector, all generated fixtures run; use
 `list` to list fixture IDs, `--json` for machine-readable list/results, and


### PR DESCRIPTION
## Summary

Follow-up for #1742.

Adds three low-shape generated fixture catalogue entries:

- `minimal.ctor-field.getter` — explicit constructor assigns a readonly field; getter returns it; expected `Exact` for ctor/getter
- `minimal.method-call.same-type` — public method calls a private same-type method; expected `Exact` for ctor/Method1/Method2
- `minimal.auto-property.getter` — get-only auto-property assigned in constructor; records the current compile-back skeleton `RecompileFail` frontier for ctor/getter

This keeps the generated fixture ladder growing progressively while making the new auto-property gap explicit and addressable.

## Evidence

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures list
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.method-call.same-type
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.auto-property.getter
npx markdownlint-cli tools/DecompilerHarness/README.md
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
```

Auto-property frontier smoke:

```text
PASS frontier  minimal.auto-property.getter  GeneratedFixtures.MinimalAutoPropertyGetter.Class1::.ctor#0  decompiler=Full  compile-back=RecompileFail  expected=RecompileFail
    detail: CS0200: Property or indexer 'Class1.Method1' cannot be assigned to -- it is read only
PASS frontier  minimal.auto-property.getter  GeneratedFixtures.MinimalAutoPropertyGetter.Class1::get_Method1#0  decompiler=Full  compile-back=RecompileFail  expected=RecompileFail
    detail: CS1061: 'Class1' does not contain a definition for 'Method1' ...
```

## Adversarial review

Requested Opus 4.8 and MAI-Code-1-Flash reviews before opening. Both reported no significant issues. They specifically checked that the auto-property `RecompileFail` is an honest compile-back skeleton frontier rather than a decompiler fidelity failure, that method IDs resolve against compiled metadata, and that selector/list behavior remains stable.
