### PR TITLE
Trust-gate Blazor render-method suppression (#1714)

### DIFF
--- a/src/ILInspector.Analysis.RenderFixtures/ILInspector.Analysis.RenderFixtures.csproj
+++ b/src/ILInspector.Analysis.RenderFixtures/ILInspector.Analysis.RenderFixtures.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Fixture exercising the REAL, trusted Blazor RenderTreeBuilder (from the
+    Microsoft.AspNetCore.App shared framework, which carries a framework
+    public-key-token). A method taking it allocates a capturing delegate in a
+    loop; LibraryBodyIndex.IsBlazorRenderMethod must suppress it as intrinsic
+    render plumbing. Paired with the untrusted RenderTreeBuilder lookalike in
+    the test assembly (which must NOT be suppressed). Loaded by path; never
+    referenced for compilation.
+  -->
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.RenderFixtures/RealRenderFixtures.cs
+++ b/src/ILInspector.Analysis.RenderFixtures/RealRenderFixtures.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace ILInspector.Analysis.RenderFixtures;
+
+public static class RealRenderFixtures
+{
+    // Takes the REAL framework RenderTreeBuilder and allocates a capturing delegate inside a
+    // loop. Because RenderTreeBuilder carries a trusted framework public-key-token, this is
+    // recognized as intrinsic Blazor render plumbing and its allocations are suppressed.
+    public static int RenderWithDelegateLoop(RenderTreeBuilder builder, int[] values, int seed)
+    {
+        var total = 0;
+        foreach (var v in values)
+        {
+            Func<int> handler = () => v + seed;
+            total += handler();
+        }
+
+        return total;
+    }
+}

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="..\ILInspector.Analysis.FacadeFixtures\ILInspector.Analysis.FacadeFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.SpoofFixtures\ILInspector.Analysis.SpoofFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.SpoofRuntimeFixtures\ILInspector.Analysis.SpoofRuntimeFixtures.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ILInspector.Analysis.RenderFixtures\ILInspector.Analysis.RenderFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphTarget\ILInspector.Analysis.CallerGraphTarget.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCaller\ILInspector.Analysis.CallerGraphCaller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphCallerTwin\ILInspector.Analysis.CallerGraphCallerTwin.csproj" ReferenceOutputAssembly="false" />

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1203,14 +1203,28 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
-    public void OptimizationOpportunities_SuppressesBlazorRenderMethods()
+    public void OptimizationOpportunities_SuppressesRealBlazorRenderMethods()
+    {
+        // The REAL framework RenderTreeBuilder (trusted public-key-token, from
+        // Microsoft.AspNetCore.App) marks a method as Razor render plumbing, so its capturing
+        // delegate is suppressed (intrinsic component-model cost, not actionable).
+        var index = LibraryBodyIndex.Open(RenderFixturePath());
+
+        Assert.DoesNotContain(index.OptimizationOpportunities, o =>
+            o.Method.Name == "RenderWithDelegateLoop");
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_LookalikeRenderTreeBuilder_IsNotSuppressed()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 
-        // RenderLikeMethod takes a RenderTreeBuilder and allocates a capturing delegate, but
-        // Razor render plumbing is suppressed (intrinsic component-model cost, not actionable).
-        Assert.DoesNotContain(index.OptimizationOpportunities, o =>
-            o.Method.Name == nameof(OptimizationOpportunityFixtures.RenderLikeMethod));
+        // RenderLikeMethod takes an UNTRUSTED RenderTreeBuilder lookalike (no framework
+        // public-key-token). The render-method suppression is trust-gated (#1708), so this is
+        // not mistaken for render plumbing and its in-loop capturing delegate is reported.
+        Assert.Contains(index.OptimizationOpportunities, o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.RenderLikeMethod)
+            && o.Shape == "capturing-delegate");
     }
 
     [Fact]
@@ -2000,6 +2014,20 @@ public class LibraryBodyIndexTests
         return path;
     }
 
+    static string RenderFixturePath()
+    {
+        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string path = Path.GetFullPath(Path.Combine(
+            outputDirectory.FullName,
+            "..",
+            "..",
+            "ILInspector.Analysis.RenderFixtures",
+            outputDirectory.Name,
+            "ILInspector.Analysis.RenderFixtures.dll"));
+        Assert.True(File.Exists(path), $"Expected render fixture assembly at {path}");
+        return path;
+    }
+
     // #1708 Row A end-to-end. A real assembly literally named "System.Linq" (unsigned,
     // so no framework public-key-token) exposes a System.Linq.Enumerable.ToArray
     // lookalike. Simple-name identity accepted it as a framework copy; strong
@@ -2208,12 +2236,21 @@ public class OptimizationOpportunityFixtures
         return total;
     }
 
-    // Razor/Blazor render plumbing: a method taking a RenderTreeBuilder. Even though it
-    // allocates a capturing delegate, it must be suppressed (intrinsic component-model cost).
-    public static void RenderLikeMethod(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder, int seed)
+    // A method taking an UNTRUSTED RenderTreeBuilder lookalike (defined in this test assembly,
+    // so it carries no framework public-key-token). It allocates a capturing delegate in a
+    // loop; because the parameter type is not the trusted framework RenderTreeBuilder, this is
+    // NOT treated as Blazor render plumbing and the allocation IS reported. The trusted
+    // counterpart (RealRenderFixtures.RenderWithDelegateLoop) is suppressed.
+    public static int RenderLikeMethod(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder, int[] values, int seed)
     {
-        System.Func<int> handler = () => seed + 1;
-        builder.Use(handler);
+        var total = 0;
+        foreach (var v in values)
+        {
+            System.Func<int> handler = () => v + seed;
+            total += handler();
+        }
+
+        return total;
     }
 
     public int[] MakesArrayAfterFieldAccess()

--- a/src/ILInspector.Analysis.Tests/RenderTreeBuilderStub.cs
+++ b/src/ILInspector.Analysis.Tests/RenderTreeBuilderStub.cs
@@ -1,7 +1,9 @@
-// Minimal stub matching the Blazor render-tree builder by namespace + simple name, so a
-// fixture method can take it as a parameter without referencing the AspNetCore Components
-// package. LibraryBodyIndex.IsBlazorRenderMethod keys on the (namespace, name), so a method
-// taking this type exercises the Razor render-method suppression end-to-end.
+// An UNTRUSTED lookalike of the Blazor render-tree builder: it reuses the framework type's
+// namespace and simple name but lives in the (unsigned) test assembly, so it carries no
+// framework public-key-token. LibraryBodyIndex.IsBlazorRenderMethod is trust-gated (#1708),
+// so a method taking this type is NOT mistaken for render plumbing and its genuine allocation
+// findings are reported. The trusted counterpart lives in ILInspector.Analysis.RenderFixtures
+// (the real RenderTreeBuilder, which IS suppressed).
 namespace Microsoft.AspNetCore.Components.Rendering;
 
 public sealed class RenderTreeBuilder

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1267,13 +1267,19 @@ public sealed class LibraryBodyIndex
         // delegates, EventCallback boxing, RenderFragment closures) are intrinsic to the
         // component model — not user-actionable source-shape fixes. Hand-written code
         // essentially never takes a RenderTreeBuilder, so the parameter is a precise signal.
+        //
+        // The match is trust-gated (public-key-token, #1708): only the real framework
+        // RenderTreeBuilder counts, so a user-defined type that merely reuses the namespace and
+        // name does not silently suppress that method's genuine allocation findings.
         static bool IsBlazorRenderMethod(MethodIdentity caller)
         {
             foreach (var parameter in caller.ParameterTypes)
             {
-                var definition = parameter.Kind == TypeRefKind.GenericInstance ? parameter.ElementType ?? parameter : parameter;
-                if (definition.Namespace == "Microsoft.AspNetCore.Components.Rendering"
-                    && definition.Name == "RenderTreeBuilder")
+                if (FrameworkIdentity.IsKnownFrameworkType(
+                        parameter,
+                        "Microsoft.AspNetCore.Components",
+                        "Microsoft.AspNetCore.Components.Rendering",
+                        "RenderTreeBuilder"))
                     return true;
             }
             return false;


### PR DESCRIPTION
## What

Trust-gates the Razor/Blazor render-method suppression. `IsBlazorRenderMethod` suppresses allocation findings (event-handler delegates, `EventCallback` boxing, `RenderFragment` closures) for any method that takes a `Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder` — these are intrinsic to the Blazor component model and not user-actionable. Render plumbing is the single biggest noise source in component-heavy assemblies (~38% of Aspire.Dashboard's rows), so this suppression is high-value, but it was matching the parameter type by **namespace + simple name only**, with no public-key-token gate.

This is the same identity weakness #1708 fixed elsewhere (`IsEnumerableDefinition`, the copy-API checks): a user-defined type that merely reuses the namespace and name (`Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder`) would silently suppress that method's genuine allocation findings.

## Change

`IsBlazorRenderMethod` now matches via `FrameworkIdentity.IsKnownFrameworkType(parameter, "Microsoft.AspNetCore.Components", "Microsoft.AspNetCore.Components.Rendering", "RenderTreeBuilder")` — the same trust-gated identity used across the analyzer. Only the real framework `RenderTreeBuilder` (carrying a trusted public-key-token, `adb9793829ddae60`) counts.

## Verification (production CLI, decompilation-checked)

- **Real framework type still suppressed:** Aspire.Dashboard `Performance Triage` is unchanged — 0 `BuildRenderTree`/render-method rows (the AspNetCore PKT is trusted, so all previously-suppressed methods stay suppressed).
- **Lookalike no longer suppressed:** a user assembly defining its own `Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder` and a method taking it that allocates a capturing delegate in a loop is now correctly flagged (`capturing-delegate`) instead of silently dropped.

## Tests

Adds a real+lookalike fixture pair, mirroring the #1708 spoof-fixture pattern:
- New `ILInspector.Analysis.RenderFixtures` project (`FrameworkReference` to `Microsoft.AspNetCore.App`) with a method taking the **real** trusted `RenderTreeBuilder` → asserted **suppressed**.
- The in-test-assembly `RenderTreeBuilder` is repurposed as the documented **untrusted lookalike**; `RenderLikeMethod` (in-loop capturing delegate) is asserted **flagged** (the inverted regression guard for the fix).

Full suite green: ILInspector.Analysis.Tests 209, dotnet-inspect.Tests 1380 (9 ildasm skips).
