### PR TITLE
Authenticate Google.Protobuf identity for generated-code suppression (#1735)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -874,16 +875,19 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
-    public void GeneratedFrameworkTypeNames_DetectsProtobufAndGrpcGeneratedTypes()
+    public void GeneratedFrameworkTypeNames_DetectsGrpcStub_AndRejectsUnauthenticProtobufSpoof()
     {
         var index = LibraryBodyIndex.Open(typeof(FakeProtobufReflection).Assembly.Location);
         var generated = index.GeneratedFrameworkTypeNames;
 
-        // protobuf reflection holder: its initializer calls FileDescriptor.FromGeneratedCode.
-        Assert.Contains(typeof(FakeProtobufReflection).FullName!, generated);
-        // protobuf message: its initializer constructs MessageParser<T>.
-        Assert.Contains(typeof(FakeProtobufMessage).FullName!, generated);
-        // gRPC service stub: binds via ServerServiceDefinition and declares __Helper_ members.
+        // #1735: the bootstrap types are bound from an unsigned assembly literally named
+        // Google.Protobuf (no real public-key-token), so these must NOT be classified as
+        // protobuf-generated — otherwise a same-name spoof could suppress actionable product
+        // rows. (Authentic Google.Protobuf identity is exercised by the unit test below.)
+        Assert.DoesNotContain(typeof(FakeProtobufReflection).FullName!, generated);
+        Assert.DoesNotContain(typeof(FakeProtobufMessage).FullName!, generated);
+        // gRPC detection is identity-independent (namespace + generated __* members tied to a
+        // Grpc.Core call), so the gRPC service stub is still correctly detected.
         Assert.Contains(typeof(FakeGrpcServiceStub).FullName!, generated);
         // A normal protobuf-using type that doesn't bootstrap generated infrastructure stays out.
         Assert.DoesNotContain(typeof(NormalProtobufConsumer).FullName!, generated);
@@ -898,6 +902,45 @@ public class LibraryBodyIndexTests
         Assert.Contains(index.OptimizationOpportunities, opportunity =>
             opportunity.Method.DeclaringType.Name == nameof(GeneratedLookalike)
             && opportunity.Method.Name == nameof(GeneratedLookalike.MakesLocalArrayUnsuppressed));
+    }
+
+    // #1735: generated-code suppression must authenticate Google.Protobuf by public-key-token,
+    // not simple name. The unsigned fixture assembly named Google.Protobuf is NOT authentic; the
+    // real strong-named package assembly IS.
+    [Fact]
+    public void GoogleProtobufIdentity_AuthenticatesByPublicKeyToken()
+    {
+        using (var pe = new System.Reflection.PortableExecutable.PEReader(System.IO.File.OpenRead(ProtobufSpoofAssemblyPath())))
+            Assert.False(FrameworkAssemblyKeys.GoogleProtobufIdentityIsAuthentic(pe.GetMetadataReader()),
+                "an unsigned same-name assembly must not be treated as the real Google.Protobuf");
+
+        var realProtobuf = FindRealGoogleProtobufAssembly();
+        if (realProtobuf is null)
+            return; // the Google.Protobuf package is not restored in this environment
+
+        using var realPe = new System.Reflection.PortableExecutable.PEReader(System.IO.File.OpenRead(realProtobuf));
+        Assert.True(FrameworkAssemblyKeys.GoogleProtobufIdentityIsAuthentic(realPe.GetMetadataReader()),
+            "the real strong-named Google.Protobuf must be authentic");
+    }
+
+    static string ProtobufSpoofAssemblyPath()
+    {
+        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string path = Path.GetFullPath(Path.Combine(
+            outputDirectory.FullName, "..", "..", "ILInspector.Analysis.ProtobufFixtures", outputDirectory.Name, "Google.Protobuf.dll"));
+        Assert.True(File.Exists(path), $"Expected protobuf spoof fixture at {path}");
+        return path;
+    }
+
+    static string? FindRealGoogleProtobufAssembly()
+    {
+        string root = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages", "google.protobuf");
+        if (!Directory.Exists(root))
+            return null;
+        return Directory.EnumerateFiles(root, "Google.Protobuf.dll", SearchOption.AllDirectories)
+            .OrderByDescending(p => p)
+            .FirstOrDefault();
     }
 
     [Fact]

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -911,7 +911,7 @@ public class LibraryBodyIndexTests
     public void GoogleProtobufIdentity_AuthenticatesByPublicKeyToken()
     {
         using (var pe = new System.Reflection.PortableExecutable.PEReader(System.IO.File.OpenRead(ProtobufSpoofAssemblyPath())))
-            Assert.False(FrameworkAssemblyKeys.GoogleProtobufIdentityIsAuthentic(pe.GetMetadataReader()),
+            Assert.False(FrameworkAssemblyKeys.IsAuthenticProtobufDefinition(pe.GetMetadataReader()),
                 "an unsigned same-name assembly must not be treated as the real Google.Protobuf");
 
         var realProtobuf = FindRealGoogleProtobufAssembly();
@@ -919,7 +919,7 @@ public class LibraryBodyIndexTests
             return; // the Google.Protobuf package is not restored in this environment
 
         using var realPe = new System.Reflection.PortableExecutable.PEReader(System.IO.File.OpenRead(realProtobuf));
-        Assert.True(FrameworkAssemblyKeys.GoogleProtobufIdentityIsAuthentic(realPe.GetMetadataReader()),
+        Assert.True(FrameworkAssemblyKeys.IsAuthenticProtobufDefinition(realPe.GetMetadataReader()),
             "the real strong-named Google.Protobuf must be authentic");
     }
 

--- a/src/ILInspector.Analysis.Tests/ProtobufGrpcGeneratedFixtures.cs
+++ b/src/ILInspector.Analysis.Tests/ProtobufGrpcGeneratedFixtures.cs
@@ -1,10 +1,11 @@
 // Minimal stand-ins for the gRPC infrastructure that real generated code calls, plus
 // protobuf/gRPC consumer fixtures. The protobuf runtime stand-ins (FileDescriptor,
 // GeneratedClrTypeInfo, MessageParser<T>) live in the separate ILInspector.Analysis.ProtobufFixtures
-// project, which compiles to an assembly named Google.Protobuf; the consumers below bind to
-// those external types so the generated-bootstrap predicates see real Google.Protobuf assembly
-// identity (#1580). The gRPC stand-in is matched by namespace + generated __* members, not by
-// assembly, so it stays local.
+// project, which compiles to an unsigned assembly literally named Google.Protobuf. Because that
+// assembly does NOT carry the real Google.Protobuf public-key-token, it is a same-name *spoof*:
+// generated-bootstrap suppression must require strong identity, so the consumers below that bind
+// to it must NOT be classified as protobuf-generated (#1735). The gRPC stand-in is matched by
+// namespace + generated __* members (not by assembly identity), so it stays local and is detected.
 
 namespace Grpc.Core
 {

--- a/src/ILInspector.Analysis/FrameworkAssemblyKeys.cs
+++ b/src/ILInspector.Analysis/FrameworkAssemblyKeys.cs
@@ -47,26 +47,34 @@ public static class FrameworkAssemblyKeys
     public const string GoogleProtobufToken = "a7d26565bac4d604";
 
     /// <summary>
-    /// Whether the Google.Protobuf identity visible to the inspected assembly (a
-    /// reference to it, or the inspected assembly itself) carries the real
-    /// Google.Protobuf public-key-token. True when no Google.Protobuf identity is present
-    /// — there is then no spoof to reject, and the protobuf type predicates also gate on
-    /// the assembly name (#1735).
+    /// Whether a specific assembly reference is NOT a Google.Protobuf spoof: true unless the
+    /// reference is named Google.Protobuf with a public-key-token other than the real one.
+    /// Stamped onto each decoded reference so generated-code suppression can reject a spoofed
+    /// reference even when an authentic Google.Protobuf reference coexists in the same assembly
+    /// (#1735). References to other assemblies are never protobuf, so they return true.
     /// </summary>
-    public static bool GoogleProtobufIdentityIsAuthentic(MetadataReader reader)
+    public static bool IsAuthenticProtobufReference(MetadataReader reader, AssemblyReferenceHandle handle)
     {
-        foreach (var handle in reader.AssemblyReferences)
-        {
-            var reference = reader.GetAssemblyReference(handle);
-            if (reader.GetString(reference.Name) != "Google.Protobuf")
-                continue;
-            return TokenHex(
-                reader.GetBlobBytes(reference.PublicKeyOrToken),
-                isFullKey: (reference.Flags & AssemblyFlags.PublicKey) != 0) == GoogleProtobufToken;
-        }
-        if (reader.IsAssembly && reader.GetString(reader.GetAssemblyDefinition().Name) == "Google.Protobuf")
-            return TokenHex(reader.GetBlobBytes(reader.GetAssemblyDefinition().PublicKey), isFullKey: true) == GoogleProtobufToken;
-        return true;
+        var reference = reader.GetAssemblyReference(handle);
+        if (reader.GetString(reference.Name) != "Google.Protobuf")
+            return true;
+        return TokenHex(
+            reader.GetBlobBytes(reference.PublicKeyOrToken),
+            isFullKey: (reference.Flags & AssemblyFlags.PublicKey) != 0) == GoogleProtobufToken;
+    }
+
+    /// <summary>
+    /// Whether the inspected assembly definition is NOT a Google.Protobuf spoof: true unless the
+    /// assembly is itself named Google.Protobuf with a public-key-token other than the real one.
+    /// Used when a type resolves to the inspected assembly (a definition or a module-scoped
+    /// reference) so a self-named unsigned Google.Protobuf cannot bootstrap-suppress its own
+    /// types (#1735).
+    /// </summary>
+    public static bool IsAuthenticProtobufDefinition(MetadataReader reader)
+    {
+        if (!reader.IsAssembly || reader.GetString(reader.GetAssemblyDefinition().Name) != "Google.Protobuf")
+            return true;
+        return TokenHex(reader.GetBlobBytes(reader.GetAssemblyDefinition().PublicKey), isFullKey: true) == GoogleProtobufToken;
     }
 
     static bool IsFrameworkKeyOrToken(byte[] keyOrToken, bool isFullKey)

--- a/src/ILInspector.Analysis/FrameworkAssemblyKeys.cs
+++ b/src/ILInspector.Analysis/FrameworkAssemblyKeys.cs
@@ -12,7 +12,7 @@ namespace ILInspector.Analysis;
 /// assembly name. This rejects spoofs such as a user assembly named <c>System.Linq</c>
 /// exposing a <c>System.Linq.Enumerable</c> lookalike.
 /// </summary>
-internal static class FrameworkAssemblyKeys
+public static class FrameworkAssemblyKeys
 {
     // Public-key-tokens used by the .NET frameworks (lowercase hex).
     static readonly HashSet<string> s_frameworkTokens = new(StringComparer.OrdinalIgnoreCase)
@@ -41,6 +41,34 @@ internal static class FrameworkAssemblyKeys
         return IsFrameworkKeyOrToken(reader.GetBlobBytes(reader.GetAssemblyDefinition().PublicKey), isFullKey: true);
     }
 
+    // The real Google.Protobuf NuGet package public-key-token. Generated-code suppression
+    // gates on this so a user assembly that merely names itself Google.Protobuf cannot
+    // make ordinary product code look protobuf-generated (#1735).
+    public const string GoogleProtobufToken = "a7d26565bac4d604";
+
+    /// <summary>
+    /// Whether the Google.Protobuf identity visible to the inspected assembly (a
+    /// reference to it, or the inspected assembly itself) carries the real
+    /// Google.Protobuf public-key-token. True when no Google.Protobuf identity is present
+    /// — there is then no spoof to reject, and the protobuf type predicates also gate on
+    /// the assembly name (#1735).
+    /// </summary>
+    public static bool GoogleProtobufIdentityIsAuthentic(MetadataReader reader)
+    {
+        foreach (var handle in reader.AssemblyReferences)
+        {
+            var reference = reader.GetAssemblyReference(handle);
+            if (reader.GetString(reference.Name) != "Google.Protobuf")
+                continue;
+            return TokenHex(
+                reader.GetBlobBytes(reference.PublicKeyOrToken),
+                isFullKey: (reference.Flags & AssemblyFlags.PublicKey) != 0) == GoogleProtobufToken;
+        }
+        if (reader.IsAssembly && reader.GetString(reader.GetAssemblyDefinition().Name) == "Google.Protobuf")
+            return TokenHex(reader.GetBlobBytes(reader.GetAssemblyDefinition().PublicKey), isFullKey: true) == GoogleProtobufToken;
+        return true;
+    }
+
     static bool IsFrameworkKeyOrToken(byte[] keyOrToken, bool isFullKey)
     {
         if (keyOrToken.Length == 0)
@@ -59,5 +87,14 @@ internal static class FrameworkAssemblyKeys
         for (int i = 0; i < token.Length; i++)
             token[i] = hash[hash.Length - 1 - i];
         return token;
+    }
+
+    // Lowercase hex public-key-token, or "" when unsigned / malformed.
+    static string TokenHex(byte[] keyOrToken, bool isFullKey)
+    {
+        if (keyOrToken.Length == 0)
+            return "";
+        byte[] token = isFullKey ? ComputeToken(keyOrToken) : keyOrToken;
+        return token.Length == 8 ? Convert.ToHexString(token).ToLowerInvariant() : "";
     }
 }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -24,7 +24,8 @@ public sealed class LibraryBodyIndex
         IReadOnlyDictionary<(string Namespace, string Name), bool> inAssemblyTypeIsException,
         IReadOnlySet<int> suppressedOpportunityTokens,
         IReadOnlySet<string> exceptionTypeNames,
-        IReadOnlySet<string> inAssemblyValueTypeNames)
+        IReadOnlySet<string> inAssemblyValueTypeNames,
+        bool protobufIdentityAuthentic)
     {
         Path = path;
         Methods = methods;
@@ -40,6 +41,7 @@ public sealed class LibraryBodyIndex
         _suppressedOpportunityTokens = suppressedOpportunityTokens;
         _exceptionTypeNames = exceptionTypeNames;
         _inAssemblyValueTypeNames = inAssemblyValueTypeNames;
+        _protobufIdentityAuthentic = protobufIdentityAuthentic;
     }
 
     public string Path { get; }
@@ -50,6 +52,7 @@ public sealed class LibraryBodyIndex
 
     readonly ImmutableArray<OptimizationOpportunity> _rawOpportunities;
     readonly ImmutableArray<MethodIdentity> _unsafeLeverageMethods;
+    readonly bool _protobufIdentityAuthentic;
     ImmutableArray<OptimizationOpportunity> _opportunities;
 
     /// <summary>
@@ -525,10 +528,11 @@ public sealed class LibraryBodyIndex
         => ns is not null
             && (ns == "Grpc.Core" || ns.StartsWith("Grpc.Core.", StringComparison.Ordinal));
 
-    static bool IsProtobufType(TypeRef type, string ns, string name)
+    bool IsProtobufType(TypeRef type, string ns, string name)
     {
         var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
         return definition is not null
+            && _protobufIdentityAuthentic
             && definition.Assembly == "Google.Protobuf"
             && definition.Namespace == ns
             && StripGenericArity(definition.Name) == name;
@@ -553,7 +557,8 @@ public sealed class LibraryBodyIndex
             path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
             index.OptimizationOpportunities, index.UnsafeLeverageMethods, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
             index.BodySignals, index.InAssemblyTypeIsException, index.SuppressedOpportunityTokens, index.ExceptionTypeNames,
-            index.InAssemblyValueTypeNames);
+            index.InAssemblyValueTypeNames,
+            FrameworkAssemblyKeys.GoogleProtobufIdentityIsAuthentic(reader));
     }
 
     public ImmutableArray<DirectCall> FindCalls(MemberPattern pattern)

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -24,8 +24,7 @@ public sealed class LibraryBodyIndex
         IReadOnlyDictionary<(string Namespace, string Name), bool> inAssemblyTypeIsException,
         IReadOnlySet<int> suppressedOpportunityTokens,
         IReadOnlySet<string> exceptionTypeNames,
-        IReadOnlySet<string> inAssemblyValueTypeNames,
-        bool protobufIdentityAuthentic)
+        IReadOnlySet<string> inAssemblyValueTypeNames)
     {
         Path = path;
         Methods = methods;
@@ -41,7 +40,6 @@ public sealed class LibraryBodyIndex
         _suppressedOpportunityTokens = suppressedOpportunityTokens;
         _exceptionTypeNames = exceptionTypeNames;
         _inAssemblyValueTypeNames = inAssemblyValueTypeNames;
-        _protobufIdentityAuthentic = protobufIdentityAuthentic;
     }
 
     public string Path { get; }
@@ -52,7 +50,6 @@ public sealed class LibraryBodyIndex
 
     readonly ImmutableArray<OptimizationOpportunity> _rawOpportunities;
     readonly ImmutableArray<MethodIdentity> _unsafeLeverageMethods;
-    readonly bool _protobufIdentityAuthentic;
     ImmutableArray<OptimizationOpportunity> _opportunities;
 
     /// <summary>
@@ -528,11 +525,11 @@ public sealed class LibraryBodyIndex
         => ns is not null
             && (ns == "Grpc.Core" || ns.StartsWith("Grpc.Core.", StringComparison.Ordinal));
 
-    bool IsProtobufType(TypeRef type, string ns, string name)
+    static bool IsProtobufType(TypeRef type, string ns, string name)
     {
         var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
         return definition is not null
-            && _protobufIdentityAuthentic
+            && definition.TrustedProtobufAssembly
             && definition.Assembly == "Google.Protobuf"
             && definition.Namespace == ns
             && StripGenericArity(definition.Name) == name;
@@ -557,8 +554,7 @@ public sealed class LibraryBodyIndex
             path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
             index.OptimizationOpportunities, index.UnsafeLeverageMethods, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
             index.BodySignals, index.InAssemblyTypeIsException, index.SuppressedOpportunityTokens, index.ExceptionTypeNames,
-            index.InAssemblyValueTypeNames,
-            FrameworkAssemblyKeys.GoogleProtobufIdentityIsAuthentic(reader));
+            index.InAssemblyValueTypeNames);
     }
 
     public ImmutableArray<DirectCall> FindCalls(MemberPattern pattern)

--- a/src/ILInspector.Analysis/TypeRef.cs
+++ b/src/ILInspector.Analysis/TypeRef.cs
@@ -55,13 +55,22 @@ public sealed class TypeRef : IEquatable<TypeRef>
     // it is derived metadata, not part of structural type identity.
     public bool TrustedFrameworkAssembly { get; private init; } = true;
 
-    public static TypeRef Definition(string assembly, string ns, string name, bool trustedFrameworkAssembly = true)
+    // Whether this type's declaring assembly identity is NOT a Google.Protobuf spoof: false
+    // only for a type resolved through a reference (or self-assembly) named Google.Protobuf
+    // whose public-key-token is not the real one (#1735). Stamped per decoded reference so
+    // generated-code suppression rejects a spoofed Google.Protobuf reference even when an
+    // authentic one coexists. Defaults to true (synthetic/corelib refs and all non-protobuf
+    // identities are not spoofs). Excluded from equality/hash: derived metadata, not identity.
+    public bool TrustedProtobufAssembly { get; private init; } = true;
+
+    public static TypeRef Definition(string assembly, string ns, string name, bool trustedFrameworkAssembly = true, bool trustedProtobufAssembly = true)
         => new(TypeRefKind.Definition)
         {
             Assembly = CanonicalAssembly(assembly),
             Namespace = ns,
             Name = name,
             TrustedFrameworkAssembly = trustedFrameworkAssembly,
+            TrustedProtobufAssembly = trustedProtobufAssembly,
         };
 
     public static TypeRef CoreLib(string ns, string name) => Definition(CoreLibrary, ns, name);

--- a/src/ILInspector.Analysis/TypeRefDecoder.cs
+++ b/src/ILInspector.Analysis/TypeRefDecoder.cs
@@ -44,12 +44,12 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
         if (typeDef.IsNested)
         {
             var declaring = GetTypeFromDefinition(reader, typeDef.GetDeclaringType(), 0);
-            return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{name}", declaring.TrustedFrameworkAssembly);
+            return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{name}", declaring.TrustedFrameworkAssembly, declaring.TrustedProtobufAssembly);
         }
         string assembly = reader.IsAssembly
             ? reader.GetString(reader.GetAssemblyDefinition().Name)
             : "";
-        return TypeRef.Definition(assembly, ns, name, FrameworkAssemblyKeys.IsFrameworkDefinition(reader));
+        return TypeRef.Definition(assembly, ns, name, FrameworkAssemblyKeys.IsFrameworkDefinition(reader), FrameworkAssemblyKeys.IsAuthenticProtobufDefinition(reader));
     }
 
     public TypeRef GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
@@ -63,7 +63,8 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
                 reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)typeRef.ResolutionScope).Name),
                 ns,
                 name,
-                FrameworkAssemblyKeys.IsFrameworkReference(reader, (AssemblyReferenceHandle)typeRef.ResolutionScope)),
+                FrameworkAssemblyKeys.IsFrameworkReference(reader, (AssemblyReferenceHandle)typeRef.ResolutionScope),
+                FrameworkAssemblyKeys.IsAuthenticProtobufReference(reader, (AssemblyReferenceHandle)typeRef.ResolutionScope)),
             HandleKind.TypeReference => NestedReference(reader, (TypeReferenceHandle)typeRef.ResolutionScope, name),
             // ModuleReference / nil scope: the type is in the current assembly (another
             // module of it, or an exported/forwarded type resolved in this manifest), so
@@ -74,7 +75,8 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
                 reader.IsAssembly ? reader.GetString(reader.GetAssemblyDefinition().Name) : "",
                 ns,
                 name,
-                FrameworkAssemblyKeys.IsFrameworkDefinition(reader)),
+                FrameworkAssemblyKeys.IsFrameworkDefinition(reader),
+                FrameworkAssemblyKeys.IsAuthenticProtobufDefinition(reader)),
         };
     }
 
@@ -99,7 +101,7 @@ internal sealed class TypeRefDecoder : ISignatureTypeProvider<TypeRef, GenericSc
     static TypeRef NestedReference(MetadataReader reader, TypeReferenceHandle declaringHandle, string nestedName)
     {
         var declaring = Instance.GetTypeFromReference(reader, declaringHandle, 0);
-        return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{nestedName}", declaring.TrustedFrameworkAssembly);
+        return TypeRef.Definition(declaring.Assembly, declaring.Namespace, $"{declaring.Name}+{nestedName}", declaring.TrustedFrameworkAssembly, declaring.TrustedProtobufAssembly);
     }
 
     static string NameAt(ImmutableArray<string> names, int index)


### PR DESCRIPTION
## Summary
Generated-code suppression treated any assembly *named* `Google.Protobuf` as the real runtime, so an unsigned same-name assembly could spoof it and silently suppress actionable Performance Triage rows. This gates protobuf-generated classification on the real Google.Protobuf **public-key-token** (`a7d26565bac4d604`), parallel to the framework-signal identity gate (#1724).

## Changes
- **`FrameworkAssemblyKeys`**: add `GoogleProtobufToken` + `GoogleProtobufIdentityIsAuthentic(MetadataReader)` (checks the `Google.Protobuf` assembly reference's PKT, or the self assembly when self-named). Class made `public` so the authenticity check is directly unit-testable (parallels `GenericMemberIdentity`).
- **`LibraryBodyIndex`**: compute `_protobufIdentityAuthentic` once at `Open()` time (the metadata reader is only available there; the index does not retain it) and gate `IsProtobufType` on it.
- **Tests**: the existing unsigned `Google.Protobuf` fixture is now the spoof, so the protobuf assertions flip to `DoesNotContain` (gRPC detection is identity-independent and still passes). Added `GoogleProtobufIdentity_AuthenticatesByPublicKeyToken`: the fixture → `false`, the real strong-named package assembly → `true` (skips if the package isn't restored).

## Verification
- `ILInspector.Analysis.Tests`: 209/209.
- `dotnet-inspect.Tests`: 1380 passed, 9 skipped.
- **Non-vacuity**: removing `&& _protobufIdentityAuthentic` makes the spoof-rejection test FAIL (the unsigned fixture is detected as protobuf-generated); restored.
- Real Google.Protobuf PKT confirmed empirically against the restored 3.30.2/3.34.1 package assemblies.

Closes #1735

Part of the analysis quality ladder (#1623), rung 5 (Performance Triage ranking / generated-code suppression honesty).