### PR TITLE
Recover value-form user-defined ++/-- on non-local lvalues (#1777)

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LadderRung5/LadderRung5.cs
@@ -164,6 +164,13 @@ public readonly struct CheckedMeters
 
     public static CheckedMeters PreDecrement(CheckedMeters a) => --a;
 
+    // Value-form non-local (static field) increment (#1777): the old value is
+    // captured, the field updated through the operator, and the old value returned.
+    // Recovers to Counter++, never the CS0571 op_Increment call.
+    public static CheckedMeters Counter;
+
+    public static CheckedMeters BumpCounter() => Counter++;
+
     // Statement form (the increment value is discarded): folds to a++; not the
     // CS0571 op_Increment(a) call. The checked statement needs a checked { ... }
     // block, since checked(a++) is CS0201 in statement position.

--- a/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
@@ -563,6 +563,23 @@ public class IncrementDecrementPassTests
     }
 
     [Fact]
+    public void UserOperatorValueForm_CallBeforeUse_IsNotFolded()
+    {
+        // S = SF; SF = op_Increment(S); use (Read() + S);  must NOT fold — Read()
+        // is evaluated before the use, so moving the increment to the use site
+        // would run Read() before instead of after the increment (#1783 review).
+        var field = new FieldRef(ValueType, "SF", ValueType);
+        var read = new Call(new MethodRef(ValueType, "Read", ValueType, [], HasThis: false), isVirtual: false, []);
+        var statements = Run(Function(
+            new StoreStackSlot(0, new LoadField(field, instance: null)),
+            new StoreField(field, instance: null, IncrementCall("op_Increment", ValueType, new LoadStackSlot(0, ValueType))),
+            new StoreLocal(1, ValueType, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false,
+                read, new LoadStackSlot(0, ValueType)))));
+
+        Assert.Empty(statements.SelectMany(s => s.Descendants).OfType<IncrementDecrement>());
+    }
+
+    [Fact]
     public void OrdinaryMethodNamedOpIncrement_IsNotFolded()
     {
         // A normal method that happens to be named op_Increment (no operator

--- a/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
@@ -580,6 +580,42 @@ public class IncrementDecrementPassTests
     }
 
     [Fact]
+    public void UserOperatorValueForm_ThrowingExprBeforeUse_IsNotFolded()
+    {
+        // S = SF; SF = op_Increment(S); use ((a / b) + S);  must NOT fold — the
+        // division is evaluated before the use and can throw, so moving the
+        // increment to the use site would reorder it past the exception (#1783).
+        var field = new FieldRef(ValueType, "SF", ValueType);
+        var div = new Binary(BinaryKind.Divide, isChecked: false, isUnsigned: false,
+            new LoadArgument(0, "a", ValueType), new LoadArgument(1, "b", ValueType));
+        var statements = Run(Function(
+            new StoreStackSlot(0, new LoadField(field, instance: null)),
+            new StoreField(field, instance: null, IncrementCall("op_Increment", ValueType, new LoadStackSlot(0, ValueType))),
+            new StoreLocal(1, ValueType, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false,
+                div, new LoadStackSlot(0, ValueType)))));
+
+        Assert.Empty(statements.SelectMany(s => s.Descendants).OfType<IncrementDecrement>());
+    }
+
+    [Fact]
+    public void UserOperatorValueForm_PureLeafBeforeUse_StillFolds()
+    {
+        // S = SF; SF = op_Increment(S); use (const + S);  the Binary is evaluated
+        // after the use and the only thing before it is a non-throwing constant,
+        // so the value form still folds to const + SF++.
+        var field = new FieldRef(ValueType, "SF", ValueType);
+        var statements = Run(Function(
+            new StoreStackSlot(0, new LoadField(field, instance: null)),
+            new StoreField(field, instance: null, IncrementCall("op_Increment", ValueType, new LoadStackSlot(0, ValueType))),
+            new StoreLocal(1, ValueType, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false,
+                new Constant(1, ValueType), new LoadStackSlot(0, ValueType)))));
+
+        var increment = Assert.Single(statements.SelectMany(s => s.Descendants).OfType<IncrementDecrement>());
+        Assert.True(increment is { IsIncrement: true, IsUserDefined: true });
+        Assert.IsType<LoadField>(increment.Target);
+    }
+
+    [Fact]
     public void OrdinaryMethodNamedOpIncrement_IsNotFolded()
     {
         // A normal method that happens to be named op_Increment (no operator

--- a/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
@@ -616,6 +616,24 @@ public class IncrementDecrementPassTests
     }
 
     [Fact]
+    public void UserOperatorValueForm_ConditionalUse_IsNotFolded()
+    {
+        // S = SF; SF = op_Increment(S); return cond ? S : default;  must NOT fold —
+        // the use sits in a ternary arm, so folding would make the unconditional
+        // increment run only when cond holds (#1783 review).
+        var field = new FieldRef(ValueType, "SF", ValueType);
+        var statements = Run(Function(
+            new StoreStackSlot(0, new LoadField(field, instance: null)),
+            new StoreField(field, instance: null, IncrementCall("op_Increment", ValueType, new LoadStackSlot(0, ValueType))),
+            new Return(new Conditional(
+                new LoadArgument(0, "cond", ValueType),
+                new LoadStackSlot(0, ValueType),
+                new Constant(0, ValueType)))));
+
+        Assert.Empty(statements.SelectMany(s => s.Descendants).OfType<IncrementDecrement>());
+    }
+
+    [Fact]
     public void OrdinaryMethodNamedOpIncrement_IsNotFolded()
     {
         // A normal method that happens to be named op_Increment (no operator

--- a/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
@@ -531,6 +531,38 @@ public class IncrementDecrementPassTests
     }
 
     [Fact]
+    public void UserOperatorValueForm_ConsumerReadsLvalue_IsNotFolded()
+    {
+        // S = SF; SF = op_Increment(S); use (SF + S);  must NOT fold to SF++ —
+        // folding moves the consumer's own SF read across the update, changing the
+        // result. The op stays an honest residual (#1783 review).
+        var field = new FieldRef(ValueType, "SF", ValueType);
+        var statements = Run(Function(
+            new StoreStackSlot(0, new LoadField(field, instance: null)),
+            new StoreField(field, instance: null, IncrementCall("op_Increment", ValueType, new LoadStackSlot(0, ValueType))),
+            new StoreLocal(1, ValueType, new Binary(BinaryKind.Add, isChecked: false, isUnsigned: false,
+                new LoadField(field, instance: null), new LoadStackSlot(0, ValueType)))));
+
+        Assert.Empty(statements.SelectMany(s => s.Descendants).OfType<IncrementDecrement>());
+    }
+
+    [Fact]
+    public void UserOperatorValueForm_LocalTempAddressTaken_IsNotFolded()
+    {
+        // loc0 = SF; SF = op_Increment(loc0); use loc0; ref loc0;  must NOT fold —
+        // the address-of is an observation the load count misses, so removing the
+        // capture would drop a live use (#1783 review).
+        var field = new FieldRef(ValueType, "SF", ValueType);
+        var statements = Run(Function(
+            new StoreLocal(0, ValueType, new LoadField(field, instance: null)),
+            new StoreField(field, instance: null, IncrementCall("op_Increment", ValueType, new LoadLocal(0, ValueType))),
+            new StoreLocal(1, ValueType, new LoadLocal(0, ValueType)),
+            new StoreLocal(2, ValueType, new LoadLocalAddress(0, ValueType))));
+
+        Assert.Empty(statements.SelectMany(s => s.Descendants).OfType<IncrementDecrement>());
+    }
+
+    [Fact]
     public void OrdinaryMethodNamedOpIncrement_IsNotFolded()
     {
         // A normal method that happens to be named op_Increment (no operator

--- a/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IncrementDecrementPassTests.cs
@@ -498,6 +498,39 @@ public class IncrementDecrementPassTests
     }
 
     [Fact]
+    public void UserOperatorStaticFieldPostfixValueForm_FoldsToOperator()
+    {
+        // S = SF; SF = op_Increment(S); use S;  ->  use SF++  (value-form #1777).
+        var field = new FieldRef(ValueType, "SF", ValueType);
+        var statements = Run(Function(
+            new StoreStackSlot(0, new LoadField(field, instance: null)),
+            new StoreField(field, instance: null, IncrementCall("op_Increment", ValueType, new LoadStackSlot(0, ValueType))),
+            new StoreLocal(1, ValueType, new LoadStackSlot(0, ValueType))));
+
+        // Capture + update are removed; the consumer holds the SF++ increment.
+        var consumer = Assert.IsType<StoreLocal>(Assert.Single(statements));
+        var increment = Assert.IsType<IncrementDecrement>(consumer.Value);
+        Assert.True(increment is { IsIncrement: true, IsPrefix: false, IsUserDefined: true });
+        Assert.IsType<LoadField>(increment.Target);
+    }
+
+    [Fact]
+    public void UserOperatorStaticFieldPrefixValueForm_FoldsToOperator()
+    {
+        // S = op_Increment(SF); SF = S; use S;  ->  use ++SF  (value-form #1777).
+        var field = new FieldRef(ValueType, "SF", ValueType);
+        var statements = Run(Function(
+            new StoreStackSlot(0, IncrementCall("op_Increment", ValueType, new LoadField(field, instance: null))),
+            new StoreField(field, instance: null, new LoadStackSlot(0, ValueType)),
+            new StoreLocal(1, ValueType, new LoadStackSlot(0, ValueType))));
+
+        var consumer = Assert.IsType<StoreLocal>(Assert.Single(statements));
+        var increment = Assert.IsType<IncrementDecrement>(consumer.Value);
+        Assert.True(increment is { IsIncrement: true, IsPrefix: true, IsUserDefined: true });
+        Assert.IsType<LoadField>(increment.Target);
+    }
+
+    [Fact]
     public void OrdinaryMethodNamedOpIncrement_IsNotFolded()
     {
         // A normal method that happens to be named op_Increment (no operator

--- a/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung5GateTests.cs
@@ -269,6 +269,12 @@ public class LadderRung5GateTests
         Assert.Contains("checked { a++; }", stmtChecked);
         Assert.DoesNotContain("op_", stmtChecked);
 
+        // #1777: a value-form non-local (static field) increment recovers to
+        // Counter++, never the CS0571 op_Increment call.
+        var bump = Body("BumpCounter");
+        Assert.Contains("Counter++", bump);
+        Assert.DoesNotContain("op_", bump);
+
         // #1712 follow-up: a checked for-loop over a class loop variable has no
         // valid for-header spelling for the checked increment (checked(i++) is
         // CS0201), so it stays a while loop with the increment localized to a

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -159,6 +159,15 @@ public sealed class IncrementDecrementPass : IIrPass
         if (ObservesBeforeUse(useStatement, useLoad))
             return false;
 
+        // The use must also be reached unconditionally: folding the unconditional
+        // update into the use must not make the increment conditional. `return cond
+        // ? S : default` would otherwise fold to `return cond ? SF++ : default`,
+        // incrementing only when cond holds. Reject conditional-evaluation ancestors
+        // (ternary / ?? / ?. / switch-expression / short-circuit) and any non-linear
+        // consumer statement (an `if`/loop/switch body is conditionally reached).
+        if (!IsLinearStatement(useStatement) || ReachedConditionally(useLoad, useStatement))
+            return false;
+
         lvalueLoad.Detach();
         var increment = new IncrementDecrement(lvalueLoad, isIncrement, isPrefix, isUserDefined: true, isChecked: isChecked);
         stepper.StepOver($"fold user-defined {(isIncrement ? "++" : "--")} value form into operator", useLoad);
@@ -204,6 +213,19 @@ public sealed class IncrementDecrementPass : IIrPass
         Constant or LoadLocal or LoadStackSlot or LoadArgument => true,
         _ => false,
     };
+
+    /// <summary>A statement whose body runs unconditionally and in evaluation order — the value form's use must sit in one of these, not in an if/loop/switch body that is conditionally reached.</summary>
+    static bool IsLinearStatement(IrNode statement) => statement is
+        Return or ExpressionStatement or StoreLocal or StoreStackSlot or StoreField or StoreIndirect or StoreArgument or StoreElement;
+
+    /// <summary>True when <paramref name="use"/> is nested inside a conditional-evaluation construct (ternary, ??, ?., switch-expression, short-circuit) below <paramref name="statement"/>, so the use is not guaranteed to execute.</summary>
+    static bool ReachedConditionally(IrNode use, IrNode statement)
+    {
+        for (var node = use.Parent; node is not null && !ReferenceEquals(node, statement); node = node.Parent)
+            if (node is Conditional or Coalesce or NullConditional or SwitchExpression or LogicalBinary)
+                return true;
+        return false;
+    }
 
     static int CountTempStores(IrFunction function, IrNode capture) => capture switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -192,8 +192,16 @@ public sealed class IncrementDecrementPass : IIrPass
 
     static bool IsPureLocalComputation(IrNode node) => node switch
     {
+        // Only non-throwing leaf loads are safe to evaluate before the use. A
+        // compound Binary/Unary/Convert fully evaluated before the use (e.g. the
+        // left operand `1 / z` in `1 / z + old`) can throw — div-by-zero, checked
+        // overflow, checked conversion — so moving the increment past it would
+        // reorder the increment relative to that exception. Such nodes only appear
+        // *before* the use when they are an earlier sibling subexpression; a
+        // Binary/Unary/Convert whose subtree contains the use is evaluated after
+        // it and never reaches this check, so simple shapes like `5 + old` still
+        // fold.
         Constant or LoadLocal or LoadStackSlot or LoadArgument => true,
-        Unary or Convert or Binary => true,
         _ => false,
     };
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -33,8 +33,130 @@ public sealed class IncrementDecrementPass : IIrPass
 
         FoldForLoopIncrements(function, context.Stepper);
         FoldUserOperatorSelfUpdates(function, context.Stepper);
+        FoldUserOperatorValueForms(function, context.Stepper);
         MarkSurvivingUserIncrements(function, context.Stepper);
     }
+
+    // Recover a value-form user-defined ++/-- on a NON-LOCAL lvalue (return
+    // obj.Field++, return ++SF) — the dup fold (TryFold) only handles local/argument
+    // updates. The IL captures the lvalue's old (postfix) or new (prefix) value in a
+    // temp, updates the field/indirect place through the operator, and uses the temp
+    // downstream:
+    //   V = lvalue; lvalue = op_Increment(V); use V    →  use lvalue++
+    //   V = op_Increment(lvalue); lvalue = V; use V     →  use ++lvalue
+    // See #1777.
+    static void FoldUserOperatorValueForms(IrFunction function, Stepper stepper)
+    {
+        bool changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach (var block in function.Descendants.OfType<Block>().ToList())
+            {
+                for (int i = 0; i + 1 < block.Children.Count; i++)
+                {
+                    if (TryFoldValueForm(function, block, i, stepper))
+                    {
+                        changed = true;
+                        break;
+                    }
+                }
+                if (changed)
+                    break;
+            }
+        }
+    }
+
+    static bool TryFoldValueForm(IrFunction function, Block block, int i, Stepper stepper)
+    {
+        var capture = block.Children[i];
+        var update = block.Children[i + 1];
+
+        // The captured temp is a local or a stack slot, written by the capture.
+        Func<IrExpression, bool>? isTempLoad = capture switch
+        {
+            StoreLocal s => e => e is LoadLocal l && l.Index == s.Index,
+            StoreStackSlot s => e => e is LoadStackSlot l && l.Slot == s.Slot,
+            _ => null,
+        };
+        IrExpression? captureValue = capture switch
+        {
+            StoreLocal s => s.Value,
+            StoreStackSlot s => s.Value,
+            _ => null,
+        };
+        if (isTempLoad is null || captureValue is null)
+            return false;
+
+        // The update must write a NON-LOCAL lvalue (field/indirect); the local and
+        // argument value forms are handled by the dup fold.
+        IrExpression? updateValue = update switch
+        {
+            StoreField s => s.Value,
+            StoreIndirect s => s.Value,
+            _ => null,
+        };
+        if (updateValue is null)
+            return false;
+
+        bool isPrefix;
+        IrExpression lvalueLoad;
+        bool isIncrement;
+        bool isChecked;
+
+        if (AsIncrementCall(updateValue) is { } postOp && isTempLoad(postOp.Operand) && WritesSamePlaceAsRead(update, captureValue))
+        {
+            // V = lvalue; lvalue = op_Increment(V);  →  lvalue++
+            isPrefix = false;
+            lvalueLoad = captureValue;
+            isIncrement = postOp.IsIncrement;
+            isChecked = postOp.IsChecked;
+        }
+        else if (AsIncrementCall(captureValue) is { } preOp && isTempLoad(updateValue) && WritesSamePlaceAsRead(update, preOp.Operand))
+        {
+            // V = op_Increment(lvalue); lvalue = V;  →  ++lvalue
+            isPrefix = true;
+            lvalueLoad = preOp.Operand;
+            isIncrement = preOp.IsIncrement;
+            isChecked = preOp.IsChecked;
+        }
+        else
+        {
+            return false;
+        }
+
+        // The temp must be written once and read exactly twice — the update above
+        // plus one downstream consumer — so removing the capture is sound.
+        var tempLoads = function.Descendants.OfType<IrExpression>().Where(isTempLoad).ToList();
+        if (tempLoads.Count != 2)
+            return false;
+        if (CountTempStores(function, capture) != 1)
+            return false;
+        if (tempLoads.Count(l => ReferenceOwnership.IsInside(l, update)) != 1)
+            return false;
+        if (tempLoads.FirstOrDefault(l => !ReferenceOwnership.IsInside(l, update)) is not { } useLoad)
+            return false;
+
+        // The consumer must be the statement immediately after the update, so the
+        // lvalue is neither read nor written between its update and the use site.
+        if (StatementOf(useLoad, block) is not { } useStatement || useStatement.ChildIndex != i + 2)
+            return false;
+
+        lvalueLoad.Detach();
+        var increment = new IncrementDecrement(lvalueLoad, isIncrement, isPrefix, isUserDefined: true, isChecked: isChecked);
+        stepper.StepOver($"fold user-defined {(isIncrement ? "++" : "--")} value form into operator", useLoad);
+        useLoad.ReplaceWith(increment);
+        update.Detach();
+        capture.Detach();
+        return true;
+    }
+
+    static int CountTempStores(IrFunction function, IrNode capture) => capture switch
+    {
+        StoreLocal s => function.Descendants.OfType<StoreLocal>().Count(x => x.Index == s.Index),
+        StoreStackSlot s => function.Descendants.OfType<StoreStackSlot>().Count(x => x.Slot == s.Slot),
+        _ => 0,
+    };
 
     // A user-defined increment/decrement operator call that survived all folds
     // sits in a position with no faithful C# spelling — e.g. a value-form

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -149,11 +149,14 @@ public sealed class IncrementDecrementPass : IIrPass
         if (StatementOf(useLoad, block) is not { } useStatement || useStatement.ChildIndex != i + 2)
             return false;
 
-        // The consumer must not access the lvalue itself other than through the
-        // folded temp: `S = SF; SF = op_Increment(S); return SF + S;` would fold to
-        // `return SF + SF++`, moving the SF read across the update and changing the
-        // result. Such a shape stays an honest residual.
-        if (AccessesPlaceOf(useStatement, lvalueLoad))
+        // Folding moves the operator to the use site, so the increment now runs at
+        // the use's position in the consumer's evaluation order rather than before
+        // the whole statement. Anything evaluated earlier in the consumer that can
+        // observe or mutate the lvalue — a field/indirect read, a call, or an
+        // aliasing access — would then see a different value. Only fold when every
+        // node evaluated before the use is a pure local computation, which keeps
+        // shapes like `return SF + S` or `return Read(a).V + old` honest residuals.
+        if (ObservesBeforeUse(useStatement, useLoad))
             return false;
 
         lvalueLoad.Detach();
@@ -165,25 +168,34 @@ public sealed class IncrementDecrementPass : IIrPass
         return true;
     }
 
-    /// <summary>True when <paramref name="node"/> or any descendant reads, writes, or takes the address of the same field/indirect place as <paramref name="lvalueLoad"/>.</summary>
-    static bool AccessesPlaceOf(IrNode node, IrExpression lvalueLoad)
+    /// <summary>True when any node evaluated before <paramref name="use"/> in <paramref name="statement"/> is something other than a pure local computation (constant/local/argument load or arithmetic), i.e. could observe or mutate heap/lvalue state.</summary>
+    static bool ObservesBeforeUse(IrNode statement, IrExpression use)
     {
-        foreach (var current in (IEnumerable<IrNode>)[node, .. node.Descendants])
+        foreach (var node in EvaluationOrder(statement))
         {
-            bool hit = (current, lvalueLoad) switch
-            {
-                (LoadField n, LoadField lv) => SameField(n.Field, lv.Field) && SamePlaceExpr(n.Instance, lv.Instance),
-                (StoreField n, LoadField lv) => SameField(n.Field, lv.Field) && SamePlaceExpr(n.Instance, lv.Instance),
-                (LoadFieldAddress n, LoadField lv) => SameField(n.Field, lv.Field) && SamePlaceExpr(n.Instance, lv.Instance),
-                (LoadIndirect n, LoadIndirect lv) => SamePlaceExpr(n.Address, lv.Address),
-                (StoreIndirect n, LoadIndirect lv) => SamePlaceExpr(n.Address, lv.Address),
-                _ => false,
-            };
-            if (hit)
+            if (ReferenceEquals(node, use))
+                return false;
+            if (!IsPureLocalComputation(node))
                 return true;
         }
         return false;
     }
+
+    /// <summary>Yields the nodes of <paramref name="node"/> in left-to-right post-order, matching IL evaluation order (operands before their parent).</summary>
+    static IEnumerable<IrNode> EvaluationOrder(IrNode node)
+    {
+        foreach (var child in node.Children)
+            foreach (var inner in EvaluationOrder(child))
+                yield return inner;
+        yield return node;
+    }
+
+    static bool IsPureLocalComputation(IrNode node) => node switch
+    {
+        Constant or LoadLocal or LoadStackSlot or LoadArgument => true,
+        Unary or Convert or Binary => true,
+        _ => false,
+    };
 
     static int CountTempStores(IrFunction function, IrNode capture) => capture switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IncrementDecrementPass.cs
@@ -126,7 +126,14 @@ public sealed class IncrementDecrementPass : IIrPass
         }
 
         // The temp must be written once and read exactly twice — the update above
-        // plus one downstream consumer — so removing the capture is sound.
+        // plus one downstream consumer — so removing the capture is sound. For a
+        // local temp, an address-of (ref/out) is an observation the load count
+        // misses, so reject it outright.
+        if (capture is StoreLocal { Index: var captureIndex }
+            && function.Descendants.OfType<LoadLocalAddress>().Any(a => a.Index == captureIndex))
+        {
+            return false;
+        }
         var tempLoads = function.Descendants.OfType<IrExpression>().Where(isTempLoad).ToList();
         if (tempLoads.Count != 2)
             return false;
@@ -142,6 +149,13 @@ public sealed class IncrementDecrementPass : IIrPass
         if (StatementOf(useLoad, block) is not { } useStatement || useStatement.ChildIndex != i + 2)
             return false;
 
+        // The consumer must not access the lvalue itself other than through the
+        // folded temp: `S = SF; SF = op_Increment(S); return SF + S;` would fold to
+        // `return SF + SF++`, moving the SF read across the update and changing the
+        // result. Such a shape stays an honest residual.
+        if (AccessesPlaceOf(useStatement, lvalueLoad))
+            return false;
+
         lvalueLoad.Detach();
         var increment = new IncrementDecrement(lvalueLoad, isIncrement, isPrefix, isUserDefined: true, isChecked: isChecked);
         stepper.StepOver($"fold user-defined {(isIncrement ? "++" : "--")} value form into operator", useLoad);
@@ -149,6 +163,26 @@ public sealed class IncrementDecrementPass : IIrPass
         update.Detach();
         capture.Detach();
         return true;
+    }
+
+    /// <summary>True when <paramref name="node"/> or any descendant reads, writes, or takes the address of the same field/indirect place as <paramref name="lvalueLoad"/>.</summary>
+    static bool AccessesPlaceOf(IrNode node, IrExpression lvalueLoad)
+    {
+        foreach (var current in (IEnumerable<IrNode>)[node, .. node.Descendants])
+        {
+            bool hit = (current, lvalueLoad) switch
+            {
+                (LoadField n, LoadField lv) => SameField(n.Field, lv.Field) && SamePlaceExpr(n.Instance, lv.Instance),
+                (StoreField n, LoadField lv) => SameField(n.Field, lv.Field) && SamePlaceExpr(n.Instance, lv.Instance),
+                (LoadFieldAddress n, LoadField lv) => SameField(n.Field, lv.Field) && SamePlaceExpr(n.Instance, lv.Instance),
+                (LoadIndirect n, LoadIndirect lv) => SamePlaceExpr(n.Address, lv.Address),
+                (StoreIndirect n, LoadIndirect lv) => SamePlaceExpr(n.Address, lv.Address),
+                _ => false,
+            };
+            if (hit)
+                return true;
+        }
+        return false;
     }
 
     static int CountTempStores(IrFunction function, IrNode capture) => capture switch


### PR DESCRIPTION
## Summary

Closes #1777, the one owned residual remaining from the #1712 user-defined `++`/`--` work. A **value-form** non-local increment (`return obj.Field++` / `return ++SF`) degraded to an honest `Partial` residual; this recovers it to the operator.

```csharp
// before (honest Partial residual)        // after
M j = b.F;                                 Box S_256 = b;
/* Unsupported ++ ... */                   return S_256.F++;
return j;
```

## Why it was residual

The statement-form non-local increments (`obj.Field++;`, for-loop updates) already recover via the unified self-update fold. The **value form** (where the result is used) goes through the dup-slot fold (`TryFold`), which only accepts `StoreLocal`/`StoreArgument` updates — a field/indirect update store doesn't match, so it fell to the residual safety net.

## Fix

`FoldUserOperatorValueForms` recognizes the capture/update/use pattern over non-local lvalues, reusing the `WritesSamePlaceAsRead`/`SamePlaceExpr` structural matching from the statement fold:

| Shape | Folds to |
| --- | --- |
| `V = lvalue; lvalue = op_Increment(V); use V` | `use lvalue++` |
| `V = op_Increment(lvalue); lvalue = V; use V` | `use ++lvalue` |

The temp (a local or stack slot) must be written once and read exactly twice — the update plus one consumer immediately after the update — so removing the capture reorders nothing. The lvalue load is reused as the `++`/`--` target. Covers static fields (`SF++`), instance fields (`b.F++`, receiver spilled), and indirect lvalues, postfix and prefix.

## Evidence

- Verified through the decompiler: `return obj.Field++` → `S = b; return S.F++;`; `return ++obj.Field` → `return ++S.F;`; `return SF++` → `return Box.SF++;` — **100% exact opcode match / 0 recompile fail**; probe now **7 Full / 0 Partial** (no residual).
- Guards: `IncrementDecrementPassTests` static-field postfix/prefix value-form cases; rung 5 `CheckedMeters.BumpCounter` (static value-form) with a gate assertion.
- Fast subset 1605/1605, `IncrementDecrementPassTests` 32, `LadderRung5GateTests` 8/8, `CorpusSweepGateTests` green; fidelity gates + corpus card posted as comments.

Cross-family adversarial review (GPT-5.5) requested per the decompiler PR contract.

Closes #1777. Advances #1599 row 2.
