### PR TITLE
Fix char conditional element stores (#1751)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -497,6 +497,9 @@ public class CfgSampleClass
 
     public static void SetCharElement(char[] a, int v) => a[0] = (char)v;
 
+    public static void CharConditionalElementStore(char[] chars, int index, long ticks)
+        => chars[index] = ticks >= 0 ? '+' : '-';
+
     public static int BoolArrayVisited(int index)
     {
         bool[] visited = new bool[index + 1];

--- a/src/ILInspector.Decompiler.Tests/CharElementStorePrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CharElementStorePrinterTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Issue #1751: a conditional materialized by IL as int may still feed a char[]
+// store. The stack slot must render as char instead of emitting invalid
+// `chars[index] = intSlot;` at Full fidelity.
+public class CharElementStorePrinterTests
+{
+    [Fact]
+    public void ConditionalIntStackSlot_FeedingCharElementStore_RendersCharSlot()
+    {
+        string body = RenderFixture(nameof(CfgSampleClass.CharConditionalElementStore));
+
+        Assert.Contains("char S_", body);
+        Assert.Contains("? '+' : '-'", body);
+        Assert.Contains("chars[S_", body);
+        Assert.DoesNotContain("int S_2 = ticks", body);
+        Assert.DoesNotContain("] = (char)S_", body);
+        AssertCompiles("public static void M(char[] chars, int index, long ticks)", body);
+    }
+
+    static string RenderFixture(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        Assert.Equal(DecompilationFidelity.Full, function!.Fidelity);
+        var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+        Assert.NotNull(result.Output);
+        return result.Output!;
+    }
+
+    static void AssertCompiles(string header, string body)
+    {
+        var errors = Recompile(header, body)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToArray();
+        Assert.True(errors.Length == 0, "Rendered body must compile, got:\n  " + string.Join("\n  ", errors) + "\n--- body ---\n" + body);
+    }
+
+    static ImmutableArray<Diagnostic> Recompile(string methodHeader, string body)
+    {
+        string source = $$"""
+            using System;
+            static class __Gate
+            {
+                {{methodHeader}}
+                {
+            {{body}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "__gate",
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        return compilation.GetDiagnostics();
+    }
+
+    static ImmutableArray<MetadataReference> RuntimeReferences()
+    {
+        var references = ImmutableArray.CreateBuilder<MetadataReference>();
+        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+            try { references.Add(MetadataReference.CreateFromFile(path)); }
+            catch { }
+        }
+        return references.ToImmutable();
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -937,6 +937,10 @@ public sealed partial class CSharpPrinter
         if (target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
             && EffectiveType(value) is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary })
             return $"{Condition(value)} ? 1 : 0";
+        if (value is Conditional conditional
+            && target is { } conditionalTarget
+            && TryConditionalTextForTarget(conditional, conditionalTarget) is { } targetedConditional)
+            return targetedConditional;
         // Cast only off a value whose rendered C# type reliably equals its IR
         // result type. A merge node (ternary/coalesce) reports a merged type the
         // arms may not actually share, and a stack slot's type is the join of
@@ -970,8 +974,10 @@ public sealed partial class CSharpPrinter
             || TypeFamilies.Of(a) == StackFamily.I && TypeFamilies.Of(b) == StackFamily.I;
 
     string ConditionalText(Conditional conditional)
+        => ConditionalText(conditional, conditional.MergedType);
+
+    string ConditionalText(Conditional conditional, TypeRef? target)
     {
-        var target = conditional.MergedType;
         // `?:` is right-associative, so a conditional in the condition position
         // reassociates without parentheses (`(a ? b : c) ? d : e` would reparse
         // as `a ? b : (c ? d : e)`). The arms render through Operand, which
@@ -983,10 +989,44 @@ public sealed partial class CSharpPrinter
     }
 
     string ConditionalArm(IrExpression arm, TypeRef? target)
-        => target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
+        => target is { } charTarget && IsCoreChar(charTarget) && TryCharConstantText(arm, out var charText)
+            ? charText
+            : target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
             && EffectiveType(arm) is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary }
                 ? $"({Condition(arm)} ? 1 : 0)"
                 : Operand(arm);
+
+    string? TryConditionalTextForTarget(Conditional conditional, TypeRef target)
+        => CanRenderConditionalForTarget(conditional, target)
+            ? ConditionalText(conditional, target)
+            : null;
+
+    static bool CanRenderConditionalForTarget(Conditional conditional, TypeRef target)
+        => IsCoreChar(target)
+            && TryCharConstantText(conditional.WhenTrue, out _)
+            && TryCharConstantText(conditional.WhenFalse, out _);
+
+    static bool IsCoreChar(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Char" };
+
+    static bool TryCharConstantText(IrExpression expression, out string text)
+    {
+        switch (expression)
+        {
+            case Constant { Value: char c }:
+                text = CharText(c);
+                return true;
+            case Constant { Value: int i } when i is >= char.MinValue and <= char.MaxValue:
+                text = CharText((char)i);
+                return true;
+            case Constant { Value: long l } when l is >= char.MinValue and <= char.MaxValue:
+                text = CharText((char)l);
+                return true;
+            default:
+                text = "";
+                return false;
+        }
+    }
 
     /// <summary>
     /// An integer constant rendered for a numeric target: bare when in range (C#

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -522,6 +522,19 @@ public sealed partial class CSharpPrinter
             }
         }
 
+        foreach (var storeElement in nodes.OfType<StoreElement>())
+        {
+            if (storeElement is not { Value: LoadStackSlot load, ElementType: { } elementType })
+                continue;
+            if (!storesBySlot.TryGetValue(load.Slot, out var stores)
+                || stores.Count == 0
+                || !stores.All(store => store is Conditional conditional && CanRenderConditionalForTarget(conditional, elementType)))
+            {
+                continue;
+            }
+            (loadsBySlot.TryGetValue(load.Slot, out var loads) ? loads : loadsBySlot[load.Slot] = []).Add(elementType);
+        }
+
         foreach (int slot in storesBySlot.Keys.Concat(loadsBySlot.Keys).Distinct())
         {
             if (TryChooseUnifiedStackSlotType(
@@ -590,6 +603,8 @@ public sealed partial class CSharpPrinter
     bool CanAssignTo(IrExpression value, TypeRef target)
         => value is Constant { Value: null }
             ? IsReferenceLike(target)
+            : value is Conditional conditional && CanRenderConditionalForTarget(conditional, target)
+                ? true
             : value.ResultType is { } source && CanAssignType(source, target);
 
     bool CanAssignType(TypeRef source, TypeRef target)


### PR DESCRIPTION
## Summary

Fixes #1751 by keeping a conditional stack slot typed as `char` when it feeds a
`char[]` element store. The printer now renders the row shape as:

```csharp
char S_2 = ticks >= ((long)0) ? '+' : '-';
chars[S_1] = S_2;
```

instead of `int S_2 = ... 43 : 45; chars[S_1] = S_2;`, avoiding the invalid
`int` to `char` assignment at claimed `Full` fidelity.

The propagation is intentionally narrow: only StoreElement stack-slot consumers
whose slot stores are conditionals that can render for the element target,
currently char targets with char-range constant arms.

## Validation

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CharElementStorePrinterTests/*" -filter "/*/*/IrImporterTests/TypedStelem_TakesElementTypeFromArray_NotOpcodeSign*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- Harness dump for `CfgSampleClass::CharConditionalElementStore` shows `// fidelity: Full`, `char S_2 = ticks >= ((long)0) ? '+' : '-';`, and `chars[S_1] = S_2;`.
- PR quick corpus card:

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 15 assemblies, 1,462 methods
Sample: hash-stable 100 methods per assembly
Correctness coverage: validity not run; fidelity not run

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 1,461 -> 1,462 (+1)
- ILInspector.MetadataPrimitives: 61 -> 62 methods (+1)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 1,213 (83.03%) | 1,216 (83.17%) | +3 |
| Conditional-branch residual | 35 (2.40%) | 35 (2.39%) | 0 |
| Forward-merge stops | 27 (1.85%) | 29 (1.98%) | +2 |
| Full malformed | not run | not run | - |
| Semantic defects | not run | not run | - |
| Fidelity diffs | not run | not run | - |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 82.17% -> 82.17% (0 bps); conditional residual 3.00% -> 3.00% (0 bps); Full malformed 0 -> 0 (0); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Advisory aggregate rate movement (not a PR quick hard gate; review for decompiler-risky changes):
- forward-merge stop increased 13 bps (baseline 1.85%, PR 1.98%, tolerance 10 bps)

Verdict: corpus sensor matched baseline tolerances.
```

Note: an attempted focused compile-back fidelity canary for this fixture reports
`OpcodeDiff` due broader pre-existing stack-spill locals, so this PR claims and
validates the row's invalid-Full binding fix, not exact opcode fidelity for the
synthetic fixture.

## Adversarial review

Cross-model adversarial reviews from Claude Opus 4.8 and MAI-Code-1-Flash are
running. I will post the reconciled review summary on the PR before marking it
ready.
