### PR TITLE
Fix native-int argument address rendering

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AddressInValuePositionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AddressInValuePositionTests.cs
@@ -46,6 +46,23 @@ public class AddressInValuePositionTests
         return CSharpPrinter.Print(function).Output!;
     }
 
+    static string RenderSyntheticRawAddress()
+    {
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, NInt, new LoadArgumentAddress(0, "value", Int)));
+        block.Add(new Return(null));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [new Parameter("value", Int)], HasThis: false, GenericParameterCount: 0),
+            [NInt],
+            body);
+        return CSharpPrinter.Print(function).Output!;
+    }
+
     [Fact]
     public void ValueTypeArrayElementMemberAccess_DropsRefOnTheReceiver()
     {
@@ -99,6 +116,15 @@ public class AddressInValuePositionTests
 
         Assert.Contains("nint V_0 = (int)(&value);", output);
         Assert.DoesNotContain("= (nint)(&value);", output);
+        Assert.DoesNotContain("ref value", output);
+    }
+
+    [Fact]
+    public void RawArgumentAddressStoredToNativeInt_RendersAddressOf()
+    {
+        var output = RenderSyntheticRawAddress();
+
+        Assert.Contains("nint V_0 = (nint)(&value);", output);
         Assert.DoesNotContain("ref value", output);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/AddressInValuePositionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AddressInValuePositionTests.cs
@@ -9,6 +9,9 @@ namespace ILInspector.Decompiler.Tests;
 // rendering the bare `ref` form.
 public class AddressInValuePositionTests
 {
+    static readonly TypeRef Int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef NInt = TypeRef.CoreLib("System", "IntPtr");
+
     static string Render(string methodName)
     {
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
@@ -16,6 +19,30 @@ public class AddressInValuePositionTests
         Assert.NotNull(function);
         IrPasses.Run(function!);
         function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    static string RenderSyntheticNarrowedAddress()
+    {
+        var block = new Block(0);
+        block.Add(new StoreLocal(
+            0,
+            NInt,
+            new ILInspector.Decompiler.Pipeline.Convert(
+                Int,
+                isChecked: false,
+                isUnsigned: false,
+                new LoadArgumentAddress(0, "value", Int))));
+        block.Add(new Return(null));
+
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [new Parameter("value", Int)], HasThis: false, GenericParameterCount: 0),
+            [NInt],
+            body);
         return CSharpPrinter.Print(function).Output!;
     }
 
@@ -62,6 +89,16 @@ public class AddressInValuePositionTests
         var output = Render(nameof(CfgSampleClass.StoreArgumentAddressAsNativeInt));
 
         Assert.Contains("s_argumentAddress = (nint)(&value);", output);
+        Assert.DoesNotContain("ref value", output);
+    }
+
+    [Fact]
+    public void NonNativeAddressConversion_PreservesIntermediateConversion()
+    {
+        var output = RenderSyntheticNarrowedAddress();
+
+        Assert.Contains("nint V_0 = (int)(&value);", output);
+        Assert.DoesNotContain("= (nint)(&value);", output);
         Assert.DoesNotContain("ref value", output);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/AddressInValuePositionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AddressInValuePositionTests.cs
@@ -42,4 +42,26 @@ public class AddressInValuePositionTests
         Assert.Contains("(nuint)(&value)", output);
         Assert.DoesNotContain("ref value", output);
     }
+
+    [Fact]
+    public void ArgumentAddressConvertedToNativeUInt_RendersAddressOf()
+    {
+        // EventSource payload helpers lower DataPointer assignments as
+        // `ldarga; conv.u`; value-position argument addresses use `&`, not `ref`.
+        var output = Render(nameof(CfgSampleClass.ArgumentAddressAsNativeUInt));
+
+        Assert.Contains("(nuint)(&value)", output);
+        Assert.DoesNotContain("ref value", output);
+    }
+
+    [Fact]
+    public void ArgumentAddressStoredToNativeInt_RendersAddressOf()
+    {
+        // Some store/call boundaries consume the converted native-int type and see
+        // the raw address node; that value-position spelling is still `&value`.
+        var output = Render(nameof(CfgSampleClass.StoreArgumentAddressAsNativeInt));
+
+        Assert.Contains("s_argumentAddress = (nint)(&value);", output);
+        Assert.DoesNotContain("ref value", output);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -3081,6 +3081,18 @@ public class CfgSampleClass
         return (nuint)(&value);
     }
 
+    public static unsafe nuint ArgumentAddressAsNativeUInt(int value)
+    {
+        return (nuint)(&value);
+    }
+
+    static nint s_argumentAddress;
+
+    public static unsafe void StoreArgumentAddressAsNativeInt(int value)
+    {
+        s_argumentAddress = (nint)(&value);
+    }
+
     // A pointer compared to null: csc lowers `p == null` to `ldc.i4.0; conv.u;
     // ceq`, so the zero arrives as a native-int constant. The branch must spell
     // `p == null`, not the CS0019 `p == (nuint)0`.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -843,6 +843,12 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string CastValue(IrExpression value, TypeRef? target)
     {
+        if (target is { } nativeTarget
+            && IsNativeInteger(nativeTarget)
+            && AddressOfValue(value) is { } address)
+        {
+            return $"({TypeText(nativeTarget)})(&{Deref(address)})";
+        }
         // A fixed-statement pinned local reads as a pointer (the fixed variable),
         // so the IL's conv.u/conv.i deriving an unmanaged pointer from it
         // (Convert over the pinned load) is a pointer reinterpret. Into a pointer
@@ -964,6 +970,14 @@ public sealed partial class CSharpPrinter
                 : $"({TypeText(target!)}){Operand(conv.Operand)}";
         return $"({TypeText(target!)}){Operand(value)}";
     }
+
+    static IrExpression? AddressOfValue(IrExpression value)
+        => value switch
+        {
+            LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress or LoadElementAddress => value,
+            Convert { Operand: LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress or LoadElementAddress } convert => convert.Operand,
+            _ => null,
+        };
 
     static bool SameNumericSlotWidth(TypeRef? a, TypeRef? b)
         => TypeFamilies.SameWidth(a, b)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -990,7 +990,11 @@ public sealed partial class CSharpPrinter
         => value switch
         {
             LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress or LoadElementAddress => value,
-            Convert { Operand: LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress or LoadElementAddress } convert => convert.Operand,
+            Convert
+            {
+                Target: { Namespace: "System", Assembly: TypeRef.CoreLibrary, Name: "IntPtr" or "UIntPtr" },
+                Operand: LoadLocalAddress or LoadArgumentAddress or LoadFieldAddress or LoadElementAddress
+            } convert => convert.Operand,
             _ => null,
         };
 


### PR DESCRIPTION
## Summary

Fixes #1749 by treating managed address nodes that flow into native-int value positions as C# address-of expressions. This covers both retained `Convert(ldarga/ldloca/...)` values and boundaries where the native-int target has already consumed the conversion, avoiding invalid `(nint)(ref x)` output.

## Evidence

Before, `System.Buffers.ArrayPoolEventSource::BufferRented` rendered:

```csharp
payload.DataPointer = (nint)(ref bufferId);
```

After, it renders:

```csharp
payload.DataPointer = (nint)(&bufferId);
```

Validation run on the final branch tip:

```text
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded. 0 Warning(s), 0 Error(s)

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/AddressInValuePositionTests/*"
ILInspector.Decompiler.Tests Total: 4, Failed: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
ILInspector.Decompiler.Tests Total: 1607, Failed: 0

dotnet run --project tools/DecompilerHarness -c Release -- --validity-check --compile-cap 100 --max-examples 30
Full malformed   : 0 (0.00% of Full)
with a non-binding-noise error: 0 (0.00%)
```

I also started the full slow `ILInspector.Decompiler.Tests` suite before the latest `origin/main` merge, but stopped it after it was still running beyond 30 minutes; the final branch evidence above uses the focused canaries, PR-gate fast subset, product build, and CoreLib validity boss.

## Review

Decompiler printer semantics require cross-model adversarial review before merge. I will post the reconciliation comment on this PR.
