### PR TITLE
Fix negative user-defined conversion casts

### DIFF
--- a/src/ILInspector.Decompiler.Tests/NegativeCastParenthesizationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NegativeCastParenthesizationTests.cs
@@ -1,4 +1,5 @@
 using ILInspector.Decompiler.Pipeline;
+using System.Numerics;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -10,9 +11,12 @@ namespace ILInspector.Decompiler.Tests;
 public class NegativeCastParenthesizationTests
 {
     static string Render(string methodName)
+        => Render(typeof(CfgSampleClass), methodName);
+
+    static string Render(Type declaringType, string methodName)
     {
-        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
-        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        using var source = MetadataSource.Open(declaringType.Assembly.Location);
+        var function = IrImporter.Import(source, declaringType.FullName!, methodName);
         Assert.NotNull(function);
         IrPasses.Run(function!);
         function!.CheckInvariant();
@@ -27,4 +31,28 @@ public class NegativeCastParenthesizationTests
         Assert.Contains("(nint)(-1)", output);
         Assert.DoesNotContain("(nint)-1", output);
     }
+
+    [Fact]
+    public void NegativeUserDefinedConversion_ParenthesizesOperand()
+    {
+        var output = Render(typeof(NegativeConversionSpecimens), nameof(NegativeConversionSpecimens.NegativeBigInteger));
+
+        Assert.Contains("(BigInteger)(-128)", output);
+        Assert.DoesNotContain("(BigInteger)-128", output);
+    }
+
+    [Fact]
+    public void PositiveUserDefinedConversion_StaysBare()
+    {
+        var output = Render(typeof(NegativeConversionSpecimens), nameof(NegativeConversionSpecimens.PositiveBigInteger));
+
+        Assert.Contains("(BigInteger)128", output);
+        Assert.DoesNotContain("(BigInteger)(128)", output);
+    }
+}
+
+public class NegativeConversionSpecimens
+{
+    public static BigInteger NegativeBigInteger() => -128;
+    public static BigInteger PositiveBigInteger() => 128;
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2210,11 +2210,20 @@ public sealed partial class CSharpPrinter
                 "op_UnaryPlus" => $"+{Operand(arguments[0])}",
                 "op_LogicalNot" => $"!{Operand(arguments[0])}",
                 "op_OnesComplement" => $"~{Operand(arguments[0])}",
-                "op_Implicit" or "op_Explicit" => $"({TypeText(call.Callee.ReturnType)}){Operand(arguments[0])}",
+                "op_Implicit" or "op_Explicit" => ConversionOperatorSpelling(call.Callee.ReturnType, arguments[0]),
                 _ => null,
             };
         }
         return null;
+    }
+
+    string ConversionOperatorSpelling(TypeRef target, IrExpression value)
+    {
+        string operand = Operand(value);
+        string targetText = TypeText(target);
+        if (NeedsCastOperandParentheses(operand, targetText))
+            operand = $"({operand})";
+        return $"({targetText}){operand}";
     }
 
     /// <summary>The checked-context spelling of a user-defined checked operator call (op_Checked*), or null when the name has no faithful operator form.</summary>
@@ -2224,7 +2233,7 @@ public sealed partial class CSharpPrinter
 
         // checked explicit conversion: checked((T)x).
         if (call.Callee.Name == "op_CheckedExplicit" && arguments.Count == 1)
-            return WrapChecked(() => $"({TypeText(call.Callee.ReturnType)}){Operand(arguments[0])}");
+            return WrapChecked(() => ConversionOperatorSpelling(call.Callee.ReturnType, arguments[0]));
 
         // The remaining checked operators share their symbol with the unchecked
         // form (op_CheckedAddition → "+"); reuse the single mapping the signature
@@ -2498,13 +2507,18 @@ public sealed partial class CSharpPrinter
         // keyword type the parser treats as cast-disambiguating. `nint`/`nuint`
         // are contextual keywords and named types are not, so `(nint)-1` misparses
         // — wrap the operand: `(nint)(-1)`. The parens are opcode-identical.
-        if (operand.Length > 0 && operand[0] is '-' or '+' && !s_castDisambiguatingKeywords.Contains(targetText))
+        if (NeedsCastOperandParentheses(operand, targetText))
             operand = $"({operand})";
         string cast = $"({targetText}){operand}";
         if (wrap)
             return $"checked({cast})";
         return uncheckedOverflow ? $"unchecked({cast})" : cast;
     }
+
+    static bool NeedsCastOperandParentheses(string operand, string targetText)
+        => operand.Length > 0
+            && operand[0] is '-' or '+'
+            && !s_castDisambiguatingKeywords.Contains(targetText);
 
     // The predefined-type keyword spellings the C# parser treats as
     // cast-disambiguating: `(int)-1` is a cast, but `(nint)-1` (a contextual


### PR DESCRIPTION
## Summary

Fixes #1779 by reusing the existing cast-operand parenthesization rule for user-defined conversion operator spellings.

Negative literal operands now render as `(BigInteger)(-128)` for named/contextual cast targets instead of invalid `(BigInteger)-128`, while predefined keyword casts and positive operands stay unchanged.

## Evidence

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/NegativeCastParenthesizationTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- `dotnet run --project tools/DecompilerHarness -c Release -- /tmp/dvNegativeConversion/bin/Release/net11.0/dvNegativeConversion.dll --validity-check --compile-cap 20 --max-examples 20`
- `dotnet run --project tools/DecompilerHarness -c Release -- /tmp/dvNegativeConversion/bin/Release/net11.0/dvNegativeConversion.dll --fidelity-check --compile-cap 20 --max-examples 20`

The reduced fixture now renders `public static System.Numerics.BigInteger M() => (BigInteger)(-128);`, passes validity, and compile-back reports 2/2 exact opcode matches.

## Adversarial review

Requested cross-model adversarial review from Claude Opus 4.8 and MAI-Code-1-Flash; both found no blocking findings. Summary comment to follow on this PR.
