### PR TITLE
Surface hotness-only allocation regressions in Analysis Diff (#1736)

### DIFF
--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -18,6 +18,12 @@ namespace DiffFixtureSample
             sink.Add(new object());
         }
 
+        // V1: one allocation, not in a loop (count 1, allocInLoop=false).
+        public static void SameAllocationCountBecomesHot(int n, List<object> sink)
+        {
+            sink.Add(new object());
+        }
+
         // Identical in both versions -> no diff row.
         public static int Stable() => 42;
     }

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -19,6 +19,14 @@ namespace DiffFixtureSample
             sink.Add(new object());
         }
 
+        // V2: the same single allocation moved into a loop (count still 1, but
+        // allocInLoop=true) -> a hotness-only allocation regression the count delta misses.
+        public static void SameAllocationCountBecomesHot(int n, List<object> sink)
+        {
+            for (int i = 0; i < n; i++)
+                sink.Add(new object());
+        }
+
         // Identical in both versions -> no diff row.
         public static int Stable() => 42;
     }

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -240,6 +240,31 @@ public class DiffCommandTests
         Assert.DoesNotContain(result.Rows, r => r.Member.Contains("Stable"));
     }
 
+    // #1736: a hotness-only allocation regression. The allocation count is unchanged
+    // (1 -> 1) but the allocation moves into a loop (allocInLoop false -> true). The raw
+    // count delta is zero, so this must still surface as an in-place allocations row with
+    // a "hot" delta and "in-loop" shape, and must be kept by allocation-regression focus.
+    [Fact]
+    public void BuildAnalysisDiff_VersionPair_SurfacesHotnessOnlyAllocationRegression()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var result = DiffCommand.BuildAnalysisDiff([v1], [v2], new DiffOptions { ChangedOnly = true });
+
+        var hot = Assert.Single(result.Rows, r =>
+            r.Member.Contains("SameAllocationCountBecomesHot") && r.Signal == "allocations");
+        Assert.Equal("1", hot.Old);
+        Assert.Equal("1", hot.New);
+        Assert.Equal("hot", hot.Delta);
+        Assert.Equal("in-loop", hot.Shape);
+
+        // It is a regression, so allocation-regression focus mode keeps it.
+        var focus = DiffCommand.BuildAnalysisDiff([v1], [v2], new DiffOptions { AllocRegressionsOnly = true });
+        Assert.Contains(focus.Rows, r =>
+            r.Member.Contains("SameAllocationCountBecomesHot") && r.Signal == "allocations" && r.Shape == "in-loop");
+    }
+
     // #1623 rung 6: identity / no spurious deltas. Diffing a build against itself must
     // produce zero in-place signal changes (guards signal determinism across two opens
     // and the zero-delta filter).

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -263,6 +263,18 @@ public class DiffCommandTests
         var focus = DiffCommand.BuildAnalysisDiff([v1], [v2], new DiffOptions { AllocRegressionsOnly = true });
         Assert.Contains(focus.Rows, r =>
             r.Member.Contains("SameAllocationCountBecomesHot") && r.Signal == "allocations" && r.Shape == "in-loop");
+
+        // Reversed (V2 -> V1): the allocation leaves the loop. Count is still 1 -> 1, but it
+        // surfaces as a "cold" improvement annotated in-loop (the old, cost-bearing version
+        // was hot) and must NOT be kept by allocation-regression focus.
+        var reversed = DiffCommand.BuildAnalysisDiff([v2], [v1], new DiffOptions { ChangedOnly = true });
+        var cold = Assert.Single(reversed.Rows, r =>
+            r.Member.Contains("SameAllocationCountBecomesHot") && r.Signal == "allocations");
+        Assert.Equal("cold", cold.Delta);
+        Assert.Equal("in-loop", cold.Shape);
+
+        var reversedFocus = DiffCommand.BuildAnalysisDiff([v2], [v1], new DiffOptions { AllocRegressionsOnly = true });
+        Assert.DoesNotContain(reversedFocus.Rows, r => r.Member.Contains("SameAllocationCountBecomesHot"));
     }
 
     // #1623 rung 6: identity / no spurious deltas. Diffing a build against itself must

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -499,9 +499,33 @@ public class DiffCommand
 
     private static void AddCountRow(List<RankedAnalysisRow> rows, string display, bool inBoth, string signal, int oldValue, int newValue, string? evidence, bool oldAllocInLoop = false, bool newAllocInLoop = false)
     {
-        if (oldValue == newValue)
-            return;
         var delta = newValue - oldValue;
+        if (delta == 0)
+        {
+            // #1736: hotness-only allocation change. The raw count is unchanged but an
+            // allocation moved into or out of a loop, which a count delta alone misses.
+            // Only the allocations signal carries loop hotness, and only when at least one
+            // allocation remains to be hot. false->true is a regression (became hot);
+            // true->false is an improvement (left the loop).
+            if (newValue > 0 && oldAllocInLoop != newAllocInLoop)
+            {
+                bool becameHot = newAllocInLoop;
+                rows.Add(new RankedAnalysisRow(
+                    new AnalysisDiffRow(
+                        MarkoutInline.Code(display),
+                        signal,
+                        oldValue.ToString(),
+                        newValue.ToString(),
+                        becameHot ? "hot" : "cold",
+                        becameHot ? "in-loop" : null,
+                        evidence),
+                    1,
+                    becameHot ? 1 : -1,
+                    inBoth,
+                    becameHot));
+            }
+            return;
+        }
         // Annotate from the version that bears the cost: the new method for a
         // regression (allocations up), the old method for an improvement. A loop
         // allocation is repeated/hot; one-time or error-path allocations are not.

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -510,6 +510,11 @@ public class DiffCommand
             if (newValue > 0 && oldAllocInLoop != newAllocInLoop)
             {
                 bool becameHot = newAllocInLoop;
+                // The allocation that changed hotness is in a loop on its cost-bearing side
+                // (the new method when it became hot, the old method when it left the loop),
+                // so annotate "in-loop" either way — matching the count-change path, which
+                // also annotates improvements from the old (cost-bearing) version. Direction
+                // (+1 regression / -1 improvement) carries the hot-vs-cold meaning.
                 rows.Add(new RankedAnalysisRow(
                     new AnalysisDiffRow(
                         MarkoutInline.Code(display),
@@ -517,12 +522,12 @@ public class DiffCommand
                         oldValue.ToString(),
                         newValue.ToString(),
                         becameHot ? "hot" : "cold",
-                        becameHot ? "in-loop" : null,
+                        "in-loop",
                         evidence),
                     1,
                     becameHot ? 1 : -1,
                     inBoth,
-                    becameHot));
+                    true));
             }
             return;
         }


### PR DESCRIPTION
## Summary
The #1623 rung-6 Analysis Diff claim was too strong: `AddCountRow` returned early whenever `oldValue == newValue`, so an allocation that **moves into a loop** without changing count (count `1 -> 1`, `allocInLoop` `false -> true`) produced *no* in-place signal change — a missed per-iteration regression.

## Fix
`AddCountRow` now treats a **zero count delta** on the `allocations` signal as a hotness change when the alloc-in-loop bit flips:
- `false -> true` → regression row, delta `hot`, shape `in-loop`, direction `+1` (kept by `--alloc-regressions` focus and counted as in-loop).
- `true -> false` → improvement row, delta `cold`, direction `-1`.

Loop hotness is only carried by the allocations signal, so other count signals are unaffected (their loop flags default false → no spurious rows).

## Product surface (now)
```text
| SameAllocationCountBecomesHot(...) | allocations | 1 | 1 | hot | in-loop | old IL_0001; new IL_0005 |
```

## Tests
- New `DiffFixtures` V1/V2 `SameAllocationCountBecomesHot` (one allocation; V2 moves it into a loop).
- `BuildAnalysisDiff_VersionPair_SurfacesHotnessOnlyAllocationRegression`: asserts the `1 -> 1` / `hot` / `in-loop` row surfaces and is kept by `AllocRegressionsOnly`.

## Verification
- `dotnet-inspect.Tests`: 1381 passed / 9 skipped.
- **Non-vacuity**: gating the hotness branch off (runtime-false condition) fails the new guard; restored.
- End-to-end confirmed via the product `diff` command against the built fixtures.

Closes #1736

Part of the analysis quality ladder (#1623), rung 6 (Analysis Diff).