### PR TITLE
Fix negated isinst null-test rendering

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -87,6 +87,10 @@ public class CfgSampleClass
     // with a null operand. The printer must spell it `o is not null`, not the
     // CS0019 `o > null`.
     public static bool IsNotNullReference(object o) => o != null;
+
+    public static bool IsNotByteArrayMultiContent(object? content)
+        => content is System.Collections.IEnumerable && content is not string && content is not byte[];
+
     // A string literal containing the C# line terminators that are not
     // `char.IsControl`: U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR.
     // The printer must escape them (\u2028/\u2029) or the emitted literal splits

--- a/src/ILInspector.Decompiler.Tests/ReferenceNullOrderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReferenceNullOrderingTests.cs
@@ -27,6 +27,16 @@ public class ReferenceNullOrderingTests
     }
 
     [Fact]
+    public void NegatedIsInstanceNullTest_RendersTypeTest()
+    {
+        var output = Render(nameof(CfgSampleClass.IsNotByteArrayMultiContent));
+
+        Assert.Contains("content is not byte[]", output);
+        Assert.DoesNotContain("<= null", output);
+        Assert.DoesNotContain("as byte[]", output);
+    }
+
+    [Fact]
     public void UnsignedGreaterThanZero_StaysComparison_NotNullCheck()
     {
         // `x > 0` on a uint emits the same `cgt.un` opcode against a zero constant,

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -704,18 +704,27 @@ public sealed partial class CSharpPrinter
         }
         // The `cgt.un`/`clt.un` against null idiom csc emits for a reference
         // inequality (`ldnull; cgt.un` = `obj != null`): an unsigned ordering of a
-        // reference against null tests non-nullness (null is 0, so `x > 0` / `0 <
-        // x` unsigned is `x != 0`). There is no is-null ordering form, so this is
-        // always the not-null test; rendered literally `obj > null` is CS0019.
-        // Pointers forbid the is-pattern (CS8521), so spell those `!= null`.
+        // reference against null tests nullness (null is 0, so `x > 0` / `0 < x`
+        // unsigned is `x != 0`; the inverted dual is `x == 0`). There is no
+        // is-null ordering form; rendered literally `obj > null` or `obj <= null`
+        // is CS0019. Pointers forbid the is-pattern (CS8521), so spell those with
+        // equality.
         if (isUnsigned
             && ((kind == ComparisonKind.GreaterThan && right is Constant { Value: null })
-                || (kind == ComparisonKind.LessThan && left is Constant { Value: null })))
+                || (kind == ComparisonKind.LessThan && left is Constant { Value: null })
+                || (kind == ComparisonKind.LessThanOrEqual && right is Constant { Value: null })
+                || (kind == ComparisonKind.GreaterThanOrEqual && left is Constant { Value: null })))
         {
-            var operand = kind == ComparisonKind.GreaterThan ? left : right;
+            bool isNullTest = kind is ComparisonKind.LessThanOrEqual or ComparisonKind.GreaterThanOrEqual;
+            var operand = kind is ComparisonKind.GreaterThan or ComparisonKind.LessThanOrEqual ? left : right;
+            if (operand is IsInstance isInstance)
+            {
+                string test = $"{Operand(isInstance.Operand)} is {(isNullTest ? "not " : "")}{TypeText(isInstance.Type)}";
+                return test;
+            }
             return operand.ResultType is { Kind: TypeRefKind.Pointer }
-                ? $"{Operand(operand)} != null"
-                : $"{Operand(operand)} is not null";
+                ? $"{Operand(operand)} {(isNullTest ? "==" : "!=")} null"
+                : $"{Operand(operand)} is {(isNullTest ? "" : "not ")}null";
         }
         // A pointer compared to a native-int zero is a null check: csc lowers
         // `ptr == null` to `ldc.i4.0; conv.u; ceq`, so the zero arrives as an


### PR DESCRIPTION
## Summary

Fixes #1760 by extending unsigned reference/null ordering recovery to the inverted `cgt.un`/`clt.un` duals, so a negated `isinst` null test renders as a valid type test instead of `<= null`.

The importer-backed fixture now renders:

```csharp
public static bool IsNotByteArrayMultiContent(object? content) => content is IEnumerable && !(content is string) && content is not byte[];
```

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/ReferenceNullOrderingTests/*"` — 4/4 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/GenericIsInstanceNullTestTests/*"` — 2/2 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"` — 1610 passed
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` — passed
- `dotnet run --project tools/DecompilerHarness -c Release -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --validity-check --compile-cap 200 --max-examples 20` — Full malformed 0; remaining semantic examples are pre-existing #1748-class CS0159 and CorpusSensor::PortablePath CS0023

## Review

- MAI-Code-1-Flash adversarial review: no actionable findings; focused `ReferenceNullOrderingTests` passed.
- Claude Opus 4.8 adversarial review is still running; I will post the reconciled review comment before merge readiness.
