### PR TITLE
Fix member type-name receiver collisions (#1776)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MemberNameCollisionRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberNameCollisionRenderingTests.cs
@@ -1,0 +1,147 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class MemberNameCollisionRenderingTests
+{
+    [Fact]
+    public void PropertyReceiverNamedLikeItsType_QualifiesThis()
+    {
+        string body = Render(typeof(ListNamePropertySpecimen), "get_Count");
+
+        Assert.Contains("return this.List.Count;", body);
+        AssertBodyCompiles("""
+            using System.Collections.Generic;
+            public class __Gate
+            {
+                private List<int> List { get; } = new();
+                public int M()
+                {
+            """, body);
+    }
+
+    [Fact]
+    public void FieldReceiverNamedLikeItsType_QualifiesThis()
+    {
+        string body = Render(typeof(ListNameFieldSpecimen), "get_Count");
+
+        Assert.Contains("return this.List.Count;", body);
+        AssertBodyCompiles("""
+            using System.Collections.Generic;
+            public class __Gate
+            {
+                private readonly List<int> List = new();
+                public int M()
+                {
+            """, body);
+    }
+
+    [Fact]
+    public void MemberInfoReceiverNamedLikeItsType_QualifiesThis()
+    {
+        string body = Render(typeof(MemberInfoNameSpecimen), "get_Name");
+
+        Assert.Contains("return this.MemberInfo.Name;", body);
+        AssertBodyCompiles("""
+            using System;
+            using System.Reflection;
+            public class __Gate
+            {
+                public MethodInfo MemberInfo { get; set; } =
+                    typeof(string).GetMethod(nameof(string.ToString), Type.EmptyTypes)!;
+                public string M()
+                {
+            """, body);
+    }
+
+    [Fact]
+    public void TypeReceiverNamedLikeItsType_QualifiesThis()
+    {
+        string body = Render(typeof(TypeNameSpecimen), nameof(TypeNameSpecimen.IsAssignableTo));
+
+        Assert.Contains("return this.Type.IsAssignableTo(type);", body);
+        AssertBodyCompiles("""
+            using System;
+            public class __Gate
+            {
+                public Type Type { get; } = typeof(string);
+                public bool M(Type type)
+                {
+            """, body);
+    }
+
+    static string Render(Type fixtureType, string methodName)
+    {
+        using var source = MetadataSource.Open(fixtureType.Assembly.Location);
+        var function = IrImporter.Import(source, fixtureType.FullName!, methodName);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
+        Assert.NotNull(result.Output);
+        return result.Output!;
+    }
+
+    static void AssertBodyCompiles(string prefix, string body)
+    {
+        string source = $$"""
+            {{prefix}}
+            {{body}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "__gate",
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        var errors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToArray();
+        Assert.True(errors.Length == 0, "Rendered body must compile, got:\n  " + string.Join("\n  ", errors) + "\n--- body ---\n" + body);
+    }
+
+    static ImmutableArray<MetadataReference> RuntimeReferences()
+    {
+        var references = ImmutableArray.CreateBuilder<MetadataReference>();
+        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                references.Add(MetadataReference.CreateFromFile(path));
+        }
+        return references.ToImmutable();
+    }
+}
+
+public class ListNamePropertySpecimen
+{
+    private List<int> List { get; } = new();
+    public int Count => List.Count;
+}
+
+public class ListNameFieldSpecimen
+{
+    readonly List<int> List = new();
+    public int Count => List.Count;
+}
+
+public class MemberInfoNameSpecimen
+{
+    public MethodInfo MemberInfo { get; set; } =
+        typeof(string).GetMethod(nameof(string.ToString), Type.EmptyTypes)!;
+
+    public string Name => MemberInfo.Name;
+}
+
+public class TypeNameSpecimen
+{
+    public Type Type { get; } = typeof(string);
+
+    public bool IsAssignableTo(Type type) => Type.IsAssignableTo(type);
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -40,7 +40,7 @@ public sealed partial class CSharpPrinter
             // bare name binds to it, not the field (e.g. int Foo(int _x) =>
             // this._x + _x). Qualify with this. to reach the field; an
             // unshadowed instance field stays bare per the taste convention.
-            LoadArgument { Index: 0, Name: "this" } => IsShadowedByLocal(field.Name) ? $"this.{fieldName}" : fieldName,
+            LoadArgument { Index: 0, Name: "this" } => QualifyThisMember(field.Name, field.Type) ? $"this.{fieldName}" : fieldName,
             _ => $"{ReceiverText(instance)}.{fieldName}",
         };
     }
@@ -58,7 +58,7 @@ public sealed partial class CSharpPrinter
             // Deconstruct(out int X, ...) whose body reads this.X). Qualify with
             // this. to reach the property; an unshadowed instance property stays
             // bare per the taste convention, matching FieldTarget.
-            LoadArgument { Index: 0, Name: "this" } => IsShadowedByLocal(name) ? "this" : "",
+            LoadArgument { Index: 0, Name: "this" } => QualifyThisMember(name, AccessorValueType(accessor)) ? "this" : "",
             _ => ReceiverText(instance),
         };
         // An instance property accessor with index arguments IS an indexer,
@@ -69,6 +69,44 @@ public sealed partial class CSharpPrinter
         string dotted = receiver.Length == 0 ? escapedName : $"{receiver}.{escapedName}";
         return indexArguments.Count == 0 ? dotted : $"{dotted}[{Arguments(indexArguments)}]";
     }
+
+    bool QualifyThisMember(string memberName, TypeRef? valueType)
+        => IsShadowedByLocal(memberName) || MemberNameCollidesWithTypeName(memberName, valueType);
+
+    static bool MemberNameCollidesWithTypeName(string memberName, TypeRef? valueType)
+        => valueType is not null
+            && (CSharpNaming.EscapeIdentifier(memberName) == SimpleTypeName(valueType)
+                || IsKnownBaseTypeCollision(memberName, valueType));
+
+    static string? SimpleTypeName(TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        if (definition is not { Kind: TypeRefKind.Definition })
+            return null;
+        int nested = definition.Name.LastIndexOf('+');
+        string innermost = nested < 0 ? definition.Name : definition.Name[(nested + 1)..];
+        return CSharpNaming.TypeNameSegment(innermost);
+    }
+
+    static bool IsKnownBaseTypeCollision(string memberName, TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        // The product path does not load inspected assemblies to walk inheritance.
+        // Keep this to well-known framework bases whose derived names frequently
+        // appear as same-named instance properties, e.g. MethodInfo MemberInfo.
+        return memberName == "MemberInfo"
+            && definition is
+            {
+                Kind: TypeRefKind.Definition,
+                Namespace: "System" or "System.Reflection",
+                Name: "Type" or "TypeInfo" or "MemberInfo" or "MethodBase" or "MethodInfo" or "ConstructorInfo" or "PropertyInfo" or "FieldInfo" or "EventInfo",
+            };
+    }
+
+    static TypeRef? AccessorValueType(MethodRef accessor)
+        => accessor.Name.StartsWith("get_", StringComparison.Ordinal) ? accessor.ReturnType
+            : accessor.ParameterTypes.Length > 0 ? accessor.ParameterTypes[^1]
+            : null;
 
     /// <summary>True when the member's declaring DEFINITION differs from the function's — self-calls in generic types arrive as instantiations (List&lt;!0&gt;) and must not count as cross-type.</summary>
     bool IsCrossType(TypeRef memberDeclaringType)


### PR DESCRIPTION
## Summary

Fixes #1776 by preserving the instance receiver when an unqualified this-member name can bind as an in-scope type name instead of the intended instance member.

The printer now qualifies this-receiver fields/properties when:

- the member still needs existing local/parameter-shadow disambiguation; or
- the member name matches the simple name of its value type, such as List/List<T> and Type/System.Type; or
- the member name is the known framework base type MemberInfo for common System.Reflection member-info derived types such as MethodInfo.

This narrows false Full output like:

```csharp
return List.Count;
return MemberInfo.Name;
return Type.IsAssignableTo(type);
```

to valid instance access:

```csharp
return this.List.Count;
return this.MemberInfo.Name;
return this.Type.IsAssignableTo(type);
```

## Evidence

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/MemberNameCollisionRenderingTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- `dotnet run --project tools/DecompilerHarness -c Release -- /tmp/dvMemberCollision/bin/Release/net11.0/dvMemberCollision.dll --validity-check --compile-cap 20 --max-examples 20`

Harness result:

```text
COMPILE-CHECK over 12 rendered methods (12 Full, 0 Partial)

Syntactic validity (parse + statement legality — false-positive-free):
  Full malformed   : 0 (0.00% of Full) — the "claimed good but won't parse" set
  Partial malformed: 0 (0 of Partial) — expected: the diagnosed unsupported bits

Semantic binding (Full + syntactically-valid, capped at 12 bound):
  with a non-binding-noise error: 0 (0.00%)
```

## Review

Adversarial review is required before merge; I will post the reconciled results here.
