### PR TITLE
Fix foreach field-address collection rendering

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -439,6 +439,26 @@ public class ForeachStatementPassTests
     }
 
     [Fact]
+    public void EnumeratorUsingLoop_WithStructFieldAddressReceiver_RendersValueCollection()
+    {
+        var function = BuildStructFieldCollectionEnumeratorUsingWhile();
+
+        new ForeachStatementPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var foreachStatement = Assert.Single(function.Descendants.OfType<ForeachStatement>());
+        var collection = Assert.IsType<LoadField>(foreachStatement.Collection);
+        Assert.Equal("items", collection.Field.Name);
+        Assert.Empty(function.Descendants.OfType<UsingStatement>());
+        Assert.Empty(function.Descendants.OfType<WhileLoop>());
+
+        var output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("foreach (int value in items)", output);
+        Assert.DoesNotContain("foreach (int value in ref items)", output);
+        Assert.DoesNotContain(" in ref ", output);
+    }
+
+    [Fact]
     public void EnumeratorUsingLoop_WithCopiedCurrentReceiver_StaysUsingWhile()
     {
         var function = BuildEnumeratorUsingWhileWithCopiedCurrentReceiver();
@@ -554,6 +574,47 @@ public class ForeachStatementPassTests
             [enumeratorType, intType, collectionType],
             body);
         function.LocalNames = [null, "value", "items"];
+        return function;
+    }
+
+    static IrFunction BuildStructFieldCollectionEnumeratorUsingWhile()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var ownerType = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var collectionType = TypeRef.Definition("UserAssembly", "Samples", "StructCollection", ValueTypeHint.ValueType);
+        var enumeratorType = TypeRef.Definition("UserAssembly", "Samples", "StructEnumerator", ValueTypeHint.ValueType);
+        var collectionField = new FieldRef(ownerType, "items", collectionType);
+        var getEnumerator = new MethodRef(collectionType, "GetEnumerator", enumeratorType, [], HasThis: true);
+        var moveNext = new MethodRef(enumeratorType, "MoveNext", boolType, [], HasThis: true);
+        var current = new MethodRef(enumeratorType, "get_Current", intType, [], HasThis: true)
+        {
+            IsSpecialName = true,
+        };
+
+        var loopBody = new Block();
+        loopBody.Add(new StoreLocal(1, intType, new LoadProperty(current, new LoadLocalAddress(0, enumeratorType), [])));
+
+        var usingBody = new BlockContainer();
+        var usingBlock = new Block();
+        usingBlock.Add(new WhileLoop(new Call(moveNext, isVirtual: false, [new LoadLocalAddress(0, enumeratorType)]), loopBody));
+        usingBody.Add(usingBlock);
+
+        var entry = new Block();
+        entry.Add(new UsingStatement(
+            0,
+            enumeratorType,
+            new Call(getEnumerator, isVirtual: false, [new LoadFieldAddress(collectionField, new LoadArgument(0, "this", ownerType))]),
+            usingBody));
+        var body = new BlockContainer();
+        body.Add(entry);
+        var function = new IrFunction(
+            "M",
+            ownerType,
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: true, GenericParameterCount: 0),
+            [enumeratorType, intType],
+            body);
+        function.LocalNames = [null, "value"];
         return function;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -259,8 +259,16 @@ public sealed class ForeachStatementPass : IIrPass
     {
         LoadArgumentAddress address => new LoadArgument(address.Index, address.Name, address.Type),
         LoadLocalAddress address => new LoadLocal(address.Index, address.Type),
+        LoadFieldAddress address => new LoadField(address.Field, DetachCollectionReceiver(address.Instance)),
         _ => expression,
     };
+
+    static IrExpression? DetachCollectionReceiver(IrExpression? expression)
+    {
+        if (expression?.Parent is not null)
+            expression.Detach();
+        return expression;
+    }
 
     sealed record IndexedCandidate(
         ForLoop Loop,


### PR DESCRIPTION
## Summary

Fixes #1202 by normalizing `LoadFieldAddress` foreach collection receivers after the existing foreach matcher has already accepted the lowered shape.

This is the field-address counterpart to the existing local/argument address normalization: accepted struct collection loops now render value receivers such as `_collections` or `extracted2.Strings` instead of invalid `in ref ...` foreach headers.

## Evidence

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/ForeachStatementPassTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- `dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll member 'Microsoft.CodeAnalysis.UnionCollection`1' CopyTo --library "$HOME/.nuget/packages/microsoft.codeanalysis.common/5.8.0-1.26277.111/lib/netstandard2.0/Microsoft.CodeAnalysis.dll" --all -S "Decompiled Source" --bare`
- `dotnet run --project tools/DecompilerHarness -c Release -- "$HOME/.nuget/packages/microsoft.codeanalysis.common/5.8.0-1.26277.111/lib/netstandard2.0/Microsoft.CodeAnalysis.dll" --validity-check --compile-cap 80 --max-examples 20`

The Roslyn witness now renders `foreach (ICollection<T> collection in _collections)`, not `in ref _collections`. The Roslyn validity check reports `Full malformed: 0`.

## Adversarial review

Requested cross-model adversarial review from Claude Opus 4.8 and MAI-Code-1-Flash; both found no blocking findings. Summary comment to follow on this PR.
