### PR TITLE
Fix generic unbox object bridge (#1780)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1183,6 +1183,9 @@ public class CfgSampleClass
     public static bool GreaterAsByte<T>(T left, T right) where T : struct
         => (byte)(object)left > (byte)(object)right;
 
+    public static T ArrayAsTypeParameter<T>(System.Array array)
+        => (T)(object)array;
+
     public struct Pair { public int A; public int B; }
 
     public static int FirstA(Pair[] pairs) => pairs[0].A;

--- a/src/ILInspector.Decompiler.Tests/UnboxAnyRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnboxAnyRenderingTests.cs
@@ -27,4 +27,13 @@ public class UnboxAnyRenderingTests
         Assert.DoesNotContain("(byte)(left)", output);
         Assert.DoesNotContain("(byte)(right)", output);
     }
+
+    [Fact]
+    public void UnboxToTypeParameter_FromReferenceOperand_KeepsObjectIntermediary()
+    {
+        var output = Print(nameof(CfgSampleClass.ArrayAsTypeParameter));
+
+        Assert.Contains("return (T)(object)array;", output);
+        Assert.DoesNotContain("return (T)array;", output);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1473,7 +1473,7 @@ public sealed partial class CSharpPrinter
         SingleElementListPattern p => $"{Operand(p.Value)} is [{ListPatternAlternativesText(p)}]",
         PositionalPattern p => PositionalPatternText(p),
         CastClass c => $"({TypeText(c.Type)}){Operand(c.Operand)}",
-        UnboxAny u => $"({TypeText(u.Type)}){UnboxAnyOperand(u.Operand)}",
+        UnboxAny u => $"({TypeText(u.Type)}){UnboxAnyOperand(u)}",
         Unbox u => $"ref ({TypeText(u.Type)}){Operand(u.Operand)}",
         LoadLocalAddress a => $"ref {LocalName(a.Index)}",
         LoadArgumentAddress a => $"ref {CSharpNaming.EscapeIdentifier(a.Name)}",
@@ -1610,8 +1610,29 @@ public sealed partial class CSharpPrinter
     // object slot. `(U)x` over a generic type parameter has no direct conversion and
     // is CS0030 — and even for a concrete type, collapsing box+unbox.any to a plain
     // `(U)x` drops the round-trip the IL actually performs. Keep the intermediary.
-    string UnboxAnyOperand(IrExpression operand)
-        => operand is Box box ? $"(object){Operand(box.Operand)}" : Operand(operand);
+    string UnboxAnyOperand(UnboxAny unbox)
+    {
+        if (unbox.Operand is Box box)
+            return $"(object){Operand(box.Operand)}";
+        if (NeedsObjectBridgeForGenericUnbox(unbox.Type, unbox.Operand.ResultType))
+            return $"(object){Operand(unbox.Operand)}";
+        return Operand(unbox.Operand);
+    }
+
+    bool NeedsObjectBridgeForGenericUnbox(TypeRef target, TypeRef? source)
+    {
+        if (target.Kind is not (TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter)
+            || source is null
+            || source is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Object" })
+        {
+            return false;
+        }
+
+        return TypeFamilies.Of(source) == StackFamily.O
+            || source.Kind is TypeRefKind.SzArray or TypeRefKind.Array
+            || source.DeclaredValueTypeHint == ValueTypeHint.ReferenceType
+            || _function.TypeShapes.GetValueOrDefault(source) == TypeShape.Reference;
+    }
 
     /// <summary>
     /// True when an expression renders as a C# <c>bool</c> regardless of its IR


### PR DESCRIPTION
## Summary

Fixes #1780 by preserving the required `(object)` bridge when `unbox.any` targets an unconstrained generic parameter from a known reference-typed operand.

The row's false `Full` claim was:

```csharp
public static T Make<T>(System.Array array) => (T)array;
```

That direct `Array` -> `T` cast is invalid C# (`CS0030`). The decompiler now renders:

```csharp
public static T Make<T>(System.Array array) => (T)(object)array;
```

The bridge is intentionally narrow: it applies only for generic-parameter unbox targets when the operand is known reference-typed, and keeps the existing `box T; unbox.any U` generic-math path intact.

## Evidence

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/UnboxAnyRenderingTests/*"` — 2 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"` — 1612 passed
- Reduced fixture render: `public static T Make<T>(System.Array array) => (T)(object)array;`
- Reduced fixture validity: 2 Full / 0 malformed / 0 semantic binding errors
- Reduced fixture fidelity: 2/2 exact opcode matches
- System.CommandLine witness `Argument<T>::CreateDefaultValue` now renders `(T)(object)Array.CreateInstance(...)`; validity sweep over System.CommandLine reported 530 Full / 0 non-binding-noise errors.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 15 assemblies, 1,462 methods
Sample: hash-stable 100 methods per assembly
Correctness coverage: validity not run; fidelity not run

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (`--emit-corpus-baseline`) before trusting count-based regressions.
- total methods 1,461 -> 1,462 (+1)
- ILInspector.MetadataPrimitives: 61 -> 62 methods (+1)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 1,213 (83.03%) | 1,215 (83.11%) | +2 |
| Conditional-branch residual | 35 (2.40%) | 35 (2.39%) | 0 |
| Forward-merge stops | 27 (1.85%) | 29 (1.98%) | +2 |
| Full malformed | not run | not run | - |
| Semantic defects | not run | not run | - |
| Fidelity diffs | not run | not run | - |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate: Fully raised 82.17% -> 82.17% (0 bps); conditional residual 3.00% -> 3.00% (0 bps); Full malformed 0 -> 0 (0); fidelity ungated.

Verdict: corpus sensor matched baseline tolerances.

## Adversarial review

Requested cross-model adversarial review from Claude Opus 4.8 and MAI-Code-1-Flash. I will post the reconciled review summary on this PR before marking it ready.

Closes #1780. Part of #1687.
