### PR TITLE
Fix bool comparison arithmetic decompile (#1764)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/BoolIntArithmeticTests.cs
+++ b/src/ILInspector.Decompiler.Tests/BoolIntArithmeticTests.cs
@@ -1,0 +1,38 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A comparison consumed by integer arithmetic is a 0/1 i4 value in IL, but C#
+// requires the value-context spelling `(cond ? 1 : 0)` rather than `int + bool`.
+public class BoolIntArithmeticTests
+{
+    static string Render(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        IrPasses.Run(function!);
+        function!.CheckInvariant();
+        return CSharpPrinter.Print(function).Output!;
+    }
+
+    [Fact]
+    public void MaterializedComparisonFeedsAddAsInteger()
+    {
+        var output = Render(nameof(CfgSampleClass.BoolArithmeticChunkCount));
+
+        Assert.Contains("? 1 : 0", output);
+        Assert.DoesNotContain("+ (value.Length % 10240 > 0)", output);
+        Assert.DoesNotContain("+ ((value.Length % 10240) > 0)", output);
+    }
+
+    [Fact]
+    public void MaterializesBothComparisonOperands()
+    {
+        var output = Render(nameof(CfgSampleClass.BoolArithmeticTwoComparisons));
+
+        Assert.Contains("(left > 0 ? 1 : 0) + (right > 0 ? 1 : 0)", output);
+        Assert.DoesNotContain("left > 0 +", output);
+        Assert.DoesNotContain("+ right > 0", output);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -178,6 +178,17 @@ public class CfgSampleClass
     public static int AndNestedBoolIntMix(int a, int i, int j)
         => ((((a > 0 ? 1 : 0) & i) != 0) ? 1 : 0) & j;
 
+    // A comparison result consumed directly by integer arithmetic stays an i4 0/1
+    // on the IL stack (`cgt; add`). C# cannot spell `int + bool`, so the bool
+    // operand must materialize back to `cond ? 1 : 0`.
+    public static int BoolArithmeticChunkCount(string value)
+        => (value.Length / 10240) + ((value.Length % 10240) > 0 ? 1 : 0);
+
+    // Both arithmetic operands can be comparison-produced bools. Each one must
+    // materialize; leaving either side raw is still invalid C#.
+    public static int BoolArithmeticTwoComparisons(int left, int right)
+        => (left > 0 ? 1 : 0) + (right > 0 ? 1 : 0);
+
     // Adversarial near-miss for the not-null idiom: `x > 0` on a uint also emits
     // `cgt.un` against a zero constant, but the zero is an integer literal, not a
     // reference null. It must stay an unsigned `x > 0` comparison, never `is not null`.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ArithmeticBoolOperandPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ArithmeticBoolOperandPass.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Materializes <c>bool</c> operands that feed integer arithmetic/shift opcodes.
+/// IL comparisons carry an <c>i4</c> 0/1 value, so <c>add</c>/<c>sub</c>/...
+/// can legally consume them, but C# has no <c>int + bool</c> spelling.
+/// </summary>
+public sealed class ArithmeticBoolOperandPass : IIrPass
+{
+    public string Name => "arithmetic-bool-operand";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        var matches = function.Descendants
+            .OfType<Binary>()
+            .Where(IsArithmeticBoolIntegerMix)
+            .ToList();
+
+        matches.Reverse();
+        foreach (var binary in matches)
+        {
+            foreach (var boolOperand in BoolOperands(binary).ToList())
+            {
+                context.Stepper.StepOver("materialize bool operand of arithmetic op to (cond ? 1 : 0)", boolOperand);
+                boolOperand.ReplaceWith(Materialize(boolOperand));
+            }
+        }
+    }
+
+    static IEnumerable<IrExpression> BoolOperands(Binary binary)
+    {
+        if (TypeFamilies.IsBoolean(binary.Left.ResultType))
+            yield return binary.Left;
+        if (TypeFamilies.IsBoolean(binary.Right.ResultType))
+            yield return binary.Right;
+    }
+
+    static bool IsArithmeticBoolIntegerMix(Binary binary)
+    {
+        if (binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor)
+            return false;
+
+        bool leftBool = TypeFamilies.IsBoolean(binary.Left.ResultType);
+        bool rightBool = TypeFamilies.IsBoolean(binary.Right.ResultType);
+        if (!leftBool && !rightBool)
+            return false;
+
+        // `cgt; cgt; add` has no bool source operator; both comparisons are still
+        // integer 0/1 operands and both must materialize.
+        if (leftBool && rightBool)
+            return true;
+        return leftBool
+            ? TypeFamilies.IsInteger(binary.Right.ResultType)
+            : TypeFamilies.IsInteger(binary.Left.ResultType);
+    }
+
+    static Conditional Materialize(IrExpression boolOperand)
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        return new Conditional(
+            (IrExpression)boolOperand.Clone(),
+            new Constant(1, intType),
+            new Constant(0, intType))
+        {
+            MergedType = intType,
+        };
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -204,6 +204,10 @@ public static class IrPasses
         // flat it renders `b > false` (CS0019) and the method never binds. Runs
         // after inlining so the bool operand is in its final position.
         new BoolToIntNormalizationPass(),
+        // A comparison or bool slot consumed by integer arithmetic is an i4 0/1
+        // value in IL, but C# rejects `int + bool`; materialize the bool operand
+        // before the printer sees the binary.
+        new ArithmeticBoolOperandPass(),
         // The operand-side complement of the bool→int normalization: a bool
         // operand of an integer bitwise &/|/^ (a comparison result or bool slot
         // landing in `flags | (b ? 1 : 0)` shape) is `bool & int` (CS0019).

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -81,6 +81,8 @@ internal static class NativePasses
     public static TypedConstantsPass TypedConstants => new();
     [Native(NativeCategory.IlErasure, "bool marshalled as int (cgt against 0) normalized")]
     public static BoolToIntNormalizationPass BoolToIntNormalization => new();
+    [Native(NativeCategory.IlErasure, "a bool operand of integer arithmetic (erased to i4 on the IL stack) materialized back to (cond ? 1 : 0) so the mix is not CS0019 int + bool")]
+    public static ArithmeticBoolOperandPass ArithmeticBoolOperand => new();
     [Native(NativeCategory.IlErasure, "a bool operand of an integer bitwise &/|/^ (erased to i4 on the IL stack) materialized back to (cond ? 1 : 0) so the mix is not CS0019 bool & int")]
     public static BitwiseBoolOperandPass BitwiseBoolOperand => new();
     [Native(NativeCategory.IlErasure, "a standing static function-pointer load (ldftn) spelled &Method")]


### PR DESCRIPTION
## Summary

Fixes #1764 by adding a narrow decompiler-native IL-erasure pass that materializes comparison-produced `bool` operands before integer arithmetic. The row's invalid `Full` shape now renders as:

```csharp
chunkCount = (format.Length / 10240) + ((format.Length % 10240) > 0 ? 1 : 0);
```

instead of `int + bool`.

## Shape proof

- Added `ArithmeticBoolOperandPass` after `BoolToIntNormalizationPass`, alongside the existing bitwise bool/int materialization pass.
- Added compiled fixture canaries for:
  - comparison + integer arithmetic (`BoolArithmeticChunkCount`)
  - both arithmetic operands as comparison-produced bools (`BoolArithmeticTwoComparisons`)
- The pass leaves bitwise `&`/`|`/`^` to the existing `BitwiseBoolOperandPass` and does not touch branch/condition truthiness.

## Row evidence

Final render checks on the framework examples:

```text
chunkCount = (format.Length / 10240) + ((format.Length % 10240) > 0 ? 1 : 0);
chunkCount = (descriptorString.Length / 10240) + ((descriptorString.Length % 10240) > 0 ? 1 : 0);
```

`Microsoft.Extensions.DependencyInjection.dll` validity check no longer reports the row's CS0019 examples; remaining non-noise diagnostic is unrelated existing `ConstructorCallSite::get_ImplementationType` CS0120.

```text
COMPILE-CHECK over 380 rendered methods (366 Full, 14 Partial)
Full malformed: 0
Semantic binding: with a non-binding-noise error: 1 (CS0120)
```

## Validation

```text
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
Build succeeded. 0 Warning(s), 0 Error(s)

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/BoolIntArithmeticTests/*"
Total: 2, Errors: 0, Failed: 0, Skipped: 0

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
Total: 1613, Errors: 0, Failed: 0, Skipped: 0
```

Full unfiltered `ILInspector.Decompiler.Tests` was attempted earlier in the session but did not complete on the shared machine after a long CPU-bound run; final evidence uses the fast decompiler gate, focused canaries, real framework-method render checks, DI validity check, and corpus card.

## Corpus quality card

```text
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity sampled 25,185 / 89,065 (28.28%); fidelity sampled 36 / 89,065 (0.04%)

| Metric | Baseline | PR | Delta |
| --- | ---: | ---: | ---: |
| Fully raised | 78,394 (88.02%) | 78,394 (88.02%) | 0 |
| Conditional-branch residual | 2,408 (2.70%) | 2,408 (2.70%) | 0 |
| Forward-merge stops | 2,294 (2.58%) | 2,294 (2.58%) | 0 |
| Full malformed | 32 | 32 | 0 |
| Semantic defects | 149/25,185 — sampled 25,185 / 89,065 (28.28%) | 141/25,185 — sampled 25,185 / 89,065 (28.28%) | -8 |
| Fidelity diffs | opcode-diff 0/0, exact 0, recompile-failed 0, context-failed 0; sampled 0 / 89,065 (0.00%) | opcode-diff 9/36, exact 27, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | +9 |
| Pass bugs | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.02% (0 bps); conditional residual 2.70% -> 2.70% (0 bps); Full malformed 32 -> 32 (0); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Verdict: corpus sensor matched baseline tolerances.
```

## Adversarial review

Two cross-model reviews were requested before PR creation:

- **Claude Opus 4.8:** no blocking issues. Confirmed pipeline placement, scope, both-operand handling, and noted unsigned/checked/shift arithmetic as a non-blocking hardening area.
- **MAI Code Flash:** flagged that the bool+bool arithmetic predicate looked accidental because `TypeFamilies.IsInteger(bool)` is true. I kept bool+bool arithmetic intentionally because `cgt; cgt; add` is still integer 0/1 arithmetic with no C# bool+bool source operator, and added an explicit branch/comment plus a two-comparison canary in commit 48cee1340923ad18bd4ef9432b3e35dd9ba8e985.
