### PR TITLE
Resolve cross-package accessor metadata

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
+using System.Reflection;
 
+using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
 
@@ -109,6 +111,31 @@ public class CrossAssemblyMethodFactsTests
     }
 
     [Fact]
+    public void CrossAssemblyPropertyAccessorMemberRef_RecoversAccessorKind()
+    {
+        using var fixture = CrossAssemblyFixture.Create();
+        using var source = MetadataSource.Open(fixture.ConsumerPath);
+
+        var call = SingleCall(source, nameof(CrossAssemblyFixtureMethods.UseProperty), "get_Count");
+
+        Assert.Equal(AccessorKind.PropertyGet, call.Callee.AccessorKind);
+    }
+
+    [Fact]
+    public void CrossAssemblyPropertyAccessorMemberRef_RendersPropertyAccess()
+    {
+        using var fixture = CrossAssemblyFixture.Create();
+        using var source = MetadataSource.Open(fixture.ConsumerPath);
+
+        var function = ImportFunction(source, nameof(CrossAssemblyFixtureMethods.UseProperty));
+        var result = CSharpPrinter.PrintRaised(function, out _);
+
+        Assert.Equal(DecompilationFidelity.Full, result.Fidelity);
+        Assert.Contains("library.Count", result.Output);
+        Assert.DoesNotContain("get_Count", result.Output);
+    }
+
+    [Fact]
     public void CrossAssemblyInlineArrayHelper_RecoversInlineArrayTypeArgumentFact()
     {
         using var fixture = CrossAssemblyFixture.Create();
@@ -142,12 +169,89 @@ public class CrossAssemblyMethodFactsTests
         Assert.Equal(MetadataFactState.Unknown, operatorLike.Callee.IsOperator);
     }
 
+    [Fact]
+    public void MissingCrossAssemblyAccessorMetadata_KeepsAccessorFactUnknown()
+    {
+        using var fixture = CrossAssemblyFixture.Create();
+        using var source = MetadataSource.Open(fixture.ConsumerPath, locator: (_, _) => null);
+
+        var function = ImportFunction(source, nameof(CrossAssemblyFixtureMethods.UseProperty));
+        var call = Assert.Single(function.Descendants.OfType<Call>(), c => c.Callee.Name == "get_Count");
+
+        Assert.Equal(AccessorKind.Unknown, call.Callee.AccessorKind);
+        Assert.True(call.Callee.IsSpecialNameInferred);
+    }
+
+    [Fact]
+    public void NuGetDependencyProbe_SelectsCurrentTfmDependencyGroup()
+    {
+        string directory = Directory.CreateTempSubdirectory("dotnet-inspect-nuspec-deps-").FullName;
+        try
+        {
+            string packageDir = Path.Combine(directory, "root.package", "1.0.0");
+            Directory.CreateDirectory(packageDir);
+            File.WriteAllText(
+                Path.Combine(packageDir, "root.package.nuspec"),
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+                  <metadata>
+                    <id>Root.Package</id>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <group targetFramework=".NETStandard2.0">
+                        <dependency id="Shared.Package" version="2.0.0" />
+                      </group>
+                      <group targetFramework="net8.0">
+                        <dependency id="Shared.Package" version="8.0.0" />
+                      </group>
+                    </dependencies>
+                  </metadata>
+                </package>
+                """);
+
+            var dependencies = ReadNuGetDependencyPackageVersions(packageDir, "Root.Package", "1.0.0", "net8.0");
+
+            Assert.Equal("1.0.0", dependencies["Root.Package"]);
+            Assert.Equal("8.0.0", dependencies["Shared.Package"]);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void NuGetDependencyProbe_HandlesSingleBracketExactRangeAndLowercaseVersionDirectory()
+    {
+        string directory = Directory.CreateTempSubdirectory("dotnet-inspect-nuspec-probe-").FullName;
+        try
+        {
+            string dependencyVersionDir = Path.Combine(directory, "shared.package", "8.0.0-rc1");
+            string dependencyAssetDir = Path.Combine(dependencyVersionDir, "lib", "net8.0");
+            Directory.CreateDirectory(dependencyAssetDir);
+            string dependencyAssembly = Path.Combine(dependencyAssetDir, "Shared.dll");
+            File.WriteAllText(dependencyAssembly, "");
+
+            string? exactVersion = DependencyExactVersion("[8.0.0-RC1]");
+            Assert.Equal("8.0.0-RC1", exactVersion);
+            var versions = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Shared.Package"] = exactVersion,
+            };
+
+            Assert.Equal(dependencyAssembly, ProbeNuGetPackages(directory, "Shared.dll", versions, "net8.0"));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
     static string Print(MetadataSource source, string methodName)
     {
-        var function = IrImporter.Import(source, "ExternalFacts.Consumer", methodName);
-        Assert.NotNull(function);
-        function.CheckInvariant();
-        return CSharpPrinter.Print(function!).Output ?? "";
+        var function = ImportFunction(source, methodName);
+        return CSharpPrinter.Print(function).Output ?? "";
     }
 
     static void AssertCallRefKind(MetadataSource source, string methodName, string calleeName, ArgumentRefKind expected)
@@ -159,18 +263,44 @@ public class CrossAssemblyMethodFactsTests
 
     static Call SingleCall(MetadataSource source, string methodName, string calleeName)
     {
-        var function = IrImporter.Import(source, "ExternalFacts.Consumer", methodName);
-        Assert.NotNull(function);
-        function.CheckInvariant();
-        return Assert.Single(function!.Descendants.OfType<Call>(), c => c.Callee.Name == calleeName);
+        var function = ImportFunction(source, methodName);
+        return Assert.Single(function.Descendants.OfType<Call>(), c => c.Callee.Name == calleeName);
     }
 
     static NewObject SingleNewObject(MetadataSource source, string methodName)
     {
+        var function = ImportFunction(source, methodName);
+        return Assert.Single(function.Descendants.OfType<NewObject>());
+    }
+
+    static IrFunction ImportFunction(MetadataSource source, string methodName)
+    {
         var function = IrImporter.Import(source, "ExternalFacts.Consumer", methodName);
         Assert.NotNull(function);
         function.CheckInvariant();
-        return Assert.Single(function!.Descendants.OfType<NewObject>());
+        return function!;
+    }
+
+    static IReadOnlyDictionary<string, string?> ReadNuGetDependencyPackageVersions(string packageVersionDir, string packageId, string packageVersion, string tfm)
+    {
+        var method = typeof(MetadataSource).GetMethod("NuGetDependencyPackageVersions", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        var result = method!.Invoke(null, [packageVersionDir, packageId, packageVersion, tfm]);
+        return Assert.IsAssignableFrom<IReadOnlyDictionary<string, string?>>(result);
+    }
+
+    static string? ProbeNuGetPackages(string root, string fileName, IReadOnlyDictionary<string, string?> packageVersions, string tfm)
+    {
+        var method = typeof(MetadataSource).GetMethod("ProbeNuGetPackages", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        return (string?)method!.Invoke(null, [root, fileName, packageVersions, tfm]);
+    }
+
+    static string? DependencyExactVersion(string version)
+    {
+        var method = typeof(MetadataSource).GetMethod("DependencyExactVersion", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        return (string?)method!.Invoke(null, [version]);
     }
 
     sealed class CrossAssemblyFixture : IDisposable
@@ -216,6 +346,12 @@ public class CrossAssemblyMethodFactsTests
                     {
                         public static int op_Addition(int left, int right) => left - right;
                         public static int op_Implicit(int value) => value + 1;
+                    }
+
+                    public sealed class PropertyLibrary
+                    {
+                        public PropertyLibrary(int count) => Count = count;
+                        public int Count { get; }
                     }
 
                     public readonly struct ExternalNumber
@@ -280,6 +416,9 @@ public class CrossAssemblyMethodFactsTests
 
                         public static ExternalNumber UseRealOperator(ExternalNumber left, ExternalNumber right)
                             => left + right;
+
+                        public static int UseProperty(PropertyLibrary library)
+                            => library.Count;
 
                         public static bool UseUri(string value)
                             => System.Uri.TryCreate(value, System.UriKind.Absolute, out var uri) && uri is not null;
@@ -366,6 +505,7 @@ public class CrossAssemblyMethodFactsTests
         public const string UseOperatorLikeAddition = nameof(UseOperatorLikeAddition);
         public const string UseOperatorLikeImplicit = nameof(UseOperatorLikeImplicit);
         public const string UseRealOperator = nameof(UseRealOperator);
+        public const string UseProperty = nameof(UseProperty);
         public const string UseUri = nameof(UseUri);
         public const string UseExternalInlineArray = nameof(UseExternalInlineArray);
     }

--- a/src/ILInspector.Decompiler.Tests/FidelityRemarksTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityRemarksTests.cs
@@ -81,4 +81,74 @@ public class FidelityRemarksTests
         Assert.Contains("<>c__DisplayClass0_0", remark.Reason);
         Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
     }
+
+    [Fact]
+    public void Collect_UnverifiedAccessorLikeCall_ReportsDec0009()
+    {
+        var holder = TypeRef.Definition("Synthetic", "Samples", "Holder");
+        var location = TypeRef.Definition("Synthetic", "Samples", "Location");
+        var accessorLike = new MethodRef(holder, "get_Location", location, [], HasThis: true)
+        {
+            IsSpecialName = true,
+            AccessorKind = AccessorKind.Unknown,
+        };
+        var container = new BlockContainer();
+        var entry = new Block(0x10);
+        container.Add(entry);
+        entry.Add(new Return(new Call(accessorLike, isVirtual: true, [new LoadArgument(0, "self", holder)])));
+
+        var signature = new MethodSignature(location, [new Parameter("self", holder)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("AccessorLike", holder, signature, [], container);
+
+        var remark = Assert.Single(FidelityRemarks.Collect(function),
+            r => r.Code == DiagnosticIds.UnrepresentableMetadataName);
+        Assert.Equal(0x10, remark.Offset);
+        Assert.Contains("accessor metadata was unavailable", remark.Reason);
+        Assert.Equal(DecompilationFidelity.Partial, function.Fidelity);
+    }
+
+    [Fact]
+    public void Collect_ResolvedNonAccessorGetMethod_RemainsFull()
+    {
+        var holder = TypeRef.Definition("Synthetic", "Samples", "Holder");
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var nonAccessor = new MethodRef(holder, "get_Count", int32, [], HasThis: true)
+        {
+            IsSpecialName = true,
+            AccessorKind = AccessorKind.None,
+        };
+        var container = new BlockContainer();
+        var entry = new Block(0x10);
+        container.Add(entry);
+        entry.Add(new Return(new Call(nonAccessor, isVirtual: true, [new LoadArgument(0, "self", holder)])));
+
+        var signature = new MethodSignature(int32, [new Parameter("self", holder)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("NonAccessor", holder, signature, [], container);
+
+        Assert.Empty(FidelityRemarks.Collect(function));
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
+
+    [Fact]
+    public void Collect_NameInferredAccessorLikeMemberRef_RemainsFullUntilMetadataResolves()
+    {
+        var holder = TypeRef.Definition("Synthetic", "Samples", "Holder");
+        var int32 = TypeRef.CoreLib("System", "Int32");
+        var ambiguous = new MethodRef(holder, "get_Count", int32, [], HasThis: true)
+        {
+            IsSpecialName = true,
+            IsSpecialNameInferred = true,
+            AccessorKind = AccessorKind.Unknown,
+        };
+        var container = new BlockContainer();
+        var entry = new Block(0x10);
+        container.Add(entry);
+        entry.Add(new Return(new Call(ambiguous, isVirtual: true, [new LoadArgument(0, "self", holder)])));
+
+        var signature = new MethodSignature(int32, [new Parameter("self", holder)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("AmbiguousMemberRef", holder, signature, [], container);
+
+        Assert.Empty(FidelityRemarks.Collect(function));
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpSpellability.cs
@@ -85,6 +85,9 @@ internal static class CSharpSpellability
         if (method.Name is ".ctor")
             return null;
 
+        if (IsUnverifiedAccessorLikeMethod(method))
+            return $"method '{method.Name}' looks like a property/event accessor but accessor metadata was unavailable; explicit accessor calls have no C# spelling";
+
         string name = CSharpNaming.MethodName(method.Name);
         return CSharpNaming.IsEscapableIdentifier(name)
             ? null
@@ -103,6 +106,15 @@ internal static class CSharpSpellability
         => CSharpNaming.IsUsableIdentifier(name)
             ? null
             : $"property name '{name}' has no C# spelling";
+
+    static bool IsUnverifiedAccessorLikeMethod(MethodRef method)
+        => method.AccessorKind == AccessorKind.Unknown
+            && method.IsSpecialName
+            && !method.IsSpecialNameInferred
+            && (method.Name.StartsWith("get_", StringComparison.Ordinal)
+                || method.Name.StartsWith("set_", StringComparison.Ordinal)
+                || method.Name.StartsWith("add_", StringComparison.Ordinal)
+                || method.Name.StartsWith("remove_", StringComparison.Ordinal));
 
     // A local function name is emitted through CSharpNaming.EscapeIdentifier, so a
     // reserved keyword (e.g. return -> @return) is spellable; only a name with

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1754,6 +1754,12 @@ public static class IrImporter
                 var accessorKind = MemberReferenceAccessorKind(reader, member, memberName);
                 if (accessorKind == AccessorKind.Unknown && IsTrustedPlatformMemberReference(reader, member.Parent))
                     accessorKind = AccessorKindFromName(memberName);
+                bool inferredSpecialName = memberName.StartsWith("get_", StringComparison.Ordinal)
+                    || memberName.StartsWith("set_", StringComparison.Ordinal)
+                    || memberName.StartsWith("add_", StringComparison.Ordinal)
+                    || memberName.StartsWith("remove_", StringComparison.Ordinal)
+                    || memberName.StartsWith("op_", StringComparison.Ordinal)
+                    || memberName is ".ctor" or ".cctor";
                 return new MethodRef(
                     declaring,
                     memberName,
@@ -1764,12 +1770,8 @@ public static class IrImporter
                     // MemberRefs carry no flags; keep name-inferred SpecialName
                     // separate from AccessorKind so property/event sugar requires
                     // positive metadata semantics rather than a get_/set_ prefix.
-                    IsSpecialName = memberName.StartsWith("get_", StringComparison.Ordinal)
-                        || memberName.StartsWith("set_", StringComparison.Ordinal)
-                        || memberName.StartsWith("add_", StringComparison.Ordinal)
-                        || memberName.StartsWith("remove_", StringComparison.Ordinal)
-                        || memberName.StartsWith("op_", StringComparison.Ordinal)
-                        || memberName is ".ctor" or ".cctor",
+                    IsSpecialName = inferredSpecialName,
+                    IsSpecialNameInferred = inferredSpecialName,
                     AccessorKind = accessorKind,
                     DeclaringTypeIsDelegate = MemberIdentity.IsKnownCoreLibraryDelegateType(declaring)
                         ? MetadataFactState.Yes

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -61,6 +61,14 @@ public sealed record MethodRef(
     public bool IsSpecialName { get; init; }
 
     /// <summary>
+    /// True when <see cref="IsSpecialName"/> came from a MemberRef name prefix
+    /// rather than MethodDef metadata. The flag preserves the distinction between
+    /// "could be an accessor/operator if metadata resolves" and "metadata proves
+    /// SpecialName" for final spellability checks.
+    /// </summary>
+    public bool IsSpecialNameInferred { get; init; }
+
+    /// <summary>
     /// Positive metadata evidence that this method is a user-defined C# operator.
     /// MemberRefs may carry name-inferred <see cref="IsSpecialName"/>, but resolved
     /// non-operators use this fact to keep explicit method-call spelling.

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Xml.Linq;
 using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Pipeline;
@@ -98,6 +99,13 @@ public sealed class MetadataSource : IDisposable
     public static MetadataSource OpenWithoutSymbols(string path, AssemblyLocator? locator = null, MetadataContext? context = null)
         => OpenCore(path, externalPdbPath: null, readSymbols: false, locator, context);
 
+    /// <summary>
+    /// Default referenced-assembly probing policy for callers that need to share a
+    /// <see cref="MetadataContext"/> across several <see cref="MetadataSource"/>
+    /// instances.
+    /// </summary>
+    public static AssemblyLocator DefaultAssemblyLocator(string path) => SiblingLocator(path);
+
     static MetadataSource OpenCore(string path, string? externalPdbPath, bool readSymbols, AssemblyLocator? locator, MetadataContext? context)
     {
         var stream = File.OpenRead(path);
@@ -111,7 +119,7 @@ public sealed class MetadataSource : IDisposable
             string assemblyName = reader.IsAssembly
                 ? reader.GetString(reader.GetAssemblyDefinition().Name)
                 : System.IO.Path.GetFileNameWithoutExtension(path);
-            return new MetadataSource(path, stream, peReader, reader, assemblyName, externalPdbPath, readSymbols, locator ?? SiblingLocator(path), context);
+            return new MetadataSource(path, stream, peReader, reader, assemblyName, externalPdbPath, readSymbols, locator ?? DefaultAssemblyLocator(path), context);
         }
         catch
         {
@@ -131,13 +139,236 @@ public sealed class MetadataSource : IDisposable
     static AssemblyLocator SiblingLocator(string path)
     {
         string? dir = System.IO.Path.GetDirectoryName(path);
+        var packageProbe = NuGetPackageProbe(path);
+        var packageCache = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
         return (name, trust) =>
         {
-            if (dir is null)
+            if (dir is not null)
+            {
+                string sibling = System.IO.Path.Combine(dir, name + ".dll");
+                if (File.Exists(sibling))
+                    return sibling;
+            }
+
+            if (trust == AssemblyTrust.Platform || packageProbe is null)
                 return null;
-            string sibling = System.IO.Path.Combine(dir, name + ".dll");
-            return File.Exists(sibling) ? sibling : null;
+
+            if (!packageCache.TryGetValue(name, out var cached))
+            {
+                cached = packageProbe(name);
+                packageCache[name] = cached;
+            }
+            return cached;
         };
+    }
+
+    static Func<string, string?>? NuGetPackageProbe(string path)
+    {
+        var roots = NuGetPackageRoots()
+            .Where(Directory.Exists)
+            .Select(root => System.IO.Path.GetFullPath(root).TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (roots.Length == 0)
+            return null;
+
+        string fullPath = System.IO.Path.GetFullPath(path);
+        IReadOnlyDictionary<string, string?>? packageVersions = null;
+        string? startingTfm = null;
+        bool isNuGetPackageAsset = false;
+        foreach (string root in roots)
+        {
+            string prefix = root + System.IO.Path.DirectorySeparatorChar;
+            if (!fullPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var parts = fullPath[prefix.Length..].Split(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar);
+            if (parts.Length >= 5 && (parts[2] == "lib" || parts[2] == "ref"))
+            {
+                string packageId = parts[0];
+                string packageVersion = parts[1];
+                startingTfm = parts[3];
+                isNuGetPackageAsset = true;
+                packageVersions = NuGetDependencyPackageVersions(System.IO.Path.Combine(root, packageId, packageVersion), packageId, packageVersion, startingTfm);
+            }
+            break;
+        }
+        if (!isNuGetPackageAsset || packageVersions is null)
+            return null;
+
+        return assemblyName =>
+        {
+            string fileName = assemblyName + ".dll";
+            foreach (string root in roots)
+            {
+                if (ProbeNuGetPackages(root, fileName, packageVersions, startingTfm) is { } anyVersion)
+                    return anyVersion;
+            }
+            return null;
+        };
+    }
+
+    static IEnumerable<string> NuGetPackageRoots()
+    {
+        if (Environment.GetEnvironmentVariable("NUGET_PACKAGES") is { Length: > 0 } envRoot)
+            yield return envRoot;
+
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrEmpty(home))
+            yield return System.IO.Path.Combine(home, ".nuget", "packages");
+    }
+
+    static IReadOnlyDictionary<string, string?> NuGetDependencyPackageVersions(string packageVersionDir, string packageId, string packageVersion, string? tfm)
+    {
+        var versions = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            [packageId] = packageVersion,
+        };
+
+        try
+        {
+            foreach (string nuspec in Directory.EnumerateFiles(packageVersionDir, "*.nuspec"))
+            {
+                var document = XDocument.Load(nuspec);
+                AddDependencyVersions(versions, SelectNuGetDependencies(document, tfm));
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Xml.XmlException)
+        {
+        }
+
+        return versions;
+    }
+
+    static IEnumerable<XElement> SelectNuGetDependencies(XDocument document, string? tfm)
+    {
+        var dependencies = document.Descendants().FirstOrDefault(e => e.Name.LocalName == "dependencies");
+        if (dependencies is null)
+            yield break;
+
+        var directDependencies = dependencies.Elements().Where(e => e.Name.LocalName == "dependency").ToArray();
+        var groups = dependencies.Elements().Where(e => e.Name.LocalName == "group").ToArray();
+        string? normalizedTfm = NormalizeNuGetFramework(tfm);
+        var selectedGroup = normalizedTfm is null
+            ? null
+            : groups.FirstOrDefault(g => NormalizeNuGetFramework(g.Attribute("targetFramework")?.Value) == normalizedTfm);
+
+        if (selectedGroup is not null)
+        {
+            foreach (var dependency in selectedGroup.Elements().Where(e => e.Name.LocalName == "dependency"))
+                yield return dependency;
+            yield break;
+        }
+
+        foreach (var dependency in directDependencies)
+            yield return dependency;
+    }
+
+    static void AddDependencyVersions(Dictionary<string, string?> versions, IEnumerable<XElement> dependencies)
+    {
+        foreach (var dependency in dependencies)
+        {
+            string? id = dependency.Attribute("id")?.Value;
+            if (string.IsNullOrWhiteSpace(id))
+                continue;
+            versions.TryAdd(id, DependencyExactVersion(dependency.Attribute("version")?.Value));
+        }
+    }
+
+    static string? NormalizeNuGetFramework(string? tfm)
+    {
+        if (string.IsNullOrWhiteSpace(tfm))
+            return null;
+
+        tfm = tfm.Trim().ToLowerInvariant();
+        if (tfm.StartsWith(".netstandard", StringComparison.Ordinal))
+            return "netstandard" + tfm[".netstandard".Length..];
+        if (tfm.StartsWith(".netcoreapp", StringComparison.Ordinal))
+            return "netcoreapp" + tfm[".netcoreapp".Length..];
+        if (tfm.StartsWith(".netframework", StringComparison.Ordinal))
+            return "net" + tfm[".netframework".Length..].Replace(".", "", StringComparison.Ordinal);
+        return tfm;
+    }
+
+    static string? DependencyExactVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return null;
+
+        version = version.Trim();
+        if (version.Length >= 5 && version[0] == '[' && version[^1] == ']')
+        {
+            string inner = version[1..^1].Trim();
+            var range = inner.Split(',', 2);
+            if (range.Length == 1)
+                return inner;
+            if (range.Length == 2
+                && string.Equals(range[0].Trim(), range[1].Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                return range[0].Trim();
+            }
+        }
+
+        return version.IndexOfAny(['[', ']', '(', ')', ',']) < 0 ? version : null;
+    }
+
+    static string? ProbeNuGetPackages(string root, string fileName, IReadOnlyDictionary<string, string?> packageVersions, string? tfm)
+    {
+        try
+        {
+            foreach (var (packageId, version) in packageVersions)
+            {
+                string packageDir = System.IO.Path.Combine(root, packageId.ToLowerInvariant());
+                if (!Directory.Exists(packageDir))
+                    continue;
+
+                if (version is not null)
+                {
+                    string versionDir = System.IO.Path.Combine(packageDir, version.ToLowerInvariant());
+                    if (Directory.Exists(versionDir)
+                        && ProbeNuGetPackageVersion(versionDir, fileName, tfm) is { } exact)
+                    {
+                        return exact;
+                    }
+                    continue;
+                }
+
+                foreach (string versionDir in Directory.EnumerateDirectories(packageDir).OrderDescending(StringComparer.OrdinalIgnoreCase))
+                {
+                    if (ProbeNuGetPackageVersion(versionDir, fileName, tfm) is { } found)
+                        return found;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+        }
+        return null;
+    }
+
+    static string? ProbeNuGetPackageVersion(string versionDir, string fileName, string? tfm)
+    {
+        foreach (string assetKind in (string[])["lib", "ref"])
+        {
+            if (tfm is not null)
+            {
+                string candidate = System.IO.Path.Combine(versionDir, assetKind, tfm, fileName);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+
+            string assetRoot = System.IO.Path.Combine(versionDir, assetKind);
+            if (!Directory.Exists(assetRoot))
+                continue;
+
+            foreach (string tfmDir in Directory.EnumerateDirectories(assetRoot).OrderDescending(StringComparer.OrdinalIgnoreCase))
+            {
+                string candidate = System.IO.Path.Combine(tfmDir, fileName);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
+        }
+        return null;
     }
 
     /// <summary>

--- a/tools/DecompilerHarness/CorpusMetadata.cs
+++ b/tools/DecompilerHarness/CorpusMetadata.cs
@@ -17,10 +17,14 @@ static class CorpusMetadata
 {
     public static MetadataContext Create(IEnumerable<string> assemblies)
     {
-        var directories = assemblies
-            .Select(p => Path.GetDirectoryName(Path.GetFullPath(p)))
+        var assemblyPaths = assemblies.Select(Path.GetFullPath).ToList();
+        var directories = assemblyPaths
+            .Select(Path.GetDirectoryName)
             .Where(d => !string.IsNullOrEmpty(d))
             .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var defaultLocators = assemblyPaths
+            .Select(MetadataSource.DefaultAssemblyLocator)
             .ToList();
         var platformAssemblies = TrustedPlatformAssemblies();
 
@@ -44,6 +48,9 @@ static class CorpusMetadata
                 if (File.Exists(candidate))
                     return candidate;
             }
+            foreach (var locator in defaultLocators)
+                if (locator(name, trust) is { } resolved)
+                    return resolved;
             return null;
         };
 


### PR DESCRIPTION
Fixes #1774.

## What changed

- Resolve cross-package MethodRef facts for NuGet package assemblies by extending the default decompiler assembly locator to probe the current package's declared nuspec dependencies for the active TFM.
- Preserve the distinction between name-inferred MemberRef `SpecialName` and proven MethodDef `SpecialName`, so ambiguous unresolved `get_*` methods are not falsely downgraded.
- Keep honest degradation for proven accessor-like methods whose metadata cannot be classified.

## Evidence

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CrossAssemblyMethodFactsTests/*"` — 15 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/FidelityRemarksTests/*"` — 7 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"` — 1619 passed
- Roslyn target before/after: `HasCollectionExpressionApplicableConstructor` now renders `syntax.Location` at both tracked call sites and no longer emits `syntax.get_Location()`.
- Validity boss on `Microsoft.CodeAnalysis.CSharp.dll` no longer reports #1774's tracked `CS0571` examples (`HasCollectionExpressionApplicableConstructor`, `LocalBinderFactory::.ctor`) in the Full semantic-defect examples; remaining reported defects are other burndown rows.

A full fixed-corpus quality card was attempted locally but did not produce output under current machine contention before being stopped; the targeted validity boss above is the row-specific proof.

## Adversarial review

Cross-model adversarial review was requested from Claude Opus 4.8 and MAI-Code-1-Flash. Initial findings about false `get_*` downgrades, filename-only NuGet probing, TFM-specific dependency groups, and exact-version range parsing were addressed in this PR. A final Claude follow-up pass is still running and will be summarized in a PR comment when complete.
