### PR TITLE
Show desired direction in quality diff card

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -519,15 +519,15 @@ The tool emits a block like:
 Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 87,907 methods
 Correctness coverage: validity sampled 350 / 87,907 (0.40%); fidelity sampled 6 / 87,907 (0.01%)
 
-| Metric | Baseline | PR | Delta |
+| Metric (desired direction) | Baseline | PR | Count delta |
 | --- | ---: | ---: | ---: |
-| Fully raised | 77,376 (88.02%) | 77,376 (88.02%) | 0 |
-| Conditional-branch residual | 2,298 (2.61%) | 2,298 (2.61%) | 0 |
-| Forward-merge stops | 2,290 (2.61%) | 2,290 (2.61%) | 0 |
-| Full malformed | 165 | 165 | 0 |
-| Semantic defects | 4/350 — sampled 350 / 87,907 (0.40%) | 4/350 — sampled 350 / 87,907 (0.40%) | 0 |
-| Fidelity diffs | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,907 (0.01%) | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,907 (0.01%) | 0 |
-| Pass bugs | 0 | 0 | 0 |
+| Fully raised (+) | 77,376 (88.02%) | 77,376 (88.02%) | 0 |
+| Conditional-branch residual (-) | 2,298 (2.61%) | 2,298 (2.61%) | 0 |
+| Forward-merge stops (-) | 2,290 (2.61%) | 2,290 (2.61%) | 0 |
+| Full malformed (-) | 165 | 165 | 0 |
+| Semantic defects (-) | 4/350 — sampled 350 / 87,907 (0.40%) | 4/350 — sampled 350 / 87,907 (0.40%) | 0 |
+| Fidelity diffs (-) | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,907 (0.01%) | opcode-diff 1/6, exact 5, recompile-failed 0, context-failed 0; sampled 6 / 87,907 (0.01%) | 0 |
+| Pass bugs (-) | 0 | 0 | 0 |
 
 Verdict: corpus sensor matched baseline tolerances.
 ```

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -698,55 +698,55 @@ internal static class CorpusSensor
             PrintRiskyCoverageGuidance(current);
         PrintBaselineStaleness(baseline, current);
         Console.WriteLine();
-        Console.WriteLine("| Metric | Baseline | PR | Delta |");
+        Console.WriteLine("| Metric (desired direction) | Baseline | PR | Count delta |");
         Console.WriteLine("| --- | ---: | ---: | ---: |");
         PrintMetric(
-            "Fully raised",
+            "Fully raised (+)",
             CountPercent(baseline.Metrics.FullyRaisedMethods, baseline.Metrics.FullyRaisedBasisPoints),
             CountPercent(current.Metrics.FullyRaisedMethods, current.Metrics.FullyRaisedBasisPoints),
             Delta(current.Metrics.FullyRaisedMethods - baseline.Metrics.FullyRaisedMethods));
         PrintMetric(
-            "Conditional-branch residual",
+            "Conditional-branch residual (-)",
             CountPercent(baseline.Metrics.ConditionalBranchMethods, baseline.Metrics.ConditionalBranchBasisPoints),
             CountPercent(current.Metrics.ConditionalBranchMethods, current.Metrics.ConditionalBranchBasisPoints),
             Delta(current.Metrics.ConditionalBranchMethods - baseline.Metrics.ConditionalBranchMethods));
         PrintMetric(
-            "Forward-merge stops",
+            "Forward-merge stops (-)",
             CountPercent(baseline.Metrics.ForwardMergeStoppedContainers, baseline.Metrics.ForwardMergeBasisPoints),
             CountPercent(current.Metrics.ForwardMergeStoppedContainers, current.Metrics.ForwardMergeBasisPoints),
             Delta(current.Metrics.ForwardMergeStoppedContainers - baseline.Metrics.ForwardMergeStoppedContainers));
         if (current.ValidityCompileCap <= 0)
         {
-            PrintMetric("Full malformed", "not run", "not run", "-");
-            PrintMetric("Semantic defects", "not run", "not run", "-");
+            PrintMetric("Full malformed (-)", "not run", "not run", "-");
+            PrintMetric("Semantic defects (-)", "not run", "not run", "-");
         }
         else
         {
             PrintMetric(
-                "Full malformed",
+                "Full malformed (-)",
                 Number(baseline.Metrics.FullMalformedMethods),
                 Number(current.Metrics.FullMalformedMethods),
                 Delta(current.Metrics.FullMalformedMethods - baseline.Metrics.FullMalformedMethods));
             PrintMetric(
-                "Semantic defects",
+                "Semantic defects (-)",
                 FractionWithCoverage(baseline.Metrics.SemanticDefectMethods, baseline.Metrics.SemanticCheckedMethods, baseline.Metrics.TotalMethods),
                 FractionWithCoverage(current.Metrics.SemanticDefectMethods, current.Metrics.SemanticCheckedMethods, current.Metrics.TotalMethods),
                 Delta(current.Metrics.SemanticDefectMethods - baseline.Metrics.SemanticDefectMethods));
         }
         if (current.FidelityCompileCap <= 0)
         {
-            PrintMetric("Fidelity diffs", "not run", "not run", "-");
+            PrintMetric("Fidelity diffs (-)", "not run", "not run", "-");
         }
         else
         {
             PrintMetric(
-                "Fidelity diffs",
+                "Fidelity diffs (-)",
                 FidelityWithCoverage(baseline.Metrics.Fidelity, baseline.Metrics.TotalMethods),
                 FidelityWithCoverage(current.Metrics.Fidelity, current.Metrics.TotalMethods),
                 Delta(current.Metrics.Fidelity.OpcodeDiffMethods - baseline.Metrics.Fidelity.OpcodeDiffMethods));
         }
         PrintMetric(
-            "Pass bugs",
+            "Pass bugs (-)",
             Number(baseline.Metrics.PassBugs),
             Number(current.Metrics.PassBugs),
             Delta(current.Metrics.PassBugs - baseline.Metrics.PassBugs));


### PR DESCRIPTION
## Summary

Updates the generated decompiler quality-diff card so the table explains which direction is desired:

- header becomes `Metric (desired direction)`;
- metrics are labeled with `(+)` or `(-)`, e.g. `Fully raised (+)` and `Forward-merge stops (-)`;
- `Delta` becomes `Count delta` to clarify that the value is the raw count movement, not the desired/undesired verdict.

This makes positive forward-merge stop movement visibly bad while preserving the existing verdict/gating logic.

## Validation

- `dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet`
- `npx markdownlint-cli --fix docs/decompiler-quality.md`
- `npx markdownlint-cli docs/decompiler-quality.md`
- Generated a PR quick quality card with `eng/prepare-decompiler-pr-corpus.sh` + `pr-quick-baseline.json` and verified the new header/labels render.

No decompiler behavior changes.
