### PR TITLE
Document corpus delta reproduction

### DIFF
--- a/docs/decompiler-corpus-delta-repro.md
+++ b/docs/decompiler-corpus-delta-repro.md
@@ -1,0 +1,108 @@
+# Reproducing decompiler corpus deltas
+
+Use this when a decompiler quality-diff card reports changed rows and the PR body
+shows only a capped Markdown sample. The card is intentionally reviewer-sized;
+this guide explains how to reproduce the full delta locally at the matching
+commit.
+
+## Pick the matching commit
+
+The corpus card is commit-specific. Reproducing it from a later PR head can
+legitimately change the row set.
+
+Use the first available source of truth:
+
+1. **Card revision**, if the PR body or comment prints one.
+2. **CI run commit**, if you are reproducing the `decompiler-pr-corpus` artifact
+   from a check run.
+3. **Current PR head**, only when you intentionally want to inspect the latest
+   branch state rather than the exact posted card.
+
+For the current PR head:
+
+```bash
+gh pr checkout <PR>
+git rev-parse HEAD
+```
+
+For an exact card revision that is still reachable from the PR branch:
+
+```bash
+gh pr checkout <PR>
+git fetch origin pull/<PR>/head
+git checkout <card-sha>
+```
+
+If the exact SHA is no longer reachable because the branch was force-pushed,
+download the CI artifact from the run that produced the card, or ask the author
+to regenerate the card from the current PR head.
+
+## Reproduce the PR quick quality card
+
+The PR quick card must use the PR quick corpus script with the PR quick baseline.
+Do not mix it with the daily/manual corpus script or baseline.
+
+```bash
+dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+bash eng/prepare-decompiler-pr-corpus.sh /tmp/pr-corpus-assemblies.txt
+mapfile -t assemblies < /tmp/pr-corpus-assemblies.txt
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --diff-corpus-baseline tools/DecompilerHarness/corpus/pr-quick-baseline.json \
+  --quality-diff-card \
+  --corpus-method-cap 100 \
+  --compile-cap 0 \
+  --corpus-fidelity-cap 0 \
+  --max-examples 24
+```
+
+Use `--max-examples 24` when you want local output to match the review card's
+"show about two dozen rows" convention. Use a smaller value for a terse smoke
+check.
+
+## Reproduce the full method delta
+
+Add `--emit-corpus-delta` to write the full machine-readable per-method delta.
+This is useful when the collapsed Markdown section is capped.
+
+```bash
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --diff-corpus-baseline tools/DecompilerHarness/corpus/pr-quick-baseline.json \
+  --quality-diff-card \
+  --emit-corpus-delta /tmp/corpus-delta.json \
+  --corpus-method-cap 100 \
+  --compile-cap 0 \
+  --corpus-fidelity-cap 0 \
+  --max-examples 24
+```
+
+The JSON delta records method-level changes such as `fullyRaised`, `residual`,
+`validity`, `fidelityCheck`, and `passBug`. Aggregate-only metrics that do not
+yet have per-method snapshot rows require their own evidence layer before a full
+row-level delta can be reproduced.
+
+## Reproduce the daily/manual real-world card
+
+Use this broader card when reviewing risky decompiler behavior or validating a
+manual corpus claim. It uses the daily/manual corpus script and baseline.
+
+```bash
+dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+bash eng/prepare-decompiler-corpus.sh /tmp/corpus-assemblies.txt
+mapfile -t assemblies < /tmp/corpus-assemblies.txt
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
+  --quality-diff-card \
+  --compile-cap 25 \
+  --corpus-fidelity-cap 3 \
+  --max-examples 24
+```
+
+Only rebaseline after reviewed corpus movement:
+
+```bash
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --emit-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
+  --compile-cap 25 \
+  --corpus-fidelity-cap 3 \
+  --max-examples 24
+```

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -495,7 +495,8 @@ harder for a reviewer to validate. Method-level examples are the only
 hand-authored addendum, and only when the PR intentionally changes behaviour. The
 card is reviewer-sized evidence, not a dump-stage artifact; keep `--dump
 --steps` output in linked diagnosis notes only when reviewers need the
-drill-down.
+drill-down. To reproduce the full row set behind a capped card, follow
+[Reproducing decompiler corpus deltas](decompiler-corpus-delta-repro.md).
 
 For behaviour-preserving refactors, the existing #1174/#1166 real-world corpus
 sensor values are enough when you need the broader daily/manual signal:

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -144,6 +144,10 @@ corpus script with the PR quick baseline, or the card will report artificial
 assembly additions/removals such as System.Private.CoreLib appearing to drop out
 of the sample.
 
+When a card shows capped changed rows, use
+[Reproducing decompiler corpus deltas](../../docs/decompiler-corpus-delta-repro.md)
+to select the matching PR commit and regenerate the full local delta.
+
 ```bash
 dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
 bash eng/prepare-decompiler-pr-corpus.sh /tmp/pr-corpus-assemblies.txt


### PR DESCRIPTION
## Summary

Adds a focused docs page for reproducing decompiler corpus card deltas:

- how to pick the matching PR/card commit;
- how to reproduce the PR quick card with the correct corpus script and baseline;
- how to emit the full method delta locally when a Markdown section is capped;
- how to run the broader daily/manual real-world card without mixing baselines.

Also links the focused guide from the harness README and decompiler quality card guidance.

## Validation

- `npx markdownlint-cli --fix docs/decompiler-corpus-delta-repro.md docs/decompiler-quality.md tools/DecompilerHarness/README.md`
- `npx markdownlint-cli docs/decompiler-corpus-delta-repro.md docs/decompiler-quality.md tools/DecompilerHarness/README.md`

Docs-only; no decompiler behavior changes.
