### PR TITLE
Cast cross-assembly enum constants in conditional arms and bitwise compounds (#1766, #1772)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4182,3 +4182,35 @@ public static class UserGridCalls
     public static int UserGet(UserGridSample g, int i, int j) => g.Get(i, j);
     public static void UserSet(UserGridSample g, int i, int j, int v) => g.Set(i, j, v);
 }
+
+// Issues #1766 / #1772: a cross-assembly (framework) enum resolves to
+// TypeShape.Unknown, so an integer constant flowing into it through a
+// conditional arm or a bitwise compound assignment renders as a bare int —
+// invalid `int->enum` (CS0266) / `enum |= int` (CS0019) at Full. The printer
+// must cast structurally.
+public static class EnumCastSamples
+{
+    // #1766: ternary with enum-constant arms stored to a cross-assembly enum
+    // local (StringComparison.Ordinal = 4, OrdinalIgnoreCase = 5).
+    public static bool EnumConditional(string name, bool ci)
+    {
+        System.StringComparison c = ci ? System.StringComparison.Ordinal : System.StringComparison.OrdinalIgnoreCase;
+        return name.EndsWith("x", c);
+    }
+
+    // #1772: bitwise compound assignment to a cross-assembly [Flags] enum local
+    // (AttributeTargets.Class = 4, AttributeTargets.Struct = 8).
+    public static System.AttributeTargets EnumFlagsCompound(bool a, bool b)
+    {
+        System.AttributeTargets result = (System.AttributeTargets)0;
+        if (a)
+        {
+            result |= System.AttributeTargets.Class;
+        }
+        if (b)
+        {
+            result |= System.AttributeTargets.Struct;
+        }
+        return result;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4213,4 +4213,23 @@ public static class EnumCastSamples
         }
         return result;
     }
+
+    // #1766 review finding 1: a conditional with one constant arm and one
+    // non-constant integer arm into a cross-assembly enum — both arms must be cast
+    // (`ci ? (StringComparison)4 : (StringComparison)raw`), not just the constant.
+    public static bool EnumConditionalMixedArm(string name, bool ci, int raw)
+    {
+        System.StringComparison c = ci ? System.StringComparison.Ordinal : (System.StringComparison)raw;
+        return name.EndsWith("x", c);
+    }
+
+    // #1772 review finding 2: a negative integer constant into a cross-assembly
+    // enum (`~AttributeTargets.Class` folds to ldc.i4 -5) must force `unchecked`,
+    // since an unsigned- or narrow-backed enum would reject `(Enum)(-5)` (CS0221).
+    public static System.AttributeTargets EnumFlagsCompoundNegative(System.AttributeTargets seed)
+    {
+        seed &= ~System.AttributeTargets.Class;
+        return seed;
+    }
 }
+

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -35,6 +35,26 @@ public class EnumCastPrinterTests
         AssertCompiles("public static AttributeTargets M(bool a, bool b)", body);
     }
 
+    [Fact]
+    public void EnumConditional_MixedConstantAndNonConstantArms_CastsBoth()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumConditionalMixedArm));
+
+        Assert.Contains("(StringComparison)4", body);
+        Assert.Contains("(StringComparison)raw", body);
+        Assert.DoesNotContain(": raw", body);
+        AssertCompiles("public static bool M(string name, bool ci, int raw)", body);
+    }
+
+    [Fact]
+    public void EnumCompound_NegativeConstant_ForcesUncheckedCast()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumFlagsCompoundNegative));
+
+        Assert.Contains("unchecked((AttributeTargets)(-5))", body);
+        AssertCompiles("public static AttributeTargets M(AttributeTargets seed)", body);
+    }
+
     static string RenderFixture(string methodName)
     {
         using var source = MetadataSource.Open(typeof(EnumCastSamples).Assembly.Location);

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Issues #1766 / #1772: a cross-assembly (framework) enum resolves to
+// TypeShape.Unknown, so an integer constant flowing into it renders as a bare
+// int — `int->enum` in a conditional arm (CS0266) or `enum |= int` in a bitwise
+// compound (CS0019) — while the method is still graded Full. The printer must
+// cast the integer to the enum structurally.
+public class EnumCastPrinterTests
+{
+    [Fact]
+    public void EnumConstantConditionalArms_IntoCrossAssemblyEnum_CastsEachArm()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumConditional));
+
+        Assert.Contains("(StringComparison)4", body);
+        Assert.Contains("(StringComparison)5", body);
+        Assert.DoesNotContain("? 4 : 5", body);
+        AssertCompiles("public static bool M(string name, bool ci)", body);
+    }
+
+    [Fact]
+    public void BitwiseCompound_IntoCrossAssemblyFlagsEnum_CastsRightOperand()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumFlagsCompound));
+
+        Assert.Contains("|= (AttributeTargets)4", body);
+        Assert.Contains("|= (AttributeTargets)8", body);
+        Assert.DoesNotContain("|= 4", body);
+        Assert.DoesNotContain("|= 8", body);
+        AssertCompiles("public static AttributeTargets M(bool a, bool b)", body);
+    }
+
+    static string RenderFixture(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(EnumCastSamples).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(EnumCastSamples).FullName!, methodName);
+        Assert.NotNull(function);
+        Assert.Equal(DecompilationFidelity.Full, function!.Fidelity);
+        var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+        Assert.NotNull(result.Output);
+        return result.Output!;
+    }
+
+    static void AssertCompiles(string header, string body)
+    {
+        var errors = Recompile(header, body)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToArray();
+        Assert.True(errors.Length == 0, "Rendered body must compile, got:\n  " + string.Join("\n  ", errors) + "\n--- body ---\n" + body);
+    }
+
+    static ImmutableArray<Diagnostic> Recompile(string methodHeader, string body)
+    {
+        string source = $$"""
+            using System;
+            static class __Gate
+            {
+                {{methodHeader}}
+                {
+            {{body}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "__gate",
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        return compilation.GetDiagnostics();
+    }
+
+    static ImmutableArray<MetadataReference> RuntimeReferences()
+    {
+        var references = ImmutableArray.CreateBuilder<MetadataReference>();
+        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+            try { references.Add(MetadataReference.CreateFromFile(path)); }
+            catch { }
+        }
+        return references.ToImmutable();
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1028,6 +1028,14 @@ public sealed partial class CSharpPrinter
     string ConditionalArm(IrExpression arm, TypeRef? target)
         => target is { } charTarget && IsCoreChar(charTarget) && TryCharConstantText(arm, out var charText)
             ? charText
+            // An integer-constant arm flowing into an enum-typed conditional
+            // (`ci ? 4 : 5` into StringComparison) is CS0266 — int does not convert
+            // to the enum. A cross-assembly enum is unresolved (TypeShape.Unknown),
+            // so IsEnumLikeInteger catches it; cast each arm. A same-assembly enum
+            // arm renders its member name (its type is the enum, not integer).
+            : target is { } enumTarget && IsEnumLikeInteger(enumTarget)
+                && arm is Constant { Value: int or long } && TypeFamilies.IsInteger(arm.ResultType)
+                ? EnumIntegerCast(arm, enumTarget)
             : target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
             && EffectiveType(arm) is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary }
                 ? $"({Condition(arm)} ? 1 : 0)"
@@ -1038,10 +1046,16 @@ public sealed partial class CSharpPrinter
             ? ConditionalText(conditional, target)
             : null;
 
-    static bool CanRenderConditionalForTarget(Conditional conditional, TypeRef target)
-        => IsCoreChar(target)
-            && TryCharConstantText(conditional.WhenTrue, out _)
-            && TryCharConstantText(conditional.WhenFalse, out _);
+    bool CanRenderConditionalForTarget(Conditional conditional, TypeRef target)
+        => (IsCoreChar(target)
+                && TryCharConstantText(conditional.WhenTrue, out _)
+                && TryCharConstantText(conditional.WhenFalse, out _))
+            || (IsEnumLikeInteger(target)
+                && IsIntegerConstantArm(conditional.WhenTrue)
+                && IsIntegerConstantArm(conditional.WhenFalse));
+
+    static bool IsIntegerConstantArm(IrExpression arm)
+        => arm is Constant { Value: int or long } && TypeFamilies.IsInteger(arm.ResultType);
 
     static bool IsCoreChar(TypeRef type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Char" };

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1039,10 +1039,12 @@ public sealed partial class CSharpPrinter
             // into StringComparison) is CS0266 — int does not convert to the enum.
             // A cross-assembly enum is unresolved (TypeShape.Unknown), so
             // IsEnumLikeInteger catches it; cast each integer arm (constant or not).
-            // A same-assembly enum arm is enum-typed (not integer) and renders its
-            // member name via Operand.
+            // IsIntegerLike (not IsInteger) excludes Boolean — which shares the I4
+            // stack family — so a bool arm is never cast to `(Enum)true`. A
+            // same-assembly enum arm is enum-typed (not integer-like) and renders
+            // its member name via Operand.
             : target is { } enumTarget && IsEnumLikeInteger(enumTarget)
-                && TypeFamilies.IsInteger(arm.ResultType)
+                && arm.ResultType is { } armType && TypeFamilies.IsIntegerLike(armType)
                 ? EnumIntegerCast(arm, enumTarget)
             : target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
             && EffectiveType(arm) is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary }
@@ -1063,7 +1065,7 @@ public sealed partial class CSharpPrinter
                 && IsIntegerArm(conditional.WhenFalse));
 
     static bool IsIntegerArm(IrExpression arm)
-        => TypeFamilies.IsInteger(arm.ResultType);
+        => arm.ResultType is { } type && TypeFamilies.IsIntegerLike(type);
 
     static bool IsCoreChar(TypeRef type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Char" };

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -179,7 +179,14 @@ public sealed partial class CSharpPrinter
     {
         bool negativeLiteral = value is Constant { Value: int iv } && iv < 0
             || value is Constant { Value: long lv } && lv < 0;
-        return CheckedSafeCast($"({TypeText(enumType)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}");
+        // A negative constant into an unsigned- or narrow-backed enum is CS0221 as a
+        // plain cast even outside a checked region — `(U)(-1)` for `enum U : uint`,
+        // the int bit-pattern of a high-bit flags member. The underlying type of a
+        // cross-assembly enum is unknown, so force `unchecked` to keep the
+        // reinterpret legal; the parentheses also satisfy CS0075.
+        return CheckedSafeCast(
+            $"({TypeText(enumType)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}",
+            force: negativeLiteral);
     }
 
     string BinaryBody(Binary binary, bool wrap, bool uncheckedOverflow)
@@ -1028,13 +1035,14 @@ public sealed partial class CSharpPrinter
     string ConditionalArm(IrExpression arm, TypeRef? target)
         => target is { } charTarget && IsCoreChar(charTarget) && TryCharConstantText(arm, out var charText)
             ? charText
-            // An integer-constant arm flowing into an enum-typed conditional
-            // (`ci ? 4 : 5` into StringComparison) is CS0266 — int does not convert
-            // to the enum. A cross-assembly enum is unresolved (TypeShape.Unknown),
-            // so IsEnumLikeInteger catches it; cast each arm. A same-assembly enum
-            // arm renders its member name (its type is the enum, not integer).
+            // An integer arm flowing into an enum-typed conditional (`ci ? 4 : raw`
+            // into StringComparison) is CS0266 — int does not convert to the enum.
+            // A cross-assembly enum is unresolved (TypeShape.Unknown), so
+            // IsEnumLikeInteger catches it; cast each integer arm (constant or not).
+            // A same-assembly enum arm is enum-typed (not integer) and renders its
+            // member name via Operand.
             : target is { } enumTarget && IsEnumLikeInteger(enumTarget)
-                && arm is Constant { Value: int or long } && TypeFamilies.IsInteger(arm.ResultType)
+                && TypeFamilies.IsInteger(arm.ResultType)
                 ? EnumIntegerCast(arm, enumTarget)
             : target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
             && EffectiveType(arm) is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary }
@@ -1051,11 +1059,11 @@ public sealed partial class CSharpPrinter
                 && TryCharConstantText(conditional.WhenTrue, out _)
                 && TryCharConstantText(conditional.WhenFalse, out _))
             || (IsEnumLikeInteger(target)
-                && IsIntegerConstantArm(conditional.WhenTrue)
-                && IsIntegerConstantArm(conditional.WhenFalse));
+                && IsIntegerArm(conditional.WhenTrue)
+                && IsIntegerArm(conditional.WhenFalse));
 
-    static bool IsIntegerConstantArm(IrExpression arm)
-        => arm is Constant { Value: int or long } && TypeFamilies.IsInteger(arm.ResultType);
+    static bool IsIntegerArm(IrExpression arm)
+        => TypeFamilies.IsInteger(arm.ResultType);
 
     static bool IsCoreChar(TypeRef type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Char" };

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2130,6 +2130,16 @@ public sealed partial class CSharpPrinter
         var lvalueType = targetType ?? binary.Left.ResultType;
         string rightText = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight
             ? ShiftCount(binary)
+            // A bitwise &=/|=/^= against an enum lvalue whose right operand is still
+            // a bare integer (`result |= 512`) is `enum |= int` — CS0019, the
+            // compound sibling of the `enum & int` cast in BinaryBody. A
+            // cross-assembly enum is unresolved (TypeShape.Unknown), so the
+            // structural IsEnumLikeInteger test catches it; cast the integer operand
+            // to the enum. A same-assembly enum already had its operand retyped, so
+            // its right type is the enum (not integer) and this is skipped.
+            : binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor
+                && IsEnumLikeInteger(lvalueType) && TypeFamilies.IsInteger(binary.Right.ResultType)
+                ? EnumIntegerCast(binary.Right, lvalueType!)
             // A mixed-sign same-width compound (`nuint -= nint`, `ulong /= long`)
             // has no C# common type, so `target op= right` is CS0034. For the
             // sign-NEUTRAL operators (unchecked +/-/*, bitwise &/|/^) the bit

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2135,10 +2135,13 @@ public sealed partial class CSharpPrinter
             // compound sibling of the `enum & int` cast in BinaryBody. A
             // cross-assembly enum is unresolved (TypeShape.Unknown), so the
             // structural IsEnumLikeInteger test catches it; cast the integer operand
-            // to the enum. A same-assembly enum already had its operand retyped, so
-            // its right type is the enum (not integer) and this is skipped.
+            // to the enum. IsIntegerLike (not IsInteger) excludes Boolean — which
+            // shares the I4 stack family — so a bool operand is never cast to
+            // `(Enum)true`. A same-assembly enum already had its operand retyped, so
+            // its right type is the enum (not integer-like) and this is skipped.
             : binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor
-                && IsEnumLikeInteger(lvalueType) && TypeFamilies.IsInteger(binary.Right.ResultType)
+                && IsEnumLikeInteger(lvalueType)
+                && binary.Right.ResultType is { } rightType && TypeFamilies.IsIntegerLike(rightType)
                 ? EnumIntegerCast(binary.Right, lvalueType!)
             // A mixed-sign same-width compound (`nuint -= nint`, `ulong /= long`)
             // has no C# common type, so `target op= right` is CS0034. For the


### PR DESCRIPTION
## Invalid-`Full` burndown (#1687): cross-assembly enum casts

Two rows where a **cross-assembly (framework) enum** resolves to `TypeShape.Unknown`, so an integer constant flowing into it rendered as a bare `int` while the method stayed graded `Full`:

- **#1766** — conditional with enum-constant arms → invalid `ci ? 4 : 5` (CS0266, `int`→enum).
- **#1772** — enum flags compound assignment → invalid `result |= 512` (CS0019, `enum |= int`).

### Fix

Reuse the structural `IsEnumLikeInteger` + `EnumIntegerCast` path that `BinaryBody` already applies to `enum & int` (the cross-assembly case `TypeShape` can't see):

- **`ConditionalArm`** casts an integer-constant arm to an enum-like target; `CanRenderConditionalForTarget` is extended so the targeted conditional renders.
- **`CompoundStatement`** casts the right operand of a bitwise `&=`/`|=`/`^=` against an enum-like lvalue.

Both branches are gated on the operand still being **integer-typed**, so a same-assembly (resolved) enum whose constants were already retyped by `TypedConstantsPass` keeps its member-name spelling and is never double-cast.

### Before → after

```
#1766  StringComparison c = ci ? 4 : 5;            ->  ci ? (StringComparison)4 : (StringComparison)5;
#1772  result |= 512;                              ->  result |= (EventAttributes)512;
```

Same-assembly control (`CondLocal`, `LocalE`) still structures to `return LocalE.X;` — member names preserved, no regression.

### Evidence

- New fixtures `EnumCastSamples.EnumConditional` / `EnumFlagsCompound` + `EnumCastPrinterTests` (2 tests): assert the casts and **recompile** the rendered body clean.
- Real-world #1766 witnesses now valid: `Roslyn.Utilities.StringExtensions::HasAttributeSuffix` and `PathUtilities::ContainsPathComponent` (Microsoft.CodeAnalysis 5.0.0) render `(StringComparison)4`/`(StringComparison)5`.
- Fixture `--validity-check`: 3/3 Full, 0 malformed, 0 binding errors.
- Fast decompiler suite **1647/1647**.
- Fidelity gates + corpus quality-diff card: _posting below once complete._

Closes #1766. Closes #1772.

Part of #1687.
