### PR TITLE
Reconstruct auto-property skeletons for compile-back

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -68,15 +68,15 @@ public class GeneratedFixtureCatalogTests
             "minimal.auto-property.getter",
             "GeneratedFixtures.MinimalAutoPropertyGetter.Class1",
             ".ctor",
-            FidelityCheck.CompileBackStatus.RecompileFail,
-            frontier: true);
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
         AssertTarget(
             run,
             "minimal.auto-property.getter",
             "GeneratedFixtures.MinimalAutoPropertyGetter.Class1",
             "get_Method1",
-            FidelityCheck.CompileBackStatus.RecompileFail,
-            frontier: true);
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
         AssertTarget(
             run,
             "minimal.method-call.same-type",

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1677,12 +1677,14 @@ static class FidelityCheck
     /// namespace inclusion and ctor stubs land, because the method loop otherwise
     /// emits a property's <c>get_X</c>/<c>set_X</c> as plain methods that a
     /// property access cannot resolve to. Scoped to pure-stub properties: a
-    /// property whose getter or setter is a target is skipped (left to the method
-    /// loop), so the target accessor's own emission and opcode comparison are
-    /// unchanged. The replaced accessor method names are added to
-    /// <paramref name="skipAccessors"/> so the caller does not also emit them as
-    /// methods. Stub accessors throw; over-permissive accessibility on a stub is
-    /// safe because the body never runs and only needs to bind.
+    /// property whose getter or setter is a target is normally skipped (left to
+    /// the method loop), unless the metadata has a compiler auto-property backing
+    /// field: in that case, emitting the auto-property lets the generated accessor
+    /// and constructor assignment round-trip through normal C# syntax. The replaced
+    /// accessor method names are added to <paramref name="skipAccessors"/> so the
+    /// caller does not also emit them as methods. Stub accessors throw;
+    /// over-permissive accessibility on a stub is safe because the body never runs
+    /// and only needs to bind.
     /// </summary>
     static void EmitStubProperties(MetadataReader reader, TypeDefinition typeDef,
         IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets,
@@ -1693,10 +1695,6 @@ static class FidelityCheck
         {
             var prop = reader.GetPropertyDefinition(ph);
             var pa = prop.GetAccessors();
-            // A target accessor must stay a method so its own body is emitted and
-            // compared unchanged — skip the whole property.
-            if ((!pa.Getter.IsNil && targets.ContainsKey(pa.Getter)) || (!pa.Setter.IsNil && targets.ContainsKey(pa.Setter)))
-                continue;
             string pname = reader.GetString(prop.Name);
             if (pname.Contains('<') || pname.Contains('.'))
                 continue; // compiler-generated / explicit interface impl
@@ -1728,6 +1726,21 @@ static class FidelityCheck
                     && !accessorMethod.Attributes.HasFlag(MethodAttributes.Final);
                 string modifier = isStatic ? "static " : (emitVirtual ? "virtual " : "");
                 string unsafeMod = RequiresUnsafeSignature(ret) ? "unsafe " : "";
+                bool isAutoProperty = hasGet
+                    && AccessorsAreCompilerGenerated(reader, pa)
+                    && HasAutoPropertyBackingField(reader, typeDef, pname, ret, isStatic);
+                bool accessorIsTarget = (!pa.Getter.IsNil && targets.ContainsKey(pa.Getter))
+                    || (!pa.Setter.IsNil && targets.ContainsKey(pa.Setter));
+                if (accessorIsTarget && !isAutoProperty)
+                    continue;
+                if (isAutoProperty)
+                {
+                    string autoBody = " get;" + (hasSet ? " set;" : "");
+                    sb.AppendLine($"{pad}public {modifier}{unsafeMod}{ret} {Identifier(pname)} {{{autoBody} }}");
+                    if (!pa.Getter.IsNil) skipAccessors.Add(pa.Getter);
+                    if (!pa.Setter.IsNil) skipAccessors.Add(pa.Setter);
+                    continue;
+                }
                 string body = (hasGet ? " get => throw null;" : "") + (hasSet ? " set => throw null;" : "");
                 sb.AppendLine($"{pad}public {modifier}{unsafeMod}{ret} {Identifier(pname)} {{{body} }}");
                 if (!pa.Getter.IsNil) skipAccessors.Add(pa.Getter);
@@ -1735,6 +1748,55 @@ static class FidelityCheck
             }
             catch { }
         }
+    }
+
+    static bool HasAutoPropertyBackingField(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string propertyName,
+        string propertyType,
+        bool isStaticProperty)
+    {
+        string backingName = $"<{propertyName}>k__BackingField";
+        var context = GenericContext.ForType(reader, typeDef);
+        foreach (var fieldHandle in typeDef.GetFields())
+        {
+            var field = reader.GetFieldDefinition(fieldHandle);
+            if (reader.GetString(field.Name) != backingName)
+                continue;
+            if (field.Attributes.HasFlag(FieldAttributes.Static) != isStaticProperty)
+                continue;
+            if (!HasCompilerGeneratedAttribute(reader, field.GetCustomAttributes()))
+                return false;
+            try
+            {
+                return Clean(field.DecodeSignature(SignatureDecoder.Instance, context)) == propertyType;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    static bool AccessorsAreCompilerGenerated(MetadataReader reader, PropertyAccessors accessors)
+    {
+        if (!accessors.Getter.IsNil
+            && !HasCompilerGeneratedAttribute(reader, reader.GetMethodDefinition(accessors.Getter).GetCustomAttributes()))
+            return false;
+        if (!accessors.Setter.IsNil
+            && !HasCompilerGeneratedAttribute(reader, reader.GetMethodDefinition(accessors.Setter).GetCustomAttributes()))
+            return false;
+        return true;
+    }
+
+    static bool HasCompilerGeneratedAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes)
+    {
+        foreach (var attributeHandle in attributes)
+            if (AttributeTypeFullName(reader, reader.GetCustomAttribute(attributeHandle)) == "System.Runtime.CompilerServices.CompilerGeneratedAttribute")
+                return true;
+        return false;
     }
 
     static bool CanEmitAccessor(MetadataReader reader, TypeDefinition typeDef, MethodDefinitionHandle handle, SignatureAccessibility accessibility)

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -100,11 +100,9 @@ internal static class GeneratedFixtureCatalog
         """,
         [
             new("GeneratedFixtures.MinimalAutoPropertyGetter.Class1", ".ctor",
-                FidelityCheck.CompileBackStatus.RecompileFail, IsFrontier: true,
-                Note: "Compile-back skeleton does not reconstruct the get-only auto-property surface yet."),
+                FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalAutoPropertyGetter.Class1", "get_Method1",
-                FidelityCheck.CompileBackStatus.RecompileFail, IsFrontier: true,
-                Note: "Compile-back skeleton does not reconstruct the get-only auto-property surface yet."),
+                FidelityCheck.CompileBackStatus.Exact),
         ],
         ["minimal", "constructor", "auto-property"]);
 

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -13,9 +13,8 @@ generated-fixture catalogue entries into a temporary class library, runs the
 compile-back oracle, and prints results by stable fixture ID plus target method.
 This is the first step toward an addressable progressive fixture ladder:
 `minimal.property.literal`, `minimal.ctor-field.getter`,
-and `minimal.method-call.same-type` are expected `Exact`, while
-`minimal.auto-property.getter` records the current get-only auto-property
-`RecompileFail` frontier and
+`minimal.auto-property.getter`, and `minimal.method-call.same-type` are expected
+`Exact`, while
 `minimal.primary-ctor.field-init` records the current constructor `OpcodeDiff`
 frontier and the exact getter. With no selector, all generated fixtures run; use
 `list` to list fixture IDs, `--json` for machine-readable list/results, and


### PR DESCRIPTION
## Summary

Fixes #1789.

Teaches the compile-back skeleton to reconstruct compiler-generated auto-properties as property syntax when the metadata has strong auto-property evidence:

- accessor methods carry `CompilerGeneratedAttribute`
- a matching `<Property>k__BackingField` exists
- the backing field carries `CompilerGeneratedAttribute`
- backing field type and static-ness match the property

This lets get-only auto-property constructor assignment and getter targets compile back through normal C# syntax and reach opcode comparison. The generated fixture `minimal.auto-property.getter` now moves from `RecompileFail` frontier to `Exact`.

## Evidence

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.auto-property.getter
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures
npx markdownlint-cli tools/DecompilerHarness/README.md
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
```

Generated fixture smoke:

```text
GENERATED FIXTURE COMPILE-BACK over 1 fixture(s), 2 target method(s)
  PASS  minimal.auto-property.getter  GeneratedFixtures.MinimalAutoPropertyGetter.Class1::.ctor#0  decompiler=Full  compile-back=Exact  expected=Exact
  PASS  minimal.auto-property.getter  GeneratedFixtures.MinimalAutoPropertyGetter.Class1::get_Method1#0  decompiler=Full  compile-back=Exact  expected=Exact
```

Note: I also attempted the broader `SkeletonEmitTests` class, but stopped it after several minutes because it was much broader than this focused harness fix. The exact generated fixture path and full generated catalogue were validated directly.

## Adversarial review

Requested Opus 4.8 and MAI-Code-1-Flash reviews before opening. Opus initially flagged that backing-field-name detection alone was too broad. I tightened the gate to require `CompilerGeneratedAttribute` evidence on both the backing field and accessors. Final Opus and MAI reviews reported no significant issues.
