### PR TITLE
Bump version to 0.14.1

### DIFF
--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -24,7 +24,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.14.0</VersionPrefix>
+    <VersionPrefix>0.14.1</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Bumps `VersionPrefix` from `0.14.0` to `0.14.1` — version change only, no code.

Cuts a release so `dnx dotnet-inspect` and the `dotnet-allocation-triage` skill resolve the precision work merged since 0.14.0 (render-method trust-gating, `allocation-hotspot` gating, throw-path box suppression, `string-build-in-loop`, delegate calibration, plus the decompiler fixes) rather than the noisier 0.14.0 build.

Context: #1805 (the skill's `dnx` path currently fetches 0.14.0, which emits ~919 rows on Aspire.Dashboard vs ~497 on current `main`).
