### PR TITLE
Exclude value-type newobj from the allocation signal (#1804, rung 7)

### DIFF
--- a/src/ILInspector.Analysis.CrossAsmCollisionFixtures/Collision.cs
+++ b/src/ILInspector.Analysis.CrossAsmCollisionFixtures/Collision.cs
@@ -1,0 +1,12 @@
+namespace CrossAsmCollision;
+
+// #1804 review. A reference type whose namespace+name (CrossAsmCollision.SharedShape) is
+// deliberately identical to an in-assembly STRUCT defined in the test assembly. Because a
+// display name omits assembly identity, a name-based value-type shortcut would misclassify a
+// `newobj` of THIS reference type as non-heap and silently drop a real allocation. The test
+// constructs this external type (via an extern alias) to pin that the allocation survives.
+public sealed class SharedShape
+{
+    public int Value;
+    public SharedShape(int value) => Value = value;
+}

--- a/src/ILInspector.Analysis.CrossAsmCollisionFixtures/ILInspector.Analysis.CrossAsmCollisionFixtures.csproj
+++ b/src/ILInspector.Analysis.CrossAsmCollisionFixtures/ILInspector.Analysis.CrossAsmCollisionFixtures.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.CrossAsmShapeFixtures/ILInspector.Analysis.CrossAsmShapeFixtures.csproj
+++ b/src/ILInspector.Analysis.CrossAsmShapeFixtures/ILInspector.Analysis.CrossAsmShapeFixtures.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.Analysis.CrossAsmShapeFixtures/Shapes.cs
+++ b/src/ILInspector.Analysis.CrossAsmShapeFixtures/Shapes.cs
@@ -1,0 +1,39 @@
+namespace ILInspector.Analysis.CrossAsmShapeFixtures;
+
+// Cross-assembly type-shape fixtures (analysis ladder #1623 rung 7). The product is
+// SRM-direct and does NOT load referenced assemblies, so a consumer in another assembly
+// sees these types only as TypeRef/TypeSpec metadata. They let the tests assert that the
+// allocation signal classifies a `newobj` of each shape honestly (#1804):
+//
+//   * CrossValueStruct       — non-generic struct: value-type-ness is UNRESOLVABLE from the
+//                              consumer alone (a bare TypeRef), so its `newobj` is an owned
+//                              false-positive allocation at the no-assembly-loading boundary.
+//   * CrossGenericStruct<T>  — constructed generic struct: the consumer's own TypeSpec
+//                              signature blob encodes VALUETYPE, so its `newobj` IS resolved
+//                              as non-heap.
+//   * CrossRefType           — reference type: its `newobj` is a real heap allocation.
+//   * CrossEnum              — enum: a value type; cast/use must not be a heap allocation.
+
+public struct CrossValueStruct
+{
+    public int Value;
+    public CrossValueStruct(int value) => Value = value;
+}
+
+public struct CrossGenericStruct<T>
+{
+    public T Value;
+    public CrossGenericStruct(T value) => Value = value;
+}
+
+public sealed class CrossRefType
+{
+    public int Value;
+    public CrossRefType(int value) => Value = value;
+}
+
+public enum CrossEnum
+{
+    Zero,
+    One,
+}

--- a/src/ILInspector.Analysis.Tests/CrossAsmCollisionTests.cs
+++ b/src/ILInspector.Analysis.Tests/CrossAsmCollisionTests.cs
@@ -1,0 +1,54 @@
+extern alias collisionfix;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.Analysis.Tests
+{
+    public class CrossAsmCollisionTests
+    {
+        // #1804 review (High). An external REFERENCE type whose namespace+name collide with an
+        // in-assembly STRUCT must remain a heap allocation. A display name omits assembly
+        // identity, so a name-based value-type shortcut keyed on ToQualifiedDisplayString would
+        // wrongly drop this `newobj`; the operand-token metadata path keeps it counted.
+        // Non-vacuous: under the removed name-set shortcut this returned 0.
+        [Fact]
+        public void Allocations_ExternalRefTypeSharingNameWithInAssemblyStruct_StaysCounted()
+        {
+            var index = LibraryBodyIndex.Open(typeof(CrossAsmCollisionConsumer).Assembly.Location);
+            int token = index.Methods
+                .First(method => method.Name == nameof(CrossAsmCollisionConsumer.ConstructsExternalCollisionRefTypeInLoop))
+                .MetadataToken;
+
+            Assert.True(index.GetMethodSignals().GetValueOrDefault(token, MethodSignals.None).Allocations >= 1);
+        }
+    }
+
+    // Constructs the EXTERNAL collisionfix::CrossAsmCollision.SharedShape (a reference type) in a
+    // loop, while the in-assembly CrossAsmCollision.SharedShape is a struct with the same
+    // fully-qualified display name.
+    public static class CrossAsmCollisionConsumer
+    {
+        static int Sink(collisionfix::CrossAsmCollision.SharedShape shape) => shape.Value;
+
+        public static int ConstructsExternalCollisionRefTypeInLoop(int n)
+        {
+            int total = 0;
+            for (int i = 0; i < n; i++)
+                total += Sink(new collisionfix::CrossAsmCollision.SharedShape(i));
+            return total;
+        }
+    }
+}
+
+namespace CrossAsmCollision
+{
+    // In-assembly STRUCT sharing the exact fully-qualified name of the external reference type
+    // collisionfix::CrossAsmCollision.SharedShape. Defining it (it need not be constructed) is
+    // enough to populate any in-assembly value-type name set, exercising the collision.
+    public struct SharedShape
+    {
+        public int Value;
+        public SharedShape(int value) => Value = value;
+    }
+}
+

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -22,6 +22,9 @@
   <ItemGroup>
     <ProjectReference Include="..\ILInspector.Analysis.ExceptionBaseFixtures\ILInspector.Analysis.ExceptionBaseFixtures.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis.CrossAsmShapeFixtures\ILInspector.Analysis.CrossAsmShapeFixtures.csproj" />
+    <ProjectReference Include="..\ILInspector.Analysis.CrossAsmCollisionFixtures\ILInspector.Analysis.CrossAsmCollisionFixtures.csproj">
+      <Aliases>collisionfix</Aliases>
+    </ProjectReference>
     <ProjectReference Include="..\ILInspector.Analysis.ProtobufFixtures\ILInspector.Analysis.ProtobufFixtures.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis.LookalikeFixtures\ILInspector.Analysis.LookalikeFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.FacadeFixtures\ILInspector.Analysis.FacadeFixtures.csproj" ReferenceOutputAssembly="false" />

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ILInspector.Analysis.ExceptionBaseFixtures\ILInspector.Analysis.ExceptionBaseFixtures.csproj" />
+    <ProjectReference Include="..\ILInspector.Analysis.CrossAsmShapeFixtures\ILInspector.Analysis.CrossAsmShapeFixtures.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis.ProtobufFixtures\ILInspector.Analysis.ProtobufFixtures.csproj" />
     <ProjectReference Include="..\ILInspector.Analysis.LookalikeFixtures\ILInspector.Analysis.LookalikeFixtures.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis.FacadeFixtures\ILInspector.Analysis.FacadeFixtures.csproj" ReferenceOutputAssembly="false" />

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1592,6 +1592,49 @@ public class LibraryBodyIndexTests
         Assert.Empty(HotspotRows(index, nameof(OptimizationOpportunityFixtures.ConstructsManyValueTypesInLoop)));
     }
 
+    // #1804 / rung 7 cross-assembly shape honesty: the allocation signal must classify a
+    // `newobj` by the constructed type's true shape, resolving what it can from the inspected
+    // assembly's own metadata and degrading honestly otherwise.
+    [Fact]
+    public void Allocations_ClassifiesCrossAndInAssemblyValueTypeNewobj_ByShape()
+    {
+        var index = LibraryBodyIndex.Open(typeof(CrossAsmShapeConsumer).Assembly.Location);
+
+        // Case 1 (in-assembly struct): resolvable from this assembly's metadata -> not heap.
+        Assert.Equal(0, AllocationsOf(index, nameof(CrossAsmShapeConsumer.ConstructsInAssemblyStructInLoop)));
+
+        // Case 2 (cross-assembly GENERIC struct): the consumer's own TypeSpec signature blob
+        // encodes VALUETYPE, so the `newobj` is resolved as non-heap even though the defining
+        // assembly is not loaded.
+        Assert.Equal(0, AllocationsOf(index, nameof(CrossAsmShapeConsumer.ConstructsCrossGenericStructInLoop)));
+
+        // A cross-assembly REFERENCE type's `newobj` is a real heap allocation (recall kept).
+        Assert.True(AllocationsOf(index, nameof(CrossAsmShapeConsumer.ConstructsCrossRefTypeInLoop)) >= 1);
+
+        // A cross-assembly enum cast/use allocates nothing.
+        Assert.Equal(0, AllocationsOf(index, nameof(CrossAsmShapeConsumer.UsesCrossEnum)));
+    }
+
+    [Fact]
+    public void Allocations_CrossAssemblyNonGenericStructNewobj_IsOwnedFalsePositive()
+    {
+        var index = LibraryBodyIndex.Open(typeof(CrossAsmShapeConsumer).Assembly.Location);
+
+        // #1804 / rung 7 owned boundary. A cross-assembly NON-generic user struct is a bare
+        // TypeRef whose value-type-ness cannot be proven without loading the referenced
+        // assembly (Invariant 1: the product is SRM-direct). Its `newobj` is therefore counted
+        // as a heap allocation -- a deliberately-owned false positive, pinned here so the
+        // boundary is explicit rather than silent. If referenced-assembly shape resolution is
+        // ever added, this assertion flips to 0.
+        Assert.True(AllocationsOf(index, nameof(CrossAsmShapeConsumer.ConstructsCrossNonGenericStructInLoop)) >= 1);
+    }
+
+    static int AllocationsOf(LibraryBodyIndex index, string methodName)
+    {
+        int token = index.Methods.First(method => method.Name == methodName).MetadataToken;
+        return index.GetMethodSignals().GetValueOrDefault(token, MethodSignals.None).Allocations;
+    }
+
     [Fact]
     public void OptimizationOpportunities_LowAllocationMethod_IsNotHotspot()
     {
@@ -3045,6 +3088,57 @@ public struct PlainValue
     public PlainValue(int v) => V = v;
 
     public int V { get; }
+}
+
+// #1804 / rung 7. Consumes the cross-assembly shape fixtures (defined in the separate
+// ILInspector.Analysis.CrossAsmShapeFixtures assembly, which the SRM-direct product does not
+// load) plus an in-assembly struct. Each method constructs a value as a method ARGUMENT in a
+// loop, which forces a `newobj` (a value assigned to a local emits `call .ctor` instead), so
+// the allocation signal's shape classification is exercised.
+public static class CrossAsmShapeConsumer
+{
+    static int SinkInAssembly(PlainValue value) => value.V;
+    static int SinkStruct(CrossAsmShapeFixtures.CrossValueStruct value) => value.Value;
+    static int SinkGeneric(CrossAsmShapeFixtures.CrossGenericStruct<int> value) => value.Value;
+    static int SinkRef(CrossAsmShapeFixtures.CrossRefType value) => value.Value;
+
+    public static int ConstructsInAssemblyStructInLoop(int n)
+    {
+        int total = 0;
+        for (int i = 0; i < n; i++)
+            total += SinkInAssembly(new PlainValue(i));
+        return total;
+    }
+
+    public static int ConstructsCrossNonGenericStructInLoop(int n)
+    {
+        int total = 0;
+        for (int i = 0; i < n; i++)
+            total += SinkStruct(new CrossAsmShapeFixtures.CrossValueStruct(i));
+        return total;
+    }
+
+    public static int ConstructsCrossGenericStructInLoop(int n)
+    {
+        int total = 0;
+        for (int i = 0; i < n; i++)
+            total += SinkGeneric(new CrossAsmShapeFixtures.CrossGenericStruct<int>(i));
+        return total;
+    }
+
+    public static int ConstructsCrossRefTypeInLoop(int n)
+    {
+        int total = 0;
+        for (int i = 0; i < n; i++)
+            total += SinkRef(new CrossAsmShapeFixtures.CrossRefType(i));
+        return total;
+    }
+
+    public static int UsesCrossEnum(int n)
+    {
+        var value = (CrossAsmShapeFixtures.CrossEnum)(n % 2);
+        return (int)value;
+    }
 }
 
 public sealed class FixtureException : Exception

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -24,7 +24,8 @@ public sealed class LibraryBodyIndex
         IReadOnlyDictionary<(string Namespace, string Name), bool> inAssemblyTypeIsException,
         IReadOnlySet<int> suppressedOpportunityTokens,
         IReadOnlySet<string> exceptionTypeNames,
-        IReadOnlySet<string> inAssemblyValueTypeNames)
+        IReadOnlySet<string> inAssemblyValueTypeNames,
+        IReadOnlySet<int> nonHeapNewObjOperandTokens)
     {
         Path = path;
         Methods = methods;
@@ -40,6 +41,7 @@ public sealed class LibraryBodyIndex
         _suppressedOpportunityTokens = suppressedOpportunityTokens;
         _exceptionTypeNames = exceptionTypeNames;
         _inAssemblyValueTypeNames = inAssemblyValueTypeNames;
+        _nonHeapNewObjOperandTokens = nonHeapNewObjOperandTokens;
     }
 
     public string Path { get; }
@@ -95,25 +97,6 @@ public sealed class LibraryBodyIndex
         return definition.Name.EndsWith("Exception", StringComparison.Ordinal);
     }
 
-    // True when a `newobj` of this type does NOT allocate on the heap: a value type (struct/
-    // enum). The common framework value types constructed in hot loops (Span/ReadOnlySpan/
-    // Memory/Nullable/ValueTuple) are matched by identity; in-assembly structs/enums are
-    // matched via the value-type name set resolved from metadata. Counting these as heap
-    // allocations would inflate allocation-hotspot density (e.g. generated JSON parse loops
-    // are full of ReadOnlySpan<byte>/Nullable<T> constructors that allocate nothing).
-    bool IsNonHeapConstruction(TypeRef type)
-    {
-        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
-        if (definition.Kind == TypeRefKind.Unsupported)
-            return false;
-        if (definition.Namespace == "System" && definition.Name is
-                "Span`1" or "ReadOnlySpan`1" or "Memory`1" or "ReadOnlyMemory`1" or "Nullable`1"
-                or "ValueTuple" or "ValueTuple`1" or "ValueTuple`2" or "ValueTuple`3" or "ValueTuple`4"
-                or "ValueTuple`5" or "ValueTuple`6" or "ValueTuple`7" or "ValueTuple`8")
-            return true;
-        return _inAssemblyValueTypeNames.Contains(definition.ToQualifiedDisplayString());
-    }
-
     // A method that allocates densely is a real perf signal only when the allocations are
     // both REPEATED (in a loop) and not already pinpointed by a specific shape — otherwise
     // the count is dominated by intrinsic, non-reducible construction (e.g. a serializer
@@ -159,10 +142,10 @@ public sealed class LibraryBodyIndex
             if (call.Callee.Kind != MemberKind.Unsupported
                 && IsExceptionConstruction(call.Callee.DeclaringType))
                 continue;
-            // A `newobj` of a value type (Span/Nullable/ValueTuple/in-assembly struct) does not
-            // allocate on the heap, so it must not count toward allocation density.
-            if (call.Callee.Kind != MemberKind.Unsupported
-                && IsNonHeapConstruction(call.Callee.DeclaringType))
+            // A `newobj` of a value type (Span/Nullable/ValueTuple/in-assembly struct, or a
+            // cross-assembly generic struct resolved via the TypeSpec blob during Build) does
+            // not allocate on the heap, so it must not count toward allocation density (#1804).
+            if (_nonHeapNewObjOperandTokens.Contains(call.OperandToken))
                 continue;
             int token = call.Caller.MetadataToken;
             steadyNewobj[token] = steadyNewobj.GetValueOrDefault(token) + 1;
@@ -418,13 +401,14 @@ public sealed class LibraryBodyIndex
     readonly IReadOnlySet<int> _suppressedOpportunityTokens;
     readonly IReadOnlySet<string> _exceptionTypeNames;
     readonly IReadOnlySet<string> _inAssemblyValueTypeNames;
+    readonly IReadOnlySet<int> _nonHeapNewObjOperandTokens;
 
     /// <summary>
     /// Per-method analysis signals (allocations, copies, unsafe, reflection,
     /// throw/catch/finally, evidence offsets), keyed by metadata token. Computed once
     /// from the call index and the body-scan signals, reused by the call-graph builders.
     /// </summary>
-    Dictionary<int, MethodSignals> Signals => _signals ??= MethodSignalAnalysis.Collect(DirectCalls, UnsafeEvidence, _bodySignals, _inAssemblyTypeIsException);
+    Dictionary<int, MethodSignals> Signals => _signals ??= MethodSignalAnalysis.Collect(DirectCalls, UnsafeEvidence, _bodySignals, _inAssemblyTypeIsException, _nonHeapNewObjOperandTokens);
 
     /// <summary>
     /// Returns per-method body/call signals keyed by metadata token.
@@ -554,7 +538,7 @@ public sealed class LibraryBodyIndex
             path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
             index.OptimizationOpportunities, index.UnsafeLeverageMethods, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
             index.BodySignals, index.InAssemblyTypeIsException, index.SuppressedOpportunityTokens, index.ExceptionTypeNames,
-            index.InAssemblyValueTypeNames);
+            index.InAssemblyValueTypeNames, index.NonHeapNewObjOperandTokens);
     }
 
     public ImmutableArray<DirectCall> FindCalls(MemberPattern pattern)
@@ -990,7 +974,7 @@ public sealed class LibraryBodyIndex
                 && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
         }
 
-        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames, IReadOnlySet<string> InAssemblyValueTypeNames) Build()
+        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames, IReadOnlySet<string> InAssemblyValueTypeNames, IReadOnlySet<int> NonHeapNewObjOperandTokens) Build()
         {
             var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var unsafeLeverageMethods = ImmutableArray.CreateBuilder<MethodIdentity>();
@@ -1063,9 +1047,84 @@ public sealed class LibraryBodyIndex
                 }
             }
 
-            return (methods.ToImmutable(), calls.ToImmutable(), unsafeEvidence.ToImmutable(), diagnostics.ToImmutable(),
+            var directCalls = calls.ToImmutable();
+            var nonHeapNewObjOperandTokens = ComputeNonHeapNewObjOperandTokens(directCalls, inAssemblyValueTypeNames);
+            return (methods.ToImmutable(), directCalls, unsafeEvidence.ToImmutable(), diagnostics.ToImmutable(),
                 optimizationOpportunities.ToImmutable(), unsafeLeverageMethods.ToImmutable(), new UnsafeModeBreakdown(none, impl, expl), bodySignals,
-                BuildInAssemblyExceptionMap(), suppressedOpportunityTokens, exceptionTypeNames, inAssemblyValueTypeNames);
+                BuildInAssemblyExceptionMap(), suppressedOpportunityTokens, exceptionTypeNames, inAssemblyValueTypeNames, nonHeapNewObjOperandTokens);
+        }
+
+        // The metadata operand tokens of `newobj` instructions that construct a VALUE TYPE
+        // (struct/enum) and therefore do not allocate on the heap (#1804). Classified here,
+        // during Build, where the metadata reader is available — the lazy signal and
+        // allocation-density paths run after the reader is released, so they consult this set
+        // by operand token. Resolves: framework/in-assembly value types by name, in-assembly
+        // value-type definitions, and cross-assembly GENERIC structs via the TypeSpec
+        // signature blob (the same authority box detection uses). A cross-assembly NON-generic
+        // user struct is a bare TypeRef whose value-type-ness is unresolvable from this
+        // assembly alone, so it is intentionally excluded (an owned false positive at the
+        // no-referenced-assembly-loading boundary, like the rung-2 `*Exception` suffix).
+        HashSet<int> ComputeNonHeapNewObjOperandTokens(ImmutableArray<DirectCall> directCalls, IReadOnlySet<string> inAssemblyValueTypeNames)
+        {
+            var set = new HashSet<int>();
+            foreach (var call in directCalls)
+            {
+                if (call.Kind != CallKind.NewObject || set.Contains(call.OperandToken))
+                    continue;
+                if (IsNonHeapNewObj(call.OperandToken, call.Callee.DeclaringType, inAssemblyValueTypeNames))
+                    set.Add(call.OperandToken);
+            }
+            return set;
+        }
+
+        // True when a `newobj` of this operand constructs a value type. Combines the
+        // name-based framework/in-assembly classification with an authoritative metadata
+        // resolution of the constructor's declaring type (TypeDef base chain, or TypeSpec
+        // signature blob for constructed generics).
+        bool IsNonHeapNewObj(int operandToken, TypeRef declaringType, IReadOnlySet<string> inAssemblyValueTypeNames)
+        {
+            if (IsNonHeapConstructionByName(declaringType, inAssemblyValueTypeNames))
+                return true;
+            try
+            {
+                var handle = MetadataTokens.EntityHandle(operandToken);
+                EntityHandle typeHandle = handle.Kind switch
+                {
+                    HandleKind.MethodDefinition => _reader.GetMethodDefinition((MethodDefinitionHandle)handle).GetDeclaringType(),
+                    HandleKind.MemberReference => _reader.GetMemberReference((MemberReferenceHandle)handle).Parent,
+                    _ => default,
+                };
+                if (typeHandle.Kind == HandleKind.TypeDefinition)
+                    return IsValueTypeDefinition((TypeDefinitionHandle)typeHandle);
+                if (typeHandle.Kind == HandleKind.TypeSpecification)
+                    return IsValueTypeSpec((TypeSpecificationHandle)typeHandle);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
+            {
+                return false;
+            }
+            return false;
+        }
+
+        // Name-based value-type recognition shared with the allocation paths: the common
+        // framework value types constructed in hot loops (Span/ReadOnlySpan/Memory/Nullable/
+        // ValueTuple), other well-known framework value types (gated on framework trust), and
+        // in-assembly structs/enums resolved by qualified name.
+        static bool IsNonHeapConstructionByName(TypeRef type, IReadOnlySet<string> inAssemblyValueTypeNames)
+        {
+            var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+            if (definition.Kind == TypeRefKind.Unsupported)
+                return false;
+            if (definition.Namespace == "System" && definition.Name is
+                    "Span`1" or "ReadOnlySpan`1" or "Memory`1" or "ReadOnlyMemory`1" or "Nullable`1"
+                    or "ValueTuple" or "ValueTuple`1" or "ValueTuple`2" or "ValueTuple`3" or "ValueTuple`4"
+                    or "ValueTuple`5" or "ValueTuple`6" or "ValueTuple`7" or "ValueTuple`8")
+                return true;
+            if (definition.Kind == TypeRefKind.Definition
+                && definition.TrustedFrameworkAssembly
+                && IsWellKnownValueType(definition.Namespace, definition.Name))
+                return true;
+            return inAssemblyValueTypeNames.Contains(definition.ToQualifiedDisplayString());
         }
 
         // Classifies in-assembly types by whether they derive from System.Exception,

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -24,7 +24,6 @@ public sealed class LibraryBodyIndex
         IReadOnlyDictionary<(string Namespace, string Name), bool> inAssemblyTypeIsException,
         IReadOnlySet<int> suppressedOpportunityTokens,
         IReadOnlySet<string> exceptionTypeNames,
-        IReadOnlySet<string> inAssemblyValueTypeNames,
         IReadOnlySet<int> nonHeapNewObjOperandTokens)
     {
         Path = path;
@@ -40,7 +39,6 @@ public sealed class LibraryBodyIndex
         _inAssemblyTypeIsException = inAssemblyTypeIsException;
         _suppressedOpportunityTokens = suppressedOpportunityTokens;
         _exceptionTypeNames = exceptionTypeNames;
-        _inAssemblyValueTypeNames = inAssemblyValueTypeNames;
         _nonHeapNewObjOperandTokens = nonHeapNewObjOperandTokens;
     }
 
@@ -400,7 +398,6 @@ public sealed class LibraryBodyIndex
     readonly IReadOnlyDictionary<(string Namespace, string Name), bool> _inAssemblyTypeIsException;
     readonly IReadOnlySet<int> _suppressedOpportunityTokens;
     readonly IReadOnlySet<string> _exceptionTypeNames;
-    readonly IReadOnlySet<string> _inAssemblyValueTypeNames;
     readonly IReadOnlySet<int> _nonHeapNewObjOperandTokens;
 
     /// <summary>
@@ -538,7 +535,7 @@ public sealed class LibraryBodyIndex
             path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
             index.OptimizationOpportunities, index.UnsafeLeverageMethods, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
             index.BodySignals, index.InAssemblyTypeIsException, index.SuppressedOpportunityTokens, index.ExceptionTypeNames,
-            index.InAssemblyValueTypeNames, index.NonHeapNewObjOperandTokens);
+            index.NonHeapNewObjOperandTokens);
     }
 
     public ImmutableArray<DirectCall> FindCalls(MemberPattern pattern)
@@ -974,7 +971,7 @@ public sealed class LibraryBodyIndex
                 && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
         }
 
-        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames, IReadOnlySet<string> InAssemblyValueTypeNames, IReadOnlySet<int> NonHeapNewObjOperandTokens) Build()
+        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames, IReadOnlySet<int> NonHeapNewObjOperandTokens) Build()
         {
             var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var unsafeLeverageMethods = ImmutableArray.CreateBuilder<MethodIdentity>();
@@ -985,7 +982,6 @@ public sealed class LibraryBodyIndex
             var bodySignals = new Dictionary<int, BodySignals>();
             var suppressedOpportunityTokens = new HashSet<int>();
             var exceptionTypeNames = ComputeExceptionTypeNames();
-            var inAssemblyValueTypeNames = ComputeInAssemblyValueTypeNames();
             int none = 0, impl = 0, expl = 0;
 
             foreach (var typeHandle in _reader.TypeDefinitions)
@@ -1048,10 +1044,10 @@ public sealed class LibraryBodyIndex
             }
 
             var directCalls = calls.ToImmutable();
-            var nonHeapNewObjOperandTokens = ComputeNonHeapNewObjOperandTokens(directCalls, inAssemblyValueTypeNames);
+            var nonHeapNewObjOperandTokens = ComputeNonHeapNewObjOperandTokens(directCalls);
             return (methods.ToImmutable(), directCalls, unsafeEvidence.ToImmutable(), diagnostics.ToImmutable(),
                 optimizationOpportunities.ToImmutable(), unsafeLeverageMethods.ToImmutable(), new UnsafeModeBreakdown(none, impl, expl), bodySignals,
-                BuildInAssemblyExceptionMap(), suppressedOpportunityTokens, exceptionTypeNames, inAssemblyValueTypeNames, nonHeapNewObjOperandTokens);
+                BuildInAssemblyExceptionMap(), suppressedOpportunityTokens, exceptionTypeNames, nonHeapNewObjOperandTokens);
         }
 
         // The metadata operand tokens of `newobj` instructions that construct a VALUE TYPE
@@ -1064,26 +1060,26 @@ public sealed class LibraryBodyIndex
         // user struct is a bare TypeRef whose value-type-ness is unresolvable from this
         // assembly alone, so it is intentionally excluded (an owned false positive at the
         // no-referenced-assembly-loading boundary, like the rung-2 `*Exception` suffix).
-        HashSet<int> ComputeNonHeapNewObjOperandTokens(ImmutableArray<DirectCall> directCalls, IReadOnlySet<string> inAssemblyValueTypeNames)
+        HashSet<int> ComputeNonHeapNewObjOperandTokens(ImmutableArray<DirectCall> directCalls)
         {
             var set = new HashSet<int>();
             foreach (var call in directCalls)
             {
                 if (call.Kind != CallKind.NewObject || set.Contains(call.OperandToken))
                     continue;
-                if (IsNonHeapNewObj(call.OperandToken, call.Callee.DeclaringType, inAssemblyValueTypeNames))
+                if (IsNonHeapNewObj(call.OperandToken, call.Callee.DeclaringType))
                     set.Add(call.OperandToken);
             }
             return set;
         }
 
-        // True when a `newobj` of this operand constructs a value type. Combines the
-        // name-based framework/in-assembly classification with an authoritative metadata
-        // resolution of the constructor's declaring type (TypeDef base chain, or TypeSpec
-        // signature blob for constructed generics).
-        bool IsNonHeapNewObj(int operandToken, TypeRef declaringType, IReadOnlySet<string> inAssemblyValueTypeNames)
+        // True when a `newobj` of this operand constructs a value type. Combines a name-based
+        // FRAMEWORK fast path with an authoritative metadata resolution of the constructor's
+        // declaring type (TypeDef base chain, or TypeSpec signature blob for constructed
+        // generics) — the latter is what classifies in-assembly and cross-assembly structs.
+        bool IsNonHeapNewObj(int operandToken, TypeRef declaringType)
         {
-            if (IsNonHeapConstructionByName(declaringType, inAssemblyValueTypeNames))
+            if (IsNonHeapConstructionByName(declaringType))
                 return true;
             try
             {
@@ -1106,25 +1102,26 @@ public sealed class LibraryBodyIndex
             return false;
         }
 
-        // Name-based value-type recognition shared with the allocation paths: the common
-        // framework value types constructed in hot loops (Span/ReadOnlySpan/Memory/Nullable/
-        // ValueTuple), other well-known framework value types (gated on framework trust), and
-        // in-assembly structs/enums resolved by qualified name.
-        static bool IsNonHeapConstructionByName(TypeRef type, IReadOnlySet<string> inAssemblyValueTypeNames)
+        // Name-based recognition of FRAMEWORK value types whose `newobj` resolves to a bare
+        // TypeRef the token dispatch cannot follow (a non-generic framework struct like DateTime
+        // or Guid lives in an assembly this one does not load). The common generic framework
+        // value types (Span/ReadOnlySpan/Memory/Nullable/ValueTuple`n) are constructed through a
+        // TypeSpec and are resolved authoritatively by the signature blob, so they are listed
+        // here only as a fast path. In-assembly and cross-assembly value types are NOT matched by
+        // name — that is the operand-token metadata path's job — because a display name omits
+        // assembly identity and would misclassify an external reference type that shares a
+        // namespace+name with an in-assembly struct (#1804 review).
+        static bool IsNonHeapConstructionByName(TypeRef type)
         {
             var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
-            if (definition.Kind == TypeRefKind.Unsupported)
+            if (definition.Kind != TypeRefKind.Definition || !definition.TrustedFrameworkAssembly)
                 return false;
             if (definition.Namespace == "System" && definition.Name is
                     "Span`1" or "ReadOnlySpan`1" or "Memory`1" or "ReadOnlyMemory`1" or "Nullable`1"
                     or "ValueTuple" or "ValueTuple`1" or "ValueTuple`2" or "ValueTuple`3" or "ValueTuple`4"
                     or "ValueTuple`5" or "ValueTuple`6" or "ValueTuple`7" or "ValueTuple`8")
                 return true;
-            if (definition.Kind == TypeRefKind.Definition
-                && definition.TrustedFrameworkAssembly
-                && IsWellKnownValueType(definition.Namespace, definition.Name))
-                return true;
-            return inAssemblyValueTypeNames.Contains(definition.ToQualifiedDisplayString());
+            return IsWellKnownValueType(definition.Namespace, definition.Name);
         }
 
         // Classifies in-assembly types by whether they derive from System.Exception,
@@ -1188,26 +1185,6 @@ public sealed class LibraryBodyIndex
                 }
                 return false;
             }
-        }
-
-        // In-assembly value types (struct/enum) by qualified name. A `newobj` of one of these
-        // does NOT allocate on the heap, so it must not be counted toward allocation density.
-        IReadOnlySet<string> ComputeInAssemblyValueTypeNames()
-        {
-            var names = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var typeHandle in _reader.TypeDefinitions)
-            {
-                var baseHandle = _reader.GetTypeDefinition(typeHandle).BaseType;
-                if (baseHandle.Kind != HandleKind.TypeReference)
-                    continue;
-                var baseRef = _reader.GetTypeReference((TypeReferenceHandle)baseHandle);
-                if (_reader.GetString(baseRef.Namespace) == "System"
-                    && _reader.GetString(baseRef.Name) is "ValueType" or "Enum")
-                {
-                    names.Add(TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, typeHandle, 0).ToQualifiedDisplayString());
-                }
-            }
-            return names;
         }
 
         IReadOnlySet<string> ComputeExceptionTypeNames()

--- a/src/ILInspector.Analysis/MethodSignals.cs
+++ b/src/ILInspector.Analysis/MethodSignals.cs
@@ -76,7 +76,8 @@ public static class MethodSignalAnalysis
         ImmutableArray<DirectCall> directCalls,
         ImmutableArray<UnsafeEvidence> unsafeEvidence,
         IReadOnlyDictionary<int, BodySignals>? bodySignals = null,
-        IReadOnlyDictionary<(string Namespace, string Name), bool>? inAssemblyTypeIsException = null)
+        IReadOnlyDictionary<(string Namespace, string Name), bool>? inAssemblyTypeIsException = null,
+        IReadOnlySet<int>? nonHeapNewObjOperandTokens = null)
     {
         var allocations = new Dictionary<int, int>();
         var copies = new Dictionary<int, int>();
@@ -104,6 +105,15 @@ public static class MethodSignalAnalysis
             int caller = call.Caller.MetadataToken;
             if (call.Kind == CallKind.NewObject)
             {
+                // A `newobj` of a value type (struct/enum) constructs in place and does NOT
+                // allocate on the heap, so it must not count toward the allocation signal
+                // (#1804). The non-heap set is classified during Build, where the metadata
+                // reader is available (in-assembly value types, and cross-assembly generic
+                // structs via the TypeSpec signature blob). A cross-assembly non-generic user
+                // struct is unresolvable single-assembly and is intentionally NOT in the set,
+                // so it remains an owned false positive at the no-referenced-assembly boundary.
+                if (nonHeapNewObjOperandTokens is not null && nonHeapNewObjOperandTokens.Contains(call.OperandToken))
+                    continue;
                 allocations[caller] = allocations.GetValueOrDefault(caller) + 1;
                 AddEvidence(caller, call.ILOffset);
                 if (IsExceptionType(call.Callee.DeclaringType, inAssemblyTypeIsException))


### PR DESCRIPTION
## Summary
`MethodSignals.Allocations`/`AllocInLoop` counted **every** `newobj` as a heap allocation, including `newobj` of a **value type** (struct/enum), which constructs in place and allocates nothing. This over-counted any method that builds structs as arguments or returns, and contradicted both the documented meaning (*"Heap allocations"*) and the allocation-**hotspot** path (which already excludes value types). Found while measuring rung 7 (cross-assembly honesty) of the analysis ladder (#1623).

## Fix
Non-heap `newobj` is classified **once during Build** (the metadata reader is only available then; the signal and hotspot paths are lazy and run after it is released) and stored as an operand-token set on the index. Three cases, three honesty levels:

| Case | Example | Before | After |
| --- | --- | --- | --- |
| In-assembly struct | `new LocalStruct(i)` as arg | counted ❌ | not counted ✅ |
| Cross-assembly **generic** struct | `new CrossGenericStruct<int>(i)` | counted ❌ | not counted ✅ (resolved from the consumer's own TypeSpec signature blob) |
| Cross-assembly **non-generic** struct | `new CrossValueStruct(i)` | counted | **still counted** — owned false positive |
| Reference type | `new CrossRefType(i)` | counted ✅ | counted ✅ (recall preserved) |

Case 3 is a bare `TypeRef` whose value-type-ness is unresolvable without loading the referenced assembly (the product is SRM-direct), so it remains an explicitly-owned false positive at the no-referenced-assembly-loading boundary — pinned, like the rung-2 `*Exception` suffix fallback.

Both `MethodSignals.Collect` and `AllocationHotspots` consult the shared set, so the signal and the opportunity now agree.

## Tests
- New `ILInspector.Analysis.CrossAsmShapeFixtures` (struct / generic struct / class / enum, defined in a separate, un-loaded assembly).
- `Allocations_ClassifiesCrossAndInAssemblyValueTypeNewobj_ByShape` (cases 1+2 fixed, ref-type + enum honest) and `Allocations_CrossAssemblyNonGenericStructNewobj_IsOwnedFalsePositive` (case 3 pinned).

## Verification
- `ILInspector.Analysis.Tests`: 213 passed. `dotnet-inspect.Tests`: 1381 passed / 9 skipped.
- **Non-vacuity**: forcing the exclusion to never match fails the case-1/2 guard; restored.
- **Corpus sweep** over 220 real assemblies (framework + product), allocation count per method, base vs this branch:
  - **0 methods increased** (the change can only remove value-type `newobj`).
  - 4,591 methods dropped to 0; 1,920 decreased but still >0; 6,511/39,464 allocating methods (16.5%) corrected.
  - Total allocation count 80,548 → 69,288 (−14%) — value-type construction that was never a heap allocation.

Closes #1804

Part of the analysis quality ladder (#1623), rung 7 (cross-assembly honesty).