### PR TITLE
Tighten decompiler quality card output

### DIFF
--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -497,6 +497,13 @@ card is reviewer-sized evidence, not a dump-stage artifact; keep `--dump
 --steps` output in linked diagnosis notes only when reviewers need the
 drill-down. To reproduce the full row set behind a capped card, follow
 [Reproducing decompiler corpus deltas](decompiler-corpus-delta-repro.md).
+Use the terse PR body shape in
+[docs/templates/decompiler-pr.md](templates/decompiler-pr.md) when writing the
+human summary around the generated card.
+
+Rate deltas in card prose use **percentage points** (`pp`): `+0.49 pp` means
+the rate increased from, for example, `82.17%` to `82.66%`. Counts still use raw
+signed count deltas in `Count delta`.
 
 For behaviour-preserving refactors, the existing #1174/#1166 real-world corpus
 sensor values are enough when you need the broader daily/manual signal:

--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -1,0 +1,102 @@
+# Decompiler PR template
+
+<!--
+Use this for decompiler PRs that affect raising, structuring, validity,
+fidelity, or corpus behavior. Delete sections that do not apply. Keep generated
+tables generated; do not re-key metric rows by hand.
+-->
+
+- Fixes/advances #{issue}
+- Changes {one-line product behavior}
+- Card revision: `{git-sha}`
+
+## Change
+
+> Should we accept this change?
+
+**Conclusion:** **PASS/REVIEW/BLOCKED** — {one sentence with the decisive reason}.
+
+Before:
+
+```csharp
+// short failing or lower-quality output
+```
+
+After:
+
+```csharp
+// short fixed or improved output
+```
+
+## Evidence
+
+| Check | Result |
+| --- | --- |
+| Product build | Pass |
+| Focused tests | `{test class}` passed |
+| Decompiler fast suite | Pass |
+| Reduced fixture validity | Pass / not applicable |
+| Reduced fixture fidelity | Pass / not currently checkable |
+| Real witness | `{Type::Method}` fixed / not applicable |
+
+## Decompiler quality
+
+> Should the corpus signal block this PR?
+
+**Conclusion:** **PASS/ADVISORY/BLOCKED** — {pinned gate verdict, then any
+aggregate advisory in one sentence}.
+
+### PR quick gate
+
+Run: PR quick corpus, hash-stable 100 methods per assembly; {coverage summary}.
+
+| Metric (goal) | Baseline | PR | Rate delta |
+| --- | ---: | ---: | ---: |
+| Fully raised (+) | {%} | {%} | {pp} |
+| Conditional residual (-) | {%} | {%} | {pp} |
+| Pass bugs (-) | 0 | 0 | 0 |
+
+> **Conclusion:** **PASS/FAIL** — {one-line gate verdict}.
+
+### Aggregate context
+
+Corpus: {assemblies}, {methods}. Baseline drift: {none or concise drift}.
+
+| Metric (goal) | Baseline | PR | Count delta |
+| --- | ---: | ---: | ---: |
+| Fully raised (+) | {count/rate} | {count/rate} | {count} |
+| Conditional-branch residual (-) | {count/rate} | {count/rate} | {count} |
+| Forward-merge stops (-) | {count/rate} | {count/rate} | {count} |
+
+> **Conclusion:** **PASS/ADVISORY/BLOCKED** — {one-line aggregate verdict}.
+
+<!-- markdownlint-disable MD033 -->
+<details>
+<summary>{Metric} changes ({net}; showing up to 24 rows)</summary>
+
+| Direction | Method | Reason | Baseline | PR |
+| --- | --- | --- | --- | --- |
+| New/Regressed/Improved/Resolved | `{Type::Method}` | `{bucket}` | `{old}` | `{new}` |
+
+For the full local delta, see
+[Reproducing decompiler corpus deltas](../decompiler-corpus-delta-repro.md).
+
+</details>
+<!-- markdownlint-enable MD033 -->
+
+## Review
+
+| Reviewer | Result | Notes |
+| --- | --- | --- |
+| {model/reviewer} | No blocking findings / findings resolved | {short evidence} |
+| {model/reviewer} | No blocking findings / findings resolved | {short evidence} |
+
+**Review conclusion:** **PASS/REVIEW/BLOCKED** — {one-line reconciliation}.
+
+## Validation
+
+```bash
+dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/{FocusedTests}/*"
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
+```

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -616,7 +616,7 @@ internal static class CorpusSensor
         if (change > tolerance)
         {
             string direction = lowerIsRegression ? "dropped" : "increased";
-            failures.Add($"{name} {direction} {change} bps (baseline {FormatBps(baseline)}, current {FormatBps(current)}, tolerance {tolerance} bps)");
+            failures.Add($"{name} {direction} {FormatPercentagePoints(change)} (baseline {FormatBps(baseline)}, current {FormatBps(current)}, tolerance {FormatPercentagePoints(tolerance)})");
         }
     }
 
@@ -715,12 +715,7 @@ internal static class CorpusSensor
             CountPercent(baseline.Metrics.ForwardMergeStoppedContainers, baseline.Metrics.ForwardMergeBasisPoints),
             CountPercent(current.Metrics.ForwardMergeStoppedContainers, current.Metrics.ForwardMergeBasisPoints),
             Delta(current.Metrics.ForwardMergeStoppedContainers - baseline.Metrics.ForwardMergeStoppedContainers));
-        if (current.ValidityCompileCap <= 0)
-        {
-            PrintMetric("Full malformed (-)", "not run", "not run", "-");
-            PrintMetric("Semantic defects (-)", "not run", "not run", "-");
-        }
-        else
+        if (current.ValidityCompileCap > 0)
         {
             PrintMetric(
                 "Full malformed (-)",
@@ -733,11 +728,7 @@ internal static class CorpusSensor
                 FractionWithCoverage(current.Metrics.SemanticDefectMethods, current.Metrics.SemanticCheckedMethods, current.Metrics.TotalMethods),
                 Delta(current.Metrics.SemanticDefectMethods - baseline.Metrics.SemanticDefectMethods));
         }
-        if (current.FidelityCompileCap <= 0)
-        {
-            PrintMetric("Fidelity diffs (-)", "not run", "not run", "-");
-        }
-        else
+        if (current.FidelityCompileCap > 0)
         {
             PrintMetric(
                 "Fidelity diffs (-)",
@@ -790,15 +781,18 @@ internal static class CorpusSensor
             ? $"opcode diffs {Number(basePinned.OpcodeDiff)} -> {Number(curPinned.OpcodeDiff)} "
                 + $"({Delta(curPinned.OpcodeDiff - basePinned.OpcodeDiff)})"
             : "fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity)";
+        var fullMalformed = current.ValidityCompileCap > 0
+            ? $"Full malformed {Number(basePinned.FullMalformed)} -> {Number(curPinned.FullMalformed)} "
+                + $"({Delta(curPinned.FullMalformed - basePinned.FullMalformed)}); "
+            : "";
         Console.WriteLine();
         Console.WriteLine(
             "Pinned-subset gate (PR quick rate/count regressions evaluated here): "
             + $"Fully raised {FormatBps(basePinned.FullyRaisedBasisPoints)} -> {FormatBps(curPinned.FullyRaisedBasisPoints)} "
-            + $"({Delta(curPinned.FullyRaisedBasisPoints - basePinned.FullyRaisedBasisPoints)} bps); "
+            + $"({DeltaPercentagePoints(curPinned.FullyRaisedBasisPoints - basePinned.FullyRaisedBasisPoints)}); "
             + $"conditional residual {FormatBps(basePinned.ConditionalBranchBasisPoints)} -> {FormatBps(curPinned.ConditionalBranchBasisPoints)} "
-            + $"({Delta(curPinned.ConditionalBranchBasisPoints - basePinned.ConditionalBranchBasisPoints)} bps); "
-            + $"Full malformed {Number(basePinned.FullMalformed)} -> {Number(curPinned.FullMalformed)} "
-            + $"({Delta(curPinned.FullMalformed - basePinned.FullMalformed)}); "
+            + $"({DeltaPercentagePoints(curPinned.ConditionalBranchBasisPoints - basePinned.ConditionalBranchBasisPoints)}); "
+            + fullMalformed
             + fidelity + ".");
     }
 
@@ -823,7 +817,7 @@ internal static class CorpusSensor
             if (change > toleranceBps)
             {
                 string direction = lowerIsRegression ? "dropped" : "increased";
-                advisories.Add($"{name} {direction} {change} bps (baseline {FormatBps(baselineRate)}, PR {FormatBps(currentRate)}, tolerance {toleranceBps} bps)");
+                advisories.Add($"{name} {direction} {FormatPercentagePoints(change)} (baseline {FormatBps(baselineRate)}, PR {FormatBps(currentRate)}, tolerance {FormatPercentagePoints(toleranceBps)})");
             }
         }
     }
@@ -948,6 +942,12 @@ internal static class CorpusSensor
 
     static string Delta(int value)
         => value > 0 ? $"+{Number(value)}" : Number(value);
+
+    static string DeltaPercentagePoints(int basisPoints)
+        => basisPoints == 0 ? "0 pp" : $"{(basisPoints > 0 ? "+" : "")}{FormatPercentagePoints(basisPoints)}";
+
+    static string FormatPercentagePoints(int basisPoints)
+        => $"{basisPoints / 100.0:F2} pp";
 
     static string Number(int value)
         => value.ToString("N0", CultureInfo.InvariantCulture);


### PR DESCRIPTION
## Summary

Updates decompiler PR quality-card guidance and generated output:

- uses percentage points (`pp`) instead of `bps` in rate-delta prose;
- omits metric rows whose checks were not run, keeping coverage in the coverage line;
- keeps count movement in the `Count delta` column;
- adds `docs/templates/decompiler-pr.md`, a terse PR body template modeled on the compact card style.

I used `pp` rather than finance-style `bp` because the cards are PR-review evidence, not finance/math output; `+0.49 pp` is more readable next to percentage rates like `82.17% -> 82.66%`.

## Validation

- `dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet`
- `npx markdownlint-cli --fix docs/decompiler-quality.md docs/templates/decompiler-pr.md`
- `npx markdownlint-cli docs/decompiler-quality.md docs/templates/decompiler-pr.md`
- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`
- Generated a PR quick quality card with `eng/prepare-decompiler-pr-corpus.sh` + `pr-quick-baseline.json`; confirmed `pp` deltas and no `not run` table rows.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CorpusSensorComparisonTests/*"`
