### PR TITLE
Render reference truthiness from isinst as is null, not boolean negation (#1759)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4256,3 +4256,33 @@ public static class FinallyDisposeSamples
         }
     }
 }
+
+// Issue #1759 (review): a nested local function reusing the same stack-slot
+// number must not disable the isinst provenance for the outer finally-dispose
+// slot. Provenance is scoped to the current function body, so this still renders
+// `is null`, not `!S`.
+public static class FinallyDisposeNestedSamples
+{
+    public static int DisposeWithNestedLocalFunction(System.Collections.IDictionary dictionary, int x)
+    {
+        int seed = SquarePlusOne(x);
+        System.Collections.IDictionaryEnumerator enumerator = dictionary.GetEnumerator();
+        try
+        {
+            while (enumerator.MoveNext())
+            {
+            }
+        }
+        finally
+        {
+            (enumerator as System.IDisposable)?.Dispose();
+        }
+        return seed;
+
+        static int SquarePlusOne(int v)
+        {
+            int y = v + 1;
+            return y * y;
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4233,3 +4233,26 @@ public static class EnumCastSamples
     }
 }
 
+
+// Issue #1759: a reference-typed value produced by `as`/isinst and tested for
+// truthiness in a branch (here the `?.Dispose()` null-conditional inside a
+// finally) must render `is null`/`is not null`, not `!S` — `!IDisposable` is
+// CS0023. IDisposable is a cross-assembly interface (TypeShape.Unknown), so the
+// reference classification comes from the isinst provenance.
+public static class FinallyDisposeSamples
+{
+    public static void DisposeEnumeratorInFinally(System.Collections.IDictionary dictionary)
+    {
+        System.Collections.IDictionaryEnumerator enumerator = dictionary.GetEnumerator();
+        try
+        {
+            while (enumerator.MoveNext())
+            {
+            }
+        }
+        finally
+        {
+            (enumerator as System.IDisposable)?.Dispose();
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/FinallyDisposePrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FinallyDisposePrinterTests.cs
@@ -22,6 +22,23 @@ public class FinallyDisposePrinterTests
         AssertCompiles("public static void M(System.Collections.IDictionary dictionary)", body);
     }
 
+    [Fact]
+    public void ReferenceTruthiness_NestedFunctionReusesSlot_StillRendersIsNull()
+    {
+        // A nested local function reuses the same stack-slot number; provenance is
+        // scoped to the current function body, so the outer finally-dispose slot
+        // is still recognized as isinst-produced and renders `is null` (#1759 review).
+        using var source = MetadataSource.Open(typeof(FinallyDisposeNestedSamples).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(FinallyDisposeNestedSamples).FullName!,
+            nameof(FinallyDisposeNestedSamples.DisposeWithNestedLocalFunction));
+        Assert.NotNull(function);
+        Assert.Equal(DecompilationFidelity.Full, function!.Fidelity);
+        var body = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method)).Output!;
+
+        Assert.Contains("is null", body);
+        Assert.DoesNotContain("!S_", body);
+    }
+
     static string RenderFixture(string methodName)
     {
         using var source = MetadataSource.Open(typeof(FinallyDisposeSamples).Assembly.Location);

--- a/src/ILInspector.Decompiler.Tests/FinallyDisposePrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FinallyDisposePrinterTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Issue #1759: a reference-typed value from `as`/isinst tested for truthiness in
+// a branch must render `is null`/`is not null`, not boolean negation. `!x` on an
+// IDisposable is CS0023. The reference classification comes from the isinst
+// provenance because the interface type is cross-assembly (TypeShape.Unknown).
+public class FinallyDisposePrinterTests
+{
+    [Fact]
+    public void ReferenceTruthinessInFinally_RendersIsNull_NotBangOperator()
+    {
+        string body = RenderFixture(nameof(FinallyDisposeSamples.DisposeEnumeratorInFinally));
+
+        Assert.Contains("is null", body);
+        Assert.DoesNotContain("!S_", body);
+        Assert.DoesNotContain("!enumerator", body);
+        AssertCompiles("public static void M(System.Collections.IDictionary dictionary)", body);
+    }
+
+    static string RenderFixture(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(FinallyDisposeSamples).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(FinallyDisposeSamples).FullName!, methodName);
+        Assert.NotNull(function);
+        Assert.Equal(DecompilationFidelity.Full, function!.Fidelity);
+        var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+        Assert.NotNull(result.Output);
+        return result.Output!;
+    }
+
+    static void AssertCompiles(string header, string body)
+    {
+        var errors = Recompile(header, body)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToArray();
+        Assert.True(errors.Length == 0, "Rendered body must compile, got:\n  " + string.Join("\n  ", errors) + "\n--- body ---\n" + body);
+    }
+
+    static ImmutableArray<Diagnostic> Recompile(string methodHeader, string body)
+    {
+        string source = $$"""
+            using System;
+            using System.Collections;
+            static class __Gate
+            {
+                {{methodHeader}}
+                {
+            {{body}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "__gate",
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        return compilation.GetDiagnostics();
+    }
+
+    static ImmutableArray<MetadataReference> RuntimeReferences()
+    {
+        var references = ImmutableArray.CreateBuilder<MetadataReference>();
+        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+            try { references.Add(MetadataReference.CreateFromFile(path)); }
+            catch { }
+        }
+        return references.ToImmutable();
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1616,8 +1616,39 @@ public sealed partial class CSharpPrinter
         {
             TypeShape.Reference => reference,
             TypeShape.Enum => integer,
-            _ => null,   // a struct cannot be a branch operand; unknown stays raw
+            // A cross-assembly type is unresolved (Unknown shape): an interface like
+            // IDisposable or a framework class is indistinguishable from a framework
+            // enum by its TypeRef alone. Fall back to provenance — a value produced
+            // by `isinst`/`as` is always a reference (or null), so its truthiness is
+            // `is null`/`is not null`, never `!x` (CS0023). Spelling the integer
+            // `!= 0` form for a genuine cross-assembly enum is handled above by the
+            // operand's resolved type, not by this branch-operand provenance.
+            _ => ProducesReference(operand) ? reference : null,
         };
+    }
+
+    /// <summary>True when the branch operand provably holds a reference because its sole definition is an <c>isinst</c>/<c>as</c> (which yields a reference or null). Sees through a single-store stack slot or local the value was spilled to.</summary>
+    bool ProducesReference(IrExpression operand) => SoleDefinition(operand) is IsInstance;
+
+    IrExpression? SoleDefinition(IrExpression operand)
+    {
+        switch (operand)
+        {
+            case IsInstance:
+                return operand;
+            case LoadStackSlot load:
+            {
+                var stores = _function.Descendants.OfType<StoreStackSlot>().Where(s => s.Slot == load.Slot).ToList();
+                return stores.Count == 1 ? stores[0].Value : null;
+            }
+            case LoadLocal load:
+            {
+                var stores = _function.Descendants.OfType<StoreLocal>().Where(s => s.Index == load.Index).ToList();
+                return stores.Count == 1 ? stores[0].Value : null;
+            }
+            default:
+                return null;
+        }
     }
 
     // `box T; unbox.any U` is the generic-math `(U)(object)x` idiom: the box is an

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1638,12 +1638,16 @@ public sealed partial class CSharpPrinter
                 return operand;
             case LoadStackSlot load:
             {
-                var stores = _function.Descendants.OfType<StoreStackSlot>().Where(s => s.Slot == load.Slot).ToList();
+                // Scope to the current function body: stack-slot numbers are
+                // per-imported-function, so a nested local function / lambda can
+                // reuse this slot independently and must not count as a second
+                // definition (that would disable the provenance and reprint `!x`).
+                var stores = DescendantsOutsideNestedFunctions(_function).OfType<StoreStackSlot>().Where(s => s.Slot == load.Slot).ToList();
                 return stores.Count == 1 ? stores[0].Value : null;
             }
             case LoadLocal load:
             {
-                var stores = _function.Descendants.OfType<StoreLocal>().Where(s => s.Index == load.Index).ToList();
+                var stores = DescendantsOutsideNestedFunctions(_function).OfType<StoreLocal>().Where(s => s.Index == load.Index).ToList();
                 return stores.Count == 1 ? stores[0].Value : null;
             }
             default:


### PR DESCRIPTION
## Invalid-`Full` burndown (#1687): reference truthiness from `isinst`

A value produced by `as`/`isinst` and tested for truthiness in a branch — the `?.Dispose()` null-conditional inside a `finally` — rendered as `if (!S_256)` where `S_256` is an `IDisposable`. That is `CS0023: operator '!' cannot be applied to operand of type 'IDisposable'`, while the method stayed graded `Full`.

Real-world hit: `Newtonsoft.Json.Utilities.DictionaryWrapper<TKey,TValue>::CopyTo`.

### Root cause

`IDisposable` is a cross-assembly interface, so it resolves to `TypeShape.Unknown` and has no value-type hint. By its `TypeRef` alone it is indistinguishable from a framework enum (which would correctly render `!= 0`), so `Truthiness` fell through to the bare `!x` form.

### Fix

Add a **provenance** fallback in `Truthiness`: a branch operand whose sole definition is an `IsInstance` is provably a reference (`isinst`/`as` yields a reference or null), so it renders `is null` / `is not null`. It sees through a single-store stack slot or local the value was spilled to (the direct-`isinst` case was already handled). Genuine cross-assembly enums keep their resolved-type `!= 0` classification and are unaffected.

### Before → after

```
finally { S_256 = enumerator as IDisposable; ... if (!S_256) { } else { S_0.Dispose(); } }
->
finally { S_256 = enumerator as IDisposable; ... if (S_256 is null) { } else { S_0.Dispose(); } }
```

### Evidence

- Real witness `Newtonsoft DictionaryWrapper::CopyTo` now renders `if (S_257 is null)`.
- New fixture `FinallyDisposeSamples.DisposeEnumeratorInFinally` + `FinallyDisposePrinterTests`: assert `is null` / no `!S_` and **recompile** clean.
- Fixture `--validity-check`: 1/1 Full, 0 malformed, 0 binding errors.
- Fast decompiler suite **1650/1650**.
- Corpus quality-diff: _posting below once complete._

Closes #1759. Part of #1687.
