### PR TITLE
Reconstruct primary constructor skeletons

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -40,8 +40,8 @@ public class GeneratedFixtureCatalogTests
             "minimal.primary-ctor.field-init",
             "GeneratedFixtures.MinimalPrimaryCtorFieldInit.Class1",
             ".ctor",
-            FidelityCheck.CompileBackStatus.OpcodeDiff,
-            frontier: true);
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
         AssertTarget(
             run,
             "minimal.primary-ctor.field-init",
@@ -104,9 +104,8 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.ctor-field.getter", report);
         Assert.Contains("minimal.auto-property.getter", report);
         Assert.Contains("minimal.method-call.same-type", report);
-        Assert.Contains("PASS frontier", report);
         Assert.Contains("decompiler=Full", report);
-        Assert.Contains("compile-back=OpcodeDiff", report);
+        Assert.Contains("compile-back=Exact", report);
     }
 
     [Fact]
@@ -145,8 +144,8 @@ public class GeneratedFixtureCatalogTests
             fixture => fixture.GetProperty("Id").GetString() == "minimal.primary-ctor.field-init");
         var ctor = Assert.Single(primaryCtor.GetProperty("Targets").EnumerateArray(),
             target => target.GetProperty("Method").GetString() == ".ctor");
-        Assert.Equal("OpcodeDiff", ctor.GetProperty("ExpectedStatus").GetString());
-        Assert.True(ctor.GetProperty("IsFrontier").GetBoolean());
+        Assert.Equal("Exact", ctor.GetProperty("ExpectedStatus").GetString());
+        Assert.False(ctor.GetProperty("IsFrontier").GetBoolean());
     }
 
     [Fact]

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -791,14 +791,142 @@ static class FidelityCheck
             catch { continue; }
             if (body is null)
                 continue;
+            PrimaryConstructorShape? primaryConstructor = PrimaryConstructorFromPrologue(reader, method, function, body);
             var original = ILDisassembler.Disassemble(pe, reader, method);
             if (original is null)
                 continue;
             var origOps = original.Select(i => CanonicalOpcode(i.OpCodeName)).ToList();
-            entries.Add(new Entry(mh, name, overload, CorpusMethodIdentity.SignatureText(function.Signature), new TargetBody(body, chain, function.RequiresAsyncBodyModifier), fieldInits,
+            entries.Add(new Entry(mh, name, overload, CorpusMethodIdentity.SignatureText(function.Signature), new TargetBody(body, chain, function.RequiresAsyncBodyModifier, primaryConstructor), fieldInits,
                 string.Join(" ", origOps), origOps, function.Fidelity == DecompilationFidelity.Full));
         }
         return (fullType, entries);
+    }
+
+    static PrimaryConstructorShape? PrimaryConstructorFromPrologue(
+        MetadataReader reader,
+        MethodDefinition method,
+        IrFunction function,
+        string renderedBody)
+    {
+        if (reader.GetString(method.Name) != ".ctor"
+            || method.Attributes.HasFlag(MethodAttributes.Static))
+            return null;
+        var declaringHandle = method.GetDeclaringType();
+        var declaringType = reader.GetTypeDefinition(declaringHandle);
+        if (CountInstanceConstructors(reader, declaringType) != 1
+            || HasInAssemblyDerivedType(reader, declaringHandle))
+            return null;
+        if (function.Body.Blocks is not [{ } entry, ..])
+            return null;
+
+        int? chainIndex = null;
+        for (int i = 0; i < entry.Children.Count; i++)
+        {
+            if (entry.Children[i] is ExpressionStatement
+                {
+                    Expression: Call { Callee: { Name: ".ctor", HasThis: true }, Arguments: [LoadArgument { Index: 0 }] }
+                })
+            {
+                chainIndex = i;
+                break;
+            }
+        }
+
+        if (chainIndex is not > 0)
+            return null;
+        if (entry.Children.Skip(chainIndex.Value + 1).Any(node => node is not Return))
+            return null;
+
+        var parameterNames = ParameterNames(reader, method);
+        if (parameterNames.Count == 0)
+            return null;
+
+        var initializers = new List<(string Field, string Value)>();
+        foreach (var node in entry.Children.Take(chainIndex.Value))
+        {
+            if (node is not StoreField
+                {
+                    HasInstance: true,
+                    Instance: LoadArgument { Index: 0 },
+                    Value: LoadArgument { Index: > 0 } value
+                } store)
+                return null;
+            if (!parameterNames.TryGetValue(value.Index - 1, out string? parameterName))
+                return null;
+
+            initializers.Add((store.Field.Name, parameterName));
+        }
+
+        if (initializers.Count == 0)
+            return null;
+        if (!RenderedBodyMatchesPrimaryConstructorInitializers(renderedBody, initializers))
+            return null;
+
+        string parameters = Parameters(reader, method, method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, declaringType, method)));
+        return new PrimaryConstructorShape(parameters, initializers);
+    }
+
+    static int CountInstanceConstructors(MetadataReader reader, TypeDefinition typeDef)
+    {
+        int count = 0;
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) == ".ctor"
+                && !method.Attributes.HasFlag(MethodAttributes.Static))
+                count++;
+        }
+        return count;
+    }
+
+    static bool HasInAssemblyDerivedType(MetadataReader reader, TypeDefinitionHandle baseHandle)
+    {
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            if (typeHandle == baseHandle)
+                continue;
+            var type = reader.GetTypeDefinition(typeHandle);
+            if (type.BaseType.Kind == HandleKind.TypeDefinition
+                && (TypeDefinitionHandle)type.BaseType == baseHandle)
+                return true;
+        }
+        return false;
+    }
+
+    static bool RenderedBodyMatchesPrimaryConstructorInitializers(
+        string renderedBody,
+        IReadOnlyList<(string Field, string Value)> initializers)
+    {
+        var lines = renderedBody
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(line => line.TrimEnd('\r'))
+            .Where(line => line.Length > 0)
+            .ToArray();
+        if (lines.Length != initializers.Count)
+            return false;
+
+        for (int i = 0; i < initializers.Count; i++)
+        {
+            var (field, value) = initializers[i];
+            string fieldName = Identifier(field);
+            string expectedBare = $"{fieldName} = {value};";
+            string expectedThis = $"this.{fieldName} = {value};";
+            if (lines[i] != expectedBare && lines[i] != expectedThis)
+                return false;
+        }
+        return true;
+    }
+
+    static Dictionary<int, string> ParameterNames(MetadataReader reader, MethodDefinition method)
+    {
+        var names = new Dictionary<int, string>();
+        foreach (var parameterHandle in method.GetParameters())
+        {
+            var parameter = reader.GetParameter(parameterHandle);
+            if (parameter.SequenceNumber >= 1)
+                names[parameter.SequenceNumber - 1] = Identifier(reader.GetString(parameter.Name));
+        }
+        return names;
     }
 
     /// <summary>
@@ -949,7 +1077,7 @@ static class FidelityCheck
         CSharpParseOptions parseOptions, CSharpCompilationOptions compileOptions, string fullType, Entry e)
     {
         string unit;
-        try { unit = BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.FieldInits, references.Accessibility); }
+        try { unit = BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility); }
         catch { return new(fullType, e.Name, e.Overload, e.Signature, CompileBackStatus.ContextFail, e.OrigText, "", "skeleton-emit"); }
 
         var tree = CSharpSyntaxTree.ParseText(unit, parseOptions);
@@ -1058,7 +1186,7 @@ static class FidelityCheck
         for (int iteration = 0; iteration < maxIterations; iteration++)
         {
             string unit;
-            try { unit = BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.FieldInits, references.Accessibility, include); }
+            try { unit = BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility, include); }
             catch { return null; } // fall back to the whole-module build
 
             var tree = CSharpSyntaxTree.ParseText(unit, parseOptions);
@@ -1372,15 +1500,24 @@ static class FidelityCheck
     /// assembly.
     /// </summary>
     /// <summary>The real decompiled body (and optional ctor chain) for one target method.</summary>
-    public readonly record struct TargetBody(string Body, string? Chain, bool RequiresAsync);
+    public readonly record struct TargetBody(
+        string Body,
+        string? Chain,
+        bool RequiresAsync,
+        PrimaryConstructorShape? PrimaryConstructor = null);
+
+    public sealed record PrimaryConstructorShape(
+        string Parameters,
+        IReadOnlyList<(string Field, string Value)> FieldInitializers);
 
     /// <summary>Single-method unit — the per-method fallback path when a grouped build fails.</summary>
     static string BuildUnit(MetadataReader reader, MethodDefinitionHandle target, string targetBody, string? targetChain,
         bool targetRequiresAsync,
+        PrimaryConstructorShape? targetPrimaryConstructor,
         IReadOnlyList<(string Field, string Value)> targetFieldInits,
         SignatureAccessibility accessibility, IReadOnlySet<TypeDefinitionHandle>? includeRoots = null)
     {
-        var targets = new Dictionary<MethodDefinitionHandle, TargetBody> { [target] = new(targetBody, targetChain, targetRequiresAsync) };
+        var targets = new Dictionary<MethodDefinitionHandle, TargetBody> { [target] = new(targetBody, targetChain, targetRequiresAsync, targetPrimaryConstructor) };
         var fieldInitType = reader.GetMethodDefinition(target).GetDeclaringType();
         return BuildUnit(reader, targets, targetFieldInits, fieldInitType, accessibility, includeRoots);
     }
@@ -1504,13 +1641,21 @@ static class FidelityCheck
         // struct otherwise has no such conversion and the body fails to recompile.
         if (kind == TypeKind.Struct && InlineArrayAttributeText(reader, typeDef) is { } inlineArrayAttr)
             sb.AppendLine($"{pad}{inlineArrayAttr}");
+        var primaryConstructorTarget = targets
+            .FirstOrDefault(target =>
+                target.Value.PrimaryConstructor is not null
+                && reader.GetMethodDefinition(target.Key).GetDeclaringType() == typeHandle);
+        var primaryConstructor = primaryConstructorTarget.Value.PrimaryConstructor;
+        string primaryParameters = primaryConstructor is null ? "" : $"({primaryConstructor.Parameters})";
         string unsafeModifier = TypeHasAwaitTarget(reader, typeHandle, targets) ? "" : "unsafe ";
-        sb.AppendLine($"{pad}public {unsafeModifier}{keyword} {Identifier(name)}{genParams}{baseClause}{whereClauses}");
+        sb.AppendLine($"{pad}public {unsafeModifier}{keyword} {Identifier(name)}{genParams}{primaryParameters}{baseClause}{whereClauses}");
         sb.AppendLine($"{pad}{{");
 
         // Field initializers lifted from a target ctor apply to this type's
         // fields only when this is the type that lifted them.
         var thisFieldInits = typeHandle == fieldInitType ? fieldInits : [];
+        if (primaryConstructor is not null)
+            thisFieldInits = [.. thisFieldInits, .. primaryConstructor.FieldInitializers];
 
         foreach (var fh in typeDef.GetFields())
             EmitField(reader, fh, typeContext, thisFieldInits, accessibility, sb, pad + "    ");
@@ -1530,6 +1675,8 @@ static class FidelityCheck
         {
             if (stubPropertyAccessors.Contains(mh))
                 continue; // emitted as a property accessor above
+            if (mh == primaryConstructorTarget.Key)
+                continue; // emitted as the type's primary constructor header
             var hasTarget = targets.TryGetValue(mh, out var target);
             EmitMethod(reader, typeHandle, mh,
                 hasTarget ? target.Body : null,
@@ -1551,7 +1698,10 @@ static class FidelityCheck
         // ordinal and compare it against this throwing stub. Last-ordinal keeps the
         // real ctors at 0..k-1 and the synthetic at k (never requested), so it
         // cannot change a target's fidelity.
-        if (keyword == "class" && !IsStaticClass(typeDef) && !HasParameterlessInstanceCtor(reader, typeDef))
+        if (keyword == "class"
+            && primaryConstructor is null
+            && !IsStaticClass(typeDef)
+            && !HasParameterlessInstanceCtor(reader, typeDef))
             sb.AppendLine($"{pad}    public {Identifier(name)}() {{ throw null; }}");
 
         foreach (var nested in typeDef.GetNestedTypes())

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -50,9 +50,7 @@ internal static class GeneratedFixtureCatalog
             new(
                 "GeneratedFixtures.MinimalPrimaryCtorFieldInit.Class1",
                 ".ctor",
-                FidelityCheck.CompileBackStatus.OpcodeDiff,
-                IsFrontier: true,
-                Note: "Primary-constructor field initializer stores before base(); reconstructed constructor body stores after base()."),
+                FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalPrimaryCtorFieldInit.Class1", "get_Method1",
                 FidelityCheck.CompileBackStatus.Exact),
         ],

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -13,12 +13,11 @@ generated-fixture catalogue entries into a temporary class library, runs the
 compile-back oracle, and prints results by stable fixture ID plus target method.
 This is the first step toward an addressable progressive fixture ladder:
 `minimal.property.literal`, `minimal.ctor-field.getter`,
-`minimal.auto-property.getter`, and `minimal.method-call.same-type` are expected
-`Exact`, while
-`minimal.primary-ctor.field-init` records the current constructor `OpcodeDiff`
-frontier and the exact getter. With no selector, all generated fixtures run; use
-`list` to list fixture IDs, `--json` for machine-readable list/results, and
-`--keep-generated-fixtures` to preserve the generated project for drill-down.
+`minimal.auto-property.getter`, `minimal.method-call.same-type`, and
+`minimal.primary-ctor.field-init` are expected `Exact`. With no selector, all
+generated fixtures run; use `list` to list fixture IDs, `--json` for
+machine-readable list/results, and `--keep-generated-fixtures` to preserve the
+generated project for drill-down.
 
 **Library report** (`--library-report`): a portfolio view. It combines the IR
 residual buckets from `--gaps` with the Roslyn-backed validity oracle from


### PR DESCRIPTION
- Fixes #1788
- Changes compile-back skeleton reconstruction for simple primary-constructor field-initializer shapes
- Card revision: `1ffca9f3`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated primary-constructor fixture now reaches opcode-exact compile-back without broadening detection beyond the simple constructor-prologue shape.

Before:

```text
minimal.primary-ctor.field-init::.ctor
compile-back=OpcodeDiff
orig : ldarg ldarg stfld ldarg call ret
recmp: ldarg call ldarg ldarg stfld ret
```

After:

```text
minimal.primary-ctor.field-init::.ctor
compile-back=Exact
```

The harness now detects only a narrow primary-constructor skeleton shape: a single instance constructor, no in-assembly derived type, leading `this.field = ctorParameter` stores, an implicit `base()` call, and only `return` afterward. It also requires the rendered constructor body to match those field assignments before using the synthesized primary-constructor skeleton, so decompiler body regressions still surface.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Reduced fixture fidelity | Pass: `--generated-fixtures minimal.primary-ctor.field-init` exact |
| Full generated fixture catalogue | Pass: all 5 fixtures / 11 targets exact |
| Fallback compile-back path | Pass: `CB_NOGROUP=1 --fidelity-check` over the kept generated assembly was 2/2 exact |
| Markdown | Pass: `npx markdownlint-cli tools/DecompilerHarness/README.md` |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — this is a harness reconstruction fix for a generated minimal fixture; no corpus card was run because product decompiler output/corpus behavior is unchanged.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Findings resolved | Initial review found fallback `BuildUnit` lost `PrimaryConstructorShape`; fixed by threading it through single-target/fallback builds. |
| MAI-Code-1-Flash | Findings resolved | Initial review warned that skeleton synthesis could mask rendered-body regressions and future secondary/derived shapes; fixed by matching rendered body lines and gating to exactly one ctor/no in-assembly derived type. |
| Claude Opus 4.8 | No blocking findings | Re-review found no significant issues. |
| MAI-Code-1-Flash | No blocking findings | Re-review found no significant issues and verified grouped/fallback parity. |

**Review conclusion:** **PASS** — both reviewers' actionable findings were addressed before opening this PR.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.primary-ctor.field-init
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures
CB_NOGROUP=1 dotnet run --project tools/DecompilerHarness -c Release --no-build -- --fidelity-check <kept-generated-fixture-dll>
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
```
