### PR TITLE
Add enumerator-allocation shape (loop-gated); defer state-machine (#1805)

### DIFF
--- a/src/ILInspector.Analysis.Tests/EnumeratorLookalikeStub.cs
+++ b/src/ILInspector.Analysis.Tests/EnumeratorLookalikeStub.cs
@@ -1,0 +1,15 @@
+// An UNTRUSTED enumerator lookalike for the enumerator-allocation trust gate (#1814): a type in
+// the framework collections namespace whose name starts with "IEnumerator", but defined in this
+// (unsigned) test assembly, so it carries no framework public-key-token. A foreach that binds to
+// a GetEnumerator returning this type must NOT be flagged as an enumerator allocation —
+// LibraryBodyIndex.IsInterfaceEnumeratorAllocation is trust-gated (#1708), so only the real
+// framework IEnumerator/IEnumerator<T> counts. The MoveNext/Current members let it satisfy the
+// foreach enumerator pattern.
+namespace System.Collections.Generic;
+
+public sealed class IEnumeratorLookalike
+{
+    public bool MoveNext() => false;
+
+    public int Current => 0;
+}

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1460,6 +1460,43 @@ public class LibraryBodyIndexTests
             .Where(o => o.Method.Name == methodName && o.Shape == "string-build-in-loop")
             .ToList();
 
+    static System.Collections.Generic.List<OptimizationOpportunity> EnumeratorRows(LibraryBodyIndex index, string methodName)
+        => index.OptimizationOpportunities
+            .Where(o => o.Method.Name == methodName && o.Shape == "enumerator-allocation")
+            .ToList();
+
+    [Fact]
+    public void OptimizationOpportunities_ForeachInterfaceInLoop_IsEnumeratorAllocation()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // foreach over an interface-typed sequence inside a loop allocates a reference-type
+        // enumerator each outer iteration.
+        var row = Assert.Single(EnumeratorRows(index, nameof(OptimizationOpportunityFixtures.ForeachInterfaceInLoop)));
+        Assert.Equal("medium", row.Confidence);
+        Assert.True(row.InLoop);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_ForeachInterfaceOnce_IsNotEnumeratorAllocation()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // A one-shot foreach (not in a loop) allocates one enumerator -> not flagged (the
+        // non-loop tier was measured to be essentially all noise).
+        Assert.Empty(EnumeratorRows(index, nameof(OptimizationOpportunityFixtures.ForeachInterfaceOnce)));
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_ForeachConcreteListInLoop_IsNotEnumeratorAllocation()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // foreach over a concrete List<T> uses a struct enumerator (returns by value): no heap
+        // allocation, so it must not be flagged even inside a loop.
+        Assert.Empty(EnumeratorRows(index, nameof(OptimizationOpportunityFixtures.ForeachConcreteListInLoop)));
+    }
+
     [Fact]
     public void OptimizationOpportunities_StringAppendInLoop_IsHighStringBuild()
     {
@@ -2448,6 +2485,46 @@ public class OptimizationOpportunityFixtures
         foreach (var x in items)
             s = x + " " + s.Trim();
         return s;
+    }
+
+    // --- Enumerator allocation (enumerator-allocation) ---
+
+    // foreach over an interface-typed sequence INSIDE a loop: GetEnumerator returns the
+    // reference-type IEnumerator<T>, allocated on each outer iteration.
+    public static int ForeachInterfaceInLoop(System.Collections.Generic.IEnumerable<int> items, int times)
+    {
+        var total = 0;
+        for (int i = 0; i < times; i++)
+        {
+            foreach (var x in items)
+                total += x;
+        }
+
+        return total;
+    }
+
+    // foreach over an interface-typed sequence with no enclosing loop: a single enumerator
+    // allocation -> not flagged.
+    public static int ForeachInterfaceOnce(System.Collections.Generic.IEnumerable<int> items)
+    {
+        var total = 0;
+        foreach (var x in items)
+            total += x;
+        return total;
+    }
+
+    // foreach over a concrete List<T> inside a loop: List<T>.GetEnumerator returns the struct
+    // List<T>.Enumerator by value -> no heap allocation, must not be flagged.
+    public static int ForeachConcreteListInLoop(System.Collections.Generic.List<int> items, int times)
+    {
+        var total = 0;
+        for (int i = 0; i < times; i++)
+        {
+            foreach (var x in items)
+                total += x;
+        }
+
+        return total;
     }
 
     // --- Copy allocation (span-to-array) ---

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1498,6 +1498,17 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_ForeachLookalikeEnumeratorInLoop_IsNotEnumeratorAllocation()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        // foreach binding to a GetEnumerator that returns an untrusted IEnumerator lookalike (a
+        // user type reusing the framework namespace + name) must not be flagged: the enumerator
+        // identity is trust-gated (#1708), so only the real framework IEnumerator counts.
+        Assert.Empty(EnumeratorRows(index, nameof(OptimizationOpportunityFixtures.ForeachLookalikeEnumeratorInLoop)));
+    }
+
+    [Fact]
     public void OptimizationOpportunities_StringAppendInLoop_IsHighStringBuild()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -2521,6 +2532,22 @@ public class OptimizationOpportunityFixtures
         for (int i = 0; i < times; i++)
         {
             foreach (var x in items)
+                total += x;
+        }
+
+        return total;
+    }
+
+    // foreach over a collection whose GetEnumerator returns an UNTRUSTED IEnumerator lookalike
+    // (defined in this test assembly). Even inside a loop it must not be flagged — the framework
+    // enumerator identity is trust-gated, so a same-namespace/name user type is not mistaken for
+    // the real IEnumerator.
+    public static int ForeachLookalikeEnumeratorInLoop(LookalikeEnumeratorCollection c, int times)
+    {
+        var total = 0;
+        for (int i = 0; i < times; i++)
+        {
+            foreach (var x in c)
                 total += x;
         }
 
@@ -3981,4 +4008,12 @@ public static class OverloadCallers
         OverloadTargets.M(1);
         OverloadTargets.M("x");
     }
+}
+
+// A collection whose GetEnumerator returns an untrusted IEnumerator lookalike (see
+// EnumeratorLookalikeStub.cs). foreach binds to this GetEnumerator via the enumerator pattern;
+// because the return type is not the trusted framework IEnumerator, it must not be flagged.
+public sealed class LookalikeEnumeratorCollection
+{
+    public System.Collections.Generic.IEnumeratorLookalike GetEnumerator() => new();
 }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -258,6 +258,23 @@ public sealed class LibraryBodyIndex
             && member.Name == "Concat"
             && FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "String");
 
+    // A GetEnumerator call that returns a reference-type enumerator — i.e. iterating the
+    // sequence allocates an enumerator object on the heap. `foreach` over a concrete type with a
+    // struct enumerator (List<T>.Enumerator, …) returns it by value and allocates nothing; only
+    // a foreach over an interface (IEnumerable/IEnumerable<T>) binds to GetEnumerator returning
+    // the framework IEnumerator/IEnumerator<T> interface, whose implementation is a heap object.
+    // Gating on the framework interface return type is the precise reference-vs-struct signal.
+    public static bool IsInterfaceEnumeratorAllocation(MemberRef member)
+    {
+        if (member.Kind == MemberKind.Unsupported || member.Name != "GetEnumerator")
+            return false;
+        var ret = member.ReturnType;
+        var def = ret.Kind == TypeRefKind.GenericInstance ? ret.ElementType ?? ret : ret;
+        return def.Kind != TypeRefKind.Unsupported
+            && (def.Namespace == "System.Collections" || def.Namespace == "System.Collections.Generic")
+            && def.Name.StartsWith("IEnumerator", StringComparison.Ordinal);
+    }
+
     // A lazy/deferred Enumerable operator (Where/Select/…): it returns an iterator without
     // enumerating at the call site. A helper that returns such a query is itself a deferred
     // linear scan — the scan runs when the caller enumerates the result.
@@ -1589,6 +1606,25 @@ public sealed class LibraryBodyIndex
                                 true,
                                 offset,
                                 null));
+                        }
+                        else if (IsInterfaceEnumeratorAllocation(callee) && IsInLoopRegion(offset, loopRegions))
+                        {
+                            // foreach over an interface (IEnumerable/IEnumerable<T>) binds to a
+                            // GetEnumerator returning the reference-type IEnumerator/IEnumerator<T>,
+                            // whose implementation is a heap object — one allocation per foreach.
+                            // foreach over a concrete type uses a struct enumerator and allocates
+                            // nothing. Only the in-loop case is reported: a foreach inside a loop
+                            // re-allocates the enumerator each outer iteration. A one-shot foreach
+                            // allocates once and was measured to be essentially all noise.
+                            opportunities.Add(new OptimizationOpportunity(
+                                caller,
+                                "enumerator-allocation",
+                                $"foreach over an interface allocates a reference-type enumerator ({callee.ReturnType.ToQualifiedDisplayString()})",
+                                "Iterating an interface-typed sequence inside a loop allocates an enumerator each pass; foreach over the concrete type (e.g. List<T>) uses a struct enumerator, or index/iterate it once outside the loop.",
+                                "medium",
+                                true,
+                                offset,
+                                "No allocation when the static type has a struct enumerator; worthwhile only if the concrete type is reachable at this call site."));
                         }
                         break;
                     }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -263,16 +263,16 @@ public sealed class LibraryBodyIndex
     // struct enumerator (List<T>.Enumerator, …) returns it by value and allocates nothing; only
     // a foreach over an interface (IEnumerable/IEnumerable<T>) binds to GetEnumerator returning
     // the framework IEnumerator/IEnumerator<T> interface, whose implementation is a heap object.
-    // Gating on the framework interface return type is the precise reference-vs-struct signal.
+    // The return type is matched by trusted-framework identity (#1708), not namespace+name, so a
+    // user type that merely reuses the IEnumerator namespace and name is not mistaken for it.
     public static bool IsInterfaceEnumeratorAllocation(MemberRef member)
     {
         if (member.Kind == MemberKind.Unsupported || member.Name != "GetEnumerator")
             return false;
         var ret = member.ReturnType;
         var def = ret.Kind == TypeRefKind.GenericInstance ? ret.ElementType ?? ret : ret;
-        return def.Kind != TypeRefKind.Unsupported
-            && (def.Namespace == "System.Collections" || def.Namespace == "System.Collections.Generic")
-            && def.Name.StartsWith("IEnumerator", StringComparison.Ordinal);
+        return FrameworkIdentity.IsCoreLibraryType(def, "System.Collections.Generic", "IEnumerator`1")
+            || FrameworkIdentity.IsCoreLibraryType(def, "System.Collections", "IEnumerator");
     }
 
     // A lazy/deferred Enumerable operator (Where/Select/…): it returns an iterator without


### PR DESCRIPTION
## What

Adds a new Performance Triage shape, **`enumerator-allocation`** (loop-gated), ported from the decompiler's `AllocationClassifier` per #1805 / #1807.

`foreach` over an interface-typed sequence (`IEnumerable`/`IEnumerable<T>`) binds to a `GetEnumerator` returning the reference-type `IEnumerator`/`IEnumerator<T>`, whose implementation is a heap object — one allocation per `foreach`. `foreach` over a concrete type with a struct enumerator (`List<T>.Enumerator`, …) returns it by value and allocates nothing. The detection gates on the **framework `IEnumerator` interface return type** (namespace `System.Collections[.Generic]`, name starts with `IEnumerator`) — the precise reference-vs-struct signal, so struct enumerators are never flagged.

## Precision: loop-gated only

A single `foreach` allocates one enumerator — measured to be essentially all noise (one-shot `foreach`: **OpenAI 554, Aspire 83, Microsoft.OpenApi 138**). So this reports **only the in-loop case**, where a `foreach` inside a loop re-allocates the enumerator each outer iteration. Loop-gated counts are modest and decompilation-confirmed:

| Assembly | in-loop hits |
| --- | ---: |
| Aspire.Dashboard | 13 |
| Microsoft.OpenApi | 6 |
| OpenAI | 3 |
| Humanizer | 2 |

Confidence `medium`, with the caveat "no allocation when the static type has a struct enumerator; worthwhile only if the concrete type is reachable at this call site."

## state-machine-allocation deferred (with evidence)

The other shape from #1805 is **not shipped here**. The naive per-method version flags **every iterator** (`newobj <Method>d__N`): OpenAI **86**, all non-loop (the state-machine `newobj` sits at iterator-method entry, never in a loop), dominated by intrinsic async iterators — not actionable, the same flood pattern that made `linq-materialize-in-loop` not worth shipping. The genuinely actionable form is **cross-method** ("an iterator allocated then enumerated inside a loop"), which reuses the `ScanMethodsInvokedInLoops` machinery — tracked as a follow-up on #1805/#1807.

## Tests

3 fixtures + tests in `LibraryBodyIndexTests`: interface-foreach-in-loop (flagged), interface-foreach-once (not flagged), concrete-`List<T>`-foreach-in-loop (struct enumerator, not flagged). Full suite green: ILInspector.Analysis.Tests 214, dotnet-inspect.Tests 1381 (9 ildasm skips).

Relates to #1805, #1807.
