### PR TITLE
Classify ReferenceEqualityComparer validity shell collision

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ValidityShellNoiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidityShellNoiseTests.cs
@@ -14,29 +14,29 @@ public class ValidityShellNoiseTests
     [Fact]
     public void DeclaringTypeStaticPropertyCtorAssignmentCollision_IsFiltered()
     {
-        var (diagnostic, tree) = ReadOnlyInstanceDiagnostic();
+        var (diagnostic, tree, semanticModel) = ReadOnlyInstanceDiagnostic();
         var function = StaticConstructorWithBackingStore(ReferenceEqualityComparerType, "Instance");
 
-        Assert.True(ValidityCheck.IsDeclaringTypeStaticPropertyCtorAssignmentNoise(diagnostic, tree, function));
+        Assert.True(ValidityCheck.IsDeclaringTypeStaticPropertyCtorAssignmentNoise(diagnostic, tree, function, semanticModel));
     }
 
     [Fact]
     public void DeclaringTypeStaticPropertyCtorAssignmentWithoutBackingStore_StaysReported()
     {
-        var (diagnostic, tree) = ReadOnlyInstanceDiagnostic();
+        var (diagnostic, tree, semanticModel) = ReadOnlyInstanceDiagnostic();
         var function = StaticConstructorWithBackingStore(ReferenceEqualityComparerType, backingPropertyName: null);
 
-        Assert.False(ValidityCheck.IsDeclaringTypeStaticPropertyCtorAssignmentNoise(diagnostic, tree, function));
+        Assert.False(ValidityCheck.IsDeclaringTypeStaticPropertyCtorAssignmentNoise(diagnostic, tree, function, semanticModel));
     }
 
     [Fact]
     public void OtherTypeStaticPropertyAssignment_StaysReported()
     {
-        var (diagnostic, tree) = ReadOnlyInstanceDiagnostic();
+        var (diagnostic, tree, semanticModel) = ReadOnlyInstanceDiagnostic();
         var otherType = TypeRef.Definition("fixture", "Fixture", "Holder");
         var function = StaticConstructorWithBackingStore(otherType, "Instance");
 
-        Assert.False(ValidityCheck.IsDeclaringTypeStaticPropertyCtorAssignmentNoise(diagnostic, tree, function));
+        Assert.False(ValidityCheck.IsDeclaringTypeStaticPropertyCtorAssignmentNoise(diagnostic, tree, function, semanticModel));
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public class ValidityShellNoiseTests
         Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
     }
 
-    static (Diagnostic Diagnostic, SyntaxTree Tree) ReadOnlyInstanceDiagnostic()
+    static (Diagnostic Diagnostic, SyntaxTree Tree, SemanticModel SemanticModel) ReadOnlyInstanceDiagnostic()
     {
         var tree = CSharpSyntaxTree.ParseText("""
             #pragma warning disable
@@ -71,21 +71,22 @@ public class ValidityShellNoiseTests
                 }
             }
             """, new CSharpParseOptions(LanguageVersion.Preview));
-        var diagnostic = Assert.Single(Compile(tree), d => d.Id == "CS0200");
-        return (diagnostic, tree);
+        var compilation = CreateCompilation(tree);
+        var diagnostic = Assert.Single(compilation.GetDiagnostics(), d => d.Id == "CS0200");
+        return (diagnostic, tree, compilation.GetSemanticModel(tree));
     }
 
     static ImmutableArray<Diagnostic> Compile(string source)
-        => Compile(CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview)));
+        => CreateCompilation(CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview)))
+            .GetDiagnostics();
 
-    static ImmutableArray<Diagnostic> Compile(SyntaxTree tree)
+    static CSharpCompilation CreateCompilation(SyntaxTree tree)
         => CSharpCompilation.Create(
                 "validity-shell-noise",
                 [tree],
                 ValidityCheck.RuntimeReferences(),
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true)
-                    .WithMetadataImportOptions(MetadataImportOptions.All))
-            .GetDiagnostics();
+                    .WithMetadataImportOptions(MetadataImportOptions.All));
 
     static IrFunction StaticConstructorWithBackingStore(TypeRef declaringType, string? backingPropertyName)
     {

--- a/src/ILInspector.Decompiler.Tests/ValidityShellNoiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ValidityShellNoiseTests.cs
@@ -1,0 +1,107 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ValidityShellNoiseTests
+{
+    static readonly TypeRef ReferenceEqualityComparerType =
+        TypeRef.Definition("Microsoft.CodeAnalysis", "System.Collections.Generic", "ReferenceEqualityComparer");
+
+    [Fact]
+    public void DeclaringTypeStaticPropertyCtorAssignmentCollision_IsFiltered()
+    {
+        var (diagnostic, tree) = ReadOnlyInstanceDiagnostic();
+        var function = StaticConstructorWithBackingStore(ReferenceEqualityComparerType, "Instance");
+
+        Assert.True(ValidityCheck.IsDeclaringTypeStaticPropertyCtorAssignmentNoise(diagnostic, tree, function));
+    }
+
+    [Fact]
+    public void DeclaringTypeStaticPropertyCtorAssignmentWithoutBackingStore_StaysReported()
+    {
+        var (diagnostic, tree) = ReadOnlyInstanceDiagnostic();
+        var function = StaticConstructorWithBackingStore(ReferenceEqualityComparerType, backingPropertyName: null);
+
+        Assert.False(ValidityCheck.IsDeclaringTypeStaticPropertyCtorAssignmentNoise(diagnostic, tree, function));
+    }
+
+    [Fact]
+    public void OtherTypeStaticPropertyAssignment_StaysReported()
+    {
+        var (diagnostic, tree) = ReadOnlyInstanceDiagnostic();
+        var otherType = TypeRef.Definition("fixture", "Fixture", "Holder");
+        var function = StaticConstructorWithBackingStore(otherType, "Instance");
+
+        Assert.False(ValidityCheck.IsDeclaringTypeStaticPropertyCtorAssignmentNoise(diagnostic, tree, function));
+    }
+
+    [Fact]
+    public void DeclaringTypeGetOnlyPropertyAssignment_BindsInsideStaticConstructor()
+    {
+        var diagnostics = Compile("""
+            public sealed class Rq
+            {
+                public static Rq Instance { get; }
+
+                static Rq()
+                {
+                    Rq.Instance = new Rq();
+                }
+            }
+            """);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    static (Diagnostic Diagnostic, SyntaxTree Tree) ReadOnlyInstanceDiagnostic()
+    {
+        var tree = CSharpSyntaxTree.ParseText("""
+            #pragma warning disable
+            using System.Collections.Generic;
+
+            class __Shell
+            {
+                void __M()
+                {
+                    ReferenceEqualityComparer.Instance = null!;
+                }
+            }
+            """, new CSharpParseOptions(LanguageVersion.Preview));
+        var diagnostic = Assert.Single(Compile(tree), d => d.Id == "CS0200");
+        return (diagnostic, tree);
+    }
+
+    static ImmutableArray<Diagnostic> Compile(string source)
+        => Compile(CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview)));
+
+    static ImmutableArray<Diagnostic> Compile(SyntaxTree tree)
+        => CSharpCompilation.Create(
+                "validity-shell-noise",
+                [tree],
+                ValidityCheck.RuntimeReferences(),
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true)
+                    .WithMetadataImportOptions(MetadataImportOptions.All))
+            .GetDiagnostics();
+
+    static IrFunction StaticConstructorWithBackingStore(TypeRef declaringType, string? backingPropertyName)
+    {
+        var field = new FieldRef(declaringType, "<Instance>k__BackingField", declaringType)
+        {
+            BackingPropertyName = backingPropertyName,
+        };
+        var block = new Block();
+        block.Add(new StoreField(field, instance: null, new Constant(null, declaringType)));
+        var body = new BlockContainer();
+        body.Add(block);
+        return new IrFunction(
+            ".cctor",
+            declaringType,
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+    }
+}

--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -181,6 +181,7 @@ internal static class LibraryReport
                     .Where(d => !ValidityCheck.IsShellArtifact(d))
                     .Where(d => !ValidityCheck.IsGenericArityCollisionNoise(d, tree, function))
                     .Where(d => !ValidityCheck.IsSimpleNameStaticTypeCollisionNoise(d, tree, function))
+                    .Where(d => !ValidityCheck.IsDeclaringTypeStaticPropertyCtorAssignmentNoise(d, tree, function))
                     .ToList();
                 if (defects.Count == 0)
                 {

--- a/tools/DecompilerHarness/LibraryReport.cs
+++ b/tools/DecompilerHarness/LibraryReport.cs
@@ -175,13 +175,14 @@ internal static class LibraryReport
                 report.SemanticChecked++;
 
                 var compilation = CSharpCompilation.Create("check", [tree], references, compileOptions);
+                var semanticModel = compilation.GetSemanticModel(tree);
                 var defects = compilation.GetDiagnostics()
                     .Where(ValidityCheck.IsError)
                     .Where(d => !ValidityCheck.BindingNoise.Contains(d.Id))
                     .Where(d => !ValidityCheck.IsShellArtifact(d))
                     .Where(d => !ValidityCheck.IsGenericArityCollisionNoise(d, tree, function))
                     .Where(d => !ValidityCheck.IsSimpleNameStaticTypeCollisionNoise(d, tree, function))
-                    .Where(d => !ValidityCheck.IsDeclaringTypeStaticPropertyCtorAssignmentNoise(d, tree, function))
+                    .Where(d => !ValidityCheck.IsDeclaringTypeStaticPropertyCtorAssignmentNoise(d, tree, function, semanticModel))
                     .ToList();
                 if (defects.Count == 0)
                 {

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -224,6 +224,7 @@ static class ValidityCheck
                         .Where(d => !IsShellArtifact(d))
                         .Where(d => !IsGenericArityCollisionNoise(d, tree, function))
                         .Where(d => !IsSimpleNameStaticTypeCollisionNoise(d, tree, function))
+                        .Where(d => !IsDeclaringTypeStaticPropertyCtorAssignmentNoise(d, tree, function))
                         .Select(d => new ValidityDiagnostic(d.Id, d.GetMessage()))
                         .ToImmutableArray();
                     results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, [], SemanticChecked: true, defects));
@@ -656,6 +657,65 @@ static class ValidityCheck
 
         return ShellNoise.ReferencesNonGenericTypeNamed(function, simpleName)
             && !ShellNoise.ReferencesGenericTypeNamed(function, simpleName);
+    }
+
+    /// <summary>
+    /// The shell wraps a static constructor body in <c>__Shell.__M</c>, so a
+    /// same-full-name platform type can win over the reconstructed declaring type.
+    /// A get-only auto-property assignment backed by an original static backing
+    /// field store is legal inside the real declaring type's static constructor;
+    /// CS0200 here means the shell resolved the receiver to the colliding external
+    /// type instead.
+    /// </summary>
+    internal static bool IsDeclaringTypeStaticPropertyCtorAssignmentNoise(Diagnostic diagnostic, SyntaxTree tree, IrFunction function)
+    {
+        if (diagnostic.Id != "CS0200" || function.Name != ".cctor" || diagnostic.Location.SourceTree != tree)
+            return false;
+
+        var node = tree.GetRoot().FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+        if (node.FirstAncestorOrSelf<MemberAccessExpressionSyntax>() is not { } memberAccess)
+            return false;
+        if (!IsAssignmentLeft(memberAccess))
+            return false;
+        if (!ReceiverNamesDeclaringType(memberAccess.Expression, function.DeclaringType))
+            return false;
+
+        string propertyName = memberAccess.Name.Identifier.ValueText;
+        return function.Descendants.OfType<StoreField>().Any(store =>
+            !store.HasInstance
+            && store.Field.BackingPropertyName == propertyName
+            && SameTypeDefinition(store.Field.DeclaringType, function.DeclaringType));
+    }
+
+    static bool IsAssignmentLeft(MemberAccessExpressionSyntax memberAccess)
+    {
+        var assignment = memberAccess.FirstAncestorOrSelf<AssignmentExpressionSyntax>();
+        return assignment is not null
+            && assignment.Left.Span.Start <= memberAccess.Span.Start
+            && memberAccess.Span.End <= assignment.Left.Span.End;
+    }
+
+    static bool ReceiverNamesDeclaringType(ExpressionSyntax receiver, TypeRef declaringType)
+    {
+        string text = receiver.ToString();
+        string simpleName = ShellNoise.SimpleName(declaringType.Name);
+        if (text == simpleName)
+            return true;
+        if (declaringType.Namespace.Length == 0)
+            return false;
+        string fullName = declaringType.Namespace + "." + simpleName;
+        return text == fullName || text == "global::" + fullName;
+    }
+
+    static bool SameTypeDefinition(TypeRef left, TypeRef right)
+    {
+        left = left.Kind == TypeRefKind.GenericInstance ? left.ElementType! : left;
+        right = right.Kind == TypeRefKind.GenericInstance ? right.ElementType! : right;
+        return left.Kind == TypeRefKind.Definition
+            && right.Kind == TypeRefKind.Definition
+            && left.Assembly == right.Assembly
+            && left.Namespace == right.Namespace
+            && left.Name == right.Name;
     }
 
     static string? SimpleNameAtDiagnosticLocation(Diagnostic diagnostic, SyntaxTree tree)

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -218,13 +218,14 @@ static class ValidityCheck
                     }
                     semChecked++;
                     var compilation = CSharpCompilation.Create("check", [tree], references, compileOptions);
+                    var semanticModel = compilation.GetSemanticModel(tree);
                     var defects = compilation.GetDiagnostics()
                         .Where(IsError)
                         .Where(d => !BindingNoise.Contains(d.Id))
                         .Where(d => !IsShellArtifact(d))
                         .Where(d => !IsGenericArityCollisionNoise(d, tree, function))
                         .Where(d => !IsSimpleNameStaticTypeCollisionNoise(d, tree, function))
-                        .Where(d => !IsDeclaringTypeStaticPropertyCtorAssignmentNoise(d, tree, function))
+                        .Where(d => !IsDeclaringTypeStaticPropertyCtorAssignmentNoise(d, tree, function, semanticModel))
                         .Select(d => new ValidityDiagnostic(d.Id, d.GetMessage()))
                         .ToImmutableArray();
                     results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, [], SemanticChecked: true, defects));
@@ -667,7 +668,7 @@ static class ValidityCheck
     /// CS0200 here means the shell resolved the receiver to the colliding external
     /// type instead.
     /// </summary>
-    internal static bool IsDeclaringTypeStaticPropertyCtorAssignmentNoise(Diagnostic diagnostic, SyntaxTree tree, IrFunction function)
+    internal static bool IsDeclaringTypeStaticPropertyCtorAssignmentNoise(Diagnostic diagnostic, SyntaxTree tree, IrFunction function, SemanticModel semanticModel)
     {
         if (diagnostic.Id != "CS0200" || function.Name != ".cctor" || diagnostic.Location.SourceTree != tree)
             return false;
@@ -677,7 +678,7 @@ static class ValidityCheck
             return false;
         if (!IsAssignmentLeft(memberAccess))
             return false;
-        if (!ReceiverNamesDeclaringType(memberAccess.Expression, function.DeclaringType))
+        if (!ReceiverResolvesToDeclaringType(memberAccess.Expression, function.DeclaringType, semanticModel))
             return false;
 
         string propertyName = memberAccess.Name.Identifier.ValueText;
@@ -695,16 +696,34 @@ static class ValidityCheck
             && memberAccess.Span.End <= assignment.Left.Span.End;
     }
 
-    static bool ReceiverNamesDeclaringType(ExpressionSyntax receiver, TypeRef declaringType)
+    static bool ReceiverResolvesToDeclaringType(ExpressionSyntax receiver, TypeRef declaringType, SemanticModel semanticModel)
     {
-        string text = receiver.ToString();
-        string simpleName = ShellNoise.SimpleName(declaringType.Name);
-        if (text == simpleName)
-            return true;
-        if (declaringType.Namespace.Length == 0)
+        var symbolInfo = semanticModel.GetSymbolInfo(receiver);
+        ISymbol? symbol = symbolInfo.Symbol
+            ?? symbolInfo.CandidateSymbols.OfType<INamedTypeSymbol>().FirstOrDefault();
+        if (symbol is IAliasSymbol alias)
+            symbol = alias.Target;
+        if (symbol is not INamedTypeSymbol namedType)
             return false;
-        string fullName = declaringType.Namespace + "." + simpleName;
-        return text == fullName || text == "global::" + fullName;
+
+        return MetadataFullName(namedType) == MetadataFullName(declaringType);
+    }
+
+    static string MetadataFullName(INamedTypeSymbol type)
+    {
+        var names = new Stack<string>();
+        for (INamedTypeSymbol? current = type; current is not null; current = current.ContainingType)
+            names.Push(current.Name);
+        string nested = string.Join(".", names);
+        string ns = type.ContainingNamespace.IsGlobalNamespace ? "" : type.ContainingNamespace.ToDisplayString();
+        return ns.Length == 0 ? nested : ns + "." + nested;
+    }
+
+    static string MetadataFullName(TypeRef type)
+    {
+        type = type.Kind == TypeRefKind.GenericInstance ? type.ElementType! : type;
+        string name = string.Join(".", type.Name.Split('+').Select(ShellNoise.SimpleName));
+        return type.Namespace.Length == 0 ? name : type.Namespace + "." + name;
     }
 
     static bool SameTypeDefinition(TypeRef left, TypeRef right)


### PR DESCRIPTION
- Fixes/advances #1815
- Changes harness validity classification only; product decompiler output is unchanged.
- Card revision: `462608b9`

## Change

**Conclusion:** **PASS** — same-full-name polyfill/BCL CS0200 is now classified as validity-shell noise only when Roslyn resolves the receiver to the same metadata full name and the original IR proves a static backing-field store to the declaring type's get-only property.

Before: `System.Collections.Generic.ReferenceEqualityComparer::.cctor` in the Roslyn netstandard2.0 polyfill counted as an invalid-`Full` semantic defect because the validity shell bound `ReferenceEqualityComparer.Instance` to the BCL type.

After: the same Roslyn witness no longer appears in semantic-defect examples; unrelated CS0200 cases stay reported unless they are `.cctor` assignments backed by original same-declaring-type backing-field evidence.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `ValidityShellNoiseTests` passed (4/4) |
| Decompiler fast suite | Pass (1655/1655) |
| Real witness | Roslyn `ReferenceEqualityComparer::.cctor` absent from final validity defect output |
| PR CI | Pass; branch clean |

## Decompiler quality

**Conclusion:** **PASS** — harness-only classification fix; no product raise/structuring/printer behavior changes and no corpus quality card required.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked both validity paths, IR backing-field gate, assignment-left gate, and false-negative-safe nested-type note. |
| MAI-Code-1-Flash | Finding resolved | Flagged syntax-only receiver matching; resolved by `462608b9`, which requires semantic receiver resolution to the same metadata full name. Re-review found no blocking findings. |

**Review conclusion:** **PASS** — required adversarial review is reconciled; the only actionable finding was fixed in `462608b9`.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/ValidityShellNoiseTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet run --project tools/DecompilerHarness -c Release -- ~/.nuget/packages/microsoft.codeanalysis.common/5.8.0-1.26277.111/lib/netstandard2.0/Microsoft.CodeAnalysis.dll --validity-check --compile-cap 3000 --max-examples 120
```
