### PR TITLE
Fix reference conditional slot naming (#1767)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4240,6 +4240,8 @@ public static class EnumCastSamples
         return seed;
     }
 }
+
+
 // Issue #1759: a reference-typed value produced by `as`/isinst and tested for
 // truthiness in a branch (here the `?.Dispose()` null-conditional inside a
 // finally) must render `is null`/`is not null`, not `!S` — `!IDisposable` is

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -1960,6 +1960,14 @@ public class CfgSampleClass
 
     public static int TernaryInt(int a, int b) => a > b ? a : b;
 
+    string? _dateTimeFormat;
+
+    public string? SlotMergedDateTimeFormat
+    {
+        get => _dateTimeFormat;
+        set => _dateTimeFormat = string.IsNullOrEmpty(value) ? null : value;
+    }
+
     public static int GuardReturnAfterLocalPrelude(int value, int whenPositive, int otherwise)
     {
         int positive = whenPositive;
@@ -4232,8 +4240,6 @@ public static class EnumCastSamples
         return seed;
     }
 }
-
-
 // Issue #1759: a reference-typed value produced by `as`/isinst and tested for
 // truthiness in a branch (here the `?.Dispose()` null-conditional inside a
 // finally) must render `is null`/`is not null`, not `!S` — `!IDisposable` is

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1953,6 +1953,91 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void ReferenceConditionalStore_UsesConsumerSlotType()
+    {
+        // A null/string conditional can arrive with object as its merged stack type
+        // while the single live consumer is a string field store. The slot must
+        // declare as the consumer type; otherwise the load gets a split S_0_1 name
+        // that was never assigned (CS0165).
+        var owner = TypeRef.Definition("Synthetic", "Samples", "SlotProbe");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var stringType = TypeRef.CoreLib("System", "String");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new StoreStackSlot(0, new Conditional(
+            new LoadArgument(1, "empty", boolType),
+            new Constant(null, objectType),
+            new LoadArgument(2, "value", stringType))
+        { MergedType = objectType }));
+        block.Add(new StoreField(
+            new FieldRef(owner, "_fmt", stringType),
+            new LoadArgument(0, "this", owner),
+            new LoadStackSlot(0, stringType)));
+        block.Add(new Return(null));
+        var signature = new MethodSignature(voidType,
+            [new Parameter("empty", boolType), new Parameter("value", stringType)],
+            HasThis: true,
+            GenericParameterCount: 0);
+        var function = new IrFunction("set_DateTimeFormat", owner, signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+
+        Assert.Contains("string S_0", output);
+        Assert.Contains("_fmt = S_0;", output);
+        Assert.DoesNotContain("object S_0", output);
+        Assert.DoesNotContain("S_0_1", output);
+    }
+
+    [Fact]
+    public void ReferenceConditionalStore_DoesNotNarrowToUnprovenReferenceTarget()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "SlotProbe");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var objectType = TypeRef.CoreLib("System", "Object");
+        var unresolved = TypeRef.Definition("OtherAssembly", "Samples", "MaybeStruct");
+        var voidType = TypeRef.CoreLib("System", "Void");
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new StoreStackSlot(0, new Conditional(
+            new LoadArgument(0, "empty", boolType),
+            new Constant(null, objectType),
+            new LoadArgument(1, "value", unresolved))
+        { MergedType = objectType }));
+        block.Add(new StoreField(
+            new FieldRef(owner, "Maybe", unresolved),
+            new LoadArgument(2, "this", owner),
+            new LoadStackSlot(0, unresolved)));
+        block.Add(new Return(null));
+        var signature = new MethodSignature(voidType,
+            [new Parameter("empty", boolType), new Parameter("value", unresolved)],
+            HasThis: true,
+            GenericParameterCount: 0);
+        var function = new IrFunction("set_Maybe", owner, signature, [], container);
+
+        IrPasses.Run(function);
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+
+        Assert.Contains("object S_0", output);
+        Assert.DoesNotContain("MaybeStruct S_0 =", output);
+    }
+
+    [Fact]
+    public void ReferenceConditionalStore_CompiledSetterUsesOneSlotName()
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        string output = PrintWithPasses(typeof(CfgSampleClass).FullName!, "set_SlotMergedDateTimeFormat", source);
+
+        Assert.Contains("_dateTimeFormat", output);
+        Assert.DoesNotContain("object S_", output);
+        Assert.DoesNotContain("S_1_1", output);
+    }
+
+    [Fact]
     public void BooleanMaterialization_ReusedReceiverSlot_KeepsBoolLiveRangeDistinct()
     {
         // A ?. bool test can reuse the same edge slot first for the string

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1062,7 +1062,10 @@ public sealed partial class CSharpPrinter
                 && TryCharConstantText(conditional.WhenFalse, out _))
             || (IsEnumLikeInteger(target)
                 && IsIntegerArm(conditional.WhenTrue)
-                && IsIntegerArm(conditional.WhenFalse));
+                && IsIntegerArm(conditional.WhenFalse))
+            || (IsKnownReferenceLike(target)
+                && CanAssignTo(conditional.WhenTrue, target)
+                && CanAssignTo(conditional.WhenFalse, target));
 
     static bool IsIntegerArm(IrExpression arm)
         => arm.ResultType is { } type && TypeFamilies.IsIntegerLike(type);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -634,6 +634,19 @@ public sealed partial class CSharpPrinter
             && !TypeFamilies.IsNumericPrimitive(type);
     }
 
+    bool IsKnownReferenceLike(TypeRef type)
+    {
+        if (type.Kind is TypeRefKind.ByRef or TypeRefKind.Pointer or TypeRefKind.FunctionPointer)
+            return false;
+        if (TypeFamilies.Of(type) == StackFamily.O)
+            return true;
+        if (type.DeclaredValueTypeHint == ValueTypeHint.ReferenceType)
+            return true;
+        if (_function.TypeShapes.GetValueOrDefault(type) == TypeShape.Reference)
+            return true;
+        return type.Kind is TypeRefKind.SzArray or TypeRefKind.Array;
+    }
+
     static bool IsCoreObject(TypeRef type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Object" };
 


### PR DESCRIPTION
- Fixes #1767
- Part of #1687
- Changes reference conditional stack-slot naming so a proven reference consumer can unify an object-merged null/reference ternary to one assigned slot name.
- Card revision: `922f9971`

## Change

**Conclusion:** **PASS** — narrows the false Full CS0165 shape without allowing unresolved value-type targets to masquerade as reference sinks.

Before:

```csharp
object S_1 = StringUtils.IsNullOrEmpty(value) ? null : value;
S_0._dateTimeFormat = S_1_1; // unassigned
```

After:

```csharp
string S_1 = StringUtils.IsNullOrEmpty(value) ? null : value;
S_0._dateTimeFormat = S_1;
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `RaisingPassTests/ReferenceConditionalStore*` passed (3/3) |
| Decompiler fast suite | Pass (1658/1658) |
| Real witness | `Newtonsoft.Json.Converters.IsoDateTimeConverter::set_DateTimeFormat` renders one assigned `string S_1` slot |
| Real witness validity | Newtonsoft.Json 13.0.4 validity sweep: tracked methods absent from semantic-defect examples; remaining CS0165 rows are different buckets |
| PR CI | Pass; branch clean |

## Decompiler quality

**Conclusion:** **PASS** — PR quick pinned-subset gate is stable; aggregate forward-merge movement is advisory baseline/corpus drift.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 15 assemblies, 1,462 methods
Sample: hash-stable 100 methods per assembly
Correctness coverage: validity not run; fidelity not run

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (`--emit-corpus-baseline`) before trusting count-based regressions.

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 1,213 (83.03%) | 1,216 (83.17%) | +3 |
| Conditional-branch residual (-) | 35 (2.40%) | 35 (2.39%) | 0 |
| Forward-merge stops (-) | 27 (1.85%) | 29 (1.98%) | +2 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 82.17% -> 82.17% (0 pp); conditional residual 3.00% -> 3.00% (0 pp); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Advisory aggregate rate movement (not a PR quick hard gate; review for decompiler-risky changes): forward-merge stop increased 0.13 pp (baseline 1.85%, PR 1.98%, tolerance 0.10 pp).

Verdict: corpus sensor matched baseline tolerances.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| MAI-Code-1-Flash | Finding resolved | Found the initial reference-like target gate was too broad for unresolved value-type-shaped targets; fixed by requiring `IsKnownReferenceLike` and adding an unresolved-target negative canary. |
| Claude Opus 4.8 | No blocking findings | Verified the two original canaries reproduced the S_N/S_N_1 split when reverted and found no branch-only regression in conditional/slot/enum/char sweeps. Final implementation is stricter than the reviewed initial gate. |

**Review conclusion:** **PASS** — actionable MAI guidance was resolved in the implementation; no remaining blocking findings.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/RaisingPassTests/ReferenceConditionalStore*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet run --project tools/DecompilerHarness -c Release -- ~/.nuget/packages/newtonsoft.json/13.0.4/lib/netstandard2.0/Newtonsoft.Json.dll --validity-check --compile-cap 2000 --max-examples 120
bash eng/prepare-decompiler-pr-corpus.sh /tmp/pr-corpus-assemblies-1767.txt
mapfile -t assemblies < /tmp/pr-corpus-assemblies-1767.txt
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --diff-corpus-baseline tools/DecompilerHarness/corpus/pr-quick-baseline.json --quality-diff-card --corpus-method-cap 100 --compile-cap 0 --corpus-fidelity-cap 0 --max-examples 3
```
