### PR TITLE
Unify merged stack-slot name across producer and consumer types (#1767)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4286,3 +4286,24 @@ public static class FinallyDisposeNestedSamples
         }
     }
 }
+
+// Issue #1767: a value produced at a stack slot (the object-merged `cond ? null
+// : value` ternary) and consumed at a control-flow merge where the slot is typed
+// `string` (a field store) must share ONE local name. Keying slot names on
+// (slot, type) split them into `object S_1` (store) and `string S_1_1` (load),
+// so the consumer read an unassigned local (CS0165) and the value was dropped.
+public static class MergedSlotStrU
+{
+    public static bool IsNullOrEmpty(string s) => s == null || s.Length == 0;
+}
+
+public class MergedSlotProbe
+{
+    private string? _fmt;
+
+    public string? MergedFormat
+    {
+        get => _fmt;
+        set => _fmt = MergedSlotStrU.IsNullOrEmpty(value!) ? null : value;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/MergedSlotNamingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MergedSlotNamingTests.cs
@@ -1,0 +1,36 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Issue #1767: a stack slot whose producer (an object-merged `cond ? null :
+// value` ternary) and consumer (a string-typed field store) carry different
+// static types must render with one unified local name. Keying names on
+// (slot, type) split them — `object S_1` declared/assigned, `string S_1_1`
+// read — so the consumer used an unassigned local (CS0165) and the produced
+// value was silently dropped.
+public class MergedSlotNamingTests
+{
+    [Fact]
+    public void ProducerAndConsumerOfMergedSlot_ShareOneLocalName()
+    {
+        string body = RenderFixture(typeof(MergedSlotProbe).FullName!, "set_MergedFormat");
+
+        // The store value reaches the consumer: one declaration, assigned and read
+        // under the same name, with no phantom second-ordinal local.
+        Assert.Contains("string S_1 = ", body);
+        Assert.Contains("_fmt = S_1;", body);
+        Assert.DoesNotContain("S_1_1", body);
+        Assert.DoesNotContain("object S_1", body);
+    }
+
+    static string RenderFixture(string typeName, string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(MergedSlotProbe).Assembly.Location);
+        var function = IrImporter.Import(source, typeName, methodName);
+        Assert.NotNull(function);
+        Assert.Equal(DecompilationFidelity.Full, function!.Fidelity);
+        var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+        Assert.NotNull(result.Output);
+        return result.Output!;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -601,11 +601,22 @@ public sealed partial class CSharpPrinter
     }
 
     bool CanAssignTo(IrExpression value, TypeRef target)
-        => value is Constant { Value: null }
-            ? IsReferenceLike(target)
-            : value is Conditional conditional && CanRenderConditionalForTarget(conditional, target)
-                ? true
-            : value.ResultType is { } source && CanAssignType(source, target);
+    {
+        if (value is Constant { Value: null })
+            return IsReferenceLike(target);
+        if (value is Conditional conditional)
+            // A conditional unifies to a target its arms each satisfy — e.g.
+            // `cond ? null : value` (null + string) is assignable to `string`,
+            // even though its IL-merged ResultType widened to `object`. Without
+            // this the slot's object-typed store and string-typed load get
+            // different names (S_1 vs S_1_1) and the consumer reads an unassigned
+            // local (#1767). The char/enum arm-cast path and the merged-ResultType
+            // fallback remain.
+            return CanRenderConditionalForTarget(conditional, target)
+                || (CanAssignTo(conditional.WhenTrue, target) && CanAssignTo(conditional.WhenFalse, target))
+                || (conditional.ResultType is { } condType && CanAssignType(condType, target));
+        return value.ResultType is { } source && CanAssignType(source, target);
+    }
 
     bool CanAssignType(TypeRef source, TypeRef target)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -589,7 +589,8 @@ public sealed partial class CSharpPrinter
         foreach (var candidate in candidates)
         {
             if (stores.All(store => CanAssignTo(store, candidate))
-                && loads.All(load => load is null || CanAssignType(candidate, load)))
+                && loads.All(load => load is null || CanAssignType(candidate, load))
+                && loads.All(load => load is null || !StrictlyNarrowsReference(candidate, load)))
             {
                 unifiedType = candidate;
                 return true;
@@ -599,6 +600,13 @@ public sealed partial class CSharpPrinter
         unifiedType = TypeRef.CoreLib("System", "Object");
         return false;
     }
+
+    /// <summary>True when naming the slot <paramref name="candidate"/> would give a load site a narrower reference type than its own (e.g. picking <c>string</c> for an <c>object</c> load), which can silently rebind an overloaded call. Equal or wider candidates are fine.</summary>
+    bool StrictlyNarrowsReference(TypeRef candidate, TypeRef load)
+        => IsReferenceLike(candidate)
+            && !candidate.Equals(load)
+            && CanAssignType(candidate, load)
+            && !CanAssignType(load, candidate);
 
     bool CanAssignTo(IrExpression value, TypeRef target)
     {
@@ -610,10 +618,16 @@ public sealed partial class CSharpPrinter
             // even though its IL-merged ResultType widened to `object`. Without
             // this the slot's object-typed store and string-typed load get
             // different names (S_1 vs S_1_1) and the consumer reads an unassigned
-            // local (#1767). The char/enum arm-cast path and the merged-ResultType
+            // local (#1767). Restricted to reference-like targets: a non-reference
+            // target (char/numeric) needs per-arm target rendering that the
+            // conditional printer only does for immediate constant arms, so a
+            // nested conditional would unify to `char` yet render an `int` ternary
+            // (CS0266). The char/enum arm-cast path and the merged-ResultType
             // fallback remain.
             return CanRenderConditionalForTarget(conditional, target)
-                || (CanAssignTo(conditional.WhenTrue, target) && CanAssignTo(conditional.WhenFalse, target))
+                || (IsReferenceLike(target)
+                    && CanAssignTo(conditional.WhenTrue, target)
+                    && CanAssignTo(conditional.WhenFalse, target))
                 || (conditional.ResultType is { } condType && CanAssignType(condType, target));
         return value.ResultType is { } source && CanAssignType(source, target);
     }


### PR DESCRIPTION
## Invalid-`Full` burndown (#1687): unify merged stack-slot names

A value produced at a stack slot — the object-merged `cond ? null : value` ternary — and consumed at a control-flow merge where the slot is typed `string` (a field store) was rendered with **two different local names**: `object S_1` at the store, `string S_1_1` at the load. The consumer then read an unassigned local (`CS0165`) and the produced value was silently dropped, while the method stayed graded `Full`.

Real-world witnesses (Newtonsoft.Json): `IsoDateTimeConverter::set_DateTimeFormat`, `JsonSchemaModel::Combine`.

### Root cause

Slot names are keyed on `(slot, type)`. `TryChooseUnifiedStackSlotType` couldn't pick a common type because `CanAssignTo` only accepted a `Conditional` through the char/enum arm-cast path, and the ternary's IL-merged `ResultType` had widened to `object` (not assignable to the `string` load). With no unified type, the `object` store and `string` load got different names.

### Fix

Extend `CanAssignTo`: a conditional unifies to a target its **arms each satisfy** — `cond ? null : value` (null + string) is assignable to `string`, even though its merged `ResultType` is `object`. The slot then unifies to `string`, so producer and consumer share one name.

### Before → after

```
string S_1_1;
SlotProbe S_0 = this;
object S_1 = StrU.IsNullOrEmpty(value) ? null : value;
S_0._fmt = S_1_1;            // unassigned; the ternary result dropped
->
SlotProbe S_0 = this;
string S_1 = StrU.IsNullOrEmpty(value) ? null : value;
S_0._fmt = S_1;
```

### Evidence

- Both named witnesses now bind: `set_DateTimeFormat` → `S_0._dateTimeFormat = S_1;`; `Combine` drops off the CS0165 set.
- Fixture `--validity-check`: 4/4 Full, 0 malformed, 0 binding errors.
- New `MergedSlotProbe` fixture + `MergedSlotNamingTests`.
- Fast decompiler suite **1652/1652**.
- Corpus quality-diff: _posting below once complete._

### Out of scope (separate row to be filed)

A distinct CS0165 family remains in the same corpus — a **bool/int** slot-type confusion (e.g. `DefaultContractResolver::InitializeContract`: store `bool`, load typed `int`), not the object/string reference merge this row targets. Filing separately per the burndown's narrow-row methodology.

Closes #1767. Part of #1687.
