### PR TITLE
Fix cross-assembly enum constants in target contexts

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4183,7 +4183,7 @@ public static class UserGridCalls
     public static void UserSet(UserGridSample g, int i, int j, int v) => g.Set(i, j, v);
 }
 
-// Issues #1766 / #1772: a cross-assembly (framework) enum resolves to
+// Issues #1766 / #1772 / #1806: a cross-assembly (framework) enum resolves to
 // TypeShape.Unknown, so an integer constant flowing into it through a
 // conditional arm or a bitwise compound assignment renders as a bare int —
 // invalid `int->enum` (CS0266) / `enum |= int` (CS0019) at Full. The printer
@@ -4231,6 +4231,30 @@ public static class EnumCastSamples
         seed &= ~System.AttributeTargets.Class;
         return seed;
     }
+
+    // #1806: the fallback of `Nullable<cross-assembly enum> ?? enumConstant`
+    // needs the same structural enum cast as conditional arms.
+    public static System.StringComparison EnumCoalesce(System.StringComparison? value)
+        => value ?? System.StringComparison.Ordinal;
+
+    // #1806: switch-expression arms yielding cross-assembly enum constants need
+    // target-aware casts, including the direct-return multi-line switch form.
+    public static System.StringComparison EnumSwitchExpression(int value)
+        => value switch
+        {
+            0 => System.StringComparison.Ordinal,
+            _ => System.StringComparison.OrdinalIgnoreCase,
+        };
+
+    public static CfgPriority SameAssemblyEnumCoalesce(CfgPriority? value)
+        => value ?? CfgPriority.High;
+
+    public static CfgPriority SameAssemblyEnumSwitchExpression(int value)
+        => value switch
+        {
+            0 => CfgPriority.High,
+            _ => CfgPriority.Critical,
+        };
 }
 
 

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -55,6 +55,109 @@ public class EnumCastPrinterTests
         AssertCompiles("public static AttributeTargets M(AttributeTargets seed)", body);
     }
 
+    [Fact]
+    public void EnumCoalesce_IntoCrossAssemblyEnum_CastsFallback()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.EnumCoalesce));
+
+        Assert.Contains("?? (StringComparison)4", body);
+        Assert.DoesNotContain("?? 4", body);
+        AssertCompiles("public static StringComparison M(StringComparison? value)", body);
+    }
+
+    [Fact]
+    public void EnumSwitchExpression_ReturningCrossAssemblyEnum_CastsArms()
+    {
+        var enumType = TypeRef.CoreLib("System", "StringComparison");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        string body = RenderSyntheticSwitchExpression(
+            enumType,
+            new Constant(4, intType),
+            new Constant(5, intType));
+
+        Assert.Contains("=> (StringComparison)4", body);
+        Assert.Contains("=> (StringComparison)5", body);
+        Assert.DoesNotContain("=> 4", body);
+        Assert.DoesNotContain("=> 5", body);
+        AssertCompiles("public static StringComparison M(int value)", body);
+    }
+
+    [Fact]
+    public void SameAssemblyEnumCoalesce_KeepsNamedMember()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.SameAssemblyEnumCoalesce));
+
+        Assert.Contains("CfgPriority.High", body);
+        Assert.DoesNotContain("(CfgPriority)2", body);
+        AssertCompiles("public static CfgPriority M(CfgPriority? value)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    [Fact]
+    public void SameAssemblyEnumSwitchExpression_KeepsNamedMembers()
+    {
+        var enumType = TypeRef.Definition("test", "", "CfgPriority");
+        string body = RenderSyntheticSwitchExpression(
+            enumType,
+            new Constant(2, enumType),
+            new Constant(3, enumType),
+            new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum },
+            new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>
+            {
+                [enumType] = new Dictionary<long, string> { [2] = "High", [3] = "Critical" },
+            });
+
+        Assert.Contains("CfgPriority.High", body);
+        Assert.Contains("CfgPriority.Critical", body);
+        Assert.DoesNotContain("(CfgPriority)2", body);
+        Assert.DoesNotContain("(CfgPriority)3", body);
+        AssertCompiles("public static CfgPriority M(int value)", body, "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    [Fact]
+    public void UnknownEnumPositiveConstantThatMayOverflow_ForcesUncheckedCast()
+    {
+        string sbyteBody = RenderUnknownEnumReturnConstant(128);
+        string byteBody = RenderUnknownEnumReturnConstant(300);
+
+        Assert.Contains("return unchecked((Tiny)128);", sbyteBody);
+        Assert.DoesNotContain("return (Tiny)128;", sbyteBody);
+        AssertCompiles("public static Tiny M()", sbyteBody, "public enum Tiny : sbyte { }");
+
+        Assert.Contains("return unchecked((Tiny)300);", byteBody);
+        Assert.DoesNotContain("return (Tiny)300;", byteBody);
+        AssertCompiles("public static Tiny M()", byteBody, "public enum Tiny : byte { }");
+    }
+
+    [Fact]
+    public void UnknownEnumSwitchLabelPositiveConstantThatMayOverflow_ForcesUncheckedCast()
+    {
+        string body = RenderUnknownEnumSwitchLabel(128);
+
+        Assert.Contains("case unchecked((Tiny)128):", body);
+        Assert.DoesNotContain("case (Tiny)128:", body);
+        AssertCompiles("public static void M(Tiny value)", body, "public enum Tiny : sbyte { }");
+    }
+
+    [Fact]
+    public void UnknownEnumSwitchExpressionLabelPositiveConstantThatMayOverflow_ForcesUncheckedCast()
+    {
+        string body = RenderUnknownEnumSwitchExpressionLabel(128);
+
+        Assert.Contains("unchecked((Tiny)128) => 1", body);
+        Assert.DoesNotContain("(Tiny)128 => 1", body);
+        AssertCompiles("public static int M(Tiny value)", body, "public enum Tiny : sbyte { }");
+    }
+
+    [Fact]
+    public void IntegerNullableCoalesce_IntoUnknownEnum_CastsWholeCoalesce()
+    {
+        string body = RenderIntegerNullableCoalesceIntoUnknownEnum();
+
+        Assert.Contains("return (Tiny)(value ?? 4);", body);
+        Assert.DoesNotContain("value ?? (Tiny)4", body);
+        AssertCompiles("public static Tiny M(int? value)", body, "public enum Tiny { }");
+    }
+
     static string RenderFixture(string methodName)
     {
         using var source = MetadataSource.Open(typeof(EnumCastSamples).Assembly.Location);
@@ -66,19 +169,140 @@ public class EnumCastPrinterTests
         return result.Output!;
     }
 
-    static void AssertCompiles(string header, string body)
+    static string RenderSyntheticSwitchExpression(
+        TypeRef returnType,
+        IrExpression firstArm,
+        IrExpression defaultArm,
+        IReadOnlyDictionary<TypeRef, TypeShape>? typeShapes = null,
+        IReadOnlyDictionary<TypeRef, IReadOnlyDictionary<long, string>>? enumMembers = null)
     {
-        var errors = Recompile(header, body)
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var switchExpression = new SwitchExpression(
+            new LoadArgument(0, "value", intType),
+            [
+                new SwitchExpressionArm(ImmutableArray.Create(0), isDefault: false, firstArm),
+                new SwitchExpressionArm(ImmutableArray<int>.Empty, isDefault: true, defaultArm),
+            ]);
+        var block = new Block(0);
+        block.Add(new Return(switchExpression));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(returnType, [new Parameter("value", intType)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], container)
+        {
+            TypeShapes = typeShapes ?? new Dictionary<TypeRef, TypeShape>(),
+            EnumMembers = enumMembers ?? new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>(),
+        };
+
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    static string RenderUnknownEnumReturnConstant(int value)
+    {
+        var enumType = TypeRef.Definition("other", "", "Tiny");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var block = new Block(0);
+        block.Add(new Return(new Constant(value, intType)));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(enumType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], container);
+
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    static string RenderUnknownEnumSwitchLabel(int value)
+    {
+        var enumType = TypeRef.Definition("other", "", "Tiny");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Switch(
+            new LoadArgument(0, "value", enumType),
+            [
+                new SwitchSection(ImmutableArray.Create(new Constant(value, intType)), isDefault: false, SingleReturnContainer()),
+                new SwitchSection(ImmutableArray<Constant>.Empty, isDefault: true, SingleReturnContainer()),
+            ]));
+        body.Add(block);
+        var signature = new MethodSignature(
+            TypeRef.CoreLib("System", "Void"),
+            [new Parameter("value", enumType)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], body);
+
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    static string RenderUnknownEnumSwitchExpressionLabel(int value)
+    {
+        var enumType = TypeRef.Definition("other", "", "Tiny");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var switchExpression = new SwitchExpression(
+            new LoadArgument(0, "value", enumType),
+            [
+                new SwitchExpressionArm(ImmutableArray.Create(value), isDefault: false, new Constant(1, intType)),
+                new SwitchExpressionArm(ImmutableArray<int>.Empty, isDefault: true, new Constant(0, intType)),
+            ]);
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Return(switchExpression));
+        body.Add(block);
+        var signature = new MethodSignature(
+            intType,
+            [new Parameter("value", enumType)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], body);
+
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    static string RenderIntegerNullableCoalesceIntoUnknownEnum()
+    {
+        var enumType = TypeRef.Definition("other", "", "Tiny");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var nullableInt = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System", "Nullable`1"),
+            ImmutableArray.Create(intType));
+        var coalesce = new Coalesce(new LoadArgument(0, "value", nullableInt), new Constant(4, intType));
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Return(coalesce));
+        body.Add(block);
+        var signature = new MethodSignature(
+            enumType,
+            [new Parameter("value", nullableInt)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], body);
+
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    static BlockContainer SingleReturnContainer()
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Return(null));
+        container.Add(block);
+        return container;
+    }
+
+    static void AssertCompiles(string header, string body, string extraDeclarations = "")
+    {
+        var errors = Recompile(header, body, extraDeclarations)
             .Where(d => d.Severity == DiagnosticSeverity.Error)
             .Select(d => $"{d.Id}: {d.GetMessage()}")
             .ToArray();
         Assert.True(errors.Length == 0, "Rendered body must compile, got:\n  " + string.Join("\n  ", errors) + "\n--- body ---\n" + body);
     }
 
-    static ImmutableArray<Diagnostic> Recompile(string methodHeader, string body)
+    static ImmutableArray<Diagnostic> Recompile(string methodHeader, string body, string extraDeclarations)
     {
         string source = $$"""
             using System;
+            {{extraDeclarations}}
             static class __Gate
             {
                 {{methodHeader}}

--- a/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
@@ -99,8 +99,8 @@ public class LadderRung9GateTests
         AssertDynamicPartial(members, "DynamicSetMember", "Binder.SetMember");
         AssertDynamicPartial(members, "DynamicGetIndex", "Binder.GetIndex");
         AssertDynamicPartial(members, "DynamicSetIndex", "Binder.SetIndex");
-        AssertDynamicPartial(members, "DynamicCompoundMember", "Binder.SetMember((CSharpBinderFlags)128", "Binder.GetMember", "Binder.BinaryOperation");
-        AssertDynamicPartial(members, "DynamicResultDiscarded", "Binder.InvokeMember((CSharpBinderFlags)256", "CallSite<Action<CallSite, object>>");
+        AssertDynamicPartial(members, "DynamicCompoundMember", "Binder.SetMember(unchecked((CSharpBinderFlags)128)", "Binder.GetMember", "Binder.BinaryOperation");
+        AssertDynamicPartial(members, "DynamicResultDiscarded", "Binder.InvokeMember(unchecked((CSharpBinderFlags)256)", "CallSite<Action<CallSite, object>>");
         AssertDynamicPartial(members, "DynamicEventAdd", "Binder.IsEvent", "add_Changed");
         AssertDynamicPartial(members, "DynamicEventRemove", "Binder.IsEvent", "remove_Changed");
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -179,14 +179,28 @@ public sealed partial class CSharpPrinter
     {
         bool negativeLiteral = value is Constant { Value: int iv } && iv < 0
             || value is Constant { Value: long lv } && lv < 0;
-        // A negative constant into an unsigned- or narrow-backed enum is CS0221 as a
-        // plain cast even outside a checked region — `(U)(-1)` for `enum U : uint`,
-        // the int bit-pattern of a high-bit flags member. The underlying type of a
-        // cross-assembly enum is unknown, so force `unchecked` to keep the
-        // reinterpret legal; the parentheses also satisfy CS0075.
+        bool forceUnchecked = negativeLiteral || MayOverflowUnknownEnumBackingType(value, enumType);
+        // A constant can be CS0221 as a plain cast even outside a checked region:
+        // negative into an unsigned-backed enum (`(U)(-1)`) or positive values that
+        // may overflow a signed- or unsigned-byte-backed unknown enum
+        // (`(Tiny)128` for sbyte, `(Tiny)300` for byte).
+        // Force `unchecked` when the target shape cannot prove the backing width;
+        // negative literals also need parentheses after the cast (CS0075).
         return CheckedSafeCast(
             $"({TypeText(enumType)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}",
-            force: negativeLiteral);
+            force: forceUnchecked);
+    }
+
+    bool MayOverflowUnknownEnumBackingType(IrExpression value, TypeRef enumType)
+    {
+        if (_function.TypeShapes.GetValueOrDefault(enumType) != TypeShape.Unknown)
+            return false;
+        return value switch
+        {
+            Constant { Value: int iv } => iv > sbyte.MaxValue,
+            Constant { Value: long lv } => lv > sbyte.MaxValue,
+            _ => false,
+        };
     }
 
     string BinaryBody(Binary binary, bool wrap, bool uncheckedOverflow)
@@ -917,11 +931,7 @@ public sealed partial class CSharpPrinter
             && EffectiveType(value) is { } enumSource && !enumTarget.Equals(enumSource)
             && TypeFamilies.IsIntegerLike(enumSource))
         {
-            // A negative literal must be parenthesized after the cast (CS0075),
-            // as the enum-constant path above (line ~482) already does.
-            bool negativeLiteral = value is Constant { Value: int iv } && iv < 0
-                || value is Constant { Value: long lv } && lv < 0;
-            return $"({TypeText(enumTarget)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}";
+            return EnumIntegerCast(value, enumTarget);
         }
         if (value is Binary enumArithmetic
             && target is { } enumArithmeticTarget
@@ -955,9 +965,7 @@ public sealed partial class CSharpPrinter
             && !TypeFamilies.IsNumericPrimitive(unknownEnum)
             && EffectiveType(value) is { } unknownEnumSource && TypeFamilies.IsIntegerLike(unknownEnumSource))
         {
-            bool negativeLiteral = value is Constant { Value: int iv } && iv < 0
-                || value is Constant { Value: long lv } && lv < 0;
-            return $"({TypeText(unknownEnum)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}";
+            return EnumIntegerCast(value, unknownEnum);
         }
         // A bool-valued expression flowing into an integer target is IL's
         // comparison/test result consumed as a number — `cgt.un; ret` from an int
@@ -973,6 +981,14 @@ public sealed partial class CSharpPrinter
             && target is { } conditionalTarget
             && TryConditionalTextForTarget(conditional, conditionalTarget) is { } targetedConditional)
             return targetedConditional;
+        if (value is SwitchExpression switchExpression
+            && target is { } switchTarget
+            && CanRenderSwitchExpressionForTarget(switchExpression, switchTarget))
+            return SwitchExpressionInline(switchExpression, switchTarget);
+        if (value is Coalesce coalesce
+            && target is { } coalesceTarget
+            && TryCoalesceTextForTarget(coalesce, coalesceTarget) is { } targetedCoalesce)
+            return targetedCoalesce;
         // Cast only off a value whose rendered C# type reliably equals its IR
         // result type. A merge node (ternary/coalesce) reports a merged type the
         // arms may not actually share, and a stack slot's type is the join of
@@ -1066,6 +1082,20 @@ public sealed partial class CSharpPrinter
 
     static bool IsIntegerArm(IrExpression arm)
         => arm.ResultType is { } type && TypeFamilies.IsIntegerLike(type);
+
+    bool CanRenderSwitchExpressionForTarget(SwitchExpression expression, TypeRef target)
+        => IsEnumLikeInteger(target) && expression.Arms.All(arm => IsIntegerArm(arm.Value));
+
+    string? TryCoalesceTextForTarget(Coalesce coalesce, TypeRef target)
+    {
+        if (!IsEnumLikeInteger(target))
+            return null;
+        if (NullableValueType(coalesce.Left.ResultType)?.Equals(target) == true && IsIntegerArm(coalesce.Right))
+            return CoalesceText(coalesce, target);
+        return coalesce.ResultType is { } resultType && TypeFamilies.IsIntegerLike(resultType)
+            ? EnumIntegerCast(coalesce, target)
+            : null;
+    }
 
     static bool IsCoreChar(TypeRef type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Char" };

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -150,12 +150,30 @@ public sealed partial class CSharpPrinter
     };
 
     /// <summary>The text of one switch-expression arm: its labels (or <c>_</c>) and the value it yields.</summary>
-    string SwitchArmText(SwitchExpressionArm arm)
-        => $"{(arm.IsDefault ? "_" : string.Join(" or ", arm.Labels))} => {Expression(arm.Value)}";
+    string SwitchArmText(SwitchExpressionArm arm, TypeRef? target = null, TypeRef? labelEnum = null)
+        => $"{SwitchExpressionLabelText(arm, labelEnum)} => {SwitchArmValueText(arm.Value, target)}";
+
+    string SwitchExpressionLabelText(SwitchExpressionArm arm, TypeRef? labelEnum)
+        => arm.IsDefault
+            ? "_"
+            : string.Join(" or ", arm.Labels.Select(label => SwitchLabelText(
+                new Constant(label, TypeRef.CoreLib("System", "Int32")),
+                labelEnum)));
+
+    string SwitchArmValueText(IrExpression value, TypeRef? target)
+        => target is { } enumTarget
+            && IsEnumLikeInteger(enumTarget)
+            && value.ResultType is { } valueType
+            && TypeFamilies.IsIntegerLike(valueType)
+                ? EnumIntegerCast(value, enumTarget)
+                : Expression(value);
 
     /// <summary>The single-line form of a switch expression, used when it is nested inside another expression.</summary>
-    string SwitchExpressionInline(SwitchExpression node)
-        => $"{Operand(node.Value)} switch {{ {string.Join(", ", node.Arms.Select(SwitchArmText))} }}";
+    string SwitchExpressionInline(SwitchExpression node, TypeRef? target = null)
+    {
+        var labelEnum = SwitchLabelEnumType(node.Value);
+        return $"{Operand(node.Value)} switch {{ {string.Join(", ", node.Arms.Select(arm => SwitchArmText(arm, target, labelEnum)))} }}";
+    }
 
     string InterpolatedStringText(InterpolatedStringExpression node)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -896,10 +896,11 @@ public sealed partial class CSharpPrinter
             // indented under the governing value — the statement context knows the
             // indent the inline Expression() form cannot.
             string inner = pad + "    ";
+            var labelEnum = SwitchLabelEnumType(returnedSwitch.Value);
             sb.Append(pad).Append("return ").Append(Operand(returnedSwitch.Value)).AppendLine(" switch");
             sb.Append(pad).AppendLine("{");
             foreach (var arm in returnedSwitch.Arms)
-                sb.Append(inner).Append(SwitchArmText(arm)).AppendLine(",");
+                sb.Append(inner).Append(SwitchArmText(arm, _function.Signature.ReturnType, labelEnum)).AppendLine(",");
             sb.Append(pad).AppendLine("};");
             return;
         }
@@ -1506,8 +1507,29 @@ public sealed partial class CSharpPrinter
         _ => $"/* {node.Describe()} */",
     };
 
-    string CoalesceText(Coalesce co)
-        => $"{CoalesceOperand(co.Left)} ?? {Operand(co.Right)}";
+    string CoalesceText(Coalesce co, TypeRef? target = null)
+    {
+        TypeRef? coalesceTarget = target ?? NullableValueType(co.Left.ResultType) ?? co.ResultType;
+        return $"{CoalesceOperand(co.Left)} ?? {CoalesceRightText(co.Right, coalesceTarget)}";
+    }
+
+    string CoalesceRightText(IrExpression right, TypeRef? target)
+        => target is { } enumTarget
+            && IsEnumLikeInteger(enumTarget)
+            && right.ResultType is { } rightType
+            && TypeFamilies.IsIntegerLike(rightType)
+                ? EnumIntegerCast(right, enumTarget)
+                : Operand(right);
+
+    static TypeRef? NullableValueType(TypeRef? type)
+        => type is
+        {
+            Kind: TypeRefKind.GenericInstance,
+            ElementType: { Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Nullable`1" },
+            TypeArguments: [var value],
+        }
+            ? value
+            : null;
 
     string CoalesceOperand(IrExpression expression)
         => expression is LoadIndirect
@@ -2667,7 +2689,7 @@ public sealed partial class CSharpPrinter
         var typed = new Constant(value, enumType);
         if (EnumMemberName(typed) is { } named)
             return named;
-        return $"({TypeText(enumType)}){(value < 0 ? $"({value.ToString(CultureInfo.InvariantCulture)})" : value.ToString(CultureInfo.InvariantCulture))}";
+        return EnumIntegerCast(label, enumType);
     }
 
     static string ConstantText(Constant constant) => constant.Value switch


### PR DESCRIPTION
- Fixes #1806
- Changes cross-assembly enum integer constants to cast in coalesce, switch-expression values, and enum switch labels; unknown enum constants above `sbyte.MaxValue` use `unchecked` so narrow-backed enums stay valid.
- Card revision: `51469d90`

## Change

**Conclusion:** **PASS** — target-aware enum casts remove invalid bare integers without loading referenced assemblies.

Before:

```csharp
return value ?? 4;
return value switch { 0 => 4, _ => 5 };
case (Tiny)128:
```

After:

```csharp
return value ?? (StringComparison)4;
return value switch { 0 => (StringComparison)4, _ => (StringComparison)5 };
case unchecked((Tiny)128):
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `EnumCastPrinterTests` passed (12 tests) |
| Decompiler fast suite | Pass (`-trait- "Speed=Slow"`, 1663 tests) |
| Reduced fixture validity | Pass (Roslyn compile canaries for coalesce, switch-expression arms/labels, and narrow unknown enum constants) |
| Real witness | Current corpus has no #1806 witness; this is forward-looking hardening from #1802 adversarial review |

## Decompiler quality

**Conclusion:** **PASS** — PR quick pinned-subset gate matched tolerances. The full real-world card remains red on both this branch and clean current `origin/main` because the checked baseline is stale (`Full malformed 32 -> 37` reproduces on `origin/main` b2669350), so that red full-card result is not branch-specific.

### PR quick gate

Run: PR quick corpus, hash-stable 100 methods per assembly.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 15 assemblies, 1,462 methods
Sample: hash-stable 100 methods per assembly
Correctness coverage: validity not run; fidelity not run

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (`--emit-corpus-baseline`) before trusting count-based regressions.
- total methods 1,461 -> 1,462 (+1)
- ILInspector.MetadataPrimitives: 61 -> 62 methods (+1)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 1,213 (83.03%) | 1,218 (83.31%) | +5 |
| Conditional-branch residual (-) | 35 (2.40%) | 35 (2.39%) | 0 |
| Forward-merge stops (-) | 27 (1.85%) | 29 (1.98%) | +2 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 82.17% -> 82.17% (0 pp); conditional residual 3.00% -> 3.00% (0 pp); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Advisory aggregate rate movement (not a PR quick hard gate; review for decompiler-risky changes):
- forward-merge stop increased 0.13 pp (baseline 1.85%, PR 1.98%, tolerance 0.10 pp)

Verdict: corpus sensor matched baseline tolerances.

## Review

Adversarial review pending.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "ILInspector.Decompiler.Tests.EnumCastPrinterTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
bash eng/prepare-decompiler-pr-corpus.sh /tmp/pr-corpus-assemblies-1806.txt
mapfile -t assemblies < /tmp/pr-corpus-assemblies-1806.txt
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
  --diff-corpus-baseline tools/DecompilerHarness/corpus/pr-quick-baseline.json \
  --quality-diff-card \
  --corpus-method-cap 100 \
  --compile-cap 0 \
  --corpus-fidelity-cap 0 \
  --max-examples 3
```
