### PR TITLE
Add generated analysis-fixture catalogue with expected-signal ledger (#1819)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,8 +226,8 @@ jobs:
       - name: Run decompiler unit tests (fast)
         run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
 
-      - name: Run analysis tests
-        run: dotnet run --project src/ILInspector.Analysis.Tests -c Release
+      - name: Run analysis tests (fast)
+        run: dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -trait- "Speed=Slow"
 
       # The IL round-trip oracle (vendored managed ILAssembler) is
       # platform-neutral at the IL level, so one leg suffices. It is expensive,

--- a/.github/workflows/decompiler-daily.yml
+++ b/.github/workflows/decompiler-daily.yml
@@ -56,6 +56,12 @@ jobs:
       - name: Run decompiler tests
         run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release
 
+      # Analysis tests including the Slow generated-fixture catalogue (#1819), which the PR
+      # lane excludes for cost. The daily run is the catalogue's automated home: it materializes
+      # and grades every fixture so the analysis ledger does not drift unobserved.
+      - name: Run analysis tests (including slow)
+        run: dotnet run --project src/ILInspector.Analysis.Tests -c Release
+
       - name: Prepare real-world corpus
         run: bash eng/prepare-decompiler-corpus.sh corpus-assemblies.txt
 

--- a/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
+++ b/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
@@ -33,6 +33,30 @@ public class AnalysisFixtureCatalogTests
         AssertBoundary(run, "exception.unsuffixed.external", "Throws", OwnedBoundary.FalseNegative);
     }
 
+    // The grader must refuse to silently grade an ambiguous target name (an overload or a
+    // same-named method on another type) rather than pick the first metadata match (#1819 review).
+    [Fact]
+    public void AmbiguousTargetName_FailsExplicitly()
+    {
+        var ambiguous = new AnalysisFixtureDefinition(
+            "test.ambiguous-name",
+            """
+            namespace Fix;
+            public static class A { public static int Dup() => 1; }
+            public static class B { public static int Dup() => 2; }
+            """,
+            ExternalSource: null,
+            ExternalNeedsAlias: false,
+            [new AnalysisFixtureTarget("Dup", new AnalysisExpectation(AllocationsExactly: 0))],
+            ["test"]);
+
+        var run = AnalysisFixtureRunner.Run([ambiguous]);
+        var result = Assert.Single(run.Results);
+
+        Assert.False(result.Passed);
+        Assert.Contains("ambiguous", result.Failure);
+    }
+
     static AnalysisFixtureResult Result(AnalysisFixtureRunResult run, string fixtureId, string method)
         => Assert.Single(run.Results, r => r.FixtureId == fixtureId && r.Method == method);
 

--- a/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
+++ b/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+
+using ILInspector.AnalysisHarness;
+
+namespace ILInspector.Analysis.Tests;
+
+/// <summary>
+/// The seed analysis-fixture catalogue (#1819): materialize small source-shape entries into
+/// temporary consumer + external assemblies, grade each target method's signals against its
+/// expected-signal ledger entry with the real analyzer, and report by stable fixture id. Slow
+/// because each fixture runs `dotnet build`; excluded from the fast PR lane like the decompiler
+/// generated-fixture catalogue.
+/// </summary>
+[Trait("Speed", "Slow")]
+public class AnalysisFixtureCatalogTests
+{
+    [Fact]
+    public void SeedCatalogue_GradesEveryTargetByFixtureId()
+    {
+        var run = AnalysisFixtureRunner.Run(AnalysisFixtureCatalog.All);
+        string report = AnalysisFixtureRunner.FormatReport(run);
+
+        Assert.True(run.Passed, report);
+
+        // Resolved cases: the allocation signal classifies the newobj by true shape.
+        AssertAllocations(run, "alloc.value-struct-newobj.in-assembly", "ConstructsInLoop", 0);
+        AssertAllocations(run, "alloc.value-struct-newobj.cross-asm-generic", "ConstructsInLoop", 0);
+        AssertAllocationsAtLeast(run, "alloc.reftype-newobj.cross-asm-name-collision", "ConstructsInLoop", 1);
+
+        // Owned boundaries: deliberately-imperfect outcomes at the no-referenced-assembly edge.
+        AssertBoundary(run, "alloc.value-struct-newobj.cross-asm-nongeneric", "ConstructsInLoop", OwnedBoundary.FalsePositive);
+        AssertBoundary(run, "exception.suffix-lookalike.external", "ConstructsLookalike", OwnedBoundary.FalsePositive);
+        AssertBoundary(run, "exception.unsuffixed.external", "Throws", OwnedBoundary.FalseNegative);
+    }
+
+    static AnalysisFixtureResult Result(AnalysisFixtureRunResult run, string fixtureId, string method)
+        => Assert.Single(run.Results, r => r.FixtureId == fixtureId && r.Method == method);
+
+    static void AssertAllocations(AnalysisFixtureRunResult run, string fixtureId, string method, int expected)
+    {
+        var result = Result(run, fixtureId, method);
+        Assert.True(result.Passed, result.Failure);
+        Assert.Equal(expected, result.Allocations);
+    }
+
+    static void AssertAllocationsAtLeast(AnalysisFixtureRunResult run, string fixtureId, string method, int atLeast)
+    {
+        var result = Result(run, fixtureId, method);
+        Assert.True(result.Passed, result.Failure);
+        Assert.True(result.Allocations >= atLeast);
+    }
+
+    static void AssertBoundary(AnalysisFixtureRunResult run, string fixtureId, string method, OwnedBoundary expected)
+    {
+        var result = Result(run, fixtureId, method);
+        Assert.Equal(expected, result.Boundary);
+        Assert.True(result.Passed, result.Failure);
+    }
+}

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\DiffAsmFixtures.Target\DiffAsmFixtures.Target.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffAsmFixtures.Caller\DiffAsmFixtures.Caller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
+    <ProjectReference Include="..\..\tools\AnalysisHarness\AnalysisHarness.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
+++ b/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
@@ -1,0 +1,281 @@
+using System.Diagnostics;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.AnalysisHarness;
+
+/// <summary>
+/// One expectation on a target method's analysis signals. The analysis "oracle" is the set
+/// of signals the analyzer actually emits — there is no compile-back equivalent — so an
+/// expectation names the exact signal outcome a fixture pins. Unset fields are not checked.
+/// </summary>
+public sealed record AnalysisExpectation(
+    int? AllocationsExactly = null,
+    int? AllocationsAtLeast = null,
+    string? ExceptionTypePresent = null,
+    string? ExceptionTypeAbsent = null,
+    string? OpportunityShapePresent = null,
+    string? OpportunityShapeAbsent = null);
+
+/// <summary>
+/// How a fixture's expected outcome relates to the ideal one. Most targets are
+/// <see cref="None"/> — a true positive or a true negative (must-not-flag). The interesting
+/// ledger entries are the two owned boundaries: a deliberately-accepted wrong answer at the
+/// SRM-only, no-referenced-assembly-loading edge.
+/// </summary>
+public enum OwnedBoundary
+{
+    None,
+    FalsePositive,
+    FalseNegative,
+}
+
+/// <summary>A method in the generated consumer assembly and the signal outcome it pins.</summary>
+/// <param name="Boundary">
+/// Whether the expected outcome is a deliberately-accepted false positive/negative (not a bug),
+/// recorded so a future improvement flips the entry on purpose. <see cref="OwnedBoundary.None"/>
+/// for ordinary true positives and must-not-flag negatives.
+/// </param>
+/// <param name="BlockedOn">
+/// For a deferred owned false negative, the issue whose work is expected to flip it to detected
+/// (e.g. "#1807"). Null for permanent boundaries and non-boundary targets.
+/// </param>
+public sealed record AnalysisFixtureTarget(
+    string Method,
+    AnalysisExpectation Expect,
+    OwnedBoundary Boundary = OwnedBoundary.None,
+    string? BlockedOn = null,
+    string? Note = null);
+
+/// <summary>
+/// An addressable analysis fixture: a stable id, the consumer source compiled into the
+/// inspected assembly, an optional second source compiled into a REFERENCED external assembly
+/// (cross-assembly identity is central to analysis, so most fixtures need one), and the target
+/// methods with their expected signals.
+/// </summary>
+public sealed record AnalysisFixtureDefinition(
+    string Id,
+    string ConsumerSource,
+    string? ExternalSource,
+    bool ExternalNeedsAlias,
+    IReadOnlyList<AnalysisFixtureTarget> Targets,
+    IReadOnlyList<string> Tags);
+
+public sealed record AnalysisFixtureResult(
+    string FixtureId,
+    string Method,
+    int Allocations,
+    IReadOnlyList<string> ExceptionTypes,
+    IReadOnlyList<string> OpportunityShapes,
+    bool Passed,
+    OwnedBoundary Boundary,
+    string? BlockedOn,
+    string Expected,
+    string Actual,
+    string? Failure,
+    string? Note);
+
+public sealed record AnalysisFixtureRunResult(
+    string WorkspaceDirectory,
+    IReadOnlyList<AnalysisFixtureResult> Results)
+{
+    public bool Passed => Results.All(result => result.Passed);
+}
+
+public sealed record AnalysisFixtureRunOptions(bool KeepArtifacts = false, string? TargetFramework = null)
+{
+    public static readonly AnalysisFixtureRunOptions Default = new();
+}
+
+/// <summary>
+/// The seed analysis-fixture catalogue (#1819): the smallest, highest-signal entries already
+/// pinned in the rung 1-7 tests, made addressable. The external assembly alias used by the
+/// name-collision fixture.
+/// </summary>
+public static class AnalysisFixtureCatalog
+{
+    public const string ExternalAlias = "externalfix";
+
+    public static readonly AnalysisFixtureDefinition AllocInAssemblyStruct = new(
+        "alloc.value-struct-newobj.in-assembly",
+        """
+        namespace Fix;
+        public struct InAssemblyStruct { public int V; public InAssemblyStruct(int v) => V = v; }
+        public static class Consumer
+        {
+            static int Sink(InAssemblyStruct s) => s.V;
+            public static int ConstructsInLoop(int n)
+            {
+                int total = 0;
+                for (int i = 0; i < n; i++) total += Sink(new InAssemblyStruct(i));
+                return total;
+            }
+        }
+        """,
+        ExternalSource: null,
+        ExternalNeedsAlias: false,
+        [
+            new("ConstructsInLoop", new AnalysisExpectation(AllocationsExactly: 0),
+                Note: "In-assembly struct newobj resolved via the operand-token TypeDef path (#1804)."),
+        ],
+        ["alloc", "value-type", "in-assembly", "rung7"]);
+
+    public static readonly AnalysisFixtureDefinition AllocCrossAsmGenericStruct = new(
+        "alloc.value-struct-newobj.cross-asm-generic",
+        """
+        namespace Fix;
+        public static class Consumer
+        {
+            static int Sink(External.GenericStruct<int> s) => s.V;
+            public static int ConstructsInLoop(int n)
+            {
+                int total = 0;
+                for (int i = 0; i < n; i++) total += Sink(new External.GenericStruct<int>(i));
+                return total;
+            }
+        }
+        """,
+        ExternalSource:
+        """
+        namespace External;
+        public struct GenericStruct<T> { public T V; public GenericStruct(T v) => V = v; }
+        """,
+        ExternalNeedsAlias: false,
+        [
+            new("ConstructsInLoop", new AnalysisExpectation(AllocationsExactly: 0),
+                Note: "Cross-assembly generic struct resolved via the consumer's own TypeSpec blob (#1804)."),
+        ],
+        ["alloc", "value-type", "cross-assembly", "generic", "rung7"]);
+
+    public static readonly AnalysisFixtureDefinition AllocCrossAsmNonGenericStruct = new(
+        "alloc.value-struct-newobj.cross-asm-nongeneric",
+        """
+        namespace Fix;
+        public static class Consumer
+        {
+            static int Sink(External.ValueStruct s) => s.V;
+            public static int ConstructsInLoop(int n)
+            {
+                int total = 0;
+                for (int i = 0; i < n; i++) total += Sink(new External.ValueStruct(i));
+                return total;
+            }
+        }
+        """,
+        ExternalSource:
+        """
+        namespace External;
+        public struct ValueStruct { public int V; public ValueStruct(int v) => V = v; }
+        """,
+        ExternalNeedsAlias: false,
+        [
+            new("ConstructsInLoop", new AnalysisExpectation(AllocationsAtLeast: 1), OwnedBoundary.FalsePositive,
+                Note: "Cross-assembly NON-generic user struct is a bare TypeRef, unresolvable single-assembly; counted as an OWNED false positive at the no-referenced-assembly-loading boundary (#1804)."),
+        ],
+        ["alloc", "value-type", "cross-assembly", "owned-boundary", "rung7"]);
+
+    public static readonly AnalysisFixtureDefinition AllocCrossAsmNameCollision = new(
+        "alloc.reftype-newobj.cross-asm-name-collision",
+        $$"""
+        extern alias {{ExternalAlias}};
+        namespace Fix
+        {
+            public static class Consumer
+            {
+                static int Sink({{ExternalAlias}}::Collide.Shape s) => s.V;
+                public static int ConstructsInLoop(int n)
+                {
+                    int total = 0;
+                    for (int i = 0; i < n; i++) total += Sink(new {{ExternalAlias}}::Collide.Shape(i));
+                    return total;
+                }
+            }
+        }
+        namespace Collide
+        {
+            // In-assembly STRUCT sharing the external reference type's fully-qualified name.
+            public struct Shape { public int V; public Shape(int v) => V = v; }
+        }
+        """,
+        ExternalSource:
+        """
+        namespace Collide;
+        public sealed class Shape { public int V; public Shape(int v) => V = v; }
+        """,
+        ExternalNeedsAlias: true,
+        [
+            new("ConstructsInLoop", new AnalysisExpectation(AllocationsAtLeast: 1),
+                Note: "External REFERENCE type whose FQN collides with an in-assembly struct must stay counted; display names omit assembly identity (#1809 review)."),
+        ],
+        ["alloc", "reference-type", "cross-assembly", "name-collision", "rung7"]);
+
+    public static readonly AnalysisFixtureDefinition ExceptionSuffixLookalikeExternal = new(
+        "exception.suffix-lookalike.external",
+        """
+        namespace Fix;
+        public static class Consumer
+        {
+            static object Sink(object o) => o;
+            public static object ConstructsLookalike() => Sink(new External.WidgetException());
+        }
+        """,
+        ExternalSource:
+        """
+        namespace External;
+        // Ends in "Exception" but is NOT a System.Exception.
+        public sealed class WidgetException { }
+        """,
+        ExternalNeedsAlias: false,
+        [
+            new("ConstructsLookalike", new AnalysisExpectation(ExceptionTypePresent: "WidgetException"), OwnedBoundary.FalsePositive,
+                Note: "External *Exception-named non-exception is counted via the suffix fallback; OWNED false positive at the no-referenced-assembly boundary (rung 2, #1709)."),
+        ],
+        ["exception", "cross-assembly", "owned-boundary", "rung2"]);
+
+    public static readonly AnalysisFixtureDefinition ExceptionUnsuffixedExternal = new(
+        "exception.unsuffixed.external",
+        """
+        namespace Fix;
+        public static class Consumer
+        {
+            public static void Throws() => throw new External.ErrorState();
+        }
+        """,
+        ExternalSource:
+        """
+        namespace External;
+        using System;
+        // A real exception whose simple name does NOT end in "Exception".
+        public sealed class ErrorState : Exception { }
+        """,
+        ExternalNeedsAlias: false,
+        [
+            new("Throws", new AnalysisExpectation(ExceptionTypeAbsent: "ErrorState"), OwnedBoundary.FalseNegative,
+                Note: "Real external exception not ending in 'Exception' is missed by the suffix fallback; OWNED false negative (rung 2, #1709)."),
+        ],
+        ["exception", "cross-assembly", "owned-boundary", "rung2"]);
+
+    public static IReadOnlyList<AnalysisFixtureDefinition> All { get; } =
+    [
+        AllocInAssemblyStruct,
+        AllocCrossAsmGenericStruct,
+        AllocCrossAsmNonGenericStruct,
+        AllocCrossAsmNameCollision,
+        ExceptionSuffixLookalikeExternal,
+        ExceptionUnsuffixedExternal,
+    ];
+
+    public static IReadOnlyList<AnalysisFixtureDefinition> Select(string? selector)
+    {
+        if (string.IsNullOrWhiteSpace(selector) || selector is "all")
+            return All;
+        return [.. All.Where(fixture =>
+            fixture.Id.Equals(selector, StringComparison.OrdinalIgnoreCase)
+            || fixture.Id.StartsWith(selector, StringComparison.OrdinalIgnoreCase)
+            || fixture.Tags.Contains(selector, StringComparer.OrdinalIgnoreCase))];
+    }
+}

--- a/tools/AnalysisHarness/AnalysisFixtureRunner.cs
+++ b/tools/AnalysisHarness/AnalysisFixtureRunner.cs
@@ -1,0 +1,331 @@
+using System.Diagnostics;
+using System.Runtime.Versioning;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.AnalysisHarness;
+
+/// <summary>
+/// Materializes analysis fixtures into temporary assemblies and grades them with the real
+/// analyzer (<see cref="LibraryBodyIndex"/>). Each fixture builds in isolation: a consumer
+/// assembly (the inspected one) plus, when the fixture is cross-assembly, a referenced external
+/// assembly. Isolation keeps same-fully-qualified-name collision fixtures and extern aliases
+/// from clashing across catalogue entries.
+/// </summary>
+public static class AnalysisFixtureRunner
+{
+    static readonly JsonSerializerOptions s_jsonOptions = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public static AnalysisFixtureRunResult Run(
+        IReadOnlyList<AnalysisFixtureDefinition> fixtures,
+        AnalysisFixtureRunOptions? options = null)
+    {
+        if (fixtures.Count == 0)
+            throw new ArgumentException("At least one analysis fixture is required.", nameof(fixtures));
+
+        options ??= AnalysisFixtureRunOptions.Default;
+        string tfm = options.TargetFramework ?? CurrentTargetFramework();
+        var root = Path.Combine(Path.GetTempPath(), "dotnet-inspect-analysis-fixtures", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            var results = new List<AnalysisFixtureResult>();
+            foreach (var fixture in fixtures)
+                results.AddRange(RunFixture(fixture, Path.Combine(root, SafeFileName(fixture.Id)), tfm));
+            return new AnalysisFixtureRunResult(root, results);
+        }
+        finally
+        {
+            if (!options.KeepArtifacts)
+                TryDelete(root);
+        }
+    }
+
+    static IEnumerable<AnalysisFixtureResult> RunFixture(AnalysisFixtureDefinition fixture, string dir, string tfm)
+    {
+        Directory.CreateDirectory(dir);
+        bool hasExternal = fixture.ExternalSource is not null;
+
+        if (hasExternal)
+        {
+            string externalDir = Path.Combine(dir, "External");
+            Directory.CreateDirectory(externalDir);
+            File.WriteAllText(Path.Combine(externalDir, "External.csproj"), LibraryProjectFile(tfm, "External"));
+            File.WriteAllText(Path.Combine(externalDir, "External.cs"), fixture.ExternalSource!);
+        }
+
+        string consumerDir = Path.Combine(dir, "Consumer");
+        Directory.CreateDirectory(consumerDir);
+        File.WriteAllText(
+            Path.Combine(consumerDir, "Consumer.csproj"),
+            ConsumerProjectFile(tfm, hasExternal, fixture.ExternalNeedsAlias));
+        File.WriteAllText(Path.Combine(consumerDir, "Consumer.cs"), fixture.ConsumerSource);
+
+        Build(consumerDir);
+        string consumerDll = Path.Combine(consumerDir, "bin", "Release", tfm, "Consumer.dll");
+        if (!File.Exists(consumerDll))
+            throw new InvalidOperationException($"Fixture '{fixture.Id}' did not produce {consumerDll}.");
+
+        var index = LibraryBodyIndex.Open(consumerDll);
+        var signalsByToken = index.GetMethodSignals();
+
+        foreach (var target in fixture.Targets)
+            yield return Grade(fixture, target, index, signalsByToken);
+    }
+
+    static AnalysisFixtureResult Grade(
+        AnalysisFixtureDefinition fixture,
+        AnalysisFixtureTarget target,
+        LibraryBodyIndex index,
+        IReadOnlyDictionary<int, MethodSignals> signalsByToken)
+    {
+        var method = index.Methods.FirstOrDefault(m => m.Name == target.Method);
+        if (method is null)
+        {
+            return new AnalysisFixtureResult(
+                fixture.Id, target.Method, 0, [], [], false, target.Boundary, target.BlockedOn,
+                Describe(target.Expect), "target-method-not-found", "target-method-not-found", target.Note);
+        }
+
+        var signals = signalsByToken.GetValueOrDefault(method.MetadataToken, MethodSignals.None);
+        var exceptionTypes = signals.ExceptionTypes;
+        var opportunityShapes = index.OptimizationOpportunities
+            .Where(o => o.Method.Name == target.Method)
+            .Select(o => o.Shape)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(shape => shape, StringComparer.Ordinal)
+            .ToArray();
+
+        string? failure = Evaluate(target.Expect, signals, exceptionTypes, opportunityShapes);
+        string actual =
+            $"allocations={signals.Allocations}, exceptions=[{string.Join(",", exceptionTypes)}], opportunities=[{string.Join(",", opportunityShapes)}]";
+
+        return new AnalysisFixtureResult(
+            fixture.Id,
+            target.Method,
+            signals.Allocations,
+            exceptionTypes,
+            opportunityShapes,
+            failure is null,
+            target.Boundary,
+            target.BlockedOn,
+            Describe(target.Expect),
+            actual,
+            failure,
+            target.Note);
+    }
+
+    static string? Evaluate(
+        AnalysisExpectation expect,
+        MethodSignals signals,
+        IReadOnlyList<string> exceptionTypes,
+        IReadOnlyList<string> opportunityShapes)
+    {
+        if (expect.AllocationsExactly is { } exact && signals.Allocations != exact)
+            return $"expected allocations={exact} but was {signals.Allocations}";
+        if (expect.AllocationsAtLeast is { } atLeast && signals.Allocations < atLeast)
+            return $"expected allocations>={atLeast} but was {signals.Allocations}";
+        if (expect.ExceptionTypePresent is { } present && !exceptionTypes.Contains(present))
+            return $"expected exception type '{present}' present but exceptions were [{string.Join(",", exceptionTypes)}]";
+        if (expect.ExceptionTypeAbsent is { } absent && exceptionTypes.Contains(absent))
+            return $"expected exception type '{absent}' absent but it was present";
+        if (expect.OpportunityShapePresent is { } shape && !opportunityShapes.Contains(shape))
+            return $"expected opportunity shape '{shape}' but shapes were [{string.Join(",", opportunityShapes)}]";
+        if (expect.OpportunityShapeAbsent is { } absentShape && opportunityShapes.Contains(absentShape))
+            return $"expected opportunity shape '{absentShape}' absent but it was present";
+        return null;
+    }
+
+    static string Describe(AnalysisExpectation expect)
+    {
+        var parts = new List<string>(3);
+        if (expect.AllocationsExactly is { } e) parts.Add($"allocations={e}");
+        if (expect.AllocationsAtLeast is { } a) parts.Add($"allocations>={a}");
+        if (expect.ExceptionTypePresent is { } p) parts.Add($"exception+'{p}'");
+        if (expect.ExceptionTypeAbsent is { } ab) parts.Add($"exception-'{ab}'");
+        if (expect.OpportunityShapePresent is { } s) parts.Add($"opportunity+'{s}'");
+        if (expect.OpportunityShapeAbsent is { } sa) parts.Add($"opportunity-'{sa}'");
+        return parts.Count == 0 ? "(no expectation)" : string.Join(", ", parts);
+    }
+
+    public static string FormatReport(AnalysisFixtureRunResult run)
+    {
+        var sb = new StringBuilder();
+        int fixtureCount = run.Results.Select(r => r.FixtureId).Distinct(StringComparer.Ordinal).Count();
+        sb.AppendLine($"ANALYSIS FIXTURE LEDGER over {fixtureCount} fixture(s), {run.Results.Count} target method(s)");
+        foreach (var result in run.Results
+            .OrderBy(r => r.FixtureId, StringComparer.Ordinal)
+            .ThenBy(r => r.Method, StringComparer.Ordinal))
+        {
+            string status = result.Passed ? "PASS" : "FAIL";
+            string boundary = BoundaryTag(result.Boundary, result.BlockedOn);
+            sb.AppendLine($"  {status}{boundary}  {result.FixtureId}  {result.Method}");
+            sb.AppendLine($"      expected: {result.Expected}");
+            sb.AppendLine($"      actual:   {result.Actual}");
+            if (result.Failure is not null)
+                sb.AppendLine($"      failure:  {result.Failure}");
+            if (!string.IsNullOrWhiteSpace(result.Note))
+                sb.AppendLine($"      note:     {result.Note}");
+        }
+        return sb.ToString();
+    }
+
+    public static string FormatJson(AnalysisFixtureRunResult run)
+        => JsonSerializer.Serialize(new { run.Results, run.Passed }, s_jsonOptions);
+
+    public static string FormatList(IReadOnlyList<AnalysisFixtureDefinition> fixtures)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"ANALYSIS FIXTURE CATALOG ({fixtures.Count} fixture(s))");
+        foreach (var fixture in fixtures.OrderBy(fixture => fixture.Id, StringComparer.Ordinal))
+        {
+            sb.AppendLine($"  {fixture.Id}  [{string.Join(", ", fixture.Tags)}]");
+            foreach (var target in fixture.Targets)
+            {
+                string boundary = BoundaryTag(target.Boundary, target.BlockedOn);
+                sb.AppendLine($"      {target.Method}  expected={Describe(target.Expect)}{boundary}");
+            }
+        }
+        return sb.ToString();
+    }
+
+    static string BoundaryTag(OwnedBoundary boundary, string? blockedOn) => boundary switch
+    {
+        OwnedBoundary.FalsePositive => " [owned-FP]",
+        OwnedBoundary.FalseNegative => blockedOn is null ? " [owned-FN]" : $" [owned-FN blocked-on {blockedOn}]",
+        _ => "",
+    };
+
+    public static string FormatListJson(IReadOnlyList<AnalysisFixtureDefinition> fixtures)
+    {
+        var items = fixtures
+            .OrderBy(fixture => fixture.Id, StringComparer.Ordinal)
+            .Select(fixture => new
+            {
+                fixture.Id,
+                fixture.Tags,
+                Targets = fixture.Targets.Select(target => new
+                {
+                    target.Method,
+                    Expected = Describe(target.Expect),
+                    Boundary = target.Boundary.ToString(),
+                    target.BlockedOn,
+                    target.Note,
+                }),
+            });
+        return JsonSerializer.Serialize(items, s_jsonOptions);
+    }
+
+    static string LibraryProjectFile(string tfm, string assemblyName) =>
+        $$"""
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>{{tfm}}</TargetFramework>
+            <ImplicitUsings>disable</ImplicitUsings>
+            <Nullable>disable</Nullable>
+            <LangVersion>preview</LangVersion>
+            <IsPackable>false</IsPackable>
+            <IsAotCompatible>false</IsAotCompatible>
+            <AssemblyName>{{assemblyName}}</AssemblyName>
+          </PropertyGroup>
+        </Project>
+        """;
+
+    static string ConsumerProjectFile(string tfm, bool hasExternal, bool needsAlias)
+    {
+        string reference = hasExternal
+            ? needsAlias
+                ? $"""
+                  <ItemGroup>
+                    <ProjectReference Include="..\External\External.csproj">
+                      <Aliases>{AnalysisFixtureCatalog.ExternalAlias}</Aliases>
+                    </ProjectReference>
+                  </ItemGroup>
+                """
+                : """
+                  <ItemGroup>
+                    <ProjectReference Include="..\External\External.csproj" />
+                  </ItemGroup>
+                """
+            : "";
+        return $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>{{tfm}}</TargetFramework>
+                <ImplicitUsings>disable</ImplicitUsings>
+                <Nullable>disable</Nullable>
+                <LangVersion>preview</LangVersion>
+                <IsPackable>false</IsPackable>
+                <IsAotCompatible>false</IsAotCompatible>
+                <AssemblyName>Consumer</AssemblyName>
+              </PropertyGroup>
+            {{reference}}
+            </Project>
+            """;
+    }
+
+    static string CurrentTargetFramework()
+    {
+        var frameworkName = typeof(AnalysisFixtureRunner).Assembly
+            .GetCustomAttributes(typeof(TargetFrameworkAttribute), inherit: false)
+            .OfType<TargetFrameworkAttribute>()
+            .FirstOrDefault()
+            ?.FrameworkName;
+        if (frameworkName is null)
+            return "net11.0";
+
+        const string prefix = ".NETCoreApp,Version=v";
+        return frameworkName.StartsWith(prefix, StringComparison.Ordinal)
+            ? "net" + frameworkName[prefix.Length..]
+            : "net11.0";
+    }
+
+    static string SafeFileName(string id)
+        => new([.. id.Select(ch => char.IsLetterOrDigit(ch) ? ch : '_')]);
+
+    static void Build(string workingDirectory)
+    {
+        using var process = new Process();
+        process.StartInfo.FileName = "dotnet";
+        process.StartInfo.WorkingDirectory = workingDirectory;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.StartInfo.RedirectStandardError = true;
+        process.StartInfo.ArgumentList.Add("build");
+        process.StartInfo.ArgumentList.Add("-c");
+        process.StartInfo.ArgumentList.Add("Release");
+        process.StartInfo.ArgumentList.Add("--nologo");
+        process.StartInfo.ArgumentList.Add("--verbosity");
+        process.StartInfo.ArgumentList.Add("quiet");
+        if (!process.Start())
+            throw new InvalidOperationException("Could not start dotnet build for analysis fixtures.");
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(milliseconds: 120_000))
+        {
+            try { process.Kill(entireProcessTree: true); }
+            catch (InvalidOperationException) { }
+            throw new TimeoutException("Analysis fixture build timed out.");
+        }
+
+        string stdout = stdoutTask.GetAwaiter().GetResult();
+        string stderr = stderrTask.GetAwaiter().GetResult();
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"Analysis fixture build failed with exit code {process.ExitCode}.\n{stdout}\n{stderr}");
+    }
+
+    static void TryDelete(string path)
+    {
+        try { Directory.Delete(path, recursive: true); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+}

--- a/tools/AnalysisHarness/AnalysisFixtureRunner.cs
+++ b/tools/AnalysisHarness/AnalysisFixtureRunner.cs
@@ -86,18 +86,25 @@ public static class AnalysisFixtureRunner
         LibraryBodyIndex index,
         IReadOnlyDictionary<int, MethodSignals> signalsByToken)
     {
-        var method = index.Methods.FirstOrDefault(m => m.Name == target.Method);
-        if (method is null)
+        var matches = index.Methods.Where(m => m.Name == target.Method).ToList();
+        if (matches.Count != 1)
         {
+            // Grade only an unambiguous target: 0 matches is a missing method, >1 is an
+            // ambiguous name (an overload or a same-named method on another type) that could
+            // otherwise silently grade the wrong method's signals.
+            string why = matches.Count == 0
+                ? "target-method-not-found"
+                : $"target-method-ambiguous ({matches.Count} methods named '{target.Method}')";
             return new AnalysisFixtureResult(
                 fixture.Id, target.Method, 0, [], [], false, target.Boundary, target.BlockedOn,
-                Describe(target.Expect), "target-method-not-found", "target-method-not-found", target.Note);
+                Describe(target.Expect), why, why, target.Note);
         }
 
+        var method = matches[0];
         var signals = signalsByToken.GetValueOrDefault(method.MetadataToken, MethodSignals.None);
         var exceptionTypes = signals.ExceptionTypes;
         var opportunityShapes = index.OptimizationOpportunities
-            .Where(o => o.Method.Name == target.Method)
+            .Where(o => o.Method.MetadataToken == method.MetadataToken)
             .Select(o => o.Shape)
             .Distinct(StringComparer.Ordinal)
             .OrderBy(shape => shape, StringComparer.Ordinal)

--- a/tools/AnalysisHarness/AnalysisHarness.csproj
+++ b/tools/AnalysisHarness/AnalysisHarness.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>analysis-harness</AssemblyName>
+    <RootNamespace>ILInspector.AnalysisHarness</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/ILInspector.Analysis/ILInspector.Analysis.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -1,0 +1,73 @@
+using ILInspector.AnalysisHarness;
+
+const string Usage =
+    """
+    analysis-harness --generated-fixtures [<selector>|list] [--json] [--keep]
+
+      Materializes the analysis fixture catalogue into temporary assemblies and grades each
+      target method against its expected-signal ledger entry using the real analyzer.
+
+      <selector>   a fixture id, id prefix, or tag; omit (or 'all') to run every fixture.
+      list         list catalogue entries and expected outcomes without building.
+      --json       emit machine-readable JSON.
+      --keep       keep the generated temporary projects for drill-down.
+    """;
+
+if (args.Length == 0)
+{
+    Console.Error.WriteLine(Usage);
+    return 2;
+}
+
+string? selector = null;
+bool json = false;
+bool keep = false;
+bool list = false;
+
+for (int i = 0; i < args.Length; i++)
+{
+    switch (args[i])
+    {
+        case "--generated-fixtures":
+            if (i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal))
+                selector = args[++i];
+            break;
+        case "list":
+            list = true;
+            break;
+        case "--json":
+            json = true;
+            break;
+        case "--keep":
+            keep = true;
+            break;
+        case "-h" or "--help":
+            Console.WriteLine(Usage);
+            return 0;
+        default:
+            Console.Error.WriteLine($"Unknown argument: {args[i]}");
+            Console.Error.WriteLine(Usage);
+            return 2;
+    }
+}
+
+if (list || selector is "list")
+{
+    Console.Write(json
+        ? AnalysisFixtureRunner.FormatListJson(AnalysisFixtureCatalog.All)
+        : AnalysisFixtureRunner.FormatList(AnalysisFixtureCatalog.All));
+    return 0;
+}
+
+var fixtures = AnalysisFixtureCatalog.Select(selector);
+if (fixtures.Count == 0)
+{
+    Console.Error.WriteLine($"No analysis fixture IDs match '{selector}'. Use '--generated-fixtures list'.");
+    return 2;
+}
+
+var run = AnalysisFixtureRunner.Run(fixtures, new AnalysisFixtureRunOptions(KeepArtifacts: keep));
+Console.Write(json ? AnalysisFixtureRunner.FormatJson(run) : AnalysisFixtureRunner.FormatReport(run));
+if (json)
+    Console.WriteLine();
+return run.Passed ? 0 : 1;

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -1,0 +1,46 @@
+# Analysis Harness
+
+The fixture-catalogue side of the analysis harness (#1818, Layer 1) — the analysis analog of
+the decompiler generated-fixture catalogue (#1742). It makes the `ILInspector.Analysis` rung
+fixtures **addressable** and **generated**, and grades each target method's signals against an
+**expected-signal ledger** using the real analyzer.
+
+Unlike the decompiler harness there is no mechanical compile-back oracle: analysis output is
+triage candidates a human/agent judges. The mechanical part the catalogue *can* check is "does
+the analyzer emit the declared signals?", so each entry declares its expected `MethodSignals` /
+`OptimizationOpportunity` outcome. The interesting entries are **owned boundaries** —
+deliberately-accepted false positives/negatives at the SRM-only, no-referenced-assembly-loading
+edge — recorded so a future improvement flips them on purpose rather than as a silent diff.
+
+## Run
+
+```bash
+dotnet build tools/AnalysisHarness -c Release
+DLL=tools/AnalysisHarness/bin/Release/net11.0/analysis-harness.dll
+
+dotnet "$DLL" --generated-fixtures list          # list entries + expected outcomes
+dotnet "$DLL" --generated-fixtures               # build and grade every fixture
+dotnet "$DLL" --generated-fixtures alloc --json  # grade a subset (id/prefix/tag), JSON output
+dotnet "$DLL" --generated-fixtures exception.unsuffixed.external --keep  # keep temp projects
+```
+
+Each fixture builds in isolation: a consumer assembly (the inspected one) plus, when the
+fixture is cross-assembly, a referenced external assembly (with an extern alias for the
+name-collision case). Isolation keeps same-fully-qualified-name and alias fixtures from clashing
+across catalogue entries.
+
+## Test
+
+`ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests` runs the catalogue and asserts each
+target. It is `[Trait("Speed", "Slow")]` (every fixture runs `dotnet build`), so it is excluded
+from the fast PR lane — like the decompiler generated-fixture catalogue. Run it directly:
+
+```bash
+dotnet artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tests.dll \
+  -method "*SeedCatalogue*"
+```
+
+## Layers above this
+
+This is Layer 1 of #1818. The corpus stability sensor (Layer 2) and the sampled-judgment
+precision/recall loop (Layer 3) are tracked there.


### PR DESCRIPTION
## Summary

The analysis analog of the decompiler generated-fixture catalogue (#1742), and Layer 1 of the analysis harness plan (#1818). Makes the rung 1-7 fixtures **addressable and generated**, grading each target method's signals against an **expected-signal ledger** with the real analyzer (`LibraryBodyIndex`) — there is no compile-back oracle, so the mechanical check is "does the analyzer emit the declared signals?".

## What it adds

- **`tools/AnalysisHarness`** mirroring `tools/DecompilerHarness`: `AnalysisFixtureCatalog` (entries) + `AnalysisFixtureRunner` (materialize → `dotnet build` → grade) + a `--generated-fixtures [<selector>|list] [--json] [--keep]` CLI.
- **Cross-assembly support**: each fixture builds in isolation as a consumer assembly plus, when cross-assembly, a referenced external assembly (with an **extern alias** for the name-collision case). Cross-assembly identity is central to analysis, so most entries need the second assembly — the main structural difference from the single-assembly decompiler catalogue.
- **Owned-boundary ledger** (per @richlander's #1819 direction): targets are classified `owned-false-positive` / `owned-false-negative` with an optional `blocked-on` issue reference, so deferred false negatives flip deliberately when their substrate lands. Opportunity-present and -absent (must-not-flag) expectations.
- **Six seed entries** from the rung 2 + rung 7 alloc/exception pins, three of them owned boundaries.

## Sample output

```text
PASS             alloc.value-struct-newobj.in-assembly           ConstructsInLoop
PASS             alloc.value-struct-newobj.cross-asm-generic      ConstructsInLoop
PASS [owned-FP]  alloc.value-struct-newobj.cross-asm-nongeneric   ConstructsInLoop
PASS             alloc.reftype-newobj.cross-asm-name-collision    ConstructsInLoop
PASS [owned-FP]  exception.suffix-lookalike.external              ConstructsLookalike
PASS [owned-FN]  exception.unsuffixed.external                    Throws
```

## CI cost

The catalogue test (`AnalysisFixtureCatalogTests`) is `[Trait("Speed","Slow")]` (every fixture runs `dotnet build`), and the CI analysis step now runs `-trait- "Speed=Slow"` — matching the decompiler lane — so the per-fixture build cost stays out of every PR. Fast lane: 218 tests, ~6s. The Slow test passes locally (6 fixtures, ~17s).

## Alignment / direction

This is the foundation. The next increment (tracked on #1819) adds the recently-merged Performance Triage shapes as seeds — string-build (#1763), enumerator (#1814), render-suppression (#1781), box-throw-path (#1747) — with their must-not-flag negatives and deferred owned-FNs (`blocked-on #1714` / `#1807`), so the substrate work lands as intentional ledger flips. Layer 2 (corpus sensor) and Layer 3 (sampled judgment) stay on #1818.

Refs #1818. Closes #1819
