### PR TITLE
Add opportunity-shape seeds (string-build, box-throw) to the analysis fixture catalogue

### DIFF
--- a/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
+++ b/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
@@ -31,6 +31,20 @@ public class AnalysisFixtureCatalogTests
         AssertBoundary(run, "alloc.value-struct-newobj.cross-asm-nongeneric", "ConstructsInLoop", OwnedBoundary.FalsePositive);
         AssertBoundary(run, "exception.suffix-lookalike.external", "ConstructsLookalike", OwnedBoundary.FalsePositive);
         AssertBoundary(run, "exception.unsuffixed.external", "Throws", OwnedBoundary.FalseNegative);
+
+        // Opportunity-shape seeds: true positive, must-not-flag, and a deferred owned-FN.
+        AssertPasses(run, "alloc.string-build.accumulation-in-loop", "AppendsStringInLoop");
+        AssertPasses(run, "alloc.string-build.accumulation-in-loop", "ConcatsIntoListInLoop");
+        AssertBoundary(run, "alloc.string-build.accumulation-in-loop", "DerivedAccumulatorInLoop", OwnedBoundary.FalseNegative);
+        AssertPasses(run, "suppress.box.throw-path", "BoxesIntoStringFormat");
+        AssertPasses(run, "suppress.box.throw-path", "ThrowsWithBoxedValue");
+        AssertBoundary(run, "suppress.box.throw-path", "ThrowsViaHelper", OwnedBoundary.FalseNegative);
+    }
+
+    static void AssertPasses(AnalysisFixtureRunResult run, string fixtureId, string method)
+    {
+        var result = Result(run, fixtureId, method);
+        Assert.True(result.Passed, result.Failure);
     }
 
     // The grader must refuse to silently grade an ambiguous target name (an overload or a

--- a/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
+++ b/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
@@ -38,7 +38,7 @@ public class AnalysisFixtureCatalogTests
         AssertBoundary(run, "alloc.string-build.accumulation-in-loop", "DerivedAccumulatorInLoop", OwnedBoundary.FalseNegative);
         AssertPasses(run, "suppress.box.throw-path", "BoxesIntoStringFormat");
         AssertPasses(run, "suppress.box.throw-path", "ThrowsWithBoxedValue");
-        AssertBoundary(run, "suppress.box.throw-path", "ThrowsViaHelper", OwnedBoundary.FalseNegative);
+        AssertBoundary(run, "suppress.box.throw-path", "ThrowsViaHelper", OwnedBoundary.FalsePositive);
     }
 
     static void AssertPasses(AnalysisFixtureRunResult run, string fixtureId, string method)

--- a/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
+++ b/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
@@ -366,8 +366,8 @@ public static class AnalysisFixtureCatalog
             new("ThrowsWithBoxedValue", new AnalysisExpectation(OpportunityShapeAbsent: "box-value-type"),
                 Note: "Box feeding a throw is suppressed as an error-path allocation (#1747)."),
             new("ThrowsViaHelper", new AnalysisExpectation(OpportunityShapePresent: "box-value-type"),
-                OwnedBoundary.FalseNegative, BlockedOn: "#1714",
-                Note: "Box feeding a throwing helper is not yet recognized as throw-path; deferred broadening (#1714)."),
+                OwnedBoundary.FalsePositive, BlockedOn: "#1714",
+                Note: "Box feeding a throwing helper is not yet recognized as throw-path, so it is still flagged; deferred suppression broadening (#1714)."),
         ],
         ["opportunity", "box", "suppression", "in-assembly", "rung5"]);
 

--- a/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
+++ b/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
@@ -259,6 +259,118 @@ public static class AnalysisFixtureCatalog
         ],
         ["exception", "cross-assembly", "owned-boundary", "rung2"]);
 
+    public static readonly AnalysisFixtureDefinition StringBuildAccumulationInLoop = new(
+        "alloc.string-build.accumulation-in-loop",
+        """
+        namespace Fix;
+        using System.Collections.Generic;
+        public static class Consumer
+        {
+            // True positives: an accumulator concatenated back into itself each iteration (O(n^2)).
+            public static string AppendsStringInLoop(string[] items)
+            {
+                var s = "";
+                foreach (var x in items) s += x;
+                return s;
+            }
+            public static string PrependsStringInLoop(string[] items)
+            {
+                var s = "";
+                foreach (var x in items) s = x + " " + s;
+                return s;
+            }
+
+            // Must-not-flag: a fresh string added to a list (never stored back into an input).
+            public static List<string> ConcatsIntoListInLoop(Dictionary<string, string> pairs)
+            {
+                var parts = new List<string>();
+                foreach (var kv in pairs) parts.Add(kv.Key + "=" + kv.Value);
+                return parts;
+            }
+            // Must-not-flag: `s += b` outside any loop (no repeated copy).
+            public static string AppendsStringOnce(string a, string b)
+            {
+                var s = a;
+                s += b;
+                return s;
+            }
+            // Must-not-flag (stack-aware guard): the slot is loaded only to pass to an unrelated
+            // call, then reassigned from operands that do not include it.
+            public static string ReassignsUnrelatedSlotInLoop(string seed, string a, string b, string[] items)
+            {
+                foreach (var x in items)
+                {
+                    System.Console.WriteLine(seed);
+                    seed = a + b;
+                }
+                return seed;
+            }
+
+            // Owned false negative: the accumulator flows through a call (`s.Trim()`) before the
+            // concat, so the bare-load bit does not survive -- conservatively not flagged today.
+            public static string DerivedAccumulatorInLoop(string[] items)
+            {
+                var s = "";
+                foreach (var x in items) s = x + " " + s.Trim();
+                return s;
+            }
+        }
+        """,
+        ExternalSource: null,
+        ExternalNeedsAlias: false,
+        [
+            new("AppendsStringInLoop", new AnalysisExpectation(OpportunityShapePresent: "string-build-in-loop")),
+            new("PrependsStringInLoop", new AnalysisExpectation(OpportunityShapePresent: "string-build-in-loop")),
+            new("ConcatsIntoListInLoop", new AnalysisExpectation(OpportunityShapeAbsent: "string-build-in-loop")),
+            new("AppendsStringOnce", new AnalysisExpectation(OpportunityShapeAbsent: "string-build-in-loop")),
+            new("ReassignsUnrelatedSlotInLoop", new AnalysisExpectation(OpportunityShapeAbsent: "string-build-in-loop"),
+                Note: "Stack-aware false-positive guard (#1763 MAI review)."),
+            new("DerivedAccumulatorInLoop", new AnalysisExpectation(OpportunityShapeAbsent: "string-build-in-loop"),
+                OwnedBoundary.FalseNegative, BlockedOn: "#1714",
+                Note: "Accumulator flows through a call before the concat; deferred broadening (#1714)."),
+        ],
+        ["opportunity", "string-build", "in-assembly", "rung5"]);
+
+    public static readonly AnalysisFixtureDefinition BoxThrowPathSuppression = new(
+        "suppress.box.throw-path",
+        """
+        namespace Fix;
+        public static class Consumer
+        {
+            // True positive: an int boxed into an object-typed API argument escapes via the call.
+            public static string BoxesIntoStringFormat(int value) => string.Format("v={0}", value);
+
+            // Suppressed: the box feeds an exception thrown immediately -- an error-path
+            // allocation (executes at most once before unwinding), so it must NOT be flagged.
+            public static void ThrowsWithBoxedValue(int value)
+            {
+                if (value < 0)
+                    throw new System.ArgumentException(string.Format("bad {0}", value));
+            }
+
+            // Owned false negative: the boxed value is formatted and passed to a throwing HELPER
+            // rather than thrown directly, so the throw-path suppression does not yet reach it and
+            // the box is still flagged. Deferred broadening (#1714).
+            public static void ThrowsViaHelper(int value)
+            {
+                if (value < 0)
+                    Fail(string.Format("bad {0}", value));
+            }
+            static void Fail(string message) => throw new System.InvalidOperationException(message);
+        }
+        """,
+        ExternalSource: null,
+        ExternalNeedsAlias: false,
+        [
+            new("BoxesIntoStringFormat", new AnalysisExpectation(OpportunityShapePresent: "box-value-type")),
+            new("ThrowsWithBoxedValue", new AnalysisExpectation(OpportunityShapeAbsent: "box-value-type"),
+                Note: "Box feeding a throw is suppressed as an error-path allocation (#1747)."),
+            new("ThrowsViaHelper", new AnalysisExpectation(OpportunityShapePresent: "box-value-type"),
+                OwnedBoundary.FalseNegative, BlockedOn: "#1714",
+                Note: "Box feeding a throwing helper is not yet recognized as throw-path; deferred broadening (#1714)."),
+        ],
+        ["opportunity", "box", "suppression", "in-assembly", "rung5"]);
+
     public static IReadOnlyList<AnalysisFixtureDefinition> All { get; } =
     [
         AllocInAssemblyStruct,
@@ -267,6 +379,8 @@ public static class AnalysisFixtureCatalog
         AllocCrossAsmNameCollision,
         ExceptionSuffixLookalikeExternal,
         ExceptionUnsuffixedExternal,
+        StringBuildAccumulationInLoop,
+        BoxThrowPathSuppression,
     ];
 
     public static IReadOnlyList<AnalysisFixtureDefinition> Select(string? selector)


### PR DESCRIPTION
## Summary

Extends the analysis fixture catalogue (#1819, merged in #1824) beyond alloc/exception signals to **Performance Triage opportunity shapes**, exercising the opportunity present/absent (must-not-flag) and deferred owned-false-negative ledger mechanics end-to-end.

## Seeds added

- **`alloc.string-build.accumulation-in-loop`** (#1763)
  - TP: `AppendsStringInLoop`, `PrependsStringInLoop` → emit `string-build-in-loop`.
  - Must-not-flag: `ConcatsIntoListInLoop`, `AppendsStringOnce`, `ReassignsUnrelatedSlotInLoop` (the stack-aware false-positive guard) → stay quiet.
  - Owned-FN `DerivedAccumulatorInLoop` (accumulator flows through a call before the concat) → `blocked-on #1714`.
- **`suppress.box.throw-path`** (#1747)
  - TP: `BoxesIntoStringFormat` → emits `box-value-type`.
  - Suppressed: `ThrowsWithBoxedValue` (box feeds an immediate throw, an error-path allocation) → not flagged.
  - Owned-FN `ThrowsViaHelper` (box feeds a throwing *helper*, not a direct throw) → still flagged today, `blocked-on #1714`.

The owned-FN mechanic is now demonstrated live: `ThrowsViaHelper` currently emits `box-value-type`; when #1714 broadens the throw-path suppression to reach helpers, the opportunity disappears, the ledger entry **fails**, and it must be flipped from owned-FN to suppressed on purpose — the catalogue doubling as the substrate to-do list.

## Sample output

```text
PASS                              alloc.string-build.accumulation-in-loop  AppendsStringInLoop      opportunities=[string-build-in-loop]
PASS                              alloc.string-build.accumulation-in-loop  ConcatsIntoListInLoop    opportunities=[]
PASS [owned-FN blocked-on #1714]  alloc.string-build.accumulation-in-loop  DerivedAccumulatorInLoop opportunities=[]
PASS                              suppress.box.throw-path                  BoxesIntoStringFormat    opportunities=[box-value-type]
PASS                              suppress.box.throw-path                  ThrowsWithBoxedValue     opportunities=[]
PASS [owned-FN blocked-on #1714]  suppress.box.throw-path                  ThrowsViaHelper          opportunities=[box-value-type]
```

## Scope

Both seeds are pure in-assembly source. The trust-gated cross-assembly shapes (enumerator #1814, render-suppression #1781 — they need a framework-trusted external assembly) and the remaining owned-FNs (state-machine #1805, linq-materialize `blocked-on #1807`) are a later increment.

## Verification

Tool + tests build clean; both catalogue tests pass (8 fixtures, ~20s, Slow lane). New explicit assertions cover a TP, a must-not-flag, and an owned-FN per seed.

Refs #1818 #1819
