### PR TITLE
Add next minimal generated fixture rungs

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -98,12 +98,64 @@ public class GeneratedFixtureCatalogTests
             "Method2",
             FidelityCheck.CompileBackStatus.Exact,
             frontier: false);
+        AssertTarget(
+            run,
+            "minimal.static-method-call",
+            "GeneratedFixtures.MinimalStaticMethodCall.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.static-method-call",
+            "GeneratedFixtures.MinimalStaticMethodCall.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.static-method-call",
+            "GeneratedFixtures.MinimalStaticMethodCall.Class1",
+            "Helper",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.if-else",
+            "GeneratedFixtures.MinimalIfElse.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.if-else",
+            "GeneratedFixtures.MinimalIfElse.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.null-coalesce",
+            "GeneratedFixtures.MinimalNullCoalesce.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.null-coalesce",
+            "GeneratedFixtures.MinimalNullCoalesce.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
 
         Assert.Contains("minimal.property.literal", report);
         Assert.Contains("minimal.primary-ctor.field-init", report);
         Assert.Contains("minimal.ctor-field.getter", report);
         Assert.Contains("minimal.auto-property.getter", report);
         Assert.Contains("minimal.method-call.same-type", report);
+        Assert.Contains("minimal.static-method-call", report);
+        Assert.Contains("minimal.if-else", report);
+        Assert.Contains("minimal.null-coalesce", report);
         Assert.Contains("decompiler=Full", report);
         Assert.Contains("compile-back=Exact", report);
     }
@@ -119,9 +171,12 @@ public class GeneratedFixtureCatalogTests
             [
                 "minimal.auto-property.getter",
                 "minimal.ctor-field.getter",
+                "minimal.if-else",
                 "minimal.method-call.same-type",
+                "minimal.null-coalesce",
                 "minimal.primary-ctor.field-init",
                 "minimal.property.literal",
+                "minimal.static-method-call",
             ],
             GeneratedFixtureCatalog.Select("minimal").Select(fixture => fixture.Id).Order(StringComparer.Ordinal).ToArray());
 
@@ -139,6 +194,9 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.ctor-field.getter");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.auto-property.getter");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.method-call.same-type");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.static-method-call");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.null-coalesce");
 
         var primaryCtor = Assert.Single(fixtures,
             fixture => fixture.GetProperty("Id").GetString() == "minimal.primary-ctor.field-init");

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -126,6 +126,69 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "method-call"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalStaticMethodCall = new(
+        "minimal.static-method-call",
+        """
+        namespace GeneratedFixtures.MinimalStaticMethodCall;
+
+        public class Class1
+        {
+            public static string Method1() => Helper();
+
+            private static string Helper() => "Hello World";
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalStaticMethodCall.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalStaticMethodCall.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalStaticMethodCall.Class1", "Helper",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "static", "method-call"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalIfElse = new(
+        "minimal.if-else",
+        """
+        namespace GeneratedFixtures.MinimalIfElse;
+
+        public class Class1
+        {
+            public int Method1(int value)
+            {
+                if (value < 0)
+                    return -1;
+                return 1;
+            }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalIfElse.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalIfElse.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "branch", "if-else"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalNullCoalesce = new(
+        "minimal.null-coalesce",
+        """
+        namespace GeneratedFixtures.MinimalNullCoalesce;
+
+        public class Class1
+        {
+            public string Method1(string value) => value ?? "fallback";
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalNullCoalesce.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalNullCoalesce.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "null-coalesce"]);
+
     public static IReadOnlyList<GeneratedFixtureDefinition> All { get; } =
     [
         MinimalPropertyLiteral,
@@ -133,6 +196,9 @@ internal static class GeneratedFixtureCatalog
         MinimalCtorFieldGetter,
         MinimalAutoPropertyGetter,
         MinimalMethodCallSameType,
+        MinimalStaticMethodCall,
+        MinimalIfElse,
+        MinimalNullCoalesce,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> MinimalCompileBackRungs => All;

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -14,7 +14,8 @@ compile-back oracle, and prints results by stable fixture ID plus target method.
 This is the first step toward an addressable progressive fixture ladder:
 `minimal.property.literal`, `minimal.ctor-field.getter`,
 `minimal.auto-property.getter`, `minimal.method-call.same-type`, and
-`minimal.primary-ctor.field-init` are expected `Exact`. With no selector, all
+`minimal.primary-ctor.field-init` are expected `Exact`; the static-call, if/else,
+and null-coalescing rungs extend that minimal exact set. With no selector, all
 generated fixtures run; use `list` to list fixture IDs, `--json` for
 machine-readable list/results, and `--keep-generated-fixtures` to preserve the
 generated project for drill-down.


### PR DESCRIPTION
- Advances #1742
- Changes generated decompiler fixture catalogue coverage only
- Card revision: `50068183`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated fixture ladder gains three more low-shape exact compile-back rungs with no harness behavior changes.

Before:

```text
minimal generated fixture catalogue: 5 fixtures / 11 targets
```

After:

```text
minimal generated fixture catalogue: 8 fixtures / 18 targets
new exact rungs: minimal.static-method-call, minimal.if-else, minimal.null-coalesce
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Decompiler fast suite | Not run; additive generated-fixture catalogue entries only |
| Reduced fixture validity | Not applicable |
| Reduced fixture fidelity | Pass: each new generated fixture reports `Exact` |
| Real witness | Generated fixtures: static call, if/else, null-coalesce |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes; this only adds generated fixture catalogue rows.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked expected `Exact` outcomes, implicit ctor target, selector/list behavior, and README accuracy. |
| MAI-Code-1-Flash | No blocking findings | Verified `AssertTarget` exercises the real compile-back oracle and the new IDs are exact. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.static-method-call
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.if-else
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.null-coalesce
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
```
