### PR TITLE
ci: scope pack jobs to dotnet-inspect package inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,15 +72,22 @@ jobs:
               src/DotnetInspector.Core/*) ILROUNDTRIP=true ;;
               *.props|*.sln) ILROUNDTRIP=true ;;
             esac
-            # Packaging/pack-smoke validation only needs to run when build or
-            # packaging configuration changes. Most PRs (e.g. decompiler raises)
-            # don't touch these, so gating pack/pack-rid here keeps them off the
+            # Packaging/pack-smoke validation only needs to run when something
+            # that affects the *packaged* tool changes. pack/pack-rid only run
+            # `dotnet pack src/dotnet-inspect`, so the output is determined by
+            # that project's csproj plus shared build infra (root + src build
+            # props/targets, global.json/nuget config) and the pack workflow
+            # itself. Test/harness csproj changes and unrelated workflow edits
+            # don't affect the package, so they must not trip this. Most PRs
+            # (e.g. decompiler raises) touch none of these, keeping pack off the
             # hot PR path. On push to main, pack still runs (see job `if`s) to
             # produce the artifacts release.yml publishes.
             case "$file" in
-              *.csproj|*.props|*.targets|*.sln) PACKAGING=true ;;
+              src/dotnet-inspect/dotnet-inspect.csproj) PACKAGING=true ;;
+              Directory.Build.props|Directory.Build.targets|Directory.Packages.props) PACKAGING=true ;;
+              src/Directory.Build.props) PACKAGING=true ;;
               global.json|nuget.config|NuGet.config) PACKAGING=true ;;
-              .github/workflows/*) PACKAGING=true ;;
+              .github/workflows/ci.yml|.github/workflows/release.yml) PACKAGING=true ;;
             esac
           done <<< "$FILES"
           echo "code=$CODE" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The `changes` job's `PACKAGING` filter triggered the `pack` and `pack-rid` jobs for **any** `*.csproj`, `*.props`, `*.targets`, `*.sln`, or `.github/workflows/*` change. But those jobs only run `dotnet pack src/dotnet-inspect`, so the package output is determined by a small, fixed set of inputs. Test/harness `.csproj` edits and unrelated workflow changes (e.g. `decompiler-daily.yml`) spun up both pack jobs for no benefit — as seen in #1824, which touched only test/harness `.csproj` files and `decompiler-daily.yml`.

## Change

Narrow the `PACKAGING` filter to inputs that actually affect the packaged tool:

- `src/dotnet-inspect/dotnet-inspect.csproj` (the packed project + packaging metadata)
- shared build infra: `Directory.Build.props`, `Directory.Build.targets`, `Directory.Packages.props`, `src/Directory.Build.props`
- `global.json` / nuget config
- the pack workflows themselves: `ci.yml`, `release.yml`

Referenced-project source changes are still covered by the build/test job (`code` filter); they don't need the pack smoke test.

## Behavior

- PR #1824's file set (test/harness csproj + `decompiler-daily.yml`) → **pack skipped** ✅
- `src/dotnet-inspect/dotnet-inspect.csproj` / shared build props → pack runs ✅
- Push-to-main pack behavior **unchanged** — those jobs gate on `event_name`, not this filter, so `release.yml` artifacts are unaffected.

## Risk

Low / CI-config only. No product code changes. YAML validated locally; filter logic simulated against #1824's file list and packaging-relevant changes.