### PR TITLE
Fix bool/int stack-slot naming (#1822)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StackSlotReuseRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackSlotReuseRenderingTests.cs
@@ -68,6 +68,27 @@ public class StackSlotReuseRenderingTests
     }
 
     [Fact]
+    public void BoolSlotWithIntegerTypedConsumerUsesBoolNameWhenTargetIsBool()
+    {
+        var field = new FieldRef(Holder, "Flag", Bool);
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(0, new Conditional(
+            new LoadArgument(0, "isValueType", Bool),
+            new Constant(false, Bool),
+            new LoadArgument(1, "hasDefaultConstructor", Bool))
+        { MergedType = Bool }));
+        block.Add(new StoreField(field, null, new LoadStackSlot(0, Int32)));
+        block.Add(new Return(null));
+
+        var output = CSharpPrinter.Print(Function(Void, block)).Output!;
+
+        Assert.Contains("bool S_0", output);
+        Assert.Contains("Flag = S_0;", output);
+        Assert.DoesNotContain("int S_0_1", output);
+        Assert.DoesNotContain("Flag = S_0_1;", output);
+    }
+
+    [Fact]
     public void SubtypeStoreSupertypeLoadStaysOneVariable()
     {
         var consumeObject = new MethodRef(Holder, "ConsumeObject", Void, [Object], HasThis: false);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -508,7 +508,8 @@ public sealed partial class CSharpPrinter
 
         var nodes = DescendantsOutsideNestedFunctions(function).ToList();
         var storesBySlot = new Dictionary<int, List<IrExpression>>();
-        var loadsBySlot = new Dictionary<int, List<TypeRef?>>();
+        var loadsBySlot = new Dictionary<int, List<LoadStackSlot>>();
+        var extraLoadTargetsBySlot = new Dictionary<int, List<TypeRef>>();
         foreach (var node in nodes)
         {
             switch (node)
@@ -517,7 +518,7 @@ public sealed partial class CSharpPrinter
                     (storesBySlot.TryGetValue(store.Slot, out var stores) ? stores : storesBySlot[store.Slot] = []).Add(store.Value);
                     break;
                 case LoadStackSlot load:
-                    (loadsBySlot.TryGetValue(load.Slot, out var loads) ? loads : loadsBySlot[load.Slot] = []).Add(load.Type);
+                    (loadsBySlot.TryGetValue(load.Slot, out var loads) ? loads : loadsBySlot[load.Slot] = []).Add(load);
                     break;
             }
         }
@@ -532,7 +533,7 @@ public sealed partial class CSharpPrinter
             {
                 continue;
             }
-            (loadsBySlot.TryGetValue(load.Slot, out var loads) ? loads : loadsBySlot[load.Slot] = []).Add(elementType);
+            (extraLoadTargetsBySlot.TryGetValue(load.Slot, out var targets) ? targets : extraLoadTargetsBySlot[load.Slot] = []).Add(elementType);
         }
 
         foreach (int slot in storesBySlot.Keys.Concat(loadsBySlot.Keys).Distinct())
@@ -540,6 +541,7 @@ public sealed partial class CSharpPrinter
             if (TryChooseUnifiedStackSlotType(
                 storesBySlot.GetValueOrDefault(slot) ?? [],
                 loadsBySlot.GetValueOrDefault(slot) ?? [],
+                extraLoadTargetsBySlot.GetValueOrDefault(slot) ?? [],
                 out var unifiedType))
             {
                 _stackSlotUnifiedTypes[slot] = unifiedType;
@@ -579,9 +581,15 @@ public sealed partial class CSharpPrinter
         }
     }
 
-    bool TryChooseUnifiedStackSlotType(IReadOnlyList<IrExpression> stores, IReadOnlyList<TypeRef?> loads, out TypeRef unifiedType)
+    bool TryChooseUnifiedStackSlotType(
+        IReadOnlyList<IrExpression> stores,
+        IReadOnlyList<LoadStackSlot> loads,
+        IReadOnlyList<TypeRef> extraLoadTargets,
+        out TypeRef unifiedType)
     {
-        var candidates = loads.Concat(stores.Select(store => store.ResultType))
+        var candidates = loads.Select(load => load.Type)
+            .Concat(extraLoadTargets)
+            .Concat(stores.Select(store => store.ResultType))
             .Where(type => type is not null)
             .Cast<TypeRef>()
             .Distinct()
@@ -589,8 +597,8 @@ public sealed partial class CSharpPrinter
         foreach (var candidate in candidates)
         {
             if (stores.All(store => CanAssignTo(store, candidate))
-                && loads.All(load => load is null || CanAssignType(candidate, load))
-                && loads.All(load => load is null || !StrictlyNarrowsReference(candidate, load)))
+                && loads.All(load => CanLoadAsType(candidate, load))
+                && extraLoadTargets.All(target => CanAssignType(candidate, target) && !StrictlyNarrowsReference(candidate, target)))
             {
                 unifiedType = candidate;
                 return true;
@@ -607,6 +615,31 @@ public sealed partial class CSharpPrinter
             && !candidate.Equals(load)
             && CanAssignType(candidate, load)
             && !CanAssignType(load, candidate);
+
+    bool CanLoadAsType(TypeRef source, LoadStackSlot load)
+    {
+        if (load.Type is null)
+            return true;
+        if (CanAssignType(source, load.Type))
+            return !StrictlyNarrowsReference(source, load.Type);
+        return TypeFamilies.IsBoolean(source)
+            && TypeFamilies.IsIntegerLike(load.Type)
+            && StackSlotLoadTargetType(load) is { } target
+            && TypeFamilies.IsBoolean(target);
+    }
+
+    TypeRef? StackSlotLoadTargetType(LoadStackSlot load)
+        => load.Parent switch
+        {
+            StoreLocal store when ReferenceEquals(store.Value, load) => store.Type,
+            StoreArgument store when ReferenceEquals(store.Value, load) => store.Type,
+            StoreField store when ReferenceEquals(store.Value, load) => store.Field.Type,
+            StoreProperty store when ReferenceEquals(store.Value, load) => StorePropertyTargetType(store),
+            StoreElement store when ReferenceEquals(store.Value, load) => store.ElementType,
+            StoreIndirect store when ReferenceEquals(store.Value, load) => store.Type,
+            Return ret when ReferenceEquals(ret.Value, load) => _function.Signature.ReturnType,
+            _ => null,
+        };
 
     bool CanAssignTo(IrExpression value, TypeRef target)
     {


### PR DESCRIPTION
- Fixes #1822
- Part of #1687
- Changes stack-slot name unification so a bool-producing slot can share one name with an integer-typed load only when that load feeds a known bool target.
- Card revision: `97443089`

## Change

**Conclusion:** **PASS** — fixes the false Full CS0165 bool/int slot split while keeping numeric consumers split.

Before:

```csharp
bool S_1;
int S_1_1;
S_1 = contract.CreatedType.IsValueType() ? false : (ReflectionUtils.GetDefaultConstructor(contract.CreatedType) == null);
contract.DefaultCreatorNonPublic = S_1_1;
```

After:

```csharp
bool S_1;
S_1 = contract.CreatedType.IsValueType() ? false : (ReflectionUtils.GetDefaultConstructor(contract.CreatedType) == null);
contract.DefaultCreatorNonPublic = S_1;
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `StackSlotReuseRenderingTests` passed |
| Decompiler fast suite | Pass, 1668 tests |
| Real witness | `Newtonsoft.Json.Serialization.DefaultContractResolver::InitializeContract` renders one assigned `bool S_1` slot |
| Real witness validity | Newtonsoft.Json 13.0.4 validity sweep: Full malformed 0, semantic binding defects 0/1000 |

## Decompiler quality

**Conclusion:** **ADVISORY** — generated full-card remains red against the stale checked baseline; this is the same current-main baseline drift seen on adjacent #1687 work, not a row-specific witness regression.

Generated card:

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity sampled 350 / 89,065 (0.39%); fidelity sampled 36 / 89,065 (0.04%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,394 (88.02%) | 78,394 (88.02%) | 0 |
| Conditional-branch residual (-) | 2,408 (2.70%) | 2,407 (2.70%) | -1 |
| Forward-merge stops (-) | 2,294 (2.58%) | 2,294 (2.58%) | 0 |
| Full malformed (-) | 32 | 37 | +5 |
| Semantic defects (-) | 149/25,185 — sampled 25,185 / 89,065 (28.28%) | 1/350 — sampled 350 / 89,065 (0.39%) | -148 |
| Fidelity diffs (-) | opcode-diff 0/0, exact 0, recompile-failed 0, context-failed 0; sampled 0 / 89,065 (0.00%) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | +5 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.02% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 32 -> 37 (+5); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25185, current 350)
- Full malformed methods (pinned) increased by 5 (baseline 32, current 37, tolerance 0)

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| MAI-Code-1-Flash | No blocking findings | Reported no significant issues. |
| Claude Opus 4.8 | No blocking findings | Traced the target-context guard and found numeric consumers remain split; noted its runtime could not execute tests, but local validation above did. |

**Review conclusion:** **PASS** — both adversarial reviews found no blockers. After syncing with latest main, the final conflict resolution preserved current main's reference-narrowing guard and kept the #1822 bool-target relaxation conservative.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/StackSlotReuseRenderingTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet run --project tools/DecompilerHarness -c Release -- ~/.nuget/packages/newtonsoft.json/13.0.4/lib/netstandard2.0/Newtonsoft.Json.dll --validity-check --compile-cap 1000 --max-examples 80
bash eng/prepare-decompiler-corpus.sh /tmp/issue1822-corpus-assemblies.txt
# then run DecompilerHarness over that assembly list with --diff-corpus-baseline, --quality-diff-card, --compile-cap 25, --corpus-fidelity-cap 3, --max-examples 10
```
