### PR TITLE
Add decompiler burndown fix PR template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,8 +101,9 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
 
 For decompiler-affecting PRs, follow this evidence and review contract:
 
-- Use `docs/templates/decompiler-pr.md` for the PR body. Keep the human summary
-  terse and conclusion-first.
+- Use `docs/templates/decompiler-pr.md` for general decompiler PR bodies and
+  `docs/templates/decompiler-burndown-fix-pr.md` for focused invalid-`Full` /
+  burndown row fixes. Keep the human summary terse and conclusion-first.
 - Include the tool-generated quality-diff card; do not hand-construct or re-key
   metric tables. Use the matching corpus script/baseline pair documented in
   `tools/DecompilerHarness/README.md`. If a card has capped changed rows, link

--- a/docs/templates/decompiler-burndown-fix-pr.md
+++ b/docs/templates/decompiler-burndown-fix-pr.md
@@ -1,0 +1,104 @@
+# Decompiler burndown fix PR template
+
+<!--
+Use this for focused burndown rows, especially invalid-Full validity fixes.
+The center of gravity is the concrete false claim and branch-vs-main validity
+evidence, not a broad quality-card narrative. Delete sections that do not apply.
+-->
+
+- Fixes #{row-issue}; part of #{burndown-issue}
+- Row: `{short row title}`
+- Evidence revision: `{git-sha}`
+
+## Fix
+
+> Should we accept this row fix?
+
+**Conclusion:** **PASS/REVIEW/BLOCKED** — {one sentence naming the false claim,
+the fix, and the decisive evidence}.
+
+False `Full` claim:
+
+```csharp
+// short invalid output, e.g. unassigned local / invalid cast / missing label
+```
+
+Fixed output:
+
+```csharp
+// short valid output or honest degradation
+```
+
+## Root cause and scope
+
+- **Root cause:** {why the product produced invalid `Full` output}.
+- **Fix shape:** {narrow code/predicate/rendering change}.
+- **Scope boundary:** {what this intentionally does not fix}.
+
+## Witnesses
+
+| Witness | Before | After |
+| --- | --- | --- |
+| `{Type::Method}` | `{diagnostic or bad output}` | `{valid output or lower fidelity}` |
+| `{ReducedFixture::Method}` | `{diagnostic}` | `{valid / exact / not checkable}` |
+
+## Evidence
+
+| Check | Result |
+| --- | --- |
+| Product build | Pass |
+| Focused tests | `{test class}` passed |
+| Decompiler fast suite | Pass |
+| Reduced fixture validity | `{Full count}` Full; 0 malformed; 0 binding errors |
+| Reduced fixture fidelity | `{exact count}` exact / not currently checkable |
+| Real witness validity | `{named method}` binds / degrades honestly |
+
+## Corpus validity
+
+> Did this row fix introduce new invalid-`Full` defects?
+
+**Conclusion:** **PASS/ADVISORY/BLOCKED** — {branch-vs-main validity verdict}.
+
+Run: `{corpus shape}`, branch vs clean `origin/main`.
+
+| Metric | Clean main | PR |
+| --- | ---: | ---: |
+| Full malformed (-) | {count} | {count} |
+| Newly malformed/defective vs main (-) | - | {count} |
+| Defect methods fixed vs main (+) | - | {count} |
+
+<!-- markdownlint-disable MD033 -->
+<details>
+<summary>Fixed / changed validity rows (showing up to 24)</summary>
+
+| Direction | Method | Diagnostic / bucket | Main | PR |
+| --- | --- | --- | --- | --- |
+| Fixed | `{Type::Method}` | `{CSxxxx or bucket}` | `{bad}` | `{valid}` |
+| New | `{Type::Method}` | `{CSxxxx or bucket}` | `{valid}` | `{bad}` |
+
+For the full local delta, see
+[Reproducing decompiler corpus deltas](../decompiler-corpus-delta-repro.md).
+
+</details>
+<!-- markdownlint-enable MD033 -->
+
+## Out of scope / sibling rows
+
+- `{separate root cause}` — filed as #{issue} / not filed because {reason}.
+
+## Review
+
+| Reviewer | Result | Notes |
+| --- | --- | --- |
+| {model/reviewer} | No blocking findings / findings resolved | {short evidence} |
+| {model/reviewer} | No blocking findings / findings resolved | {short evidence} |
+
+**Review conclusion:** **PASS/REVIEW/BLOCKED** — {one-line reconciliation}.
+
+## Validation
+
+```bash
+dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/{FocusedTests}/*"
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
+```

--- a/docs/templates/decompiler-pr.md
+++ b/docs/templates/decompiler-pr.md
@@ -4,6 +4,9 @@
 Use this for decompiler PRs that affect raising, structuring, validity,
 fidelity, or corpus behavior. Delete sections that do not apply. Keep generated
 tables generated; do not re-key metric rows by hand.
+
+For focused invalid-Full / burndown row fixes, prefer
+`docs/templates/decompiler-burndown-fix-pr.md`.
 -->
 
 - Fixes/advances #{issue}


### PR DESCRIPTION
## Summary

Adds a focused decompiler burndown/invalid-Full PR template for fixes like #1821:

- centers the false `Full` claim, root cause, scope boundary, witnesses, and branch-vs-main validity evidence;
- keeps broad quality-card content out of the main path when the row is a targeted validity fix;
- updates the general decompiler PR template to point focused burndown rows at the new template;
- updates `AGENTS.md` so agents choose between the general template and the burndown-fix template.

## Validation

- `npx markdownlint-cli --fix AGENTS.md docs/templates/decompiler-pr.md docs/templates/decompiler-burndown-fix-pr.md`
- `npx markdownlint-cli AGENTS.md docs/templates/decompiler-pr.md docs/templates/decompiler-burndown-fix-pr.md`

Docs-only; no behavior changes.
