### PR TITLE
Gate conditional slot unification to proven reference targets (fix main red)

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -625,12 +625,28 @@ public sealed partial class CSharpPrinter
             // (CS0266). The char/enum arm-cast path and the merged-ResultType
             // fallback remain.
             return CanRenderConditionalForTarget(conditional, target)
-                || (IsReferenceLike(target)
+                || (IsProvenReference(target)
                     && CanAssignTo(conditional.WhenTrue, target)
                     && CanAssignTo(conditional.WhenFalse, target))
                 || (conditional.ResultType is { } condType && CanAssignType(condType, target));
         return value.ResultType is { } source && CanAssignType(source, target);
     }
+
+    /// <summary>
+    /// A type known to be a reference WITHOUT resolution — a stack-O family
+    /// (object/string/array), a signature-declared class, or a same-assembly
+    /// reference shape. Unlike <see cref="IsReferenceLike"/> this excludes the
+    /// optimistic "a bare cross-assembly definition is probably a class" fallback:
+    /// narrowing a slot to an UNPROVEN target would print `MaybeStruct S = a ? null
+    /// : value`, which is CS0037 if the type resolves to a struct. Used to gate the
+    /// conditional arm-assignability unification so it only narrows to a target a
+    /// null arm is provably assignable to.
+    /// </summary>
+    bool IsProvenReference(TypeRef type)
+        => type.Kind is not (TypeRefKind.ByRef or TypeRefKind.Pointer or TypeRefKind.FunctionPointer)
+            && (TypeFamilies.Of(type) == StackFamily.O
+                || type.DeclaredValueTypeHint == ValueTypeHint.ReferenceType
+                || _function.TypeShapes.GetValueOrDefault(type) == TypeShape.Reference);
 
     bool CanAssignType(TypeRef source, TypeRef target)
     {


### PR DESCRIPTION
## Fix main red: `RaisingPassTests.ReferenceConditionalStore_DoesNotNarrowToUnprovenReferenceTarget`

Two #1767 PRs landed in parallel — #1820 ("reference conditional slot naming", which added this test) and #1821 ("unify merged stack-slot name"). Their merge interaction broke the test on `main`:

- #1821 added a conditional **arm-assignability** clause to `CanAssignTo`: a `cond ? null : value` slot unifies to a target both arms satisfy, gated on `IsReferenceLike(target)`.
- `IsReferenceLike` **optimistically** treats an unresolved cross-assembly definition as a reference. So a slot whose load type is an unproven type (which could resolve to a struct) now narrows to it, printing `MaybeStruct S_0 = empty ? null : value;` — CS0037 if it's a struct — exactly what #1820's test forbids (`Assert.Contains("object S_0")`).

### Fix

Gate the arm-assignability clause on a new `IsProvenReference` predicate — a stack-`O` family (`object`/`string`/array), a signature-declared class (`ReferenceType` hint), or a same-assembly `TypeShape.Reference` — instead of `IsReferenceLike`. The slot only narrows to a target a `null` arm is provably assignable to. Proven references (`string`, `object`, arrays) still unify (the #1767 witnesses); unproven cross-assembly definitions no longer do.

### Evidence

- `RaisingPassTests` 101/0 (the failing test now passes); full decompiler suite **1667/1667** (was 1666 + 1 red on main).
- #1767 string witness preserved: `string S_1 = StrU.IsNullOrEmpty(value) ? null : value; S_0._fmt = S_1;`.

Tightly-scoped, one-method change; the pre-existing #1820 test is the canary.
