### PR TITLE
Keep unproven conditional slot targets as object (#1767)

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -618,16 +618,13 @@ public sealed partial class CSharpPrinter
             // even though its IL-merged ResultType widened to `object`. Without
             // this the slot's object-typed store and string-typed load get
             // different names (S_1 vs S_1_1) and the consumer reads an unassigned
-            // local (#1767). Restricted to reference-like targets: a non-reference
-            // target (char/numeric) needs per-arm target rendering that the
-            // conditional printer only does for immediate constant arms, so a
-            // nested conditional would unify to `char` yet render an `int` ternary
-            // (CS0266). The char/enum arm-cast path and the merged-ResultType
-            // fallback remain.
+            // local (#1767). That known-reference arm-unification lives in
+            // CanRenderConditionalForTarget, which gates on IsKnownReferenceLike:
+            // an unproven/unresolved target (which may be a value type) must stay
+            // `object`, since a `null` arm need not be assignable to it
+            // (ReferenceConditionalStore_DoesNotNarrowToUnprovenReferenceTarget).
+            // The char/enum arm-cast path and the merged-ResultType fallback remain.
             return CanRenderConditionalForTarget(conditional, target)
-                || (IsReferenceLike(target)
-                    && CanAssignTo(conditional.WhenTrue, target)
-                    && CanAssignTo(conditional.WhenFalse, target))
                 || (conditional.ResultType is { } condType && CanAssignType(condType, target));
         return value.ResultType is { } source && CanAssignType(source, target);
     }


### PR DESCRIPTION
## Summary

Fixes a base-`main` regression where `RaisingPassTests.ReferenceConditionalStore_DoesNotNarrowToUnprovenReferenceTarget` fails (expects `object S_0`, got `MaybeStruct S_0`). The failure red-lights **every** open PR's `test` job; it is invisible on `main` because push-to-main skips the test job by design.

## Root cause

Two PRs spawned from issue #1767 were merged back-to-back and never reconciled:

- **#1820** (`416124ff`) added `IsKnownReferenceLike` (strict: O-family / `ReferenceType` hint / `TypeShape.Reference` / array — **false** for unresolved cross-assembly types) and gated conditional arm-unification in `CanRenderConditionalForTarget` on it. Intent: an object-merged `cond ? null : value` whose store target is *unproven* (could be a struct) must stay `object`, since `null` need not be assignable to it. It also added the now-failing test.
- **#1821** (`47aefcd8`, merged ~14 min later) independently added a **duplicate** arm-unification clause to `CanAssignTo`, but gated it on the **looser** `IsReferenceLike`, which *also* matches unresolved types. That re-opened narrowing to unproven targets and broke #1820's guard.

## Fix

Remove #1821's redundant loose clause from `CanAssignTo`. `CanRenderConditionalForTarget` (the first clause of `CanAssignTo`) already covers the legitimate **known**-reference unification, so:

- Unproven/unresolved targets correctly stay `object` (regression fixed).
- #1821's `string`/resolved-reference witnesses keep their unified single slot name.

One-line behavioral change (removed a strictly-looser duplicate predicate path); net `+6/-9`.

## Verification

- `MergedSlotNamingTests.ProducerAndConsumerOfMergedSlot_ShareOneLocalName` (#1821) — pass
- `ReferenceConditionalStore_*` (3 tests, incl. the regressed one) — pass
- Full fast decompiler suite: **1667 passed, 0 failed** (was 1 failed)
- Real-world witness `Newtonsoft.Json IsoDateTimeConverter::set_DateTimeFormat` still renders unified `string S_1 = StringUtils.IsNullOrEmpty(value) ? null : value;` — #1821's improvement preserved.

## Risk

Low and strictly conservative: the only behavior change is declining to narrow conditional slots to *unproven* (potential value-type) targets, reverting to the pre-#1821 `object` behavior for exactly those cases. Adversarial review requested (decompiler printer-semantics change).
