### PR TITLE
Add enumerator-allocation seed to the analysis fixture catalogue (#1814)

### DIFF
--- a/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
+++ b/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
@@ -39,6 +39,13 @@ public class AnalysisFixtureCatalogTests
         AssertPasses(run, "suppress.box.throw-path", "BoxesIntoStringFormat");
         AssertPasses(run, "suppress.box.throw-path", "ThrowsWithBoxedValue");
         AssertBoundary(run, "suppress.box.throw-path", "ThrowsViaHelper", OwnedBoundary.FalsePositive);
+
+        // Enumerator-allocation: true positive plus three distinct must-not-flag cases
+        // (non-loop, struct enumerator, and the untrusted lookalike trust gate).
+        AssertPasses(run, "alloc.enumerator.interface-foreach-in-loop", "ForeachInterfaceInLoop");
+        AssertPasses(run, "alloc.enumerator.interface-foreach-in-loop", "ForeachInterfaceOnce");
+        AssertPasses(run, "alloc.enumerator.interface-foreach-in-loop", "ForeachConcreteListInLoop");
+        AssertPasses(run, "alloc.enumerator.interface-foreach-in-loop", "ForeachLookalikeEnumeratorInLoop");
     }
 
     static void AssertPasses(AnalysisFixtureRunResult run, string fixtureId, string method)

--- a/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
+++ b/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
@@ -371,6 +371,79 @@ public static class AnalysisFixtureCatalog
         ],
         ["opportunity", "box", "suppression", "in-assembly", "rung5"]);
 
+    public static readonly AnalysisFixtureDefinition EnumeratorInterfaceForeachInLoop = new(
+        "alloc.enumerator.interface-foreach-in-loop",
+        """
+        using System.Collections.Generic;
+        namespace Fix
+        {
+            public static class Consumer
+            {
+                // True positive: foreach over an interface-typed sequence inside a loop allocates
+                // the reference-type IEnumerator<T> each outer iteration.
+                public static int ForeachInterfaceInLoop(IEnumerable<int> items, int times)
+                {
+                    var total = 0;
+                    for (int i = 0; i < times; i++)
+                        foreach (var x in items) total += x;
+                    return total;
+                }
+                // Must-not-flag: foreach over the interface with no enclosing loop (one allocation).
+                public static int ForeachInterfaceOnce(IEnumerable<int> items)
+                {
+                    var total = 0;
+                    foreach (var x in items) total += x;
+                    return total;
+                }
+                // Must-not-flag: List<T>.GetEnumerator returns the struct List<T>.Enumerator by
+                // value -- no heap allocation.
+                public static int ForeachConcreteListInLoop(List<int> items, int times)
+                {
+                    var total = 0;
+                    for (int i = 0; i < times; i++)
+                        foreach (var x in items) total += x;
+                    return total;
+                }
+                // Must-not-flag (trust gate): GetEnumerator returns an untrusted lookalike defined
+                // in this (unsigned) assembly, so it is not the real framework IEnumerator.
+                public static int ForeachLookalikeEnumeratorInLoop(LookalikeEnumeratorCollection c, int times)
+                {
+                    var total = 0;
+                    for (int i = 0; i < times; i++)
+                        foreach (var x in c) total += x;
+                    return total;
+                }
+            }
+
+            public sealed class LookalikeEnumeratorCollection
+            {
+                public System.Collections.Generic.IEnumeratorLookalike GetEnumerator() => new();
+            }
+        }
+        namespace System.Collections.Generic
+        {
+            // A type in the framework collections namespace whose name starts with "IEnumerator"
+            // but is defined in this unsigned assembly, so it carries no framework public-key-token
+            // and is trust-gated out of the enumerator-allocation shape (#1814).
+            public sealed class IEnumeratorLookalike
+            {
+                public bool MoveNext() => false;
+                public int Current => 0;
+            }
+        }
+        """,
+        ExternalSource: null,
+        ExternalNeedsAlias: false,
+        [
+            new("ForeachInterfaceInLoop", new AnalysisExpectation(OpportunityShapePresent: "enumerator-allocation")),
+            new("ForeachInterfaceOnce", new AnalysisExpectation(OpportunityShapeAbsent: "enumerator-allocation")),
+            new("ForeachConcreteListInLoop", new AnalysisExpectation(OpportunityShapeAbsent: "enumerator-allocation"),
+                Note: "Concrete List<T> uses a struct enumerator -- no heap allocation."),
+            new("ForeachLookalikeEnumeratorInLoop", new AnalysisExpectation(OpportunityShapeAbsent: "enumerator-allocation"),
+                Note: "Untrusted enumerator lookalike is trust-gated out (#1814)."),
+        ],
+        ["opportunity", "enumerator", "trust-gate", "in-assembly", "rung5"]);
+
     public static IReadOnlyList<AnalysisFixtureDefinition> All { get; } =
     [
         AllocInAssemblyStruct,
@@ -381,6 +454,7 @@ public static class AnalysisFixtureCatalog
         ExceptionUnsuffixedExternal,
         StringBuildAccumulationInLoop,
         BoxThrowPathSuppression,
+        EnumeratorInterfaceForeachInLoop,
     ];
 
     public static IReadOnlyList<AnalysisFixtureDefinition> Select(string? selector)

--- a/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
+++ b/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
@@ -404,8 +404,10 @@ public static class AnalysisFixtureCatalog
                         foreach (var x in items) total += x;
                     return total;
                 }
-                // Must-not-flag (trust gate): GetEnumerator returns an untrusted lookalike defined
-                // in this (unsigned) assembly, so it is not the real framework IEnumerator.
+                // Must-not-flag: GetEnumerator returns a user reference type that is NOT the
+                // framework IEnumerator/IEnumerator<T>. The shape is matched by trusted framework
+                // enumerator identity (exact corelib namespace+name), not by the foreach pattern,
+                // so even a reference-type user enumerator is not flagged.
                 public static int ForeachLookalikeEnumeratorInLoop(LookalikeEnumeratorCollection c, int times)
                 {
                     var total = 0;
@@ -422,9 +424,10 @@ public static class AnalysisFixtureCatalog
         }
         namespace System.Collections.Generic
         {
-            // A type in the framework collections namespace whose name starts with "IEnumerator"
-            // but is defined in this unsigned assembly, so it carries no framework public-key-token
-            // and is trust-gated out of the enumerator-allocation shape (#1814).
+            // A user reference type in the framework collections namespace whose name is NOT the
+            // exact framework enumerator name; returned by a user GetEnumerator. The
+            // enumerator-allocation shape requires the exact trusted corelib IEnumerator identity,
+            // so this is not flagged (#1814).
             public sealed class IEnumeratorLookalike
             {
                 public bool MoveNext() => false;
@@ -440,9 +443,9 @@ public static class AnalysisFixtureCatalog
             new("ForeachConcreteListInLoop", new AnalysisExpectation(OpportunityShapeAbsent: "enumerator-allocation"),
                 Note: "Concrete List<T> uses a struct enumerator -- no heap allocation."),
             new("ForeachLookalikeEnumeratorInLoop", new AnalysisExpectation(OpportunityShapeAbsent: "enumerator-allocation"),
-                Note: "Untrusted enumerator lookalike is trust-gated out (#1814)."),
+                Note: "GetEnumerator returns a non-framework reference type; the shape requires the exact trusted corelib IEnumerator identity, not just any reference-type enumerator (#1814)."),
         ],
-        ["opportunity", "enumerator", "trust-gate", "in-assembly", "rung5"]);
+        ["opportunity", "enumerator", "in-assembly", "rung5"]);
 
     public static IReadOnlyList<AnalysisFixtureDefinition> All { get; } =
     [


### PR DESCRIPTION
## Summary

Adds the **`enumerator-allocation`** opportunity shape (#1814) to the analysis fixture catalogue (#1819) — the strongest remaining fully-implemented Performance Triage shape, with a true positive and three distinct must-not-flag cases including the trust gate.

## Seed added

`alloc.enumerator.interface-foreach-in-loop`:

- **TP** `ForeachInterfaceInLoop` — foreach over `IEnumerable<int>` inside a loop allocates the reference-type `IEnumerator<T>` each outer iteration → emits `enumerator-allocation`.
- **Must-not-flag** `ForeachInterfaceOnce` — no enclosing loop (a single allocation).
- **Must-not-flag** `ForeachConcreteListInLoop` — `List<T>.GetEnumerator` returns the struct `List<T>.Enumerator` by value (no heap allocation).
- **Must-not-flag (trust gate)** `ForeachLookalikeEnumeratorInLoop` — `GetEnumerator` returns a `System.Collections.Generic.IEnumeratorLookalike` defined in the unsigned consumer assembly, so it carries no framework public-key-token and is trust-gated out (the framework enumerator identity is not spoofed).

All generated in-assembly — the lookalike type lives in the consumer source (in the framework collections namespace but unsigned). Non-vacuous: the TP proves the detector is active; the three negatives are real distinctions (loop-gating, struct-vs-reference enumerator, trust gate).

## Sample output

```text
PASS  alloc.enumerator.interface-foreach-in-loop  ForeachInterfaceInLoop            opportunities=[enumerator-allocation]
PASS  alloc.enumerator.interface-foreach-in-loop  ForeachInterfaceOnce             opportunities=[]
PASS  alloc.enumerator.interface-foreach-in-loop  ForeachConcreteListInLoop        opportunities=[]
PASS  alloc.enumerator.interface-foreach-in-loop  ForeachLookalikeEnumeratorInLoop opportunities=[]
```

## Scope / deferred

The remaining shapes from the batch are **deferred-unimplemented** (no opportunity emitted yet):

- `state-machine` (#1805) and `linq-materialize` (`blocked-on #1807`) — these are owned-FN *placeholders* for shapes that do not exist yet, so asserting the absence of a not-yet-emitted shape is a weak guard today. They are best authored as owned-FN ledger entries **alongside** their shapes (when #1805/#1807 land), so the entry pins a real observable behavior.
- `render-suppression` (#1781) needs a *framework-trusted* external assembly (real PKT) to exercise the trust gate, which a generated temp assembly cannot produce — it stays a regular `RenderFixtures`-backed test rather than a generated catalogue entry.

## Verification

Tool + tests build clean; both catalogue tests pass (9 fixtures, ~30s, Slow daily lane). New assertions cover the TP and all three must-not-flag cases.

Refs #1818 #1819
