### PR TITLE
Fix owned-boundary labels per #1819 review (ThrowsViaHelper, ForeachInterfaceOnce)

### DIFF
--- a/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
+++ b/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
@@ -43,7 +43,7 @@ public class AnalysisFixtureCatalogTests
         // Enumerator-allocation: true positive plus three distinct must-not-flag cases
         // (non-loop, struct enumerator, and the untrusted lookalike trust gate).
         AssertPasses(run, "alloc.enumerator.interface-foreach-in-loop", "ForeachInterfaceInLoop");
-        AssertPasses(run, "alloc.enumerator.interface-foreach-in-loop", "ForeachInterfaceOnce");
+        AssertBoundary(run, "alloc.enumerator.interface-foreach-in-loop", "ForeachInterfaceOnce", OwnedBoundary.FalseNegative);
         AssertPasses(run, "alloc.enumerator.interface-foreach-in-loop", "ForeachConcreteListInLoop");
         AssertPasses(run, "alloc.enumerator.interface-foreach-in-loop", "ForeachLookalikeEnumeratorInLoop");
     }

--- a/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
+++ b/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
@@ -348,9 +348,10 @@ public static class AnalysisFixtureCatalog
                     throw new System.ArgumentException(string.Format("bad {0}", value));
             }
 
-            // Owned false negative: the boxed value is formatted and passed to a throwing HELPER
+            // Owned false positive: the boxed value is formatted and passed to a throwing HELPER
             // rather than thrown directly, so the throw-path suppression does not yet reach it and
-            // the box is still flagged. Deferred broadening (#1714).
+            // the box IS still flagged -- a spurious box-value-type row (over-report). Deferred
+            // suppression broadening (#1714) will remove it.
             public static void ThrowsViaHelper(int value)
             {
                 if (value < 0)
@@ -367,7 +368,7 @@ public static class AnalysisFixtureCatalog
                 Note: "Box feeding a throw is suppressed as an error-path allocation (#1747)."),
             new("ThrowsViaHelper", new AnalysisExpectation(OpportunityShapePresent: "box-value-type"),
                 OwnedBoundary.FalsePositive, BlockedOn: "#1714",
-                Note: "Box feeding a throwing helper is not yet recognized as throw-path, so it is still flagged; deferred suppression broadening (#1714)."),
+                Note: "Suppression fails to fire through the helper, so the box is still flagged -- a spurious box-value-type row (over-report = false positive); deferred suppression broadening (#1714)."),
         ],
         ["opportunity", "box", "suppression", "in-assembly", "rung5"]);
 
@@ -388,7 +389,9 @@ public static class AnalysisFixtureCatalog
                         foreach (var x in items) total += x;
                     return total;
                 }
-                // Must-not-flag: foreach over the interface with no enclosing loop (one allocation).
+                // Owned false negative: foreach over the interface with no enclosing loop still
+                // allocates ONE real reference-type enumerator, but the shape is loop-gated as a
+                // noise policy (a single allocation is not pay-dirt), so it is deliberately dropped.
                 public static int ForeachInterfaceOnce(IEnumerable<int> items)
                 {
                     var total = 0;
@@ -439,7 +442,9 @@ public static class AnalysisFixtureCatalog
         ExternalNeedsAlias: false,
         [
             new("ForeachInterfaceInLoop", new AnalysisExpectation(OpportunityShapePresent: "enumerator-allocation")),
-            new("ForeachInterfaceOnce", new AnalysisExpectation(OpportunityShapeAbsent: "enumerator-allocation")),
+            new("ForeachInterfaceOnce", new AnalysisExpectation(OpportunityShapeAbsent: "enumerator-allocation"),
+                OwnedBoundary.FalseNegative,
+                Note: "A single interface enumerator allocation is real but loop-gated out as a noise policy (deliberately dropped, not pay-dirt)."),
             new("ForeachConcreteListInLoop", new AnalysisExpectation(OpportunityShapeAbsent: "enumerator-allocation"),
                 Note: "Concrete List<T> uses a struct enumerator -- no heap allocation."),
             new("ForeachLookalikeEnumeratorInLoop", new AnalysisExpectation(OpportunityShapeAbsent: "enumerator-allocation"),


### PR DESCRIPTION
## Summary

Addresses @richlander's review feedback on the merged analysis fixture catalogue (#1819 / #1824 / #1825 / #1832). Two owned-boundary label corrections; no behavior change.

## Changes

- **`suppress.box.throw-path` / `ThrowsViaHelper`** — the classification enum was already correct (`OwnedBoundary.FalsePositive`), but the source comment and the `Note` still read *"false negative."* A suppression that fails to fire ⇒ the box **is reported** ⇒ a spurious `box-value-type` row = over-report = **false positive**. Fixed the comment + Note wording to match the enum.

- **`alloc.enumerator.interface-foreach-in-loop` / `ForeachInterfaceOnce`** — reclassified from a plain true-negative to an **owned false-negative**, and adopted a convention for "deliberately dropped as low-value":
  - **true negative** = loop-gating *eliminates the cost* (a single `s += b` has no O(n²) cost, so `AppendsStringOnce` stays a true negative).
  - **owned false-negative** = loop-gating only *filters noise* on a still-real allocation (a single interface `foreach` allocates one real reference-type enumerator, deliberately dropped as not pay-dirt).
  - The struct-enumerator (`ForeachConcreteListInLoop`) and non-framework-enumerator (`ForeachLookalikeEnumeratorInLoop`) absences stay **true negatives** — they allocate nothing / are not the framework type.

The test assertion for `ForeachInterfaceOnce` is updated to `OwnedBoundary.FalseNegative`. `DerivedAccumulatorInLoop` stays correctly `FalseNegative` (a real O(n²) accumulation the analyzer misses).

## Verification

Tool + tests build clean; the catalogue test passes (9 fixtures). The harness now renders `ThrowsViaHelper [owned-FP]` and `ForeachInterfaceOnce [owned-FN]`.

Refs #1819
