### PR TITLE
Add minimal try-finally generated fixture rung

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -147,6 +147,20 @@ public class GeneratedFixtureCatalogTests
             "Method1",
             FidelityCheck.CompileBackStatus.Exact,
             frontier: false);
+        AssertTarget(
+            run,
+            "minimal.try-finally",
+            "GeneratedFixtures.MinimalTryFinally.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.try-finally",
+            "GeneratedFixtures.MinimalTryFinally.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
 
         Assert.Contains("minimal.property.literal", report);
         Assert.Contains("minimal.primary-ctor.field-init", report);
@@ -156,6 +170,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.static-method-call", report);
         Assert.Contains("minimal.if-else", report);
         Assert.Contains("minimal.null-coalesce", report);
+        Assert.Contains("minimal.try-finally", report);
         Assert.Contains("decompiler=Full", report);
         Assert.Contains("compile-back=Exact", report);
     }
@@ -177,6 +192,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.primary-ctor.field-init",
                 "minimal.property.literal",
                 "minimal.static-method-call",
+                "minimal.try-finally",
             ],
             GeneratedFixtureCatalog.Select("minimal").Select(fixture => fixture.Id).Order(StringComparer.Ordinal).ToArray());
 
@@ -197,6 +213,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.static-method-call");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.null-coalesce");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.try-finally");
 
         var primaryCtor = Assert.Single(fixtures,
             fixture => fixture.GetProperty("Id").GetString() == "minimal.primary-ctor.field-init");

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -189,6 +189,36 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "null-coalesce"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalTryFinally = new(
+        "minimal.try-finally",
+        """
+        namespace GeneratedFixtures.MinimalTryFinally;
+
+        public class Class1
+        {
+            private int _count;
+
+            public int Method1(int value)
+            {
+                try
+                {
+                    return value + 1;
+                }
+                finally
+                {
+                    _count++;
+                }
+            }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalTryFinally.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalTryFinally.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "try-finally", "lifetime"]);
+
     public static IReadOnlyList<GeneratedFixtureDefinition> All { get; } =
     [
         MinimalPropertyLiteral,
@@ -199,6 +229,7 @@ internal static class GeneratedFixtureCatalog
         MinimalStaticMethodCall,
         MinimalIfElse,
         MinimalNullCoalesce,
+        MinimalTryFinally,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> MinimalCompileBackRungs => All;

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -15,10 +15,10 @@ This is the first step toward an addressable progressive fixture ladder:
 `minimal.property.literal`, `minimal.ctor-field.getter`,
 `minimal.auto-property.getter`, `minimal.method-call.same-type`, and
 `minimal.primary-ctor.field-init` are expected `Exact`; the static-call, if/else,
-and null-coalescing rungs extend that minimal exact set. With no selector, all
-generated fixtures run; use `list` to list fixture IDs, `--json` for
-machine-readable list/results, and `--keep-generated-fixtures` to preserve the
-generated project for drill-down.
+null-coalescing, and try/finally rungs extend that minimal exact set. With no
+selector, all generated fixtures run; use `list` to list fixture IDs, `--json`
+for machine-readable list/results, and `--keep-generated-fixtures` to preserve
+the generated project for drill-down.
 
 **Library report** (`--library-report`): a portfolio view. It combines the IR
 residual buckets from `--gaps` with the Roslyn-backed validity oracle from


### PR DESCRIPTION
- Advances #1742
- Changes generated decompiler fixture catalogue coverage only
- Card revision: `d1403807`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated fixture ladder gains a first lifetime/control-flow rung and it is opcode-exact.

Before:

```text
minimal generated fixture catalogue: 8 fixtures / 18 targets
```

After:

```text
minimal generated fixture catalogue: 9 fixtures / 20 targets
new exact rung: minimal.try-finally
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Decompiler fast suite | Not run; additive generated-fixture catalogue entry only |
| Reduced fixture validity | Not applicable |
| Reduced fixture fidelity | Pass: `minimal.try-finally` reports `Exact` for `.ctor` and `Method1` |
| Real witness | Generated fixture: try/finally with return from try and field mutation in finally |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes; this only adds a generated fixture catalogue row.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked exactness, implicit ctor target, try/finally return semantics, selector/list behavior, and README accuracy. |
| MAI-Code-1-Flash | No blocking findings | Verified the compile-back oracle reports exact for the try/finally shape and full catalogue remains passing. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.try-finally
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
```
