### PR TITLE
Strip address-of from in/ref user-defined operator operands (#1835)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4365,3 +4365,17 @@ public class InOperatorProbe
         return arg != current;
     }
 }
+
+// C# 11 user-defined unsigned right shift with an `in` left operand: must
+// operator-spell `a >>> n`, not the CS0571 explicit op_UnsignedRightShift call.
+public readonly struct ShiftBox
+{
+    public readonly int Bits;
+    public ShiftBox(int bits) { Bits = bits; }
+    public static ShiftBox operator >>>(in ShiftBox a, int n) => new ShiftBox(a.Bits >> n);
+}
+
+public static class ShiftProbe
+{
+    public static ShiftBox Shift(ShiftBox value, int n) => value >>> n;
+}

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4339,3 +4339,29 @@ public class MergedSlotProbe
         set => _fmt = MergedSlotStrU.IsNullOrEmpty(value!) ? null : value;
     }
 }
+
+// Issue: a user-defined operator with `in`/`ref` parameters is called with the
+// operands' addresses (ldarga/ldloca). The operator must spell as `a != b`, not
+// `(ref a) != (ref b)` — the latter is CS1525 "Invalid expression term 'ref'".
+// Mirrors the Roslyn `SeparatedSyntaxList<T>` op_Inequality used throughout the
+// red-green tree `Update` methods.
+public readonly struct InOperatorVec
+{
+    public readonly int X;
+    public InOperatorVec(int x) { X = x; }
+    public static bool operator ==(in InOperatorVec a, in InOperatorVec b) => a.X == b.X;
+    public static bool operator !=(in InOperatorVec a, in InOperatorVec b) => a.X != b.X;
+    public override bool Equals(object? o) => o is InOperatorVec v && this == v;
+    public override int GetHashCode() => X;
+}
+
+public class InOperatorProbe
+{
+    public InOperatorVec Field;
+
+    public bool Changed(InOperatorVec arg)
+    {
+        InOperatorVec current = Field;
+        return arg != current;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/InOperatorOperandTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InOperatorOperandTests.cs
@@ -19,6 +19,16 @@ public class InOperatorOperandTests
         Assert.DoesNotContain("(ref ", body);
     }
 
+    [Fact]
+    public void UserDefinedUnsignedRightShift_RendersOperator_NotExplicitCall()
+    {
+        string body = RenderFixture(typeof(ShiftProbe).FullName!, nameof(ShiftProbe.Shift));
+
+        Assert.Contains("value >>> n", body);
+        Assert.DoesNotContain("op_UnsignedRightShift", body);
+        Assert.DoesNotContain("(ref ", body);
+    }
+
     static string RenderFixture(string typeName, string methodName)
     {
         using var source = MetadataSource.Open(typeof(InOperatorProbe).Assembly.Location);

--- a/src/ILInspector.Decompiler.Tests/InOperatorOperandTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InOperatorOperandTests.cs
@@ -1,0 +1,32 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// A user-defined operator with `in`/`ref` parameters is invoked with the
+// operands' addresses (ldarga/ldloca). The operator spelling must drop the
+// address-of — `a != b`, not `(ref a) != (ref b)` (CS1525). This is the Roslyn
+// `SeparatedSyntaxList<T>` op_Inequality used throughout the red-green tree
+// `Update` methods (~31 corpus methods were malformed before the fix).
+public class InOperatorOperandTests
+{
+    [Fact]
+    public void InParameterOperator_RendersValueOperands_NotRefAddresses()
+    {
+        string body = RenderFixture(typeof(InOperatorProbe).FullName!, nameof(InOperatorProbe.Changed));
+
+        Assert.Contains("arg != current", body);
+        Assert.DoesNotContain("ref arg", body);
+        Assert.DoesNotContain("(ref ", body);
+    }
+
+    static string RenderFixture(string typeName, string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(InOperatorProbe).Assembly.Location);
+        var function = IrImporter.Import(source, typeName, methodName);
+        Assert.NotNull(function);
+        Assert.Equal(DecompilationFidelity.Full, function!.Fidelity);
+        var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+        Assert.NotNull(result.Output);
+        return result.Output!;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2425,7 +2425,7 @@ public sealed partial class CSharpPrinter
 
     string ConversionOperatorSpelling(TypeRef target, IrExpression value)
     {
-        string operand = Operand(value);
+        string operand = OperatorOperand(value);
         string targetText = TypeText(target);
         if (NeedsCastOperandParentheses(operand, targetText))
             operand = $"({operand})";
@@ -2451,9 +2451,9 @@ public sealed partial class CSharpPrinter
         return (symbol, arguments.Count) switch
         {
             ("+" or "-" or "*" or "/", 2)
-                => WrapChecked(() => $"{Operand(arguments[0])} {symbol} {Operand(arguments[1])}"),
+                => WrapChecked(() => $"{OperatorOperand(arguments[0])} {symbol} {OperatorOperand(arguments[1])}"),
             ("-", 1) // op_CheckedUnaryNegation
-                => WrapChecked(() => $"-{Operand(arguments[0])}"),
+                => WrapChecked(() => $"-{OperatorOperand(arguments[0])}"),
             _ => null,
         };
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2391,6 +2391,7 @@ public sealed partial class CSharpPrinter
                 "op_Multiply" => "*", "op_Division" => "/", "op_Modulus" => "%",
                 "op_BitwiseAnd" => "&", "op_BitwiseOr" => "|", "op_ExclusiveOr" => "^",
                 "op_LeftShift" => "<<", "op_RightShift" => ">>",
+                "op_UnsignedRightShift" => ">>>",
                 _ => null,
             };
             return op is null ? null : $"{OperatorOperand(arguments[0])} {op} {OperatorOperand(arguments[1])}";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2393,22 +2393,35 @@ public sealed partial class CSharpPrinter
                 "op_LeftShift" => "<<", "op_RightShift" => ">>",
                 _ => null,
             };
-            return op is null ? null : $"{Operand(arguments[0])} {op} {Operand(arguments[1])}";
+            return op is null ? null : $"{OperatorOperand(arguments[0])} {op} {OperatorOperand(arguments[1])}";
         }
         if (arguments.Count == 1)
         {
             return call.Callee.Name switch
             {
-                "op_UnaryNegation" => $"-{Operand(arguments[0])}",
-                "op_UnaryPlus" => $"+{Operand(arguments[0])}",
-                "op_LogicalNot" => $"!{Operand(arguments[0])}",
-                "op_OnesComplement" => $"~{Operand(arguments[0])}",
+                "op_UnaryNegation" => $"-{OperatorOperand(arguments[0])}",
+                "op_UnaryPlus" => $"+{OperatorOperand(arguments[0])}",
+                "op_LogicalNot" => $"!{OperatorOperand(arguments[0])}",
+                "op_OnesComplement" => $"~{OperatorOperand(arguments[0])}",
                 "op_Implicit" or "op_Explicit" => ConversionOperatorSpelling(call.Callee.ReturnType, arguments[0]),
                 _ => null,
             };
         }
         return null;
     }
+
+    /// <summary>
+    /// An operand of a user-defined operator call. The operator's parameters may
+    /// be <c>in</c>/<c>ref</c>, so the IL passes the operand's address
+    /// (<c>ldarga</c>/<c>ldloca</c>/<c>ldflda</c>); C# operator syntax takes that
+    /// address implicitly, so the operand is the place itself — <c>a != b</c>, not
+    /// the CS1525 <c>(ref a) != (ref b)</c>. Strip the address-of; other operands
+    /// render normally.
+    /// </summary>
+    string OperatorOperand(IrExpression argument)
+        => argument is LoadArgumentAddress or LoadLocalAddress or LoadFieldAddress or LoadElementAddress
+            ? Deref(argument)
+            : Operand(argument);
 
     string ConversionOperatorSpelling(TypeRef target, IrExpression value)
     {


### PR DESCRIPTION
## Invalid-`Full` fix: `in`/`ref`-parameter operator renders `(ref a) != (ref b)`

Found via a fresh corpus validity sweep after the #1687 queue drained.

A user-defined operator whose parameters are `in`/`ref` is invoked in IL with the operands' **addresses** (`ldarga`/`ldloca`/`ldflda`). `OperatorSpelling` rendered each operand via `Operand`, which spells an address-of as `ref x` — producing `(ref a) != (ref b)`, **CS1525** ("Invalid expression term 'ref'"), while graded `Full`.

### Fix

Render binary/unary operator operands through a new `OperatorOperand` helper that `Deref`s an address-of operand instead of spelling `ref x`. C# operator syntax takes the `in`/`ref` address implicitly, so the operand is the place itself.

```
if (!((ref arguments) != (ref V_0)) && ...)   ->   if (!(arguments != V_0) && ...)
```

### Measured impact

Corpus `--validity-check` (14 assemblies, 89,065 methods): **Full malformed 37 → 6** (−31), CS1525 37 → 6. No new malformed.

The dominant source is Roslyn's `SeparatedSyntaxList<T>.op_Inequality(in, in)`, used in every red-green tree `*Syntax::Update` "unchanged?" guard (~31 methods).

### Tests

- New `InOperatorProbe` fixture (a `readonly struct` with `in`-parameter `==`/`!=`) + `InOperatorOperandTests`.
- Fast decompiler suite **1668/1668**.

Closes #1835.
