### PR TITLE
Add minimal using-dispose generated fixture rung

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -161,6 +161,20 @@ public class GeneratedFixtureCatalogTests
             "Method1",
             FidelityCheck.CompileBackStatus.Exact,
             frontier: false);
+        AssertTarget(
+            run,
+            "minimal.using-dispose",
+            "GeneratedFixtures.MinimalUsingDispose.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.using-dispose",
+            "GeneratedFixtures.MinimalUsingDispose.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
 
         Assert.Contains("minimal.property.literal", report);
         Assert.Contains("minimal.primary-ctor.field-init", report);
@@ -171,6 +185,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.if-else", report);
         Assert.Contains("minimal.null-coalesce", report);
         Assert.Contains("minimal.try-finally", report);
+        Assert.Contains("minimal.using-dispose", report);
         Assert.Contains("decompiler=Full", report);
         Assert.Contains("compile-back=Exact", report);
     }
@@ -193,6 +208,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.property.literal",
                 "minimal.static-method-call",
                 "minimal.try-finally",
+                "minimal.using-dispose",
             ],
             GeneratedFixtureCatalog.Select("minimal").Select(fixture => fixture.Id).Order(StringComparer.Ordinal).ToArray());
 
@@ -214,6 +230,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.null-coalesce");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.try-finally");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.using-dispose");
 
         var primaryCtor = Assert.Single(fixtures,
             fixture => fixture.GetProperty("Id").GetString() == "minimal.primary-ctor.field-init");

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -219,6 +219,28 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "try-finally", "lifetime"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalUsingDispose = new(
+        "minimal.using-dispose",
+        """
+        namespace GeneratedFixtures.MinimalUsingDispose;
+
+        public class Class1
+        {
+            public long Method1()
+            {
+                using var stream = new System.IO.MemoryStream();
+                return stream.Length;
+            }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalUsingDispose.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalUsingDispose.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "using", "dispose", "lifetime"]);
+
     public static IReadOnlyList<GeneratedFixtureDefinition> All { get; } =
     [
         MinimalPropertyLiteral,
@@ -230,6 +252,7 @@ internal static class GeneratedFixtureCatalog
         MinimalIfElse,
         MinimalNullCoalesce,
         MinimalTryFinally,
+        MinimalUsingDispose,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> MinimalCompileBackRungs => All;

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -15,10 +15,10 @@ This is the first step toward an addressable progressive fixture ladder:
 `minimal.property.literal`, `minimal.ctor-field.getter`,
 `minimal.auto-property.getter`, `minimal.method-call.same-type`, and
 `minimal.primary-ctor.field-init` are expected `Exact`; the static-call, if/else,
-null-coalescing, and try/finally rungs extend that minimal exact set. With no
-selector, all generated fixtures run; use `list` to list fixture IDs, `--json`
-for machine-readable list/results, and `--keep-generated-fixtures` to preserve
-the generated project for drill-down.
+null-coalescing, try/finally, and using/dispose rungs extend that minimal exact
+set. With no selector, all generated fixtures run; use `list` to list fixture
+IDs, `--json` for machine-readable list/results, and `--keep-generated-fixtures`
+to preserve the generated project for drill-down.
 
 **Library report** (`--library-report`): a portfolio view. It combines the IR
 residual buckets from `--gaps` with the Roslyn-backed validity oracle from


### PR DESCRIPTION
- Advances #1742
- Changes generated decompiler fixture catalogue coverage only
- Card revision: `7a69e82b`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated fixture ladder gains a higher-level using/dispose lifetime rung and it is opcode-exact.

Before:

```text
minimal generated fixture catalogue: 9 fixtures / 20 targets
```

After:

```text
minimal generated fixture catalogue: 10 fixtures / 22 targets
new exact rung: minimal.using-dispose
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Decompiler fast suite | Not run; additive generated-fixture catalogue entry only |
| Reduced fixture validity | Not applicable |
| Reduced fixture fidelity | Pass: `minimal.using-dispose` reports `Exact` for `.ctor` and `Method1` |
| Real witness | Generated fixture: `using var` with BCL `System.IO.MemoryStream` disposable |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes; this only adds a generated fixture catalogue row.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked exactness, target names, using-var lowering, selector/list behavior, and README accuracy. |
| MAI-Code-1-Flash | No blocking findings | Verified tests pass and the additive catalogue row is consistent with existing rungs. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.using-dispose
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
```
