### PR TITLE
Add minimal foreach-array generated fixture rung

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -175,6 +175,20 @@ public class GeneratedFixtureCatalogTests
             "Method1",
             FidelityCheck.CompileBackStatus.Exact,
             frontier: false);
+        AssertTarget(
+            run,
+            "minimal.foreach-array",
+            "GeneratedFixtures.MinimalForeachArray.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.foreach-array",
+            "GeneratedFixtures.MinimalForeachArray.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
 
         Assert.Contains("minimal.property.literal", report);
         Assert.Contains("minimal.primary-ctor.field-init", report);
@@ -186,6 +200,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.null-coalesce", report);
         Assert.Contains("minimal.try-finally", report);
         Assert.Contains("minimal.using-dispose", report);
+        Assert.Contains("minimal.foreach-array", report);
         Assert.Contains("decompiler=Full", report);
         Assert.Contains("compile-back=Exact", report);
     }
@@ -201,6 +216,7 @@ public class GeneratedFixtureCatalogTests
             [
                 "minimal.auto-property.getter",
                 "minimal.ctor-field.getter",
+                "minimal.foreach-array",
                 "minimal.if-else",
                 "minimal.method-call.same-type",
                 "minimal.null-coalesce",
@@ -231,6 +247,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.null-coalesce");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.try-finally");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.using-dispose");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.foreach-array");
 
         var primaryCtor = Assert.Single(fixtures,
             fixture => fixture.GetProperty("Id").GetString() == "minimal.primary-ctor.field-init");

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -241,6 +241,30 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "using", "dispose", "lifetime"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalForeachArray = new(
+        "minimal.foreach-array",
+        """
+        namespace GeneratedFixtures.MinimalForeachArray;
+
+        public class Class1
+        {
+            public int Method1(int[] values)
+            {
+                var sum = 0;
+                foreach (var value in values)
+                    sum += value;
+                return sum;
+            }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalForeachArray.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalForeachArray.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "foreach", "array", "loop"]);
+
     public static IReadOnlyList<GeneratedFixtureDefinition> All { get; } =
     [
         MinimalPropertyLiteral,
@@ -253,6 +277,7 @@ internal static class GeneratedFixtureCatalog
         MinimalNullCoalesce,
         MinimalTryFinally,
         MinimalUsingDispose,
+        MinimalForeachArray,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> MinimalCompileBackRungs => All;

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -15,10 +15,10 @@ This is the first step toward an addressable progressive fixture ladder:
 `minimal.property.literal`, `minimal.ctor-field.getter`,
 `minimal.auto-property.getter`, `minimal.method-call.same-type`, and
 `minimal.primary-ctor.field-init` are expected `Exact`; the static-call, if/else,
-null-coalescing, try/finally, and using/dispose rungs extend that minimal exact
-set. With no selector, all generated fixtures run; use `list` to list fixture
-IDs, `--json` for machine-readable list/results, and `--keep-generated-fixtures`
-to preserve the generated project for drill-down.
+null-coalescing, try/finally, using/dispose, and foreach-array rungs extend that
+minimal exact set. With no selector, all generated fixtures run; use `list` to
+list fixture IDs, `--json` for machine-readable list/results, and
+`--keep-generated-fixtures` to preserve the generated project for drill-down.
 
 **Library report** (`--library-report`): a portfolio view. It combines the IR
 residual buckets from `--gaps` with the Roslyn-backed validity oracle from


### PR DESCRIPTION
- Advances #1742
- Changes generated decompiler fixture catalogue coverage only
- Card revision: `6a80113d`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated fixture ladder gains a foreach-over-array loop rung and it is opcode-exact.

Before:

```text
minimal generated fixture catalogue: 10 fixtures / 22 targets
```

After:

```text
minimal generated fixture catalogue: 11 fixtures / 24 targets
new exact rung: minimal.foreach-array
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Decompiler fast suite | Not run; additive generated-fixture catalogue entry only |
| Reduced fixture validity | Not applicable |
| Reduced fixture fidelity | Pass: `minimal.foreach-array` reports `Exact` for `.ctor` and `Method1` |
| Real witness | Generated fixture: foreach over `int[]` accumulating a sum |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes; this only adds a generated fixture catalogue row.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked exactness, target names, implicit ctor, selector/list behavior, and README accuracy. |
| MAI-Code-1-Flash | No blocking findings | Verified `AssertTarget` exercises the real compile-back oracle and the foreach-array rung is exact. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.foreach-array
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
```
