### PR TITLE
Add Performance Triage row predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,20 @@ allocation pay-dirt first — ranking in-loop (hot) and high-confidence
 opportunities ahead of raw leverage — across actionable rewrite shapes (small
 non-escaping arrays, temporary or span-to-array copies, capturing and instance
 method-group delegates, and value-type boxing) plus `allocation-hotspot` rows
-for methods that allocate heavily without matching a specific shape. Drill
-candidates with `Call Graph` (bounded outbound tree) and `Caller Graph`
-(bounded reverse tree to entry points), and project per-node cost with
-`--fields`. Ranking rows carry a copyable `Stable` selector, `Visibility`, and
-`Selector`; add `--all` to drill non-public members.
+for methods that allocate heavily without matching a specific shape. Use
+`--top`, `--loop`, `--min-confidence`, and `--triage-shape` to ask the tool for
+the curated pay-dirt rows directly instead of post-processing. Drill candidates
+with `Call Graph` (bounded outbound tree) and `Caller Graph` (bounded reverse
+tree to entry points), and project per-node cost with `--fields`. Ranking rows
+carry a copyable `Stable` selector, `Visibility`, and `Selector`; add `--all` to
+drill non-public members.
 
 ```bash
 dotnet-inspect library MyLib.dll -S "Top Leverage"
 dotnet-inspect type MyType --library MyLib.dll --all -S "Top Leverage"
 dotnet-inspect library MyLib.dll -S "Performance Triage"
+dotnet-inspect library MyLib.dll --loop --min-confidence high --top 20 --tsv
+dotnet-inspect library MyLib.dll --triage-shape capturing-delegate --top 10 --jsonl
 dotnet-inspect member MyType Method:1 --library MyLib.dll -S "Call Graph,Facts"
 dotnet-inspect member MyType Method:1 --library MyLib.dll -S "Caller Graph" --fields "Throw,Catch,Finally"
 ```

--- a/README.md
+++ b/README.md
@@ -114,11 +114,13 @@ non-escaping arrays, temporary or span-to-array copies, capturing and instance
 method-group delegates, and value-type boxing) plus `allocation-hotspot` rows
 for methods that allocate heavily without matching a specific shape. Use
 `--top`, `--loop`, `--min-confidence`, and `--triage-shape` to ask the tool for
-the curated pay-dirt rows directly instead of post-processing. Drill candidates
-with `Call Graph` (bounded outbound tree) and `Caller Graph` (bounded reverse
-tree to entry points), and project per-node cost with `--fields`. Ranking rows
-carry a copyable `Stable` selector, `Visibility`, and `Selector`; add `--all` to
-drill non-public members.
+the curated pay-dirt rows directly instead of post-processing. `--top` limits
+the ranked data before rendering; `-n N --rows` remains a renderer cap and is
+applied afterward if both are supplied. Drill candidates with `Call Graph`
+(bounded outbound tree) and `Caller Graph` (bounded reverse tree to entry
+points), and project per-node cost with `--fields`. Ranking rows carry a
+copyable `Stable` selector, `Visibility`, and `Selector`; add `--all` to drill
+non-public members.
 
 ```bash
 dotnet-inspect library MyLib.dll -S "Top Leverage"
@@ -129,6 +131,10 @@ dotnet-inspect library MyLib.dll --triage-shape capturing-delegate --top 10 --js
 dotnet-inspect member MyType Method:1 --library MyLib.dll -S "Call Graph,Facts"
 dotnet-inspect member MyType Method:1 --library MyLib.dll -S "Caller Graph" --fields "Throw,Catch,Finally"
 ```
+
+Common `--triage-shape` values include `capturing-delegate`,
+`box-value-type`, `small-array`, `linq-scan-in-loop`,
+`string-build-in-loop`, `enumerator-allocation`, and `allocation-hotspot`.
 
 ### Decompiler
 

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -47,7 +47,11 @@ devirtualization, bounds-check elimination, null-check folding).
 Use `--loop` for repeated hot costs, `--min-confidence high|medium|low` for a
 confidence floor, `--triage-shape` for one or more shapes, and `--top N` for the
 curated ranked prefix. Supplying any of those flags selects `Performance Triage`
-automatically on `library`, `type`, and `member`.
+automatically on `library`, `type`, and `member`. `--top` narrows the ranked data
+before rendering; `-n N --rows` is a generic rendered-row cap applied afterward.
+Common shapes include `capturing-delegate`, `box-value-type`, `small-array`,
+`linq-scan-in-loop`, `string-build-in-loop`, `enumerator-allocation`, and
+`allocation-hotspot`.
 
 ## Drill a candidate
 

--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -36,11 +36,18 @@ delegates, stateless instance methods — so hot, fixable members surface first.
 
 ```bash
 dnx dotnet-inspect -y -- library MyLib.dll -S "Performance Triage"
+dnx dotnet-inspect -y -- library MyLib.dll --loop --min-confidence high --top 20 --tsv
+dnx dotnet-inspect -y -- library MyLib.dll --triage-shape capturing-delegate --top 10 --jsonl
 ```
 
 Target IL-visible costs (allocations: box, newarr, delegate newobj,
 ToArray/ToList/Concat), not JIT-handled concerns (isinst/castclass folding,
 devirtualization, bounds-check elimination, null-check folding).
+
+Use `--loop` for repeated hot costs, `--min-confidence high|medium|low` for a
+confidence floor, `--triage-shape` for one or more shapes, and `--top N` for the
+curated ranked prefix. Supplying any of those flags selects `Performance Triage`
+automatically on `library`, `type`, and `member`.
 
 ## Drill a candidate
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -246,6 +246,28 @@ public class CommandExecutionTests
         });
     }
 
+    [Theory]
+    [InlineData("library")]
+    [InlineData("type")]
+    [InlineData("member")]
+    public async Task PerformanceTriagePredicates_DoNotAlterDiscovery(string command)
+    {
+        string[] BaseArgs() => command switch
+        {
+            "library" => [command, TestAssemblyPath, "--discover"],
+            "type" => [command, nameof(OutputFormatterTests), "--library", TestAssemblyPath, "--discover"],
+            "member" => [command, nameof(OutputFormatterTests), "--library", TestAssemblyPath, "--discover"],
+            _ => throw new ArgumentOutOfRangeException(nameof(command), command, null)
+        };
+
+        var baseline = await RunAppAsync(BaseArgs());
+        var filtered = await RunAppAsync([.. BaseArgs(), "--loop"]);
+
+        Assert.Equal(0, baseline.Exit);
+        Assert.Equal(0, filtered.Exit);
+        Assert.Equal(baseline.Output, filtered.Output);
+    }
+
     // ── bare router ───────────────────────────────────────────────────
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -268,6 +268,17 @@ public class CommandExecutionTests
         Assert.Equal(baseline.Output, filtered.Output);
     }
 
+    [Fact]
+    public async Task PerformanceTriageShape_UnknownShapeReportsValidShapes()
+    {
+        var (exit, output, error) = await RunAppAsync("library", TestAssemblyPath, "--triage-shape", "typo-shape", "--tsv");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("Unknown Performance Triage shape 'typo-shape'", error);
+        Assert.Contains("capturing-delegate", error);
+    }
+
     // ── bare router ───────────────────────────────────────────────────
 
     [Fact]

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -315,7 +315,7 @@ public class OutputFormatterTests
                 new PerformanceTriageOptions
                 {
                     LoopOnly = true,
-                    MinConfidence = "high",
+                    MinConfidence = "High",
                     Shapes = ["capturing-delegate"],
                     Top = 1
                 })

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -299,6 +299,32 @@ public class OutputFormatterTests
         Assert.True(knownHighReach < knownReachLow, "higher reach must precede lower reach at equal tier");
     }
 
+    [Fact]
+    public void FilterAndOrderTriageOpportunities_AppliesPaydirtPredicatesAfterRanking()
+    {
+        var opportunities = new[]
+        {
+            Opp("LoopMediumDelegate", inLoop: true, confidence: "medium", rootReach: 10, shape: "capturing-delegate"),
+            Opp("LoopHighDelegateLowReach", inLoop: true, confidence: "high", rootReach: 1, shape: "capturing-delegate"),
+            Opp("LoopHighArray", inLoop: true, confidence: "high", rootReach: 99, shape: "small-array"),
+            Opp("NoLoopHighDelegate", inLoop: false, confidence: "high", rootReach: 500, shape: "capturing-delegate"),
+        };
+
+        var filtered = LibraryMetadataService.FilterAndOrderTriageOpportunities(
+                opportunities,
+                new PerformanceTriageOptions
+                {
+                    LoopOnly = true,
+                    MinConfidence = "high",
+                    Shapes = ["capturing-delegate"],
+                    Top = 1
+                })
+            .Select(opportunity => opportunity.Method.Name)
+            .ToList();
+
+        Assert.Equal(["LoopHighDelegateLowReach"], filtered);
+    }
+
     static ILInspector.Analysis.OptimizationOpportunity Opp(string name, bool inLoop, string confidence, int rootReach, string shape)
     {
         var declaring = ILInspector.Analysis.TypeRef.Definition("Asm", "Ns", "Type");

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -93,6 +93,7 @@ public static class ApiCommandDefinitions
         typeCommand.Options.Add(kindOption);
         opts.AddSectionOptionsTo(typeCommand);
         opts.AddCountOptionTo(typeCommand);
+        opts.AddPerformanceTriageOptionsTo(typeCommand);
         typeCommand.Options.Add(opts.Markdown);
         typeCommand.Options.Add(opts.PlainText);
         typeCommand.Options.Add(opts.Bare);
@@ -223,6 +224,7 @@ public static class ApiCommandDefinitions
         memberCommand.Options.Add(kindOption);
         opts.AddSectionOptionsTo(memberCommand);
         opts.AddCountOptionTo(memberCommand);
+        opts.AddPerformanceTriageOptionsTo(memberCommand);
         memberCommand.Options.Add(opts.Markdown);
         memberCommand.Options.Add(opts.PlainText);
         memberCommand.Options.Add(opts.Bare);

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using DotnetInspector.Commands;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Sections;
 using DotnetInspector.Services;
 
 namespace DotnetInspector.CommandLine;
@@ -150,6 +151,7 @@ public static class InspectionCommandDefinitions
         assemblyCommand.Options.Add(extractResourcesOption);
         opts.AddAllOptionsTo(assemblyCommand);
         opts.AddCountOptionTo(assemblyCommand);
+        opts.AddPerformanceTriageOptionsTo(assemblyCommand);
 
         assemblyCommand.SetAction(async (parseResult, ct) =>
         {
@@ -208,8 +210,11 @@ public static class InspectionCommandDefinitions
 
             var typeFilter = parseResult.GetValue(typeFilterOption);
             var select = opts.ParseSelect(parseResult);
+            var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
             if (!string.IsNullOrWhiteSpace(typeFilter))
                 select = [.. select ?? [], "Source Files"];
+            if (performanceTriage.HasFilters)
+                select = [.. select ?? [], SectionNames.PerformanceTriage];
 
             var options = new LibraryOptions
             {
@@ -245,6 +250,7 @@ public static class InspectionCommandDefinitions
                 Fields = opts.ParseFields(parseResult),
                 Count = parseResult.GetValue(opts.Count),
                 Rows = opts.ParseRows(parseResult),
+                PerformanceTriage = performanceTriage,
                 Schema = opts.ParseSchema(parseResult),
                 NoHeader = parseResult.GetValue(opts.NoHeaders),
                 SourceOptions = opts.ParseNuGetSourceOptions(parseResult),

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -213,7 +213,7 @@ public static class InspectionCommandDefinitions
             var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
             if (!string.IsNullOrWhiteSpace(typeFilter))
                 select = [.. select ?? [], "Source Files"];
-            if (performanceTriage.HasFilters)
+            if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult))
                 select = [.. select ?? [], SectionNames.PerformanceTriage];
 
             var options = new LibraryOptions

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -211,6 +211,11 @@ public static class InspectionCommandDefinitions
             var typeFilter = parseResult.GetValue(typeFilterOption);
             var select = opts.ParseSelect(parseResult);
             var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
+            if (!PerformanceTriageOptions.TryValidateShapes(performanceTriage, out var triageShapeError))
+            {
+                Console.Error.WriteLine(triageShapeError);
+                return 1;
+            }
             if (!string.IsNullOrWhiteSpace(typeFilter))
                 select = [.. select ?? [], "Source Files"];
             if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult))

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -219,6 +219,9 @@ public static class MemberOptionsParser
         var select = opts.ParseSelect(parseResult);
         if (showMemberIndex)
             select = [.. select ?? [], SectionNames.MemberIndex];
+        var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
+        if (performanceTriage.HasFilters)
+            select = [.. select ?? [], SectionNames.PerformanceTriage];
 
         var options = new MemberOptions
         {
@@ -261,6 +264,7 @@ public static class MemberOptionsParser
             Fields = opts.ParseFields(parseResult),
             Count = parseResult.GetValue(opts.Count),
             Rows = opts.ParseRows(parseResult),
+            PerformanceTriage = performanceTriage,
             Schema = opts.ParseSchema(parseResult),
             Verbose = parseResult.GetValue(opts.Verbose),
             Verbosity = opts.ParseVerbosity(parseResult),

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -220,7 +220,7 @@ public static class MemberOptionsParser
         if (showMemberIndex)
             select = [.. select ?? [], SectionNames.MemberIndex];
         var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
-        if (performanceTriage.HasFilters)
+        if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult))
             select = [.. select ?? [], SectionNames.PerformanceTriage];
 
         var options = new MemberOptions

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -220,6 +220,8 @@ public static class MemberOptionsParser
         if (showMemberIndex)
             select = [.. select ?? [], SectionNames.MemberIndex];
         var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
+        if (!PerformanceTriageOptions.TryValidateShapes(performanceTriage, out var triageShapeError))
+            return new VersionError(triageShapeError);
         if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult))
             select = [.. select ?? [], SectionNames.PerformanceTriage];
 

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -112,7 +112,7 @@ public static class TypeOptionsParser
         var routePolicy = TypeRoutePolicy.Resolve(sourceSelection.Args, sourceSelection.HasExplicitSource, source);
         var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
         var select = opts.ParseSelect(parseResult);
-        if (performanceTriage.HasFilters)
+        if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult))
             select = [.. select ?? [], SectionNames.PerformanceTriage];
 
         var options = routePolicy.ApplyTo(new TypeOptions

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using DotnetInspector.Options;
+using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 
@@ -109,6 +110,10 @@ public static class TypeOptionsParser
         var kindValues = parseResult.GetValue(args.KindOption) ?? [];
         var kindFilter = SharedParsers.ParseKindFilter(kindValues);
         var routePolicy = TypeRoutePolicy.Resolve(sourceSelection.Args, sourceSelection.HasExplicitSource, source);
+        var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
+        var select = opts.ParseSelect(parseResult);
+        if (performanceTriage.HasFilters)
+            select = [.. select ?? [], SectionNames.PerformanceTriage];
 
         var options = routePolicy.ApplyTo(new TypeOptions
         {
@@ -143,11 +148,12 @@ public static class TypeOptionsParser
             UnsafeOnly = parseResult.GetValue(args.UnsafeOption),
             Discover = opts.ParseDiscover(parseResult),
             Tree = parseResult.GetValue(opts.Tree),
-            Select = opts.ParseSelect(parseResult),
+            Select = select,
             Columns = opts.ParseColumns(parseResult),
             Fields = opts.ParseFields(parseResult),
             Count = parseResult.GetValue(opts.Count),
             Rows = opts.ParseRows(parseResult),
+            PerformanceTriage = performanceTriage,
             Schema = opts.ParseSchema(parseResult),
             Verbose = parseResult.GetValue(opts.Verbose),
             Verbosity = opts.ParseVerbosity(parseResult),

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -111,6 +111,8 @@ public static class TypeOptionsParser
         var kindFilter = SharedParsers.ParseKindFilter(kindValues);
         var routePolicy = TypeRoutePolicy.Resolve(sourceSelection.Args, sourceSelection.HasExplicitSource, source);
         var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
+        if (!PerformanceTriageOptions.TryValidateShapes(performanceTriage, out var triageShapeError))
+            return new VersionError(triageShapeError);
         var select = opts.ParseSelect(parseResult);
         if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult))
             select = [.. select ?? [], SectionNames.PerformanceTriage];

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -672,6 +672,7 @@ public class ApiCommand
                 && GetRequestedMemberSections(type, options).Contains(SectionNames.PerformanceTriage))
             {
                 ApiOutputFormatter.PopulateOptimizationOpportunities(view, type, optimizationDllPath, options.IncludeSections,
+                    options.PerformanceTriage,
                     restrictToModelMembers: ApiMemberSectionPipelines.UsesDetailPipeline(options)
                         || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options));
             }

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -65,7 +65,8 @@ internal static class LibraryMetadataService
                 FileName = Path.GetFileName(path),
                 FileType = "dll",
                 IsFacadeAssembly = isPlatformAssembly ? PlatformResolver.IsFacadeOnlyAssembly(path) : null,
-                UseDependenciesView = options.IncludeDependencies
+                UseDependenciesView = options.IncludeDependencies,
+                PerformanceTriageOptions = options.PerformanceTriage
             };
 
             inspection.AssemblyInfo = pdbContext.ExtractAssemblyInfo(options.IncludeReferences || options.IncludeDependencies || needsAuditSignals);
@@ -707,18 +708,21 @@ internal static class LibraryMetadataService
 
     /// <summary>
     /// Collects safe, local optimization opportunities across the whole assembly. Emits the
-    /// full set (ordered by declaring type, member, then IL offset) so the generic row limiter
-    /// (<c>-n</c>/<c>--rows</c>) controls how many rows are shown, matching the type-scoped view.
+    /// filtered set in triage priority order so the highest-value pay-dirt surfaces first.
     /// </summary>
-    internal static List<OptimizationOpportunitySummary>? ScanOptimizationOpportunities(string path, VerboseLogger logger)
+    internal static List<OptimizationOpportunitySummary>? ScanOptimizationOpportunities(
+        string path,
+        VerboseLogger logger,
+        PerformanceTriageOptions? options = null)
     {
         try
         {
             var index = Analysis.LibraryBodyIndex.Open(path);
             var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
-            var rows = OrderByTriagePriority(
+            var rows = FilterAndOrderTriageOpportunities(
                     index.OptimizationOpportunities
-                        .Where(opportunity => !IsGeneratedMethod(opportunity.Method, generatedFrameworkTypes)))
+                        .Where(opportunity => !IsGeneratedMethod(opportunity.Method, generatedFrameworkTypes)),
+                    options)
                 .Select(opportunity => new OptimizationOpportunitySummary
                 {
                     Member = FormatMethod(opportunity.Method),
@@ -762,6 +766,29 @@ internal static class LibraryMetadataService
         "medium" => 1,
         _ => 0,
     };
+
+    internal static IEnumerable<Analysis.OptimizationOpportunity> FilterAndOrderTriageOpportunities(
+        IEnumerable<Analysis.OptimizationOpportunity> opportunities,
+        PerformanceTriageOptions? options)
+    {
+        options ??= PerformanceTriageOptions.Default;
+        var filtered = opportunities;
+        if (options.LoopOnly)
+            filtered = filtered.Where(opportunity => opportunity.InLoop);
+        if (options.MinConfidence is { Length: > 0 } confidence)
+        {
+            var minimumRank = ConfidenceRank(confidence);
+            filtered = filtered.Where(opportunity => ConfidenceRank(opportunity.Confidence) >= minimumRank);
+        }
+        if (options.Shapes.Length > 0)
+        {
+            var shapes = options.Shapes.ToHashSet(StringComparer.OrdinalIgnoreCase);
+            filtered = filtered.Where(opportunity => shapes.Contains(opportunity.Shape));
+        }
+
+        var ordered = OrderByTriagePriority(filtered);
+        return options.Top is { } top ? ordered.Take(top) : ordered;
+    }
 
     internal static List<IntegrationSignal>? ScanOpenTelemetry(string path, VerboseLogger logger)
     {

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -760,12 +760,14 @@ internal static class LibraryMetadataService
             .ThenBy(opportunity => opportunity.Shape, StringComparer.Ordinal);
 
     // Triage ordering weight for a confidence label (high allocations are the surest pay-dirt).
-    static int ConfidenceRank(string confidence) => confidence switch
+    static int ConfidenceRank(string confidence)
     {
-        "high" => 2,
-        "medium" => 1,
-        _ => 0,
-    };
+        if (confidence.Equals("high", StringComparison.OrdinalIgnoreCase))
+            return 2;
+        if (confidence.Equals("medium", StringComparison.OrdinalIgnoreCase))
+            return 1;
+        return 0;
+    }
 
     internal static IEnumerable<Analysis.OptimizationOpportunity> FilterAndOrderTriageOpportunities(
         IEnumerable<Analysis.OptimizationOpportunity> opportunities,

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using DotnetInspector.Options;
 using ILInspector.Metadata;
 
 namespace DotnetInspector.Models;
@@ -215,6 +216,9 @@ public class LibraryInspection
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<OptimizationOpportunitySummary>? OptimizationOpportunities { get; set; }
+
+    [JsonIgnore]
+    public PerformanceTriageOptions PerformanceTriageOptions { get; set; } = PerformanceTriageOptions.Default;
 
     /// <summary>
     /// Public P/Invoke (DllImport/LibraryImport) methods.

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -70,6 +70,7 @@ public partial record ApiOptions
     public bool Schema { get; init; }
     public bool Count { get; init; }
     public int? Rows { get; init; }
+    public PerformanceTriageOptions PerformanceTriage { get; init; } = PerformanceTriageOptions.Default;
     public TipLevel TipLevel { get; init; } = TipLevel.Minimal;
 
     /// <summary>

--- a/src/dotnet-inspect/Options/LibraryOptions.cs
+++ b/src/dotnet-inspect/Options/LibraryOptions.cs
@@ -189,6 +189,11 @@ public record LibraryOptions
     public int? Rows { get; init; }
 
     /// <summary>
+    /// Row predicates for the Performance Triage section.
+    /// </summary>
+    public PerformanceTriageOptions PerformanceTriage { get; init; } = PerformanceTriageOptions.Default;
+
+    /// <summary>
     /// NuGet source configuration options.
     /// </summary>
     public NuGetSourceOptions? SourceOptions { get; init; }

--- a/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
+++ b/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
@@ -6,6 +6,21 @@ namespace DotnetInspector.Options;
 public sealed record PerformanceTriageOptions
 {
     public static PerformanceTriageOptions Default { get; } = new();
+    public static readonly string[] KnownShapes =
+    [
+        "allocation-hotspot",
+        "box-value-type",
+        "capturing-delegate",
+        "enumerator-allocation",
+        "instance-method-group-delegate",
+        "linq-scan-in-loop",
+        "scan-method-in-loop-call",
+        "small-array",
+        "span-to-array-copy",
+        "stackalloc-candidate",
+        "string-build-in-loop",
+        "temporary-byte-array-copy",
+    ];
 
     public bool LoopOnly { get; init; }
     public string? MinConfidence { get; init; }
@@ -17,4 +32,19 @@ public sealed record PerformanceTriageOptions
         || !string.IsNullOrWhiteSpace(MinConfidence)
         || Shapes.Length > 0
         || Top.HasValue;
+
+    public static bool TryValidateShapes(PerformanceTriageOptions options, out string error)
+    {
+        var known = KnownShapes.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var invalid = options.Shapes.Where(shape => !known.Contains(shape)).ToArray();
+        if (invalid.Length == 0)
+        {
+            error = "";
+            return true;
+        }
+
+        var quotedInvalid = string.Join(", ", invalid.Select(shape => $"'{shape}'"));
+        error = $"Error: Unknown Performance Triage shape{(invalid.Length == 1 ? "" : "s")} {quotedInvalid}. Valid shapes: {string.Join(", ", KnownShapes)}.";
+        return false;
+    }
 }

--- a/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
+++ b/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
@@ -1,0 +1,20 @@
+namespace DotnetInspector.Options;
+
+/// <summary>
+/// Row predicates for the Performance Triage section.
+/// </summary>
+public sealed record PerformanceTriageOptions
+{
+    public static PerformanceTriageOptions Default { get; } = new();
+
+    public bool LoopOnly { get; init; }
+    public string? MinConfidence { get; init; }
+    public string[] Shapes { get; init; } = [];
+    public int? Top { get; init; }
+
+    public bool HasFilters =>
+        LoopOnly
+        || !string.IsNullOrWhiteSpace(MinConfidence)
+        || Shapes.Length > 0
+        || Top.HasValue;
+}

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1522,20 +1522,24 @@ public static class ApiOutputFormatter
             view.UnsafeMemberRows = rows;
     }
 
-    internal static void PopulateOptimizationOpportunities(TypeView view, ApiType type, string dllPath, IReadOnlySet<string>? explicitSections = null, bool restrictToModelMembers = false)
+    internal static void PopulateOptimizationOpportunities(
+        TypeView view,
+        ApiType type,
+        string dllPath,
+        IReadOnlySet<string>? explicitSections = null,
+        PerformanceTriageOptions? options = null,
+        bool restrictToModelMembers = false)
     {
         var index = Analysis.LibraryBodyIndex.Open(dllPath);
         HashSet<int>? memberTokens = restrictToModelMembers
             ? type.Members.Where(m => m.MetadataToken is not null).Select(m => m.MetadataToken!.Value).ToHashSet()
             : null;
-        var rows = index.OptimizationOpportunities
-            .Where(opportunity => SameType(opportunity.Method.DeclaringType, type))
-            .Where(opportunity => !LibraryMetadataService.IsGeneratedMethod(opportunity.Method, index.GeneratedFrameworkTypeNames))
-            .Where(opportunity => memberTokens is null || memberTokens.Contains(opportunity.Method.MetadataToken))
-            .OrderByDescending(opportunity => opportunity.RootReach)
-            .ThenBy(opportunity => opportunity.Method.Name, StringComparer.Ordinal)
-            .ThenBy(opportunity => opportunity.ILOffset ?? -1)
-            .ThenBy(opportunity => opportunity.Shape, StringComparer.Ordinal)
+        var rows = LibraryMetadataService.FilterAndOrderTriageOpportunities(
+                index.OptimizationOpportunities
+                    .Where(opportunity => SameType(opportunity.Method.DeclaringType, type))
+                    .Where(opportunity => !LibraryMetadataService.IsGeneratedMethod(opportunity.Method, index.GeneratedFrameworkTypeNames))
+                    .Where(opportunity => memberTokens is null || memberTokens.Contains(opportunity.Method.MetadataToken)),
+                options)
             .Select(opportunity => new OptimizationOpportunityRow(
                 MarkoutInline.Code(FormatMember(null, opportunity.Method.Name, opportunity.Method.ParameterTypes, [])),
                 opportunity.RootReach.ToString(),

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -99,7 +99,8 @@ public static class LibrarySections
             .Add(ScannerTopLeverage, ctx =>
                 ctx.Model.TopLeverage = LibraryMetadataService.ScanTopLeverage(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerOptimizationOpportunities, ctx =>
-                ctx.Model.OptimizationOpportunities = LibraryMetadataService.ScanOptimizationOpportunities(ctx.AssemblyPath, ctx.Logger))
+                ctx.Model.OptimizationOpportunities = LibraryMetadataService.ScanOptimizationOpportunities(
+                    ctx.AssemblyPath, ctx.Logger, ctx.Model.PerformanceTriageOptions))
             .Add(ScannerIntegrations, ctx =>
                 LibraryMetadataService.ScanIntegrations(ctx.AssemblyPath, ctx.Model, ctx.Logger))
             .Add(ScannerIntegrationOpportunities, ctx =>

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -50,6 +50,16 @@ public class SharedOptions
     public Option<bool> Schema { get; } = new("--schema") { Description = "With -D: show the full static schema without resolving/loading source (offline)" };
     public Option<bool> Tree { get; } = new("--tree") { Description = "Show discovery as a tree (sections → items)" };
 
+    // Performance Triage row predicates
+    public Option<bool> PerformanceTriageLoop { get; } = new("--loop") { Description = "Performance Triage: show only opportunities inside loops" };
+    public Option<string?> PerformanceTriageMinConfidence { get; } = new("--min-confidence") { Description = "Performance Triage: minimum confidence (low, medium, high)" };
+    public Option<string[]> PerformanceTriageShape { get; } = new("--triage-shape")
+    {
+        Description = "Performance Triage: include only shape(s), comma-separated or repeated",
+        AllowMultipleArgumentsPerToken = true
+    };
+    public Option<int?> PerformanceTriageTop { get; } = new("--top") { Description = "Performance Triage: show the top N ranked rows" };
+
     // NuGet source options
     public Option<string[]> Source { get; } = new("--source")
     {
@@ -69,6 +79,7 @@ public class SharedOptions
     public SharedOptions()
     {
         Verbosity.AcceptOnlyFromAmong(StringComparer.OrdinalIgnoreCase, OptionParsers.ValidVerbosityValues);
+        PerformanceTriageMinConfidence.AcceptOnlyFromAmong(StringComparer.OrdinalIgnoreCase, "low", "medium", "high");
 
         Limit = new Option<int?>("-n") { Description = "Limit to first N lines (like head -n)" };
         Limit.Aliases.Add("--head");
@@ -167,6 +178,17 @@ public class SharedOptions
     }
 
     /// <summary>
+    /// Adds Performance Triage row predicates to commands that can render that section.
+    /// </summary>
+    public void AddPerformanceTriageOptionsTo(Command command)
+    {
+        command.Options.Add(PerformanceTriageLoop);
+        command.Options.Add(PerformanceTriageMinConfidence);
+        command.Options.Add(PerformanceTriageShape);
+        command.Options.Add(PerformanceTriageTop);
+    }
+
+    /// <summary>
     /// Adds the print output option to commands that can render a printable document section.
     /// </summary>
     public void AddPrintOptionTo(Command command)
@@ -176,6 +198,24 @@ public class SharedOptions
 
     public int? ParseRows(ParseResult parseResult)
         => parseResult.GetValue(Rows) ? parseResult.GetValue(Limit) : null;
+
+    public PerformanceTriageOptions ParsePerformanceTriageOptions(ParseResult parseResult)
+    {
+        var shapes = (parseResult.GetValue(PerformanceTriageShape) ?? [])
+            .SelectMany(value => value.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Where(value => value.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var top = parseResult.GetValue(PerformanceTriageTop);
+        return new PerformanceTriageOptions
+        {
+            LoopOnly = parseResult.GetValue(PerformanceTriageLoop),
+            MinConfidence = parseResult.GetValue(PerformanceTriageMinConfidence),
+            Shapes = shapes,
+            Top = top is > 0 ? top : null
+        };
+    }
 
     /// <summary>
     /// Adds NuGet source options to a command.

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -55,7 +55,7 @@ public class SharedOptions
     public Option<string?> PerformanceTriageMinConfidence { get; } = new("--min-confidence") { Description = "Performance Triage: minimum confidence (low, medium, high)" };
     public Option<string[]> PerformanceTriageShape { get; } = new("--triage-shape")
     {
-        Description = "Performance Triage: include only shape(s), comma-separated or repeated",
+        Description = "Performance Triage: include only shape(s), comma-separated or repeated; run -S \"Performance Triage\" to see shapes",
         AllowMultipleArgumentsPerToken = true
     };
     public Option<int?> PerformanceTriageTop { get; } = new("--top") { Description = "Performance Triage: show the top N ranked rows" };


### PR DESCRIPTION
## Summary

Adds first-class `Performance Triage` row predicates so users and agents can ask for curated pay-dirt rows directly instead of dumping all rows and slicing with `jq`.

- adds `--loop`, `--min-confidence`, `--triage-shape`, and `--top` to `library`, `type`, and `member`
- auto-selects `Performance Triage` when any triage predicate is used
- applies the same filtered triage ordering at library and type/member scope
- documents the new workflow in README and `skill performance`

Part of #1805.

## Validation

- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --nologo --verbosity quiet`
- `dotnet run --project src/dotnet-inspect.Tests -c Release`
- `npx markdownlint-cli README.md skills/performance/SKILL.md`
- `dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll library artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll --loop --min-confidence high --top 3 --tsv`

## Build-event note

The build-event VMR preflight/final logs both stopped at the existing `NU1603` feed/toolchain setup mismatch for `11.0.0-dev` packages. Host build and product tests passed after rebasing on latest `origin/main`.

## Review

Adversarial review requested after opening because this changes analysis CLI behavior and ranking/filtering semantics.