### PR TITLE
Normalize address-valued array-element foreach collection (#1841)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4379,3 +4379,21 @@ public static class ShiftProbe
 {
     public static ShiftBox Shift(ShiftBox value, int n) => value >>> n;
 }
+
+// Issue #1841 (#1202 residual): foreach over a struct array element takes the
+// element address (ldelema); the collection must render as `arr[i]`, not the
+// invalid `ref arr[i]`. ImmutableArray<int> is a struct, so `foreach (x in
+// Rows[i])` enumerates by address.
+public class ForeachElementProbe
+{
+    public System.Collections.Immutable.ImmutableArray<int>[] Rows = new System.Collections.Immutable.ImmutableArray<int>[1];
+    public int Sum(int i)
+    {
+        int total = 0;
+        foreach (int x in Rows[i])
+        {
+            total += x;
+        }
+        return total;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ForeachElementCollectionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachElementCollectionTests.cs
@@ -1,0 +1,22 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Issue #1841 (#1202 residual): foreach over a struct array element takes the
+// element address (ldelema); the collection must render as `Rows[i]`, not the
+// invalid `ref Rows[i]` (CS1525). LoadElementAddress is normalized to LoadElement.
+public class ForeachElementCollectionTests
+{
+    [Fact]
+    public void ForeachOverStructArrayElement_RendersValueCollection_NotRef()
+    {
+        using var source = MetadataSource.Open(typeof(ForeachElementProbe).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(ForeachElementProbe).FullName!, nameof(ForeachElementProbe.Sum));
+        Assert.NotNull(function);
+        Assert.Equal(DecompilationFidelity.Full, function!.Fidelity);
+        var body = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method)).Output!;
+
+        Assert.Contains("in Rows[", body);
+        Assert.DoesNotContain("in ref", body);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -260,8 +260,18 @@ public sealed class ForeachStatementPass : IIrPass
         LoadArgumentAddress address => new LoadArgument(address.Index, address.Name, address.Type),
         LoadLocalAddress address => new LoadLocal(address.Index, address.Type),
         LoadFieldAddress address => new LoadField(address.Field, DetachCollectionReceiver(address.Instance)),
+        LoadElementAddress address => MakeLoadElement(address),
         _ => expression,
     };
+
+    static LoadElement MakeLoadElement(LoadElementAddress address)
+    {
+        var array = address.Array;
+        var index = address.Index;
+        index.Detach();   // detach last child first to keep array's index stable
+        array.Detach();
+        return new LoadElement(address.ElementType, array, index);
+    }
 
     static IrExpression? DetachCollectionReceiver(IrExpression? expression)
     {


### PR DESCRIPTION
## Invalid-`Full` burndown: address-valued array-element foreach (#1841, #1202 residual)

A `foreach` over a **struct array element** takes the element address (`ldelema`), so `ForeachStatementPass.CollectionValue` saw a `LoadElementAddress` it didn't normalize and the printer spelled the collection `ref arr[i]` — **CS1525**, invalid `Full`. #1202 normalized `LoadLocal`/`Field`/`Argument` address collections but not `LoadElementAddress`.

Real witness: `Microsoft.CodeAnalysis.CSharp.BuiltInOperators::GetSimpleBuiltInOperators` — `foreach (... in ref _builtInUnaryOperators[i])` (the last 2 syntactic malformed in the corpus).

### Fix

Add `LoadElementAddress -> LoadElement` to `CollectionValue`, detaching the index child before the array so the array's child index stays stable. Renders `foreach (x in arr[i])`.

### Evidence

- Witness now `foreach (... in _builtInUnaryOperators[i])`; CodeAnalysis.CSharp Full malformed → 0.
- `ForeachElementProbe` fixture (`foreach` over `ImmutableArray<int>[]` element) + test.
- Fast decompiler suite **1671/1671**.
- Corpus quality-diff: _posting below._

Closes #1841. Part of #1687.
