### PR TITLE
Add minimal switch-int generated fixture rung

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -189,6 +189,20 @@ public class GeneratedFixtureCatalogTests
             "Method1",
             FidelityCheck.CompileBackStatus.Exact,
             frontier: false);
+        AssertTarget(
+            run,
+            "minimal.switch-int",
+            "GeneratedFixtures.MinimalSwitchInt.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.switch-int",
+            "GeneratedFixtures.MinimalSwitchInt.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
 
         Assert.Contains("minimal.property.literal", report);
         Assert.Contains("minimal.primary-ctor.field-init", report);
@@ -201,6 +215,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.try-finally", report);
         Assert.Contains("minimal.using-dispose", report);
         Assert.Contains("minimal.foreach-array", report);
+        Assert.Contains("minimal.switch-int", report);
         Assert.Contains("decompiler=Full", report);
         Assert.Contains("compile-back=Exact", report);
     }
@@ -223,6 +238,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.primary-ctor.field-init",
                 "minimal.property.literal",
                 "minimal.static-method-call",
+                "minimal.switch-int",
                 "minimal.try-finally",
                 "minimal.using-dispose",
             ],
@@ -248,6 +264,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.try-finally");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.using-dispose");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.foreach-array");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.switch-int");
 
         var primaryCtor = Assert.Single(fixtures,
             fixture => fixture.GetProperty("Id").GetString() == "minimal.primary-ctor.field-init");

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -265,6 +265,39 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "foreach", "array", "loop"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalSwitchInt = new(
+        "minimal.switch-int",
+        """
+        namespace GeneratedFixtures.MinimalSwitchInt;
+
+        public class Class1
+        {
+            public string Method1(int value)
+            {
+                switch (value)
+                {
+                    case 0:
+                        return "zero";
+                    case 1:
+                        return "one";
+                    case 2:
+                        return "two";
+                    case 3:
+                        return "three";
+                    default:
+                        return "many";
+                }
+            }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalSwitchInt.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalSwitchInt.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "switch", "int", "branch"]);
+
     public static IReadOnlyList<GeneratedFixtureDefinition> All { get; } =
     [
         MinimalPropertyLiteral,
@@ -278,6 +311,7 @@ internal static class GeneratedFixtureCatalog
         MinimalTryFinally,
         MinimalUsingDispose,
         MinimalForeachArray,
+        MinimalSwitchInt,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> MinimalCompileBackRungs => All;

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -16,9 +16,10 @@ This is the first step toward an addressable progressive fixture ladder:
 `minimal.auto-property.getter`, `minimal.method-call.same-type`, and
 `minimal.primary-ctor.field-init` are expected `Exact`; the static-call, if/else,
 null-coalescing, try/finally, using/dispose, and foreach-array rungs extend that
-minimal exact set. With no selector, all generated fixtures run; use `list` to
-list fixture IDs, `--json` for machine-readable list/results, and
-`--keep-generated-fixtures` to preserve the generated project for drill-down.
+minimal exact set; `minimal.switch-int` adds the first switch statement rung.
+With no selector, all generated fixtures run; use `list` to list fixture IDs,
+`--json` for machine-readable list/results, and `--keep-generated-fixtures` to
+preserve the generated project for drill-down.
 
 **Library report** (`--library-report`): a portfolio view. It combines the IR
 residual buckets from `--gaps` with the Roslyn-backed validity oracle from


### PR DESCRIPTION
- Advances #1742
- Changes generated decompiler fixture catalogue coverage only
- Card revision: `272dde41`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated fixture ladder gains a first switch statement rung and it is opcode-exact.

Before:

```text
minimal generated fixture catalogue: 11 fixtures / 24 targets
```

After:

```text
minimal generated fixture catalogue: 12 fixtures / 26 targets
new exact rung: minimal.switch-int
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Decompiler fast suite | Not run; additive generated-fixture catalogue entry only |
| Reduced fixture validity | Not applicable |
| Reduced fixture fidelity | Pass: `minimal.switch-int` reports `Exact` for `.ctor` and `Method1` |
| Real witness | Generated fixture: dense int switch statement over 0..3 plus default |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes; this only adds a generated fixture catalogue row.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked exactness, target names, true dense switch lowering, selector/list behavior, and README accuracy. |
| MAI-Code-1-Flash | No blocking findings | Verified tests pass and `AssertTarget` exercises the real compile-back oracle. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.switch-int
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
```
