### PR TITLE
Fix null-coalescing assignment false positives

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -2926,6 +2926,14 @@ public class CfgSampleClass
         return holder.CacheProp;
     }
 
+    public static string ManualPropertyNullAssignment(CacheHolder holder, string fallback)
+    {
+        if (holder.CacheProp == null)
+            holder.CacheProp = fallback;
+
+        return holder.CacheProp;
+    }
+
     // Indexer ??= — the property form plus index arguments. csc spills the receiver
     // and index to locals read identically by the get and set, so the two accesses
     // fold into one re-evaluable d[k] place.
@@ -2945,6 +2953,14 @@ public class CfgSampleClass
     public static string NullCoalescingAssignDictionaryIndexer(System.Collections.Generic.Dictionary<string, string> map, string key, string fallback)
     {
         map[key] ??= fallback;
+        return map[key];
+    }
+
+    public static string ManualIndexerNullAssignment(System.Collections.Generic.Dictionary<string, string> map, string key, string fallback)
+    {
+        if (map[key] == null)
+            map[key] = fallback;
+
         return map[key];
     }
 

--- a/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NullCoalescingAssignmentPassTests.cs
@@ -236,6 +236,21 @@ public class NullCoalescingAssignmentPassTests
     }
 
     [Fact]
+    public void ManualPropertyNullAssignmentWithoutValueSpill_IsNotRaised()
+    {
+        var function = Raised(nameof(CfgSampleClass.ManualPropertyNullAssignment));
+
+        Assert.Empty(function.Descendants.OfType<NullCoalescingPropertyAssignment>());
+        Assert.Single(function.Descendants.OfType<IfStatement>());
+        Assert.Single(function.Descendants.OfType<StoreProperty>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.DoesNotContain("??=", output);
+        Assert.Contains("if (holder.CacheProp is null)", output);
+        Assert.Contains("holder.CacheProp = fallback;", output);
+    }
+
+    [Fact]
     public void PropertyNullAssignmentWithIncompatibleAccessors_IsNotRaised()
     {
         var function = FunctionWithPropertyNullAssignment(
@@ -376,6 +391,21 @@ public class NullCoalescingAssignmentPassTests
 
         Assert.NotNull(output);
         Assert.Contains("map[key] ??= fallback;", output);
+    }
+
+    [Fact]
+    public void ManualDictionaryIndexerNullAssignmentWithoutValueSpill_IsNotRaised()
+    {
+        var function = Raised(nameof(CfgSampleClass.ManualIndexerNullAssignment));
+
+        Assert.Empty(function.Descendants.OfType<NullCoalescingPropertyAssignment>());
+        Assert.Single(function.Descendants.OfType<IfStatement>());
+        Assert.Single(function.Descendants.OfType<StoreProperty>());
+        var output = CSharpPrinter.Print(function).Output;
+        Assert.NotNull(output);
+        Assert.DoesNotContain("??=", output);
+        Assert.Contains("if (map[key] is null)", output);
+        Assert.Contains("map[key] = fallback;", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullCoalescingAssignmentPass.cs
@@ -10,11 +10,13 @@ namespace ILInspector.Decompiler.Pipeline;
 /// scoped to a re-evaluable receiver (a local/argument/this, or none for a static
 /// field), so collapsing the two member loads into one <c>??=</c> reorders
 /// nothing. The property form (<c>obj.Prop ??= fallback</c>) pairs the getter and
-/// setter as one property and folds csc's value-spill (the setter takes the value
-/// through a temp so the assignment can also be the expression's result; in
-/// statement position that result is dead). The indexer form (<c>d[k] ??= fallback</c>)
-/// is the property form plus index arguments, accepted when the receiver and every
-/// index argument are pairwise re-evaluable (<see cref="PlaceIdentity.SameOperands"/>).
+/// setter as one property when csc's instance/indexer value-spill is present (the
+/// setter takes the value through a temp so the assignment can also be the
+/// expression's result; in statement position that result is dead). The indexer
+/// form (<c>d[k] ??= fallback</c>) is the property form plus index arguments,
+/// accepted when the receiver and every index argument are pairwise re-evaluable
+/// (<see cref="PlaceIdentity.SameOperands"/>). Static properties have no receiver
+/// to re-evaluate and may lower to a direct setter.
 /// </summary>
 public sealed class NullCoalescingAssignmentPass : IIrPass
 {
@@ -106,13 +108,11 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
 
     sealed record PropertyMatch(StoreProperty Store, IrExpression Value);
 
-    // obj.Prop ??= fallback lowers to a get/set diamond:
-    //   if (obj.get_Prop() is null) obj.set_Prop(fallback);
-    // The setter is a call, so csc routes the value through a temp — the slot the
-    // setter reads is also stored to a (dead, in statement position) local so the
-    // assignment can double as the ??= expression's result. We pair the getter and
-    // setter as one property, require a re-evaluable receiver, and recover the
-    // original value from behind that spill.
+    // obj.Prop ??= fallback lowers to a get/set diamond where the setter value is
+    // routed through a compiler temp; hand-written `if (obj.Prop is null) obj.Prop
+    // = fallback` feeds the setter directly. For receiver/indexer properties, the
+    // spill is the discriminator that lets this pass pair the getter and setter
+    // without changing compile-back IL.
     static PropertyMatch? TryMatchProperty(IrFunction function, IfStatement statement)
     {
         if (statement.HasElse
@@ -156,18 +156,23 @@ public sealed class NullCoalescingAssignmentPass : IIrPass
 
     static bool IsVoid(TypeRef type) => type is { Namespace: "System", Name: "Void" };
 
-    // The clean form is `Then = [store]` with the value inline (a static property,
-    // or any setter csc fed directly). The spilled form is
+    // The spilled form is
     //   [StoreStackSlot S = fallback, (StoreLocal dead = S)*, store(value: load S)]
     // where the setter and the dead ??= result both read slot S. We return the real
     // value (fallback) only when slot S and the dead local are confined to this
     // block — i.e. nothing else in the function reads them, so dropping the spill is
-    // sound.
+    // sound. A direct setter value is deliberately declined when a receiver or
+    // index argument would be collapsed: that is the manual property/indexer
+    // assignment shape, not csc's `??=` lowering.
     static IrExpression? RecoverSpilledValue(IrFunction function, Block then, StoreProperty store)
     {
         var children = then.Children;
         if (store.Value is not LoadStackSlot slot)
-            return children.Count == 1 ? store.Value : null;
+        {
+            return !store.HasInstance && store.IndexArguments.Count == 0 && children.Count == 1
+                ? store.Value
+                : null;
+        }
 
         if (children.Count < 2 || children[0] is not StoreStackSlot spill || spill.Slot != slot.Slot)
             return null;


### PR DESCRIPTION
- Fixes #1746
- Row: `NullCoalescingAssignmentPass false-raises manual property/indexer null assignments to ??=`
- Evidence revision: `1db4b56c`

## Fix

> Should we accept this row fix?

**Conclusion:** **PASS** — manual receiver/indexer property null assignments no longer claim `??=`; the pass now requires the compiler value-spill discriminator and focused/fast gates plus adversarial review found no blockers.

False `Full` claim:

```csharp
public static string ManualIndexerNullAssignment(Dictionary<string, string> map, string key, string fallback)
{
    map[key] ??= fallback;
    return map[key];
}
```

Fixed output:

```csharp
public static string ManualIndexerNullAssignment(Dictionary<string, string> map, string key, string fallback)
{
    if (map[key] is null)
    {
        map[key] = fallback;
    }
    return map[key];
}
```

## Root cause and scope

- **Root cause:** `NullCoalescingAssignmentPass` accepted direct setter values for property/indexer diamonds, so hand-written null-test assignments without csc's `??=` value spill were raised as `??=`.
- **Fix shape:** receiver/indexer property raises now require a `LoadStackSlot` value-spill shape owned by the matched then-block; no-receiver/no-index static properties keep the pre-existing direct-setter path.
- **Scope boundary:** static manual property null assignment remains a sibling risk because expression inlining can erase the raw static `??=` spill before this pass sees the property store; filed #1845.

## Witnesses

| Witness | Before | After |
| --- | --- | --- |
| `CfgSampleClass::ManualPropertyNullAssignment` | `holder.CacheProp ??= fallback;` | `if (holder.CacheProp is null) { holder.CacheProp = fallback; }` |
| `CfgSampleClass::ManualIndexerNullAssignment` | `map[key] ??= fallback;` | `if (map[key] is null) { map[key] = fallback; }` |
| `CfgSampleClass::NullCoalescingAssignDictionaryIndexer` | true `??=` positive | still `map[key] ??= fallback;` |

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `NullCoalescingAssignmentPassTests` passed: 32/32 |
| Decompiler fast suite | Pass: 1672/1672 |
| Analysis fast suite | Pass: 220/220 |
| Reduced fixture validity | Manual fixtures render statement-legal `if`/setter output; true indexer `??=` still raises |
| Reduced fixture fidelity | Not separately method-filtered; shape proof is compiled-fixture-backed and fast suite preserves IR invariants |
| Real witness validity | #1746 repro shape is pinned by compiled fixtures |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **ADVISORY** — quick corpus matches current-main advisory state with no pinned Full-malformed regression after merging latest main.

Run: #1166 real-world decompiler corpus sensor, 14 assemblies, 89,065 methods; validity sampled 350 methods, fidelity sampled 36 methods.

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,394 (88.02%) | 78,394 (88.02%) | 0 |
| Conditional-branch residual (-) | 2,408 (2.70%) | 2,407 (2.70%) | -1 |
| Forward-merge stops (-) | 2,294 (2.58%) | 2,294 (2.58%) | 0 |
| Full malformed (-) | 32 | 2 | -30 |
| Semantic defects (-) | 149/25,185 | 1/350 | -148 |
| Fidelity diffs (-) | opcode-diff 0/0, exact 0, recompile-failed 0, context-failed 0 | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0 | +5 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate: Fully raised 88.02% -> 88.02% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 32 -> 2 (-30). Harness returned nonzero because the PR quick caps are lower than the historical baseline (`compile-cap 25`, `corpus-fidelity-cap 3`), not because of a branch-vs-current-main regression.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Verified the spill gate preserves instance/chained/indexer positives and structural invariants; identified static manual property as pre-existing sibling risk, filed #1845. |
| MAI-Code-1-Flash | No blocking findings | Confirmed static no-receiver path does not reintroduce the receiver/index hazard; suggested stronger structural assertions, added before PR. |

**Review conclusion:** **PASS** — both adversarial reviews found no blockers; one non-blocking test-hardening suggestion was applied and one out-of-scope sibling defect was filed as #1845.

## Build-event workflow report

Followed `/home/rich/git/dotnet-inspect-build-event-query/BUILD-EVENT-AGENT-GUIDE.md` and appended Trial 2 feedback to `/home/rich/git/dotnet-inspect-build-event-query/BUILD-EVENT-AGENT-FEEDBACK.md`.

Build-event logs:

- Before: `/home/rich/.dotnet/build-events/2026-06-28/20260628T215221.5136903Z-729733-build-bcbcbb03.jsonl`
- After: `/home/rich/.dotnet/build-events/2026-06-28/20260628T215400.8681242Z-731283-build-bcbcbb03.jsonl`
- Compare: `NU1603 8 -> 8 (unchanged)`, classified as VMR/feed setup mismatch because host build passed.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/NullCoalescingAssignmentPassTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet run --project src/ILInspector.Analysis.Tests -c Release
bash eng/prepare-decompiler-corpus.sh /tmp/corpus-assemblies-1746.txt
mapfile -t assemblies < /tmp/corpus-assemblies-1746.txt
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
  --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
  --quality-diff-card \
  --compile-cap 25 \
  --corpus-fidelity-cap 3 \
  --max-examples 3
```
