### PR TITLE
Fold mixed ||/&& short-circuit chains for structuring (#1175 PR1)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -3912,6 +3912,24 @@ public class CfgSampleClass
             acc += data[i] * weight;
         return acc;
     }
+
+    // #1175 / MixedShortCircuitChainPass: a mixed || / && condition with
+    // effectful arms. csc lowers the guard chain so the guards branch to BOTH
+    // diamond arms, which the pure-OR fold (or-chain-diamond) cannot name; the
+    // mixed pass reverses it to `if (Guard(a) || (Guard(b) && Guard(c)))`. The
+    // method-call guards keep it residual without the pass. Pinned opcode-exact
+    // so a regression to RecompileFail or a worse shape is caught by the always-run
+    // fidelity gate, not left to the sampled corpus.
+    static bool Guard(int x) => x > 0;
+
+    public static int MixedOrAndArms(int a, int b, int c, System.Text.StringBuilder sb)
+    {
+        if (Guard(a) || (Guard(b) && Guard(c)))
+            sb.Append('x');
+        else
+            sb.Append('y');
+        return sb.Length;
+    }
 }
 
 internal static class AwaitOrderingHelpers

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -168,6 +168,10 @@ public class FidelityGateTests
         "SharedCaptureLambdas",
         "DoubleViaLocalFunction",
         "CapturingLocalFunction",
+        // MixedOrAndArms (#1175): the mixed ||/&& fold raises and recompiles
+        // opcode-exact; pinned so a regression to flat/RecompileFail is caught
+        // on every fidelity-gate run, not left to the sampled corpus.
+        "MixedOrAndArms",
         "CheckedAdd",
         "UnsignedShift",
         "Shadowed",

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -97,6 +97,11 @@ public class FidelityGateTests
         // is compile-back-checked on every fidelity-gate run rather than left to
         // the sampled corpus.
         "SwitchStoreThenUse",
+        // CharConditionalElementStore (#1784): the char ternary element store
+        // spills to temps and recompiles to a different (valid) stream. Honest
+        // over-render. Pre-existing slow-docket gap surfaced by running the gate
+        // locally — the lowered/sugared gates are Speed=Slow (daily only).
+        "CharConditionalElementStore",
     };
 
     /// <summary>

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -108,6 +108,9 @@ public class LoweredFidelityGateTests
     static readonly string[] PinnedExact =
     {
         "CheckedAdd",
+        // MixedOrAndArms (#1175): mixed ||/&& fold stays opcode-exact in the
+        // lowered view too — pinned so a regression trips the always-run gate.
+        "MixedOrAndArms",
         "UnsignedShift",
         "Shadowed",
         ".ctor",

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -77,6 +77,13 @@ public class LoweredFidelityGateTests
         // `(uint)` mixed-sign reinterpret. The And* siblings stay opcode-exact.
         "OrBoolIntMix",
         "OrBoolUintMix",
+        // SwitchStoreThenUse (#1743) is a known opcode-diff in the sibling sugared
+        // FidelityGateTests docket — the ConditionalStoreChainPass ternary
+        // (sel == 0 ? 11 : ...) re-lowers differently than the per-arm stores. It
+        // diffs identically in the lowered view; this entry was missing because the
+        // lowered gate is Speed=Slow and only runs in the daily, not PR CI. Verified
+        // pre-existing (fails with MixedShortCircuitChainPass off as well).
+        "SwitchStoreThenUse",
     };
 
     /// <summary>

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -84,6 +84,14 @@ public class LoweredFidelityGateTests
         // lowered gate is Speed=Slow and only runs in the daily, not PR CI. Verified
         // pre-existing (fails with MixedShortCircuitChainPass off as well).
         "SwitchStoreThenUse",
+        // CharConditionalElementStore (#1784) and WhileNestedContinueKeepsArmExclusive:
+        // pre-existing slow-docket gaps from recent main merges (a char ternary
+        // element store that spills to temps; a nested-continue loop structuring),
+        // both honest valid re-lowerings. Surfaced by running the Speed=Slow gate
+        // locally; verified independent of MixedShortCircuitChainPass (it folds
+        // neither). See the sibling FidelityGateTests docket.
+        "CharConditionalElementStore",
+        "WhileNestedContinueKeepsArmExclusive",
     };
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -109,6 +109,12 @@ public static class IrPasses
         // of or-chain-guard for the else-arm case; runs last so it folds the final
         // normalized shape just before structuring.
         new OrChainDiamondPass(),
+        // Sibling of or-chain-diamond for the MIXED case: a guard chain whose
+        // guards branch to BOTH diamond arms (a condition mixing || and &&, e.g.
+        // `a || (b && c)`). Reverse the short-circuit lowering into one conditional
+        // the structuring pass can name. Runs right after the pure-OR fold so it
+        // sees the same pre-structuring normalized shape (#1175).
+        new MixedShortCircuitChainPass(),
         // Raise csc's single-element string-array list-pattern lowering after
         // the OR-chain folds expose its null/length guard, equality chain, and
         // bool-result diamond as one pre-structuring run.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/MixedShortCircuitChainPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/MixedShortCircuitChainPass.cs
@@ -1,0 +1,318 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Folds a <em>mixed</em> short-circuit guard chain — one whose guards branch to
+/// <em>both</em> arms of a diamond — into a single <see cref="ConditionalBranch"/>,
+/// before structuring. <see cref="OrChainDiamondPass"/> already handles the pure
+/// case where every guard branches to the same true arm (<c>a || b</c>); a
+/// condition that mixes <c>||</c> and <c>&amp;&amp;</c>, e.g.
+/// <c>a || (b &amp;&amp; c)</c>, lowers to a run of guards that branch to the
+/// true arm and the false arm in turn:
+/// <code>
+///   if (a)        goto THEN;   // → the branch (taken) arm
+///   if (!b || !c) goto ELSE;   // → the fall arm, the OTHER arm
+///   THEN: …; goto M;            // (the block right after the chain)
+///   ELSE: …;                    // falls to M
+///   M: REST
+/// </code>
+/// The guards target two distinct arms, so neither <see cref="OrChainDiamondPass"/>
+/// (same true arm) nor the lexical <see cref="StructuringPass"/> diamond model
+/// (one conditional per diamond) can name the join, and the container stays flat.
+///
+/// <para>This pass reverses the short-circuit lowering. The chain is a maximal run
+/// of pure single-condition guards <c>[p, q]</c> that fall through to each other;
+/// the last guard <c>q</c> branches to one arm (<c>branchArm</c>) and falls into
+/// the other (<c>fallArm</c>, the block right after the chain). Every earlier
+/// guard branches to one of those two arms. Reconstruct the condition under which
+/// control reaches <c>branchArm</c>, processed back to front so evaluation order
+/// and short-circuiting are preserved exactly:</para>
+/// <list type="bullet">
+/// <item>last guard: <c>reach = cond_q</c> (it branches to <c>branchArm</c>).</item>
+/// <item>earlier guard to <c>branchArm</c>: <c>reach = cond_i || reach</c>.</item>
+/// <item>earlier guard to <c>fallArm</c>: <c>reach = !cond_i &amp;&amp; reach</c>.</item>
+/// </list>
+/// The chain collapses to <c>if (reach) goto branchArm</c> with the fall arm as
+/// the fall-through region — the single-conditional diamond the structuring pass
+/// raises (it negates the condition back to <c>if (!reach) { fallArm } else
+/// { branchArm }</c>).
+///
+/// <para>Sound and order-preserving, mirroring <see cref="OrChainDiamondPass"/>'s
+/// discipline: inner guards must be pure single-condition blocks (only the root
+/// may carry leading operand setup), the run must genuinely mix the two arms (at
+/// least one earlier guard branches to <c>fallArm</c>, else it is the pure-OR
+/// shape the other pass owns), the fall arm must end by branching strictly past
+/// <c>branchArm</c> to a real merge (a true diamond), and nothing outside the run
+/// may branch into the inner guards the fold drops. Each guard condition is used
+/// exactly once, left to right, so <c>a</c> is evaluated before <c>b</c> just as
+/// the fall-through chain did, and re-lowers to the same branch sequence.</para>
+/// </summary>
+public sealed class MixedShortCircuitChainPass : IIrPass
+{
+    public string Name => "mixed-short-circuit-chain";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        while (FoldOne(function, context.Stepper))
+        {
+        }
+    }
+
+    static bool FoldOne(IrFunction function, Stepper stepper)
+    {
+        // A surviving leave may target a block this fold drops (an inner guard) —
+        // including from another container the per-container scan cannot see.
+        var leaveTargets = function.Descendants.OfType<Leave>()
+            .Select(leave => leave.TargetOffset)
+            .ToHashSet();
+        foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
+        {
+            if (TryFold(container, leaveTargets, stepper))
+                return true;
+        }
+        return false;
+    }
+
+    static bool TryFold(BlockContainer container, HashSet<int> leaveTargets, Stepper stepper)
+    {
+        var blocks = container.Blocks;
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+
+        for (int p = 0; p < blocks.Count; p++)
+        {
+            if (Chain(blocks, offsetToIndex, p) is { } chain
+                && NoExternalEntry(blocks, p, chain.LastGuard, leaveTargets))
+            {
+                Fold(container, chain, stepper);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    readonly record struct ChainShape(int Root, int LastGuard, int BranchArmOffset, int FallArmOffset);
+
+    /// <summary>
+    /// The mixed-arm guard chain rooted at <paramref name="p"/>, or null. Guards
+    /// [p, LastGuard] are pure single-condition blocks (the root may carry leading
+    /// setup) that fall through to each other; the last branches to
+    /// <c>BranchArmOffset</c> and falls into <c>FallArmOffset</c>; every guard
+    /// branches to one of those two arms and at least one earlier guard branches
+    /// to the fall arm (a genuine mix, not the pure-OR shape).
+    /// </summary>
+    static ChainShape? Chain(IReadOnlyList<Block> blocks, Dictionary<int, int> offsetToIndex, int p)
+    {
+        if (ConditionTargetAtEnd(blocks[p]) is null)
+            return null;
+
+        // Extend the run while each following block is a pure single-condition
+        // guard that falls through from the previous one (consecutive blocks; a
+        // conditional's fall-through is the next block).
+        int q = p;
+        while (q + 1 < blocks.Count && ConditionTarget(blocks[q + 1]) is not null)
+            q++;
+        if (q == p)
+            return null;   // a lone conditional is the single-target diamond already
+
+        // The fall arm is the block right after the chain; the branch arm is the
+        // last guard's taken target. Both must be real blocks outside the chain.
+        int fallArmIndex = q + 1;
+        if (fallArmIndex >= blocks.Count)
+            return null;
+        int fallArmOffset = blocks[fallArmIndex].StartOffset;
+
+        if (TakenTarget(blocks[q]) is not { } branchArmOffset
+            || !offsetToIndex.TryGetValue(branchArmOffset, out int branchArmIndex))
+            return null;
+        if (branchArmOffset == fallArmOffset)
+            return null;   // last guard branches where it falls — not a two-arm split
+        if (branchArmIndex <= q)
+            return null;   // the branch arm must be strictly forward of the chain:
+                           // a target at or before the chain is a back-edge (loop
+                           // latch) or an entry into the dropped run, not a forward
+                           // diamond arm. With fallArm = q+1, both arms are then
+                           // forward, so every guard target is a forward edge.
+
+        // Every guard must branch to one of the two arms, and at least one earlier
+        // guard must branch to the fall arm (else all target the branch arm — the
+        // pure-OR chain OrChainDiamondPass owns). The fall arm is reached by a
+        // guard's taken edge, not the chain fall-through, so the mix is genuine.
+        bool mixed = false;
+        for (int i = p; i <= q; i++)
+        {
+            int target = TakenTarget(blocks[i]) ?? -1;
+            if (target != branchArmOffset && target != fallArmOffset)
+                return null;
+            if (i < q && target == fallArmOffset)
+                mixed = true;
+        }
+        if (!mixed)
+            return null;
+
+        // A true diamond: the fall arm ends by branching strictly past the branch
+        // arm to a real merge, so structuring can name the join after the fold.
+        if (UnconditionalBranchTarget(blocks[branchArmIndex - 1]) is not { } mergeOffset
+            || !offsetToIndex.TryGetValue(mergeOffset, out int mergeIndex)
+            || mergeIndex <= branchArmIndex)
+            return null;
+
+        return new ChainShape(p, q, branchArmOffset, fallArmOffset);
+    }
+
+    /// <summary>The taken branch target of a block ending in a conditional branch, or null.</summary>
+    static int? TakenTarget(Block block)
+        => block.Children.Count > 0 && block.Children[^1] is ConditionalBranch conditional
+            ? conditional.TargetOffset
+            : null;
+
+    /// <summary>The single branch target of a pure one-statement condition block, or null.</summary>
+    static int? ConditionTarget(Block block)
+        => block.Children is [ConditionalBranch conditional] ? conditional.TargetOffset : null;
+
+    /// <summary>
+    /// The branch target of a block whose last statement is a conditional branch
+    /// and whose earlier statements are all straight-line (no control flow), or
+    /// null. Only the chain root may carry such setup — inner guards must be pure,
+    /// since their leading statements would move out of short-circuit order.
+    /// </summary>
+    static int? ConditionTargetAtEnd(Block block)
+    {
+        if (block.Children.Count == 0 || block.Children[^1] is not ConditionalBranch conditional)
+            return null;
+        for (int s = 0; s < block.Children.Count - 1; s++)
+            if (block.Children[s] is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter)
+                return null;
+        return conditional.TargetOffset;
+    }
+
+    /// <summary>
+    /// The target of a block that ends with an unconditional <see cref="Branch"/>
+    /// and is otherwise straight-line, or null. The fall arm's terminating goto.
+    /// </summary>
+    static int? UnconditionalBranchTarget(Block block)
+    {
+        if (block.Children.Count == 0 || block.Children[^1] is not Branch branch)
+            return null;
+        for (int s = 0; s < block.Children.Count - 1; s++)
+            if (block.Children[s] is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter)
+                return null;
+        return branch.TargetOffset;
+    }
+
+    /// <summary>
+    /// No block outside the chain may branch into the inner guards [Root+1, LastGuard]
+    /// the fold drops — those edges would dangle at a vanished offset. The root and
+    /// every block from the fall arm onward stay, so edges to them are fine; a
+    /// leave into a dropped guard aborts the fold too.
+    /// </summary>
+    static bool NoExternalEntry(IReadOnlyList<Block> blocks, int p, int lastGuard, HashSet<int> leaveTargets)
+    {
+        var forbidden = new HashSet<int>();
+        for (int idx = p + 1; idx <= lastGuard; idx++)
+            forbidden.Add(blocks[idx].StartOffset);
+
+        if (forbidden.Overlaps(leaveTargets))
+            return false;
+
+        for (int idx = 0; idx < blocks.Count; idx++)
+        {
+            if (idx > p && idx <= lastGuard)
+                continue;   // inside the dropped run — internal fall-throughs are fine
+            foreach (var node in blocks[idx].Children)
+                foreach (int target in Targets(node))
+                    if (forbidden.Contains(target))
+                        return false;
+        }
+        return true;
+    }
+
+    static IEnumerable<int> Targets(IrNode node) => node switch
+    {
+        Branch branch => [branch.TargetOffset],
+        ConditionalBranch conditional => [conditional.TargetOffset],
+        SwitchBranch sw => sw.TargetOffsets,
+        _ => [],
+    };
+
+    /// <summary>
+    /// Negation that pushes through the short-circuit operators (De Morgan) and
+    /// cancels double negations, so a folded condition reads as its clean dual
+    /// (<c>!(!b || !c)</c> becomes <c>b &amp;&amp; c</c>) rather than a nested
+    /// <see cref="LogicalNot"/>. Falls back to <see cref="Conditions.Negate"/> for
+    /// leaves (comparisons invert, everything else wraps once).
+    /// </summary>
+    static IrExpression NegateClean(IrExpression condition)
+    {
+        switch (condition)
+        {
+            case LogicalNot not:
+                return (IrExpression)not.DetachChildren()[0];
+            case LogicalBinary binary:
+                var operands = binary.DetachChildren();
+                var left = NegateClean((IrExpression)operands[0]);
+                var right = NegateClean((IrExpression)operands[1]);
+                return new LogicalBinary(binary.Kind == LogicalKind.Or ? LogicalKind.And : LogicalKind.Or, left, right);
+            default:
+                return Conditions.Negate(condition);
+        }
+    }
+
+    static void Fold(BlockContainer container, ChainShape chain, Stepper stepper)
+    {
+        var blocks = container.Blocks.ToList();
+        int p = chain.Root, q = chain.LastGuard;
+
+        // Each guard's taken target and condition, in chain order.
+        var targets = new int[q - p + 1];
+        var conditions = new IrExpression[q - p + 1];
+        for (int i = p; i <= q; i++)
+        {
+            var conditional = (ConditionalBranch)blocks[i].Children[^1];
+            targets[i - p] = conditional.TargetOffset;
+            conditions[i - p] = (IrExpression)conditional.DetachChildren()[0];
+        }
+
+        // Reconstruct "reach the FALL arm" back to front as a clean positive
+        // expression, then branch on its negation. Building the fall-arm condition
+        // (rather than the branch-arm one) means the structuring pass's own
+        // negation cancels the wrapper to a clean positive instead of a double
+        // negation. The last guard branches to branchArm, so it reaches fallArm iff
+        // its condition is false; an earlier guard to fallArm contributes
+        // `cond || reach`, to branchArm contributes `!cond && reach`. Leftmost-first
+        // preserves evaluation order; NegateClean keeps the De Morgan dual readable.
+        IrExpression reachFall = NegateClean(conditions[q - p]);
+        for (int i = q - 1; i >= p; i--)
+        {
+            int idx = i - p;
+            reachFall = targets[idx] == chain.FallArmOffset
+                ? new LogicalBinary(LogicalKind.Or, conditions[idx], reachFall)
+                : new LogicalBinary(LogicalKind.And, NegateClean(conditions[idx]), reachFall);
+        }
+
+        // The folded guard keeps the root block's leading setup and branches to the
+        // branch arm when the fall-arm condition does NOT hold. Wrapping in a single
+        // LogicalNot lets the structuring pass's Negate unwrap it back to the clean
+        // positive `if (reachFall) { fallArm } else { branchArm }`.
+        var folded = new Block(blocks[p].StartOffset);
+        var rootChildren = blocks[p].DetachChildren();
+        for (int k = 0; k < rootChildren.Count - 1; k++)
+            folded.Add(rootChildren[k]);
+        folded.Add(new ConditionalBranch(new LogicalNot(reachFall), chain.BranchArmOffset));
+
+        foreach (var block in blocks)
+            block.Detach();
+
+        var rebuilt = new BlockContainer();
+        for (int idx = 0; idx < p; idx++)
+            rebuilt.Add(blocks[idx]);
+        rebuilt.Add(folded);
+        for (int idx = q + 1; idx < blocks.Count; idx++)
+            rebuilt.Add(blocks[idx]);
+        stepper.StepOver("fold mixed short-circuit guard chain", container);
+        container.ReplaceWith(rebuilt);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/MixedShortCircuitChainPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/MixedShortCircuitChainPass.cs
@@ -141,11 +141,17 @@ public sealed class MixedShortCircuitChainPass : IIrPass
         // guard must branch to the fall arm (else all target the branch arm — the
         // pure-OR chain OrChainDiamondPass owns). The fall arm is reached by a
         // guard's taken edge, not the chain fall-through, so the mix is genuine.
+        // Each guard condition must be boolean: the fold negates fall-arm guards
+        // and composes with && / ||, so a non-boolean condition (e.g. a brtrue on
+        // an int slot) would yield invalid C# (`!intVal`, CS0023). Pure-OR keeps
+        // conditions as-is and stays sound; the mixed fold cannot.
         bool mixed = false;
         for (int i = p; i <= q; i++)
         {
             int target = TakenTarget(blocks[i]) ?? -1;
             if (target != branchArmOffset && target != fallArmOffset)
+                return null;
+            if (!IsBoolean(((ConditionalBranch)blocks[i].Children[^1]).Condition))
                 return null;
             if (i < q && target == fallArmOffset)
                 mixed = true;
@@ -168,6 +174,13 @@ public sealed class MixedShortCircuitChainPass : IIrPass
         => block.Children.Count > 0 && block.Children[^1] is ConditionalBranch conditional
             ? conditional.TargetOffset
             : null;
+
+    /// <summary>True when the guard condition is boolean — composing/negating a non-boolean
+    /// (a brtrue on an int slot) would yield invalid C# (CS0023). Comparisons and
+    /// short-circuit forms are already boolean; otherwise the type must say so.</summary>
+    static bool IsBoolean(IrExpression condition)
+        => condition is Comparison or LogicalBinary or LogicalNot
+            || TypeFamilies.IsBoolean(condition.ResultType);
 
     /// <summary>The single branch target of a pure one-statement condition block, or null.</summary>
     static int? ConditionTarget(Block block)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -49,6 +49,8 @@ internal static class NativePasses
     public static OrChainGuardPass OrChainGuard => new();
     [Native(NativeCategory.EmitArtifact, "short-circuit OR chain selecting a diamond's two arms folded so structuring can consume it")]
     public static OrChainDiamondPass OrChainDiamond => new();
+    [Native(NativeCategory.EmitArtifact, "mixed short-circuit guard chain (guards branching to both diamond arms, e.g. a || (b && c)) reversed into one conditional so structuring can consume it")]
+    public static MixedShortCircuitChainPass MixedShortCircuitChain => new();
     [Native(NativeCategory.EmitArtifact, "single-element string-array list-pattern lowering collapsed after OR-chain folding exposes the compiler bool diamond")]
     public static ListPatternPass ListPattern => new();
     [Native(NativeCategory.EmitArtifact, "a spilled-to-slot conditional result (flat slot diamond returning one slot) folded to a conditional return so structuring can consume the surrounding dispatch")]

--- a/tools/DecompilerHarness/PostDomProbe.cs
+++ b/tools/DecompilerHarness/PostDomProbe.cs
@@ -1,0 +1,232 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Read-only step-4 prototype probe (issue #1175, throwaway). For every method
+/// the Default pipeline leaves with a residual <see cref="ConditionalBranch"/>
+/// (the <c>structuring: conditional-branch</c> bucket the index-range
+/// <see cref="StructuringPass"/> could not consume), this computes the
+/// <see cref="PostDominators"/> merge that the index-range model cannot name and
+/// reports how the population breaks down by merge shape.
+///
+/// <para>The whole point is the go/no-go sizing the design doc
+/// (docs/design/control-flow-structuring.md, "Soundness strategy") demands
+/// before any production change: how many residual-conditional methods have a
+/// single post-dominator merge (the Target-A retained-label slice), how many a
+/// short return-tail merge (the Target-B cheap-elimination slice), and how many
+/// are multi-merge or unrooted (out of the first slice). It mutates nothing: it
+/// runs the same passes and only inspects the finished flat container.</para>
+/// </summary>
+static class PostDomProbe
+{
+    // A merge block counts as a "short return tail" (Target B, cheap full
+    // elimination by inlining) when it is small and ends in a return — the
+    // ReturnMergePass-style shape the doc calls out as the clean case.
+    const int MaxReturnTailStatements = 3;
+
+    enum MergeShape
+    {
+        SingleMerge,            // one real-block post-dominator join — Target A
+        SingleMergeReturnTail,  // that join is a short return tail — Target B
+        ExitMerge,              // arms flow to the method exit independently
+        MultiMerge,             // residual conditionals join at >1 distinct block
+        Unrooted,               // a residual conditional cannot reach the exit
+        Loop,                   // a back-edge survives — out of forward-structuring scope
+    }
+
+    public static int Run(List<string> assemblies, int cap, int sample)
+    {
+        long total = 0, residualMethods = 0;
+        var byShape = new Dictionary<string, long>(StringComparer.Ordinal);
+        var byMerge = new Dictionary<MergeShape, (long Count, string Example)>();
+        // (shape bucket x merge shape) so the reader sees which residual shapes
+        // carry foldable merges.
+        var crossTab = new Dictionary<(string, MergeShape), long>();
+        var samples = new List<string>();
+        bool capped = false;
+
+        using var metadata = CorpusMetadata.Create(assemblies);
+        foreach (var assemblyPath in assemblies)
+        {
+            using var source = MetadataSource.Open(assemblyPath, context: metadata);
+            foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+            {
+                if (total >= cap) { capped = true; break; }
+                total++;
+
+                var context = new PassContext(new Stepper(enabled: false), new StructuringDiagnostics());
+                try { IrPasses.Run(function, IrPasses.Default, context); }
+                catch { continue; }   // pass bugs are inventoried elsewhere
+
+                var container = ResidualConditionalContainer(function);
+                if (container is null)
+                    continue;
+                residualMethods++;
+
+                string shape = ConditionalBranchShapeClassifier.Classify(function);
+                byShape[shape] = byShape.GetValueOrDefault(shape) + 1;
+
+                var merge = ClassifyMerge(container);
+                var priorM = byMerge.GetValueOrDefault(merge);
+                byMerge[merge] = (priorM.Count + 1, priorM.Example ?? $"{typeName}::{methodName}");
+                crossTab[(shape, merge)] = crossTab.GetValueOrDefault((shape, merge)) + 1;
+
+                if (samples.Count < sample
+                    && merge is MergeShape.SingleMerge or MergeShape.SingleMergeReturnTail)
+                    samples.Add(Sketch(typeName, methodName, container, merge));
+            }
+            if (capped) break;
+        }
+
+        string scope = capped ? $"{total} methods (capped)" : $"{total} methods";
+        Console.WriteLine();
+        Console.WriteLine($"post-dominator merge probe over {scope}:");
+        Console.WriteLine($"  {residualMethods} methods left with a residual conditional branch");
+        Console.WriteLine();
+        Console.WriteLine("by post-dominator merge shape:");
+        foreach (var entry in byMerge.OrderByDescending(e => e.Value.Count))
+            Console.WriteLine($"  {entry.Value.Count,8}  {entry.Key,-24}  e.g. {entry.Value.Example}");
+
+        Console.WriteLine();
+        Console.WriteLine("residual conditional-branch shape x merge shape:");
+        foreach (var shapeEntry in byShape.OrderByDescending(e => e.Value))
+        {
+            Console.WriteLine($"  {shapeEntry.Value,8}  {shapeEntry.Key}");
+            foreach (var mergeShape in Enum.GetValues<MergeShape>())
+                if (crossTab.TryGetValue((shapeEntry.Key, mergeShape), out long n) && n > 0)
+                    Console.WriteLine($"           {n,8}  -> {mergeShape}");
+        }
+
+        if (samples.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"single-merge readability sketches ({samples.Count}):");
+            foreach (var s in samples)
+            {
+                Console.WriteLine();
+                Console.WriteLine(s);
+            }
+        }
+        return 0;
+    }
+
+    /// <summary>The first container holding a residual flat conditional branch, or null.</summary>
+    static BlockContainer? ResidualConditionalContainer(IrFunction function)
+    {
+        foreach (var c in function.Descendants.OfType<BlockContainer>())
+            if (c.Blocks.Any(b => b.Children.Count > 0 && b.Children.Any(n => n is ConditionalBranch)))
+                return c;
+        return null;
+    }
+
+    static MergeShape ClassifyMerge(BlockContainer container)
+    {
+        var blocks = container.Blocks;
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+
+        // A back-edge (a branch to a block at or before its own index) means an
+        // unraised loop survives in the container — out of the acyclic
+        // forward-merge first slice (doc step 4 scope), and its post-dominator
+        // merge would otherwise masquerade as a foldable return tail.
+        for (int i = 0; i < blocks.Count; i++)
+            foreach (int target in BranchTargets(blocks[i]))
+                if (offsetToIndex.TryGetValue(target, out int ti) && ti <= i)
+                    return MergeShape.Loop;
+
+        var pd = PostDominators.Of(blocks);
+
+        var merges = new HashSet<int>();
+        bool anyExit = false;
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            if (blocks[i].Children.Count == 0 || blocks[i].Children[^1] is not ConditionalBranch)
+                continue;
+            int ipdom = pd.ImmediatePostDominator(i);
+            if (ipdom == PostDominators.None)
+                return MergeShape.Unrooted;
+            if (ipdom == PostDominators.VirtualExit)
+                anyExit = true;
+            else
+                merges.Add(ipdom);
+        }
+
+        if (merges.Count == 0)
+            return MergeShape.ExitMerge;
+        if (merges.Count > 1)
+            return MergeShape.MultiMerge;
+
+        // Exactly one real-block join. If a residual conditional also flowed
+        // straight to the exit, the arms are not a clean single diamond.
+        if (anyExit)
+            return MergeShape.MultiMerge;
+
+        int merge = merges.Single();
+        return IsShortReturnTail(blocks[merge])
+            ? MergeShape.SingleMergeReturnTail
+            : MergeShape.SingleMerge;
+    }
+
+    static IEnumerable<int> BranchTargets(Block block)
+    {
+        foreach (var node in block.Children)
+            switch (node)
+            {
+                case Branch b: yield return b.TargetOffset; break;
+                case ConditionalBranch c: yield return c.TargetOffset; break;
+                case SwitchBranch sw:
+                    foreach (int t in sw.TargetOffsets) yield return t;
+                    break;
+                case Leave lv: yield return lv.TargetOffset; break;
+            }
+    }
+
+    static bool IsShortReturnTail(Block block) =>
+        block.Children.Count is > 0 and <= MaxReturnTailStatements
+        && block.Children[^1] is Return;
+
+    static string Sketch(string typeName, string methodName, BlockContainer container, MergeShape merge)
+    {
+        var blocks = container.Blocks;
+        var offsetToIndex = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Count; i++)
+            offsetToIndex[blocks[i].StartOffset] = i;
+        var pd = PostDominators.Of(blocks);
+
+        var lines = new List<string>
+        {
+            $"  {typeName}::{methodName}  [{merge}, {blocks.Count} blocks]",
+        };
+        for (int i = 0; i < blocks.Count; i++)
+        {
+            var last = blocks[i].Children.Count > 0 ? blocks[i].Children[^1] : null;
+            string term = last switch
+            {
+                ConditionalBranch cb => $"if (…) goto {Label(cb.TargetOffset, offsetToIndex)}  | ipdom={Label(pd, i)}",
+                Branch b => $"goto {Label(b.TargetOffset, offsetToIndex)}",
+                Return => "return",
+                Throw => "throw",
+                _ => "(fallthrough)",
+            };
+            lines.Add($"    B{i,-2} IL_{blocks[i].StartOffset:X4}  {term}");
+        }
+        return string.Join('\n', lines);
+    }
+
+    static string Label(int offset, Dictionary<int, int> offsetToIndex) =>
+        offsetToIndex.TryGetValue(offset, out int idx) ? $"B{idx}" : $"IL_{offset:X4}(ext)";
+
+    static string Label(PostDominators pd, int block)
+    {
+        int ipdom = pd.ImmediatePostDominator(block);
+        return ipdom switch
+        {
+            PostDominators.VirtualExit => "exit",
+            PostDominators.None => "none",
+            _ => $"B{ipdom}",
+        };
+    }
+}

--- a/tools/DecompilerHarness/PostDomProbe.cs
+++ b/tools/DecompilerHarness/PostDomProbe.cs
@@ -45,6 +45,12 @@ static class PostDomProbe
         // (shape bucket x merge shape) so the reader sees which residual shapes
         // carry foldable merges.
         var crossTab = new Dictionary<(string, MergeShape), long>();
+        // Within the safe non-crossing forward-merge buckets, split by whether the
+        // residual is a pure boolean-expression diamond (all guard blocks pure ->
+        // extendable via sound OR-combination, no all-or-nothing relaxation) or a
+        // genuine merge with effectful guard blocks (needs the structurer).
+        long safePureGuards = 0, safeEffectful = 0;
+        string? pureExample = null, effectfulExample = null;
         var samples = new List<string>();
         bool capped = false;
 
@@ -73,6 +79,21 @@ static class PostDomProbe
                 var priorM = byMerge.GetValueOrDefault(merge);
                 byMerge[merge] = (priorM.Count + 1, priorM.Example ?? $"{typeName}::{methodName}");
                 crossTab[(shape, merge)] = crossTab.GetValueOrDefault((shape, merge)) + 1;
+
+                // The safe slice = non-crossing forward merges with a real join.
+                if (merge is MergeShape.SingleMerge or MergeShape.SingleMergeReturnTail or MergeShape.MultiMergeNested)
+                {
+                    if (AllGuardsPure(container))
+                    {
+                        safePureGuards++;
+                        pureExample ??= $"{typeName}::{methodName}";
+                    }
+                    else
+                    {
+                        safeEffectful++;
+                        effectfulExample ??= $"{typeName}::{methodName}";
+                    }
+                }
 
                 if (samples.Count < sample
                     && merge is MergeShape.SingleMerge or MergeShape.SingleMergeReturnTail)
@@ -110,7 +131,39 @@ static class PostDomProbe
                 Console.WriteLine(s);
             }
         }
+
+        Console.WriteLine();
+        Console.WriteLine("safe non-crossing slice (SingleMerge + ReturnTail + MultiMergeNested) by guard purity:");
+        Console.WriteLine($"  {safePureGuards,8}  pure-guard boolean diamonds (OR-combination-extensible, no all-or-nothing relaxation)  e.g. {pureExample}");
+        Console.WriteLine($"  {safeEffectful,8}  effectful-condition genuine merges (need the structurer)  e.g. {effectfulExample}");
         return 0;
+    }
+
+    /// <summary>
+    /// Approximates "this residual is a boolean-expression diamond an extended
+    /// OR-combination could fold soundly" — mirrors <c>OrChainDiamondPass</c>'s
+    /// rule that inner guards are pure single-condition blocks (<c>[ConditionalBranch]</c>),
+    /// allowing only the root guard to carry leading operand setup. When at most
+    /// one guard block carries extra statements, the guard run is a pure
+    /// short-circuit chain (the condition is the only work); two or more
+    /// effectful guards mean the decisions do independent side-effecting work — a
+    /// genuine merge that needs the structurer, not condition-combining.
+    /// </summary>
+    static bool AllGuardsPure(BlockContainer container)
+    {
+        int guardsWithSetup = 0;
+        foreach (var block in container.Blocks)
+        {
+            if (block.Children.Count == 0 || block.Children[^1] is not ConditionalBranch)
+                continue;
+            // Any control flow among the non-terminal statements disqualifies outright.
+            for (int s = 0; s < block.Children.Count - 1; s++)
+                if (block.Children[s] is Branch or ConditionalBranch or SwitchBranch or Leave or EndFinally or EndFilter)
+                    return false;
+            if (block.Children.Count > 1)
+                guardsWithSetup++;
+        }
+        return guardsWithSetup <= 1;
     }
 
     /// <summary>The first container holding a residual flat conditional branch, or null.</summary>

--- a/tools/DecompilerHarness/PostDomProbe.cs
+++ b/tools/DecompilerHarness/PostDomProbe.cs
@@ -30,8 +30,9 @@ static class PostDomProbe
     {
         SingleMerge,            // one real-block post-dominator join — Target A
         SingleMergeReturnTail,  // that join is a short return tail — Target B
+        MultiMergeNested,       // >1 join, but regions nest/sequence — safe (SingleMerge x N)
+        MultiMergeCrossing,     // >1 join whose regions overlap — the genuine hard climb
         ExitMerge,              // arms flow to the method exit independently
-        MultiMerge,             // residual conditionals join at >1 distinct block
         Unrooted,               // a residual conditional cannot reach the exit
         Loop,                   // a back-edge survives — out of forward-structuring scope
     }
@@ -139,6 +140,11 @@ static class PostDomProbe
 
         var pd = PostDominators.Of(blocks);
 
+        // Each residual conditional's region is the half-open span [decision, join)
+        // from the branch block to its immediate post-dominator. Crossing spans are
+        // the interleaved/irreducible shape; nested or sequential (disjoint, or
+        // sharing only a boundary) spans are the safe SingleMerge-x-N case.
+        var regions = new List<(int Start, int End)>();
         var merges = new HashSet<int>();
         bool anyExit = false;
         for (int i = 0; i < blocks.Count; i++)
@@ -151,23 +157,47 @@ static class PostDomProbe
             if (ipdom == PostDominators.VirtualExit)
                 anyExit = true;
             else
+            {
                 merges.Add(ipdom);
+                regions.Add((i, ipdom));
+            }
         }
 
         if (merges.Count == 0)
             return MergeShape.ExitMerge;
-        if (merges.Count > 1)
-            return MergeShape.MultiMerge;
 
-        // Exactly one real-block join. If a residual conditional also flowed
-        // straight to the exit, the arms are not a clean single diamond.
-        if (anyExit)
-            return MergeShape.MultiMerge;
+        if (merges.Count > 1 || anyExit)
+        {
+            // anyExit alongside a real join means at least one decision escapes
+            // while another rejoins — treat the escape as a degenerate region
+            // [decision, exit) that spans to the container end.
+            if (anyExit)
+                for (int i = 0; i < blocks.Count; i++)
+                    if (blocks[i].Children.Count > 0 && blocks[i].Children[^1] is ConditionalBranch
+                        && pd.ImmediatePostDominator(i) == PostDominators.VirtualExit)
+                        regions.Add((i, blocks.Count));
+            return AnyCrossing(regions) ? MergeShape.MultiMergeCrossing : MergeShape.MultiMergeNested;
+        }
 
         int merge = merges.Single();
         return IsShortReturnTail(blocks[merge])
             ? MergeShape.SingleMergeReturnTail
             : MergeShape.SingleMerge;
+    }
+
+    /// <summary>True when two region spans partially overlap without one nesting the
+    /// other — the interleaved (crossing) shape. Disjoint, shared-boundary, and
+    /// nested spans are all non-crossing.</summary>
+    static bool AnyCrossing(List<(int Start, int End)> regions)
+    {
+        for (int i = 0; i < regions.Count; i++)
+            for (int j = i + 1; j < regions.Count; j++)
+            {
+                var (a, b) = regions[i].Start <= regions[j].Start ? (regions[i], regions[j]) : (regions[j], regions[i]);
+                if (a.Start < b.Start && b.Start < a.End && a.End < b.End)
+                    return true;
+            }
+        return false;
     }
 
     static IEnumerable<int> BranchTargets(Block block)

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -50,6 +50,8 @@ static class Program
         string? passImpactPass = null;
         bool showDiff = false;
         bool structuringStops = false;
+        bool postdomProbe = false;
+        int postdomSample = 0;
         bool libraryReport = false;
         bool unsupportedNodes = false;
         bool typeCheck = false;
@@ -109,6 +111,8 @@ static class Program
                     break;
                 case "--show-diff": showDiff = true; break;
                 case "--structuring-stops": structuringStops = true; break;
+                case "--postdom-probe": postdomProbe = true; break;
+                case "--postdom-sample": postdomProbe = true; postdomSample = int.Parse(args[++i]); break;
                 case "--library-report": libraryReport = true; break;
                 case "--unsupported-nodes": unsupportedNodes = true; break;
                 case "--type-check": typeCheck = true; break;
@@ -227,6 +231,9 @@ static class Program
 
         if (structuringStops)
             return StructuringStops(assemblies, cap);
+
+        if (postdomProbe)
+            return PostDomProbe.Run(assemblies, cap, postdomSample);
 
         // Default: the pipeline's fidelity/stop-reason inventory.
         return Inventory(assemblies);
@@ -1239,6 +1246,13 @@ static class Program
           --structuring-stops   tally why StructuringPass leaves containers flat:
                                 a per-container histogram of stop reasons (the
                                 common-exit merge docket). Honors --cap.
+          --postdom-probe       step-4 prototype (#1175): classify each residual
+                                conditional-branch method by its post-dominator
+                                merge shape (single-merge / return-tail / multi-
+                                merge / exit / loop). Read-only sizing of the
+                                retained-label slice. Honors --cap.
+          --postdom-sample <n>  with --postdom-probe: also print readability
+                                sketches for the first n single-merge methods.
           --cap <n>             with --pass-impact/--structuring-stops: stop after
                                 n methods (default: unlimited). Bounds a full-CoreLib
                                 stage sweep.


### PR DESCRIPTION
- Advances #1175 (step 4 — forward-merge structuring), high-certainty first slice
- Changes: folds mixed `||`/`&&` short-circuit guard chains so the structuring pass raises them; adds a read-only post-dominator sizing probe
- Card revision: `a63c6e45`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — sound OR-combination widening (no all-or-nothing relaxation); validity A/B byte-identical, fidelity gates green, reproducer opcode-exact.

`OrChainDiamondPass` folds pure-OR chains; the mixed `||`/`&&` case stayed flat. `MixedShortCircuitChainPass` reverses the short-circuit lowering for the genuinely-mixed two-arm chain, preserving evaluation order, so the existing structurer raises it. No relaxation of the structuring all-or-nothing invariant.

Before: `if (a || (b && c)) X; else Y;` → flat `goto` soup (residual conditional). 
After:
```csharp
if (Mm.F(a) || (Mm.F(b) && Mm.F(c))) { sb.Append('x'); } else { sb.Append('y'); }
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | FidelityGateTests + LoweredFidelityGateTests passed |
| Decompiler fast suite | Pass (1655) |
| Validity A/B (pass on vs off, merged base) | Byte-identical defect sets — 0 new invalid |
| Reduced fixture fidelity | `Mm::E` opcode-exact |
| Real witness | mixed `a||(b&&c)` raises to exact source |

Strictly gated: inner guards pure single-condition; branch arm strictly forward (excludes loop latches); genuinely mixed (else pure-OR); fall arm ends past branch arm at a real merge; conditions boolean; no external entry to dropped guards.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **ADVISORY** — pass-on/off validity A/B is byte-identical (this change is validity-neutral + structuring-positive). Aggregate vs the pinned baseline reflects 26 merged main commits (stale baseline), not this pass.

| Metric | Baseline | PR | Δ |
| --- | ---: | ---: | ---: |
| Fully raised | 78,394 | 78,399 | +5 |
| Conditional residual | 2,408 | 2,401 | −7 |
| Forward-merge stops | 2,294 | 2,286 | −8 |
| Pass bugs | 0 | 0 | 0 |

Full malformed +5 and one `valid→CS0023` (`Imports::Concat`, a recompile-shell artifact) are vs the stale baseline and present with this pass disabled — recommend a rebaseline after merge.

## Validation

```bash
dotnet build src/ILInspector.Decompiler -c Release
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*FidelityGateTests" -class "*LoweredFidelityGateTests"
```

## Review

Cross-model adversarial reviews pending (#1734).
