### PR TITLE
Analysis corpus stability sensor (#1818 Layer 2)

### DIFF
--- a/.github/workflows/decompiler-daily.yml
+++ b/.github/workflows/decompiler-daily.yml
@@ -77,6 +77,19 @@ jobs:
             --corpus-fidelity-cap 3 \
             --max-examples 3
 
+      # Analysis corpus stability sensor (#1818, Layer 2): same pinned corpus, but it checks
+      # analyzer robustness (every assembly opens, no analyzer-diagnostic jump) against a
+      # committed baseline. Signal-count drift is reported, not failed; only a regression
+      # (stops opening / times out / diagnostics increase) is nonzero.
+      - name: Run analysis corpus sensor
+        shell: bash
+        run: |
+          mkdir -p artifacts/analysis-daily
+          dotnet run --project tools/AnalysisHarness -c Release -- \
+            --corpus-list corpus-assemblies.txt \
+            --emit-corpus-snapshot artifacts/analysis-daily/analysis-corpus-snapshot.json \
+            --diff-corpus-baseline tools/AnalysisHarness/corpus/analysis-baseline.json
+
       - name: Upload corpus snapshot
         if: always()
         uses: actions/upload-artifact@v7

--- a/src/ILInspector.Analysis.Tests/AnalysisCorpusSensorTests.cs
+++ b/src/ILInspector.Analysis.Tests/AnalysisCorpusSensorTests.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+
+using ILInspector.AnalysisHarness;
+
+namespace ILInspector.Analysis.Tests;
+
+public class AnalysisCorpusSensorTests
+{
+    static AssemblyMetrics Asm(string name, bool opened = true, bool timedOut = false, int methods = 10, int diagnostics = 0, int allocations = 5, params (string Shape, int Count)[] shapes)
+        => new(name, opened, timedOut, methods, diagnostics, allocations, 0,
+            shapes.ToDictionary(s => s.Shape, s => s.Count));
+
+    [Fact]
+    public void Diff_IdenticalSnapshots_NoRegressionNoDrift()
+    {
+        var snap = new CorpusSnapshot([Asm("A.dll"), Asm("B.dll", shapes: ("box-value-type", 3))]);
+        var diff = AnalysisCorpusSensor.Diff(snap, snap);
+        Assert.False(diff.HasRegression);
+        Assert.Empty(diff.Drift);
+    }
+
+    [Fact]
+    public void Diff_AssemblyStopsOpening_IsRegression()
+    {
+        var baseline = new CorpusSnapshot([Asm("A.dll")]);
+        var current = new CorpusSnapshot([Asm("A.dll", opened: false)]);
+        Assert.True(AnalysisCorpusSensor.Diff(baseline, current).HasRegression);
+    }
+
+    [Fact]
+    public void Diff_DiagnosticsIncrease_IsRegression()
+    {
+        var baseline = new CorpusSnapshot([Asm("A.dll", diagnostics: 0)]);
+        var current = new CorpusSnapshot([Asm("A.dll", diagnostics: 2)]);
+        Assert.True(AnalysisCorpusSensor.Diff(baseline, current).HasRegression);
+    }
+
+    [Fact]
+    public void Diff_TimeoutThenMeasured_IsNotRegression()
+    {
+        // A previously timed-out assembly that now measures is an improvement, not a regression.
+        var baseline = new CorpusSnapshot([Asm("Big.dll", opened: false, timedOut: true, methods: 0)]);
+        var current = new CorpusSnapshot([Asm("Big.dll", methods: 9000)]);
+        var diff = AnalysisCorpusSensor.Diff(baseline, current);
+        Assert.False(diff.HasRegression);
+    }
+
+    [Fact]
+    public void Diff_SignalCountMovement_IsDriftNotRegression()
+    {
+        var baseline = new CorpusSnapshot([Asm("A.dll", allocations: 5, shapes: ("box-value-type", 3))]);
+        var current = new CorpusSnapshot([Asm("A.dll", allocations: 4, shapes: ("box-value-type", 5))]);
+        var diff = AnalysisCorpusSensor.Diff(baseline, current);
+        Assert.False(diff.HasRegression);
+        Assert.NotEmpty(diff.Drift);
+    }
+
+    [Fact]
+    public void Diff_AddedOrRemoved_IsNotRegression()
+    {
+        var baseline = new CorpusSnapshot([Asm("A.dll")]);
+        var current = new CorpusSnapshot([Asm("A.dll"), Asm("New.dll")]);
+        var diff = AnalysisCorpusSensor.Diff(baseline, current);
+        Assert.False(diff.HasRegression);
+        Assert.Single(diff.AddedOrRemoved);
+    }
+
+    [Fact]
+    public void JsonRoundTrip_PreservesMetrics()
+    {
+        var snap = new CorpusSnapshot([Asm("A.dll", methods: 42, allocations: 7, shapes: ("small-array", 2))]);
+        var back = AnalysisCorpusSensor.FromJson(AnalysisCorpusSensor.ToJson(snap));
+        Assert.Equal(42, back.Assemblies[0].Methods);
+        Assert.Equal(2, back.Assemblies[0].Shapes["small-array"]);
+    }
+}

--- a/src/ILInspector.Analysis.Tests/AnalysisCorpusSensorTests.cs
+++ b/src/ILInspector.Analysis.Tests/AnalysisCorpusSensorTests.cs
@@ -66,6 +66,16 @@ public class AnalysisCorpusSensorTests
     }
 
     [Fact]
+    public void Diff_TimeoutThenMeasuredWithDiagnostics_IsNotRegression()
+    {
+        // A previously timed-out assembly that now measures, even WITH diagnostics, is an
+        // improvement: diagnostics are only compared when both baseline and current opened.
+        var baseline = new CorpusSnapshot([Asm("Big.dll", opened: false, timedOut: true, methods: 0, diagnostics: 0)]);
+        var current = new CorpusSnapshot([Asm("Big.dll", methods: 9000, diagnostics: 4)]);
+        Assert.False(AnalysisCorpusSensor.Diff(baseline, current).HasRegression);
+    }
+
+    [Fact]
     public void JsonRoundTrip_PreservesMetrics()
     {
         var snap = new CorpusSnapshot([Asm("A.dll", methods: 42, allocations: 7, shapes: ("small-array", 2))]);

--- a/tools/AnalysisHarness/CorpusSensor.cs
+++ b/tools/AnalysisHarness/CorpusSensor.cs
@@ -128,18 +128,20 @@ public static class AnalysisCorpusSensor
                 continue;
             }
 
-            if (b!.Opened && !c!.Opened)
-                regressions.Add($"{name}: {(c.TimedOut ? "timed out" : "stopped opening")} (was {b.Methods} methods)");
-            if (c!.Opened && c.Diagnostics > b.Diagnostics)
-                regressions.Add($"{name}: analyzer diagnostics {b.Diagnostics} -> {c.Diagnostics}");
+            AssemblyMetrics baseMetrics = b!;
+            AssemblyMetrics curMetrics = c!;
+            if (baseMetrics.Opened && !curMetrics.Opened)
+                regressions.Add($"{name}: {(curMetrics.TimedOut ? "timed out" : "stopped opening")} (was {baseMetrics.Methods} methods)");
+            if (baseMetrics.Opened && curMetrics.Opened && curMetrics.Diagnostics > baseMetrics.Diagnostics)
+                regressions.Add($"{name}: analyzer diagnostics {baseMetrics.Diagnostics} -> {curMetrics.Diagnostics}");
 
-            if (c.Opened && b.Opened)
+            if (curMetrics.Opened && baseMetrics.Opened)
             {
-                AddDrift(drift, name, "methods", b.Methods, c.Methods);
-                AddDrift(drift, name, "allocations", b.Allocations, c.Allocations);
-                AddDrift(drift, name, "exception-constructions", b.ExceptionConstructions, c.ExceptionConstructions);
-                foreach (var shape in b.Shapes.Keys.Union(c.Shapes.Keys).OrderBy(s => s, StringComparer.Ordinal))
-                    AddDrift(drift, name, shape, b.Shapes.GetValueOrDefault(shape), c.Shapes.GetValueOrDefault(shape));
+                AddDrift(drift, name, "methods", baseMetrics.Methods, curMetrics.Methods);
+                AddDrift(drift, name, "allocations", baseMetrics.Allocations, curMetrics.Allocations);
+                AddDrift(drift, name, "exception-constructions", baseMetrics.ExceptionConstructions, curMetrics.ExceptionConstructions);
+                foreach (var shape in baseMetrics.Shapes.Keys.Union(curMetrics.Shapes.Keys).OrderBy(s => s, StringComparer.Ordinal))
+                    AddDrift(drift, name, shape, baseMetrics.Shapes.GetValueOrDefault(shape), curMetrics.Shapes.GetValueOrDefault(shape));
             }
         }
 

--- a/tools/AnalysisHarness/CorpusSensor.cs
+++ b/tools/AnalysisHarness/CorpusSensor.cs
@@ -1,0 +1,189 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.AnalysisHarness;
+
+/// <summary>Per-assembly analysis metrics: the mechanically-checkable corpus signals.</summary>
+public sealed record AssemblyMetrics(
+    string Name,
+    bool Opened,
+    int Methods,
+    int Diagnostics,
+    int Allocations,
+    int ExceptionConstructions,
+    IReadOnlyDictionary<string, int> Shapes);
+
+/// <summary>A corpus snapshot: per-assembly metrics plus the run's tool version marker.</summary>
+public sealed record CorpusSnapshot(IReadOnlyList<AssemblyMetrics> Assemblies);
+
+public sealed record CorpusDiff(
+    IReadOnlyList<string> Regressions,
+    IReadOnlyList<string> Drift,
+    IReadOnlyList<string> AddedOrRemoved)
+{
+    public bool HasRegression => Regressions.Count > 0;
+}
+
+/// <summary>
+/// The analysis corpus stability sensor (#1818, Layer 2). It sweeps <see cref="LibraryBodyIndex"/>
+/// over a fixed corpus and reports the mechanically-checkable signals — did every assembly open,
+/// did the analyzer choke (recoverable diagnostics), and how did the aggregate signal counts move
+/// against a committed baseline. The point is to separate a REGRESSION (an assembly that stops
+/// opening, or a jump in analyzer diagnostics) from DRIFT (signal-count movement, expected as the
+/// analyzer improves and rebaselined deliberately). There is no precision/recall judgement here —
+/// that is Layer 3.
+/// </summary>
+public static class AnalysisCorpusSensor
+{
+    static readonly JsonSerializerOptions s_json = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public static CorpusSnapshot Measure(IReadOnlyList<string> assemblyPaths)
+    {
+        var assemblies = new List<AssemblyMetrics>(assemblyPaths.Count);
+        foreach (var path in assemblyPaths)
+            assemblies.Add(MeasureOne(path));
+        assemblies.Sort((a, b) => string.CompareOrdinal(a.Name, b.Name));
+        return new CorpusSnapshot(assemblies);
+    }
+
+    static AssemblyMetrics MeasureOne(string path)
+    {
+        string name = Path.GetFileName(path);
+        LibraryBodyIndex index;
+        try
+        {
+            index = LibraryBodyIndex.Open(path);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or IOException or ArgumentException)
+        {
+            return new AssemblyMetrics(name, Opened: false, 0, 0, 0, 0, new Dictionary<string, int>());
+        }
+
+        var signals = index.GetMethodSignals();
+        int allocations = 0;
+        int exceptionConstructions = 0;
+        foreach (var method in index.Methods)
+        {
+            var signal = signals.GetValueOrDefault(method.MetadataToken, MethodSignals.None);
+            allocations += signal.Allocations;
+            exceptionConstructions += signal.ExceptionTypes.Length;
+        }
+
+        var shapes = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        foreach (var opportunity in index.OptimizationOpportunities)
+            shapes[opportunity.Shape] = shapes.GetValueOrDefault(opportunity.Shape) + 1;
+
+        return new AssemblyMetrics(
+            name,
+            Opened: true,
+            index.Methods.Length,
+            index.Diagnostics.Length,
+            allocations,
+            exceptionConstructions,
+            shapes);
+    }
+
+    // Regression = a robustness loss that is always a bug: an assembly that stops opening, or a
+    // jump in analyzer diagnostics (recoverable method failures). Drift = expected signal-count
+    // movement, surfaced for review/rebaseline but not a failure.
+    public static CorpusDiff Diff(CorpusSnapshot baseline, CorpusSnapshot current)
+    {
+        var regressions = new List<string>();
+        var drift = new List<string>();
+        var addedOrRemoved = new List<string>();
+
+        var currentByName = current.Assemblies.ToDictionary(a => a.Name, StringComparer.Ordinal);
+        var baselineByName = baseline.Assemblies.ToDictionary(a => a.Name, StringComparer.Ordinal);
+
+        foreach (var name in baselineByName.Keys.Union(currentByName.Keys).OrderBy(n => n, StringComparer.Ordinal))
+        {
+            bool inBase = baselineByName.TryGetValue(name, out var b);
+            bool inCur = currentByName.TryGetValue(name, out var c);
+            if (!inBase || !inCur)
+            {
+                addedOrRemoved.Add($"{name}: {(inCur ? "added" : "removed")}");
+                continue;
+            }
+
+            if (b!.Opened && !c!.Opened)
+                regressions.Add($"{name}: stopped opening (was {b.Methods} methods)");
+            if (c!.Opened && c.Diagnostics > b.Diagnostics)
+                regressions.Add($"{name}: analyzer diagnostics {b.Diagnostics} -> {c.Diagnostics}");
+
+            if (c.Opened && b.Opened)
+            {
+                AddDrift(drift, name, "methods", b.Methods, c.Methods);
+                AddDrift(drift, name, "allocations", b.Allocations, c.Allocations);
+                AddDrift(drift, name, "exception-constructions", b.ExceptionConstructions, c.ExceptionConstructions);
+                foreach (var shape in b.Shapes.Keys.Union(c.Shapes.Keys).OrderBy(s => s, StringComparer.Ordinal))
+                    AddDrift(drift, name, shape, b.Shapes.GetValueOrDefault(shape), c.Shapes.GetValueOrDefault(shape));
+            }
+        }
+
+        return new CorpusDiff(regressions, drift, addedOrRemoved);
+    }
+
+    static void AddDrift(List<string> drift, string name, string metric, int oldValue, int newValue)
+    {
+        if (oldValue != newValue)
+            drift.Add($"{name}: {metric} {oldValue} -> {newValue}");
+    }
+
+    public static string FormatCard(CorpusSnapshot snapshot)
+    {
+        var sb = new StringBuilder();
+        int failed = snapshot.Assemblies.Count(a => !a.Opened);
+        int diagnostics = snapshot.Assemblies.Sum(a => a.Diagnostics);
+        int methods = snapshot.Assemblies.Sum(a => a.Methods);
+        int allocations = snapshot.Assemblies.Sum(a => a.Allocations);
+        var shapeTotals = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        foreach (var assembly in snapshot.Assemblies)
+            foreach (var (shape, count) in assembly.Shapes)
+                shapeTotals[shape] = shapeTotals.GetValueOrDefault(shape) + count;
+
+        sb.AppendLine($"ANALYSIS CORPUS CARD: {snapshot.Assemblies.Count} assemblies, {failed} failed to open");
+        sb.AppendLine($"  methods={methods} diagnostics={diagnostics} allocations={allocations}");
+        sb.AppendLine($"  opportunity shapes: {string.Join(", ", shapeTotals.Select(kv => $"{kv.Key}={kv.Value}"))}");
+        foreach (var assembly in snapshot.Assemblies)
+        {
+            string status = assembly.Opened ? "" : " FAILED";
+            sb.AppendLine($"  {assembly.Name}{status}  methods={assembly.Methods} diag={assembly.Diagnostics} alloc={assembly.Allocations} shapes={assembly.Shapes.Values.Sum()}");
+        }
+        return sb.ToString();
+    }
+
+    public static string FormatDiffCard(CorpusDiff diff)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"ANALYSIS CORPUS DIFF: {diff.Regressions.Count} regression(s), {diff.Drift.Count} drift, {diff.AddedOrRemoved.Count} added/removed");
+        if (diff.Regressions.Count > 0)
+        {
+            sb.AppendLine("  REGRESSIONS:");
+            foreach (var line in diff.Regressions) sb.AppendLine($"    {line}");
+        }
+        if (diff.AddedOrRemoved.Count > 0)
+        {
+            sb.AppendLine("  added/removed:");
+            foreach (var line in diff.AddedOrRemoved) sb.AppendLine($"    {line}");
+        }
+        if (diff.Drift.Count > 0)
+        {
+            sb.AppendLine("  drift:");
+            foreach (var line in diff.Drift) sb.AppendLine($"    {line}");
+        }
+        return sb.ToString();
+    }
+
+    public static string ToJson(CorpusSnapshot snapshot) => JsonSerializer.Serialize(snapshot, s_json);
+
+    public static CorpusSnapshot FromJson(string json)
+        => JsonSerializer.Deserialize<CorpusSnapshot>(json, s_json)
+           ?? throw new InvalidOperationException("Empty corpus snapshot.");
+}

--- a/tools/AnalysisHarness/CorpusSensor.cs
+++ b/tools/AnalysisHarness/CorpusSensor.cs
@@ -10,6 +10,7 @@ namespace ILInspector.AnalysisHarness;
 public sealed record AssemblyMetrics(
     string Name,
     bool Opened,
+    bool TimedOut,
     int Methods,
     int Diagnostics,
     int Allocations,
@@ -44,13 +45,27 @@ public static class AnalysisCorpusSensor
         Converters = { new JsonStringEnumConverter() },
     };
 
-    public static CorpusSnapshot Measure(IReadOnlyList<string> assemblyPaths)
+    public static CorpusSnapshot Measure(IReadOnlyList<string> assemblyPaths, int perAssemblyTimeoutSeconds = 60)
     {
         var assemblies = new List<AssemblyMetrics>(assemblyPaths.Count);
         foreach (var path in assemblyPaths)
-            assemblies.Add(MeasureOne(path));
+            assemblies.Add(MeasureWithTimeout(path, perAssemblyTimeoutSeconds));
         assemblies.Sort((a, b) => string.CompareOrdinal(a.Name, b.Name));
         return new CorpusSnapshot(assemblies);
+    }
+
+    // Bound each assembly so one pathological input cannot hang the whole sweep. A timeout is
+    // recorded as a stable signal (TimedOut) rather than a crash; the orphaned worker exits with
+    // the process. Going from measured to timed-out (or vice versa) is a regression in the diff.
+    static AssemblyMetrics MeasureWithTimeout(string path, int timeoutSeconds)
+    {
+        string name = Path.GetFileName(path);
+        AssemblyMetrics? result = null;
+        var worker = new Thread(() => result = MeasureOne(path)) { IsBackground = true };
+        worker.Start();
+        if (worker.Join(TimeSpan.FromSeconds(timeoutSeconds)) && result is not null)
+            return result;
+        return new AssemblyMetrics(name, Opened: false, TimedOut: true, 0, 0, 0, 0, new Dictionary<string, int>());
     }
 
     static AssemblyMetrics MeasureOne(string path)
@@ -63,7 +78,7 @@ public static class AnalysisCorpusSensor
         }
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or IOException or ArgumentException)
         {
-            return new AssemblyMetrics(name, Opened: false, 0, 0, 0, 0, new Dictionary<string, int>());
+            return new AssemblyMetrics(name, Opened: false, TimedOut: false, 0, 0, 0, 0, new Dictionary<string, int>());
         }
 
         var signals = index.GetMethodSignals();
@@ -83,6 +98,7 @@ public static class AnalysisCorpusSensor
         return new AssemblyMetrics(
             name,
             Opened: true,
+            TimedOut: false,
             index.Methods.Length,
             index.Diagnostics.Length,
             allocations,
@@ -113,7 +129,7 @@ public static class AnalysisCorpusSensor
             }
 
             if (b!.Opened && !c!.Opened)
-                regressions.Add($"{name}: stopped opening (was {b.Methods} methods)");
+                regressions.Add($"{name}: {(c.TimedOut ? "timed out" : "stopped opening")} (was {b.Methods} methods)");
             if (c!.Opened && c.Diagnostics > b.Diagnostics)
                 regressions.Add($"{name}: analyzer diagnostics {b.Diagnostics} -> {c.Diagnostics}");
 
@@ -140,6 +156,7 @@ public static class AnalysisCorpusSensor
     {
         var sb = new StringBuilder();
         int failed = snapshot.Assemblies.Count(a => !a.Opened);
+        int timedOut = snapshot.Assemblies.Count(a => a.TimedOut);
         int diagnostics = snapshot.Assemblies.Sum(a => a.Diagnostics);
         int methods = snapshot.Assemblies.Sum(a => a.Methods);
         int allocations = snapshot.Assemblies.Sum(a => a.Allocations);
@@ -148,12 +165,12 @@ public static class AnalysisCorpusSensor
             foreach (var (shape, count) in assembly.Shapes)
                 shapeTotals[shape] = shapeTotals.GetValueOrDefault(shape) + count;
 
-        sb.AppendLine($"ANALYSIS CORPUS CARD: {snapshot.Assemblies.Count} assemblies, {failed} failed to open");
+        sb.AppendLine($"ANALYSIS CORPUS CARD: {snapshot.Assemblies.Count} assemblies, {failed} not measured ({timedOut} timed out)");
         sb.AppendLine($"  methods={methods} diagnostics={diagnostics} allocations={allocations}");
         sb.AppendLine($"  opportunity shapes: {string.Join(", ", shapeTotals.Select(kv => $"{kv.Key}={kv.Value}"))}");
         foreach (var assembly in snapshot.Assemblies)
         {
-            string status = assembly.Opened ? "" : " FAILED";
+            string status = assembly.Opened ? "" : assembly.TimedOut ? " TIMED-OUT" : " FAILED";
             sb.AppendLine($"  {assembly.Name}{status}  methods={assembly.Methods} diag={assembly.Diagnostics} alloc={assembly.Allocations} shapes={assembly.Shapes.Values.Sum()}");
         }
         return sb.ToString();

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -2,15 +2,22 @@ using ILInspector.AnalysisHarness;
 
 const string Usage =
     """
-    analysis-harness --generated-fixtures [<selector>|list] [--json] [--keep]
+    analysis-harness <mode>
 
-      Materializes the analysis fixture catalogue into temporary assemblies and grades each
-      target method against its expected-signal ledger entry using the real analyzer.
+      --generated-fixtures [<selector>|list] [--json] [--keep]
+          Materialize the analysis fixture catalogue into temporary assemblies and grade each
+          target method against its expected-signal ledger entry using the real analyzer.
+          <selector>  a fixture id, id prefix, or tag; omit (or 'all') to run every fixture.
+          list        list catalogue entries and expected outcomes without building.
 
-      <selector>   a fixture id, id prefix, or tag; omit (or 'all') to run every fixture.
-      list         list catalogue entries and expected outcomes without building.
-      --json       emit machine-readable JSON.
-      --keep       keep the generated temporary projects for drill-down.
+      --corpus-list <file> [--diff-corpus-baseline <file>] [--emit-corpus-snapshot <file>] [--json]
+          Sweep the analyzer over a corpus (one assembly path per line in <file>) and report the
+          stability card. With --diff-corpus-baseline, compare against a committed baseline and
+          exit nonzero on a REGRESSION (an assembly that stops opening, or an analyzer-diagnostic
+          increase); signal-count DRIFT is reported but not a failure. --emit-corpus-snapshot
+          writes the snapshot JSON (use it to (re)generate a baseline).
+
+      Common: --json machine-readable output; --keep keep generated fixture projects.
     """;
 
 if (args.Length == 0)
@@ -19,7 +26,11 @@ if (args.Length == 0)
     return 2;
 }
 
-string? selector = null;
+string? fixtureSelector = null;
+bool fixturesMode = false;
+string? corpusList = null;
+string? diffBaseline = null;
+string? emitSnapshot = null;
 bool json = false;
 bool keep = false;
 bool list = false;
@@ -29,8 +40,18 @@ for (int i = 0; i < args.Length; i++)
     switch (args[i])
     {
         case "--generated-fixtures":
+            fixturesMode = true;
             if (i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal))
-                selector = args[++i];
+                fixtureSelector = args[++i];
+            break;
+        case "--corpus-list":
+            corpusList = NextValue(args, ref i);
+            break;
+        case "--diff-corpus-baseline":
+            diffBaseline = NextValue(args, ref i);
+            break;
+        case "--emit-corpus-snapshot":
+            emitSnapshot = NextValue(args, ref i);
             break;
         case "list":
             list = true;
@@ -51,23 +72,84 @@ for (int i = 0; i < args.Length; i++)
     }
 }
 
-if (list || selector is "list")
+if (corpusList is not null)
+    return RunCorpus(corpusList, diffBaseline, emitSnapshot, json);
+
+if (fixturesMode || list)
+    return RunFixtures(fixtureSelector, list, json, keep);
+
+Console.Error.WriteLine(Usage);
+return 2;
+
+static int RunFixtures(string? selector, bool list, bool json, bool keep)
 {
-    Console.Write(json
-        ? AnalysisFixtureRunner.FormatListJson(AnalysisFixtureCatalog.All)
-        : AnalysisFixtureRunner.FormatList(AnalysisFixtureCatalog.All));
-    return 0;
+    if (list || selector is "list")
+    {
+        Console.Write(json
+            ? AnalysisFixtureRunner.FormatListJson(AnalysisFixtureCatalog.All)
+            : AnalysisFixtureRunner.FormatList(AnalysisFixtureCatalog.All));
+        return 0;
+    }
+
+    var fixtures = AnalysisFixtureCatalog.Select(selector);
+    if (fixtures.Count == 0)
+    {
+        Console.Error.WriteLine($"No analysis fixture IDs match '{selector}'. Use '--generated-fixtures list'.");
+        return 2;
+    }
+
+    var run = AnalysisFixtureRunner.Run(fixtures, new AnalysisFixtureRunOptions(KeepArtifacts: keep));
+    Console.Write(json ? AnalysisFixtureRunner.FormatJson(run) : AnalysisFixtureRunner.FormatReport(run));
+    if (json)
+        Console.WriteLine();
+    return run.Passed ? 0 : 1;
 }
 
-var fixtures = AnalysisFixtureCatalog.Select(selector);
-if (fixtures.Count == 0)
+static int RunCorpus(string corpusList, string? diffBaseline, string? emitSnapshot, bool json)
 {
-    Console.Error.WriteLine($"No analysis fixture IDs match '{selector}'. Use '--generated-fixtures list'.");
-    return 2;
+    if (!File.Exists(corpusList))
+    {
+        Console.Error.WriteLine($"Corpus list not found: {corpusList}");
+        return 2;
+    }
+
+    var paths = File.ReadAllLines(corpusList)
+        .Select(line => line.Trim())
+        .Where(line => line.Length > 0 && !line.StartsWith('#'))
+        .ToList();
+    if (paths.Count == 0)
+    {
+        Console.Error.WriteLine($"Corpus list is empty: {corpusList}");
+        return 2;
+    }
+
+    var snapshot = AnalysisCorpusSensor.Measure(paths);
+
+    if (emitSnapshot is not null)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(emitSnapshot))!);
+        File.WriteAllText(emitSnapshot, AnalysisCorpusSensor.ToJson(snapshot));
+        Console.Error.WriteLine($"Wrote corpus snapshot: {emitSnapshot}");
+    }
+
+    if (diffBaseline is null)
+    {
+        Console.Write(json ? AnalysisCorpusSensor.ToJson(snapshot) : AnalysisCorpusSensor.FormatCard(snapshot));
+        if (json) Console.WriteLine();
+        return 0;
+    }
+
+    if (!File.Exists(diffBaseline))
+    {
+        Console.Error.WriteLine($"Baseline not found: {diffBaseline}");
+        return 2;
+    }
+
+    var baseline = AnalysisCorpusSensor.FromJson(File.ReadAllText(diffBaseline));
+    var diff = AnalysisCorpusSensor.Diff(baseline, snapshot);
+    Console.Write(AnalysisCorpusSensor.FormatDiffCard(diff));
+    return diff.HasRegression ? 1 : 0;
 }
 
-var run = AnalysisFixtureRunner.Run(fixtures, new AnalysisFixtureRunOptions(KeepArtifacts: keep));
-Console.Write(json ? AnalysisFixtureRunner.FormatJson(run) : AnalysisFixtureRunner.FormatReport(run));
-if (json)
-    Console.WriteLine();
-return run.Passed ? 0 : 1;
+static string? NextValue(string[] args, ref int i)
+    => i + 1 < args.Length ? args[++i] : null;

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -42,5 +42,16 @@ dotnet artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tes
 
 ## Layers above this
 
-This is Layer 1 of #1818. The corpus stability sensor (Layer 2) and the sampled-judgment
-precision/recall loop (Layer 3) are tracked there.
+This is Layer 1 of #1818. The corpus stability sensor (Layer 2) is `--corpus-list`:
+
+```bash
+dotnet "$DLL" --corpus-list assemblies.txt                                    # stability card
+dotnet "$DLL" --corpus-list assemblies.txt --diff-corpus-baseline corpus/analysis-baseline.json
+```
+
+It sweeps the analyzer over a pinned corpus (one assembly path per line) and reports the
+mechanically-checkable signals — did every assembly open, did the analyzer choke (recoverable
+diagnostics) — diffed against a committed baseline. A REGRESSION (an assembly that stops opening,
+times out, or whose diagnostics increase) exits nonzero; signal-count DRIFT is reported, not
+failed. Each assembly is bounded by a per-assembly timeout so one pathological input cannot hang
+the sweep. The sampled-judgment precision/recall loop (Layer 3) is tracked on #1818.

--- a/tools/AnalysisHarness/corpus/analysis-baseline.json
+++ b/tools/AnalysisHarness/corpus/analysis-baseline.json
@@ -1,0 +1,234 @@
+{
+  "Assemblies": [
+    {
+      "Name": "DotnetInspector.Core.dll",
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 285,
+      "Diagnostics": 0,
+      "Allocations": 89,
+      "ExceptionConstructions": 5,
+      "Shapes": {
+        "box-value-type": 1,
+        "capturing-delegate": 2
+      }
+    },
+    {
+      "Name": "DotnetInspector.Packages.dll",
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 303,
+      "Diagnostics": 0,
+      "Allocations": 102,
+      "ExceptionConstructions": 5,
+      "Shapes": {
+        "capturing-delegate": 5,
+        "small-array": 3
+      }
+    },
+    {
+      "Name": "DotnetInspector.Services.dll",
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 450,
+      "Diagnostics": 0,
+      "Allocations": 197,
+      "ExceptionConstructions": 2,
+      "Shapes": {
+        "capturing-delegate": 18,
+        "enumerator-allocation": 1,
+        "linq-scan-in-loop": 3,
+        "scan-method-in-loop-call": 2,
+        "small-array": 7,
+        "span-to-array-copy": 1
+      }
+    },
+    {
+      "Name": "ILInspector.Analysis.dll",
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 725,
+      "Diagnostics": 0,
+      "Allocations": 301,
+      "ExceptionConstructions": 7,
+      "Shapes": {
+        "box-value-type": 1,
+        "capturing-delegate": 20,
+        "enumerator-allocation": 1,
+        "instance-method-group-delegate": 1,
+        "scan-method-in-loop-call": 2,
+        "small-array": 5
+      }
+    },
+    {
+      "Name": "ILInspector.Decompiler.dll",
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 5440,
+      "Diagnostics": 0,
+      "Allocations": 2669,
+      "ExceptionConstructions": 79,
+      "Shapes": {
+        "box-value-type": 25,
+        "capturing-delegate": 202,
+        "enumerator-allocation": 77,
+        "instance-method-group-delegate": 29,
+        "linq-scan-in-loop": 53,
+        "scan-method-in-loop-call": 45,
+        "small-array": 97,
+        "span-to-array-copy": 4,
+        "string-build-in-loop": 3
+      }
+    },
+    {
+      "Name": "ILInspector.Metadata.dll",
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 1842,
+      "Diagnostics": 0,
+      "Allocations": 548,
+      "ExceptionConstructions": 15,
+      "Shapes": {
+        "box-value-type": 8,
+        "capturing-delegate": 16,
+        "enumerator-allocation": 2,
+        "linq-scan-in-loop": 1,
+        "small-array": 7,
+        "string-build-in-loop": 1
+      }
+    },
+    {
+      "Name": "ILInspector.MetadataPrimitives.dll",
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 61,
+      "Diagnostics": 0,
+      "Allocations": 14,
+      "ExceptionConstructions": 0,
+      "Shapes": {
+        "box-value-type": 1,
+        "capturing-delegate": 3
+      }
+    },
+    {
+      "Name": "Microsoft.ApplicationInsights.dll",
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 2478,
+      "Diagnostics": 0,
+      "Allocations": 1111,
+      "ExceptionConstructions": 195,
+      "Shapes": {
+        "box-value-type": 51,
+        "capturing-delegate": 18,
+        "enumerator-allocation": 1,
+        "instance-method-group-delegate": 16,
+        "linq-scan-in-loop": 3,
+        "small-array": 153,
+        "string-build-in-loop": 5,
+        "temporary-byte-array-copy": 4
+      }
+    },
+    {
+      "Name": "Microsoft.CodeAnalysis.CSharp.dll",
+      "Opened": false,
+      "TimedOut": true,
+      "Methods": 0,
+      "Diagnostics": 0,
+      "Allocations": 0,
+      "ExceptionConstructions": 0,
+      "Shapes": {}
+    },
+    {
+      "Name": "Microsoft.CodeAnalysis.dll",
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 17331,
+      "Diagnostics": 0,
+      "Allocations": 5490,
+      "ExceptionConstructions": 950,
+      "Shapes": {
+        "box-value-type": 285,
+        "capturing-delegate": 116,
+        "enumerator-allocation": 22,
+        "instance-method-group-delegate": 97,
+        "linq-scan-in-loop": 3,
+        "scan-method-in-loop-call": 1,
+        "small-array": 300,
+        "span-to-array-copy": 2,
+        "string-build-in-loop": 3,
+        "temporary-byte-array-copy": 1
+      }
+    },
+    {
+      "Name": "Newtonsoft.Json.dll",
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 4107,
+      "Diagnostics": 0,
+      "Allocations": 1745,
+      "ExceptionConstructions": 328,
+      "Shapes": {
+        "box-value-type": 124,
+        "capturing-delegate": 61,
+        "enumerator-allocation": 13,
+        "instance-method-group-delegate": 10,
+        "linq-scan-in-loop": 7,
+        "scan-method-in-loop-call": 3,
+        "small-array": 144
+      }
+    },
+    {
+      "Name": "NuGet.Versioning.dll",
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 309,
+      "Diagnostics": 0,
+      "Allocations": 133,
+      "ExceptionConstructions": 26,
+      "Shapes": {
+        "box-value-type": 6,
+        "capturing-delegate": 3,
+        "small-array": 1
+      }
+    },
+    {
+      "Name": "System.CommandLine.dll",
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 977,
+      "Diagnostics": 0,
+      "Allocations": 480,
+      "ExceptionConstructions": 68,
+      "Shapes": {
+        "box-value-type": 10,
+        "capturing-delegate": 28,
+        "enumerator-allocation": 8,
+        "instance-method-group-delegate": 7,
+        "linq-scan-in-loop": 1,
+        "small-array": 27,
+        "string-build-in-loop": 1
+      }
+    },
+    {
+      "Name": "dotnet-inspect.dll",
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 12637,
+      "Diagnostics": 0,
+      "Allocations": 10768,
+      "ExceptionConstructions": 238,
+      "Shapes": {
+        "box-value-type": 14,
+        "capturing-delegate": 234,
+        "enumerator-allocation": 15,
+        "instance-method-group-delegate": 75,
+        "linq-scan-in-loop": 13,
+        "scan-method-in-loop-call": 9,
+        "small-array": 771,
+        "span-to-array-copy": 1,
+        "string-build-in-loop": 6
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Layer 2 of the analysis harness plan (#1818): an **analysis corpus stability sensor** — the analog of the decompiler's `--diff-corpus-baseline`, but for analyzer robustness. It sweeps `LibraryBodyIndex` over the pinned corpus and diffs against a committed baseline, separating a **regression** from expected **drift**.

## What it checks

- **Regression (exit nonzero)**: an assembly that stops opening, **times out**, or whose analyzer diagnostics increase. These are always-bad robustness losses.
- **Drift (reported, not failed)**: per-assembly signal-count movement (methods, allocations, exception constructions, opportunity-shape histogram) — expected as the analyzer improves; rebaselined deliberately.
- A **per-assembly timeout** so one pathological input can't hang the sweep. The transition is one-directional: measured→timeout is a regression; timeout→measured is an improvement.

## CLI

`tools/AnalysisHarness` gains a corpus mode:

```bash
analysis-harness --corpus-list <file> [--diff-corpus-baseline <file>] [--emit-corpus-snapshot <file>] [--json]
```

## Corpus

Reuses the pinned #1150 corpus (`eng/prepare-decompiler-corpus.sh`): 6 pinned NuGet packages + 8 `dotnet-inspect.any` self-assemblies. The committed baseline (`tools/AnalysisHarness/corpus/analysis-baseline.json`) measures 13/14 with **0 analyzer diagnostics** — `Microsoft.CodeAnalysis.CSharp.dll` times out (filed separately: `LibraryBodyIndex.Open` does not scale to the ~5MB Roslyn C# compiler; the timeout keeps the sensor bounded and the baseline records it stably).

## Tests + CI

- 7 fast unit tests on the diff engine (regression vs drift vs timeout→measured, JSON round-trip) — PR lane, ~0.1s.
- A daily step in `decompiler-daily.yml` runs the sensor on the same prepared corpus (no per-PR cost).

Refs #1818
