### PR TITLE
docs: centralize adversarial-review roster, add Gemini Pro

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,11 @@ non-trivial behavior changes, new heuristics/shapes, or subtle correctness risk
 
 - Claude Opus 4.8
 - GPT-5.5
+- Gemini Pro (e.g. Gemini 3.1 Pro)
 - the MAI Flash family (e.g. MAI-Code-1-Flash)
+
+This list is the single source of truth for the reviewer roster; other scenario
+docs reference this section rather than restating the models.
 
 Rules:
 

--- a/agents/ladder-tester.md
+++ b/agents/ladder-tester.md
@@ -37,7 +37,8 @@ switching from tester to implementer.
 ## Review
 
 Ladder PRs that add or change fixture/corpus coverage, guards, success bars, or
-rung-completion claims need cross-model adversarial review before merge. The
-review should try to falsify the rung bar and guard: missing constructs,
+rung-completion claims need cross-model adversarial review before merge (two
+reviewers from the AGENTS.md "Adversarial Review" roster, never your own model).
+The review should try to falsify the rung bar and guard: missing constructs,
 too-weak success criteria, unguarded regression paths, and over-broad completion
 claims.

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -188,7 +188,10 @@ Report:
 4. per-method delta artifact;
 5. changed-method fidelity result, or a clear statement that changed methods are
    not currently checkable;
-6. cross-model adversarial review summary with resolution commit links.
+6. cross-model adversarial review summary with resolution commit links (two
+   reviewers from the AGENTS.md
+   [Adversarial Review](../AGENTS.md#adversarial-review) roster, never your own
+   model).
 
 For #1175-class retained-label work, the changed-method population must include
 the forward-merge / structuring-residual methods the PR changes. A green global

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -311,7 +311,9 @@ milestone.
 Use a separate **Decompiler Adversarial Reviewer** role when the concern is not
 "is the queue metadata honest?" but "is this raise actually sound?" The curator
 keeps the map current; the adversarial reviewer tries to falsify the map's
-claims.
+claims. Pick two reviewers from the model roster in the AGENTS.md
+[Adversarial Review](../AGENTS.md#adversarial-review) section, never your own
+model.
 
 This is different from simply "creating adversarial fixtures." A fixture is one
 artifact the review may produce; the role is the upstream proof audit that


### PR DESCRIPTION
## Summary

- Add **Gemini Pro (e.g. Gemini 3.1 Pro)** to the adversarial-review reviewer roster in `AGENTS.md`, alongside Claude Opus 4.8, GPT-5.5, and the MAI Flash family.
- Mark the `AGENTS.md` "Adversarial Review" section as the single source of truth for the roster; the "pick two, never your own model" rule is unchanged.
- Point scenario docs/agents at that one section instead of restating the models: `docs/decompiler-quality.md`, `docs/decompiler-correctness-pipeline.md`, `agents/ladder-tester.md`.

## Validation

Docs-only, low-risk; no adversarial review needed. `markdownlint` passes on all four changed files.