### PR TITLE
Bound LongestChain so leverage ranking scales to large cyclic assemblies (#1849)

### DIFF
--- a/src/ILInspector.Analysis/MethodLeverage.cs
+++ b/src/ILInspector.Analysis/MethodLeverage.cs
@@ -82,6 +82,11 @@ public static class MethodLeverageRanking
         // fires the value is treated as path-dependent and is not cached.
         var depthCache = new Dictionary<int, int>();
         var onStack = new HashSet<int>();
+        // Cap total chain work: on a cyclic graph (e.g. Roslyn) cut subtrees are uncached, so the
+        // naive per-method DFS is O(methods x graph). The budget bounds it to near-linear; once
+        // exhausted, remaining chains truncate (depth is a coarse leverage cue) and stay uncached.
+        // Deterministic: methods are visited in a fixed order, so the cut-off is reproducible.
+        long chainBudget = 12_000_000;
 
         (int Depth, bool CutCycle) LongestChain(int token, int guard)
         {
@@ -92,7 +97,7 @@ public static class MethodLeverageRanking
                 depthCache[token] = 1;
                 return (1, false);
             }
-            if (guard <= 0 || !onStack.Add(token))
+            if (guard <= 0 || --chainBudget <= 0 || !onStack.Add(token))
                 return (1, true);
 
             int best = 1;


### PR DESCRIPTION
Fixes #1849: `OptimizationOpportunities` timed out (>60s) on the Roslyn C# compiler. Localized to `MethodLeverageRanking.LongestChain` — uncached cut-cycle subtrees cause O(methods × graph) recompute on cyclic graphs. Add a global visit budget (mirrors `ComputeRootReach`); chains truncate when exhausted. CSharp: TopLeverage 1.9s, opps 1.7s (was timeout). Small assemblies never hit the budget; 228 analysis tests green; deterministic cap. The corpus sensor will flip CSharp timeout→measured next rebaseline. Closes #1849