### PR TITLE
Record two-case switch lowering frontier

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -203,7 +203,6 @@ public class GeneratedFixtureCatalogTests
             "Method1",
             FidelityCheck.CompileBackStatus.Exact,
             frontier: false);
-
         Assert.Contains("minimal.property.literal", report);
         Assert.Contains("minimal.primary-ctor.field-init", report);
         Assert.Contains("minimal.ctor-field.getter", report);
@@ -216,6 +215,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.using-dispose", report);
         Assert.Contains("minimal.foreach-array", report);
         Assert.Contains("minimal.switch-int", report);
+        Assert.DoesNotContain("minimal.switch-two-case-lowers-if", report);
         Assert.Contains("decompiler=Full", report);
         Assert.Contains("compile-back=Exact", report);
     }
@@ -239,6 +239,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.property.literal",
                 "minimal.static-method-call",
                 "minimal.switch-int",
+                "minimal.switch-two-case-lowers-if",
                 "minimal.try-finally",
                 "minimal.using-dispose",
             ],
@@ -250,7 +251,7 @@ public class GeneratedFixtureCatalogTests
     [Fact]
     public void CatalogueListJson_ContainsFixtureIdsAndExpectedStatuses()
     {
-        string json = GeneratedFixtureRunner.FormatListJson(GeneratedFixtureCatalog.All);
+        string json = GeneratedFixtureRunner.FormatListJson(GeneratedFixtureCatalog.Catalog);
 
         using var document = JsonDocument.Parse(json);
         var fixtures = document.RootElement.EnumerateArray().ToArray();
@@ -265,6 +266,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.using-dispose");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.foreach-array");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.switch-int");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.switch-two-case-lowers-if");
 
         var primaryCtor = Assert.Single(fixtures,
             fixture => fixture.GetProperty("Id").GetString() == "minimal.primary-ctor.field-init");
@@ -272,6 +274,30 @@ public class GeneratedFixtureCatalogTests
             target => target.GetProperty("Method").GetString() == ".ctor");
         Assert.Equal("Exact", ctor.GetProperty("ExpectedStatus").GetString());
         Assert.False(ctor.GetProperty("IsFrontier").GetBoolean());
+    }
+
+    [Fact]
+    public void CompilerLoweringFrontier_IsSelectableButNotInDefaultRun()
+    {
+        var run = GeneratedFixtureRunner.Run(GeneratedFixtureCatalog.Select("minimal.switch-two-case-lowers-if"));
+        string report = GeneratedFixtureRunner.FormatReport(run);
+
+        Assert.True(run.Passed, report);
+        AssertTarget(
+            run,
+            "minimal.switch-two-case-lowers-if",
+            "GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.switch-two-case-lowers-if",
+            "GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.OpcodeDiff,
+            frontier: true);
+        Assert.Contains("compiler-lowering", GeneratedFixtureCatalog.Frontiers.Single().Tags);
     }
 
     [Fact]

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -298,6 +298,39 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "switch", "int", "branch"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalSwitchTwoCaseLowersIf = new(
+        "minimal.switch-two-case-lowers-if",
+        """
+        namespace GeneratedFixtures.MinimalSwitchTwoCaseLowersIf;
+
+        public class Class1
+        {
+            public string Method1(int value)
+            {
+                switch (value)
+                {
+                    case 0:
+                        return "zero";
+                    case 1:
+                        return "one";
+                    default:
+                        return "many";
+                }
+            }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new(
+                "GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1",
+                "Method1",
+                FidelityCheck.CompileBackStatus.OpcodeDiff,
+                IsFrontier: true,
+                Note: "Current SDK lowers this two-case source switch to if/else; dense minimal.switch-int is the stable switch-statement rung."),
+        ],
+        ["minimal", "switch", "int", "branch", "frontier", "compiler-lowering"]);
+
     public static IReadOnlyList<GeneratedFixtureDefinition> All { get; } =
     [
         MinimalPropertyLiteral,
@@ -314,6 +347,17 @@ internal static class GeneratedFixtureCatalog
         MinimalSwitchInt,
     ];
 
+    public static IReadOnlyList<GeneratedFixtureDefinition> Frontiers { get; } =
+    [
+        MinimalSwitchTwoCaseLowersIf,
+    ];
+
+    public static IReadOnlyList<GeneratedFixtureDefinition> Catalog { get; } =
+    [
+        .. All,
+        .. Frontiers,
+    ];
+
     public static IReadOnlyList<GeneratedFixtureDefinition> MinimalCompileBackRungs => All;
 
     public static IReadOnlyList<GeneratedFixtureDefinition> Select(string? selector)
@@ -321,7 +365,7 @@ internal static class GeneratedFixtureCatalog
         if (string.IsNullOrWhiteSpace(selector))
             return All;
 
-        return All
+        return Catalog
             .Where(fixture => fixture.Id.Equals(selector, StringComparison.Ordinal)
                 || fixture.Id.StartsWith(selector, StringComparison.Ordinal))
             .ToArray();

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -238,9 +238,9 @@ static class Program
         if (selector == "list")
         {
             if (json)
-                Console.WriteLine(GeneratedFixtureRunner.FormatListJson(GeneratedFixtureCatalog.All));
+                Console.WriteLine(GeneratedFixtureRunner.FormatListJson(GeneratedFixtureCatalog.Catalog));
             else
-                Console.Write(GeneratedFixtureRunner.FormatList(GeneratedFixtureCatalog.All));
+                Console.Write(GeneratedFixtureRunner.FormatList(GeneratedFixtureCatalog.Catalog));
             return 0;
         }
 

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -17,9 +17,11 @@ This is the first step toward an addressable progressive fixture ladder:
 `minimal.primary-ctor.field-init` are expected `Exact`; the static-call, if/else,
 null-coalescing, try/finally, using/dispose, and foreach-array rungs extend that
 minimal exact set; `minimal.switch-int` adds the first switch statement rung.
-With no selector, all generated fixtures run; use `list` to list fixture IDs,
-`--json` for machine-readable list/results, and `--keep-generated-fixtures` to
-preserve the generated project for drill-down.
+`minimal.switch-two-case-lowers-if` records the current SDK's two-case
+source-switch lowering observation (lowered as if/else, not the dense switch
+shape) and is opt-in by ID. With no selector, stable generated fixtures run; use
+`list` to list fixture IDs, `--json` for machine-readable list/results, and
+`--keep-generated-fixtures` to preserve the generated project for drill-down.
 
 **Library report** (`--library-report`): a portfolio view. It combines the IR
 residual buckets from `--gaps` with the Roslyn-backed validity oracle from


### PR DESCRIPTION
- Advances #1742
- Changes generated decompiler fixture catalogue coverage only
- Card revision: `efa76fe9`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the catalogue now records the current two-case source-switch lowering observation as an opt-in frontier, without adding compiler-version-sensitive behavior to the default stable ladder.

Before:

```text
minimal.switch-int is the stable dense switch-statement rung.
The two-case source-switch attempt was only tribal knowledge.
```

After:

```text
minimal.switch-two-case-lowers-if is listed and selectable by ID.
Default --generated-fixtures excludes it; explicit selection records .ctor Exact and Method1 OpcodeDiff frontier.
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Decompiler fast suite | Not run; additive generated-fixture catalogue entry only |
| Reduced fixture validity | Not applicable |
| Reduced fixture fidelity | Pass: explicit `minimal.switch-two-case-lowers-if` reports expected `.ctor` Exact / `Method1` OpcodeDiff frontier |
| Real witness | Generated fixture: two-case source switch lowering to if/else under the current SDK |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes; this only adds an opt-in generated fixture catalogue row.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Finding resolved | Initial review warned against putting compiler-lowering observation in default ladder. Moved it to `Frontiers`, visible in list and selectable by ID only. |
| MAI-Code-1-Flash | No blocking findings | Verified explicit frontier behavior and catalogue consistency. |
| Claude Opus 4.8 | No blocking findings | Final review confirmed default exclusion, explicit selection, and list visibility. |
| MAI-Code-1-Flash | No blocking findings | Final review confirmed the isolated frontier shape. |

**Review conclusion:** **PASS** — actionable review guidance was resolved before opening.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.switch-two-case-lowers-if
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
```
