### PR TITLE
Bump version to 0.14.2

### DIFF
--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -24,7 +24,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.14.1</VersionPrefix>
+    <VersionPrefix>0.14.2</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Bumps VersionPrefix 0.14.1 -> 0.14.2 (version only, no code). Ships the Performance Triage row predicates (--loop/--min-confidence/--triage-shape/--top, #1842; validated on Aspire ~15 calls, no jq) + analysis fixture catalogue (#1819) and decompiler fixes since 0.14.1. The external dotnet-allocation-triage skill will be updated to recommend the predicates after publish.