### PR TITLE
Rebaseline analysis corpus: CSharp now measured (was timed out)

### DIFF
--- a/tools/AnalysisHarness/corpus/analysis-baseline.json
+++ b/tools/AnalysisHarness/corpus/analysis-baseline.json
@@ -131,13 +131,23 @@
     },
     {
       "Name": "Microsoft.CodeAnalysis.CSharp.dll",
-      "Opened": false,
-      "TimedOut": true,
-      "Methods": 0,
+      "Opened": true,
+      "TimedOut": false,
+      "Methods": 42120,
       "Diagnostics": 0,
-      "Allocations": 0,
-      "ExceptionConstructions": 0,
-      "Shapes": {}
+      "Allocations": 15310,
+      "ExceptionConstructions": 889,
+      "Shapes": {
+        "allocation-hotspot": 2,
+        "box-value-type": 651,
+        "capturing-delegate": 106,
+        "enumerator-allocation": 20,
+        "instance-method-group-delegate": 118,
+        "linq-scan-in-loop": 4,
+        "scan-method-in-loop-call": 6,
+        "small-array": 2364,
+        "string-build-in-loop": 2
+      }
     },
     {
       "Name": "Microsoft.CodeAnalysis.dll",


### PR DESCRIPTION
After #1851 fixed the leverage `LongestChain` scaling, `Microsoft.CodeAnalysis.CSharp.dll` analyzes in ~2s instead of timing out. Regenerate the committed analysis corpus baseline so it is measured: **42120 methods, 0 diagnostics, 3273 opportunity shapes**. All 14 corpus assemblies now measured, 0 timed out, 0 diagnostics; self-diff clean. This is the deliberate timeout→measured flip the Layer-2 sensor (#1848) recorded as a stable transition. Refs #1818.