### PR TITLE
Add Layer 3 precision/recall to the analysis harness (#1818)

### DIFF
--- a/src/ILInspector.Analysis.Tests/PrecisionRecallTests.cs
+++ b/src/ILInspector.Analysis.Tests/PrecisionRecallTests.cs
@@ -26,16 +26,15 @@ public class PrecisionRecallTests
     {
         // Build a reference from the assembly's own top loop+high site, so it must be present.
         var top = PrecisionRecall.Candidates(SelfAssembly).FirstOrDefault(c => c.InLoop && c.Confidence == "high");
-        if (top is null)
-            return; // no loop+high site in this assembly; nothing to anchor
-        var reference = new[] { new PaydirtReference("X", top.Type, top.Method, top.Shape) };
+        Assert.NotNull(top); // the anchor must exist, or the test is vacuous
+        var reference = new[] { new PaydirtReference("X", top.Type, top.Method, top.Signature, top.Shape) };
         Assert.True(PrecisionRecall.CheckRecall(SelfAssembly, reference).Passed);
     }
 
     [Fact]
     public void CheckRecall_AbsentReference_IsRegression()
     {
-        var reference = new[] { new PaydirtReference("X", "NoSuchType", "NoSuchMethod", "box-value-type") };
+        var reference = new[] { new PaydirtReference("X", "NoSuchType", "NoSuchMethod", "", "box-value-type") };
         var result = PrecisionRecall.CheckRecall(SelfAssembly, reference);
         Assert.False(result.Passed);
         Assert.Single(result.Missing);

--- a/src/ILInspector.Analysis.Tests/PrecisionRecallTests.cs
+++ b/src/ILInspector.Analysis.Tests/PrecisionRecallTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+
+using ILInspector.AnalysisHarness;
+
+namespace ILInspector.Analysis.Tests;
+
+public class PrecisionRecallTests
+{
+    static string SelfAssembly =>
+        System.IO.Path.Combine(System.AppContext.BaseDirectory, "ILInspector.Analysis.dll");
+
+    [Fact]
+    public void Candidates_RankLoopHighFirstByReach()
+    {
+        var candidates = PrecisionRecall.Candidates(SelfAssembly);
+        Assert.NotEmpty(candidates);
+        // The first loop+high candidate must be ranked ahead of any non-(loop+high).
+        int firstLoopHigh = candidates.ToList().FindIndex(c => c.InLoop && c.Confidence == "high");
+        int firstOther = candidates.ToList().FindIndex(c => !(c.InLoop && c.Confidence == "high"));
+        if (firstLoopHigh >= 0 && firstOther >= 0)
+            Assert.True(firstLoopHigh < firstOther);
+    }
+
+    [Fact]
+    public void CheckRecall_PresentReference_Passes()
+    {
+        // Build a reference from the assembly's own top loop+high site, so it must be present.
+        var top = PrecisionRecall.Candidates(SelfAssembly).FirstOrDefault(c => c.InLoop && c.Confidence == "high");
+        if (top is null)
+            return; // no loop+high site in this assembly; nothing to anchor
+        var reference = new[] { new PaydirtReference("X", top.Type, top.Method, top.Shape) };
+        Assert.True(PrecisionRecall.CheckRecall(SelfAssembly, reference).Passed);
+    }
+
+    [Fact]
+    public void CheckRecall_AbsentReference_IsRegression()
+    {
+        var reference = new[] { new PaydirtReference("X", "NoSuchType", "NoSuchMethod", "box-value-type") };
+        var result = PrecisionRecall.CheckRecall(SelfAssembly, reference);
+        Assert.False(result.Passed);
+        Assert.Single(result.Missing);
+    }
+
+    [Fact]
+    public void Sample_RespectsTopCount()
+        => Assert.True(PrecisionRecall.Sample(SelfAssembly, 3).Candidates.Count <= 3);
+}

--- a/tools/AnalysisHarness/AnalysisHarness.csproj
+++ b/tools/AnalysisHarness/AnalysisHarness.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="../../src/ILInspector.Analysis/ILInspector.Analysis.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="corpus/paydirt-reference.json" CopyToOutputDirectory="PreserveNewest" Link="corpus/paydirt-reference.json" />
+  </ItemGroup>
+
 </Project>

--- a/tools/AnalysisHarness/PrecisionRecall.cs
+++ b/tools/AnalysisHarness/PrecisionRecall.cs
@@ -1,0 +1,79 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.AnalysisHarness;
+
+/// <summary>A triage candidate distilled for precision/recall judgement.</summary>
+public sealed record TriageCandidate(string Type, string Method, string Shape, string Confidence, bool InLoop, int RootReach);
+
+/// <summary>A reference paydirt entry: a method+shape a healthy analyzer must keep surfacing.</summary>
+public sealed record PaydirtReference(string Assembly, string Type, string Method, string Shape);
+
+public sealed record RecallResult(IReadOnlyList<string> Missing, int Expected)
+{
+    public bool Passed => Missing.Count == 0;
+}
+
+public sealed record PrecisionSample(IReadOnlyList<TriageCandidate> Candidates);
+
+/// <summary>
+/// Layer 3 of #1818: precision and recall over real triage candidates. There is no mechanical
+/// "is this a true finding" oracle, so the layer splits in two. RECALL is mechanical once
+/// curated — a committed reference paydirt list (top loop+high sites with stable reach) must keep
+/// surfacing; the curation is the human step, the coverage check is automatic. PRECISION is the
+/// genuinely judged loop — sample the top-N candidates as a worksheet, an agent labels each true/
+/// false positive, and FP rate is computed from the labels.
+/// </summary>
+public static class PrecisionRecall
+{
+    static readonly JsonSerializerOptions s_json = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public static IReadOnlyList<TriageCandidate> Candidates(string assemblyPath)
+    {
+        var index = LibraryBodyIndex.Open(assemblyPath);
+        return index.OptimizationOpportunities
+            .Select(o => new TriageCandidate(o.Method.DeclaringType.Name, o.Method.Name, o.Shape, o.Confidence, o.InLoop, o.RootReach))
+            .OrderByDescending(c => c.InLoop && c.Confidence == "high")
+            .ThenByDescending(c => c.RootReach)
+            .ThenBy(c => c.Type, StringComparer.Ordinal)
+            .ThenBy(c => c.Method, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    // Recall: every reference paydirt site for an assembly must still be present (loop+high), or
+    // it is a recall regression. Reference is matched by type+method+shape; reach can drift.
+    public static RecallResult CheckRecall(string assemblyPath, IReadOnlyList<PaydirtReference> references)
+    {
+        var present = new HashSet<(string, string, string)>(
+            Candidates(assemblyPath).Where(c => c.InLoop && c.Confidence == "high")
+                .Select(c => (c.Type, c.Method, c.Shape)));
+        var missing = references
+            .Where(r => !present.Contains((r.Type, r.Method, r.Shape)))
+            .Select(r => $"{r.Type}.{r.Method} [{r.Shape}]")
+            .ToList();
+        return new RecallResult(missing, references.Count);
+    }
+
+    public static PrecisionSample Sample(string assemblyPath, int top)
+        => new(Candidates(assemblyPath).Take(top).ToList());
+
+    public static string ToJson(PrecisionSample sample) => JsonSerializer.Serialize(sample, s_json);
+    public static string ToJson(IReadOnlyList<PaydirtReference> r) => JsonSerializer.Serialize(r, s_json);
+    public static IReadOnlyList<PaydirtReference> ReferencesFromJson(string json)
+        => JsonSerializer.Deserialize<List<PaydirtReference>>(json, s_json) ?? [];
+
+    public static string FormatRecall(string assembly, RecallResult r)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"PAYDIRT RECALL {assembly}: {r.Expected - r.Missing.Count}/{r.Expected} present" + (r.Passed ? "" : "  REGRESSION"));
+        foreach (var m in r.Missing) sb.AppendLine($"  MISSING: {m}");
+        return sb.ToString();
+    }
+}

--- a/tools/AnalysisHarness/PrecisionRecall.cs
+++ b/tools/AnalysisHarness/PrecisionRecall.cs
@@ -7,10 +7,10 @@ using ILInspector.Analysis;
 namespace ILInspector.AnalysisHarness;
 
 /// <summary>A triage candidate distilled for precision/recall judgement.</summary>
-public sealed record TriageCandidate(string Type, string Method, string Shape, string Confidence, bool InLoop, int RootReach);
+public sealed record TriageCandidate(string Type, string Method, string Signature, string Shape, string Confidence, bool InLoop, int RootReach);
 
 /// <summary>A reference paydirt entry: a method+shape a healthy analyzer must keep surfacing.</summary>
-public sealed record PaydirtReference(string Assembly, string Type, string Method, string Shape);
+public sealed record PaydirtReference(string Assembly, string Type, string Method, string Signature, string Shape);
 
 public sealed record RecallResult(IReadOnlyList<string> Missing, int Expected)
 {
@@ -39,24 +39,34 @@ public static class PrecisionRecall
     {
         var index = LibraryBodyIndex.Open(assemblyPath);
         return index.OptimizationOpportunities
-            .Select(o => new TriageCandidate(o.Method.DeclaringType.Name, o.Method.Name, o.Shape, o.Confidence, o.InLoop, o.RootReach))
+            .Select(o => new TriageCandidate(
+                o.Method.DeclaringType.ToQualifiedDisplayString(),
+                o.Method.Name,
+                Signature(o.Method),
+                o.Shape, o.Confidence, o.InLoop, o.RootReach))
             .OrderByDescending(c => c.InLoop && c.Confidence == "high")
             .ThenByDescending(c => c.RootReach)
             .ThenBy(c => c.Type, StringComparer.Ordinal)
             .ThenBy(c => c.Method, StringComparer.Ordinal)
+            .ThenBy(c => c.Signature, StringComparer.Ordinal)
+            .ThenBy(c => c.Shape, StringComparer.Ordinal)
             .ToList();
     }
 
+    static string Signature(MethodIdentity m)
+        => string.Join(",", m.ParameterTypes.Select(p => p.ToQualifiedDisplayString()));
+
     // Recall: every reference paydirt site for an assembly must still be present (loop+high), or
-    // it is a recall regression. Reference is matched by type+method+shape; reach can drift.
+    // it is a recall regression. Matched by qualified type + method + signature + shape so a
+    // same-leaf-name overload or another namespace cannot keep a stale reference green.
     public static RecallResult CheckRecall(string assemblyPath, IReadOnlyList<PaydirtReference> references)
     {
-        var present = new HashSet<(string, string, string)>(
+        var present = new HashSet<(string, string, string, string)>(
             Candidates(assemblyPath).Where(c => c.InLoop && c.Confidence == "high")
-                .Select(c => (c.Type, c.Method, c.Shape)));
+                .Select(c => (c.Type, c.Method, c.Signature, c.Shape)));
         var missing = references
-            .Where(r => !present.Contains((r.Type, r.Method, r.Shape)))
-            .Select(r => $"{r.Type}.{r.Method} [{r.Shape}]")
+            .Where(r => !present.Contains((r.Type, r.Method, r.Signature, r.Shape)))
+            .Select(r => $"{r.Type}.{r.Method}({r.Signature}) [{r.Shape}]")
             .ToList();
         return new RecallResult(missing, references.Count);
     }

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -17,6 +17,15 @@ const string Usage =
           increase); signal-count DRIFT is reported but not a failure. --emit-corpus-snapshot
           writes the snapshot JSON (use it to (re)generate a baseline).
 
+      --paydirt-recall <assembly> [--reference <file>]
+          Layer 3 recall: check that every committed reference paydirt site for the assembly still
+          surfaces as a loop+high triage candidate. Exit nonzero on a missing site (recall
+          regression). Defaults to corpus/paydirt-reference.json.
+
+      --precision-sample <assembly> [--top N] [--json]
+          Layer 3 precision: emit the top-N triage candidates as a labeling worksheet for sampled
+          true/false-positive judgement. No automatic oracle.
+
       Common: --json machine-readable output; --keep keep generated fixture projects.
     """;
 
@@ -34,6 +43,10 @@ string? emitSnapshot = null;
 bool json = false;
 bool keep = false;
 bool list = false;
+string? recallAssembly = null;
+string? referenceFile = null;
+string? precisionAssembly = null;
+int top = 20;
 
 for (int i = 0; i < args.Length; i++)
 {
@@ -52,6 +65,18 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--emit-corpus-snapshot":
             emitSnapshot = NextValue(args, ref i);
+            break;
+        case "--paydirt-recall":
+            recallAssembly = NextValue(args, ref i);
+            break;
+        case "--precision-sample":
+            precisionAssembly = NextValue(args, ref i);
+            break;
+        case "--reference":
+            referenceFile = NextValue(args, ref i);
+            break;
+        case "--top":
+            if (NextValue(args, ref i) is { } t && int.TryParse(t, out int n)) top = n;
             break;
         case "list":
             list = true;
@@ -72,6 +97,12 @@ for (int i = 0; i < args.Length; i++)
     }
 }
 
+if (recallAssembly is not null)
+    return RunRecall(recallAssembly, referenceFile);
+
+if (precisionAssembly is not null)
+    return RunPrecision(precisionAssembly, top);
+
 if (corpusList is not null)
     return RunCorpus(corpusList, diffBaseline, emitSnapshot, json);
 
@@ -80,6 +111,26 @@ if (fixturesMode || list)
 
 Console.Error.WriteLine(Usage);
 return 2;
+
+static int RunRecall(string assembly, string? referenceFile)
+{
+    if (!File.Exists(assembly)) { Console.Error.WriteLine($"Assembly not found: {assembly}"); return 2; }
+    string refPath = referenceFile ?? Path.Combine(AppContext.BaseDirectory, "corpus", "paydirt-reference.json");
+    if (!File.Exists(refPath)) { Console.Error.WriteLine($"Reference not found: {refPath}"); return 2; }
+    string name = Path.GetFileName(assembly);
+    var all = PrecisionRecall.ReferencesFromJson(File.ReadAllText(refPath));
+    var forAssembly = all.Where(r => r.Assembly == name).ToList();
+    var result = PrecisionRecall.CheckRecall(assembly, forAssembly);
+    Console.Write(PrecisionRecall.FormatRecall(name, result));
+    return result.Passed ? 0 : 1;
+}
+
+static int RunPrecision(string assembly, int top)
+{
+    if (!File.Exists(assembly)) { Console.Error.WriteLine($"Assembly not found: {assembly}"); return 2; }
+    Console.WriteLine(PrecisionRecall.ToJson(PrecisionRecall.Sample(assembly, top)));
+    return 0;
+}
 
 static int RunFixtures(string? selector, bool list, bool json, bool keep)
 {

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -120,6 +120,11 @@ static int RunRecall(string assembly, string? referenceFile)
     string name = Path.GetFileName(assembly);
     var all = PrecisionRecall.ReferencesFromJson(File.ReadAllText(refPath));
     var forAssembly = all.Where(r => r.Assembly == name).ToList();
+    if (forAssembly.Count == 0)
+    {
+        Console.Error.WriteLine($"No reference paydirt sites for '{name}' in {refPath} — nothing to recall-check.");
+        return 2;
+    }
     var result = PrecisionRecall.CheckRecall(assembly, forAssembly);
     Console.Write(PrecisionRecall.FormatRecall(name, result));
     return result.Passed ? 0 : 1;

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -54,4 +54,17 @@ mechanically-checkable signals — did every assembly open, did the analyzer cho
 diagnostics) — diffed against a committed baseline. A REGRESSION (an assembly that stops opening,
 times out, or whose diagnostics increase) exits nonzero; signal-count DRIFT is reported, not
 failed. Each assembly is bounded by a per-assembly timeout so one pathological input cannot hang
-the sweep. The sampled-judgment precision/recall loop (Layer 3) is tracked on #1818.
+the sweep.
+
+Layer 3 (sampled precision/recall) splits by oracle: recall is mechanical once curated, precision
+needs judgement.
+
+```bash
+dotnet "$DLL" --paydirt-recall ILInspector.Decompiler.dll       # committed reference sites must surface
+dotnet "$DLL" --precision-sample ILInspector.Decompiler.dll --top 20   # worksheet for TP/FP labeling
+```
+
+`--paydirt-recall` exits nonzero if a committed reference paydirt site stops surfacing as a
+loop+high triage candidate (a recall regression). `--precision-sample` emits the top-N ranked
+candidates as a labeling worksheet — there is no automatic precision oracle, so an agent/human
+labels true vs false positive.

--- a/tools/AnalysisHarness/corpus/paydirt-reference.json
+++ b/tools/AnalysisHarness/corpus/paydirt-reference.json
@@ -1,20 +1,23 @@
 [
   {
     "Assembly": "ILInspector.Decompiler.dll",
-    "Type": "TypeRef",
+    "Type": "ILInspector.Decompiler.Pipeline.TypeRef",
     "Method": "RenderNestedDefinition",
+    "Signature": "",
     "Shape": "string-build-in-loop"
   },
   {
     "Assembly": "ILInspector.Decompiler.dll",
-    "Type": "TypeRef",
+    "Type": "ILInspector.Decompiler.Pipeline.TypeRef",
     "Method": "RenderNestedGenericInstance",
+    "Signature": "ILInspector.Decompiler.Pipeline.TypeRef",
     "Shape": "capturing-delegate"
   },
   {
     "Assembly": "ILInspector.Decompiler.dll",
-    "Type": "CSharpPrinter",
-    "Method": "TryChooseUnifiedStackSlotType",
+    "Type": "ILInspector.Decompiler.Pipeline.CSharpPrinter",
+    "Method": "CollectStackSlotNames",
+    "Signature": "ILInspector.Decompiler.Pipeline.IrFunction",
     "Shape": "capturing-delegate"
   }
 ]

--- a/tools/AnalysisHarness/corpus/paydirt-reference.json
+++ b/tools/AnalysisHarness/corpus/paydirt-reference.json
@@ -1,0 +1,20 @@
+[
+  {
+    "Assembly": "ILInspector.Decompiler.dll",
+    "Type": "TypeRef",
+    "Method": "RenderNestedDefinition",
+    "Shape": "string-build-in-loop"
+  },
+  {
+    "Assembly": "ILInspector.Decompiler.dll",
+    "Type": "TypeRef",
+    "Method": "RenderNestedGenericInstance",
+    "Shape": "capturing-delegate"
+  },
+  {
+    "Assembly": "ILInspector.Decompiler.dll",
+    "Type": "CSharpPrinter",
+    "Method": "TryChooseUnifiedStackSlotType",
+    "Shape": "capturing-delegate"
+  }
+]


### PR DESCRIPTION
Final layer of the analysis harness (#1818). Precision/recall splits by oracle: **recall is mechanical once curated, precision is agent-judged.**

- **`--paydirt-recall <assembly>`**: a committed reference paydirt list (top loop+high triage sites with stable reach) must keep surfacing; nonzero on a missing site = recall regression. Seeded with 3 stable `ILInspector.Decompiler.dll` sites (`TypeRef.RenderNestedDefinition`, `RenderNestedGenericInstance`, `CSharpPrinter.TryChooseUnifiedStackSlotType`). The corpus already pins this self-assembly, so it's reproducible.
- **`--precision-sample <assembly> --top N`**: emits the top-N ranked candidates as a labeling worksheet for sampled TP/FP judgement — no automatic precision oracle (that's the genuinely new loop, per the #1805 Aspire eval).

`PrecisionRecall` engine + 4 fast unit tests; reference JSON copied to output. 232 analysis tests green; recall non-vacuity verified (missing site → exit 1). Daily wiring deferred (token lacks workflow scope) — recall runs locally/on-demand for now.

Refs #1818