### PR TITLE
Extract shared ILInspector.ControlFlow kernel (#1807 phase a)

### DIFF
--- a/src/ILInspector.ControlFlow/BlockEdges.cs
+++ b/src/ILInspector.ControlFlow/BlockEdges.cs
@@ -1,0 +1,15 @@
+namespace ILInspector.ControlFlow;
+
+/// <summary>
+/// One block's outgoing structural control-flow edges. <see cref="Successors"/> are indices
+/// into the same container; <see cref="ExternalTargets"/> are branch target offsets that do not
+/// name a block in this container. A method exit, external target, or EH-survivor terminator is
+/// reported as a flag rather than resolved, so analyses can either bail or route them to a
+/// virtual exit. Shared, IL-representation-agnostic so both the decompiler and the analyzer can
+/// produce edges from their own block models and feed one dominance/dataflow kernel.
+/// </summary>
+public sealed record BlockEdges(
+    IReadOnlyList<int> Successors,
+    IReadOnlyList<int> ExternalTargets,
+    bool ExitsMethod,
+    bool LeavesRegion);

--- a/src/ILInspector.ControlFlow/ILInspector.ControlFlow.csproj
+++ b/src/ILInspector.ControlFlow/ILInspector.ControlFlow.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/src/ILInspector.ControlFlow/PostDominators.cs
+++ b/src/ILInspector.ControlFlow/PostDominators.cs
@@ -1,27 +1,10 @@
-namespace ILInspector.Decompiler.Pipeline;
+namespace ILInspector.ControlFlow;
 
 /// <summary>
-/// Immediate post-dominators over one container's block CFG — the dual of a
-/// dominator tree, and the graph property the structuring redesign needs to name
-/// a common-exit merge the index-range model cannot
-/// (docs/design/control-flow-structuring.md, step 1). Block <c>m</c>
-/// post-dominates block <c>n</c> when every path from <c>n</c> to the method exit
-/// passes through <c>m</c>; the <em>immediate</em> post-dominator is the closest
-/// such block.
-///
-/// <para>It reuses <see cref="Cfg.BlockEdges"/> — the same successor model the
-/// printer's definite-assignment dataflow and <c>--dump --cfg</c> consume — so a
-/// post-dominator computed here can never disagree with them about edges. Every
-/// method-exit terminator (<c>return</c>/<c>throw</c>), every external branch
-/// target, and every EH-survivor (<c>leave</c>/<c>endfinally</c>/<c>endfilter</c>)
-/// is treated as flowing to a single virtual exit, so the analysis is rooted even
-/// when a container has several real exits. Immediate post-dominators come from
-/// the Cooper–Harvey–Kennedy iterative fixpoint ("A Simple, Fast Dominance
-/// Algorithm") run on the reverse CFG.</para>
-///
-/// <para>This is pure analysis: nothing consumes it yet. A block that cannot
-/// reach the exit (an endless loop with no way out) has <see cref="None"/> as its
-/// immediate post-dominator rather than throwing.</para>
+/// Immediate post-dominators over one container's block CFG (dual of a dominator tree),
+/// from the Cooper-Harvey-Kennedy iterative fixpoint on the reverse CFG with a single virtual
+/// exit. Pure analysis over <see cref="BlockEdges"/>; produce dominators by passing reversed
+/// edges. Shared kernel: no dependency on any IL representation.
 /// </summary>
 public sealed class PostDominators
 {
@@ -80,9 +63,7 @@ public sealed class PostDominators
         return false;
     }
 
-    public static PostDominators Of(IReadOnlyList<Block> blocks) => Of(Cfg.Build(blocks));
-
-    public static PostDominators Of(IReadOnlyList<Cfg.BlockEdges> edges)
+    public static PostDominators Of(IReadOnlyList<BlockEdges> edges)
     {
         int n = edges.Count;
         int exit = n;             // the virtual exit shares the index space after the blocks

--- a/src/ILInspector.Decompiler.Tests/PostDominatorsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PostDominatorsTests.cs
@@ -1,3 +1,4 @@
+using ILInspector.ControlFlow;
 using ILInspector.Decompiler.Pipeline;
 
 namespace ILInspector.Decompiler.Tests;
@@ -31,7 +32,7 @@ public class PostDominatorsTests
             Term(3, new Return(null)),
         };
 
-        var pdom = PostDominators.Of(blocks);
+        var pdom = PostDominators.Of(Cfg.Build(blocks));
 
         Assert.Equal(3, pdom.ImmediatePostDominator(0));  // the merge post-dominates the split
         Assert.Equal(3, pdom.ImmediatePostDominator(1));
@@ -62,7 +63,7 @@ public class PostDominatorsTests
             Term(5, new Return(null)),
         };
 
-        var pdom = PostDominators.Of(blocks);
+        var pdom = PostDominators.Of(Cfg.Build(blocks));
 
         Assert.Equal(5, pdom.ImmediatePostDominator(0));  // the acceptance bar
         Assert.Equal(5, pdom.ImmediatePostDominator(1));
@@ -86,7 +87,7 @@ public class PostDominatorsTests
             Term(2, new Return(null)),
         };
 
-        var pdom = PostDominators.Of(blocks);
+        var pdom = PostDominators.Of(Cfg.Build(blocks));
 
         Assert.Equal(PostDominators.VirtualExit, pdom.ImmediatePostDominator(0));
         Assert.Equal(PostDominators.VirtualExit, pdom.ImmediatePostDominator(1));
@@ -107,7 +108,7 @@ public class PostDominatorsTests
             Term(2, new Return(null)),
         };
 
-        var pdom = PostDominators.Of(blocks);
+        var pdom = PostDominators.Of(Cfg.Build(blocks));
 
         Assert.Equal(PostDominators.None, pdom.ImmediatePostDominator(1));
         Assert.Equal(2, pdom.ImmediatePostDominator(0));   // the only exit path is through B2
@@ -131,7 +132,7 @@ public class PostDominatorsTests
             Term(2, new Return(null)),
         };
 
-        var pdom = PostDominators.Of(blocks);
+        var pdom = PostDominators.Of(Cfg.Build(blocks));
 
         // The body's only path to the exit is back through the header, then B2.
         Assert.Equal(0, pdom.ImmediatePostDominator(1));
@@ -153,7 +154,7 @@ public class PostDominatorsTests
             Term(2, new Return(null)),
         };
 
-        var pdom = PostDominators.Of(blocks);
+        var pdom = PostDominators.Of(Cfg.Build(blocks));
 
         Assert.True(pdom.PostDominates(postDominator: 0, block: 0));
         Assert.True(pdom.PostDominates(postDominator: 2, block: 1));

--- a/src/ILInspector.Decompiler/ILInspector.Decompiler.csproj
+++ b/src/ILInspector.Decompiler/ILInspector.Decompiler.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
+    <ProjectReference Include="..\ILInspector.ControlFlow\ILInspector.ControlFlow.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ILInspector.Decompiler/Pipeline/Cfg.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Cfg.cs
@@ -1,3 +1,5 @@
+using ILInspector.ControlFlow;
+
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
@@ -13,16 +15,6 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 public static class Cfg
 {
-    /// <summary>
-    /// One block's outgoing edges. <paramref name="Successors"/> are indices
-    /// into the same container; <paramref name="ExternalTargets"/> are branch
-    /// target offsets that do not name a block in this container.
-    /// </summary>
-    public sealed record BlockEdges(
-        IReadOnlyList<int> Successors,
-        IReadOnlyList<int> ExternalTargets,
-        bool ExitsMethod,
-        bool LeavesRegion);
 
     public static IReadOnlyList<BlockEdges> Build(IReadOnlyList<Block> blocks)
     {

--- a/src/ILInspector.Decompiler/Pipeline/CfgMermaid.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CfgMermaid.cs
@@ -1,3 +1,4 @@
+using ILInspector.ControlFlow;
 using System.Text;
 
 namespace ILInspector.Decompiler.Pipeline;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
@@ -1,3 +1,4 @@
+using ILInspector.ControlFlow;
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>

--- a/tools/DecompilerHarness/PostDomProbe.cs
+++ b/tools/DecompilerHarness/PostDomProbe.cs
@@ -1,3 +1,4 @@
+using ILInspector.ControlFlow;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 
@@ -191,7 +192,7 @@ static class PostDomProbe
                 if (offsetToIndex.TryGetValue(target, out int ti) && ti <= i)
                     return MergeShape.Loop;
 
-        var pd = PostDominators.Of(blocks);
+        var pd = PostDominators.Of(Cfg.Build(blocks));
 
         // Each residual conditional's region is the half-open span [decision, join)
         // from the branch block to its immediate post-dominator. Crossing spans are
@@ -277,7 +278,7 @@ static class PostDomProbe
         var offsetToIndex = new Dictionary<int, int>();
         for (int i = 0; i < blocks.Count; i++)
             offsetToIndex[blocks[i].StartOffset] = i;
-        var pd = PostDominators.Of(blocks);
+        var pd = PostDominators.Of(Cfg.Build(blocks));
 
         var lines = new List<string>
         {

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -1,3 +1,4 @@
+using ILInspector.ControlFlow;
 using System.Collections.Concurrent;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -1028,7 +1029,7 @@ static class Program
             ? MetadataSource.OpenWithoutSymbols(assemblyPath, context: metadata)
             : MetadataSource.Open(assemblyPath, context: metadata);
 
-    static string Succs(IReadOnlyList<Block> blocks, Cfg.BlockEdges edges)
+    static string Succs(IReadOnlyList<Block> blocks, BlockEdges edges)
     {
         var parts = new List<string>();
         foreach (int s in edges.Successors)


### PR DESCRIPTION
Phase (a) of #1807: extract BlockEdges + the Cooper-Harvey-Kennedy PostDominators kernel into a new low-level ILInspector.ControlFlow lib (depends on neither decompiler nor analyzer). Decompiler keeps Cfg.Build(Block[]) -> ControlFlow.BlockEdges; analyzer can feed the same kernel in phase (b) for linq-materialize-in-loop hoistability. Pure extraction, no behavior change: PostDominators (6) + CfgMermaid tests pass, build green. First consumer is materialize-hoistability, validated on the #1818 corpus sensor.