### PR TITLE
Retry transient empty compile-back emits

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckRetryTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckRetryTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Immutable;
+
+using ILInspector.DecompilerHarness;
+
+using Microsoft.CodeAnalysis;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class FidelityCheckRetryTests
+{
+    [Fact]
+    public void TransientEmptyEmit_RetriesAndStopsOnSuccess()
+    {
+        var attempts = FidelityCheck.TransientEmptyEmitAttemptCount(attempt =>
+            attempt == 1
+                ? new FidelityCheck.EmitAttempt(false, 0, ImmutableArray<Diagnostic>.Empty)
+                : new FidelityCheck.EmitAttempt(true, 128, ImmutableArray<Diagnostic>.Empty));
+
+        Assert.Equal(2, attempts);
+    }
+
+    [Fact]
+    public void CompilerErrorEmit_DoesNotRetry()
+    {
+        var attempts = FidelityCheck.TransientEmptyEmitAttemptCount(_ =>
+            new FidelityCheck.EmitAttempt(false, 0, ImmutableArray.Create(ErrorDiagnostic("CS1002"))));
+
+        Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public void PersistentTransientEmptyEmit_IsBounded()
+    {
+        var attempts = FidelityCheck.TransientEmptyEmitAttemptCount(_ =>
+            new FidelityCheck.EmitAttempt(false, 0, ImmutableArray<Diagnostic>.Empty));
+
+        Assert.Equal(3, attempts);
+    }
+
+    static Diagnostic ErrorDiagnostic(string id)
+        => Diagnostic.Create(
+            new DiagnosticDescriptor(
+                id,
+                "compile error",
+                "compile error",
+                "test",
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true),
+            Location.None);
+}

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -11,6 +11,7 @@ using ILInspector.Metadata;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
 
 namespace ILInspector.DecompilerHarness;
 
@@ -33,6 +34,8 @@ namespace ILInspector.DecompilerHarness;
 /// </summary>
 static class FidelityCheck
 {
+    const int MaxTransientEmptyEmitAttempts = 3;
+
     // The render path for one source: the lowered view, or the shipped raised
     // view with the cross-method import seam bound (so lambda raising can reach
     // a synthesized body in the same module). The lowered view carries no seam
@@ -1053,7 +1056,7 @@ static class FidelityCheck
         var tree = CSharpSyntaxTree.ParseText(unit, parseOptions);
         var comp = CSharpCompilation.Create("cb", [tree], references.Metadata, compileOptions);
         using var ms = new MemoryStream();
-        if (!comp.Emit(ms).Success)
+        if (!EmitWithTransientEmptyOutputRetry(comp, ms).Success)
             return false;
 
         ms.Position = 0;
@@ -1083,7 +1086,7 @@ static class FidelityCheck
         var tree = CSharpSyntaxTree.ParseText(unit, parseOptions);
         var comp = CSharpCompilation.Create("cb", [tree], references.Metadata, compileOptions);
         using var ms = new MemoryStream();
-        var emit = comp.Emit(ms);
+        var emit = EmitWithTransientEmptyOutputRetry(comp, ms);
         if (!emit.Success)
         {
             var err = emit.Diagnostics.FirstOrDefault(d => d.Severity == DiagnosticSeverity.Error);
@@ -1192,7 +1195,7 @@ static class FidelityCheck
             var tree = CSharpSyntaxTree.ParseText(unit, parseOptions);
             var comp = CSharpCompilation.Create("cb", [tree], references.Metadata, compileOptions);
             using var ms = new MemoryStream();
-            var emit = comp.Emit(ms);
+            var emit = EmitWithTransientEmptyOutputRetry(comp, ms);
             if (emit.Success)
             {
                 ms.Position = 0;
@@ -1248,6 +1251,39 @@ static class FidelityCheck
         }
         return null; // fall back to the whole-module build
     }
+
+    internal readonly record struct EmitAttempt(bool Success, long OutputLength, ImmutableArray<Diagnostic> Diagnostics);
+
+    internal static int TransientEmptyEmitAttemptCount(Func<int, EmitAttempt> emitAttempt)
+    {
+        for (int attempt = 1; ; attempt++)
+        {
+            var result = emitAttempt(attempt);
+            if (result.Success || !IsTransientEmptyEmitFailure(result) || attempt >= MaxTransientEmptyEmitAttempts)
+                return attempt;
+        }
+    }
+
+    static EmitResult EmitWithTransientEmptyOutputRetry(CSharpCompilation compilation, MemoryStream output)
+    {
+        EmitResult? result = null;
+        TransientEmptyEmitAttemptCount(_ =>
+        {
+            output.SetLength(0);
+            output.Position = 0;
+            result = compilation.Emit(output);
+            return new EmitAttempt(result.Success, output.Length, result.Diagnostics);
+        });
+        return result ?? throw new InvalidOperationException("Compilation emit did not run.");
+    }
+
+    // Retry only the observed host/resource flake signature: Roslyn reports failure before
+    // writing any PE bytes and without a compiler error. Real source/skeleton regressions
+    // carry CS diagnostics and must fail on the first attempt.
+    static bool IsTransientEmptyEmitFailure(EmitAttempt result)
+        => !result.Success
+           && result.OutputLength == 0
+           && !result.Diagnostics.Any(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
 
     /// <summary>The top-level type a (possibly nested) type definition belongs to.</summary>
     static TypeDefinitionHandle TopLevelRootOf(MetadataReader reader, TypeDefinitionHandle handle)


### PR DESCRIPTION
## Summary

Fixes #1785 by adding a bounded retry at the decompiler compile-back Roslyn emit boundary for the observed transient host/resource signature: failed emit, zero output bytes, and no compiler error diagnostics.

The retry is intentionally narrow:

- applies only inside `FidelityCheck` grouped, single-method, and cluster compile-back emits
- does not retry validity/type-bind/harness-wide test steps
- does not retry deterministic compiler errors with CS diagnostics
- leaves opcode diffs and real source/skeleton regressions as failures

## Validation

- `dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*FidelityCheckRetryTests*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`

## Baseline note

`SkeletonEmitTests.SkeletonCompilesPastExplicitImplAndConstEnum` currently fails on both this branch and `origin/main` with `CS0631: ref and out are not valid in this context`. The retry does not mask that deterministic compiler error because it carries a CS diagnostic and is not the transient empty-output signature.

## Adversarial review

Requested from Claude Opus 4.8 and Gemini 3.1 Pro; reconciliation will be posted before merge readiness.
