### PR TITLE
Add minimal for-loop generated fixture rung

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -191,6 +191,20 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.for-loop",
+            "GeneratedFixtures.MinimalForLoop.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.for-loop",
+            "GeneratedFixtures.MinimalForLoop.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.switch-int",
             "GeneratedFixtures.MinimalSwitchInt.Class1",
             ".ctor",
@@ -214,6 +228,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.try-finally", report);
         Assert.Contains("minimal.using-dispose", report);
         Assert.Contains("minimal.foreach-array", report);
+        Assert.Contains("minimal.for-loop", report);
         Assert.Contains("minimal.switch-int", report);
         Assert.DoesNotContain("minimal.switch-two-case-lowers-if", report);
         Assert.Contains("decompiler=Full", report);
@@ -231,6 +246,7 @@ public class GeneratedFixtureCatalogTests
             [
                 "minimal.auto-property.getter",
                 "minimal.ctor-field.getter",
+                "minimal.for-loop",
                 "minimal.foreach-array",
                 "minimal.if-else",
                 "minimal.method-call.same-type",
@@ -265,6 +281,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.try-finally");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.using-dispose");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.foreach-array");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.for-loop");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.switch-int");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.switch-two-case-lowers-if");
 

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -265,6 +265,30 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "foreach", "array", "loop"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalForLoop = new(
+        "minimal.for-loop",
+        """
+        namespace GeneratedFixtures.MinimalForLoop;
+
+        public class Class1
+        {
+            public int Method1(int count)
+            {
+                var sum = 0;
+                for (var i = 0; i < count; i++)
+                    sum += i;
+                return sum;
+            }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalForLoop.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalForLoop.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "for", "loop"]);
+
     public static readonly GeneratedFixtureDefinition MinimalSwitchInt = new(
         "minimal.switch-int",
         """
@@ -344,6 +368,7 @@ internal static class GeneratedFixtureCatalog
         MinimalTryFinally,
         MinimalUsingDispose,
         MinimalForeachArray,
+        MinimalForLoop,
         MinimalSwitchInt,
     ];
 

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -15,8 +15,9 @@ This is the first step toward an addressable progressive fixture ladder:
 `minimal.property.literal`, `minimal.ctor-field.getter`,
 `minimal.auto-property.getter`, `minimal.method-call.same-type`, and
 `minimal.primary-ctor.field-init` are expected `Exact`; the static-call, if/else,
-null-coalescing, try/finally, using/dispose, and foreach-array rungs extend that
-minimal exact set; `minimal.switch-int` adds the first switch statement rung.
+null-coalescing, try/finally, using/dispose, foreach-array, and for-loop rungs
+extend that minimal exact set; `minimal.switch-int` adds the first switch
+statement rung.
 `minimal.switch-two-case-lowers-if` records the current SDK's two-case
 source-switch lowering observation (lowered as if/else, not the dense switch
 shape) and is opt-in by ID. With no selector, stable generated fixtures run; use


### PR DESCRIPTION
- Advances #1742
- Changes generated decompiler fixture catalogue coverage only
- Card revision: `856c39f4`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated fixture ladder gains a for-loop rung and it is opcode-exact.

Before:

```text
minimal generated fixture catalogue: 13 fixtures / 28 targets
```

After:

```text
minimal generated fixture catalogue: 14 fixtures / 30 targets
new exact rung: minimal.for-loop
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Decompiler fast suite | Not run; additive generated-fixture catalogue entry only |
| Reduced fixture validity | Not applicable |
| Reduced fixture fidelity | Pass: `minimal.for-loop` reports `Exact` for `.ctor` and `Method1` |
| Real witness | Generated fixture: count-controlled `for` loop accumulating a sum |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes; this only adds a generated fixture catalogue row.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked exactness, target names, selector/list behavior, and README accuracy. |
| MAI-Code-1-Flash | No blocking findings | Verified the compile-back oracle reports exact for the for-loop shape. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.for-loop
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
```
