### PR TITLE
Wire analysis paydirt recall daily

### DIFF
--- a/.github/workflows/decompiler-daily.yml
+++ b/.github/workflows/decompiler-daily.yml
@@ -90,6 +90,14 @@ jobs:
             --emit-corpus-snapshot artifacts/analysis-daily/analysis-corpus-snapshot.json \
             --diff-corpus-baseline tools/AnalysisHarness/corpus/analysis-baseline.json
 
+      # Analysis recall gate (#1818, Layer 3): curated paydirt sites are a
+      # mechanical oracle once selected. Keep this daily/manual, not PR CI.
+      - name: Run analysis paydirt recall
+        run: |
+          dotnet run --project tools/AnalysisHarness -c Release -- \
+            --paydirt-recall artifacts/bin/ILInspector.Decompiler/release/ILInspector.Decompiler.dll \
+            --reference tools/AnalysisHarness/corpus/paydirt-reference.json
+
       - name: Upload corpus snapshot
         if: always()
         uses: actions/upload-artifact@v7

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -68,3 +68,8 @@ dotnet "$DLL" --precision-sample ILInspector.Decompiler.dll --top 20   # workshe
 loop+high triage candidate (a recall regression). `--precision-sample` emits the top-N ranked
 candidates as a labeling worksheet — there is no automatic precision oracle, so an agent/human
 labels true vs false positive.
+
+The daily workflow runs the generated-fixture catalogue, corpus stability sensor, and paydirt
+recall gate. The remaining non-mechanical #1818 work is the precision-labeling convention: who
+labels `--precision-sample` worksheets, where labels live, and what false-positive-rate bar turns
+the worksheet into a maintained quality signal.


### PR DESCRIPTION
## Summary

Shrinks the remaining mechanical #1818 work by wiring Layer 3 recall into the existing daily/manual analysis lane:

- adds `tools/AnalysisHarness --paydirt-recall` to `decompiler-daily.yml`
- keeps it out of PR CI; it only runs on schedule / workflow_dispatch
- documents that generated fixtures, corpus stability, and paydirt recall are now daily-covered
- leaves the precision-labeling convention as the remaining non-mechanical #1818 work

## Validation

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet build tools/AnalysisHarness -c Release`
- `dotnet run --project tools/AnalysisHarness -c Release -- --paydirt-recall artifacts/bin/ILInspector.Decompiler/release/ILInspector.Decompiler.dll --reference tools/AnalysisHarness/corpus/paydirt-reference.json` → `3/3 present`
- `npx markdownlint-cli tools/AnalysisHarness/README.md`
- `dotnet build src/ILInspector.Analysis.Tests -c Release`
- `dotnet artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tests.dll -method "*PrecisionRecall*"`

## Adversarial review

- Claude Opus 4.8: no blockers. Confirmed workflow ordering/path, no PR CI cost, explicit reference path, and README scope.
- Gemini 3.1 Pro: no blockers. Confirmed artifacts path casing, scheduled/manual isolation, copied default reference robustness, and README accuracy.
