### PR TITLE
Add minimal while-loop generated fixture rung

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -205,6 +205,20 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.while-loop",
+            "GeneratedFixtures.MinimalWhileLoop.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.while-loop",
+            "GeneratedFixtures.MinimalWhileLoop.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.switch-int",
             "GeneratedFixtures.MinimalSwitchInt.Class1",
             ".ctor",
@@ -229,6 +243,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.using-dispose", report);
         Assert.Contains("minimal.foreach-array", report);
         Assert.Contains("minimal.for-loop", report);
+        Assert.Contains("minimal.while-loop", report);
         Assert.Contains("minimal.switch-int", report);
         Assert.DoesNotContain("minimal.switch-two-case-lowers-if", report);
         Assert.Contains("decompiler=Full", report);
@@ -258,6 +273,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.switch-two-case-lowers-if",
                 "minimal.try-finally",
                 "minimal.using-dispose",
+                "minimal.while-loop",
             ],
             GeneratedFixtureCatalog.Select("minimal").Select(fixture => fixture.Id).Order(StringComparer.Ordinal).ToArray());
 
@@ -282,6 +298,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.using-dispose");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.foreach-array");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.for-loop");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.while-loop");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.switch-int");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.switch-two-case-lowers-if");
 

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -275,8 +275,8 @@ internal static class GeneratedFixtureCatalog
             public int Method1(int count)
             {
                 var sum = 0;
-                for (  i < count; i++)
-                    sum += count;
+                for (var i = 0; i < count; i++)
+                    sum += i;
                 return sum;
             }
         }
@@ -299,7 +299,6 @@ internal static class GeneratedFixtureCatalog
             public int Method1(int count)
             {
                 var sum = 0;
-                 
                 while (count > 0)
                 {
                     sum += count;

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -275,8 +275,8 @@ internal static class GeneratedFixtureCatalog
             public int Method1(int count)
             {
                 var sum = 0;
-                for (var i = 0; i < count; i++)
-                    sum += i;
+                for (  i < count; i++)
+                    sum += count;
                 return sum;
             }
         }
@@ -288,6 +288,34 @@ internal static class GeneratedFixtureCatalog
                 FidelityCheck.CompileBackStatus.Exact),
         ],
         ["minimal", "for", "loop"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalWhileLoop = new(
+        "minimal.while-loop",
+        """
+        namespace GeneratedFixtures.MinimalWhileLoop;
+
+        public class Class1
+        {
+            public int Method1(int count)
+            {
+                var sum = 0;
+                 
+                while (count > 0)
+                {
+                    sum += count;
+                    count--;
+                }
+                return sum;
+            }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalWhileLoop.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalWhileLoop.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "while", "loop"]);
 
     public static readonly GeneratedFixtureDefinition MinimalSwitchInt = new(
         "minimal.switch-int",
@@ -369,6 +397,7 @@ internal static class GeneratedFixtureCatalog
         MinimalUsingDispose,
         MinimalForeachArray,
         MinimalForLoop,
+        MinimalWhileLoop,
         MinimalSwitchInt,
     ];
 

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -15,8 +15,8 @@ This is the first step toward an addressable progressive fixture ladder:
 `minimal.property.literal`, `minimal.ctor-field.getter`,
 `minimal.auto-property.getter`, `minimal.method-call.same-type`, and
 `minimal.primary-ctor.field-init` are expected `Exact`; the static-call, if/else,
-null-coalescing, try/finally, using/dispose, foreach-array, and for-loop rungs
-extend that minimal exact set; `minimal.switch-int` adds the first switch
+null-coalescing, try/finally, using/dispose, foreach-array, for-loop, and
+while-loop rungs extend that minimal exact set; `minimal.switch-int` adds the first switch
 statement rung.
 `minimal.switch-two-case-lowers-if` records the current SDK's two-case
 source-switch lowering observation (lowered as if/else, not the dense switch


### PR DESCRIPTION
- Advances #1742
- Changes generated decompiler fixture catalogue coverage only
- Card revision: `e63108fa`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated fixture ladder gains a while-loop rung and it is opcode-exact while preserving a real `while` in product output.

Before:

```text
minimal generated fixture catalogue: 14 fixtures / 30 targets
```

After:

```text
minimal generated fixture catalogue: 15 fixtures / 32 targets
new exact rung: minimal.while-loop
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Decompiler fast suite | Not run; additive generated-fixture catalogue entry only |
| Reduced fixture validity | Not applicable |
| Reduced fixture fidelity | Pass: `minimal.while-loop` reports `Exact` for `.ctor` and `Method1` |
| Shape dump | Pass: shipped product output for `Method1` contains `while (count > 0)` |
| Real witness | Generated fixture: count-controlled `while` loop accumulating a sum |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes; this only adds a generated fixture catalogue row.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked exactness, target names, selector/list behavior, and README accuracy. |
| Gemini 3.1 Pro | Fixed finding | Found the first candidate was raised to `for` and was only opcode-equivalent; fixed in `e63108fa` by using a while-preserving source shape and confirming the dump emits `while`. |

**Review conclusion:** **PASS** — the actionable Gemini finding was fixed; no findings remain open.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.for-loop
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.while-loop
dotnet run --project tools/DecompilerHarness -c Release --no-build -- /tmp/dotnet-inspect-generated-fixtures/c96070de1bd64dce8265523313af60cf/bin/Release/net11.0/GeneratedDecompilerFixtures.dll --dump 'GeneratedFixtures.MinimalWhileLoop.Class1::Method1'
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
git diff --check
```
