### PR TITLE
Add minimal do-while generated fixture rung

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -219,6 +219,20 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.do-while",
+            "GeneratedFixtures.MinimalDoWhileLoop.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.do-while",
+            "GeneratedFixtures.MinimalDoWhileLoop.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.switch-int",
             "GeneratedFixtures.MinimalSwitchInt.Class1",
             ".ctor",
@@ -244,6 +258,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.foreach-array", report);
         Assert.Contains("minimal.for-loop", report);
         Assert.Contains("minimal.while-loop", report);
+        Assert.Contains("minimal.do-while", report);
         Assert.Contains("minimal.switch-int", report);
         Assert.DoesNotContain("minimal.switch-two-case-lowers-if", report);
         Assert.Contains("decompiler=Full", report);
@@ -261,6 +276,7 @@ public class GeneratedFixtureCatalogTests
             [
                 "minimal.auto-property.getter",
                 "minimal.ctor-field.getter",
+                "minimal.do-while",
                 "minimal.for-loop",
                 "minimal.foreach-array",
                 "minimal.if-else",
@@ -299,6 +315,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.foreach-array");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.for-loop");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.while-loop");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.do-while");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.switch-int");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.switch-two-case-lowers-if");
 

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -316,6 +316,34 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "while", "loop"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalDoWhileLoop = new(
+        "minimal.do-while",
+        """
+        namespace GeneratedFixtures.MinimalDoWhileLoop;
+
+        public class Class1
+        {
+            public int Method1(int count)
+            {
+                var sum = 0;
+                do
+                {
+                    sum += count;
+                    count--;
+                }
+                while (count > 0);
+                return sum;
+            }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalDoWhileLoop.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalDoWhileLoop.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "do-while", "loop"]);
+
     public static readonly GeneratedFixtureDefinition MinimalSwitchInt = new(
         "minimal.switch-int",
         """
@@ -397,6 +425,7 @@ internal static class GeneratedFixtureCatalog
         MinimalForeachArray,
         MinimalForLoop,
         MinimalWhileLoop,
+        MinimalDoWhileLoop,
         MinimalSwitchInt,
     ];
 

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -15,9 +15,9 @@ This is the first step toward an addressable progressive fixture ladder:
 `minimal.property.literal`, `minimal.ctor-field.getter`,
 `minimal.auto-property.getter`, `minimal.method-call.same-type`, and
 `minimal.primary-ctor.field-init` are expected `Exact`; the static-call, if/else,
-null-coalescing, try/finally, using/dispose, foreach-array, for-loop, and
-while-loop rungs extend that minimal exact set; `minimal.switch-int` adds the first switch
-statement rung.
+null-coalescing, try/finally, using/dispose, foreach-array, for-loop,
+while-loop, and do-while rungs extend that minimal exact set;
+`minimal.switch-int` adds the first switch statement rung.
 `minimal.switch-two-case-lowers-if` records the current SDK's two-case
 source-switch lowering observation (lowered as if/else, not the dense switch
 shape) and is opt-in by ID. With no selector, stable generated fixtures run; use


### PR DESCRIPTION
- Advances #1742
- Changes generated decompiler fixture catalogue coverage only
- Card revision: `7748388f`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated fixture ladder gains a do-while rung and it is opcode-exact while preserving a real `do`/`while` in product output.

Before:

```text
minimal generated fixture catalogue: 15 fixtures / 32 targets
```

After:

```text
minimal generated fixture catalogue: 16 fixtures / 34 targets
new exact rung: minimal.do-while
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Decompiler fast suite | Not run; additive generated-fixture catalogue entry only |
| Reduced fixture validity | Not applicable |
| Reduced fixture fidelity | Pass: `minimal.do-while` reports `Exact` for `.ctor` and `Method1` |
| Shape dump | Pass: shipped product output for `Method1` contains `do { ... } while (count > 0);` |
| Real witness | Generated fixture: bottom-tested `do`/`while` loop accumulating a sum |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes; this only adds a generated fixture catalogue row.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked exactness, product shape dump, target names, selector/list behavior, and README accuracy. |
| Gemini 3.1 Pro | No blocking findings | Checked exactness, distinct bottom-tested loop shape, target names, catalogue membership, tests, and README accuracy. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.do-while --keep-generated-fixtures
dotnet run --project tools/DecompilerHarness -c Release --no-build -- /tmp/dotnet-inspect-generated-fixtures/35c16da703af4131ad2977444c31c3f6/bin/Release/net11.0/GeneratedDecompilerFixtures.dll --dump 'GeneratedFixtures.MinimalDoWhileLoop.Class1::Method1'
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
git diff --check
```
