### PR TITLE
Add minimal array-length generated fixture rung

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -149,6 +149,20 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.array-length",
+            "GeneratedFixtures.MinimalArrayLength.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.array-length",
+            "GeneratedFixtures.MinimalArrayLength.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.null-coalesce",
             "GeneratedFixtures.MinimalNullCoalesce.Class1",
             ".ctor",
@@ -267,6 +281,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.static-method-call", report);
         Assert.Contains("minimal.if-else", report);
         Assert.Contains("minimal.array-index", report);
+        Assert.Contains("minimal.array-length", report);
         Assert.Contains("minimal.null-coalesce", report);
         Assert.Contains("minimal.try-finally", report);
         Assert.Contains("minimal.using-dispose", report);
@@ -290,6 +305,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Equal(
             [
                 "minimal.array-index",
+                "minimal.array-length",
                 "minimal.auto-property.getter",
                 "minimal.ctor-field.getter",
                 "minimal.do-while",
@@ -326,6 +342,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.static-method-call");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-index");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-length");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.null-coalesce");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.try-finally");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.using-dispose");

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -189,6 +189,24 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "array", "index"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalArrayLength = new(
+        "minimal.array-length",
+        """
+        namespace GeneratedFixtures.MinimalArrayLength;
+
+        public class Class1
+        {
+            public int Method1(int[] values) => values.Length;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalArrayLength.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalArrayLength.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "array", "length"]);
+
     public static readonly GeneratedFixtureDefinition MinimalNullCoalesce = new(
         "minimal.null-coalesce",
         """
@@ -438,6 +456,7 @@ internal static class GeneratedFixtureCatalog
         MinimalStaticMethodCall,
         MinimalIfElse,
         MinimalArrayIndex,
+        MinimalArrayLength,
         MinimalNullCoalesce,
         MinimalTryFinally,
         MinimalUsingDispose,

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -15,7 +15,7 @@ This is the first step toward an addressable progressive fixture ladder:
 `minimal.property.literal`, `minimal.ctor-field.getter`,
 `minimal.auto-property.getter`, `minimal.method-call.same-type`, and
 `minimal.primary-ctor.field-init` are expected `Exact`; the static-call, if/else,
-array-index, null-coalescing, try/finally, using/dispose, foreach-array,
+array-index, array-length, null-coalescing, try/finally, using/dispose, foreach-array,
 for-loop, while-loop, and do-while rungs extend that minimal exact set;
 `minimal.switch-int` adds the first switch statement rung.
 `minimal.switch-two-case-lowers-if` records the current SDK's two-case


### PR DESCRIPTION
- Advances #1742
- Changes generated decompiler fixture catalogue coverage only
- Card revision: `be9d2667`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated fixture ladder gains an array-length rung, and it is opcode-exact while preserving `values.Length` in product output.

Before:

```text
minimal generated fixture catalogue: 17 fixtures / 36 targets
```

After:

```text
minimal generated fixture catalogue: 18 fixtures / 38 targets
new exact rung: minimal.array-length
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Decompiler fast suite | Not run; additive generated-fixture catalogue entry only |
| Reduced fixture validity | Not applicable |
| Reduced fixture fidelity | Pass: `minimal.array-length` reports `Exact` for `.ctor` and `Method1` |
| Shape dump | Pass: shipped product output for `Method1` is `return values.Length;` |
| Real witness | Generated fixture: parameterized array length read |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes; this only adds a generated fixture catalogue row.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked exactness, product shape dump, target names, catalogue placement, tests, README accuracy, and non-redundancy with array-index. |
| Gemini 3.1 Pro | No blocking findings | Checked exactness, `ldlen`/`conv.i4` stability, target names, test updates, README accuracy, and stable `All` membership. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.array-length --keep-generated-fixtures
dotnet run --project tools/DecompilerHarness -c Release --no-build -- /tmp/dotnet-inspect-generated-fixtures/b32fefac3504422ab1b3c77697c8c7c6/bin/Release/net11.0/GeneratedDecompilerFixtures.dll --dump 'GeneratedFixtures.MinimalArrayLength.Class1::Method1'
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
git diff --check
```
