### PR TITLE
Add render suppression analysis catalogue seeds

### DIFF
--- a/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
+++ b/src/ILInspector.Analysis.Tests/AnalysisFixtureCatalogTests.cs
@@ -46,6 +46,12 @@ public class AnalysisFixtureCatalogTests
         AssertBoundary(run, "alloc.enumerator.interface-foreach-in-loop", "ForeachInterfaceOnce", OwnedBoundary.FalseNegative);
         AssertPasses(run, "alloc.enumerator.interface-foreach-in-loop", "ForeachConcreteListInLoop");
         AssertPasses(run, "alloc.enumerator.interface-foreach-in-loop", "ForeachLookalikeEnumeratorInLoop");
+
+        // Render-method suppression: real framework RenderTreeBuilder suppresses intrinsic Blazor
+        // render plumbing, while a same-namespace/name user lookalike does not.
+        AssertPasses(run, "suppress.render-method.real-framework-builder", "RenderWithDelegateLoop");
+        AssertPasses(run, "suppress.render-method.real-framework-builder", "NonRenderDelegateLoop");
+        AssertPasses(run, "suppress.render-method.lookalike-builder", "RenderLikeMethod");
     }
 
     static void AssertPasses(AnalysisFixtureRunResult run, string fixtureId, string method)

--- a/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
+++ b/tools/AnalysisHarness/AnalysisFixtureCatalog.cs
@@ -63,7 +63,10 @@ public sealed record AnalysisFixtureDefinition(
     string? ExternalSource,
     bool ExternalNeedsAlias,
     IReadOnlyList<AnalysisFixtureTarget> Targets,
-    IReadOnlyList<string> Tags);
+    IReadOnlyList<string> Tags)
+{
+    public IReadOnlyList<string> ConsumerFrameworkReferences { get; init; } = [];
+}
 
 public sealed record AnalysisFixtureResult(
     string FixtureId,
@@ -452,6 +455,94 @@ public static class AnalysisFixtureCatalog
         ],
         ["opportunity", "enumerator", "in-assembly", "rung5"]);
 
+    public static readonly AnalysisFixtureDefinition RenderMethodRealFrameworkSuppression = new(
+        "suppress.render-method.real-framework-builder",
+        """
+        using System;
+        using Microsoft.AspNetCore.Components.Rendering;
+        namespace Fix;
+        public static class Consumer
+        {
+            // Must-not-flag: a method taking the REAL framework RenderTreeBuilder is treated as
+            // intrinsic Blazor render plumbing, so delegate allocations in the render loop are
+            // suppressed (#1781).
+            public static int RenderWithDelegateLoop(RenderTreeBuilder builder, int[] values, int seed)
+            {
+                var total = 0;
+                foreach (var v in values)
+                {
+                    Func<int> handler = () => v + seed;
+                    total += handler();
+                }
+                return total;
+            }
+
+            // Same allocation shape, no RenderTreeBuilder parameter: proves the fixture would
+            // surface a capturing-delegate row without the render-method suppression.
+            public static int NonRenderDelegateLoop(int[] values, int seed)
+            {
+                var total = 0;
+                foreach (var v in values)
+                {
+                    Func<int> handler = () => v + seed;
+                    total += handler();
+                }
+                return total;
+            }
+        }
+        """,
+        ExternalSource: null,
+        ExternalNeedsAlias: false,
+        [
+            new("RenderWithDelegateLoop", new AnalysisExpectation(OpportunityShapeAbsent: "capturing-delegate"),
+                Note: "Trusted Microsoft.AspNetCore.Components.RenderTreeBuilder suppresses render-method opportunities (#1781)."),
+            new("NonRenderDelegateLoop", new AnalysisExpectation(OpportunityShapePresent: "capturing-delegate"),
+                Note: "Control row: the same in-loop capturing delegate is reported outside render plumbing."),
+        ],
+        ["opportunity", "render", "suppression", "framework", "rung5"])
+    {
+        ConsumerFrameworkReferences = ["Microsoft.AspNetCore.App"],
+    };
+
+    public static readonly AnalysisFixtureDefinition RenderMethodLookalikeBuilderNotSuppressed = new(
+        "suppress.render-method.lookalike-builder",
+        """
+        using System;
+        namespace Fix
+        {
+            public static class Consumer
+            {
+                // Must flag: this parameter has the framework namespace/name but comes from the
+                // inspected user assembly, so it is not a trusted framework RenderTreeBuilder.
+                public static int RenderLikeMethod(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder, int[] values, int seed)
+                {
+                    var total = 0;
+                    foreach (var v in values)
+                    {
+                        Func<int> handler = () => v + seed;
+                        total += handler();
+                    }
+                    return total;
+                }
+            }
+        }
+
+        namespace Microsoft.AspNetCore.Components.Rendering
+        {
+            public sealed class RenderTreeBuilder
+            {
+                public void Use(Func<int> handler) => handler();
+            }
+        }
+        """,
+        ExternalSource: null,
+        ExternalNeedsAlias: false,
+        [
+            new("RenderLikeMethod", new AnalysisExpectation(OpportunityShapePresent: "capturing-delegate"),
+                Note: "Untrusted RenderTreeBuilder lookalike must not suppress genuine allocation opportunities (#1781)."),
+        ],
+        ["opportunity", "render", "suppression", "lookalike", "rung5"]);
+
     public static IReadOnlyList<AnalysisFixtureDefinition> All { get; } =
     [
         AllocInAssemblyStruct,
@@ -463,6 +554,8 @@ public static class AnalysisFixtureCatalog
         StringBuildAccumulationInLoop,
         BoxThrowPathSuppression,
         EnumeratorInterfaceForeachInLoop,
+        RenderMethodRealFrameworkSuppression,
+        RenderMethodLookalikeBuilderNotSuppressed,
     ];
 
     public static IReadOnlyList<AnalysisFixtureDefinition> Select(string? selector)

--- a/tools/AnalysisHarness/AnalysisFixtureRunner.cs
+++ b/tools/AnalysisHarness/AnalysisFixtureRunner.cs
@@ -65,7 +65,7 @@ public static class AnalysisFixtureRunner
         Directory.CreateDirectory(consumerDir);
         File.WriteAllText(
             Path.Combine(consumerDir, "Consumer.csproj"),
-            ConsumerProjectFile(tfm, hasExternal, fixture.ExternalNeedsAlias));
+            ConsumerProjectFile(tfm, hasExternal, fixture.ExternalNeedsAlias, fixture.ConsumerFrameworkReferences));
         File.WriteAllText(Path.Combine(consumerDir, "Consumer.cs"), fixture.ConsumerSource);
 
         Build(consumerDir);
@@ -245,7 +245,7 @@ public static class AnalysisFixtureRunner
         </Project>
         """;
 
-    static string ConsumerProjectFile(string tfm, bool hasExternal, bool needsAlias)
+    static string ConsumerProjectFile(string tfm, bool hasExternal, bool needsAlias, IReadOnlyList<string> frameworkReferences)
     {
         string reference = hasExternal
             ? needsAlias
@@ -262,6 +262,11 @@ public static class AnalysisFixtureRunner
                   </ItemGroup>
                 """
             : "";
+        string frameworks = frameworkReferences.Count == 0
+            ? ""
+            : "  <ItemGroup>\n"
+              + string.Concat(frameworkReferences.Select(framework => $"    <FrameworkReference Include=\"{framework}\" />\n"))
+              + "  </ItemGroup>\n";
         return $$"""
             <Project Sdk="Microsoft.NET.Sdk">
               <PropertyGroup>
@@ -274,6 +279,7 @@ public static class AnalysisFixtureRunner
                 <AssemblyName>Consumer</AssemblyName>
               </PropertyGroup>
             {{reference}}
+            {{frameworks}}
             </Project>
             """;
     }

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -27,7 +27,18 @@ dotnet "$DLL" --generated-fixtures exception.unsuffixed.external --keep  # keep 
 Each fixture builds in isolation: a consumer assembly (the inspected one) plus, when the
 fixture is cross-assembly, a referenced external assembly (with an extern alias for the
 name-collision case). Isolation keeps same-fully-qualified-name and alias fixtures from clashing
-across catalogue entries.
+across catalogue entries. Fixtures may opt into framework references when the signal depends on a
+trusted platform identity, such as the real ASP.NET Core `RenderTreeBuilder`.
+
+## Deferred catalogue seeds
+
+The catalogue should pin only shapes with a clear discriminator. Deferred #1871 seeds stay out of
+the generated ledger until their analyzer shape exists:
+
+| Seed | Blocker |
+| --- | --- |
+| State-machine allocation | The useful form is cross-method: an iterator/async state machine allocated and consumed in an outer loop. The naive per-method constructor shape floods every iterator and is intentionally not pinned (#1805). |
+| LINQ materialize/dataflow shapes | Need the #1807 dataflow/escape discriminator so transient, streamable object graphs can be separated from necessary model construction. |
 
 ## Test
 


### PR DESCRIPTION
## Summary

Adds the #1871 render-method catalogue slice:

- adds opt-in framework-reference support to generated AnalysisHarness consumer fixtures
- adds `suppress.render-method.real-framework-builder`: real ASP.NET Core `RenderTreeBuilder` suppresses intrinsic render-method `capturing-delegate` rows, with a non-render control that still flags
- adds `suppress.render-method.lookalike-builder`: same namespace/name user lookalike is not trusted and still flags `capturing-delegate`
- documents why the remaining deferred seeds stay blocked: state-machine allocation needs the cross-method discriminator from #1805, and LINQ materialize/dataflow needs #1807 escape/dataflow

Closes #1871.

## Validation

- `dotnet build tools/AnalysisHarness -c Release --nologo --verbosity quiet`
- `dotnet run --project tools/AnalysisHarness -c Release -- --generated-fixtures render`
- `npx markdownlint-cli --fix tools/AnalysisHarness/README.md`
- `npx markdownlint-cli tools/AnalysisHarness/README.md`
- `dotnet build src/ILInspector.Analysis.Tests -c Release --nologo --verbosity quiet`
- `dotnet artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tests.dll -method "*SeedCatalogue*"`
- `dotnet run --project tools/AnalysisHarness -c Release -- --generated-fixtures`
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`

## Adversarial review

- Claude Opus 4.8: no blockers. Verified real framework fixture suppresses, lookalike/control flag, targets are unambiguous, README blocker table is coherent. Non-blocking note: the framework seed depends on ASP.NET Core shared framework availability, consistent with the slow lane.
- Gemini 3.1 Pro: no blockers. Verified generated XML, fixture validity, SRM identity discrimination, opt-in framework-reference isolation, test coverage, and docs.
