### PR TITLE
Add minimal string-length generated fixture rung

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -163,6 +163,20 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.string-length",
+            "GeneratedFixtures.MinimalStringLength.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.string-length",
+            "GeneratedFixtures.MinimalStringLength.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.null-coalesce",
             "GeneratedFixtures.MinimalNullCoalesce.Class1",
             ".ctor",
@@ -282,6 +296,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.if-else", report);
         Assert.Contains("minimal.array-index", report);
         Assert.Contains("minimal.array-length", report);
+        Assert.Contains("minimal.string-length", report);
         Assert.Contains("minimal.null-coalesce", report);
         Assert.Contains("minimal.try-finally", report);
         Assert.Contains("minimal.using-dispose", report);
@@ -317,6 +332,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.primary-ctor.field-init",
                 "minimal.property.literal",
                 "minimal.static-method-call",
+                "minimal.string-length",
                 "minimal.switch-int",
                 "minimal.switch-two-case-lowers-if",
                 "minimal.try-finally",
@@ -343,6 +359,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-index");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-length");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.string-length");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.null-coalesce");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.try-finally");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.using-dispose");

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -207,6 +207,24 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "array", "length"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalStringLength = new(
+        "minimal.string-length",
+        """
+        namespace GeneratedFixtures.MinimalStringLength;
+
+        public class Class1
+        {
+            public int Method1(string value) => value.Length;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalStringLength.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalStringLength.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "string", "length"]);
+
     public static readonly GeneratedFixtureDefinition MinimalNullCoalesce = new(
         "minimal.null-coalesce",
         """
@@ -457,6 +475,7 @@ internal static class GeneratedFixtureCatalog
         MinimalIfElse,
         MinimalArrayIndex,
         MinimalArrayLength,
+        MinimalStringLength,
         MinimalNullCoalesce,
         MinimalTryFinally,
         MinimalUsingDispose,

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -15,8 +15,9 @@ This is the first step toward an addressable progressive fixture ladder:
 `minimal.property.literal`, `minimal.ctor-field.getter`,
 `minimal.auto-property.getter`, `minimal.method-call.same-type`, and
 `minimal.primary-ctor.field-init` are expected `Exact`; the static-call, if/else,
-array-index, array-length, null-coalescing, try/finally, using/dispose, foreach-array,
-for-loop, while-loop, and do-while rungs extend that minimal exact set;
+array-index, array-length, string-length, null-coalescing, try/finally,
+using/dispose, foreach-array, for-loop, while-loop, and do-while rungs extend
+that minimal exact set;
 `minimal.switch-int` adds the first switch statement rung.
 `minimal.switch-two-case-lowers-if` records the current SDK's two-case
 source-switch lowering observation (lowered as if/else, not the dense switch


### PR DESCRIPTION
- Advances #1742
- Changes generated decompiler fixture catalogue coverage only
- Card revision: `87711d04`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated fixture ladder gains a string-length rung, and it is opcode-exact while preserving `value.Length` in product output.

Before:

```text
minimal generated fixture catalogue: 18 fixtures / 38 targets
```

After:

```text
minimal generated fixture catalogue: 19 fixtures / 40 targets
new exact rung: minimal.string-length
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Decompiler fast suite | Not run; additive generated-fixture catalogue entry only |
| Reduced fixture validity | Not applicable |
| Reduced fixture fidelity | Pass: `minimal.string-length` reports `Exact` for `.ctor` and `Method1` |
| Shape dump | Pass: shipped product output for `Method1` is `return value.Length;` |
| Real witness | Generated fixture: parameterized string length read |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes; this only adds a generated fixture catalogue row.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked exactness, product shape, target names, catalogue placement, tests, README accuracy, and non-redundancy with array-length. |
| Gemini 3.1 Pro | No blocking findings | Checked exactness, stable `callvirt string.get_Length` lowering, target names, tests, README accuracy, and stable `All` membership. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.string-length --keep-generated-fixtures
dotnet run --project tools/DecompilerHarness -c Release --no-build -- /tmp/dotnet-inspect-generated-fixtures/5761e295e9d24e8f885b7a47e63bdd7c/bin/Release/net11.0/GeneratedDecompilerFixtures.dll --dump 'GeneratedFixtures.MinimalStringLength.Class1::Method1'
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
git diff --check
```
