### PR TITLE
Add shared ControlFlow dataflow fixpoint

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,6 +10,7 @@ It is built for both humans and agents. Markdown is the default output because h
 - `src/ILInspector.Metadata/` reads PE metadata, API surfaces, SourceLink/PDB data, method classification, and assembly details.
 - `src/ILInspector.Analysis/` indexes IL method-body evidence such as direct call sites without decompiling to C#.
 - `src/ILInspector.Analysis.App/` is a temporary console harness for exercising Analysis queries until CLI wiring exists.
+- `src/ILInspector.ControlFlow/` contains shared block-edge, dominance, and dataflow kernels used below Analysis and Decompiler without depending on either.
 - `src/DotnetInspector.Packages/` handles NuGet package extraction, package/source caches, feeds, symbol package acquisition, and version resolution.
 - `src/DotnetInspector.Services/` contains shared services such as platform/package resolution, dependency resolution, signatures, source fetching, and nuspec parsing.
 - `src/ILInspector.Decompiler/` emits lowered C#, raw IL, and annotated IL from method bodies.

--- a/src/ILInspector.ControlFlow/ForwardDataflow.cs
+++ b/src/ILInspector.ControlFlow/ForwardDataflow.cs
@@ -1,0 +1,192 @@
+namespace ILInspector.ControlFlow;
+
+/// <summary>How predecessor out-sets merge into a block's in-set.</summary>
+public enum DataflowMerge
+{
+    /// <summary>May analysis: a fact is present when any predecessor carries it.</summary>
+    Union,
+
+    /// <summary>Must analysis: a fact is present only when every predecessor carries it.</summary>
+    Intersection,
+}
+
+/// <summary>How the entry block's in-set handles CFG predecessors.</summary>
+public enum DataflowEntry
+{
+    /// <summary>The entry block's in-set is exactly the external entry facts.</summary>
+    Fixed,
+
+    /// <summary>The entry block also joins reachable predecessor out-sets, useful for general loops.</summary>
+    MergePredecessors,
+}
+
+/// <summary>A block-local gen/kill transfer function over integer fact ids.</summary>
+public sealed record GenKillSet(IReadOnlySet<int> Gen, IReadOnlySet<int> Kill)
+{
+    public static readonly GenKillSet Empty = new(new HashSet<int>(), new HashSet<int>());
+}
+
+/// <summary>Dataflow state for one block.</summary>
+public sealed record DataflowBlockState(
+    IReadOnlyList<int> Predecessors,
+    IReadOnlySet<int> In,
+    IReadOnlySet<int> Out,
+    bool Reachable);
+
+/// <summary>Result of a forward dataflow fixpoint over one block container.</summary>
+public sealed record ForwardDataflowResult(IReadOnlyList<DataflowBlockState> Blocks);
+
+/// <summary>
+/// Representation-agnostic forward gen/kill dataflow over <see cref="BlockEdges"/>.
+/// Consumers supply their own fact ids and transfer sets; the kernel owns only
+/// CFG predecessor construction, merge, transfer, and fixpoint iteration.
+/// </summary>
+public static class ForwardDataflow
+{
+    /// <summary>
+    /// Solves a forward gen/kill fixpoint with block 0 as the entry block.
+    /// For intersection analyses, non-entry blocks start at <paramref name="universe"/>;
+    /// for union analyses, they start empty. External targets/leaves are represented in
+    /// <see cref="BlockEdges"/> for callers to handle before invoking the kernel.
+    /// </summary>
+    public static ForwardDataflowResult Solve(
+        IReadOnlyList<BlockEdges> edges,
+        IReadOnlyList<GenKillSet> transfers,
+        IReadOnlySet<int> entry,
+        IReadOnlySet<int> universe,
+        DataflowMerge merge,
+        DataflowEntry entryBehavior = DataflowEntry.Fixed)
+    {
+        if (edges.Count != transfers.Count)
+            throw new ArgumentException("Edge and transfer counts must match.", nameof(transfers));
+
+        int n = edges.Count;
+        if (n == 0)
+            return new ForwardDataflowResult([]);
+
+        var predecessors = BuildPredecessors(edges);
+        var reachable = ComputeReachable(edges);
+
+        var inSets = new HashSet<int>[n];
+        var outSets = new HashSet<int>[n];
+        inSets[0] = new HashSet<int>(entry);
+        outSets[0] = Apply(inSets[0], transfers[0]);
+
+        for (int i = 1; i < n; i++)
+        {
+            inSets[i] = merge == DataflowMerge.Intersection
+                ? new HashSet<int>(universe)
+                : [];
+            outSets[i] = Apply(inSets[i], transfers[i]);
+        }
+
+        bool changed = true;
+        while (changed)
+        {
+            changed = false;
+            for (int block = entryBehavior == DataflowEntry.Fixed ? 1 : 0; block < n; block++)
+            {
+                if (predecessors[block].Count == 0 && block != 0)
+                    continue;
+                if (block != 0 && !predecessors[block].Any(predecessor => reachable[predecessor]))
+                    continue;
+
+                var merged = MergePredecessors(predecessors[block], outSets, reachable, merge, seed: block == 0 ? entry : null);
+                if (!merged.SetEquals(inSets[block]))
+                {
+                    inSets[block] = merged;
+                    outSets[block] = Apply(merged, transfers[block]);
+                    changed = true;
+                }
+            }
+        }
+
+        var states = new DataflowBlockState[n];
+        for (int i = 0; i < n; i++)
+        {
+            states[i] = new DataflowBlockState(
+                predecessors[i],
+                new HashSet<int>(inSets[i]),
+                new HashSet<int>(outSets[i]),
+                reachable[i]);
+        }
+        return new ForwardDataflowResult(states);
+    }
+
+    static IReadOnlyList<int>[] BuildPredecessors(IReadOnlyList<BlockEdges> edges)
+    {
+        int n = edges.Count;
+        var predecessors = new List<int>[n];
+        for (int i = 0; i < n; i++)
+            predecessors[i] = [];
+        for (int from = 0; from < n; from++)
+        {
+            foreach (int to in edges[from].Successors)
+            {
+                if ((uint)to >= (uint)n)
+                    throw new ArgumentOutOfRangeException(nameof(edges), $"Successor {to} from block {from} is outside the block range.");
+                predecessors[to].Add(from);
+            }
+        }
+        return predecessors;
+    }
+
+    static bool[] ComputeReachable(IReadOnlyList<BlockEdges> edges)
+    {
+        int n = edges.Count;
+        var reachable = new bool[n];
+        var stack = new Stack<int>();
+        reachable[0] = true;
+        stack.Push(0);
+        while (stack.Count > 0)
+        {
+            int block = stack.Pop();
+            foreach (int successor in edges[block].Successors)
+            {
+                if (!reachable[successor])
+                {
+                    reachable[successor] = true;
+                    stack.Push(successor);
+                }
+            }
+        }
+        return reachable;
+    }
+
+    static HashSet<int> MergePredecessors(
+        IReadOnlyList<int> predecessors,
+        HashSet<int>[] outSets,
+        IReadOnlyList<bool> reachable,
+        DataflowMerge merge,
+        IReadOnlySet<int>? seed)
+    {
+        if (merge == DataflowMerge.Union)
+        {
+            var result = seed is null ? new HashSet<int>() : new HashSet<int>(seed);
+            foreach (int predecessor in predecessors)
+                if (reachable[predecessor])
+                    result.UnionWith(outSets[predecessor]);
+            return result;
+        }
+
+        HashSet<int>? intersection = seed is null ? null : new HashSet<int>(seed);
+        foreach (int predecessor in predecessors)
+        {
+            if (!reachable[predecessor])
+                continue;
+            if (intersection is null)
+                intersection = new HashSet<int>(outSets[predecessor]);
+            else
+                intersection.IntersectWith(outSets[predecessor]);
+        }
+        return intersection ?? [];
+    }
+
+    static HashSet<int> Apply(IReadOnlySet<int> input, GenKillSet transfer)
+    {
+        var output = new HashSet<int>(input);
+        output.ExceptWith(transfer.Kill);
+        output.UnionWith(transfer.Gen);
+        return output;
+    }
+}

--- a/src/ILInspector.ControlFlow/ForwardDataflow.cs
+++ b/src/ILInspector.ControlFlow/ForwardDataflow.cs
@@ -60,6 +60,17 @@ public static class ForwardDataflow
         if (edges.Count != transfers.Count)
             throw new ArgumentException("Edge and transfer counts must match.", nameof(transfers));
 
+        // Intersection (must) analyses join the entry block with its back-edge
+        // predecessors under MergePredecessors, which can silently drop a fact
+        // that holds on entry but is killed around a loop. That is sound but
+        // imprecise (it floods toward "no fact"), and no consumer needs it:
+        // must-entry facts are external axioms, so must-analyses use Fixed.
+        // Reject the pair so a future consumer cannot adopt it unknowingly.
+        if (merge == DataflowMerge.Intersection && entryBehavior == DataflowEntry.MergePredecessors)
+            throw new ArgumentException(
+                "Intersection (must) analyses must use DataflowEntry.Fixed; MergePredecessors can drop entry facts across back-edges.",
+                nameof(entryBehavior));
+
         int n = edges.Count;
         if (n == 0)
             return new ForwardDataflowResult([]);

--- a/src/ILInspector.Decompiler.Tests/ForwardDataflowTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForwardDataflowTests.cs
@@ -119,6 +119,29 @@ public class ForwardDataflowTests
     }
 
     [Fact]
+    public void Solve_Intersection_WithMergePredecessors_Throws()
+    {
+        var edges = new[]
+        {
+            Edge(1),
+            Edge(0),
+        };
+        var transfers = new[]
+        {
+            Gen(),
+            Gen(),
+        };
+
+        Assert.Throws<ArgumentException>(() => ForwardDataflow.Solve(
+            edges,
+            transfers,
+            entry: new HashSet<int> { 0 },
+            universe: new HashSet<int> { 0 },
+            DataflowMerge.Intersection,
+            DataflowEntry.MergePredecessors));
+    }
+
+    [Fact]
     public void Solve_FixedEntry_IgnoresEntryBackEdges()
     {
         var edges = new[]

--- a/src/ILInspector.Decompiler.Tests/ForwardDataflowTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForwardDataflowTests.cs
@@ -1,0 +1,204 @@
+using ILInspector.ControlFlow;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ForwardDataflowTests
+{
+    [Fact]
+    public void Solve_Intersection_DropsFactsMissingOnOnePredecessor()
+    {
+        var edges = new[]
+        {
+            Edge(1, 2),
+            Edge(3),
+            Edge(3),
+            Exit(),
+        };
+        var transfers = new[]
+        {
+            Gen(),
+            Gen(0),
+            Gen(),
+            Gen(),
+        };
+
+        var result = ForwardDataflow.Solve(
+            edges,
+            transfers,
+            entry: new HashSet<int>(),
+            universe: new HashSet<int> { 0 },
+            DataflowMerge.Intersection);
+
+        Assert.Empty(result.Blocks[3].In);
+        Assert.Equal([0], result.Blocks[1].Out.Order());
+        Assert.Empty(result.Blocks[2].Out);
+    }
+
+    [Fact]
+    public void Solve_Intersection_KeepsFactsGeneratedOnEveryPredecessor()
+    {
+        var edges = new[]
+        {
+            Edge(1, 2),
+            Edge(3),
+            Edge(3),
+            Exit(),
+        };
+        var transfers = new[]
+        {
+            Gen(),
+            Gen(0),
+            Gen(0),
+            Gen(),
+        };
+
+        var result = ForwardDataflow.Solve(
+            edges,
+            transfers,
+            entry: new HashSet<int>(),
+            universe: new HashSet<int> { 0 },
+            DataflowMerge.Intersection);
+
+        Assert.Equal([0], result.Blocks[3].In.Order());
+    }
+
+    [Fact]
+    public void Solve_Union_AppliesGenKillAndMergesAnyPredecessorFact()
+    {
+        var edges = new[]
+        {
+            Edge(1, 2),
+            Edge(3),
+            Edge(3),
+            Exit(),
+        };
+        var transfers = new[]
+        {
+            Gen(0),
+            new GenKillSet(new HashSet<int>(), new HashSet<int> { 0 }),
+            Gen(1),
+            Gen(),
+        };
+
+        var result = ForwardDataflow.Solve(
+            edges,
+            transfers,
+            entry: new HashSet<int>(),
+            universe: new HashSet<int> { 0, 1 },
+            DataflowMerge.Union);
+
+        Assert.Equal([0], result.Blocks[1].In.Order());
+        Assert.Empty(result.Blocks[1].Out);
+        Assert.Equal([0, 1], result.Blocks[3].In.Order());
+    }
+
+    [Fact]
+    public void Solve_MergePredecessors_IncludesEntryBackEdges()
+    {
+        var edges = new[]
+        {
+            Edge(1),
+            Edge(0),
+        };
+        var transfers = new[]
+        {
+            Gen(),
+            Gen(1),
+        };
+
+        var result = ForwardDataflow.Solve(
+            edges,
+            transfers,
+            entry: new HashSet<int> { 0 },
+            universe: new HashSet<int> { 0, 1 },
+            DataflowMerge.Union,
+            DataflowEntry.MergePredecessors);
+
+        Assert.Equal([0, 1], result.Blocks[0].In.Order());
+        Assert.Equal([0, 1], result.Blocks[0].Out.Order());
+    }
+
+    [Fact]
+    public void Solve_FixedEntry_IgnoresEntryBackEdges()
+    {
+        var edges = new[]
+        {
+            Edge(1),
+            Edge(0),
+        };
+        var transfers = new[]
+        {
+            Gen(),
+            Gen(1),
+        };
+
+        var result = ForwardDataflow.Solve(
+            edges,
+            transfers,
+            entry: new HashSet<int> { 0 },
+            universe: new HashSet<int> { 0, 1 },
+            DataflowMerge.Union);
+
+        Assert.Equal([0], result.Blocks[0].In.Order());
+        Assert.Equal([0], result.Blocks[0].Out.Order());
+    }
+
+    [Fact]
+    public void Solve_IgnoresUnreachablePredecessorsWhenMergingReachableBlock()
+    {
+        var edges = new[]
+        {
+            Edge(2),
+            Edge(2),
+            Exit(),
+        };
+        var transfers = new[]
+        {
+            Gen(0),
+            new GenKillSet(new HashSet<int>(), new HashSet<int> { 0 }),
+            Gen(),
+        };
+
+        var result = ForwardDataflow.Solve(
+            edges,
+            transfers,
+            entry: new HashSet<int>(),
+            universe: new HashSet<int> { 0 },
+            DataflowMerge.Intersection);
+
+        Assert.False(result.Blocks[1].Reachable);
+        Assert.Equal([0], result.Blocks[2].In.Order());
+    }
+
+    [Fact]
+    public void Solve_MarksBlocksUnreachableFromEntry()
+    {
+        var edges = new[]
+        {
+            Edge(1),
+            Exit(),
+            Edge(2),
+        };
+        var transfers = new[] { Gen(), Gen(), Gen(0) };
+
+        var result = ForwardDataflow.Solve(
+            edges,
+            transfers,
+            entry: new HashSet<int>(),
+            universe: new HashSet<int> { 0 },
+            DataflowMerge.Intersection);
+
+        Assert.True(result.Blocks[0].Reachable);
+        Assert.True(result.Blocks[1].Reachable);
+        Assert.False(result.Blocks[2].Reachable);
+    }
+
+    static BlockEdges Edge(params int[] successors)
+        => new(successors, [], ExitsMethod: false, LeavesRegion: false);
+
+    static BlockEdges Exit()
+        => new([], [], ExitsMethod: true, LeavesRegion: false);
+
+    static GenKillSet Gen(params int[] facts)
+        => new(new HashSet<int>(facts), new HashSet<int>());
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
@@ -149,67 +149,32 @@ static class DefiniteAssignment
                 BailAll();
                 return DefiniteFlow.Bail;
             }
-            var successors = new List<int>[n];
-            for (int i = 0; i < n; i++)
-                successors[i] = [.. edges[i].Successors];
-
             // gen[i]: locals block i assigns on every path through it (order
             // within the block does not matter for what holds at its exit).
-            var gen = new HashSet<int>[n];
+            var transfers = new GenKillSet[n];
             for (int i = 0; i < n; i++)
             {
-                gen[i] = [];
+                var gen = new HashSet<int>();
                 foreach (var child in blocks[i].Children)
                 {
                     if (child is StoreLocal store)
-                        gen[i].Add(store.Index);
+                        gen.Add(store.Index);
                     else if (child is InitObject { Address: LoadLocalAddress address })
-                        gen[i].Add(address.Index);
+                        gen.Add(address.Index);
                 }
+                transfers[i] = new GenKillSet(gen, new HashSet<int>());
             }
 
-            var preds = new List<int>[n];
-            for (int i = 0; i < n; i++)
-                preds[i] = [];
-            for (int i = 0; i < n; i++)
-                foreach (var s in successors[i])
-                    preds[s].Add(i);
-
-            // in[0] is the entry assignments: the external edge always supplies
-            // them, and a local assigned before the container stays assigned
-            // across any back edge. Other blocks start at the universe so the
-            // first intersection narrows down; intersection only shrinks, so the
-            // fixpoint terminates.
-            var inSets = new HashSet<int>[n];
-            inSets[0] = new HashSet<int>(entryAssigned);
-            for (int i = 1; i < n; i++)
-                inSets[i] = new HashSet<int>(Enumerable.Range(0, function.Locals.Length));
-
-            bool changed = true;
-            while (changed)
-            {
-                changed = false;
-                for (int k = 1; k < n; k++)
-                {
-                    if (preds[k].Count == 0)
-                        continue;  // unreachable: leaving it at the universe never narrows a reachable join
-                    HashSet<int>? merged = null;
-                    foreach (var p in preds[k])
-                    {
-                        var outP = new HashSet<int>(inSets[p]);
-                        outP.UnionWith(gen[p]);
-                        if (merged is null)
-                            merged = outP;
-                        else
-                            merged.IntersectWith(outP);
-                    }
-                    if (merged is not null && !merged.SetEquals(inSets[k]))
-                    {
-                        inSets[k] = merged;
-                        changed = true;
-                    }
-                }
-            }
+            // in[0] is the fixed entry assignment set: the external edge always
+            // supplies it, and a local assigned before the container stays
+            // assigned across any back edge. Other blocks start at the universe
+            // for the must/intersection fixpoint and narrow down.
+            var flow = ForwardDataflow.Solve(
+                edges,
+                transfers,
+                entryAssigned,
+                new HashSet<int>(Enumerable.Range(0, function.Locals.Length)),
+                DataflowMerge.Intersection);
 
             // With the assignment-on-entry known per block, check reads in
             // program order within each block.
@@ -218,24 +183,23 @@ static class DefiniteAssignment
                 var blockFacts = new List<DataflowFacts.BlockFacts>(n);
                 for (int i = 0; i < n; i++)
                 {
-                    bool reachable = i == 0 || preds[i].Count > 0;
-                    var outI = new HashSet<int>(inSets[i]);
-                    outI.UnionWith(gen[i]);
+                    var state = flow.Blocks[i];
+                    bool legacyReachable = i == 0 || state.Predecessors.Count > 0;
                     blockFacts.Add(new DataflowFacts.BlockFacts(
                         blocks[i].StartOffset,
-                        [.. preds[i].Select(p => blocks[p].StartOffset).Order()],
-                        [.. successors[i].Select(s => blocks[s].StartOffset).Order()],
-                        [.. gen[i].Order()],
-                        reachable ? [.. inSets[i].Order()] : [],
-                        reachable ? [.. outI.Order()] : [],
-                        reachable));
+                        [.. state.Predecessors.Select(p => blocks[p].StartOffset).Order()],
+                        [.. edges[i].Successors.Select(s => blocks[s].StartOffset).Order()],
+                        [.. transfers[i].Gen.Order()],
+                        legacyReachable ? [.. state.In.Order()] : [],
+                        legacyReachable ? [.. state.Out.Order()] : [],
+                        legacyReachable));
                 }
                 facts.AddContainer(new DataflowFacts.ContainerFacts(blockFacts));
             }
 
             for (int k = 0; k < n; k++)
             {
-                var running = new HashSet<int>(inSets[k]);
+                var running = new HashSet<int>(flow.Blocks[k].In);
                 foreach (var child in blocks[k].Children)
                 {
                     switch (child)


### PR DESCRIPTION
## Summary

Advances #1807 with the next substrate slice after `BlockEdges`/`PostDominators`:

- adds a representation-agnostic `ILInspector.ControlFlow.ForwardDataflow` gen/kill fixpoint
- supports union/may and intersection/must analyses plus fixed-entry vs entry-backedge merging
- filters unreachable predecessors so unreachable islands cannot poison reachable joins
- refactors decompiler definite-assignment CFG handling to consume the shared kernel while preserving its fixed-entry semantics and existing `DataflowFacts` reachability convention
- adds direct kernel tests for intersection, union, gen/kill, entry back-edges, and unreachable predecessors
- documents `ILInspector.ControlFlow` in the architecture overview

This intentionally does not add a new Analysis Performance Triage shape yet; it establishes the shared primitive needed by future #1807 dataflow/escape consumers.

## Validation

- `npx markdownlint-cli --fix docs/overview.md`
- `npx markdownlint-cli docs/overview.md`
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet`
- `dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class "*ForwardDataflowTests" -class "*DataflowFactsTests" -class "*PostDominatorsTests"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`

Note: a full `dotnet run --project src/ILInspector.Decompiler.Tests -c Release` attempt was stopped after ~12 minutes with no additional output in the shared environment; focused decompiler dataflow/control-flow tests completed successfully.

## Adversarial review

Initial review:

- Claude Opus 4.8: no blockers; noted only the facts-only reachability divergence for unreachable cycles.
- Gemini 3.1 Pro: found blockers in the first draft: entry block back-edges were ignored for general consumers, unreachable predecessors could corrupt merges, and decompiler facts reachability changed.

Resolution:

- Added `DataflowEntry.Fixed` / `MergePredecessors` so decompiler keeps fixed-entry semantics while future consumers can opt into entry back-edge merging.
- Filtered unreachable predecessors during merges and added regression tests.
- Preserved decompiler `DataflowFacts` legacy reachability convention.

Re-review:

- Claude Opus 4.8: no blockers; confirmed fixes and termination reasoning.
- Gemini 3.1 Pro: no blockers; confirmed the prior critical findings are resolved.
