### PR TITLE
Demote amortized constructor triage rows

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1404,6 +1404,52 @@ public class LibraryBodyIndexTests
         }
     }
 
+    [Fact]
+    public void OptimizationOpportunities_ConstructorDelegate_IsAmortizedSetup()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.DeclaringType.Name.EndsWith("+AmortizedConstructorFixture", StringComparison.Ordinal)
+            && o.Method.Name == ".ctor"
+            && o.Shape == "capturing-delegate"));
+
+        Assert.True(op.InLoop);
+        Assert.Equal("low", op.Confidence);
+        Assert.True(op.Amortized);
+        Assert.Contains("constructor/type-initializer setup", op.SafeFixDirection, StringComparison.Ordinal);
+        Assert.Contains("Amortized setup", op.Caveat, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_ConstructorCalledInLoop_RemainsHigh()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.DeclaringType.Name.EndsWith("+HotConstructorFixture", StringComparison.Ordinal)
+            && o.Method.Name == ".ctor"
+            && o.Shape == "capturing-delegate"));
+
+        Assert.True(op.InLoop);
+        Assert.Equal("high", op.Confidence);
+        Assert.False(op.Amortized);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_OrdinaryLoopDelegate_RemainsHigh()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.CapturingDelegateInLoop)
+            && o.Shape == "capturing-delegate"));
+
+        Assert.True(op.InLoop);
+        Assert.Equal("high", op.Confidence);
+        Assert.False(op.Amortized);
+    }
+
     [Theory]
     [InlineData(nameof(OptimizationOpportunityFixtures.InstanceMethodGroup))]
     [InlineData(nameof(OptimizationOpportunityFixtures.VirtualInstanceMethodGroup))]
@@ -2947,6 +2993,45 @@ public class OptimizationOpportunityFixtures
 
         public TResult RunOnEmptyStack<TArg, TResult>(Func<TArg, TResult> action, TArg argument)
             => action(argument);
+    }
+
+    public sealed class AmortizedConstructorFixture
+    {
+        public int Total;
+
+        public AmortizedConstructorFixture(int[] values, int seed)
+        {
+            foreach (var value in values)
+            {
+                Func<int> projector = () => value + seed;
+                Total += projector();
+            }
+        }
+    }
+
+    public sealed class HotConstructorFixture
+    {
+        public int Total;
+
+        public HotConstructorFixture(int[] values, int seed)
+        {
+            foreach (var value in values)
+            {
+                Func<int> projector = () => value + seed;
+                Total += projector();
+            }
+        }
+    }
+
+    public static int CreateHotConstructorsInLoop(int[][] inputs, int seed)
+    {
+        var total = 0;
+        foreach (var values in inputs)
+        {
+            total += new HotConstructorFixture(values, seed).Total;
+        }
+
+        return total;
     }
 
     // Boxes a value into an exception message on a throw path inside a loop -> the box only

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -73,7 +73,8 @@ public sealed class LibraryBodyIndex
                     {
                         int reach = reachByToken.TryGetValue(opportunity.Method.MetadataToken, out int r) ? r : opportunity.RootReach;
                         var adjusted = reach != opportunity.RootReach ? opportunity with { RootReach = reach } : opportunity;
-                        var confidence = IsColdOpportunity(adjusted)
+                        adjusted = MarkAmortizedSetup(adjusted);
+                        var confidence = IsLowFrequencyOpportunity(adjusted)
                             ? "low"
                             : AdjustDelegateConfidenceForReach(adjusted.Shape, adjusted.InLoop, adjusted.Confidence, reach);
                         return confidence != adjusted.Confidence ? adjusted with { Confidence = confidence } : adjusted;
@@ -125,8 +126,36 @@ public sealed class LibraryBodyIndex
             ? "medium"
             : confidence;
 
-    static bool IsColdOpportunity(OptimizationOpportunity opportunity)
-        => opportunity.ColdPath;
+    static bool IsLowFrequencyOpportunity(OptimizationOpportunity opportunity)
+        => opportunity.ColdPath || opportunity.Amortized;
+
+    OptimizationOpportunity MarkAmortizedSetup(OptimizationOpportunity opportunity)
+    {
+        if (opportunity.Amortized)
+            return opportunity;
+        if (opportunity.Method.Name is not (".ctor" or ".cctor"))
+            return opportunity;
+        // Type initializers are exact amortized setup: one execution per type.
+        // Instance constructors are less certain, so demote only when this assembly
+        // does not itself instantiate the constructor from a loop. That preserves a
+        // known-hot transient-constructor signal while still lowering setup-only rows
+        // such as DI/SignalR constructors that are not loop-invoked in their assembly.
+        if (opportunity.Method.Name == ".ctor" && ConstructorIsInvokedInLoop(opportunity.Method))
+            return opportunity;
+
+        return opportunity with
+        {
+            Amortized = true,
+            SafeFixDirection = "This allocation is in constructor/type-initializer setup, not a steady-state per-call path. Optimize only if profiles show this setup is hot or repeated unexpectedly.",
+            Caveat = "Amortized setup path: constructor/type-initializer allocations are usually once per instance/type, not per steady-state operation.",
+        };
+    }
+
+    bool ConstructorIsInvokedInLoop(MethodIdentity constructor)
+        => DirectCalls.Any(call =>
+            call.Kind == CallKind.NewObject
+            && call.InLoop
+            && call.CalleeDefinitionToken == constructor.MetadataToken);
 
     IEnumerable<OptimizationOpportunity> AllocationHotspots(Dictionary<int, int> reachByToken, IReadOnlySet<int> methodsWithSpecificShape)
     {

--- a/src/ILInspector.Analysis/OptimizationOpportunity.cs
+++ b/src/ILInspector.Analysis/OptimizationOpportunity.cs
@@ -10,4 +10,7 @@ public sealed record OptimizationOpportunity(
     int? ILOffset,
     string? Caveat,
     int RootReach = 0,
-    bool ColdPath = false);
+    bool ColdPath = false)
+{
+    public bool Amortized { get; init; }
+}


### PR DESCRIPTION
## Summary

Addresses #1860 row 3 / #1670 amortized setup allocations:

- marks shaped opportunities in constructors/type initializers as amortized setup when the constructor is not loop-instantiated in the same assembly
- forces those low-frequency setup rows to `low` confidence with setup-specific fix text
- preserves known-hot constructors that are instantiated from loops, and preserves ordinary in-loop delegate rows

## Evidence

Before this branch, SignalR `DefaultHubDispatcher..ctor` surfaced three high loop `capturing-delegate` rows alongside the real hot `HubConnectionContext.HandshakeAsync` row.

After this branch:

```text
DefaultHubDispatcher..ctor ... capturing-delegate ... low ... This allocation is in constructor/type-initializer setup ...
HubConnectionContext.HandshakeAsync ... instance-method-group-delegate ... high ... loop ...
```

With `--loop --min-confidence high`, `DefaultHubDispatcher..ctor` drops out while `HubConnectionContext.HandshakeAsync` remains.

## Validation

- `dotnet artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tests.dll -method "*ConstructorDelegate_IsAmortizedSetup*" -method "*ConstructorCalledInLoop_RemainsHigh*" -method "*OrdinaryLoopDelegate_RemainsHigh*"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- source CLI SignalR checks for full triage and `--loop --min-confidence high`

## Adversarial review

- Claude Opus 4.8: no blockers. Noted the constructor marking applies only to shaped opportunities, not aggregate hotspots/cross-method scans; that is intentional for this narrow row-3 slice.
- Gemini 3.1 Pro: found two blockers. Resolved by moving `Amortized` to an init-only property (no public record constructor/deconstruct break) and by narrowing instance-constructor demotion: constructors called from loops in the same assembly remain high. Added `HotConstructorFixture` to pin that true-positive case.
