### PR TITLE
Add minimal integer-addition generated fixture rung

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -135,6 +135,20 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.integer-addition",
+            "GeneratedFixtures.MinimalIntegerAddition.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.integer-addition",
+            "GeneratedFixtures.MinimalIntegerAddition.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.array-index",
             "GeneratedFixtures.MinimalArrayIndex.Class1",
             ".ctor",
@@ -294,6 +308,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.method-call.same-type", report);
         Assert.Contains("minimal.static-method-call", report);
         Assert.Contains("minimal.if-else", report);
+        Assert.Contains("minimal.integer-addition", report);
         Assert.Contains("minimal.array-index", report);
         Assert.Contains("minimal.array-length", report);
         Assert.Contains("minimal.string-length", report);
@@ -327,6 +342,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.for-loop",
                 "minimal.foreach-array",
                 "minimal.if-else",
+                "minimal.integer-addition",
                 "minimal.method-call.same-type",
                 "minimal.null-coalesce",
                 "minimal.primary-ctor.field-init",
@@ -357,6 +373,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.method-call.same-type");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.static-method-call");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.integer-addition");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-index");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-length");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.string-length");

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -171,6 +171,24 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "branch", "if-else"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalIntegerAddition = new(
+        "minimal.integer-addition",
+        """
+        namespace GeneratedFixtures.MinimalIntegerAddition;
+
+        public class Class1
+        {
+            public int Method1(int left, int right) => left + right;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalIntegerAddition.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalIntegerAddition.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "integer", "arithmetic", "addition"]);
+
     public static readonly GeneratedFixtureDefinition MinimalArrayIndex = new(
         "minimal.array-index",
         """
@@ -473,6 +491,7 @@ internal static class GeneratedFixtureCatalog
         MinimalMethodCallSameType,
         MinimalStaticMethodCall,
         MinimalIfElse,
+        MinimalIntegerAddition,
         MinimalArrayIndex,
         MinimalArrayLength,
         MinimalStringLength,

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -15,9 +15,9 @@ This is the first step toward an addressable progressive fixture ladder:
 `minimal.property.literal`, `minimal.ctor-field.getter`,
 `minimal.auto-property.getter`, `minimal.method-call.same-type`, and
 `minimal.primary-ctor.field-init` are expected `Exact`; the static-call, if/else,
-array-index, array-length, string-length, null-coalescing, try/finally,
-using/dispose, foreach-array, for-loop, while-loop, and do-while rungs extend
-that minimal exact set;
+integer-addition, array-index, array-length, string-length, null-coalescing,
+try/finally, using/dispose, foreach-array, for-loop, while-loop, and do-while
+rungs extend that minimal exact set;
 `minimal.switch-int` adds the first switch statement rung.
 `minimal.switch-two-case-lowers-if` records the current SDK's two-case
 source-switch lowering observation (lowered as if/else, not the dense switch


### PR DESCRIPTION
- Advances #1742
- Changes generated decompiler fixture catalogue coverage only
- Card revision: `ba85a900`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated fixture ladder gains an integer-addition rung, and it is opcode-exact while preserving `left + right` in product output.

Before:

```text
minimal generated fixture catalogue: 19 fixtures / 40 targets
```

After:

```text
minimal generated fixture catalogue: 20 fixtures / 42 targets
new exact rung: minimal.integer-addition
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Decompiler fast suite | Not run; additive generated-fixture catalogue entry only |
| Reduced fixture validity | Not applicable |
| Reduced fixture fidelity | Pass: `minimal.integer-addition` reports `Exact` for `.ctor` and `Method1` |
| Shape dump | Pass: shipped product output for `Method1` is `return left + right;` |
| Real witness | Generated fixture: unchecked integer addition expression |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes; this only adds a generated fixture catalogue row.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked exactness, product shape, target names, catalogue placement, tests, README accuracy, and non-redundancy. |
| Gemini 3.1 Pro | No blocking findings | Checked exactness, stable unchecked `add` lowering, target names, tests, README accuracy, and stable `All` membership. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.integer-addition --keep-generated-fixtures
dotnet run --project tools/DecompilerHarness -c Release --no-build -- /tmp/dotnet-inspect-generated-fixtures/864aefef423f4faf95e3d9d2584ba7c8/bin/Release/net11.0/GeneratedDecompilerFixtures.dll --dump 'GeneratedFixtures.MinimalIntegerAddition.Class1::Method1'
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
git diff --check
```
