### PR TITLE
Add shape verdicts to generated decompiler fixtures

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -328,6 +328,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("shape=ForStatement", report);
         Assert.Contains("shape=ElementAccessExpression", report);
 
+        AssertShape(run, "minimal.integer-addition", "Method1", SyntaxKind.AddExpression);
         AssertShape(run, "minimal.array-index", "Method1", SyntaxKind.ElementAccessExpression);
         AssertShape(run, "minimal.array-length", "Method1", SyntaxKind.SimpleMemberAccessExpression);
         AssertShape(run, "minimal.string-length", "Method1", SyntaxKind.SimpleMemberAccessExpression);

--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 
 using ILInspector.DecompilerHarness;
 
+using Microsoft.CodeAnalysis.CSharp;
+
 namespace ILInspector.Decompiler.Tests;
 
 /// <summary>
@@ -323,6 +325,19 @@ public class GeneratedFixtureCatalogTests
         Assert.DoesNotContain("minimal.switch-two-case-lowers-if", report);
         Assert.Contains("decompiler=Full", report);
         Assert.Contains("compile-back=Exact", report);
+        Assert.Contains("shape=ForStatement", report);
+        Assert.Contains("shape=ElementAccessExpression", report);
+
+        AssertShape(run, "minimal.array-index", "Method1", SyntaxKind.ElementAccessExpression);
+        AssertShape(run, "minimal.array-length", "Method1", SyntaxKind.SimpleMemberAccessExpression);
+        AssertShape(run, "minimal.string-length", "Method1", SyntaxKind.SimpleMemberAccessExpression);
+        AssertShape(run, "minimal.null-coalesce", "Method1", SyntaxKind.CoalesceExpression);
+        AssertShape(run, "minimal.try-finally", "Method1", SyntaxKind.TryStatement);
+        AssertShape(run, "minimal.foreach-array", "Method1", SyntaxKind.ForEachStatement);
+        AssertShape(run, "minimal.for-loop", "Method1", SyntaxKind.ForStatement);
+        AssertShape(run, "minimal.while-loop", "Method1", SyntaxKind.WhileStatement);
+        AssertShape(run, "minimal.do-while", "Method1", SyntaxKind.DoStatement);
+        AssertShape(run, "minimal.switch-int", "Method1", SyntaxKind.SwitchStatement);
     }
 
     [Fact]
@@ -392,7 +407,14 @@ public class GeneratedFixtureCatalogTests
         var ctor = Assert.Single(primaryCtor.GetProperty("Targets").EnumerateArray(),
             target => target.GetProperty("Method").GetString() == ".ctor");
         Assert.Equal("Exact", ctor.GetProperty("ExpectedStatus").GetString());
+        Assert.Equal(JsonValueKind.Null, ctor.GetProperty("ExpectedShape").ValueKind);
         Assert.False(ctor.GetProperty("IsFrontier").GetBoolean());
+
+        var arrayIndex = Assert.Single(fixtures,
+            fixture => fixture.GetProperty("Id").GetString() == "minimal.array-index");
+        var arrayIndexMethod = Assert.Single(arrayIndex.GetProperty("Targets").EnumerateArray(),
+            target => target.GetProperty("Method").GetString() == "Method1");
+        Assert.Equal("ElementAccessExpression", arrayIndexMethod.GetProperty("ExpectedShape").GetString());
     }
 
     [Fact]
@@ -422,7 +444,7 @@ public class GeneratedFixtureCatalogTests
     [Fact]
     public void SelectedFixtureRunJson_ContainsOnlySelectedFixtureResults()
     {
-        var selected = GeneratedFixtureCatalog.Select("minimal.property.literal");
+        var selected = GeneratedFixtureCatalog.Select("minimal.array-index");
         var run = GeneratedFixtureRunner.Run(selected);
         string json = GeneratedFixtureRunner.FormatJson(run);
 
@@ -430,11 +452,12 @@ public class GeneratedFixtureCatalogTests
         var results = document.RootElement.GetProperty("Results").EnumerateArray().ToArray();
 
         Assert.Equal(2, results.Length);
-        Assert.All(results, result =>
-        {
-            Assert.Equal("minimal.property.literal", result.GetProperty("FixtureId").GetString());
-            Assert.Equal("Exact", result.GetProperty("ActualStatus").GetString());
-        });
+        Assert.All(results, result => Assert.Equal("minimal.array-index", result.GetProperty("FixtureId").GetString()));
+        var method = Assert.Single(results, result => result.GetProperty("Method").GetString() == "Method1");
+        Assert.Equal("Exact", method.GetProperty("ActualStatus").GetString());
+        Assert.Equal("ElementAccessExpression", method.GetProperty("ActualShape").GetString());
+        Assert.Equal("ElementAccessExpression", method.GetProperty("ExpectedShape").GetString());
+        Assert.True(method.GetProperty("ShapePassed").GetBoolean());
     }
 
     static void AssertTarget(
@@ -452,8 +475,21 @@ public class GeneratedFixtureCatalogTests
 
         Assert.Equal(expectedStatus, result.ExpectedStatus);
         Assert.Equal(expectedStatus, result.ActualStatus);
+        Assert.True(result.CompileBackPassed);
+        Assert.True(result.ShapePassed);
         Assert.Equal(frontier, result.IsFrontier);
         Assert.Equal("Full", result.DecompilerFidelity);
         Assert.True(result.Passed);
+    }
+
+    static void AssertShape(GeneratedFixtureRunResult run, string fixtureId, string method, SyntaxKind expected)
+    {
+        var result = Assert.Single(run.Results, r =>
+            r.FixtureId == fixtureId &&
+            r.Method == method);
+
+        Assert.Equal(expected, result.ExpectedShape);
+        Assert.Equal(expected, result.ActualShape);
+        Assert.True(result.ShapePassed);
     }
 }

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -6,13 +6,17 @@ using System.Text.Json.Serialization;
 
 using ILInspector.Decompiler.Pipeline;
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
 namespace ILInspector.DecompilerHarness;
 
 /// <summary>
-/// Addressable generated C# fixtures for progressive compile-back checks. The
-/// catalogue names the source shape, expected target methods, and expected
-/// compile-back outcome; the runner materializes those entries as a temporary
-/// class library and grades them with <see cref="FidelityCheck.Evaluate(string)"/>.
+/// Addressable generated C# fixtures for progressive shape and compile-back
+/// checks. The catalogue names the source shape, expected target methods, and
+/// expected outcomes; the runner materializes those entries as a temporary class
+/// library and grades them with a Roslyn shape check plus
+/// <see cref="FidelityCheck.Evaluate(string)"/>.
 /// </summary>
 internal static class GeneratedFixtureCatalog
 {
@@ -203,7 +207,8 @@ internal static class GeneratedFixtureCatalog
             new("GeneratedFixtures.MinimalArrayIndex.Class1", ".ctor",
                 FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalArrayIndex.Class1", "Method1",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedShape: SyntaxKind.ElementAccessExpression),
         ],
         ["minimal", "array", "index"]);
 
@@ -221,7 +226,8 @@ internal static class GeneratedFixtureCatalog
             new("GeneratedFixtures.MinimalArrayLength.Class1", ".ctor",
                 FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalArrayLength.Class1", "Method1",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedShape: SyntaxKind.SimpleMemberAccessExpression),
         ],
         ["minimal", "array", "length"]);
 
@@ -239,7 +245,8 @@ internal static class GeneratedFixtureCatalog
             new("GeneratedFixtures.MinimalStringLength.Class1", ".ctor",
                 FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalStringLength.Class1", "Method1",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedShape: SyntaxKind.SimpleMemberAccessExpression),
         ],
         ["minimal", "string", "length"]);
 
@@ -257,7 +264,8 @@ internal static class GeneratedFixtureCatalog
             new("GeneratedFixtures.MinimalNullCoalesce.Class1", ".ctor",
                 FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalNullCoalesce.Class1", "Method1",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedShape: SyntaxKind.CoalesceExpression),
         ],
         ["minimal", "null-coalesce"]);
 
@@ -287,7 +295,8 @@ internal static class GeneratedFixtureCatalog
             new("GeneratedFixtures.MinimalTryFinally.Class1", ".ctor",
                 FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalTryFinally.Class1", "Method1",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedShape: SyntaxKind.TryStatement),
         ],
         ["minimal", "try-finally", "lifetime"]);
 
@@ -333,7 +342,8 @@ internal static class GeneratedFixtureCatalog
             new("GeneratedFixtures.MinimalForeachArray.Class1", ".ctor",
                 FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalForeachArray.Class1", "Method1",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedShape: SyntaxKind.ForEachStatement),
         ],
         ["minimal", "foreach", "array", "loop"]);
 
@@ -357,7 +367,8 @@ internal static class GeneratedFixtureCatalog
             new("GeneratedFixtures.MinimalForLoop.Class1", ".ctor",
                 FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalForLoop.Class1", "Method1",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedShape: SyntaxKind.ForStatement),
         ],
         ["minimal", "for", "loop"]);
 
@@ -384,7 +395,8 @@ internal static class GeneratedFixtureCatalog
             new("GeneratedFixtures.MinimalWhileLoop.Class1", ".ctor",
                 FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalWhileLoop.Class1", "Method1",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedShape: SyntaxKind.WhileStatement),
         ],
         ["minimal", "while", "loop"]);
 
@@ -412,7 +424,8 @@ internal static class GeneratedFixtureCatalog
             new("GeneratedFixtures.MinimalDoWhileLoop.Class1", ".ctor",
                 FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalDoWhileLoop.Class1", "Method1",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedShape: SyntaxKind.DoStatement),
         ],
         ["minimal", "do-while", "loop"]);
 
@@ -445,7 +458,8 @@ internal static class GeneratedFixtureCatalog
             new("GeneratedFixtures.MinimalSwitchInt.Class1", ".ctor",
                 FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalSwitchInt.Class1", "Method1",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedShape: SyntaxKind.SwitchStatement),
         ],
         ["minimal", "switch", "int", "branch"]);
 
@@ -542,7 +556,8 @@ internal sealed record GeneratedFixtureTarget(
     FidelityCheck.CompileBackStatus ExpectedStatus,
     int Overload = 0,
     bool IsFrontier = false,
-    string? Note = null)
+    string? Note = null,
+    SyntaxKind? ExpectedShape = null)
 {
     public string DisplayMember => $"{Type}::{Method}#{Overload}";
 }
@@ -570,16 +585,42 @@ internal sealed record GeneratedFixtureResult(
     string DecompilerFidelity,
     FidelityCheck.CompileBackStatus? ActualStatus,
     FidelityCheck.CompileBackStatus ExpectedStatus,
+    SyntaxKind? ActualShape,
+    SyntaxKind? ExpectedShape,
+    string? ShapeDetail,
     bool IsFrontier,
     string? Detail,
     string? Note)
 {
-    public bool Passed => ActualStatus == ExpectedStatus;
+    public bool CompileBackPassed => ActualStatus == ExpectedStatus;
+    public bool ShapePassed => ExpectedShape is null || ActualShape == ExpectedShape;
+    public bool Passed => CompileBackPassed && ShapePassed;
     public string DisplayMember => $"{Type}::{Method}#{Overload}";
 }
 
+internal sealed record GeneratedFixtureRender(string DecompilerFidelity, string? Body);
+
 internal static class GeneratedFixtureRunner
 {
+    static readonly SyntaxKind[] s_interestingShapes =
+    [
+        SyntaxKind.IfStatement,
+        SyntaxKind.ForStatement,
+        SyntaxKind.ForEachStatement,
+        SyntaxKind.WhileStatement,
+        SyntaxKind.DoStatement,
+        SyntaxKind.SwitchStatement,
+        SyntaxKind.TryStatement,
+        SyntaxKind.UsingStatement,
+        SyntaxKind.ConditionalExpression,
+        SyntaxKind.CoalesceExpression,
+        SyntaxKind.ElementAccessExpression,
+        SyntaxKind.SimpleMemberAccessExpression,
+        SyntaxKind.AddExpression,
+        SyntaxKind.InvocationExpression,
+        SyntaxKind.ReturnStatement,
+    ];
+
     static readonly JsonSerializerOptions s_jsonOptions = new()
     {
         WriteIndented = true,
@@ -615,21 +656,26 @@ internal static class GeneratedFixtureRunner
 
             var compileBack = FidelityCheck.Evaluate(assemblyPath)
                 .ToDictionary(result => Key(result.Type, result.Method, result.Overload), StringComparer.Ordinal);
-            var decompilerFidelity = DecompilerFidelity(assemblyPath, fixtures);
+            var renders = DecompilerRenders(assemblyPath, fixtures);
             var results = new List<GeneratedFixtureResult>();
             foreach (var fixture in fixtures)
             {
                 foreach (var target in fixture.Targets)
                 {
                     compileBack.TryGetValue(Key(target.Type, target.Method, target.Overload), out var actual);
+                    renders.TryGetValue(Key(target.Type, target.Method, target.Overload), out var render);
+                    var shape = ShapeVerdict(render?.Body, target.ExpectedShape);
                     results.Add(new GeneratedFixtureResult(
                         fixture.Id,
                         target.Type,
                         target.Method,
                         target.Overload,
-                        decompilerFidelity.GetValueOrDefault(Key(target.Type, target.Method, target.Overload), "Unknown"),
+                        render?.DecompilerFidelity ?? "Unknown",
                         actual?.Status,
                         target.ExpectedStatus,
+                        shape.ActualShape,
+                        target.ExpectedShape,
+                        shape.Detail,
                         target.IsFrontier,
                         actual?.Detail ?? (actual is null ? "target-method-not-found" : null),
                         target.Note));
@@ -654,13 +700,18 @@ internal static class GeneratedFixtureRunner
         foreach (var result in run.Results.OrderBy(r => r.FixtureId, StringComparer.Ordinal).ThenBy(r => r.DisplayMember, StringComparer.Ordinal))
         {
             string actual = result.ActualStatus?.ToString() ?? "Missing";
+            string shape = result.ExpectedShape is null
+                ? ""
+                : $"  shape={result.ActualShape?.ToString() ?? "Missing"}  expected-shape={result.ExpectedShape}";
             string frontier = result.IsFrontier ? " frontier" : "";
             string status = result.Passed ? "PASS" : "FAIL";
             sb.AppendLine(
                 $"  {status}{frontier}  {result.FixtureId}  {result.DisplayMember}  " +
-                $"decompiler={result.DecompilerFidelity}  compile-back={actual}  expected={result.ExpectedStatus}");
+                $"decompiler={result.DecompilerFidelity}  compile-back={actual}  expected={result.ExpectedStatus}{shape}");
             if (!string.IsNullOrWhiteSpace(result.Detail))
                 sb.AppendLine($"      detail: {result.Detail}");
+            if (!string.IsNullOrWhiteSpace(result.ShapeDetail))
+                sb.AppendLine($"      shape-detail: {result.ShapeDetail}");
             if (!string.IsNullOrWhiteSpace(result.Note))
                 sb.AppendLine($"      note: {result.Note}");
         }
@@ -710,6 +761,7 @@ internal static class GeneratedFixtureRunner
                     target.Method,
                     target.Overload,
                     ExpectedStatus = target.ExpectedStatus.ToString(),
+                    ExpectedShape = target.ExpectedShape?.ToString(),
                     target.IsFrontier,
                     target.Note,
                 }),
@@ -756,11 +808,11 @@ internal static class GeneratedFixtureRunner
         return new string(chars);
     }
 
-    static Dictionary<string, string> DecompilerFidelity(
+    static Dictionary<string, GeneratedFixtureRender> DecompilerRenders(
         string assemblyPath,
         IReadOnlyList<GeneratedFixtureDefinition> fixtures)
     {
-        var fidelities = new Dictionary<string, string>(StringComparer.Ordinal);
+        var renders = new Dictionary<string, GeneratedFixtureRender>(StringComparer.Ordinal);
         using var source = MetadataSource.Open(assemblyPath);
         foreach (var target in fixtures.SelectMany(fixture => fixture.Targets))
         {
@@ -768,11 +820,48 @@ internal static class GeneratedFixtureRunner
             if (function is null)
                 continue;
 
-            _ = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
-            fidelities[Key(target.Type, target.Method, target.Overload)] = function.Fidelity.ToString();
+            var rendered = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+            renders[Key(target.Type, target.Method, target.Overload)] = new(function.Fidelity.ToString(), rendered.Output);
         }
 
-        return fidelities;
+        return renders;
+    }
+
+    static (SyntaxKind? ActualShape, string? Detail) ShapeVerdict(string? body, SyntaxKind? expected)
+    {
+        if (expected is null)
+            return (null, null);
+        if (string.IsNullOrWhiteSpace(body))
+            return (null, "shape-body-missing");
+
+        var tree = CSharpSyntaxTree.ParseText(
+            $$"""
+            class __GeneratedFixtureShapeShell
+            {
+                void __M()
+                {
+            {{Indent(body)}}
+                }
+            }
+            """,
+            new CSharpParseOptions(LanguageVersion.Preview));
+        var root = tree.GetRoot();
+        if (root.DescendantNodes().Any(node => node.IsKind(expected.Value)))
+            return (expected.Value, null);
+
+        var observed = root
+            .DescendantNodes()
+            .Select(node => (SyntaxKind)node.RawKind)
+            .FirstOrDefault(kind => s_interestingShapes.Contains(kind));
+        return observed == SyntaxKind.None
+            ? (null, "shape-not-found")
+            : (observed, "shape-not-found");
+    }
+
+    static string Indent(string body)
+    {
+        var lines = body.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        return string.Join(Environment.NewLine, lines.Select(line => "        " + line));
     }
 
     static void Build(string workingDirectory)

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -189,7 +189,8 @@ internal static class GeneratedFixtureCatalog
             new("GeneratedFixtures.MinimalIntegerAddition.Class1", ".ctor",
                 FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalIntegerAddition.Class1", "Method1",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedShape: SyntaxKind.AddExpression),
         ],
         ["minimal", "integer", "arithmetic", "addition"]);
 

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -10,8 +10,9 @@ The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — t
 
 **Generated fixtures** (`--generated-fixtures [id|prefix|list]`): builds selected
 generated-fixture catalogue entries into a temporary class library, runs the
-compile-back oracle, and prints results by stable fixture ID plus target method.
-This is the first step toward an addressable progressive fixture ladder:
+Roslyn shape oracle and compile-back oracle, and prints results by stable fixture
+ID plus target method. This is the first step toward an addressable progressive
+fixture ladder:
 `minimal.property.literal`, `minimal.ctor-field.getter`,
 `minimal.auto-property.getter`, `minimal.method-call.same-type`, and
 `minimal.primary-ctor.field-init` are expected `Exact`; the static-call, if/else,
@@ -24,6 +25,10 @@ source-switch lowering observation (lowered as if/else, not the dense switch
 shape) and is opt-in by ID. With no selector, stable generated fixtures run; use
 `list` to list fixture IDs, `--json` for machine-readable list/results, and
 `--keep-generated-fixtures` to preserve the generated project for drill-down.
+Rows may carry two independent expectations: a Roslyn `SyntaxKind` shape verdict
+for the intended C# idiom, and a compile-back opcode verdict for semantic
+fidelity. A row can therefore be opcode-exact while still exposing a shape
+frontier.
 
 **Library report** (`--library-report`): a portfolio view. It combines the IR
 residual buckets from `--gaps` with the Roslyn-backed validity oracle from


### PR DESCRIPTION
- Advances #1742
- Adds dual generated-fixture verdicts: Roslyn shape plus compile-back
- Card revision: `c752b98b`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — generated decompiler fixtures now report shape and compile-back as separate verdict axes for the same source specimen.

Before:

```text
generated fixture target verdict: compile-back only
```

After:

```text
generated fixture target verdicts: compile-back + optional Roslyn SyntaxKind shape
example: minimal.array-index Method1 => compile-back Exact, shape ElementAccessExpression
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Decompiler fast suite | Not run; harness/generated-fixture verdict model only |
| Reduced fixture validity | Not applicable |
| Reduced fixture fidelity | Pass: `minimal.integer-addition` reports `Exact` and `AddExpression` |
| JSON output | Pass: `minimal.array-index` includes `CompileBackPassed`, `ShapePassed`, `ActualShape`, and `ExpectedShape` |
| Real witness | Generated fixtures with shape expectations for array index/length, string length, integer addition, null-coalesce, loops, try/finally, foreach, and switch |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes. This only makes the generated fixture harness distinguish source-shape recovery from semantic opcode fidelity.

`minimal.if-else` intentionally remains compile-back-only in this PR because current output is opcode-exact but not `IfStatement`-shaped; that is exactly the kind of source-shape frontier the dual model is meant to expose without conflating it with compile-back.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked shape parsing, optional expectations, pass semantics, output coherence, tests, and stable row choices. |
| Gemini 3.1 Pro | No blocking findings | Checked shape evaluation, false-failure avoidance, fallback diagnostics, pass semantics, test coverage, Roslyn dependency use, and selected JSON outputs. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.integer-addition
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.array-index --json >/tmp/dual-fixture-array-index.json
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
git diff --check
```
