### PR TITLE
Uniform -D discovery across commands (#1881)

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3717,7 +3717,7 @@ public class CommandExecutionTests
 
             foreach (var command in commands)
             {
-                var discoveryArgs = command.Concat(["-D", "--table", "--tips", "q"]).ToArray();
+                var discoveryArgs = command.Concat(["-D", "--tips", "q"]).ToArray();
                 var (discoverExit, discoverOutput, discoverError) = await RunAppAsync(discoveryArgs);
                 Assert.Equal(0, discoverExit);
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1327,7 +1327,7 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Type_SingleType_Discover_DefaultsToEffective_DropsEmptySections()
+    public async Task Type_SingleType_Discover_DefaultsToDiscoverableSections()
     {
         // -D with no --schema now defaults to effective discovery: it resolves the source
         // and lists only sections that actually have data (the empty-section footgun fix).
@@ -1343,8 +1343,7 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Contains("| Method Groups | section |", output);
-        // JsonSerializer has no custom attributes, so effective-by-default must drop it.
-        Assert.DoesNotContain("| Custom Attributes | section |", output);
+        Assert.Contains("| Custom Attributes | section |", output);
     }
 
     [Fact]
@@ -1389,7 +1388,7 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Type_SingleType_DiscoverEffective_ExcludesMemberDetailCodeSections()
+    public async Task Type_SingleType_DiscoverEffective_IncludesSelectableCodeSections()
     {
         var options = new TypeOptions
         {
@@ -1404,12 +1403,10 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Contains("| Properties | section |", output);
         Assert.Contains("| Method Groups | section |", output);
-        // Code sections (Decompiled Source, Original Source, IL) are member-detail
-        // sections not present in the type schema. They must not appear in effective
-        // discovery, since they are not queryable via -D <Section>.
-        Assert.DoesNotContain("| Decompiled Source | section |", output);
-        Assert.DoesNotContain("| Original Source | section |", output);
-        Assert.DoesNotContain("| IL | section |", output);
+        Assert.Contains("| Decompiled Source | section |", output);
+        Assert.Contains("| Original Source | section |", output);
+        Assert.Contains("| IL | section |", output);
+        Assert.Contains("| Facts | section (opt-in) |", output);
     }
 
     [Fact]
@@ -1426,7 +1423,7 @@ public class CommandExecutionTests
     }
 
     [Fact]
-    public async Task Type_SingleType_DiscoverEffective_ExcludesEmptyCustomAttributesSection()
+    public async Task Type_SingleType_DiscoverEffective_IncludesSelectableCustomAttributesSection()
     {
         var options = new TypeOptions
         {
@@ -1440,10 +1437,7 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Contains("| Method Groups | section |", output);
-        // Custom Attributes is in the type schema, but its CanRender probe is a coarse
-        // "type has methods" proxy; the section only has data when a specific member's
-        // attributes are read. JsonSerializer has none, so effective discovery must not list it.
-        Assert.DoesNotContain("| Custom Attributes | section |", output);
+        Assert.Contains("| Custom Attributes | section |", output);
     }
 
     [Fact]
@@ -3697,6 +3691,55 @@ public class CommandExecutionTests
         Assert.Contains("| Library Info | section |", output);
         Assert.Contains("| Async Methods | section (opt-in) |", output);
         Assert.Contains("| Custom Attributes | section (opt-in) |", output);
+    }
+
+    [Fact]
+    public async Task CliDiscoverySections_AreSelectable()
+    {
+        var (packagePath, tempDir) = CreateLocalRefPackage("System.Runtime");
+        try
+        {
+            var diffV1 = Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(TestAssemblyPath)!, "..", "..",
+                "DiffFixtures.V1", "release", "DiffFixtureSample.dll"));
+            var diffV2 = Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(TestAssemblyPath)!, "..", "..",
+                "DiffFixtures.V2", "release", "DiffFixtureSample.dll"));
+
+            List<string[]> commands =
+            [
+                ["library", TestAssemblyPath],
+                ["type", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath],
+                ["member", typeof(MemberCallsFixture).FullName!, nameof(MemberCallsFixture.CallsInterfaceItem), "--library", TestAssemblyPath],
+                ["package", packagePath],
+                ["diff", "--library", $"{diffV1}..{diffV2}"]
+            ];
+
+            foreach (var command in commands)
+            {
+                var discoveryArgs = command.Concat(["-D", "--table", "--tips", "q"]).ToArray();
+                var (discoverExit, discoverOutput, discoverError) = await RunAppAsync(discoveryArgs);
+                Assert.Equal(0, discoverExit);
+
+                var sections = ExtractDiscoveryRows(discoverOutput)
+                    .Where(row => row.Kind.StartsWith("section", StringComparison.OrdinalIgnoreCase))
+                    .Select(row => row.Name)
+                    .ToArray();
+                Assert.NotEmpty(sections);
+
+                foreach (var section in sections)
+                {
+                    var selectArgs = command.Concat(["-S", section, "--table", "--tips", "q", "-n", "40"]).ToArray();
+                    var (selectExit, _, selectError) = await RunAppAsync(selectArgs);
+                    Assert.True(selectExit == 0,
+                        $"{command[0]} -S '{section}' failed after being listed by -D. Discovery stderr: {discoverError}. Selection stderr: {selectError}");
+                }
+            }
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1406,7 +1406,7 @@ public class CommandExecutionTests
         Assert.Contains("| Decompiled Source | section |", output);
         Assert.Contains("| Original Source | section |", output);
         Assert.Contains("| IL | section |", output);
-        Assert.Contains("| Facts | section (opt-in) |", output);
+        Assert.DoesNotContain("| Facts | section", output);
     }
 
     [Fact]
@@ -3710,7 +3710,9 @@ public class CommandExecutionTests
             [
                 ["library", TestAssemblyPath],
                 ["type", typeof(MemberCallsFixture).FullName!, "--library", TestAssemblyPath],
+                ["type", typeof(EmptyDiscoveryFixture).FullName!, "--library", TestAssemblyPath],
                 ["member", typeof(MemberCallsFixture).FullName!, nameof(MemberCallsFixture.CallsInterfaceItem), "--library", TestAssemblyPath],
+                ["member", typeof(MemberCallsFixture).FullName!, nameof(MemberCallsFixture.Overloaded), "--library", TestAssemblyPath],
                 ["package", packagePath],
                 ["diff", "--library", $"{diffV1}..{diffV2}"]
             ];
@@ -3725,14 +3727,22 @@ public class CommandExecutionTests
                     .Where(row => row.Kind.StartsWith("section", StringComparison.OrdinalIgnoreCase))
                     .Select(row => row.Name)
                     .ToArray();
-                Assert.NotEmpty(sections);
+                if (!IsNoMemberTypeDiscoveryCommand(command))
+                    Assert.NotEmpty(sections);
 
                 foreach (var section in sections)
                 {
                     var selectArgs = command.Concat(["-S", section, "--table", "--tips", "q", "-n", "40"]).ToArray();
-                    var (selectExit, _, selectError) = await RunAppAsync(selectArgs);
+                    var (selectExit, selectOutput, selectError) = await RunAppAsync(selectArgs);
                     Assert.True(selectExit == 0,
                         $"{command[0]} -S '{section}' failed after being listed by -D. Discovery stderr: {discoverError}. Selection stderr: {selectError}");
+                    if (RequiresRealDataDiscoveryGuard(command))
+                    {
+                        Assert.False(string.IsNullOrWhiteSpace(selectOutput),
+                            $"{command[0]} -S '{section}' produced no data after being listed by -D.");
+                        Assert.DoesNotContain("has no data", selectOutput, StringComparison.OrdinalIgnoreCase);
+                        Assert.DoesNotContain("has no data", selectError, StringComparison.OrdinalIgnoreCase);
+                    }
                 }
             }
         }
@@ -3741,6 +3751,73 @@ public class CommandExecutionTests
             Directory.Delete(tempDir, recursive: true);
         }
     }
+
+    private static bool RequiresRealDataDiscoveryGuard(string[] command)
+        => IsNoMemberTypeDiscoveryCommand(command)
+           || command is ["member", _, var memberName, ..]
+                && memberName == nameof(MemberCallsFixture.Overloaded);
+
+    private static bool IsNoMemberTypeDiscoveryCommand(string[] command)
+        => command is ["type", var typeName, ..]
+           && typeName == typeof(EmptyDiscoveryFixture).FullName;
+
+    [Fact]
+    public async Task MemberDiscovery_MultiOverload_DoesNotListSingleOverloadSections()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberCallsFixture).FullName!, nameof(MemberCallsFixture.Overloaded),
+            "--library", TestAssemblyPath, "-D", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("Tip:", error);
+
+        var sections = ExtractDiscoveryRows(output)
+            .Where(row => row.Kind.StartsWith("section", StringComparison.OrdinalIgnoreCase))
+            .Select(row => row.Name)
+            .ToArray();
+
+        foreach (var section in SingleOverloadDiscoverySections)
+            Assert.DoesNotContain(section, sections);
+    }
+
+    [Fact]
+    public async Task TypeDiscovery_NoMemberType_DoesNotListMethodBodySections()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", typeof(EmptyDiscoveryFixture).FullName!, "--library", TestAssemblyPath, "-D", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("Tip:", error);
+
+        var sections = ExtractDiscoveryRows(output)
+            .Where(row => row.Kind.StartsWith("section", StringComparison.OrdinalIgnoreCase))
+            .Select(row => row.Name)
+            .ToArray();
+
+        Assert.DoesNotContain("Top Leverage", sections);
+        Assert.DoesNotContain("Performance Triage", sections);
+        Assert.DoesNotContain("Facts", sections);
+        Assert.DoesNotContain("IL", sections);
+        Assert.DoesNotContain("Source Files", sections);
+    }
+
+    private static readonly string[] SingleOverloadDiscoverySections =
+    [
+        "Signature",
+        "Custom Attributes",
+        "Decompiled Source",
+        "Annotated Source",
+        "Original Source",
+        "Calls",
+        "Callers",
+        "Call Graph",
+        "Caller Graph",
+        "Unsafe Operations",
+        "Top Leverage",
+        "Performance Triage",
+        "Facts",
+        "IL"
+    ];
 
     [Fact]
     public async Task LibraryCommand_DiscoverEffective_ListsSourceLinkAuditSections()
@@ -6610,4 +6687,8 @@ public class CommandExecutionTests
             Directory.Delete(tempDir, recursive: true);
         }
     }
+}
+
+public interface EmptyDiscoveryFixture
+{
 }

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1332,7 +1332,7 @@ public class SectionPipelineTests
         var apiType = new ApiType
         {
             Name = "Sample",
-            Kind = "class",
+            Kind = "enum",
             BaseType = "Base",
             Interfaces = ["IDisposable"],
             SourceUrl = "https://example.com/Sample.cs",
@@ -1363,7 +1363,13 @@ public class SectionPipelineTests
         var overloadPipeline = ApiMemberOverloadSectionDescriptors.CreatePipeline();
         yield return DiscoverableCase("member-overload", overloadPipeline, apiType);
         var detailPipeline = ApiMemberDetailSectionDescriptors.CreatePipeline();
-        yield return DiscoverableCase("member-detail", detailPipeline, apiType);
+        var detailType = new ApiType
+        {
+            Name = "Sample",
+            Kind = "class",
+            Members = [new ApiMember { Name = "Method", Kind = "method" }]
+        };
+        yield return DiscoverableCase("member-detail", detailPipeline, detailType);
 
         var diffPipeline = DiffSections.CreatePipeline();
         yield return DiscoverableCase("diff", diffPipeline, new DiffDiscoveryModel());
@@ -1373,7 +1379,7 @@ public class SectionPipelineTests
         string command,
         SectionPipeline<TModel> pipeline,
         TModel model) =>
-        [command, pipeline.AllSectionNames, pipeline.GetDiscoverableSections(model)];
+        [command, pipeline.SelectableSectionNames, pipeline.GetDiscoverableSections(model)];
 
     // ===== API type-list pipeline tests =====
 

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -256,6 +256,21 @@ public class SectionPipelineTests
         Assert.Contains("Performance Triage", pipeline.AllSectionNames);
     }
 
+    [Theory]
+    [MemberData(nameof(DiscoverablePipelineCases))]
+    public void DiscoverableSections_ContainEverySelectableSection(
+        string command,
+        string[] registered,
+        IReadOnlyCollection<string> discoverable)
+    {
+        var missing = registered
+            .Where(name => !discoverable.Contains(name, StringComparer.OrdinalIgnoreCase))
+            .ToArray();
+
+        Assert.True(missing.Length == 0,
+            $"{command} -D missed selectable section(s): {string.Join(", ", missing)}");
+    }
+
     [Fact]
     public void MemberDetailPipeline_OptimizationOpportunities_IsStructurallyDiscoverable()
     {
@@ -1190,6 +1205,175 @@ public class SectionPipelineTests
 
         Assert.Equal(["Package Info", "Library Files"], pipeline.InfoSectionNames);
     }
+
+    public static IEnumerable<object[]> DiscoverablePipelineCases()
+    {
+        var libraryPipeline = LibrarySections.CreatePipeline();
+        var library = new LibraryInspection
+        {
+            AssemblyInfo = new AssemblyInfo
+            {
+                References = [new AssemblyReference("System.Runtime", "1.0.0.0", null, null)],
+                TransitiveReferences = [new AssemblyReferenceNode { Name = "System.Runtime", Version = "1.0.0.0" }]
+            },
+            PdbPath = "test.pdb",
+            HasSourceLink = true,
+            HasEmbeddedPdb = true,
+            HasSwitches = true,
+            HasExtensionTypes = true,
+            HasUnsafeCode = true,
+            HasMethodBodies = true,
+            HasPInvokeImports = true,
+            HasRuntimeAsync = true,
+            HasStateMachineAsync = true,
+            HasManifestResources = true,
+            HasAssemblyAttributes = true,
+            HasExportedTypeForwarders = true,
+            HasAspNetCoreSupport = true,
+            HasAspireSupport = true,
+            HasOpenTelemetrySupport = true,
+            HasAISupport = true,
+            HasAuthenticationSupport = true,
+            HasConfigurationSupport = true,
+            HasDependencyInjectionSupport = true,
+            HasLoggingSupport = true,
+            HasOptionsSupport = true,
+            HasHostingSupport = true,
+            HasHealthChecksSupport = true,
+            HasHttpClientSupport = true,
+            HasOpenApiSupport = true,
+            IntegrationCount = 1,
+            SourceFiles = [new SourceFileInfo("T", "https://example.com/T.cs")],
+            AllSourcesAccessible = true,
+            TotalSourceFiles = 1,
+            MissingSourceFiles = ["missing.cs"],
+            SourceIntegrityChecked = true,
+            AuditSignals = [new AuditSignal("Provenance", "SourceLink", "Present", "test")],
+            Switches = [new SwitchInfo("Feature Switch", "Switch", "Api")],
+            ExtensionMethods = [new ExtensionMethodSummary { MethodName = "Ext", ExtendedType = "Target", ExtensionClass = "Extensions" }],
+            UnsafeMembers = [new UnsafeMemberSummary { Member = "T.M()", Reason = "Unsafe signature", Detail = "int*", Kind = "signature" }],
+            TopLeverage = [new MethodLeverageSummary { Member = "T.M()", Callers = 1 }],
+            OptimizationOpportunities =
+            [
+                new OptimizationOpportunitySummary
+                {
+                    Member = "T.M()",
+                    Shape = "capturing-delegate",
+                    Evidence = "delegate over a captured receiver or closure",
+                    Fix = "Use a static local function.",
+                    Confidence = "high"
+                }
+            ],
+            PInvokeMethods = [new ClassifiedMethodSummary { MethodName = "P", DeclaringType = "T", Signature = "void P()" }],
+            AsyncMethods = [new AsyncMethodSummary { MethodName = "A", DeclaringType = "T", Signature = "void A()" }],
+            Resources = [new ResourceSummary { Name = "res", Size = 1, Visibility = "public" }],
+            CustomAttributes = [new CustomAttributeSummary { Name = "Attr", Target = "Assembly" }],
+            TypeForwarders = [new TypeForwarderSummary { TypeName = "T", TargetAssembly = "Other" }],
+            NonNormalizedPaths = ["C:\\src\\T.cs"],
+            Integrations = [new IntegrationSummary("Integration", 1)],
+            IntegrationOpportunities = [new IntegrationOpportunityInfo("Aspire", "T", "Builder", "Add*")],
+            AI = [new IntegrationSignal("T", "M", "Evidence")],
+            AspNetCore = [new IntegrationSignal("T", "M", "Evidence")],
+            Authentication = [new IntegrationSignal("T", "M", "Evidence")],
+            Aspire = [new IntegrationSignal("T", "M", "Evidence")],
+            Configuration = [new IntegrationSignal("T", "M", "Evidence")],
+            DependencyInjection = [new IntegrationSignal("T", "M", "Evidence")],
+            Logging = [new IntegrationSignal("T", "M", "Evidence")],
+            OpenTelemetry = [new IntegrationSignal("T", "M", "Evidence")],
+            OpenApi = [new IntegrationSignal("T", "M", "Evidence")],
+            Options = [new IntegrationSignal("T", "M", "Evidence")],
+            Hosting = [new IntegrationSignal("T", "M", "Evidence")],
+            HealthChecks = [new IntegrationSignal("T", "M", "Evidence")],
+            HttpClient = [new IntegrationSignal("T", "M", "Evidence")]
+        };
+        yield return DiscoverableCase("library", libraryPipeline, library);
+
+        var packagePipeline = PackageSectionDescriptors.CreatePipeline();
+        var package = new InspectionResult
+        {
+            PackageName = "Test",
+            Version = "1.0.0",
+            PackageReadmeFile = "README.md",
+            PackageFiles =
+            [
+                new PackageFile("README.md", 1, IsReadme: true),
+                new PackageFile("docs/guide.md", 1),
+                new PackageFile("lib/net8.0/Test.dll", 1)
+            ],
+            AuditSignals = [new AuditSignal("Package", "Assemblies", "1", "test")],
+            TotalDownloads = 1,
+            TargetFrameworks = ["net8.0"],
+            LibraryFiles = ["lib/net8.0/Test.dll"],
+            SourceFiles = [new PackageSourceFileInfo("lib/net8.0/Test.dll", "T", "https://example.com/T.cs")],
+            SignatureResult = new SignatureVerificationResult { AuthorVerified = true, Publisher = "test" },
+            DependencyGroups = [new DependencyGroup { TargetFramework = "net8.0", Dependencies = [new PackageDependency { Id = "Dep", Version = "1.0" }] }],
+            Vulnerabilities = [new PackageVulnerability { AdvisoryUrl = "https://example.com", Severity = "High" }],
+            RuntimeIdentifierPackages = [new RidPackageReference { RuntimeIdentifier = "win-x64", PackageId = "Test.win-x64" }],
+            RuntimeDependencies = [new PackageDependency { Id = "Runtime.Dep", Version = "1.0" }],
+            Files = [new PackageFile("lib/net8.0/Test.dll", 1)],
+            AssemblyCount = 1
+        };
+        yield return DiscoverableCase("package", packagePipeline, package);
+
+        var typePipeline = ApiTypeSectionDescriptors.CreatePipeline();
+        var surface = new ApiSurface
+        {
+            Types =
+            [
+                new ApiType { Name = "C", Kind = "class" },
+                new ApiType { Name = "S", Kind = "struct" },
+                new ApiType { Name = "I", Kind = "interface" },
+                new ApiType { Name = "E", Kind = "enum" },
+                new ApiType { Name = "D", Kind = "delegate" },
+            ]
+        };
+        yield return DiscoverableCase("type", typePipeline, surface);
+
+        var apiType = new ApiType
+        {
+            Name = "Sample",
+            Kind = "class",
+            BaseType = "Base",
+            Interfaces = ["IDisposable"],
+            SourceUrl = "https://example.com/Sample.cs",
+            AdditionalSourceFiles =
+            [
+                new PartialSourceFileInfo
+                {
+                    FilePath = "Sample.Other.cs",
+                    SourceUrl = "https://example.com/Sample.Other.cs"
+                }
+            ],
+            TypeParameters = [new TypeParameter { Name = "T" }],
+            Members =
+            [
+                new ApiMember { Name = "Value", Kind = "field", EnumValue = 1 },
+                new ApiMember { Name = ".ctor", Kind = "constructor" },
+                new ApiMember { Name = "Field", Kind = "field" },
+                new ApiMember { Name = "Property", Kind = "property" },
+                new ApiMember { Name = "Method", Kind = "method" },
+                new ApiMember { Name = "op_Equality", Kind = "operator" },
+                new ApiMember { Name = "IFoo.Bar", Kind = "explicit-interface-implementation" },
+                new ApiMember { Name = "Ext", Kind = "extension-method" },
+                new ApiMember { Name = "Changed", Kind = "event" }
+            ]
+        };
+        var memberPipeline = ApiMemberSectionDescriptors.CreatePipeline();
+        yield return DiscoverableCase("member", memberPipeline, apiType);
+        var overloadPipeline = ApiMemberOverloadSectionDescriptors.CreatePipeline();
+        yield return DiscoverableCase("member-overload", overloadPipeline, apiType);
+        var detailPipeline = ApiMemberDetailSectionDescriptors.CreatePipeline();
+        yield return DiscoverableCase("member-detail", detailPipeline, apiType);
+
+        var diffPipeline = DiffSections.CreatePipeline();
+        yield return DiscoverableCase("diff", diffPipeline, new DiffDiscoveryModel());
+    }
+
+    private static object[] DiscoverableCase<TModel>(
+        string command,
+        SectionPipeline<TModel> pipeline,
+        TModel model) =>
+        [command, pipeline.AllSectionNames, pipeline.GetDiscoverableSections(model)];
 
     // ===== API type-list pipeline tests =====
 

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -45,6 +45,16 @@ public class SectionPipelineTests
         public static bool CanRender(TestModel model) => model.Count > 0;
     }
 
+    private sealed class UnprobedSection : ISectionDescriptor<TestModel>
+    {
+        public static string Name => "Unprobed";
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static bool ProbeEffectiveness => false;
+        public static string? ScannerKey => null;
+        public static bool CanRender(TestModel model) => model.Count > 0;
+    }
+
     private static SectionPipeline<TestModel> CreateTestPipeline() =>
         new SectionPipeline<TestModel>()
             .Add<AlwaysSection>()
@@ -120,6 +130,16 @@ public class SectionPipelineTests
         Assert.Equal(["Structural"], applicable);
         Assert.Empty(available);
         Assert.Equal(["Structural"], explicitlyApplicable);
+    }
+
+    [Fact]
+    public void GetDiscoverableSections_UnprobedStillRequiresApplicability()
+    {
+        var pipeline = new SectionPipeline<TestModel>()
+            .Add<UnprobedSection>();
+
+        Assert.Empty(pipeline.GetDiscoverableSections(new TestModel("target", 0)));
+        Assert.Equal(["Unprobed"], pipeline.GetDiscoverableSections(new TestModel("target", 1)));
     }
 
     [Fact]
@@ -270,6 +290,66 @@ public class SectionPipelineTests
         Assert.True(missing.Length == 0,
             $"{command} -D missed selectable section(s): {string.Join(", ", missing)}");
     }
+
+    [Fact]
+    public void MemberOverloadPipeline_MultiOverload_DoesNotDiscoverSingleOverloadSections()
+    {
+        var pipeline = ApiMemberOverloadSectionDescriptors.CreatePipeline();
+        var type = new ApiType
+        {
+            Namespace = "N",
+            Name = "T",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember { Kind = "method", Name = "M" },
+                new ApiMember { Kind = "method", Name = "M" }
+            ]
+        };
+
+        var discoverable = pipeline.GetDiscoverableSections(type);
+
+        foreach (var section in SingleOverloadSections)
+            Assert.DoesNotContain(section, discoverable);
+    }
+
+    [Fact]
+    public void MemberPipeline_NoMemberType_DoesNotDiscoverMethodBodySections()
+    {
+        var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
+        var type = new ApiType
+        {
+            Namespace = "N",
+            Name = "Empty",
+            Kind = "interface"
+        };
+
+        var discoverable = pipeline.GetDiscoverableSections(type);
+
+        Assert.DoesNotContain(SectionNames.TopLeverage, discoverable);
+        Assert.DoesNotContain(SectionNames.PerformanceTriage, discoverable);
+        Assert.DoesNotContain(SectionNames.Facts, discoverable);
+        Assert.DoesNotContain(SectionNames.IL, discoverable);
+        Assert.DoesNotContain(SectionNames.SourceFiles, discoverable);
+    }
+
+    private static readonly string[] SingleOverloadSections =
+    [
+        SectionNames.Signature,
+        SectionNames.CustomAttributes,
+        SectionNames.DecompiledSource,
+        SectionNames.AnnotatedSource,
+        SectionNames.OriginalSource,
+        SectionNames.Calls,
+        SectionNames.Callers,
+        SectionNames.CallGraph,
+        SectionNames.CallerGraph,
+        SectionNames.UnsafeOperations,
+        SectionNames.TopLeverage,
+        SectionNames.PerformanceTriage,
+        SectionNames.Facts,
+        SectionNames.IL
+    ];
 
     [Fact]
     public void MemberDetailPipeline_OptimizationOpportunities_IsStructurallyDiscoverable()
@@ -1358,10 +1438,6 @@ public class SectionPipelineTests
                 new ApiMember { Name = "Changed", Kind = "event" }
             ]
         };
-        var memberPipeline = ApiMemberSectionDescriptors.CreatePipeline();
-        yield return DiscoverableCase("member", memberPipeline, apiType);
-        var overloadPipeline = ApiMemberOverloadSectionDescriptors.CreatePipeline();
-        yield return DiscoverableCase("member-overload", overloadPipeline, apiType);
         var detailPipeline = ApiMemberDetailSectionDescriptors.CreatePipeline();
         var detailType = new ApiType
         {
@@ -1369,6 +1445,10 @@ public class SectionPipelineTests
             Kind = "class",
             Members = [new ApiMember { Name = "Method", Kind = "method" }]
         };
+        var memberPipeline = ApiMemberSectionDescriptors.CreatePipeline();
+        yield return DiscoverableCase("member", memberPipeline, apiType, detailType);
+        var overloadPipeline = ApiMemberOverloadSectionDescriptors.CreatePipeline();
+        yield return DiscoverableCase("member-overload", overloadPipeline, apiType, detailType);
         yield return DiscoverableCase("member-detail", detailPipeline, detailType);
 
         var diffPipeline = DiffSections.CreatePipeline();
@@ -1378,8 +1458,14 @@ public class SectionPipelineTests
     private static object[] DiscoverableCase<TModel>(
         string command,
         SectionPipeline<TModel> pipeline,
-        TModel model) =>
-        [command, pipeline.SelectableSectionNames, pipeline.GetDiscoverableSections(model)];
+        params TModel[] models)
+    {
+        var discoverable = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var model in models)
+            discoverable.UnionWith(pipeline.GetDiscoverableSections(model));
+
+        return [command, pipeline.SelectableSectionNames, discoverable.ToArray()];
+    }
 
     // ===== API type-list pipeline tests =====
 

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -70,6 +70,8 @@ public static class InspectionCommandDefinitions
         diffCommand.Options.Add(legendOption);
         opts.AddOutputOptionsTo(diffCommand);
         opts.AddNuGetOptionsTo(diffCommand);
+        diffCommand.Options.Add(opts.Discover);
+        diffCommand.Options.Add(opts.Tree);
         diffCommand.Options.Add(opts.Select);
 
         var commandArgs = new DiffOptionsParser.DiffCommandArgs(

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -235,11 +235,12 @@ public class ApiCommand
             ApiViewContext.Default.GetSchemaInfo<ExplicitInterfaceImplementationsView>()!.ToDocumentSchema(),
             ApiViewContext.Default.GetSchemaInfo<ExtensionMethodsView>()!.ToDocumentSchema(),
             ApiViewContext.Default.GetSchemaInfo<EventsView>()!.ToDocumentSchema());
-        if (!ApiMemberSectionPipelines.UsesDetailPipeline(options))
-            return schema;
-
+        // MemberCodeView owns source/IL/fact/call-graph sections. Type discovery also needs
+        // those schema entries because the type pipeline exposes whole-type code sections.
         var detailSchema = MergeSchemas(schema,
             ApiViewContext.Default.GetSchemaInfo<MemberCodeView>()!.ToDocumentSchema());
+        if (!ApiMemberSectionPipelines.UsesDetailPipeline(options))
+            return detailSchema;
         if (detailSchema.GetSection(SectionNames.Calls) == null)
             detailSchema.Add(SectionNames.Calls, "column", "Callee", "Kind", "IL", "Token");
         if (detailSchema.GetSection(SectionNames.Callers) == null)
@@ -883,32 +884,16 @@ public class ApiCommand
     {
         var fullSchema = GetTypeDocumentSchema(options);
         var filteredType = BuildFilteredTypeForSections(apiType, options);
-        var applicable = memberPipeline.GetApplicableSections(filteredType, options.IncludeSections);
-        applicable = DiscoverOutput.RestrictToSchemaSections(applicable, fullSchema);
-        var explicitlyApplicable = memberPipeline.GetExplicitlyApplicableSections(filteredType, options.IncludeSections);
-        // Index-backed sections (Calls, Callers, Unsafe Operations) declare ProbeEffectiveness=false:
-        // they are listed structurally via IsApplicable and never rendered during discovery, so -D does
-        // not open the whole-assembly IL index just to test them.
+        var effective = memberPipeline.GetDiscoverableSections(filteredType, options.IncludeSections);
+        effective = DiscoverOutput.RestrictToSchemaSections(effective, fullSchema);
         var unprobed = memberPipeline.GetUnprobedSections();
         var bareDiscover = options.Discover is null or { Length: 0 };
         var discoveryRenderSections = bareDiscover
             ? options is MemberOptions { OverloadIndex: not null }
-                ? [.. applicable.Where(s => !unprobed.Contains(s))]
-                : [.. applicable.Where(memberPipeline.GetCostAnnotations().ContainsKey)]
+                ? [.. effective.Where(s => !unprobed.Contains(s))]
+                : [.. effective.Where(memberPipeline.GetCostAnnotations().ContainsKey)]
             : (IReadOnlyCollection<string>?)null;
         var rendered = RenderTypeSectionsMarkdown(filteredType, options, discoveryRenderSections);
-        var renderedKept = DiscoverOutput.RestrictToRenderedSections(applicable, fullSchema, rendered);
-        // Keep rendered sections plus sections that intentionally opted into structural discovery,
-        // preserving registration order. Explicit applicability covers sections whose default
-        // render pass may choose a compact alternate representation (for example Method Groups
-        // instead of Methods) even though the full section is selectable and content-producing.
-        var keep = new HashSet<string>(renderedKept, StringComparer.OrdinalIgnoreCase);
-        foreach (var s in applicable)
-        {
-            if (unprobed.Contains(s) || explicitlyApplicable.Contains(s))
-                keep.Add(s);
-        }
-        var effective = applicable.Where(keep.Contains).ToList();
         var schema = DiscoverOutput.FilterSchemaToRenderedHeaders(effective, fullSchema, rendered);
         // Unprobed sections may render empty and must be opt-in by policy, so the
         // normal opt-in annotation is sufficient and avoids double labels.

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -65,7 +65,7 @@ public class ApiCommand
         bool hasTypeName = !string.IsNullOrWhiteSpace(options.TypeName);
         bool typeNameIsGlob = hasTypeName && (options.TypeName!.Contains('*') || options.TypeName!.Contains('?'));
         bool singleTypeMode = options is MemberOptions || (hasTypeName && !typeNameIsGlob);
-        var knownSections = singleTypeMode ? memberPipeline.AllSectionNames : typePipeline.AllSectionNames;
+        var knownSections = singleTypeMode ? memberPipeline.SelectableSectionNames : typePipeline.SelectableSectionNames;
 
         // Discovery mode: -D/--discover lists effective sections (resolves source) by
         // default; --schema opts out to the cheap, offline static schema listing.
@@ -361,7 +361,7 @@ public class ApiCommand
         if (options.Discover is { Length: > 0 } discover)
         {
             var resolved = SelectResolver.ResolveSelectAsSections(
-                discover, pipeline.AllSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
+                discover, pipeline.SelectableSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
             if (!resolved.HasError && resolved.Sections is { Count: > 0 })
                 sections.UnionWith(resolved.Sections);
         }
@@ -894,11 +894,27 @@ public class ApiCommand
                 : [.. effective.Where(memberPipeline.GetCostAnnotations().ContainsKey)]
             : (IReadOnlyCollection<string>?)null;
         var rendered = RenderTypeSectionsMarkdown(filteredType, options, discoveryRenderSections);
-        var schema = DiscoverOutput.FilterSchemaToRenderedHeaders(effective, fullSchema, rendered);
         // Unprobed sections may render empty and must be opt-in by policy, so the
         // normal opt-in annotation is sufficient and avoids double labels.
         var displayAnnotations = memberPipeline.GetCostAnnotations();
-        return DiscoverOutput.ExecuteEffective(options.Discover, effective, schema,
+        var queryEffective = effective;
+        var specificSectionDiscover = options.Discover is { Length: > 0 }
+            && options.Discover.Any(name => !name.StartsWith("@", StringComparison.Ordinal));
+        if (specificSectionDiscover)
+        {
+            var renderedKept = DiscoverOutput.RestrictToRenderedSections(effective, fullSchema, rendered);
+            var keep = new HashSet<string>(renderedKept, StringComparer.OrdinalIgnoreCase);
+            foreach (var section in effective)
+            {
+                if (unprobed.Contains(section)
+                    || displayAnnotations.TryGetValue(section, out var annotation)
+                       && annotation.Equals(SectionAnnotations.OptIn, StringComparison.OrdinalIgnoreCase))
+                    keep.Add(section);
+            }
+            queryEffective = effective.Where(keep.Contains).ToList();
+        }
+        var schema = DiscoverOutput.FilterSchemaToRenderedHeaders(queryEffective, fullSchema, rendered);
+        return DiscoverOutput.ExecuteEffective(options.Discover, queryEffective, schema,
             tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.OneLine && !options.JsonOutput,
             verbosity: (int)options.Verbosity, fullSchema: fullSchema,
             sectionCostAnnotations: displayAnnotations,
@@ -938,7 +954,7 @@ public class ApiCommand
         {
             var pipeline = ApiMemberSectionPipelines.Create(options);
             var resolved = SelectResolver.ResolveSelectAsSections(
-                discover, pipeline.AllSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
+                discover, pipeline.SelectableSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
             if (!resolved.HasError && resolved.Sections is { Count: > 0 })
             {
                 var include = renderOptions.IncludeSections is null

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -22,7 +22,7 @@ public class DiffCommand
     {
         var pipeline = DiffSections.CreatePipeline();
         var selectResult = SelectResolver.ResolveSelectAsSections(
-            options.Select, pipeline.AllSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
+            options.Select, pipeline.SelectableSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
         if (SelectOutput.WriteUnresolved(selectResult))
             return 1;
         if (selectResult.Sections != null)

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -20,6 +20,14 @@ public class DiffCommand
     public const string Name = "diff";
     public static async Task<int> ExecuteAsync(DiffOptions options)
     {
+        var pipeline = DiffSections.CreatePipeline();
+        var selectResult = SelectResolver.ResolveSelectAsSections(
+            options.Select, pipeline.AllSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
+        if (SelectOutput.WriteUnresolved(selectResult))
+            return 1;
+        if (selectResult.Sections != null)
+            options = options with { IncludeSections = selectResult.Sections };
+
         var hasPlatform = !string.IsNullOrEmpty(options.PlatformVersionRange);
         var hasPackage = !string.IsNullOrEmpty(options.PackageVersionRange);
         var hasLibrary = !string.IsNullOrEmpty(options.LibraryVersionRange);
@@ -27,11 +35,12 @@ public class DiffCommand
         // Discovery mode: -D/--discover lists schema
         if (options.Discover != null)
         {
-            var schemaMap = new DocumentSchema()
-                .Add("Changes", "column", "Change", "Type", "Detail")
-                .Add("Analysis Diff", "section", "Member", "Signal", "Old", "New", "Delta", "Shape", "Evidence");
-            return DiscoverOutput.Execute(options.Discover, schemaMap,
-                tree: options.Tree, json: false, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.OneLine);
+            var schemaMap = DiffSections.CreateSchema();
+            var discoverable = pipeline.GetDiscoverableSections(new DiffDiscoveryModel(), options.IncludeSections);
+            return DiscoverOutput.ExecuteEffective(options.Discover, discoverable, schemaMap,
+                tree: options.Tree, json: false, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.OneLine,
+                sectionCostAnnotations: pipeline.GetCostAnnotations(),
+                sectionCategories: pipeline.GetCategoryMap());
         }
 
         if (!hasPlatform && !hasPackage && !hasLibrary)
@@ -346,7 +355,7 @@ public class DiffCommand
 
     private static bool SelectsAnalysisDiff(DiffOptions options)
         => options.AllocRegressionsOnly
-            || options.Select?.Any(value => string.Equals(value, "Analysis Diff", StringComparison.OrdinalIgnoreCase)) == true;
+            || options.IncludeSections?.Contains("Analysis Diff") == true;
 
     internal sealed record AnalysisDiffResult(List<AnalysisDiffRow> Rows, string Summary);
 
@@ -776,6 +785,7 @@ public record DiffOptions
     public string[]? Discover { get; init; }
     public bool Tree { get; init; }
     public string[]? Select { get; init; }
+    public HashSet<string>? IncludeSections { get; init; }
     public string[]? Columns { get; init; }
     public string[]? Fields { get; init; }
     public int? Rows { get; init; }

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -57,7 +57,7 @@ public class LibraryCommand
 
         // -S/--select with values: resolve as section filter for backpressure
         var selectResult = SelectResolver.ResolveSelectAsSections(
-            options.Select, pipeline.AllSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
+            options.Select, pipeline.SelectableSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
         if (SelectOutput.WriteUnresolved(selectResult)) return 1;
         if (selectResult.Sections != null)
             options = options with { IncludeSections = selectResult.Sections };

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -306,7 +306,7 @@ public class LibraryCommand
         // Compute all structurally applicable sections for discovery/caching,
         // including opt-in sections whose renderability depends on the section's
         // own work (for example SourceLink audit sections).
-        var allEffective = pipeline.GetApplicableSections(inspection);
+        var allEffective = pipeline.GetDiscoverableSections(inspection);
         var schemaMap = InspectionContext.Default.GetSchemaInfo<LibraryInspectionView>()!.ToDocumentSchema();
 
         // Field-level filtering on ALL effective sections (unfiltered) for caching

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -29,7 +29,7 @@ public class PackageCommand
         var packageArgs = options.PackageArgs;
         var explicitVersion = options.ExplicitVersion;
         var pipeline = PackageSectionDescriptors.CreatePipeline();
-        var sectionNames = pipeline.AllSectionNames;
+        var sectionNames = pipeline.SelectableSectionNames;
         bool packageLibraryMode = options.PackageLibrary != null || options.AllLibraries;
 
         // Static discovery mode: -D --schema lists schema without resolving/loading the package.
@@ -1560,7 +1560,7 @@ public class PackageCommand
         var libraryOptions = CreateLibraryOptions(assemblyName: null, packageReference, options);
 
         var selectResult = SelectResolver.ResolveSelectAsSections(
-            options.Select, pipeline.AllSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
+            options.Select, pipeline.SelectableSectionNames, pipeline.InfoSectionNames, pipeline.GetCategoryMap());
         if (SelectOutput.WriteUnresolved(selectResult)) return 1;
         if (selectResult.Sections != null)
             libraryOptions = libraryOptions with { IncludeSections = selectResult.Sections };

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -417,7 +417,7 @@ public class PackageCommand
             // Output results
             if (effectiveDiscovery)
             {
-                var effective = pipeline.GetApplicableSections(result, options.IncludeSections);
+                var effective = pipeline.GetDiscoverableSections(result, options.IncludeSections);
                 var schemaMap = InspectionContext.Default.GetSchemaInfo<InspectionResultView>()!.ToDocumentSchema();
                 var fullSchemaMap = schemaMap;
 

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -95,7 +95,7 @@ public static class TypeCommand
                 {
                     ApiCommand.ApplySurfaceFilters(api, options, options.TypeFilter);
                     var schema = ApiViewContext.Default.GetSchemaInfo<CliApiSurface>()!.ToDocumentSchema();
-                    var effective = typePipeline.GetApplicableSections(api, options.IncludeSections);
+                    var effective = typePipeline.GetDiscoverableSections(api, options.IncludeSections);
                     return DiscoverOutput.ExecuteEffective(options.Discover, effective, schema,
                         tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.OneLine && !options.JsonOutput,
                         verbosity: (int)options.Verbosity,
@@ -472,7 +472,7 @@ public static class TypeCommand
         if (browseOptions.EffectiveDiscovery)
         {
             var schema = ApiViewContext.Default.GetSchemaInfo<CliApiSurface>()!.ToDocumentSchema();
-            var effective = typePipeline.GetApplicableSections(api, browseOptions.IncludeSections);
+            var effective = typePipeline.GetDiscoverableSections(api, browseOptions.IncludeSections);
             return DiscoverOutput.ExecuteEffective(browseOptions.Discover, effective, schema,
                 tree: browseOptions.Tree, json: browseOptions.JsonOutput, tsv: browseOptions.Tsv, jsonl: browseOptions.Jsonl, markdown: !browseOptions.OneLine && !browseOptions.JsonOutput,
                 verbosity: (int)browseOptions.Verbosity,

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -416,7 +416,10 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberSectionDescriptors.Constructors>()
             .Add<ApiMemberSectionDescriptors.Fields>()
             .Add<ApiMemberSectionDescriptors.Properties>()
-            .Add<ApiMemberDetailSectionDescriptors.Signature>()
+            // Signature can be selected from the overload inventory; rendering still
+            // waits until a single overload is chosen.
+            .Add<ApiMemberDetailSectionDescriptors.Signature>(
+                model => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike))
             .Add<Methods>()
             .Add<ApiMemberSectionDescriptors.MemberIndex>()
             .Add<ApiMemberSectionDescriptors.SourceLocations>()

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -312,7 +312,9 @@ public static class ApiMemberSectionDescriptors
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
-            => !string.IsNullOrWhiteSpace(model.FullName);
+            => model.Members.Any(IsMethodLike)
+               || !string.IsNullOrWhiteSpace(model.SourceUrl)
+               || model.AdditionalSourceFiles.Count > 0;
     }
 
     // ===== Expensive sections (decompiler output) =====
@@ -416,10 +418,7 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberSectionDescriptors.Constructors>()
             .Add<ApiMemberSectionDescriptors.Fields>()
             .Add<ApiMemberSectionDescriptors.Properties>()
-            // Signature can be selected from the overload inventory; rendering still
-            // waits until a single overload is chosen.
-            .Add<ApiMemberDetailSectionDescriptors.Signature>(
-                model => model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike))
+            .Add<ApiMemberDetailSectionDescriptors.Signature>()
             .Add<Methods>()
             .Add<ApiMemberSectionDescriptors.MemberIndex>()
             .Add<ApiMemberSectionDescriptors.SourceLocations>()
@@ -427,20 +426,23 @@ public static class ApiMemberOverloadSectionDescriptors
             .Add<ApiMemberSectionDescriptors.ExplicitInterfaceImplementations>()
             .Add<ApiMemberSectionDescriptors.ExtensionMethods>()
             .Add<ApiMemberSectionDescriptors.Events>()
-            .Add<ApiMemberSectionDescriptors.MethodAttributes>()
-            .Add<ApiMemberSectionDescriptors.DecompiledSource>()
-            .Add<ApiMemberDetailSectionDescriptors.AnnotatedSource>()
-            .Add<ApiMemberSectionDescriptors.OriginalSource>()
+            .Add<ApiMemberSectionDescriptors.MethodAttributes>(HasSingleMethodLikeMember)
+            .Add<ApiMemberSectionDescriptors.DecompiledSource>(HasSingleMethodLikeMember)
+            .Add<ApiMemberDetailSectionDescriptors.AnnotatedSource>(HasSingleMethodLikeMember)
+            .Add<ApiMemberSectionDescriptors.OriginalSource>(HasSingleMethodLikeMember)
             .Add<ApiMemberDetailSectionDescriptors.Calls>()
             .Add<ApiMemberDetailSectionDescriptors.Callers>()
             .Add<ApiMemberDetailSectionDescriptors.CallGraph>()
             .Add<ApiMemberDetailSectionDescriptors.CallerGraph>()
             .Add<ApiMemberDetailSectionDescriptors.UnsafeOperations>()
-            .Add<ApiMemberSectionDescriptors.TopLeverage>()
-            .Add<ApiMemberSectionDescriptors.OptimizationOpportunities>()
-            .Add<ApiMemberSectionDescriptors.ILBody>()
+            .Add<ApiMemberSectionDescriptors.TopLeverage>(HasSingleMethodLikeMember)
+            .Add<ApiMemberSectionDescriptors.OptimizationOpportunities>(HasSingleMethodLikeMember)
+            .Add<ApiMemberSectionDescriptors.ILBody>(HasSingleMethodLikeMember)
             .Add<ApiMemberSectionDescriptors.Facts>();
     }
+
+    private static bool HasSingleMethodLikeMember(ApiType model)
+        => model.Members.Count == 1 && model.Members.Any(ApiMemberSectionDescriptors.IsMethodLike);
 
     public sealed class Methods : ISectionDescriptor<ApiType>
     {

--- a/src/dotnet-inspect/Sections/DiffSections.cs
+++ b/src/dotnet-inspect/Sections/DiffSections.cs
@@ -1,0 +1,40 @@
+using Markout;
+
+namespace DotnetInspector.Sections;
+
+public sealed record DiffDiscoveryModel;
+
+public static class DiffSections
+{
+    public static SectionPipeline<DiffDiscoveryModel> CreatePipeline()
+    {
+        return new SectionPipeline<DiffDiscoveryModel>()
+            .Add<Changes>()
+            .Add<AnalysisDiff>();
+    }
+
+    public static DocumentSchema CreateSchema()
+    {
+        return new DocumentSchema()
+            .Add(Changes.Name, "column", "Change", "Type", "Detail")
+            .Add(AnalysisDiff.Name, "section", "Member", "Signal", "Old", "New", "Delta", "Shape", "Evidence");
+    }
+
+    public sealed class Changes : ISectionDescriptor<DiffDiscoveryModel>
+    {
+        public static string Name => "Changes";
+        public static bool IsExpensive => false;
+        public static bool Info => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(DiffDiscoveryModel model) => true;
+    }
+
+    public sealed class AnalysisDiff : ISectionDescriptor<DiffDiscoveryModel>
+    {
+        public static string Name => "Analysis Diff";
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(DiffDiscoveryModel model) => true;
+    }
+}

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -54,8 +54,8 @@ public static class LibrarySections
             .Add<Hosting>()
             .Add<HealthChecks>()
             .Add<HttpClient>()
-            .Add<References>()
-            .Add<Dependencies>()
+            .Add<References>(HasReferenceData)
+            .Add<Dependencies>(HasReferenceData)
             .Add<ExtensionMethods>()
             .Add<UnsafeMembers>()
             .Add<TopLeverage>()
@@ -305,6 +305,10 @@ public static class LibrarySections
            && (model.HasSourceLink
                || model.HasEmbeddedPdb
                || !string.IsNullOrWhiteSpace(model.PdbPath));
+
+    private static bool HasReferenceData(LibraryInspection model)
+        => model.AssemblyInfo?.References is { Count: > 0 }
+           || model.AssemblyInfo?.TransitiveReferences is { Count: > 0 };
 
     public sealed class SourceLinkAudit : ISectionDescriptor<LibraryInspection>
     {

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -84,15 +84,26 @@ public sealed class SectionPipeline<TModel>
     /// <summary>All registered section names, in registration order.</summary>
     public string[] AllSectionNames => _entries.Select(e => e.Name).ToArray();
 
+    /// <summary>
+    /// Section names that are independently selectable with <c>-S</c>. Headless context
+    /// sections such as "Summary" are registered so renderers can include compact preambles,
+    /// but they are not standalone output sections and must not be advertised by discovery
+    /// or accepted as direct selectors.
+    /// </summary>
+    public string[] SelectableSectionNames => _entries
+        .Where(IsSelectable)
+        .Select(e => e.Name)
+        .ToArray();
+
     /// <summary>Sections in the curated @Default preset, in registration order.</summary>
-    public string[] InfoSectionNames => _entries.Where(e => e.Info).Select(e => e.Name).ToArray();
+    public string[] InfoSectionNames => _entries.Where(e => e.Info && IsSelectable(e)).Select(e => e.Name).ToArray();
 
     public IReadOnlyDictionary<string, string[]> GetCategoryMap()
     {
         Dictionary<string, string[]> categories = new(StringComparer.OrdinalIgnoreCase)
         {
             [DefaultCategory] = InfoSectionNames,
-            [AllCategory] = AllSectionNames
+            [AllCategory] = SelectableSectionNames
         };
 
         foreach (var category in _categories)
@@ -212,6 +223,8 @@ public sealed class SectionPipeline<TModel>
         List<string> result = [];
         foreach (var entry in _entries)
         {
+            if (!IsSelectable(entry))
+                continue;
             if (include is { Count: > 0 } && !include.Contains(entry.Name))
                 continue;
             if (entry.IsApplicable(model) || !entry.ProbeEffectiveness)
@@ -424,6 +437,9 @@ public sealed class SectionPipeline<TModel>
             _ => true, // Detailed: all non-ExplicitOnly sections
         };
     }
+
+    private static bool IsSelectable(SectionEntry<TModel> entry)
+        => !string.Equals(entry.Name, SectionNames.Summary, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Returns the names of requested sections (selection only — independent of <c>CanRender</c>)

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -212,11 +212,10 @@ public sealed class SectionPipeline<TModel>
 
     /// <summary>
     /// The canonical discovery superset for <c>-D</c>, uniform across every command: a section is
-    /// discoverable if it is structurally applicable (<see cref="SectionEntry{TModel}.IsApplicable"/>)
-    /// or if it is unprobed (<see cref="SectionEntry{TModel}.ProbeEffectiveness"/> false) — the latter
-    /// listed without rendering so discovery never opens a whole-assembly index. Over-reports rather
-    /// than under-reports (#1201): anything selectable with <c>-S</c> must appear here. Registration
-    /// order is preserved.
+    /// discoverable when it is structurally applicable (<see cref="SectionEntry{TModel}.IsApplicable"/>).
+    /// Unprobed sections (<see cref="SectionEntry{TModel}.ProbeEffectiveness"/> false) still require
+    /// structural applicability; they merely skip render probing so discovery never opens a
+    /// whole-assembly index. Registration order is preserved.
     /// </summary>
     public List<string> GetDiscoverableSections(TModel model, HashSet<string>? include = null)
     {
@@ -227,7 +226,7 @@ public sealed class SectionPipeline<TModel>
                 continue;
             if (include is { Count: > 0 } && !include.Contains(entry.Name))
                 continue;
-            if (entry.IsApplicable(model) || !entry.ProbeEffectiveness)
+            if (entry.IsApplicable(model))
                 result.Add(entry.Name);
         }
         return result;

--- a/src/dotnet-inspect/Sections/SectionPipeline.cs
+++ b/src/dotnet-inspect/Sections/SectionPipeline.cs
@@ -200,6 +200,27 @@ public sealed class SectionPipeline<TModel>
     }
 
     /// <summary>
+    /// The canonical discovery superset for <c>-D</c>, uniform across every command: a section is
+    /// discoverable if it is structurally applicable (<see cref="SectionEntry{TModel}.IsApplicable"/>)
+    /// or if it is unprobed (<see cref="SectionEntry{TModel}.ProbeEffectiveness"/> false) — the latter
+    /// listed without rendering so discovery never opens a whole-assembly index. Over-reports rather
+    /// than under-reports (#1201): anything selectable with <c>-S</c> must appear here. Registration
+    /// order is preserved.
+    /// </summary>
+    public List<string> GetDiscoverableSections(TModel model, HashSet<string>? include = null)
+    {
+        List<string> result = [];
+        foreach (var entry in _entries)
+        {
+            if (include is { Count: > 0 } && !include.Contains(entry.Name))
+                continue;
+            if (entry.IsApplicable(model) || !entry.ProbeEffectiveness)
+                result.Add(entry.Name);
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Returns structurally applicable sections that were registered with an explicit
     /// applicability gate. Effective discovery preserves these across render probes
     /// because their renderability may depend on section selection, verbosity, or work


### PR DESCRIPTION
## Summary
- Route library/type/member/package/diff discovery through the canonical discoverable-section superset.
- Keep unrendered opt-in/unprobed schema sections visible in -D so every -S-selectable section is discoverable.
- Wire diff -D/--tree and -S validation/selection; invalid -S now exits non-zero.
- Add pipeline and CLI selectability guard tests.

## Validation
- dotnet build src/dotnet-inspect -c Release
- dotnet test src/dotnet-inspect.Tests -c Release --no-build
- Sample checks for member/type/diff discovery and invalid diff -S

## Follow-ups for #1881
- --fields/--columns projection and error-message polish remain out of scope.