### PR TITLE
Name generated fixture ladder stages

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -21,6 +21,7 @@ public class GeneratedFixtureCatalogTests
         string report = GeneratedFixtureRunner.FormatReport(run);
 
         Assert.True(run.Passed, report);
+        Assert.Contains("GENERATED FIXTURE LADDER", report);
 
         AssertTarget(
             run,
@@ -380,6 +381,11 @@ public class GeneratedFixtureCatalogTests
     public void CatalogueListJson_ContainsFixtureIdsAndExpectedStatuses()
     {
         string json = GeneratedFixtureRunner.FormatListJson(GeneratedFixtureCatalog.Catalog);
+        string list = GeneratedFixtureRunner.FormatList(GeneratedFixtureCatalog.Catalog);
+
+        Assert.Contains("compile-back=Exact", list);
+        Assert.Contains("shape=ElementAccessExpression", list);
+        Assert.Contains("shape=none", list);
 
         using var document = JsonDocument.Parse(json);
         var fixtures = document.RootElement.EnumerateArray().ToArray();

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -697,7 +697,7 @@ internal static class GeneratedFixtureRunner
         var sb = new StringBuilder();
         int fixtureCount = run.Results.Select(r => r.FixtureId).Distinct(StringComparer.Ordinal).Count();
         sb.AppendLine(
-            $"GENERATED FIXTURE COMPILE-BACK over {fixtureCount} fixture(s), {run.Results.Count} target method(s)");
+            $"GENERATED FIXTURE LADDER over {fixtureCount} fixture(s), {run.Results.Count} target method(s)");
         foreach (var result in run.Results.OrderBy(r => r.FixtureId, StringComparer.Ordinal).ThenBy(r => r.DisplayMember, StringComparer.Ordinal))
         {
             string actual = result.ActualStatus?.ToString() ?? "Missing";
@@ -708,7 +708,7 @@ internal static class GeneratedFixtureRunner
             string status = result.Passed ? "PASS" : "FAIL";
             sb.AppendLine(
                 $"  {status}{frontier}  {result.FixtureId}  {result.DisplayMember}  " +
-                $"decompiler={result.DecompilerFidelity}  compile-back={actual}  expected={result.ExpectedStatus}{shape}");
+                $"decompiler={result.DecompilerFidelity}  compile-back={actual}  expected-compile-back={result.ExpectedStatus}{shape}");
             if (!string.IsNullOrWhiteSpace(result.Detail))
                 sb.AppendLine($"      detail: {result.Detail}");
             if (!string.IsNullOrWhiteSpace(result.ShapeDetail))
@@ -741,8 +741,9 @@ internal static class GeneratedFixtureRunner
             foreach (var target in fixture.Targets)
             {
                 string frontier = target.IsFrontier ? " frontier" : "";
+                string shape = target.ExpectedShape?.ToString() ?? "none";
                 sb.AppendLine(
-                    $"      {target.DisplayMember}  expected={target.ExpectedStatus}{frontier}");
+                    $"      {target.DisplayMember}  compile-back={target.ExpectedStatus}  shape={shape}{frontier}");
             }
         }
         return sb.ToString();

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -30,6 +30,17 @@ for the intended C# idiom, and a compile-back opcode verdict for semantic
 fidelity. A row can therefore be opcode-exact while still exposing a shape
 frontier.
 
+The generated fixture ladder is intentionally staged:
+
+| Stage | Harness responsibility |
+| --- | --- |
+| Specimen | Catalogue row with source, fixture ID, tags, targets, expected shape, and expected compile-back outcome. |
+| Materialization | Build the selected source snippets into one temporary class library; `--keep-generated-fixtures` preserves it. |
+| Projection | Decompile each target through the shipped raised product path and record the decompiler fidelity grade. |
+| Shape verdict | Parse the rendered body with Roslyn and compare the optional expected `SyntaxKind`. |
+| Compile-back verdict | Recompile the rendered body and compare canonical opcode streams with `FidelityCheck`. |
+| Frontier ledger | Keep expected non-exact or compiler-lowering observations explicit and opt-in. |
+
 **Library report** (`--library-report`): a portfolio view. It combines the IR
 residual buckets from `--gaps` with the Roslyn-backed validity oracle from
 `--validity-check`, then prints a global top-pattern section and one section per


### PR DESCRIPTION
- Advances #1742
- Follows #1884 dual generated-fixture verdicts
- Card revision: `437a5250`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated fixture mode now reads as a staged ladder instead of a compile-back-only report.

Before:

```text
GENERATED FIXTURE COMPILE-BACK ...
expected=Exact
```

After:

```text
GENERATED FIXTURE LADDER ...
compile-back=Exact  shape=ElementAccessExpression
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Harness smoke | Pass: `--generated-fixtures minimal.array-index` and `--generated-fixtures list` show ladder/shape/compile-back wording |
| Markdown | Pass: `npx markdownlint-cli tools/DecompilerHarness/README.md` |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes. This only clarifies generated fixture harness output and docs around the specimen/materialization/projection/shape/compile-back/frontier ladder.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked report/list wording, JSON stability, test pinning, docs accuracy, and absence of stale generated-fixture output references. |
| Gemini 3.1 Pro | No blocking findings | Checked JSON stability, output alignment/coherence, tests, docs, and CLI/plain-text backward compatibility. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.array-index
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures list

dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
git diff --check
```
