### PR TITLE
Add conditional-expression shape frontier

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -324,6 +324,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.do-while", report);
         Assert.Contains("minimal.switch-int", report);
         Assert.DoesNotContain("minimal.switch-two-case-lowers-if", report);
+        Assert.DoesNotContain("minimal.conditional-expression-shape-frontier", report);
         Assert.Contains("decompiler=Full", report);
         Assert.Contains("compile-back=Exact", report);
         Assert.Contains("shape=ForStatement", report);
@@ -354,6 +355,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.array-index",
                 "minimal.array-length",
                 "minimal.auto-property.getter",
+                "minimal.conditional-expression-shape-frontier",
                 "minimal.ctor-field.getter",
                 "minimal.do-while",
                 "minimal.for-loop",
@@ -392,6 +394,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.property.literal");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.ctor-field.getter");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.auto-property.getter");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.conditional-expression-shape-frontier");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.method-call.same-type");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.static-method-call");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
@@ -422,30 +425,70 @@ public class GeneratedFixtureCatalogTests
         var arrayIndexMethod = Assert.Single(arrayIndex.GetProperty("Targets").EnumerateArray(),
             target => target.GetProperty("Method").GetString() == "Method1");
         Assert.Equal("ElementAccessExpression", arrayIndexMethod.GetProperty("ExpectedShape").GetString());
+
+        var conditionalFrontier = Assert.Single(fixtures,
+            fixture => fixture.GetProperty("Id").GetString() == "minimal.conditional-expression-shape-frontier");
+        var conditionalTarget = Assert.Single(conditionalFrontier.GetProperty("Targets").EnumerateArray(),
+            target => target.GetProperty("Method").GetString() == "Method1");
+        Assert.Equal("ReturnStatement", conditionalTarget.GetProperty("ExpectedShape").GetString());
+        Assert.Equal("ConditionalExpression", conditionalTarget.GetProperty("FrontierShape").GetString());
+        Assert.True(conditionalTarget.GetProperty("IsFrontier").GetBoolean());
     }
 
     [Fact]
-    public void CompilerLoweringFrontier_IsSelectableButNotInDefaultRun()
+    public void CompilerLoweringFrontiers_AreSelectableButNotInDefaultRun()
     {
-        var run = GeneratedFixtureRunner.Run(GeneratedFixtureCatalog.Select("minimal.switch-two-case-lowers-if"));
-        string report = GeneratedFixtureRunner.FormatReport(run);
+        var switchRun = GeneratedFixtureRunner.Run(GeneratedFixtureCatalog.Select("minimal.switch-two-case-lowers-if"));
+        string switchReport = GeneratedFixtureRunner.FormatReport(switchRun);
 
-        Assert.True(run.Passed, report);
+        Assert.True(switchRun.Passed, switchReport);
         AssertTarget(
-            run,
+            switchRun,
             "minimal.switch-two-case-lowers-if",
             "GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1",
             ".ctor",
             FidelityCheck.CompileBackStatus.Exact,
             frontier: false);
         AssertTarget(
-            run,
+            switchRun,
             "minimal.switch-two-case-lowers-if",
             "GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1",
             "Method1",
             FidelityCheck.CompileBackStatus.OpcodeDiff,
             frontier: true);
-        Assert.Contains("compiler-lowering", GeneratedFixtureCatalog.Frontiers.Single().Tags);
+
+        var shapeRun = GeneratedFixtureRunner.Run(GeneratedFixtureCatalog.Select("minimal.conditional-expression-shape-frontier"));
+        string shapeReport = GeneratedFixtureRunner.FormatReport(shapeRun);
+
+        Assert.True(shapeRun.Passed, shapeReport);
+        AssertTarget(
+            shapeRun,
+            "minimal.conditional-expression-shape-frontier",
+            "GeneratedFixtures.MinimalConditionalExpressionShapeFrontier.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            shapeRun,
+            "minimal.conditional-expression-shape-frontier",
+            "GeneratedFixtures.MinimalConditionalExpressionShapeFrontier.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: true);
+        var shapeResult = Assert.Single(shapeRun.Results, result =>
+            result.FixtureId == "minimal.conditional-expression-shape-frontier" &&
+            result.Method == "Method1");
+        Assert.Equal(SyntaxKind.ReturnStatement, shapeResult.ExpectedShape);
+        Assert.Equal(SyntaxKind.ReturnStatement, shapeResult.ActualShape);
+        Assert.Equal(SyntaxKind.ConditionalExpression, shapeResult.FrontierShape);
+        Assert.Contains("frontier-shape=ConditionalExpression", shapeReport);
+
+        Assert.Contains(GeneratedFixtureCatalog.Frontiers, fixture =>
+            fixture.Id == "minimal.switch-two-case-lowers-if" &&
+            fixture.Tags.Contains("compiler-lowering"));
+        Assert.Contains(GeneratedFixtureCatalog.Frontiers, fixture =>
+            fixture.Id == "minimal.conditional-expression-shape-frontier" &&
+            fixture.Tags.Contains("shape"));
     }
 
     [Fact]
@@ -464,6 +507,24 @@ public class GeneratedFixtureCatalogTests
         Assert.Equal("Exact", method.GetProperty("ActualStatus").GetString());
         Assert.Equal("ElementAccessExpression", method.GetProperty("ActualShape").GetString());
         Assert.Equal("ElementAccessExpression", method.GetProperty("ExpectedShape").GetString());
+        Assert.True(method.GetProperty("ShapePassed").GetBoolean());
+    }
+
+    [Fact]
+    public void ShapeFrontierRunJson_ReportsAcceptedAndFrontierShapes()
+    {
+        var selected = GeneratedFixtureCatalog.Select("minimal.conditional-expression-shape-frontier");
+        var run = GeneratedFixtureRunner.Run(selected);
+        string json = GeneratedFixtureRunner.FormatJson(run);
+
+        using var document = JsonDocument.Parse(json);
+        var results = document.RootElement.GetProperty("Results").EnumerateArray().ToArray();
+        var method = Assert.Single(results, result => result.GetProperty("Method").GetString() == "Method1");
+
+        Assert.Equal("Exact", method.GetProperty("ActualStatus").GetString());
+        Assert.Equal("ReturnStatement", method.GetProperty("ActualShape").GetString());
+        Assert.Equal("ReturnStatement", method.GetProperty("ExpectedShape").GetString());
+        Assert.Equal("ConditionalExpression", method.GetProperty("FrontierShape").GetString());
         Assert.True(method.GetProperty("ShapePassed").GetBoolean());
     }
 

--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -528,6 +528,42 @@ public class GeneratedFixtureCatalogTests
         Assert.True(method.GetProperty("ShapePassed").GetBoolean());
     }
 
+    [Fact]
+    public void ShapeFrontierRun_FailsWhenFrontierShapeIsAchieved()
+    {
+        var alreadyImproved = new GeneratedFixtureDefinition(
+            "test.frontier-shape-achieved",
+            """
+            namespace GeneratedFixtures.TestFrontierShapeAchieved;
+
+            public class Class1
+            {
+                public int Method1(int left, int right) => left + right;
+            }
+            """,
+            [
+                new(
+                    "GeneratedFixtures.TestFrontierShapeAchieved.Class1",
+                    "Method1",
+                    FidelityCheck.CompileBackStatus.Exact,
+                    IsFrontier: true,
+                    ExpectedShape: SyntaxKind.ReturnStatement,
+                    FrontierShape: SyntaxKind.AddExpression),
+            ],
+            ["test"]);
+
+        var run = GeneratedFixtureRunner.Run([alreadyImproved]);
+        string report = GeneratedFixtureRunner.FormatReport(run);
+        var result = Assert.Single(run.Results);
+
+        Assert.False(run.Passed);
+        Assert.Equal(SyntaxKind.AddExpression, result.ActualShape);
+        Assert.Equal(SyntaxKind.ReturnStatement, result.ExpectedShape);
+        Assert.Equal(SyntaxKind.AddExpression, result.FrontierShape);
+        Assert.False(result.ShapePassed);
+        Assert.Contains("frontier-shape-achieved", report);
+    }
+
     static void AssertTarget(
         GeneratedFixtureRunResult run,
         string fixtureId,

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -692,7 +692,7 @@ internal static class GeneratedFixtureRunner
                 {
                     compileBack.TryGetValue(Key(target.Type, target.Method, target.Overload), out var actual);
                     renders.TryGetValue(Key(target.Type, target.Method, target.Overload), out var render);
-                    var shape = ShapeVerdict(render?.Body, target.ExpectedShape);
+                    var shape = ShapeVerdict(render?.Body, target.ExpectedShape, target.FrontierShape);
                     results.Add(new GeneratedFixtureResult(
                         fixture.Id,
                         target.Type,
@@ -862,7 +862,7 @@ internal static class GeneratedFixtureRunner
         return renders;
     }
 
-    static (SyntaxKind? ActualShape, string? Detail) ShapeVerdict(string? body, SyntaxKind? expected)
+    static (SyntaxKind? ActualShape, string? Detail) ShapeVerdict(string? body, SyntaxKind? expected, SyntaxKind? frontier)
     {
         if (expected is null)
             return (null, null);
@@ -881,6 +881,9 @@ internal static class GeneratedFixtureRunner
             """,
             new CSharpParseOptions(LanguageVersion.Preview));
         var root = tree.GetRoot();
+        if (frontier is { } frontierKind && root.DescendantNodes().Any(node => node.IsKind(frontierKind)))
+            return (frontierKind, "frontier-shape-achieved");
+
         if (root.DescendantNodes().Any(node => node.IsKind(expected.Value)))
             return (expected.Value, null);
 

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -497,6 +497,30 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "switch", "int", "branch", "frontier", "compiler-lowering"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalConditionalExpressionShapeFrontier = new(
+        "minimal.conditional-expression-shape-frontier",
+        """
+        namespace GeneratedFixtures.MinimalConditionalExpressionShapeFrontier;
+
+        public class Class1
+        {
+            public int Method1(bool flag) => flag ? 1 : 2;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalConditionalExpressionShapeFrontier.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new(
+                "GeneratedFixtures.MinimalConditionalExpressionShapeFrontier.Class1",
+                "Method1",
+                FidelityCheck.CompileBackStatus.Exact,
+                IsFrontier: true,
+                Note: "Current output is compile-back exact but does not preserve the conditional-expression source shape.",
+                ExpectedShape: SyntaxKind.ReturnStatement,
+                FrontierShape: SyntaxKind.ConditionalExpression),
+        ],
+        ["minimal", "conditional-expression", "branch", "frontier", "shape"]);
+
     public static IReadOnlyList<GeneratedFixtureDefinition> All { get; } =
     [
         MinimalPropertyLiteral,
@@ -523,6 +547,7 @@ internal static class GeneratedFixtureCatalog
     public static IReadOnlyList<GeneratedFixtureDefinition> Frontiers { get; } =
     [
         MinimalSwitchTwoCaseLowersIf,
+        MinimalConditionalExpressionShapeFrontier,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> Catalog { get; } =
@@ -558,7 +583,8 @@ internal sealed record GeneratedFixtureTarget(
     int Overload = 0,
     bool IsFrontier = false,
     string? Note = null,
-    SyntaxKind? ExpectedShape = null)
+    SyntaxKind? ExpectedShape = null,
+    SyntaxKind? FrontierShape = null)
 {
     public string DisplayMember => $"{Type}::{Method}#{Overload}";
 }
@@ -588,6 +614,7 @@ internal sealed record GeneratedFixtureResult(
     FidelityCheck.CompileBackStatus ExpectedStatus,
     SyntaxKind? ActualShape,
     SyntaxKind? ExpectedShape,
+    SyntaxKind? FrontierShape,
     string? ShapeDetail,
     bool IsFrontier,
     string? Detail,
@@ -676,6 +703,7 @@ internal static class GeneratedFixtureRunner
                         target.ExpectedStatus,
                         shape.ActualShape,
                         target.ExpectedShape,
+                        target.FrontierShape,
                         shape.Detail,
                         target.IsFrontier,
                         actual?.Detail ?? (actual is null ? "target-method-not-found" : null),
@@ -704,11 +732,14 @@ internal static class GeneratedFixtureRunner
             string shape = result.ExpectedShape is null
                 ? ""
                 : $"  shape={result.ActualShape?.ToString() ?? "Missing"}  expected-shape={result.ExpectedShape}";
+            string frontierShape = result.FrontierShape is null
+                ? ""
+                : $"  frontier-shape={result.FrontierShape}";
             string frontier = result.IsFrontier ? " frontier" : "";
             string status = result.Passed ? "PASS" : "FAIL";
             sb.AppendLine(
                 $"  {status}{frontier}  {result.FixtureId}  {result.DisplayMember}  " +
-                $"decompiler={result.DecompilerFidelity}  compile-back={actual}  expected-compile-back={result.ExpectedStatus}{shape}");
+                $"decompiler={result.DecompilerFidelity}  compile-back={actual}  expected-compile-back={result.ExpectedStatus}{shape}{frontierShape}");
             if (!string.IsNullOrWhiteSpace(result.Detail))
                 sb.AppendLine($"      detail: {result.Detail}");
             if (!string.IsNullOrWhiteSpace(result.ShapeDetail))
@@ -742,8 +773,9 @@ internal static class GeneratedFixtureRunner
             {
                 string frontier = target.IsFrontier ? " frontier" : "";
                 string shape = target.ExpectedShape?.ToString() ?? "none";
+                string frontierShape = target.FrontierShape is null ? "" : $"  frontier-shape={target.FrontierShape}";
                 sb.AppendLine(
-                    $"      {target.DisplayMember}  compile-back={target.ExpectedStatus}  shape={shape}{frontier}");
+                    $"      {target.DisplayMember}  compile-back={target.ExpectedStatus}  shape={shape}{frontierShape}{frontier}");
             }
         }
         return sb.ToString();
@@ -764,6 +796,7 @@ internal static class GeneratedFixtureRunner
                     target.Overload,
                     ExpectedStatus = target.ExpectedStatus.ToString(),
                     ExpectedShape = target.ExpectedShape?.ToString(),
+                    FrontierShape = target.FrontierShape?.ToString(),
                     target.IsFrontier,
                     target.Note,
                 }),

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -22,13 +22,18 @@ rungs extend that minimal exact set;
 `minimal.switch-int` adds the first switch statement rung.
 `minimal.switch-two-case-lowers-if` records the current SDK's two-case
 source-switch lowering observation (lowered as if/else, not the dense switch
-shape) and is opt-in by ID. With no selector, stable generated fixtures run; use
-`list` to list fixture IDs, `--json` for machine-readable list/results, and
-`--keep-generated-fixtures` to preserve the generated project for drill-down.
+shape) and is opt-in by ID. `minimal.conditional-expression-shape-frontier`
+records a source-shape frontier: the conditional-expression source is
+compile-back exact, but the accepted current output is return-statement shaped
+rather than `ConditionalExpression` shaped. With no selector, stable generated
+fixtures run; use `list` to list fixture IDs, `--json` for machine-readable
+list/results, and `--keep-generated-fixtures` to preserve the generated project
+for drill-down.
 Rows may carry two independent expectations: a Roslyn `SyntaxKind` shape verdict
 for the intended C# idiom, and a compile-back opcode verdict for semantic
 fidelity. A row can therefore be opcode-exact while still exposing a shape
-frontier.
+frontier. Shape frontiers record both the accepted current shape and the desired
+frontier shape.
 
 The generated fixture ladder is intentionally staged:
 


### PR DESCRIPTION
- Advances #1742
- Follows #1884/#1886 dual generated-fixture ladder work
- Card revision: `afd159f8`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — the generated fixture ladder now records a source-shape frontier separately from compile-back fidelity, and shape frontiers fail loudly when the desired shape is achieved.

Before:

```text
shape verdict: expected current shape only
```

After:

```text
minimal.conditional-expression-shape-frontier
compile-back: Exact
accepted current shape: ReturnStatement
frontier shape: ConditionalExpression
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `GeneratedFixtureCatalogTests` passed |
| Harness smoke | Pass: selected frontier reports `Exact`, `shape=ReturnStatement`, and `frontier-shape=ConditionalExpression` |
| JSON output | Pass: selected frontier includes `ActualShape=ReturnStatement`, `ExpectedShape=ReturnStatement`, `FrontierShape=ConditionalExpression` |
| Frontier-achieved guard | Pass: synthetic test proves a row fails when its desired frontier shape appears under the accepted shape |
| Markdown | Pass: `npx markdownlint-cli tools/DecompilerHarness/README.md` |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes. This only adds an opt-in generated fixture frontier and teaches the harness to represent desired shape separately from the accepted current shape.

The new frontier is intentionally not in the default stable run. It records that conditional-expression source is semantic-fidelity exact today, while the current product output is not yet `ConditionalExpression` shaped.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked accepted-vs-frontier shape distinction, catalog placement, selected run, JSON/list/report coherence, tests, and docs. |
| Gemini 3.1 Pro | Fixed finding | Found that a desired frontier shape nested under the accepted shape would pass silently; fixed in `afd159f8` by checking `FrontierShape` first and adding a regression test. |

**Review conclusion:** **PASS** — Gemini's actionable finding was fixed; no required findings remain open.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*GeneratedFixtureCatalogTests"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.conditional-expression-shape-frontier --json >/tmp/conditional-shape-frontier.json
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --generated-fixtures minimal.conditional-expression-shape-frontier
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
npx markdownlint-cli tools/DecompilerHarness/README.md
git diff --check
```
