### PR TITLE
Enable nested type triage drilldown

### DIFF
--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -26,14 +26,10 @@ public static class ApiSurfaceExtractor
             var attributes = typeDef.Attributes;
 
             // Only include public types by default. --all (includeAll) also surfaces
-            // non-public TOP-LEVEL types (internal classes/structs/records) so an author can
-            // inspect and drill into their own library's internals. Nested types keep their
-            // existing public-only rule: a non-public nested type's selector cannot round-trip
-            // through the member command's name resolution yet, so surfacing it would emit a
-            // dead selector. Compiler-generated types are still skipped below regardless.
-            bool isTopLevel = (typeDef.Attributes & TypeAttributes.VisibilityMask)
-                is TypeAttributes.Public or TypeAttributes.NotPublic;
-            if (!typeDef.IsPublic && !(includeAll && isTopLevel))
+            // non-public types, including nested private/internal types, so ranking/triage rows
+            // that already surface non-public IL can be copied into type/member drill commands.
+            // Compiler-generated types are still skipped below regardless.
+            if (!typeDef.IsPublic && !includeAll)
                 continue;
 
             string metadataName = reader.GetString(typeDef.Name);

--- a/src/ILInspector.Metadata/TypeMatcher.cs
+++ b/src/ILInspector.Metadata/TypeMatcher.cs
@@ -33,9 +33,11 @@ public static class TypeMatcher
         if (string.IsNullOrEmpty(candidate) || string.IsNullOrEmpty(target))
             return false;
 
-        // Normalize both for comparison
-        var normalizedCandidate = Normalize(candidate);
-        var normalizedTarget = Normalize(target);
+        // Normalize both for comparison. Metadata APIs and analysis rows render nested types
+        // with '.', while users often paste CLR-style '+'. Treat those separators as
+        // equivalent for lookup, without changing Normalize's public formatting contract.
+        var normalizedCandidate = NormalizeForLookup(candidate);
+        var normalizedTarget = NormalizeForLookup(target);
 
         // Exact match
         if (normalizedCandidate.Equals(normalizedTarget, StringComparison.OrdinalIgnoreCase))
@@ -99,6 +101,9 @@ public static class TypeMatcher
         var suffix = closeIdx + 1 < typeName.Length ? typeName[(closeIdx + 1)..] : "";
         return $"{baseName}`{arity}{suffix}";
     }
+
+    private static string NormalizeForLookup(string typeName)
+        => Normalize(typeName).Replace('+', '.');
 
     /// <summary>
     /// Normalizes a member selector to metadata member names.

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -19,6 +19,13 @@ public class CommandExecutionTests
     private static readonly string TestAssemblyPath =
         typeof(CommandExecutionTests).Assembly.Location;
 
+    private sealed class NestedDrillTarget
+    {
+        public NestedDrillTarget(int value) => Value = value;
+
+        public int Value { get; }
+    }
+
     private static (string PackagePath, string TempDir) CreateLocalRefPackage(params string[] assemblyNames)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"package-test-{Guid.NewGuid():N}");
@@ -277,6 +284,95 @@ public class CommandExecutionTests
         Assert.Empty(output);
         Assert.Contains("Unknown Performance Triage shape 'typo-shape'", error);
         Assert.Contains("capturing-delegate", error);
+    }
+
+    [Theory]
+    [InlineData("DotnetInspector.Tests.CommandExecutionTests.NestedDrillTarget")]
+    [InlineData("DotnetInspector.Tests.CommandExecutionTests+NestedDrillTarget")]
+    public async Task TypeCommand_AllowsDrillingNonPublicNestedTypes(string typeName)
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", typeName,
+            "--library", TestAssemblyPath,
+            "--all",
+            "-S", "Member Index",
+            "-n", "80");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("NestedDrillTarget", output);
+        Assert.Contains(".ctor", output);
+    }
+
+    [Theory]
+    [InlineData("DotnetInspector.Tests.CommandExecutionTests.NestedDrillTarget")]
+    [InlineData("DotnetInspector.Tests.CommandExecutionTests+NestedDrillTarget")]
+    public async Task MemberCommand_AllowsDrillingNonPublicNestedConstructors(string typeName)
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeName, ".ctor:1",
+            "--library", TestAssemblyPath,
+            "--all",
+            "-S", "Decompiled Source",
+            "-n", "80");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("NestedDrillTarget", output);
+        Assert.Contains("Value = value", output);
+    }
+
+    [Theory]
+    [InlineData("DotnetInspector.Tests.CommandExecutionTests.NestedDrillTarget..ctor")]
+    [InlineData("DotnetInspector.Tests.CommandExecutionTests.NestedDrillTarget..ctor:1")]
+    [InlineData("DotnetInspector.Tests.CommandExecutionTests+NestedDrillTarget..ctor")]
+    [InlineData("DotnetInspector.Tests.CommandExecutionTests+NestedDrillTarget..ctor:1")]
+    public async Task MemberCommand_AllowsCopiedNestedConstructorSelector(string selector)
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", selector,
+            "--library", TestAssemblyPath,
+            "--all",
+            "-S", "Decompiled Source",
+            "-n", "80");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("NestedDrillTarget", output);
+        Assert.Contains("Value = value", output);
+    }
+
+    [Theory]
+    [InlineData("DotnetInspector.Tests.CommandExecutionTests.NestedDrillTarget")]
+    [InlineData("DotnetInspector.Tests.CommandExecutionTests+NestedDrillTarget")]
+    public async Task MemberCommand_AllowsCopiedNestedConstructorDigestSelector(string typeName)
+    {
+        var index = await RunAppAsync(
+            "type", typeName,
+            "--library", TestAssemblyPath,
+            "--all",
+            "-S", "Member Index",
+            "-n", "80");
+        Assert.Equal(0, index.Exit);
+        var stable = index.Output
+            .Split('\n')
+            .Select(line => line.Split('|', StringSplitOptions.TrimEntries))
+            .Where(parts => parts.Length >= 3 && parts[1] == "`.ctor`")
+            .Select(parts => parts[2].Trim('`'))
+            .Single();
+
+        var selector = $"{typeName}.{stable}";
+        var (exit, output, error) = await RunAppAsync(
+            "member", selector,
+            "--library", TestAssemblyPath,
+            "--all",
+            "-S", "Decompiled Source",
+            "-n", "80");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("NestedDrillTarget", output);
+        Assert.Contains("Value = value", output);
     }
 
     // ── bare router ───────────────────────────────────────────────────

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -283,16 +283,18 @@ public static class MemberOptionsParser
     }
 
     /// <summary>
-    /// True when the trailing segment of a dotted name (after the last top-level dot) carries an
-    /// overload (":N") or digest ("~hash") selector. Such a suffix is unambiguously a member,
-    /// since a type name can contain neither character.
+    /// True when the trailing segment of a dotted name is unambiguously a member:
+    /// it carries an overload (":N") / digest ("~hash") selector, or it is a
+    /// metadata constructor token ("..ctor"/"..cctor").
     /// </summary>
     private static bool HasMemberSelectorSuffix(string typeName)
     {
         var (splitTypeName, splitMemberName) = SharedParsers.SplitTrailingMember(typeName);
         return splitTypeName != null
             && splitMemberName != null
-            && (splitMemberName.Contains(':') || splitMemberName.Contains('~'));
+            && (splitMemberName.Contains(':')
+                || splitMemberName.Contains('~')
+                || splitMemberName is ".ctor" or ".cctor");
     }
 
     private static (HashSet<string> Filter, int? Limit) BuildMemberFilter(string[] allMembers, bool ctorOnly, out bool clearShorthand)

--- a/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
@@ -74,6 +74,14 @@ public static class SharedParsers
 
     public static (string TypeName, string? MemberName) SplitTrailingMember(string typeName)
     {
+        var (digestHead, _) = ParseDigestShorthand(typeName);
+        var (overloadHead, _) = ParseOverloadShorthand(digestHead);
+        var suffixLength = typeName.Length - overloadHead.Length;
+        if (overloadHead.EndsWith("..ctor", StringComparison.Ordinal))
+            return (overloadHead[..^6], ".ctor" + typeName[^suffixLength..]);
+        if (overloadHead.EndsWith("..cctor", StringComparison.Ordinal))
+            return (overloadHead[..^7], ".cctor" + typeName[^suffixLength..]);
+
         var lastDot = FqnParser.LastTopLevelDot(typeName);
         if (lastDot <= 0)
             return (typeName, null);


### PR DESCRIPTION
## Summary

Fixes #1860 row 4 / #1670 nested-type drillability:

- `--all` API extraction now includes non-public nested types, so non-public triage rows can be drilled instead of producing dead selectors
- type lookup treats CLR `+` and display `.` nested separators as equivalent for lookup only
- member parsing recognizes copied constructor selectors like `NestedType..ctor`, `NestedType..ctor:1`, and `NestedType..ctor~digest`

## Evidence

The ServiceDiscovery triage row:

```text
Microsoft.Extensions.ServiceDiscovery.Http.HttpServiceEndpointResolver.ResolverEntry..ctor(...)
```

now drills with:

```bash
dotnet-inspect member Microsoft.Extensions.ServiceDiscovery.Http.HttpServiceEndpointResolver.ResolverEntry..ctor:1 --library <Microsoft.Extensions.ServiceDiscovery.dll> --all -S "Decompiled Source"
dotnet-inspect member Microsoft.Extensions.ServiceDiscovery.Http.HttpServiceEndpointResolver.ResolverEntry.<stable .ctor~digest> --library <Microsoft.Extensions.ServiceDiscovery.dll> --all -S "Decompiled Source"
```

Both resolve to `ResolverEntry..ctor` and render the constructor body.

## Validation

- `dotnet artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll -method "*AllowsDrillingNonPublicNestedTypes*" -method "*AllowsDrillingNonPublicNestedConstructors*" -method "*AllowsCopiedNestedConstructorSelector*" -method "*AllowsCopiedNestedConstructorDigestSelector*" -method "*NestedGenericType_ParsesCorrectly*"`
- `dotnet tests/ILInspector.Metadata.Tests/bin/Release/net11.0/ILInspector.Metadata.Tests.dll -class "*TypeMatcherTests*"`
- `dotnet run --project src/dotnet-inspect.Tests -c Release` (1409 total, 9 expected ilasm skips)
- source CLI ServiceDiscovery copied-selector checks for `..ctor:1` and `~digest`

## Adversarial review

- Claude Opus 4.8: no blockers. Noted theoretical `+`/`.` false-match and bare `..ctor` edge cases; both fail safely or are scoped to explicit `--all` drillability.
- Gemini 3.1 Pro: found a blocker that copied `..ctor:1` / `..ctor~digest` selectors were not split. Fixed by stripping overload/digest suffixes before constructor split and adding `:1` plus real digest selector tests.
