### PR TITLE
Fix zero-signal guard review findings

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityZeroSignalGuardTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityZeroSignalGuardTests.cs
@@ -60,4 +60,56 @@ public class FidelityZeroSignalGuardTests
         Assert.True(guard.ProbeCompleted);
         Assert.Equal(4000, guard.EffectiveCap(total: 100));
     }
+
+    [Fact]
+    public void Observe_StopsWhenAllRowsAreContextFail()
+    {
+        var guard = new FidelityCheck.ZeroSignalGuard(probeCount: 100, requestedCap: 4000);
+
+        guard.Observe(
+            total: 100,
+            exact: 0,
+            diffCount: 0,
+            recompileFail: 0,
+            contextFail: 100,
+            recompileFailCodes: new Dictionary<string, int>());
+
+        Assert.True(guard.Stopped);
+        Assert.Equal("context-fail", guard.DominantBucket);
+        Assert.Equal(100, guard.DominantCount);
+    }
+
+    [Fact]
+    public void Observe_StopsWhenContextFailDominatesMixedFailures()
+    {
+        var guard = new FidelityCheck.ZeroSignalGuard(probeCount: 100, requestedCap: 4000);
+
+        guard.Observe(
+            total: 100,
+            exact: 0,
+            diffCount: 0,
+            recompileFail: 1,
+            contextFail: 99,
+            recompileFailCodes: new Dictionary<string, int> { ["CS0103"] = 1 });
+
+        Assert.True(guard.Stopped);
+        Assert.Equal("context-fail", guard.DominantBucket);
+        Assert.Equal(99, guard.DominantCount);
+    }
+
+    [Fact]
+    public void Observe_RerunsWithoutGuardWhenProbeDoesNotStop()
+    {
+        var guard = new FidelityCheck.ZeroSignalGuard(probeCount: 100, requestedCap: 4000);
+
+        guard.Observe(
+            total: 100,
+            exact: 1,
+            diffCount: 0,
+            recompileFail: 99,
+            contextFail: 0,
+            recompileFailCodes: new Dictionary<string, int> { ["CS0234"] = 99 });
+
+        Assert.True(guard.ShouldRerunWithoutGuard);
+    }
 }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -72,7 +72,7 @@ static class FidelityCheck
         using var metadata = CorpusMetadata.Create(assemblies);
         foreach (var path in assemblies)
         {
-            if (total >= cap || zeroSignal?.Stopped == true)
+            if (total >= cap || zeroSignal?.Stopped == true || zeroSignal?.ShouldRerunWithoutGuard == true)
                 break;
             PEReader pe;
             try { pe = new PEReader(File.OpenRead(path)); }
@@ -91,7 +91,7 @@ static class FidelityCheck
                     var render = Renderer(source, lowered);
                     foreach (var typeHandle in reader.TypeDefinitions)
                     {
-                        if (total >= cap || zeroSignal?.Stopped == true)
+                        if (total >= cap || zeroSignal?.Stopped == true || zeroSignal?.ShouldRerunWithoutGuard == true)
                             break;
                         int effectiveCap = zeroSignal?.EffectiveCap(total) ?? cap;
                         RunType(reader, pe, source, typeHandle, references, parseOptions, compileOptions,
@@ -104,7 +104,10 @@ static class FidelityCheck
         }
 
         if (zeroSignal?.ShouldRerunWithoutGuard == true)
+        {
+            zeroSignal.Report();
             return Run(assemblies, cap, maxExamples, lowered, timings, zeroSignalGuard: 0);
+        }
 
         Report(total, full, exact, contextFail, recompileFail, diffCount,
             recompileFailCodes, diffExamples, zeroSignal);

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -72,7 +72,7 @@ static class FidelityCheck
         using var metadata = CorpusMetadata.Create(assemblies);
         foreach (var path in assemblies)
         {
-            if (total >= cap)
+            if (total >= cap || zeroSignal?.Stopped == true)
                 break;
             PEReader pe;
             try { pe = new PEReader(File.OpenRead(path)); }
@@ -102,6 +102,9 @@ static class FidelityCheck
                 }
             }
         }
+
+        if (zeroSignal?.ShouldRerunWithoutGuard == true)
+            return Run(assemblies, cap, maxExamples, lowered, timings, zeroSignalGuard: 0);
 
         Report(total, full, exact, contextFail, recompileFail, diffCount,
             recompileFailCodes, diffExamples, zeroSignal);
@@ -394,6 +397,7 @@ static class FidelityCheck
 
         public bool Stopped { get; private set; }
         public bool ProbeCompleted { get; private set; }
+        public bool ShouldRerunWithoutGuard => ProbeCompleted && !Stopped;
         public int StopCount { get; private set; }
         public string? DominantBucket { get; private set; }
         public int DominantCount { get; private set; }
@@ -420,9 +424,14 @@ static class FidelityCheck
                 .OrderByDescending(kv => kv.Value)
                 .ThenBy(kv => kv.Key, StringComparer.Ordinal)
                 .FirstOrDefault();
-            string bucket = dominant.Key ?? (contextFail > 0 ? "context-fail" : "<unknown>");
-            int count = dominant.Value != 0 ? dominant.Value : contextFail;
-            if (count * 10 < total * 9)
+            string bucket = dominant.Key ?? "<unknown>";
+            int count = dominant.Value;
+            if (contextFail > count)
+            {
+                bucket = "context-fail";
+                count = contextFail;
+            }
+            if (count * 10L < total * 9L)
                 return;
 
             Stopped = true;


### PR DESCRIPTION
## Summary

Follow-up to #1894 after adversarial review.

Fixes the guard edge cases found after #1894 merged:

- lets `context-fail` compete as a first-class dominant failure bucket instead of only falling back when there are no recompile-fail codes;
- uses overflow-safe threshold arithmetic;
- exits the outer assembly loop once the guard stops;
- reruns without the guard when the probe finds useful or mixed signal, avoiding skipped methods from the probe-boundary type;
- adds tests for all-context-fail, mixed context/recompile dominance, and rerun-needed probes.

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/FidelityZeroSignalGuardTests/*"`
- `dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet`
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- Roslyn guard smoke: `Microsoft.CodeAnalysis.CSharp.dll --fidelity-check --compile-cap 4000 --fidelity-zero-signal-guard 100` stopped after 100 rows in ~59s with dominant `CS0234: 94`.

## Review reconciliation

Gemini found: context-fail dominance ignored when any recompile-fail code exists; probe-boundary type methods skipped if probe continues; outer assembly loop does pointless work after stop; threshold arithmetic should be 64-bit; tests missed mixed context/recompile scenarios.

Claude independently found the context-fail dominance/test gap.

All findings are addressed here.