### PR TITLE
Resolve NuGet dependencies for fidelity-check context

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckNuGetReferenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckNuGetReferenceTests.cs
@@ -5,7 +5,7 @@ namespace ILInspector.Decompiler.Tests;
 public class FidelityCheckNuGetReferenceTests
 {
     [Fact]
-    public void PackageDependencyReferencePaths_SelectsMatchingTfmDependencies()
+    public void PackageDependencyReferencePaths_SelectsCompatibleTfmDependencyGroup()
     {
         string root = Directory.CreateTempSubdirectory("dotnet-inspect-nuget-context-").FullName;
         string? previousRoot = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
@@ -27,9 +27,6 @@ public class FidelityCheckNuGetReferenceTests
                     <version>1.0.0</version>
                     <dependencies>
                       <group targetFramework=".NETStandard2.0">
-                        <dependency id="Shared.Package" version="2.0.0" />
-                      </group>
-                      <group targetFramework="net8.0">
                         <dependency id="Shared.Package" version="[8.0.0]" />
                       </group>
                     </dependencies>
@@ -45,6 +42,55 @@ public class FidelityCheckNuGetReferenceTests
             var references = FidelityCheck.PackageDependencyReferencePaths(targetPath);
 
             Assert.Contains(sharedPath, references);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", previousRoot);
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PackageDependencyReferencePaths_PrefersExactRefAssetBeforeCompatibleLibFallback()
+    {
+        string root = Directory.CreateTempSubdirectory("dotnet-inspect-nuget-context-").FullName;
+        string? previousRoot = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        try
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", root);
+            string packageDir = Path.Combine(root, "root.package", "1.0.0");
+            string targetDir = Path.Combine(packageDir, "lib", "net8.0");
+            Directory.CreateDirectory(targetDir);
+            string targetPath = Path.Combine(targetDir, "Root.dll");
+            File.WriteAllText(targetPath, "");
+            File.WriteAllText(
+                Path.Combine(packageDir, "root.package.nuspec"),
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <package>
+                  <metadata>
+                    <dependencies>
+                      <group targetFramework="net8.0">
+                        <dependency id="Shared.Package" version="8.0.0" />
+                      </group>
+                    </dependencies>
+                  </metadata>
+                </package>
+                """);
+
+            string refDir = Path.Combine(root, "shared.package", "8.0.0", "ref", "net8.0");
+            Directory.CreateDirectory(refDir);
+            string refPath = Path.Combine(refDir, "Shared.dll");
+            File.WriteAllText(refPath, "");
+            string libDir = Path.Combine(root, "shared.package", "8.0.0", "lib", "netstandard2.0");
+            Directory.CreateDirectory(libDir);
+            string libPath = Path.Combine(libDir, "Shared.dll");
+            File.WriteAllText(libPath, "");
+
+            var references = FidelityCheck.PackageDependencyReferencePaths(targetPath);
+
+            Assert.Contains(refPath, references);
+            Assert.DoesNotContain(libPath, references);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/FidelityCheckNuGetReferenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckNuGetReferenceTests.cs
@@ -1,0 +1,98 @@
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class FidelityCheckNuGetReferenceTests
+{
+    [Fact]
+    public void PackageDependencyReferencePaths_SelectsMatchingTfmDependencies()
+    {
+        string root = Directory.CreateTempSubdirectory("dotnet-inspect-nuget-context-").FullName;
+        string? previousRoot = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        try
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", root);
+            string packageDir = Path.Combine(root, "root.package", "1.0.0");
+            string targetDir = Path.Combine(packageDir, "lib", "net8.0");
+            Directory.CreateDirectory(targetDir);
+            string targetPath = Path.Combine(targetDir, "Root.dll");
+            File.WriteAllText(targetPath, "");
+            File.WriteAllText(
+                Path.Combine(packageDir, "root.package.nuspec"),
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+                  <metadata>
+                    <id>Root.Package</id>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <group targetFramework=".NETStandard2.0">
+                        <dependency id="Shared.Package" version="2.0.0" />
+                      </group>
+                      <group targetFramework="net8.0">
+                        <dependency id="Shared.Package" version="[8.0.0]" />
+                      </group>
+                    </dependencies>
+                  </metadata>
+                </package>
+                """);
+
+            string sharedDir = Path.Combine(root, "shared.package", "8.0.0", "lib", "net8.0");
+            Directory.CreateDirectory(sharedDir);
+            string sharedPath = Path.Combine(sharedDir, "Shared.dll");
+            File.WriteAllText(sharedPath, "");
+
+            var references = FidelityCheck.PackageDependencyReferencePaths(targetPath);
+
+            Assert.Contains(sharedPath, references);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", previousRoot);
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PackageDependencyReferencePaths_IgnoresNonExactRanges()
+    {
+        string root = Directory.CreateTempSubdirectory("dotnet-inspect-nuget-context-").FullName;
+        string? previousRoot = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        try
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", root);
+            string packageDir = Path.Combine(root, "root.package", "1.0.0");
+            string targetDir = Path.Combine(packageDir, "lib", "net8.0");
+            Directory.CreateDirectory(targetDir);
+            string targetPath = Path.Combine(targetDir, "Root.dll");
+            File.WriteAllText(targetPath, "");
+            File.WriteAllText(
+                Path.Combine(packageDir, "root.package.nuspec"),
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <package>
+                  <metadata>
+                    <dependencies>
+                      <group targetFramework="net8.0">
+                        <dependency id="Shared.Package" version="[1.0.0,2.0.0)" />
+                      </group>
+                    </dependencies>
+                  </metadata>
+                </package>
+                """);
+
+            string sharedDir = Path.Combine(root, "shared.package", "1.0.0", "lib", "net8.0");
+            Directory.CreateDirectory(sharedDir);
+            File.WriteAllText(Path.Combine(sharedDir, "Shared.dll"), "");
+
+            var references = FidelityCheck.PackageDependencyReferencePaths(targetPath);
+
+            Assert.Empty(references);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("NUGET_PACKAGES", previousRoot);
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -3026,7 +3026,16 @@ static class FidelityCheck
         string? normalizedTfm = NormalizeNuGetFramework(tfm);
         var selectedGroup = normalizedTfm is null
             ? null
-            : groups.FirstOrDefault(g => NormalizeNuGetFramework(g.Attribute("targetFramework")?.Value) == normalizedTfm);
+            : groups
+                .Select(group => new
+                {
+                    Group = group,
+                    Score = NuGetFrameworkCompatibilityScore(normalizedTfm, NormalizeNuGetFramework(group.Attribute("targetFramework")?.Value)),
+                })
+                .Where(candidate => candidate.Score is not null)
+                .OrderByDescending(candidate => candidate.Score)
+                .Select(candidate => candidate.Group)
+                .FirstOrDefault();
 
         if (selectedGroup is not null)
         {
@@ -3054,6 +3063,65 @@ static class FidelityCheck
         return tfm;
     }
 
+    static int? NuGetFrameworkCompatibilityScore(string target, string? candidate)
+    {
+        if (candidate is null)
+            return null;
+        if (string.Equals(target, candidate, StringComparison.OrdinalIgnoreCase))
+            return 100_000;
+        if (!TryParseNuGetFramework(target, out var targetFramework) ||
+            !TryParseNuGetFramework(candidate, out var candidateFramework))
+            return null;
+
+        int versionScore = candidateFramework.Major * 100 + candidateFramework.Minor;
+        return targetFramework.Family switch
+        {
+            "net" when candidateFramework.Family == "net" && candidateFramework.VersionScore <= targetFramework.VersionScore
+                => 90_000 + versionScore,
+            "net" when candidateFramework.Family == "netcoreapp" && candidateFramework.VersionScore <= targetFramework.VersionScore
+                => 80_000 + versionScore,
+            "net" when candidateFramework.Family == "netstandard" && candidateFramework.VersionScore <= 201
+                => 70_000 + versionScore,
+            "netcoreapp" when candidateFramework.Family == "netcoreapp" && candidateFramework.VersionScore <= targetFramework.VersionScore
+                => 90_000 + versionScore,
+            "netcoreapp" when candidateFramework.Family == "netstandard" && candidateFramework.VersionScore <= 201
+                => 80_000 + versionScore,
+            "netstandard" when candidateFramework.Family == "netstandard" && candidateFramework.VersionScore <= targetFramework.VersionScore
+                => 90_000 + versionScore,
+            _ => null,
+        };
+    }
+
+    readonly record struct NuGetFramework(string Family, int Major, int Minor)
+    {
+        public int VersionScore => Major * 100 + Minor;
+    }
+
+    static bool TryParseNuGetFramework(string tfm, out NuGetFramework framework)
+    {
+        framework = default;
+        if (tfm.StartsWith("netstandard", StringComparison.Ordinal))
+            return TryParseVersionedFramework("netstandard", tfm["netstandard".Length..], out framework);
+        if (tfm.StartsWith("netcoreapp", StringComparison.Ordinal))
+            return TryParseVersionedFramework("netcoreapp", tfm["netcoreapp".Length..], out framework);
+        if (tfm.StartsWith("net", StringComparison.Ordinal) && tfm[3..].Contains('.', StringComparison.Ordinal))
+            return TryParseVersionedFramework("net", tfm["net".Length..], out framework);
+        return false;
+    }
+
+    static bool TryParseVersionedFramework(string family, string version, out NuGetFramework framework)
+    {
+        framework = default;
+        var parts = version.Split('.', 3);
+        if (parts.Length == 0 || !int.TryParse(parts[0], out int major))
+            return false;
+        int minor = 0;
+        if (parts.Length >= 2 && !int.TryParse(parts[1], out minor))
+            return false;
+        framework = new(family, major, minor);
+        return true;
+    }
+
     static string? DependencyExactVersion(string? version)
     {
         if (string.IsNullOrWhiteSpace(version))
@@ -3079,30 +3147,53 @@ static class FidelityCheck
         if (!Directory.Exists(packageDir))
             yield break;
 
-        foreach (string assetKind in (string[])["lib", "ref"])
+        foreach (string assetKind in (string[])["ref", "lib"])
         {
-            if (tfm is not null)
+            if (tfm is not null && AssetDirectory(packageDir, assetKind, tfm) is { } exactAssetDir)
             {
-                string assetDir = Path.Combine(packageDir, assetKind, tfm);
-                if (Directory.Exists(assetDir))
-                {
-                    foreach (var path in Directory.EnumerateFiles(assetDir, "*.dll"))
-                        yield return path;
-                    yield break;
-                }
-            }
-
-            string assetRoot = Path.Combine(packageDir, assetKind);
-            if (!Directory.Exists(assetRoot))
-                continue;
-
-            foreach (string tfmDir in Directory.EnumerateDirectories(assetRoot).OrderDescending(StringComparer.OrdinalIgnoreCase))
-            {
-                foreach (var path in Directory.EnumerateFiles(tfmDir, "*.dll"))
+                foreach (var path in Directory.EnumerateFiles(exactAssetDir, "*.dll"))
                     yield return path;
                 yield break;
             }
         }
+
+        foreach (string assetKind in (string[])["ref", "lib"])
+        {
+            if (tfm is not null && CompatibleAssetDirectory(packageDir, assetKind, tfm) is { } compatibleAssetDir)
+            {
+                foreach (var path in Directory.EnumerateFiles(compatibleAssetDir, "*.dll"))
+                    yield return path;
+                yield break;
+            }
+        }
+    }
+
+    static string? AssetDirectory(string packageDir, string assetKind, string tfm)
+    {
+        string assetDir = Path.Combine(packageDir, assetKind, tfm);
+        return Directory.Exists(assetDir) ? assetDir : null;
+    }
+
+    static string? CompatibleAssetDirectory(string packageDir, string assetKind, string targetTfm)
+    {
+        string assetRoot = Path.Combine(packageDir, assetKind);
+        if (!Directory.Exists(assetRoot))
+            return null;
+
+        string? normalizedTarget = NormalizeNuGetFramework(targetTfm);
+        if (normalizedTarget is null)
+            return null;
+
+        return Directory.EnumerateDirectories(assetRoot)
+            .Select(dir => new
+            {
+                Directory = dir,
+                Score = NuGetFrameworkCompatibilityScore(normalizedTarget, NormalizeNuGetFramework(Path.GetFileName(dir))),
+            })
+            .Where(candidate => candidate.Score is not null)
+            .OrderByDescending(candidate => candidate.Score)
+            .Select(candidate => candidate.Directory)
+            .FirstOrDefault();
     }
 
     static void AddDepsJsonReferences(string targetDirectory, string targetName, Action<string> addReference)

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -5,6 +5,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Text;
 using System.Text.Json;
+using System.Xml.Linq;
 
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
@@ -2914,6 +2915,9 @@ static class FidelityCheck
             catch (ArgumentException) { }
         }
 
+        foreach (var path in PackageDependencyReferencePaths(targetPath))
+            Add(path);
+
         foreach (var path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
             .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
             Add(path);
@@ -2937,6 +2941,168 @@ static class FidelityCheck
                 Add(path);
 
         return new ReferenceSet(builder.ToImmutable(), new SignatureAccessibility(referencePaths));
+    }
+
+    internal static IReadOnlyList<string> PackageDependencyReferencePaths(string targetPath)
+    {
+        if (NuGetPackageContext(targetPath) is not { } context)
+            return [];
+
+        var nuspec = Directory.EnumerateFiles(context.PackageDirectory, "*.nuspec").FirstOrDefault();
+        if (nuspec is null)
+            return [];
+
+        var references = new List<string>();
+        try
+        {
+            var document = XDocument.Load(nuspec);
+            foreach (var dependency in SelectNuGetDependencies(document, context.TargetFramework))
+            {
+                string? id = dependency.Attribute("id")?.Value;
+                string? version = DependencyExactVersion(dependency.Attribute("version")?.Value);
+                if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(version))
+                    continue;
+
+                foreach (var root in NuGetPackageRoots())
+                {
+                    var packageDir = Path.Combine(root, id.ToLowerInvariant(), version.ToLowerInvariant());
+                    foreach (var path in ProbeNuGetPackageVersionDlls(packageDir, context.TargetFramework))
+                        references.Add(path);
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Xml.XmlException)
+        {
+            return [];
+        }
+
+        return references;
+    }
+
+    sealed record NuGetReferenceContext(
+        string PackageDirectory,
+        string TargetFramework);
+
+    static NuGetReferenceContext? NuGetPackageContext(string targetPath)
+    {
+        string fullPath = Path.GetFullPath(targetPath);
+        foreach (var root in NuGetPackageRoots())
+        {
+            string fullRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            string prefix = fullRoot + Path.DirectorySeparatorChar;
+            if (!fullPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var parts = fullPath[prefix.Length..].Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (parts.Length < 5 || !parts[2].Equals("lib", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            return new(
+                Path.Combine(fullRoot, parts[0], parts[1]),
+                parts[3]);
+        }
+
+        return null;
+    }
+
+    static IEnumerable<string> NuGetPackageRoots()
+    {
+        if (Environment.GetEnvironmentVariable("NUGET_PACKAGES") is { Length: > 0 } envRoot)
+            yield return envRoot;
+
+        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!string.IsNullOrEmpty(home))
+            yield return Path.Combine(home, ".nuget", "packages");
+    }
+
+    static IEnumerable<XElement> SelectNuGetDependencies(XDocument document, string? tfm)
+    {
+        var dependencies = document.Descendants().FirstOrDefault(e => e.Name.LocalName == "dependencies");
+        if (dependencies is null)
+            yield break;
+
+        var directDependencies = dependencies.Elements().Where(e => e.Name.LocalName == "dependency").ToArray();
+        var groups = dependencies.Elements().Where(e => e.Name.LocalName == "group").ToArray();
+        string? normalizedTfm = NormalizeNuGetFramework(tfm);
+        var selectedGroup = normalizedTfm is null
+            ? null
+            : groups.FirstOrDefault(g => NormalizeNuGetFramework(g.Attribute("targetFramework")?.Value) == normalizedTfm);
+
+        if (selectedGroup is not null)
+        {
+            foreach (var dependency in selectedGroup.Elements().Where(e => e.Name.LocalName == "dependency"))
+                yield return dependency;
+            yield break;
+        }
+
+        foreach (var dependency in directDependencies)
+            yield return dependency;
+    }
+
+    static string? NormalizeNuGetFramework(string? tfm)
+    {
+        if (string.IsNullOrWhiteSpace(tfm))
+            return null;
+
+        tfm = tfm.Trim().ToLowerInvariant();
+        if (tfm.StartsWith(".netstandard", StringComparison.Ordinal))
+            return "netstandard" + tfm[".netstandard".Length..];
+        if (tfm.StartsWith(".netcoreapp", StringComparison.Ordinal))
+            return "netcoreapp" + tfm[".netcoreapp".Length..];
+        if (tfm.StartsWith(".netframework", StringComparison.Ordinal))
+            return "net" + tfm[".netframework".Length..].Replace(".", "", StringComparison.Ordinal);
+        return tfm;
+    }
+
+    static string? DependencyExactVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return null;
+
+        version = version.Trim();
+        if (version.Length >= 5 && version[0] == '[' && version[^1] == ']')
+        {
+            string inner = version[1..^1].Trim();
+            var range = inner.Split(',', 2);
+            if (range.Length == 1)
+                return inner;
+            if (range.Length == 2
+                && string.Equals(range[0].Trim(), range[1].Trim(), StringComparison.OrdinalIgnoreCase))
+                return range[0].Trim();
+        }
+
+        return version.IndexOfAny(['[', ']', '(', ')', ',']) < 0 ? version : null;
+    }
+
+    static IEnumerable<string> ProbeNuGetPackageVersionDlls(string packageDir, string? tfm)
+    {
+        if (!Directory.Exists(packageDir))
+            yield break;
+
+        foreach (string assetKind in (string[])["lib", "ref"])
+        {
+            if (tfm is not null)
+            {
+                string assetDir = Path.Combine(packageDir, assetKind, tfm);
+                if (Directory.Exists(assetDir))
+                {
+                    foreach (var path in Directory.EnumerateFiles(assetDir, "*.dll"))
+                        yield return path;
+                    yield break;
+                }
+            }
+
+            string assetRoot = Path.Combine(packageDir, assetKind);
+            if (!Directory.Exists(assetRoot))
+                continue;
+
+            foreach (string tfmDir in Directory.EnumerateDirectories(assetRoot).OrderDescending(StringComparer.OrdinalIgnoreCase))
+            {
+                foreach (var path in Directory.EnumerateFiles(tfmDir, "*.dll"))
+                    yield return path;
+                yield break;
+            }
+        }
     }
 
     static void AddDepsJsonReferences(string targetDirectory, string targetName, Action<string> addReference)


### PR DESCRIPTION
- Fixes #1893
- Harness-only fidelity-check reference context change
- Card revision: `17dce450`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — standalone NuGet package assemblies now get exact package dependency references before TPA fallback in the compile-back harness.

Before:

```text
Microsoft.CodeAnalysis.CSharp cap 100/1000/4000: CS0234 dominated, 0 useful opcode rows
```

After:

```text
Microsoft.CodeAnalysis.CSharp cap 100: CS0234 no longer appears; next blockers are CS0311/CS1525/CS0122, 0 useful opcode rows
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `FidelityCheckNuGetReferenceTests` passed |
| Roslyn cap-100 | Pass for #1893 scope: `CS0311: 95`, `CS1525: 3`, `CS0122: 2`; no CS0234 bucket |
| Useful rows | Still 0 Exact / 0 OpcodeDiff; expected for this first CS0234 dependency-context slice |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — no product decompiler behavior changes. This is harness-only and keeps the product decompiler path unchanged.

This PR intentionally does not solve Roslyn hierarchy/slot reconstruction. It moves the Roslyn sample past the standalone package dependency blocker so the remaining failures are the next known context track (`CS0311`, `CS0122`, slot/override diagnostics), not CFG/fidelity evidence.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked layout detection, exact version handling, precedence before TPA, harness-only scope, tests, and #1893 evidence. |
| Gemini 3.1 Pro | Fixed findings | Found missing compatible TFM fallback and incorrect asset probing priority. Fixed in `17dce450` with compatible group selection and exact `ref`-before-`lib` probing plus tests. |

**Review conclusion:** **PASS** — Gemini's actionable findings were fixed. MetadataSource helper duplication is pre-existing/product-path behavior and was left unchanged to keep this PR scoped to the harness context slice.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*FidelityCheckNuGetReferenceTests"
/usr/bin/time -f 'elapsed=%E cpu=%P maxrss=%MKB' \
  dotnet run --project tools/DecompilerHarness -c Release -- \
  /home/rich/.nuget/packages/microsoft.codeanalysis.csharp/5.8.0-1.26277.111/lib/net10.0/Microsoft.CodeAnalysis.CSharp.dll \
  --fidelity-check --compile-cap 100 --max-examples 5 --fidelity-timings
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
git diff --check
```
