### PR TITLE
Preserve slot-store diamond branch polarity

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1314,7 +1314,7 @@ public class CSharpPrinterTests
         // The slot/local carrying the ternary declares as the common base,
         // never the WhenTrue arm — config-agnostic (Release spills a stack
         // slot, Debug keeps a named local).
-        Assert.Matches(@"JoinBase \w+ = flag \?", output);
+        Assert.Matches(@"JoinBase \w+ = !flag \?", output);
         Assert.DoesNotContain("JoinDerived S_", output);
         Assert.DoesNotContain("JoinDerived V_", output);
     }

--- a/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
@@ -171,6 +171,73 @@ public class SlotStoreDiamondPassTests
         Assert.Equal("fallthrough", Assert.IsType<Constant>(conditional.WhenFalse).Value);
     }
 
+    [Fact]
+    public void SlotDiamond_PreservesNegatedBranchPolarityWhenFolding()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var body = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LogicalNot(new LoadArgument(0, "cond", Bool)), 8));
+        var falseArm = new Block(4);
+        falseArm.Add(new StoreStackSlot(0, new Constant("fallthrough", Object)));
+        falseArm.Add(new Branch(12));
+        var trueArm = new Block(8);
+        trueArm.Add(new StoreStackSlot(0, new Constant("target", Object)));
+        var merge = new Block(12);
+        merge.Add(new Return(new LoadStackSlot(0, Object)));
+        foreach (var block in (Block[])[head, falseArm, trueArm, merge])
+            body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(Object, [new Parameter("cond", Bool)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        var pass = new SlotDiamondPass();
+        pass.Run(function, PassContext.None);
+
+        var conditional = Assert.Single(function.Descendants.OfType<Conditional>());
+        Assert.IsType<LogicalNot>(conditional.Condition);
+        Assert.Equal("target", Assert.IsType<Constant>(conditional.WhenTrue).Value);
+        Assert.Equal("fallthrough", Assert.IsType<Constant>(conditional.WhenFalse).Value);
+    }
+
+    [Fact]
+    public void BooleanFolding_PreservesNegatedBranchPolarityWhenFoldingStoreDiamond()
+    {
+        static Block BlockOf(params IrNode[] nodes)
+        {
+            var block = new Block();
+            foreach (var node in nodes)
+                block.Add(node);
+            return block;
+        }
+
+        var block = new Block(0);
+        block.Add(new IfStatement(
+            new LogicalNot(new LoadArgument(0, "cond", Bool)),
+            BlockOf(new StoreStackSlot(0, new Constant("target", Object))),
+            BlockOf(new StoreStackSlot(0, new Constant("fallthrough", Object)))));
+        block.Add(new Return(new LoadStackSlot(0, Object)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.Definition("Synthetic", "Samples", "Owner"),
+            new MethodSignature(Object, [new Parameter("cond", Bool)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        var pass = new BooleanFoldingPass();
+        pass.Run(function, PassContext.None);
+
+        var conditional = Assert.Single(function.Descendants.OfType<Conditional>());
+        Assert.IsType<LogicalNot>(conditional.Condition);
+        Assert.Equal("target", Assert.IsType<Constant>(conditional.WhenTrue).Value);
+        Assert.Equal("fallthrough", Assert.IsType<Constant>(conditional.WhenFalse).Value);
+    }
+
     static IrFunction BuildEffectfulPrefixDiamond(bool reverseLoadOrder)
     {
         var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");

--- a/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
@@ -139,6 +139,38 @@ public class SlotStoreDiamondPassTests
         Assert.Contains(function.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
     }
 
+    [Fact]
+    public void PreservesNegatedBranchPolarityWhenFolding()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var body = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LogicalNot(new LoadArgument(0, "cond", Bool)), 8));
+        var falseArm = new Block(4);
+        falseArm.Add(new StoreStackSlot(0, new Constant("fallthrough", Object)));
+        falseArm.Add(new Branch(12));
+        var trueArm = new Block(8);
+        trueArm.Add(new StoreStackSlot(0, new Constant("target", Object)));
+        var merge = new Block(12);
+        merge.Add(new Return(new LoadStackSlot(0, Object)));
+        foreach (var block in (Block[])[head, falseArm, trueArm, merge])
+            body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(Object, [new Parameter("cond", Bool)], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        var pass = new SlotStoreDiamondPass();
+        pass.Run(function, PassContext.None);
+
+        var conditional = Assert.Single(function.Descendants.OfType<Conditional>());
+        Assert.IsType<LogicalNot>(conditional.Condition);
+        Assert.Equal("target", Assert.IsType<Constant>(conditional.WhenTrue).Value);
+        Assert.Equal("fallthrough", Assert.IsType<Constant>(conditional.WhenFalse).Value);
+    }
+
     static IrFunction BuildEffectfulPrefixDiamond(bool reverseLoadOrder)
     {
         var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");

--- a/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/BooleanFoldingPass.cs
@@ -691,12 +691,6 @@ public sealed class BooleanFoldingPass : IIrPass
         condition.Detach();
         var whenTrue = (IrExpression)thenStore.DetachChildren()[0];
         var whenFalse = (IrExpression)elseStore.DetachChildren()[0];
-        if (condition is LogicalNot doubleNegative)
-        {
-            // !c ? b : a reads backwards; unwrap and swap the arms.
-            condition = (IrExpression)doubleNegative.DetachChildren()[0];
-            (whenTrue, whenFalse) = (whenFalse, whenTrue);
-        }
         stepper.StepOver("fold store diamond into ternary", diamond);
         diamond.ReplaceWith(new StoreStackSlot(thenStore.Slot, new Conditional(condition, whenTrue, whenFalse) { MergedType = mergedType }));
         return true;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotDiamondPass.cs
@@ -169,16 +169,11 @@ public sealed class SlotDiamondPass : IIrPass
             return null;
 
         // `if (c) goto trueArm` takes the true arm when c holds, so the true arm's
-        // value is the when-true result. A LogicalNot condition reads backwards;
-        // unwrap and swap, mirroring BooleanFoldingPass.FoldSlotDiamond.
+        // value is the when-true result. Keep a LogicalNot condition intact so the
+        // rendered conditional preserves the original branch polarity.
         var condition = branch.Condition;
         var whenTrue = trueStore.Value;
         var whenFalse = falseStore.Value;
-        if (condition is LogicalNot negated)
-        {
-            condition = negated.Operand;
-            (whenTrue, whenFalse) = (whenFalse, whenTrue);
-        }
         if (HasNullArmForNonNullableValue(whenTrue, whenFalse, load.Type, function))
             return null;
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -101,11 +101,6 @@ public sealed class SlotStoreDiamondPass : IIrPass
             return null;
         var whenFalse = (IrExpression)falseStore.Value.Clone();
         var condition = (IrExpression)branch.Condition.Clone();
-        if (condition is LogicalNot negated)
-        {
-            condition = (IrExpression)negated.Operand.Clone();
-            (whenTrue, whenFalse) = (whenFalse, whenTrue);
-        }
         if (!NormalizeArmTypes(ref whenTrue, ref whenFalse))
             return null;
         var resultType = whenTrue.ResultType ?? whenFalse.ResultType;


### PR DESCRIPTION
## Summary

Fixes #1900 by preserving the imported branch polarity when `SlotStoreDiamondPass` folds a stack-slot diamond into a conditional expression.

Previously the pass normalized `LogicalNot` by stripping the negation and swapping arms. That made prettier C#, but it caused compile-back to flip branch orientation. The Humanizer CFG artifact exposed this in `HeadingExtensions.ToHeading`: original IL used `brfalse` to the `HeadingsShort` arm, while recompiled output used `brtrue` after normalization.

The folded conditional now keeps the original negated condition and target/fallthrough arm order, yielding:

```csharp
style == 0 ? HeadingExtensions.HeadingsShort[headingsIndex] : HeadingExtensions.Headings[headingsIndex]
```

instead of the polarity-flipped `style != 0 ? ...`.

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/SlotStoreDiamondPassTests/*"`
- `dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet`
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- Focused Humanizer fidelity:

```bash
CB_TYPE=HeadingExtensions dotnet run --project tools/DecompilerHarness -c Release -- \
  ~/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll \
  --fidelity-check --compile-cap 50 --max-examples 10 --fidelity-timings
```

Result: `COMPILE-BACK over 7 rendered methods (7 Full)`, `exact opcode match: 5`, `opcode diff (Full): 0`, `recompile fail: 2` (`CS1061`).

Humanizer `ToHeading` now renders with branch polarity preserved and no longer appears as an OpcodeDiff in the focused `HeadingExtensions` run.

## Risk

This changes C# spelling for negated slot-store diamonds from positive-condition/swapped-arms to original-condition/original-arms. It preserves semantics and improves opcode fidelity, but it can make some conditionals render with `== 0` / negated predicates rather than the normalized positive form.

Adversarial review pending.