### PR TITLE
Gate local array escape with reaching definitions

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Emit;
 using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -1033,6 +1035,26 @@ public class LibraryBodyIndexTests
         Assert.Equal("small-array", local);
     }
 
+    [Fact]
+    public void OptimizationOpportunities_ReachingDefinitionsSeparateReusedLocalSlots()
+    {
+        var (path, directory) = BuildSlotReuseArrayFixture();
+        try
+        {
+            var index = LibraryBodyIndex.Open(path);
+
+            var shapes = ArrayShapes(index, "LocalThenEscapingSlotReuse").ToArray();
+
+            Assert.Equal(2, shapes.Length);
+            Assert.Contains("stackalloc-candidate", shapes);
+            Assert.Contains("small-array", shapes);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
     [Theory]
     [InlineData(nameof(OptimizationOpportunityFixtures.ReturnsSmallArray))]
     [InlineData(nameof(OptimizationOpportunityFixtures.StoresArrayToField))]
@@ -1525,6 +1547,47 @@ public class LibraryBodyIndexTests
         => index.OptimizationOpportunities
             .Where(o => o.Method.Name == methodName && o.Shape is "small-array" or "stackalloc-candidate")
             .Select(o => o.Shape);
+
+    static (string Path, string Directory) BuildSlotReuseArrayFixture()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "dotnet-inspect-slot-reuse-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "SlotReuseArrayFixture.dll");
+
+        var assemblyName = new AssemblyName("SlotReuseArrayFixture");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        var type = module.DefineType("SlotReuseArrayFixture", TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
+        var method = type.DefineMethod(
+            "LocalThenEscapingSlotReuse",
+            MethodAttributes.Public | MethodAttributes.Static,
+            typeof(int[]),
+            Type.EmptyTypes);
+        var il = method.GetILGenerator();
+        il.DeclareLocal(typeof(int[]));
+
+        il.Emit(OpCodes.Ldc_I4_4);
+        il.Emit(OpCodes.Newarr, typeof(int));
+        il.Emit(OpCodes.Stloc_0);
+        il.Emit(OpCodes.Ldloc_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stelem_I4);
+        il.Emit(OpCodes.Ldloc_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_I4);
+        il.Emit(OpCodes.Pop);
+
+        il.Emit(OpCodes.Ldc_I4_4);
+        il.Emit(OpCodes.Newarr, typeof(int));
+        il.Emit(OpCodes.Stloc_0);
+        il.Emit(OpCodes.Ldloc_0);
+        il.Emit(OpCodes.Ret);
+
+        type.CreateType();
+        assembly.Save(path);
+        return (path, directory);
+    }
 
     static IEnumerable<string> DelegateShapes(LibraryBodyIndex index, string methodName)
         => index.OptimizationOpportunities

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1024,6 +1024,15 @@ public class LibraryBodyIndexTests
         Assert.Equal("stackalloc-candidate", local);
     }
 
+    [Fact]
+    public void OptimizationOpportunities_DoesNotTrustIncompleteReachingDefinitionsForArrayEscape()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var local = Assert.Single(ArrayShapes(index, nameof(OptimizationOpportunityFixtures.LocalArrayInTryCatch)));
+        Assert.Equal("small-array", local);
+    }
+
     [Theory]
     [InlineData(nameof(OptimizationOpportunityFixtures.ReturnsSmallArray))]
     [InlineData(nameof(OptimizationOpportunityFixtures.StoresArrayToField))]
@@ -2511,6 +2520,20 @@ public class OptimizationOpportunityFixtures
         a[0] = 1;
         a[3] = 2;
         return a[0] + a[3];
+    }
+
+    public static int LocalArrayInTryCatch(int value)
+    {
+        try
+        {
+            var a = new int[4];
+            a[0] = value;
+            return a[0];
+        }
+        catch (InvalidOperationException)
+        {
+            return -1;
+        }
     }
 
     // Non-escaping but a managed (reference) element type -> not stackalloc-eligible.

--- a/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
+++ b/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
@@ -69,6 +69,26 @@ public class ReachingDefinitionsTests
     }
 
     [Fact]
+    public void Analyze_SlotReuse_SeparatesUsesByReachingDefinition()
+    {
+        var result = ReachingDefinitions.Analyze([
+            Op(ILOpCode.Ldc_i4_0),
+            Op(ILOpCode.Stloc_0),
+            Op(ILOpCode.Ldloc_0),
+            Op(ILOpCode.Pop),
+            Op(ILOpCode.Ldc_i4_1),
+            Op(ILOpCode.Stloc_0),
+            Op(ILOpCode.Ldloc_0),
+            Op(ILOpCode.Ret),
+        ], argumentSlotCount: 0);
+
+        var firstUse = Assert.Single(result.Uses.Where(use => !use.IsArgument && use.Slot == 0 && use.Offset == 2));
+        Assert.Equal([1], firstUse.ReachingDefinitions.Select(def => def.Offset).ToArray());
+        var secondUse = Assert.Single(result.Uses.Where(use => !use.IsArgument && use.Slot == 0 && use.Offset == 6));
+        Assert.Equal([5], secondUse.ReachingDefinitions.Select(def => def.Offset).ToArray());
+    }
+
+    [Fact]
     public void Analyze_MalformedHugeSwitch_ThrowsBeforeAllocatingTargetTable()
     {
         Assert.Throws<BadImageFormatException>(() => ReachingDefinitions.Analyze([

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1074,7 +1074,7 @@ public sealed class LibraryBodyIndex
                             && !HasGeneratedCodeAttribute(methodAttributes)
                             && !HasCompilerGeneratedAttribute(methodAttributes)
                             && !IsBlazorRenderMethod(caller))
-                            optimizationOpportunities.AddRange(CollectOptimizationOpportunities(il, caller, scope, loopRegions));
+                            optimizationOpportunities.AddRange(CollectOptimizationOpportunities(il, body.ExceptionRegions, caller, scope, loopRegions));
                         else
                             suppressedOpportunityTokens.Add(caller.MetadataToken);
                         var signals = CollectBodySignals(il, body, scope, loopRegions);
@@ -1451,9 +1451,13 @@ public sealed class LibraryBodyIndex
             return found;
         }
 
-        ImmutableArray<OptimizationOpportunity> CollectOptimizationOpportunities(byte[] il, MethodIdentity caller, GenericScope callerScope, IReadOnlyList<(int Start, int End)> loopRegions)
+        ImmutableArray<OptimizationOpportunity> CollectOptimizationOpportunities(byte[] il, IReadOnlyCollection<ExceptionRegion> exceptionRegions, MethodIdentity caller, GenericScope callerScope, IReadOnlyList<(int Start, int End)> loopRegions)
         {
             var opportunities = ImmutableArray.CreateBuilder<OptimizationOpportunity>();
+            ReachingDefinitionsResult? reachingDefinitions = null;
+            ReachingDefinitionsResult GetReachingDefinitions()
+                => reachingDefinitions ??= ReachingDefinitions.Analyze(il, ArgumentSlotCount(caller), exceptionRegions);
+
             int? pendingConstant = null;
             // Delegate creation is `<push target>; ldftn/ldvirtftn M; newobj DelegateCtor`.
             // Track the pending function-pointer load so a single row is emitted at the
@@ -1520,7 +1524,7 @@ public sealed class LibraryBodyIndex
                             // array provably stays local AND its element type is stackalloc-
                             // eligible (an unmanaged primitive); otherwise keep the
                             // non-committal shape.
-                            bool local = ArrayProvablyStaysLocal(il, position, caller)
+                            bool local = ArrayProvablyStaysLocal(il, GetReachingDefinitions(), position)
                                 && IsStackallocEligibleElement(ResolveTypeToken(elementToken, callerScope));
                             opportunities.Add(local
                                 ? new OptimizationOpportunity(
@@ -2185,14 +2189,31 @@ public sealed class LibraryBodyIndex
         // load is an in-place element access / length read — never returned, stored to a
         // field, address-taken, or passed to a call. Any shape we cannot prove local returns
         // false (keep the non-committal `small-array`), so a false positive is impossible.
-        bool ArrayProvablyStaysLocal(byte[] il, int positionAfterNewarr, MethodIdentity caller)
+        bool ArrayProvablyStaysLocal(byte[] il, ReachingDefinitionsResult reachingDefinitions, int positionAfterNewarr)
         {
             try
             {
-                int slot = ReadStoreLocalSlot(il, positionAfterNewarr);
-                if (slot < 0)
+                if (!TryReadStoreLocalDefinition(il, positionAfterNewarr, out int slot, out int storeOffset))
                     return false;
-                return !LocalArrayEscapes(il, slot);
+                if (!reachingDefinitions.IsComplete)
+                    return false;
+                var definition = reachingDefinitions.Definitions.FirstOrDefault(d =>
+                    !d.IsArgument && d.Slot == slot && d.Offset == storeOffset);
+                if (definition is null)
+                    return false;
+
+                foreach (var use in reachingDefinitions.UsesOf(definition))
+                {
+                    if (use.Address)
+                        return false;
+                    if (!TryPositionAfterLoadLocal(il, use.Offset, slot, out int positionAfterLoad)
+                        || ArrayLoadEscapes(il, positionAfterLoad))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
             {
@@ -2200,14 +2221,19 @@ public sealed class LibraryBodyIndex
             }
         }
 
-        // If the next instruction stores to a local, returns its slot; otherwise -1.
-        static int ReadStoreLocalSlot(byte[] il, int position)
+        static int ArgumentSlotCount(MethodIdentity method)
+            => method.ParameterTypes.Length + (method.IsStatic ? 0 : 1);
+
+        // If the next instruction stores to a local, returns its slot and IL offset.
+        static bool TryReadStoreLocalDefinition(byte[] il, int position, out int slot, out int storeOffset)
         {
+            slot = -1;
+            storeOffset = position;
             if (position >= il.Length)
-                return -1;
+                return false;
             int probe = position;
             var opcode = ReadOpcode(il, ref probe);
-            return opcode switch
+            slot = opcode switch
             {
                 ILOpCode.Stloc_0 => 0,
                 ILOpCode.Stloc_1 => 1,
@@ -2217,51 +2243,15 @@ public sealed class LibraryBodyIndex
                 ILOpCode.Stloc => BinaryPrimitives.ReadUInt16LittleEndian(il.AsSpan(probe)),
                 _ => -1,
             };
+            return slot >= 0;
         }
 
-        // Scans the whole body for uses of the array local. The array escapes if its address
-        // is taken (`ldloca`) or any load is not consumed in place by an element access /
-        // length read. Conservative: any unrecognized use counts as an escape.
-        bool LocalArrayEscapes(byte[] il, int slot)
+        static bool TryPositionAfterLoadLocal(byte[] il, int offset, int slot, out int positionAfterLoad)
         {
-            int position = 0;
-            while (position < il.Length)
-            {
-                int offset = position;
-                var opcode = ReadOpcode(il, ref position);
-                if (IsLoadLocalAddress(il, opcode, ref position, slot, out bool addressOfSlot))
-                {
-                    if (addressOfSlot)
-                        return true; // address taken -> may escape
-                    continue;
-                }
-                if (IsLoadLocal(il, opcode, ref position, slot, out bool loadsSlot))
-                {
-                    if (loadsSlot && ArrayLoadEscapes(il, position))
-                        return true;
-                    continue;
-                }
-                SkipOperand(il, opcode, ref position, offset);
-            }
-            return false;
-        }
-
-        static bool IsLoadLocalAddress(byte[] il, ILOpCode opcode, ref int position, int slot, out bool matchesSlot)
-        {
-            matchesSlot = false;
-            switch (opcode)
-            {
-                case ILOpCode.Ldloca_s:
-                    matchesSlot = il[position] == slot;
-                    position += 1;
-                    return true;
-                case ILOpCode.Ldloca:
-                    matchesSlot = BinaryPrimitives.ReadUInt16LittleEndian(il.AsSpan(position)) == slot;
-                    position += 2;
-                    return true;
-                default:
-                    return false;
-            }
+            positionAfterLoad = offset;
+            var opcode = ReadOpcode(il, ref positionAfterLoad);
+            return IsLoadLocal(il, opcode, ref positionAfterLoad, slot, out bool loadsSlot)
+                && loadsSlot;
         }
 
         static bool IsLoadLocal(byte[] il, ILOpCode opcode, ref int position, int slot, out bool matchesSlot)


### PR DESCRIPTION
## Summary

Implements the first #1891 Rung 3 consumer slice: `small-array` / `stackalloc-candidate` escape proof now consumes the Rung 1 `ReachingDefinitions` producer instead of scanning every use of a local slot.

## Details

- Proves locality against uses reached by the specific `newarr; stloc` definition, not every later reuse of that local slot.
- Lazily memoizes reaching definitions per method body only when a small constant-array candidate exists.
- Honors `ReachingDefinitionsResult.IsComplete`; EH / `leave` / external-target methods stay conservative as `small-array`.
- Adds slot-reuse def-use coverage and a try/catch array fixture to ensure incomplete facts are not trusted.

## Validation

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -class '*ReachingDefinitionsTests'`\n- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -method '*OptimizationOpportunities_PromotesProvablyLocalArrayToStackalloc*' -method '*OptimizationOpportunities_DoesNotTrustIncompleteReachingDefinitionsForArrayEscape*' -method '*OptimizationOpportunities_KeepsEscapingOrIneligibleArrayAsSmallArray*'`\n- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`\n- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal`\n- `dotnet run --project tools/AnalysisHarness -c Release -- --generated-fixtures`\n- `bash eng/prepare-decompiler-corpus.sh /tmp/analysis-corpus-assemblies.txt && dotnet run --project tools/AnalysisHarness -c Release -- --corpus-list /tmp/analysis-corpus-assemblies.txt --diff-corpus-baseline tools/AnalysisHarness/corpus/analysis-baseline.json`\n\nCorpus note: the analysis corpus diff reports `dotnet-inspect.dll: instance-method-group-delegate 75 -> 73`, and the same drift reproduces on clean `origin/main` (`fe2a6863`), so it is baseline drift, not introduced by this PR.\n\n## Adversarial review\n\nTwo-family review completed before opening:\n\n- Claude Opus 4.8: no significant correctness issues. Confirmed exact-definition `UsesOf` use, incomplete-result gate, method-body memoization, address-taken conservatism, and argument-slot handling.\n- Gemini 3.1 Pro: no significant correctness issues. Confirmed EH/incomplete fallback, false-promotion guard, escaping-use handling, and test adequacy.\n\nNo follow-up changes were required from review.\n\nRelates to #1891.\n