### PR TITLE
Model EH edges in reaching definitions

### DIFF
--- a/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
+++ b/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
@@ -149,6 +149,21 @@ public class ReachingDefinitionsTests
     }
 
     [Fact]
+    public void Analyze_NestedFinallyToCatch_UseSeesFinallyDefinition()
+    {
+        var result = AnalyzeFixture(nameof(NestedFinallyToCatchReadsLocal));
+        var finalizerDefinition = result.Definitions
+            .Where(definition => !definition.IsArgument && definition.Slot == 0)
+            .MaxBy(definition => definition.Offset);
+
+        Assert.True(result.IsComplete, result.IncompleteReason);
+        Assert.Contains(result.Uses, use =>
+            !use.IsArgument
+            && use.Slot == 0
+            && use.ReachingDefinitions.Any(definition => definition.Id == finalizerDefinition?.Id));
+    }
+
+    [Fact]
     public void Analyze_LeaveRegion_MarksResultIncomplete()
     {
         var result = ReachingDefinitions.Analyze([
@@ -241,6 +256,28 @@ public class ReachingDefinitionsTests
             MaybeThrow();
         }
         catch (InvalidOperationException) when (Filter(value))
+        {
+            return value;
+        }
+        return value;
+    }
+
+    static int NestedFinallyToCatchReadsLocal()
+    {
+        int value = 0;
+        try
+        {
+            try
+            {
+                value = 1;
+                MaybeThrow();
+            }
+            finally
+            {
+                value = 2;
+            }
+        }
+        catch
         {
             return value;
         }

--- a/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
+++ b/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
@@ -140,6 +140,15 @@ public class ReachingDefinitionsTests
     }
 
     [Fact]
+    public void Analyze_FilterRegion_UseSeesDefinitionsFromTryRegion()
+    {
+        var result = AnalyzeFixture(nameof(TryFilterReadsLocal));
+
+        Assert.True(result.IsComplete, result.IncompleteReason);
+        Assert.Contains(result.Uses, use => !use.IsArgument && use.ReachingDefinitions.Length >= 2);
+    }
+
+    [Fact]
     public void Analyze_LeaveRegion_MarksResultIncomplete()
     {
         var result = ReachingDefinitions.Analyze([
@@ -184,6 +193,13 @@ public class ReachingDefinitionsTests
     [MethodImpl(MethodImplOptions.NoInlining)]
     static void Sink(int value) => s_sink = value;
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool Filter(int value)
+    {
+        Sink(value);
+        return true;
+    }
+
     static int TryCatchReadsLocal()
     {
         int value = 0;
@@ -213,5 +229,21 @@ public class ReachingDefinitionsTests
         {
             Sink(value);
         }
+    }
+
+    static int TryFilterReadsLocal()
+    {
+        int value = 0;
+        try
+        {
+            MaybeThrow();
+            value = 1;
+            MaybeThrow();
+        }
+        catch (InvalidOperationException) when (Filter(value))
+        {
+            return value;
+        }
+        return value;
     }
 }

--- a/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
+++ b/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
@@ -1,4 +1,6 @@
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
 
 using ILInspector.Analysis;
 
@@ -109,14 +111,32 @@ public class ReachingDefinitionsTests
     }
 
     [Fact]
-    public void Analyze_ExceptionRegions_MarksResultIncomplete()
+    public void Analyze_MalformedExceptionRegion_MarksResultIncomplete()
     {
         var result = ReachingDefinitions.Analyze([
             Op(ILOpCode.Ret),
         ], argumentSlotCount: 0, [default(ExceptionRegion)]);
 
         Assert.False(result.IsComplete);
-        Assert.Contains("Exception-handler", result.IncompleteReason);
+        Assert.Contains("Exception try region", result.IncompleteReason);
+    }
+
+    [Fact]
+    public void Analyze_CatchRegion_UseSeesDefinitionsFromTryRegion()
+    {
+        var result = AnalyzeFixture(nameof(TryCatchReadsLocal));
+
+        Assert.True(result.IsComplete, result.IncompleteReason);
+        Assert.Contains(result.Uses, use => !use.IsArgument && use.ReachingDefinitions.Length >= 2);
+    }
+
+    [Fact]
+    public void Analyze_FinallyRegion_UseSeesDefinitionsFromTryRegion()
+    {
+        var result = AnalyzeFixture(nameof(TryFinallyReadsLocal));
+
+        Assert.True(result.IsComplete, result.IncompleteReason);
+        Assert.Contains(result.Uses, use => !use.IsArgument && use.ReachingDefinitions.Length >= 2);
     }
 
     [Fact]
@@ -132,4 +152,66 @@ public class ReachingDefinitionsTests
     }
 
     static byte Op(ILOpCode opcode) => checked((byte)opcode);
+
+    static ReachingDefinitionsResult AnalyzeFixture(string methodName)
+    {
+        using var stream = File.OpenRead(typeof(ReachingDefinitionsTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            if (reader.GetString(type.Name) != nameof(ReachingDefinitionsTests))
+                continue;
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) != methodName)
+                    continue;
+                return ReachingDefinitions.Analyze(peReader.GetMethodBody(method.RelativeVirtualAddress), argumentSlotCount: 0);
+            }
+        }
+        throw new InvalidOperationException($"Fixture method {methodName} not found.");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void MaybeThrow()
+    {
+    }
+
+    static int s_sink;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Sink(int value) => s_sink = value;
+
+    static int TryCatchReadsLocal()
+    {
+        int value = 0;
+        try
+        {
+            MaybeThrow();
+            value = 1;
+            MaybeThrow();
+        }
+        catch (InvalidOperationException)
+        {
+            return value;
+        }
+        return value;
+    }
+
+    static void TryFinallyReadsLocal()
+    {
+        int value = 0;
+        try
+        {
+            MaybeThrow();
+            value = 1;
+            MaybeThrow();
+        }
+        finally
+        {
+            Sink(value);
+        }
+    }
 }

--- a/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
+++ b/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
@@ -127,7 +127,7 @@ public class ReachingDefinitionsTests
         var result = AnalyzeFixture(nameof(TryCatchReadsLocal));
 
         Assert.True(result.IsComplete, result.IncompleteReason);
-        Assert.Contains(result.Uses, use => !use.IsArgument && use.ReachingDefinitions.Length >= 2);
+        AssertSomeUseSeesFirstAndLastSlotDefinitions(result);
     }
 
     [Fact]
@@ -136,7 +136,7 @@ public class ReachingDefinitionsTests
         var result = AnalyzeFixture(nameof(TryFinallyReadsLocal));
 
         Assert.True(result.IsComplete, result.IncompleteReason);
-        Assert.Contains(result.Uses, use => !use.IsArgument && use.ReachingDefinitions.Length >= 2);
+        AssertSomeUseSeesFirstAndLastSlotDefinitions(result);
     }
 
     [Fact]
@@ -145,22 +145,33 @@ public class ReachingDefinitionsTests
         var result = AnalyzeFixture(nameof(TryFilterReadsLocal));
 
         Assert.True(result.IsComplete, result.IncompleteReason);
-        Assert.Contains(result.Uses, use => !use.IsArgument && use.ReachingDefinitions.Length >= 2);
+        AssertSomeUseSeesFirstAndLastSlotDefinitions(result);
     }
 
     [Fact]
     public void Analyze_NestedFinallyToCatch_UseSeesFinallyDefinition()
     {
         var result = AnalyzeFixture(nameof(NestedFinallyToCatchReadsLocal));
-        var finalizerDefinition = result.Definitions
-            .Where(definition => !definition.IsArgument && definition.Slot == 0)
-            .MaxBy(definition => definition.Offset);
 
         Assert.True(result.IsComplete, result.IncompleteReason);
+        AssertSomeUseSeesFirstAndLastSlotDefinitions(result);
+    }
+
+    static void AssertSomeUseSeesFirstAndLastSlotDefinitions(ReachingDefinitionsResult result)
+    {
+        var slotDefinitions = result.Definitions
+            .Where(definition => !definition.IsArgument && definition.Slot == 0)
+            .OrderBy(definition => definition.Offset)
+            .ToArray();
+        Assert.True(slotDefinitions.Length >= 2);
+        var firstDefinition = slotDefinitions[0];
+        var lastDefinition = slotDefinitions[^1];
+
         Assert.Contains(result.Uses, use =>
             !use.IsArgument
             && use.Slot == 0
-            && use.ReachingDefinitions.Any(definition => definition.Id == finalizerDefinition?.Id));
+            && use.ReachingDefinitions.Any(definition => definition.Id == firstDefinition.Id)
+            && use.ReachingDefinitions.Any(definition => definition.Id == lastDefinition.Id));
     }
 
     [Fact]

--- a/src/ILInspector.Analysis/ReachingDefinitions.cs
+++ b/src/ILInspector.Analysis/ReachingDefinitions.cs
@@ -28,31 +28,33 @@ public sealed record ReachingDefinitionsResult(
 public static class ReachingDefinitions
 {
     public static ReachingDefinitionsResult Analyze(byte[] il, int argumentSlotCount)
-        => Analyze(il, argumentSlotCount, hasExceptionRegions: false);
+        => Analyze(il, argumentSlotCount, []);
 
     public static ReachingDefinitionsResult Analyze(byte[] il, int argumentSlotCount, IReadOnlyCollection<ExceptionRegion> exceptionRegions)
     {
         ArgumentNullException.ThrowIfNull(exceptionRegions);
-        return Analyze(il, argumentSlotCount, exceptionRegions.Count > 0);
+        return AnalyzeCore(il, argumentSlotCount, exceptionRegions);
     }
 
     public static ReachingDefinitionsResult Analyze(MethodBodyBlock body, int argumentSlotCount)
     {
         ArgumentNullException.ThrowIfNull(body);
-        return Analyze(body.GetILBytes() ?? [], argumentSlotCount, body.ExceptionRegions.Length > 0);
+        return AnalyzeCore(body.GetILBytes() ?? [], argumentSlotCount, body.ExceptionRegions);
     }
 
-    static ReachingDefinitionsResult Analyze(byte[] il, int argumentSlotCount, bool hasExceptionRegions)
+    static ReachingDefinitionsResult AnalyzeCore(byte[] il, int argumentSlotCount, IReadOnlyCollection<ExceptionRegion> exceptionRegions)
     {
         ArgumentNullException.ThrowIfNull(il);
         if (argumentSlotCount < 0)
             throw new ArgumentOutOfRangeException(nameof(argumentSlotCount));
         if (il.Length == 0)
-            return new ReachingDefinitionsResult([], [], !hasExceptionRegions, hasExceptionRegions ? "Exception-handler edges are not modeled." : null);
+            return new ReachingDefinitionsResult([], [], exceptionRegions.Count == 0,
+                exceptionRegions.Count == 0 ? null : "Exception-handler regions reference empty IL.");
 
         var instructions = DecodeInstructions(il);
-        var blocks = BuildBlocks(il.Length, instructions);
-        var incompleteReason = IncompleteReason(blocks, hasExceptionRegions);
+        var regionModels = BuildRegionModels(il.Length, instructions, exceptionRegions, out var regionIncompleteReasons);
+        var blocks = BuildBlocks(il.Length, instructions, regionModels);
+        var incompleteReason = IncompleteReason(blocks, instructions, regionModels, regionIncompleteReasons);
         var definitions = ImmutableArray.CreateBuilder<LocalDefinition>();
         var definitionsBySlot = new Dictionary<SlotKey, List<int>>();
         var definitionByOffset = new Dictionary<int, int>();
@@ -125,14 +127,27 @@ public static class ReachingDefinitions
         }
     }
 
-    static string? IncompleteReason(IReadOnlyList<Block> blocks, bool hasExceptionRegions)
+    static string? IncompleteReason(
+        IReadOnlyList<Block> blocks,
+        IReadOnlyList<Instruction> instructions,
+        IReadOnlyList<ExceptionRegionModel> regions,
+        IReadOnlyList<string> regionIncompleteReasons)
     {
-        if (hasExceptionRegions)
-            return "Exception-handler edges are not modeled.";
         if (blocks.Any(block => block.Edges.LeavesRegion))
-            return "Region-leaving control-flow edges are not modeled.";
+        {
+            foreach (var instruction in instructions)
+            {
+                if (!instruction.LeavesRegion)
+                    continue;
+                if (regions.Any(region => region.ContainsAny(instruction.Offset)))
+                    continue;
+                return "Region-leaving control-flow edges are not modeled.";
+            }
+        }
         if (blocks.Any(block => block.Edges.ExternalTargets.Count > 0))
             return "External control-flow targets are not modeled.";
+        if (regionIncompleteReasons.Count > 0)
+            return string.Join("; ", regionIncompleteReasons);
         return null;
     }
 
@@ -169,7 +184,10 @@ public static class ReachingDefinitions
             current.ExceptWith(ids);
     }
 
-    static ImmutableArray<Block> BuildBlocks(int ilLength, IReadOnlyList<Instruction> instructions)
+    static ImmutableArray<Block> BuildBlocks(
+        int ilLength,
+        IReadOnlyList<Instruction> instructions,
+        IReadOnlyList<ExceptionRegionModel> regions)
     {
         var instructionOffsets = instructions.Select(instruction => instruction.Offset).ToHashSet();
         var leaders = new SortedSet<int> { 0 };
@@ -187,13 +205,35 @@ public static class ReachingDefinitions
             if ((instruction.Branches || instruction.Exits) && instruction.NextOffset < ilLength)
                 leaders.Add(instruction.NextOffset);
         }
+        foreach (var region in regions)
+        {
+            AddLeader(region.TryStart);
+            AddLeader(region.TryEnd);
+            AddLeader(region.HandlerStart);
+            AddLeader(region.HandlerEnd);
+            if (region.Kind == ExceptionRegionKind.Filter)
+            {
+                AddLeader(region.FilterStart);
+                AddLeader(region.FilterEnd);
+            }
+        }
+        foreach (var instruction in instructions)
+        {
+            if (regions.Any(region => region.ContainsAny(instruction.Offset)))
+                AddLeader(instruction.Offset);
+        }
 
         var starts = leaders.ToImmutableArray();
         var offsetToBlock = new Dictionary<int, int>(starts.Length);
         for (int i = 0; i < starts.Length; i++)
             offsetToBlock[starts[i]] = i;
 
-        var blocks = ImmutableArray.CreateBuilder<Block>(starts.Length);
+        var successorsByBlock = new List<int>[starts.Length];
+        var externalByBlock = new List<int>[starts.Length];
+        var exitsByBlock = new bool[starts.Length];
+        var leavesByBlock = new bool[starts.Length];
+        var lastByBlock = new Instruction?[starts.Length];
+
         for (int i = 0; i < starts.Length; i++)
         {
             int start = starts[i];
@@ -202,6 +242,7 @@ public static class ReachingDefinitions
             var successors = new List<int>();
             var external = new List<int>();
             bool exits = last.Exits;
+            bool leaves = last.LeavesRegion;
             if (last.Offset >= 0)
             {
                 foreach (int target in last.Targets)
@@ -216,10 +257,171 @@ public static class ReachingDefinitions
                     successors.Add(i + 1);
             }
 
-            blocks.Add(new Block(start, end, new BlockEdges(successors, external, exits, last.LeavesRegion)));
+            successorsByBlock[i] = successors;
+            externalByBlock[i] = external;
+            exitsByBlock[i] = exits;
+            leavesByBlock[i] = leaves;
+            lastByBlock[i] = last.Offset >= 0 ? last : null;
         }
 
+        AddExceptionEdges(regions, instructions, starts, offsetToBlock, successorsByBlock, externalByBlock, lastByBlock);
+
+        var blocks = ImmutableArray.CreateBuilder<Block>(starts.Length);
+        for (int i = 0; i < starts.Length; i++)
+        {
+            blocks.Add(new Block(
+                starts[i],
+                i + 1 < starts.Length ? starts[i + 1] : ilLength,
+                new BlockEdges(
+                    successorsByBlock[i].Distinct().Order().ToArray(),
+                    externalByBlock[i].Distinct().Order().ToArray(),
+                    exitsByBlock[i],
+                    leavesByBlock[i])));
+        }
         return blocks.ToImmutable();
+
+        void AddLeader(int offset)
+        {
+            if (offset < ilLength)
+                leaders.Add(offset);
+        }
+    }
+
+    static ImmutableArray<ExceptionRegionModel> BuildRegionModels(
+        int ilLength,
+        IReadOnlyList<Instruction> instructions,
+        IReadOnlyCollection<ExceptionRegion> regions,
+        out ImmutableArray<string> incompleteReasons)
+    {
+        var instructionOffsets = instructions.Select(instruction => instruction.Offset).ToHashSet();
+        var models = ImmutableArray.CreateBuilder<ExceptionRegionModel>();
+        var reasons = ImmutableArray.CreateBuilder<string>();
+        foreach (var region in regions)
+        {
+            if (!TryRange("try", region.TryOffset, region.TryLength, out int tryEnd)
+                || !TryRange("handler", region.HandlerOffset, region.HandlerLength, out int handlerEnd))
+                continue;
+
+            int filterStart = -1;
+            int filterEnd = -1;
+            switch (region.Kind)
+            {
+                case ExceptionRegionKind.Catch:
+                case ExceptionRegionKind.Finally:
+                case ExceptionRegionKind.Fault:
+                    break;
+                case ExceptionRegionKind.Filter:
+                    filterStart = region.FilterOffset;
+                    filterEnd = region.HandlerOffset;
+                    if (!IsBoundary(filterStart) || filterStart >= filterEnd)
+                    {
+                        reasons.Add("Filter exception-handler region has unsupported boundaries.");
+                        continue;
+                    }
+                    break;
+                default:
+                    reasons.Add($"Unsupported exception-handler kind {region.Kind}.");
+                    continue;
+            }
+
+            models.Add(new ExceptionRegionModel(
+                region.Kind,
+                region.TryOffset,
+                tryEnd,
+                region.HandlerOffset,
+                handlerEnd,
+                filterStart,
+                filterEnd));
+        }
+
+        incompleteReasons = reasons.ToImmutable();
+        return models.ToImmutable();
+
+        bool TryRange(string name, int start, int length, out int end)
+        {
+            end = 0;
+            long computedEnd = (long)start + length;
+            if (start < 0 || length <= 0 || computedEnd > ilLength)
+            {
+                reasons.Add($"Exception {name} region has unsupported boundaries.");
+                return false;
+            }
+            end = (int)computedEnd;
+            if (!IsBoundary(start) || !IsBoundary(end))
+            {
+                reasons.Add($"Exception {name} region does not align with instruction boundaries.");
+                return false;
+            }
+            return true;
+        }
+
+        bool IsBoundary(int offset)
+            => offset == ilLength || instructionOffsets.Contains(offset);
+    }
+
+    static void AddExceptionEdges(
+        IReadOnlyList<ExceptionRegionModel> regions,
+        IReadOnlyList<Instruction> instructions,
+        IReadOnlyList<int> blockStarts,
+        IReadOnlyDictionary<int, int> offsetToBlock,
+        IReadOnlyList<List<int>> successorsByBlock,
+        IReadOnlyList<List<int>> externalByBlock,
+        IReadOnlyList<Instruction?> lastByBlock)
+    {
+        foreach (var region in regions)
+        {
+            int handlerBlock = offsetToBlock[region.HandlerStart];
+            int exceptionEntryBlock = region.Kind == ExceptionRegionKind.Filter
+                ? offsetToBlock[region.FilterStart]
+                : handlerBlock;
+
+            foreach (int block in BlocksInRange(region.TryStart, region.TryEnd))
+                successorsByBlock[block].Add(exceptionEntryBlock);
+
+            if (region.Kind == ExceptionRegionKind.Filter)
+            {
+                foreach (int block in BlocksInRange(region.FilterStart, region.FilterEnd))
+                    successorsByBlock[block].Add(handlerBlock);
+            }
+
+            if (region.Kind == ExceptionRegionKind.Finally)
+            {
+                var leaveTargets = LeaveTargetsLeaving(region, instructions).ToArray();
+                if (leaveTargets.Length == 0)
+                    continue;
+                foreach (int block in BlocksInRange(region.HandlerStart, region.HandlerEnd))
+                {
+                    if (lastByBlock[block] is not { OpCode: ILOpCode.Endfinally })
+                        continue;
+                    foreach (int target in leaveTargets)
+                    {
+                        if (offsetToBlock.TryGetValue(target, out int targetBlock))
+                            successorsByBlock[block].Add(targetBlock);
+                        else
+                            externalByBlock[block].Add(target);
+                    }
+                }
+            }
+        }
+
+        IEnumerable<int> BlocksInRange(int start, int end)
+        {
+            for (int i = 0; i < blockStarts.Count; i++)
+                if (blockStarts[i] >= start && blockStarts[i] < end)
+                    yield return i;
+        }
+    }
+
+    static IEnumerable<int> LeaveTargetsLeaving(ExceptionRegionModel region, IReadOnlyList<Instruction> instructions)
+    {
+        foreach (var instruction in instructions)
+        {
+            if (!instruction.LeavesRegion || !region.ContainsTry(instruction.Offset))
+                continue;
+            foreach (int target in instruction.Targets)
+                if (!region.ContainsTry(target))
+                    yield return target;
+        }
     }
 
     static ImmutableArray<Instruction> DecodeInstructions(byte[] il)
@@ -245,7 +447,8 @@ public static class ReachingDefinitions
             }
             else
             {
-                exits = opcode is ILOpCode.Ret or ILOpCode.Throw or ILOpCode.Rethrow or ILOpCode.Jmp;
+                exits = opcode is ILOpCode.Ret or ILOpCode.Throw or ILOpCode.Rethrow or ILOpCode.Jmp
+                    or ILOpCode.Endfinally or ILOpCode.Endfilter;
                 fallsThrough = !exits;
                 SkipOperand(il, opcode, ref position, offset);
             }
@@ -458,4 +661,24 @@ public static class ReachingDefinitions
         bool LeavesRegion);
 
     readonly record struct Block(int Start, int End, BlockEdges Edges);
+
+    readonly record struct ExceptionRegionModel(
+        ExceptionRegionKind Kind,
+        int TryStart,
+        int TryEnd,
+        int HandlerStart,
+        int HandlerEnd,
+        int FilterStart,
+        int FilterEnd)
+    {
+        public bool ContainsTry(int offset) => offset >= TryStart && offset < TryEnd;
+
+        public bool ContainsHandler(int offset) => offset >= HandlerStart && offset < HandlerEnd;
+
+        public bool ContainsFilter(int offset)
+            => Kind == ExceptionRegionKind.Filter && offset >= FilterStart && offset < FilterEnd;
+
+        public bool ContainsAny(int offset)
+            => ContainsTry(offset) || ContainsHandler(offset) || ContainsFilter(offset);
+    }
 }

--- a/src/ILInspector.Analysis/ReachingDefinitions.cs
+++ b/src/ILInspector.Analysis/ReachingDefinitions.cs
@@ -381,7 +381,19 @@ public static class ReachingDefinitions
             if (region.Kind == ExceptionRegionKind.Filter)
             {
                 foreach (int block in BlocksInRange(region.FilterStart, region.FilterEnd))
+                {
                     successorsByBlock[block].Add(handlerBlock);
+                    foreach (var sibling in regions)
+                    {
+                        if (sibling.Equals(region)
+                            || sibling.TryStart != region.TryStart
+                            || sibling.TryEnd != region.TryEnd)
+                            continue;
+                        successorsByBlock[block].Add(sibling.Kind == ExceptionRegionKind.Filter
+                            ? offsetToBlock[sibling.FilterStart]
+                            : offsetToBlock[sibling.HandlerStart]);
+                    }
+                }
             }
 
             if (region.Kind == ExceptionRegionKind.Finally)


### PR DESCRIPTION
## Summary

Models exception-handler edges in `ReachingDefinitions` so EH methods can be complete when all relevant edges are represented, instead of blanket-failing closed for any exception region.

- validates EH ranges and keeps malformed/unsupported regions incomplete
- splits EH regions at instruction granularity so handler edges do not mask definitions before throwing instructions
- adds try-region edges to catch/filter/finally/fault handlers, filter-to-handler edges, and finally exit edges for normal leave targets
- leaves `LibraryBodyIndex` untouched

## Evidence

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -filter "/*/*/ReachingDefinitionsTests/*"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project tools/AnalysisHarness -c Release -- --generated-fixtures`
- `bash eng/prepare-decompiler-corpus.sh /tmp/analysis-corpus-1891-track2.txt && dotnet run --project tools/AnalysisHarness -c Release -- --corpus-list /tmp/analysis-corpus-1891-track2.txt --diff-corpus-baseline tools/AnalysisHarness/corpus/analysis-baseline.json --emit-corpus-snapshot /tmp/analysis-corpus-1891-track2-snapshot.json`

Corpus result: 0 regressions, 1 drift (`dotnet-inspect.dll: instance-method-group-delegate 75 -> 73`).

## Review status

Two-family adversarial review requested per #1891. Results will be reconciled in a PR comment before merge readiness.

Relates to #1891.
