### PR TITLE
Declare assigned ref locals at first store

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1,5 +1,8 @@
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -1674,6 +1677,40 @@ public class CSharpPrinterTests
 
 public class RaisingPassTests
 {
+    static void AssertRefLocalBodyCompiles(string body)
+    {
+        string source = $$"""
+            using System;
+
+            public static class T
+            {
+                static int s_value;
+                public static ref int A() => ref s_value;
+                public static ref int A(ref int value) => ref s_value;
+                public static void Use(ref int value) { }
+                public static void M()
+                {
+            {{body}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var references = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Distinct(StringComparer.Ordinal)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "RefLocalCanary",
+            [tree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+
+        EmitResult result = compilation.Emit(Stream.Null);
+        Assert.True(result.Success,
+            string.Join(Environment.NewLine, result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error))
+            + Environment.NewLine + source);
+    }
+
     static string PrintWithPasses(string typeName, string methodName, MetadataSource source)
     {
         var function = IrImporter.Import(source, typeName, methodName);
@@ -2483,7 +2520,12 @@ public class RaisingPassTests
         var body = new Block(1);
         container.Add(body);
         var getRef = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "A", refInt, [], HasThis: false);
+        var use = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "Use", TypeRef.CoreLib("System", "Void"), [refInt], HasThis: false)
+        {
+            ParameterRefKinds = [ArgumentRefKind.Ref],
+        };
         body.Add(new StoreLocal(0, refInt, new Call(getRef, isVirtual: false, [])));
+        body.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadLocal(0, refInt)])));
         body.Add(new Return(null));
         var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
             [], HasThis: false, GenericParameterCount: 0);
@@ -2492,6 +2534,99 @@ public class RaisingPassTests
         string output = CSharpPrinter.Print(function).Output!;
         Assert.Contains("ref int V_0 = ref T.A();", output);
         Assert.DoesNotContain("Unsafe.NullRef", output);
+        AssertRefLocalBodyCompiles(output);
+    }
+
+    [Fact]
+    public void RefLocal_AssignedBeforeUseInLaterBlock_InitializesToNullRef()
+    {
+        // A declaration at the store would strand the later block's use outside
+        // scope. Keep the up-front null ref when references leave the store block.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var refInt = TypeRef.ByRef(intType);
+        var container = new BlockContainer();
+        var entry = new Block(0);
+        container.Add(entry);
+        entry.Add(new Branch(1));
+        var assign = new Block(1);
+        container.Add(assign);
+        var getRef = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "A", refInt, [], HasThis: false);
+        assign.Add(new StoreLocal(0, refInt, new Call(getRef, isVirtual: false, [])));
+        assign.Add(new Branch(2));
+        var useBlock = new Block(2);
+        container.Add(useBlock);
+        var use = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "Use", TypeRef.CoreLib("System", "Void"), [refInt], HasThis: false)
+        {
+            ParameterRefKinds = [ArgumentRefKind.Ref],
+        };
+        useBlock.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadLocal(0, refInt)])));
+        useBlock.Add(new Return(null));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [refInt], container);
+
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("ref int V_0 = ref System.Runtime.CompilerServices.Unsafe.NullRef<int>();", output);
+        Assert.Contains("V_0 = ref T.A();", output);
+        AssertRefLocalBodyCompiles(output);
+    }
+
+    [Fact]
+    public void RefLocal_LaterLabelTarget_InitializesToNullRef()
+    {
+        // A branch can target a later statement in the same flat block. Declaring
+        // at the store would let the goto bypass the declaration and hit CS0165.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var refInt = TypeRef.ByRef(intType);
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new ConditionalBranch(new Constant(true, boolType), 0x10));
+        var getRef = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "A", refInt, [], HasThis: false);
+        block.Add(new StoreLocal(0, refInt, new Call(getRef, isVirtual: false, [])));
+        var use = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "Use", TypeRef.CoreLib("System", "Void"), [refInt], HasThis: false)
+        {
+            ParameterRefKinds = [ArgumentRefKind.Ref],
+        };
+        var useStatement = new ExpressionStatement(new Call(use, isVirtual: false, [new LoadLocal(0, refInt)]));
+        useStatement.SetSourceOffset(0x10);
+        block.Add(useStatement);
+        block.Add(new Return(null));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [refInt], container);
+
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("ref int V_0 = ref System.Runtime.CompilerServices.Unsafe.NullRef<int>();", output);
+        Assert.Contains("V_0 = ref T.A();", output);
+        AssertRefLocalBodyCompiles(output);
+    }
+
+    [Fact]
+    public void RefLocal_SelfReferentialStore_InitializesToNullRef()
+    {
+        // IL can read the zero-initialized ref local while computing its first
+        // store. C# cannot reference a variable in its own declaration initializer.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var refInt = TypeRef.ByRef(intType);
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        var getRef = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "A", refInt, [refInt], HasThis: false)
+        {
+            ParameterRefKinds = [ArgumentRefKind.Ref],
+        };
+        block.Add(new StoreLocal(0, refInt, new Call(getRef, isVirtual: false, [new LoadLocal(0, refInt)])));
+        block.Add(new Return(null));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [refInt], container);
+
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("ref int V_0 = ref System.Runtime.CompilerServices.Unsafe.NullRef<int>();", output);
+        Assert.Contains("V_0 = ref T.A(ref V_0);", output);
+        AssertRefLocalBodyCompiles(output);
     }
 
     [Fact]
@@ -2519,6 +2654,7 @@ public class RaisingPassTests
 
         string output = CSharpPrinter.Print(function).Output!;
         Assert.Contains("ref int V_0 = ref System.Runtime.CompilerServices.Unsafe.NullRef<int>();", output);
+        AssertRefLocalBodyCompiles(output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2468,11 +2468,12 @@ public class RaisingPassTests
     }
 
     [Fact]
-    public void RefLocal_DeclaredBeforeStore_InitializesToNullRef()
+    public void RefLocal_AssignedBeforeUse_DeclaresAtRefAssignment()
     {
-        // A ref local whose defining store is not the entry-block first
-        // reference declares up front. A bare `ref int V_0;` is CS8174, so it
-        // spells IL's null-reference zero-init via Unsafe.NullRef<T>().
+        // A ref local whose defining store is not the entry-block first reference
+        // can still declare at that store when every reference stays in the same
+        // block after it. This avoids a synthetic Unsafe.NullRef<T>() initializer
+        // whose call/stloc was not present in the original IL (#1899).
         var intType = TypeRef.CoreLib("System", "Int32");
         var refInt = TypeRef.ByRef(intType);
         var container = new BlockContainer();
@@ -2489,8 +2490,35 @@ public class RaisingPassTests
         var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [refInt], container);
 
         string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("ref int V_0 = ref T.A();", output);
+        Assert.DoesNotContain("Unsafe.NullRef", output);
+    }
+
+    [Fact]
+    public void RefLocal_ReadBeforeStore_InitializesToNullRef()
+    {
+        // If a ref local is referenced before its first store, C# has no bare
+        // declaration spelling. Preserve IL's zero-initialized managed pointer with
+        // Unsafe.NullRef<T>().
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var refInt = TypeRef.ByRef(intType);
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        var use = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "Use", TypeRef.CoreLib("System", "Void"), [refInt], HasThis: false)
+        {
+            ParameterRefKinds = [ArgumentRefKind.Ref],
+        };
+        var getRef = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "A", refInt, [], HasThis: false);
+        block.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadLocal(0, refInt)])));
+        block.Add(new StoreLocal(0, refInt, new Call(getRef, isVirtual: false, [])));
+        block.Add(new Return(null));
+        var signature = new MethodSignature(TypeRef.CoreLib("System", "Void"),
+            [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [refInt], container);
+
+        string output = CSharpPrinter.Print(function).Output!;
         Assert.Contains("ref int V_0 = ref System.Runtime.CompilerServices.Unsafe.NullRef<int>();", output);
-        Assert.DoesNotContain("ref int V_0;", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -787,7 +787,9 @@ public sealed partial class CSharpPrinter
             {
                 case StoreLocal store when !seenLocals.Contains(store.Index):
                     seenLocals.Add(store.Index);
-                    if (entryStatements.Contains(store))
+                    if (entryStatements.Contains(store)
+                        && !StoreValueReferencesLocal(store)
+                        && !HasBranchTargetAfterStatement(store))
                         _declaringStores.Add(store);
                     else if (store.Type.Kind == TypeRefKind.ByRef
                         && LocalReferencesStayInBlockAfterStore(function, store))
@@ -886,11 +888,15 @@ public sealed partial class CSharpPrinter
         return true;
     }
 
-    static bool LocalReferencesStayInBlockAfterStore(IrFunction function, StoreLocal store)
+    bool LocalReferencesStayInBlockAfterStore(IrFunction function, StoreLocal store)
     {
         if (store.Parent is not Block block || store.ChildIndex < 0)
             return false;
+        if (StoreValueReferencesLocal(store))
+            return false;
         var allowed = block.Children.Skip(store.ChildIndex).ToList();
+        if (HasBranchTargetAfterStatement(store))
+            return false;
         foreach (var node in DescendantsOutsideNestedFunctions(function))
         {
             if (node is StoreLocal s && s.Index == store.Index
@@ -904,6 +910,29 @@ public sealed partial class CSharpPrinter
         return true;
     }
 
+    static bool StoreValueReferencesLocal(StoreLocal store)
+        => ReferencesLocal(store.Value, store.Index);
+
+    bool HasBranchTargetAfterStatement(IrNode statement)
+    {
+        if (statement.Parent is not Block block || statement.ChildIndex < 0)
+            return false;
+        return block.Children.Skip(statement.ChildIndex + 1)
+            .SelectMany(DescendantsAndSelfOutsideNestedFunctions)
+            .Any(n => n.SourceOffset >= 0 && _labelTargets.Contains(n.SourceOffset));
+    }
+
+    static bool ReferencesLocal(IrNode node, int index)
+    {
+        if (IsLocalReference(node, index))
+            return true;
+        return DescendantsOutsideNestedFunctions(node).Any(n => IsLocalReference(n, index));
+    }
+
+    static bool IsLocalReference(IrNode node, int index)
+        => node is LoadLocal load && load.Index == index
+            || node is LoadLocalAddress address && address.Index == index;
+
     static bool IsDescendantOrSelf(IrNode node, IrNode ancestor)
     {
         for (var current = node; current is not null; current = current.Parent)
@@ -912,6 +941,15 @@ public sealed partial class CSharpPrinter
                 return true;
         }
         return false;
+    }
+
+    static IEnumerable<IrNode> DescendantsAndSelfOutsideNestedFunctions(IrNode node)
+    {
+        yield return node;
+        if (node is Lambda or LocalFunctionStatement)
+            yield break;
+        foreach (var descendant in DescendantsOutsideNestedFunctions(node))
+            yield return descendant;
     }
 
     /// <summary>True when the local's last program-order reference sits inside the given subtree.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -789,6 +789,15 @@ public sealed partial class CSharpPrinter
                     seenLocals.Add(store.Index);
                     if (entryStatements.Contains(store))
                         _declaringStores.Add(store);
+                    else if (store.Type.Kind == TypeRefKind.ByRef
+                        && LocalReferencesStayInBlockAfterStore(function, store))
+                    {
+                        // A ref local cannot be declared bare up front (CS8174), and
+                        // synthesizing Unsafe.NullRef<T>() changes IL. If the first
+                        // definition dominates every reference inside one block, declare
+                        // at that ref assignment instead.
+                        _declaringStores.Add(store);
+                    }
                     else if (store is { Parent: ForLoop forLoop, ChildIndex: 0 }
                         && LastReferenceIsInside(function, store.Index, forLoop))
                     {
@@ -871,6 +880,24 @@ public sealed partial class CSharpPrinter
                 for (int i = start; i <= end; i++)
                     insideRun |= IsDescendantOrSelf(node, container.Children[i]);
                 if (!insideRun)
+                    return false;
+            }
+        }
+        return true;
+    }
+
+    static bool LocalReferencesStayInBlockAfterStore(IrFunction function, StoreLocal store)
+    {
+        if (store.Parent is not Block block || store.ChildIndex < 0)
+            return false;
+        var allowed = block.Children.Skip(store.ChildIndex).ToList();
+        foreach (var node in DescendantsOutsideNestedFunctions(function))
+        {
+            if (node is StoreLocal s && s.Index == store.Index
+                || node is LoadLocal l && l.Index == store.Index
+                || node is LoadLocalAddress a && a.Index == store.Index)
+            {
+                if (!allowed.Any(statement => IsDescendantOrSelf(node, statement)))
                     return false;
             }
         }


### PR DESCRIPTION
- Fixes #1899
- Changes ref-local declaration placement so safe same-block first stores declare inline instead of emitting synthetic `Unsafe.NullRef<T>()`
- Card revision: `056f3455`

## Change

**Conclusion:** **PASS** — this removes the extra `Unsafe.NullRef<T>()` call/stloc from the Humanizer witness while preserving C# definite-assignment safety for branch and self-reference edge cases.

Before:

```csharp
ref ReadOnlySpan<char> V_6 = ref System.Runtime.CompilerServices.Unsafe.NullRef<ReadOnlySpan<char>>();
...
V_6 = ref item;
```

After:

```csharp
ref ReadOnlySpan<char> V_6 = ref item;
```

The inline declaration is gated to cases where all references stay in the same block suffix after the store. It falls back to the up-front `Unsafe.NullRef<T>()` initializer when a later use is outside the store block, a label target can jump past the declaration, or the store initializer references the same local.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | 8 ref-local/ref-slot tests passed |
| Decompiler fast suite | Pass, 1710 tests |
| Reduced fixture validity | Roslyn compile canaries added for accepted and rejected ref-local shapes |
| Real witness | `Humanizer.EnglishArticle::AppendArticlePrefix` no longer emits `Unsafe.NullRef` for `V_6` |
| Changed-method fidelity | Still opcode-diff due to a later unrelated temporary difference; the leading synthetic `Unsafe.NullRef` call/stloc is gone |
| Build-event preflight | Pass: 0 errors, 0 warnings |
| Build-event compare | Pass: no diagnostic deltas; before and after logs both green |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Findings resolved | Suggested stronger accepted/rejected boundary tests; added same-block use and later-block rejection coverage. |
| Gemini 3.1 Pro | Findings resolved | Found branch-target bypass and self-referential initializer CS0165 holes; fixed both gates and added compile canaries. |

**Review conclusion:** **PASS** — all actionable adversarial findings were resolved in this commit.

## Validation

```bash
dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet
dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -method "*RefLocal*" -method "*RefSlot_DeclaredUpFront_InitializesToNullRef*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll member Humanizer.EnglishArticle AppendArticlePrefix:1 --library /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --all -S "Decompiled Source" -n 80
dotnet run --project tools/DecompilerHarness -c Release -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --dump 'Humanizer.EnglishArticle::AppendArticlePrefix' --fidelity-check --diff --max-examples 2
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh prepare src/ILInspector.Decompiler.Tests -- -c Release --nologo --verbosity quiet
/home/rich/git/dotnet-build-events-vmr-preview5-events/artifacts/preview5-events-sdk-test/dotnet build src/ILInspector.Decompiler.Tests --no-incremental --view types --event-log-stderr -c Release --nologo --verbosity quiet
dotnet run --project /home/rich/git/dotnet-inspect-build-event-query/src/dotnet-inspect -c Release --no-build -- build /home/rich/.dotnet/build-events/2026-06-29/20260629T204514.2031592Z-1762227-build-a22a81d4.jsonl -S Compare --compare /home/rich/.dotnet/build-events/2026-06-29/20260629T204631.7553041Z-1766058-build-a22a81d4.jsonl --tsv
```

Build-event logs:

- Before: `/home/rich/.dotnet/build-events/2026-06-29/20260629T204514.2031592Z-1762227-build-a22a81d4.jsonl`
- After: `/home/rich/.dotnet/build-events/2026-06-29/20260629T204631.7553041Z-1766058-build-a22a81d4.jsonl`

Workflow feedback for the build-event prototype was written to `/home/rich/git/dotnet-inspect-build-event-query/BUILD-EVENT-AGENT-FEEDBACK-1899.md`.
