### PR TITLE
Gate span ToArray copy opportunities on escape

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1069,9 +1069,10 @@ public class LibraryBodyIndexTests
     }
 
     [Theory]
-    [InlineData(nameof(OptimizationOpportunityFixtures.SpanToArrayCopy))]
-    [InlineData(nameof(OptimizationOpportunityFixtures.MutableSpanToArrayCopy))]
-    public void OptimizationOpportunities_FlagsSpanToArrayCopy(string methodName)
+    [InlineData(nameof(OptimizationOpportunityFixtures.ReadsSpanToArrayLocally))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ReadsMutableSpanToArrayLocally))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ReadsSpanToArrayLengthLocally))]
+    public void OptimizationOpportunities_FlagsNonEscapingSpanToArrayCopy(string methodName)
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 
@@ -1080,6 +1081,37 @@ public class LibraryBodyIndexTests
         // The IL offset must point at the real ToArray call (oracle-verifiable), not be inferred.
         Assert.NotNull(opportunity.ILOffset);
         Assert.Equal("medium", opportunity.Confidence);
+    }
+
+    [Theory]
+    [InlineData(nameof(OptimizationOpportunityFixtures.SpanToArrayCopy))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.MutableSpanToArrayCopy))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.SpanToArrayPassedToArrayApi))]
+    public void OptimizationOpportunities_DoesNotFlagEscapingSpanToArrayCopy(string methodName)
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.DoesNotContain(index.OptimizationOpportunities, o =>
+            o.Method.Name == methodName && o.Shape == "span-to-array-copy");
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_SpanToArrayReachingDefinitionsTrackStoredLocal()
+    {
+        var (path, directory) = BuildSpanToArrayLocalFixture();
+        try
+        {
+            var index = LibraryBodyIndex.Open(path);
+
+            Assert.Contains(index.OptimizationOpportunities, o =>
+                o.Method.Name == "LocalRead" && o.Shape == "span-to-array-copy");
+            Assert.DoesNotContain(index.OptimizationOpportunities, o =>
+                o.Method.Name == "LocalReturn" && o.Shape == "span-to-array-copy");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
     }
 
     [Fact]
@@ -1589,6 +1621,65 @@ public class LibraryBodyIndexTests
         return (path, directory);
     }
 
+    static (string Path, string Directory) BuildSpanToArrayLocalFixture()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "dotnet-inspect-span-local-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "SpanToArrayLocalFixture.dll");
+
+        var assemblyName = new AssemblyName("SpanToArrayLocalFixture");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        var type = module.DefineType("SpanToArrayLocalFixture", TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
+        var spanType = typeof(ReadOnlySpan<int>);
+        var toArray = spanType.GetMethod(nameof(ReadOnlySpan<int>.ToArray), Type.EmptyTypes)!;
+
+        DefineLocalRead(type, spanType, toArray);
+        DefineLocalReturn(type, spanType, toArray);
+
+        type.CreateType();
+        assembly.Save(path);
+        return (path, directory);
+
+        static void DefineLocalRead(TypeBuilder type, Type spanType, MethodInfo toArray)
+        {
+            var method = type.DefineMethod(
+                "LocalRead",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(int),
+                [spanType]);
+            var il = method.GetILGenerator();
+            il.DeclareLocal(typeof(int[]));
+            il.Emit(OpCodes.Ldarga_S, (byte)0);
+            il.Emit(OpCodes.Call, toArray);
+            il.Emit(OpCodes.Stloc_0);
+            il.Emit(OpCodes.Ldloc_0);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldelem_I4);
+            il.Emit(OpCodes.Ldloc_0);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Ldelem_I4);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Ret);
+        }
+
+        static void DefineLocalReturn(TypeBuilder type, Type spanType, MethodInfo toArray)
+        {
+            var method = type.DefineMethod(
+                "LocalReturn",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(int[]),
+                [spanType]);
+            var il = method.GetILGenerator();
+            il.DeclareLocal(typeof(int[]));
+            il.Emit(OpCodes.Ldarga_S, (byte)0);
+            il.Emit(OpCodes.Call, toArray);
+            il.Emit(OpCodes.Stloc_0);
+            il.Emit(OpCodes.Ldloc_0);
+            il.Emit(OpCodes.Ret);
+        }
+    }
+
     static IEnumerable<string> DelegateShapes(LibraryBodyIndex index, string methodName)
         => index.OptimizationOpportunities
             .Where(o => o.Method.Name == methodName && o.Shape is "delegate-allocation" or "capturing-delegate" or "instance-method-group-delegate")
@@ -2059,7 +2150,7 @@ public class LibraryBodyIndexTests
         // --- OptimizationOpportunity shapes ---
         Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop), "allocation-hotspot"), "allocation-hotspot");
         Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), "stackalloc-candidate"), "stackalloc-candidate");
-        Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.SpanToArrayCopy), "span-to-array-copy"), "span-to-array-copy");
+        Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.ReadsSpanToArrayLocally), "span-to-array-copy"), "span-to-array-copy");
         Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.FirstValueByte), "temporary-byte-array-copy"), "temporary-byte-array-copy");
         Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.BoxesIntoStringFormat), "box-value-type"), "box-value-type");
         Assert.True(HasOpportunity(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), "box-value-type"), "box: external well-known value type (Guid)");
@@ -2762,11 +2853,30 @@ public class OptimizationOpportunityFixtures
 
     // --- Copy allocation (span-to-array) ---
 
-    // ReadOnlySpan<T>.ToArray() materializes a copy -> span-to-array-copy.
+    // ReadOnlySpan<T>.ToArray() materializes a copy but the array is returned, so the copy is
+    // required by this API shape. It remains a copy signal but is not an optimization row.
     public static int[] SpanToArrayCopy(System.ReadOnlySpan<int> span) => span.ToArray();
 
-    // Span<T>.ToArray() also copies -> span-to-array-copy.
+    // Span<T>.ToArray() also copies, but returning the array retains it.
     public static int[] MutableSpanToArrayCopy(System.Span<int> span) => span.ToArray();
+
+    public static int ReadsSpanToArrayLocally(System.ReadOnlySpan<int> span)
+    {
+        var copy = span.ToArray();
+        return copy[0];
+    }
+
+    public static int ReadsMutableSpanToArrayLocally(System.Span<int> span)
+    {
+        var copy = span.ToArray();
+        return copy[0];
+    }
+
+    public static int ReadsSpanToArrayLengthLocally(System.ReadOnlySpan<int> span)
+        => span.ToArray().Length;
+
+    public static void SpanToArrayPassedToArrayApi(System.ReadOnlySpan<int> span)
+        => ConsumeArray(span.ToArray());
 
     // List<T>.ToArray() is a common, usually-legitimate snapshot -> deliberately NOT flagged
     // as span-to-array-copy (kept out to avoid flooding the section).

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1643,15 +1643,18 @@ public sealed class LibraryBodyIndex
                         }
                         else if (IsSpanToArrayCopy(callee, out var copyReceiver))
                         {
-                            opportunities.Add(new OptimizationOpportunity(
-                                caller,
-                                "span-to-array-copy",
-                                copyReceiver,
-                                "Let the span flow through to the consumer instead of materializing a copy when the array is not retained.",
-                                "medium",
-                                IsInLoopRegion(offset, loopRegions),
-                                offset,
-                                "The copy is required if the array escapes (returned, stored, or passed to an array-typed API)."));
+                            if (!SpanToArrayResultEscapes(il, GetReachingDefinitions(), position))
+                            {
+                                opportunities.Add(new OptimizationOpportunity(
+                                    caller,
+                                    "span-to-array-copy",
+                                    copyReceiver,
+                                    "Let the span flow through to the consumer instead of materializing a copy when the array is not retained.",
+                                    "medium",
+                                    IsInLoopRegion(offset, loopRegions),
+                                    offset,
+                                    "The copy is required if the array escapes (returned, stored, or passed to an array-typed API)."));
+                            }
                         }
                         else if (IsLinqMembershipScan(callee, out var scanOp) && IsInLoopRegion(offset, loopRegions))
                         {
@@ -2252,6 +2255,43 @@ public sealed class LibraryBodyIndex
             var opcode = ReadOpcode(il, ref positionAfterLoad);
             return IsLoadLocal(il, opcode, ref positionAfterLoad, slot, out bool loadsSlot)
                 && loadsSlot;
+        }
+
+        bool SpanToArrayResultEscapes(byte[] il, ReachingDefinitionsResult reachingDefinitions, int positionAfterCall)
+        {
+            try
+            {
+                if (!reachingDefinitions.IsComplete)
+                    return true;
+
+                SkipNops(il, ref positionAfterCall);
+                if (TryReadStoreLocalDefinition(il, positionAfterCall, out int slot, out int storeOffset))
+                {
+                    var definition = reachingDefinitions.Definitions.FirstOrDefault(d =>
+                        !d.IsArgument && d.Slot == slot && d.Offset == storeOffset);
+                    if (definition is null)
+                        return true;
+
+                    foreach (var use in reachingDefinitions.UsesOf(definition))
+                    {
+                        if (use.Address)
+                            return true;
+                        if (!TryPositionAfterLoadLocal(il, use.Offset, slot, out int positionAfterLoad)
+                            || ArrayLoadEscapes(il, positionAfterLoad))
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                }
+
+                return ArrayLoadEscapes(il, positionAfterCall);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException or IndexOutOfRangeException)
+            {
+                return true;
+            }
         }
 
         static bool IsLoadLocal(byte[] il, ILOpCode opcode, ref int position, int slot, out bool matchesSlot)


### PR DESCRIPTION
## Summary

Implements #1891 Rung 3b: `span-to-array-copy` opportunities now require a non-escaping `Span<T>.ToArray()` result. The analyzer still counts `ToArray()` as a copy signal, but it no longer recommends an optimization when the materialized array is returned, stored, passed to another API, or the reaching-definitions result is incomplete.

## Details

- Uses `ReachingDefinitions` to follow stored-local `ToArray()` results to their exact uses.
- Keeps rows only for local element/length consumption; suppresses returned, retained, API-passed, EH/incomplete, or ambiguous consumers.
- Adds local-use fixtures for `ReadOnlySpan<T>` and `Span<T>` plus a persisted IL fixture forcing stored-local reaching-definitions coverage.

## Measurement

Pre-change corpus measurement found 8 `span-to-array-copy` rows. Manual IL sampling showed all 8 were retained/returned/passed and therefore false positives under the existing caveat:

- `Microsoft.CodeAnalysis.dll`: direct `stfld`; `dup` + call + `ret`
- `DotnetInspector.Services.dll`: `ToArray(); ldstr; call`
- `dotnet-inspect.dll`: `ToArray(); ldstr; call`
- `ILInspector.Decompiler.dll`: `ToArray(); newobj` x2; `ToArray(); call` x2

After the change, direct measurement reports 0 corpus `span-to-array-copy` rows. Official AnalysisHarness corpus diff:

```text
ANALYSIS CORPUS DIFF: 0 regression(s), 5 drift, 0 added/removed
  drift:
    DotnetInspector.Services.dll: span-to-array-copy 1 -> 0
    ILInspector.Decompiler.dll: span-to-array-copy 4 -> 0
    Microsoft.CodeAnalysis.dll: span-to-array-copy 2 -> 0
    dotnet-inspect.dll: instance-method-group-delegate 75 -> 73
    dotnet-inspect.dll: span-to-array-copy 1 -> 0
```

The `instance-method-group-delegate` drift is pre-existing on clean `origin/main`; the four `span-to-array-copy` drifts are the intended false-positive removal.

## Validation

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -method '*OptimizationOpportunities_SpanToArrayReachingDefinitionsTrackStoredLocal*' -method '*OptimizationOpportunities_FlagsNonEscapingSpanToArrayCopy*' -method '*OptimizationOpportunities_DoesNotFlagEscapingSpanToArrayCopy*'`\n- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`\n- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal`\n- `dotnet run --project tools/AnalysisHarness -c Release -- --generated-fixtures`\n- `dotnet run --project tools/AnalysisHarness -c Release -- --corpus-list /tmp/analysis-corpus-assemblies.txt --diff-corpus-baseline tools/AnalysisHarness/corpus/analysis-baseline.json`\n\n## Adversarial review\n\nTwo-family review completed before opening:\n\n- Claude Opus 4.8 found one low-severity robustness issue: the new span-copy IL walk needed a local defensive catch so malformed IL suppresses only the span row instead of dropping unrelated method opportunities. Fixed in this PR by wrapping `SpanToArrayResultEscapes` and returning conservative escape on malformed IL.\n- Gemini 3.1 Pro found one medium-severity test adequacy issue: Release C# fixtures may not force stored-local `ReachingDefinitions` tracking. Fixed in this PR with a persisted IL fixture covering stored-local `ToArray()` local read vs local return.\n\nNo review findings remain unresolved.\n\nRelates to #1891.\n