### PR TITLE
Refresh analysis baseline and add allocation parity gate

### DIFF
--- a/src/ILInspector.Analysis.Tests/AllocationAnnotationParityTests.cs
+++ b/src/ILInspector.Analysis.Tests/AllocationAnnotationParityTests.cs
@@ -11,14 +11,16 @@ public class AllocationAnnotationParityTests
             """
             [
               { "id": "alloc.box", "category": "Allocation", "conditionality": "Always", "offset": 12, "detail": "int" },
-              { "id": "unsafe.deref", "category": "Unsafety", "conditionality": "Always", "offset": 12, "detail": "int*" }
+              { "id": "unsafe.deref", "category": "Unsafety", "conditionality": "Always", "offset": 12, "detail": "int*" },
+              { "id": "bad.category", "category": 42, "conditionality": "Always", "offset": 99, "detail": "ignored" }
             ]
             """;
         var actual =
             """
             [
               { "id": "alloc.box", "category": "Allocation", "conditionality": "Always", "offset": 12, "detail": "int" },
-              { "id": "lifetime.stack-bound", "category": "Lifetime", "conditionality": "Always", "offset": 1, "detail": "span" }
+              { "id": "lifetime.stack-bound", "category": "Lifetime", "conditionality": "Always", "offset": 1, "detail": "span" },
+              { "id": "bad.category", "category": { "kind": "not-string" }, "conditionality": "Always", "offset": 99, "detail": "ignored" }
             ]
             """;
 
@@ -27,6 +29,19 @@ public class AllocationAnnotationParityTests
         Assert.True(result.Passed, AllocationAnnotationParity.Format(result));
         Assert.Empty(result.Missing);
         Assert.Empty(result.Unexpected);
+    }
+
+    [Fact]
+    public void Parse_NonStringDetail_IsTreatedAsNull()
+    {
+        var rows = AllocationAnnotationParity.Parse(
+            """
+            [
+              { "id": "alloc.box", "category": "Allocation", "conditionality": "Always", "offset": 12, "detail": 123 }
+            ]
+            """);
+
+        Assert.Null(Assert.Single(rows).Detail);
     }
 
     [Fact]

--- a/src/ILInspector.Analysis.Tests/AllocationAnnotationParityTests.cs
+++ b/src/ILInspector.Analysis.Tests/AllocationAnnotationParityTests.cs
@@ -1,0 +1,64 @@
+using ILInspector.AnalysisHarness;
+
+namespace ILInspector.Analysis.Tests;
+
+public class AllocationAnnotationParityTests
+{
+    [Fact]
+    public void CompareJson_ExactAllocationRows_PassesAndIgnoresNonAllocationRows()
+    {
+        var expected =
+            """
+            [
+              { "id": "alloc.box", "category": "Allocation", "conditionality": "Always", "offset": 12, "detail": "int" },
+              { "id": "unsafe.deref", "category": "Unsafety", "conditionality": "Always", "offset": 12, "detail": "int*" }
+            ]
+            """;
+        var actual =
+            """
+            [
+              { "id": "alloc.box", "category": "Allocation", "conditionality": "Always", "offset": 12, "detail": "int" },
+              { "id": "lifetime.stack-bound", "category": "Lifetime", "conditionality": "Always", "offset": 1, "detail": "span" }
+            ]
+            """;
+
+        var result = AllocationAnnotationParity.CompareJson(expected, actual);
+
+        Assert.True(result.Passed, AllocationAnnotationParity.Format(result));
+        Assert.Empty(result.Missing);
+        Assert.Empty(result.Unexpected);
+    }
+
+    [Fact]
+    public void Compare_ReportsMissingAndUnexpectedRows()
+    {
+        var expected = new[]
+        {
+            new AllocationAnnotationRow("alloc.array", 0x10, "Always", "int[]"),
+            new AllocationAnnotationRow("alloc.delegate", 0x20, "CachedOnce", "System.Func<int>"),
+        };
+        var actual = new[]
+        {
+            new AllocationAnnotationRow("alloc.array", 0x10, "Always", "int[]"),
+            new AllocationAnnotationRow("alloc.new", 0x24, "Always", "Widget"),
+        };
+
+        var result = AllocationAnnotationParity.Compare(expected, actual);
+
+        Assert.False(result.Passed);
+        Assert.Equal("alloc.delegate", Assert.Single(result.Missing).Id);
+        Assert.Equal("alloc.new", Assert.Single(result.Unexpected).Id);
+    }
+
+    [Fact]
+    public void Compare_DistinguishesDuplicateOccurrences()
+    {
+        var row = new AllocationAnnotationRow("alloc.box", 0x10, "Always", "int");
+
+        var result = AllocationAnnotationParity.Compare([row, row], [row]);
+
+        Assert.False(result.Passed);
+        Assert.Equal(row, Assert.Single(result.Missing));
+        Assert.Empty(result.Unexpected);
+    }
+}

--- a/tools/AnalysisHarness/AllocationAnnotationParity.cs
+++ b/tools/AnalysisHarness/AllocationAnnotationParity.cs
@@ -65,7 +65,8 @@ public static class AllocationAnnotationParity
         foreach (var element in doc.RootElement.EnumerateArray())
         {
             if (!element.TryGetProperty("category", out var category)
-                || !string.Equals(category.GetString(), "Allocation", StringComparison.Ordinal))
+                || category.ValueKind != JsonValueKind.String
+                || !category.ValueEquals("Allocation"))
             {
                 continue;
             }
@@ -76,7 +77,7 @@ public static class AllocationAnnotationParity
                 ? offsetElement.GetInt32()
                 : -1;
             string? detail = element.TryGetProperty("detail", out var detailElement)
-                && detailElement.ValueKind != JsonValueKind.Null
+                && detailElement.ValueKind == JsonValueKind.String
                 ? detailElement.GetString()
                 : null;
 

--- a/tools/AnalysisHarness/AllocationAnnotationParity.cs
+++ b/tools/AnalysisHarness/AllocationAnnotationParity.cs
@@ -1,0 +1,137 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ILInspector.AnalysisHarness;
+
+public sealed record AllocationAnnotationRow(
+    string Id,
+    int Offset,
+    string Conditionality,
+    string? Detail);
+
+public sealed record AllocationAnnotationParityResult(
+    IReadOnlyList<AllocationAnnotationRow> Missing,
+    IReadOnlyList<AllocationAnnotationRow> Unexpected)
+{
+    public bool Passed => Missing.Count == 0 && Unexpected.Count == 0;
+}
+
+public static class AllocationAnnotationParity
+{
+    static readonly JsonSerializerOptions s_json = new()
+    {
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public static AllocationAnnotationParityResult CompareJson(string expectedJson, string actualJson)
+        => Compare(Parse(expectedJson), Parse(actualJson));
+
+    public static AllocationAnnotationParityResult Compare(
+        IReadOnlyList<AllocationAnnotationRow> expected,
+        IReadOnlyList<AllocationAnnotationRow> actual)
+    {
+        var expectedCounts = CountRows(expected);
+        var actualCounts = CountRows(actual);
+
+        var missing = new List<AllocationAnnotationRow>();
+        var unexpected = new List<AllocationAnnotationRow>();
+
+        foreach (var (row, count) in expectedCounts)
+        {
+            int actualCount = actualCounts.GetValueOrDefault(row);
+            for (int i = actualCount; i < count; i++)
+                missing.Add(row);
+        }
+
+        foreach (var (row, count) in actualCounts)
+        {
+            int expectedCount = expectedCounts.GetValueOrDefault(row);
+            for (int i = expectedCount; i < count; i++)
+                unexpected.Add(row);
+        }
+
+        return new AllocationAnnotationParityResult(Sort(missing), Sort(unexpected));
+    }
+
+    public static IReadOnlyList<AllocationAnnotationRow> Parse(string annotationJson)
+    {
+        var rows = new List<AllocationAnnotationRow>();
+        using var doc = JsonDocument.Parse(annotationJson);
+        if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            throw new InvalidOperationException("Annotation JSON must be an array.");
+
+        foreach (var element in doc.RootElement.EnumerateArray())
+        {
+            if (!element.TryGetProperty("category", out var category)
+                || !string.Equals(category.GetString(), "Allocation", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string id = RequiredString(element, "id");
+            string conditionality = RequiredString(element, "conditionality");
+            int offset = element.TryGetProperty("offset", out var offsetElement) && offsetElement.ValueKind == JsonValueKind.Number
+                ? offsetElement.GetInt32()
+                : -1;
+            string? detail = element.TryGetProperty("detail", out var detailElement)
+                && detailElement.ValueKind != JsonValueKind.Null
+                ? detailElement.GetString()
+                : null;
+
+            rows.Add(new AllocationAnnotationRow(id, offset, conditionality, detail));
+        }
+
+        return Sort(rows);
+    }
+
+    public static string Format(AllocationAnnotationParityResult result)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"ALLOCATION ANNOTATION PARITY: {(result.Passed ? "PASS" : "FAIL")} ({result.Missing.Count} missing, {result.Unexpected.Count} unexpected)");
+        if (result.Missing.Count > 0)
+        {
+            sb.AppendLine("  missing:");
+            foreach (var row in result.Missing)
+                sb.AppendLine($"    {Describe(row)}");
+        }
+
+        if (result.Unexpected.Count > 0)
+        {
+            sb.AppendLine("  unexpected:");
+            foreach (var row in result.Unexpected)
+                sb.AppendLine($"    {Describe(row)}");
+        }
+
+        return sb.ToString();
+    }
+
+    public static string ToJson(AllocationAnnotationParityResult result)
+        => JsonSerializer.Serialize(result, s_json);
+
+    static Dictionary<AllocationAnnotationRow, int> CountRows(IReadOnlyList<AllocationAnnotationRow> rows)
+    {
+        var counts = new Dictionary<AllocationAnnotationRow, int>();
+        foreach (var row in rows)
+            counts[row] = counts.GetValueOrDefault(row) + 1;
+        return counts;
+    }
+
+    static IReadOnlyList<AllocationAnnotationRow> Sort(IEnumerable<AllocationAnnotationRow> rows)
+        => [.. rows
+            .OrderBy(row => row.Offset)
+            .ThenBy(row => row.Id, StringComparer.Ordinal)
+            .ThenBy(row => row.Conditionality, StringComparer.Ordinal)
+            .ThenBy(row => row.Detail, StringComparer.Ordinal)];
+
+    static string Describe(AllocationAnnotationRow row)
+        => $"{row.Id} {Offset(row.Offset)} {row.Conditionality} {row.Detail ?? ""}".TrimEnd();
+
+    static string Offset(int offset) => offset < 0 ? "" : $"IL_{offset:X4}";
+
+    static string RequiredString(JsonElement element, string property)
+        => element.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString() ?? ""
+            : throw new InvalidOperationException($"Annotation row missing string property '{property}'.");
+}

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -80,8 +80,8 @@ for (int i = 0; i < args.Length; i++)
             precisionAssembly = NextValue(args, ref i);
             break;
         case "--allocation-parity":
-            allocationParityExpected = NextValue(args, ref i);
-            allocationParityActual = NextValue(args, ref i);
+            allocationParityExpected = NextPathValue(args, ref i);
+            allocationParityActual = NextPathValue(args, ref i);
             break;
         case "--reference":
             referenceFile = NextValue(args, ref i);
@@ -243,3 +243,8 @@ static int RunCorpus(string corpusList, string? diffBaseline, string? emitSnapsh
 
 static string? NextValue(string[] args, ref int i)
     => i + 1 < args.Length ? args[++i] : null;
+
+static string? NextPathValue(string[] args, ref int i)
+    => i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal)
+        ? args[++i]
+        : null;

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -26,6 +26,11 @@ const string Usage =
           Layer 3 precision: emit the top-N triage candidates as a labeling worksheet for sampled
           true/false-positive judgement. No automatic oracle.
 
+      --allocation-parity <expected-annotations.json> <actual-annotations.json> [--json]
+          Compare allocation annotations from the legacy decompiler classifier and a candidate
+          occurrence-derived projection. The gate is exact on id, IL offset, detail, and
+          conditionality; non-allocation annotations are ignored.
+
       Common: --json machine-readable output; --keep keep generated fixture projects.
     """;
 
@@ -46,6 +51,8 @@ bool list = false;
 string? recallAssembly = null;
 string? referenceFile = null;
 string? precisionAssembly = null;
+string? allocationParityExpected = null;
+string? allocationParityActual = null;
 int top = 20;
 
 for (int i = 0; i < args.Length; i++)
@@ -71,6 +78,10 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--precision-sample":
             precisionAssembly = NextValue(args, ref i);
+            break;
+        case "--allocation-parity":
+            allocationParityExpected = NextValue(args, ref i);
+            allocationParityActual = NextValue(args, ref i);
             break;
         case "--reference":
             referenceFile = NextValue(args, ref i);
@@ -102,6 +113,9 @@ if (recallAssembly is not null)
 
 if (precisionAssembly is not null)
     return RunPrecision(precisionAssembly, top);
+
+if (allocationParityExpected is not null)
+    return RunAllocationParity(allocationParityExpected, allocationParityActual, json);
 
 if (corpusList is not null)
     return RunCorpus(corpusList, diffBaseline, emitSnapshot, json);
@@ -135,6 +149,26 @@ static int RunPrecision(string assembly, int top)
     if (!File.Exists(assembly)) { Console.Error.WriteLine($"Assembly not found: {assembly}"); return 2; }
     Console.WriteLine(PrecisionRecall.ToJson(PrecisionRecall.Sample(assembly, top)));
     return 0;
+}
+
+static int RunAllocationParity(string expectedPath, string? actualPath, bool json)
+{
+    if (actualPath is null)
+    {
+        Console.Error.WriteLine("--allocation-parity requires expected and actual annotation JSON files.");
+        return 2;
+    }
+    if (!File.Exists(expectedPath)) { Console.Error.WriteLine($"Expected annotation JSON not found: {expectedPath}"); return 2; }
+    if (!File.Exists(actualPath)) { Console.Error.WriteLine($"Actual annotation JSON not found: {actualPath}"); return 2; }
+
+    var result = AllocationAnnotationParity.CompareJson(
+        File.ReadAllText(expectedPath),
+        File.ReadAllText(actualPath));
+    Console.Write(json
+        ? AllocationAnnotationParity.ToJson(result)
+        : AllocationAnnotationParity.Format(result));
+    if (json) Console.WriteLine();
+    return result.Passed ? 0 : 1;
 }
 
 static int RunFixtures(string? selector, bool list, bool json, bool keep)

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -84,6 +84,23 @@ The daily workflow runs the generated-fixture catalogue, corpus stability sensor
 recall gate. Precision labeling, baseline refreshes, and recall-reference edits remain
 maintainer-owned upkeep: they are documented conventions, not automatic CI gates.
 
+## Allocation convergence parity
+
+The Rung 4 allocation-convergence build must prove that a candidate
+occurrence-derived projection produces the same decompiler allocation annotations
+as the legacy `AllocationClassifier`. Use the parity gate with two
+`AnnotationStructuredView.Json(...)` outputs: the legacy allocation annotations
+and the candidate projection serialized in the same structured shape.
+
+```bash
+dotnet "$DLL" --allocation-parity legacy-annotations.json candidate-annotations.json
+```
+
+The comparison ignores non-allocation annotations and is exact for allocation
+annotation `id`, IL `offset`, `conditionality`, and `detail`. Duplicate rows are
+counted, so Track A can use this as a mechanical exit gate for identical
+projection rather than manually inspecting mixed-source output.
+
 ## Precision labeling convention
 
 `--precision-sample` is an agent/human worksheet, not a gate. The analyzer has no automatic

--- a/tools/AnalysisHarness/corpus/analysis-baseline.json
+++ b/tools/AnalysisHarness/corpus/analysis-baseline.json
@@ -39,8 +39,7 @@
         "enumerator-allocation": 1,
         "linq-scan-in-loop": 3,
         "scan-method-in-loop-call": 2,
-        "small-array": 7,
-        "span-to-array-copy": 1
+        "small-array": 7
       }
     },
     {
@@ -76,7 +75,6 @@
         "linq-scan-in-loop": 53,
         "scan-method-in-loop-call": 45,
         "small-array": 97,
-        "span-to-array-copy": 4,
         "string-build-in-loop": 3
       }
     },
@@ -165,7 +163,6 @@
         "linq-scan-in-loop": 3,
         "scan-method-in-loop-call": 1,
         "small-array": 300,
-        "span-to-array-copy": 2,
         "string-build-in-loop": 3,
         "temporary-byte-array-copy": 1
       }
@@ -232,11 +229,10 @@
         "box-value-type": 14,
         "capturing-delegate": 234,
         "enumerator-allocation": 15,
-        "instance-method-group-delegate": 75,
+        "instance-method-group-delegate": 73,
         "linq-scan-in-loop": 13,
         "scan-method-in-loop-call": 9,
         "small-array": 771,
-        "span-to-array-copy": 1,
         "string-build-in-loop": 6
       }
     }


### PR DESCRIPTION
## Summary

Implements #1908 Track B. This refreshes the AnalysisHarness corpus baseline after #1905/#1907 and adds a mechanical allocation annotation parity gate for the Track A allocation-convergence build.

## Details

- Refreshes `tools/AnalysisHarness/corpus/analysis-baseline.json` to current `origin/main` reality after EH completion and span-copy false-positive removal.
- Adds `--allocation-parity <expected-annotations.json> <actual-annotations.json>` to `tools/AnalysisHarness`.
- The parity gate compares allocation annotations exactly on `id`, IL `offset`, `conditionality`, and `detail`; non-allocation annotations are ignored and duplicate rows are counted.
- Documents the parity workflow in `tools/AnalysisHarness/README.md`.

## Baseline refresh rationale

Generated with:

```bash
bash eng/prepare-decompiler-corpus.sh /tmp/track-b-corpus-assemblies.txt
dotnet run --project tools/AnalysisHarness -c Release -- \
  --corpus-list /tmp/track-b-corpus-assemblies.txt \
  --diff-corpus-baseline tools/AnalysisHarness/corpus/analysis-baseline.json \
  --emit-corpus-snapshot /tmp/track-b-analysis-baseline.json
```

Pre-refresh diff:

```text
ANALYSIS CORPUS DIFF: 0 regression(s), 5 drift, 0 added/removed
  drift:
    DotnetInspector.Services.dll: span-to-array-copy 1 -> 0
    ILInspector.Decompiler.dll: span-to-array-copy 4 -> 0
    Microsoft.CodeAnalysis.dll: span-to-array-copy 2 -> 0
    dotnet-inspect.dll: instance-method-group-delegate 75 -> 73
    dotnet-inspect.dll: span-to-array-copy 1 -> 0
```

The `span-to-array-copy` drift is the intended #1907 false-positive removal. The `instance-method-group-delegate` 75 -> 73 drift reflects current main after the recent reaching-definitions/EH work. After copying the snapshot into the baseline, the corpus diff is clean: `0 regression(s), 0 drift, 0 added/removed`.

## Validation

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -class '*AllocationAnnotationParityTests'`\n- `dotnet run --project tools/AnalysisHarness -c Release -- --allocation-parity /tmp/allocation-parity-empty.json /tmp/allocation-parity-empty.json`\n- missing-argument CLI check for `--allocation-parity`\n- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`\n- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity minimal`\n- `dotnet run --project tools/AnalysisHarness -c Release -- --generated-fixtures`\n- `dotnet run --project tools/AnalysisHarness -c Release -- --corpus-list /tmp/track-b-corpus-assemblies.txt --diff-corpus-baseline tools/AnalysisHarness/corpus/analysis-baseline.json`\n- `npx markdownlint-cli tools/AnalysisHarness/README.md`\n\n## Review\n\n- Claude Opus 4.8 reviewed the harness and baseline changes and found no issues.\n- Gemini 3.1 Pro found three items. Two were valid and fixed in `dd7fee5a`: robust handling for non-string ignored JSON fields and missing `--allocation-parity` positional arguments. One ownership/baseline concern was dismissed as not applicable: `git diff --name-only origin/main...HEAD` shows this branch only changes `tools/AnalysisHarness`, `tools/AnalysisHarness/corpus/analysis-baseline.json`, and the harness test file; no `LibraryBodyIndex`, `ReachingDefinitions`, or decompiler files are changed.\n\nRelates to #1908 and #1891.\n