### PR TITLE
Inline single-use address receiver temps

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1753,6 +1753,135 @@ public class CSharpPrinterTests
         Assert.Contains("ReadOnlySpan<char> V_0 = MemoryExtensions.Trim(item);", output);
         Assert.Contains("items[i] = V_0.ToString();", output);
     }
+
+    [Fact]
+    public void StoreElement_KeepsAddressReceiverTempWhenTargetHasSideEffects()
+    {
+        var stringType = TypeRef.CoreLib("System", "String");
+        var stringArray = TypeRef.SzArray(stringType);
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var charType = TypeRef.CoreLib("System", "Char");
+        var spanType = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [charType]);
+        var memoryExtensions = TypeRef.CoreLib("System", "MemoryExtensions");
+        var trim = new MethodRef(memoryExtensions, "Trim", spanType, [spanType], HasThis: false);
+        var toString = new MethodRef(spanType, "ToString", stringType, [], HasThis: true);
+        var getItems = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "GetItems", stringArray, [], HasThis: false);
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, spanType, new Call(trim, isVirtual: false, [new LoadArgument(1, "item", spanType)])));
+        block.Add(new StoreElement(
+            elementType: null,
+            new Call(getItems, isVirtual: false, []),
+            new LoadArgument(0, "i", intType),
+            new Call(toString, isVirtual: true, [new LoadLocalAddress(0, spanType)])));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [
+                new Parameter("i", intType),
+                new Parameter("item", spanType),
+            ], HasThis: false, GenericParameterCount: 0),
+            [spanType],
+            body);
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+
+        Assert.Contains("ReadOnlySpan<char> V_0 = MemoryExtensions.Trim(item);", output);
+        Assert.Contains("T.GetItems()[i] = V_0.ToString();", output);
+    }
+
+    [Fact]
+    public void StoreElement_InlinedUnsafeReceiverTempCarriesUnsafeContext()
+    {
+        var stringType = TypeRef.CoreLib("System", "String");
+        var stringArray = TypeRef.SzArray(stringType);
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var intPointer = TypeRef.Pointer(intType);
+        var toString = new MethodRef(intType, "ToString", stringType, [], HasThis: true);
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, intType, new LoadIndirect(intType, new LoadArgument(2, "p", intPointer))));
+        block.Add(new StoreElement(
+            elementType: null,
+            new LoadArgument(0, "items", stringArray),
+            new LoadArgument(1, "i", intType),
+            new Call(toString, isVirtual: true, [new LoadLocalAddress(0, intType)])));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [
+                new Parameter("items", stringArray),
+                new Parameter("i", intType),
+                new Parameter("p", intPointer),
+            ], HasThis: false, GenericParameterCount: 0),
+            [intType],
+            body)
+        {
+            UsesUpdatedMemorySafetyRules = true,
+        };
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+
+        Assert.Contains("unsafe", output);
+        Assert.Contains("items[i] = (*p).ToString();", output);
+        Assert.DoesNotContain("int V_0", output);
+    }
+
+    [Fact]
+    public void StoreElement_KeepsAddressReceiverTempCapturedByLocalFunction()
+    {
+        var stringType = TypeRef.CoreLib("System", "String");
+        var stringArray = TypeRef.SzArray(stringType);
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var charType = TypeRef.CoreLib("System", "Char");
+        var spanType = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [charType]);
+        var memoryExtensions = TypeRef.CoreLib("System", "MemoryExtensions");
+        var trim = new MethodRef(memoryExtensions, "Trim", spanType, [spanType], HasThis: false);
+        var toString = new MethodRef(spanType, "ToString", stringType, [], HasThis: true);
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, spanType, new Call(trim, isVirtual: false, [new LoadArgument(2, "item", spanType)])));
+        block.Add(new StoreElement(
+            elementType: null,
+            new LoadArgument(0, "items", stringArray),
+            new LoadArgument(1, "i", intType),
+            new Call(toString, isVirtual: true, [new LoadLocalAddress(0, spanType)])));
+        var nestedBody = new BlockContainer();
+        var nestedBlock = new Block(0);
+        nestedBody.Add(nestedBlock);
+        nestedBlock.Add(new Return(new LoadLocal(0, spanType)));
+        block.Add(new LocalFunctionStatement(
+            "Capture",
+            spanType,
+            [],
+            isStatic: false,
+            [],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            nestedBody));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [
+                new Parameter("items", stringArray),
+                new Parameter("i", intType),
+                new Parameter("item", spanType),
+            ], HasThis: false, GenericParameterCount: 0),
+            [spanType],
+            body);
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+
+        Assert.Contains("ReadOnlySpan<char> V_0 = MemoryExtensions.Trim(item);", output);
+        Assert.Contains("items[i] = V_0.ToString();", output);
+    }
 }
 
 public class RaisingPassTests

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1793,6 +1793,42 @@ public class CSharpPrinterTests
     }
 
     [Fact]
+    public void StoreElement_KeepsAddressReceiverTempWhenInitializerReferencesTarget()
+    {
+        var stringType = TypeRef.CoreLib("System", "String");
+        var stringArray = TypeRef.SzArray(stringType);
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var charType = TypeRef.CoreLib("System", "Char");
+        var spanType = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [charType]);
+        var toString = new MethodRef(spanType, "ToString", stringType, [], HasThis: true);
+        var next = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "Next", spanType, [intType], HasThis: false);
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, spanType, new Call(next, isVirtual: false, [new LoadArgument(1, "i", intType)])));
+        block.Add(new StoreElement(
+            elementType: null,
+            new LoadArgument(0, "items", stringArray),
+            new LoadArgument(1, "i", intType),
+            new Call(toString, isVirtual: true, [new LoadLocalAddress(0, spanType)])));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [
+                new Parameter("items", stringArray),
+                new Parameter("i", intType),
+            ], HasThis: false, GenericParameterCount: 0),
+            [spanType],
+            body);
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+
+        Assert.Contains("ReadOnlySpan<char> V_0 = T.Next(i);", output);
+        Assert.Contains("items[i] = V_0.ToString();", output);
+    }
+
+    [Fact]
     public void StoreElement_InlinedUnsafeReceiverTempCarriesUnsafeContext()
     {
         var stringType = TypeRef.CoreLib("System", "String");

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1673,6 +1673,86 @@ public class CSharpPrinterTests
         string candidate = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
         Assert.Equal("return _size;", candidate);
     }
+
+    [Fact]
+    public void StoreElement_InlinesSingleUseAddressReceiverTemp()
+    {
+        var stringType = TypeRef.CoreLib("System", "String");
+        var stringArray = TypeRef.SzArray(stringType);
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var charType = TypeRef.CoreLib("System", "Char");
+        var spanType = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [charType]);
+        var memoryExtensions = TypeRef.CoreLib("System", "MemoryExtensions");
+        var trim = new MethodRef(memoryExtensions, "Trim", spanType, [spanType], HasThis: false);
+        var toString = new MethodRef(spanType, "ToString", stringType, [], HasThis: true);
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, spanType, new Call(trim, isVirtual: false, [new LoadArgument(2, "item", spanType)])));
+        block.Add(new StoreElement(
+            elementType: null,
+            new LoadArgument(0, "items", stringArray),
+            new LoadArgument(1, "i", intType),
+            new Call(toString, isVirtual: true, [new LoadLocalAddress(0, spanType)])));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [
+                new Parameter("items", stringArray),
+                new Parameter("i", intType),
+                new Parameter("item", spanType),
+            ], HasThis: false, GenericParameterCount: 0),
+            [spanType],
+            body);
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+
+        Assert.Equal("items[i] = MemoryExtensions.Trim(item).ToString();", output);
+    }
+
+    [Fact]
+    public void StoreElement_KeepsAddressReceiverTempWithAdditionalUse()
+    {
+        var stringType = TypeRef.CoreLib("System", "String");
+        var stringArray = TypeRef.SzArray(stringType);
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var charType = TypeRef.CoreLib("System", "Char");
+        var spanType = TypeRef.GenericInstance(TypeRef.CoreLib("System", "ReadOnlySpan`1"), [charType]);
+        var memoryExtensions = TypeRef.CoreLib("System", "MemoryExtensions");
+        var trim = new MethodRef(memoryExtensions, "Trim", spanType, [spanType], HasThis: false);
+        var toString = new MethodRef(spanType, "ToString", stringType, [], HasThis: true);
+        var consume = new MethodRef(TypeRef.CoreLib("Synthetic", "T"), "Consume", TypeRef.CoreLib("System", "Void"), [spanType], HasThis: false)
+        {
+            ParameterRefKinds = [ArgumentRefKind.In],
+        };
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, spanType, new Call(trim, isVirtual: false, [new LoadArgument(2, "item", spanType)])));
+        block.Add(new StoreElement(
+            elementType: null,
+            new LoadArgument(0, "items", stringArray),
+            new LoadArgument(1, "i", intType),
+            new Call(toString, isVirtual: true, [new LoadLocalAddress(0, spanType)])));
+        block.Add(new ExpressionStatement(new Call(consume, isVirtual: false, [new LoadLocalAddress(0, spanType)])));
+        block.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [
+                new Parameter("items", stringArray),
+                new Parameter("i", intType),
+                new Parameter("item", spanType),
+            ], HasThis: false, GenericParameterCount: 0),
+            [spanType],
+            body);
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+
+        Assert.Contains("ReadOnlySpan<char> V_0 = MemoryExtensions.Trim(item);", output);
+        Assert.Contains("items[i] = V_0.ToString();", output);
+    }
 }
 
 public class RaisingPassTests

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1018,18 +1018,18 @@ public sealed partial class CSharpPrinter
     static bool CanEvaluateBeforeInlineValue(IrExpression expression, IrExpression value) => expression switch
     {
         Constant => true,
-        LoadArgument argument => !ReferencesArgumentAddress(value, argument.Index),
-        LoadLocal local => !ReferencesLocalAddress(value, local.Index),
+        LoadArgument argument => !ReferencesArgument(value, argument.Index),
+        LoadLocal local => !ReferencesLocal(value, local.Index),
         _ => false,
     };
 
-    static bool ReferencesArgumentAddress(IrNode node, int index)
-        => node is LoadArgumentAddress address && address.Index == index
-            || node.Descendants.Any(n => n is LoadArgumentAddress address && address.Index == index);
+    static bool ReferencesArgument(IrNode node, int index)
+        => IsArgumentReference(node, index)
+            || node.Descendants.Any(n => IsArgumentReference(n, index));
 
-    static bool ReferencesLocalAddress(IrNode node, int index)
-        => node is LoadLocalAddress address && address.Index == index
-            || node.Descendants.Any(n => n is LoadLocalAddress address && address.Index == index);
+    static bool IsArgumentReference(IrNode node, int index)
+        => node is LoadArgument argument && argument.Index == index
+            || node is LoadArgumentAddress address && address.Index == index;
 
     /// <summary>True when the local's last program-order reference sits inside the given subtree.</summary>
     static bool LastReferenceIsInside(IrFunction function, int localIndex, IrNode subtree)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1008,7 +1008,6 @@ public sealed partial class CSharpPrinter
             }
         }
         return stores == 1 && addressLoads == 1 && ReferenceEquals(call.Arguments[0], receiver);
-        return stores == 1 && addressLoads == 1 && ReferenceEquals(call.Arguments[0], receiver);
     }
 
     /// <summary>True when the local's last program-order reference sits inside the given subtree.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -987,9 +987,14 @@ public sealed partial class CSharpPrinter
         {
             return false;
         }
+        if (!CanEvaluateBeforeInlineValue(storeElement.Array, store.Value)
+            || !CanEvaluateBeforeInlineValue(storeElement.Index, store.Value))
+        {
+            return false;
+        }
 
         int stores = 0, addressLoads = 0;
-        foreach (var node in DescendantsOutsideNestedFunctions(function))
+        foreach (var node in function.Descendants)
         {
             switch (node)
             {
@@ -1009,6 +1014,22 @@ public sealed partial class CSharpPrinter
         }
         return stores == 1 && addressLoads == 1 && ReferenceEquals(call.Arguments[0], receiver);
     }
+
+    static bool CanEvaluateBeforeInlineValue(IrExpression expression, IrExpression value) => expression switch
+    {
+        Constant => true,
+        LoadArgument argument => !ReferencesArgumentAddress(value, argument.Index),
+        LoadLocal local => !ReferencesLocalAddress(value, local.Index),
+        _ => false,
+    };
+
+    static bool ReferencesArgumentAddress(IrNode node, int index)
+        => node is LoadArgumentAddress address && address.Index == index
+            || node.Descendants.Any(n => n is LoadArgumentAddress address && address.Index == index);
+
+    static bool ReferencesLocalAddress(IrNode node, int index)
+        => node is LoadLocalAddress address && address.Index == index
+            || node.Descendants.Any(n => n is LoadLocalAddress address && address.Index == index);
 
     /// <summary>True when the local's last program-order reference sits inside the given subtree.</summary>
     static bool LastReferenceIsInside(IrFunction function, int localIndex, IrNode subtree)
@@ -1381,6 +1402,8 @@ public sealed partial class CSharpPrinter
         UsingStatement u => HasUnsafeOperation(u.Resource),
         TryCatch t => t.Clauses.Any(c => HasUnsafeOperation(c.Filter)),
         TryFinally => false,
+        StoreElement s when _inlineReceiverTempStores.TryGetValue(s, out var store)
+            => HasUnsafeOperation(s) || HasUnsafeOperation(store.Value),
         _ => HasUnsafeOperation(node),
     };
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -281,6 +281,8 @@ public sealed partial class CSharpPrinter
     readonly Dictionary<StoreStackSlot, TypeRef?> _stackSlotStoreTypes = [];
     readonly Dictionary<int, TypeRef> _stackSlotUnifiedTypes = [];
     readonly SortedDictionary<(int Slot, int Ordinal), (string Name, TypeRef? Type)> _stackSlotDeclarations = [];
+    readonly Dictionary<StoreElement, StoreLocal> _inlineReceiverTempStores = [];
+    readonly HashSet<int> _inlineReceiverTempLocals = [];
 
     string PrintBody(IrFunction function)
     {
@@ -301,6 +303,7 @@ public sealed partial class CSharpPrinter
                 if (target is { Kind: DeconstructionTargetKind.Local, IsDeclared: true })
                     _deconstructionLocals.Add(target.LocalIndex);
         CollectDeclaringStores(function);
+        CollectInlineReceiverTempStores(function);
         CollectStackSlotNames(function);
         _readBeforeAssign = DefiniteAssignment.Compute(function, _labelTargets, _facts);
         if (_facts is not null)
@@ -458,7 +461,8 @@ public sealed partial class CSharpPrinter
             // Fixed/using headers and `is T t` patterns declare their owned
             // locals, not the up-front declaration block.
             if (_fixedLocals.Contains(index) || _usingLocals.Contains(index) || _foreachLocals.Contains(index)
-                || _isPatternLocals.Contains(index) || _deconstructionLocals.Contains(index))
+                || _isPatternLocals.Contains(index) || _deconstructionLocals.Contains(index)
+                || _inlineReceiverTempLocals.Contains(index))
                 continue;
             bool declaredAtStore = _declaringStores.Any(s =>
                 s is StoreLocal store && store.Index == index
@@ -952,6 +956,61 @@ public sealed partial class CSharpPrinter
             yield return descendant;
     }
 
+    void CollectInlineReceiverTempStores(IrFunction function)
+    {
+        foreach (var block in DescendantsOutsideNestedFunctions(function).OfType<Block>())
+        {
+            for (int i = 0; i + 1 < block.Children.Count; i++)
+            {
+                if (block.Children[i] is not StoreLocal store
+                    || block.Children[i + 1] is not StoreElement storeElement
+                    || !CanInlineReceiverTempStore(function, store, storeElement))
+                {
+                    continue;
+                }
+
+                _inlineReceiverTempStores[storeElement] = store;
+                _inlineReceiverTempLocals.Add(store.Index);
+            }
+        }
+    }
+
+    bool CanInlineReceiverTempStore(IrFunction function, StoreLocal store, StoreElement storeElement)
+    {
+        if (store.Type.Kind == TypeRefKind.ByRef)
+            return false;
+        if (store.SourceOffset >= 0 && _labelTargets.Contains(store.SourceOffset))
+            return false;
+        if (storeElement.Value is not Call { Callee: { HasThis: true, Name: "ToString" } callee, Arguments: [LoadLocalAddress receiver] } call
+            || receiver.Index != store.Index
+            || (storeElement.ElementType is not null && !Equals(callee.ReturnType, storeElement.ElementType)))
+        {
+            return false;
+        }
+
+        int stores = 0, addressLoads = 0;
+        foreach (var node in DescendantsOutsideNestedFunctions(function))
+        {
+            switch (node)
+            {
+                case StoreLocal s when s.Index == store.Index:
+                    stores++;
+                    if (!ReferenceEquals(s, store))
+                        return false;
+                    break;
+                case LoadLocalAddress a when a.Index == store.Index:
+                    addressLoads++;
+                    if (!ReferenceEquals(a, receiver))
+                        return false;
+                    break;
+                case LoadLocal l when l.Index == store.Index:
+                    return false;
+            }
+        }
+        return stores == 1 && addressLoads == 1 && ReferenceEquals(call.Arguments[0], receiver);
+        return stores == 1 && addressLoads == 1 && ReferenceEquals(call.Arguments[0], receiver);
+    }
+
     /// <summary>True when the local's last program-order reference sits inside the given subtree.</summary>
     static bool LastReferenceIsInside(IrFunction function, int localIndex, IrNode subtree)
     {
@@ -1264,6 +1323,12 @@ public sealed partial class CSharpPrinter
         int i = 0;
         while (i < statements.Count)
         {
+            if (statements[i] is StoreLocal inlineStore && _inlineReceiverTempStores.ContainsValue(inlineStore))
+            {
+                i++;
+                continue;
+            }
+
             if (_newMemorySafetyRules && _unsafeDepth == 0 && NeedsUnsafeContext(statements[i]))
             {
                 int j = i + 1;
@@ -1275,6 +1340,8 @@ public sealed partial class CSharpPrinter
                 _unsafeDepth++;
                 for (int k = i; k < j; k++)
                 {
+                    if (statements[k] is StoreLocal unsafeInlineStore && _inlineReceiverTempStores.ContainsValue(unsafeInlineStore))
+                        continue;
                     AppendStatementLabel(sb, statements[k], indent + 1);
                     AppendStatement(sb, statements[k], indent + 1);
                 }
@@ -1510,6 +1577,7 @@ public sealed partial class CSharpPrinter
                 && PlaceIdentity.SameOperands(load.IndexArguments, s.IndexArguments),
             StorePropertyTargetType(s)),
         EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {CastValue(e.Value, e.Accessor.ParameterTypes[0])};",
+        StoreElement s when InlineReceiverTempStoreValue(s) is { } value => $"{Operand(s.Array)}[{Expression(s.Index)}] = {value};",
         StoreElement s => $"{Operand(s.Array)}[{Expression(s.Index)}] = {CastValue(s.Value, s.ElementType)};",
         StoreIndirect s => AssignmentText(
             IndirectTarget(s.Address, IndirectStoreType(s.Address, s.Type)),
@@ -1541,6 +1609,22 @@ public sealed partial class CSharpPrinter
         EndFilter f => $"// endfilter({Expression(f.Value)})",
         _ => $"/* {node.Describe()} */",
     };
+
+    string? InlineReceiverTempStoreValue(StoreElement storeElement)
+    {
+        if (!_inlineReceiverTempStores.TryGetValue(storeElement, out var store)
+            || storeElement.Value is not Call call)
+        {
+            return null;
+        }
+
+        string receiver = ReceiverText(store.Value);
+        string typeArguments = call.Callee.TypeArguments.IsEmpty
+            ? ""
+            : $"<{string.Join(", ", call.Callee.TypeArguments.Select(TypeText))}>";
+        string rest = Arguments(call.Arguments.Skip(1), call.Callee.ParameterTypes, call.Callee.ParameterRefKinds);
+        return $"{receiver}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
+    }
 
     string ForLoopIncrementText(IrNode node)
         => node is ExpressionStatement { Expression: IncrementDecrement { IsChecked: true } increment }


### PR DESCRIPTION
- Fixes #1904
- Changes a narrow single-use address-receiver temp pattern so array element stores can render `MemoryExtensions.Trim(item).ToString()` instead of a split temp assignment
- Card revision: `d5b8706f`

## Change

**Conclusion:** **PASS** — `Humanizer.EnglishArticle::AppendArticlePrefix` drops out of the OpcodeDiff examples while the inliner now rejects target-side-effect, target-dependency, unsafe-context, additional-use, and nested-capture edge cases.

Before:

```csharp
V_9 = MemoryExtensions.Trim(item);
transformed[i] = V_9.ToString();
```

After:

```csharp
transformed[i] = MemoryExtensions.Trim(item).ToString();
```

The rewrite is limited to a temp with one store, no value loads, exactly one address load, and an immediately following `StoreElement` whose value is a parameterless `ToString()` call on that address. It only inlines when the array/index target can be evaluated before the inlined value without changing semantics.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `CSharpPrinterTests` passed, 26 tests |
| Decompiler fast suite | Pass, 1716 tests |
| Real witness source | `AppendArticlePrefix` renders `transformed[i] = MemoryExtensions.Trim(item).ToString();` |
| Changed-method fidelity | `AppendArticlePrefix` no longer appears in OpcodeDiff examples; remaining first EnglishArticle diff is `PrependArticleSuffix` |
| Build-event preflight | Pass: 0 errors, 0 warnings |
| Build-event compare | Pass: `no-diagnostic-deltas` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | Findings resolved | Added guards/tests for target evaluation order, inlined unsafe-context detection, and nested-function captures. |
| MAI-Code-1 Flash | Finding resolved | Tightened target dependency guard so the initializer cannot reference the same local/argument used by array/index target evaluation. |

**Review conclusion:** **PASS** — all actionable findings were fixed in `6964291b` and `d5b8706f`.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*CSharpPrinterTests"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll member Humanizer.EnglishArticle AppendArticlePrefix:1 --library /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --all -S "Decompiled Source" -n 80
dotnet run --project tools/DecompilerHarness -c Release -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --dump 'Humanizer.EnglishArticle::AppendArticlePrefix' --fidelity-check --diff --max-examples 2
dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh prepare src/ILInspector.Decompiler.Tests -- -c Release --nologo --verbosity quiet
/home/rich/git/dotnet-build-events-vmr-preview5-events/artifacts/preview5-events-sdk-test/dotnet build src/ILInspector.Decompiler.Tests --no-incremental --view types --event-log-stderr -c Release --nologo --verbosity quiet
dotnet run --project /home/rich/git/dotnet-inspect-build-event-query/src/dotnet-inspect -c Release --no-build -- build /home/rich/.dotnet/build-events/2026-06-29/20260629T224805.7072731Z-1867593-build-ed13f860.jsonl -S Compare --compare /home/rich/.dotnet/build-events/2026-06-29/20260629T230639.7497578Z-1897251-build-ed13f860.jsonl --tsv
```

Build-event logs:

- Before: `/home/rich/.dotnet/build-events/2026-06-29/20260629T224805.7072731Z-1867593-build-ed13f860.jsonl`
- After: `/home/rich/.dotnet/build-events/2026-06-29/20260629T230639.7497578Z-1897251-build-ed13f860.jsonl`

Workflow feedback for the build-event prototype was written to `/home/rich/git/dotnet-inspect-build-event-query/BUILD-EVENT-AGENT-FEEDBACK-1904.md`.
