### PR TITLE
Fold same-return dispatches to positive guards

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnDispatchPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnDispatchPassTests.cs
@@ -6,6 +6,7 @@ public class ReturnDispatchPassTests
 {
     static readonly TypeRef Holder = TypeRef.CoreLib("Synthetic", "Holder");
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef String = TypeRef.CoreLib("System", "String");
 
     [Fact]
     public void LeaveTargetedArm_DeclinesReturnDispatchFold()
@@ -34,6 +35,75 @@ public class ReturnDispatchPassTests
         Assert.Equal(0x0000, block.StartOffset);
         Assert.Equal(4, block.Children.OfType<IfStatement>().Count());
         Assert.IsType<Return>(block.Children[^1]);
+    }
+
+    [Fact]
+    public void SameReturnArms_FoldToPositiveFallthroughGuard()
+    {
+        var function = BuildSameReturnDispatchCandidate(includeLaterPrefix: false);
+
+        new ReturnDispatchPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var block = Assert.Single(function.Body.Blocks);
+        Assert.IsType<StoreLocal>(block.Children[0]);
+        var ifStatement = Assert.IsType<IfStatement>(block.Children[1]);
+        Assert.IsType<LogicalBinary>(ifStatement.Condition);
+        Assert.IsType<Return>(block.Children[2]);
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+        Assert.Contains("if (V_0 > 1 && V_0 < 5 && number != 12 && number != 13)", output);
+        Assert.Contains("return \"paucal\";", output);
+        Assert.EndsWith("return resourceKey;", output);
+    }
+
+    [Fact]
+    public void SameReturnArms_WithLaterPrefix_KeepOrderedGuardReturns()
+    {
+        var function = BuildSameReturnDispatchCandidate(includeLaterPrefix: true);
+
+        new ReturnDispatchPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        var block = Assert.Single(function.Body.Blocks);
+        Assert.Equal(4, block.Children.OfType<IfStatement>().Count());
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+        Assert.DoesNotContain("V_0 > 1 &&", output);
+        Assert.Contains("V_1 = number;", output);
+        Assert.Contains("if (V_1 == 12)", output);
+    }
+
+    [Fact]
+    public void SameReturnArms_BrfalseGuard_UnwrapsDoubleNegation()
+    {
+        var body = new BlockContainer();
+        AddGuard(body, 0, new LogicalNot(new LoadArgument(1, "number", Int32)), targetOffset: 5);
+        AddGuard(body, 1, new LogicalNot(new LoadArgument(2, "other", Int32)), targetOffset: 5);
+        AddGuard(body, 2, ComparisonKind.Equal, new LoadArgument(1, "number", Int32), new Constant(12, Int32), targetOffset: 5);
+        AddGuard(body, 3, ComparisonKind.Equal, new LoadArgument(2, "other", Int32), new Constant(13, Int32), targetOffset: 5);
+        var fallback = new Block(4);
+        fallback.Add(new Return(new Constant("special", String)));
+        body.Add(fallback);
+        var common = new Block(5);
+        common.Add(new Return(new LoadArgument(0, "resourceKey", String)));
+        body.Add(common);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(String, [
+                new Parameter("resourceKey", String),
+                new Parameter("number", Int32),
+                new Parameter("other", Int32),
+            ], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new ReturnDispatchPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").TrimEnd();
+        Assert.Contains("if (number != 0 && other != 0 && number != 12 && other != 13)", output);
+        Assert.DoesNotContain("!(", output);
     }
 
     [Fact]
@@ -107,6 +177,45 @@ public class ReturnDispatchPassTests
             body);
     }
 
+    static IrFunction BuildSameReturnDispatchCandidate(bool includeLaterPrefix)
+    {
+        var body = new BlockContainer();
+        var first = new Block(0);
+        first.Add(new StoreLocal(0, Int32, new Binary(
+            BinaryKind.Remainder,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(1, "number", Int32),
+            new Constant(10, Int32))));
+        first.Add(new ConditionalBranch(
+            new Comparison(ComparisonKind.LessThanOrEqual, isUnsigned: false, new LoadLocal(0, Int32), new Constant(1, Int32)),
+            5));
+        body.Add(first);
+
+        AddGuard(body, 1, ComparisonKind.GreaterThanOrEqual, new LoadLocal(0, Int32), new Constant(5, Int32), targetOffset: 5);
+        var third = new Block(2);
+        if (includeLaterPrefix)
+            third.Add(new StoreLocal(1, Int32, new LoadArgument(1, "number", Int32)));
+        third.Add(new ConditionalBranch(
+            new Comparison(ComparisonKind.Equal, isUnsigned: false, includeLaterPrefix ? new LoadLocal(1, Int32) : new LoadArgument(1, "number", Int32), new Constant(12, Int32)),
+            5));
+        body.Add(third);
+        AddGuard(body, 3, ComparisonKind.Equal, new LoadArgument(1, "number", Int32), new Constant(13, Int32), targetOffset: 5);
+        var fallback = new Block(4);
+        fallback.Add(new Return(new Constant("paucal", String)));
+        body.Add(fallback);
+        var common = new Block(5);
+        common.Add(new Return(new LoadArgument(0, "resourceKey", String)));
+        body.Add(common);
+
+        return new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(String, [new Parameter("resourceKey", String), new Parameter("number", Int32)], HasThis: false, GenericParameterCount: 0),
+            includeLaterPrefix ? [Int32, Int32] : [Int32],
+            body);
+    }
+
     static IrFunction BuildComparisonTreeCandidate()
     {
         var body = new BlockContainer();
@@ -150,11 +259,15 @@ public class ReturnDispatchPassTests
     }
 
     static void AddGuard(BlockContainer body, int offset, ComparisonKind kind, int argIndex, int targetOffset)
+        => AddGuard(body, offset, kind, new LoadArgument(argIndex, argIndex == 0 ? "x" : "y", Int32), new Constant(0, Int32), targetOffset);
+
+    static void AddGuard(BlockContainer body, int offset, ComparisonKind kind, IrExpression left, IrExpression right, int targetOffset)
+        => AddGuard(body, offset, new Comparison(kind, isUnsigned: false, left, right), targetOffset);
+
+    static void AddGuard(BlockContainer body, int offset, IrExpression condition, int targetOffset)
     {
         var block = new Block(offset);
-        block.Add(new ConditionalBranch(
-            new Comparison(kind, isUnsigned: false, new LoadArgument(argIndex, argIndex == 0 ? "x" : "y", Int32), new Constant(0, Int32)),
-            targetOffset));
+        block.Add(new ConditionalBranch(condition, targetOffset));
         body.Add(block);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ReturnDispatchPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ReturnDispatchPass.cs
@@ -29,7 +29,7 @@ public sealed class ReturnDispatchPass : IIrPass
     }
 
     sealed record Arm(IReadOnlyList<IrNode> Prefix, IrExpression Condition, IrExpression Value, int TargetIndex);
-    sealed record Plan(List<Arm> Arms, IrExpression DefaultValue);
+    sealed record Plan(List<Arm> Arms, IrExpression DefaultValue, int DefaultIndex);
     sealed record TreePlan(Block Body, int LeafCount);
 
     static bool TryFold(IrFunction function, BlockContainer container, Stepper stepper)
@@ -46,6 +46,13 @@ public sealed class ReturnDispatchPass : IIrPass
         {
             if (HasExternalEntry(function, container, blocks))
                 return false;
+
+            if (TryBuildPositiveFallthrough(blocks, plan) is { } positiveBlock)
+            {
+                ReplaceContainer(container, positiveBlock);
+                stepper.StepOver("fold flat return dispatch to positive fallthrough guard", container);
+                return true;
+            }
 
             var block = new Block(blocks[0].StartOffset);
             foreach (var arm in plan.Arms)
@@ -119,9 +126,36 @@ public sealed class ReturnDispatchPass : IIrPass
             consumed.Add(i);
             if (arms.Count < MinArms || consumed.Count != blocks.Count)
                 return null;
-            return new Plan(arms, defaultValue);
+            return new Plan(arms, defaultValue, i);
         }
         return null;
+    }
+
+    static Block? TryBuildPositiveFallthrough(IReadOnlyList<Block> blocks, Plan plan)
+    {
+        if (plan.Arms.Count < MinArms || plan.Arms.Skip(1).Any(arm => arm.Prefix.Count != 0))
+            return null;
+        var commonValue = plan.Arms[0].Value;
+        if (plan.Arms.Any(arm => !PlaceIdentity.SameOperand(arm.Value, commonValue)))
+            return null;
+
+        var block = new Block(blocks[0].StartOffset);
+        foreach (var prefix in plan.Arms[0].Prefix)
+            block.Add(prefix.Clone());
+
+        var then = new Block(blocks[plan.DefaultIndex].StartOffset);
+        then.Add(new Return((IrExpression)plan.DefaultValue.Clone()));
+        block.Add(new IfStatement(PositiveCondition(plan.Arms), then, null));
+        block.Add(new Return((IrExpression)commonValue.Clone()));
+        return block;
+    }
+
+    static IrExpression PositiveCondition(IReadOnlyList<Arm> arms)
+    {
+        IrExpression condition = Conditions.Negate((IrExpression)arms[0].Condition.Clone());
+        for (int i = 1; i < arms.Count; i++)
+            condition = new LogicalBinary(LogicalKind.And, condition, Conditions.Negate((IrExpression)arms[i].Condition.Clone()));
+        return condition;
     }
 
     static IrExpression? ReturnValue(Block block) => block.Children switch


### PR DESCRIPTION
- Fixes #1902
- Changes flat same-return guard dispatches into a positive fallthrough guard when that preserves opcode shape
- Card revision: `d318a0de`

## Change

**Conclusion:** **PASS** — the Humanizer Croatian return-dispatch shape now renders close to original source and compile-backs opcode-exact.

Before:

```csharp
if (mod10 <= 1) return resourceKey;
if (mod10 >= 5) return resourceKey;
if (number == 12) return resourceKey;
if (number == 13) return resourceKey;
if (number == 14) return resourceKey;
return string.Concat(resourceKey, "_Paucal");
```

After:

```csharp
if (mod10 > 1 && mod10 < 5 && number != 12 && number != 13 && number != 14)
{
    return string.Concat(resourceKey, "_Paucal");
}
return resourceKey;
```

The fold is narrow: it only applies when all guard arms return the same side-effect-free operand, later arms have no prefix statements, and the original container has no external entry. Conditions are negated through `Conditions.Negate` so brfalse-derived guards avoid double-negation output.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `ReturnDispatchPassTests` passed, 7 tests |
| Decompiler fast suite | Pass, 1719 tests |
| Real witness source | `Humanizer.CroatianFormatter::GetResourceKey` renders positive fallthrough guard |
| Changed-method fidelity | `CB_TYPE=CroatianFormatter`: exact 2/2, OpcodeDiff 0, RecompileFail 0 |
| Build-event preflight | Pass: 0 errors, 0 warnings |
| Build-event compare | Pass: `no-diagnostic-deltas` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Non-blocker resolved | Confirmed value-semantics soundness; suggested `Conditions.Negate` to avoid brfalse double-negation drift. |
| Gemini 3.1 Pro | Non-blocker resolved | No blockers; independently suggested `Conditions.Negate` for normalized IR/C# condition spelling. |

**Review conclusion:** **PASS** — no blockers; the shared non-blocker was resolved before PR.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*ReturnDispatchPassTests"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll member Humanizer.CroatianFormatter --member GetResourceKey --library /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --all -S "Decompiled Source" -n 80
CB_TYPE=CroatianFormatter dotnet run --project tools/DecompilerHarness -c Release -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 20 --max-examples 5
dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh prepare src/ILInspector.Decompiler.Tests -- -c Release --nologo --verbosity quiet
/home/rich/git/dotnet-build-events-vmr-preview5-events/artifacts/preview5-events-sdk-test/dotnet build src/ILInspector.Decompiler.Tests --no-incremental --view types --event-log-stderr -c Release --nologo --verbosity quiet
dotnet run --project /home/rich/git/dotnet-inspect-build-event-query/src/dotnet-inspect -c Release --no-build -- build /home/rich/.dotnet/build-events/2026-06-29/20260629T232108.2805883Z-1910537-build-e787cf09.jsonl -S Compare --compare /home/rich/.dotnet/build-events/2026-06-29/20260629T233000.0924020Z-1919453-build-e787cf09.jsonl --tsv
```

Build-event logs:

- Before: `/home/rich/.dotnet/build-events/2026-06-29/20260629T232108.2805883Z-1910537-build-e787cf09.jsonl`
- After: `/home/rich/.dotnet/build-events/2026-06-29/20260629T233000.0924020Z-1919453-build-e787cf09.jsonl`

Workflow feedback for the build-event prototype was written to `/home/rich/git/dotnet-inspect-build-event-query/BUILD-EVENT-AGENT-FEEDBACK-1902.md`.
