### PR TITLE
Declare consumed ref stack slots at first store

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StackSlotDeclarationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StackSlotDeclarationTests.cs
@@ -1,0 +1,37 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class StackSlotDeclarationTests
+{
+    static readonly TypeRef Holder = TypeRef.Definition("Synthetic", "Samples", "Holder");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef String = TypeRef.CoreLib("System", "String");
+
+    [Fact]
+    public void RefStackSlot_AssignedAndConsumedInOneBlock_DeclaresAtStore()
+    {
+        var stringRef = TypeRef.ByRef(String);
+        var use = new MethodRef(Holder, "Use", Void, [stringRef], HasThis: false);
+        var entry = new Block(0);
+        entry.Add(new Branch(1));
+        var consume = new Block(1);
+        consume.Add(new StoreStackSlot(0, new LoadLocalAddress(0, String)));
+        consume.Add(new ExpressionStatement(new Call(use, isVirtual: false, [new LoadStackSlot(0, stringRef)])));
+        consume.Add(new Return(null));
+        var body = new BlockContainer();
+        body.Add(entry);
+        body.Add(consume);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [String],
+            body);
+
+        string output = CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n");
+
+        Assert.DoesNotContain("Unsafe.NullRef", output);
+        Assert.Contains("ref string S_0 = ref V_0;", output);
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -828,7 +828,18 @@ public sealed partial class CSharpPrinter
                     seenSlots.Add(slotStore.Slot);
                     if (entryStatements.Contains(slotStore) && slotStore.Value.ResultType is not null
                         && slotStoreCounts[slotStore.Slot] == 1)
+                    {
                         _declaringStores.Add(slotStore);
+                    }
+                    else if (StackSlotTargetType(slotStore) is { Kind: TypeRefKind.ByRef }
+                        && StackSlotReferencesStayInBlockAfterStore(function, slotStore))
+                    {
+                        // A ref stack-slot temp cannot be declared bare up front
+                        // (CS8174), and synthesizing Unsafe.NullRef<T>() adds IL.
+                        // If every reference stays in the assignment block after
+                        // the first store, declare at that ref assignment instead.
+                        _declaringStores.Add(slotStore);
+                    }
                     break;
                 case LoadStackSlot slotLoad: seenSlots.Add(slotLoad.Slot); break;
             }
@@ -914,6 +925,29 @@ public sealed partial class CSharpPrinter
         return true;
     }
 
+    bool StackSlotReferencesStayInBlockAfterStore(IrFunction function, StoreStackSlot store)
+    {
+        if (store.Parent is not Block block || store.ChildIndex < 0)
+            return false;
+        if (ReferencesStackSlot(store.Value, store.Slot))
+            return false;
+        var allowed = block.Children.Skip(store.ChildIndex).ToList();
+        if (HasBranchTargetAfterStatement(store))
+            return false;
+        bool sawLoad = false;
+        foreach (var node in DescendantsOutsideNestedFunctions(function))
+        {
+            if (node is StoreStackSlot s && s.Slot == store.Slot
+                || node is LoadStackSlot l && l.Slot == store.Slot)
+            {
+                if (!allowed.Any(statement => IsDescendantOrSelf(node, statement)))
+                    return false;
+                sawLoad |= node is LoadStackSlot;
+            }
+        }
+        return sawLoad;
+    }
+
     static bool StoreValueReferencesLocal(StoreLocal store)
         => ReferencesLocal(store.Value, store.Index);
 
@@ -933,9 +967,20 @@ public sealed partial class CSharpPrinter
         return DescendantsOutsideNestedFunctions(node).Any(n => IsLocalReference(n, index));
     }
 
+    static bool ReferencesStackSlot(IrNode node, int slot)
+    {
+        if (IsStackSlotReference(node, slot))
+            return true;
+        return DescendantsOutsideNestedFunctions(node).Any(n => IsStackSlotReference(n, slot));
+    }
+
     static bool IsLocalReference(IrNode node, int index)
         => node is LoadLocal load && load.Index == index
             || node is LoadLocalAddress address && address.Index == index;
+
+    static bool IsStackSlotReference(IrNode node, int slot)
+        => node is LoadStackSlot load && load.Slot == slot
+            || node is StoreStackSlot store && store.Slot == slot;
 
     static bool IsDescendantOrSelf(IrNode node, IrNode ancestor)
     {


### PR DESCRIPTION
- Uses #1897 Humanizer artifact selection
- Fixes the selected `Humanizer.EnglishArticle::PrependArticleSuffix` opcode diff
- Card revision: `eccb44d7`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — `PrependArticleSuffix` moves from OpcodeDiff to Exact by avoiding synthetic `Unsafe.NullRef<T>()` initializers for ref stack-slot temps that are assigned and consumed in one block.

Before:

```text
PrependArticleSuffix: OpcodeDiff
recompiled stream starts with extra: call pop call pop call pop
```

After:

```text
PrependArticleSuffix: Exact
EnglishArticle focused run: exact 3/4, OpcodeDiff 0, RecompileFail 1
Humanizer cap 1000: exact 603, OpcodeDiff 215 (was exact 602, OpcodeDiff 216)
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `RefSlot_DeclaredUpFront_InitializesToNullRef` and `RefStackSlot_AssignedAndConsumedInOneBlock_DeclaresAtStore` |
| Decompiler fast suite | Pass: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"` |
| Humanizer focused fidelity | Pass: `CB_TYPE=EnglishArticle` gives `exact 3`, `OpcodeDiff 0`, `RecompileFail 1` |
| Humanizer cap 1000 | Pass: useful rows still high; selected first OpcodeDiff removed |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — this is a focused printer/declaration fix for a measured Humanizer opcode diff. The guard only declares a ref stack-slot at its store when all same-slot refs stay after that store in one block, there is a later load, the store value does not self-reference the slot, and no later branch target can enter after the declaration.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked dominance/scope, branch-target safety, self-reference guard, NullRef preservation, join-slot bounds, predicate precedence, and targeted regression tests. |
| Gemini 3.1 Pro | No blocking findings | Checked dominance/scope, branch-target safety, self-reference guard, NullRef fallback, test coverage, and Humanizer mechanism. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*RefSlot_DeclaredUpFront_InitializesToNullRef" -method "*RefStackSlot_AssignedAndConsumedInOneBlock_DeclaresAtStore"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
CB_TYPE=EnglishArticle dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 80 --max-examples 5 --fidelity-timings
/usr/bin/time -f 'elapsed=%E cpu=%P maxrss=%MKB' dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 1000 --max-examples 5 --fidelity-timings
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
git diff --check
```
