### PR TITLE
Fix discovery projection gaps

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -5060,6 +5060,16 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Package_DiscoverSchema_ListsPublishedPackageInfoField()
+    {
+        var (exit, output, error) = await RunAppAsync("package", "-D", "Package Info", "--schema", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("| Published | field |", output);
+    }
+
+    [Fact]
     public async Task Package_DiscoverSection_ListsSignalsColumns()
     {
         var (packagePath, tempDir) = CreateLocalRefPackage("System.Runtime");
@@ -5096,6 +5106,27 @@ public class CommandExecutionTests
             Assert.Contains("Package Info", output);
             Assert.Contains("Authors", output);
             Assert.DoesNotContain("README.md", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_TreeWithoutDiscovery_ReportsLayoutAlternative()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage(
+            "Test.TreeAlias",
+            "README.md",
+            "# Test package");
+        try
+        {
+            var (exit, _, error) = await RunAppAsync("package", packagePath, "--tree", "--tips", "q");
+
+            Assert.Equal(1, exit);
+            Assert.Contains("requires -D/--discover", error);
+            Assert.Contains("Use --layout", error);
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3997,6 +3997,23 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryCommand_DiscoverPerformanceTriage_ListsRenderableColumns()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath, "-D", "Performance Triage", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("not found", error);
+        Assert.Contains("| Member | column |", output);
+        Assert.Contains("| Root Reach | column |", output);
+        Assert.Contains("| Shape | column |", output);
+        Assert.Contains("| Fix | column |", output);
+        Assert.Contains("| Confidence | column |", output);
+        Assert.Contains("| Loop | column |", output);
+        Assert.Contains("| IL | column |", output);
+    }
+
+    [Fact]
     public async Task LibraryCommand_SourceFilesSection_RendersTypeUrls()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -5008,6 +5025,82 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Contains("Source: Platform", output);
         Assert.DoesNotContain("Tip:", error);
+    }
+
+    [Fact]
+    public async Task Package_DiscoverSection_ListsPackageInfoFields()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage(
+            "Test.PackageInfoDiscovery",
+            "README.md",
+            "# Test package");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "-D", "Package Info", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.Contains("| Authors | field |", output);
+            Assert.Contains("| Version | field |", output);
+
+            var (projectExit, projected, projectError) = await RunAppAsync(
+                "package", packagePath, "-S", "Package Info", "--fields", "Authors,Version", "-v:q", "--tips", "q");
+
+            Assert.Equal(0, projectExit);
+            Assert.DoesNotContain("not found", projectError);
+            Assert.Contains("Authors", projected);
+            Assert.Contains("tests", projected);
+            Assert.Contains("Version", projected);
+            Assert.Contains("1.0.0", projected);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_DiscoverSection_ListsSignalsColumns()
+    {
+        var (packagePath, tempDir) = CreateLocalRefPackage("System.Runtime");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "-D", "Signals", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.DoesNotContain("not found", error);
+            Assert.Contains("| Area | column |", output);
+            Assert.Contains("| Signal | column |", output);
+            Assert.Contains("| Value | column |", output);
+            Assert.Contains("| Evidence | column |", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Package_DiscoverTree_UsesDiscoveryTreeNotFileTree()
+    {
+        var (packagePath, tempDir) = CreateLocalReadmePackage(
+            "Test.DiscoveryTree",
+            "README.md",
+            "# Test package");
+        try
+        {
+            var (exit, output, error) = await RunAppAsync("package", packagePath, "-D", "--tree", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.Contains("Package Info", output);
+            Assert.Contains("Authors", output);
+            Assert.DoesNotContain("README.md", output);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
@@ -25,7 +25,6 @@ public static class PackageCommandDefinitions
 
         var dependenciesOption = new Option<bool>("--dependencies") { Description = "Show transitive package dependency tree (tip: use 'depends --package' instead)" };
         var layoutOption = new Option<bool>("--layout") { Description = "Show package file tree" };
-        layoutOption.Aliases.Add("--tree");
         var pathOption = new Option<string[]>("--path")
         {
             Description = "List package files with sizes (the Files section), scoped to a file, directory, glob, @readme (AGENTS.md > README.md > PACKAGE.md), or @agents. Can repeat. Pass --path with no value for the whole package.",

--- a/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
@@ -126,7 +126,7 @@ public static class PackageOptionsParser
             TypeFilter = typeFilter,
             PackageLibrary = packageLibrary,
             AllLibraries = parseResult.GetValue(args.AllLibrariesOption),
-            ListLayout = parseResult.GetValue(args.LayoutOption),
+            ListLayout = parseResult.GetValue(args.LayoutOption) && !opts.IsDiscoveryMode(parseResult),
             PathFilter = pathFilter,
             PathFilters = pathFilters,
             PathMatchMode = parseResult.GetValue(args.PathMatchOption) ?? "all",

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -427,14 +427,7 @@ public class LibraryCommand
                 continue;
             }
 
-            var effectiveItems = section.Items
-                .Where(item => rendered.Contains(item.Name, StringComparison.OrdinalIgnoreCase))
-                .Select(item => item.Name)
-                .ToArray();
-
-            if (effectiveItems.Length > 0)
-                filtered.Add(name, section.ItemKind, effectiveItems);
-            else if (section.Items.Length > 0)
+            if (section.Items.Length > 0)
                 filtered.Add(name, section.ItemKind, section.Items.Select(i => i.Name).ToArray());
             else
                 filtered.AddSection(name);

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -326,7 +326,7 @@ public class LibraryCommand
 
     // ── Effective sections cache ──
 
-    private const string EffectiveCategory = "effective-v8";
+    private const string EffectiveCategory = "effective-v9";
 
     static LibraryCommand()
     {

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -647,6 +647,7 @@ public class PackageCommand
         "License",
         "License URL",
         "Owners",
+        "Published",
         "Readme",
         "Repository",
         "Repository Commit",
@@ -749,6 +750,13 @@ public class PackageCommand
     private static bool ValidatePackageContentMode(InspectionOptions options)
     {
         bool scopedContent = options.ContentScope != PackageFileContentScope.Full;
+        if (options.Tree && options.Discover == null)
+        {
+            Console.Error.WriteLine("Error: package --tree is discovery-tree output and requires -D/--discover.");
+            Console.Error.WriteLine("Use --layout to show the package file tree.");
+            return false;
+        }
+
         if (options.FrontmatterRequested && options.BodyRequested)
         {
             Console.Error.WriteLine("Error: --frontmatter/--yaml-header cannot be combined with --body.");

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -36,7 +36,7 @@ public class PackageCommand
         // Also keep no-target package discovery static because there is no target to make effective.
         if (!packageLibraryMode && options.Discover != null && (options.Schema || packageArgs.Length < 1))
         {
-            var schemaMap = InspectionContext.Default.GetSchemaInfo<InspectionResultView>()!.ToDocumentSchema();
+            var schemaMap = PackageDiscoverySchema();
             return DiscoverOutput.Execute(options.Discover, schemaMap,
                 tree: options.Tree, json: options.JsonOutput, tsv: options.Tsv, jsonl: options.Jsonl, markdown: !options.OneLine && !options.JsonOutput,
                 verbosity: (int)options.Verbosity,
@@ -76,7 +76,7 @@ public class PackageCommand
             // Pre-render validation: check --fields/--columns names against the section schema
             if ((options.Fields is { Length: > 0 } || options.Columns is { Length: > 0 }) && options.IncludeSections is { Count: > 0 })
             {
-                var schemaMap = InspectionContext.Default.GetSchemaInfo<InspectionResultView>()!.ToDocumentSchema();
+                var schemaMap = PackageDiscoverySchema();
                 if (!ProjectionDiagnostics.ValidateProjection(schemaMap, options.IncludeSections, options.Fields, options.Columns))
                     return 1;
             }
@@ -362,7 +362,8 @@ public class PackageCommand
                 packageSize = new FileInfo(resolution.NupkgPath).Length;
             }
 
-            bool wantsSignals = options.IncludeSections?.Contains(PackageSections.Signals) == true;
+            bool wantsSignals = options.IncludeSections?.Contains(PackageSections.Signals) == true
+                || DiscoverRequestsSection(options.Discover, PackageSections.Signals, pipeline);
             bool allowsVulnerabilityTraffic = options.Verbosity >= Verbosity.Detailed
                 || options.IncludeSections?.Any(IsNetworkUsingPackageSection) == true;
             using var vulnerabilityTrafficScope = allowsVulnerabilityTraffic
@@ -418,7 +419,7 @@ public class PackageCommand
             if (effectiveDiscovery)
             {
                 var effective = pipeline.GetDiscoverableSections(result, options.IncludeSections);
-                var schemaMap = InspectionContext.Default.GetSchemaInfo<InspectionResultView>()!.ToDocumentSchema();
+                var schemaMap = PackageDiscoverySchema();
                 var fullSchemaMap = schemaMap;
 
                 // Field-level filtering: detect which fields produced output
@@ -631,6 +632,94 @@ public class PackageCommand
 
         Console.Error.WriteLine($"Error: Multiple package row output does not support section: {section}.");
         Console.Error.WriteLine("Use --json, or select Package Info, Files, Library Files, or Markdown Files.");
+        return false;
+    }
+
+    private static readonly string[] PackageInfoFieldNames =
+    [
+        "Authors",
+        "Built",
+        "Content",
+        "Deprecated Note",
+        "Framework Dependent",
+        "Highest TFM",
+        "Libraries",
+        "License",
+        "License URL",
+        "Owners",
+        "Readme",
+        "Repository",
+        "Repository Commit",
+        "Repository Type",
+        "RID-Specific Pointer",
+        "Runtime Identifiers",
+        "Runtime Target RID",
+        "Signed",
+        "Size",
+        "Source",
+        "TFM Count",
+        "Tool Commands",
+        "Type",
+        "Verified",
+        "Version",
+        "Vulnerabilities"
+    ];
+
+    private static readonly string[] PackageSignalsColumnNames =
+    [
+        "Area",
+        "Signal",
+        "Value",
+        "Evidence"
+    ];
+
+    private static DocumentSchema PackageDiscoverySchema()
+        => AddPackageDynamicDiscoveryItems(InspectionContext.Default.GetSchemaInfo<InspectionResultView>()!.ToDocumentSchema());
+
+    private static DocumentSchema AddPackageDynamicDiscoveryItems(DocumentSchema schema)
+    {
+        var result = new DocumentSchema();
+        foreach (var name in schema.SectionNames)
+        {
+            var section = schema.GetSection(name);
+            if (string.Equals(name, PackageSections.PackageInfo, StringComparison.OrdinalIgnoreCase))
+            {
+                result.Add(name, "field", PackageInfoFieldNames);
+            }
+            else if (string.Equals(name, PackageSections.Signals, StringComparison.OrdinalIgnoreCase))
+            {
+                result.Add(name, "column", PackageSignalsColumnNames);
+            }
+            else if (section is { Items.Length: > 0 })
+            {
+                result.Add(name, section.ItemKind, section.Items.Select(i => i.Name).ToArray());
+            }
+            else
+            {
+                result.AddSection(name);
+            }
+        }
+
+        return result;
+    }
+
+    private static bool DiscoverRequestsSection(string[]? discover, string sectionName, SectionPipeline<InspectionResult> pipeline)
+    {
+        if (discover is not { Length: > 0 })
+            return false;
+
+        var categories = pipeline.GetCategoryMap();
+        foreach (var value in discover)
+        {
+            if (categories.TryGetValue(value, out var categorySections)
+                && categorySections.Contains(sectionName, StringComparer.OrdinalIgnoreCase))
+                return true;
+
+            var (matches, miss) = SelectResolver.ResolveSingle(value, pipeline.SelectableSectionNames, singleGlob: true);
+            if (miss == null && matches.Contains(sectionName, StringComparer.OrdinalIgnoreCase))
+                return true;
+        }
+
         return false;
     }
 
@@ -904,7 +993,8 @@ public class PackageCommand
             if (resolution.NupkgPath != null && File.Exists(resolution.NupkgPath))
                 packageSize = new FileInfo(resolution.NupkgPath).Length;
 
-            bool wantsSignals = options.IncludeSections?.Contains(PackageSections.Signals) == true;
+            bool wantsSignals = options.IncludeSections?.Contains(PackageSections.Signals) == true
+                || DiscoverRequestsSection(options.Discover, PackageSections.Signals, PackageSectionDescriptors.CreatePipeline());
             var result = await PackageInspector.InspectAsync(
                 extractPath,
                 target.PackageName,
@@ -2335,15 +2425,23 @@ public class PackageCommand
             var section = schema.GetSection(name);
             if (section == null) { filtered.AddSection(name); continue; }
 
-            var effectiveItems = section.Items
-                .Where(item => rendered.Contains(item.Name, StringComparison.OrdinalIgnoreCase))
-                .Select(item => item.Name)
-                .ToArray();
-
-            if (effectiveItems.Length > 0)
-                filtered.Add(name, section.ItemKind, effectiveItems);
+            if (string.Equals(name, PackageSections.PackageInfo, StringComparison.OrdinalIgnoreCase))
+            {
+                var effectiveItems = section.Items
+                    .Where(item => rendered.Contains(item.Name, StringComparison.OrdinalIgnoreCase))
+                    .Select(item => item.Name)
+                    .ToArray();
+                filtered.Add(name, section.ItemKind,
+                    effectiveItems.Length > 0 ? effectiveItems : section.Items.Select(i => i.Name).ToArray());
+            }
+            else if (section.Items.Length > 0)
+            {
+                filtered.Add(name, section.ItemKind, section.Items.Select(i => i.Name).ToArray());
+            }
             else
+            {
                 filtered.AddSection(name);
+            }
         }
         return filtered;
     }

--- a/src/dotnet-inspect/Program.cs
+++ b/src/dotnet-inspect/Program.cs
@@ -138,6 +138,12 @@ if (CommandLineBuilder.TailLines is int tailLines)
 // Create and invoke command
 var rootCommand = CommandLineBuilder.CreateRootCommand();
 var result = rootCommand.Parse(args);
+if (result.Errors.Count > 0)
+{
+    foreach (var error in result.Errors)
+        Console.Error.WriteLine(FormatParseError(error.Message));
+    return 1;
+}
 int exitCode;
 try
 {
@@ -177,6 +183,54 @@ if (showInfo)
 
     Console.Error.WriteLine();
     MarkoutSerializer.Serialize(view, Console.Error, InfoViewContext.Default);
+}
+
+static string FormatParseError(string message)
+{
+    if (message.StartsWith("Cannot parse argument '", StringComparison.Ordinal)
+        && TryParseCannotParseArgument(message, out var value, out var option, out var type))
+    {
+        var expected = type switch
+        {
+            "System.Int32" or "System.Nullable`1[System.Int32]" => "an integer",
+            _ => "a valid value",
+        };
+        return $"Error: Cannot parse value '{value}' for option '{option}' as {expected}.";
+    }
+
+    return message.StartsWith("Error:", StringComparison.OrdinalIgnoreCase)
+        ? message
+        : $"Error: {message}";
+}
+
+static bool TryParseCannotParseArgument(string message, out string value, out string option, out string type)
+{
+    value = "";
+    option = "";
+    type = "";
+    const string prefix = "Cannot parse argument '";
+    int valueStart = prefix.Length;
+    int valueEnd = message.IndexOf('\'', valueStart);
+    const string middle = " for option '";
+    if (valueEnd < 0 || !message.AsSpan(valueEnd + 1).StartsWith(middle, StringComparison.Ordinal))
+        return false;
+
+    int optionStart = valueEnd + 1 + middle.Length;
+    int optionEnd = message.IndexOf('\'', optionStart);
+    const string typeMarker = " as expected type '";
+    int typeStart = message.IndexOf(typeMarker, optionEnd + 1, StringComparison.Ordinal);
+    if (optionEnd < 0 || typeStart < 0)
+        return false;
+
+    typeStart += typeMarker.Length;
+    int typeEnd = message.IndexOf('\'', typeStart);
+    if (typeEnd < 0)
+        return false;
+
+    value = message[valueStart..valueEnd];
+    option = message[optionStart..optionEnd];
+    type = message[typeStart..typeEnd];
+    return true;
 }
 
 if (traceMermaid != null)


### PR DESCRIPTION
Fixes #1881.

## Summary

This fixes the narrowed discovery/projection gaps:

- package `-D "Package Info"` now lists dynamic package-info fields, and `--fields Authors,Version` validates/renders.
- package `-D Signals` now lists `Area`, `Signal`, `Value`, and `Evidence`.
- library `-D "Performance Triage"` now reports all selectable/renderable columns instead of only the runtime-populated subset.
- package `-D --tree` now renders the discovery tree; package file-tree output stays available via `--layout`.
- typed parse errors like `--top abc` no longer print CLR type names or full command help.

## Evidence

| Check | Result |
| --- | --- |
| Focused tests | Pass, 6 tests |
| Parser/command-line tests | Pass, 159 tests |
| Full `dotnet-inspect.Tests` executable | Pass, 1415 total / 9 skipped |
| Product build | Pass |
| Source CLI spot checks | Pass |
| Build-event preflight | Pass: 0 errors, 0 warnings |
| Build-event compare | Pass: `no-diagnostic-deltas` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| code-review agent | Findings resolved | Added `Published`, rejected package `--tree` outside discovery with `--layout` hint, bumped library effective-discovery cache. |

## Validation

```bash
dotnet build src/dotnet-inspect.Tests -c Release --nologo --verbosity quiet
dotnet artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll \
  -method "*Package_DiscoverSection_ListsPackageInfoFields*" \
  -method "*Package_DiscoverSchema_ListsPublishedPackageInfoField*" \
  -method "*Package_DiscoverSection_ListsSignalsColumns*" \
  -method "*Package_DiscoverTree_UsesDiscoveryTreeNotFileTree*" \
  -method "*Package_TreeWithoutDiscovery_ReportsLayoutAlternative*" \
  -method "*LibraryCommand_DiscoverPerformanceTriage_ListsRenderableColumns*"
dotnet artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll \
  -class "*CommandLineTests" -class "*PackageOptionsParserTests"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh prepare src/dotnet-inspect.Tests -- -c Release --nologo --verbosity quiet
/home/rich/git/dotnet-build-events-vmr-preview5-events/artifacts/preview5-events-sdk-test/dotnet build src/dotnet-inspect.Tests --no-incremental --view types --event-log-stderr -c Release --nologo --verbosity quiet
dotnet run --project /home/rich/git/dotnet-inspect-build-event-query/src/dotnet-inspect -c Release --no-build -- build /home/rich/.dotnet/build-events/2026-06-30/20260630T005215.7646780Z-2013280-build-17d23a44.jsonl -S Compare --compare /home/rich/.dotnet/build-events/2026-06-30/20260630T010029.1550298Z-2023224-build-17d23a44.jsonl --tsv
```

Build-event logs:

- Before: `/home/rich/.dotnet/build-events/2026-06-30/20260630T005215.7646780Z-2013280-build-17d23a44.jsonl`
- After: `/home/rich/.dotnet/build-events/2026-06-30/20260630T010029.1550298Z-2023224-build-17d23a44.jsonl`

Workflow feedback for the build-event prototype was written to `/home/rich/git/dotnet-inspect-build-event-query/BUILD-EVENT-AGENT-FEEDBACK-1881.md`.
