### PR TITLE
Raise union value type tests

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -216,12 +216,16 @@ public class TypeSourceComposerUnionTests
             public static class Matcher
             {
                 public static bool IsCat(Pet pet) => pet is Cat;
+                public static bool IsNotNull(Pet pet) => pet is not null;
                 public static bool IsNull(Pet pet) => pet is null;
+                public static Cat? AsCat(Pet pet) => pet.Value as Cat;
             }
             """);
 
         Assert.Equal("return pet is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCat"));
+        Assert.Equal("return pet is not null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNotNull"));
         Assert.Equal("return pet is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
+        Assert.Equal("return pet.Value as Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "AsCat"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.PortableExecutable;
+using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -202,6 +203,88 @@ public class TypeSourceComposerUnionTests
         Assert.DoesNotContain("public ref union RefPet", source);
     }
 
+    [Fact]
+    public async Task UnionMatchingTypeAndNullTests_RenderAgainstUnion()
+    {
+        using var assembly = await CompileWithSdk("""
+            namespace UnionFixtures;
+
+            public sealed class Cat { }
+            public sealed class Dog { }
+            public union Pet(Cat, Dog);
+
+            public static class Matcher
+            {
+                public static bool IsCat(Pet pet) => pet is Cat;
+                public static bool IsNull(Pet pet) => pet is null;
+            }
+            """);
+
+        Assert.Equal("return pet is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCat"));
+        Assert.Equal("return pet is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
+    }
+
+    [Fact]
+    public void NonUnionValuePropertyTypeTest_KeepsValueAccess()
+    {
+        using var assembly = Compile("""
+            #nullable enable
+            namespace UnionFixtures
+            {
+                public sealed class Cat { }
+
+                public readonly struct PetLike
+                {
+                    public PetLike(Cat value) => Value = value;
+                    public object? Value { get; }
+                }
+
+                public static class Matcher
+                {
+                    public static bool IsCat(PetLike pet) => pet.Value is Cat;
+                    public static bool IsNull(PetLike pet) => pet.Value is null;
+                }
+            }
+            """);
+
+        Assert.Equal("return pet.Value is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCat"));
+        Assert.Equal("return pet.Value is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
+    }
+
+    [Fact]
+    public void UnionAttributeWithoutRuntimeIUnionMatching_KeepsValueAccess()
+    {
+        using var assembly = Compile("""
+            #nullable enable
+            namespace System.Runtime.CompilerServices
+            {
+                [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct)]
+                public sealed class UnionAttribute : System.Attribute;
+            }
+
+            namespace UnionFixtures
+            {
+                public sealed class Cat { }
+
+                [System.Runtime.CompilerServices.Union]
+                public readonly struct PetLike
+                {
+                    public PetLike(Cat value) => Value = value;
+                    public object? Value { get; }
+                }
+
+                public static class Matcher
+                {
+                    public static bool IsCat(PetLike pet) => pet.Value is Cat;
+                    public static bool IsNull(PetLike pet) => pet.Value is null;
+                }
+            }
+            """);
+
+        Assert.Equal("return pet.Value is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCat"));
+        Assert.Equal("return pet.Value is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
+    }
+
     static string ComposeType(string path, string fullName)
     {
         using var pe = new PEReader(File.OpenRead(path));
@@ -226,6 +309,40 @@ public class TypeSourceComposerUnionTests
         var result = compilation.Emit(stream);
         Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
         return new TempAssembly(path);
+    }
+
+    static async Task<TempAssembly> CompileWithSdk(string source)
+    {
+        var project = TempDirectory.Create();
+        File.WriteAllText(Path.Combine(project.Path, "union-fixture.csproj"), """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net11.0</TargetFramework>
+                <LangVersion>preview</LangVersion>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(project.Path, "Fixture.cs"), source);
+
+        var result = await RunDotnetBuild(project.Path);
+        Assert.True(result.ExitCode == 0,
+            "Union fixture must build with the preview SDK, got exit "
+            + result.ExitCode + "\n--- output ---\n" + result.Output + "\n--- source ---\n" + source);
+
+        string dll = Path.Combine(project.Path, "bin", "Debug", "net11.0", "union-fixture.dll");
+        return new TempAssembly(dll, project);
+    }
+
+    static string RenderMember(string assemblyPath, string typeName, string methodName)
+    {
+        using var source = MetadataSource.Open(assemblyPath);
+        var function = IrImporter.Import(source, typeName, methodName);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function);
+        Assert.NotNull(result.Output);
+        return result.Output!.Trim();
     }
 
     static async Task AssertSdkPreviewBuilds(string source)
@@ -307,12 +424,17 @@ public class TypeSourceComposerUnionTests
         return references.ToImmutable();
     }
 
-    sealed class TempAssembly(string path) : IDisposable
+    sealed class TempAssembly(string path, TempDirectory? directory = null) : IDisposable
     {
         public string Path { get; } = path;
 
         public void Dispose()
         {
+            if (directory is not null)
+            {
+                directory.Dispose();
+                return;
+            }
             try { File.Delete(Path); }
             catch { }
         }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -749,6 +749,8 @@ public sealed partial class CSharpPrinter
             var operand = kind is ComparisonKind.GreaterThan or ComparisonKind.LessThanOrEqual ? left : right;
             if (IsInstanceNullTestText(operand, isNotNull: !isNullTest) is { } typeTest)
                 return typeTest;
+            if (UnionValueReceiverText(operand) is { } unionReceiver)
+                return $"{unionReceiver} is {(isNullTest ? "" : "not ")}null";
 
             return operand.ResultType is { Kind: TypeRefKind.Pointer }
                 ? $"{Operand(operand)} {(isNullTest ? "==" : "!=")} null"

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -713,6 +713,12 @@ public sealed partial class CSharpPrinter
             var operand = right is Constant { Value: null } ? left : right;
             if (IsInstanceNullTestText(operand, isNotNull: kind == ComparisonKind.NotEqual) is { } typeTest)
                 return typeTest;
+            if (UnionValueReceiverText(operand) is { } unionReceiver)
+            {
+                return kind == ComparisonKind.Equal
+                    ? $"{unionReceiver} is null"
+                    : $"{unionReceiver} is not null";
+            }
 
             return kind == ComparisonKind.Equal
                 ? $"{Operand(operand)} is null"
@@ -813,8 +819,8 @@ public sealed partial class CSharpPrinter
         if (operand is not IsInstance ii)
             return null;
 
-        string test = $"{Operand(ii.Operand)} is {TypeText(ii.Type)}";
-        return isNotNull ? test : $"{Operand(ii.Operand)} is not {TypeText(ii.Type)}";
+        string test = $"{TypeTestValueText(ii.Operand)} is {TypeText(ii.Type)}";
+        return isNotNull ? test : $"{TypeTestValueText(ii.Operand)} is not {TypeText(ii.Type)}";
     }
 
     static bool IsFloatComparison(IrExpression left, IrExpression right)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1786,7 +1786,7 @@ public sealed partial class CSharpPrinter
         StackAllocate s => $"stackalloc byte[{Expression(s.Size)}]",
         StackAllocArray s => $"stackalloc {TypeText(s.ElementType)}[{Expression(s.Count)}]",
         Box b => Expression(b.Operand),
-        IsInstance i => $"{TypeTestValueText(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
+        IsInstance i => $"{Operand(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
         IsPattern p => $"{Operand(p.Value)} is {TypeText(p.Type)} {LocalName(p.LocalIndex)}",
         RecursivePropertyDeclarationPattern p => $"{Operand(p.Value)} is {{ {p.PropertyName}: {TypeText(p.PatternType)} {LocalName(p.LocalIndex)} }}",
         SingleElementListPattern p => $"{Operand(p.Value)} is [{ListPatternAlternativesText(p)}]",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1786,7 +1786,7 @@ public sealed partial class CSharpPrinter
         StackAllocate s => $"stackalloc byte[{Expression(s.Size)}]",
         StackAllocArray s => $"stackalloc {TypeText(s.ElementType)}[{Expression(s.Count)}]",
         Box b => Expression(b.Operand),
-        IsInstance i => $"{Operand(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
+        IsInstance i => $"{TypeTestValueText(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
         IsPattern p => $"{Operand(p.Value)} is {TypeText(p.Type)} {LocalName(p.LocalIndex)}",
         RecursivePropertyDeclarationPattern p => $"{Operand(p.Value)} is {{ {p.PropertyName}: {TypeText(p.PatternType)} {LocalName(p.LocalIndex)} }}",
         SingleElementListPattern p => $"{Operand(p.Value)} is [{ListPatternAlternativesText(p)}]",
@@ -1869,6 +1869,36 @@ public sealed partial class CSharpPrinter
     string InvertedUserTruthiness(IrExpression value)
         => $"({OperatorOperand(value)} ? false : true)";
 
+    string TypeTestValueText(IrExpression value)
+        => UnionValueReceiverText(value) ?? Operand(value);
+
+    string? UnionValueReceiverText(IrExpression value)
+        => value is LoadProperty property ? UnionValueReceiverText(property) : null;
+
+    string? UnionValueReceiverText(LoadProperty property)
+    {
+        if (property.PropertyName != "Value"
+            || property.IndexArguments.Count != 0
+            || !_function.UnionTypes.Contains(NamedDefinition(property.Accessor.DeclaringType)))
+        {
+            return null;
+        }
+
+        return property.Instance switch
+        {
+            LoadArgumentAddress argument => CSharpNaming.EscapeIdentifier(argument.Name),
+            LoadArgument argument => CSharpNaming.EscapeIdentifier(argument.Name),
+            LoadLocalAddress local => LocalName(local.Index),
+            LoadLocal local => LocalName(local.Index),
+            LoadFieldAddress field => FieldTarget(field.Field, field.Instance),
+            LoadField field => FieldTarget(field.Field, field.Instance),
+            _ => null,
+        };
+    }
+
+    static TypeRef NamedDefinition(TypeRef type)
+        => type is { Kind: TypeRefKind.GenericInstance, ElementType: { } definition } ? definition : type;
+
     /// <summary>
     /// Spellings for a non-bool branch operand: <c>!= 0</c> for integers and
     /// enums, <c>is null</c>/<c>is not null</c> for reference shapes. The
@@ -1892,7 +1922,7 @@ public sealed partial class CSharpPrinter
         // in `!= 0` would be `bool != int` (CS0019); the inverse negates it.
         if (operand is IsInstance ii)
         {
-            string test = $"{Operand(ii.Operand)} is {TypeText(ii.Type)}";
+            string test = $"{TypeTestValueText(ii.Operand)} is {TypeText(ii.Type)}";
             return (test, $"!({test})");
         }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -405,6 +405,7 @@ public static class IrImporter
         Dictionary<TypeRef, IReadOnlyDictionary<long, string>>? enums = null;
         Dictionary<TypeRef, TypeRef>? enumUnderlyingTypes = null;
         var collectionInitializerTypes = ImmutableHashSet.CreateBuilder<TypeRef>();
+        var unionTypes = ImmutableHashSet.CreateBuilder<TypeRef>();
 
         void Consider(TypeRef? type)
         {
@@ -427,6 +428,8 @@ public static class IrImporter
                 return;
             var shape = source.ResolveShape(type);
             shapes[type] = shape;
+            if (source.IsUnionType(type))
+                unionTypes.Add(type);
             if (shape == TypeShape.Enum && source.ResolveEnumMembers(type) is { } members)
             {
                 enums ??= [];
@@ -475,6 +478,8 @@ public static class IrImporter
             function.EnumUnderlyingTypes = enumUnderlyingTypes;
         if (collectionInitializerTypes.Count > 0)
             function.CollectionInitializerTypes = collectionInitializerTypes.ToImmutable();
+        if (unionTypes.Count > 0)
+            function.UnionTypes = unionTypes.ToImmutable();
     }
 
     /// <summary>Block leaders: entry, branch and leave targets, instructions following a terminator, and every exception-region boundary.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -325,6 +325,14 @@ public sealed class IrFunction : IrNode
     public IReadOnlySet<TypeRef> CollectionInitializerTypes { get; set; }
         = ImmutableHashSet<TypeRef>.Empty;
 
+    /// <summary>
+    /// Same-assembly types proven to carry <c>UnionAttribute</c>. Used by the
+    /// metadata-free printer to spell compiler-lowered <c>union.Value is T</c>
+    /// tests back as union matching without guessing from member names alone.
+    /// </summary>
+    public IReadOnlySet<TypeRef> UnionTypes { get; set; }
+        = ImmutableHashSet<TypeRef>.Empty;
+
     public override IEnumerable<TypeRef> DirectTypes
         => Signature.Parameters.Select(p => p.Type)
             .Append(Signature.ReturnType)

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -403,6 +403,7 @@ public sealed class MetadataSource : IDisposable
     Dictionary<TypeRef, TypeRef?>? _baseTypes;
     HashSet<TypeRef>? _interfaces;
     Dictionary<TypeRef, ImmutableArray<TypeRef>>? _interfaceImpls;
+    HashSet<TypeRef>? _unionTypes;
 
     /// <summary>
     /// The C# shape of a type defined in THIS assembly — enum, struct, or
@@ -418,6 +419,13 @@ public sealed class MetadataSource : IDisposable
             return TypeShape.Unknown;
         EnsureTypeMaps();
         return _shapes!.GetValueOrDefault(type, TypeShape.Unknown);
+    }
+
+    internal bool IsUnionType(TypeRef type)
+    {
+        EnsureTypeMaps();
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        return definition is not null && _unionTypes!.Contains(definition);
     }
 
     /// <summary>
@@ -451,6 +459,7 @@ public sealed class MetadataSource : IDisposable
         var bases = new Dictionary<TypeRef, TypeRef?>();
         var interfaces = new HashSet<TypeRef>();
         var interfaceImpls = new Dictionary<TypeRef, ImmutableArray<TypeRef>>();
+        var unionTypes = new HashSet<TypeRef>();
         foreach (var handle in Reader.TypeDefinitions)
         {
             var typeDef = Reader.GetTypeDefinition(handle);
@@ -467,7 +476,11 @@ public sealed class MetadataSource : IDisposable
             bases[key] = DecodeBaseType(typeDef.BaseType, scope);
             if ((typeDef.Attributes & System.Reflection.TypeAttributes.Interface) != 0)
                 interfaces.Add(key);
-            interfaceImpls[key] = DecodeInterfaces(typeDef, scope);
+            var impls = DecodeInterfaces(typeDef, scope);
+            if (MethodDefinitionFacts.HasUnionAttribute(Reader, typeDef)
+                && impls.Any(IsUnionInterface))
+                unionTypes.Add(key);
+            interfaceImpls[key] = impls;
             if (shape == TypeShape.Enum)
             {
                 enums[key] = BuildEnumMembers(typeDef);
@@ -480,6 +493,7 @@ public sealed class MetadataSource : IDisposable
         _baseTypes = bases;
         _interfaces = interfaces;
         _interfaceImpls = interfaceImpls;
+        _unionTypes = unionTypes;
         _shapes = shapes;   // assign last: ResolveShape gates on _shapes
     }
 
@@ -492,6 +506,9 @@ public sealed class MetadataSource : IDisposable
             names.Add(Reader.GetString(Reader.GetGenericParameter(handle).Name));
         return names.MoveToImmutable();
     }
+
+    static bool IsUnionInterface(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition, Namespace: "System.Runtime.CompilerServices", Name: "IUnion" };
 
     /// <summary>The interfaces a definition directly implements, decoded with the type's own generic scope (open — concrete instances substitute later).</summary>
     ImmutableArray<TypeRef> DecodeInterfaces(TypeDefinition typeDef, GenericScope scope)

--- a/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MethodDefinitionFacts.cs
@@ -46,6 +46,9 @@ internal static class MethodDefinitionFacts
     internal static bool HasInlineArrayAttribute(MetadataReader reader, TypeDefinition type)
         => HasAttribute(reader, type.GetCustomAttributes(), "System.Runtime.CompilerServices", "InlineArrayAttribute");
 
+    internal static bool HasUnionAttribute(MetadataReader reader, TypeDefinition type)
+        => HasAttribute(reader, type.GetCustomAttributes(), "System.Runtime.CompilerServices", "UnionAttribute");
+
     // The compiler stamps ExtensionAttribute on an extension method (and on its
     // declaring class and module). The method-level mark is the precise signal.
     internal static bool HasExtensionAttribute(MetadataReader reader, MethodDefinition method)


### PR DESCRIPTION
- Advances #1917
- Changes decompiled member bodies so compiler-lowered `union.Value` type/null tests render as union matching when the union type is proven by same-assembly metadata.
- Card revision: `98a8cf54`

## Change

**Conclusion:** **REVIEW** — this is a narrow first union-matching slice: `pet.Value is Cat` → `pet is Cat`, and `pet.Value is null` → `pet is null`; switch reconstruction remains in #1917.

Before:

```csharp
return pet.Value is Cat;
return pet.Value is null;
```

After:

```csharp
return pet is Cat;
return pet is null;
```

The rewrite is gated on same-assembly metadata: the type must carry `UnionAttribute` and implement `System.Runtime.CompilerServices.IUnion`. Non-union `Value` property lookalikes stay lowered.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `TypeSourceComposerUnionTests`: 8 passed |
| Decompiler fast suite | 1728 passed |
| Build-event validation | `Summary`: 263 projects, 0 failed, 0 errors, 0 warnings; event log `20260630T024642.1955276Z-2060931-build-225aee62` |
| Real witness | Preview SDK union fixture: `UnionFixtures.Matcher::IsCat` and `::IsNull` improve |
| Near miss | Plain `PetLike.Value` and `[Union]` without runtime `IUnion` keep `.Value` |

A concurrent host build and build-event validation run produced transient `MSB3030` missing-artifact copy errors; the subsequent serial host build/test passed, so this was validation-concurrency noise per the build-event guide.

## Decompiler quality

**Conclusion:** **ADVISORY** — no corpus card included for this first targeted preview-language slice; the changed behavior is fixture-gated and requires union metadata that is not expected in the current fixed corpus. No method-body fidelity claim beyond the focused preview SDK fixture.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Findings resolved | `30385152` keeps `as` casts lowered and raises `is not null`. |
| Gemini 3.1 Pro | Blocking finding resolved | `30385152` fixes the unsigned-null path for `is not null`. |

**Review conclusion:** **PASS** — required adversarial reviews completed and reconciliation posted.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate src/ILInspector.Decompiler.Tests -- -c Release --nologo --verbosity quiet
```

