### PR TITLE
Document Research overlay architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,8 +132,8 @@ single overlay layer:
   annotated IL, and supplies IR anchors for source-line placement.
 - **Research** is the bridge. `ILInspector.Research` depends on both Analysis
   and Decompiler; neither depends back on Research or on each other. It owns the
-  offset-keyed fact overlay and the presenters behind `Annotated Source`,
-  annotated IL, and the structured `Facts` rows.
+  offset-keyed fact overlay for `Annotated Source`, annotated IL, and the
+  structured `Facts` rows.
 
 `ResearchFactRegistry` is the dogfooded analyzer registry for the overlay.
 Producers implement `IResearchFactProducer` with a stable name, produced fact
@@ -480,7 +480,7 @@ Research overlay bridge, and the application layer:
 │  ILInspector.Research (Fact overlay bridge)                 │
 │                                                             │
 │  ResearchFactRegistry       ordered fact producers           │
-│  ResearchViews              Annotated Source / IL / Facts    │
+│  ResearchViews              fact overlay for source/IL/Facts  │
 │  *FactProducer              Analysis or Decompiler adapters  │
 ├─────────────────────────────────────────────────────────────┤
 │  ILInspector.Decompiler (R2 method projection)              │
@@ -582,4 +582,4 @@ src/ILInspector.Research/       # Registered fact overlay and annotated views
 
 9. **Deliberate metadata duplication — `ILInspector.Analysis` is a standalone product** — The whole-assembly memory-safety analyzer (`ILInspector.Analysis`: `LibraryBodyIndex`, `CallTree`, the `Hollow`/`Opaque`/`UnsafeLeverage` classifications) keeps **zero project references** and re-derives its own `TypeRef` / `TypeRefDecoder` / `MemberResolver` rather than sharing the codebase's other type-identity layers (`ILInspector.Metadata`, `ILInspector.MetadataPrimitives`, and the decompiler's `Pipeline/TypeRef`). This is a committed product boundary, not drift: the three `TypeRef` models answer different questions (display string, evidence matching, codegen IR), and `Analysis`'s SRM-direct independence is load-bearing — it ships and evolves as an independent memory-safety deliverable. The full rationale, the rejected consolidation path, and the single trip-wire that would reopen it are in [docs/metadata-primitives.md](metadata-primitives.md) ("Decision (2026-06): stop after step 3").
 
-10. **Research seam for R1/R2 overlays** — `ILInspector.Research` is the accepted bridge above Analysis (R1 lower representation) and Decompiler (R2 projection/recovery representation). Research owns the `ResearchFactRegistry`, annotation producers, and annotated presenters, so new facts flow through one offset-keyed overlay instead of direct `Analysis <-> Decompiler` edges or bypass renderers.
+10. **Research seam for R1/R2 overlays** — `ILInspector.Research` is the accepted bridge above Analysis (R1 lower representation) and Decompiler (R2 projection/recovery representation). Research owns the `ResearchFactRegistry`, annotation producers, and fact-overlay presenters, so new facts flow through one offset-keyed overlay instead of direct `Analysis <-> Decompiler` edges or bypass renderers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,6 +118,40 @@ Run `dotnet-inspect skill` to print the embedded SKILL.md.
 - **Full signatures** - Parameter names included, not just types
 - **Minimal noise** - Hidden/obsolete members excluded by default
 
+## Analysis, Research, and Decompiler Evidence
+
+Method-body evidence is split by representation altitude, then joined by a
+single overlay layer:
+
+- **R1** is the lower, metadata/IL representation. `ILInspector.Analysis` reads
+  assemblies with `System.Reflection.Metadata`, builds whole-assembly indexes,
+  and produces method signals, direct-call evidence, allocation occurrences, and
+  leverage data without depending on the decompiler IR.
+- **R2** is the higher decompiler representation. `ILInspector.Decompiler`
+  imports one method into IR, raises/lowers it for C# printing, projects raw or
+  annotated IL, and supplies IR anchors for source-line placement.
+- **Research** is the bridge. `ILInspector.Research` depends on both Analysis
+  and Decompiler; neither depends back on Research or on each other. It owns the
+  offset-keyed fact overlay and the presenters behind `Annotated Source`,
+  annotated IL, and the structured `Facts` rows.
+
+`ResearchFactRegistry` is the dogfooded analyzer registry for the overlay.
+Producers implement `IResearchFactProducer` with a stable name, produced fact
+ids, dependency names, and a `Produce(ResearchFactContext)` method. The registry
+orders producers by dependencies, invokes them for an imported method, and merges
+their annotations by IL offset and descriptor id. The default registry currently
+includes:
+
+| Producer | Source | Facts |
+| -------- | ------ | ----- |
+| `AllocationOccurrenceFactProducer` | `ILInspector.Analysis` `LibraryBodyIndex` allocation occurrences | `alloc.box`, `alloc.array`, `alloc.new`, `alloc.closure`, `alloc.statemachine`, `alloc.delegate`, `alloc.enumerator` |
+| `DecompilerHiddenFactProducer` | existing decompiler annotation classifier | `unsafe.*`, `lifetime.*` |
+
+The important boundary is that Analysis remains SRM-only, NativeAOT-friendly,
+Roslyn-free, and free of `IrNode`/decompiler dependencies. New whole-assembly or
+R1 facts should be new Analysis-backed producers registered through Research,
+not direct `Decompiler -> Analysis` calls and not parallel presentation paths.
+
 ## Library Inspection
 
 The tool uses `System.Reflection.Metadata` and `System.Reflection.PortableExecutable` for low-level assembly inspection without loading assemblies into the runtime.
@@ -429,7 +463,8 @@ Packages are resolved in order:
 
 ## Project Structure
 
-The codebase is organized into four layers, from bottom (domain-agnostic) to top (application-specific):
+The codebase is organized into domain providers, shared method-body engines, the
+Research overlay bridge, and the application layer:
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
@@ -441,6 +476,26 @@ The codebase is organized into four layers, from bottom (domain-agnostic) to top
 │  Output/          Formatters, serialization pivot            │
 │  Inspectors/      App-specific inspection logic             │
 │  Options/         CLI option types                          │
+├─────────────────────────────────────────────────────────────┤
+│  ILInspector.Research (Fact overlay bridge)                 │
+│                                                             │
+│  ResearchFactRegistry       ordered fact producers           │
+│  ResearchViews              Annotated Source / IL / Facts    │
+│  *FactProducer              Analysis or Decompiler adapters  │
+├─────────────────────────────────────────────────────────────┤
+│  ILInspector.Decompiler (R2 method projection)              │
+│                                                             │
+│  IrImporter, CSharpPrinter, IlProjection                    │
+│  Per-method IR, source rendering, annotation anchors         │
+├─────────────────────────────────────────────────────────────┤
+│  ILInspector.Analysis (R1 whole-assembly evidence)          │
+│                                                             │
+│  LibraryBodyIndex, CallTree, MethodSignals                  │
+│  AllocationOccurrence, leverage, direct calls               │
+├─────────────────────────────────────────────────────────────┤
+│  ILInspector.ControlFlow (Shared kernels)                   │
+│                                                             │
+│  Block edges, dominance, dataflow fixpoint                  │
 ├─────────────────────────────────────────────────────────────┤
 │  DotnetInspector.Services (Shared services)                 │
 │                                                             │
@@ -456,7 +511,7 @@ The codebase is organized into four layers, from bottom (domain-agnostic) to top
 │  PackageExtractor, NuGetCache, TfmResolver                  │
 │  DependencyGroup, PackageDependency                         │
 ├─────────────────────────────────────────────────────────────┤
-│  ILInspector.Metadata (Domain provider — PE/Assembly)   │
+│  ILInspector.Metadata (Domain provider — PE/Assembly)       │
 │                                                             │
 │  AssemblyReader, ApiSurface models, PdbReader                │
 └─────────────────────────────────────────────────────────────┘
@@ -466,6 +521,9 @@ The codebase is organized into four layers, from bottom (domain-agnostic) to top
 
 - **Domain providers** are application-agnostic. They know about NuGet packages and PE files, not about dotnet-inspect.
 - **Services** return DTOs (`NuspecData`, `DepsJsonData`, `PackageMetadata`), never mutate app types. They use `Action<string>?` for logging instead of app-specific logger types.
+- **Analysis** owns R1 whole-assembly evidence and must not depend on the decompiler IR, Roslyn, or inspected-assembly loading.
+- **Decompiler** owns R2 method projection and rendering evidence, not whole-assembly analysis indexes.
+- **Research** is the only bridge between Analysis and Decompiler evidence. New overlay facts register as producers; presenters consume the merged offset-keyed overlay.
 - **Models** are pure data with no Markout references. JSON conditional attributes (`[JsonIgnore(Condition = ...)]`) are acceptable since they control data serialization, not presentation.
 - **Views** wrap models and own all Markout attributes, sections, field builders, and computed display properties. They are the only types registered in `MarkoutContext`.
 - **Commands** orchestrate: they call services, populate models, and hand off to `OutputFormatter`. Most commands should not import Markout directly.
@@ -497,7 +555,11 @@ src/dotnet-inspect/
 
 src/DotnetInspector.Services/   # Shared, app-agnostic services
 src/DotnetInspector.Packages/   # NuGet domain provider
-src/ILInspector.Metadata/   # PE/assembly domain provider
+src/ILInspector.Metadata/       # PE/assembly domain provider
+src/ILInspector.ControlFlow/    # Shared control-flow/dataflow kernels
+src/ILInspector.Analysis/       # R1 whole-assembly method-body evidence
+src/ILInspector.Decompiler/     # R2 per-method IR and source/IL projection
+src/ILInspector.Research/       # Registered fact overlay and annotated views
 ```
 
 ## Key Design Decisions
@@ -518,4 +580,6 @@ src/ILInspector.Metadata/   # PE/assembly domain provider
 
 8. **Signature-first output** — Full method signatures with parameter names are the primary output, not just type names, because LLMs need complete information to generate correct code.
 
-9. **Deliberate metadata duplication — `ILInspector.Analysis` is a standalone product** — The whole-assembly memory-safety analyzer (`ILInspector.Analysis`: `LibraryBodyIndex`, `CallTree`, the `Hollow`/`Opaque`/`UnsafeLeverage` classifications) keeps **zero project references** and re-derives its own `TypeRef` / `TypeRefDecoder` / `MemberResolver` rather than sharing the codebase's other type-identity layers (`ILInspector.Metadata`, `ILInspector.MetadataPrimitives`, and the decompiler's `Pipeline/TypeRef`). This is a committed product boundary, not drift: the three `TypeRef` models answer different questions (display string, evidence matching, codegen IR), and `Analysis`'s SRM-direct independence is load-bearing — it ships and evolves as an independent memory-safety deliverable. The full rationale, the rejected consolidation path, and the single trip-wire that would reopen it are in [docs/metadata-primitives.md](metadata-primitives.md) ("Decision (2026-06): stop after step 3"). The two analysis subsystems are also distinct: `ILInspector.Decompiler.Annotations` (hidden-fact *annotations* on the decompiler IR — "where in this method are the allocations/unsafe ops?") versus the `ILInspector.Analysis` assembly ("which methods across this assembly require `unsafe`, and who calls them?").
+9. **Deliberate metadata duplication — `ILInspector.Analysis` is a standalone product** — The whole-assembly memory-safety analyzer (`ILInspector.Analysis`: `LibraryBodyIndex`, `CallTree`, the `Hollow`/`Opaque`/`UnsafeLeverage` classifications) keeps **zero project references** and re-derives its own `TypeRef` / `TypeRefDecoder` / `MemberResolver` rather than sharing the codebase's other type-identity layers (`ILInspector.Metadata`, `ILInspector.MetadataPrimitives`, and the decompiler's `Pipeline/TypeRef`). This is a committed product boundary, not drift: the three `TypeRef` models answer different questions (display string, evidence matching, codegen IR), and `Analysis`'s SRM-direct independence is load-bearing — it ships and evolves as an independent memory-safety deliverable. The full rationale, the rejected consolidation path, and the single trip-wire that would reopen it are in [docs/metadata-primitives.md](metadata-primitives.md) ("Decision (2026-06): stop after step 3").
+
+10. **Research seam for R1/R2 overlays** — `ILInspector.Research` is the accepted bridge above Analysis (R1 lower representation) and Decompiler (R2 projection/recovery representation). Research owns the `ResearchFactRegistry`, annotation producers, and annotated presenters, so new facts flow through one offset-keyed overlay instead of direct `Analysis <-> Decompiler` edges or bypass renderers.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -8,12 +8,13 @@ It is built for both humans and agents. Markdown is the default output because h
 
 - `src/dotnet-inspect/` contains the CLI, command routing, parsers, options, output views, section descriptors, and inspectors.
 - `src/ILInspector.Metadata/` reads PE metadata, API surfaces, SourceLink/PDB data, method classification, and assembly details.
-- `src/ILInspector.Analysis/` indexes IL method-body evidence such as direct call sites without decompiling to C#.
+- `src/ILInspector.Analysis/` indexes IL method-body evidence such as direct call sites, allocation occurrences, method signals, and whole-assembly leverage without decompiling to C#.
 - `src/ILInspector.Analysis.App/` is a temporary console harness for exercising Analysis queries until CLI wiring exists.
 - `src/ILInspector.ControlFlow/` contains shared block-edge, dominance, and dataflow kernels used below Analysis and Decompiler without depending on either.
 - `src/DotnetInspector.Packages/` handles NuGet package extraction, package/source caches, feeds, symbol package acquisition, and version resolution.
 - `src/DotnetInspector.Services/` contains shared services such as platform/package resolution, dependency resolution, signatures, source fetching, and nuspec parsing.
 - `src/ILInspector.Decompiler/` emits lowered C#, raw IL, and annotated IL from method bodies.
+- `src/ILInspector.Research/` owns the offset-keyed fact overlay above Analysis and Decompiler: its registry orders fact producers, joins R1 analysis occurrences with R2 decompiler projections, and renders the annotated source/IL/Facts views used by `member`.
 
 ## Agent contract
 
@@ -25,6 +26,7 @@ Agents working in this repo should preserve these principles:
 4. Preserve the progressive-disclosure model: verbosity for curated defaults, `-D`/`-S` for query and backpressure, opt-in sections for expensive work, and `-S @All` only for intentional exhaustive output.
 5. Use built-in query/limiter concepts (`-D`, `-S`, `--columns`, `--fields`, `--count`, `--rows`) instead of shell-pipe workarounds when possible.
 6. Treat cache schema changes as versioned categories and invalidate/clean stale metadata caches deliberately.
+7. Preserve the R1/R2 boundary for method-body evidence: Analysis and ControlFlow stay SRM-only and decompiler-IR-free, while Research is the bridge that projects registered producers into user-visible annotation views.
 
 ## Important systems
 
@@ -35,6 +37,7 @@ Agents working in this repo should preserve these principles:
 - [Progressive disclosure](design/progressive-disclosure.md): verbosity, `-D`/`-S`, opt-in sections, `-S @All`, and limiter behavior.
 - [Integrations](design/integrations.md): library ecosystem integration roll-ups and focused API currency.
 - [Section model](design/section-model.md): section selection and query behavior.
+- [Hidden-fact annotations](design/hidden-fact-annotations.md): offset-keyed fact overlay semantics, validation, and projections.
 - [Member Index](design/member-index.md): overload selector and digest contract.
 - [Member ordering](design/member-order.md): canonical type/member section order and member-kind mapping.
 - [Version resolution](design/version-resolution.md): package/platform version and cache behavior.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,8 +13,8 @@ It is built for both humans and agents. Markdown is the default output because h
 - `src/ILInspector.ControlFlow/` contains shared block-edge, dominance, and dataflow kernels used below Analysis and Decompiler without depending on either.
 - `src/DotnetInspector.Packages/` handles NuGet package extraction, package/source caches, feeds, symbol package acquisition, and version resolution.
 - `src/DotnetInspector.Services/` contains shared services such as platform/package resolution, dependency resolution, signatures, source fetching, and nuspec parsing.
-- `src/ILInspector.Decompiler/` emits lowered C#, raw IL, and annotated IL from method bodies.
-- `src/ILInspector.Research/` owns the offset-keyed fact overlay above Analysis and Decompiler: its registry orders fact producers, joins R1 analysis occurrences with R2 decompiler projections, and renders the annotated source/IL/Facts views used by `member`.
+- `src/ILInspector.Decompiler/` emits lowered C#, raw IL, and structural annotated IL from method bodies.
+- `src/ILInspector.Research/` owns the offset-keyed fact overlay above Analysis and Decompiler: its registry orders fact producers, joins R1 analysis occurrences with R2 decompiler projections, and projects facts into the Annotated Source, annotated IL, and Facts views used by `member`.
 
 ## Agent contract
 


### PR DESCRIPTION
## Summary

- Document `ILInspector.Research` as the overlay bridge above Analysis and Decompiler.
- Describe the `ResearchFactRegistry` producer model and current default producers.
- Refresh the project-structure and layer rules for the R1/R2 evidence boundary.

## Validation

- `npx markdownlint-cli --fix docs/overview.md docs/architecture.md && npx markdownlint-cli docs/overview.md docs/architecture.md`

Docs-only change. No adversarial review needed. Build-event diagnostics were not used because this is documentation-only work with markdownlint as the relevant proof.
