### PR TITLE
Round-trip constructor auto-property initializers

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -95,6 +95,36 @@ public class FidelityCheckGeneratedFilterTests
         }
     }
 
+    [Fact]
+    public void Evaluate_RoundTripsConstructorAssignedAutoProperties()
+    {
+        var assemblyPath = CompileFixture("""
+            public class AutoPropertyPairFixture
+            {
+                public AutoPropertyPairFixture(int left, int right)
+                {
+                    Left = left;
+                    Right = right;
+                }
+
+                public int Left { get; }
+                public int Right { get; }
+            }
+            """);
+        try
+        {
+            var ctor = Assert.Single(
+                FidelityCheck.Evaluate(assemblyPath),
+                result => result.Type == "AutoPropertyPairFixture" && result.Method == ".ctor");
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, ctor.Status);
+        }
+        finally
+        {
+            File.Delete(assemblyPath);
+        }
+    }
+
     static string CompileFixture(string source)
     {
         var path = Path.Combine(Path.GetTempPath(), $"fidelity-generated-filter-{Guid.NewGuid():N}.dll");

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1017,7 +1017,9 @@ static class FidelityCheck
             if (!parameterNames.TryGetValue(value.Index - 1, out string? parameterName))
                 return null;
 
-            initializers.Add((store.Field.Name, parameterName));
+            string name = AutoPropertyNameForBackingField(reader, declaringType, store.Field.Name)
+                ?? store.Field.Name;
+            initializers.Add((name, parameterName));
         }
 
         if (initializers.Count == 0)
@@ -1914,7 +1916,7 @@ static class FidelityCheck
         // defensive copy against a mutable stub, changing the target's opcodes.
         var stubPropertyAccessors = new HashSet<MethodDefinitionHandle>();
         if (keyword == "class")
-            EmitStubProperties(reader, typeDef, targets, accessibility, stubPropertyAccessors, sb, pad + "    ");
+            EmitStubProperties(reader, typeDef, targets, accessibility, thisFieldInits, stubPropertyAccessors, sb, pad + "    ");
 
         foreach (var mh in typeDef.GetMethods())
         {
@@ -2083,7 +2085,8 @@ static class FidelityCheck
     /// </summary>
     static void EmitStubProperties(MetadataReader reader, TypeDefinition typeDef,
         IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets,
-        SignatureAccessibility accessibility, HashSet<MethodDefinitionHandle> skipAccessors, StringBuilder sb, string pad)
+        SignatureAccessibility accessibility, IReadOnlyList<(string Field, string Value)> fieldInits,
+        HashSet<MethodDefinitionHandle> skipAccessors, StringBuilder sb, string pad)
     {
         var typeContext = GenericContext.ForType(reader, typeDef);
         foreach (var ph in typeDef.GetProperties())
@@ -2130,8 +2133,11 @@ static class FidelityCheck
                     continue;
                 if (isAutoProperty)
                 {
+                    string initializer = fieldInits.FirstOrDefault(init => init.Field == pname).Value is { } value
+                        ? $" = {value};"
+                        : "";
                     string autoBody = " get;" + (hasSet ? " set;" : "");
-                    sb.AppendLine($"{pad}public {modifier}{unsafeMod}{ret} {Identifier(pname)} {{{autoBody} }}");
+                    sb.AppendLine($"{pad}public {modifier}{unsafeMod}{ret} {Identifier(pname)} {{{autoBody} }}{initializer}");
                     if (!pa.Getter.IsNil) skipAccessors.Add(pa.Getter);
                     if (!pa.Setter.IsNil) skipAccessors.Add(pa.Setter);
                     continue;
@@ -2173,6 +2179,21 @@ static class FidelityCheck
             }
         }
         return false;
+    }
+
+    static string? AutoPropertyNameForBackingField(MetadataReader reader, TypeDefinition typeDef, string fieldName)
+    {
+        if (!fieldName.StartsWith('<') || !fieldName.EndsWith(">k__BackingField", StringComparison.Ordinal))
+            return null;
+
+        string propertyName = fieldName[1..^">k__BackingField".Length];
+        foreach (var propertyHandle in typeDef.GetProperties())
+        {
+            var property = reader.GetPropertyDefinition(propertyHandle);
+            if (reader.GetString(property.Name) == propertyName)
+                return propertyName;
+        }
+        return null;
     }
 
     static bool AccessorsAreCompilerGenerated(MetadataReader reader, PropertyAccessors accessors)


### PR DESCRIPTION
- Uses #1897 Humanizer artifact selection
- Fixes the selected `Humanizer.ByteRate::.ctor` compile-back skeleton opcode diff
- Card revision: `fd718fe0`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — `ByteRate::.ctor` moves from OpcodeDiff to Exact by teaching the compile-back skeleton to emit primary-constructor auto-property initializers for constructor-assigned backing fields.

Before:

```text
ByteRate::.ctor: OpcodeDiff
orig : ldarg ldarg stfld ldarg ldarg stfld ldarg call ret
recmp: ldarg call ldarg ldarg stfld ldarg ldarg stfld ret
```

After:

```text
ByteRate focused run: exact 4/5, OpcodeDiff 0, RecompileFail 1
Humanizer cap 1000: exact 604, OpcodeDiff 214
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `FidelityCheckGeneratedFilterTests` passed, including constructor-assigned auto-property exactness |
| Decompiler fast suite | Pass: 1726 tests |
| Humanizer focused fidelity | Pass: `CB_TYPE=ByteRate` gives `exact 4`, `OpcodeDiff 0`, `RecompileFail 1` |
| Humanizer cap 1000 | Pass: selected `ByteRate::.ctor` diff removed; `exact 604`, `OpcodeDiff 214` |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — product decompiler output is unchanged. This is a compile-back skeleton/context fix: it reconstructs constructor-assigned auto-property backing fields as primary-constructor auto-property initializers so the skeleton can reproduce the compiler's before-`base()` field-store order.

`Humanizer.ByteSize::Equals` was triaged first and blocked: preserving the redundant struct copy in IR/source still recompiles without the redundant `ldloc; stloc`, so it remains a compile-back/source-shape frontier rather than this focused fix.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked scope/no product change, backing-field mapping, false-positive guards, primary-constructor detection safety, opcode-order correctness, and Humanizer evidence. |
| Gemini 3.1 Pro | No blocking findings | Checked primary-constructor detection, backing-field-to-property mapping, initializer emission, product-path isolation, false-positive guards, accessor interaction, and Humanizer evidence. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*FidelityCheckGeneratedFilterTests"
CB_TYPE=ByteRate dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 20 --max-examples 5 --fidelity-timings
/usr/bin/time -f 'elapsed=%E cpu=%P maxrss=%MKB' dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 1000 --max-examples 5 --fidelity-timings
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
git diff --check
```
