### PR TITLE
Raise union declaration patterns

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -229,6 +229,34 @@ public class TypeSourceComposerUnionTests
     }
 
     [Fact]
+    public async Task UnionDeclarationPattern_RendersAgainstUnion()
+    {
+        using var assembly = await CompileWithSdk("""
+            namespace UnionFixtures;
+
+            public sealed class Cat { public string Name { get; } = "cat"; }
+            public sealed class Dog { }
+            public union Pet(Cat, Dog);
+
+            public static class Matcher
+            {
+                public static bool HasNamedCat(Pet pet) => pet is Cat cat && cat.Name.Length > 0;
+
+                public static string IfDeclaration(Pet pet)
+                {
+                    if (pet is Cat cat)
+                        return cat.Name;
+                    return "none";
+                }
+            }
+            """);
+
+        Assert.Equal("return pet is Cat cat && cat.Name.Length > 0;",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "HasNamedCat"));
+        Assert.Contains("if (pet is Cat cat)", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IfDeclaration"));
+    }
+
+    [Fact]
     public void NonUnionValuePropertyTypeTest_KeepsValueAccess()
     {
         using var assembly = Compile("""
@@ -247,12 +275,18 @@ public class TypeSourceComposerUnionTests
                 {
                     public static bool IsCat(PetLike pet) => pet.Value is Cat;
                     public static bool IsNull(PetLike pet) => pet.Value is null;
+                    public static bool HasCat(PetLike pet)
+                    {
+                        Cat cat = pet.Value as Cat;
+                        return cat is not null;
+                    }
                 }
             }
             """);
 
         Assert.Equal("return pet.Value is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCat"));
         Assert.Equal("return pet.Value is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
+        Assert.Equal("return pet.Value is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "HasCat"));
     }
 
     [Fact]
@@ -334,7 +368,7 @@ public class TypeSourceComposerUnionTests
             "Union fixture must build with the preview SDK, got exit "
             + result.ExitCode + "\n--- output ---\n" + result.Output + "\n--- source ---\n" + source);
 
-        string dll = Path.Combine(project.Path, "bin", "Debug", "net11.0", "union-fixture.dll");
+        string dll = Path.Combine(project.Path, "bin", "Release", "net11.0", "union-fixture.dll");
         return new TempAssembly(dll, project);
     }
 
@@ -386,7 +420,7 @@ public class TypeSourceComposerUnionTests
 
     static async Task<(int ExitCode, string Output)> RunDotnetBuild(string workingDirectory)
     {
-        var psi = new ProcessStartInfo("dotnet", "build --nologo --verbosity quiet")
+        var psi = new ProcessStartInfo("dotnet", "build -c Release --nologo --verbosity quiet")
         {
             WorkingDirectory = workingDirectory,
             RedirectStandardOutput = true,

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1787,7 +1787,7 @@ public sealed partial class CSharpPrinter
         StackAllocArray s => $"stackalloc {TypeText(s.ElementType)}[{Expression(s.Count)}]",
         Box b => Expression(b.Operand),
         IsInstance i => $"{Operand(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
-        IsPattern p => $"{Operand(p.Value)} is {TypeText(p.Type)} {LocalName(p.LocalIndex)}",
+        IsPattern p => $"{TypeTestValueText(p.Value)} is {TypeText(p.Type)} {LocalName(p.LocalIndex)}",
         RecursivePropertyDeclarationPattern p => $"{Operand(p.Value)} is {{ {p.PropertyName}: {TypeText(p.PatternType)} {LocalName(p.LocalIndex)} }}",
         SingleElementListPattern p => $"{Operand(p.Value)} is [{ListPatternAlternativesText(p)}]",
         PositionalPattern p => PositionalPatternText(p),

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -75,7 +75,7 @@ public sealed class IsPatternPass : IIrPass
 
                 // The tested value is inlined into the pattern, so it must not
                 // depend on the pattern local and must be reorder-safe.
-                if (ReferenceOwnership.SubtreeReferencesLocal(asCast.Operand, store.Index) || !IsSideEffectFree(asCast.Operand))
+                if (ReferenceOwnership.SubtreeReferencesLocal(asCast.Operand, store.Index) || !IsSideEffectFree(function, asCast.Operand))
                     continue;
 
                 if (FindTest(children[i + 1], store.Index) is not { } site)
@@ -409,16 +409,33 @@ public sealed class IsPatternPass : IIrPass
     /// arguments, fields, and constants, plus reference conversions over them.
     /// Excludes calls (including property getters), allocations, and increments.
     /// </summary>
-    static bool IsSideEffectFree(IrExpression expr) => expr switch
+    static bool IsSideEffectFree(IrFunction function, IrExpression expr) => expr switch
     {
         Constant or LoadLocal or LoadArgument or LoadLocalAddress or LoadArgumentAddress => true,
-        LoadField field => field.Instance is null || IsSideEffectFree(field.Instance),
-        LoadFieldAddress fieldAddress => fieldAddress.Instance is null || IsSideEffectFree(fieldAddress.Instance),
-        Convert convert => IsSideEffectFree(convert.Operand),
-        CastClass cast => IsSideEffectFree(cast.Operand),
-        IsInstance isInstance => IsSideEffectFree(isInstance.Operand),
+        LoadField field => field.Instance is null || IsSideEffectFree(function, field.Instance),
+        LoadFieldAddress fieldAddress => fieldAddress.Instance is null || IsSideEffectFree(function, fieldAddress.Instance),
+        LoadProperty property when IsUnionValueProperty(function, property) => IsSimpleUnionValueReceiver(property.Instance),
+        Convert convert => IsSideEffectFree(function, convert.Operand),
+        CastClass cast => IsSideEffectFree(function, cast.Operand),
+        IsInstance isInstance => IsSideEffectFree(function, isInstance.Operand),
         _ => false,
     };
+
+    static bool IsUnionValueProperty(IrFunction function, LoadProperty property)
+        => property.PropertyName == "Value"
+        && property.IndexArguments.Count == 0
+        && function.UnionTypes.Contains(NamedDefinition(property.Accessor.DeclaringType));
+
+    static bool IsSimpleUnionValueReceiver(IrExpression? receiver) => receiver switch
+    {
+        LoadArgumentAddress or LoadArgument or LoadLocalAddress or LoadLocal => true,
+        LoadFieldAddress field => field.Instance is null || IsSimpleUnionValueReceiver(field.Instance),
+        LoadField field => field.Instance is null || IsSimpleUnionValueReceiver(field.Instance),
+        _ => false,
+    };
+
+    static TypeRef NamedDefinition(TypeRef type)
+        => type is { Kind: TypeRefKind.GenericInstance, ElementType: { } definition } ? definition : type;
 
     static bool HasSourceLocalName(IrFunction function, int index)
         => index >= 0


### PR DESCRIPTION
- Advances #1917
- Changes declaration-pattern output so compiler-lowered `Cat cat = pet.Value as Cat; if/&& cat is not null ...` renders as `pet is Cat cat` when the receiver type is proven union metadata.
- Card revision: `1be63871`

## Change

**Conclusion:** **REVIEW** — this is the next narrow union-matching slice: declaration patterns over proven union `Value` getters on simple receivers. Union switch-expression reconstruction remains follow-up work.

Before:

```csharp
Cat cat = pet.Value as Cat;
if (cat is not null)
{
    return cat.Name;
}
```

After:

```csharp
if (pet is Cat cat)
{
    return cat.Name;
}
```

The pass only treats proven union `Value` getters as reorder-safe when the receiver is a simple argument/local/field shape that the printer can render back as the union receiver. Non-union `Value` property lookalikes still keep `.Value`.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `TypeSourceComposerUnionTests`: 9 passed |
| Decompiler fast suite | 1730 passed |
| Build-event validation | `Summary`: 263 projects, 0 failed, 0 errors, 0 warnings; event log `20260630T035014.3810925Z-2145541-build-5164deb1` |
| Real witness | Preview SDK union fixture: `HasNamedCat` renders `pet is Cat cat && ...`; `IfDeclaration` renders `if (pet is Cat cat)` |
| Near miss | Plain `PetLike.Value` declaration-pattern lowering keeps `.Value` |

## Decompiler quality

**Conclusion:** **ADVISORY** — no corpus card included for this preview-language targeted slice; behavior is fixture-gated on union metadata and is not expected to affect the current fixed corpus. No broader switch-expression reconstruction claimed.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Conservative gating and valid fallback confirmed. |
| Gemini 3.1 Pro | No blocking findings | Side-effect ordering, ref/address receiver handling, generics, and false-positive gates confirmed. |

**Review conclusion:** **PASS** — required adversarial reviews completed; no follow-up changes required.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate src/ILInspector.Decompiler.Tests -- -c Release --nologo --verbosity quiet
```

