### PR TITLE
Raise declaration patterns with else arms

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -248,12 +248,19 @@ public class TypeSourceComposerUnionTests
                         return cat.Name;
                     return "none";
                 }
+
+                public static string SwitchWithDefault(Pet pet) => pet switch
+                {
+                    Cat cat => cat.Name,
+                    _ => "other",
+                };
             }
             """);
 
         Assert.Equal("return pet is Cat cat && cat.Name.Length > 0;",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "HasNamedCat"));
         Assert.Contains("if (pet is Cat cat)", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IfDeclaration"));
+        Assert.Contains("if (pet is Cat cat)", RenderMember(assembly.Path, "UnionFixtures.Matcher", "SwitchWithDefault"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -260,7 +260,16 @@ public class TypeSourceComposerUnionTests
         Assert.Equal("return pet is Cat cat && cat.Name.Length > 0;",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "HasNamedCat"));
         Assert.Contains("if (pet is Cat cat)", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IfDeclaration"));
-        Assert.Contains("if (pet is Cat cat)", RenderMember(assembly.Path, "UnionFixtures.Matcher", "SwitchWithDefault"));
+        Assert.Equal("""
+            if (pet is Cat cat)
+            {
+                return cat.Name;
+            }
+            else
+            {
+                return "other";
+            }
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "SwitchWithDefault"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -6,7 +6,7 @@ namespace ILInspector.Decompiler.Pipeline;
 /// boolean folding:
 /// <code>
 ///   T t = value as T;          // StoreLocal t = IsInstance T(value)
-///   if (t != null) { ...t... } // statement guard
+///   if (t != null) { ...t... } // statement guard, optional else that cannot use t
 ///   // or, as a short-circuit expression:
 ///   ... t != null &amp;&amp; ...t... // LogicalAnd(LoadLocal t, rest)
 /// </code>
@@ -17,7 +17,8 @@ namespace ILInspector.Decompiler.Pipeline;
 /// <c>T t = value as T; if (t is not null) { ... }</c> — the owed
 /// <c>is</c>-pattern idiom. Transactional: the pattern local must be referenced
 /// only by the <c>as</c> store, the null test being replaced, and the scope the
-/// test gates (the <c>if</c>-body or the <c>&amp;&amp;</c> right operand), and
+/// test gates (the <c>if</c>-body or the <c>&amp;&amp;</c> right operand — not an
+/// <c>else</c> arm), and
 /// the tested value must be side-effect-free so moving it into the pattern
 /// cannot reorder observable effects. Otherwise the construct is left flat.</para>
 ///
@@ -388,9 +389,10 @@ public sealed class IsPatternPass : IIrPass
             }
         }
 
-        // Statement-guard form: `if (t != null) { ...t... }` — the whole
-        // condition is the bare truthy load; the then-arm is the gated scope.
-        if (next is IfStatement { Condition: LoadLocal guardLoad } guard && guardLoad.Index == index && guard.Else is null)
+        // Statement-guard form: `if (t != null) { ...t... } else { ... }` —
+        // only the then-arm is gated by the successful pattern. The caller's
+        // LocalReferencesOnlyWithin check rejects any else-arm use of t.
+        if (next is IfStatement { Condition: LoadLocal guardLoad } guard && guardLoad.Index == index)
             return new TestSite(guard.Condition, guard.Then);
 
         return null;


### PR DESCRIPTION
- Advances #1917
- Changes declaration-pattern raising to handle adjacent `as`/null-test `if` statements that have an `else` arm, enabling the union switch-with-default lowering to render `if (pet is Cat cat) ... else ...` instead of keeping `pet.Value as Cat`.
- Card revision: `e42e9736`

## Change

**Conclusion:** **REVIEW** — this is a narrow switch-frontier slice, not full multi-arm switch-expression reconstruction. It improves the preview-SDK `pet switch { Cat cat => ..., _ => ... }` lowering by allowing the existing declaration-pattern pass to raise the guarded `if/else` form.

Before:

```csharp
Cat cat = pet.Value as Cat;
if (cat is not null)
{
    return cat.Name;
}
else
{
    return "other";
}
```

After:

```csharp
if (pet is Cat cat)
{
    return cat.Name;
}
else
{
    return "other";
}
```

The existing `LocalReferencesOnlyWithin` gate still rejects any `else` arm that uses the pattern local, so the pattern variable remains scoped only to the successful arm.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `TypeSourceComposerUnionTests`: 9 passed |
| Decompiler fast suite | 1731 passed |
| Build-event validation | `Summary`: 263 projects, 0 failed, 0 errors, 0 warnings; event log `20260630T042418.0286101Z-2191631-build-568e28f2` |
| Real witness | Preview SDK union fixture: `SwitchWithDefault` now contains `if (pet is Cat cat)` |

## Decompiler quality

**Conclusion:** **ADVISORY** — no corpus card included for this targeted preview-language slice; behavior is fixture-gated around an existing pattern-raise pass and not expected to affect the current fixed corpus materially. Full multi-arm union switch-expression reconstruction remains follow-up #1917 work.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | No blocking findings | Test-strength concern fixed in `0c8d426b`. |
| Claude Opus 4.8 | No blocking findings | Same test-strength concern already fixed; local-use gate verified. |

**Review conclusion:** **PASS** — required adversarial reviews completed and the only review guidance was resolved.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate src/ILInspector.Decompiler.Tests -- -c Release --nologo --verbosity quiet
```

