### PR TITLE
Emit struct object overrides in fidelity skeletons

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -125,6 +125,39 @@ public class FidelityCheckGeneratedFilterTests
         }
     }
 
+    [Fact]
+    public void Evaluate_RoundTripsStructObjectToStringDispatch()
+    {
+        var assemblyPath = CompileFixture("""
+            public readonly struct StructWithToString
+            {
+                public override string ToString() => "value";
+            }
+
+            public static class StructWithToStringExtensions
+            {
+                public static string Humanize(this StructWithToString value, string? format)
+                {
+                    if (!string.IsNullOrWhiteSpace(format))
+                        return format;
+                    return value.ToString();
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(
+                FidelityCheck.Evaluate(assemblyPath),
+                result => result.Type == "StructWithToStringExtensions" && result.Method == "Humanize");
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+        }
+        finally
+        {
+            File.Delete(assemblyPath);
+        }
+    }
+
     static string CompileFixture(string source)
     {
         var path = Path.Combine(Path.GetTempPath(), $"fidelity-generated-filter-{Guid.NewGuid():N}.dll");

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2385,13 +2385,37 @@ static class FidelityCheck
             ? "async "
             : "";
         string unsafeModifier = asyncModifier.Length == 0 ? "unsafe " : "";
+        string slotModifier = StructObjectOverrideModifier(reader, typeDef, method, name, returnType, sig.ParameterTypes.Length);
         if (name.StartsWith("op_", StringComparison.Ordinal)
             && OperatorDeclaration(name, returnType, parameters) is { } operatorDeclaration)
         {
             sb.AppendLine($"{pad}public {unsafeModifier}static {operatorDeclaration} {{{body}}}");
             return;
         }
-        sb.AppendLine($"{pad}public {unsafeModifier}{(isStatic ? "static " : "")}{asyncModifier}{returnType} {Identifier(name)}{genParams}({parameters}){whereClauses} {{{body}}}");
+        sb.AppendLine($"{pad}public {unsafeModifier}{(isStatic ? "static " : slotModifier)}{asyncModifier}{returnType} {Identifier(name)}{genParams}({parameters}){whereClauses} {{{body}}}");
+    }
+
+    static string StructObjectOverrideModifier(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        MethodDefinition method,
+        string name,
+        string returnType,
+        int parameterCount)
+    {
+        if (ShapeOf(reader, typeDef) != TypeKind.Struct
+            || method.Attributes.HasFlag(MethodAttributes.Static)
+            || !method.Attributes.HasFlag(MethodAttributes.Virtual)
+            || method.Attributes.HasFlag(MethodAttributes.NewSlot))
+            return "";
+
+        return (name, returnType, parameterCount) switch
+        {
+            ("ToString", "string", 0) => "override ",
+            ("GetHashCode", "int", 0) => "override ",
+            ("Equals", "bool", 1) => "override ",
+            _ => "",
+        };
     }
 
     static string? OperatorDeclaration(string name, string returnType, string parameters)


### PR DESCRIPTION
- Uses #1897 Humanizer artifact selection
- Fixes `Humanizer.ByteSizeExtensions::Humanize` compile-back skeleton opcode diff
- Card revision: `7d2d7e8b`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — `ByteSizeExtensions::Humanize` moves from OpcodeDiff to Exact by emitting struct `object` overrides in compile-back skeletons.

Before:

```text
orig : ... constrained. callvirt ret
recmp: ... call ret
```

After:

```text
ByteSizeExtensions focused run: exact 51/51, OpcodeDiff 0, RecompileFail 0
Humanizer cap 1000: exact 605, OpcodeDiff 213
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` |
| Focused tests | Pass: `FidelityCheckGeneratedFilterTests` passed, including struct `ToString` extension exactness |
| Decompiler fast suite | Pass: 1732 tests |
| Humanizer focused fidelity | Pass: `CB_TYPE=ByteSizeExtensions` gives `exact 51`, `OpcodeDiff 0`, `RecompileFail 0` |
| Humanizer cap 1000 | Pass: selected `ByteSizeExtensions::Humanize` diff removed; `exact 605`, `OpcodeDiff 213` |

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS** — product decompiler output is unchanged. This is a compile-back skeleton/context fix: struct `ToString`/`Equals(object)`/`GetHashCode` overrides are emitted with `override` so C# recompiles value-type object dispatch as constrained `callvirt` instead of a direct `call`.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked override/slot detection empirically, signature safety, struct-only scope, product-path isolation, modifier ordering, and focused regression coverage. |
| Gemini 3.1 Pro | No blocking findings | Checked slot detection, struct-only scope, no product-path changes, overload/signature safety, synthetic skeleton interaction, Humanizer evidence, and scope narrowness. |

**Review conclusion:** **PASS** — no follow-up changes were required after review.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*FidelityCheckGeneratedFilterTests"
CB_TYPE=ByteSizeExtensions dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 80 --max-examples 5 --fidelity-timings
/usr/bin/time -f 'elapsed=%E cpu=%P maxrss=%MKB' dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 1000 --max-examples 5 --fidelity-timings
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
git diff --check
```
