### PR TITLE
Update print row projection skill guidance

### DIFF
--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -26,7 +26,7 @@ Default output is Markdown. Pick a machine or compact shape when you need one:
 - `--json` — structured documents.
 - `--bare` — one undecorated payload or URL list.
 - `--count` — a bare row count.
-- `--print` — print one document behind a selected section row; use `-n N` or numeric shorthand like `-2` when multiple printable rows exist.
+- `--print` — print one document behind a selected printable row; use `--row N` when multiple printable rows exist.
 - `--print-all` — print every printable row from one selected section, with text separators or one JSON object per row under `--jsonl`.
 - `--mermaid` — graph-shaped output.
 
@@ -53,7 +53,7 @@ Prefer built-in limits to shell pipes:
 - `-n N` and numeric shorthand like `-6` cap output lines, like `head`.
 - `--tail N` shows the end, like `tail`.
 - `--rows` makes `-n` cap Markdown table data rows instead of output lines.
-- With `--print`, `-n N` chooses the Nth printable row instead of limiting output lines.
+- With `--print`, `--row N` chooses the Nth printable row; `-n N` still limits printed document lines.
 - `--count` counts rows in one selected table.
 
 Command-specific caps: `-t N` for type/find rows, `-m N` for members, and

--- a/skills/sourcelink/SKILL.md
+++ b/skills/sourcelink/SKILL.md
@@ -31,17 +31,22 @@ dnx dotnet-inspect -y -- member Type Method:1 -S "Source Locations"
 
 `-S "Original Source"` returns the original source body when SourceLink can
 resolve it (also part of the `-S @Source` bundle alongside the decompiled and IL
-views).
+views). Use `--print` to fetch the source body behind one printable SourceLink
+row; add `--row N` when the selected section has multiple printable rows.
 
 ```bash
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json Serialize:1 -S "Original Source"
+dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Source Files" --print --row 1
+dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Serialize -S "Source Locations" --print --row 1
+dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Source Files" --print-all --jsonl
 ```
 
 ## URL forms
 
-PDBs *carry* SourceLink data; they are not SourceLink themselves. SourceLink URLs
-default to raw/fetchable form; add `--blob` for browser URLs. Use `--bare` to
-extract a clean URL list for scripting.
+PDBs *carry* SourceLink data; they are not SourceLink themselves. SourceLink URL
+rows default to raw/fetchable form; add `--blob` for browser URLs. Use `--bare`
+to extract a clean URL list for scripting; use `--print` when you want the
+referenced source body.
 
 ```bash
 dnx dotnet-inspect -y -- member Type Method:1 -S "Source Locations" --bare


### PR DESCRIPTION
## Summary

Fixes #1938.

Updates the embedded skill guidance after #1935 settled the print projection UX:

- `skills/query`: documents `--print`, `--print-all`, `--row N`, and keeps `-n N` as head/output limiting for printed content.
- `skills/sourcelink`: distinguishes URL rows (`--bare`) from fetched source bodies (`--print` / `--print-all`) and adds SourceLink row-print examples.

## Validation

- `npx markdownlint-cli skills/query/SKILL.md skills/sourcelink/SKILL.md`
- `git diff --check`

Docs-only; no product behavior change.
