### PR TITLE
Raise two-arm union switch expressions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -273,13 +273,56 @@ public class TypeSourceComposerUnionTests
     }
 
     [Fact]
+    public async Task UnionSwitchExpression_RendersTypePatternArms()
+    {
+        using var assembly = await CompileWithSdk("""
+            namespace UnionFixtures;
+
+            public sealed class Cat { public string Name { get; } = "cat"; }
+            public sealed class Dog { public string Name { get; } = "dog"; }
+            public union Pet(Cat, Dog);
+
+            public static class Matcher
+            {
+                public static string Describe(Pet pet) => pet switch
+                {
+                    Cat cat => cat.Name,
+                    Dog dog => dog.Name,
+                };
+
+                public static int Kind(Pet pet) => pet switch
+                {
+                    Cat => 1,
+                    Dog => 2,
+                };
+            }
+            """);
+
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat => cat.Name,
+                Dog dog => dog.Name,
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Describe"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat => 1,
+                Dog => 2,
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Kind"));
+    }
+
+    [Fact]
     public void NonUnionValuePropertyTypeTest_KeepsValueAccess()
     {
         using var assembly = Compile("""
             #nullable enable
             namespace UnionFixtures
             {
-                public sealed class Cat { }
+                public sealed class Cat { public string Name { get; } = "cat"; }
+                public sealed class Dog { public string Name { get; } = "dog"; }
 
                 public readonly struct PetLike
                 {
@@ -296,6 +339,13 @@ public class TypeSourceComposerUnionTests
                         Cat cat = pet.Value as Cat;
                         return cat is not null;
                     }
+
+                    public static string Describe(PetLike pet) => pet.Value switch
+                    {
+                        Cat cat => cat.Name,
+                        Dog dog => dog.Name,
+                        _ => "other",
+                    };
                 }
             }
             """);
@@ -303,6 +353,7 @@ public class TypeSourceComposerUnionTests
         Assert.Equal("return pet.Value is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCat"));
         Assert.Equal("return pet.Value is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
         Assert.Equal("return pet.Value is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "HasCat"));
+        Assert.DoesNotContain("return pet switch", RenderMember(assembly.Path, "UnionFixtures.Matcher", "Describe"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -360,6 +360,12 @@ public class TypeSourceComposerUnionTests
                         Dog dog => dog.Name,
                         _ => "other",
                     };
+
+                    public static string ExhaustiveLooking(PetLike pet) => pet.Value switch
+                    {
+                        Cat cat => cat.Name,
+                        Dog dog => dog.Name,
+                    };
                 }
             }
             """);
@@ -368,6 +374,7 @@ public class TypeSourceComposerUnionTests
         Assert.Equal("return pet.Value is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
         Assert.Equal("return pet.Value is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "HasCat"));
         Assert.DoesNotContain("return pet switch", RenderMember(assembly.Path, "UnionFixtures.Matcher", "Describe"));
+        Assert.DoesNotContain("return pet switch", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ExhaustiveLooking"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -295,6 +295,16 @@ public class TypeSourceComposerUnionTests
                     Cat => 1,
                     Dog => 2,
                 };
+
+                public static int KindWithOffset(Pet pet, int offset)
+                {
+                    int baseValue = offset + 1;
+                    return pet switch
+                    {
+                        Cat => baseValue,
+                        Dog dog => dog.Name.Length + baseValue,
+                    };
+                }
             }
             """);
 
@@ -312,6 +322,10 @@ public class TypeSourceComposerUnionTests
                 Dog => 2,
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Kind"));
+        var withOffset = RenderMember(assembly.Path, "UnionFixtures.Matcher", "KindWithOffset");
+        Assert.Contains("int baseValue = offset + 1;", withOffset);
+        Assert.Contains("return pet switch", withOffset);
+        Assert.Contains("Dog dog => dog.Name.Length + baseValue", withOffset);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -993,6 +993,9 @@ public sealed partial class CSharpPrinter
             && target is { } switchTarget
             && CanRenderSwitchExpressionForTarget(switchExpression, switchTarget))
             return SwitchExpressionInline(switchExpression, switchTarget);
+        if (value is UnionSwitchExpression unionSwitchExpression
+            && target is { } unionSwitchTarget)
+            return UnionSwitchExpressionInline(unionSwitchExpression, unionSwitchTarget);
         if (value is Coalesce coalesce
             && target is { } coalesceTarget
             && TryCoalesceTextForTarget(coalesce, coalesceTarget) is { } targetedCoalesce)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -175,6 +175,15 @@ public sealed partial class CSharpPrinter
         return $"{Operand(node.Value)} switch {{ {string.Join(", ", node.Arms.Select(arm => SwitchArmText(arm, target, labelEnum)))} }}";
     }
 
+    string UnionSwitchExpressionInline(UnionSwitchExpression node, TypeRef? target = null)
+        => $"{UnionSwitchReceiverText(node.Value)} switch {{ {string.Join(", ", node.Arms.Select(arm => UnionSwitchArmText(arm, target)))} }}";
+
+    string UnionSwitchArmText(UnionSwitchExpressionArm arm, TypeRef? target = null)
+        => $"{TypeText(arm.PatternType)}{(arm.LocalIndex is { } index ? $" {LocalName(index)}" : "")} => {SwitchArmValueText(arm.Value, target)}";
+
+    string UnionSwitchReceiverText(IrExpression value)
+        => UnionValueReceiverText(value) ?? Operand(value);
+
     string InterpolatedStringText(InterpolatedStringExpression node)
     {
         var sb = new StringBuilder().Append("$\"");

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -298,6 +298,9 @@ public sealed partial class CSharpPrinter
             _isPatternLocals.Add(pattern.LocalIndex);
         foreach (var pattern in DescendantsOutsideNestedFunctions(function).OfType<RecursivePropertyDeclarationPattern>())
             _isPatternLocals.Add(pattern.LocalIndex);
+        foreach (var arm in DescendantsOutsideNestedFunctions(function).OfType<UnionSwitchExpressionArm>())
+            if (arm.LocalIndex is { } localIndex)
+                _isPatternLocals.Add(localIndex);
         foreach (var deconstruction in DescendantsOutsideNestedFunctions(function).OfType<DeconstructionAssignment>())
             foreach (var target in deconstruction.Targets)
                 if (target is { Kind: DeconstructionTargetKind.Local, IsDeclared: true })
@@ -1180,6 +1183,16 @@ public sealed partial class CSharpPrinter
             sb.Append(pad).AppendLine("};");
             return;
         }
+        if (node is Return { Value: UnionSwitchExpression unionSwitch })
+        {
+            string inner = pad + "    ";
+            sb.Append(pad).Append("return ").Append(UnionSwitchReceiverText(unionSwitch.Value)).AppendLine(" switch");
+            sb.Append(pad).AppendLine("{");
+            foreach (var arm in unionSwitch.Arms)
+                sb.Append(inner).Append(UnionSwitchArmText(arm, _function.Signature.ReturnType)).AppendLine(",");
+            sb.Append(pad).AppendLine("};");
+            return;
+        }
         if (node is Return { Value: StackAllocate stackAllocate }
             && _function.Signature.ReturnType is { Kind: TypeRefKind.Pointer } returnPointer)
         {
@@ -1741,6 +1754,7 @@ public sealed partial class CSharpPrinter
         LogicalBinary l => LogicalText(l),
         Conditional t => ConditionalText(t),
         SwitchExpression se => SwitchExpressionInline(se),
+        UnionSwitchExpression se => UnionSwitchExpressionInline(se),
         Coalesce co => CoalesceText(co),
         NullConditional nc => NullConditionalText(nc),
         Unary { Kind: UnaryKind.Negate } u => $"-{Operand(u.Operand)}",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -689,6 +689,48 @@ public sealed class SwitchExpressionArm : IrNode
 }
 
 /// <summary>
+/// A raised type-pattern switch expression over a union receiver:
+/// <c>pet switch { Cat cat =&gt; ..., Dog =&gt; ... }</c>. The value is the
+/// compiler-emitted union <c>Value</c> getter access; the printer uses the
+/// proven union receiver when rendering the switch input.
+/// </summary>
+public sealed class UnionSwitchExpression : IrExpression
+{
+    public UnionSwitchExpression(IrExpression value, IEnumerable<UnionSwitchExpressionArm> arms)
+    {
+        AddChild(value);
+        foreach (var arm in arms)
+            AddChild(arm);
+    }
+
+    public IrExpression Value => (IrExpression)Children[0];
+    public IReadOnlyList<UnionSwitchExpressionArm> Arms => Children.Skip(1).Cast<UnionSwitchExpressionArm>().ToList();
+    public override TypeRef? ResultType => Arms.Select(a => a.Value.ResultType).FirstOrDefault(t => t is not null);
+
+    public override string Describe() => $"UnionSwitchExpression ({Children.Count - 1} arms)";
+}
+
+/// <summary>One type-pattern arm of a <see cref="UnionSwitchExpression"/>.</summary>
+public sealed class UnionSwitchExpressionArm : IrNode
+{
+    public UnionSwitchExpressionArm(TypeRef patternType, int? localIndex, IrExpression value)
+    {
+        PatternType = patternType;
+        LocalIndex = localIndex;
+        AddChild(value);
+    }
+
+    public TypeRef PatternType { get; }
+    public int? LocalIndex { get; }
+    public IrExpression Value => (IrExpression)Children[0];
+
+    public override IEnumerable<TypeRef> DirectTypes => [PatternType];
+    public override string Describe() => LocalIndex is { } index
+        ? $"arm {PatternType.ToDisplayString()} V_{index}"
+        : $"arm {PatternType.ToDisplayString()}";
+}
+
+/// <summary>
 /// A raised <c>lock</c> statement. Produced by the lock-sugar pass from the
 /// csc Monitor lowering — <c>Monitor.Enter(obj, ref taken)</c> in a try whose
 /// finally is <c>if (taken) Monitor.Exit(obj)</c>.

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -200,6 +200,10 @@ public static class IrPasses
         // `&&` short-circuit operand are both formed; left flat it renders as
         // a separate `T t = value as T; if (t is not null)`.
         new IsPatternPass(),
+        // Raise the two-arm union switch-expression lowering (cached Value,
+        // ordered type tests, value arms, and the compiler's unreachable throw
+        // fallback) into `union switch { T t => ..., U => ... }`.
+        new UnionSwitchExpressionPass(),
         // Fold the compiler's dup-based ++/-- idiom (a value-carrying increment
         // spilled to a single-use slot beside the local update) back into the
         // operator at the use site, so a[--i] = src[j++] recompiles to the same

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -41,6 +41,8 @@ internal static class NativePasses
     public static ReturnMergePass ReturnMerge => new();
     [Native(NativeCategory.EmitArtifact, "whole-method flat guard return dispatch collapsed to ordered guard returns")]
     public static ReturnDispatchPass ReturnDispatch => new();
+    [Native(NativeCategory.EmitArtifact, "two-arm union type-test switch-expression dispatch collapsed from cached Value tests and compiler fallback throw")]
+    public static UnionSwitchExpressionPass UnionSwitchExpression => new();
     [Native(NativeCategory.EmitArtifact, "a prologue if (c) goto L; return X; guard folded to a structured if even when the rest of the body stays EH-entangled-flat")]
     public static PrologueGuardReturnPass PrologueGuardReturn => new();
     [Native(NativeCategory.EmitArtifact, "return-accumulator temp spilled across an EH/lock region eliminated")]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -1,0 +1,204 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Raises the two-arm union switch-expression lowering Roslyn currently emits:
+/// one cached <c>union.Value</c>, two ordered type tests, value arms, and the
+/// compiler's unreachable <c>ThrowSwitchExpressionException</c> fallback. This is
+/// deliberately narrower than general pattern-switch reconstruction.
+/// </summary>
+public sealed class UnionSwitchExpressionPass : IIrPass
+{
+    public string Name => "union-switch-expression";
+
+    sealed record Arm(TypeRef PatternType, int? LocalIndex, IrExpression Value, IReadOnlyList<IrNode> LocalRoots);
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
+        {
+            if (container.Blocks is [var block] && TryMatch(function, block, out var switchExpression))
+            {
+                foreach (var child in block.Children.ToList())
+                    child.Detach();
+                block.Add(new Return(switchExpression));
+                context.Stepper.StepOver("raise union type-test dispatch to switch expression", block);
+                return;
+            }
+        }
+    }
+
+    static bool TryMatch(IrFunction function, Block block, out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        var children = block.Children;
+        if (children.Count < 4
+            || children[0] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsUnionValueProperty(function, unionValue))
+        {
+            return false;
+        }
+
+        int tempLocal = valueStore.Index;
+        Arm firstArm;
+        if (children[1] is StoreLocal { Value: IsInstance firstAs } firstStore)
+        {
+            if (children.Count != 5
+                || !IsTempTypeTest(firstAs, tempLocal)
+                || children[2] is not IfStatement firstIf
+                || !IsNotLocal(firstIf.Condition, firstStore.Index))
+            {
+                return false;
+            }
+            if (!TryStoreReturn(children, 3, out int resultLocal, out var firstValue))
+            {
+                return false;
+            }
+            firstArm = new Arm(firstAs.Type, firstStore.Index, firstValue, [firstStore, firstIf.Condition, firstValue]);
+            return TryBuild(function, unionValue, tempLocal, resultLocal, firstIf, firstArm, firstStore, out switchExpression);
+        }
+
+        if (children[1] is IfStatement noLocalIf
+            && noLocalIf.Condition is LogicalNot { Operand: IsInstance firstTest }
+            && IsTempTypeTest(firstTest, tempLocal))
+        {
+            if (children.Count != 4)
+                return false;
+            if (!TryStoreReturn(children, 2, out int resultLocal, out var firstValue))
+                return false;
+            firstArm = new Arm(firstTest.Type, LocalIndex: null, firstValue, []);
+            return TryBuild(function, unionValue, tempLocal, resultLocal, noLocalIf, firstArm, extraTempUse: null, out switchExpression);
+        }
+
+        return false;
+    }
+
+    static bool TryBuild(
+        IrFunction function,
+        LoadProperty unionValue,
+        int tempLocal,
+        int resultLocal,
+        IfStatement firstIf,
+        Arm firstArm,
+        IrNode? extraTempUse,
+        out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        if (firstIf.HasElse
+            || firstIf.Then.Children is not [IfStatement secondIf, ExpressionStatement throwStatement, Return throwReturn]
+            || !IsThrowSwitchExpression(throwStatement)
+            || !ReturnsLocal(throwReturn, resultLocal)
+            || !TrySecondArm(secondIf, tempLocal, resultLocal, out var secondArm))
+        {
+            return false;
+        }
+
+        // The cached Value local exists only to feed the tests this switch owns.
+        var allowedTempUses = extraTempUse is null
+            ? (IReadOnlyList<IrNode>)[unionValue.Parent!, firstIf]
+            : [unionValue.Parent!, extraTempUse, firstIf];
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, tempLocal, allowedTempUses)
+            || !ArmLocalReferencesAreOwned(function, firstArm)
+            || !ArmLocalReferencesAreOwned(function, secondArm))
+        {
+            return false;
+        }
+
+        switchExpression = new UnionSwitchExpression(
+            (IrExpression)unionValue.Clone(),
+            [
+                new UnionSwitchExpressionArm(firstArm.PatternType, firstArm.LocalIndex, (IrExpression)firstArm.Value.Clone()),
+                new UnionSwitchExpressionArm(secondArm.PatternType, secondArm.LocalIndex, (IrExpression)secondArm.Value.Clone()),
+            ]);
+        return true;
+    }
+
+    static bool TrySecondArm(IfStatement secondIf, int tempLocal, int resultLocal, out Arm arm)
+    {
+        arm = null!;
+        if (secondIf.HasElse || secondIf.Then.Children.Count != 2)
+            return false;
+
+        if (!TryStoreReturn(secondIf.Then.Children, 0, out int secondResultLocal, out var value)
+            || secondResultLocal != resultLocal)
+        {
+            return false;
+        }
+
+        switch (secondIf.Condition)
+        {
+            case IsPattern pattern when IsTempLoad(pattern.Value, tempLocal) && ReferencesLocalOnly(value, pattern.LocalIndex):
+                arm = new Arm(pattern.Type, pattern.LocalIndex, value, [pattern, value]);
+                return true;
+            case IsInstance test when IsTempTypeTest(test, tempLocal):
+                arm = new Arm(test.Type, LocalIndex: null, value, []);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    static bool TryStoreReturn(IReadOnlyList<IrNode> nodes, int index, out int local, out IrExpression value)
+    {
+        local = -1;
+        value = null!;
+        if (index + 1 >= nodes.Count
+            || nodes[index] is not StoreLocal store
+            || nodes[index + 1] is not Return ret
+            || !ReturnsLocal(ret, store.Index))
+        {
+            return false;
+        }
+
+        local = store.Index;
+        value = store.Value;
+        return true;
+    }
+
+    static bool ReturnsLocal(Return ret, int local)
+        => ret.Value is LoadLocal load && load.Index == local;
+
+    static bool IsNotLocal(IrExpression expression, int local)
+        => expression is LogicalNot { Operand: LoadLocal load } && load.Index == local;
+
+    static bool IsTempTypeTest(IsInstance test, int tempLocal)
+        => IsTempLoad(test.Operand, tempLocal);
+
+    static bool IsTempLoad(IrExpression expression, int tempLocal)
+        => expression is LoadLocal load && load.Index == tempLocal;
+
+    static bool ReferencesLocalOnly(IrExpression expression, int local)
+        => expression.Descendants.Prepend(expression)
+            .OfType<LoadLocal>()
+            .All(load => load.Index == local);
+
+    static bool ArmLocalReferencesAreOwned(IrFunction function, Arm arm)
+        => arm.LocalIndex is not { } local
+            || ReferenceOwnership.LocalReferencesOnlyWithin(function, local, arm.LocalRoots);
+
+    static bool IsThrowSwitchExpression(ExpressionStatement statement)
+        => statement.Expression is Call
+        {
+            Callee:
+            {
+                Name: "ThrowSwitchExpressionException",
+                DeclaringType.Name: "<PrivateImplementationDetails>",
+            },
+        };
+
+    static bool IsUnionValueProperty(IrFunction function, LoadProperty property)
+        => property.PropertyName == "Value"
+        && property.IndexArguments.Count == 0
+        && function.UnionTypes.Contains(NamedDefinition(property.Accessor.DeclaringType))
+        && IsSimpleUnionValueReceiver(property.Instance);
+
+    static bool IsSimpleUnionValueReceiver(IrExpression? receiver) => receiver switch
+    {
+        LoadArgumentAddress or LoadArgument or LoadLocalAddress or LoadLocal => true,
+        LoadFieldAddress field => field.Instance is null || IsSimpleUnionValueReceiver(field.Instance),
+        LoadField field => field.Instance is null || IsSimpleUnionValueReceiver(field.Instance),
+        _ => false,
+    };
+
+    static TypeRef NamedDefinition(TypeRef type)
+        => type is { Kind: TypeRefKind.GenericInstance, ElementType: { } definition } ? definition : type;
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -11,45 +11,67 @@ public sealed class UnionSwitchExpressionPass : IIrPass
     public string Name => "union-switch-expression";
 
     sealed record Arm(TypeRef PatternType, int? LocalIndex, IrExpression Value, IReadOnlyList<IrNode> LocalRoots);
+    sealed record Match(int StartIndex, UnionSwitchExpression SwitchExpression);
 
     public void Run(IrFunction function, PassContext context)
     {
         foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
         {
-            if (container.Blocks is [var block] && TryMatch(function, block, out var switchExpression))
+            if (container.Blocks is [var block] && TryMatch(function, block, out var match))
             {
-                foreach (var child in block.Children.ToList())
-                    child.Detach();
-                block.Add(new Return(switchExpression));
+                block.SetChild(match.StartIndex, new Return(match.SwitchExpression));
+                for (int i = block.Children.Count - 1; i > match.StartIndex; i--)
+                    block.Children[i].Detach();
                 context.Stepper.StepOver("raise union type-test dispatch to switch expression", block);
-                return;
+                continue;
             }
         }
     }
 
-    static bool TryMatch(IrFunction function, Block block, out UnionSwitchExpression switchExpression)
+    static bool TryMatch(IrFunction function, Block block, out Match match)
+    {
+        match = null!;
+        var children = block.Children;
+        for (int start = 0; start < children.Count; start++)
+        {
+            if (TryMatchAt(function, children, start, out var switchExpression))
+            {
+                match = new Match(start, switchExpression);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool TryMatchAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out UnionSwitchExpression switchExpression)
     {
         switchExpression = null!;
-        var children = block.Children;
-        if (children.Count < 4
-            || children[0] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+        if (start + 3 >= children.Count
+            || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
             || !IsUnionValueProperty(function, unionValue))
         {
             return false;
         }
 
+        // The switch-expression dispatch is terminal. Prefix statements are OK;
+        // trailing statements would be unreachable or unrelated and stay flat.
         int tempLocal = valueStore.Index;
         Arm firstArm;
-        if (children[1] is StoreLocal { Value: IsInstance firstAs } firstStore)
+        if (children[start + 1] is StoreLocal { Value: IsInstance firstAs } firstStore)
         {
-            if (children.Count != 5
+            if (start + 5 != children.Count
                 || !IsTempTypeTest(firstAs, tempLocal)
-                || children[2] is not IfStatement firstIf
+                || children[start + 2] is not IfStatement firstIf
                 || !IsNotLocal(firstIf.Condition, firstStore.Index))
             {
                 return false;
             }
-            if (!TryStoreReturn(children, 3, out int resultLocal, out var firstValue))
+            if (!TryStoreReturn(children, start + 3, out int resultLocal, out var firstValue))
             {
                 return false;
             }
@@ -57,13 +79,13 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             return TryBuild(function, unionValue, tempLocal, resultLocal, firstIf, firstArm, firstStore, out switchExpression);
         }
 
-        if (children[1] is IfStatement noLocalIf
+        if (children[start + 1] is IfStatement noLocalIf
             && noLocalIf.Condition is LogicalNot { Operand: IsInstance firstTest }
             && IsTempTypeTest(firstTest, tempLocal))
         {
-            if (children.Count != 4)
+            if (start + 4 != children.Count)
                 return false;
-            if (!TryStoreReturn(children, 2, out int resultLocal, out var firstValue))
+            if (!TryStoreReturn(children, start + 2, out int resultLocal, out var firstValue))
                 return false;
             firstArm = new Arm(firstTest.Type, LocalIndex: null, firstValue, []);
             return TryBuild(function, unionValue, tempLocal, resultLocal, noLocalIf, firstArm, extraTempUse: null, out switchExpression);
@@ -126,7 +148,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
 
         switch (secondIf.Condition)
         {
-            case IsPattern pattern when IsTempLoad(pattern.Value, tempLocal) && ReferencesLocalOnly(value, pattern.LocalIndex):
+            case IsPattern pattern when IsTempLoad(pattern.Value, tempLocal):
                 arm = new Arm(pattern.Type, pattern.LocalIndex, value, [pattern, value]);
                 return true;
             case IsInstance test when IsTempTypeTest(test, tempLocal):
@@ -165,11 +187,6 @@ public sealed class UnionSwitchExpressionPass : IIrPass
 
     static bool IsTempLoad(IrExpression expression, int tempLocal)
         => expression is LoadLocal load && load.Index == tempLocal;
-
-    static bool ReferencesLocalOnly(IrExpression expression, int local)
-        => expression.Descendants.Prepend(expression)
-            .OfType<LoadLocal>()
-            .All(load => load.Index == local);
 
     static bool ArmLocalReferencesAreOwned(IrFunction function, Arm arm)
         => arm.LocalIndex is not { } local


### PR DESCRIPTION
- Advances #1917
- Changes two-arm exhaustive union switch-expression lowering to render as a source-level union switch expression.
- Card revision: ce002bd8

## Change

**Conclusion:** **REVIEW** — this is the full two-arm union switch-expression slice for the current preview lowering: cached Value, ordered type tests, value arms, and the compiler fallback throw. Broader/general pattern-switch reconstruction remains out of scope.

Before:

```csharp
object V_3 = pet.Value;
Cat cat = V_3 as Cat;
if (cat is null)
{
    if (V_3 is Dog dog)
    {
        V_2 = dog.Name;
        return V_2;
    }
    ThrowSwitchExpressionException(pet);
    return V_2;
}
V_2 = cat.Name;
return V_2;
```

After:

```csharp
return pet switch
{
    Cat cat => cat.Name,
    Dog dog => dog.Name,
};
```

The pass is narrow: it requires same-assembly union metadata already recorded on the function, a cached union Value getter on a simple receiver, exactly two ordered type-test arms, a common result local, and the compiler ThrowSwitchExpressionException fallback.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `TypeSourceComposerUnionTests`: 10 passed |
| Lowering coverage | Pass |
| Build-event validation | `Summary`: 263 projects, 0 failed, 0 errors, 0 warnings; event log `20260630T051619.0814260Z-2233403-build-e36f6165` |
| Real witness | Preview SDK union fixture: `Describe` renders declaration arms; `Kind` renders non-declaration type arms |
| Near miss | Non-union `Value` switch does not render `pet switch` |

Local full decompiler fast suite note: two `FidelityCheckGeneratedFilterTests` currently fail as `RecompileFail` on this environment, and the same two failures reproduce on pristine `origin/main` (`ff28b210`), so they are baseline/tooling noise rather than a regression from this PR.

## Decompiler quality

**Conclusion:** **ADVISORY** — no corpus card included for this targeted preview-language slice; behavior is fixture-gated on union metadata and is not expected to affect the current fixed corpus materially.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | Findings resolved | `5b15d385` fixed container traversal, prefix-slice matching, and outer-local arm values. |
| Claude Opus 4.8 | No blocking findings | Strong non-union near-miss suggestion fixed in `6409ad15`. |

**Review conclusion:** **PASS** — required adversarial reviews completed and actionable guidance resolved.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringCoverageTests/*"
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate src/ILInspector.Decompiler.Tests -- -c Release --nologo --verbosity quiet
```


