### PR TITLE
Render in/out parameters in fidelity skeletons (daily red fix, #1931)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -102,6 +102,21 @@ public class FidelityGateTests
         // over-render. Pre-existing slow-docket gap surfaced by running the gate
         // locally — the lowered/sugared gates are Speed=Slow (daily only).
         "CharConditionalElementStore",
+        // Unmasked by the in/out skeleton-parameter fix (#1931): these CfgSampleClass
+        // methods were RecompileFail before — the whole reconstructed type failed to
+        // compile because InOperatorVec's in-parameter operators rendered as illegal
+        // `ref`. With the type compiling, they are finally compile-checked and show
+        // honest pre-existing body over-renders (ref/in/out call sites, positional
+        // patterns, slot/ternary merges, null-coalescing assignment).
+        "CallOutTarget",
+        "FloatPositionalPattern",
+        "GenericRefKindCallSites",
+        "ManualPositionalPatternLookalike",
+        "MergedReferenceSlot",
+        "MergedTernaryDeclaration",
+        "NullCoalescingAssignStaticProperty",
+        "RefKindCallSites",
+        "set_SlotMergedDateTimeFormat",
     };
 
     /// <summary>

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -92,6 +92,19 @@ public class LoweredFidelityGateTests
         // neither). See the sibling FidelityGateTests docket.
         "CharConditionalElementStore",
         "WhileNestedContinueKeepsArmExclusive",
+        // Unmasked by the in/out skeleton-parameter fix (#1931): RecompileFail before
+        // (the reconstructed CfgSampleClass failed to compile on InOperatorVec's
+        // in-parameter operators rendered as illegal `ref`). Now compile-checked,
+        // showing honest pre-existing over-renders. Same set as the sugared docket.
+        "CallOutTarget",
+        "FloatPositionalPattern",
+        "GenericRefKindCallSites",
+        "ManualPositionalPatternLookalike",
+        "MergedReferenceSlot",
+        "MergedTernaryDeclaration",
+        "NullCoalescingAssignStaticProperty",
+        "RefKindCallSites",
+        "set_SlotMergedDateTimeFormat",
     };
 
     /// <summary>

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2488,18 +2488,24 @@ static class FidelityCheck
     static string Parameters(MetadataReader reader, MethodDefinition method, MethodSignature<string> sig, bool firstIsExtensionReceiver = false)
     {
         var names = new Dictionary<int, string>();
+        var refKinds = new Dictionary<int, ByRefParameterInfo>();
         foreach (var ph in method.GetParameters())
         {
             var p = reader.GetParameter(ph);
             if (p.SequenceNumber >= 1)
+            {
                 names[p.SequenceNumber - 1] = reader.GetString(p.Name);
+                refKinds[p.SequenceNumber - 1] = new ByRefParameterInfo(
+                    p.Attributes,
+                    HasIsReadOnlyAttribute(reader, p.GetCustomAttributes()));
+            }
         }
         var parts = new List<string>();
         for (int i = 0; i < sig.ParameterTypes.Length; i++)
         {
             string name = names.TryGetValue(i, out var n) && n.Length > 0 ? n : $"arg{i}";
             string modifier = firstIsExtensionReceiver && i == 0 ? "this " : "";
-            parts.Add($"{modifier}{Clean(sig.ParameterTypes[i])} {Identifier(name)}");
+            parts.Add($"{modifier}{ByRefKeyword(sig.ParameterTypes[i], refKinds.GetValueOrDefault(i))} {Identifier(name)}");
         }
         return string.Join(", ", parts);
     }
@@ -2517,6 +2523,41 @@ static class FidelityCheck
     static bool CanSpellExtensionReceiver(string parameterType)
         => !parameterType.StartsWith("ref ", StringComparison.Ordinal)
            && !parameterType.Contains('*', StringComparison.Ordinal);
+
+    /// <summary>
+    /// Renders a parameter type, correcting the signature decoder's bare <c>ref</c>
+    /// for a by-reference parameter to the C# direction keyword the metadata proves:
+    /// <c>out</c> for out-only, <c>in</c> for csc's readonly-ref encoding
+    /// (<see cref="ParameterAttributes.In"/> plus <c>IsReadOnlyAttribute</c>), and
+    /// <c>ref</c> for plain ref or marshal-directional <c>[In]</c>/<c>[In,Out]</c>
+    /// ref parameters.
+    /// </summary>
+    readonly record struct ByRefParameterInfo(ParameterAttributes Attributes, bool IsReadOnly);
+
+    static string ByRefKeyword(string parameterType, ByRefParameterInfo parameter)
+    {
+        string type = Clean(parameterType);
+        if (!type.StartsWith("ref ", StringComparison.Ordinal))
+            return type;
+        string rest = type["ref ".Length..];
+        var attributes = parameter.Attributes;
+        const ParameterAttributes inOut = ParameterAttributes.In | ParameterAttributes.Out;
+        if ((attributes & inOut) == inOut)
+            return type;
+        if ((attributes & ParameterAttributes.Out) != 0)
+            return $"out {rest}";
+        if ((attributes & ParameterAttributes.In) != 0 && parameter.IsReadOnly)
+            return $"in {rest}";
+        return type;
+    }
+
+    static bool HasIsReadOnlyAttribute(MetadataReader reader, CustomAttributeHandleCollection attributes)
+    {
+        foreach (var attributeHandle in attributes)
+            if (AttributeTypeFullName(reader, reader.GetCustomAttribute(attributeHandle)) == "System.Runtime.CompilerServices.IsReadOnlyAttribute")
+                return true;
+        return false;
+    }
 
     // ---- Small helpers ----
 


### PR DESCRIPTION
Fixes #1931

## Change

> Should we accept this change?

**Conclusion:** **PASS** — fixes a deterministic skeleton-emit bug that has been turning the decompiler-daily red; strictly increases fidelity coverage (RecompileFail → compile-checked).

`FidelityCheck.Parameters()` rendered every by-reference parameter as `ref T` — the signature decoder can't tell `ref`/`in`/`out` apart (by-ref is one IL form). For an **`in`** parameter that produces `ref`, which is **illegal on operator/conversion declarations** (`CS0631`). The `InOperatorVec` fixture (in-parameter `operator ==`/`!=`, from #1836) reconstructed as `operator ==(ref InOperatorVec, ref InOperatorVec)`, and because it is part of the **shared reconstructed test unit**, that one malformed type failed the whole group compile — emptying the recompiled stream across the entire fidelity/skeleton suite. That is the broad simultaneous `RecompileFail` behind the recurring daily reds (deterministic — reproduced on current `main`; **not** the transient empty-emit that #1863 retries).

Fix: correct the bare `ref` to the keyword the parameter metadata flags imply — `ParameterAttributes.Out` → `out`, `ParameterAttributes.In` → `in` (csc's readonly-ref encoding); plain `ref` untouched.

Before: `operator ==(ref InOperatorVec a, ref InOperatorVec b)` → CS0631 → whole group RecompileFail.
After: `operator ==(in InOperatorVec a, in InOperatorVec b)` → compiles; the group is checkable again.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| `FidelityGateTests.SwitchStoreFold_StaysCompileBackCheckable` (was failing) | Pass |
| FidelityGateTests + LoweredFidelityGateTests + SkeletonEmitTests (slow) | Pass (broad RecompileFail batch gone) |
| Decompiler fast suite | Pass (1725) |
| Newly compile-checkable methods | 9 RecompileFail → OpcodeDiff, docketed as honest pre-existing over-renders |

The fix unmasked 9 methods (ref/in/out call sites, positional patterns, slot/ternary merges, null-coalescing assign) that were `RecompileFail` behind the poisoned group; they now compile-check and show honest pre-existing body over-renders, added to both fidelity dockets (strictly more coverage).

## Review

Two cross-model adversarial reviews pending (#1734).
