### PR TITLE
Preserve extension methods in fidelity skeletons

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -43,7 +43,7 @@ public class FidelityCheckGeneratedFilterTests
         }
         finally
         {
-            File.Delete(assemblyPath);
+            DeleteFixture(assemblyPath);
         }
     }
 
@@ -70,7 +70,7 @@ public class FidelityCheckGeneratedFilterTests
         }
         finally
         {
-            File.Delete(assemblyPath);
+            DeleteFixture(assemblyPath);
         }
     }
 
@@ -91,7 +91,7 @@ public class FidelityCheckGeneratedFilterTests
         }
         finally
         {
-            File.Delete(assemblyPath);
+            DeleteFixture(assemblyPath);
         }
     }
 
@@ -121,7 +121,7 @@ public class FidelityCheckGeneratedFilterTests
         }
         finally
         {
-            File.Delete(assemblyPath);
+            DeleteFixture(assemblyPath);
         }
     }
 
@@ -150,17 +150,61 @@ public class FidelityCheckGeneratedFilterTests
                 FidelityCheck.Evaluate(assemblyPath),
                 result => result.Type == "StructWithToStringExtensions" && result.Method == "Humanize");
 
-            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.True(result.Status == FidelityCheck.CompileBackStatus.Exact, result.Detail);
         }
         finally
         {
-            File.Delete(assemblyPath);
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_RoundTripsExtensionMethodForwarding()
+    {
+        var assemblyPath = CompileFixture("""
+            namespace ExtensionForwardingFixture;
+
+            public readonly struct TinyDate
+            {
+                public override string ToString() => "tiny";
+            }
+
+            public static class TinyDateExtensions
+            {
+                public static string Humanize(this TinyDate input, int style)
+                    => input.ToString() + style.ToString();
+
+                public static string Humanize(this TinyDate? input, int style)
+                {
+                    if (input.HasValue)
+                    {
+                        return input.Value.Humanize(style);
+                    }
+                    return "never";
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(
+                FidelityCheck.Evaluate(assemblyPath),
+                result => result.Type == "ExtensionForwardingFixture.TinyDateExtensions"
+                          && result.Method == "Humanize"
+                          && result.Signature.Contains("Nullable", StringComparison.Ordinal));
+
+            Assert.True(result.Status == FidelityCheck.CompileBackStatus.Exact, result.Detail);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
         }
     }
 
     static string CompileFixture(string source)
     {
-        var path = Path.Combine(Path.GetTempPath(), $"fidelity-generated-filter-{Guid.NewGuid():N}.dll");
+        var directory = Path.Combine(Path.GetTempPath(), $"fidelity-generated-filter-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "fixture.dll");
         var references = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
             .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
             .Select(path => MetadataReference.CreateFromFile(path));
@@ -176,5 +220,13 @@ public class FidelityCheckGeneratedFilterTests
         var emit = compilation.Emit(path);
         Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
         return path;
+    }
+
+    static void DeleteFixture(string assemblyPath)
+    {
+        var directory = Path.GetDirectoryName(assemblyPath);
+        File.Delete(assemblyPath);
+        if (directory is not null && Path.GetFileName(directory).StartsWith("fidelity-generated-filter-", StringComparison.Ordinal))
+            Directory.Delete(directory, recursive: true);
     }
 }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1881,7 +1881,7 @@ static class FidelityCheck
         // as ref structs; otherwise the whole compile-back unit becomes invalid.
         string keyword = kind == TypeKind.Struct
             ? (IsByRefLike(reader, typeDef) ? "ref struct" : "struct")
-            : "class";
+            : IsStaticClass(typeDef) ? "static class" : "class";
         string baseClause = BaseClause(reader, typeDef, kind);
         // An [InlineArray(N)] struct must carry the attribute for its span
         // conversions (e.g. `(Span<T>)place`) to bind; the bare reconstructed
@@ -1915,7 +1915,7 @@ static class FidelityCheck
         // a readonly-struct member accessed through a readonly receiver would take a
         // defensive copy against a mutable stub, changing the target's opcodes.
         var stubPropertyAccessors = new HashSet<MethodDefinitionHandle>();
-        if (keyword == "class")
+        if (kind == TypeKind.Class)
             EmitStubProperties(reader, typeDef, targets, accessibility, thisFieldInits, stubPropertyAccessors, sb, pad + "    ");
 
         foreach (var mh in typeDef.GetMethods())
@@ -2351,7 +2351,7 @@ static class FidelityCheck
         catch { return; }
 
         bool isStatic = method.Attributes.HasFlag(MethodAttributes.Static);
-        string parameters = Parameters(reader, method, sig);
+        string parameters = Parameters(reader, method, sig, IsExtensionMethod(reader, typeDef, method));
         string body = realBody is null ? " throw null;" : "\n" + realBody + "\n" + pad;
 
         if (name is ".ctor")
@@ -2484,7 +2484,7 @@ static class FidelityCheck
         or "int" or "uint" or "long" or "ulong" or "float" or "double"
         or "decimal" or "string" or "object" or "nint" or "nuint";
 
-    static string Parameters(MetadataReader reader, MethodDefinition method, MethodSignature<string> sig)
+    static string Parameters(MetadataReader reader, MethodDefinition method, MethodSignature<string> sig, bool firstIsExtensionReceiver = false)
     {
         var names = new Dictionary<int, string>();
         foreach (var ph in method.GetParameters())
@@ -2497,10 +2497,19 @@ static class FidelityCheck
         for (int i = 0; i < sig.ParameterTypes.Length; i++)
         {
             string name = names.TryGetValue(i, out var n) && n.Length > 0 ? n : $"arg{i}";
-            parts.Add($"{Clean(sig.ParameterTypes[i])} {Identifier(name)}");
+            string modifier = firstIsExtensionReceiver && i == 0 ? "this " : "";
+            parts.Add($"{modifier}{Clean(sig.ParameterTypes[i])} {Identifier(name)}");
         }
         return string.Join(", ", parts);
     }
+
+    static bool IsExtensionMethod(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
+        => method.Attributes.HasFlag(MethodAttributes.Static)
+           && IsStaticClass(typeDef)
+           && typeDef.GetDeclaringType().IsNil
+           && typeDef.GetGenericParameters().Count == 0
+           && AttributeReader.HasExtensionAttribute(reader, typeDef.GetCustomAttributes())
+           && AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes());
 
     // ---- Small helpers ----
 

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2351,7 +2351,7 @@ static class FidelityCheck
         catch { return; }
 
         bool isStatic = method.Attributes.HasFlag(MethodAttributes.Static);
-        string parameters = Parameters(reader, method, sig, IsExtensionMethod(reader, typeDef, method));
+        string parameters = Parameters(reader, method, sig, IsExtensionMethod(reader, typeDef, method, sig));
         string body = realBody is null ? " throw null;" : "\n" + realBody + "\n" + pad;
 
         if (name is ".ctor")
@@ -2386,7 +2386,8 @@ static class FidelityCheck
             : "";
         string unsafeModifier = asyncModifier.Length == 0 ? "unsafe " : "";
         string slotModifier = StructObjectOverrideModifier(reader, typeDef, method, name, returnType, sig.ParameterTypes.Length);
-        if (name.StartsWith("op_", StringComparison.Ordinal)
+        if (!IsStaticClass(typeDef)
+            && name.StartsWith("op_", StringComparison.Ordinal)
             && OperatorDeclaration(name, returnType, parameters) is { } operatorDeclaration)
         {
             sb.AppendLine($"{pad}public {unsafeModifier}static {operatorDeclaration} {{{body}}}");
@@ -2503,13 +2504,19 @@ static class FidelityCheck
         return string.Join(", ", parts);
     }
 
-    static bool IsExtensionMethod(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method)
+    static bool IsExtensionMethod(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method, MethodSignature<string> sig)
         => method.Attributes.HasFlag(MethodAttributes.Static)
            && IsStaticClass(typeDef)
            && typeDef.GetDeclaringType().IsNil
            && typeDef.GetGenericParameters().Count == 0
+           && sig.ParameterTypes.Length > 0
+           && CanSpellExtensionReceiver(sig.ParameterTypes[0])
            && AttributeReader.HasExtensionAttribute(reader, typeDef.GetCustomAttributes())
            && AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes());
+
+    static bool CanSpellExtensionReceiver(string parameterType)
+        => !parameterType.StartsWith("ref ", StringComparison.Ordinal)
+           && !parameterType.Contains('*', StringComparison.Ordinal);
 
     // ---- Small helpers ----
 


### PR DESCRIPTION
- Advances Humanizer compile-back fidelity.
- Changes fidelity skeleton behavior only: extension classes stay static, and simple extension-method receiver parameters keep `this` so extension-call product output can bind in compile-back.
- Card revision: `39b97df1`

## Change

**Conclusion:** **PASS** — the skeleton now models extension method declarations closely enough to recompile overload-forwarding bodies without changing product output.

Before, Humanizer `DateHumanizeExtensions` had extension forwarding rows blocked by CS1061. After, those rows compile back and the remaining non-exact row is an opcode-shape frontier, not a skeleton bind failure.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `FidelityCheckGeneratedFilterTests` passed |
| Decompiler fast suite | Pass, 1733 tests |
| Real witness | `Humanizer.DateHumanizeExtensions::Humanize` improved to 7 exact, 1 opcode diff, 0 recompile fail |

## Decompiler quality

**Conclusion:** **PASS** — Humanizer cap-1000 exacts improved and recompile failures dropped; opcode diffs increased only because formerly uncheckable extension-forwarding rows are now checkable.

Humanizer cap-1000 after this change:

```text
COMPILE-BACK over 1000 rendered methods (958 Full)

  exact opcode match : 639 (63.90%)
  opcode diff (Full) : 225
  context-build fail : 2
  recompile fail     : 130
```

Baseline before this change in the same worktree was 605 exact, 213 opcode diff, 2 context-build fail, 176 recompile fail.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Verified static-class, receiver, stub-property, and temp-fixture behavior; ran affected tests |
| Gemini Pro | Findings resolved or non-blocking | Static-class operator stubs and unsupported byref/pointer receivers hardened in `39b97df1`; fixture cleanup concern is non-blocking test-diagnostics tradeoff |

**Review conclusion:** **PASS** — actionable adversarial findings were addressed in `39b97df1`; remaining note is non-blocking test fixture cleanup behavior.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*FidelityCheckGeneratedFilterTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
CB_TYPE=DateHumanizeExtensions dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 80 --max-examples 5
/usr/bin/time -f 'elapsed=%E cpu=%P maxrss=%MKB' dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 1000 --max-examples 12 --fidelity-timings
```
