### PR TITLE
Raise three-case union switch expressions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -280,7 +280,10 @@ public class TypeSourceComposerUnionTests
 
             public sealed class Cat { public string Name { get; } = "cat"; }
             public sealed class Dog { public string Name { get; } = "dog"; }
+            public sealed class Bird { public string Name { get; } = "bird"; }
             public union Pet(Cat, Dog);
+            public union Pet3(Cat, Dog, Bird);
+            public union Box<T>(Cat, Dog, T);
 
             public static class Matcher
             {
@@ -305,6 +308,27 @@ public class TypeSourceComposerUnionTests
                         Dog dog => dog.Name.Length + baseValue,
                     };
                 }
+
+                public static string DescribeThree(Pet3 pet) => pet switch
+                {
+                    Cat cat => cat.Name,
+                    Dog dog => dog.Name,
+                    Bird bird => bird.Name,
+                };
+
+                public static int KindThree(Pet3 pet) => pet switch
+                {
+                    Cat => 1,
+                    Dog => 2,
+                    Bird => 3,
+                };
+
+                public static string Generic(Box<Bird> box) => box switch
+                {
+                    Cat cat => cat.Name,
+                    Dog dog => dog.Name,
+                    Bird bird => bird.Name,
+                };
             }
             """);
 
@@ -326,6 +350,24 @@ public class TypeSourceComposerUnionTests
         Assert.Contains("int baseValue = offset + 1;", withOffset);
         Assert.Contains("return pet switch", withOffset);
         Assert.Contains("Dog dog => dog.Name.Length + baseValue", withOffset);
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat => cat.Name,
+                Dog dog => dog.Name,
+                Bird bird => bird.Name,
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "DescribeThree"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat => 1,
+                Dog => 2,
+                Bird => 3,
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "KindThree"));
+        Assert.Contains("return box switch", RenderMember(assembly.Path, "UnionFixtures.Matcher", "Generic"));
+        Assert.Contains("Bird bird => bird.Name", RenderMember(assembly.Path, "UnionFixtures.Matcher", "Generic"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -366,8 +366,14 @@ public class TypeSourceComposerUnionTests
                 Bird => 3,
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "KindThree"));
-        Assert.Contains("return box switch", RenderMember(assembly.Path, "UnionFixtures.Matcher", "Generic"));
-        Assert.Contains("Bird bird => bird.Name", RenderMember(assembly.Path, "UnionFixtures.Matcher", "Generic"));
+        Assert.Equal("""
+            return box switch
+            {
+                Cat cat => cat.Name,
+                Dog dog => dog.Name,
+                Bird bird => bird.Name,
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Generic"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -2,7 +2,7 @@ namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
 /// Raises the union switch-expression lowering Roslyn currently emits:
-/// one cached <c>union.Value</c>, two ordered type tests, value arms, and the
+/// one cached <c>union.Value</c>, ordered type tests, value arms, and the
 /// compiler's unreachable <c>ThrowSwitchExpressionException</c> fallback. This is
 /// deliberately narrower than general pattern-switch reconstruction.
 /// </summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -1,7 +1,7 @@
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
-/// Raises the two-arm union switch-expression lowering Roslyn currently emits:
+/// Raises the union switch-expression lowering Roslyn currently emits:
 /// one cached <c>union.Value</c>, two ordered type tests, value arms, and the
 /// compiler's unreachable <c>ThrowSwitchExpressionException</c> fallback. This is
 /// deliberately narrower than general pattern-switch reconstruction.
@@ -106,10 +106,12 @@ public sealed class UnionSwitchExpressionPass : IIrPass
     {
         switchExpression = null!;
         if (firstIf.HasElse
-            || firstIf.Then.Children is not [IfStatement secondIf, ExpressionStatement throwStatement, Return throwReturn]
+            || firstIf.Then.Children.Count < 3
+            || firstIf.Then.Children[^2] is not ExpressionStatement throwStatement
+            || firstIf.Then.Children[^1] is not Return throwReturn
             || !IsThrowSwitchExpression(throwStatement)
             || !ReturnsLocal(throwReturn, resultLocal)
-            || !TrySecondArm(secondIf, tempLocal, resultLocal, out var secondArm))
+            || !TryInnerArms(firstIf.Then.Children.Take(firstIf.Then.Children.Count - 2), tempLocal, resultLocal, out var innerArms))
         {
             return false;
         }
@@ -120,33 +122,51 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             : [unionValue.Parent!, extraTempUse, firstIf];
         if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, tempLocal, allowedTempUses)
             || !ArmLocalReferencesAreOwned(function, firstArm)
-            || !ArmLocalReferencesAreOwned(function, secondArm))
+            || innerArms.Any(arm => !ArmLocalReferencesAreOwned(function, arm)))
         {
             return false;
         }
+
+        var arms = new[] { firstArm }.Concat(innerArms).ToArray();
+        if (arms.Select(arm => arm.PatternType).Distinct().Count() != arms.Length)
+            return false;
 
         switchExpression = new UnionSwitchExpression(
             (IrExpression)unionValue.Clone(),
-            [
-                new UnionSwitchExpressionArm(firstArm.PatternType, firstArm.LocalIndex, (IrExpression)firstArm.Value.Clone()),
-                new UnionSwitchExpressionArm(secondArm.PatternType, secondArm.LocalIndex, (IrExpression)secondArm.Value.Clone()),
-            ]);
+            arms.Select(arm => new UnionSwitchExpressionArm(arm.PatternType, arm.LocalIndex, (IrExpression)arm.Value.Clone())));
         return true;
     }
 
-    static bool TrySecondArm(IfStatement secondIf, int tempLocal, int resultLocal, out Arm arm)
+    static bool TryInnerArms(IEnumerable<IrNode> nodes, int tempLocal, int resultLocal, out IReadOnlyList<Arm> arms)
+    {
+        var builder = new List<Arm>();
+        foreach (var node in nodes)
+        {
+            if (node is not IfStatement armIf || !TryArm(armIf, tempLocal, resultLocal, out var arm))
+            {
+                arms = [];
+                return false;
+            }
+            builder.Add(arm);
+        }
+
+        arms = builder;
+        return arms.Count > 0;
+    }
+
+    static bool TryArm(IfStatement armIf, int tempLocal, int resultLocal, out Arm arm)
     {
         arm = null!;
-        if (secondIf.HasElse || secondIf.Then.Children.Count != 2)
+        if (armIf.HasElse || armIf.Then.Children.Count != 2)
             return false;
 
-        if (!TryStoreReturn(secondIf.Then.Children, 0, out int secondResultLocal, out var value)
-            || secondResultLocal != resultLocal)
+        if (!TryStoreReturn(armIf.Then.Children, 0, out int armResultLocal, out var value)
+            || armResultLocal != resultLocal)
         {
             return false;
         }
 
-        switch (secondIf.Condition)
+        switch (armIf.Condition)
         {
             case IsPattern pattern when IsTempLoad(pattern.Value, tempLocal):
                 arm = new Arm(pattern.Type, pattern.LocalIndex, value, [pattern, value]);


### PR DESCRIPTION
- Advances #1917
- Changes union switch-expression reconstruction to support 3+ case unions and generic union instances, while preserving non-union Value switch fallbacks.
- Card revision: cd49dada

## Change

**Conclusion:** **REVIEW** — this hardens the existing union switch-expression pass from exactly two arms to one or more inner arms under the same terminal cached-Value/type-test/ThrowSwitchExpressionException shape.

Before, 3-case union switches stayed lowered:

```csharp
object V_4 = pet.Value;
Cat cat = V_4 as Cat;
if (cat is null)
{
    if (V_4 is Dog dog) { ... }
    if (V_4 is Bird bird) { ... }
    ThrowSwitchExpressionException(pet);
}
```

After:

```csharp
return pet switch
{
    Cat cat => cat.Name,
    Dog dog => dog.Name,
    Bird bird => bird.Name,
};
```

The same metadata and ownership gates remain: proven union Value receiver, terminal fallback throw, common result local, owned cached temp, and owned pattern-local references.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `TypeSourceComposerUnionTests`: 10 passed |
| Lowering coverage | Pass |
| Build-event validation | `Summary`: 263 projects, 0 failed, 0 errors, 0 warnings; event log `20260630T060818.5834781Z-2280598-build-a6a5a939` |
| Real witness | Preview SDK fixtures: 3-case declaration arms, 3-case non-declaration arms, generic `Box<Bird>` union |
| Near miss | Two-arm non-union `Value switch` still does not render `pet switch` |

## Decompiler quality

**Conclusion:** **ADVISORY** — no corpus card included for this targeted preview-language hardening slice; behavior is fixture-gated on union metadata and not expected to affect the current fixed corpus materially.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Non-blocking fixture/doc cleanup fixed in `c720e85f`. |
| Gemini 3.1 Pro | No significant issues | N-arm generalization and ownership/metadata gates confirmed. |

**Review conclusion:** **PASS** — required adversarial reviews completed and non-blocking guidance resolved.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringCoverageTests/*"
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate src/ILInspector.Decompiler.Tests -- -c Release --nologo --verbosity quiet
```

