### PR TITLE
Emit struct auto-properties in fidelity skeletons

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -126,6 +126,47 @@ public class FidelityCheckGeneratedFilterTests
     }
 
     [Fact]
+    public void Evaluate_RoundTripsStructAutoProperties()
+    {
+        var assemblyPath = CompileFixture("""
+            public readonly struct StructAutoPropertyPairFixture
+            {
+                public StructAutoPropertyPairFixture(double left, double right)
+                {
+                    Left = left;
+                    Right = right;
+                }
+
+                public double Left { get; }
+                public double Right { get; }
+
+                public double Sum() => this.Left + this.Right;
+            }
+            """);
+        try
+        {
+            var results = FidelityCheck.Evaluate(assemblyPath);
+            var ctor = Assert.Single(
+                results,
+                result => result.Type == "StructAutoPropertyPairFixture" && result.Method == ".ctor");
+            var getter = Assert.Single(
+                results,
+                result => result.Type == "StructAutoPropertyPairFixture" && result.Method == "get_Left");
+            var sum = Assert.Single(
+                results,
+                result => result.Type == "StructAutoPropertyPairFixture" && result.Method == "Sum");
+
+            Assert.True(ctor.Status == FidelityCheck.CompileBackStatus.Exact, ctor.Detail);
+            Assert.True(getter.Status == FidelityCheck.CompileBackStatus.Exact, getter.Detail);
+            Assert.True(sum.Status == FidelityCheck.CompileBackStatus.Exact, sum.Detail);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void Evaluate_RoundTripsStructObjectToStringDispatch()
     {
         var assemblyPath = CompileFixture("""

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1911,12 +1911,14 @@ static class FidelityCheck
         // binds — the dominant cluster bail (CS1061) once namespace + ctor stubs
         // land. A property whose accessor is a target is left to the method loop
         // unchanged, so the target's own emission and opcode comparison are
-        // untouched; the replaced accessor handles are skipped below. Classes only:
-        // a readonly-struct member accessed through a readonly receiver would take a
-        // defensive copy against a mutable stub, changing the target's opcodes.
+        // untouched; the replaced accessor handles are skipped below. Structs are
+        // restricted to compiler auto-properties: a non-auto mutable stub on a
+        // readonly receiver can introduce a defensive copy and change opcodes, but
+        // an auto-property preserves the field-backed accessor shape.
         var stubPropertyAccessors = new HashSet<MethodDefinitionHandle>();
-        if (kind == TypeKind.Class)
-            EmitStubProperties(reader, typeDef, targets, accessibility, thisFieldInits, stubPropertyAccessors, sb, pad + "    ");
+        if (kind is TypeKind.Class or TypeKind.Struct)
+            EmitStubProperties(reader, typeDef, targets, accessibility, thisFieldInits, stubPropertyAccessors, sb, pad + "    ",
+                requireAutoProperty: kind == TypeKind.Struct);
 
         foreach (var mh in typeDef.GetMethods())
         {
@@ -2086,7 +2088,8 @@ static class FidelityCheck
     static void EmitStubProperties(MetadataReader reader, TypeDefinition typeDef,
         IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets,
         SignatureAccessibility accessibility, IReadOnlyList<(string Field, string Value)> fieldInits,
-        HashSet<MethodDefinitionHandle> skipAccessors, StringBuilder sb, string pad)
+        HashSet<MethodDefinitionHandle> skipAccessors, StringBuilder sb, string pad,
+        bool requireAutoProperty = false)
     {
         var typeContext = GenericContext.ForType(reader, typeDef);
         foreach (var ph in typeDef.GetProperties())
@@ -2127,6 +2130,8 @@ static class FidelityCheck
                 bool isAutoProperty = hasGet
                     && AccessorsAreCompilerGenerated(reader, pa)
                     && HasAutoPropertyBackingField(reader, typeDef, pname, ret, isStatic);
+                if (requireAutoProperty && !isAutoProperty)
+                    continue;
                 bool accessorIsTarget = (!pa.Getter.IsNil && targets.ContainsKey(pa.Getter))
                     || (!pa.Setter.IsNil && targets.ContainsKey(pa.Setter));
                 if (accessorIsTarget && !isAutoProperty)


### PR DESCRIPTION
- Advances Humanizer compile-back fidelity.
- Changes fidelity skeleton behavior only: struct properties are emitted as property syntax when they are compiler auto-properties; non-auto struct property stubs still decline to avoid readonly-receiver defensive-copy risk.
- Card revision: `2b9fa445`

## Change

**Conclusion:** **PASS** — the skeleton now models field-backed struct auto-properties closely enough for bodies like `this.Bits` / `value.Bytes` to bind and compile back.

Before, Humanizer `ByteSize` rows failed with CS1061 because the skeleton emitted struct auto-property accessors as methods and did not expose `Bits`, `Bytes`, `Terabytes`, etc. as properties. After, the CS1061 bucket disappears from the targeted Humanizer changed-method run.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `FidelityCheckGeneratedFilterTests` passed, 7 tests |
| Decompiler fast suite | Pass, 1735 tests |
| Real witness | Targeted Humanizer changed-method compile-back improved recompile failures 54 -> 38; CS1061 11 -> 0 |
| Build-event validation | Pass; Compare `no-diagnostic-deltas` |

## Decompiler quality

**Conclusion:** **PASS** — targeted Humanizer compile-back converts struct-auto-property skeleton failures into checkable rows; full cap-1000 exacts improve while recompile failures drop.

Targeted Humanizer Full-method delta after this change:

```text
CHANGED-METHOD COMPILE-BACK over 1075 current changed methods (1075 attempted)

  exact opcode match : 862
  opcode diff (Full) : 102
  not Full           : 1
  recompile fail     : 38
  context fail       : 72
```

Targeted baseline before this change in the same worktree was 850 exact, 98 opcode diff, 1 not Full, 54 recompile fail, 72 context fail; CS1061 dropped from 11 to 0.

Humanizer cap-1000 after this change:

```text
COMPILE-BACK over 1000 rendered methods (958 Full)

  exact opcode match : 663 (66.30%)
  opcode diff (Full) : 229
  context-build fail : 2
  recompile fail     : 102
```

## Build-event validation

| View | Result |
| --- | --- |
| Preflight Summary | 138 projects, 0 failed, 0 errors, 0 warnings; `20260630T060550.7989870Z-2271756-build-3e2351f0` |
| Final Summary | 138 projects, 0 failed, 0 errors, 0 warnings; `20260630T060956.7080418Z-2283134-build-3e2351f0` |
| Compare | `no-diagnostic-deltas` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Verified readonly auto-getter identity, non-auto struct-stub decline, skip-accessor safety, static/virtual safety, and reduced fixture coverage |
| Gemini Pro | No blocking findings | Verified constructor assignment, getter targets, sibling `this.Property` calls, static backing-field matching, and Humanizer ByteSize witness alignment |

**Review conclusion:** **PASS** — both reviews independently found the struct auto-property skeleton expansion tightly scoped and safe; no follow-up code changes required.

## Validation

```bash
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate tools/DecompilerHarness -- -c Release --nologo --verbosity quiet

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*FidelityCheckGeneratedFilterTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet

dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --fidelity-method-delta /tmp/humanizer-cs1061-delta.json --max-examples 30
/usr/bin/time -f 'elapsed=%E cpu=%P maxrss=%MKB' dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 1000 --max-examples 12 --fidelity-timings

/home/rich/git/dotnet-build-events-vmr-preview5-events/artifacts/preview5-events-sdk-test/dotnet build tools/DecompilerHarness --no-incremental --view types --event-log-stderr -c Release --nologo --verbosity quiet
dotnet run --project /home/rich/git/dotnet-inspect-build-event-query/src/dotnet-inspect -c Release --no-build -- build /home/rich/.dotnet/build-events/2026-06-30/20260630T060550.7989870Z-2271756-build-3e2351f0.jsonl -S Compare --compare /home/rich/.dotnet/build-events/2026-06-30/20260630T060956.7080418Z-2283134-build-3e2351f0.jsonl --tsv
```
