### PR TITLE
Add Rung 7 performance triage shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ depth, and loop calls; `Performance Triage` surfaces the highest-value
 allocation pay-dirt first — ranking in-loop (hot) and high-confidence
 opportunities ahead of raw leverage — across actionable rewrite shapes (small
 non-escaping arrays, temporary or span-to-array copies, capturing and instance
-method-group delegates, and value-type boxing) plus `allocation-hotspot` rows
+method-group delegates, async state-machine setup, loop-invariant
+materialization, and value-type boxing) plus `allocation-hotspot` rows
 for methods that allocate heavily without matching a specific shape. Use
 `--top`, `--loop`, `--min-confidence`, and `--triage-shape` to ask the tool for
 the curated pay-dirt rows directly instead of post-processing. `--top` limits
@@ -133,8 +134,9 @@ dotnet-inspect member MyType Method:1 --library MyLib.dll -S "Caller Graph" --fi
 ```
 
 Common `--triage-shape` values include `capturing-delegate`,
-`box-value-type`, `small-array`, `linq-scan-in-loop`,
-`string-build-in-loop`, `enumerator-allocation`, and `allocation-hotspot`.
+`async-state-machine`, `box-value-type`, `small-array`, `linq-scan-in-loop`,
+`materialize-in-loop`, `string-build-in-loop`, `enumerator-allocation`, and
+`allocation-hotspot`.
 
 ### Decompiler
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1352,6 +1352,9 @@ public class LibraryBodyIndexTests
         Assert.DoesNotContain(index.OptimizationOpportunities, o =>
             o.Method.Name == nameof(OptimizationOpportunityFixtures.MaterializesPerIterationSourceInLoop)
             && o.Shape == "materialize-in-loop");
+        Assert.DoesNotContain(index.OptimizationOpportunities, o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.MaterializesSourceMutatedByRefInLoop)
+            && o.Shape == "materialize-in-loop");
     }
 
     [Theory]
@@ -2720,6 +2723,23 @@ public class OptimizationOpportunityFixtures
             total += filtered.ToArray().Length;
         }
         return total;
+    }
+
+    public static int MaterializesSourceMutatedByRefInLoop(IEnumerable<int> source, IEnumerable<int> replacement, int count)
+    {
+        var current = source;
+        var total = 0;
+        for (int i = 0; i < count; i++)
+        {
+            ReplaceSource(ref current, replacement);
+            total += current.ToArray().Length;
+        }
+        return total;
+    }
+
+    static void ReplaceSource(ref IEnumerable<int> source, IEnumerable<int> replacement)
+    {
+        source = replacement;
     }
 
     // A method taking an UNTRUSTED RenderTreeBuilder lookalike (defined in this test assembly,

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1319,6 +1319,36 @@ public class LibraryBodyIndexTests
         Assert.Equal("high", inLoop.Confidence);
     }
 
+    [Fact]
+    public void OptimizationOpportunities_AsyncStateMachine_IsAmortized()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var row = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.AsyncStream)
+            && o.Shape == "async-state-machine"));
+        Assert.False(row.InLoop);
+        Assert.True(row.Amortized);
+        Assert.Equal("low", row.Confidence);
+        Assert.Contains("once per call/enumeration/subscription", row.Caveat);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_MaterializeInLoop_RequiresLoopInvariantSource()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var row = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.MaterializesInvariantSourceInLoop)
+            && o.Shape == "materialize-in-loop"));
+        Assert.True(row.InLoop);
+        Assert.Equal("high", row.Confidence);
+
+        Assert.DoesNotContain(index.OptimizationOpportunities, o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.MaterializesPerIterationSourceInLoop)
+            && o.Shape == "materialize-in-loop");
+    }
+
     [Theory]
     // Non-loop delegate on a high-reach method -> lifted from low to medium.
     [InlineData("capturing-delegate", false, "low", LibraryBodyIndex.DelegateHotRootReach, "medium")]
@@ -2649,6 +2679,32 @@ public class OptimizationOpportunityFixtures
         {
             System.Func<int> f = () => v + seed;
             total += f();
+        }
+        return total;
+    }
+
+    public static async IAsyncEnumerable<int> AsyncStream(int count)
+    {
+        await System.Threading.Tasks.Task.Yield();
+        for (int i = 0; i < count; i++)
+            yield return i;
+    }
+
+    public static int MaterializesInvariantSourceInLoop(IEnumerable<int> source, int count)
+    {
+        var total = 0;
+        for (int i = 0; i < count; i++)
+            total += source.ToArray().Length;
+        return total;
+    }
+
+    public static int MaterializesPerIterationSourceInLoop(IEnumerable<int> source, int count)
+    {
+        var total = 0;
+        for (int i = 0; i < count; i++)
+        {
+            var filtered = source.Where(value => value > i);
+            total += filtered.ToArray().Length;
         }
         return total;
     }

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1344,6 +1344,11 @@ public class LibraryBodyIndexTests
         Assert.True(row.InLoop);
         Assert.Equal("high", row.Confidence);
 
+        var shortArg = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.MaterializesShortFormSourceArgumentInLoop)
+            && o.Shape == "materialize-in-loop"));
+        Assert.True(shortArg.InLoop);
+
         Assert.DoesNotContain(index.OptimizationOpportunities, o =>
             o.Method.Name == nameof(OptimizationOpportunityFixtures.MaterializesPerIterationSourceInLoop)
             && o.Shape == "materialize-in-loop");
@@ -2695,6 +2700,14 @@ public class OptimizationOpportunityFixtures
         var total = 0;
         for (int i = 0; i < count; i++)
             total += source.ToArray().Length;
+        return total;
+    }
+
+    public static int MaterializesShortFormSourceArgumentInLoop(int a, int b, int c, int d, IEnumerable<int> source, int count)
+    {
+        var total = a + b + c + d;
+        for (int i = 0; i < count; i++)
+            total += source.ToList().Count;
         return total;
     }
 

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -2028,8 +2028,7 @@ public sealed class LibraryBodyIndex
                     var definition = interfaceType.Kind == TypeRefKind.GenericInstance
                         ? interfaceType.ElementType ?? interfaceType
                         : interfaceType;
-                    if (definition.Namespace == "System.Runtime.CompilerServices"
-                        && definition.Name == "IAsyncStateMachine")
+                    if (FrameworkIdentity.IsCoreLibraryType(definition, "System.Runtime.CompilerServices", "IAsyncStateMachine"))
                     {
                         set.Add(type.ToQualifiedDisplayString());
                         break;
@@ -3005,6 +3004,15 @@ public sealed class LibraryBodyIndex
                 && candidate.Slot == slot);
             if (use is null || use.Address || use.ReachingDefinitions.Length == 0)
                 return false;
+            if (reachingDefinitions.Uses.Any(candidate =>
+                candidate.Address
+                && candidate.IsArgument == isArg
+                && candidate.Slot == slot
+                && candidate.Offset >= loop.Start
+                && candidate.Offset <= loop.End))
+            {
+                return false;
+            }
             foreach (var definition in use.ReachingDefinitions)
             {
                 if (definition.Offset >= loop.Start && definition.Offset <= loop.End)

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -3032,6 +3032,8 @@ public sealed class LibraryBodyIndex
                         SkipOperandStatic(il, opcode, ref position, offset);
                     if (position > targetOffset)
                         return false;
+                    if (opcode == ILOpCode.Nop)
+                        continue;
                     previousOffset = offset;
                     previousOpcode = opcode;
                     previousOperandPosition = operandPosition;

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -3024,7 +3024,8 @@ public sealed class LibraryBodyIndex
                     int offset = position;
                     var opcode = ReadOpcode(il, ref position);
                     int operandPosition = position;
-                    SkipOperandStatic(il, opcode, ref position, offset);
+                    if (!TryReadLocalSlot(il, opcode, ref position, offset, out _, out _, out _))
+                        SkipOperandStatic(il, opcode, ref position, offset);
                     if (position > targetOffset)
                         return false;
                     previousOffset = offset;

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -83,7 +83,9 @@ public sealed class LibraryBodyIndex
                             : AdjustDelegateConfidenceForReach(adjusted.Shape, adjusted.InLoop, adjusted.Confidence, reach);
                         return confidence != adjusted.Confidence ? adjusted with { Confidence = confidence } : adjusted;
                     }),
-                    .. AllocationHotspots(reachByToken, new HashSet<int>(_rawOpportunities.Select(o => o.Method.MetadataToken))),
+                    .. AllocationHotspots(reachByToken, new HashSet<int>(_rawOpportunities
+                        .Where(o => !(o.Shape == "async-state-machine" && o.Amortized))
+                        .Select(o => o.Method.MetadataToken))),
                     .. ScanMethodsInvokedInLoops(reachByToken),
                 ];
             }
@@ -267,6 +269,8 @@ public sealed class LibraryBodyIndex
         if (!IsEnumerableDefinition(member.DeclaringType))
             return false;
         if (member.ParameterTypes.Length != 1)
+            return false;
+        if (member.TypeArguments.Length != 1)
             return false;
         switch (member.Name)
         {

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -259,6 +259,26 @@ public sealed class LibraryBodyIndex
         }
     }
 
+    static bool IsLinqMaterializer(MemberRef member, out string op)
+    {
+        op = "";
+        if (member.Kind == MemberKind.Unsupported)
+            return false;
+        if (!IsEnumerableDefinition(member.DeclaringType))
+            return false;
+        if (member.ParameterTypes.Length != 1)
+            return false;
+        switch (member.Name)
+        {
+            case "ToArray":
+            case "ToList":
+                op = member.Name;
+                return true;
+            default:
+                return false;
+        }
+    }
+
     // System.Linq.Enumerable across target frameworks: the type lives in System.Linq on
     // .NET 5+ reference assemblies, in System.Core on .NET Framework, and canonicalizes to
     // the core library on netstandard. IsKnownFrameworkType matches all three facades and
@@ -1088,7 +1108,6 @@ public sealed class LibraryBodyIndex
                         if (unsafety.Length > 0)
                             unsafetyOccurrences[caller.MetadataToken] = unsafety;
                         var methodAttributes = methodDef.GetCustomAttributes();
-                        if (caller.Name == "BoxesGenericStruct") System.IO.File.AppendAllText("box_debug.txt", $"typeGen: {typeSourceGenerated} metGen1: {HasGeneratedCodeAttribute(methodAttributes)} metGen2: {HasCompilerGeneratedAttribute(methodAttributes)} blazor: {IsBlazorRenderMethod(caller)}\n");
                         if (!typeSourceGenerated
                             && !HasGeneratedCodeAttribute(methodAttributes)
                             && !HasCompilerGeneratedAttribute(methodAttributes)
@@ -1976,6 +1995,65 @@ public sealed class LibraryBodyIndex
             }
         }
 
+        IReadOnlySet<string>? _asyncStateMachineTypes;
+
+        bool IsAsyncStateMachineType(TypeRef? type)
+        {
+            if (type is null)
+                return false;
+            var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+            return AsyncStateMachineTypes().Contains(definition.ToQualifiedDisplayString());
+        }
+
+        IReadOnlySet<string> AsyncStateMachineTypes()
+        {
+            if (_asyncStateMachineTypes is not null)
+                return _asyncStateMachineTypes;
+
+            var set = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var typeHandle in _reader.TypeDefinitions)
+            {
+                var typeDef = _reader.GetTypeDefinition(typeHandle);
+                var type = TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, typeHandle, 0);
+                if (!type.Name.Contains(">d__", StringComparison.Ordinal))
+                    continue;
+                foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
+                {
+                    var implementation = _reader.GetInterfaceImplementation(implementationHandle);
+                    var interfaceType = TypeFromEntity(implementation.Interface);
+                    var definition = interfaceType.Kind == TypeRefKind.GenericInstance
+                        ? interfaceType.ElementType ?? interfaceType
+                        : interfaceType;
+                    if (definition.Namespace == "System.Runtime.CompilerServices"
+                        && definition.Name == "IAsyncStateMachine")
+                    {
+                        set.Add(type.ToQualifiedDisplayString());
+                        break;
+                    }
+                }
+            }
+            _asyncStateMachineTypes = set;
+            return set;
+        }
+
+        TypeRef TypeFromEntity(EntityHandle handle)
+        {
+            try
+            {
+                return handle.Kind switch
+                {
+                    HandleKind.TypeDefinition => TypeRefDecoder.Instance.GetTypeFromDefinition(_reader, (TypeDefinitionHandle)handle, 0),
+                    HandleKind.TypeReference => TypeRefDecoder.Instance.GetTypeFromReference(_reader, (TypeReferenceHandle)handle, 0),
+                    HandleKind.TypeSpecification => TypeRefDecoder.Instance.GetTypeFromSpecification(_reader, new GenericScope([], []), (TypeSpecificationHandle)handle, 0),
+                    _ => TypeRef.Unsupported("interface implementation"),
+                };
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException)
+            {
+                return TypeRef.Unsupported("interface implementation");
+            }
+        }
+
         ImmutableArray<OptimizationOpportunity> CollectOptimizationOpportunities(byte[] il, IReadOnlyCollection<ExceptionRegion> exceptionRegions, MethodIdentity caller, GenericScope callerScope, IReadOnlyList<(int Start, int End)> loopRegions)
         {
             var opportunities = ImmutableArray.CreateBuilder<OptimizationOpportunity>();
@@ -2135,6 +2213,27 @@ public sealed class LibraryBodyIndex
                             }
                             pendingDelegateOffset = null;
                         }
+                        if (allocationByOffset.TryGetValue(offset, out var stateMachineAllocation)
+                            && stateMachineAllocation.Kind == AllocationKind.StateMachine
+                            && IsAsyncStateMachineType(stateMachineAllocation.AllocatedType))
+                        {
+                            var inLoop = IsInLoopRegion(offset, loopRegions);
+                            opportunities.Add(new OptimizationOpportunity(
+                                caller,
+                                "async-state-machine",
+                                $"async state-machine allocation ({stateMachineAllocation.Detail ?? "state machine"})",
+                                "Async state machines are intrinsic to async/async-iterator lowering: this usually moves work into a state object rather than eliminating it, and is often once per call/enumeration/subscription rather than per item. Optimize only if profiles show this method creates state machines repeatedly on a hot path.",
+                                inLoop ? "medium" : "low",
+                                inLoop,
+                                offset,
+                                inLoop
+                                    ? "Repeated async state-machine allocation at a loop call site; still verify whether the async operation itself is required."
+                                    : "Amortized async state-machine allocation: often once per call/enumeration/subscription, not per item.",
+                                ColdPath: false)
+                            {
+                                Amortized = !inLoop,
+                            });
+                        }
                         break;
                     }
                     case ILOpCode.Call:
@@ -2186,6 +2285,20 @@ public sealed class LibraryBodyIndex
                                     offset,
                                     "The copy is required if the array escapes (returned, stored, or passed to an array-typed API)."));
                             }
+                        }
+                        else if (IsLinqMaterializer(callee, out var materializeOp)
+                            && TryGetContainingLoop(offset, loopRegions, out var materializeLoop)
+                            && LinqMaterializerSourceIsLoopInvariant(il, GetReachingDefinitions(), offset, materializeLoop, out var sourceEvidence))
+                        {
+                            opportunities.Add(new OptimizationOpportunity(
+                                caller,
+                                "materialize-in-loop",
+                                $"Enumerable.{materializeOp}(...) inside a loop over loop-invariant source ({sourceEvidence})",
+                                "Hoist the ToArray/ToList materialization outside the loop, or cache it before the loop, so each iteration reuses the same snapshot.",
+                                "high",
+                                true,
+                                offset,
+                                "Only valid when the source sequence is unchanged during the loop; this row requires complete reaching-defs and an outside-loop source definition."));
                         }
                         else if (IsLinqMembershipScan(callee, out var scanOp) && IsInLoopRegion(offset, loopRegions))
                         {
@@ -2846,6 +2959,83 @@ public sealed class LibraryBodyIndex
                     return true;
                 default:
                     return false;
+            }
+        }
+
+        static bool TryGetContainingLoop(int offset, IReadOnlyList<(int Start, int End)> loopRegions, out (int Start, int End) loop)
+        {
+            loop = default;
+            var found = false;
+            foreach (var region in loopRegions)
+            {
+                if (offset < region.Start || offset > region.End)
+                    continue;
+                if (!found || region.End - region.Start < loop.End - loop.Start)
+                    loop = region;
+                found = true;
+            }
+            return found;
+        }
+
+        bool LinqMaterializerSourceIsLoopInvariant(
+            byte[] il,
+            ReachingDefinitionsResult reachingDefinitions,
+            int callOffset,
+            (int Start, int End) loop,
+            out string evidence)
+        {
+            evidence = "";
+            if (!reachingDefinitions.IsComplete)
+                return false;
+            if (!TryFindPreviousInstruction(il, callOffset, out int loadOffset, out var loadOpcode, out int operandPosition))
+                return false;
+            if (!TryReadLocalSlot(il, loadOpcode, ref operandPosition, loadOffset, out bool isStore, out bool isArg, out int slot)
+                || isStore)
+            {
+                return false;
+            }
+
+            var use = reachingDefinitions.Uses.FirstOrDefault(candidate =>
+                candidate.Offset == loadOffset
+                && candidate.IsArgument == isArg
+                && candidate.Slot == slot);
+            if (use is null || use.Address || use.ReachingDefinitions.Length == 0)
+                return false;
+            foreach (var definition in use.ReachingDefinitions)
+            {
+                if (definition.Offset >= loop.Start && definition.Offset <= loop.End)
+                    return false;
+            }
+
+            evidence = isArg ? $"arg{slot}" : $"V_{slot}";
+            return true;
+        }
+
+        static bool TryFindPreviousInstruction(byte[] il, int targetOffset, out int previousOffset, out ILOpCode previousOpcode, out int previousOperandPosition)
+        {
+            previousOffset = -1;
+            previousOpcode = default;
+            previousOperandPosition = -1;
+            try
+            {
+                int position = 0;
+                while (position < targetOffset)
+                {
+                    int offset = position;
+                    var opcode = ReadOpcode(il, ref position);
+                    int operandPosition = position;
+                    SkipOperandStatic(il, opcode, ref position, offset);
+                    if (position > targetOffset)
+                        return false;
+                    previousOffset = offset;
+                    previousOpcode = opcode;
+                    previousOperandPosition = operandPosition;
+                }
+                return previousOffset >= 0 && position == targetOffset;
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException or IndexOutOfRangeException)
+            {
+                return false;
             }
         }
 

--- a/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
+++ b/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
@@ -9,11 +9,13 @@ public sealed record PerformanceTriageOptions
     public static readonly string[] KnownShapes =
     [
         "allocation-hotspot",
+        "async-state-machine",
         "box-value-type",
         "capturing-delegate",
         "enumerator-allocation",
         "instance-method-group-delegate",
         "linq-scan-in-loop",
+        "materialize-in-loop",
         "scan-method-in-loop-call",
         "small-array",
         "span-to-array-copy",


### PR DESCRIPTION
## Summary

Adds the greenlit #1941 Track B shapes in `LibraryBodyIndex`:

- `async-state-machine`: reports class async state-machine `newobj` sites by metadata (`IAsyncStateMachine` plus allocation occurrence), excludes struct state machines without an observed allocation, and carries the amortized/moved-not-eliminated caveat in the rendered fix text.
- `materialize-in-loop`: reports only `Enumerable.ToArray` / `Enumerable.ToList` calls inside loops when complete reaching-defs prove the source local/argument is defined outside the containing loop. Unknown and per-iteration sources are declined.
- Leaves the typed-stack question gated: the branch relies on token/signature/reaching-defs evidence only. Existing type-aware allocation gates already use operand-token evidence for `newarr`/`box`.

Also updates `--triage-shape` validation/docs and removes a stray debug write in `LibraryBodyIndex`.

## Paydirt context

The standard corpus diff is the no-regression proof, not the full paydirt read. The #1941 Track A probe included Aspire Dashboard explicitly and found the motivating async population there: `Aspire.Dashboard.dll asyncTypes=458`, `classTypes=10`, `newobj=16`, `classNewobj=16`, including streaming/subscription methods such as `WatchSpansAsync`, `WatchLogsAsync`, `FollowSpansAsync`, `FollowLogsAsync`, `SubscribeConsoleLogs`, and `GetConsoleLogs`.

That is why the shipped row carries amortized/frequency context: these are real class state-machine allocation sites, but often once per enumeration/subscription rather than per item.

## Evidence

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `npx markdownlint-cli README.md`
- source-build smoke:
  - `dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll library artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tests.dll -S "Performance Triage" --triage-shape async-state-machine --top 5 --tsv`
  - `dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll library artifacts/bin/ILInspector.Analysis.Tests/release/ILInspector.Analysis.Tests.dll -S "Performance Triage" --triage-shape materialize-in-loop --top 5 --tsv`
- `dotnet tools/AnalysisHarness/bin/Release/net11.0/analysis-harness.dll --corpus-list /tmp/issue1941-build-corpus.txt --diff-corpus-baseline tools/AnalysisHarness/corpus/analysis-baseline.json`
  - result: `0 regression(s), 2 drift, 0 added/removed`
  - expected new-shape drift: `DotnetInspector.Core.dll: async-state-machine 0 -> 1`; `ILInspector.Decompiler.dll: materialize-in-loop 0 -> 3`

## Review status

Draft until two-family adversarial review is reconciled on the PR.

Fixes #1941 Track B.
