### PR TITLE
Raise class union switch expressions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -377,6 +377,56 @@ public class TypeSourceComposerUnionTests
     }
 
     [Fact]
+    public async Task ClassUnionSwitchExpression_RendersTypePatternArms()
+    {
+        using var assembly = await CompileWithSdk("""
+            using System.Runtime.CompilerServices;
+            namespace UnionFixtures;
+
+            public sealed class Cat { public string Name { get; } = "cat"; }
+            public sealed class Dog { public string Name { get; } = "dog"; }
+
+            [Union]
+            public sealed class Pet : IUnion
+            {
+                public Pet(Cat value) => Value = value;
+                public Pet(Dog value) => Value = value;
+                public object? Value { get; }
+            }
+
+            public static class Matcher
+            {
+                public static string Describe(Pet pet) => pet switch
+                {
+                    Cat cat => cat.Name,
+                    Dog dog => dog.Name,
+                };
+
+                public static int Kind(Pet pet) => pet switch
+                {
+                    Cat => 1,
+                    Dog => 2,
+                };
+            }
+            """);
+
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat => cat.Name,
+                Dog dog => dog.Name,
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Describe"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat => 1,
+                Dog => 2,
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Kind"));
+    }
+
+    [Fact]
     public void NonUnionValuePropertyTypeTest_KeepsValueAccess()
     {
         using var assembly = Compile("""

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -34,6 +34,12 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         var children = block.Children;
         for (int start = 0; start < children.Count; start++)
         {
+            if (TryMatchClassNullGuardAt(function, children, start, out var guardedSwitch))
+            {
+                match = new Match(start, guardedSwitch);
+                return true;
+            }
+
             if (TryMatchAt(function, children, start, out var switchExpression))
             {
                 match = new Match(start, switchExpression);
@@ -42,6 +48,43 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         }
 
         return false;
+    }
+
+    static bool TryMatchClassNullGuardAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        if (start + 3 != children.Count
+            || children[start] is not IfStatement { HasElse: false } nullGuard
+            || children[start + 1] is not ExpressionStatement throwStatement
+            || children[start + 2] is not Return throwReturn
+            || !IsThrowSwitchExpression(throwStatement)
+            || !ThrowArgumentMatches(throwStatement, nullGuard.Condition)
+            || !ReturnsLocal(throwReturn, out int resultLocal))
+        {
+            return false;
+        }
+
+        var body = nullGuard.Then.Children;
+        if (body.Count < 2
+            || body[0] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsUnionValueProperty(function, unionValue)
+            || !PlaceIdentity.SameVariable(unionValue.Instance, nullGuard.Condition))
+        {
+            return false;
+        }
+
+        int tempLocal = valueStore.Index;
+        if (!TryFirstArmWithElse(body, tempLocal, resultLocal, out var firstIf, out var firstArm, out var firstExtraUse))
+            return false;
+
+        var allowedTempUses = firstExtraUse is null
+            ? (IReadOnlyList<IrNode>)[valueStore, firstIf]
+            : [valueStore, firstExtraUse, firstIf];
+        return TryBuildSwitch(function, unionValue, tempLocal, resultLocal, firstIf.Then.Children, firstArm, allowedTempUses, out switchExpression);
     }
 
     static bool TryMatchAt(
@@ -110,8 +153,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             || firstIf.Then.Children[^2] is not ExpressionStatement throwStatement
             || firstIf.Then.Children[^1] is not Return throwReturn
             || !IsThrowSwitchExpression(throwStatement)
-            || !ReturnsLocal(throwReturn, resultLocal)
-            || !TryInnerArms(firstIf.Then.Children.Take(firstIf.Then.Children.Count - 2), tempLocal, resultLocal, out var innerArms))
+            || !ReturnsLocal(throwReturn, resultLocal))
         {
             return false;
         }
@@ -120,6 +162,23 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         var allowedTempUses = extraTempUse is null
             ? (IReadOnlyList<IrNode>)[unionValue.Parent!, firstIf]
             : [unionValue.Parent!, extraTempUse, firstIf];
+        return TryBuildSwitch(function, unionValue, tempLocal, resultLocal, firstIf.Then.Children.Take(firstIf.Then.Children.Count - 2), firstArm, allowedTempUses, out switchExpression);
+    }
+
+    static bool TryBuildSwitch(
+        IrFunction function,
+        LoadProperty unionValue,
+        int tempLocal,
+        int resultLocal,
+        IEnumerable<IrNode> innerArmNodes,
+        Arm firstArm,
+        IReadOnlyList<IrNode> allowedTempUses,
+        out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        if (!TryInnerArms(innerArmNodes, tempLocal, resultLocal, out var innerArms))
+            return false;
+
         if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, tempLocal, allowedTempUses)
             || !ArmLocalReferencesAreOwned(function, firstArm)
             || innerArms.Any(arm => !ArmLocalReferencesAreOwned(function, arm)))
@@ -179,6 +238,50 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         }
     }
 
+    static bool TryFirstArmWithElse(
+        IReadOnlyList<IrNode> body,
+        int tempLocal,
+        int resultLocal,
+        out IfStatement firstIf,
+        out Arm firstArm,
+        out IrNode? firstExtraUse)
+    {
+        firstIf = null!;
+        firstArm = null!;
+        firstExtraUse = null;
+        if (body[1] is StoreLocal { Value: IsInstance firstAs } firstStore)
+        {
+                if (!IsTempTypeTest(firstAs, tempLocal)
+                    || body[2] is not IfStatement { HasElse: true } withLocalIf
+                    || !IsNotLocal(withLocalIf.Condition, firstStore.Index)
+                    || withLocalIf.Else is not { } elseArm
+                    || !TryStoreReturn(elseArm.Children, 0, out int firstResultLocal, out var firstValue)
+                    || firstResultLocal != resultLocal)
+                {
+                    return false;
+                }
+
+                firstIf = withLocalIf;
+                firstArm = new Arm(firstAs.Type, firstStore.Index, firstValue, [firstStore, withLocalIf.Condition, firstValue]);
+                firstExtraUse = firstStore;
+                return true;
+        }
+
+        if (body[1] is IfStatement { HasElse: true } noLocalIf
+                && noLocalIf.Condition is LogicalNot { Operand: IsInstance firstTest }
+                && IsTempTypeTest(firstTest, tempLocal)
+                && noLocalIf.Else is { } noLocalElse
+                && TryStoreReturn(noLocalElse.Children, 0, out int noLocalResultLocal, out var noLocalValue)
+                && noLocalResultLocal == resultLocal)
+        {
+                firstIf = noLocalIf;
+                firstArm = new Arm(firstTest.Type, LocalIndex: null, noLocalValue, []);
+                return true;
+        }
+
+        return false;
+    }
+
     static bool TryStoreReturn(IReadOnlyList<IrNode> nodes, int index, out int local, out IrExpression value)
     {
         local = -1;
@@ -198,6 +301,18 @@ public sealed class UnionSwitchExpressionPass : IIrPass
 
     static bool ReturnsLocal(Return ret, int local)
         => ret.Value is LoadLocal load && load.Index == local;
+
+    static bool ReturnsLocal(Return ret, out int local)
+    {
+        if (ret.Value is LoadLocal load)
+        {
+            local = load.Index;
+            return true;
+        }
+
+        local = -1;
+        return false;
+    }
 
     static bool IsNotLocal(IrExpression expression, int local)
         => expression is LogicalNot { Operand: LoadLocal load } && load.Index == local;
@@ -221,6 +336,10 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 DeclaringType.Name: "<PrivateImplementationDetails>",
             },
         };
+
+    static bool ThrowArgumentMatches(ExpressionStatement statement, IrExpression receiver)
+        => statement.Expression is Call { Arguments: [var argument] }
+        && PlaceIdentity.SameVariable(argument, receiver);
 
     static bool IsUnionValueProperty(IrFunction function, LoadProperty property)
         => property.PropertyName == "Value"

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -69,7 +69,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         }
 
         var body = nullGuard.Then.Children;
-        if (body.Count < 2
+        if (body.Count is not (2 or 3)
             || body[0] is not StoreLocal { Value: LoadProperty unionValue } valueStore
             || !IsUnionValueProperty(function, unionValue)
             || !PlaceIdentity.SameVariable(unionValue.Instance, nullGuard.Condition))
@@ -251,15 +251,17 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         firstExtraUse = null;
         if (body[1] is StoreLocal { Value: IsInstance firstAs } firstStore)
         {
-                if (!IsTempTypeTest(firstAs, tempLocal)
-                    || body[2] is not IfStatement { HasElse: true } withLocalIf
-                    || !IsNotLocal(withLocalIf.Condition, firstStore.Index)
-                    || withLocalIf.Else is not { } elseArm
-                    || !TryStoreReturn(elseArm.Children, 0, out int firstResultLocal, out var firstValue)
-                    || firstResultLocal != resultLocal)
-                {
-                    return false;
-                }
+            if (!IsTempTypeTest(firstAs, tempLocal)
+                || body.Count != 3
+                || body[2] is not IfStatement { HasElse: true } withLocalIf
+                || !IsNotLocal(withLocalIf.Condition, firstStore.Index)
+                || withLocalIf.Else is not { } elseArm
+                || elseArm.Children.Count != 2
+                || !TryStoreReturn(elseArm.Children, 0, out int firstResultLocal, out var firstValue)
+                || firstResultLocal != resultLocal)
+            {
+                return false;
+            }
 
                 firstIf = withLocalIf;
                 firstArm = new Arm(firstAs.Type, firstStore.Index, firstValue, [firstStore, withLocalIf.Condition, firstValue]);
@@ -271,6 +273,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 && noLocalIf.Condition is LogicalNot { Operand: IsInstance firstTest }
                 && IsTempTypeTest(firstTest, tempLocal)
                 && noLocalIf.Else is { } noLocalElse
+                && noLocalElse.Children.Count == 2
                 && TryStoreReturn(noLocalElse.Children, 0, out int noLocalResultLocal, out var noLocalValue)
                 && noLocalResultLocal == resultLocal)
         {


### PR DESCRIPTION
- Advances #1917
- Changes union switch-expression reconstruction to support custom class-union null-guard wrappers around the cached `Value` dispatch.
- Card revision: 6fa66f5a

## Change

**Conclusion:** **REVIEW** — this hardens the union switch-expression pass for `[Union] class ... : IUnion` shapes. Struct-union paths remain covered by prior PRs.

Class union switch expressions lower through an outer null guard:

```csharp
if (pet is not null)
{
    object value = pet.Value;
    ... type-test arms ...
}
ThrowSwitchExpressionException(pet);
```

After this PR, declaration and non-declaration arms render as:

```csharp
return pet switch
{
    Cat cat => cat.Name,
    Dog dog => dog.Name,
};
```

The class wrapper path checks that the null guard receiver, `Value` receiver, and throw-helper argument are the same variable, and then reuses the same union metadata, common-result-local, temp ownership, arm ownership, and terminal fallback gates as the struct path.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `TypeSourceComposerUnionTests`: 11 passed |
| Lowering coverage | Pass |
| Build-event validation | `Summary`: 263 projects, 0 failed, 0 errors, 0 warnings; event log `20260630T063154.6652177Z-2328759-build-2308e48b` |
| Real witness | Preview SDK custom class union fixture: declaration and non-declaration arms render as `pet switch` |

## Decompiler quality

**Conclusion:** **ADVISORY** — no corpus card included for this targeted preview-language hardening slice; behavior is fixture-gated on union metadata and not expected to affect the current fixed corpus materially.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Finding resolved | `dfe5f437` adds exact child-count guards for class-union wrapper bodies. |
| Gemini 3.1 Pro | Findings resolved | `dfe5f437` fixes partial/surplus shape robustness; receiver proof confirmed. |

**Review conclusion:** **PASS** — required adversarial reviews completed and actionable guidance resolved.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringCoverageTests/*"
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate src/ILInspector.Decompiler.Tests -- -c Release --nologo --verbosity quiet
```


