### PR TITLE
Update shape projection skill guidance

### DIFF
--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -26,6 +26,7 @@ Default output is Markdown. Pick a machine or compact shape when you need one:
 - `--json` — structured documents.
 - `--bare` — one undecorated payload or URL list.
 - `--count` — a bare row count.
+- `--value` / `--urls` / `--paths` — project one selected section to scalar, URL, or path payloads.
 - `--print` — print one document behind a selected printable row; use `--row N` when multiple printable rows exist.
 - `--print-all` — print every printable row from one selected section, with text separators or one JSON object per row under `--jsonl`.
 - `--mermaid` — graph-shaped output.
@@ -53,7 +54,7 @@ Prefer built-in limits to shell pipes:
 - `-n N` and numeric shorthand like `-6` cap output lines, like `head`.
 - `--tail N` shows the end, like `tail`.
 - `--rows` makes `-n` cap Markdown table data rows instead of output lines.
-- With `--print`, `--row N` chooses the Nth printable row; `-n N` still limits printed document lines.
+- With `--print`, `--value`, `--urls`, or `--paths`, `--row N` chooses the projected row; `-n N` still limits output lines.
 - `--count` counts rows in one selected table.
 
 Command-specific caps: `-t N` for type/find rows, `-m N` for members, and

--- a/skills/sourcelink/SKILL.md
+++ b/skills/sourcelink/SKILL.md
@@ -19,12 +19,13 @@ dnx dotnet-inspect -y -- <command>
 
 `-S "Source Files"` maps types to their SourceLink URLs (on `type`, `library`,
 or `package`); `-S "Source Locations"` gives per-member file and line URLs
-without fetching the bodies.
+without fetching the bodies. Use `--urls` for a clean URL list and `--paths` for
+source path rows.
 
 ```bash
 dnx dotnet-inspect -y -- library System.Text.Json -S "Source Files"
-dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Source Files"
-dnx dotnet-inspect -y -- member Type Method:1 -S "Source Locations"
+dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Source Files" --urls
+dnx dotnet-inspect -y -- member Type Method:1 -S "Source Locations" --paths
 ```
 
 ## Fetch the original source
@@ -44,13 +45,14 @@ dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Sou
 ## URL forms
 
 PDBs *carry* SourceLink data; they are not SourceLink themselves. SourceLink URL
-rows default to raw/fetchable form; add `--blob` for browser URLs. Use `--bare`
-to extract a clean URL list for scripting; use `--print` when you want the
-referenced source body.
+rows default to raw/fetchable form; add `--blob` for browser URLs. Prefer
+`--urls` when you want URL payloads, `--paths` for file paths, and `--print` when
+you want the referenced source body. `--bare` remains a raw selected-payload
+escape hatch.
 
 ```bash
-dnx dotnet-inspect -y -- member Type Method:1 -S "Source Locations" --bare
-dnx dotnet-inspect -y -- library System.Text.Json -S "Source Files" --blob
+dnx dotnet-inspect -y -- member Type Method:1 -S "Source Locations" --urls --jsonl
+dnx dotnet-inspect -y -- library System.Text.Json -S "Source Files" --urls --blob
 ```
 
 To check *whether* SourceLink is present and valid (rather than fetch source),


### PR DESCRIPTION
## Summary

Fixes #1949.

Updates embedded skill guidance now that #1950 has landed:

- `skills/query`: documents `--value`, `--urls`, and `--paths` as selected-section shape projections, and clarifies `--row N` works with those projections as well as `--print`.
- `skills/sourcelink`: prefers `--urls` for URL payloads, `--paths` for source paths, and `--print` for fetched source bodies; keeps `--bare` as a raw selected-payload escape hatch.

## Validation

- `npx markdownlint-cli skills/query/SKILL.md skills/sourcelink/SKILL.md`
- `git diff --check`

Docs-only; no product behavior change.
