### PR TITLE
Use corpus metadata in targeted fidelity checks

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -241,6 +241,87 @@ public class FidelityCheckGeneratedFilterTests
         }
     }
 
+    [Fact]
+    public void RunMethodDelta_UsesCorpusMetadataForPlatformOutParameters()
+    {
+        var assemblyPath = CompileFixture("""
+            using System.Collections.Generic;
+
+            public class TargetedDictionaryOutFixture
+            {
+                public bool Lookup(Dictionary<string, int> dictionary, string key)
+                {
+                    int value = default;
+                    return dictionary.TryGetValue(key, out value);
+                }
+            }
+            """);
+        var originalOut = Console.Out;
+        try
+        {
+            var result = Assert.Single(
+                FidelityCheck.Evaluate(assemblyPath),
+                result => result.Type == "TargetedDictionaryOutFixture" && result.Method == "Lookup");
+            Assert.True(result.Status == FidelityCheck.CompileBackStatus.Exact, result.Detail);
+
+            var deltaPath = Path.Combine(Path.GetDirectoryName(assemblyPath)!, "delta.json");
+            File.WriteAllText(deltaPath, System.Text.Json.JsonSerializer.Serialize(new
+            {
+                schemaVersion = 1,
+                generatedUtc = DateTimeOffset.UtcNow,
+                baselineGeneratedUtc = DateTimeOffset.UtcNow,
+                currentGeneratedUtc = DateTimeOffset.UtcNow,
+                baselineHasMethodDetails = true,
+                currentHasMethodDetails = true,
+                changedMethods = new[]
+                {
+                    new
+                    {
+                        method = "fixture!TargetedDictionaryOutFixture::Lookup#0",
+                        assembly = "fixture",
+                        assemblyPath = Path.GetFileName(assemblyPath),
+                        type = "TargetedDictionaryOutFixture",
+                        methodName = "Lookup",
+                        overload = 0,
+                        signature = result.Signature,
+                        baseline = (object?)null,
+                        current = new
+                        {
+                            assembly = "fixture",
+                            assemblyPath = Path.GetFileName(assemblyPath),
+                            type = "TargetedDictionaryOutFixture",
+                            method = "Lookup",
+                            overload = 0,
+                            signature = result.Signature,
+                            fidelity = "Full",
+                            fullyRaised = true,
+                            residual = (string?)null,
+                            passBug = (string?)null,
+                            validity = "not-sampled",
+                            fidelityCheck = "not-sampled",
+                        },
+                        deltas = new[] { "triage" },
+                    },
+                },
+            }));
+
+            using var writer = new StringWriter();
+            Console.SetOut(writer);
+            int exitCode = FidelityCheck.RunMethodDelta([assemblyPath], deltaPath, maxExamples: 5);
+            Console.SetOut(originalOut);
+            var output = writer.ToString();
+
+            Assert.Equal(0, exitCode);
+            Assert.Contains("exact opcode match : 1", output);
+            Assert.DoesNotContain("CS1620", output);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     static string CompileFixture(string source)
     {
         var directory = Path.Combine(Path.GetTempPath(), $"fidelity-generated-filter-{Guid.NewGuid():N}");

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -186,7 +186,8 @@ static class FidelityCheck
         if (!pe.HasMetadata)
             return names;
         var reader = pe.GetMetadataReader();
-        using var source = MetadataSource.Open(assemblyPath);
+        using var metadata = CorpusMetadata.Create([assemblyPath]);
+        using var source = MetadataSource.Open(assemblyPath, context: metadata);
         var render = Renderer(source, lowered: false);
         foreach (var typeHandle in reader.TypeDefinitions)
         {
@@ -299,7 +300,8 @@ static class FidelityCheck
         if (!pe.HasMetadata)
             return results;
         var reader = pe.GetMetadataReader();
-        using var source = MetadataSource.Open(assemblyPath);
+        using var metadata = CorpusMetadata.Create([assemblyPath]);
+        using var source = MetadataSource.Open(assemblyPath, context: metadata);
         var render = Renderer(source, lowered);
         var references = RuntimeReferences(assemblyPath);
 
@@ -324,6 +326,7 @@ static class FidelityCheck
             nullableContextOptions: NullableContextOptions.Disable);
 
         var results = new List<CompileBackResult>();
+        using var metadata = CorpusMetadata.Create(assemblies);
         foreach (var assemblyPath in assemblies)
         {
             var assemblyResults = new List<CompileBackResult>();
@@ -338,7 +341,7 @@ static class FidelityCheck
                     continue;
                 var reader = pe.GetMetadataReader();
                 MetadataSource source;
-                try { source = MetadataSource.Open(assemblyPath); }
+                try { source = MetadataSource.Open(assemblyPath, context: metadata); }
                 catch { continue; }
                 using (source)
                 {
@@ -652,6 +655,7 @@ static class FidelityCheck
             optimizationLevel: OptimizationLevel.Release,
             nullableContextOptions: NullableContextOptions.Disable);
 
+        using var metadata = CorpusMetadata.Create(assemblies);
         var pending = targets.ToDictionary(TargetKey, StringComparer.Ordinal);
         var rows = new List<TargetedCompileBackResult>();
         foreach (var assemblyPath in assemblies)
@@ -668,7 +672,7 @@ static class FidelityCheck
                 var portablePath = PortablePath(assemblyPath);
                 var reader = pe.GetMetadataReader();
                 MetadataSource source;
-                try { source = MetadataSource.Open(assemblyPath); }
+                try { source = MetadataSource.Open(assemblyPath, context: metadata); }
                 catch { continue; }
                 using (source)
                 {


### PR DESCRIPTION
- Advances changed-method compile-back fidelity coverage.
- Changes fidelity harness behavior only: test/targeted fidelity entry points now open `MetadataSource` with the same `CorpusMetadata` context the console corpus path already uses.
- Card revision: `1ec05910`

## Change

**Conclusion:** **PASS** — targeted changed-method fidelity now recovers platform/reference method facts such as `out` parameters instead of rendering those calls with unknown byref kind and failing CS1620.

Before, the targeted Humanizer run rendered framework/reference `TryGetValue(..., out value)` calls as `ref value` because `EvaluateTargets` opened the source without corpus metadata context. The normal corpus path and dumps already had the context. This PR aligns the entry points.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `FidelityCheckGeneratedFilterTests` passed, 8 tests |
| Decompiler fast suite | Pass, 1736 tests |
| Real witness | Targeted Humanizer changed-method compile-back improved recompile failures 27 -> 18; CS1620 10 -> 0 |
| Build-event validation | Pass; Compare `no-diagnostic-deltas` |

## Decompiler quality

**Conclusion:** **PASS** — this improves the changed-method boss only; broad cap-1000 is unchanged because the non-targeted corpus path already used `CorpusMetadata`.

Targeted Humanizer Full-method delta after this change:

```text
CHANGED-METHOD COMPILE-BACK over 1075 current changed methods (1075 attempted)

  exact opcode match : 867
  opcode diff (Full) : 118
  not Full           : 0
  recompile fail     : 18
  context fail       : 72
```

Targeted baseline before this change in the same worktree was 863 exact, 112 opcode diff, 1 not Full, 27 recompile fail, 72 context fail; CS1620 dropped from 10 to 0.

Humanizer cap-1000 after this change remains:

```text
COMPILE-BACK over 1000 rendered methods (958 Full)

  exact opcode match : 666 (66.60%)
  opcode diff (Full) : 247
  context-build fail : 2
  recompile fail     : 81
```

## Build-event validation

| View | Result |
| --- | --- |
| Preflight Summary | 138 projects, 0 failed, 0 errors, 0 warnings; `20260630T062844.7449680Z-2319558-build-d3ef0bc9` |
| Final Summary | 138 projects, 0 failed, 0 errors, 0 warnings; `20260630T064342.6840935Z-2350676-build-d3ef0bc9` |
| Compare | `no-diagnostic-deltas` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Verified context lifetime, single-assembly consistency, targeted test coverage, and resource safety |
| Gemini Pro | No blocking findings | Reported no significant issues in the changed harness behavior |

**Review conclusion:** **PASS** — both reviews found the metadata-context alignment safe and correctly scoped; no follow-up code changes required.

## Validation

```bash
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate tools/DecompilerHarness -- -c Release --nologo --verbosity quiet

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*FidelityCheckGeneratedFilterTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet

dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --fidelity-method-delta /tmp/humanizer-cs1620-delta.json --max-examples 40
/usr/bin/time -f 'elapsed=%E cpu=%P maxrss=%MKB' dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 1000 --max-examples 12 --fidelity-timings

/home/rich/git/dotnet-build-events-vmr-preview5-events/artifacts/preview5-events-sdk-test/dotnet build tools/DecompilerHarness --no-incremental --view types --event-log-stderr -c Release --nologo --verbosity quiet
dotnet run --project /home/rich/git/dotnet-inspect-build-event-query/src/dotnet-inspect -c Release --no-build -- build /home/rich/.dotnet/build-events/2026-06-30/20260630T062844.7449680Z-2319558-build-d3ef0bc9.jsonl -S Compare --compare /home/rich/.dotnet/build-events/2026-06-30/20260630T064342.6840935Z-2350676-build-d3ef0bc9.jsonl --tsv
```
