### PR TITLE
Add JSON array projection output

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ dotnet-inspect library MyLib.dll --il-offset 0x06000001+0x5
 
 ## Output and querying
 
-Default output is Markdown. Use Markdown for evidence and narrative, `--table` for compact human scanning, `--tsv` for normalized tab-separated rows for agents and scripts, `--jsonl` for one JSON object per table row, and `--json` for structured object graphs. Use `--plaintext` for plain text, `--bare` for one undecorated payload without changing the selected shape, `--value` for one scalar, `--urls` for URL lists, `--paths` for path lists, `--print` to materialize one printable selected-section row (`--row N` chooses a printable row), `--print-all` to materialize every printable row with separators, `--rows -n N` to cap rendered table rows, `--count` to reduce a selected section/vector to a single row count, and `--mermaid` on `depends` for diagrams. Verbosity is `-v:q`, `-v:m`, `-v:n`, or `-v:d`. Markdown and JSON can represent multi-section documents; `--table`, `--tsv`, and `--jsonl` render one table/section at a time, so pair them with a specific `-S` selection when querying sectioned output.
+Default output is Markdown. Use Markdown for evidence and narrative, `--table` for compact human scanning, `--tsv` for normalized tab-separated rows for agents and scripts, `--jsonl` for one JSON object per table row, and `--json` for structured object graphs. Use `--plaintext` for plain text, `--bare` for one undecorated payload without changing the selected shape, `--value` for one scalar, `--urls` for URL lists, `--paths` for path lists, `--print` to materialize one printable selected-section row (`--row N` chooses a printable row), `--print-all` to materialize every printable row with separators, `--json-array` to emit projected rows as one JSON array, `--rows -n N` to cap rendered table rows, `--count` to reduce a selected section/vector to a single row count, and `--mermaid` on `depends` for diagrams. Verbosity is `-v:q`, `-v:m`, `-v:n`, or `-v:d`. Markdown and JSON can represent multi-section documents; `--table`, `--tsv`, and `--jsonl` render one table/section at a time, so pair them with a specific `-S` selection when querying sectioned output.
 
 Sections and fields are queryable without a template language:
 
@@ -180,7 +180,7 @@ dotnet-inspect package Newtonsoft.Json -S "Package Info" --fields Version --valu
 dotnet-inspect project ./src/App -S Grounding --jsonl
 dotnet-inspect project ./src/App -S Grounding --paths
 dotnet-inspect project ./src/App -S Grounding --print --row 1
-dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --urls
+dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --urls --json-array
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --print --row 1
 ```
 

--- a/docs/design/rendering-model.md
+++ b/docs/design/rendering-model.md
@@ -57,10 +57,10 @@ The `package` command inspects a NuGet package. Its default view is *package ide
 | `--content` | File content | Contents for files selected by `--path`, with separator blocks or `--jsonl` rows |
 | `--readme` | README content | Compatibility alias for best package grounding content (`AGENTS.md` > `README.md` > `PACKAGE.md` > declared readme); supports `--frontmatter`/`--body` |
 | `--value` | Scalar projection | Prints one scalar cell or field from a selected section; use `--row N` when multiple rows match |
-| `--urls` | URL projection | Prints URL-bearing selected-section rows as a URL list or JSONL rows |
-| `--paths` | Path projection | Prints path-bearing selected-section rows as a path list or JSONL rows |
+| `--urls` | URL projection | Prints URL-bearing selected-section rows as a URL list, JSONL rows, or a JSON array |
+| `--paths` | Path projection | Prints path-bearing selected-section rows as a path list, JSONL rows, or a JSON array |
 | `--print` | Row payload | Prints one document behind a selected printable section row; use `--row N` to choose the Nth printable row when multiple printable rows exist |
-| `--print-all` | Row payloads | Prints every printable row from one selected section, using separators for text or one object per row with `--jsonl` |
+| `--print-all` | Row payloads | Prints every printable row from one selected section, using separators for text, JSONL rows, or one JSON array with `--json-array` |
 | `--versions` | Version history | Available versions from nuget.org |
 | `--library` | Library metadata | Delegates to library inspection |
 

--- a/docs/workflows/core/line-and-result-limiting.md
+++ b/docs/workflows/core/line-and-result-limiting.md
@@ -1,13 +1,13 @@
 ---
 id: line-and-result-limiting
 description: Control output size with line limits, table row limits, result limits, row counts, and shape projections
-commands: [-n, --rows, -t, -m, --versions, --count, --value, --urls, --paths, --print, --row]
+commands: [-n, --rows, -t, -m, --versions, --count, --value, --urls, --paths, --json-array, --print, --row]
 areas: [output, limiting, count, agents]
 ---
 
 # Line, Result, and Row Counting
 
-> Control how much output is returned. `-n` limits output lines (like `head`), including printed document content. `--rows -n N` interprets the same count as table data rows per rendered table. `--value`, `--urls`, and `--paths` project selected sections to scalar/URL/path payloads; `--row N` chooses a projected or printable row. `-t` and `-m` limit result counts for types and members. `--versions N` limits version lists. `--count` reduces a selected section/vector to one integer row count, while `--bare` stays a presentation-only modifier for already-selected payloads. These are essential for agents that need compact, predictable output.
+> Control how much output is returned. `-n` limits output lines (like `head`), including printed document content. `--rows -n N` interprets the same count as table data rows per rendered table. `--value`, `--urls`, and `--paths` project selected sections to scalar/URL/path payloads; `--json-array` makes projected rows one JSON document; `--row N` chooses a projected or printable row. `-t` and `-m` limit result counts for types and members. `--versions N` limits version lists. `--count` reduces a selected section/vector to one integer row count, while `--bare` stays a presentation-only modifier for already-selected payloads. These are essential for agents that need compact, predictable output.
 
 ## Preconditions
 

--- a/docs/workflows/getting-started/lap-around.md
+++ b/docs/workflows/getting-started/lap-around.md
@@ -209,7 +209,7 @@ SourceLink URLs are exposed on the command you are already using.
 
 ```bash
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --table
-dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --urls
+dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --urls --json-array
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --print --row 1
 dotnet-inspect type JsonSerializer --platform System.Text.Json -S "Source Files" --print-all --jsonl
 ```

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1786,6 +1786,24 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Type_SourceFiles_UrlsJsonArray_EmitsSingleArrayDocument()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
+            "-S", "Source Files", "--urls", "--json-array", "--raw", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        using var document = JsonDocument.Parse(output);
+        var rows = document.RootElement.EnumerateArray().ToArray();
+        Assert.Equal(2, rows.Length);
+        Assert.Equal(1, rows[0].GetProperty("row").GetInt32());
+        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", rows[0].GetProperty("url").GetString());
+        Assert.Equal(2, rows[1].GetProperty("row").GetInt32());
+        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", rows[1].GetProperty("url").GetString());
+    }
+
+    [Fact]
     public async Task Type_SourceFiles_Value_RowSelectsUrl()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -1865,6 +1883,37 @@ public class CommandExecutionTests
         Assert.Equal(2, second.RootElement.GetProperty("row").GetInt32());
         Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", first.RootElement.GetProperty("url").GetString());
         Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", second.RootElement.GetProperty("url").GetString());
+    }
+
+    [Fact]
+    public async Task Type_SourceFiles_PrintAllJsonArrayFetchesAllSources()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
+            "-S", "Source Files", "--print-all", "--json-array", "--raw", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        using var document = JsonDocument.Parse(output);
+        var rows = document.RootElement.EnumerateArray().ToArray();
+        Assert.Equal(2, rows.Length);
+        Assert.Equal(1, rows[0].GetProperty("row").GetInt32());
+        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.cs", rows[0].GetProperty("url").GetString());
+        Assert.Contains("JsonReader", rows[0].GetProperty("content").GetString());
+        Assert.Equal(2, rows[1].GetProperty("row").GetInt32());
+        Assert.EndsWith("/Src/Newtonsoft.Json/JsonReader.Async.cs", rows[1].GetProperty("url").GetString());
+    }
+
+    [Fact]
+    public async Task Type_JsonArrayRequiresProjectionShape()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", "JsonReader", "--package", "Newtonsoft.Json@13.0.3",
+            "-S", "Source Files", "--json-array", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("--json-array requires --value, --urls, --paths, --print, or --print-all", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -260,6 +260,7 @@ public static class InspectionCommandDefinitions
                 Value = parseResult.GetValue(opts.Value),
                 Urls = parseResult.GetValue(opts.Urls),
                 Paths = parseResult.GetValue(opts.Paths),
+                JsonArray = parseResult.GetValue(opts.JsonArray),
                 ProjectionRow = opts.ParsePrintRow(parseResult),
                 Rows = opts.ParseRows(parseResult),
                 PerformanceTriage = performanceTriage,

--- a/src/dotnet-inspect/CommandLine/Commands/ProjectCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ProjectCommandDefinitions.cs
@@ -80,6 +80,7 @@ public static class ProjectCommandDefinitions
                 Value = parseResult.GetValue(opts.Value),
                 Urls = parseResult.GetValue(opts.Urls),
                 Paths = parseResult.GetValue(opts.Paths),
+                JsonArray = parseResult.GetValue(opts.JsonArray),
                 Tfm = parseResult.GetValue(tfmOption),
                 ContentScope = contentScope,
                 FrontmatterRequested = frontmatterRequested,

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -256,6 +256,7 @@ public static class MemberOptionsParser
             Value = parseResult.GetValue(opts.Value),
             Urls = parseResult.GetValue(opts.Urls),
             Paths = parseResult.GetValue(opts.Paths),
+            JsonArray = parseResult.GetValue(opts.JsonArray),
             NoHeader = parseResult.GetValue(opts.NoHeaders),
             UnsafeOnly = parseResult.GetValue(args.UnsafeOption),
             CtorOnly = ctorOnly,

--- a/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/PackageOptionsParser.cs
@@ -143,6 +143,7 @@ public static class PackageOptionsParser
             Value = parseResult.GetValue(opts.Value),
             Urls = parseResult.GetValue(opts.Urls),
             Paths = parseResult.GetValue(opts.Paths),
+            JsonArray = parseResult.GetValue(opts.JsonArray),
             ShowContent = parseResult.GetValue(args.ContentOption),
             ContentScope = contentScope,
             FrontmatterRequested = frontmatterRequested,

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -150,6 +150,7 @@ public static class TypeOptionsParser
             Value = parseResult.GetValue(opts.Value),
             Urls = parseResult.GetValue(opts.Urls),
             Paths = parseResult.GetValue(opts.Paths),
+            JsonArray = parseResult.GetValue(opts.JsonArray),
             NoHeader = parseResult.GetValue(opts.NoHeaders),
             ShapeOutput = parseResult.GetValue(args.ShapeOption),
             ShapeExplicitlySet = parseResult.GetResult(args.ShapeOption) is { Implicit: false },

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -129,6 +129,18 @@ public class ApiCommand
             }
         }
 
+        if (options.JsonArray && shapeCount == 0 && !options.Print && !options.PrintAll)
+        {
+            Console.Error.WriteLine("Error: --json-array requires --value, --urls, --paths, --print, or --print-all.");
+            return (null!, 1);
+        }
+
+        if (options.JsonArray && (options.JsonOutput || options.Jsonl))
+        {
+            Console.Error.WriteLine("Error: --json-array cannot be combined with --json or --jsonl.");
+            return (null!, 1);
+        }
+
         if ((options.Print || options.PrintAll) && !ValidateApiPrintSelection(options.IncludeSections))
             return (null!, 1);
 
@@ -908,6 +920,7 @@ public class ApiCommand
                 options.PrintRow,
                 options.JsonOutput,
                 options.Jsonl,
+                options.JsonArray,
                 options.Bare,
                 OutputPath: null));
     }
@@ -932,7 +945,7 @@ public class ApiCommand
 
         return ShapeProjectionOutput.Write(
             rows,
-            new ShapeProjectionOptions(kind, options.PrintRow, options.JsonOutput, options.Jsonl));
+            new ShapeProjectionOptions(kind, options.PrintRow, options.JsonOutput, options.Jsonl, options.JsonArray));
     }
 
     private static List<ShapeProjectionRow> ProjectTypeSourceFiles(TypeView view, string section, ShapeProjectionKind kind)
@@ -1028,7 +1041,7 @@ public class ApiCommand
         if (printableRows.Count == 0)
             return PrintProjectionOutput.Write(
                 [],
-                new PrintProjectionOptions(options.PrintAll, null, options.JsonOutput, options.Jsonl, options.Bare, OutputPath: null));
+                new PrintProjectionOptions(options.PrintAll, null, options.JsonOutput, options.Jsonl, options.JsonArray, options.Bare, OutputPath: null));
 
         if (!options.PrintAll)
         {
@@ -1073,6 +1086,7 @@ public class ApiCommand
                 Row: null,
                 options.JsonOutput,
                 options.Jsonl,
+                options.JsonArray,
                 options.Bare,
                 OutputPath: null));
     }

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -89,6 +89,18 @@ public class LibraryCommand
             }
         }
 
+        if (options.JsonArray && shapeCount == 0)
+        {
+            Console.Error.WriteLine("Error: --json-array requires --value, --urls, or --paths.");
+            return 1;
+        }
+
+        if (options.JsonArray && (options.JsonOutput || options.Jsonl))
+        {
+            Console.Error.WriteLine("Error: --json-array cannot be combined with --json or --jsonl.");
+            return 1;
+        }
+
         if (options.ProjectionRow is not null && shapeCount == 0)
         {
             Console.Error.WriteLine("Error: --row requires --value, --urls, or --paths.");
@@ -351,7 +363,7 @@ public class LibraryCommand
 
         return ShapeProjectionOutput.Write(
             rows,
-            new ShapeProjectionOptions(kind, options.ProjectionRow, options.JsonOutput, options.Jsonl));
+            new ShapeProjectionOptions(kind, options.ProjectionRow, options.JsonOutput, options.Jsonl, options.JsonArray));
     }
 
     private static List<ShapeProjectionRow> ProjectLibrarySourceFiles(LibraryInspection inspection, string section, ShapeProjectionKind kind, LibraryOptions options)

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -86,6 +86,18 @@ public class PackageCommand
                 }
             }
 
+            if (options.JsonArray && shapeCount == 0 && !options.Print && !options.PrintAll)
+            {
+                Console.Error.WriteLine("Error: --json-array requires --value, --urls, --paths, --print, or --print-all.");
+                return 1;
+            }
+
+            if (options.JsonArray && (options.JsonOutput || options.Jsonl))
+            {
+                Console.Error.WriteLine("Error: --json-array cannot be combined with --json or --jsonl.");
+                return 1;
+            }
+
             if ((options.Print || options.PrintAll) && !ValidatePackagePrintSelection(options.IncludeSections))
                 return 1;
 
@@ -914,7 +926,7 @@ public class PackageCommand
         }
 
         return ShapeProjectionOutput.Write(rows,
-            new ShapeProjectionOptions(kind, options.PrintRow, options.JsonOutput, options.Jsonl));
+            new ShapeProjectionOptions(kind, options.PrintRow, options.JsonOutput, options.Jsonl, options.JsonArray));
     }
 
     private static List<ShapeProjectionRow> ProjectPackageFiles(IEnumerable<PackageFileRow>? files, string section, ShapeProjectionKind kind, InspectionOptions options)
@@ -2839,6 +2851,7 @@ public class PackageCommand
                     options.PrintRow,
                     options.JsonOutput,
                     options.Jsonl,
+                    options.JsonArray,
                     options.Bare,
                     options.OutputPath));
         }

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -81,6 +81,18 @@ public class ProjectCommand
             }
         }
 
+        if (options.JsonArray && shapeCount == 0 && !options.Print && !options.PrintAll)
+        {
+            Console.Error.WriteLine("Error: --json-array requires --value, --urls, --paths, --print, or --print-all.");
+            return 1;
+        }
+
+        if (options.JsonArray && (options.JsonOutput || options.Jsonl))
+        {
+            Console.Error.WriteLine("Error: --json-array cannot be combined with --json or --jsonl.");
+            return 1;
+        }
+
         if ((options.Columns is { Length: > 0 } || options.Fields is { Length: > 0 })
             && shapeCount == 0
             && !ValidateProjectProjectionOptions())
@@ -474,6 +486,7 @@ public class ProjectCommand
                 options.Bare && !options.Print && !options.PrintAll ? 1 : options.PrintRow,
                 options.JsonOutput,
                 options.Jsonl,
+                options.JsonArray,
                 options.Bare,
                 options.OutputPath));
     }
@@ -498,7 +511,7 @@ public class ProjectCommand
 
         return ShapeProjectionOutput.Write(
             projected,
-            new ShapeProjectionOptions(kind, options.PrintRow, options.JsonOutput, options.Jsonl));
+            new ShapeProjectionOptions(kind, options.PrintRow, options.JsonOutput, options.Jsonl, options.JsonArray));
     }
 
     private static string? SelectGroundingValue(ProjectGroundingRow row, ProjectOptions options)

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -62,6 +62,8 @@ public partial record ApiOptions
 
     public bool Paths { get; init; }
 
+    public bool JsonArray { get; init; }
+
     /// <summary>
     /// True when the user explicitly chose an output format via CLI flags.
     /// When false, commands are free to apply their own default format (e.g., shape/tree).

--- a/src/dotnet-inspect/Options/InspectionOptions.cs
+++ b/src/dotnet-inspect/Options/InspectionOptions.cs
@@ -118,6 +118,8 @@ public record InspectionOptions
 
     public bool Paths { get; init; }
 
+    public bool JsonArray { get; init; }
+
     /// <summary>
     /// Print the contents of files selected by <see cref="PathFilters"/>.
     /// </summary>
@@ -259,7 +261,7 @@ public record InspectionOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown).
     /// </summary>
-    public bool IsRawOutput => Bare || JsonOutput || OneLine || Jsonl || NoHeader || ListLayout || ListTfms || ListVersions || ShowReadme || Print || PrintAll || Value || Urls || Paths || ShowContent || ShowDependencies || Count || PackageLibrary != null || AllLibraries;
+    public bool IsRawOutput => Bare || JsonOutput || OneLine || Jsonl || JsonArray || NoHeader || ListLayout || ListTfms || ListVersions || ShowReadme || Print || PrintAll || Value || Urls || Paths || ShowContent || ShowDependencies || Count || PackageLibrary != null || AllLibraries;
 
     /// <summary>
     /// All inspection features enabled.

--- a/src/dotnet-inspect/Options/LibraryOptions.cs
+++ b/src/dotnet-inspect/Options/LibraryOptions.cs
@@ -189,6 +189,8 @@ public record LibraryOptions
 
     public bool Paths { get; init; }
 
+    public bool JsonArray { get; init; }
+
     public int? ProjectionRow { get; init; }
 
     /// <summary>
@@ -236,5 +238,5 @@ public record LibraryOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown).
     /// </summary>
-    public bool IsRawOutput => JsonOutput || OneLine || Jsonl || NoHeader || ExtractResources != null || Count || Value || Urls || Paths || ILOffset != null;
+    public bool IsRawOutput => JsonOutput || OneLine || Jsonl || JsonArray || NoHeader || ExtractResources != null || Count || Value || Urls || Paths || ILOffset != null;
 }

--- a/src/dotnet-inspect/Options/ProjectOptions.cs
+++ b/src/dotnet-inspect/Options/ProjectOptions.cs
@@ -22,6 +22,8 @@ public record ProjectOptions
 
     public bool Paths { get; init; }
 
+    public bool JsonArray { get; init; }
+
     public string? Tfm { get; init; }
 
     public PackageFileContentScope ContentScope { get; init; } = PackageFileContentScope.Full;

--- a/src/dotnet-inspect/Output/PrintProjectionOutput.cs
+++ b/src/dotnet-inspect/Output/PrintProjectionOutput.cs
@@ -16,6 +16,7 @@ public sealed record PrintProjectionOptions(
     int? Row,
     bool JsonOutput,
     bool Jsonl,
+    bool JsonArray,
     bool Bare,
     string? OutputPath);
 
@@ -72,6 +73,12 @@ public static class PrintProjectionOutput
             var lines = selected
                 .Select(item => JsonSerializer.Serialize(item, PrintProjectionJsonContext.Default.PrintableDocument));
             WriteOutput(string.Join(Environment.NewLine, lines) + Environment.NewLine, options.OutputPath);
+            return 0;
+        }
+
+        if (options.JsonArray)
+        {
+            WriteOutput(JsonSerializer.Serialize(selected.ToArray(), PrintProjectionJsonContext.Default.PrintableDocumentArray), options.OutputPath);
             return 0;
         }
 

--- a/src/dotnet-inspect/Output/ShapeProjectionOutput.cs
+++ b/src/dotnet-inspect/Output/ShapeProjectionOutput.cs
@@ -22,7 +22,8 @@ public sealed record ShapeProjectionOptions(
     ShapeProjectionKind Kind,
     int? Row,
     bool JsonOutput,
-    bool Jsonl);
+    bool Jsonl,
+    bool JsonArray);
 
 public static class ShapeProjectionOutput
 {
@@ -73,6 +74,12 @@ public static class ShapeProjectionOutput
         {
             foreach (var item in selected)
                 Console.WriteLine(JsonSerializer.Serialize(item, ShapeProjectionJsonContext.Default.ShapeProjectionRow));
+            return 0;
+        }
+
+        if (options.JsonArray)
+        {
+            Console.Write(JsonSerializer.Serialize(selected.ToArray(), ShapeProjectionJsonContext.Default.ShapeProjectionRowArray));
             return 0;
         }
 

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -42,6 +42,7 @@ public class SharedOptions
     public Option<bool> Value { get; } = new("--value") { Description = "Print one scalar value from a selected section; use --row N when multiple rows exist" };
     public Option<bool> Urls { get; } = new("--urls") { Description = "Project URL-bearing selected section rows to a URL list or JSONL rows" };
     public Option<bool> Paths { get; } = new("--paths") { Description = "Project path-bearing selected section rows to a path list or JSONL rows" };
+    public Option<bool> JsonArray { get; } = new("--json-array") { Description = "With a shape projection, emit projected rows as one JSON array" };
     public Option<bool> Info { get; } = new("--info") { Description = "Show operational metrics (output, time, HTTP, cache) on stderr" };
     public Option<string?> Tips { get; }
 
@@ -208,6 +209,7 @@ public class SharedOptions
         command.Options.Add(Value);
         command.Options.Add(Urls);
         command.Options.Add(Paths);
+        command.Options.Add(JsonArray);
         if (!command.Options.Contains(Row))
             command.Options.Add(Row);
     }


### PR DESCRIPTION
## Summary

Adds the next #1944 shape-transformer slice: `--json-array`.

`--json-array` emits projected rows as one JSON array for consumers that want a single JSON document instead of JSONL streams. It applies to the projection family introduced in #1950:

- `--value --json-array`
- `--urls --json-array`
- `--paths --json-array`
- `--print --json-array`
- `--print-all --json-array`

It intentionally does not rework generic Markout table rendering or replace `--json` object graphs. `--json` remains structured command output; `--jsonl` remains one object per row.

## Examples

```bash
dotnet-inspect type JsonReader --package Newtonsoft.Json@13.0.3 \
  -S "Source Files" --urls --json-array

dotnet-inspect type JsonReader --package Newtonsoft.Json@13.0.3 \
  -S "Source Files" --print-all --json-array
```

## Validation

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method "*JsonArray*"`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method "*SourceFiles_Urls*"`
- `npx markdownlint-cli README.md docs/design/rendering-model.md docs/workflows/core/line-and-result-limiting.md docs/workflows/getting-started/lap-around.md`
- `git diff --check`

## Review

Claude Opus 4.8 reviewed the slice and found no blocking issues. It verified option binding consistency, projection-only scope, conflict validation, and that existing `--json` / `--jsonl` behavior remains unchanged.

## Follow-up

- #1954 tracks updating embedded skill guidance after this lands.
