### PR TITLE
Update JSON array projection skill guidance

### DIFF
--- a/skills/query/SKILL.md
+++ b/skills/query/SKILL.md
@@ -23,12 +23,13 @@ Default output is Markdown. Pick a machine or compact shape when you need one:
 - `--table` — compact aligned rows.
 - `--tsv` — stable snake_case headers, no embedded tabs/newlines.
 - `--jsonl` — one JSON object per row.
+- `--json-array` — one JSON array for projected rows (`--urls`, `--paths`, `--value`, `--print-all`).
 - `--json` — structured documents.
 - `--bare` — one undecorated payload or URL list.
 - `--count` — a bare row count.
 - `--value` / `--urls` / `--paths` — project one selected section to scalar, URL, or path payloads.
 - `--print` — print one document behind a selected printable row; use `--row N` when multiple printable rows exist.
-- `--print-all` — print every printable row from one selected section, with text separators or one JSON object per row under `--jsonl`.
+- `--print-all` — print every printable row from one selected section, with text separators, `--jsonl`, or `--json-array`.
 - `--mermaid` — graph-shaped output.
 
 ## Discover and select sections

--- a/skills/sourcelink/SKILL.md
+++ b/skills/sourcelink/SKILL.md
@@ -39,7 +39,7 @@ row; add `--row N` when the selected section has multiple printable rows.
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json Serialize:1 -S "Original Source"
 dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Source Files" --print --row 1
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json -m Serialize -S "Source Locations" --print --row 1
-dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Source Files" --print-all --jsonl
+dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Source Files" --print-all --json-array
 ```
 
 ## URL forms
@@ -52,6 +52,7 @@ escape hatch.
 
 ```bash
 dnx dotnet-inspect -y -- member Type Method:1 -S "Source Locations" --urls --jsonl
+dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Source Files" --urls --json-array
 dnx dotnet-inspect -y -- library System.Text.Json -S "Source Files" --urls --blob
 ```
 


### PR DESCRIPTION
## Summary

Fixes #1954.

Updates embedded skill guidance after #1955:

- `skills/query`: documents `--json-array` as the one-document shape for projected rows and `--print-all` output.
- `skills/sourcelink`: switches one fetch-all example to `--json-array` and adds a URL projection JSON array example.

## Validation

- `npx markdownlint-cli skills/query/SKILL.md skills/sourcelink/SKILL.md`
- `git diff --check`

Docs-only; no product behavior change.
