### PR TITLE
Raise guarded union switch arms

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -377,6 +377,52 @@ public class TypeSourceComposerUnionTests
     }
 
     [Fact]
+    public async Task UnionSwitchExpression_RendersGuardedPropertyPatternArms()
+    {
+        using var assembly = await CompileWithSdk("""
+            namespace UnionFixtures;
+
+            public sealed class Cat { public string Name { get; } = "cat"; public int Age { get; } = 5; }
+            public sealed class Dog { public string Name { get; } = "dog"; public int Age { get; } = 7; }
+            public union Pet(Cat, Dog);
+
+            public static class Matcher
+            {
+                public static string DescribeByName(Pet pet) => pet switch
+                {
+                    Cat { Name: "cat" } cat => cat.Name,
+                    Dog dog => dog.Name,
+                    _ => "other",
+                };
+
+                public static string DescribeByAge(Pet pet) => pet switch
+                {
+                    Cat { Age: > 3 } cat => cat.Name,
+                    Dog { Age: > 5 } dog => dog.Name,
+                    _ => "other",
+                };
+            }
+            """);
+
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat when cat.Name == "cat" => cat.Name,
+                Dog dog => dog.Name,
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "DescribeByName"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat when cat.Age > 3 => cat.Name,
+                Dog dog when dog.Age > 5 => dog.Name,
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "DescribeByAge"));
+    }
+
+    [Fact]
     public async Task ClassUnionSwitchExpression_RendersTypePatternArms()
     {
         using var assembly = await CompileWithSdk("""
@@ -464,6 +510,13 @@ public class TypeSourceComposerUnionTests
                         Cat cat => cat.Name,
                         Dog dog => dog.Name,
                     };
+
+                    public static string Guarded(PetLike pet) => pet.Value switch
+                    {
+                        Cat { Name: "cat" } cat => cat.Name,
+                        Dog dog => dog.Name,
+                        _ => "other",
+                    };
                 }
             }
             """);
@@ -473,6 +526,7 @@ public class TypeSourceComposerUnionTests
         Assert.Equal("return pet.Value is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "HasCat"));
         Assert.DoesNotContain("return pet switch", RenderMember(assembly.Path, "UnionFixtures.Matcher", "Describe"));
         Assert.DoesNotContain("return pet switch", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ExhaustiveLooking"));
+        Assert.DoesNotContain("return pet switch", RenderMember(assembly.Path, "UnionFixtures.Matcher", "Guarded"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -176,10 +176,15 @@ public sealed partial class CSharpPrinter
     }
 
     string UnionSwitchExpressionInline(UnionSwitchExpression node, TypeRef? target = null)
-        => $"{UnionSwitchReceiverText(node.Value)} switch {{ {string.Join(", ", node.Arms.Select(arm => UnionSwitchArmText(arm, target)))} }}";
+    {
+        var arms = node.Arms.Select(arm => UnionSwitchArmText(arm, target));
+        if (node.DefaultValue is { } defaultValue)
+            arms = arms.Append($"_ => {SwitchArmValueText(defaultValue, target)}");
+        return $"{UnionSwitchReceiverText(node.Value)} switch {{ {string.Join(", ", arms)} }}";
+    }
 
     string UnionSwitchArmText(UnionSwitchExpressionArm arm, TypeRef? target = null)
-        => $"{TypeText(arm.PatternType)}{(arm.LocalIndex is { } index ? $" {LocalName(index)}" : "")} => {SwitchArmValueText(arm.Value, target)}";
+        => $"{TypeText(arm.PatternType)}{(arm.LocalIndex is { } index ? $" {LocalName(index)}" : "")}{(arm.Guard is { } guard ? $" when {Condition(guard)}" : "")} => {SwitchArmValueText(arm.Value, target)}";
 
     string UnionSwitchReceiverText(IrExpression value)
         => UnionValueReceiverText(value) ?? Operand(value);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1190,6 +1190,8 @@ public sealed partial class CSharpPrinter
             sb.Append(pad).AppendLine("{");
             foreach (var arm in unionSwitch.Arms)
                 sb.Append(inner).Append(UnionSwitchArmText(arm, _function.Signature.ReturnType)).AppendLine(",");
+            if (unionSwitch.DefaultValue is { } defaultValue)
+                sb.Append(inner).Append("_ => ").Append(SwitchArmValueText(defaultValue, _function.Signature.ReturnType)).AppendLine(",");
             sb.Append(pad).AppendLine("};");
             return;
         }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -696,33 +696,53 @@ public sealed class SwitchExpressionArm : IrNode
 /// </summary>
 public sealed class UnionSwitchExpression : IrExpression
 {
-    public UnionSwitchExpression(IrExpression value, IEnumerable<UnionSwitchExpressionArm> arms)
+    readonly bool _hasDefault;
+
+    public UnionSwitchExpression(IrExpression value, IEnumerable<UnionSwitchExpressionArm> arms, IrExpression? defaultValue = null)
     {
         AddChild(value);
         foreach (var arm in arms)
             AddChild(arm);
+        if (defaultValue is not null)
+        {
+            _hasDefault = true;
+            AddChild(defaultValue);
+        }
     }
 
     public IrExpression Value => (IrExpression)Children[0];
-    public IReadOnlyList<UnionSwitchExpressionArm> Arms => Children.Skip(1).Cast<UnionSwitchExpressionArm>().ToList();
-    public override TypeRef? ResultType => Arms.Select(a => a.Value.ResultType).FirstOrDefault(t => t is not null);
+    public bool HasDefault => _hasDefault;
+    public IReadOnlyList<UnionSwitchExpressionArm> Arms
+        => Children.Skip(1).Take(Children.Count - 1 - (_hasDefault ? 1 : 0)).Cast<UnionSwitchExpressionArm>().ToList();
+    public IrExpression? DefaultValue => _hasDefault ? (IrExpression)Children[^1] : null;
+    public override TypeRef? ResultType
+        => Arms.Select(a => a.Value.ResultType).Append(DefaultValue?.ResultType).FirstOrDefault(t => t is not null);
 
-    public override string Describe() => $"UnionSwitchExpression ({Children.Count - 1} arms)";
+    public override string Describe() => $"UnionSwitchExpression ({Arms.Count} arms{(_hasDefault ? " + default" : "")})";
 }
 
 /// <summary>One type-pattern arm of a <see cref="UnionSwitchExpression"/>.</summary>
 public sealed class UnionSwitchExpressionArm : IrNode
 {
-    public UnionSwitchExpressionArm(TypeRef patternType, int? localIndex, IrExpression value)
+    readonly bool _hasGuard;
+
+    public UnionSwitchExpressionArm(TypeRef patternType, int? localIndex, IrExpression value, IrExpression? guard = null)
     {
         PatternType = patternType;
         LocalIndex = localIndex;
+        if (guard is not null)
+        {
+            _hasGuard = true;
+            AddChild(guard);
+        }
         AddChild(value);
     }
 
     public TypeRef PatternType { get; }
     public int? LocalIndex { get; }
-    public IrExpression Value => (IrExpression)Children[0];
+    public bool HasGuard => _hasGuard;
+    public IrExpression? Guard => _hasGuard ? (IrExpression)Children[0] : null;
+    public IrExpression Value => (IrExpression)Children[_hasGuard ? 1 : 0];
 
     public override IEnumerable<TypeRef> DirectTypes => [PatternType];
     public override string Describe() => LocalIndex is { } index

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -243,6 +243,10 @@ public static class IrPasses
         // formed; expression inlining leaves these temps standing because it
         // refuses to move a value across a leave/region edge.
         new ReturnSinkingPass(),
+        // Re-run after return-sinking: union switch expressions with default
+        // arms normalize from store/return accumulator blocks to direct returns,
+        // the shape this deliberately narrow pass recognizes.
+        new UnionSwitchExpressionPass(),
         // Raise the csc reference-type using lowering (resource local +
         // try/finally with an IDisposable.Dispose null guard) back into a
         // using statement. Runs after return sinking so a `return` from inside

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -10,7 +10,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
 {
     public string Name => "union-switch-expression";
 
-    sealed record Arm(TypeRef PatternType, int? LocalIndex, IrExpression Value, IReadOnlyList<IrNode> LocalRoots);
+    sealed record Arm(TypeRef PatternType, int? LocalIndex, IrExpression Value, IReadOnlyList<IrNode> LocalRoots, IrExpression? Guard = null);
     sealed record Match(int StartIndex, UnionSwitchExpression SwitchExpression);
 
     public void Run(IrFunction function, PassContext context)
@@ -40,6 +40,12 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 return true;
             }
 
+            if (TryMatchDefaultChainAt(function, children, start, out var defaultSwitch))
+            {
+                match = new Match(start, defaultSwitch);
+                return true;
+            }
+
             if (TryMatchAt(function, children, start, out var switchExpression))
             {
                 match = new Match(start, switchExpression);
@@ -48,6 +54,78 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         }
 
         return false;
+    }
+
+    static bool TryMatchDefaultChainAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        if (start + 2 >= children.Count
+            || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsUnionValueProperty(function, unionValue))
+        {
+            return false;
+        }
+
+        IrExpression defaultValue;
+        IReadOnlyList<IrNode> armNodes;
+        if (TryFinalFallbackDefault(children, start + 1, out var finalDefault))
+        {
+            defaultValue = finalDefault;
+            armNodes = children.Skip(start + 1).ToArray();
+        }
+        else if (children[^1] is Return { Value: { } trailingDefault })
+        {
+            defaultValue = trailingDefault;
+            armNodes = children.Skip(start + 1).Take(children.Count - start - 2).ToArray();
+        }
+        else
+        {
+            return false;
+        }
+
+        int tempLocal = valueStore.Index;
+        if (!TryDefaultArms(armNodes, tempLocal, defaultValue, out var arms))
+            return false;
+
+        var allowedTempUses = new List<IrNode> { valueStore };
+        allowedTempUses.AddRange(armNodes);
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, tempLocal, allowedTempUses)
+            || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+            || arms.Select(arm => arm.PatternType).Distinct().Count() != arms.Count)
+        {
+            return false;
+        }
+
+        switchExpression = new UnionSwitchExpression(
+            (IrExpression)unionValue.Clone(),
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+            (IrExpression)defaultValue.Clone());
+        return true;
+    }
+
+    static bool TryFinalFallbackDefault(IReadOnlyList<IrNode> children, int armStart, out IrExpression defaultValue)
+    {
+        defaultValue = null!;
+        if (children.Count - armStart < 3
+            || children[^3] is not StoreLocal { Value: IsInstance }
+            || children[^2] is not IfStatement nullGuard
+            || nullGuard.HasElse
+            || nullGuard.Then.Children is not [Return { Value: { } fallback }]
+            || children[^1] is not Return)
+        {
+            return false;
+        }
+
+        defaultValue = fallback;
+        return true;
     }
 
     static bool TryMatchClassNullGuardAt(
@@ -192,8 +270,94 @@ public sealed class UnionSwitchExpressionPass : IIrPass
 
         switchExpression = new UnionSwitchExpression(
             (IrExpression)unionValue.Clone(),
-            arms.Select(arm => new UnionSwitchExpressionArm(arm.PatternType, arm.LocalIndex, (IrExpression)arm.Value.Clone())));
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())));
         return true;
+    }
+
+    static bool TryDefaultArm(IfStatement armIf, int tempLocal, IrExpression defaultValue, out Arm arm)
+    {
+        arm = null!;
+        if (armIf.HasElse)
+            return false;
+
+        if (TryArmPattern(armIf.Condition, tempLocal, out var patternType, out var localIndex, out var patternRoots)
+            && TryArmBody(armIf.Then.Children, localIndex, defaultValue, out var value, out var guard, out var guardRoots))
+        {
+            var localRoots = new List<IrNode>(patternRoots) { value };
+            localRoots.AddRange(guardRoots);
+            arm = new Arm(patternType, localIndex, value, localRoots, guard);
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool TryArmPattern(IrExpression condition, int tempLocal, out TypeRef patternType, out int? localIndex, out IReadOnlyList<IrNode> roots)
+    {
+        switch (condition)
+        {
+            case IsPattern pattern when IsTempLoad(pattern.Value, tempLocal):
+                patternType = pattern.Type;
+                localIndex = pattern.LocalIndex;
+                roots = [pattern];
+                return true;
+            case IsInstance test when IsTempTypeTest(test, tempLocal):
+                patternType = test.Type;
+                localIndex = null;
+                roots = [];
+                return true;
+            default:
+                patternType = null!;
+                localIndex = null;
+                roots = [];
+                return false;
+        }
+    }
+
+    static bool TryArmBody(
+        IReadOnlyList<IrNode> nodes,
+        int? localIndex,
+        IrExpression defaultValue,
+        out IrExpression value,
+        out IrExpression? guard,
+        out IReadOnlyList<IrNode> guardRoots)
+    {
+        value = null!;
+        guard = null;
+        guardRoots = [];
+
+        if (nodes is [Return { Value: { } direct }])
+        {
+            value = direct;
+            return true;
+        }
+
+        if (nodes is [IfStatement { HasElse: false } guardIf, Return fallback]
+            && fallback.Value is { } fallbackValue
+            && PlaceIdentity.SameOperand(fallbackValue, defaultValue)
+            && guardIf.Then.Children is [Return { Value: { } guardedValue }])
+        {
+            value = guardedValue;
+            guard = guardIf.Condition;
+            guardRoots = [guardIf.Condition];
+            return true;
+        }
+
+        if (nodes is [IfStatement { HasElse: false } invertedGuardIf, Return { Value: { } invertedValue }]
+            && invertedGuardIf.Then.Children is [Return { Value: { } nestedFallback }]
+            && PlaceIdentity.SameOperand(nestedFallback, defaultValue))
+        {
+            value = invertedValue;
+            guard = Conditions.Negate((IrExpression)invertedGuardIf.Condition.Clone());
+            guardRoots = [invertedGuardIf.Condition];
+            return true;
+        }
+
+        return false;
     }
 
     static bool TryInnerArms(IEnumerable<IrNode> nodes, int tempLocal, int resultLocal, out IReadOnlyList<Arm> arms)
@@ -207,6 +371,41 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 return false;
             }
             builder.Add(arm);
+        }
+
+        arms = builder;
+        return arms.Count > 0;
+    }
+
+    static bool TryDefaultArms(IReadOnlyList<IrNode> nodes, int tempLocal, IrExpression defaultValue, out IReadOnlyList<Arm> arms)
+    {
+        var builder = new List<Arm>();
+        for (int i = 0; i < nodes.Count;)
+        {
+            if (nodes[i] is IfStatement armIf && TryDefaultArm(armIf, tempLocal, defaultValue, out var arm))
+            {
+                builder.Add(arm);
+                i++;
+                continue;
+            }
+
+            if (i + 2 < nodes.Count
+                && nodes[i] is StoreLocal { Value: IsInstance asCast } store
+                && IsTempTypeTest(asCast, tempLocal)
+                && nodes[i + 1] is IfStatement nullGuard
+                && !nullGuard.HasElse
+                && IsNotLocal(nullGuard.Condition, store.Index)
+                && nullGuard.Then.Children is [Return { Value: { } fallback }]
+                && PlaceIdentity.SameOperand(fallback, defaultValue)
+                && nodes[i + 2] is Return { Value: { } value })
+            {
+                builder.Add(new Arm(asCast.Type, store.Index, value, [store, nullGuard.Condition, value]));
+                i += 3;
+                continue;
+            }
+
+            arms = [];
+            return false;
         }
 
         arms = builder;


### PR DESCRIPTION
- Advances #1917
- Changes union switch-expression reconstruction to support distinct-type guarded arms and default arms for property/relational pattern switch lowerings.
- Card revision: b0e9b855

## Change

**Conclusion:** **REVIEW** — this hardens union switch reconstruction for preview-SDK distinct-type property/relational pattern arms, rendering guarded type arms with `when` clauses and preserving the default arm.

Before:

```csharp
object V_3 = pet.Value;
if (V_3 is Cat cat)
{
    if (cat.Age > 3) return cat.Name;
    return "other";
}
if (V_3 is Dog dog)
{
    if (dog.Age <= 5) return "other";
    return dog.Name;
}
return "other";
```

After:

```csharp
return pet switch
{
    Cat cat when cat.Age > 3 => cat.Name,
    Dog dog when dog.Age > 5 => dog.Name,
    _ => "other",
};
```

The pass still requires a terminal cached union `Value` dispatch, same-assembly union metadata, owned temp/pattern locals, and non-union `Value` lookalikes stay lowered.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `TypeSourceComposerUnionTests`: 12 passed |
| Lowering coverage | Pass |
| Build-event validation | `Summary`: 263 projects, 0 failed, 0 errors, 0 warnings; event log `20260630T070650.8046522Z-2378618-build-aa36c2b1` |
| Real witness | Preview SDK fixtures: string equality property pattern and relational property pattern arms render as `when` guards |
| Near miss | Non-union `Value switch` with guarded arms still does not render `pet switch` |

## Decompiler quality

**Conclusion:** **ADVISORY** — no corpus card included for this targeted preview-language slice; behavior is fixture-gated on union metadata and not expected to affect the current fixed corpus materially.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Validated guard/default semantics; noted theoretical no-local guard temp case and test coverage gaps. |
| Gemini 3.1 Pro | Broader-scope findings deferred | Same-type guarded fallback and exhaustive guarded switches remain lowered; tracked as follow-up. |

**Review conclusion:** **PASS** — reviews completed; #1957 scope is distinct-type guarded/default arms.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringCoverageTests/*"
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate src/ILInspector.Decompiler.Tests -- -c Release --nologo --verbosity quiet
```

