### PR TITLE
Document Rung 7 triage shapes in performance skill

### DIFF
--- a/skills/performance/SKILL.md
+++ b/skills/performance/SKILL.md
@@ -50,8 +50,15 @@ curated ranked prefix. Supplying any of those flags selects `Performance Triage`
 automatically on `library`, `type`, and `member`. `--top` narrows the ranked data
 before rendering; `-n N --rows` is a generic rendered-row cap applied afterward.
 Common shapes include `capturing-delegate`, `box-value-type`, `small-array`,
-`linq-scan-in-loop`, `string-build-in-loop`, `enumerator-allocation`, and
-`allocation-hotspot`.
+`linq-scan-in-loop`, `materialize-in-loop` (a loop-invariant `ToArray`/`ToList`
+that can be hoisted), `string-build-in-loop`, `enumerator-allocation`,
+`async-state-machine`, and `allocation-hotspot`.
+
+Not every shape is a pure hot-path win. `async-state-machine` is reported as
+amortized (low confidence) unless the allocation sits in a loop: async lowering
+moves work into a state object rather than eliminating it, often once per
+call/enumeration/subscription. Treat amortized rows as context, and confirm a
+real per-item cost with a profiler before optimizing.
 
 ## Drill a candidate
 


### PR DESCRIPTION
## Summary

Keeps the canonical triage-shape enumeration honest now that the Rung 7 shapes
from #1948 are live on `main`. `skills/performance/SKILL.md` is the only place
that lists the `--triage-shape` values, and it was missing the two new ones.

- Add **`materialize-in-loop`** (loop-invariant `ToArray`/`ToList` that can be hoisted).
- Add **`async-state-machine`**, with a short note that it is reported as
  amortized (low confidence) off-loop — async lowering moves work into a state
  object rather than eliminating it, often once per call/enumeration/subscription
  — so the row is not read as a pure hot-path win.

## Why repo skill, not external

Per the skill split, repo skills are the canonical, tool-only capability docs;
the external `richlander/dotnet-skills` `dotnet-allocation-triage` skill is
workflow-only and deliberately defers shapes/flags to the embedded guide
(`dnx dotnet-inspect -y -- skill`). It enumerates no shapes, so it does not drift
and needs no change. This PR is the single doc update the new shapes require.

## Scope and risk

Docs-only, low-risk. The skill file is embedded verbatim at build (no codegen);
no test asserts the skill body text; frontmatter is untouched.

## Validation

- `npx markdownlint-cli skills/performance/SKILL.md` — pass

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>