### PR TITLE
Raise same-type guarded union switch defaults

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -423,6 +423,48 @@ public class TypeSourceComposerUnionTests
     }
 
     [Fact]
+    public async Task UnionSwitchExpression_RendersSameTypeGuardedFallbackArms()
+    {
+        using var assembly = await CompileWithSdk("""
+            namespace UnionFixtures;
+
+            public sealed class Cat { public string Name { get; } = "cat"; public int Age { get; } = 5; }
+            public sealed class Dog { public string Name { get; } = "dog"; public int Age { get; } = 7; }
+            public union Pet(Cat, Dog);
+
+            public static class Matcher
+            {
+                public static string Defaulted(Pet pet) => pet switch
+                {
+                    Cat { Name: "cat" } cat => cat.Name,
+                    Cat => "other cat",
+                    Dog dog => dog.Name,
+                    _ => "other",
+                };
+
+                public static string Exhaustive(Pet pet) => pet switch
+                {
+                    Cat { Name: "cat" } cat => cat.Name,
+                    Cat => "other cat",
+                    Dog dog => dog.Name,
+                };
+            }
+            """);
+
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat when cat.Name == "cat" => cat.Name,
+                Cat => "other cat",
+                Dog dog => dog.Name,
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Defaulted"));
+        Assert.DoesNotContain("return pet switch",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "Exhaustive"));
+    }
+
+    [Fact]
     public async Task ClassUnionSwitchExpression_RendersTypePatternArms()
     {
         using var assembly = await CompileWithSdk("""

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -442,6 +442,14 @@ public class TypeSourceComposerUnionTests
                     _ => "other",
                 };
 
+                public static string Inverted(Pet pet) => pet switch
+                {
+                    Cat { Age: <= 3 } => "young",
+                    Cat => "old",
+                    Dog dog => dog.Name,
+                    _ => "other",
+                };
+
                 public static string Exhaustive(Pet pet) => pet switch
                 {
                     Cat { Name: "cat" } cat => cat.Name,
@@ -460,6 +468,15 @@ public class TypeSourceComposerUnionTests
                 _ => "other",
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Defaulted"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat V_3 when V_3.Age <= 3 => "young",
+                Cat => "old",
+                Dog dog => dog.Name,
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Inverted"));
         Assert.DoesNotContain("return pet switch",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "Exhaustive"));
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -347,7 +347,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 return true;
             }
 
-            if (localIndex is { } local && !ReferencesLocal(fallbackValue, local))
+            if (localIndex is not { } fallbackLocal || !ReferencesLocal(fallbackValue, fallbackLocal))
             {
                 arms =
                 [
@@ -359,11 +359,23 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         }
 
         if (nodes is [IfStatement { HasElse: false } invertedGuardIf, Return { Value: { } invertedValue }]
-            && invertedGuardIf.Then.Children is [Return { Value: { } nestedFallback }]
-            && PlaceIdentity.SameOperand(nestedFallback, defaultValue))
+            && invertedGuardIf.Then.Children is [Return { Value: { } nestedFallback }])
         {
-            arms = [new ArmBody(invertedValue, Conditions.Negate((IrExpression)invertedGuardIf.Condition.Clone()), [invertedGuardIf.Condition], KeepsLocal: true)];
-            return true;
+            if (PlaceIdentity.SameOperand(nestedFallback, defaultValue))
+            {
+                arms = [new ArmBody(invertedValue, Conditions.Negate((IrExpression)invertedGuardIf.Condition.Clone()), [invertedGuardIf.Condition], KeepsLocal: true)];
+                return true;
+            }
+
+            if (localIndex is not { } invertedFallbackLocal || !ReferencesLocal(nestedFallback, invertedFallbackLocal))
+            {
+                arms =
+                [
+                    new ArmBody(invertedValue, Conditions.Negate((IrExpression)invertedGuardIf.Condition.Clone()), [invertedGuardIf.Condition], KeepsLocal: true),
+                    new ArmBody(nestedFallback, Guard: null, GuardRoots: [], KeepsLocal: false),
+                ];
+                return true;
+            }
         }
 
         return false;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -95,7 +95,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         allowedTempUses.AddRange(armNodes);
         if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, tempLocal, allowedTempUses)
             || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
-            || arms.Select(arm => arm.PatternType).Distinct().Count() != arms.Count)
+            || !DuplicateTypesAreGuarded(arms))
         {
             return false;
         }
@@ -278,23 +278,28 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         return true;
     }
 
-    static bool TryDefaultArm(IfStatement armIf, int tempLocal, IrExpression defaultValue, out Arm arm)
+    static bool TryDefaultArm(IfStatement armIf, int tempLocal, IrExpression defaultValue, out IReadOnlyList<Arm> arms)
     {
-        arm = null!;
+        arms = [];
         if (armIf.HasElse)
             return false;
 
         if (TryArmPattern(armIf.Condition, tempLocal, out var patternType, out var localIndex, out var patternRoots)
-            && TryArmBody(armIf.Then.Children, localIndex, defaultValue, out var value, out var guard, out var guardRoots))
+            && TryArmBody(armIf.Then.Children, localIndex, defaultValue, out var matchedArms))
         {
-            var localRoots = new List<IrNode>(patternRoots) { value };
-            localRoots.AddRange(guardRoots);
-            arm = new Arm(patternType, localIndex, value, localRoots, guard);
+            arms = matchedArms.Select(arm =>
+            {
+                var localRoots = new List<IrNode>(patternRoots) { arm.Value };
+                localRoots.AddRange(arm.GuardRoots);
+                return new Arm(patternType, arm.KeepsLocal ? localIndex : null, arm.Value, localRoots, arm.Guard);
+            }).ToArray();
             return true;
         }
 
         return false;
     }
+
+    sealed record ArmBody(IrExpression Value, IrExpression? Guard, IReadOnlyList<IrNode> GuardRoots, bool KeepsLocal);
 
     static bool TryArmPattern(IrExpression condition, int tempLocal, out TypeRef patternType, out int? localIndex, out IReadOnlyList<IrNode> roots)
     {
@@ -322,43 +327,50 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         IReadOnlyList<IrNode> nodes,
         int? localIndex,
         IrExpression defaultValue,
-        out IrExpression value,
-        out IrExpression? guard,
-        out IReadOnlyList<IrNode> guardRoots)
+        out IReadOnlyList<ArmBody> arms)
     {
-        value = null!;
-        guard = null;
-        guardRoots = [];
+        arms = [];
 
         if (nodes is [Return { Value: { } direct }])
         {
-            value = direct;
+            arms = [new ArmBody(direct, Guard: null, GuardRoots: [], KeepsLocal: localIndex is not null && ReferencesLocal(direct, localIndex.Value))];
             return true;
         }
 
         if (nodes is [IfStatement { HasElse: false } guardIf, Return fallback]
             && fallback.Value is { } fallbackValue
-            && PlaceIdentity.SameOperand(fallbackValue, defaultValue)
             && guardIf.Then.Children is [Return { Value: { } guardedValue }])
         {
-            value = guardedValue;
-            guard = guardIf.Condition;
-            guardRoots = [guardIf.Condition];
-            return true;
+            if (PlaceIdentity.SameOperand(fallbackValue, defaultValue))
+            {
+                arms = [new ArmBody(guardedValue, guardIf.Condition, [guardIf.Condition], KeepsLocal: true)];
+                return true;
+            }
+
+            if (localIndex is { } local && !ReferencesLocal(fallbackValue, local))
+            {
+                arms =
+                [
+                    new ArmBody(guardedValue, guardIf.Condition, [guardIf.Condition], KeepsLocal: true),
+                    new ArmBody(fallbackValue, Guard: null, GuardRoots: [], KeepsLocal: false),
+                ];
+                return true;
+            }
         }
 
         if (nodes is [IfStatement { HasElse: false } invertedGuardIf, Return { Value: { } invertedValue }]
             && invertedGuardIf.Then.Children is [Return { Value: { } nestedFallback }]
             && PlaceIdentity.SameOperand(nestedFallback, defaultValue))
         {
-            value = invertedValue;
-            guard = Conditions.Negate((IrExpression)invertedGuardIf.Condition.Clone());
-            guardRoots = [invertedGuardIf.Condition];
+            arms = [new ArmBody(invertedValue, Conditions.Negate((IrExpression)invertedGuardIf.Condition.Clone()), [invertedGuardIf.Condition], KeepsLocal: true)];
             return true;
         }
 
         return false;
     }
+
+    static bool ReferencesLocal(IrExpression expression, int local)
+        => expression.Descendants.Prepend(expression).OfType<LoadLocal>().Any(load => load.Index == local);
 
     static bool TryInnerArms(IEnumerable<IrNode> nodes, int tempLocal, int resultLocal, out IReadOnlyList<Arm> arms)
     {
@@ -384,7 +396,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         {
             if (nodes[i] is IfStatement armIf && TryDefaultArm(armIf, tempLocal, defaultValue, out var arm))
             {
-                builder.Add(arm);
+                builder.AddRange(arm);
                 i++;
                 continue;
             }
@@ -528,6 +540,22 @@ public sealed class UnionSwitchExpressionPass : IIrPass
     static bool ArmLocalReferencesAreOwned(IrFunction function, Arm arm)
         => arm.LocalIndex is not { } local
             || ReferenceOwnership.LocalReferencesOnlyWithin(function, local, arm.LocalRoots);
+
+    static bool DuplicateTypesAreGuarded(IReadOnlyList<Arm> arms)
+    {
+        for (int i = 0; i < arms.Count; i++)
+        {
+            for (int j = i + 1; j < arms.Count; j++)
+            {
+                if (arms[i].PatternType.Equals(arms[j].PatternType)
+                    && arms[i].Guard is null)
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
 
     static bool IsThrowSwitchExpression(ExpressionStatement statement)
         => statement.Expression is Call

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -382,7 +382,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
     }
 
     static bool ReferencesLocal(IrExpression expression, int local)
-        => expression.Descendants.Prepend(expression).OfType<LoadLocal>().Any(load => load.Index == local);
+        => ReferenceOwnership.SubtreeReferencesLocal(expression, local);
 
     static bool TryInnerArms(IEnumerable<IrNode> nodes, int tempLocal, int resultLocal, out IReadOnlyList<Arm> arms)
     {


### PR DESCRIPTION
- Advances #1960
- Changes default-arm union switch reconstruction to support a guarded type arm followed by an unguarded same-type fallback arm.
- Card revision: f989d08d

## Change

**Conclusion:** **REVIEW** — this handles the default-arm same-type guarded fallback shape from #1960. The exhaustive guarded same-type shape remains deliberately flat and is tracked separately in #1961.

Before:

```csharp
if (V_3 is Cat cat)
{
    if (cat.Name == "cat") return cat.Name;
    return "other cat";
}
```

After:

```csharp
return pet switch
{
    Cat cat when cat.Name == "cat" => cat.Name,
    Cat => "other cat",
    Dog dog => dog.Name,
    _ => "other",
};
```

The fallback arm is emitted only when it does not reference the pattern local. Duplicate type arms remain rejected unless every earlier duplicate is guarded.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `TypeSourceComposerUnionTests`: 13 passed |
| Lowering coverage | Pass |
| Build-event validation | `Summary`: 263 projects, 0 failed, 0 errors, 0 warnings; event log `20260630T072550.4078356Z-2406708-build-440442a6` |
| Real witness | Preview SDK fixture: `Cat { Name: "cat" }`, `Cat`, `Dog`, `_` renders as a switch expression |
| Near miss | Exhaustive same-type guarded switch remains lowered; follow-up #1961 |

## Decompiler quality

**Conclusion:** **ADVISORY** — no corpus card included for this targeted preview-language hardening slice; behavior is fixture-gated on union metadata and not expected to affect the current fixed corpus materially.

## Review

Required adversarial review is pending. This PR changes decompiler output and should not be marked ready until review reconciliation is posted.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringCoverageTests/*"
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate src/ILInspector.Decompiler.Tests -- -c Release --nologo --verbosity quiet
```
