### PR TITLE
Align library value projection with rendered fields

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4165,6 +4165,73 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryCommand_Value_UsesEffectiveLibraryInfoFieldNames()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "Library Info", "--fields", "Assembly Version", "--value", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Matches(@"^\d+\.\d+\.\d+\.\d+$", output.Trim());
+    }
+
+    [Fact]
+    public async Task LibraryCommand_Value_RejectsNonDiscoveredFieldName()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "Library Info", "--fields", "TFM", "--value", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("field 'TFM' not found in section 'Library Info'", error);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_DiscoverLibraryInfo_FiltersFieldsToRenderedRows()
+    {
+        var (selectExit, selectOutput, selectError) = await RunAppAsync(
+            "library", "System.Text.Json", "-S", "Library Info", "--tips", "q");
+        var (discoverExit, discoverOutput, discoverError) = await RunAppAsync(
+            "library", "System.Text.Json", "-D", "Library Info", "--tips", "q");
+
+        Assert.Equal(0, selectExit);
+        Assert.Equal(0, discoverExit);
+        Assert.Empty(selectError);
+        Assert.Empty(discoverError);
+        Assert.Equal(
+            selectOutput.Contains("| Architecture |", StringComparison.Ordinal),
+            discoverOutput.Contains("| Architecture | field |", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task LibraryCommand_DiscoverLibraryInfo_DoesNotKeepSubstringOnlyFields()
+    {
+        var (assemblyPath, _, _, error) = PlatformResolver.ResolveAssembly("System.Runtime");
+        if (assemblyPath == null || error != null)
+        {
+            Assert.Skip($"System.Runtime not available: {error}");
+            return;
+        }
+
+        Assert.SkipUnless(PlatformResolver.IsFacadeOnlyAssembly(assemblyPath),
+            "System.Runtime is not facade-only in this runtime.");
+
+        var (selectExit, selectOutput, selectError) = await RunAppAsync(
+            "library", "System.Runtime", "-S", "Library Info", "--tips", "q");
+        var (discoverExit, discoverOutput, discoverError) = await RunAppAsync(
+            "library", "System.Runtime", "-D", "Library Info", "--tips", "q");
+
+        Assert.Equal(0, selectExit);
+        Assert.Equal(0, discoverExit);
+        Assert.Empty(selectError);
+        Assert.Empty(discoverError);
+        Assert.DoesNotContain("| Methods |", selectOutput);
+        Assert.DoesNotContain("| Methods | field |", discoverOutput);
+        Assert.Contains("| Async Methods | field |", discoverOutput);
+        Assert.Contains("| Extension Methods | field |", discoverOutput);
+    }
+
+    [Fact]
     public async Task LibraryCommand_DiscoverEffective_RendersMarkdownTable()
     {
         var (exit, output, _) = await RunAppAsync("library", "System.Text.Json", "-D");

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -12,6 +12,8 @@ using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 using Markout;
+using System.Globalization;
+using System.Text;
 
 namespace DotnetInspector.Commands;
 
@@ -360,6 +362,8 @@ public class LibraryCommand
             Console.Error.WriteLine($"Error: section '{section}' does not expose {kind.ToString().ToLowerInvariant()} values.");
             return 1;
         }
+        if (rows.Count == 0 && section == "Library Info" && kind == ShapeProjectionKind.Value)
+            return 1;
 
         return ShapeProjectionOutput.Write(
             rows,
@@ -402,6 +406,10 @@ public class LibraryCommand
     {
         if (kind != ShapeProjectionKind.Value)
             return [];
+        var info = new LibraryInspectionView(inspection).AssemblyInfoSection;
+        if (info is null)
+            return [];
+
         var field = options.Fields?.SingleOrDefault() ?? options.Columns?.SingleOrDefault();
         if (string.IsNullOrWhiteSpace(field))
         {
@@ -409,21 +417,60 @@ public class LibraryCommand
             return [];
         }
 
-        string? value = field.ToLowerInvariant() switch
+        var values = GetLibraryInfoValues(info);
+        if (!values.TryGetValue(field, out var value))
         {
-            "name" => inspection.AssemblyInfo?.AssemblyName ?? Path.GetFileNameWithoutExtension(inspection.FileName),
-            "version" => inspection.PlatformVersion ?? inspection.AssemblyInfo?.AssemblyVersion,
-            "tfm" => inspection.Tfm,
-            "source" => inspection.Source,
-            "file" or "filename" => inspection.FileName,
-            "repository" => inspection.RepositoryUrl,
-            "pdb" or "pdb path" or "pdb_path" => inspection.PdbPath,
-            _ => null
+            Console.Error.WriteLine($"Error: field '{field}' was not found in Library Info.");
+            return [];
+        }
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            Console.Error.WriteLine($"Error: field '{field}' has no value in Library Info.");
+            return [];
+        }
+
+        return [new ShapeProjectionRow(1, section, value, Label: field)];
+    }
+
+    private static Dictionary<string, string?> GetLibraryInfoValues(LibraryInfoSection info)
+    {
+        Dictionary<string, string?> values = new(StringComparer.OrdinalIgnoreCase);
+        foreach (var property in typeof(LibraryInfoSection).GetProperties())
+        {
+            var name = ToPascalCaseWords(property.Name);
+            values[name] = FormatLibraryInfoValue(property.GetValue(info));
+        }
+
+        return values;
+    }
+
+    private static string? FormatLibraryInfoValue(object? value)
+        => value switch
+        {
+            null => null,
+            bool b => b ? "Yes" : "No",
+            IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+            _ => value.ToString()
         };
 
-        return string.IsNullOrWhiteSpace(value)
-            ? []
-            : [new ShapeProjectionRow(1, section, value, Label: field)];
+    private static string ToPascalCaseWords(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+
+        var builder = new StringBuilder(value.Length + 8);
+        builder.Append(value[0]);
+        for (var i = 1; i < value.Length; i++)
+        {
+            var current = value[i];
+            var previous = value[i - 1];
+            if (char.IsUpper(current) && (char.IsLower(previous) || char.IsDigit(previous)))
+                builder.Append(' ');
+            builder.Append(current);
+        }
+
+        return builder.ToString();
     }
 
     private static int WriteEffectiveSections(string assemblyPath, LibraryInspection inspection,
@@ -553,12 +600,40 @@ public class LibraryCommand
                 continue;
             }
 
-            if (section.Items.Length > 0)
+            if (string.Equals(name, "Library Info", StringComparison.OrdinalIgnoreCase))
+            {
+                var renderedLabels = GetRenderedFieldLabels(rendered);
+                var effectiveItems = section.Items
+                    .Where(item => renderedLabels.Contains(item.Name))
+                    .Select(item => item.Name)
+                    .ToArray();
+                filtered.Add(name, section.ItemKind,
+                    effectiveItems.Length > 0 ? effectiveItems : section.Items.Select(i => i.Name).ToArray());
+            }
+            else if (section.Items.Length > 0)
                 filtered.Add(name, section.ItemKind, section.Items.Select(i => i.Name).ToArray());
             else
                 filtered.AddSection(name);
         }
         return filtered;
+    }
+
+    private static HashSet<string> GetRenderedFieldLabels(string rendered)
+    {
+        HashSet<string> labels = new(StringComparer.OrdinalIgnoreCase);
+        foreach (var line in rendered.ReplaceLineEndings("\n").Split('\n'))
+        {
+            if (!line.StartsWith('|'))
+                continue;
+
+            var cells = line.Split('|', StringSplitOptions.TrimEntries);
+            if (cells.Length < 3 || cells[1] is "Field" or "---" or "-----")
+                continue;
+
+            labels.Add(cells[1]);
+        }
+
+        return labels;
     }
 
     private static void WarnEmptySections(LibraryInspection inspection, LibraryOptions options,


### PR DESCRIPTION
## Summary

Fixes the high-priority #1959 shape-projection usability issue for `library -S "Library Info" --value`.

The bug was not `-D` versus `-S`: effective `-D "Library Info"` and `-S "Library Info"` were mostly aligned. The drift was that `--value` used a private switch (`version`, `tfm`, etc.) instead of the rendered `LibraryInfoSection` field names and values. This PR makes `--value` consume `LibraryInfoSection` so discovered/rendered field names such as `Assembly Version` work.

Also tightens effective discovery filtering for `Library Info` so fields are kept only when their own rendered row appears. This avoids substring false positives such as `Methods` being retained because `Async Methods` or `Extension Methods` rendered.

## Examples

Before:

```bash
dotnet-inspect library System.Text.Json -S "Library Info" --fields "Assembly Version" --value
# Error: selected section has no scalar values.
```

After:

```bash
dotnet-inspect library System.Text.Json -S "Library Info" --fields "Assembly Version" --value
11.0.0.0
```

## Validation

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method "*LibraryCommand_Value*"`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method "*DiscoverLibraryInfo*"`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method "*Value*"`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method "*Urls*"`
- `git diff --check`

## Review

Claude Opus 4.8 found that the first implementation filtered effective fields with a naive substring search. That could keep fields such as `Methods` only because `Async Methods` or `Extension Methods` rendered. Fixed by extracting rendered table field labels and matching exact labels.

