### PR TITLE
Release 0.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,10 @@ env:
 
 # Cancel superseded PR runs (e.g. when an agent pushes again to the same branch)
 # so only the latest commit of a PR consumes a full CI run. Pushes to main are
-# NOT cancelled: release.yml publishes from a main-push CI run's package
-# artifacts, so those runs must always complete.
+# not cancelled, but they only run the lightweight changes/markdownlint legs
+# (test/pack/pack-rid are PR-only), so there is little to cancel. release.yml
+# builds all release packages fresh at publish time and does not consume CI
+# artifacts.
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -80,8 +82,9 @@ jobs:
             # itself. Test/harness csproj changes and unrelated workflow edits
             # don't affect the package, so they must not trip this. Most PRs
             # (e.g. decompiler raises) touch none of these, keeping pack off the
-            # hot PR path. On push to main, pack still runs (see job `if`s) to
-            # produce the artifacts release.yml publishes.
+            # hot PR path. pack/pack-rid are a PR-only packaging smoke test and
+            # never produce release artifacts: release.yml builds all packages
+            # fresh at publish time from the resolved commit SHA.
             case "$file" in
               src/dotnet-inspect/dotnet-inspect.csproj) PACKAGING=true ;;
               Directory.Build.props|Directory.Build.targets|Directory.Packages.props) PACKAGING=true ;;

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dotnet-inspect
-version: 0.14.0
+version: 0.16.0
 description: Find evidence instead of guessing for .NET packages, platform libraries, local assemblies, APIs, dependencies, and version-to-version API changes.
 ---
 

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -24,7 +24,7 @@
     <Authors>Richard Lander</Authors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-inspect</ToolCommandName>
-    <VersionPrefix>0.15.0</VersionPrefix>
+    <VersionPrefix>0.16.0</VersionPrefix>
     <PackageId>dotnet-inspect</PackageId>
     <Description>A CLI tool for inspecting .NET assemblies and NuGet packages</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/dotnet-inspect/release-notes.md
+++ b/src/dotnet-inspect/release-notes.md
@@ -1,5 +1,50 @@
 # Release Notes
 
+## v0.16.0
+
+### Research overlay and performance analysis (experimental)
+
+- Adds the `ILInspector.Research` overlay layer over Analysis and the
+  Decompiler, with explicit `Cost` and `Semantics` overlay sections and a
+  structured `Facts` table (#1920, #1934, #1932, #1927).
+- Builds a shared `ControlFlow` dataflow fixpoint and reaching-definitions
+  pass, then uses them to gate allocation triage: local-array and span
+  `ToArray` copies are now promoted only when the value actually escapes,
+  cutting false positives (#1880, #1896, #1905, #1903, #1907).
+- Converges allocation and unsafety facts on the Analysis occurrences and
+  adds an allocation-parity regression gate (#1910, #1918, #1909).
+- Adds Rung 7 `Performance Triage` shapes: `async-state-machine` (reported as
+  amortized off-loop) and `materialize-in-loop` (loop-invariant
+  `ToArray`/`ToList`), plus nested-type triage drilldown (#1948, #1889).
+
+### Output and projections
+
+- Adds JSON array projection output and scalar URL/path shape projections,
+  generalizes print row projection, and aligns library value projection with
+  rendered fields (#1955, #1950, #1935, #1963, #1928).
+
+### Decompiler fidelity and unions (experimental)
+
+- Raises discriminated-union switch and declaration-pattern shapes
+  (declaration rendering, value-type tests, two-arm/three-case/guarded switch
+  expressions, else arms) (#1915, #1925, #1933, #1936, #1942, #1946, #1951,
+  #1957, #1962).
+- Improves fidelity skeletons: struct auto-properties and object overrides,
+  extension methods, `in`/`out` parameters, constructor auto-property
+  initializers, and ref-local/ref-slot declaration accuracy (#1947, #1937,
+  #1945, #1943, #1929, #1906, #1919, #1911, #1901).
+- Hardens fidelity-check infrastructure: zero-signal guard, phase timings,
+  NuGet dependency resolution, and corpus-metadata-driven targeted checks
+  (#1894, #1895, #1890, #1898, #1953).
+
+### Docs and skills
+
+- Documents the Research overlay architecture and refreshes performance,
+  query, and projection skill guidance (#1927, #1958, #1956, #1940, #1952).
+- Corrects stale `ci.yml` comments that described the old release-artifact
+  model; `release.yml` builds every package fresh at publish time and CI
+  never produces release artifacts (#1699).
+
 ## v0.14.0
 
 ### Grounding and skill workflow


### PR DESCRIPTION
## Summary

Cuts the **0.16.0** release and bundles in the stale-comment fix from #1699.

- **Version bump** — `VersionPrefix` 0.15.0 → 0.16.0 in `dotnet-inspect.csproj`. After merge, dispatch `release.yml` (Publish) against this merge commit's CI run to build all packages fresh and create the `v0.16.0` GitHub Release.
- **Skill versioning** — re-syncs the version-matched base router skill `skills/dotnet-inspect/SKILL.md` 0.14.0 → 0.16.0 (it had drifted; 0.15.0 was skipped). Focused scenario skills keep their independent `0.1.0` versions — there is no precedent for per-release bumps and no breaking invocation change this cycle (the performance/query/sourcelink skill edits were additive guidance).
- **Release notes** — adds a `v0.16.0` entry to the embedded `release-notes.md` covering the Research overlay layer, escape-gated allocation triage, Rung 7 triage shapes, projection output, and decompiler union/fidelity work.
- **#1699 (closes)** — corrects two stale `ci.yml` comments that described the old release-artifact model. Verified against current job logic: on push to main only `changes` (+ `markdownlint`) runs; `test`/`pack`/`pack-rid` are PR-only, and `release.yml` builds every package fresh at publish time, so CI never produces release artifacts. Comments only — no workflow logic change.

## What 0.16.0 ships

Research overlay (`Cost`/`Semantics` sections, structured `Facts` table) over Analysis + Decompiler; shared ControlFlow dataflow + reaching-definitions that gate local-array/span-`ToArray` triage on real escape; Rung 7 shapes (`async-state-machine` amortized, `materialize-in-loop`); JSON array + scalar shape projections; and a large body of discriminated-union raising and fidelity skeleton accuracy.

## Scope and risk

Low-risk: version/docs/comment changes only, no product code paths touched.

## Validation

- `markdownlint` on `release-notes.md` and the base skill — pass
- `ci.yml` YAML parse — valid
- Confirmed no test asserts version/release-notes consistency

Closes #1699
