### PR TITLE
Constrain Library Info field extraction to section

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4237,6 +4237,34 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public void LibraryCommand_RenderedFieldLabels_IgnoreOtherSections()
+    {
+        const string rendered = """
+            ## Library Info
+
+            | Field | Value |
+            | ----- | ----- |
+            | Assembly Version | 1.0.0.0 |
+            | Async Methods | 0 |
+
+            ## Other Section
+
+            | Name | Value |
+            | :--- | ---: |
+            | Methods | Polluting first-column value |
+            | Source | Another polluting value |
+            """;
+
+        var labels = LibraryCommand.GetRenderedFieldLabelsForTests(rendered, "Library Info");
+
+        Assert.Contains("Assembly Version", labels);
+        Assert.Contains("Async Methods", labels);
+        Assert.DoesNotContain("Methods", labels);
+        Assert.DoesNotContain("Source", labels);
+        Assert.DoesNotContain(":---", labels);
+    }
+
+    [Fact]
     public async Task LibraryCommand_DiscoverEffective_RendersMarkdownTable()
     {
         var (exit, output, _) = await RunAppAsync("library", "System.Text.Json", "-D");

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4220,13 +4220,18 @@ public class CommandExecutionTests
             "library", "System.Runtime", "-S", "Library Info", "--tips", "q");
         var (discoverExit, discoverOutput, discoverError) = await RunAppAsync(
             "library", "System.Runtime", "-D", "Library Info", "--tips", "q");
+        var (multiDiscoverExit, multiDiscoverOutput, multiDiscoverError) = await RunAppAsync(
+            "library", "System.Runtime", "-D", "Library Info,Async Methods", "--tips", "q");
 
         Assert.Equal(0, selectExit);
         Assert.Equal(0, discoverExit);
+        Assert.Equal(0, multiDiscoverExit);
         Assert.Empty(selectError);
         Assert.Empty(discoverError);
+        Assert.Contains("section 'Async Methods' has no data", multiDiscoverError);
         Assert.DoesNotContain("| Methods |", selectOutput);
         Assert.DoesNotContain("| Methods | field |", discoverOutput);
+        Assert.DoesNotContain("| Methods | field |", multiDiscoverOutput);
         Assert.Contains("| Async Methods | field |", discoverOutput);
         Assert.Contains("| Extension Methods | field |", discoverOutput);
     }

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -618,6 +618,9 @@ public class LibraryCommand
         return filtered;
     }
 
+    internal static HashSet<string> GetRenderedFieldLabelsForTests(string rendered, string sectionName)
+        => GetRenderedFieldLabels(rendered, sectionName);
+
     private static HashSet<string> GetRenderedFieldLabels(string rendered, string sectionName)
     {
         HashSet<string> labels = new(StringComparer.OrdinalIgnoreCase);

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -602,7 +602,7 @@ public class LibraryCommand
 
             if (string.Equals(name, "Library Info", StringComparison.OrdinalIgnoreCase))
             {
-                var renderedLabels = GetRenderedFieldLabels(rendered);
+                var renderedLabels = GetRenderedFieldLabels(rendered, "Library Info");
                 var effectiveItems = section.Items
                     .Where(item => renderedLabels.Contains(item.Name))
                     .Select(item => item.Name)
@@ -618,22 +618,51 @@ public class LibraryCommand
         return filtered;
     }
 
-    private static HashSet<string> GetRenderedFieldLabels(string rendered)
+    private static HashSet<string> GetRenderedFieldLabels(string rendered, string sectionName)
     {
         HashSet<string> labels = new(StringComparer.OrdinalIgnoreCase);
-        foreach (var line in rendered.ReplaceLineEndings("\n").Split('\n'))
+        foreach (var line in ExtractSection(rendered, sectionName))
         {
             if (!line.StartsWith('|'))
                 continue;
 
             var cells = line.Split('|', StringSplitOptions.TrimEntries);
-            if (cells.Length < 3 || cells[1] is "Field" or "---" or "-----")
+            if (cells.Length < 3
+                || cells[1].Equals("Field", StringComparison.OrdinalIgnoreCase)
+                || IsMarkdownSeparatorCell(cells[1]))
                 continue;
 
             labels.Add(cells[1]);
         }
 
         return labels;
+    }
+
+    private static IEnumerable<string> ExtractSection(string rendered, string sectionName)
+    {
+        var inSection = false;
+        var heading = "## " + sectionName;
+        foreach (var line in rendered.ReplaceLineEndings("\n").Split('\n'))
+        {
+            if (line.StartsWith("## ", StringComparison.Ordinal))
+            {
+                inSection = line.Equals(heading, StringComparison.Ordinal)
+                    || line.StartsWith(heading + " (", StringComparison.Ordinal);
+                continue;
+            }
+
+            if (inSection)
+                yield return line;
+        }
+    }
+
+    private static bool IsMarkdownSeparatorCell(string cell)
+    {
+        var trimmed = cell.Trim();
+        if (trimmed.Length == 0)
+            return false;
+
+        return trimmed.All(ch => ch is '-' or ':');
     }
 
     private static void WarnEmptySections(LibraryInspection inspection, LibraryOptions options,


### PR DESCRIPTION
## Summary

Follow-up to #1963 Gemini review.

#1963 fixed `library -S "Library Info" --value --fields <name>` to use the rendered `LibraryInfoSection` field contract, but the review found a robustness issue in effective discovery filtering: label extraction scanned every rendered table, so another section could accidentally retain an omitted `Library Info` field if its first-column text matched.

This PR constrains rendered field-label extraction to the `## Library Info` section block and hardens markdown separator detection.

## Validation

- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method '*DiscoverLibraryInfo*'`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method '*LibraryCommand_Value*'`
- `git diff --check`

## Review reconciliation

Gemini 3.1 Pro found the cross-section label-pollution risk. Fixed here with a section-scoped extractor plus a facade regression test for `System.Runtime -D "Library Info,Async Methods"` so `Methods` is not kept only because `Async Methods` / `Extension Methods` rendered.
