### PR TITLE
Add async Task state-machine fixture

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1334,6 +1334,16 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_PlainAsyncTask_IsNotClassStateMachineAllocationInRelease()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.DoesNotContain(index.OptimizationOpportunities, o =>
+            o.Method.Name == nameof(OptimizationOpportunityFixtures.PlainAsyncTask)
+            && o.Shape == "async-state-machine");
+    }
+
+    [Fact]
     public void OptimizationOpportunities_MaterializeInLoop_RequiresLoopInvariantSource()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -2696,6 +2706,12 @@ public class OptimizationOpportunityFixtures
         await System.Threading.Tasks.Task.Yield();
         for (int i = 0; i < count; i++)
             yield return i;
+    }
+
+    public static async Task<int> PlainAsyncTask(int value)
+    {
+        await Task.Yield();
+        return value + 1;
     }
 
     public static int MaterializesInvariantSourceInLoop(IEnumerable<int> source, int count)


### PR DESCRIPTION
## Summary

Adds a follow-up fixture from the #1948 optional review: a plain `async Task<int>` method that documents optimized-build behavior for the `async-state-machine` triage shape.

The test keeps the existing async iterator positive case and adds a plain `async Task<int>` negative case, asserting it does not surface as a class `async-state-machine` allocation in the Release fixture assembly.

## Evidence

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -method "*AsyncStateMachine*" -method "*PlainAsyncTask*"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`
