### PR TITLE
Add concurrent collections using to fidelity skeletons

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -322,6 +322,50 @@ public class FidelityCheckGeneratedFilterTests
         }
     }
 
+    [Fact]
+    public void Evaluate_BindsCommonFrameworkCollectionAndRegexTypes()
+    {
+        var assemblyPath = CompileFixture("""
+            using System.Collections.Concurrent;
+            using System.Collections.Frozen;
+            using System.Collections.Generic;
+            using System.Text.RegularExpressions;
+
+            public class FrameworkNamespaceFixture
+            {
+                public ConcurrentDictionary<string, int> CreateConcurrent()
+                    => new ConcurrentDictionary<string, int>();
+
+                public FrozenDictionary<string, int> Freeze(Dictionary<string, int> source)
+                    => source.ToFrozenDictionary();
+
+                public Match MatchS(string input)
+                    => Regex.Match(input, "s");
+            }
+            """);
+        try
+        {
+            var results = FidelityCheck.Evaluate(assemblyPath);
+            AssertCheckable(results, "CreateConcurrent");
+            AssertCheckable(results, "Freeze");
+            AssertCheckable(results, "MatchS");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+
+        static void AssertCheckable(IReadOnlyList<FidelityCheck.CompileBackResult> results, string method)
+        {
+            var result = Assert.Single(
+                results,
+                result => result.Type == "FrameworkNamespaceFixture" && result.Method == method);
+            Assert.True(
+                result.Status is FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff,
+                result.Detail);
+        }
+    }
+
     static string CompileFixture(string source)
     {
         var directory = Path.Combine(Path.GetTempPath(), $"fidelity-generated-filter-{Guid.NewGuid():N}");

--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -323,32 +323,21 @@ public class FidelityCheckGeneratedFilterTests
     }
 
     [Fact]
-    public void Evaluate_BindsCommonFrameworkCollectionAndRegexTypes()
+    public void Evaluate_BindsConcurrentCollectionsNamespace()
     {
         var assemblyPath = CompileFixture("""
             using System.Collections.Concurrent;
-            using System.Collections.Frozen;
-            using System.Collections.Generic;
-            using System.Text.RegularExpressions;
 
             public class FrameworkNamespaceFixture
             {
                 public ConcurrentDictionary<string, int> CreateConcurrent()
                     => new ConcurrentDictionary<string, int>();
-
-                public FrozenDictionary<string, int> Freeze(Dictionary<string, int> source)
-                    => source.ToFrozenDictionary();
-
-                public Match MatchS(string input)
-                    => Regex.Match(input, "s");
             }
             """);
         try
         {
             var results = FidelityCheck.Evaluate(assemblyPath);
             AssertCheckable(results, "CreateConcurrent");
-            AssertCheckable(results, "Freeze");
-            AssertCheckable(results, "MatchS");
         }
         finally
         {

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2247,7 +2247,6 @@ static class FidelityCheck
         "System.Buffers",
         "System.Collections",
         "System.Collections.Concurrent",
-        "System.Collections.Frozen",
         "System.Collections.Generic",
         "System.Collections.Immutable",
         "System.Globalization",
@@ -2260,7 +2259,6 @@ static class FidelityCheck
         "System.Runtime.CompilerServices",
         "System.Runtime.InteropServices",
         "System.Text",
-        "System.Text.RegularExpressions",
         "System.Threading",
         "System.Threading.Tasks",
     ];

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2246,6 +2246,8 @@ static class FidelityCheck
         "System",
         "System.Buffers",
         "System.Collections",
+        "System.Collections.Concurrent",
+        "System.Collections.Frozen",
         "System.Collections.Generic",
         "System.Collections.Immutable",
         "System.Globalization",
@@ -2258,6 +2260,7 @@ static class FidelityCheck
         "System.Runtime.CompilerServices",
         "System.Runtime.InteropServices",
         "System.Text",
+        "System.Text.RegularExpressions",
         "System.Threading",
         "System.Threading.Tasks",
     ];


### PR DESCRIPTION
- Advances Humanizer targeted compile-back fidelity coverage.
- Changes fidelity skeleton behavior only: add the low-collision `System.Collections.Concurrent` namespace used by emitted skeleton bodies.
- Card revision: `c126fba4`

## Change

**Conclusion:** **PASS** — short names for concurrent collection types that the product printer emits now bind in compile-back skeletons.

Before, targeted Humanizer rows failed with CS0246 for `ConcurrentDictionary<,>`. The initial PR also imported Frozen/Regex namespaces, but adversarial review flagged broader short-name/extension-method hijacking risk, so this revision keeps only `System.Collections.Concurrent` and leaves Frozen/Regex as current namespace-stripping limitations.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `FidelityCheckGeneratedFilterTests` passed, 9 tests |
| Decompiler fast suite | Pass, 1740 tests |
| Real witness | Targeted Humanizer changed-method compile-back improved recompile failures 18 -> 16; CS0246 5 -> 3 |
| Build-event validation | Pass; Compare `no-diagnostic-deltas` |

## Decompiler quality

**Conclusion:** **PASS** — targeted Humanizer compile-back converts the low-risk concurrent-collections namespace failures into checkable rows. Frozen/Regex rows remain as explicit limitations pending a namespace-aware design.

Targeted Humanizer Full-method delta after this change:

```text
CHANGED-METHOD COMPILE-BACK over 1075 current changed methods (1075 attempted)

  exact opcode match : 869
  opcode diff (Full) : 118
  not Full           : 0
  recompile fail     : 16
  context fail       : 72
```

Targeted baseline before this change in the same worktree was 867 exact, 118 opcode diff, 0 not Full, 18 recompile fail, 72 context fail.

Humanizer cap-1000 after this change:

```text
COMPILE-BACK over 1000 rendered methods (958 Full)

  exact opcode match : 667 (66.70%)
  opcode diff (Full) : 247
  context-build fail : 2
  recompile fail     : 80
```

## Build-event validation

| View | Result |
| --- | --- |
| Preflight Summary | 138 projects, 0 failed, 0 errors, 0 warnings; `20260630T074653.0763737Z-2431565-build-a9a1f5ac` |
| Final Summary | 138 projects, 0 failed, 0 errors, 0 warnings; `20260630T080159.7994054Z-2447723-build-a9a1f5ac` |
| Compare | `no-diagnostic-deltas` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Checked type and extension-method collision risk for the broader initial import set |
| Gemini Pro | Findings resolved | Flagged Frozen/Regex global imports as possible short-name/extension-method hijacking; resolved by commit `c126fba4`, narrowing to Concurrent only |

**Review conclusion:** **PASS** — the actionable Gemini finding was resolved in `c126fba4`; the remaining change is the low-collision Concurrent namespace import.

## Validation

```bash
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate tools/DecompilerHarness -- -c Release --nologo --verbosity quiet

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*FidelityCheckGeneratedFilterTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet

dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --fidelity-method-delta /tmp/humanizer-tail-delta.json --max-examples 80
/usr/bin/time -f 'elapsed=%E cpu=%P maxrss=%MKB' dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 1000 --max-examples 20 --fidelity-timings

/home/rich/git/dotnet-build-events-vmr-preview5-events/artifacts/preview5-events-sdk-test/dotnet build tools/DecompilerHarness --no-incremental --view types --event-log-stderr -c Release --nologo --verbosity quiet
dotnet run --project /home/rich/git/dotnet-inspect-build-event-query/src/dotnet-inspect -c Release --no-build -- build /home/rich/.dotnet/build-events/2026-06-30/20260630T074653.0763737Z-2431565-build-a9a1f5ac.jsonl -S Compare --compare /home/rich/.dotnet/build-events/2026-06-30/20260630T080159.7994054Z-2447723-build-a9a1f5ac.jsonl --tsv
```
