### PR TITLE
Raise exhaustive same-type guarded union switches

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -477,8 +477,14 @@ public class TypeSourceComposerUnionTests
                 _ => "other",
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Inverted"));
-        Assert.DoesNotContain("return pet switch",
-            RenderMember(assembly.Path, "UnionFixtures.Matcher", "Exhaustive"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat when cat.Name == "cat" => cat.Name,
+                Cat => "other cat",
+                Dog dog => dog.Name,
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Exhaustive"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -456,6 +456,13 @@ public class TypeSourceComposerUnionTests
                     Cat => "other cat",
                     Dog dog => dog.Name,
                 };
+
+                public static string ExhaustiveNoLocal(Pet pet) => pet switch
+                {
+                    Cat { Age: <= 3 } => "young",
+                    Cat => "old",
+                    Dog dog => dog.Name,
+                };
             }
             """);
 
@@ -485,6 +492,14 @@ public class TypeSourceComposerUnionTests
                 Dog dog => dog.Name,
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Exhaustive"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat V_3 when V_3.Age <= 3 => "young",
+                Cat => "old",
+                Dog dog => dog.Name,
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ExhaustiveNoLocal"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -46,6 +46,12 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 return true;
             }
 
+            if (TryMatchExhaustiveGuardedChainAt(function, children, start, out var exhaustiveGuardedSwitch))
+            {
+                match = new Match(start, exhaustiveGuardedSwitch);
+                return true;
+            }
+
             if (TryMatchAt(function, children, start, out var switchExpression))
             {
                 match = new Match(start, switchExpression);
@@ -214,6 +220,145 @@ public sealed class UnionSwitchExpressionPass : IIrPass
 
         return false;
     }
+
+    static bool TryMatchExhaustiveGuardedChainAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        if (start + 5 >= children.Count
+            || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsUnionValueProperty(function, unionValue)
+            || !TryFinalThrowArm(children, start + 1, out int resultLocal, out var finalArm, out var finalNodes))
+        {
+            return false;
+        }
+
+        int tempLocal = valueStore.Index;
+        if (!IsTempLocal(finalArm, tempLocal))
+            return false;
+
+        var leadingNodes = children.Skip(start + 1).Take(children.Count - start - 1 - finalNodes.Count).ToArray();
+        if (!TryExhaustiveGuardedArms(leadingNodes, tempLocal, resultLocal, out var leadingArms))
+            return false;
+
+        var arms = leadingArms.Append(finalArm).ToArray();
+        var allowedTempUses = new List<IrNode> { valueStore };
+        allowedTempUses.AddRange(leadingNodes);
+        allowedTempUses.AddRange(finalNodes);
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, tempLocal, allowedTempUses)
+            || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+            || !DuplicateTypesAreGuarded(arms))
+        {
+            return false;
+        }
+
+        switchExpression = new UnionSwitchExpression(
+            (IrExpression)unionValue.Clone(),
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())));
+        return true;
+    }
+
+    static bool TryExhaustiveGuardedArms(IReadOnlyList<IrNode> nodes, int tempLocal, int resultLocal, out IReadOnlyList<Arm> arms)
+    {
+        var builder = new List<Arm>();
+        foreach (var node in nodes)
+        {
+            if (node is not IfStatement armIf
+                || !TryArmPattern(armIf.Condition, tempLocal, out var patternType, out var localIndex, out var patternRoots)
+                || !TryExhaustiveArmBody(armIf.Then.Children, localIndex, resultLocal, out var matchedArms))
+            {
+                arms = [];
+                return false;
+            }
+
+            foreach (var body in matchedArms)
+            {
+                var localRoots = new List<IrNode>(patternRoots) { body.Value };
+                localRoots.AddRange(body.GuardRoots);
+                builder.Add(new Arm(patternType, body.KeepsLocal ? localIndex : null, body.Value, localRoots, body.Guard));
+            }
+        }
+
+        arms = builder;
+        return arms.Count > 0;
+    }
+
+    static bool TryExhaustiveArmBody(
+        IReadOnlyList<IrNode> nodes,
+        int? localIndex,
+        int resultLocal,
+        out IReadOnlyList<ArmBody> arms)
+    {
+        arms = [];
+        if (nodes is [IfStatement { HasElse: false } guardIf, StoreLocal fallbackStore, Return fallbackReturn]
+            && guardIf.Then.Children is [StoreLocal guardedStore, Return guardedReturn]
+            && StoreReturnMatch(guardedStore, guardedReturn, resultLocal)
+            && StoreReturnMatch(fallbackStore, fallbackReturn, resultLocal)
+            && localIndex is { } local
+            && !ReferencesLocal(fallbackStore.Value, local))
+        {
+            arms =
+            [
+                new ArmBody(guardedStore.Value, guardIf.Condition, [guardIf.Condition], KeepsLocal: true),
+                new ArmBody(fallbackStore.Value, Guard: null, GuardRoots: [], KeepsLocal: false),
+            ];
+            return true;
+        }
+
+        if (nodes is [StoreLocal store, Return ret]
+            && StoreReturnMatch(store, ret, resultLocal))
+        {
+            arms = [new ArmBody(store.Value, Guard: null, GuardRoots: [], KeepsLocal: localIndex is { } armLocal && ReferencesLocal(store.Value, armLocal))];
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool TryFinalThrowArm(
+        IReadOnlyList<IrNode> children,
+        int armStart,
+        out int resultLocal,
+        out Arm arm,
+        out IReadOnlyList<IrNode> consumed)
+    {
+        resultLocal = -1;
+        arm = null!;
+        consumed = [];
+        if (children.Count - armStart < 4
+            || children[^4] is not StoreLocal { Value: IsInstance test } store
+            || children[^3] is not IfStatement nullGuard
+            || nullGuard.HasElse
+            || !IsNotLocal(nullGuard.Condition, store.Index)
+            || nullGuard.Then.Children is not [ExpressionStatement throwStatement, Return throwReturn]
+            || !IsThrowSwitchExpression(throwStatement)
+            || children[^2] is not StoreLocal valueStore
+            || children[^1] is not Return valueReturn
+            || !StoreReturnMatch(valueStore, valueReturn, valueStore.Index)
+            || !ReturnsLocal(throwReturn, valueStore.Index))
+        {
+            return false;
+        }
+
+        resultLocal = valueStore.Index;
+        arm = new Arm(test.Type, store.Index, valueStore.Value, [store, nullGuard.Condition, valueStore.Value]);
+        consumed = [children[^4], children[^3], children[^2], children[^1]];
+        return true;
+    }
+
+    static bool StoreReturnMatch(StoreLocal store, Return ret, int local)
+        => store.Index == local && ReturnsLocal(ret, local);
+
+    static bool IsTempLocal(Arm arm, int tempLocal)
+        => arm.LocalRoots.OfType<StoreLocal>().FirstOrDefault()?.Value is IsInstance test
+            && IsTempTypeTest(test, tempLocal);
 
     static bool TryBuild(
         IrFunction function,

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -301,8 +301,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             && guardIf.Then.Children is [StoreLocal guardedStore, Return guardedReturn]
             && StoreReturnMatch(guardedStore, guardedReturn, resultLocal)
             && StoreReturnMatch(fallbackStore, fallbackReturn, resultLocal)
-            && localIndex is { } local
-            && !ReferencesLocal(fallbackStore.Value, local))
+            && (localIndex is not { } local || !ReferencesLocal(fallbackStore.Value, local)))
         {
             arms =
             [


### PR DESCRIPTION
## Summary

Raises exhaustive union switch expressions where a same-type guarded arm is followed by the same case type's fallback arm and the switch has no `_` default arm.

This extends the #1962 default-arm support to the exhaustive lowering shape that retains Roslyn's `ThrowSwitchExpressionException` path. The pass keeps the same conservative proof model: proven union `Value`, owned cached temp, owned pattern locals, and duplicate case types only when earlier duplicates are guarded.

Fixes #1961.

## Before / After

Source shape:

```csharp
return pet switch
{
    Cat { Name: "cat" } cat => cat.Name,
    Cat => "other cat",
    Dog dog => dog.Name,
};
```

Before, the exhaustive same-type guarded shape stayed flat as cached `Value` dispatch plus nested guard/fallback scaffolding:

```csharp
object V_3 = pet.Value;
if (V_3 is Cat cat)
{
    if (cat.Name == "cat")
    {
        return cat.Name;
    }
    return "other cat";
}
// ... Dog arm plus compiler ThrowSwitchExpressionException fallback ...
```

After, it raises back to the source-level union switch expression:

```csharp
return pet switch
{
    Cat cat when cat.Name == "cat" => cat.Name,
    Cat => "other cat",
    Dog dog => dog.Name,
};
```

The review fix also covers the no-local guarded variant:

```csharp
return pet switch
{
    Cat V_3 when V_3.Age <= 3 => "young",
    Cat => "old",
    Dog dog => dog.Name,
};
```

## Evidence

- Stage 0 entry gate:
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"` — 13 passed.
  - `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` — passed.
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringCoverageTests/*"` — 6 passed.
- Shape proof:
  - `UnionSwitchExpression_RendersSameTypeGuardedFallbackArms` now proves the exhaustive same-type guarded fixture renders as `pet switch` with guarded `Cat`, unguarded `Cat`, and `Dog` arms.
  - The same fixture covers the type-only/no-local guarded variant added after MAI review.
  - Existing default-arm same-type guarded, inverted guarded, distinct guarded/default, class-union, and generic-union fixtures remain green.
- Build-event validation-only:
  - 263 projects, 0 failed, 0 errors, 0 warnings.
  - Event log: `20260630T083842.0189011Z-2504722-build-87e82b69`.

## Review

Adversarial reviews are reconciled in PR comments; Gemini, MAI, and Claude found no remaining blockers. Ready to merge.
