### PR TITLE
Strengthen union declaration binding proof

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -11,7 +11,7 @@ namespace ILInspector.Decompiler.Tests;
 public class TypeSourceComposerUnionTests
 {
     [Fact]
-    public void LoweredUnionDeclaration_RendersUnionHeaderAndHidesBasicPattern()
+    public async Task LoweredUnionDeclaration_RendersUnionHeaderAndHidesBasicPattern()
     {
         using var assembly = Compile("""
             #nullable enable
@@ -66,6 +66,7 @@ public class TypeSourceComposerUnionTests
         Assert.DoesNotContain("public Pet(List<Bird> value)", source);
         Assert.DoesNotContain("public object", source);
         Assert.Contains("Describe", source);
+        await AssertSdkPreviewBuilds(source);
     }
 
     [Fact]
@@ -705,6 +706,7 @@ public class TypeSourceComposerUnionTests
                 <TargetFramework>net11.0</TargetFramework>
                 <LangVersion>preview</LangVersion>
                 <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
               </PropertyGroup>
             </Project>
             """);


### PR DESCRIPTION
## Summary

Strengthens the union declaration type-binding proof so the richer rendered declaration from #1915 is built with the preview SDK, not just the minimal `public union Pet(Cat, Dog)` form.

The expanded proof now covers the rendered `readonly union` header with preserved non-`IUnion` interface inheritance, generic case type display (`List<Bird>`), external namespace use, hidden lowered union members, and a preserved member body that references the generated `Value` property.

Fixes #1917.

## Before / After

Before, the SDK-backed binding proof only compiled a minimal rendered union declaration:

```csharp
namespace UnionFixtures;

public union Pet(Cat, Dog);
```

That proved the preview SDK accepted the basic `union` syntax, but the richer declaration renderer was still covered only by string assertions.

After, the richer rendered output is the source that gets written to `RenderedUnion.cs` and compiled by the preview SDK:

```csharp
using Other;

namespace UnionFixtures;

public readonly union Pet(Cat, Dog, List<Bird>) : IMarker
{
    public string Describe() => Value?.ToString() ?? "";
}
```

The bind project supplies the case/interface stubs and enables SDK implicit usings, matching `TypeSourceComposer`'s emitted-source contract for `System.Collections.Generic`:

```csharp
namespace Other
{
    public sealed class Bird { }
}

namespace UnionFixtures
{
    public sealed class Cat { }
    public sealed class Dog { }
    public interface IMarker { }
}
```

## Evidence

- Type binding boss: the richer rendered union source is compiled by a preview-SDK project with `LangVersion=preview`.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"` — 13 passed.
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` — passed.
- Build-event validation-only summary: 263 projects, 0 failed, 0 errors, 0 warnings; event log `20260630T081607.4773126Z-2469651-build-9909d815`.

This is test/proof-only; it does not change product decompiler behavior.

## Review

Adversarial reviews are reconciled in PR comments; Gemini and Claude found no blockers. Merged.
