### PR TITLE
Import namespaces required by fidelity target bodies

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -323,21 +323,32 @@ public class FidelityCheckGeneratedFilterTests
     }
 
     [Fact]
-    public void Evaluate_BindsConcurrentCollectionsNamespace()
+    public void Evaluate_BindsNamespacesReferencedByTargetBodies()
     {
         var assemblyPath = CompileFixture("""
             using System.Collections.Concurrent;
+            using System.Collections.Frozen;
+            using System.Collections.Generic;
+            using System.Text.RegularExpressions;
 
             public class FrameworkNamespaceFixture
             {
                 public ConcurrentDictionary<string, int> CreateConcurrent()
                     => new ConcurrentDictionary<string, int>();
+
+                public FrozenDictionary<string, int> Freeze(Dictionary<string, int> source)
+                    => source.ToFrozenDictionary();
+
+                public Match MatchS(string input)
+                    => Regex.Match(input, "s");
             }
             """);
         try
         {
             var results = FidelityCheck.Evaluate(assemblyPath);
             AssertCheckable(results, "CreateConcurrent");
+            AssertCheckable(results, "Freeze");
+            AssertCheckable(results, "MatchS");
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -349,9 +349,16 @@ public class FidelityCheckGeneratedFilterTests
             AssertCheckable(results, "CreateConcurrent");
             AssertCheckable(results, "Freeze");
             AssertCheckable(results, "MatchS");
+
+            Environment.SetEnvironmentVariable("CB_NOGROUP", "1");
+            var perMethodResults = FidelityCheck.Evaluate(assemblyPath);
+            AssertCheckable(perMethodResults, "CreateConcurrent");
+            AssertCheckable(perMethodResults, "Freeze");
+            AssertCheckable(perMethodResults, "MatchS");
         }
         finally
         {
+            Environment.SetEnvironmentVariable("CB_NOGROUP", null);
             DeleteFixture(assemblyPath);
         }
 

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1303,8 +1303,8 @@ static class FidelityCheck
     {
         string unit;
         try { unit = timings is null
-            ? BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility)
-            : timings.MeasureSkeletonEmit(() => BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility)); }
+            ? BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility, e.Target.RequiredNamespaces)
+            : timings.MeasureSkeletonEmit(() => BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility, e.Target.RequiredNamespaces)); }
         catch { return new(fullType, e.Name, e.Overload, e.Signature, CompileBackStatus.ContextFail, e.OrigText, "", "skeleton-emit"); }
 
         var tree = timings is null
@@ -1423,8 +1423,8 @@ static class FidelityCheck
         {
             string unit;
             try { unit = timings is null
-                ? BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility, include)
-                : timings.MeasureSkeletonEmit(() => BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility, include)); }
+                ? BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility, e.Target.RequiredNamespaces, include)
+                : timings.MeasureSkeletonEmit(() => BuildUnit(reader, e.Handle, e.Target.Body, e.Target.Chain, e.Target.RequiresAsync, e.Target.PrimaryConstructor, e.FieldInits, references.Accessibility, e.Target.RequiredNamespaces, include)); }
             catch { return null; } // fall back to the whole-module build
 
             var tree = timings is null
@@ -1803,11 +1803,13 @@ static class FidelityCheck
         bool targetRequiresAsync,
         PrimaryConstructorShape? targetPrimaryConstructor,
         IReadOnlyList<(string Field, string Value)> targetFieldInits,
-        SignatureAccessibility accessibility, IReadOnlySet<TypeDefinitionHandle>? includeRoots = null)
+        SignatureAccessibility accessibility,
+        IReadOnlySet<string>? requiredNamespaces = null,
+        IReadOnlySet<TypeDefinitionHandle>? includeRoots = null)
     {
         var targets = new Dictionary<MethodDefinitionHandle, TargetBody> { [target] = new(targetBody, targetChain, targetRequiresAsync, targetPrimaryConstructor) };
         var fieldInitType = reader.GetMethodDefinition(target).GetDeclaringType();
-        return BuildUnit(reader, targets, targetFieldInits, fieldInitType, accessibility, includeRoots);
+        return BuildUnit(reader, targets, targetFieldInits, fieldInitType, accessibility, includeRoots, requiredNamespaces);
     }
 
     /// <summary>
@@ -1822,7 +1824,8 @@ static class FidelityCheck
     /// </summary>
     static string BuildUnit(MetadataReader reader, IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets,
         IReadOnlyList<(string Field, string Value)> fieldInits, TypeDefinitionHandle fieldInitType,
-        SignatureAccessibility accessibility, IReadOnlySet<TypeDefinitionHandle>? includeRoots = null)
+        SignatureAccessibility accessibility, IReadOnlySet<TypeDefinitionHandle>? includeRoots = null,
+        IReadOnlySet<string>? isolatedTargetNamespaces = null)
     {
         var sb = new StringBuilder();
         sb.AppendLine("#pragma warning disable");
@@ -1834,10 +1837,9 @@ static class FidelityCheck
         // collision namespaces — so a body's short name resolves without
         // introducing CS0104 ambiguity.
         var usings = new SortedSet<string>(SkeletonUsings, StringComparer.Ordinal);
-        foreach (var target in targets.Values)
-            if (target.RequiredNamespaces is not null)
-                foreach (var ns in target.RequiredNamespaces)
-                    usings.Add(ns);
+        if (isolatedTargetNamespaces is not null)
+            foreach (var ns in isolatedTargetNamespaces)
+                usings.Add(ns);
         foreach (var ns in usings)
             sb.AppendLine($"using {ns};");
         foreach (var typeHandle in reader.TypeDefinitions)

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -931,17 +931,53 @@ static class FidelityCheck
             catch { continue; }
             if (body is null)
                 continue;
+            var requiredNamespaces = RequiredNamespaces(function);
             PrimaryConstructorShape? primaryConstructor = PrimaryConstructorFromPrologue(reader, method, function, body);
             var original = ILDisassembler.Disassemble(pe, reader, method);
             if (original is null)
                 continue;
             var origOps = original.Select(i => CanonicalOpcode(i.OpCodeName)).ToList();
-            entries.Add(new Entry(mh, name, overload, CorpusMethodIdentity.SignatureText(function.Signature), new TargetBody(body, chain, function.RequiresAsyncBodyModifier, primaryConstructor), fieldInits,
+            entries.Add(new Entry(mh, name, overload, CorpusMethodIdentity.SignatureText(function.Signature), new TargetBody(body, chain, function.RequiresAsyncBodyModifier, primaryConstructor, requiredNamespaces), fieldInits,
                 string.Join(" ", origOps), origOps, function.Fidelity == DecompilationFidelity.Full));
             if (entries.Count >= maxEntries)
                 break;
         }
         return (fullType, entries);
+    }
+
+    static IReadOnlySet<string> RequiredNamespaces(IrFunction function)
+    {
+        var namespaces = new SortedSet<string>(StringComparer.Ordinal);
+
+        void Add(TypeRef? type)
+        {
+            switch (type?.Kind)
+            {
+                case TypeRefKind.Definition:
+                    if (type.Namespace.Length > 0)
+                        namespaces.Add(type.Namespace);
+                    break;
+                case TypeRefKind.GenericInstance:
+                    Add(type.ElementType);
+                    foreach (var argument in type.TypeArguments)
+                        Add(argument);
+                    break;
+                case TypeRefKind.SzArray or TypeRefKind.Array
+                    or TypeRefKind.ByRef or TypeRefKind.Pointer or TypeRefKind.Pinned:
+                    Add(type.ElementType);
+                    break;
+            }
+        }
+
+        foreach (var node in function.Descendants.Prepend(function))
+        {
+            foreach (var type in node.DirectTypes)
+                Add(type);
+            if (node is IrExpression expression)
+                Add(expression.ResultType);
+        }
+
+        return namespaces;
     }
 
     static bool IsGeneratedType(MetadataReader reader, TypeDefinition typeDef, string fullType)
@@ -1755,7 +1791,8 @@ static class FidelityCheck
         string Body,
         string? Chain,
         bool RequiresAsync,
-        PrimaryConstructorShape? PrimaryConstructor = null);
+        PrimaryConstructorShape? PrimaryConstructor = null,
+        IReadOnlySet<string>? RequiredNamespaces = null);
 
     public sealed record PrimaryConstructorShape(
         string Parameters,
@@ -1796,7 +1833,12 @@ static class FidelityCheck
         // whole-module compile. Kept conservative — only widely-assumed, low-
         // collision namespaces — so a body's short name resolves without
         // introducing CS0104 ambiguity.
-        foreach (var ns in SkeletonUsings)
+        var usings = new SortedSet<string>(SkeletonUsings, StringComparer.Ordinal);
+        foreach (var target in targets.Values)
+            if (target.RequiredNamespaces is not null)
+                foreach (var ns in target.RequiredNamespaces)
+                    usings.Add(ns);
+        foreach (var ns in usings)
             sb.AppendLine($"using {ns};");
         foreach (var typeHandle in reader.TypeDefinitions)
         {


### PR DESCRIPTION
- Advances Humanizer targeted compile-back fidelity coverage after #1967.
- Changes fidelity skeleton behavior only: isolated single-method/cluster fallback skeletons now import namespaces referenced by the raised IR target body, while grouped builds keep the conservative global using set.
- Card revision: `ac745818`

## Change

**Conclusion:** **PASS** — high-collision framework namespaces such as `System.Collections.Frozen` and `System.Text.RegularExpressions` now bind only in isolated target-body skeletons that actually reference those namespaces, without contaminating grouped builds.

This is the safer follow-up to #1967. #1967 intentionally kept only the low-collision `System.Collections.Concurrent` global import after review flagged broad Frozen/Regex imports as possible short-name or extension-method hijacking. This PR scopes those imports to isolated target bodies; grouped builds remain on the fixed conservative using set and fall back to isolated builds when needed.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `FidelityCheckGeneratedFilterTests` passed, 9 tests |
| Decompiler fast suite | Pass, 1740 tests |
| Real witness | Targeted Humanizer changed-method compile-back improved recompile failures 16 -> 10; CS0246 3 -> 0; CS1061 3 -> 0 |
| Build-event validation | Pass; Compare `no-diagnostic-deltas` |

## Decompiler quality

**Conclusion:** **PASS** — targeted Humanizer compile-back converts namespace-stripping failures into checkable rows while preserving grouped-build isolation.

Targeted Humanizer Full-method delta after this change:

```text
CHANGED-METHOD COMPILE-BACK over 1075 current changed methods (1075 attempted)

  exact opcode match : 874
  opcode diff (Full) : 119
  not Full           : 0
  recompile fail     : 10
  context fail       : 72
```

Targeted baseline before this change, after #1967, was 869 exact, 118 opcode diff, 0 not Full, 16 recompile fail, 72 context fail.

Humanizer cap-1000 after this change:

```text
COMPILE-BACK over 1000 rendered methods (958 Full)

  exact opcode match : 681 (68.10%)
  opcode diff (Full) : 251
  context-build fail : 2
  recompile fail     : 62
```

## Build-event validation

| View | Result |
| --- | --- |
| Preflight Summary | 138 projects, 0 failed, 0 errors, 0 warnings; `20260630T081727.3157647Z-2474007-build-d8af5b61` |
| Final Summary | 138 projects, 0 failed, 0 errors, 0 warnings; `20260630T082853.2159973Z-2498201-build-d8af5b61` |
| Compare | `no-diagnostic-deltas` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Finding resolved | Found per-method/cluster fallback initially dropped required namespaces and grouped union could contaminate sibling targets; fixed by `ac745818` |
| Gemini Pro | Finding resolved | Flagged grouped cross-target namespace/extension hijacking; fixed by `ac745818`, leaving grouped builds on conservative usings and applying dynamic namespaces only to isolated target builds |

**Review conclusion:** **PASS** — both adversarial findings were resolved by scoping dynamic namespaces to isolated fallback builds and adding a `CB_NOGROUP` regression.

## Validation

```bash
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate tools/DecompilerHarness -- -c Release --nologo --verbosity quiet

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*Evaluate_BindsNamespacesReferencedByTargetBodies*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*FidelityCheckGeneratedFilterTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet

dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --fidelity-method-delta /tmp/post1967-humanizer-delta.json --max-examples 80
/usr/bin/time -f 'elapsed=%E cpu=%P maxrss=%MKB' dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 1000 --max-examples 20 --fidelity-timings

/home/rich/git/dotnet-build-events-vmr-preview5-events/artifacts/preview5-events-sdk-test/dotnet build tools/DecompilerHarness --no-incremental --view types --event-log-stderr -c Release --nologo --verbosity quiet
dotnet run --project /home/rich/git/dotnet-inspect-build-event-query/src/dotnet-inspect -c Release --no-build -- build /home/rich/.dotnet/build-events/2026-06-30/20260630T081727.3157647Z-2474007-build-d8af5b61.jsonl -S Compare --compare /home/rich/.dotnet/build-events/2026-06-30/20260630T082853.2159973Z-2498201-build-d8af5b61.jsonl --tsv
```
