### PR TITLE
Raise guarded class-union switch defaults

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -512,6 +512,13 @@ public class TypeSourceComposerUnionTests
                     Cat => 1,
                     Dog => 2,
                 };
+
+                public static string GuardedDefault(Pet pet) => pet switch
+                {
+                    Cat { Name: "cat" } cat => cat.Name,
+                    Dog dog => dog.Name,
+                    _ => "other",
+                };
             }
             """);
 
@@ -529,6 +536,14 @@ public class TypeSourceComposerUnionTests
                 Dog => 2,
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Kind"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat when cat.Name == "cat" => cat.Name,
+                Dog dog => dog.Name,
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedDefault"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -34,6 +34,12 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         var children = block.Children;
         for (int start = 0; start < children.Count; start++)
         {
+            if (TryMatchClassDefaultAt(function, children, start, out var classDefaultSwitch))
+            {
+                match = new Match(start, classDefaultSwitch);
+                return true;
+            }
+
             if (TryMatchClassNullGuardAt(function, children, start, out var guardedSwitch))
             {
                 match = new Match(start, guardedSwitch);
@@ -54,6 +60,54 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         }
 
         return false;
+    }
+
+    static bool TryMatchClassDefaultAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        if (start + 2 != children.Count
+            || children[start] is not IfStatement { HasElse: false } nullGuard
+            || children[start + 1] is not Return { Value: { } defaultValue })
+        {
+            return false;
+        }
+
+        var body = nullGuard.Then.Children;
+        if (body.Count < 2
+            || body[0] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsUnionValueProperty(function, unionValue)
+            || !PlaceIdentity.SameVariable(unionValue.Instance, nullGuard.Condition))
+        {
+            return false;
+        }
+
+        int tempLocal = valueStore.Index;
+        var armNodes = body.Skip(1).ToArray();
+        if (!TryDefaultArms(armNodes, tempLocal, defaultValue, out var arms))
+            return false;
+
+        var allowedTempUses = new List<IrNode> { valueStore };
+        allowedTempUses.AddRange(armNodes);
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, tempLocal, allowedTempUses)
+            || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+            || !DuplicateTypesAreGuarded(arms))
+        {
+            return false;
+        }
+
+        switchExpression = new UnionSwitchExpression(
+            (IrExpression)unionValue.Clone(),
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+            (IrExpression)defaultValue.Clone());
+        return true;
     }
 
     static bool TryMatchDefaultChainAt(


### PR DESCRIPTION
## Summary

Raises class/custom union switch expressions that use guarded arms plus an explicit `_` default.

Struct unions already handled this guarded/default shape. Class unions lower through an outer null guard before caching `Value`, so this adds a class-specific default matcher that composes the existing guarded/default arm parser with the class null-guard proof.

Fixes #1971.

## Before / After

Source shape:

```csharp
return pet switch
{
    Cat { Name: "cat" } cat => cat.Name,
    Dog dog => dog.Name,
    _ => "other",
};
```

Before, class unions stayed flat because the lowering wraps the cached `Value` dispatch in an outer null guard and returns the default outside that guard:

```csharp
Dog dog;
object V_3;

if (pet is not null)
{
    V_3 = pet.Value;
    if (V_3 is Cat cat)
    {
        if (cat.Name == "cat")
        {
            return cat.Name;
        }
        return "other";
    }
    dog = V_3 as Dog;
    if (dog is null)
    {
        return "other";
    }
    return dog.Name;
}
return "other";
```

After, it raises back to the source-level class-union switch expression while preserving null/default semantics:

```csharp
return pet switch
{
    Cat cat when cat.Name == "cat" => cat.Name,
    Dog dog => dog.Name,
    _ => "other",
};
```

## Evidence

- Stage 0 entry gate:
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"` — 13 passed.
  - `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` — passed.
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringCoverageTests/*"` — 6 passed.
- Shape proof:
  - `ClassUnionSwitchExpression_RendersTypePatternArms` now includes a preview-SDK `[Union] class Pet : IUnion` guarded/default switch and expects `pet switch { Cat cat when ..., Dog dog ..., _ ... }`.
  - Existing class-union simple type arms and non-union `Value switch` near misses remain green.
- Build-event validation-only:
  - 263 projects, 0 failed, 0 errors, 0 warnings.
  - Event log: `20260630T082419.3120722Z-2492540-build-a8309936`.

## Review

Adversarial reviews are reconciled in PR comments; Gemini and MAI found no blockers. Ready to merge.
