### PR TITLE
Emit abstract overload stubs in fidelity skeletons

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -373,6 +373,49 @@ public class FidelityCheckGeneratedFilterTests
         }
     }
 
+    [Fact]
+    public void Evaluate_RetainsAbstractOverloadsForForwardingCalls()
+    {
+        var assemblyPath = CompileFixture("""
+            public abstract class AbstractForwardingFixture
+            {
+                public enum Gender
+                {
+                    Neutral,
+                }
+
+                public string Convert(long value)
+                    => Convert(value, Gender.Neutral, true);
+
+                public string ConvertToOrdinal(int value, bool words)
+                    => ConvertToOrdinal(value);
+
+                public abstract string Convert(long value, Gender gender, bool words);
+                public abstract string ConvertToOrdinal(int value);
+            }
+            """);
+        try
+        {
+            var results = FidelityCheck.Evaluate(assemblyPath);
+            AssertCheckable(results, "Convert");
+            AssertCheckable(results, "ConvertToOrdinal");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+
+        static void AssertCheckable(IReadOnlyList<FidelityCheck.CompileBackResult> results, string method)
+        {
+            var result = Assert.Single(
+                results,
+                result => result.Type == "AbstractForwardingFixture" && result.Method == method);
+            Assert.True(
+                result.Status is FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff,
+                result.Detail);
+        }
+    }
+
     static string CompileFixture(string source)
     {
         var directory = Path.Combine(Path.GetTempPath(), $"fidelity-generated-filter-{Guid.NewGuid():N}");

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -2394,9 +2394,6 @@ static class FidelityCheck
         // emitted so a changed explicit impl is not silently lost.
         if (realBody is null && name.Contains('.') && name is not ".ctor" and not ".cctor")
             return;
-        if (method.RelativeVirtualAddress == 0 && realBody is null)
-            return; // abstract/extern sibling — no body, and we strip abstractness
-
         var context = GenericContext.ForMethod(reader, typeDef, method);
         if (realBody is null && !accessibility.CanEmitMethod(reader, method, context))
             return;
@@ -2405,6 +2402,12 @@ static class FidelityCheck
         catch { return; }
 
         bool isStatic = method.Attributes.HasFlag(MethodAttributes.Static);
+        bool isAbstractStub = method.RelativeVirtualAddress == 0
+            && realBody is null
+            && !isStatic
+            && method.Attributes.HasFlag(MethodAttributes.Abstract);
+        if (method.RelativeVirtualAddress == 0 && realBody is null && !isAbstractStub)
+            return; // extern sibling — no body, and no C# stub shape we can safely infer
         string parameters = Parameters(reader, method, sig, IsExtensionMethod(reader, typeDef, method, sig));
         string body = realBody is null ? " throw null;" : "\n" + realBody + "\n" + pad;
 
@@ -2440,6 +2443,7 @@ static class FidelityCheck
             : "";
         string unsafeModifier = asyncModifier.Length == 0 ? "unsafe " : "";
         string slotModifier = StructObjectOverrideModifier(reader, typeDef, method, name, returnType, sig.ParameterTypes.Length);
+        string instanceModifier = isAbstractStub ? "virtual " : slotModifier;
         if (!IsStaticClass(typeDef)
             && name.StartsWith("op_", StringComparison.Ordinal)
             && OperatorDeclaration(name, returnType, parameters) is { } operatorDeclaration)
@@ -2447,7 +2451,7 @@ static class FidelityCheck
             sb.AppendLine($"{pad}public {unsafeModifier}static {operatorDeclaration} {{{body}}}");
             return;
         }
-        sb.AppendLine($"{pad}public {unsafeModifier}{(isStatic ? "static " : slotModifier)}{asyncModifier}{returnType} {Identifier(name)}{genParams}({parameters}){whereClauses} {{{body}}}");
+        sb.AppendLine($"{pad}public {unsafeModifier}{(isStatic ? "static " : instanceModifier)}{asyncModifier}{returnType} {Identifier(name)}{genParams}({parameters}){whereClauses} {{{body}}}");
     }
 
     static string StructObjectOverrideModifier(


### PR DESCRIPTION
- Advances Humanizer targeted compile-back fidelity coverage after #1970.
- Changes fidelity skeleton behavior only: abstract no-body overloads are emitted as throwing virtual stubs so forwarding methods see the same overload set.
- Card revision: `3b67b9df`

## Change

**Conclusion:** **PASS** — skeletons now keep abstract overload signatures that target bodies call, rather than dropping them and letting overload resolution fail or select the wrong overload.

Before, Humanizer abstract converter rows failed with CS1503/CS1501 because abstract overloads such as `Convert(long, GrammaticalGender, bool)` or `ConvertToOrdinal(int)` were skipped from the skeleton. After, those overloads bind and the affected rows become checkable.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `FidelityCheckGeneratedFilterTests` passed, 10 tests |
| Decompiler fast suite | Pass, 1741 tests |
| Real witness | Targeted Humanizer changed-method compile-back improved recompile failures 10 -> 6; CS1503 3 -> 1; CS1501 2 -> 0 |
| Build-event validation | Pass; Compare `no-diagnostic-deltas` |

## Decompiler quality

**Conclusion:** **PASS** — targeted Humanizer compile-back converts abstract-overload skeleton failures into checkable rows; broad cap-1000 exacts improve and context-build failures drop to zero.

Targeted Humanizer Full-method delta after this change:

```text
CHANGED-METHOD COMPILE-BACK over 1075 current changed methods (1075 attempted)

  exact opcode match : 880
  opcode diff (Full) : 118
  not Full           : 0
  recompile fail     : 6
  context fail       : 71
```

Targeted baseline before this change, after #1970, was 874 exact, 119 opcode diff, 0 not Full, 10 recompile fail, 72 context fail.

Humanizer cap-1000 after this change:

```text
COMPILE-BACK over 1000 rendered methods (958 Full)

  exact opcode match : 694 (69.40%)
  opcode diff (Full) : 251
  context-build fail : 0
  recompile fail     : 51
```

## Build-event validation

| View | Result |
| --- | --- |
| Preflight Summary | 138 projects, 0 failed, 0 errors, 0 warnings; `20260630T135830.9135184Z-2537025-build-e373ea2f` |
| Final Summary | 138 projects, 0 failed, 0 errors, 0 warnings; `20260630T135947.7156176Z-2539194-build-e373ea2f` |
| Compare | `no-diagnostic-deltas` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Verified overload ordinal alignment, extern/static/interface safety, `virtual` legality, and caller opcode behavior |
| Gemini Pro | No blocking findings | Verified the fix preserves the overload set and avoids unsafe extern/PInvoke/static abstract emission |

**Review conclusion:** **PASS** — both reviews found the abstract-overload skeleton fix safe and directly aligned with the Humanizer failure mechanism; no follow-up code changes required.

## Validation

```bash
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate tools/DecompilerHarness -- -c Release --nologo --verbosity quiet

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*Evaluate_RetainsAbstractOverloadsForForwardingCalls*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*FidelityCheckGeneratedFilterTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet

dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --fidelity-method-delta /tmp/post1970-humanizer-delta.json --max-examples 100
/usr/bin/time -f 'elapsed=%E cpu=%P maxrss=%MKB' dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 1000 --max-examples 20 --fidelity-timings

/home/rich/git/dotnet-build-events-vmr-preview5-events/artifacts/preview5-events-sdk-test/dotnet build tools/DecompilerHarness --no-incremental --view types --event-log-stderr -c Release --nologo --verbosity quiet
dotnet run --project /home/rich/git/dotnet-inspect-build-event-query/src/dotnet-inspect -c Release --no-build -- build /home/rich/.dotnet/build-events/2026-06-30/20260630T135830.9135184Z-2537025-build-e373ea2f.jsonl -S Compare --compare /home/rich/.dotnet/build-events/2026-06-30/20260630T135947.7156176Z-2539194-build-e373ea2f.jsonl --tsv
```
