### PR TITLE
Raise exhaustive guarded class-union switches

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -541,6 +541,13 @@ public class TypeSourceComposerUnionTests
                     Dog dog => dog.Name,
                     _ => "other",
                 };
+
+                public static string GuardedExhaustive(Pet pet) => pet switch
+                {
+                    Cat { Name: "cat" } cat => cat.Name,
+                    Cat => "other cat",
+                    Dog dog => dog.Name,
+                };
             }
             """);
 
@@ -566,6 +573,14 @@ public class TypeSourceComposerUnionTests
                 _ => "other",
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedDefault"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat when cat.Name == "cat" => cat.Name,
+                Cat => "other cat",
+                Dog dog => dog.Name,
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedExhaustive"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -17,6 +17,17 @@ public sealed class UnionSwitchExpressionPass : IIrPass
     {
         foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
         {
+            if (TryMatchClassExhaustiveGuardedBlocks(function, container, out var classExhaustiveSwitch))
+            {
+                int startOffset = container.Blocks[0].StartOffset;
+                container.DetachChildren();
+                var replacementBlock = new Block(startOffset);
+                replacementBlock.Add(new Return(classExhaustiveSwitch));
+                container.Add(replacementBlock);
+                context.Stepper.StepOver("raise class union guarded dispatch to switch expression", container);
+                continue;
+            }
+
             if (container.Blocks is [var block] && TryMatch(function, block, out var match))
             {
                 block.SetChild(match.StartIndex, new Return(match.SwitchExpression));
@@ -66,6 +77,83 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         }
 
         return false;
+    }
+
+    static bool TryMatchClassExhaustiveGuardedBlocks(
+        IrFunction function,
+        BlockContainer container,
+        out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        var blocks = container.Blocks;
+        if (blocks.Count != 9
+            || blocks[0].Children is not [ConditionalBranch nullBranch]
+            || nullBranch.Condition is not LogicalNot { Operand: var receiver }
+            || blocks[1].Children is not
+            [
+                StoreLocal { Value: LoadProperty unionValue } valueStore,
+                StoreLocal { Value: IsInstance firstTest } firstStore,
+                ConditionalBranch firstNullBranch
+            ]
+            || !IsUnionValueProperty(function, unionValue)
+            || !PlaceIdentity.SameVariable(unionValue.Instance, receiver)
+            || !IsTempTypeTest(firstTest, valueStore.Index)
+            || !IsNotLocal(firstNullBranch.Condition, firstStore.Index)
+            || blocks[2].Children is not [ConditionalBranch guardBranch]
+            || blocks[3].Children is not [StoreLocal firstFallbackStore, Return firstFallbackReturn]
+            || blocks[4].Children is not
+            [
+                StoreLocal { Value: IsInstance finalTest } finalStore,
+                ConditionalBranch finalValueBranch
+            ]
+            || !IsTempTypeTest(finalTest, valueStore.Index)
+            || finalValueBranch.Condition is not LoadLocal finalCondition || finalCondition.Index != finalStore.Index
+            || blocks[5].Children is not [Branch finalThrowBranch]
+            || blocks[6].Children is not [StoreLocal firstGuardedStore, Return firstGuardedReturn]
+            || blocks[7].Children is not [StoreLocal finalValueStore, Return finalValueReturn]
+            || blocks[8].Children is not [ExpressionStatement throwStatement, Return throwReturn]
+            || nullBranch.TargetOffset != blocks[8].StartOffset
+            || firstNullBranch.TargetOffset != blocks[4].StartOffset
+            || guardBranch.TargetOffset != blocks[6].StartOffset
+            || finalValueBranch.TargetOffset != blocks[7].StartOffset
+            || finalThrowBranch.TargetOffset != blocks[8].StartOffset
+            || !IsThrowSwitchExpression(throwStatement)
+            || !ThrowArgumentMatches(throwStatement, receiver)
+            || !StoreReturnMatch(firstFallbackStore, firstFallbackReturn, firstFallbackStore.Index)
+            || !StoreReturnMatch(firstGuardedStore, firstGuardedReturn, firstFallbackStore.Index)
+            || !StoreReturnMatch(finalValueStore, finalValueReturn, firstFallbackStore.Index)
+            || !ReturnsLocal(throwReturn, firstFallbackStore.Index)
+            || ReferencesLocal(firstFallbackStore.Value, firstStore.Index))
+        {
+            return false;
+        }
+
+        var arms = new[]
+        {
+            new Arm(firstTest.Type, firstStore.Index, firstGuardedStore.Value,
+                [firstStore, firstNullBranch.Condition, guardBranch.Condition, firstGuardedStore.Value],
+                guardBranch.Condition),
+            new Arm(firstTest.Type, LocalIndex: null, firstFallbackStore.Value, [firstFallbackStore.Value]),
+            new Arm(finalTest.Type, finalStore.Index, finalValueStore.Value,
+                [finalStore, finalValueBranch.Condition, finalValueStore.Value]),
+        };
+
+        var allowedTempUses = blocks.SelectMany(block => block.Children).ToArray();
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, allowedTempUses)
+            || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+            || !DuplicateTypesAreGuarded(arms))
+        {
+            return false;
+        }
+
+        switchExpression = new UnionSwitchExpression(
+            (IrExpression)unionValue.Clone(),
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())));
+        return true;
     }
 
     static bool TryMatchClassDefaultAt(


### PR DESCRIPTION
## Summary

Raises exhaustive same-type guarded switch expressions for class/custom unions.

Class unions lower this shape as a flat multi-block dispatch: an initial null branch to the compiler fallback, a cached `Value` temp, same-type guarded/fallback arms, and a final `ThrowSwitchExpressionException` path. This PR recognizes that exact shape and collapses it to a `UnionSwitchExpression` only when the null guard, cached `Value` temp, branch targets, result local, compiler fallback throw, duplicate-type ordering, and pattern-local ownership all line up.

Fixes #1976.

## Before / After

Source shape:

```csharp
return pet switch
{
    Cat { Name: "cat" } cat => cat.Name,
    Cat => "other cat",
    Dog dog => dog.Name,
};
```

Before, class unions stayed flat because this exhaustive lowering remains a multi-block branch graph after return sinking:

```csharp
Cat cat;
Dog dog;
string V_2 = default;
object V_3;

if (pet is null) goto IL_004E;
V_3 = pet.Value;
cat = V_3 as Cat;
if (cat is null) goto IL_0028;
if (cat.Name == "cat") goto IL_0034;
V_2 = "other cat";
return V_2;
IL_0028:
dog = V_3 as Dog;
if (dog is not null) goto IL_0045;
goto IL_004E;
IL_0034:
V_2 = cat.Name;
return V_2;
IL_0045:
V_2 = dog.Name;
return V_2;
IL_004E:
<PrivateImplementationDetails>.ThrowSwitchExpressionException(pet);
return V_2;
```

After, it raises back to the source-level class-union switch expression:

```csharp
return pet switch
{
    Cat cat when cat.Name == "cat" => cat.Name,
    Cat => "other cat",
    Dog dog => dog.Name,
};
```

## Evidence

- Stage 0 entry gate:
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"` — 13 passed.
  - `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` — passed.
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringCoverageTests/*"` — 6 passed.
- Shape proof:
  - `ClassUnionSwitchExpression_RendersTypePatternArms` now includes a preview-SDK `[Union] class Pet : IUnion` exhaustive same-type guarded switch and expects `pet switch { Cat cat when ..., Cat ..., Dog dog ... }`.
  - Existing class-union simple arms, class guarded/default arms, struct guarded/exhaustive arms, and non-union `Value switch` near misses remain green.
- Build-event validation-only:
  - 263 projects, 0 failed, 0 errors, 0 warnings.
  - Event log: `20260630T141807.9298963Z-2556327-build-a2713386`.

## Review

Decompiler behavior change; adversarial review requested separately before marking ready.
