### PR TITLE
Preserve Exception base in fidelity skeletons

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -417,7 +417,7 @@ public class FidelityCheckGeneratedFilterTests
     }
 
     [Fact]
-    public void Evaluate_RetainsSimpleBaseAndInterfaceClauses()
+    public void Evaluate_RetainsExceptionBaseClause()
     {
         var assemblyPath = CompileFixture("""
             using System;
@@ -430,40 +430,16 @@ public class FidelityCheckGeneratedFilterTests
                 }
             }
 
-            public interface ILeft
-            {
-                string Transform(string input);
-            }
-
-            public interface IRight
-            {
-                string Format(string input);
-            }
-
-            public class BothTransformers : ILeft, IRight
-            {
-                public string Transform(string input) => input;
-                public string Format(string input) => input;
-            }
-
             public static class BaseAndInterfaceFixture
             {
                 public static void ThrowCustom()
                     => throw new CustomException("bad");
-
-                public static ILeft CreateLeft()
-                    => new BothTransformers();
-
-                public static IRight CreateRight()
-                    => new BothTransformers();
             }
             """);
         try
         {
             var results = FidelityCheck.Evaluate(assemblyPath);
             AssertCheckable(results, "ThrowCustom");
-            AssertCheckable(results, "CreateLeft");
-            AssertCheckable(results, "CreateRight");
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -416,6 +416,71 @@ public class FidelityCheckGeneratedFilterTests
         }
     }
 
+    [Fact]
+    public void Evaluate_RetainsSimpleBaseAndInterfaceClauses()
+    {
+        var assemblyPath = CompileFixture("""
+            using System;
+
+            public class CustomException : Exception
+            {
+                public CustomException(string message)
+                    : base(message)
+                {
+                }
+            }
+
+            public interface ILeft
+            {
+                string Transform(string input);
+            }
+
+            public interface IRight
+            {
+                string Format(string input);
+            }
+
+            public class BothTransformers : ILeft, IRight
+            {
+                public string Transform(string input) => input;
+                public string Format(string input) => input;
+            }
+
+            public static class BaseAndInterfaceFixture
+            {
+                public static void ThrowCustom()
+                    => throw new CustomException("bad");
+
+                public static ILeft CreateLeft()
+                    => new BothTransformers();
+
+                public static IRight CreateRight()
+                    => new BothTransformers();
+            }
+            """);
+        try
+        {
+            var results = FidelityCheck.Evaluate(assemblyPath);
+            AssertCheckable(results, "ThrowCustom");
+            AssertCheckable(results, "CreateLeft");
+            AssertCheckable(results, "CreateRight");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+
+        static void AssertCheckable(IReadOnlyList<FidelityCheck.CompileBackResult> results, string method)
+        {
+            var result = Assert.Single(
+                results,
+                result => result.Type == "BaseAndInterfaceFixture" && result.Method == method);
+            Assert.True(
+                result.Status is FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff,
+                result.Detail);
+        }
+    }
+
     static string CompileFixture(string source)
     {
         var directory = Path.Combine(Path.GetTempPath(), $"fidelity-generated-filter-{Guid.NewGuid():N}");

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1882,15 +1882,52 @@ static class FidelityCheck
     {
         if (kind != TypeKind.Class || typeDef.BaseType.IsNil)
             return "";
-        if (typeDef.BaseType.Kind != HandleKind.TypeDefinition)
-            return ""; // TypeReference (out of assembly) / TypeSpec (generic) — not reliably spellable
-        var baseDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType);
-        if (baseDef.GetGenericParameters().Count != 0)
-            return "";
+        if (typeDef.BaseType.Kind == HandleKind.TypeDefinition)
+        {
+            var baseDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType);
+            if (baseDef.GetGenericParameters().Count != 0)
+                return "";
+        }
+        else if (typeDef.BaseType.Kind != HandleKind.TypeReference || BaseTypeName(reader, typeDef.BaseType) is not "System.Exception")
+        {
+            return ""; // TypeSpec / most TypeReference bases — not reliably spellable
+        }
+
         string baseName = BaseTypeName(reader, typeDef.BaseType);
         if (baseName is "System.Object")
             return "";
-        return $" : {baseName}";
+        return $" : {Clean(baseName)}";
+    }
+
+    static string InterfaceClause(MetadataReader reader, TypeDefinitionHandle typeHandle, TypeKind kind, string baseClause)
+    {
+        if (kind is not TypeKind.Class)
+            return "";
+        var interfaces = new List<string>();
+        foreach (var handle in reader.GetTypeDefinition(typeHandle).GetInterfaceImplementations())
+        {
+            var impl = reader.GetInterfaceImplementation(handle);
+            if (SimpleInterfaceName(reader, impl.Interface) is { } iface)
+                interfaces.Add(iface);
+        }
+        if (interfaces.Count == 0)
+            return "";
+        string prefix = baseClause.Length == 0 ? " : " : ", ";
+        return prefix + string.Join(", ", interfaces.Distinct(StringComparer.Ordinal));
+    }
+
+    static string? SimpleInterfaceName(MetadataReader reader, EntityHandle handle)
+    {
+        switch (handle.Kind)
+        {
+            case HandleKind.TypeDefinition:
+                var definition = reader.GetTypeDefinition((TypeDefinitionHandle)handle);
+                if (!definition.GetDeclaringType().IsNil || definition.GetGenericParameters().Count != 0)
+                    return null;
+                return FullName(reader, definition);
+            default:
+                return null;
+        }
     }
 
     static void EmitType(MetadataReader reader, TypeDefinitionHandle typeHandle,
@@ -1931,6 +1968,7 @@ static class FidelityCheck
             ? (IsByRefLike(reader, typeDef) ? "ref struct" : "struct")
             : IsStaticClass(typeDef) ? "static class" : "class";
         string baseClause = BaseClause(reader, typeDef, kind);
+        string interfaceClause = InterfaceClause(reader, typeHandle, kind, baseClause);
         // An [InlineArray(N)] struct must carry the attribute for its span
         // conversions (e.g. `(Span<T>)place`) to bind; the bare reconstructed
         // struct otherwise has no such conversion and the body fails to recompile.
@@ -1943,7 +1981,7 @@ static class FidelityCheck
         var primaryConstructor = primaryConstructorTarget.Value.PrimaryConstructor;
         string primaryParameters = primaryConstructor is null ? "" : $"({primaryConstructor.Parameters})";
         string unsafeModifier = TypeHasAwaitTarget(reader, typeHandle, targets) ? "" : "unsafe ";
-        sb.AppendLine($"{pad}public {unsafeModifier}{keyword} {Identifier(name)}{genParams}{primaryParameters}{baseClause}{whereClauses}");
+        sb.AppendLine($"{pad}public {unsafeModifier}{keyword} {Identifier(name)}{genParams}{primaryParameters}{baseClause}{interfaceClause}{whereClauses}");
         sb.AppendLine($"{pad}{{");
 
         // Field initializers lifted from a target ctor apply to this type's

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1899,37 +1899,6 @@ static class FidelityCheck
         return $" : {Clean(baseName)}";
     }
 
-    static string InterfaceClause(MetadataReader reader, TypeDefinitionHandle typeHandle, TypeKind kind, string baseClause)
-    {
-        if (kind is not TypeKind.Class)
-            return "";
-        var interfaces = new List<string>();
-        foreach (var handle in reader.GetTypeDefinition(typeHandle).GetInterfaceImplementations())
-        {
-            var impl = reader.GetInterfaceImplementation(handle);
-            if (SimpleInterfaceName(reader, impl.Interface) is { } iface)
-                interfaces.Add(iface);
-        }
-        if (interfaces.Count == 0)
-            return "";
-        string prefix = baseClause.Length == 0 ? " : " : ", ";
-        return prefix + string.Join(", ", interfaces.Distinct(StringComparer.Ordinal));
-    }
-
-    static string? SimpleInterfaceName(MetadataReader reader, EntityHandle handle)
-    {
-        switch (handle.Kind)
-        {
-            case HandleKind.TypeDefinition:
-                var definition = reader.GetTypeDefinition((TypeDefinitionHandle)handle);
-                if (!definition.GetDeclaringType().IsNil || definition.GetGenericParameters().Count != 0)
-                    return null;
-                return FullName(reader, definition);
-            default:
-                return null;
-        }
-    }
-
     static void EmitType(MetadataReader reader, TypeDefinitionHandle typeHandle,
         IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> targets,
         IReadOnlyList<(string Field, string Value)> fieldInits, TypeDefinitionHandle fieldInitType,
@@ -1968,7 +1937,6 @@ static class FidelityCheck
             ? (IsByRefLike(reader, typeDef) ? "ref struct" : "struct")
             : IsStaticClass(typeDef) ? "static class" : "class";
         string baseClause = BaseClause(reader, typeDef, kind);
-        string interfaceClause = InterfaceClause(reader, typeHandle, kind, baseClause);
         // An [InlineArray(N)] struct must carry the attribute for its span
         // conversions (e.g. `(Span<T>)place`) to bind; the bare reconstructed
         // struct otherwise has no such conversion and the body fails to recompile.
@@ -1981,7 +1949,7 @@ static class FidelityCheck
         var primaryConstructor = primaryConstructorTarget.Value.PrimaryConstructor;
         string primaryParameters = primaryConstructor is null ? "" : $"({primaryConstructor.Parameters})";
         string unsafeModifier = TypeHasAwaitTarget(reader, typeHandle, targets) ? "" : "unsafe ";
-        sb.AppendLine($"{pad}public {unsafeModifier}{keyword} {Identifier(name)}{genParams}{primaryParameters}{baseClause}{interfaceClause}{whereClauses}");
+        sb.AppendLine($"{pad}public {unsafeModifier}{keyword} {Identifier(name)}{genParams}{primaryParameters}{baseClause}{whereClauses}");
         sb.AppendLine($"{pad}{{");
 
         // Field initializers lifted from a target ctor apply to this type's


### PR DESCRIPTION
- Advances Humanizer targeted compile-back fidelity coverage after #1975.
- Changes fidelity skeleton behavior only: preserve the narrowly-spellable `System.Exception` base clause for reconstructed exception subclasses.
- Card revision: `7adc51d4`

## Change

**Conclusion:** **PASS** — skeletons now keep the `System.Exception` base for exception subclasses, so throws/catches expecting `Exception` bind without pretending to support arbitrary external bases.

The initial version also tried simple same-assembly interface clauses. Adversarial review found explicit-interface implementation regressions, so `7adc51d4` removes that part and keeps only the safe Exception-base clause.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `FidelityCheckGeneratedFilterTests` passed, 11 tests |
| Decompiler fast suite | Pass, 1742 tests |
| Real witness | Targeted Humanizer changed-method compile-back improved recompile failures 6 -> 5; CS0029 1 -> 0 |
| Build-event validation | Pass; Compare `no-diagnostic-deltas` |

## Decompiler quality

**Conclusion:** **PASS** — targeted Humanizer compile-back converts the exception-base skeleton failure into a checkable row; broader interface-clause support is intentionally left for a safer design.

Targeted Humanizer Full-method delta after this change:

```text
CHANGED-METHOD COMPILE-BACK over 1075 current changed methods (1075 attempted)

  exact opcode match : 880
  opcode diff (Full) : 119
  not Full           : 0
  recompile fail     : 5
  context fail       : 71
```

Targeted baseline before this change, after #1975, was 880 exact, 118 opcode diff, 0 not Full, 6 recompile fail, 71 context fail.

Humanizer cap-1000 after this change:

```text
COMPILE-BACK over 1000 rendered methods (958 Full)

  exact opcode match : 696 (69.60%)
  opcode diff (Full) : 252
  context-build fail : 0
  recompile fail     : 48
```

## Build-event validation

| View | Result |
| --- | --- |
| Preflight Summary | 138 projects, 0 failed, 0 errors, 0 warnings; `20260630T141253.3897485Z-2544653-build-f74eb7b3` |
| Final Summary | 138 projects, 0 failed, 0 errors, 0 warnings; `20260630T144838.3316886Z-2585680-build-f74eb7b3` |
| Compare | `no-diagnostic-deltas` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Finding resolved | Flagged unsafe interface-clause regressions; `7adc51d4` removes interface clauses and keeps Exception base only |
| Gemini Pro | Finding resolved | Flagged explicit-interface implementation failures; `7adc51d4` removes interface clauses and keeps Exception base only |

**Review conclusion:** **PASS** — both adversarial findings were resolved by narrowing the PR to the safe Exception-base clause.

## Validation

```bash
/home/rich/git/dotnet-inspect-build-event-query/scripts/build-event-agent.sh validate tools/DecompilerHarness -- -c Release --nologo --verbosity quiet

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -method "*Evaluate_RetainsExceptionBaseClause*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class "*FidelityCheckGeneratedFilterTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet

dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --fidelity-method-delta /tmp/humanizer-bundle-delta.json --max-examples 120
/usr/bin/time -f 'elapsed=%E cpu=%P maxrss=%MKB' dotnet run --project tools/DecompilerHarness -c Release --no-build -- /home/rich/.nuget/packages/humanizer.core/3.0.10/lib/net10.0/Humanizer.dll --fidelity-check --compile-cap 1000 --max-examples 20 --fidelity-timings

/home/rich/git/dotnet-build-events-vmr-preview5-events/artifacts/preview5-events-sdk-test/dotnet build tools/DecompilerHarness --no-incremental --view types --event-log-stderr -c Release --nologo --verbosity quiet
dotnet run --project /home/rich/git/dotnet-inspect-build-event-query/src/dotnet-inspect -c Release --no-build -- build /home/rich/.dotnet/build-events/2026-06-30/20260630T141253.3897485Z-2544653-build-f74eb7b3.jsonl -S Compare --compare /home/rich/.dotnet/build-events/2026-06-30/20260630T144838.3316886Z-2585680-build-f74eb7b3.jsonl --tsv
```
