### PR TITLE
Add Union Types library integration section

### DIFF
--- a/src/ILInspector.Metadata/AssemblyDetailScanner.cs
+++ b/src/ILInspector.Metadata/AssemblyDetailScanner.cs
@@ -413,10 +413,15 @@ public static class AssemblyDetailScanner
         foreach (var typeDefHandle in reader.TypeDefinitions)
         {
             if (flags.HasExtensionTypes && flags.HasPInvokeImports && flags.HasUnsafeCode
+                && flags.HasUnionTypes
                 && flags.HasRuntimeAsync && flags.HasStateMachineAsync && flags.HasMethodBodies)
                 break;
 
             var typeDef = reader.GetTypeDefinition(typeDefHandle);
+
+            if (!flags.HasUnionTypes
+                && AttributeReader.HasAttribute(reader, typeDef.GetCustomAttributes(), KnownAttributeNames.UnionAttribute))
+                flags.HasUnionTypes = true;
 
             // Extension types: static class with [Extension] attribute
             if (!flags.HasExtensionTypes)
@@ -508,6 +513,7 @@ public class PresenceFlags
     public bool HasManifestResources { get; set; }
     public bool HasAssemblyAttributes { get; set; }
     public bool HasTypeForwarders { get; set; }
+    public bool HasUnionTypes { get; set; }
     public int IntegrationCount { get; set; }
     public bool HasSwitches { get; set; }
     public int SwitchCount { get; set; }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4480,6 +4480,7 @@ public class CommandExecutionTests
                 "Switches",
                 "Top Leverage",
                 "Type Forwarders",
+                "Union Types",
                 "Unsafe Members"
             ],
             optInNames);

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -251,7 +251,7 @@ public class SectionPipelineTests
     {
         var pipeline = LibrarySections.CreatePipeline();
 
-        Assert.Equal(35, pipeline.AllSectionNames.Length);
+        Assert.Equal(36, pipeline.AllSectionNames.Length);
         Assert.Contains("AI", pipeline.AllSectionNames);
         Assert.Contains("ASP.NET Core", pipeline.AllSectionNames);
         Assert.Contains("Aspire", pipeline.AllSectionNames);
@@ -274,6 +274,7 @@ public class SectionPipelineTests
         Assert.Contains("Switches", pipeline.AllSectionNames);
         Assert.Contains("Top Leverage", pipeline.AllSectionNames);
         Assert.Contains("Performance Triage", pipeline.AllSectionNames);
+        Assert.Contains("Union Types", pipeline.AllSectionNames);
     }
 
     [Theory]
@@ -702,6 +703,15 @@ public class SectionPipelineTests
                 "Switches"
             ],
             sections);
+    }
+
+    [Fact]
+    public void LibraryPipeline_IntegrationsCategory_IncludesUnionTypes()
+    {
+        var categories = LibrarySections.CreatePipeline().GetCategoryMap();
+
+        Assert.True(categories.TryGetValue("@Integrations", out var sections));
+        Assert.Contains("Union Types", sections);
     }
 
     [Fact]
@@ -1313,6 +1323,7 @@ public class SectionPipelineTests
             HasManifestResources = true,
             HasAssemblyAttributes = true,
             HasExportedTypeForwarders = true,
+            HasUnionTypes = true,
             HasAspNetCoreSupport = true,
             HasAspireSupport = true,
             HasOpenTelemetrySupport = true,

--- a/src/dotnet-inspect.Tests/UnionTypesSectionTests.cs
+++ b/src/dotnet-inspect.Tests/UnionTypesSectionTests.cs
@@ -1,0 +1,45 @@
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using System.Runtime.CompilerServices;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public class UnionTypesSectionTests
+{
+    [Fact]
+    public async Task LibraryUnionTypes_ListsUnionAttributeTypes()
+    {
+        var result = await ConsoleCapture.RunAsync(() => LibraryCommand.ExecuteAsync(new LibraryOptions
+        {
+            AssemblyName = typeof(SampleDiscoveredUnion).Assembly.Location,
+            IncludeSections = ["Union Types"],
+            Markdown = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Union Types", result.Output);
+        Assert.Contains("DotnetInspector.Tests.SampleDiscoveredUnion", result.Output);
+        Assert.Contains("SampleUnionCat", result.Output);
+        Assert.Contains("SampleUnionDog", result.Output);
+        Assert.Contains("| Yes |", result.Output);
+        Assert.DoesNotContain(nameof(SampleUnionLookalike), result.Output);
+    }
+}
+
+public sealed class SampleUnionCat;
+public sealed class SampleUnionDog;
+
+[Union]
+public readonly struct SampleDiscoveredUnion : IUnion
+{
+    public SampleDiscoveredUnion(SampleUnionCat value) => Value = value;
+    public SampleDiscoveredUnion(SampleUnionDog value) => Value = value;
+
+    public object? Value { get; }
+}
+
+public sealed class SampleUnionLookalike : IUnion
+{
+    public object? Value => null;
+}

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -1,5 +1,7 @@
 using DotnetInspector.Core;
 using DotnetInspector.Models;
+using System.Reflection;
+using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using DotnetInspector.Inspectors;
 using ILInspector.Metadata;
@@ -96,6 +98,7 @@ internal static class LibraryMetadataService
             inspection.IntegrationCount = presenceFlags.IntegrationCount;
             inspection.HasAssemblyAttributes = presenceFlags.HasAssemblyAttributes;
             inspection.HasExportedTypeForwarders = presenceFlags.HasTypeForwarders;
+            inspection.HasUnionTypes = presenceFlags.HasUnionTypes;
             inspection.HasSwitches = presenceFlags.HasSwitches;
             inspection.SwitchCount = presenceFlags.SwitchCount;
 
@@ -143,6 +146,7 @@ internal static class LibraryMetadataService
                     ScanClassifiedMethods(peReader, path, inspection, logger);
                     inspection.Resources = ScanResources(peReader, path, logger);
                     ScanCustomAttributes(peReader, path, inspection, logger);
+                    inspection.UnionTypes = ScanUnionTypes(peReader, path, logger);
                     ScanTypeForwarders(peReader, path, inspection, logger);
                 }
                 catch (Exception ex)
@@ -1031,6 +1035,105 @@ internal static class LibraryMetadataService
         {
             logger.Log($"Warning: Error scanning custom attributes in {path}: {ex.Message}");
         }
+    }
+
+    internal static List<UnionTypeSummary>? ScanUnionTypes(string path, VerboseLogger logger)
+    {
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            return ScanUnionTypes(peReader, path, logger);
+        }
+        catch (Exception ex)
+        {
+            logger.Log($"Warning: Error scanning union types in {path}: {ex.Message}");
+            return null;
+        }
+    }
+
+    internal static List<UnionTypeSummary>? ScanUnionTypes(PEReader peReader, string path, VerboseLogger logger)
+    {
+        try
+        {
+            var reader = peReader.GetMetadataReader();
+            var results = new List<UnionTypeSummary>();
+
+            foreach (var typeHandle in reader.TypeDefinitions)
+            {
+                var typeDef = reader.GetTypeDefinition(typeHandle);
+                if (!AttributeReader.HasAttribute(reader, typeDef.GetCustomAttributes(), KnownAttributeNames.UnionAttribute))
+                    continue;
+
+                var context = GenericContext.ForType(reader, typeDef);
+                bool implementsIUnion = ImplementsIUnion(reader, typeDef, context);
+                var caseTypes = UnionCaseTypes(reader, typeDef).ToList();
+
+                results.Add(new UnionTypeSummary
+                {
+                    TypeName = reader.GetFullTypeName(typeDef),
+                    Kind = TypeKind(reader, typeDef),
+                    ImplementsIUnion = implementsIUnion,
+                    CaseTypes = caseTypes
+                });
+            }
+
+            return results.Count == 0 ? null : results;
+        }
+        catch (Exception ex)
+        {
+            logger.Log($"Warning: Error scanning union types in {path}: {ex.Message}");
+            return null;
+        }
+    }
+
+    static bool ImplementsIUnion(MetadataReader reader, TypeDefinition typeDef, GenericContext context)
+    {
+        foreach (var interfaceHandle in typeDef.GetInterfaceImplementations())
+        {
+            var iface = reader.GetInterfaceImplementation(interfaceHandle);
+            if (TypeResolver.GetTypeName(reader, iface.Interface, context) == "System.Runtime.CompilerServices.IUnion")
+                return true;
+        }
+
+        return false;
+    }
+
+    static IEnumerable<string> UnionCaseTypes(MetadataReader reader, TypeDefinition typeDef)
+    {
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != ".ctor")
+                continue;
+            if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
+                continue;
+            if ((method.Attributes & MethodAttributes.Static) != 0)
+                continue;
+
+            MethodSignature<string> signature;
+            try
+            {
+                signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (signature.ParameterTypes.Length == 1)
+                yield return signature.ParameterTypes[0];
+        }
+    }
+
+    static string TypeKind(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var attrs = typeDef.Attributes;
+        if ((attrs & TypeAttributes.Interface) != 0)
+            return "interface";
+        if (TypeResolver.GetTypeName(reader, typeDef.BaseType) == "System.ValueType")
+            return "struct";
+        return "class";
     }
 
     /// <summary>

--- a/src/dotnet-inspect/JsonContext.cs
+++ b/src/dotnet-inspect/JsonContext.cs
@@ -31,6 +31,8 @@ namespace DotnetInspector;
 [JsonSerializable(typeof(List<UnsafeMemberSummary>))]
 [JsonSerializable(typeof(OptimizationOpportunitySummary))]
 [JsonSerializable(typeof(List<OptimizationOpportunitySummary>))]
+[JsonSerializable(typeof(UnionTypeSummary))]
+[JsonSerializable(typeof(List<UnionTypeSummary>))]
 [JsonSerializable(typeof(RidPackageReference))]
 [JsonSerializable(typeof(SourceFileInfo))]
 [JsonSerializable(typeof(List<SourceFileInfo>))]

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -353,6 +353,12 @@ public class LibraryInspection
     public List<TypeForwarderSummary>? TypeForwarders { get; set; }
 
     /// <summary>
+    /// Types annotated with System.Runtime.CompilerServices.UnionAttribute.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<UnionTypeSummary>? UnionTypes { get; set; }
+
+    /// <summary>
     /// Feature, compatibility, and runtime switches discovered in metadata or IL.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -459,6 +465,10 @@ public class LibraryInspection
     /// <summary>Whether the assembly has type forwarders.</summary>
     [JsonIgnore]
     public bool HasExportedTypeForwarders { get; set; }
+
+    /// <summary>Whether the assembly has types annotated with UnionAttribute.</summary>
+    [JsonIgnore]
+    public bool HasUnionTypes { get; set; }
 
     /// <summary>Whether the assembly has feature, compatibility, or runtime switches.</summary>
     [JsonIgnore]
@@ -607,4 +617,15 @@ public record class TypeForwarderSummary
 {
     public string TypeName { get; init; } = "";
     public string TargetAssembly { get; init; } = "";
+}
+
+/// <summary>
+/// Summary of a C# union-shaped type in a library.
+/// </summary>
+public record class UnionTypeSummary
+{
+    public string TypeName { get; init; } = "";
+    public string Kind { get; init; } = "";
+    public bool ImplementsIUnion { get; init; }
+    public List<string> CaseTypes { get; init; } = [];
 }

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -16,6 +16,7 @@ public static class LibrarySections
     public const string ScannerClassifiedMethods = "ClassifiedMethods";
     public const string ScannerResources = "Resources";
     public const string ScannerCustomAttributes = "CustomAttributes";
+    public const string ScannerUnionTypes = "UnionTypes";
     public const string ScannerTypeForwarders = "TypeForwarders";
     public const string ScannerInfoCounts = "InfoCounts";
     public const string ScannerSymbols = "Symbols";
@@ -64,13 +65,14 @@ public static class LibrarySections
             .Add<AsyncMethods>()
             .Add<Resources>()
             .Add<CustomAttributes>()
+            .Add<UnionTypes>()
             .Add<TypeForwarders>()
             .Add<NonNormalizedPaths>()
             .AddCategory(SectionCategoryNames.Audit,
                 SectionNames.UnsafeMembers,
                 "P/Invoke Methods",
                 "Switches")
-            .AddCategory("@Integrations", [.. LibraryIntegrationCatalog.CategorySections, "Integration Opportunities"])
+            .AddCategory("@Integrations", [.. LibraryIntegrationCatalog.CategorySections, "Integration Opportunities", "Union Types"])
             .AddCategory("@Switches", "Switches");
     }
 
@@ -86,6 +88,8 @@ public static class LibrarySections
                 ctx.Model.Resources = LibraryMetadataService.ScanResources(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerCustomAttributes, ctx =>
                 LibraryMetadataService.ScanCustomAttributes(ctx.AssemblyPath, ctx.Model, ctx.Logger))
+            .Add(ScannerUnionTypes, ctx =>
+                ctx.Model.UnionTypes = LibraryMetadataService.ScanUnionTypes(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerTypeForwarders, ctx =>
                 LibraryMetadataService.ScanTypeForwarders(ctx.AssemblyPath, ctx.Model, ctx.Logger))
             .Add(ScannerInfoCounts, ctx =>
@@ -448,6 +452,16 @@ public static class LibrarySections
         public static string? ScannerKey => ScannerCustomAttributes;
         public static bool CanRender(LibraryInspection model)
             => model.CustomAttributes is { Count: > 0 } || model.HasAssemblyAttributes;
+    }
+
+    public sealed class UnionTypes : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => "Union Types";
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => ScannerUnionTypes;
+        public static bool CanRender(LibraryInspection model)
+            => model.UnionTypes is { Count: > 0 } || model.HasUnionTypes;
     }
 
     public sealed class TypeForwarders : ISectionDescriptor<LibraryInspection>

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -96,6 +96,16 @@ public class LibraryInspectionView
             .ToList();
 
     [MarkoutIgnore]
+    public bool HasUnionTypes => _data.UnionTypes is { Count: > 0 };
+
+    [MarkoutSection(Name = "Union Types", ShowWhenProperty = nameof(HasUnionTypes))]
+    public List<UnionTypeRow>? UnionTypesSection =>
+        _data.UnionTypes?
+            .OrderBy(t => t.TypeName, StringComparer.OrdinalIgnoreCase)
+            .Select(t => new UnionTypeRow(t.TypeName, t.Kind, t.ImplementsIUnion ? "Yes" : "No", string.Join(", ", t.CaseTypes)))
+            .ToList();
+
+    [MarkoutIgnore]
     public bool UseDependenciesView => _data.UseDependenciesView;
 
     [MarkoutSection(Name = "Dependencies")]
@@ -148,6 +158,7 @@ public class LibraryInspectionView
         TargetFramework = info.TargetFramework,
         TypeForwarders = CountOrZero(_data.TypeForwarders),
         Types = info.TypeDefinitionCount > 0 ? info.TypeDefinitionCount.ToString("N0") : null,
+        UnionTypes = CountOrZero(_data.UnionTypes),
         Version = ResolveVersion(),
     };
 
@@ -819,8 +830,16 @@ public class LibraryInfoSection
     public string? TargetFramework { get; init; }
     public int TypeForwarders { get; init; }
     public string? Types { get; init; }
+    public int UnionTypes { get; init; }
     public string? Version { get; init; }
 }
+
+[MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords, FieldLayout = FieldLayout.Table)]
+public record UnionTypeRow(
+    string Type,
+    string Kind,
+    [property: MarkoutPropertyName("IUnion")] string IUnion,
+    string Cases);
 
 [MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords, FieldLayout = FieldLayout.Table)]
 [MarkoutSkipNull]


### PR DESCRIPTION
## Summary

Adds a first-class `Union Types` library section for finding union-shaped types in assemblies/packages/platform libraries.

The section is explicit/opt-in and also included in the `@Integrations` workflow because union usage is effectively a language/runtime integration signal. It scans type metadata for `System.Runtime.CompilerServices.UnionAttribute`, reports type kind, whether the type implements `IUnion`, and case types inferred from public single-parameter constructors.

Fixes #1980.

## Runtime search findings

- dotnet/runtime has union infrastructure in CoreLib:
  - `System.Runtime.CompilerServices.UnionAttribute`
  - `System.Runtime.CompilerServices.IUnion`
  - Added by dotnet/runtime#127001.
- System.Text.Json has union support/tests, including `System.Text.Json/tests/Common/UnionTests.cs`, from dotnet/runtime#128162 and follow-up fixes such as dotnet/runtime#128900.
- Current production library sources under `src/libraries` did not show public production union declarations in GitHub code search; current local platform `System.Private.CoreLib` and `System.Text.Json` report no `Union Types` rows.

## Before / After

Before, `library` had no type-level union discovery. The closest available section was `Custom Attributes`, but that only reports assembly/module attributes and does not list type-level `[Union]` usage:

```bash
dotnet-inspect library --platform System.Private.CoreLib -S "Custom Attributes"
```

After, union usage is directly queryable:

```bash
dotnet-inspect library MyLibrary.dll -S "Union Types"
```

Example row shape:

```text
Type                                           Kind    IUnion  Cases
DotnetInspector.Tests.SampleDiscoveredUnion   struct  Yes     DotnetInspector.Tests.SampleUnionCat, DotnetInspector.Tests.SampleUnionDog
```

The section also appears in discovery and the integrations workflow:

```bash
dotnet-inspect library -D --schema
# Union Types    section (opt-in)

dotnet-inspect library MyLibrary.dll -S @Integrations
# includes Union Types when applicable
```

## Evidence

- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/UnionTypesSectionTests/*"` — 1 passed.
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/SectionPipelineTests/*"` — 115 passed.
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` — passed.
- CLI smoke:
  - `library -D --schema --tsv` lists `Union Types`.
  - `library --platform System.Private.CoreLib -S "Union Types"` reports no rows on the current platform assembly.
  - `library --platform System.Text.Json -S "Union Types"` reports no rows on the current platform assembly.

## Review

CLI behavior change; review requested before marking ready.
