### PR TITLE
Add ILInspector.Instructions: shared IL decode + EH-aware block substrate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,9 @@ jobs:
       - name: Run CLI tests
         run: dotnet run --project src/dotnet-inspect.Tests -c Release
 
+      - name: Run instruction-substrate tests
+        run: dotnet run --project src/ILInspector.Instructions.Tests -c Release
+
       - name: Run metadata tests
         run: dotnet run --project tests/ILInspector.Metadata.Tests -c Release
 

--- a/docs/design/instruction-substrate.md
+++ b/docs/design/instruction-substrate.md
@@ -60,28 +60,62 @@ and never loads inspected assemblies.
 The typed evaluation stack is opt-in via `MethodInstructions.InterpretStack(...)`,
 so broad scans and the offset join never pay for it.
 
-## Runtime-shape alignment (legibility) and vendoring
+## dotnet/runtime heritage and upstream tracking
 
-The tool is moving to the `dotnet` org and will be reviewed by runtime/Roslyn
-engineers, so the substrate deliberately mirrors the shapes they already maintain
-in `src/coreclr/tools/Common/TypeSystem/IL` — recognition lowers review cost.
+The byte reader is **ported from `dotnet/runtime`** — the same
+`Internal.IL.ILReader` that ILVerify and the ILC type system build on — so
+runtime/Roslyn engineers reviewing this in the `dotnet` org recognize the shape,
+and the table-driven opcode sizing is correct by construction (prefixes like
+`no.`/`unaligned.`, short operand widths). Provenance is pinned in the file
+headers:
 
-- The byte reader is the runtime `ILReader` + `ILOpcodeHelper` opcode-size table,
-  **ported** (not vendored wholesale) into the substrate with the MIT
-  "ported from dotnet/runtime" headers, retargeted to SRM's `ILOpCode`. The
-  table-driven sizing is what makes prefixes like `no.`/`unaligned.` and short
-  operand widths correct by construction. A one-time port, not a tracked vendor
-  branch (IL opcodes are ECMA-frozen).
-- Recognition is the default, not a straitjacket. Deliberate, **documented**
-  divergence is fine where our use case differs: SRM handles instead of
-  `Internal.TypeSystem`'s `TypeDesc`/`MethodDesc`; a visitor/callback shape instead
-  of partial-class composition (we are a reusable cross-project library); `record`
-  / `ImmutableArray` / fail-closed idioms over older mutable-struct style. Vendor
-  the byte cursor; never the runtime type system — staying SRM-only is itself a
-  boundary reviewers expect.
-- Shapes to keep recognizable: `StackValueKind` naming, `FlowGraph.LookupIndex`
-  (the offset→block lookup), the `ILImporter`-style hook shell, and
-  `ComputeMaxStack` if a height tier is ever built.
+- `ILReader.cs` ← `src/coreclr/tools/Common/TypeSystem/IL/ILReader.cs`
+  (`Internal.IL.ILReader`), retargeted to SRM's `ILOpCode`.
+- `ILOpcodeExtensions.cs` ←
+  `src/coreclr/tools/Common/TypeSystem/IL/ILOpcodeHelper.cs`
+  (`Internal.IL.ILOpcodeHelper`) opcode-size table.
+
+Both carry the MIT "Ported from dotnet/runtime `<path>`" header.
+
+### What we adopt, diverge from, and do not use
+
+| `dotnet/runtime` | Here | Status | Why |
+| --- | --- | --- | --- |
+| `Internal.IL.ILReader` byte cursor | `ILReader.cs` | **Adopted** (ported, SRM-retargeted) | table-driven decode; correct by construction |
+| `ILOpcodeHelper` opcode-size table | `ILOpcodeExtensions.cs` | **Adopted** (ported) | prefix + short-operand widths |
+| ILVerify `StackValue`/`StackValueKind` | `StackType`/`StackValue` | **Diverged** (naming kept recognizable, SRM types) | gated Layer 1 only |
+| `FlowGraph.LookupIndex` (offset→block) | `BlockGraph.BlockIndexAt` | **Diverged** (shape kept recognizable) | our offset join key |
+| `ILImporter` partial-class composition | `MethodInstructions` façade + callbacks | **Diverged** | reusable cross-project library, not a partial class |
+| mutable-struct / older idioms | `record` / `ImmutableArray` / fail-closed | **Diverged** | modern, fail-closed contracts |
+| `Internal.TypeSystem` `TypeDesc`/`MethodDesc` | SRM `MetadataReader` handles | **Not used** | stay SRM-only; never vendor the runtime type system |
+| RyuJIT `GenTree`/`typeInfo`, `ILStackHelper` heights | (none) | **Not used** | unlike consumers do not share an abstract interpretation |
+
+The last "not used" row is load-bearing: prior art runs three *separate* typed
+stacks over one shared reader, so we share decode + identity (Layer 0) and let
+each consumer build its own Layer 1.
+
+### Do we track upstream improvements? No — by design
+
+The ported reader is a **one-time port, not a tracked vendor branch**, because
+the IL opcode set and operand encodings are **ECMA-335-frozen**: the decode
+contract cannot drift, so there is nothing upstream to chase for correctness.
+This is the opposite of the vendored managed ILAssembler (the
+`vendor/ilassembler` orphan branch), which *is* tracked because it is an evolving
+codebase.
+
+The narrow cases that would warrant touching the ported files, and how:
+
+- **A real bug in our port** → fix here directly (the fidelity gates are the
+  oracle); optionally report it upstream. No sync needed.
+- **A genuinely new IL opcode** (historically near-never for ECMA IL) → add one
+  row to the size table; no wholesale re-port.
+- **Adopting *more* of the runtime IL stack** later (e.g. a height tier /
+  `ComputeMaxStack`) → port that piece fresh from the cited path at that time.
+
+Re-sync procedure if ever needed: diff our file against the cited upstream path.
+Because we do not track upstream, the heritage headers record the *path*, not a
+pinned commit; pin a commit only if a future re-port makes ongoing comparison
+worthwhile.
 
 ## Fidelity contract
 

--- a/docs/design/instruction-substrate.md
+++ b/docs/design/instruction-substrate.md
@@ -1,0 +1,164 @@
+# Instruction Substrate (`ILInspector.Instructions`)
+
+How one shared IL decode + EH-aware basic-block builder is factored out from the
+analyzer and the decompiler, why it is shaped the way it is, and how it is proven
+to be a regression-free replacement for the decoders it subsumes. This is a design
+note about the substrate's boundaries and contracts, not a tour of every method.
+See [decompiler-substrate.md](decompiler-substrate.md) for the *predicate* substrate
+(a sibling instinct one level up), and issues
+[#1908](https://github.com/richlander/dotnet-inspect/issues/1908) (origin, gate),
+[#1939](https://github.com/richlander/dotnet-inspect/issues/1939) (tracker), and
+[#1941](https://github.com/richlander/dotnet-inspect/issues/1941) (the typed-stack
+measurement) for the running history.
+
+## Purpose
+
+Three places independently decode IL into instructions and basic blocks: the
+analyzer's reaching-definitions, the analyzer's body index (allocation/triage
+producer), and the decompiler importer. Hand-rolled IL decoders are a recurring
+source of drift (a mishandled `no.` prefix, a signed short-operand index), and
+each copy must be kept correct on its own. The substrate is the one decode +
+block builder all three converge onto, so the most-correct decoder is shared and
+the offset/block identity is computed once — which also makes it the exact join
+key for the [`ILInspector.Research`](../../src/ILInspector.Research) overlay.
+
+## Layering
+
+```text
+Research            (joins Analysis facts + Decompiler representations by IL offset)
+  |
+  +-- Analysis      (reaching-defs, allocation/loop facts, call graph)
+  +-- Decompiler    (IR import, structuring, C#)
+        |
+      Instructions  (decode -> typed instructions -> EH-aware blocks -> [gated] typed stack)
+        |
+      ControlFlow   (BlockEdges vocabulary + dominance/dataflow kernels; depends on nothing)
+```
+
+`Instructions` **depends on** `ControlFlow` (it emits `ControlFlow.BlockEdges` and
+feeds the shared dominance/dataflow kernels), exactly as Analysis does — so in
+dependency terms it sits *on top of* `ControlFlow`, which stays representation-
+agnostic at the bottom. Analysis and the decompiler depend on `Instructions`;
+neither owns it. The product path stays SRM-only, NativeAOT-friendly, Roslyn-free,
+and never loads inspected assemblies.
+
+## Layer 0 / Layer 1
+
+- **Layer 0 — identity (metadata-free, the only shared currency).** The decoded
+  instruction stream (offset-keyed), the EH-aware `BlockGraph`, and offset→
+  instruction/block lookup. This is the de-dup target and the Research join key.
+  `MethodInstructions` is the Layer 0 façade; `InstructionDecoder.Decode` +
+  `BlockGraph.Build` are the throwing primitives.
+- **Layer 1 — interpretation (per-consumer, opt-in, not shared).** Reaching-defs
+  (Analysis), allocation/loop facts (Analysis), the decompiler's symbolic IR
+  stack, and the substrate's own typed evaluation stack are each *consumers* of
+  Layer 0 that build their own model on top. Prior art is emphatic that unlike
+  consumers do not share the abstract interpretation: `dotnet/runtime` runs three
+  separate typed stacks (ILVerify's `StackValue`, RyuJIT's `GenTree*`+`typeInfo`,
+  `ILStackHelper`'s bare heights) over one shared `ILReader`/`FlowGraph`.
+
+The typed evaluation stack is opt-in via `MethodInstructions.InterpretStack(...)`,
+so broad scans and the offset join never pay for it.
+
+## Runtime-shape alignment (legibility) and vendoring
+
+The tool is moving to the `dotnet` org and will be reviewed by runtime/Roslyn
+engineers, so the substrate deliberately mirrors the shapes they already maintain
+in `src/coreclr/tools/Common/TypeSystem/IL` — recognition lowers review cost.
+
+- The byte reader is the runtime `ILReader` + `ILOpcodeHelper` opcode-size table,
+  **ported** (not vendored wholesale) into the substrate with the MIT
+  "ported from dotnet/runtime" headers, retargeted to SRM's `ILOpCode`. The
+  table-driven sizing is what makes prefixes like `no.`/`unaligned.` and short
+  operand widths correct by construction. A one-time port, not a tracked vendor
+  branch (IL opcodes are ECMA-frozen).
+- Recognition is the default, not a straitjacket. Deliberate, **documented**
+  divergence is fine where our use case differs: SRM handles instead of
+  `Internal.TypeSystem`'s `TypeDesc`/`MethodDesc`; a visitor/callback shape instead
+  of partial-class composition (we are a reusable cross-project library); `record`
+  / `ImmutableArray` / fail-closed idioms over older mutable-struct style. Vendor
+  the byte cursor; never the runtime type system — staying SRM-only is itself a
+  boundary reviewers expect.
+- Shapes to keep recognizable: `StackValueKind` naming, `FlowGraph.LookupIndex`
+  (the offset→block lookup), the `ILImporter`-style hook shell, and
+  `ComputeMaxStack` if a height tier is ever built.
+
+## Fidelity contract
+
+De-dup carries no weight if the unified decoder is *worse* than what it replaces,
+so the cutover bar is **≥ every implementation replaced** — and **zero-diff parity
+is the wrong gate**: the ported reader is strictly better (fixes `no.`, short-var
+widths, malformed handling), so it *will* differ from the old decoders exactly on
+the bugs it fixes. Two gate kinds instead:
+
+- **Absolute correctness gates** (adjudicate "is the new one right," independent of
+  any old impl): the decoded stream exactly tiles `[0, ilLength)` and branch
+  targets land on instruction boundaries; a re-encode round-trip reproduces the
+  original bytes from the decoder's semantic fields; and, for the typed stack, the
+  computed evaluation-stack depth never exceeds the body's declared `MaxStack`.
+  All hold over `System.Private.CoreLib`.
+- **Directional differential** vs each replaced decoder over the corpus: classify
+  every diff as improvement / neutral / regression; the gate is **zero
+  regressions** (not zero diffs), with improvements characterized by an absolute
+  oracle. This is the same strict-improvement discipline as the decompiler corpus
+  gate.
+
+Correctness-direction consumers (e.g. a stackalloc/`InlineArray` rewrite, or an
+ArrayPool use-after-return lint) must **hard-gate on substrate `IsComplete`**,
+never best-effort — and they fail in opposite directions: a rewrite must
+fail-closed (don't transform), a lint must fail-quiet (don't accuse). Both are
+licensed only because the substrate is fail-closed at every layer.
+
+## The Analysis cutover (done)
+
+`ReachingDefinitions` was the first de-dup. It now decodes + builds EH-aware blocks
+via the substrate (`InstructionDecoder.Decode` + `BlockGraph.Build`, the *throwing*
+Layer 0 primitives, preserving RD's malformed-IL `BadImageFormatException`
+contract — the fail-closed façade is for consumers that want it) and keeps only its
+reaching-defs dataflow. About 500 lines of duplicate decoder + block-builder +
+region modeling were deleted.
+
+Proven safe by: full block **and edge** parity vs the old builder over all of
+CoreLib (edges matter because the dataflow depends on them), and the entire
+`ILInspector.Analysis.Tests` (261) plus `dotnet-inspect.Tests` (1,415) suites
+passing unchanged.
+
+## The decompiler granularity finding
+
+The three IL-level block finders do **not** agree on granularity.
+`ReachingDefinitions` (and the substrate, which matches it) make *every instruction
+inside an EH region a leader* — needed for per-instruction exception-edge dataflow.
+`IrImporter.FindLeaders` adds only region boundaries. Measured over CoreLib, the
+substrate's leaders are a strict superset of `FindLeaders`' (zero under-splits, so
+the substrate never merges a block the decompiler needs separate), with **29,853
+extra (substrate-only) leaders** — the per-EH-instruction granularity.
+
+So the decompiler cutover needs a **minimal-CFG refactor**: Layer 0 emits the
+minimal/boundary CFG (the `FindLeaders` shape), and `ReachingDefinitions` adds its
+EH-instruction splitting as a Layer-1 step. That refactor lands *with* the
+decompiler cutover, where the benefit is realized — doing it earlier would only add
+RD-specific code without a consumer.
+
+## The gated typed stack
+
+The typed evaluation stack (decode → typed instructions → typed-stack → blocks) is
+the [#1908](https://github.com/richlander/dotnet-inspect/issues/1908) Rung-5
+placeholder. It is built **only on a measured trigger**: R1 (raw IL + metadata +
+reaching-defs) cannot satisfy a gate and the missing witness is specifically stack
+element/receiver types or stack value provenance. The
+[#1941](https://github.com/richlander/dotnet-inspect/issues/1941) probe measured
+the allocation/escape shapes and found **zero** such cases, so the gate stays
+closed on numbers. Its credible future home is **memory-safety lifetime**
+(ref-struct / `scoped` / ArrayPool aliasing — runtime `StackValue.ByRef` + flags
+territory), to be measured the same way. Until then the typed stack stays a
+minimal, opt-in Layer-1 model with its own fidelity gate, not a product dependency.
+
+## Status
+
+- Layer 0 substrate: decoder on the ported `ILReader`; tiling, round-trip, and
+  MaxStack fidelity gates over CoreLib; Layer 0/1 split with offset→block lookup.
+- De-dup: `ReachingDefinitions` cut over (done, validated). Remaining:
+  `LibraryBodyIndex` (the allocation/triage producer — convert its decode loop with
+  the full corpus baseline as guard) and the decompiler importer (with the
+  minimal-CFG refactor).
+- Typed stack: gated; no measured trigger; re-probe under memory-safety lifetime.

--- a/docs/design/instruction-substrate.md
+++ b/docs/design/instruction-substrate.md
@@ -113,6 +113,16 @@ and it is the non-shareable layer (above). A consumer that needs real
 verification should port a *targeted* upstream slice on a measured trigger, not
 re-derive it inside the decoder.
 
+The bar is also genuinely lower than runtime's, because dotnet-inspect only
+*reads* IL — it never JITs, executes, or loads the inspected assembly. runtime
+must verify IL because its output runs with full trust (illegal IL there means
+memory corruption or a security hole); our worst case is a wrong line in a report,
+and we already fail closed on anything we cannot decode. So the contract is
+*robustness* — don't crash, hang, or assert false facts on malformed or hostile
+input — not *soundness*. The security we do care about is hardening the reader
+against malformed input (one reason we track upstream reliability/perf/security
+fixes), not proving the IL is safe to execute.
+
 ### Tracking upstream improvements
 
 The decode *contract* is ECMA-335-frozen — which opcodes exist and how their

--- a/docs/design/instruction-substrate.md
+++ b/docs/design/instruction-substrate.md
@@ -147,6 +147,14 @@ fork. The lightweight tracking mechanism:
 - **Re-run the fidelity gates** after any such port; they are the acceptance
   oracle.
 
+**Pinned source.** Copied from `dotnet/runtime` at commit
+[`050adea8fc10`](https://github.com/dotnet/runtime/commit/050adea8fc1016ff3cbde74edc5453e8fdad11be)
+(also recorded in the file headers). The files are near-frozen — `ILReader.cs`
+last changed upstream 2024-07-01, `ILOpcodeHelper.cs` 2021-05-17 — so an
+occasional diff against that path is ample. Our copy is verified to match: the
+opcode size-value table is byte-for-byte identical, and `ILReader` is the same
+post-Spanify `ref struct` over `ReadOnlySpan<byte>`, modulo our divergences.
+
 Our own bug fixes go in directly (the gates are the oracle) and should be
 offered upstream where they apply.
 

--- a/docs/design/instruction-substrate.md
+++ b/docs/design/instruction-substrate.md
@@ -94,6 +94,25 @@ The last "not used" row is load-bearing: prior art runs three *separate* typed
 stacks over one shared reader, so we share decode + identity (Layer 0) and let
 each consumer build its own Layer 1.
 
+### Port boundary: what the substrate does and doesn't validate
+
+The ported `ILReader` + size table are faithful — byte-level tiling and
+round-trip hold because the reader sizes every opcode correctly, prefixes
+included. The bugs adversarial review found were all in the *connective tissue we
+hand-roll above the reader* (`InstructionDecoder`, `MethodInstructions`, the
+gated `StackTypeInterpreter`), never in the ported files.
+
+That is the deliberate boundary. The substrate guarantees **structural
+completeness** — the stream tiles `[0, ilLength)`, branch targets land on
+instruction boundaries, blocks are EH-aware, and a *dangling* prefix fails closed
+— but it does **not** perform **semantic IL verification** (e.g. that
+`constrained.` is paired with `callvirt`, or stack-type legality). That is
+verifier/importer work, and the upstream `ILImporter` that owns it is
+intentionally not ported: it is bound to `Internal.TypeSystem`, it is Layer 1,
+and it is the non-shareable layer (above). A consumer that needs real
+verification should port a *targeted* upstream slice on a measured trigger, not
+re-derive it inside the decoder.
+
 ### Tracking upstream improvements
 
 The decode *contract* is ECMA-335-frozen — which opcodes exist and how their

--- a/docs/design/instruction-substrate.md
+++ b/docs/design/instruction-substrate.md
@@ -94,28 +94,32 @@ The last "not used" row is load-bearing: prior art runs three *separate* typed
 stacks over one shared reader, so we share decode + identity (Layer 0) and let
 each consumer build its own Layer 1.
 
-### Do we track upstream improvements? No — by design
+### Tracking upstream improvements
 
-The ported reader is a **one-time port, not a tracked vendor branch**, because
-the IL opcode set and operand encodings are **ECMA-335-frozen**: the decode
-contract cannot drift, so there is nothing upstream to chase for correctness.
-This is the opposite of the vendored managed ILAssembler (the
-`vendor/ilassembler` orphan branch), which *is* tracked because it is an evolving
-codebase.
+The decode *contract* is ECMA-335-frozen — which opcodes exist and how their
+operands are encoded will not change. That is **not** a reason to ignore
+upstream. The runtime `ILReader`/`ILOpcodeHelper` *implementation* keeps
+receiving **reliability, performance, and security fixes** — edge-case
+correctness on malformed bodies, bounds-hardening against adversarial IL,
+throughput work — and those matter here precisely because the substrate decodes
+arbitrary, possibly hostile assemblies. So we **do** track upstream, for the
+engineering rather than the spec.
 
-The narrow cases that would warrant touching the ported files, and how:
+This is a one-time *copy*, not a live vendor branch — contrast the vendored
+managed ILAssembler (the `vendor/ilassembler` orphan branch), which is a full
+fork. The lightweight tracking mechanism:
 
-- **A real bug in our port** → fix here directly (the fidelity gates are the
-  oracle); optionally report it upstream. No sync needed.
-- **A genuinely new IL opcode** (historically near-never for ECMA IL) → add one
-  row to the size table; no wholesale re-port.
-- **Adopting *more* of the runtime IL stack** later (e.g. a height tier /
-  `ComputeMaxStack`) → port that piece fresh from the cited path at that time.
+- **Pin the source commit** of each ported file in its header, so the upstream
+  delta is a tractable diff instead of an open-ended comparison.
+- **Periodically — and whenever we touch a ported file — diff our copy against
+  the cited upstream path** and pull relevant reliability/perf/security fixes,
+  re-applying our intentional divergences (SRM retarget, `record` / immutable,
+  fail-closed) on top.
+- **Re-run the fidelity gates** after any such port; they are the acceptance
+  oracle.
 
-Re-sync procedure if ever needed: diff our file against the cited upstream path.
-Because we do not track upstream, the heritage headers record the *path*, not a
-pinned commit; pin a commit only if a future re-port makes ongoing comparison
-worthwhile.
+Our own bug fixes go in directly (the gates are the oracle) and should be
+offered upstream where they apply.
 
 ## Fidelity contract
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,6 +11,7 @@ It is built for both humans and agents. Markdown is the default output because h
 - `src/ILInspector.Analysis/` indexes IL method-body evidence such as direct call sites, allocation occurrences, method signals, and whole-assembly leverage without decompiling to C#.
 - `src/ILInspector.Analysis.App/` is a temporary console harness for exercising Analysis queries until CLI wiring exists.
 - `src/ILInspector.ControlFlow/` contains shared block-edge, dominance, and dataflow kernels used below Analysis and Decompiler without depending on either.
+- `src/ILInspector.Instructions/` is the shared IL decode + EH-aware basic-block substrate (one decoder the analyzer and decompiler converge onto); see [instruction substrate](design/instruction-substrate.md).
 - `src/DotnetInspector.Packages/` handles NuGet package extraction, package/source caches, feeds, symbol package acquisition, and version resolution.
 - `src/DotnetInspector.Services/` contains shared services such as platform/package resolution, dependency resolution, signatures, source fetching, and nuspec parsing.
 - `src/ILInspector.Decompiler/` emits lowered C#, raw IL, and structural annotated IL from method bodies.

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ILInspector.Decompiler\ILInspector.Decompiler.csproj" />
+    <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
     <ProjectReference Include="..\ILInspector.Research\ILInspector.Research.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LegacyUnsafe\ILInspector.Decompiler.Fixtures.LegacyUnsafe.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.NewUnsafe\ILInspector.Decompiler.Fixtures.NewUnsafe.csproj" />

--- a/src/ILInspector.Decompiler.Tests/SubstrateLeaderDifferentialTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SubstrateLeaderDifferentialTests.cs
@@ -1,0 +1,105 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Instructions;
+
+using DHandlerKind = ILInspector.Decompiler.Pipeline.HandlerKind;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Phase 1 directional differential (decompiler half): the substrate's IL-level block leaders must
+/// be a superset of the importer's <see cref="IrImporter.FindLeaders"/> set — i.e. the substrate
+/// never *under*-splits relative to the decompiler (which would merge blocks it needs separate).
+/// The substrate has *more* leaders (it makes every EH-region instruction a leader, the
+/// ReachingDefinitions granularity), so the relation is strict-superset over EH methods. This test
+/// proves no under-split and quantifies the extra granularity that the eventual minimal-CFG
+/// refactor would move to an Analysis Layer-1 concern.
+/// </summary>
+public class SubstrateLeaderDifferentialTests
+{
+    [Fact]
+    public void FindLeaders_is_a_subset_of_substrate_block_starts_over_corelib()
+    {
+        using var pe = new PEReader(File.OpenRead(typeof(object).Assembly.Location));
+        var reader = pe.GetMetadataReader();
+
+        int methods = 0;
+        long substrateLeaders = 0;
+        long importerLeaders = 0;
+        long extraLeaders = 0;
+        var underSplits = new List<string>();
+
+        foreach (var handle in reader.MethodDefinitions)
+        {
+            var method = reader.GetMethodDefinition(handle);
+            if (method.RelativeVirtualAddress == 0)
+                continue;
+            MethodBodyBlock body;
+            try { body = pe.GetMethodBody(method.RelativeVirtualAddress); }
+            catch { continue; }
+            byte[] il = body.GetILBytes() ?? [];
+            if (il.Length == 0)
+                continue;
+
+            var handlers = ToHandlerRegions(body.ExceptionRegions);
+
+            SortedSet<int> importer;
+            HashSet<int> substrate;
+            try
+            {
+                importer = IrImporter.FindLeaders(il, handlers);
+                substrate = MethodInstructions.Decode(il, il.Length, body.ExceptionRegions)
+                    .Blocks.Blocks.Select(b => b.Start).ToHashSet();
+            }
+            catch
+            {
+                continue; // malformed on one side; not this test's concern
+            }
+
+            methods++;
+            substrateLeaders += substrate.Count;
+            importerLeaders += importer.Count;
+            extraLeaders += substrate.Count - importer.Count;
+
+            // Regression-free direction: every importer leader must be a substrate block start.
+            if (!importer.IsSubsetOf(substrate) && underSplits.Count < 15)
+            {
+                var missing = importer.Where(x => !substrate.Contains(x));
+                underSplits.Add($"{reader.GetString(method.Name)}: importer leaders missing from substrate: [{string.Join(",", missing)}]");
+            }
+        }
+
+        Assert.True(methods > 10000, $"expected the full CoreLib body set, saw {methods}");
+        // The headline assertion: no under-split anywhere.
+        Assert.True(underSplits.Count == 0, $"{underSplits.Count} under-split(s):\n{string.Join("\n", underSplits)}");
+
+        // Characterize the granularity gap (informational; the superset is by design).
+        Console.WriteLine($"LEADERS methods={methods} substrate={substrateLeaders} importer={importerLeaders} extra(substrate-only)={extraLeaders}");
+    }
+
+    static ImmutableArray<HandlerRegion> ToHandlerRegions(ImmutableArray<ExceptionRegion> regions)
+    {
+        var builder = ImmutableArray.CreateBuilder<HandlerRegion>(regions.Length);
+        foreach (var region in regions)
+        {
+            builder.Add(new HandlerRegion(
+                region.Kind switch
+                {
+                    ExceptionRegionKind.Catch => DHandlerKind.Catch,
+                    ExceptionRegionKind.Filter => DHandlerKind.Filter,
+                    ExceptionRegionKind.Finally => DHandlerKind.Finally,
+                    _ => DHandlerKind.Fault,
+                },
+                region.TryOffset,
+                region.TryLength,
+                region.HandlerOffset,
+                region.HandlerLength,
+                region.FilterOffset,
+                CatchType: null));
+        }
+        return builder.MoveToImmutable();
+    }
+}

--- a/src/ILInspector.Instructions.Tests/DecodeFidelityTests.cs
+++ b/src/ILInspector.Instructions.Tests/DecodeFidelityTests.cs
@@ -79,7 +79,7 @@ public class DecodeFidelityTests
                 continue;
 
             var instructions = InstructionDecoder.Decode(il);
-            byte[] reencoded = ReEncode(instructions, il, il.Length);
+            byte[] reencoded = ReEncode(instructions, il.Length);
             methods++;
             Assert.True(reencoded.AsSpan().SequenceEqual(il),
                 $"{reader.GetString(method.Name)}: round-trip mismatch");
@@ -88,7 +88,7 @@ public class DecodeFidelityTests
         Assert.True(methods > 50, $"expected to exercise many method bodies, saw {methods}");
     }
 
-    static byte[] ReEncode(ImmutableArray<DecodedInstruction> instructions, byte[] original, int ilLength)
+    static byte[] ReEncode(ImmutableArray<DecodedInstruction> instructions, int ilLength)
     {
         var buf = new byte[ilLength];
         foreach (var ins in instructions)
@@ -105,8 +105,25 @@ public class DecodeFidelityTests
                 buf[p++] = (byte)op;
             }
 
-            if (ins.OpCode == ILOpCode.Switch)
-            {
+            // Re-encode purely from the semantic OperandKind — no special-casing on opcode.
+            // This makes the round-trip genuinely validate the decoder's classification: a
+            // mis- or unclassified operand cannot be masked by a verbatim byte copy.
+            WriteOperand(buf, p, ins);
+        }
+        return buf;
+    }
+
+    static void WriteOperand(byte[] buf, int p, DecodedInstruction ins)
+    {
+        switch (ins.Operand)
+        {
+            case OperandKind.ShortInlineBrTarget:
+                buf[p] = (byte)(sbyte)(ins.BranchTargets[0] - ins.NextOffset);
+                break;
+            case OperandKind.InlineBrTarget:
+                BinaryPrimitives.WriteInt32LittleEndian(buf.AsSpan(p), ins.BranchTargets[0] - ins.NextOffset);
+                break;
+            case OperandKind.InlineSwitch:
                 BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(p), (uint)ins.BranchTargets.Length);
                 p += 4;
                 foreach (int target in ins.BranchTargets)
@@ -114,57 +131,27 @@ public class DecodeFidelityTests
                     BinaryPrimitives.WriteInt32LittleEndian(buf.AsSpan(p), target - ins.NextOffset);
                     p += 4;
                 }
-            }
-            else if (ins.Branches)
-            {
-                int rel = ins.BranchTargets[0] - ins.NextOffset;
-                if (IsShortBranch(ins.OpCode))
-                    buf[p++] = (byte)(sbyte)rel;
-                else
-                {
-                    BinaryPrimitives.WriteInt32LittleEndian(buf.AsSpan(p), rel);
-                    p += 4;
-                }
-            }
-            else
-            {
-                p = WriteOperand(buf, p, ins, original);
-            }
-        }
-        return buf;
-    }
-
-    static int WriteOperand(byte[] buf, int p, DecodedInstruction ins, byte[] original)
-    {
-        switch (ins.Operand)
-        {
+                break;
             case OperandKind.ShortInlineVar or OperandKind.ShortInlineI:
-                buf[p++] = (byte)ins.OperandValue;
+                buf[p] = (byte)ins.OperandValue;
                 break;
             case OperandKind.InlineVar:
                 BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(p), (ushort)ins.OperandValue);
-                p += 2;
                 break;
             case OperandKind.InlineI or OperandKind.ShortInlineR or OperandKind.InlineString
                 or OperandKind.InlineMethod or OperandKind.InlineField or OperandKind.InlineType
                 or OperandKind.InlineSig or OperandKind.InlineTok:
                 BinaryPrimitives.WriteInt32LittleEndian(buf.AsSpan(p), (int)ins.OperandValue);
-                p += 4;
                 break;
             case OperandKind.InlineI8 or OperandKind.InlineR:
                 BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(p), ins.OperandValue);
-                p += 8;
                 break;
             case OperandKind.None:
-                // Uninterpreted operand bytes (e.g. the no. prefix flags byte) carry no structural
-                // meaning the decoder needs; copy them verbatim so the round-trip stays exact.
-                for (int i = ins.OperandOffset; i < ins.NextOffset; i++)
-                    buf[p++] = original[i];
+                // Every operand-bearing opcode is classified, so None must mean zero operand
+                // bytes. Assert it, so an unclassified operand can never be silently masked.
+                Assert.True(ins.OperandOffset == ins.NextOffset,
+                    $"unclassified operand bytes at IL_{ins.Offset:X4} (opcode {ins.OpCode})");
                 break;
         }
-        return p;
     }
-
-    static bool IsShortBranch(ILOpCode opcode)
-        => (opcode >= ILOpCode.Br_s && opcode <= ILOpCode.Blt_un_s) || opcode == ILOpCode.Leave_s;
 }

--- a/src/ILInspector.Instructions.Tests/DecodeFidelityTests.cs
+++ b/src/ILInspector.Instructions.Tests/DecodeFidelityTests.cs
@@ -1,0 +1,170 @@
+using System.Buffers.Binary;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Instructions.Tests;
+
+/// <summary>
+/// Decode-fidelity invariants over real compiled IL (this test assembly's own method bodies):
+/// a faithful decode exactly tiles the IL bytes and every branch target lands on an instruction
+/// boundary. These are oracle-free checks — a desync (e.g. a mishandled prefix) breaks tiling at once.
+/// </summary>
+public class DecodeFidelityTests
+{
+    [Fact]
+    public void Decoded_stream_tiles_il_and_branch_targets_align()
+    {
+        using var pe = new PEReader(File.OpenRead(typeof(DecodeFidelityTests).Assembly.Location));
+        var reader = pe.GetMetadataReader();
+
+        int methods = 0;
+        foreach (var handle in reader.MethodDefinitions)
+        {
+            var method = reader.GetMethodDefinition(handle);
+            if (method.RelativeVirtualAddress == 0)
+                continue;
+            MethodBodyBlock body;
+            try { body = pe.GetMethodBody(method.RelativeVirtualAddress); }
+            catch { continue; }
+            byte[] il = body.GetILBytes() ?? [];
+            if (il.Length == 0)
+                continue;
+
+            var instructions = InstructionDecoder.Decode(il);
+            methods++;
+            string name = reader.GetString(method.Name);
+
+            // Tiling: contiguous, starts at 0, ends exactly at il.Length, no gaps/overlaps.
+            Assert.Equal(0, instructions[0].Offset);
+            for (int i = 1; i < instructions.Length; i++)
+                Assert.True(instructions[i - 1].NextOffset == instructions[i].Offset,
+                    $"{name}: gap/overlap at IL_{instructions[i].Offset:X4}");
+            Assert.Equal(il.Length, instructions[^1].NextOffset);
+
+            // Branch-target alignment: every target is a real instruction offset.
+            var offsets = instructions.Select(x => x.Offset).ToHashSet();
+            foreach (var ins in instructions)
+                foreach (int target in ins.BranchTargets)
+                    Assert.True(offsets.Contains(target),
+                        $"{name}: branch target IL_{target:X4} not on an instruction boundary");
+        }
+
+        Assert.True(methods > 50, $"expected to exercise many method bodies, saw {methods}");
+    }
+
+    [Fact]
+    public void Decoded_stream_round_trips_to_original_il()
+    {
+        // Absolute fidelity: re-encode the IL from the decoder's semantic fields (opcode,
+        // operand value, branch targets) and require it to reproduce the original bytes.
+        // Branch displacements and typed operands are reconstructed, not copied — so a decode
+        // that loses or mis-widths an operand, or mis-computes a target, fails here.
+        using var pe = new PEReader(File.OpenRead(typeof(DecodeFidelityTests).Assembly.Location));
+        var reader = pe.GetMetadataReader();
+
+        int methods = 0;
+        foreach (var handle in reader.MethodDefinitions)
+        {
+            var method = reader.GetMethodDefinition(handle);
+            if (method.RelativeVirtualAddress == 0)
+                continue;
+            MethodBodyBlock body;
+            try { body = pe.GetMethodBody(method.RelativeVirtualAddress); }
+            catch { continue; }
+            byte[] il = body.GetILBytes() ?? [];
+            if (il.Length == 0)
+                continue;
+
+            var instructions = InstructionDecoder.Decode(il);
+            byte[] reencoded = ReEncode(instructions, il, il.Length);
+            methods++;
+            Assert.True(reencoded.AsSpan().SequenceEqual(il),
+                $"{reader.GetString(method.Name)}: round-trip mismatch");
+        }
+
+        Assert.True(methods > 50, $"expected to exercise many method bodies, saw {methods}");
+    }
+
+    static byte[] ReEncode(ImmutableArray<DecodedInstruction> instructions, byte[] original, int ilLength)
+    {
+        var buf = new byte[ilLength];
+        foreach (var ins in instructions)
+        {
+            int p = ins.Offset;
+            int op = (int)ins.OpCode;
+            if (op > 0xFF)
+            {
+                buf[p++] = 0xFE;
+                buf[p++] = (byte)(op & 0xFF);
+            }
+            else
+            {
+                buf[p++] = (byte)op;
+            }
+
+            if (ins.OpCode == ILOpCode.Switch)
+            {
+                BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(p), (uint)ins.BranchTargets.Length);
+                p += 4;
+                foreach (int target in ins.BranchTargets)
+                {
+                    BinaryPrimitives.WriteInt32LittleEndian(buf.AsSpan(p), target - ins.NextOffset);
+                    p += 4;
+                }
+            }
+            else if (ins.Branches)
+            {
+                int rel = ins.BranchTargets[0] - ins.NextOffset;
+                if (IsShortBranch(ins.OpCode))
+                    buf[p++] = (byte)(sbyte)rel;
+                else
+                {
+                    BinaryPrimitives.WriteInt32LittleEndian(buf.AsSpan(p), rel);
+                    p += 4;
+                }
+            }
+            else
+            {
+                p = WriteOperand(buf, p, ins, original);
+            }
+        }
+        return buf;
+    }
+
+    static int WriteOperand(byte[] buf, int p, DecodedInstruction ins, byte[] original)
+    {
+        switch (ins.Operand)
+        {
+            case OperandKind.ShortInlineVar or OperandKind.ShortInlineI:
+                buf[p++] = (byte)ins.OperandValue;
+                break;
+            case OperandKind.InlineVar:
+                BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(p), (ushort)ins.OperandValue);
+                p += 2;
+                break;
+            case OperandKind.InlineI or OperandKind.ShortInlineR or OperandKind.InlineString
+                or OperandKind.InlineMethod or OperandKind.InlineField or OperandKind.InlineType
+                or OperandKind.InlineSig or OperandKind.InlineTok:
+                BinaryPrimitives.WriteInt32LittleEndian(buf.AsSpan(p), (int)ins.OperandValue);
+                p += 4;
+                break;
+            case OperandKind.InlineI8 or OperandKind.InlineR:
+                BinaryPrimitives.WriteInt64LittleEndian(buf.AsSpan(p), ins.OperandValue);
+                p += 8;
+                break;
+            case OperandKind.None:
+                // Uninterpreted operand bytes (e.g. the no. prefix flags byte) carry no structural
+                // meaning the decoder needs; copy them verbatim so the round-trip stays exact.
+                for (int i = ins.OperandOffset; i < ins.NextOffset; i++)
+                    buf[p++] = original[i];
+                break;
+        }
+        return p;
+    }
+
+    static bool IsShortBranch(ILOpCode opcode)
+        => (opcode >= ILOpCode.Br_s && opcode <= ILOpCode.Blt_un_s) || opcode == ILOpCode.Leave_s;
+}

--- a/src/ILInspector.Instructions.Tests/ILInspector.Instructions.Tests.csproj
+++ b/src/ILInspector.Instructions.Tests/ILInspector.Instructions.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ILInspector.Instructions.Tests/MetadataResolverTests.cs
+++ b/src/ILInspector.Instructions.Tests/MetadataResolverTests.cs
@@ -1,0 +1,91 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Instructions.Tests;
+
+/// <summary>
+/// Compiled fixtures whose bodies the typed-stack interpreter reads back through SRM, exercising
+/// the metadata-backed resolver end to end (receiver types, return types, EH entry stacks).
+/// </summary>
+internal static class Fixtures
+{
+    internal static int StringLengthPlusOne(string s) => s.Length + 1;
+
+    internal static int DivideWithCatch(int x)
+    {
+        try { return 10 / x; }
+        catch (DivideByZeroException) { return -1; }
+    }
+}
+
+public class MetadataResolverTests
+{
+    static (MetadataReader Reader, MethodDefinitionHandle Handle, MethodBodyBlock Body) Open(string methodName)
+    {
+        string location = typeof(Fixtures).Assembly.Location;
+        var peReader = new PEReader(File.OpenRead(location));
+        var reader = peReader.GetMetadataReader();
+        foreach (var handle in reader.MethodDefinitions)
+        {
+            var method = reader.GetMethodDefinition(handle);
+            if (reader.GetString(method.Name) != methodName)
+                continue;
+            var declaring = reader.GetString(reader.GetTypeDefinition(method.GetDeclaringType()).Name);
+            if (declaring != nameof(Fixtures))
+                continue;
+            var body = peReader.GetMethodBody(method.RelativeVirtualAddress);
+            return (reader, handle, body);
+        }
+        throw new InvalidOperationException($"Method {methodName} not found.");
+    }
+
+    [Fact]
+    public void Resolves_call_receiver_type_and_provenance()
+    {
+        var (reader, handle, body) = Open(nameof(Fixtures.StringLengthPlusOne));
+        var mi = MethodInstructions.Decode(body);
+        var ts = mi.InterpretStack(reader, handle, body);
+
+        Assert.True(ts.IsComplete, ts.IncompleteReason);
+
+        // The string.Length call (get_Length, zero arguments): its receiver is the argument string,
+        // produced by the ldarg.0 at the method entry — exactly the typed-stack witness.
+        var call = mi.Instructions.Single(i => i.OpCode is ILOpCode.Call or ILOpCode.Callvirt);
+        var receiver = ts.ReceiverAt(call.Offset, argumentsBelow: 0);
+        Assert.NotNull(receiver);
+        Assert.Equal(StackType.ObjectReference, receiver!.Value.Type);
+
+        var ldarg = mi.Instructions.First(i => i.OpCode is ILOpCode.Ldarg_0 or ILOpCode.Ldarg or ILOpCode.Ldarg_s);
+        Assert.Equal(ldarg.Offset, receiver.Value.ProducerOffset);
+
+        // get_Length returns int32; the next instruction sees an int32 on top.
+        var afterCall = ts.StackBeforeOffset(call.NextOffset);
+        Assert.Equal(StackType.Int32, afterCall[^1].Type);
+
+        // Offset→instruction/block lookup (the join-key surface): the call resolves to itself,
+        // a mid-instruction offset resolves to no boundary, and every offset maps to a block.
+        Assert.Equal(call, mi.InstructionAt(call.Offset));
+        Assert.Null(mi.InstructionAt(call.Offset + 1));
+        Assert.True(mi.BlockIndexAt(call.Offset) >= 0);
+    }
+
+    [Fact]
+    public void Seeds_catch_handler_entry_with_the_exception_object()
+    {
+        var (reader, handle, body) = Open(nameof(Fixtures.DivideWithCatch));
+        var mi = MethodInstructions.Decode(body);
+        var ts = mi.InterpretStack(reader, handle, body);
+
+        // A catch handler that discards its exception begins by popping it; the interpreter
+        // stays complete only because the handler entry is seeded with the in-flight exception.
+        Assert.True(ts.IsComplete, ts.IncompleteReason);
+
+        var catchRegion = mi.Blocks.Regions.Single(r => r.Kind == HandlerKind.Catch);
+        var handlerEntry = ts.StackBeforeOffset(catchRegion.HandlerStart);
+        var exception = Assert.Single(handlerEntry);
+        Assert.Equal(StackType.ObjectReference, exception.Type);
+        Assert.Equal(StackValue.NoProducer, exception.ProducerOffset);
+    }
+}

--- a/src/ILInspector.Instructions.Tests/ReviewFixTests.cs
+++ b/src/ILInspector.Instructions.Tests/ReviewFixTests.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 
 using ILInspector.Instructions;
 
@@ -77,5 +79,31 @@ public class ReviewFixTests
         // switch (1 target = fallthrough) ; ret.
         byte[] sw = [0x45, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2A];
         Assert.Equal(OperandKind.InlineSwitch, InstructionDecoder.Decode(sw)[0].Operand);
+    }
+
+    [Fact]
+    public void Typed_stack_resolver_fails_closed_on_out_of_range_tokens()
+    {
+        using var pe = new PEReader(File.OpenRead(typeof(ReviewFixTests).Assembly.Location));
+        var reader = pe.GetMetadataReader();
+
+        // Build a resolver from any real method with a body.
+        MethodDefinitionHandle handle = default;
+        MethodBodyBlock body = default!;
+        foreach (var h in reader.MethodDefinitions)
+        {
+            var m = reader.GetMethodDefinition(h);
+            if (m.RelativeVirtualAddress == 0) continue;
+            try { body = pe.GetMethodBody(m.RelativeVirtualAddress); } catch { continue; }
+            handle = h;
+            break;
+        }
+        var resolver = MetadataStackTypeResolver.Create(reader, handle, body);
+
+        // Out-of-range tokens must coarsen / fail closed, not throw BadImageFormatException.
+        Assert.Equal(StackType.Unknown, resolver.Field(0x0400FFFF));
+        Assert.Equal(StackType.Unknown, resolver.TypeOfToken(0x0200FFFF));
+        Assert.False(resolver.TryResolveCall(0x0A00FFFF, isNewObj: false, out _, out _, out _));
+        Assert.False(resolver.TryResolveCalli(0x1100FFFF, out _, out _, out _));
     }
 }

--- a/src/ILInspector.Instructions.Tests/ReviewFixTests.cs
+++ b/src/ILInspector.Instructions.Tests/ReviewFixTests.cs
@@ -1,0 +1,81 @@
+using System.Reflection.Metadata;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Instructions.Tests;
+
+/// <summary>
+/// Regressions for adversarial-review findings on the substrate decoder (PR #1982):
+/// ilLength is honored, dangling prefixes fail closed, the no. prefix operand is captured,
+/// and branch/switch operands are classified.
+/// </summary>
+public class ReviewFixTests
+{
+    [Fact]
+    public void Decode_honors_ilLength_and_ignores_trailing_bytes()
+    {
+        // ret (0x2A) followed by a stray byte that must not be decoded as a second instruction.
+        byte[] il = [0x2A, 0x00];
+        var mi = MethodInstructions.Decode(il, ilLength: 1, []);
+
+        Assert.True(mi.IsComplete);
+        Assert.Equal(ILOpCode.Ret, Assert.Single(mi.Instructions).OpCode);
+        Assert.Null(mi.InstructionAt(1)); // the trailing byte is not an instruction boundary
+    }
+
+    [Fact]
+    public void Declared_ilLength_past_buffer_is_incomplete()
+    {
+        byte[] il = [0x2A];
+        var mi = MethodInstructions.Decode(il, ilLength: 8, []);
+        Assert.False(mi.IsComplete);
+    }
+
+    [Fact]
+    public void Dangling_tail_prefix_is_incomplete()
+    {
+        // tail. (FE 14) with no following instruction.
+        byte[] il = [0xFE, 0x14];
+        var mi = MethodInstructions.Decode(il, il.Length, []);
+        Assert.False(mi.IsComplete);
+    }
+
+    [Fact]
+    public void Dangling_constrained_prefix_is_incomplete()
+    {
+        // constrained. <token> (FE 16 + 4-byte type token) with no following callvirt.
+        byte[] il = [0xFE, 0x16, 0x01, 0x00, 0x00, 0x1B];
+        var mi = MethodInstructions.Decode(il, il.Length, []);
+        Assert.False(mi.IsComplete);
+    }
+
+    [Fact]
+    public void No_prefix_operand_value_is_captured()
+    {
+        // no. 0x04 (suppress nullcheck); ret  — the prefix flags byte must be preserved.
+        byte[] il = [0xFE, 0x19, 0x04, 0x2A];
+        var mi = MethodInstructions.Decode(il, il.Length, []);
+
+        Assert.True(mi.IsComplete);
+        var no = mi.Instructions[0];
+        Assert.Equal(0xFE19, (int)no.OpCode);
+        Assert.Equal(OperandKind.ShortInlineI, no.Operand);
+        Assert.Equal(4, no.OperandValue);
+    }
+
+    [Fact]
+    public void Branch_and_switch_operands_are_classified()
+    {
+        // br.s IL_0003 ; nop ; ret  → short branch target.
+        Assert.Equal(OperandKind.ShortInlineBrTarget,
+            InstructionDecoder.Decode([0x2B, 0x01, 0x00, 0x2A])[0].Operand);
+
+        // br IL_0005 (long, 4-byte target) ; ret.
+        Assert.Equal(OperandKind.InlineBrTarget,
+            InstructionDecoder.Decode([0x38, 0x00, 0x00, 0x00, 0x00, 0x2A])[0].Operand);
+
+        // switch (1 target = fallthrough) ; ret.
+        byte[] sw = [0x45, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2A];
+        Assert.Equal(OperandKind.InlineSwitch, InstructionDecoder.Decode(sw)[0].Operand);
+    }
+}

--- a/src/ILInspector.Instructions.Tests/SubstrateTests.cs
+++ b/src/ILInspector.Instructions.Tests/SubstrateTests.cs
@@ -1,0 +1,165 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Instructions.Tests;
+
+public class InstructionDecoderTests
+{
+    [Fact]
+    public void Decodes_offsets_opcodes_and_lengths()
+    {
+        // ldc.i4.1; ldc.i4.2; add; ret
+        byte[] il = [0x17, 0x18, 0x58, 0x2A];
+        var instructions = InstructionDecoder.Decode(il);
+
+        Assert.Equal(4, instructions.Length);
+        Assert.Equal((0, ILOpCode.Ldc_i4_1, 1), (instructions[0].Offset, instructions[0].OpCode, instructions[0].NextOffset));
+        Assert.Equal(ILOpCode.Add, instructions[2].OpCode);
+        Assert.Equal(ILOpCode.Ret, instructions[3].OpCode);
+        Assert.True(instructions[3].Exits);
+        Assert.All(instructions, i => Assert.Equal(1, i.Length));
+    }
+
+    [Fact]
+    public void Decodes_branch_targets_relative_to_next_offset()
+    {
+        // IL_0000 br.s IL_0003 ; IL_0002 nop ; IL_0003 ret
+        byte[] il = [0x2B, 0x01, 0x00, 0x2A];
+        var instructions = InstructionDecoder.Decode(il);
+
+        Assert.Equal(ILOpCode.Br_s, instructions[0].OpCode);
+        Assert.True(instructions[0].Branches);
+        Assert.True(instructions[0].IsUnconditionalBranch);
+        Assert.False(instructions[0].FallsThrough);
+        Assert.Equal(3, Assert.Single(instructions[0].BranchTargets));
+    }
+
+    [Fact]
+    public void Decodes_switch_targets()
+    {
+        // switch (2) { IL_x, IL_y } then ret. opcode 0x45, count=2, two i4 rels.
+        // layout: 0:switch 1..4:count 5..8:rel0 9..12:rel1 13:ret
+        byte[] il = new byte[14];
+        il[0] = 0x45;
+        BitConverter.GetBytes(2).CopyTo(il, 1);
+        BitConverter.GetBytes(0).CopyTo(il, 5);   // rel0 -> base (13)
+        BitConverter.GetBytes(0).CopyTo(il, 9);   // rel1 -> base (13)
+        il[13] = 0x2A;
+        var instructions = InstructionDecoder.Decode(il);
+
+        Assert.Equal(ILOpCode.Switch, instructions[0].OpCode);
+        Assert.True(instructions[0].FallsThrough);
+        Assert.Equal([13, 13], instructions[0].BranchTargets);
+    }
+
+    [Fact]
+    public void ShortInlineVar_index_is_unsigned()
+    {
+        // ldloc.s 200 (0x11 0xC8) ; ret  — index 200 must read as 200, not -56.
+        byte[] il = [0x11, 0xC8, 0x2A];
+        var instructions = InstructionDecoder.Decode(il);
+
+        Assert.Equal(ILOpCode.Ldloc_s, instructions[0].OpCode);
+        Assert.Equal(200, instructions[0].OperandValue);
+    }
+
+    [Fact]
+    public void No_prefix_does_not_desync_decode()
+    {
+        // no. 0x01 (0xFE 0x19 0x01) ; ldarg.0 (0x02) ; ret (0x2A)
+        // The no. prefix has a 1-byte operand; mishandling it would misread ldarg.0 as the operand.
+        byte[] il = [0xFE, 0x19, 0x01, 0x02, 0x2A];
+        var instructions = InstructionDecoder.Decode(il);
+
+        Assert.Equal(3, instructions.Length);
+        Assert.Equal((ILOpCode)0xFE19, instructions[0].OpCode);   // no. (not a named BCL ILOpCode member)
+        Assert.Equal(3, instructions[0].NextOffset);
+        Assert.Equal((3, ILOpCode.Ldarg_0), (instructions[1].Offset, instructions[1].OpCode));
+        Assert.Equal((4, ILOpCode.Ret), (instructions[2].Offset, instructions[2].OpCode));
+    }
+}
+
+public class BlockGraphTests
+{
+    [Fact]
+    public void Builds_blocks_at_branch_leaders()
+    {
+        // IL_0000 ldc.i4.0 ; brtrue.s IL_0006 ; ldc.i4.1 ; br.s IL_0007 ; (IL_0006) ldc.i4.2 ; (IL_0007) ret
+        byte[] il = [0x16, 0x2D, 0x03, 0x17, 0x2B, 0x01, 0x18, 0x2A];
+        var instructions = InstructionDecoder.Decode(il);
+        var graph = BlockGraph.Build(il.Length, instructions, []);
+
+        Assert.True(graph.IsComplete);
+        Assert.Equal([0, 3, 6, 7], graph.Blocks.Select(b => b.Start));
+        // Block 0 branches to the fallthrough (block 1) and the brtrue target (block 2).
+        Assert.Equal([1, 2], graph.Blocks[0].Edges.Successors);
+        // Both block 1 (br.s) and block 2 (fallthrough) reach the ret block (block 3).
+        Assert.Equal([3], graph.Blocks[1].Edges.Successors);
+        Assert.Equal([3], graph.Blocks[2].Edges.Successors);
+    }
+}
+
+public class StackTypeInterpreterTests
+{
+    [Fact]
+    public void Tracks_types_and_provenance_through_a_binary_op()
+    {
+        // ldc.i4.1 ; ldc.i4.2 ; add ; ret  (returns int)
+        byte[] il = [0x17, 0x18, 0x58, 0x2A];
+        var mi = MethodInstructions.Decode(il, il.Length, []);
+        var ts = mi.InterpretStack(methodReturnsValue: true);
+
+        Assert.True(mi.IsComplete);
+        Assert.True(ts.IsComplete);
+
+        var beforeAdd = ts.StackBeforeOffset(2);
+        Assert.Equal(
+            [(StackType.Int32, 0), (StackType.Int32, 1)],
+            beforeAdd.Select(v => (v.Type, v.ProducerOffset)));
+
+        // After the add, ret sees one int32 produced by the add at offset 2.
+        var beforeRet = ts.StackBeforeOffset(3);
+        var top = Assert.Single(beforeRet);
+        Assert.Equal((StackType.Int32, 2), (top.Type, top.ProducerOffset));
+    }
+
+    [Fact]
+    public void Merges_disagreeing_producers_to_no_provenance_but_keeps_the_type()
+    {
+        // Two paths push an int32 from different offsets, then join at ret.
+        byte[] il = [0x16, 0x2D, 0x03, 0x17, 0x2B, 0x01, 0x18, 0x2A];
+        var ts = MethodInstructions.Decode(il, il.Length, []).InterpretStack(methodReturnsValue: true);
+
+        Assert.True(ts.IsComplete);
+        var beforeRet = ts.StackBeforeOffset(7);
+        var merged = Assert.Single(beforeRet);
+        Assert.Equal(StackType.Int32, merged.Type);                 // both paths agree on the type
+        Assert.Equal(StackValue.NoProducer, merged.ProducerOffset); // but provenance is ambiguous
+    }
+
+    [Fact]
+    public void Reports_incomplete_when_a_call_signature_is_unresolved()
+    {
+        // ldarg.0 ; call <token 06000001> ; ret  — default resolver cannot resolve the call.
+        byte[] il = [0x02, 0x28, 0x01, 0x00, 0x00, 0x06, 0x2A];
+        var ts = MethodInstructions.Decode(il, il.Length, []).InterpretStack(methodReturnsValue: false);
+
+        Assert.False(ts.IsComplete);
+        Assert.Contains("Unresolved", ts.IncompleteReason);
+    }
+
+    [Fact]
+    public void Malformed_il_fails_closed_instead_of_throwing()
+    {
+        // call (0x28) with a truncated 4-byte token — decode would run off the end.
+        byte[] il = [0x28, 0x01, 0x00];
+        var mi = MethodInstructions.Decode(il, il.Length, []);
+
+        Assert.False(mi.IsComplete);
+        Assert.False(mi.Blocks.IsComplete);
+        Assert.NotNull(mi.Blocks.IncompleteReason);
+    }
+}

--- a/src/ILInspector.Instructions.Tests/TypedStackFidelityTests.cs
+++ b/src/ILInspector.Instructions.Tests/TypedStackFidelityTests.cs
@@ -1,0 +1,54 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Instructions.Tests;
+
+/// <summary>
+/// Layer 1 fidelity: validate the typed-stack interpreter's depth accounting against an external
+/// oracle — the method body's compiler-declared <c>MaxStack</c>. For any method whose typed stack
+/// is complete, the deepest evaluation-stack depth the interpreter computes must not exceed the
+/// declared bound; exceeding it means a pop/push miscount. Run over all of System.Private.CoreLib.
+/// </summary>
+public class TypedStackFidelityTests
+{
+    [Fact]
+    public void Computed_stack_depth_never_exceeds_declared_maxstack_over_corelib()
+    {
+        using var pe = new PEReader(File.OpenRead(typeof(object).Assembly.Location));
+        var reader = pe.GetMetadataReader();
+
+        int checked_ = 0;
+        var violations = new List<string>();
+        foreach (var handle in reader.MethodDefinitions)
+        {
+            var method = reader.GetMethodDefinition(handle);
+            if (method.RelativeVirtualAddress == 0)
+                continue;
+            MethodBodyBlock body;
+            try { body = pe.GetMethodBody(method.RelativeVirtualAddress); }
+            catch { continue; }
+            if ((body.GetILBytes()?.Length ?? 0) == 0)
+                continue;
+
+            var mi = MethodInstructions.Decode(body);
+            var ts = mi.InterpretStack(reader, handle, body);
+            if (!ts.IsComplete)
+                continue; // fail-closed methods don't make a depth claim
+
+            checked_++;
+            int computedMax = 0;
+            foreach (var stack in ts.StackBefore.Values)
+                if (stack.Length > computedMax)
+                    computedMax = stack.Length;
+
+            if (computedMax > body.MaxStack)
+                violations.Add($"{reader.GetString(method.Name)}: computed {computedMax} > declared MaxStack {body.MaxStack}");
+        }
+
+        Assert.True(checked_ > 5000, $"expected many complete methods, saw {checked_}");
+        Assert.True(violations.Count == 0,
+            $"{violations.Count} MaxStack violation(s):\n{string.Join("\n", violations.Take(15))}");
+    }
+}

--- a/src/ILInspector.Instructions.Tests/TypedStackFidelityTests.cs
+++ b/src/ILInspector.Instructions.Tests/TypedStackFidelityTests.cs
@@ -43,6 +43,11 @@ public class TypedStackFidelityTests
                 if (stack.Length > computedMax)
                     computedMax = stack.Length;
 
+            // Ceiling sanity bound, by design — not exact verification. computedMax is the deepest
+            // *block-entry* stack we model; if it ever exceeds the declared MaxStack the interpreter
+            // over-pushed (a real bug). The converse (under-push) is intentionally NOT asserted: we
+            // sample block-entry depths rather than the true mid-block peak, and compilers may pad
+            // MaxStack, so exact equality would be flaky. Over-push is the falsifiable claim here.
             if (computedMax > body.MaxStack)
                 violations.Add($"{reader.GetString(method.Name)}: computed {computedMax} > declared MaxStack {body.MaxStack}");
         }

--- a/src/ILInspector.Instructions/BlockGraph.cs
+++ b/src/ILInspector.Instructions/BlockGraph.cs
@@ -1,0 +1,356 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+using ILInspector.ControlFlow;
+
+namespace ILInspector.Instructions;
+
+/// <summary>The CLI exception-region kinds, mirrored from SRM so callers do not need a body block.</summary>
+public enum HandlerKind
+{
+    Catch,
+    Filter,
+    Finally,
+    Fault,
+}
+
+/// <summary>A normalized, instruction-boundary-aligned exception region.</summary>
+public sealed record ExceptionRegionModel(
+    HandlerKind Kind,
+    int TryStart,
+    int TryEnd,
+    int HandlerStart,
+    int HandlerEnd,
+    int FilterStart,
+    int FilterEnd)
+{
+    public bool ContainsTry(int offset) => offset >= TryStart && offset < TryEnd;
+    public bool ContainsHandler(int offset) => offset >= HandlerStart && offset < HandlerEnd;
+    public bool ContainsFilter(int offset) => Kind == HandlerKind.Filter && offset >= FilterStart && offset < FilterEnd;
+    public bool ContainsAny(int offset) => ContainsTry(offset) || ContainsHandler(offset) || ContainsFilter(offset);
+}
+
+/// <summary>One basic block: its IL byte span and outgoing control-flow edges.</summary>
+public sealed record InstructionBlock(int Index, int Start, int End, BlockEdges Edges);
+
+/// <summary>
+/// Builds EH-aware basic blocks from a decoded instruction stream, emitting
+/// <see cref="ControlFlow.BlockEdges"/> so the dominance/dataflow kernels can run unchanged.
+/// Block leaders, try/handler boundaries, and EH survivor edges follow ECMA-335 Partition I §12.4.
+/// </summary>
+public sealed record BlockGraph(
+    ImmutableArray<InstructionBlock> Blocks,
+    ImmutableArray<ExceptionRegionModel> Regions,
+    bool IsComplete,
+    string? IncompleteReason)
+{
+    public static BlockGraph Build(
+        int ilLength,
+        ImmutableArray<DecodedInstruction> instructions,
+        IReadOnlyCollection<ExceptionRegion> exceptionRegions)
+    {
+        ArgumentNullException.ThrowIfNull(exceptionRegions);
+        var regions = BuildRegionModels(ilLength, instructions, exceptionRegions, out var regionReasons);
+        var blocks = BuildBlocks(ilLength, instructions, regions);
+        var reason = ComputeIncompleteReason(blocks, instructions, regions, regionReasons);
+        return new BlockGraph(blocks, regions, reason is null, reason);
+    }
+
+    /// <summary>
+    /// The index of the block whose <c>[Start, End)</c> span contains <paramref name="offset"/>,
+    /// or -1 if out of range. Binary search over block starts (the blocks tile the IL), mirroring
+    /// runtime's <c>FlowGraph.LookupIndex</c> — the offset→block half of the substrate's join key.
+    /// </summary>
+    public int BlockIndexAt(int offset)
+    {
+        int lo = 0;
+        int hi = Blocks.Length - 1;
+        while (lo <= hi)
+        {
+            int mid = (lo + hi) >>> 1;
+            var block = Blocks[mid];
+            if (offset < block.Start)
+                hi = mid - 1;
+            else if (offset >= block.End)
+                lo = mid + 1;
+            else
+                return mid;
+        }
+        return -1;
+    }
+
+    static ImmutableArray<InstructionBlock> BuildBlocks(
+        int ilLength,
+        ImmutableArray<DecodedInstruction> instructions,
+        ImmutableArray<ExceptionRegionModel> regions)
+    {
+        var instructionOffsets = instructions.Select(i => i.Offset).ToHashSet();
+        var leaders = new SortedSet<int> { 0 };
+        foreach (var instruction in instructions)
+        {
+            foreach (int target in instruction.BranchTargets)
+            {
+                if (target >= 0 && target < ilLength)
+                {
+                    if (!instructionOffsets.Contains(target))
+                        throw new BadImageFormatException($"Branch target IL_{target:X4} does not align with an instruction.");
+                    leaders.Add(target);
+                }
+            }
+            if ((instruction.Branches || instruction.Exits) && instruction.NextOffset < ilLength)
+                leaders.Add(instruction.NextOffset);
+        }
+        foreach (var region in regions)
+        {
+            AddLeader(region.TryStart);
+            AddLeader(region.TryEnd);
+            AddLeader(region.HandlerStart);
+            AddLeader(region.HandlerEnd);
+            if (region.Kind == HandlerKind.Filter)
+            {
+                AddLeader(region.FilterStart);
+                AddLeader(region.FilterEnd);
+            }
+        }
+        foreach (var instruction in instructions)
+        {
+            if (regions.Any(region => region.ContainsAny(instruction.Offset)))
+                AddLeader(instruction.Offset);
+        }
+
+        var starts = leaders.ToImmutableArray();
+        var offsetToBlock = new Dictionary<int, int>(starts.Length);
+        for (int i = 0; i < starts.Length; i++)
+            offsetToBlock[starts[i]] = i;
+
+        var successorsByBlock = new List<int>[starts.Length];
+        var externalByBlock = new List<int>[starts.Length];
+        var exitsByBlock = new bool[starts.Length];
+        var leavesByBlock = new bool[starts.Length];
+        var lastByBlock = new DecodedInstruction?[starts.Length];
+
+        // Single O(n) pass: each instruction belongs to the block whose start it falls in; the last
+        // instruction seen in a block is its terminator. Starts are sorted and instructions are in
+        // offset order, so a forward block cursor suffices (vs an O(blocks*n) per-block rescan).
+        int cursor = 0;
+        foreach (var instruction in instructions)
+        {
+            while (cursor + 1 < starts.Length && instruction.Offset >= starts[cursor + 1])
+                cursor++;
+            lastByBlock[cursor] = instruction;
+        }
+
+        for (int i = 0; i < starts.Length; i++)
+        {
+            var successors = new List<int>();
+            var external = new List<int>();
+            if (lastByBlock[i] is { } terminator)
+            {
+                foreach (int target in terminator.BranchTargets)
+                {
+                    if (offsetToBlock.TryGetValue(target, out int targetBlock))
+                        successors.Add(targetBlock);
+                    else
+                        external.Add(target);
+                }
+                if (terminator.FallsThrough && i + 1 < starts.Length)
+                    successors.Add(i + 1);
+            }
+
+            successorsByBlock[i] = successors;
+            externalByBlock[i] = external;
+            exitsByBlock[i] = lastByBlock[i]?.Exits ?? false;
+            leavesByBlock[i] = lastByBlock[i]?.LeavesRegion ?? false;
+        }
+
+        AddExceptionEdges(regions, instructions, starts, offsetToBlock, successorsByBlock, externalByBlock, lastByBlock);
+
+        var blocks = ImmutableArray.CreateBuilder<InstructionBlock>(starts.Length);
+        for (int i = 0; i < starts.Length; i++)
+        {
+            blocks.Add(new InstructionBlock(
+                i,
+                starts[i],
+                i + 1 < starts.Length ? starts[i + 1] : ilLength,
+                new BlockEdges(
+                    successorsByBlock[i].Distinct().Order().ToArray(),
+                    externalByBlock[i].Distinct().Order().ToArray(),
+                    exitsByBlock[i],
+                    leavesByBlock[i])));
+        }
+        return blocks.ToImmutable();
+
+        void AddLeader(int offset)
+        {
+            if (offset < ilLength)
+                leaders.Add(offset);
+        }
+    }
+
+    static ImmutableArray<ExceptionRegionModel> BuildRegionModels(
+        int ilLength,
+        ImmutableArray<DecodedInstruction> instructions,
+        IReadOnlyCollection<ExceptionRegion> regions,
+        out ImmutableArray<string> incompleteReasons)
+    {
+        var instructionOffsets = instructions.Select(i => i.Offset).ToHashSet();
+        var models = ImmutableArray.CreateBuilder<ExceptionRegionModel>();
+        var reasons = ImmutableArray.CreateBuilder<string>();
+        foreach (var region in regions)
+        {
+            if (!TryRange("try", region.TryOffset, region.TryLength, out int tryEnd)
+                || !TryRange("handler", region.HandlerOffset, region.HandlerLength, out int handlerEnd))
+                continue;
+
+            int filterStart = -1;
+            int filterEnd = -1;
+            HandlerKind kind;
+            switch (region.Kind)
+            {
+                case ExceptionRegionKind.Catch: kind = HandlerKind.Catch; break;
+                case ExceptionRegionKind.Finally: kind = HandlerKind.Finally; break;
+                case ExceptionRegionKind.Fault: kind = HandlerKind.Fault; break;
+                case ExceptionRegionKind.Filter:
+                    kind = HandlerKind.Filter;
+                    filterStart = region.FilterOffset;
+                    filterEnd = region.HandlerOffset;
+                    if (!IsBoundary(filterStart) || filterStart >= filterEnd)
+                    {
+                        reasons.Add("Filter exception-handler region has unsupported boundaries.");
+                        continue;
+                    }
+                    break;
+                default:
+                    reasons.Add($"Unsupported exception-handler kind {region.Kind}.");
+                    continue;
+            }
+
+            models.Add(new ExceptionRegionModel(
+                kind, region.TryOffset, tryEnd, region.HandlerOffset, handlerEnd, filterStart, filterEnd));
+        }
+
+        incompleteReasons = reasons.ToImmutable();
+        return models.ToImmutable();
+
+        bool TryRange(string name, int start, int length, out int end)
+        {
+            end = 0;
+            long computedEnd = (long)start + length;
+            if (start < 0 || length <= 0 || computedEnd > ilLength)
+            {
+                reasons.Add($"Exception {name} region has unsupported boundaries.");
+                return false;
+            }
+            end = (int)computedEnd;
+            if (!IsBoundary(start) || !IsBoundary(end))
+            {
+                reasons.Add($"Exception {name} region does not align with instruction boundaries.");
+                return false;
+            }
+            return true;
+        }
+
+        bool IsBoundary(int offset) => offset == ilLength || instructionOffsets.Contains(offset);
+    }
+
+    static void AddExceptionEdges(
+        ImmutableArray<ExceptionRegionModel> regions,
+        ImmutableArray<DecodedInstruction> instructions,
+        ImmutableArray<int> blockStarts,
+        IReadOnlyDictionary<int, int> offsetToBlock,
+        IReadOnlyList<List<int>> successorsByBlock,
+        IReadOnlyList<List<int>> externalByBlock,
+        IReadOnlyList<DecodedInstruction?> lastByBlock)
+    {
+        foreach (var region in regions)
+        {
+            int handlerBlock = offsetToBlock[region.HandlerStart];
+            int exceptionEntryBlock = region.Kind == HandlerKind.Filter
+                ? offsetToBlock[region.FilterStart]
+                : handlerBlock;
+
+            foreach (int block in BlocksInRange(region.TryStart, region.TryEnd))
+                successorsByBlock[block].Add(exceptionEntryBlock);
+
+            if (region.Kind == HandlerKind.Filter)
+            {
+                foreach (int block in BlocksInRange(region.FilterStart, region.FilterEnd))
+                {
+                    successorsByBlock[block].Add(handlerBlock);
+                    foreach (var sibling in regions)
+                    {
+                        if (sibling.Equals(region)
+                            || sibling.TryStart != region.TryStart
+                            || sibling.TryEnd != region.TryEnd)
+                            continue;
+                        successorsByBlock[block].Add(sibling.Kind == HandlerKind.Filter
+                            ? offsetToBlock[sibling.FilterStart]
+                            : offsetToBlock[sibling.HandlerStart]);
+                    }
+                }
+            }
+
+            if (region.Kind == HandlerKind.Finally)
+            {
+                var leaveTargets = LeaveTargetsLeaving(region, instructions).ToArray();
+                if (leaveTargets.Length == 0)
+                    continue;
+                foreach (int block in BlocksInRange(region.HandlerStart, region.HandlerEnd))
+                {
+                    if (lastByBlock[block] is not { OpCode: ILOpCode.Endfinally })
+                        continue;
+                    foreach (int target in leaveTargets)
+                    {
+                        if (offsetToBlock.TryGetValue(target, out int targetBlock))
+                            successorsByBlock[block].Add(targetBlock);
+                        else
+                            externalByBlock[block].Add(target);
+                    }
+                }
+            }
+        }
+
+        IEnumerable<int> BlocksInRange(int start, int end)
+        {
+            for (int i = 0; i < blockStarts.Length; i++)
+                if (blockStarts[i] >= start && blockStarts[i] < end)
+                    yield return i;
+        }
+    }
+
+    static IEnumerable<int> LeaveTargetsLeaving(ExceptionRegionModel region, ImmutableArray<DecodedInstruction> instructions)
+    {
+        foreach (var instruction in instructions)
+        {
+            if (!instruction.LeavesRegion || !region.ContainsTry(instruction.Offset))
+                continue;
+            foreach (int target in instruction.BranchTargets)
+                if (!region.ContainsTry(target))
+                    yield return target;
+        }
+    }
+
+    static string? ComputeIncompleteReason(
+        ImmutableArray<InstructionBlock> blocks,
+        ImmutableArray<DecodedInstruction> instructions,
+        ImmutableArray<ExceptionRegionModel> regions,
+        ImmutableArray<string> regionIncompleteReasons)
+    {
+        if (blocks.Any(block => block.Edges.LeavesRegion))
+        {
+            foreach (var instruction in instructions)
+            {
+                if (!instruction.LeavesRegion)
+                    continue;
+                if (regions.Any(region => region.ContainsAny(instruction.Offset)))
+                    continue;
+                return "Region-leaving control-flow edges are not modeled.";
+            }
+        }
+        if (blocks.Any(block => block.Edges.ExternalTargets.Count > 0))
+            return "External control-flow targets are not modeled.";
+        if (regionIncompleteReasons.Length > 0)
+            return string.Join("; ", regionIncompleteReasons);
+        return null;
+    }
+}

--- a/src/ILInspector.Instructions/DecodedInstruction.cs
+++ b/src/ILInspector.Instructions/DecodedInstruction.cs
@@ -1,0 +1,55 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Instructions;
+
+/// <summary>
+/// Classifies an opcode's inline operand. Determines operand size during decode and
+/// lets consumers read tokens/indices/constants without re-deriving opcode shape.
+/// </summary>
+public enum OperandKind
+{
+    None,
+    ShortInlineVar,   // 1-byte local/argument index
+    InlineVar,        // 2-byte local/argument index
+    ShortInlineI,     // int8
+    InlineI,          // int32
+    InlineI8,         // int64
+    ShortInlineR,     // float32
+    InlineR,          // float64
+    InlineString,     // string token
+    InlineMethod,     // method token
+    InlineField,      // field token
+    InlineType,       // type token
+    InlineSig,        // standalone signature token (calli)
+    InlineTok,        // ldtoken: field/method/type token
+    ShortInlineBrTarget,
+    InlineBrTarget,
+    InlineSwitch,
+}
+
+/// <summary>
+/// One decoded IL instruction: its position, opcode, decoded operand classification,
+/// resolved branch targets, and the structural control-flow facts the block builder needs.
+/// The single decode shared by analysis and (eventually) the decompiler importer.
+/// </summary>
+public sealed record DecodedInstruction(
+    int Offset,
+    ILOpCode OpCode,
+    int OperandOffset,
+    int NextOffset,
+    OperandKind Operand,
+    long OperandValue,
+    ImmutableArray<int> BranchTargets,
+    bool Branches,
+    bool IsUnconditionalBranch,
+    bool Exits,
+    bool FallsThrough,
+    bool LeavesRegion)
+{
+    /// <summary>Total instruction length in bytes, including operand.</summary>
+    public int Length => NextOffset - Offset;
+
+    /// <summary>True when this instruction ends its basic block (branch, return, throw, or EH exit).</summary>
+    public bool TerminatesBlock => Branches || Exits;
+}

--- a/src/ILInspector.Instructions/ILInspector.Instructions.csproj
+++ b/src/ILInspector.Instructions/ILInspector.Instructions.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Richard Lander</Authors>
+    <Description>Gated Rung 5 typed-stack substrate: decode -> typed instructions -> typed-stack -> EH-aware blocks. SRM-only, no IrNode/structuring/C#. Prototype (issue #1908).</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <!-- System.Reflection.Metadata is part of the BCL -->
+
+  <ItemGroup>
+    <ProjectReference Include="..\ILInspector.ControlFlow\ILInspector.ControlFlow.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ILInspector.Instructions/ILOpcodeExtensions.cs
+++ b/src/ILInspector.Instructions/ILOpcodeExtensions.cs
@@ -2,8 +2,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 //
-// One-time port: the IL opcode set is ECMA-335-frozen, so no upstream sync is
-// tracked. See docs/design/instruction-substrate.md ("dotnet/runtime heritage").
+// One-time port (not a live vendor branch). Upstream still receives
+// reliability/perf/security fixes to this helper — periodically diff against the
+// cited path and port them. See docs/design/instruction-substrate.md
+// ("dotnet/runtime heritage").
 
 using System.Reflection.Metadata;
 

--- a/src/ILInspector.Instructions/ILOpcodeExtensions.cs
+++ b/src/ILInspector.Instructions/ILOpcodeExtensions.cs
@@ -1,6 +1,9 @@
 // Ported from dotnet/runtime src/coreclr/tools/Common/TypeSystem/IL/ILOpcodeHelper.cs
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+//
+// One-time port: the IL opcode set is ECMA-335-frozen, so no upstream sync is
+// tracked. See docs/design/instruction-substrate.md ("dotnet/runtime heritage").
 
 using System.Reflection.Metadata;
 

--- a/src/ILInspector.Instructions/ILOpcodeExtensions.cs
+++ b/src/ILInspector.Instructions/ILOpcodeExtensions.cs
@@ -1,11 +1,12 @@
 // Ported from dotnet/runtime src/coreclr/tools/Common/TypeSystem/IL/ILOpcodeHelper.cs
+// Sourced from runtime @ 050adea8fc1016ff3cbde74edc5453e8fdad11be (verified 2026-06-30);
+// upstream last changed this file 2021-05-17. Adapted to SRM's ILOpCode.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 //
-// One-time port (not a live vendor branch). Upstream still receives
-// reliability/perf/security fixes to this helper — periodically diff against the
-// cited path and port them. See docs/design/instruction-substrate.md
-// ("dotnet/runtime heritage").
+// One-time copy, not a live vendor branch. Upstream still receives reliability/
+// perf/security fixes — pull them with a diff against the cited path at a newer
+// commit. See docs/design/instruction-substrate.md ("dotnet/runtime heritage").
 
 using System.Reflection.Metadata;
 

--- a/src/ILInspector.Instructions/ILOpcodeExtensions.cs
+++ b/src/ILInspector.Instructions/ILOpcodeExtensions.cs
@@ -67,6 +67,18 @@ internal static class ILOpcodeExtensions
     public static bool IsUnconditionalBranch(this ILOpCode opcode)
         => opcode is ILOpCode.Br or ILOpCode.Br_s or ILOpCode.Leave or ILOpCode.Leave_s;
 
+    /// <summary>Returns true if the opcode is a short-form branch (br.s..blt.un.s, leave.s).</summary>
+    public static bool IsShortBranch(this ILOpCode opcode)
+        => (opcode >= ILOpCode.Br_s && opcode <= ILOpCode.Blt_un_s) || opcode == ILOpCode.Leave_s;
+
+    /// <summary>
+    /// Returns true if the opcode is a prefix that must be followed by another instruction
+    /// (constrained., no., readonly., tail., unaligned., volatile.) — ECMA-335 Partition III.
+    /// </summary>
+    public static bool IsPrefix(this ILOpCode opcode)
+        => opcode is ILOpCode.Constrained or ILOpCode.Readonly or ILOpCode.Tail
+            or ILOpCode.Unaligned or ILOpCode.Volatile or (ILOpCode)0xFE19; // no.
+
     /// <summary>
     /// Maps ILOpCode to a linear index for lookup table access.
     /// Single-byte opcodes (0x00–0xFE) map directly; two-byte opcodes (0xFE00+)

--- a/src/ILInspector.Instructions/ILOpcodeExtensions.cs
+++ b/src/ILInspector.Instructions/ILOpcodeExtensions.cs
@@ -1,0 +1,323 @@
+// Ported from dotnet/runtime src/coreclr/tools/Common/TypeSystem/IL/ILOpcodeHelper.cs
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection.Metadata;
+
+namespace ILInspector.Instructions;
+
+/// <summary>
+/// Extension methods for <see cref="ILOpCode"/> providing size, validity, and branch classification.
+/// Ported from dotnet/runtime Internal.IL.ILOpcodeHelper, adapted to use BCL's ILOpCode enum.
+/// </summary>
+internal static class ILOpcodeExtensions
+{
+    private const byte VariableSize = 0xFF;
+    private const byte Invalid = 0xFE;
+
+    /// <summary>
+    /// Gets the size, in bytes, of the opcode and its arguments.
+    /// For <see cref="ILOpCode.Switch"/>, the caller must handle variable sizing separately.
+    /// </summary>
+    public static int GetInstructionSize(this ILOpCode opcode)
+    {
+        int index = GetIndex(opcode);
+        if ((uint)index >= (uint)s_opcodeSizes.Length)
+            return -1;
+        byte result = s_opcodeSizes[index];
+        return result is VariableSize or Invalid ? -1 : result;
+    }
+
+    /// <summary>
+    /// Returns true if the opcode is a valid IL opcode.
+    /// </summary>
+    public static bool IsValid(this ILOpCode opcode)
+    {
+        int index = GetIndex(opcode);
+        return (uint)index < (uint)s_opcodeSizes.Length
+            && s_opcodeSizes[index] != Invalid;
+    }
+
+    /// <summary>
+    /// Returns true if the opcode is a branch instruction (conditional or unconditional),
+    /// including leave/leave.s.
+    /// </summary>
+    public static bool IsBranch(this ILOpCode opcode)
+    {
+        if (opcode >= ILOpCode.Br && opcode <= ILOpCode.Blt_un)
+            return true;
+
+        if (opcode >= ILOpCode.Br_s && opcode <= ILOpCode.Blt_un_s)
+            return true;
+
+        if (opcode is ILOpCode.Leave_s or ILOpCode.Leave)
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns true if the opcode is an unconditional branch (br, br.s, leave, leave.s).
+    /// </summary>
+    public static bool IsUnconditionalBranch(this ILOpCode opcode)
+        => opcode is ILOpCode.Br or ILOpCode.Br_s or ILOpCode.Leave or ILOpCode.Leave_s;
+
+    /// <summary>
+    /// Maps ILOpCode to a linear index for lookup table access.
+    /// Single-byte opcodes (0x00–0xFE) map directly; two-byte opcodes (0xFE00+)
+    /// map to 0x100 + second byte (after the 0xFF entry for the prefix marker).
+    /// </summary>
+    static int GetIndex(ILOpCode opcode)
+    {
+        int value = (int)opcode;
+        if (value <= 0xFE)
+            return value;
+        if ((value & 0xFF00) == 0xFE00)
+            return 0x100 + (value & 0xFF);
+        return -1;
+    }
+
+    // Indexed by GetIndex(opcode). Values are total instruction size in bytes.
+    // VariableSize (0xFF) = switch; Invalid (0xFE) = not a valid opcode.
+    static readonly byte[] s_opcodeSizes =
+    [
+        1, // nop = 0x00
+        1, // break = 0x01
+        1, // ldarg.0 = 0x02
+        1, // ldarg.1 = 0x03
+        1, // ldarg.2 = 0x04
+        1, // ldarg.3 = 0x05
+        1, // ldloc.0 = 0x06
+        1, // ldloc.1 = 0x07
+        1, // ldloc.2 = 0x08
+        1, // ldloc.3 = 0x09
+        1, // stloc.0 = 0x0a
+        1, // stloc.1 = 0x0b
+        1, // stloc.2 = 0x0c
+        1, // stloc.3 = 0x0d
+        2, // ldarg.s = 0x0e
+        2, // ldarga.s = 0x0f
+        2, // starg.s = 0x10
+        2, // ldloc.s = 0x11
+        2, // ldloca.s = 0x12
+        2, // stloc.s = 0x13
+        1, // ldnull = 0x14
+        1, // ldc.i4.m1 = 0x15
+        1, // ldc.i4.0 = 0x16
+        1, // ldc.i4.1 = 0x17
+        1, // ldc.i4.2 = 0x18
+        1, // ldc.i4.3 = 0x19
+        1, // ldc.i4.4 = 0x1a
+        1, // ldc.i4.5 = 0x1b
+        1, // ldc.i4.6 = 0x1c
+        1, // ldc.i4.7 = 0x1d
+        1, // ldc.i4.8 = 0x1e
+        2, // ldc.i4.s = 0x1f
+        5, // ldc.i4 = 0x20
+        9, // ldc.i8 = 0x21
+        5, // ldc.r4 = 0x22
+        9, // ldc.r8 = 0x23
+        Invalid, // 0x24
+        1, // dup = 0x25
+        1, // pop = 0x26
+        5, // jmp = 0x27
+        5, // call = 0x28
+        5, // calli = 0x29
+        1, // ret = 0x2a
+        2, // br.s = 0x2b
+        2, // brfalse.s = 0x2c
+        2, // brtrue.s = 0x2d
+        2, // beq.s = 0x2e
+        2, // bge.s = 0x2f
+        2, // bgt.s = 0x30
+        2, // ble.s = 0x31
+        2, // blt.s = 0x32
+        2, // bne.un.s = 0x33
+        2, // bge.un.s = 0x34
+        2, // bgt.un.s = 0x35
+        2, // ble.un.s = 0x36
+        2, // blt.un.s = 0x37
+        5, // br = 0x38
+        5, // brfalse = 0x39
+        5, // brtrue = 0x3a
+        5, // beq = 0x3b
+        5, // bge = 0x3c
+        5, // bgt = 0x3d
+        5, // ble = 0x3e
+        5, // blt = 0x3f
+        5, // bne.un = 0x40
+        5, // bge.un = 0x41
+        5, // bgt.un = 0x42
+        5, // ble.un = 0x43
+        5, // blt.un = 0x44
+        VariableSize, // switch = 0x45
+        1, // ldind.i1 = 0x46
+        1, // ldind.u1 = 0x47
+        1, // ldind.i2 = 0x48
+        1, // ldind.u2 = 0x49
+        1, // ldind.i4 = 0x4a
+        1, // ldind.u4 = 0x4b
+        1, // ldind.i8 = 0x4c
+        1, // ldind.i = 0x4d
+        1, // ldind.r4 = 0x4e
+        1, // ldind.r8 = 0x4f
+        1, // ldind.ref = 0x50
+        1, // stind.ref = 0x51
+        1, // stind.i1 = 0x52
+        1, // stind.i2 = 0x53
+        1, // stind.i4 = 0x54
+        1, // stind.i8 = 0x55
+        1, // stind.r4 = 0x56
+        1, // stind.r8 = 0x57
+        1, // add = 0x58
+        1, // sub = 0x59
+        1, // mul = 0x5a
+        1, // div = 0x5b
+        1, // div.un = 0x5c
+        1, // rem = 0x5d
+        1, // rem.un = 0x5e
+        1, // and = 0x5f
+        1, // or = 0x60
+        1, // xor = 0x61
+        1, // shl = 0x62
+        1, // shr = 0x63
+        1, // shr.un = 0x64
+        1, // neg = 0x65
+        1, // not = 0x66
+        1, // conv.i1 = 0x67
+        1, // conv.i2 = 0x68
+        1, // conv.i4 = 0x69
+        1, // conv.i8 = 0x6a
+        1, // conv.r4 = 0x6b
+        1, // conv.r8 = 0x6c
+        1, // conv.u4 = 0x6d
+        1, // conv.u8 = 0x6e
+        5, // callvirt = 0x6f
+        5, // cpobj = 0x70
+        5, // ldobj = 0x71
+        5, // ldstr = 0x72
+        5, // newobj = 0x73
+        5, // castclass = 0x74
+        5, // isinst = 0x75
+        1, // conv.r.un = 0x76
+        Invalid, // 0x77
+        Invalid, // 0x78
+        5, // unbox = 0x79
+        1, // throw = 0x7a
+        5, // ldfld = 0x7b
+        5, // ldflda = 0x7c
+        5, // stfld = 0x7d
+        5, // ldsfld = 0x7e
+        5, // ldsflda = 0x7f
+        5, // stsfld = 0x80
+        5, // stobj = 0x81
+        1, // conv.ovf.i1.un = 0x82
+        1, // conv.ovf.i2.un = 0x83
+        1, // conv.ovf.i4.un = 0x84
+        1, // conv.ovf.i8.un = 0x85
+        1, // conv.ovf.u1.un = 0x86
+        1, // conv.ovf.u2.un = 0x87
+        1, // conv.ovf.u4.un = 0x88
+        1, // conv.ovf.u8.un = 0x89
+        1, // conv.ovf.i.un = 0x8a
+        1, // conv.ovf.u.un = 0x8b
+        5, // box = 0x8c
+        5, // newarr = 0x8d
+        1, // ldlen = 0x8e
+        5, // ldelema = 0x8f
+        1, // ldelem.i1 = 0x90
+        1, // ldelem.u1 = 0x91
+        1, // ldelem.i2 = 0x92
+        1, // ldelem.u2 = 0x93
+        1, // ldelem.i4 = 0x94
+        1, // ldelem.u4 = 0x95
+        1, // ldelem.i8 = 0x96
+        1, // ldelem.i = 0x97
+        1, // ldelem.r4 = 0x98
+        1, // ldelem.r8 = 0x99
+        1, // ldelem.ref = 0x9a
+        1, // stelem.i = 0x9b
+        1, // stelem.i1 = 0x9c
+        1, // stelem.i2 = 0x9d
+        1, // stelem.i4 = 0x9e
+        1, // stelem.i8 = 0x9f
+        1, // stelem.r4 = 0xa0
+        1, // stelem.r8 = 0xa1
+        1, // stelem.ref = 0xa2
+        5, // ldelem = 0xa3
+        5, // stelem = 0xa4
+        5, // unbox.any = 0xa5
+        Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, // 0xa6-0xae
+        Invalid, Invalid, Invalid, Invalid, // 0xaf-0xb2
+        1, // conv.ovf.i1 = 0xb3
+        1, // conv.ovf.u1 = 0xb4
+        1, // conv.ovf.i2 = 0xb5
+        1, // conv.ovf.u2 = 0xb6
+        1, // conv.ovf.i4 = 0xb7
+        1, // conv.ovf.u4 = 0xb8
+        1, // conv.ovf.i8 = 0xb9
+        1, // conv.ovf.u8 = 0xba
+        Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, // 0xbb-0xc1
+        5, // refanyval = 0xc2
+        1, // ckfinite = 0xc3
+        Invalid, Invalid, // 0xc4-0xc5
+        5, // mkrefany = 0xc6
+        Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, // 0xc7-0xcf
+        5, // ldtoken = 0xd0
+        1, // conv.u2 = 0xd1
+        1, // conv.u1 = 0xd2
+        1, // conv.i = 0xd3
+        1, // conv.ovf.i = 0xd4
+        1, // conv.ovf.u = 0xd5
+        1, // add.ovf = 0xd6
+        1, // add.ovf.un = 0xd7
+        1, // mul.ovf = 0xd8
+        1, // mul.ovf.un = 0xd9
+        1, // sub.ovf = 0xda
+        1, // sub.ovf.un = 0xdb
+        1, // endfinally = 0xdc
+        5, // leave = 0xdd
+        2, // leave.s = 0xde
+        1, // stind.i = 0xdf
+        1, // conv.u = 0xe0
+        Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, // 0xe1-0xe7
+        Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, // 0xe8-0xee
+        Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, // 0xef-0xf5
+        Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, Invalid, // 0xf6-0xfc
+        Invalid, // 0xfd
+        1, // prefix1 = 0xfe (marker only, not a real instruction)
+        Invalid, // 0xff
+        // Two-byte opcodes (0xFE00+), indexed at 0xFF + second byte
+        2, // arglist = 0xfe00
+        2, // ceq = 0xfe01
+        2, // cgt = 0xfe02
+        2, // cgt.un = 0xfe03
+        2, // clt = 0xfe04
+        2, // clt.un = 0xfe05
+        6, // ldftn = 0xfe06
+        6, // ldvirtftn = 0xfe07
+        Invalid, // 0xfe08
+        4, // ldarg = 0xfe09
+        4, // ldarga = 0xfe0a
+        4, // starg = 0xfe0b
+        4, // ldloc = 0xfe0c
+        4, // ldloca = 0xfe0d
+        4, // stloc = 0xfe0e
+        2, // localloc = 0xfe0f
+        Invalid, // 0xfe10
+        2, // endfilter = 0xfe11
+        3, // unaligned. = 0xfe12
+        2, // volatile. = 0xfe13
+        2, // tail. = 0xfe14
+        6, // initobj = 0xfe15
+        6, // constrained. = 0xfe16
+        2, // cpblk = 0xfe17
+        2, // initblk = 0xfe18
+        3, // no. = 0xfe19
+        2, // rethrow = 0xfe1a
+        Invalid, // 0xfe1b
+        6, // sizeof = 0xfe1c
+        2, // refanytype = 0xfe1d
+        2, // readonly. = 0xfe1e
+    ];
+}

--- a/src/ILInspector.Instructions/ILReader.cs
+++ b/src/ILInspector.Instructions/ILReader.cs
@@ -1,6 +1,9 @@
 // Ported from dotnet/runtime src/coreclr/tools/Common/TypeSystem/IL/ILReader.cs
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+//
+// One-time port: the IL opcode set is ECMA-335-frozen, so no upstream sync is
+// tracked. See docs/design/instruction-substrate.md ("dotnet/runtime heritage").
 
 using System.Buffers.Binary;
 using System.Diagnostics;

--- a/src/ILInspector.Instructions/ILReader.cs
+++ b/src/ILInspector.Instructions/ILReader.cs
@@ -1,11 +1,12 @@
 // Ported from dotnet/runtime src/coreclr/tools/Common/TypeSystem/IL/ILReader.cs
+// Sourced from runtime @ 050adea8fc1016ff3cbde74edc5453e8fdad11be (verified 2026-06-30);
+// upstream last changed this file 2024-07-01. Retargeted to SRM's ILOpCode.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 //
-// One-time port (not a live vendor branch). Upstream still receives
-// reliability/perf/security fixes to this reader — periodically diff against the
-// cited path and port them. See docs/design/instruction-substrate.md
-// ("dotnet/runtime heritage").
+// One-time copy, not a live vendor branch. Upstream still receives reliability/
+// perf/security fixes — pull them with a diff against the cited path at a newer
+// commit. See docs/design/instruction-substrate.md ("dotnet/runtime heritage").
 
 using System.Buffers.Binary;
 using System.Diagnostics;

--- a/src/ILInspector.Instructions/ILReader.cs
+++ b/src/ILInspector.Instructions/ILReader.cs
@@ -2,8 +2,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 //
-// One-time port: the IL opcode set is ECMA-335-frozen, so no upstream sync is
-// tracked. See docs/design/instruction-substrate.md ("dotnet/runtime heritage").
+// One-time port (not a live vendor branch). Upstream still receives
+// reliability/perf/security fixes to this reader — periodically diff against the
+// cited path and port them. See docs/design/instruction-substrate.md
+// ("dotnet/runtime heritage").
 
 using System.Buffers.Binary;
 using System.Diagnostics;

--- a/src/ILInspector.Instructions/ILReader.cs
+++ b/src/ILInspector.Instructions/ILReader.cs
@@ -1,0 +1,137 @@
+// Ported from dotnet/runtime src/coreclr/tools/Common/TypeSystem/IL/ILReader.cs
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Instructions;
+
+/// <summary>
+/// IL byte reader: decodes opcodes and operands from raw IL bytes. Ported
+/// from dotnet/runtime Internal.IL.ILReader (the same reader ILVerify and
+/// the ILC type system build on), retargeted to the BCL's ILOpCode enum and
+/// extended with peeking, skipping, and branch-destination helpers. Shared
+/// by both decompiler pipelines.
+/// </summary>
+internal ref struct ILReader
+{
+    private int _currentOffset;
+    private readonly ReadOnlySpan<byte> _ilBytes;
+    private readonly int _baseOffset;
+
+    public readonly int Offset => _currentOffset;
+    /// <summary>Absolute offset in the full IL stream (baseOffset + currentOffset).</summary>
+    public readonly int AbsoluteOffset => _baseOffset + _currentOffset;
+    public readonly int Size => _ilBytes.Length;
+    public readonly bool HasNext => _currentOffset < _ilBytes.Length;
+
+    public ILReader(ReadOnlySpan<byte> ilBytes, int currentOffset = 0, int baseOffset = 0)
+    {
+        _ilBytes = ilBytes;
+        _currentOffset = currentOffset;
+        _baseOffset = baseOffset;
+    }
+
+    public byte ReadILByte()
+    {
+        if (_currentOffset + 1 > _ilBytes.Length)
+            throw new InvalidProgramException();
+        return _ilBytes[_currentOffset++];
+    }
+
+    public ushort ReadILUInt16()
+    {
+        if (!BinaryPrimitives.TryReadUInt16LittleEndian(_ilBytes.Slice(_currentOffset), out ushort value))
+            throw new InvalidProgramException();
+        _currentOffset += sizeof(ushort);
+        return value;
+    }
+
+    public uint ReadILUInt32()
+    {
+        if (!BinaryPrimitives.TryReadUInt32LittleEndian(_ilBytes.Slice(_currentOffset), out uint value))
+            throw new InvalidProgramException();
+        _currentOffset += sizeof(uint);
+        return value;
+    }
+
+    public int ReadILToken() => (int)ReadILUInt32();
+
+    public ulong ReadILUInt64()
+    {
+        if (!BinaryPrimitives.TryReadUInt64LittleEndian(_ilBytes.Slice(_currentOffset), out ulong value))
+            throw new InvalidProgramException();
+        _currentOffset += sizeof(ulong);
+        return value;
+    }
+
+    public ILOpCode ReadILOpcode()
+    {
+        byte first = ReadILByte();
+        if (first == 0xFE)
+            return (ILOpCode)(0xFE00 | ReadILByte());
+        return (ILOpCode)first;
+    }
+
+    public readonly ILOpCode PeekILOpcode()
+    {
+        byte first = _ilBytes[_currentOffset];
+        if (first == 0xFE)
+        {
+            if (_currentOffset + 2 > _ilBytes.Length)
+                throw new InvalidProgramException();
+            return (ILOpCode)(0xFE00 | _ilBytes[_currentOffset + 1]);
+        }
+        return (ILOpCode)first;
+    }
+
+    /// <summary>
+    /// Skips past the operand of the given opcode, advancing the offset.
+    /// Returns false if the opcode is invalid or has variable size that couldn't be handled.
+    /// </summary>
+    public bool TrySkip(ILOpCode opcode)
+    {
+        if (opcode != ILOpCode.Switch)
+        {
+            int size = opcode.GetInstructionSize();
+            if (size < 0)
+                return false;
+            int opcodeSize = (int)opcode <= 0xFF ? 1 : 2;
+            _currentOffset += size - opcodeSize;
+            return true;
+        }
+        else
+        {
+            uint count = ReadILUInt32();
+            _currentOffset += checked((int)(count * 4));
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Skips past the operand of the given opcode, advancing the offset.
+    /// Throws if the opcode is invalid.
+    /// </summary>
+    public void Skip(ILOpCode opcode)
+    {
+        if (!TrySkip(opcode))
+            throw new InvalidProgramException($"Cannot skip invalid opcode {opcode}");
+    }
+
+    public void Seek(int offset) => _currentOffset = offset;
+
+    /// <summary>
+    /// Reads a branch destination offset, handling both short and long forms.
+    /// Returns the absolute IL offset of the branch target.
+    /// </summary>
+    public int ReadBranchDestination(ILOpCode opcode)
+    {
+        if ((opcode >= ILOpCode.Br_s && opcode <= ILOpCode.Blt_un_s) || opcode == ILOpCode.Leave_s)
+            return (sbyte)ReadILByte() + AbsoluteOffset;
+
+        Debug.Assert((opcode >= ILOpCode.Br && opcode <= ILOpCode.Blt_un) || opcode == ILOpCode.Leave);
+        return (int)ReadILUInt32() + AbsoluteOffset;
+    }
+}

--- a/src/ILInspector.Instructions/InstructionDecoder.cs
+++ b/src/ILInspector.Instructions/InstructionDecoder.cs
@@ -1,0 +1,169 @@
+using System.Buffers.Binary;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Instructions;
+
+/// <summary>
+/// Decodes a raw IL byte stream into a typed <see cref="DecodedInstruction"/> sequence.
+/// Mechanics (opcode read, operand sizing, branch destinations) are driven by the
+/// runtime-ported <see cref="ILReader"/> + opcode-size table, so prefixes (<c>no.</c>,
+/// <c>unaligned.</c>), two-byte opcodes, and short operand widths follow the same rules the
+/// JIT/ILVerify use. This is the one decode the typed-stack substrate owns; it is intended to
+/// replace the hand-rolled decoders in <c>ReachingDefinitions</c> and the decompiler importer.
+/// Malformed IL throws <see cref="BadImageFormatException"/>; the <see cref="MethodInstructions"/>
+/// façade converts that to a fail-closed incomplete result.
+/// </summary>
+public static class InstructionDecoder
+{
+    public static ImmutableArray<DecodedInstruction> Decode(byte[] il)
+    {
+        ArgumentNullException.ThrowIfNull(il);
+        var builder = ImmutableArray.CreateBuilder<DecodedInstruction>();
+        var reader = new ILReader(il);
+
+        while (reader.HasNext)
+        {
+            int offset = reader.Offset;
+            var opcode = reader.ReadILOpcode();
+            if (!opcode.IsValid())
+                throw new BadImageFormatException($"Invalid opcode 0x{(int)opcode:X} at IL_{offset:X4}");
+
+            int operandOffset = reader.Offset;
+            var kind = Classify(opcode);
+
+            long operandValue = 0;
+            var targets = ImmutableArray<int>.Empty;
+            bool branches = false;
+            bool unconditional = false;
+            bool exits = false;
+            bool leaves = false;
+
+            if (opcode == ILOpCode.Switch)
+            {
+                operandValue = ReadSwitchTargets(ref reader, offset, out targets);
+                branches = true;
+            }
+            else if (opcode.IsBranch())
+            {
+                targets = [reader.ReadBranchDestination(opcode)];
+                branches = true;
+                unconditional = opcode.IsUnconditionalBranch();
+                leaves = opcode is ILOpCode.Leave or ILOpCode.Leave_s;
+            }
+            else
+            {
+                operandValue = ReadOperandValue(il, operandOffset, kind, offset);
+                reader.Skip(opcode);
+                if (reader.Offset > il.Length)
+                    throw new BadImageFormatException($"Truncated operand at IL_{offset:X4}");
+                exits = opcode is ILOpCode.Ret or ILOpCode.Throw or ILOpCode.Rethrow or ILOpCode.Jmp
+                    or ILOpCode.Endfinally or ILOpCode.Endfilter;
+            }
+
+            int next = reader.Offset;
+            bool fallsThrough = !(exits || unconditional);
+
+            builder.Add(new DecodedInstruction(
+                offset, opcode, operandOffset, next, kind, operandValue,
+                targets, branches, unconditional, exits, fallsThrough, leaves));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    static long ReadSwitchTargets(ref ILReader reader, int offset, out ImmutableArray<int> targets)
+    {
+        uint count = reader.ReadILUInt32();
+        long tableEnd = (long)reader.Offset + (long)count * 4;
+        if (count > int.MaxValue / 4 || tableEnd > reader.Size)
+            throw new BadImageFormatException($"Malformed switch at IL_{offset:X4}");
+        int baseOffset = (int)tableEnd;
+        var builder = ImmutableArray.CreateBuilder<int>((int)count);
+        for (uint i = 0; i < count; i++)
+            builder.Add(baseOffset + (int)reader.ReadILUInt32());
+        targets = builder.MoveToImmutable();
+        return count;
+    }
+
+    /// <summary>
+    /// Reads the value of a non-branch, non-switch operand. Short variable/argument indices are
+    /// unsigned (ECMA-335); only <see cref="OperandKind.ShortInlineI"/> is a signed int8.
+    /// </summary>
+    static long ReadOperandValue(byte[] il, int operandOffset, OperandKind kind, int offset)
+    {
+        switch (kind)
+        {
+            case OperandKind.None:
+                return 0;
+            case OperandKind.ShortInlineVar:
+                return ReadU8(il, operandOffset, offset);
+            case OperandKind.ShortInlineI:
+                return (sbyte)ReadU8(il, operandOffset, offset);
+            case OperandKind.InlineVar:
+                return BinaryPrimitives.ReadUInt16LittleEndian(Slice(il, operandOffset, 2, offset));
+            case OperandKind.InlineI:
+            case OperandKind.ShortInlineR:
+            case OperandKind.InlineString:
+            case OperandKind.InlineMethod:
+            case OperandKind.InlineField:
+            case OperandKind.InlineType:
+            case OperandKind.InlineSig:
+            case OperandKind.InlineTok:
+                return BinaryPrimitives.ReadInt32LittleEndian(Slice(il, operandOffset, 4, offset));
+            case OperandKind.InlineI8:
+            case OperandKind.InlineR:
+                return BinaryPrimitives.ReadInt64LittleEndian(Slice(il, operandOffset, 8, offset));
+            default:
+                return 0;
+        }
+    }
+
+    static byte ReadU8(byte[] il, int operandOffset, int offset)
+    {
+        if ((uint)operandOffset >= (uint)il.Length)
+            throw new BadImageFormatException($"Truncated operand at IL_{offset:X4}");
+        return il[operandOffset];
+    }
+
+    static ReadOnlySpan<byte> Slice(byte[] il, int position, int size, int offset)
+    {
+        if (position < 0 || position + size > il.Length)
+            throw new BadImageFormatException($"Truncated operand at IL_{offset:X4}");
+        return il.AsSpan(position, size);
+    }
+
+    static OperandKind Classify(ILOpCode opcode) => opcode switch
+    {
+        ILOpCode.Ldarg_s or ILOpCode.Ldarga_s or ILOpCode.Starg_s
+            or ILOpCode.Ldloc_s or ILOpCode.Ldloca_s or ILOpCode.Stloc_s
+            => OperandKind.ShortInlineVar,
+        ILOpCode.Ldarg or ILOpCode.Ldarga or ILOpCode.Starg
+            or ILOpCode.Ldloc or ILOpCode.Ldloca or ILOpCode.Stloc
+            => OperandKind.InlineVar,
+
+        ILOpCode.Ldc_i4_s or ILOpCode.Unaligned => OperandKind.ShortInlineI,
+        ILOpCode.Ldc_i4 => OperandKind.InlineI,
+        ILOpCode.Ldc_i8 => OperandKind.InlineI8,
+        ILOpCode.Ldc_r4 => OperandKind.ShortInlineR,
+        ILOpCode.Ldc_r8 => OperandKind.InlineR,
+        ILOpCode.Ldstr => OperandKind.InlineString,
+
+        ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj or ILOpCode.Jmp
+            or ILOpCode.Ldftn or ILOpCode.Ldvirtftn
+            => OperandKind.InlineMethod,
+        ILOpCode.Calli => OperandKind.InlineSig,
+        ILOpCode.Ldfld or ILOpCode.Ldflda or ILOpCode.Stfld
+            or ILOpCode.Ldsfld or ILOpCode.Ldsflda or ILOpCode.Stsfld
+            => OperandKind.InlineField,
+        ILOpCode.Cpobj or ILOpCode.Ldobj or ILOpCode.Castclass or ILOpCode.Isinst
+            or ILOpCode.Unbox or ILOpCode.Unbox_any or ILOpCode.Stobj or ILOpCode.Box
+            or ILOpCode.Newarr or ILOpCode.Ldelema or ILOpCode.Ldelem or ILOpCode.Stelem
+            or ILOpCode.Refanyval or ILOpCode.Mkrefany or ILOpCode.Initobj
+            or ILOpCode.Constrained or ILOpCode.Sizeof
+            => OperandKind.InlineType,
+        ILOpCode.Ldtoken => OperandKind.InlineTok,
+
+        _ => OperandKind.None,
+    };
+}

--- a/src/ILInspector.Instructions/InstructionDecoder.cs
+++ b/src/ILInspector.Instructions/InstructionDecoder.cs
@@ -69,6 +69,12 @@ public static class InstructionDecoder
                 targets, branches, unconditional, exits, fallsThrough, leaves));
         }
 
+        // Fail closed on a dangling prefix: a prefix (tail./constrained./no./...) must be
+        // followed by another instruction, so the stream must not end on one.
+        if (builder.Count > 0 && builder[^1].OpCode.IsPrefix())
+            throw new BadImageFormatException(
+                $"IL ends with a dangling prefix at IL_{builder[^1].Offset:X4}");
+
         return builder.ToImmutable();
     }
 
@@ -142,7 +148,7 @@ public static class InstructionDecoder
             or ILOpCode.Ldloc or ILOpCode.Ldloca or ILOpCode.Stloc
             => OperandKind.InlineVar,
 
-        ILOpCode.Ldc_i4_s or ILOpCode.Unaligned => OperandKind.ShortInlineI,
+        ILOpCode.Ldc_i4_s or ILOpCode.Unaligned or (ILOpCode)0xFE19 => OperandKind.ShortInlineI, // 0xFE19 = no.
         ILOpCode.Ldc_i4 => OperandKind.InlineI,
         ILOpCode.Ldc_i8 => OperandKind.InlineI8,
         ILOpCode.Ldc_r4 => OperandKind.ShortInlineR,
@@ -163,6 +169,10 @@ public static class InstructionDecoder
             or ILOpCode.Constrained or ILOpCode.Sizeof
             => OperandKind.InlineType,
         ILOpCode.Ldtoken => OperandKind.InlineTok,
+
+        ILOpCode.Switch => OperandKind.InlineSwitch,
+        _ when opcode.IsShortBranch() => OperandKind.ShortInlineBrTarget,
+        _ when opcode.IsBranch() => OperandKind.InlineBrTarget,
 
         _ => OperandKind.None,
     };

--- a/src/ILInspector.Instructions/MetadataStackTypeResolver.cs
+++ b/src/ILInspector.Instructions/MetadataStackTypeResolver.cs
@@ -1,0 +1,158 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILInspector.Instructions;
+
+/// <summary>
+/// An SRM-backed <see cref="IStackTypeResolver"/>: resolves local/argument types from the method
+/// and local signatures, and field/element/call/newobj effects from metadata tokens. Stays inside
+/// the substrate boundary — it reads the one <see cref="MetadataReader"/> it was built from and
+/// never loads inspected assemblies. Cross-assembly type references coarsen to object-reference;
+/// generic parameters coarsen to <see cref="StackType.Unknown"/>. This is what lets the typed
+/// stack answer "what is the receiver type at this call?" for the demonstration.
+/// </summary>
+public sealed class MetadataStackTypeResolver : IStackTypeResolver
+{
+    readonly MetadataReader _reader;
+    readonly StackTypeSignatureProvider _provider;
+    readonly ImmutableArray<StackType> _arguments;
+    readonly ImmutableArray<StackType> _locals;
+
+    /// <summary>True when the owning method has a non-void return (so <c>ret</c> pops one value).</summary>
+    public bool MethodReturnsValue { get; }
+
+    MetadataStackTypeResolver(
+        MetadataReader reader,
+        StackTypeSignatureProvider provider,
+        ImmutableArray<StackType> arguments,
+        ImmutableArray<StackType> locals,
+        bool methodReturnsValue)
+    {
+        _reader = reader;
+        _provider = provider;
+        _arguments = arguments;
+        _locals = locals;
+        MethodReturnsValue = methodReturnsValue;
+    }
+
+    public static MetadataStackTypeResolver Create(MetadataReader reader, MethodDefinitionHandle method, MethodBodyBlock body)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(body);
+        var provider = new StackTypeSignatureProvider(reader);
+        var definition = reader.GetMethodDefinition(method);
+        var signature = definition.DecodeSignature(provider, null);
+
+        var arguments = ImmutableArray.CreateBuilder<StackType>();
+        if (signature.Header.IsInstance && !signature.Header.HasExplicitThis)
+            arguments.Add(provider.Classify(definition.GetDeclaringType()) == StackType.ValueType
+                ? StackType.ManagedPointer
+                : StackType.ObjectReference);
+        foreach (var parameter in signature.ParameterTypes)
+            arguments.Add(parameter.Stack);
+
+        var locals = ImmutableArray<StackType>.Empty;
+        if (!body.LocalSignature.IsNil)
+        {
+            var localSig = reader.GetStandaloneSignature(body.LocalSignature).DecodeLocalSignature(provider, null);
+            locals = [.. localSig.Select(t => t.Stack)];
+        }
+
+        return new MetadataStackTypeResolver(reader, provider, arguments.ToImmutable(), locals, !signature.ReturnType.IsVoid);
+    }
+
+    public StackType Argument(int index) => index >= 0 && index < _arguments.Length ? _arguments[index] : StackType.Unknown;
+
+    public StackType Local(int index) => index >= 0 && index < _locals.Length ? _locals[index] : StackType.Unknown;
+
+    public StackType Field(int fieldToken)
+    {
+        var handle = MetadataTokens.EntityHandle(fieldToken);
+        return handle.Kind switch
+        {
+            HandleKind.FieldDefinition => _reader.GetFieldDefinition((FieldDefinitionHandle)handle).DecodeSignature(_provider, null).Stack,
+            HandleKind.MemberReference => _reader.GetMemberReference((MemberReferenceHandle)handle).DecodeFieldSignature(_provider, null).Stack,
+            _ => StackType.Unknown,
+        };
+    }
+
+    public StackType TypeOfToken(int typeToken) => _provider.Classify(MetadataTokens.EntityHandle(typeToken));
+
+    public bool TryResolveCall(int methodToken, bool isNewObj, out int popCount, out bool pushes, out StackType pushType)
+    {
+        popCount = -1;
+        pushes = false;
+        pushType = StackType.Unknown;
+
+        if (!TryMethodInfo(MetadataTokens.EntityHandle(methodToken), out int paramCount, out bool hasThis, out var returnType, out var declaringType))
+            return false;
+
+        if (isNewObj)
+        {
+            popCount = paramCount;
+            pushes = true;
+            pushType = _provider.Classify(declaringType);
+            return true;
+        }
+
+        popCount = paramCount + (hasThis ? 1 : 0);
+        pushes = !returnType.IsVoid;
+        pushType = returnType.Stack;
+        return true;
+    }
+
+    public bool TryResolveCalli(int signatureToken, out int popCount, out bool pushes, out StackType pushType)
+    {
+        popCount = -1;
+        pushes = false;
+        pushType = StackType.Unknown;
+        var handle = MetadataTokens.EntityHandle(signatureToken);
+        if (handle.Kind != HandleKind.StandaloneSignature)
+            return false;
+        var signature = _reader.GetStandaloneSignature((StandaloneSignatureHandle)handle).DecodeMethodSignature(_provider, null);
+        popCount = signature.ParameterTypes.Length + (signature.Header.IsInstance && !signature.Header.HasExplicitThis ? 1 : 0);
+        pushes = !signature.ReturnType.IsVoid;
+        pushType = signature.ReturnType.Stack;
+        return true;
+    }
+
+    bool TryMethodInfo(EntityHandle handle, out int paramCount, out bool hasThis, out SigType returnType, out EntityHandle declaringType)
+    {
+        paramCount = 0;
+        hasThis = false;
+        returnType = SigType.Void;
+        declaringType = default;
+
+        switch (handle.Kind)
+        {
+            case HandleKind.MethodDefinition:
+            {
+                var definition = _reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+                var signature = definition.DecodeSignature(_provider, null);
+                paramCount = signature.ParameterTypes.Length;
+                hasThis = signature.Header.IsInstance && !signature.Header.HasExplicitThis;
+                returnType = signature.ReturnType;
+                declaringType = definition.GetDeclaringType();
+                return true;
+            }
+            case HandleKind.MemberReference:
+            {
+                var member = _reader.GetMemberReference((MemberReferenceHandle)handle);
+                var signature = member.DecodeMethodSignature(_provider, null);
+                paramCount = signature.ParameterTypes.Length;
+                hasThis = signature.Header.IsInstance && !signature.Header.HasExplicitThis;
+                returnType = signature.ReturnType;
+                declaringType = member.Parent;
+                return true;
+            }
+            case HandleKind.MethodSpecification:
+            {
+                var spec = _reader.GetMethodSpecification((MethodSpecificationHandle)handle);
+                return TryMethodInfo(spec.Method, out paramCount, out hasThis, out returnType, out declaringType);
+            }
+            default:
+                return false;
+        }
+    }
+}

--- a/src/ILInspector.Instructions/MetadataStackTypeResolver.cs
+++ b/src/ILInspector.Instructions/MetadataStackTypeResolver.cs
@@ -68,16 +68,27 @@ public sealed class MetadataStackTypeResolver : IStackTypeResolver
 
     public StackType Field(int fieldToken)
     {
-        var handle = MetadataTokens.EntityHandle(fieldToken);
-        return handle.Kind switch
+        try
         {
-            HandleKind.FieldDefinition => _reader.GetFieldDefinition((FieldDefinitionHandle)handle).DecodeSignature(_provider, null).Stack,
-            HandleKind.MemberReference => _reader.GetMemberReference((MemberReferenceHandle)handle).DecodeFieldSignature(_provider, null).Stack,
-            _ => StackType.Unknown,
-        };
+            var handle = MetadataTokens.EntityHandle(fieldToken);
+            return handle.Kind switch
+            {
+                HandleKind.FieldDefinition => _reader.GetFieldDefinition((FieldDefinitionHandle)handle).DecodeSignature(_provider, null).Stack,
+                HandleKind.MemberReference => _reader.GetMemberReference((MemberReferenceHandle)handle).DecodeFieldSignature(_provider, null).Stack,
+                _ => StackType.Unknown,
+            };
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            return StackType.Unknown; // fail closed: malformed/out-of-range token coarsens to Unknown
+        }
     }
 
-    public StackType TypeOfToken(int typeToken) => _provider.Classify(MetadataTokens.EntityHandle(typeToken));
+    public StackType TypeOfToken(int typeToken)
+    {
+        try { return _provider.Classify(MetadataTokens.EntityHandle(typeToken)); }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException) { return StackType.Unknown; }
+    }
 
     public bool TryResolveCall(int methodToken, bool isNewObj, out int popCount, out bool pushes, out StackType pushType)
     {
@@ -85,21 +96,31 @@ public sealed class MetadataStackTypeResolver : IStackTypeResolver
         pushes = false;
         pushType = StackType.Unknown;
 
-        if (!TryMethodInfo(MetadataTokens.EntityHandle(methodToken), out int paramCount, out bool hasThis, out var returnType, out var declaringType))
-            return false;
-
-        if (isNewObj)
+        try
         {
-            popCount = paramCount;
-            pushes = true;
-            pushType = _provider.Classify(declaringType);
+            if (!TryMethodInfo(MetadataTokens.EntityHandle(methodToken), out int paramCount, out bool hasThis, out var returnType, out var declaringType))
+                return false;
+
+            if (isNewObj)
+            {
+                popCount = paramCount;
+                pushes = true;
+                pushType = _provider.Classify(declaringType);
+                return true;
+            }
+
+            popCount = paramCount + (hasThis ? 1 : 0);
+            pushes = !returnType.IsVoid;
+            pushType = returnType.Stack;
             return true;
         }
-
-        popCount = paramCount + (hasThis ? 1 : 0);
-        pushes = !returnType.IsVoid;
-        pushType = returnType.Stack;
-        return true;
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            popCount = -1;
+            pushes = false;
+            pushType = StackType.Unknown;
+            return false; // fail closed on malformed/out-of-range token
+        }
     }
 
     public bool TryResolveCalli(int signatureToken, out int popCount, out bool pushes, out StackType pushType)
@@ -107,14 +128,24 @@ public sealed class MetadataStackTypeResolver : IStackTypeResolver
         popCount = -1;
         pushes = false;
         pushType = StackType.Unknown;
-        var handle = MetadataTokens.EntityHandle(signatureToken);
-        if (handle.Kind != HandleKind.StandaloneSignature)
+        try
+        {
+            var handle = MetadataTokens.EntityHandle(signatureToken);
+            if (handle.Kind != HandleKind.StandaloneSignature)
+                return false;
+            var signature = _reader.GetStandaloneSignature((StandaloneSignatureHandle)handle).DecodeMethodSignature(_provider, null);
+            popCount = signature.ParameterTypes.Length + (signature.Header.IsInstance && !signature.Header.HasExplicitThis ? 1 : 0);
+            pushes = !signature.ReturnType.IsVoid;
+            pushType = signature.ReturnType.Stack;
+            return true;
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            popCount = -1;
+            pushes = false;
+            pushType = StackType.Unknown;
             return false;
-        var signature = _reader.GetStandaloneSignature((StandaloneSignatureHandle)handle).DecodeMethodSignature(_provider, null);
-        popCount = signature.ParameterTypes.Length + (signature.Header.IsInstance && !signature.Header.HasExplicitThis ? 1 : 0);
-        pushes = !signature.ReturnType.IsVoid;
-        pushType = signature.ReturnType.Stack;
-        return true;
+        }
     }
 
     bool TryMethodInfo(EntityHandle handle, out int paramCount, out bool hasThis, out SigType returnType, out EntityHandle declaringType)

--- a/src/ILInspector.Instructions/MethodInstructions.cs
+++ b/src/ILInspector.Instructions/MethodInstructions.cs
@@ -80,7 +80,19 @@ public sealed record MethodInstructions(
     {
         ArgumentNullException.ThrowIfNull(reader);
         ArgumentNullException.ThrowIfNull(body);
-        var resolver = MetadataStackTypeResolver.Create(reader, method, body);
-        return InterpretStack(resolver.MethodReturnsValue, resolver);
+        try
+        {
+            var resolver = MetadataStackTypeResolver.Create(reader, method, body);
+            return InterpretStack(resolver.MethodReturnsValue, resolver);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or ArgumentException)
+        {
+            // Fail closed: a malformed method/local signature yields an incomplete typed stack, never a throw.
+            return new TypedStackResult(
+                Instructions, Blocks,
+                ImmutableDictionary<int, ImmutableArray<StackValue>>.Empty,
+                false,
+                $"metadata signature decode failed: {ex.Message}");
+        }
     }
 }

--- a/src/ILInspector.Instructions/MethodInstructions.cs
+++ b/src/ILInspector.Instructions/MethodInstructions.cs
@@ -24,7 +24,10 @@ public sealed record MethodInstructions(
         ArgumentNullException.ThrowIfNull(il);
         try
         {
-            var instructions = InstructionDecoder.Decode(il);
+            if ((uint)ilLength > (uint)il.Length)
+                throw new BadImageFormatException(
+                    $"Declared IL length {ilLength} exceeds the {il.Length}-byte buffer.");
+            var instructions = InstructionDecoder.Decode(ilLength == il.Length ? il : il[..ilLength]);
             var blocks = BlockGraph.Build(ilLength, instructions, exceptionRegions);
             return new MethodInstructions(instructions, blocks);
         }

--- a/src/ILInspector.Instructions/MethodInstructions.cs
+++ b/src/ILInspector.Instructions/MethodInstructions.cs
@@ -1,0 +1,83 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Instructions;
+
+/// <summary>
+/// Layer 0 of the substrate: one decode + one EH-aware block builder over a method body, plus
+/// offset-keyed lookup. Metadata-free and cheap — the recall-net surface that broad scans and
+/// the offset join (Research, <c>--il-offset</c>) share, and the de-dup target for the IL-level
+/// block finders. The typed evaluation stack (Layer 1) is <b>opt-in</b> via
+/// <see cref="InterpretStack(bool, IStackTypeResolver?)"/>, so it is never paid for unless a
+/// consumer escalates to it. SRM-only; no IrNode, structuring, C#, Roslyn, or assembly loading.
+/// </summary>
+public sealed record MethodInstructions(
+    ImmutableArray<DecodedInstruction> Instructions,
+    BlockGraph Blocks)
+{
+    /// <summary>True when decode + blocks completed (Layer 0). Does not imply a typed stack was computed.</summary>
+    public bool IsComplete => Blocks.IsComplete;
+
+    /// <summary>Layer 0: decode + EH-aware blocks from raw IL and exception regions. Fail-closed on malformed IL.</summary>
+    public static MethodInstructions Decode(byte[] il, int ilLength, IReadOnlyCollection<ExceptionRegion> exceptionRegions)
+    {
+        ArgumentNullException.ThrowIfNull(il);
+        try
+        {
+            var instructions = InstructionDecoder.Decode(il);
+            var blocks = BlockGraph.Build(ilLength, instructions, exceptionRegions);
+            return new MethodInstructions(instructions, blocks);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidProgramException)
+        {
+            // Fail closed: malformed IL produces an incomplete Layer 0 with a reason, never a throw.
+            return new MethodInstructions([], new BlockGraph([], [], IsComplete: false, ex.Message));
+        }
+    }
+
+    /// <summary>Layer 0 from a method body.</summary>
+    public static MethodInstructions Decode(MethodBodyBlock body)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        byte[] il = body.GetILBytes() ?? [];
+        return Decode(il, il.Length, body.ExceptionRegions);
+    }
+
+    /// <summary>
+    /// The instruction beginning exactly at <paramref name="offset"/>, or null if the offset is not an
+    /// instruction boundary (the validation <c>--il-offset</c> wants before resolving a token/offset).
+    /// </summary>
+    public DecodedInstruction? InstructionAt(int offset)
+    {
+        int lo = 0;
+        int hi = Instructions.Length - 1;
+        while (lo <= hi)
+        {
+            int mid = (lo + hi) >>> 1;
+            int start = Instructions[mid].Offset;
+            if (start == offset)
+                return Instructions[mid];
+            if (start < offset)
+                lo = mid + 1;
+            else
+                hi = mid - 1;
+        }
+        return null;
+    }
+
+    /// <summary>The index of the block containing <paramref name="offset"/>, or -1 if out of range.</summary>
+    public int BlockIndexAt(int offset) => Blocks.BlockIndexAt(offset);
+
+    /// <summary>Layer 1 (opt-in): the typed evaluation stack with provenance over this body.</summary>
+    public TypedStackResult InterpretStack(bool methodReturnsValue, IStackTypeResolver? resolver = null)
+        => StackTypeInterpreter.Interpret(Instructions, Blocks, methodReturnsValue, resolver);
+
+    /// <summary>Layer 1 convenience: typed stack wired to an SRM-backed resolver for <paramref name="method"/>.</summary>
+    public TypedStackResult InterpretStack(MetadataReader reader, MethodDefinitionHandle method, MethodBodyBlock body)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(body);
+        var resolver = MetadataStackTypeResolver.Create(reader, method, body);
+        return InterpretStack(resolver.MethodReturnsValue, resolver);
+    }
+}

--- a/src/ILInspector.Instructions/README.md
+++ b/src/ILInspector.Instructions/README.md
@@ -1,0 +1,55 @@
+# ILInspector.Instructions (prototype)
+
+A **prototype** of the gated Rung 5 typed-stack substrate from
+[issue #1908](https://github.com/richlander/dotnet-inspect/issues/1908): one
+`decode → typed instructions → typed-stack → EH-aware blocks` pipeline, intended
+to subsume the decode + block-building currently duplicated in
+`ReachingDefinitions.BuildBlocks` and the decompiler importer, and to add the one
+witness those copies cannot: **stack element types, receiver types, and stack
+value provenance**.
+
+This library is a **named, gated placeholder** per the
+[`ILInspector.Instructions` decision protocol](https://github.com/richlander/dotnet-inspect/issues/1908#issuecomment-4837663012):
+it is built as a candidate prototype and is **not wired into `Analysis` or the
+decompiler**. Convergence happens only after owner sign-off with measured
+evidence, exactly as the `ILInspector.Research` edge decision did.
+
+## Boundary (typed-stack exit only)
+
+SRM-only, NativeAOT-friendly, Roslyn-free. No `IrNode`, expression tree,
+structuring, C#, or inspected-assembly loading. The library reads the single
+`MetadataReader` it is handed and never loads referenced assemblies; cross-assembly
+type references coarsen to object-reference and generic parameters to `Unknown`.
+
+## Pieces
+
+| Type | Role |
+| --- | --- |
+| `InstructionDecoder` | The single IL decode → `DecodedInstruction` stream. |
+| `BlockGraph` | EH-aware basic blocks emitting `ControlFlow.BlockEdges` (ECMA-335 I §12.4). |
+| `StackType` / `StackValue` | The ECMA-335 III stack-type lattice and a slot = (type, producer offset). |
+| `StackTypeInterpreter` | Abstract typed-stack with merge-at-joins and seeded EH handler entries. |
+| `IStackTypeResolver` / `MetadataStackTypeResolver` | Metadata-light token resolution for the few effects that need it. |
+| `MethodInstructions` | Layer 0 façade: decode + blocks + offset→instruction/block lookup; typed stack is opt-in via `InterpretStack`. |
+
+The typed stack is **fail-closed**: any unresolved stack effect, height
+disagreement at a join, or underflow degrades the whole method result to
+`IsComplete == false` with a reason, rather than guessing — preserving the
+two-tier model (fast scan stays the recall net; typed-stack is the escalation
+path for candidates whose gate needs typed evidence).
+
+## Evidence (real run)
+
+Dogfooded read-only over `System.Private.CoreLib` (`net11.0`): **40,956 / 41,012**
+method bodies (99.9%) produced a complete typed stack, with 48,876 object-reference
+call operands tracked; the remaining bodies fail closed with an explicit reason.
+This is evidence the decode/blocks/typed-stack are robust on real-world IL — not a
+product wiring.
+
+## Tests
+
+```bash
+dotnet run --project src/ILInspector.Instructions.Tests -c Release
+```
+
+(xUnit v3 executable runner — use `dotnet run`, not `dotnet test`.)

--- a/src/ILInspector.Instructions/StackType.cs
+++ b/src/ILInspector.Instructions/StackType.cs
@@ -1,0 +1,71 @@
+namespace ILInspector.Instructions;
+
+/// <summary>
+/// The simplified evaluation-stack type lattice from ECMA-335 Partition III §1.1.4
+/// / §1.5 (the set of types a value can have while on the CLI evaluation stack).
+/// This is deliberately coarser than the full type system: it is exactly the
+/// information a typed-stack model supplies that raw-opcode heuristics cannot
+/// (stack element kind, receiver kind, managed-pointer vs object-reference
+/// distinction), and nothing more. It stays SRM-only and metadata-light: only
+/// token-dependent results (field/element/return types) need a resolver, and
+/// those degrade to <see cref="Unknown"/> rather than loading anything.
+/// </summary>
+public enum StackType
+{
+    /// <summary>No type known yet / merge of incompatible producers (lattice top).</summary>
+    Unknown = 0,
+
+    /// <summary>ECMA <c>int32</c> — also the home of <c>bool</c>, <c>char</c>, and sub-int integers once on the stack.</summary>
+    Int32,
+
+    /// <summary>ECMA <c>int64</c>.</summary>
+    Int64,
+
+    /// <summary>ECMA <c>native int</c> (<c>I</c>).</summary>
+    NativeInt,
+
+    /// <summary>ECMA <c>F</c> — native floating point (covers <c>float32</c>/<c>float64</c> on the stack).</summary>
+    Float,
+
+    /// <summary>ECMA <c>&amp;</c> — managed pointer (by-ref).</summary>
+    ManagedPointer,
+
+    /// <summary>ECMA <c>*</c> — unmanaged/transient pointer.</summary>
+    UnmanagedPointer,
+
+    /// <summary>ECMA <c>O</c> — object reference.</summary>
+    ObjectReference,
+
+    /// <summary>A value type instance carried on the stack (boxed shape is <see cref="ObjectReference"/>).</summary>
+    ValueType,
+
+    /// <summary>ECMA typed reference (<c>typedref</c> / <c>System.TypedReference</c>).</summary>
+    TypedReference,
+}
+
+public static class StackTypeExtensions
+{
+    /// <summary>
+    /// Lattice join used when two control-flow predecessors disagree about a slot.
+    /// Equal types are preserved; anything else widens to <see cref="StackType.Unknown"/>
+    /// (the conservative top), which is how the interpreter records "this slot is
+    /// not uniformly typed across all paths" without guessing.
+    /// </summary>
+    public static StackType Merge(this StackType left, StackType right)
+        => left == right ? left : StackType.Unknown;
+
+    /// <summary>The short ECMA glyph for compact dumps (<c>i4</c>, <c>O</c>, <c>&amp;</c>, ...).</summary>
+    public static string ToGlyph(this StackType type) => type switch
+    {
+        StackType.Int32 => "i4",
+        StackType.Int64 => "i8",
+        StackType.NativeInt => "i",
+        StackType.Float => "F",
+        StackType.ManagedPointer => "&",
+        StackType.UnmanagedPointer => "*",
+        StackType.ObjectReference => "O",
+        StackType.ValueType => "vt",
+        StackType.TypedReference => "typedref",
+        _ => "?",
+    };
+}

--- a/src/ILInspector.Instructions/StackTypeInterpreter.cs
+++ b/src/ILInspector.Instructions/StackTypeInterpreter.cs
@@ -144,9 +144,25 @@ public static class StackTypeInterpreter
 
         IEnumerable<DecodedInstruction> InstructionsIn(InstructionBlock block)
         {
-            foreach (var instruction in instructions)
-                if (instruction.Offset >= block.Start && instruction.Offset < block.End)
-                    yield return instruction;
+            // instructions is sorted by Offset (contiguous tiling), so binary-search the block's
+            // first instruction instead of scanning the whole method on every block evaluation —
+            // that scan made worklist convergence O(instructions × block-evaluations).
+            int lo = 0, hi = instructions.Length - 1, start = instructions.Length;
+            while (lo <= hi)
+            {
+                int mid = (lo + hi) >>> 1;
+                if (instructions[mid].Offset >= block.Start)
+                {
+                    start = mid;
+                    hi = mid - 1;
+                }
+                else
+                {
+                    lo = mid + 1;
+                }
+            }
+            for (int i = start; i < instructions.Length && instructions[i].Offset < block.End; i++)
+                yield return instructions[i];
         }
     }
 

--- a/src/ILInspector.Instructions/StackTypeInterpreter.cs
+++ b/src/ILInspector.Instructions/StackTypeInterpreter.cs
@@ -57,14 +57,15 @@ public static class StackTypeInterpreter
         if (instructions.IsDefaultOrEmpty)
             return new TypedStackResult(instructions, blocks, stackBefore.ToImmutable(), true, null);
 
-        var instructionsByOffset = instructions.ToDictionary(i => i.Offset);
         var blockEntry = new ImmutableArray<StackValue>?[blocks.Blocks.Length];
         var ehEntryBlocks = ExceptionEntryStacks(blocks);
 
         var worklist = new Queue<int>();
-        // Entry block starts empty; EH entry blocks seed from their handler kind.
+        // Entry block starts empty; EH entry blocks seed from their handler kind. Seed in
+        // ascending block order so the result — and any incomplete reason on malformed IL —
+        // is deterministic, independent of dictionary iteration order (NativeAOT/reproducibility).
         SeedEntry(0, []);
-        foreach (var (blockIndex, entry) in ehEntryBlocks)
+        foreach (var (blockIndex, entry) in ehEntryBlocks.OrderBy(kv => kv.Key))
             SeedEntry(blockIndex, entry);
 
         string? incompleteReason = null;

--- a/src/ILInspector.Instructions/StackTypeInterpreter.cs
+++ b/src/ILInspector.Instructions/StackTypeInterpreter.cs
@@ -1,0 +1,412 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Instructions;
+
+/// <summary>
+/// The per-instruction typed evaluation-stack states for one method body, plus completeness.
+/// <see cref="StackBefore"/> is keyed by IL offset; index 0 is the bottom of the stack.
+/// </summary>
+public sealed record TypedStackResult(
+    ImmutableArray<DecodedInstruction> Instructions,
+    BlockGraph Blocks,
+    ImmutableDictionary<int, ImmutableArray<StackValue>> StackBefore,
+    bool IsComplete,
+    string? IncompleteReason)
+{
+    /// <summary>The evaluation stack just before <paramref name="offset"/> executes (bottom-to-top), or empty if unreached.</summary>
+    public ImmutableArray<StackValue> StackBeforeOffset(int offset)
+        => StackBefore.TryGetValue(offset, out var stack) ? stack : [];
+
+    /// <summary>
+    /// The receiver slot of a <c>call</c>/<c>callvirt</c>/<c>newobj</c> at <paramref name="callOffset"/>,
+    /// resolved from the typed stack: the value <paramref name="argumentsBelow"/> slots below the top.
+    /// For an instance call with <c>n</c> non-<c>this</c> arguments, pass <c>n</c> to get <c>this</c>.
+    /// Returns <c>null</c> when the stack is too shallow (e.g. typed-stack incomplete).
+    /// </summary>
+    public StackValue? ReceiverAt(int callOffset, int argumentsBelow)
+    {
+        var stack = StackBeforeOffset(callOffset);
+        int index = stack.Length - 1 - argumentsBelow;
+        return index >= 0 && index < stack.Length ? stack[index] : null;
+    }
+}
+
+/// <summary>
+/// Abstract-interprets a decoded method body to a typed evaluation stack with value provenance.
+/// This is the witness a typed-stack model supplies that more opcode heuristics cannot: stack
+/// element types, receiver types, and which instruction produced each slot. Worklist over the
+/// EH-aware <see cref="BlockGraph"/>; predecessors are joined position-wise (<see cref="StackValue.Merge"/>);
+/// catch/filter handler entries start with the in-flight exception on the stack. Fail-closed:
+/// any unresolved stack effect or height conflict degrades the whole result to incomplete.
+/// </summary>
+public static class StackTypeInterpreter
+{
+    public static TypedStackResult Interpret(
+        ImmutableArray<DecodedInstruction> instructions,
+        BlockGraph blocks,
+        bool methodReturnsValue,
+        IStackTypeResolver? resolver = null)
+    {
+        resolver ??= DefaultStackTypeResolver.Instance;
+        var stackBefore = ImmutableDictionary.CreateBuilder<int, ImmutableArray<StackValue>>();
+
+        if (!blocks.IsComplete)
+            return new TypedStackResult(instructions, blocks, stackBefore.ToImmutable(), false,
+                blocks.IncompleteReason ?? "Block graph is incomplete.");
+        if (instructions.IsDefaultOrEmpty)
+            return new TypedStackResult(instructions, blocks, stackBefore.ToImmutable(), true, null);
+
+        var instructionsByOffset = instructions.ToDictionary(i => i.Offset);
+        var blockEntry = new ImmutableArray<StackValue>?[blocks.Blocks.Length];
+        var ehEntryBlocks = ExceptionEntryStacks(blocks);
+
+        var worklist = new Queue<int>();
+        // Entry block starts empty; EH entry blocks seed from their handler kind.
+        SeedEntry(0, []);
+        foreach (var (blockIndex, entry) in ehEntryBlocks)
+            SeedEntry(blockIndex, entry);
+
+        string? incompleteReason = null;
+
+        while (worklist.Count > 0)
+        {
+            int blockIndex = worklist.Dequeue();
+            var block = blocks.Blocks[blockIndex];
+            var stack = new List<StackValue>(blockEntry[blockIndex]!.Value);
+
+            foreach (var instruction in InstructionsIn(block))
+            {
+                stackBefore[instruction.Offset] = [.. stack];
+                string? reason = Transition(instruction, stack, resolver, methodReturnsValue);
+                if (reason is not null)
+                {
+                    incompleteReason ??= reason;
+                    return new TypedStackResult(instructions, blocks, stackBefore.ToImmutable(), false, incompleteReason);
+                }
+            }
+
+            var exit = stack.ToImmutableArray();
+            foreach (int successor in block.Edges.Successors)
+            {
+                if (ehEntryBlocks.ContainsKey(successor))
+                    continue; // EH entry stack is fixed by handler kind, not by the protected region's exit.
+                if (!Propagate(successor, exit, out string? mergeReason))
+                {
+                    incompleteReason ??= mergeReason;
+                    return new TypedStackResult(instructions, blocks, stackBefore.ToImmutable(), false, incompleteReason);
+                }
+            }
+        }
+
+        return new TypedStackResult(instructions, blocks, stackBefore.ToImmutable(), true, null);
+
+        void SeedEntry(int blockIndex, ImmutableArray<StackValue> entry)
+        {
+            if (blockEntry[blockIndex] is null)
+            {
+                blockEntry[blockIndex] = entry;
+                worklist.Enqueue(blockIndex);
+            }
+        }
+
+        bool Propagate(int successor, ImmutableArray<StackValue> incoming, out string? reason)
+        {
+            reason = null;
+            if (blockEntry[successor] is not { } existing)
+            {
+                blockEntry[successor] = incoming;
+                worklist.Enqueue(successor);
+                return true;
+            }
+            if (existing.Length != incoming.Length)
+            {
+                reason = $"Evaluation stack height disagreement entering block {successor} ({existing.Length} vs {incoming.Length}).";
+                return false;
+            }
+            var merged = ImmutableArray.CreateBuilder<StackValue>(existing.Length);
+            bool changed = false;
+            for (int i = 0; i < existing.Length; i++)
+            {
+                var m = existing[i].Merge(incoming[i]);
+                if (!m.Equals(existing[i]))
+                    changed = true;
+                merged.Add(m);
+            }
+            if (changed)
+            {
+                blockEntry[successor] = merged.MoveToImmutable();
+                worklist.Enqueue(successor);
+            }
+            return true;
+        }
+
+        IEnumerable<DecodedInstruction> InstructionsIn(InstructionBlock block)
+        {
+            foreach (var instruction in instructions)
+                if (instruction.Offset >= block.Start && instruction.Offset < block.End)
+                    yield return instruction;
+        }
+    }
+
+    static Dictionary<int, ImmutableArray<StackValue>> ExceptionEntryStacks(BlockGraph blocks)
+    {
+        var offsetToBlock = new Dictionary<int, int>();
+        for (int i = 0; i < blocks.Blocks.Length; i++)
+            offsetToBlock[blocks.Blocks[i].Start] = i;
+
+        var result = new Dictionary<int, ImmutableArray<StackValue>>();
+        foreach (var region in blocks.Regions)
+        {
+            // Catch and filter handlers begin with the in-flight exception object on the stack.
+            ImmutableArray<StackValue> exceptionStack = [StackValue.Of(StackType.ObjectReference, StackValue.NoProducer)];
+            switch (region.Kind)
+            {
+                case HandlerKind.Catch:
+                    if (offsetToBlock.TryGetValue(region.HandlerStart, out int catchBlock))
+                        result[catchBlock] = exceptionStack;
+                    break;
+                case HandlerKind.Filter:
+                    if (offsetToBlock.TryGetValue(region.FilterStart, out int filterBlock))
+                        result[filterBlock] = exceptionStack;
+                    if (offsetToBlock.TryGetValue(region.HandlerStart, out int filterHandlerBlock))
+                        result[filterHandlerBlock] = exceptionStack;
+                    break;
+                case HandlerKind.Finally:
+                case HandlerKind.Fault:
+                    if (offsetToBlock.TryGetValue(region.HandlerStart, out int handlerBlock))
+                        result[handlerBlock] = [];
+                    break;
+            }
+        }
+        return result;
+    }
+
+    /// <summary>Applies one instruction's ECMA-335 Partition III stack transition. Returns null on success, or a reason string on underflow / an unresolved effect.</summary>
+    static string? Transition(
+        DecodedInstruction instruction,
+        List<StackValue> stack,
+        IStackTypeResolver resolver,
+        bool methodReturnsValue)
+    {
+        var op = instruction.OpCode;
+        int at = instruction.Offset;
+
+        switch (op)
+        {
+            // ---- no stack effect / prefixes ----
+            case ILOpCode.Nop or ILOpCode.Break or ILOpCode.Volatile or ILOpCode.Tail
+                or ILOpCode.Unaligned or ILOpCode.Readonly or ILOpCode.Constrained or (ILOpCode)0xFE19
+                or ILOpCode.Br or ILOpCode.Br_s or ILOpCode.Jmp:
+                return null;
+
+            // ---- leave / endfinally empty the evaluation stack (ECMA-335 III) ----
+            case ILOpCode.Leave or ILOpCode.Leave_s or ILOpCode.Endfinally:
+                stack.Clear();
+                return null;
+
+            // ---- constants ----
+            case ILOpCode.Ldnull: return Push(StackType.ObjectReference);
+            case ILOpCode.Ldstr: return Push(StackType.ObjectReference);
+            case >= ILOpCode.Ldc_i4_m1 and <= ILOpCode.Ldc_i4_8: return Push(StackType.Int32);
+            case ILOpCode.Ldc_i4_s or ILOpCode.Ldc_i4: return Push(StackType.Int32);
+            case ILOpCode.Ldc_i8: return Push(StackType.Int64);
+            case ILOpCode.Ldc_r4 or ILOpCode.Ldc_r8: return Push(StackType.Float);
+            case ILOpCode.Sizeof: return Push(StackType.Int32);
+            case ILOpCode.Arglist: return Push(StackType.NativeInt);
+            case ILOpCode.Ldtoken: return Push(StackType.ValueType);
+
+            // ---- locals / arguments ----
+            case >= ILOpCode.Ldarg_0 and <= ILOpCode.Ldarg_3: return Push(resolver.Argument((int)op - (int)ILOpCode.Ldarg_0));
+            case ILOpCode.Ldarg_s or ILOpCode.Ldarg: return Push(resolver.Argument((int)instruction.OperandValue));
+            case ILOpCode.Ldarga_s or ILOpCode.Ldarga: return Push(StackType.ManagedPointer);
+            case >= ILOpCode.Ldloc_0 and <= ILOpCode.Ldloc_3: return Push(resolver.Local((int)op - (int)ILOpCode.Ldloc_0));
+            case ILOpCode.Ldloc_s or ILOpCode.Ldloc: return Push(resolver.Local((int)instruction.OperandValue));
+            case ILOpCode.Ldloca_s or ILOpCode.Ldloca: return Push(StackType.ManagedPointer);
+            case >= ILOpCode.Stloc_0 and <= ILOpCode.Stloc_3: return Pop(1);
+            case ILOpCode.Stloc_s or ILOpCode.Stloc or ILOpCode.Starg_s or ILOpCode.Starg: return Pop(1);
+
+            // ---- stack manipulation ----
+            case ILOpCode.Pop: return Pop(1);
+            case ILOpCode.Dup:
+                if (stack.Count == 0) return Underflow();
+                stack.Add(stack[^1] with { ProducerOffset = at });
+                return null;
+
+            // ---- fields ----
+            case ILOpCode.Ldsfld: return Push(resolver.Field((int)instruction.OperandValue));
+            case ILOpCode.Ldsflda: return Push(StackType.ManagedPointer);
+            case ILOpCode.Stsfld: return Pop(1);
+            case ILOpCode.Ldfld: return Replace(1, resolver.Field((int)instruction.OperandValue));
+            case ILOpCode.Ldflda: return Replace(1, StackType.ManagedPointer);
+            case ILOpCode.Stfld: return Pop(2);
+
+            // ---- function pointers ----
+            case ILOpCode.Ldftn: return Push(StackType.NativeInt);
+            case ILOpCode.Ldvirtftn: return Replace(1, StackType.NativeInt);
+
+            // ---- indirect ----
+            case ILOpCode.Ldind_i1 or ILOpCode.Ldind_u1 or ILOpCode.Ldind_i2 or ILOpCode.Ldind_u2
+                or ILOpCode.Ldind_i4 or ILOpCode.Ldind_u4:
+                return Replace(1, StackType.Int32);
+            case ILOpCode.Ldind_i8: return Replace(1, StackType.Int64);
+            case ILOpCode.Ldind_i: return Replace(1, StackType.NativeInt);
+            case ILOpCode.Ldind_r4 or ILOpCode.Ldind_r8: return Replace(1, StackType.Float);
+            case ILOpCode.Ldind_ref: return Replace(1, StackType.ObjectReference);
+            case ILOpCode.Stind_i1 or ILOpCode.Stind_i2 or ILOpCode.Stind_i4 or ILOpCode.Stind_i8
+                or ILOpCode.Stind_i or ILOpCode.Stind_r4 or ILOpCode.Stind_r8 or ILOpCode.Stind_ref:
+                return Pop(2);
+            case ILOpCode.Ldobj: return Replace(1, resolver.TypeOfToken((int)instruction.OperandValue));
+            case ILOpCode.Stobj or ILOpCode.Cpobj: return Pop(2);
+            case ILOpCode.Initobj: return Pop(1);
+
+            // ---- arithmetic / logic ----
+            case ILOpCode.Add or ILOpCode.Sub or ILOpCode.Mul or ILOpCode.Div or ILOpCode.Div_un
+                or ILOpCode.Rem or ILOpCode.Rem_un or ILOpCode.And or ILOpCode.Or or ILOpCode.Xor
+                or ILOpCode.Add_ovf or ILOpCode.Add_ovf_un or ILOpCode.Sub_ovf or ILOpCode.Sub_ovf_un
+                or ILOpCode.Mul_ovf or ILOpCode.Mul_ovf_un:
+                return BinaryNumeric();
+            case ILOpCode.Shl or ILOpCode.Shr or ILOpCode.Shr_un:
+                if (stack.Count < 2) return Underflow();
+                stack.RemoveAt(stack.Count - 1); // shift amount; result keeps the shifted value's type, already on top
+                return null;
+            case ILOpCode.Neg or ILOpCode.Not:
+                return stack.Count >= 1 ? null : Underflow();
+            case ILOpCode.Ceq or ILOpCode.Cgt or ILOpCode.Cgt_un or ILOpCode.Clt or ILOpCode.Clt_un:
+                return Reduce(2, StackType.Int32);
+            case ILOpCode.Ckfinite:
+                return Replace(1, StackType.Float);
+
+            // ---- conversions ----
+            case ILOpCode.Conv_i1 or ILOpCode.Conv_u1 or ILOpCode.Conv_i2 or ILOpCode.Conv_u2
+                or ILOpCode.Conv_i4 or ILOpCode.Conv_u4
+                or ILOpCode.Conv_ovf_i1 or ILOpCode.Conv_ovf_u1 or ILOpCode.Conv_ovf_i2 or ILOpCode.Conv_ovf_u2
+                or ILOpCode.Conv_ovf_i4 or ILOpCode.Conv_ovf_u4
+                or ILOpCode.Conv_ovf_i1_un or ILOpCode.Conv_ovf_u1_un or ILOpCode.Conv_ovf_i2_un or ILOpCode.Conv_ovf_u2_un
+                or ILOpCode.Conv_ovf_i4_un or ILOpCode.Conv_ovf_u4_un:
+                return Replace(1, StackType.Int32);
+            case ILOpCode.Conv_i8 or ILOpCode.Conv_u8 or ILOpCode.Conv_ovf_i8 or ILOpCode.Conv_ovf_u8
+                or ILOpCode.Conv_ovf_i8_un or ILOpCode.Conv_ovf_u8_un:
+                return Replace(1, StackType.Int64);
+            case ILOpCode.Conv_r4 or ILOpCode.Conv_r8 or ILOpCode.Conv_r_un:
+                return Replace(1, StackType.Float);
+            case ILOpCode.Conv_i or ILOpCode.Conv_u or ILOpCode.Conv_ovf_i or ILOpCode.Conv_ovf_u
+                or ILOpCode.Conv_ovf_i_un or ILOpCode.Conv_ovf_u_un:
+                return Replace(1, StackType.NativeInt);
+
+            // ---- object model ----
+            case ILOpCode.Box: return Replace(1, StackType.ObjectReference);
+            case ILOpCode.Unbox: return Replace(1, StackType.ManagedPointer);
+            case ILOpCode.Unbox_any: return Replace(1, resolver.TypeOfToken((int)instruction.OperandValue));
+            case ILOpCode.Castclass or ILOpCode.Isinst: return Replace(1, StackType.ObjectReference);
+            case ILOpCode.Newarr: return Replace(1, StackType.ObjectReference);
+            case ILOpCode.Ldlen: return Replace(1, StackType.NativeInt);
+            case ILOpCode.Ldelema: return Reduce(2, StackType.ManagedPointer);
+            case ILOpCode.Ldelem_i1 or ILOpCode.Ldelem_u1 or ILOpCode.Ldelem_i2 or ILOpCode.Ldelem_u2
+                or ILOpCode.Ldelem_i4 or ILOpCode.Ldelem_u4:
+                return Reduce(2, StackType.Int32);
+            case ILOpCode.Ldelem_i8: return Reduce(2, StackType.Int64);
+            case ILOpCode.Ldelem_i: return Reduce(2, StackType.NativeInt);
+            case ILOpCode.Ldelem_r4 or ILOpCode.Ldelem_r8: return Reduce(2, StackType.Float);
+            case ILOpCode.Ldelem_ref: return Reduce(2, StackType.ObjectReference);
+            case ILOpCode.Ldelem: return Reduce(2, resolver.TypeOfToken((int)instruction.OperandValue));
+            case ILOpCode.Stelem_i1 or ILOpCode.Stelem_i2 or ILOpCode.Stelem_i4 or ILOpCode.Stelem_i8
+                or ILOpCode.Stelem_i or ILOpCode.Stelem_r4 or ILOpCode.Stelem_r8 or ILOpCode.Stelem_ref
+                or ILOpCode.Stelem:
+                return Pop(3);
+            case ILOpCode.Mkrefany: return Replace(1, StackType.TypedReference);
+            case ILOpCode.Refanyval: return Replace(1, StackType.ManagedPointer);
+            case ILOpCode.Refanytype: return Replace(1, StackType.ValueType);
+            case ILOpCode.Localloc: return Replace(1, StackType.UnmanagedPointer);
+            case ILOpCode.Cpblk or ILOpCode.Initblk: return Pop(3);
+
+            // ---- calls ----
+            case ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj:
+            {
+                bool isNewObj = op == ILOpCode.Newobj;
+                if (!resolver.TryResolveCall((int)instruction.OperandValue, isNewObj, out int popCount, out bool pushes, out var pushType))
+                    return $"Unresolved {op} signature at IL_{at:X4}; typed stack cannot continue.";
+                if (Pop(popCount) is { } e) return e;
+                if (pushes) stack.Add(StackValue.Of(pushType, at));
+                return null;
+            }
+            case ILOpCode.Calli:
+            {
+                if (!resolver.TryResolveCalli((int)instruction.OperandValue, out int popCount, out bool pushes, out var pushType))
+                    return $"Unresolved calli signature at IL_{at:X4}; typed stack cannot continue.";
+                if (Pop(popCount + 1) is { } e) return e; // + function pointer
+                if (pushes) stack.Add(StackValue.Of(pushType, at));
+                return null;
+            }
+
+            // ---- branches / control transfer ----
+            case ILOpCode.Brfalse or ILOpCode.Brfalse_s or ILOpCode.Brtrue or ILOpCode.Brtrue_s
+                or ILOpCode.Switch:
+                return Pop(1);
+            case ILOpCode.Beq or ILOpCode.Beq_s or ILOpCode.Bne_un or ILOpCode.Bne_un_s
+                or ILOpCode.Bge or ILOpCode.Bge_s or ILOpCode.Bge_un or ILOpCode.Bge_un_s
+                or ILOpCode.Bgt or ILOpCode.Bgt_s or ILOpCode.Bgt_un or ILOpCode.Bgt_un_s
+                or ILOpCode.Ble or ILOpCode.Ble_s or ILOpCode.Ble_un or ILOpCode.Ble_un_s
+                or ILOpCode.Blt or ILOpCode.Blt_s or ILOpCode.Blt_un or ILOpCode.Blt_un_s:
+                return Pop(2);
+            case ILOpCode.Throw: return Pop(1);
+            case ILOpCode.Rethrow: return null;
+            case ILOpCode.Endfilter: return Pop(1);
+            case ILOpCode.Ret: return methodReturnsValue ? Pop(1) : null;
+
+            default:
+                return $"Unsupported opcode {op} at IL_{at:X4} for typed-stack tracking.";
+        }
+
+        // ---- local helpers (null = success, non-null = failure reason) ----
+        string? Push(StackType type)
+        {
+            stack.Add(StackValue.Of(type, at));
+            return null;
+        }
+        string? Pop(int count)
+        {
+            if (count < 0 || stack.Count < count) return Underflow();
+            stack.RemoveRange(stack.Count - count, count);
+            return null;
+        }
+        // Pop `count` and push one value of `type` (produced here); also serves "replace top".
+        string? Reduce(int count, StackType type) => Pop(count) ?? Push(type);
+        string? Replace(int count, StackType type) => Reduce(count, type);
+        string? BinaryNumeric()
+        {
+            if (stack.Count < 2) return Underflow();
+            var b = stack[^1];
+            var a = stack[^2];
+            stack.RemoveRange(stack.Count - 2, 2);
+            return Push(BinaryNumericResult(a.Type, b.Type, op));
+        }
+        string Underflow() => $"Evaluation stack underflow at IL_{at:X4} ({op}).";
+    }
+
+    /// <summary>ECMA-335 Partition III §1.5 binary numeric result type (coarsened to the stack lattice).</summary>
+    static StackType BinaryNumericResult(StackType a, StackType b, ILOpCode op)
+    {
+        if (a == StackType.Unknown || b == StackType.Unknown)
+            return StackType.Unknown;
+
+        bool aPtr = a is StackType.ManagedPointer or StackType.UnmanagedPointer;
+        bool bPtr = b is StackType.ManagedPointer or StackType.UnmanagedPointer;
+        bool isAdd = op is ILOpCode.Add or ILOpCode.Add_ovf or ILOpCode.Add_ovf_un;
+        bool isSub = op is ILOpCode.Sub or ILOpCode.Sub_ovf or ILOpCode.Sub_ovf_un;
+
+        // ECMA-335 III.1.5: pointer arithmetic is only add/sub. & - & -> native int; ptr +/- int -> ptr;
+        // int + ptr -> ptr (add is commutative); anything else with a pointer operand is invalid.
+        if (aPtr && bPtr)
+            return isSub ? StackType.NativeInt : StackType.Unknown;
+        if (aPtr)
+            return isAdd || isSub ? a : StackType.Unknown;
+        if (bPtr)
+            return isAdd ? b : StackType.Unknown;
+
+        if (a == b) return a; // i4/i4, i8/i8, F/F, I/I
+        if ((a == StackType.Int32 && b == StackType.NativeInt) || (a == StackType.NativeInt && b == StackType.Int32))
+            return StackType.NativeInt;
+        return StackType.Unknown;
+    }
+}

--- a/src/ILInspector.Instructions/StackTypeSignatureProvider.cs
+++ b/src/ILInspector.Instructions/StackTypeSignatureProvider.cs
@@ -1,0 +1,91 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Instructions;
+
+/// <summary>A decoded signature type carried as its evaluation-stack lattice form, keeping <c>void</c> distinct from <see cref="StackType.Unknown"/>.</summary>
+public readonly record struct SigType(StackType Stack, bool IsVoid)
+{
+    public static readonly SigType Void = new(StackType.Unknown, true);
+    public static SigType Of(StackType stack) => new(stack, false);
+}
+
+/// <summary>
+/// Maps SRM signature elements to the coarse <see cref="StackType"/> lattice. Stays metadata-light:
+/// it never resolves across assemblies. Value-type vs object-reference is decided from a
+/// <see cref="TypeDefinition"/>'s base type when available; cross-assembly references default to
+/// object-reference (the honest coarse answer for the receiver-type demonstration).
+/// </summary>
+internal sealed class StackTypeSignatureProvider : ISignatureTypeProvider<SigType, object?>
+{
+    readonly MetadataReader _reader;
+
+    public StackTypeSignatureProvider(MetadataReader reader) => _reader = reader;
+
+    public SigType GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode switch
+    {
+        PrimitiveTypeCode.Boolean or PrimitiveTypeCode.Char
+            or PrimitiveTypeCode.SByte or PrimitiveTypeCode.Byte
+            or PrimitiveTypeCode.Int16 or PrimitiveTypeCode.UInt16
+            or PrimitiveTypeCode.Int32 or PrimitiveTypeCode.UInt32 => SigType.Of(StackType.Int32),
+        PrimitiveTypeCode.Int64 or PrimitiveTypeCode.UInt64 => SigType.Of(StackType.Int64),
+        PrimitiveTypeCode.IntPtr or PrimitiveTypeCode.UIntPtr => SigType.Of(StackType.NativeInt),
+        PrimitiveTypeCode.Single or PrimitiveTypeCode.Double => SigType.Of(StackType.Float),
+        PrimitiveTypeCode.String or PrimitiveTypeCode.Object => SigType.Of(StackType.ObjectReference),
+        PrimitiveTypeCode.TypedReference => SigType.Of(StackType.TypedReference),
+        PrimitiveTypeCode.Void => SigType.Void,
+        _ => SigType.Of(StackType.Unknown),
+    };
+
+    public SigType GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+        => SigType.Of(ClassifyDefinition(handle));
+
+    public SigType GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+        => SigType.Of(StackType.ObjectReference);
+
+    public SigType GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+        => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+
+    public SigType GetSZArrayType(SigType elementType) => SigType.Of(StackType.ObjectReference);
+    public SigType GetArrayType(SigType elementType, ArrayShape shape) => SigType.Of(StackType.ObjectReference);
+    public SigType GetPointerType(SigType elementType) => SigType.Of(StackType.UnmanagedPointer);
+    public SigType GetByReferenceType(SigType elementType) => SigType.Of(StackType.ManagedPointer);
+    public SigType GetPinnedType(SigType elementType) => elementType;
+    public SigType GetFunctionPointerType(MethodSignature<SigType> signature) => SigType.Of(StackType.NativeInt);
+    public SigType GetGenericInstantiation(SigType genericType, ImmutableArray<SigType> typeArguments) => genericType;
+    public SigType GetGenericMethodParameter(object? genericContext, int index) => SigType.Of(StackType.Unknown);
+    public SigType GetGenericTypeParameter(object? genericContext, int index) => SigType.Of(StackType.Unknown);
+    public SigType GetModifiedType(SigType modifier, SigType unmodifiedType, bool isRequired) => unmodifiedType;
+
+    /// <summary>Classifies a type token (TypeDef/Ref/Spec) to its stack lattice form.</summary>
+    public StackType Classify(EntityHandle handle) => handle.Kind switch
+    {
+        HandleKind.TypeDefinition => ClassifyDefinition((TypeDefinitionHandle)handle),
+        HandleKind.TypeReference => StackType.ObjectReference,
+        HandleKind.TypeSpecification => _reader.GetTypeSpecification((TypeSpecificationHandle)handle).DecodeSignature(this, null).Stack,
+        _ => StackType.Unknown,
+    };
+
+    StackType ClassifyDefinition(TypeDefinitionHandle handle)
+    {
+        var definition = _reader.GetTypeDefinition(handle);
+        if (definition.BaseType.IsNil)
+            return StackType.ObjectReference;
+        var (ns, name) = BaseTypeName(definition.BaseType);
+        return ns == "System" && name is "ValueType" or "Enum"
+            ? StackType.ValueType
+            : StackType.ObjectReference;
+    }
+
+    (string Namespace, string Name) BaseTypeName(EntityHandle baseType) => baseType.Kind switch
+    {
+        HandleKind.TypeReference => Names(_reader.GetTypeReference((TypeReferenceHandle)baseType).Namespace,
+            _reader.GetTypeReference((TypeReferenceHandle)baseType).Name),
+        HandleKind.TypeDefinition => Names(_reader.GetTypeDefinition((TypeDefinitionHandle)baseType).Namespace,
+            _reader.GetTypeDefinition((TypeDefinitionHandle)baseType).Name),
+        _ => ("", ""),
+    };
+
+    (string, string) Names(StringHandle ns, StringHandle name)
+        => (_reader.GetString(ns), _reader.GetString(name));
+}

--- a/src/ILInspector.Instructions/StackValue.cs
+++ b/src/ILInspector.Instructions/StackValue.cs
@@ -1,0 +1,75 @@
+namespace ILInspector.Instructions;
+
+/// <summary>
+/// One abstract evaluation-stack slot: its <see cref="StackType"/> plus the IL offset of the
+/// instruction that produced it (<see cref="ProducerOffset"/>). The producer offset is the
+/// "stack value provenance" the gate-decision protocol calls out — it is purely structural,
+/// needs no metadata, and lets a consumer answer "which instruction created the receiver of
+/// this call?" without re-running an abstract interpreter.
+/// </summary>
+public readonly record struct StackValue(StackType Type, int ProducerOffset)
+{
+    /// <summary>A slot whose producer is unknown (e.g. an EH-injected exception, or a merge of disagreeing paths).</summary>
+    public const int NoProducer = -1;
+
+    public static StackValue Of(StackType type, int producerOffset) => new(type, producerOffset);
+
+    /// <summary>Position-wise lattice join of two stack slots from different predecessors.</summary>
+    public StackValue Merge(StackValue other)
+        => new(Type.Merge(other.Type), ProducerOffset == other.ProducerOffset ? ProducerOffset : NoProducer);
+
+    public override string ToString()
+        => ProducerOffset == NoProducer ? Type.ToGlyph() : $"{Type.ToGlyph()}@IL_{ProducerOffset:X4}";
+}
+
+/// <summary>
+/// Resolves the few stack effects that genuinely need metadata: local/argument types, field
+/// and element types, and call/newobj/calli signatures (argument counts + return type). Kept
+/// behind an interface so the interpreter stays metadata-light: the default resolver answers
+/// <see cref="StackType.Unknown"/> for everything and reports unresolved calls, which degrades
+/// the typed-stack to incomplete rather than guessing. Token-resolving consumers (Analysis,
+/// later the decompiler) supply a real SRM-backed resolver — see <c>MetadataStackTypeResolver</c>.
+/// </summary>
+public interface IStackTypeResolver
+{
+    /// <summary>The declared stack type of local slot <paramref name="index"/>.</summary>
+    StackType Local(int index) => StackType.Unknown;
+
+    /// <summary>The declared stack type of argument slot <paramref name="index"/> (slot 0 is <c>this</c> for instance methods).</summary>
+    StackType Argument(int index) => StackType.Unknown;
+
+    /// <summary>The stack type of the field named by a field token.</summary>
+    StackType Field(int fieldToken) => StackType.Unknown;
+
+    /// <summary>The stack type named by a type token (for <c>newobj</c> value types, <c>ldobj</c>, <c>ldelem</c> token form).</summary>
+    StackType TypeOfToken(int typeToken) => StackType.Unknown;
+
+    /// <summary>
+    /// Resolves a <c>call</c>/<c>callvirt</c>/<c>newobj</c> by method token: the number of values it pops
+    /// and the stack type it pushes (or <see cref="StackType.Unknown"/> and <c>pushes=false</c> for void).
+    /// For <c>newobj</c>, <paramref name="popCount"/> is the constructor's parameter count (no <c>this</c>)
+    /// and it always pushes the constructed type.
+    /// </summary>
+    bool TryResolveCall(int methodToken, bool isNewObj, out int popCount, out bool pushes, out StackType pushType)
+    {
+        popCount = -1;
+        pushes = false;
+        pushType = StackType.Unknown;
+        return false;
+    }
+
+    /// <summary>Resolves a <c>calli</c> by standalone-signature token (pop count excludes the function pointer).</summary>
+    bool TryResolveCalli(int signatureToken, out int popCount, out bool pushes, out StackType pushType)
+    {
+        popCount = -1;
+        pushes = false;
+        pushType = StackType.Unknown;
+        return false;
+    }
+}
+
+/// <summary>A resolver that knows nothing; every token-dependent slot becomes <see cref="StackType.Unknown"/>.</summary>
+public sealed class DefaultStackTypeResolver : IStackTypeResolver
+{
+    public static readonly DefaultStackTypeResolver Instance = new();
+}


### PR DESCRIPTION
## Summary

Introduces **`ILInspector.Instructions`**, a single SRM-only IL decode +
exception-handling-aware basic-block substrate that the analyzer and decompiler
can converge onto, replacing per-consumer hand-rolled IL decoders.

**This PR is purely additive.** Nothing in the shipping product references the
substrate yet, so there is **no behavior change**. It is the foundation the
follow-up PRs build on:

- **PR2** cuts `ReachingDefinitions` over to the substrate (deletes its duplicate
  decoder).
- **PR3** ships the first product consumer (PDB-free `--il-offset` call-site
  naming).

Once this lands, the remaining reader consolidations (`LibraryBodyIndex`,
the decompiler importer's `FindLeaders`, `ILDisassembler`) become independent,
parallelizable follow-ups.

Tracker: #1939 (gate #1908).

## What's in it

- **Layer 0** — `InstructionDecoder` + `BlockGraph`: decode + EH-aware basic
  blocks, driven by a runtime-ported `ILReader`/`ILOpcodeExtensions`
  (SRM-retargeted, MIT headers). Fail-closed on malformed IL.
- **Layer 1 (gated)** — `StackTypeInterpreter` + `MetadataStackTypeResolver`
  typed stack. **Not triggered by any product path** (#1941 measured zero
  residue); reserved for memory-safety lifetime work.
- `MethodInstructions` façade with offset→instruction and offset→block lookup.
- **Fidelity gates** — decode tiling / branch-target alignment, re-encode
  round-trip, and MaxStack invariants over CoreLib.
- **Characterization** — `SubstrateLeaderDifferentialTests` shows the decompiler
  importer's `FindLeaders` set is a strict subset of the substrate's EH-aware
  leaders (41,012 methods; substrate 147,030 leaders vs importer 117,177; 29,853
  EH-instruction leaders the importer misses).
- Design doc `docs/design/instruction-substrate.md` + overview link.

## dotnet/runtime heritage

The byte reader is **ported from `dotnet/runtime`** — the same
`Internal.IL.ILReader` / `ILOpcodeHelper` that ILVerify and the ILC type system
build on — so dotnet-org reviewers recognize the shape and the table-driven
opcode sizing is correct by construction. Provenance is in the MIT file headers;
full detail in `docs/design/instruction-substrate.md` ("dotnet/runtime heritage
and upstream tracking").

- **Adopted** (ported, SRM-retargeted): the `ILReader` byte cursor and the
  `ILOpcodeHelper` opcode-size table.
- **Diverged** (recognizable shape, our idioms): `record` / `ImmutableArray` /
  fail-closed over mutable structs; a `MethodInstructions` façade + callbacks
  instead of `ILImporter` partial-class composition.
- **Not used**: `Internal.TypeSystem` (`TypeDesc`/`MethodDesc`) — we stay
  SRM-only and never vendor the runtime type system; and the runtime's
  per-consumer typed stacks (RyuJIT `GenTree`, ILVerify `StackValue`) — unlike
  consumers each build their own Layer 1.

**Source.** Copied from the local `dotnet/runtime` checkout at commit
[`050adea8fc10`](https://github.com/dotnet/runtime/commit/050adea8fc1016ff3cbde74edc5453e8fdad11be),
and verified our copy matches it (the opcode size-value table is byte-for-byte
identical; `ILReader` matches modulo our documented divergences). Both files are
years old and unchanged since — which is the whole tracking story:

| Upstream file (pinned to the source commit) | Our file | Last changed upstream |
| --- | --- | --- |
| [`ILReader.cs`](https://github.com/dotnet/runtime/blob/050adea8fc1016ff3cbde74edc5453e8fdad11be/src/coreclr/tools/Common/TypeSystem/IL/ILReader.cs) | `ILReader.cs` | 2024-07-01 |
| [`ILOpcodeHelper.cs`](https://github.com/dotnet/runtime/blob/050adea8fc1016ff3cbde74edc5453e8fdad11be/src/coreclr/tools/Common/TypeSystem/IL/ILOpcodeHelper.cs) | `ILOpcodeExtensions.cs` | 2021-05-17 |

**Upstream tracking is light, by construction** — because of *what* we took. The
**opcode size table** is the bulk of the port: a 1:1 transcription of ECMA-335's
opcode/operand definitions, i.e. frozen data that doesn't change. The **reader**
is mostly thin glue over SRM/BCL `BinaryPrimitives` + spans — we *rebuilt* it on
SRM rather than borrowing runtime's implementation, so runtime's
implementation-level perf/reliability fixes mostly don't transfer (the one perf
change in five years, Spanify 2024-02, we already match — our reader is a `ref
struct` over `ReadOnlySpan<byte>`). The only thing worth watching is a logic bug
in the small sliver of ECMA decode behaviour we mirror (two-byte `0xFE` opcodes,
`Skip`, branch-target math) — caught continuously by the tiling/round-trip gates.
So it is a one-time *copy* (not a live vendor branch like the forked
ILAssembler): the pinned source commit makes that an occasional cheap diff, not
active vendoring.

## CI

Adds a `Run instruction-substrate tests` step. There is **no solution file** in
this repo — CI runs each test project explicitly — and since no product project
references the substrate yet, `dotnet build src/dotnet-inspect` won't compile it
transitively. The new test project's run step is therefore the only thing that
builds and exercises the substrate in CI.

## Perf

Measured on an idle 24-core host, Release, over CoreLib (41,159 method bodies),
5 invocations × 5 internal passes (variance ±2%). "Old" is the
`ReachingDefinitions` decoder this substrate is built to replace; the comparison
was run at the pre-cutover commit where both coexist.

| Path | Old (ReachingDefinitions) | New (substrate) | Change |
| --- | --- | --- | --- |
| decode-only | N/A¹ | 11 ms/pass | N/A |
| decode + blocks | ~77 ms/pass | ~62 ms/pass | **−19% (faster)** |
| decode + blocks + typed-stack | N/A² | ~275 ms/pass (gated) | N/A |

¹ The old `ReachingDefinitions` fused decoding into its `Analyze` pass and
exposed no reusable decode-only entry point, so there is no old baseline. The
Layer-0 split (a standalone `InstructionDecoder.Decode`) is a new capability.

² The old system had no typed evaluation stack; this gated Layer-1 interpreter
has no predecessor and is not on any product path.

The live benchmark + repro lands with the cutover (**PR2**), where replacing the
RD decoder is the change under test; here the numbers are motivation for the
foundation.

## Validation

- `ILInspector.Instructions.Tests`: **15/15** green.
- `SubstrateLeaderDifferentialTests` (in `ILInspector.Decompiler.Tests`): green.
- `markdownlint`: clean.

## Review

Requesting **3 adversarial reviews** (GPT-5.5, Gemini 3.1 Pro, MAI-Code-1-Flash).
Attack points: decoder correctness vs ECMA-335 (prefixes, switch, short-form
operands, EH region boundaries), round-trip/tiling gate soundness, fail-closed
behavior on malformed IL, and the ported `ILReader` retargeting.

