### PR TITLE
Document union discovery in integrations skill

### DIFF
--- a/skills/relationships/SKILL.md
+++ b/skills/relationships/SKILL.md
@@ -57,8 +57,17 @@ dnx dotnet-inspect -y -- member string IndexOf:7 -S Callers --caller-package Sys
 
 `-S @Integrations` on `library` or `package --library` rolls up the ecosystem
 frameworks a library plugs into — DI, hosting, ASP.NET Core, AI, OpenTelemetry,
-configuration, logging, and more — plus `Integration Opportunities`.
+configuration, logging, and more — plus `Integration Opportunities` and
+language/runtime integration signals like C# union types.
 
 ```bash
 dnx dotnet-inspect -y -- package Microsoft.Extensions.AI --library -S @Integrations
+dnx dotnet-inspect -y -- library MyLibrary.dll -S "Union Types" --tsv
+dnx dotnet-inspect -y -- library --platform System.Text.Json -S "Union Types" --tsv
 ```
+
+Use `Union Types` when looking for C# union adoption in libraries. It reports
+types annotated with `System.Runtime.CompilerServices.UnionAttribute`, whether
+they implement `IUnion`, and constructor-derived case types. Current platform
+libraries may expose the runtime infrastructure before any production library
+declares union types, so an empty table is still a useful signal.


### PR DESCRIPTION
## Summary

Adds C# union discovery guidance to the relationships/integrations skill.

The skill now calls out `Union Types` as a language/runtime integration signal, includes direct examples for scanning a local library and platform `System.Text.Json`, and explains that an empty table can still be useful while platform libraries expose union infrastructure before production libraries declare union types.

## Evidence

- `npx markdownlint-cli --fix skills/relationships/SKILL.md`
- `npx markdownlint-cli skills/relationships/SKILL.md`

Docs-only; no product behavior change.
