### PR TITLE
Raise bound same-type union fallback arms

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -451,6 +451,14 @@ public class TypeSourceComposerUnionTests
                     _ => "other",
                 };
 
+                public static string GuardedValueEqualsDefault(Pet pet) => pet switch
+                {
+                    Cat { Name: "cat" } cat => "other",
+                    Cat => "z",
+                    Dog dog => dog.Name,
+                    _ => "other",
+                };
+
                 public static string Inverted(Pet pet) => pet switch
                 {
                     Cat { Age: <= 3 } => "young",
@@ -500,6 +508,14 @@ public class TypeSourceComposerUnionTests
                 _ => "other",
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "DefaultedBound"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat when !(cat.Name == "cat") => "z",
+                Dog dog => dog.Name,
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedValueEqualsDefault"));
         Assert.Equal("""
             return pet switch
             {

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -582,6 +582,14 @@ public class TypeSourceComposerUnionTests
                     _ => "other",
                 };
 
+                public static string GuardedDefaultBoundSameAsDefault(Pet pet) => pet switch
+                {
+                    Cat { Name: "cat" } cat => cat.Name,
+                    Cat otherCat => "other",
+                    Dog dog => dog.Name,
+                    _ => "other",
+                };
+
                 public static string GuardedExhaustive(Pet pet) => pet switch
                 {
                     Cat { Name: "cat" } cat => cat.Name,
@@ -629,6 +637,14 @@ public class TypeSourceComposerUnionTests
                 _ => "other",
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedDefaultBound"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat when cat.Name == "cat" => cat.Name,
+                Dog dog => dog.Name,
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedDefaultBoundSameAsDefault"));
         Assert.Equal("""
             return pet switch
             {

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -443,6 +443,14 @@ public class TypeSourceComposerUnionTests
                     _ => "other",
                 };
 
+                public static string DefaultedBound(Pet pet) => pet switch
+                {
+                    Cat { Name: "cat" } cat => cat.Name,
+                    Cat otherCat => otherCat.Name.ToUpperInvariant(),
+                    Dog dog => dog.Name,
+                    _ => "other",
+                };
+
                 public static string Inverted(Pet pet) => pet switch
                 {
                     Cat { Age: <= 3 } => "young",
@@ -455,6 +463,13 @@ public class TypeSourceComposerUnionTests
                 {
                     Cat { Name: "cat" } cat => cat.Name,
                     Cat => "other cat",
+                    Dog dog => dog.Name,
+                };
+
+                public static string ExhaustiveBound(Pet pet) => pet switch
+                {
+                    Cat { Name: "cat" } cat => cat.Name,
+                    Cat otherCat => otherCat.Name.ToUpperInvariant(),
                     Dog dog => dog.Name,
                 };
 
@@ -479,6 +494,15 @@ public class TypeSourceComposerUnionTests
         Assert.Equal("""
             return pet switch
             {
+                Cat cat when cat.Name == "cat" => cat.Name,
+                Cat cat => cat.Name.ToUpperInvariant(),
+                Dog dog => dog.Name,
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "DefaultedBound"));
+        Assert.Equal("""
+            return pet switch
+            {
                 Cat V_3 when V_3.Age <= 3 => "young",
                 Cat => "old",
                 Dog dog => dog.Name,
@@ -493,6 +517,14 @@ public class TypeSourceComposerUnionTests
                 Dog dog => dog.Name,
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Exhaustive"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat when cat.Name == "cat" => cat.Name,
+                Cat cat => cat.Name.ToUpperInvariant(),
+                Dog dog => dog.Name,
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ExhaustiveBound"));
         Assert.Equal("""
             return pet switch
             {
@@ -542,10 +574,25 @@ public class TypeSourceComposerUnionTests
                     _ => "other",
                 };
 
+                public static string GuardedDefaultBound(Pet pet) => pet switch
+                {
+                    Cat { Name: "cat" } cat => cat.Name,
+                    Cat otherCat => otherCat.Name.ToUpperInvariant(),
+                    Dog dog => dog.Name,
+                    _ => "other",
+                };
+
                 public static string GuardedExhaustive(Pet pet) => pet switch
                 {
                     Cat { Name: "cat" } cat => cat.Name,
                     Cat => "other cat",
+                    Dog dog => dog.Name,
+                };
+
+                public static string GuardedExhaustiveBound(Pet pet) => pet switch
+                {
+                    Cat { Name: "cat" } cat => cat.Name,
+                    Cat otherCat => otherCat.Name.ToUpperInvariant(),
                     Dog dog => dog.Name,
                 };
             }
@@ -577,10 +624,27 @@ public class TypeSourceComposerUnionTests
             return pet switch
             {
                 Cat cat when cat.Name == "cat" => cat.Name,
+                Cat cat => cat.Name.ToUpperInvariant(),
+                Dog dog => dog.Name,
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedDefaultBound"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat when cat.Name == "cat" => cat.Name,
                 Cat => "other cat",
                 Dog dog => dog.Name,
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedExhaustive"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat when cat.Name == "cat" => cat.Name,
+                Cat cat => cat.Name.ToUpperInvariant(),
+                Dog dog => dog.Name,
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedExhaustiveBound"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -124,15 +124,14 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             return false;
         }
 
-        bool fallbackKeepsLocal = ReferencesLocal(firstFallbackStore.Value, firstStore.Index);
-        var firstArms = BuildArms(
+        var firstArms = BuildSplitArms(
             firstTest.Type,
             firstStore.Index,
             [firstStore, firstNullBranch.Condition],
-            [
-                new ArmBody(firstGuardedStore.Value, guardBranch.Condition, [guardBranch.Condition], KeepsLocal: true),
-                new ArmBody(firstFallbackStore.Value, Guard: null, GuardRoots: [], fallbackKeepsLocal),
-            ]);
+            firstGuardedStore.Value,
+            guardBranch.Condition,
+            firstFallbackStore.Value,
+            defaultValue);
         var finalArm = new Arm(finalTest.Type, finalStore.Index, finalValueStore.Value,
             [finalStore, finalValueBranch.Condition, finalValueStore.Value]);
         var arms = firstArms.Append(finalArm).ToArray();
@@ -179,6 +178,41 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         }
 
         return false;
+    }
+
+    static IReadOnlyList<Arm> BuildSplitArms(
+        TypeRef patternType,
+        int localIndex,
+        IReadOnlyList<IrNode> patternRoots,
+        IrExpression guardedValue,
+        IrExpression guard,
+        IrExpression fallbackValue,
+        IrExpression? defaultValue)
+    {
+        if (defaultValue is not null)
+        {
+            if (PlaceIdentity.SameOperand(fallbackValue, defaultValue))
+            {
+                return BuildArms(patternType, localIndex, patternRoots,
+                [
+                    new ArmBody(guardedValue, guard, [guard], KeepsLocal: true),
+                ]);
+            }
+
+            if (PlaceIdentity.SameOperand(guardedValue, defaultValue))
+            {
+                return BuildArms(patternType, localIndex, patternRoots,
+                [
+                    new ArmBody(fallbackValue, Conditions.Negate((IrExpression)guard.Clone()), [guard], ReferencesLocal(fallbackValue, localIndex)),
+                ]);
+            }
+        }
+
+        return BuildArms(patternType, localIndex, patternRoots,
+        [
+            new ArmBody(guardedValue, guard, [guard], KeepsLocal: true),
+            new ArmBody(fallbackValue, Guard: null, GuardRoots: [], ReferencesLocal(fallbackValue, localIndex)),
+        ]);
     }
 
     static bool TryMatchClassDefaultAt(

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -203,7 +203,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             {
                 return BuildArms(patternType, localIndex, patternRoots,
                 [
-                    new ArmBody(fallbackValue, Conditions.Negate((IrExpression)guard.Clone()), [guard], ReferencesLocal(fallbackValue, localIndex)),
+                    new ArmBody(fallbackValue, Conditions.Negate((IrExpression)guard.Clone()), [guard], KeepsLocal: true),
                 ]);
             }
         }
@@ -684,7 +684,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
 
             if (PlaceIdentity.SameOperand(guardedValue, defaultValue))
             {
-                arms = [new ArmBody(fallbackValue, Conditions.Negate((IrExpression)guardIf.Condition.Clone()), [guardIf.Condition], KeepsLocal: localIndex is { } local && ReferencesLocal(fallbackValue, local))];
+                arms = [new ArmBody(fallbackValue, Conditions.Negate((IrExpression)guardIf.Condition.Clone()), [guardIf.Condition], KeepsLocal: localIndex is not null)];
                 return true;
             }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -111,34 +111,33 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             || blocks[5].Children is not [Branch finalThrowBranch]
             || blocks[6].Children is not [StoreLocal firstGuardedStore, Return firstGuardedReturn]
             || blocks[7].Children is not [StoreLocal finalValueStore, Return finalValueReturn]
-            || blocks[8].Children is not [ExpressionStatement throwStatement, Return throwReturn]
+            || !TryClassFinalBlock(blocks[8], firstFallbackStore.Index, receiver, out var defaultValue)
             || nullBranch.TargetOffset != blocks[8].StartOffset
             || firstNullBranch.TargetOffset != blocks[4].StartOffset
             || guardBranch.TargetOffset != blocks[6].StartOffset
             || finalValueBranch.TargetOffset != blocks[7].StartOffset
             || finalThrowBranch.TargetOffset != blocks[8].StartOffset
-            || !IsThrowSwitchExpression(throwStatement)
-            || !ThrowArgumentMatches(throwStatement, receiver)
             || !StoreReturnMatch(firstFallbackStore, firstFallbackReturn, firstFallbackStore.Index)
             || !StoreReturnMatch(firstGuardedStore, firstGuardedReturn, firstFallbackStore.Index)
-            || !StoreReturnMatch(finalValueStore, finalValueReturn, firstFallbackStore.Index)
-            || !ReturnsLocal(throwReturn, firstFallbackStore.Index)
-            || ReferencesLocal(firstFallbackStore.Value, firstStore.Index))
+            || !StoreReturnMatch(finalValueStore, finalValueReturn, firstFallbackStore.Index))
         {
             return false;
         }
 
-        var arms = new[]
-        {
-            new Arm(firstTest.Type, firstStore.Index, firstGuardedStore.Value,
-                [firstStore, firstNullBranch.Condition, guardBranch.Condition, firstGuardedStore.Value],
-                guardBranch.Condition),
-            new Arm(firstTest.Type, LocalIndex: null, firstFallbackStore.Value, [firstFallbackStore.Value]),
-            new Arm(finalTest.Type, finalStore.Index, finalValueStore.Value,
-                [finalStore, finalValueBranch.Condition, finalValueStore.Value]),
-        };
+        bool fallbackKeepsLocal = ReferencesLocal(firstFallbackStore.Value, firstStore.Index);
+        var firstArms = BuildArms(
+            firstTest.Type,
+            firstStore.Index,
+            [firstStore, firstNullBranch.Condition],
+            [
+                new ArmBody(firstGuardedStore.Value, guardBranch.Condition, [guardBranch.Condition], KeepsLocal: true),
+                new ArmBody(firstFallbackStore.Value, Guard: null, GuardRoots: [], fallbackKeepsLocal),
+            ]);
+        var finalArm = new Arm(finalTest.Type, finalStore.Index, finalValueStore.Value,
+            [finalStore, finalValueBranch.Condition, finalValueStore.Value]);
+        var arms = firstArms.Append(finalArm).ToArray();
 
-        var allowedTempUses = blocks.SelectMany(block => block.Children).ToArray();
+        var allowedTempUses = blocks.Take(8).SelectMany(block => block.Children).ToArray();
         if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, allowedTempUses)
             || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
             || !DuplicateTypesAreGuarded(arms))
@@ -152,8 +151,34 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 arm.PatternType,
                 arm.LocalIndex,
                 (IrExpression)arm.Value.Clone(),
-                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())));
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+            defaultValue is null ? null : (IrExpression)defaultValue.Clone());
         return true;
+    }
+
+    static bool TryClassFinalBlock(
+        Block finalBlock,
+        int resultLocal,
+        IrExpression receiver,
+        out IrExpression? defaultValue)
+    {
+        defaultValue = null;
+        if (finalBlock.Children is [ExpressionStatement throwStatement, Return throwReturn]
+            && IsThrowSwitchExpression(throwStatement)
+            && ThrowArgumentMatches(throwStatement, receiver)
+            && ReturnsLocal(throwReturn, resultLocal))
+        {
+            return true;
+        }
+
+        if (finalBlock.Children is [StoreLocal defaultStore, Return defaultReturn]
+            && StoreReturnMatch(defaultStore, defaultReturn, resultLocal))
+        {
+            defaultValue = defaultStore.Value;
+            return true;
+        }
+
+        return false;
     }
 
     static bool TryMatchClassDefaultAt(
@@ -420,12 +445,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 return false;
             }
 
-            foreach (var body in matchedArms)
-            {
-                var localRoots = new List<IrNode>(patternRoots) { body.Value };
-                localRoots.AddRange(body.GuardRoots);
-                builder.Add(new Arm(patternType, body.KeepsLocal ? localIndex : null, body.Value, localRoots, body.Guard));
-            }
+            builder.AddRange(BuildArms(patternType, localIndex, patternRoots, matchedArms));
         }
 
         arms = builder;
@@ -442,13 +462,13 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         if (nodes is [IfStatement { HasElse: false } guardIf, StoreLocal fallbackStore, Return fallbackReturn]
             && guardIf.Then.Children is [StoreLocal guardedStore, Return guardedReturn]
             && StoreReturnMatch(guardedStore, guardedReturn, resultLocal)
-            && StoreReturnMatch(fallbackStore, fallbackReturn, resultLocal)
-            && (localIndex is not { } local || !ReferencesLocal(fallbackStore.Value, local)))
+            && StoreReturnMatch(fallbackStore, fallbackReturn, resultLocal))
         {
+            bool fallbackKeepsLocal = localIndex is { } local && ReferencesLocal(fallbackStore.Value, local);
             arms =
             [
                 new ArmBody(guardedStore.Value, guardIf.Condition, [guardIf.Condition], KeepsLocal: true),
-                new ArmBody(fallbackStore.Value, Guard: null, GuardRoots: [], KeepsLocal: false),
+                new ArmBody(fallbackStore.Value, Guard: null, GuardRoots: [], fallbackKeepsLocal),
             ];
             return true;
         }
@@ -573,12 +593,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         if (TryArmPattern(armIf.Condition, tempLocal, out var patternType, out var localIndex, out var patternRoots)
             && TryArmBody(armIf.Then.Children, localIndex, defaultValue, out var matchedArms))
         {
-            arms = matchedArms.Select(arm =>
-            {
-                var localRoots = new List<IrNode>(patternRoots) { arm.Value };
-                localRoots.AddRange(arm.GuardRoots);
-                return new Arm(patternType, arm.KeepsLocal ? localIndex : null, arm.Value, localRoots, arm.Guard);
-            }).ToArray();
+            arms = BuildArms(patternType, localIndex, patternRoots, matchedArms);
             return true;
         }
 
@@ -633,6 +648,12 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 return true;
             }
 
+            if (PlaceIdentity.SameOperand(guardedValue, defaultValue))
+            {
+                arms = [new ArmBody(fallbackValue, Conditions.Negate((IrExpression)guardIf.Condition.Clone()), [guardIf.Condition], KeepsLocal: localIndex is { } local && ReferencesLocal(fallbackValue, local))];
+                return true;
+            }
+
             if (localIndex is not { } fallbackLocal || !ReferencesLocal(fallbackValue, fallbackLocal))
             {
                 arms =
@@ -642,6 +663,13 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 ];
                 return true;
             }
+
+            arms =
+            [
+                new ArmBody(guardedValue, guardIf.Condition, [guardIf.Condition], KeepsLocal: true),
+                new ArmBody(fallbackValue, Guard: null, GuardRoots: [], KeepsLocal: true),
+            ];
+            return true;
         }
 
         if (nodes is [IfStatement { HasElse: false } invertedGuardIf, Return { Value: { } invertedValue }]
@@ -650,6 +678,12 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             if (PlaceIdentity.SameOperand(nestedFallback, defaultValue))
             {
                 arms = [new ArmBody(invertedValue, Conditions.Negate((IrExpression)invertedGuardIf.Condition.Clone()), [invertedGuardIf.Condition], KeepsLocal: true)];
+                return true;
+            }
+
+            if (PlaceIdentity.SameOperand(invertedValue, defaultValue))
+            {
+                arms = [new ArmBody(nestedFallback, invertedGuardIf.Condition, [invertedGuardIf.Condition], KeepsLocal: true)];
                 return true;
             }
 
@@ -662,9 +696,46 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 ];
                 return true;
             }
+
+            arms =
+            [
+                new ArmBody(invertedValue, Conditions.Negate((IrExpression)invertedGuardIf.Condition.Clone()), [invertedGuardIf.Condition], KeepsLocal: true),
+                new ArmBody(nestedFallback, Guard: null, GuardRoots: [], KeepsLocal: true),
+            ];
+            return true;
         }
 
         return false;
+    }
+
+    static IReadOnlyList<Arm> BuildArms(
+        TypeRef patternType,
+        int? localIndex,
+        IReadOnlyList<IrNode> patternRoots,
+        IReadOnlyList<ArmBody> bodies)
+    {
+        var sharedLocalRoots = new List<IrNode>(patternRoots);
+        foreach (var body in bodies)
+        {
+            sharedLocalRoots.Add(body.Value);
+            sharedLocalRoots.AddRange(body.GuardRoots);
+        }
+
+        return bodies.Select(body =>
+        {
+            IReadOnlyList<IrNode> localRoots;
+            if (body.KeepsLocal && localIndex is not null)
+            {
+                localRoots = sharedLocalRoots;
+            }
+            else
+            {
+                var roots = new List<IrNode>(patternRoots) { body.Value };
+                roots.AddRange(body.GuardRoots);
+                localRoots = roots;
+            }
+            return new Arm(patternType, body.KeepsLocal ? localIndex : null, body.Value, localRoots, body.Guard);
+        }).ToArray();
     }
 
     static bool ReferencesLocal(IrExpression expression, int local)


### PR DESCRIPTION
## Summary

Raises same-type guarded union fallback arms where the fallback arm binds and uses the same lowered pattern local.

Earlier slices handled unbound fallbacks such as `Cat => "other cat"`. This PR covers the adjacent bound shape, where Roslyn reuses one lowered `Cat` local for both the guarded and fallback arms. The matcher now shares ownership roots across those split arms so both raised arms can safely bind/use the same local.

Fixes #1985.

## Before / After

Source shape:

```csharp
return pet switch
{
    Cat { Name: "cat" } cat => cat.Name,
    Cat otherCat => otherCat.Name.ToUpperInvariant(),
    Dog dog => dog.Name,
    _ => "other",
};
```

Before, the fallback-local use made the shape stay flat:

```csharp
object V_3 = pet.Value;
if (V_3 is Cat cat)
{
    if (cat.Name == "cat")
    {
        return cat.Name;
    }
    return cat.Name.ToUpperInvariant();
}
// ... Dog arm and default ...
```

After, it raises back to a union switch expression. The compiler reuses the lowered local, so both raised `Cat` arms use the same recovered local name:

```csharp
return pet switch
{
    Cat cat when cat.Name == "cat" => cat.Name,
    Cat cat => cat.Name.ToUpperInvariant(),
    Dog dog => dog.Name,
    _ => "other",
};
```

The same local-sharing proof also covers exhaustive and class/custom union variants.

## Evidence

- Stage 0 entry gate:
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"` — 13 passed.
  - `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet` — passed.
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringCoverageTests/*"` — 6 passed.
- Shape proof:
  - Struct union default and exhaustive bound same-type fallback fixtures now raise.
  - Class/custom union default and exhaustive bound same-type fallback fixtures now raise.
  - Existing unbound fallback, inverted guard, class simple/default/exhaustive, and non-union `Value switch` fixtures remain green.
- Build-event validation-only:
  - 263 projects, 0 failed, 0 errors, 0 warnings.
  - Event log: `20260630T153318.1721178Z-2653112-build-15f50e47`.
- Sanity check: duplicate pattern variable names in separate switch-expression arms compile under the current SDK.

## Review

Decompiler behavior change; adversarial review requested separately before marking ready.
