### PR TITLE
Raise union switch statement return chains

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -431,7 +431,9 @@ public class TypeSourceComposerUnionTests
 
             public sealed class Cat { public string Name { get; } = "cat"; public int Age { get; } = 5; }
             public sealed class Dog { public string Name { get; } = "dog"; }
+            public sealed class Bird { public string Name { get; } = "bird"; }
             public union Pet(Cat, Dog);
+            public union Pet3(Cat, Dog, Bird);
 
             public static class Matcher
             {
@@ -459,6 +461,33 @@ public class TypeSourceComposerUnionTests
                             return "other";
                     }
                 }
+
+                public static string StatementDefaultSwapped(Pet pet)
+                {
+                    switch (pet)
+                    {
+                        case Dog dog:
+                            return dog.Name;
+                        case Cat cat when cat.Age > 3:
+                            return cat.Name;
+                        default:
+                            return "other";
+                    }
+                }
+
+                public static string StatementThree(Pet3 pet)
+                {
+                    switch (pet)
+                    {
+                        case Cat cat:
+                            return cat.Name;
+                        case Dog dog:
+                            return dog.Name;
+                        case Bird bird:
+                            return bird.Name;
+                    }
+                    return "other";
+                }
             }
             """);
 
@@ -478,6 +507,23 @@ public class TypeSourceComposerUnionTests
                 _ => "other",
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "StatementDefault"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Dog dog => dog.Name,
+                Cat cat when cat.Age > 3 => cat.Name,
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "StatementDefaultSwapped"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat => cat.Name,
+                Dog dog => dog.Name,
+                Bird bird => bird.Name,
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "StatementThree"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -424,6 +424,63 @@ public class TypeSourceComposerUnionTests
     }
 
     [Fact]
+    public async Task UnionSwitchStatementReturnChain_RendersSwitchExpression()
+    {
+        using var assembly = await CompileWithSdk("""
+            namespace UnionFixtures;
+
+            public sealed class Cat { public string Name { get; } = "cat"; public int Age { get; } = 5; }
+            public sealed class Dog { public string Name { get; } = "dog"; }
+            public union Pet(Cat, Dog);
+
+            public static class Matcher
+            {
+                public static string Statement(Pet pet)
+                {
+                    switch (pet)
+                    {
+                        case Cat cat:
+                            return cat.Name;
+                        case Dog dog:
+                            return dog.Name;
+                    }
+                    return "other";
+                }
+
+                public static string StatementDefault(Pet pet)
+                {
+                    switch (pet)
+                    {
+                        case Cat cat when cat.Age > 3:
+                            return cat.Name;
+                        case Dog dog:
+                            return dog.Name;
+                        default:
+                            return "other";
+                    }
+                }
+            }
+            """);
+
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat => cat.Name,
+                Dog dog => dog.Name,
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Statement"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat cat when cat.Age > 3 => cat.Name,
+                Dog dog => dog.Name,
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "StatementDefault"));
+    }
+
+    [Fact]
     public async Task UnionSwitchExpression_RendersSameTypeGuardedFallbackArms()
     {
         using var assembly = await CompileWithSdk("""

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -45,6 +45,12 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         var children = block.Children;
         for (int start = 0; start < children.Count; start++)
         {
+            if (TryMatchSwitchStatementReturnChainAt(function, children, start, out var statementSwitch))
+            {
+                match = new Match(start, statementSwitch);
+                return true;
+            }
+
             if (TryMatchClassDefaultAt(function, children, start, out var classDefaultSwitch))
             {
                 match = new Match(start, classDefaultSwitch);
@@ -77,6 +83,142 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         }
 
         return false;
+    }
+
+    static bool TryMatchSwitchStatementReturnChainAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        int current = start;
+        StoreLocal? receiverStore = null;
+        if (current + 4 < children.Count
+            && children[current] is StoreLocal possibleReceiver
+            && children[current + 1] is StoreLocal { Value: LoadProperty possibleUnionValue }
+            && IsLocalReceiver(possibleUnionValue.Instance, possibleReceiver.Index))
+        {
+            receiverStore = possibleReceiver;
+            current++;
+        }
+
+        if (current + 3 >= children.Count
+            || children[current] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsUnionValueProperty(function, unionValue)
+            || children[current + 1] is not StoreLocal { Value: IsInstance firstTest } firstStore
+            || !IsTempTypeTest(firstTest, valueStore.Index)
+            || children[current + 2] is not IfStatement firstIf
+            || !IsNotLocal(firstIf.Condition, firstStore.Index))
+        {
+            return false;
+        }
+
+        if (firstIf.HasElse)
+        {
+            if (current + 4 != children.Count
+                || firstIf.Then.Children is not [IfStatement secondIf]
+                || firstIf.Else?.Children is not [IfStatement guardIf]
+                || children[current + 3] is not Return { Value: { } defaultValue }
+                || guardIf.HasElse
+                || guardIf.Then.Children is not [Return { Value: { } guardedValue }]
+                || !TryReturnArm(secondIf, valueStore.Index, out var secondArm))
+            {
+                return false;
+            }
+
+            var firstArm = new Arm(
+                firstTest.Type,
+                firstStore.Index,
+                guardedValue,
+                [firstStore, firstIf.Condition, guardIf.Condition, guardedValue],
+                guardIf.Condition);
+            return BuildStatementSwitch(function, unionValue, valueStore, firstStore, receiverStore, [firstArm, secondArm], defaultValue, firstIf, out switchExpression);
+        }
+
+        if (current + 4 != children.Count
+            || firstIf.Then.Children is not [IfStatement secondIfNoElse, Return { Value: { } defaultFromThen }]
+            || children[current + 3] is not Return { Value: { } firstValue }
+            || !TryReturnArm(secondIfNoElse, valueStore.Index, out var secondArmNoElse))
+        {
+            return false;
+        }
+
+        var firstArmNoElse = new Arm(
+            firstTest.Type,
+            firstStore.Index,
+            firstValue,
+            [firstStore, firstIf.Condition, firstValue]);
+        return BuildStatementSwitch(function, unionValue, valueStore, firstStore, receiverStore, [firstArmNoElse, secondArmNoElse], defaultFromThen, firstIf, out switchExpression);
+    }
+
+    static bool TryReturnArm(IfStatement armIf, int tempLocal, out Arm arm)
+    {
+        arm = null!;
+        if (armIf.HasElse
+            || !TryArmPattern(armIf.Condition, tempLocal, out var patternType, out var localIndex, out var patternRoots)
+            || armIf.Then.Children is not [Return { Value: { } value }])
+        {
+            return false;
+        }
+
+        var roots = new List<IrNode>(patternRoots) { value };
+        arm = new Arm(patternType, localIndex, value, roots);
+        return true;
+    }
+
+    static bool BuildStatementSwitch(
+        IrFunction function,
+        LoadProperty unionValue,
+        StoreLocal valueStore,
+        StoreLocal firstStore,
+        StoreLocal? receiverStore,
+        IReadOnlyList<Arm> arms,
+        IrExpression defaultValue,
+        IfStatement dispatchRoot,
+        out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        var allowedTempUses = new List<IrNode> { valueStore, firstStore, dispatchRoot };
+        if (receiverStore is not null)
+        {
+            allowedTempUses.Add(receiverStore);
+            if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, receiverStore.Index, [receiverStore, valueStore]))
+                return false;
+        }
+
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, allowedTempUses)
+            || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+            || arms.Select(arm => arm.PatternType).Distinct().Count() != arms.Count)
+        {
+            return false;
+        }
+
+        switchExpression = new UnionSwitchExpression(
+            UnionValueForSwitch(unionValue, receiverStore),
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+            (IrExpression)defaultValue.Clone());
+        return true;
+    }
+
+    static bool IsLocalReceiver(IrExpression? expression, int local)
+        => expression is LoadLocal load && load.Index == local
+            || expression is LoadLocalAddress address && address.Index == local;
+
+    static LoadProperty UnionValueForSwitch(LoadProperty unionValue, StoreLocal? receiverStore)
+    {
+        var instance = receiverStore is null
+            ? unionValue.Instance is null ? null : (IrExpression)unionValue.Instance.Clone()
+            : (IrExpression)receiverStore.Value.Clone();
+        return new LoadProperty(
+            unionValue.Accessor,
+            instance,
+            unionValue.IndexArguments.Select(argument => (IrExpression)argument.Clone()).ToArray())
+        { IsVirtual = unionValue.IsVirtual };
     }
 
     static bool TryMatchClassExhaustiveGuardedBlocks(

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -94,7 +94,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         switchExpression = null!;
         int current = start;
         StoreLocal? receiverStore = null;
-        if (current + 4 < children.Count
+        if (current + 1 < children.Count
             && children[current] is StoreLocal possibleReceiver
             && children[current + 1] is StoreLocal { Value: LoadProperty possibleUnionValue }
             && IsLocalReceiver(possibleUnionValue.Instance, possibleReceiver.Index))
@@ -103,7 +103,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             current++;
         }
 
-        if (current + 3 >= children.Count
+        if (current + 2 >= children.Count
             || children[current] is not StoreLocal { Value: LoadProperty unionValue } valueStore
             || !IsUnionValueProperty(function, unionValue)
             || children[current + 1] is not StoreLocal { Value: IsInstance firstTest } firstStore
@@ -116,30 +116,38 @@ public sealed class UnionSwitchExpressionPass : IIrPass
 
         if (firstIf.HasElse)
         {
-            if (current + 4 != children.Count
-                || firstIf.Then.Children is not [IfStatement secondIf]
-                || firstIf.Else?.Children is not [IfStatement guardIf]
-                || children[current + 3] is not Return { Value: { } defaultValue }
-                || guardIf.HasElse
-                || guardIf.Then.Children is not [Return { Value: { } guardedValue }]
-                || !TryReturnArm(secondIf, valueStore.Index, out var secondArm))
+            if (firstIf.Else is not { } elseBlock
+                || !TryElseArm(elseBlock.Children, firstTest.Type, firstStore.Index, [firstStore, firstIf.Condition], out var firstArm))
             {
                 return false;
             }
 
-            var firstArm = new Arm(
-                firstTest.Type,
-                firstStore.Index,
-                guardedValue,
-                [firstStore, firstIf.Condition, guardIf.Condition, guardedValue],
-                guardIf.Condition);
-            return BuildStatementSwitch(function, unionValue, valueStore, firstStore, receiverStore, [firstArm, secondArm], defaultValue, firstIf, out switchExpression);
+            IrExpression defaultValue;
+            IReadOnlyList<Arm> innerArms;
+            if (current + 4 == children.Count
+                && children[current + 3] is Return { Value: { } tailDefault }
+                && TryReturnArms(firstIf.Then.Children, valueStore.Index, out var tailArms))
+            {
+                defaultValue = tailDefault;
+                innerArms = tailArms;
+            }
+            else if (current + 3 == children.Count
+                && TryReturnArmsWithDefault(firstIf.Then.Children, valueStore.Index, out var embeddedArms, out var embeddedDefault))
+            {
+                defaultValue = embeddedDefault;
+                innerArms = embeddedArms;
+            }
+            else
+            {
+                return false;
+            }
+
+            return BuildStatementSwitch(function, unionValue, valueStore, firstStore, receiverStore, [firstArm, .. innerArms], defaultValue, firstIf, out switchExpression);
         }
 
         if (current + 4 != children.Count
-            || firstIf.Then.Children is not [IfStatement secondIfNoElse, Return { Value: { } defaultFromThen }]
             || children[current + 3] is not Return { Value: { } firstValue }
-            || !TryReturnArm(secondIfNoElse, valueStore.Index, out var secondArmNoElse))
+            || !TryReturnArmsWithDefault(firstIf.Then.Children, valueStore.Index, out var innerArmsNoElse, out var defaultFromThen))
         {
             return false;
         }
@@ -149,21 +157,127 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             firstStore.Index,
             firstValue,
             [firstStore, firstIf.Condition, firstValue]);
-        return BuildStatementSwitch(function, unionValue, valueStore, firstStore, receiverStore, [firstArmNoElse, secondArmNoElse], defaultFromThen, firstIf, out switchExpression);
+        return BuildStatementSwitch(function, unionValue, valueStore, firstStore, receiverStore, [firstArmNoElse, .. innerArmsNoElse], defaultFromThen, firstIf, out switchExpression);
+    }
+
+    static bool TryReturnArmsWithDefault(IReadOnlyList<IrNode> nodes, int tempLocal, out IReadOnlyList<Arm> arms, out IrExpression defaultValue)
+    {
+        arms = [];
+        defaultValue = null!;
+        if (nodes.Count < 1)
+            return false;
+
+        if (nodes[^1] is IfStatement finalArmIf
+            && TryReturnArmWithDefault(finalArmIf, tempLocal, out var finalArm, out var finalDefault))
+        {
+            IReadOnlyList<Arm> prefixArms = [];
+            if (nodes.Count > 1 && !TryReturnArms(nodes.Take(nodes.Count - 1).ToArray(), tempLocal, out prefixArms))
+                return false;
+
+            arms = [.. prefixArms, finalArm];
+            defaultValue = finalDefault;
+            return true;
+        }
+
+        if (nodes.Count < 2 || nodes[^1] is not Return { Value: { } retDefault })
+            return false;
+
+        if (!TryReturnArms(nodes.Take(nodes.Count - 1).ToArray(), tempLocal, out arms))
+            return false;
+
+        defaultValue = retDefault;
+        return true;
+    }
+
+    static bool TryReturnArms(IReadOnlyList<IrNode> nodes, int tempLocal, out IReadOnlyList<Arm> arms)
+    {
+        var builder = new List<Arm>();
+        foreach (var node in nodes)
+        {
+            if (node is not IfStatement armIf || !TryReturnArm(armIf, tempLocal, out var arm))
+            {
+                arms = [];
+                return false;
+            }
+
+            builder.Add(arm);
+        }
+
+        arms = builder;
+        return arms.Count > 0;
+    }
+
+    static bool TryElseArm(
+        IReadOnlyList<IrNode> nodes,
+        TypeRef patternType,
+        int localIndex,
+        IReadOnlyList<IrNode> patternRoots,
+        out Arm arm)
+    {
+        arm = null!;
+        switch (nodes)
+        {
+            case [Return { Value: { } value }]:
+            {
+                var roots = new List<IrNode>(patternRoots) { value };
+                arm = new Arm(patternType, localIndex, value, roots);
+                return true;
+            }
+            case [IfStatement guardIf] when !guardIf.HasElse && guardIf.Then.Children is [Return { Value: { } guardedValue }]:
+            {
+                var roots = new List<IrNode>(patternRoots) { guardIf.Condition, guardedValue };
+                arm = new Arm(patternType, localIndex, guardedValue, roots, guardIf.Condition);
+                return true;
+            }
+            default:
+                return false;
+        }
     }
 
     static bool TryReturnArm(IfStatement armIf, int tempLocal, out Arm arm)
     {
         arm = null!;
         if (armIf.HasElse
-            || !TryArmPattern(armIf.Condition, tempLocal, out var patternType, out var localIndex, out var patternRoots)
-            || armIf.Then.Children is not [Return { Value: { } value }])
+            || !TryArmPattern(armIf.Condition, tempLocal, out var patternType, out var localIndex, out var patternRoots))
         {
             return false;
         }
 
-        var roots = new List<IrNode>(patternRoots) { value };
-        arm = new Arm(patternType, localIndex, value, roots);
+        if (armIf.Then.Children is [Return { Value: { } value }])
+        {
+            var roots = new List<IrNode>(patternRoots) { value };
+            arm = new Arm(patternType, localIndex, value, roots);
+            return true;
+        }
+
+        if (armIf.Then.Children is [IfStatement guardIf]
+            && !guardIf.HasElse
+            && guardIf.Then.Children is [Return { Value: { } guardedValue }])
+        {
+            var roots = new List<IrNode>(patternRoots) { guardIf.Condition, guardedValue };
+            arm = new Arm(patternType, localIndex, guardedValue, roots, guardIf.Condition);
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool TryReturnArmWithDefault(IfStatement armIf, int tempLocal, out Arm arm, out IrExpression defaultValue)
+    {
+        arm = null!;
+        defaultValue = null!;
+        if (armIf.HasElse
+            || !TryArmPattern(armIf.Condition, tempLocal, out var patternType, out var localIndex, out var patternRoots)
+            || armIf.Then.Children is not [IfStatement guardIf, Return { Value: { } armDefault }]
+            || guardIf.HasElse
+            || guardIf.Then.Children is not [Return { Value: { } guardedValue }])
+        {
+            return false;
+        }
+
+        var roots = new List<IrNode>(patternRoots) { guardIf.Condition, guardedValue };
+        arm = new Arm(patternType, localIndex, guardedValue, roots, guardIf.Condition);
+        defaultValue = armDefault;
         return true;
     }
 


### PR DESCRIPTION
## Summary

Raises terminal union `switch` statement return chains back to source-level union switch expressions.

The compiler lowers return-only union switch statements into `union.Value` / `as` / nested `if` chains rather than the switch-expression throw/default shapes covered by earlier slices. This PR recognizes the narrow terminal forms and emits a `UnionSwitchExpression` when the cached `Value` temp, optional receiver copy, pattern locals, and default fallback are all owned.

Fixes #1987.

## Before / After

Source shape:

```csharp
switch (pet)
{
    case Cat cat:
        return cat.Name;
    case Dog dog:
        return dog.Name;
}
return "other";
```

Before, it stayed flat:

```csharp
object V_2 = pet.Value;
Cat cat = V_2 as Cat;
if (cat is null)
{
    if (V_2 is Dog dog)
    {
        return dog.Name;
    }
    return "other";
}
return cat.Name;
```

After, it raises to an equivalent union switch expression:

```csharp
return pet switch
{
    Cat cat => cat.Name,
    Dog dog => dog.Name,
    _ => "other",
};
```

Guarded statement arms are also covered:

```csharp
switch (pet)
{
    case Cat cat when cat.Age > 3:
        return cat.Name;
    case Dog dog:
        return dog.Name;
    default:
        return "other";
}
```

raises to:

```csharp
return pet switch
{
    Cat cat when cat.Age > 3 => cat.Name,
    Dog dog => dog.Name,
    _ => "other",
};
```

## Shape choice

This is an N-to-1 source-shape ambiguity: Roslyn lowers the terminal return-only
`switch` statement and the equivalent `return pet switch { ... }` form to the same
`Value`/`as`/`if` chain. The decompiler therefore normalizes to the switch
expression form. That matches dotnet/runtime style (`csharp_style_prefer_switch_expression = true:suggestion`) and the repo's existing preference for compact expression forms when a body is a single returned value.

## Evidence

- Stage 0 entry gate:
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/UnionSwitchStatementReturnChain_RendersSwitchExpression"` — 1 passed.
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"` — 14 passed.
  - `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet -p:PublishAot=false` — passed. Host default AOT restore currently fails on unavailable preview.6 packs; this is the documented decompiler build gate.
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringCoverageTests/*"` — 6 passed.
- Build-event validation-only:
  - 263 projects, 0 failed, 0 errors, 0 warnings.
  - Event log: `20260630T161616.1021066Z-2703686-build-3048dde0`.
  - Ran with the build-event preview5 SDK first on `PATH`; the host preview6 SDK cannot restore AOT packs from NuGet.

## Review

Decompiler behavior change; adversarial review requested separately before marking ready.

