### PR TITLE
Cut ReachingDefinitions over to the instruction substrate

### DIFF
--- a/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
+++ b/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
@@ -111,6 +111,25 @@ public class ReachingDefinitionsTests
     }
 
     [Fact]
+    public void Analyze_TruncatedInstruction_ThrowsBadImageFormat()
+    {
+        // Truncated reads go through the substrate's runtime-ported ILReader, which throws
+        // InvalidProgramException; RD must normalize these to BadImageFormatException so callers'
+        // recoverable-failure filters still fail closed. Covers a lone two-byte opcode prefix and
+        // truncated short/long branch operands and switch count.
+        byte[][] truncated =
+        [
+            [0xFE],                              // lone two-byte opcode prefix (missing second byte)
+            [Op(ILOpCode.Br_s)],                 // br.s with no displacement byte
+            [Op(ILOpCode.Br), 0x00, 0x00],       // br with fewer than 4 operand bytes
+            [Op(ILOpCode.Switch), 0x00, 0x00],   // switch with fewer than 4 count bytes
+        ];
+
+        foreach (var il in truncated)
+            Assert.Throws<BadImageFormatException>(() => ReachingDefinitions.Analyze(il, argumentSlotCount: 0));
+    }
+
+    [Fact]
     public void Analyze_MalformedExceptionRegion_MarksResultIncomplete()
     {
         var result = ReachingDefinitions.Analyze([

--- a/src/ILInspector.Analysis/ILInspector.Analysis.csproj
+++ b/src/ILInspector.Analysis/ILInspector.Analysis.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ILInspector.ControlFlow\ILInspector.ControlFlow.csproj" />
+    <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ILInspector.Analysis/ReachingDefinitions.cs
+++ b/src/ILInspector.Analysis/ReachingDefinitions.cs
@@ -51,8 +51,21 @@ public static class ReachingDefinitions
             return new ReachingDefinitionsResult([], [], exceptionRegions.Count == 0,
                 exceptionRegions.Count == 0 ? null : "Exception-handler regions reference empty IL.");
 
-        var instructions = InstructionDecoder.Decode(il);
-        var blockGraph = BlockGraph.Build(il.Length, instructions, exceptionRegions);
+        ImmutableArray<DecodedInstruction> instructions;
+        BlockGraph blockGraph;
+        try
+        {
+            instructions = InstructionDecoder.Decode(il);
+            blockGraph = BlockGraph.Build(il.Length, instructions, exceptionRegions);
+        }
+        catch (InvalidProgramException ex)
+        {
+            // Preserve RD's malformed-IL contract. The substrate's runtime-ported ILReader throws
+            // InvalidProgramException on a truncated read (opcode / branch operand / switch count),
+            // but RD — and its callers' recoverable-failure filters — expect BadImageFormatException.
+            throw new BadImageFormatException(ex.Message, ex);
+        }
+
         var blocks = blockGraph.Blocks;
         var incompleteReason = blockGraph.IncompleteReason;
         var definitions = ImmutableArray.CreateBuilder<LocalDefinition>();

--- a/src/ILInspector.Analysis/ReachingDefinitions.cs
+++ b/src/ILInspector.Analysis/ReachingDefinitions.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.Reflection.Metadata;
 
 using ILInspector.ControlFlow;
+using ILInspector.Instructions;
 
 namespace ILInspector.Analysis;
 
@@ -41,7 +42,6 @@ public static class ReachingDefinitions
         ArgumentNullException.ThrowIfNull(body);
         return AnalyzeCore(body.GetILBytes() ?? [], argumentSlotCount, body.ExceptionRegions);
     }
-
     static ReachingDefinitionsResult AnalyzeCore(byte[] il, int argumentSlotCount, IReadOnlyCollection<ExceptionRegion> exceptionRegions)
     {
         ArgumentNullException.ThrowIfNull(il);
@@ -51,10 +51,10 @@ public static class ReachingDefinitions
             return new ReachingDefinitionsResult([], [], exceptionRegions.Count == 0,
                 exceptionRegions.Count == 0 ? null : "Exception-handler regions reference empty IL.");
 
-        var instructions = DecodeInstructions(il);
-        var regionModels = BuildRegionModels(il.Length, instructions, exceptionRegions, out var regionIncompleteReasons);
-        var blocks = BuildBlocks(il.Length, instructions, regionModels);
-        var incompleteReason = IncompleteReason(blocks, instructions, regionModels, regionIncompleteReasons);
+        var instructions = InstructionDecoder.Decode(il);
+        var blockGraph = BlockGraph.Build(il.Length, instructions, exceptionRegions);
+        var blocks = blockGraph.Blocks;
+        var incompleteReason = blockGraph.IncompleteReason;
         var definitions = ImmutableArray.CreateBuilder<LocalDefinition>();
         var definitionsBySlot = new Dictionary<SlotKey, List<int>>();
         var definitionByOffset = new Dictionary<int, int>();
@@ -127,33 +127,9 @@ public static class ReachingDefinitions
         }
     }
 
-    static string? IncompleteReason(
-        IReadOnlyList<Block> blocks,
-        IReadOnlyList<Instruction> instructions,
-        IReadOnlyList<ExceptionRegionModel> regions,
-        IReadOnlyList<string> regionIncompleteReasons)
-    {
-        if (blocks.Any(block => block.Edges.LeavesRegion))
-        {
-            foreach (var instruction in instructions)
-            {
-                if (!instruction.LeavesRegion)
-                    continue;
-                if (regions.Any(region => region.ContainsAny(instruction.Offset)))
-                    continue;
-                return "Region-leaving control-flow edges are not modeled.";
-            }
-        }
-        if (blocks.Any(block => block.Edges.ExternalTargets.Count > 0))
-            return "External control-flow targets are not modeled.";
-        if (regionIncompleteReasons.Count > 0)
-            return string.Join("; ", regionIncompleteReasons);
-        return null;
-    }
-
     static GenKillSet BuildTransfer(
-        Block block,
-        IReadOnlyList<Instruction> instructions,
+        InstructionBlock block,
+        ImmutableArray<DecodedInstruction> instructions,
         IReadOnlyList<LocalDefinition> definitions,
         IReadOnlyDictionary<SlotKey, List<int>> definitionsBySlot,
         IReadOnlyDictionary<int, int> definitionByOffset)
@@ -182,346 +158,6 @@ public static class ReachingDefinitions
     {
         if (definitionsBySlot.TryGetValue(key, out var ids))
             current.ExceptWith(ids);
-    }
-
-    static ImmutableArray<Block> BuildBlocks(
-        int ilLength,
-        IReadOnlyList<Instruction> instructions,
-        IReadOnlyList<ExceptionRegionModel> regions)
-    {
-        var instructionOffsets = instructions.Select(instruction => instruction.Offset).ToHashSet();
-        var leaders = new SortedSet<int> { 0 };
-        foreach (var instruction in instructions)
-        {
-            foreach (int target in instruction.Targets)
-            {
-                if (target >= 0 && target < ilLength)
-                {
-                    if (!instructionOffsets.Contains(target))
-                        throw new BadImageFormatException($"Branch target IL_{target:X4} does not align with an instruction.");
-                    leaders.Add(target);
-                }
-            }
-            if ((instruction.Branches || instruction.Exits) && instruction.NextOffset < ilLength)
-                leaders.Add(instruction.NextOffset);
-        }
-        foreach (var region in regions)
-        {
-            AddLeader(region.TryStart);
-            AddLeader(region.TryEnd);
-            AddLeader(region.HandlerStart);
-            AddLeader(region.HandlerEnd);
-            if (region.Kind == ExceptionRegionKind.Filter)
-            {
-                AddLeader(region.FilterStart);
-                AddLeader(region.FilterEnd);
-            }
-        }
-        foreach (var instruction in instructions)
-        {
-            if (regions.Any(region => region.ContainsAny(instruction.Offset)))
-                AddLeader(instruction.Offset);
-        }
-
-        var starts = leaders.ToImmutableArray();
-        var offsetToBlock = new Dictionary<int, int>(starts.Length);
-        for (int i = 0; i < starts.Length; i++)
-            offsetToBlock[starts[i]] = i;
-
-        var successorsByBlock = new List<int>[starts.Length];
-        var externalByBlock = new List<int>[starts.Length];
-        var exitsByBlock = new bool[starts.Length];
-        var leavesByBlock = new bool[starts.Length];
-        var lastByBlock = new Instruction?[starts.Length];
-
-        for (int i = 0; i < starts.Length; i++)
-        {
-            int start = starts[i];
-            int end = i + 1 < starts.Length ? starts[i + 1] : ilLength;
-            var last = instructions.LastOrDefault(instruction => instruction.Offset >= start && instruction.Offset < end);
-            var successors = new List<int>();
-            var external = new List<int>();
-            bool exits = last.Exits;
-            bool leaves = last.LeavesRegion;
-            if (last.Offset >= 0)
-            {
-                foreach (int target in last.Targets)
-                {
-                    if (offsetToBlock.TryGetValue(target, out int targetBlock))
-                        successors.Add(targetBlock);
-                    else
-                        external.Add(target);
-                }
-
-                if (last.FallsThrough && i + 1 < starts.Length)
-                    successors.Add(i + 1);
-            }
-
-            successorsByBlock[i] = successors;
-            externalByBlock[i] = external;
-            exitsByBlock[i] = exits;
-            leavesByBlock[i] = leaves;
-            lastByBlock[i] = last.Offset >= 0 ? last : null;
-        }
-
-        AddExceptionEdges(regions, instructions, starts, offsetToBlock, successorsByBlock, externalByBlock, lastByBlock);
-
-        var blocks = ImmutableArray.CreateBuilder<Block>(starts.Length);
-        for (int i = 0; i < starts.Length; i++)
-        {
-            blocks.Add(new Block(
-                starts[i],
-                i + 1 < starts.Length ? starts[i + 1] : ilLength,
-                new BlockEdges(
-                    successorsByBlock[i].Distinct().Order().ToArray(),
-                    externalByBlock[i].Distinct().Order().ToArray(),
-                    exitsByBlock[i],
-                    leavesByBlock[i])));
-        }
-        return blocks.ToImmutable();
-
-        void AddLeader(int offset)
-        {
-            if (offset < ilLength)
-                leaders.Add(offset);
-        }
-    }
-
-    static ImmutableArray<ExceptionRegionModel> BuildRegionModels(
-        int ilLength,
-        IReadOnlyList<Instruction> instructions,
-        IReadOnlyCollection<ExceptionRegion> regions,
-        out ImmutableArray<string> incompleteReasons)
-    {
-        var instructionOffsets = instructions.Select(instruction => instruction.Offset).ToHashSet();
-        var models = ImmutableArray.CreateBuilder<ExceptionRegionModel>();
-        var reasons = ImmutableArray.CreateBuilder<string>();
-        foreach (var region in regions)
-        {
-            if (!TryRange("try", region.TryOffset, region.TryLength, out int tryEnd)
-                || !TryRange("handler", region.HandlerOffset, region.HandlerLength, out int handlerEnd))
-                continue;
-
-            int filterStart = -1;
-            int filterEnd = -1;
-            switch (region.Kind)
-            {
-                case ExceptionRegionKind.Catch:
-                case ExceptionRegionKind.Finally:
-                case ExceptionRegionKind.Fault:
-                    break;
-                case ExceptionRegionKind.Filter:
-                    filterStart = region.FilterOffset;
-                    filterEnd = region.HandlerOffset;
-                    if (!IsBoundary(filterStart) || filterStart >= filterEnd)
-                    {
-                        reasons.Add("Filter exception-handler region has unsupported boundaries.");
-                        continue;
-                    }
-                    break;
-                default:
-                    reasons.Add($"Unsupported exception-handler kind {region.Kind}.");
-                    continue;
-            }
-
-            models.Add(new ExceptionRegionModel(
-                region.Kind,
-                region.TryOffset,
-                tryEnd,
-                region.HandlerOffset,
-                handlerEnd,
-                filterStart,
-                filterEnd));
-        }
-
-        incompleteReasons = reasons.ToImmutable();
-        return models.ToImmutable();
-
-        bool TryRange(string name, int start, int length, out int end)
-        {
-            end = 0;
-            long computedEnd = (long)start + length;
-            if (start < 0 || length <= 0 || computedEnd > ilLength)
-            {
-                reasons.Add($"Exception {name} region has unsupported boundaries.");
-                return false;
-            }
-            end = (int)computedEnd;
-            if (!IsBoundary(start) || !IsBoundary(end))
-            {
-                reasons.Add($"Exception {name} region does not align with instruction boundaries.");
-                return false;
-            }
-            return true;
-        }
-
-        bool IsBoundary(int offset)
-            => offset == ilLength || instructionOffsets.Contains(offset);
-    }
-
-    static void AddExceptionEdges(
-        IReadOnlyList<ExceptionRegionModel> regions,
-        IReadOnlyList<Instruction> instructions,
-        IReadOnlyList<int> blockStarts,
-        IReadOnlyDictionary<int, int> offsetToBlock,
-        IReadOnlyList<List<int>> successorsByBlock,
-        IReadOnlyList<List<int>> externalByBlock,
-        IReadOnlyList<Instruction?> lastByBlock)
-    {
-        foreach (var region in regions)
-        {
-            int handlerBlock = offsetToBlock[region.HandlerStart];
-            int exceptionEntryBlock = region.Kind == ExceptionRegionKind.Filter
-                ? offsetToBlock[region.FilterStart]
-                : handlerBlock;
-
-            foreach (int block in BlocksInRange(region.TryStart, region.TryEnd))
-                successorsByBlock[block].Add(exceptionEntryBlock);
-
-            if (region.Kind == ExceptionRegionKind.Filter)
-            {
-                foreach (int block in BlocksInRange(region.FilterStart, region.FilterEnd))
-                {
-                    successorsByBlock[block].Add(handlerBlock);
-                    foreach (var sibling in regions)
-                    {
-                        if (sibling.Equals(region)
-                            || sibling.TryStart != region.TryStart
-                            || sibling.TryEnd != region.TryEnd)
-                            continue;
-                        successorsByBlock[block].Add(sibling.Kind == ExceptionRegionKind.Filter
-                            ? offsetToBlock[sibling.FilterStart]
-                            : offsetToBlock[sibling.HandlerStart]);
-                    }
-                }
-            }
-
-            if (region.Kind == ExceptionRegionKind.Finally)
-            {
-                var leaveTargets = LeaveTargetsLeaving(region, instructions).ToArray();
-                if (leaveTargets.Length == 0)
-                    continue;
-                foreach (int block in BlocksInRange(region.HandlerStart, region.HandlerEnd))
-                {
-                    if (lastByBlock[block] is not { OpCode: ILOpCode.Endfinally })
-                        continue;
-                    foreach (int target in leaveTargets)
-                    {
-                        if (offsetToBlock.TryGetValue(target, out int targetBlock))
-                            successorsByBlock[block].Add(targetBlock);
-                        else
-                            externalByBlock[block].Add(target);
-                    }
-                }
-            }
-        }
-
-        IEnumerable<int> BlocksInRange(int start, int end)
-        {
-            for (int i = 0; i < blockStarts.Count; i++)
-                if (blockStarts[i] >= start && blockStarts[i] < end)
-                    yield return i;
-        }
-    }
-
-    static IEnumerable<int> LeaveTargetsLeaving(ExceptionRegionModel region, IReadOnlyList<Instruction> instructions)
-    {
-        foreach (var instruction in instructions)
-        {
-            if (!instruction.LeavesRegion || !region.ContainsTry(instruction.Offset))
-                continue;
-            foreach (int target in instruction.Targets)
-                if (!region.ContainsTry(target))
-                    yield return target;
-        }
-    }
-
-    static ImmutableArray<Instruction> DecodeInstructions(byte[] il)
-    {
-        var instructions = ImmutableArray.CreateBuilder<Instruction>();
-        int position = 0;
-        while (position < il.Length)
-        {
-            int offset = position;
-            var opcode = ReadOpcode(il, ref position);
-            int operandOffset = position;
-            var targets = ImmutableArray<int>.Empty;
-            bool branches = false;
-            bool exits = false;
-            bool fallsThrough = true;
-            bool leavesRegion = false;
-
-            if (TryReadBranchTargets(opcode, il, ref position, offset, out targets, out bool unconditional))
-            {
-                branches = true;
-                fallsThrough = !unconditional || opcode == ILOpCode.Switch;
-                leavesRegion = opcode is ILOpCode.Leave or ILOpCode.Leave_s;
-            }
-            else
-            {
-                exits = opcode is ILOpCode.Ret or ILOpCode.Throw or ILOpCode.Rethrow or ILOpCode.Jmp
-                    or ILOpCode.Endfinally or ILOpCode.Endfilter;
-                fallsThrough = !exits;
-                SkipOperand(il, opcode, ref position, offset);
-            }
-
-            instructions.Add(new Instruction(offset, opcode, operandOffset, position, targets, branches, exits, fallsThrough, leavesRegion));
-        }
-
-        return instructions.ToImmutable();
-    }
-
-    static bool TryReadBranchTargets(
-        ILOpCode opcode,
-        byte[] il,
-        ref int position,
-        int offset,
-        out ImmutableArray<int> targets,
-        out bool unconditional)
-    {
-        targets = [];
-        unconditional = false;
-        switch (opcode)
-        {
-            case ILOpCode.Br_s:
-            case ILOpCode.Leave_s:
-                targets = [offset + 2 + (sbyte)ReadByte(il, ref position, offset)];
-                unconditional = true;
-                return true;
-            case ILOpCode.Br:
-            case ILOpCode.Leave:
-                targets = [offset + 5 + ReadInt32(il, ref position, offset)];
-                unconditional = true;
-                return true;
-            case ILOpCode.Brfalse_s or ILOpCode.Brtrue_s or ILOpCode.Beq_s
-                or ILOpCode.Bge_s or ILOpCode.Bgt_s or ILOpCode.Ble_s or ILOpCode.Blt_s
-                or ILOpCode.Bne_un_s or ILOpCode.Bge_un_s or ILOpCode.Bgt_un_s
-                or ILOpCode.Ble_un_s or ILOpCode.Blt_un_s:
-                targets = [offset + 2 + (sbyte)ReadByte(il, ref position, offset)];
-                return true;
-            case ILOpCode.Brfalse or ILOpCode.Brtrue or ILOpCode.Beq
-                or ILOpCode.Bge or ILOpCode.Bgt or ILOpCode.Ble or ILOpCode.Blt
-                or ILOpCode.Bne_un or ILOpCode.Bge_un or ILOpCode.Bgt_un
-                or ILOpCode.Ble_un or ILOpCode.Blt_un:
-                targets = [offset + 5 + ReadInt32(il, ref position, offset)];
-                return true;
-            case ILOpCode.Switch:
-            {
-                int count = ReadInt32(il, ref position, offset);
-                if (count < 0)
-                    throw new BadImageFormatException($"Malformed switch at IL_{offset:X4}");
-                long baseOffset = (long)position + (long)count * 4;
-                if (baseOffset > il.Length)
-                    throw new BadImageFormatException($"Malformed switch at IL_{offset:X4}");
-                var builder = ImmutableArray.CreateBuilder<int>(count);
-                for (int i = 0; i < count; i++)
-                    builder.Add((int)baseOffset + ReadInt32(il, ref position, offset));
-                targets = builder.ToImmutable();
-                return true;
-            }
-            default:
-                return false;
-        }
     }
 
     static bool TryReadLocalSlot(byte[] il, ILOpCode opcode, int operandOffset, out LocalAccess access)
@@ -558,74 +194,6 @@ public static class ReachingDefinitions
         }
     }
 
-    static ILOpCode ReadOpcode(byte[] il, ref int position)
-    {
-        byte first = ReadByte(il, ref position, position);
-        if (first != 0xFE)
-            return (ILOpCode)first;
-        byte second = ReadByte(il, ref position, position - 1);
-        return (ILOpCode)(0xFE00 | second);
-    }
-
-    static void SkipOperand(byte[] il, ILOpCode opcode, ref int position, int offset)
-    {
-        switch (opcode)
-        {
-            case ILOpCode.Switch:
-            {
-                int count = ReadInt32(il, ref position, offset);
-                if (count < 0)
-                    throw new BadImageFormatException($"Malformed switch at IL_{offset:X4}");
-                long tableBytes = (long)count * 4;
-                if (tableBytes > int.MaxValue)
-                    throw new BadImageFormatException($"Malformed switch at IL_{offset:X4}");
-                Advance(il, ref position, (int)tableBytes, offset);
-                break;
-            }
-            case ILOpCode.Br_s or ILOpCode.Brfalse_s or ILOpCode.Brtrue_s or ILOpCode.Beq_s
-                or ILOpCode.Bge_s or ILOpCode.Bgt_s or ILOpCode.Ble_s or ILOpCode.Blt_s
-                or ILOpCode.Bne_un_s or ILOpCode.Bge_un_s or ILOpCode.Bgt_un_s
-                or ILOpCode.Ble_un_s or ILOpCode.Blt_un_s or ILOpCode.Leave_s
-                or ILOpCode.Ldarg_s or ILOpCode.Ldarga_s or ILOpCode.Starg_s
-                or ILOpCode.Ldloc_s or ILOpCode.Ldloca_s or ILOpCode.Stloc_s
-                or ILOpCode.Ldc_i4_s or ILOpCode.Unaligned:
-                Advance(il, ref position, 1, offset);
-                break;
-            case ILOpCode.Ldarg or ILOpCode.Ldarga or ILOpCode.Starg
-                or ILOpCode.Ldloc or ILOpCode.Ldloca or ILOpCode.Stloc:
-                Advance(il, ref position, 2, offset);
-                break;
-            case ILOpCode.Br or ILOpCode.Brfalse or ILOpCode.Brtrue or ILOpCode.Beq
-                or ILOpCode.Bge or ILOpCode.Bgt or ILOpCode.Ble or ILOpCode.Blt
-                or ILOpCode.Bne_un or ILOpCode.Bge_un or ILOpCode.Bgt_un
-                or ILOpCode.Ble_un or ILOpCode.Blt_un or ILOpCode.Leave
-                or ILOpCode.Ldc_i4 or ILOpCode.Ldc_r4
-                or ILOpCode.Jmp or ILOpCode.Ldstr
-                or ILOpCode.Call or ILOpCode.Calli or ILOpCode.Callvirt or ILOpCode.Newobj
-                or ILOpCode.Ldftn or ILOpCode.Ldvirtftn
-                or ILOpCode.Ldfld or ILOpCode.Ldflda or ILOpCode.Stfld
-                or ILOpCode.Ldsfld or ILOpCode.Ldsflda or ILOpCode.Stsfld
-                or ILOpCode.Cpobj or ILOpCode.Ldobj or ILOpCode.Castclass
-                or ILOpCode.Isinst or ILOpCode.Unbox or ILOpCode.Stobj
-                or ILOpCode.Box or ILOpCode.Newarr or ILOpCode.Ldelema
-                or ILOpCode.Ldelem or ILOpCode.Stelem or ILOpCode.Unbox_any
-                or ILOpCode.Refanyval or ILOpCode.Mkrefany or ILOpCode.Initobj
-                or ILOpCode.Constrained or ILOpCode.Sizeof or ILOpCode.Ldtoken:
-                Advance(il, ref position, 4, offset);
-                break;
-            case ILOpCode.Ldc_i8 or ILOpCode.Ldc_r8:
-                Advance(il, ref position, 8, offset);
-                break;
-        }
-    }
-
-    static byte ReadByte(byte[] il, ref int position, int offset)
-    {
-        if ((uint)position >= (uint)il.Length)
-            throw new BadImageFormatException($"Malformed IL at IL_{offset:X4}");
-        return il[position++];
-    }
-
     static byte ReadByteAt(byte[] il, int offset)
     {
         if ((uint)offset >= (uint)il.Length)
@@ -640,57 +208,8 @@ public static class ReachingDefinitions
         return BinaryPrimitives.ReadUInt16LittleEndian(il.AsSpan(offset));
     }
 
-    static int ReadInt32(byte[] il, ref int position, int offset)
-    {
-        if (position < 0 || position + 4 > il.Length)
-            throw new BadImageFormatException($"Malformed IL operand at IL_{offset:X4}");
-        int value = BinaryPrimitives.ReadInt32LittleEndian(il.AsSpan(position));
-        position += 4;
-        return value;
-    }
-
-    static void Advance(byte[] il, ref int position, int bytes, int offset)
-    {
-        long targetPosition = (long)position + bytes;
-        if (targetPosition < position || targetPosition > il.Length)
-            throw new BadImageFormatException($"Malformed IL operand at IL_{offset:X4}");
-        position = (int)targetPosition;
-    }
-
     readonly record struct SlotKey(int Slot, bool IsArgument);
 
     readonly record struct LocalAccess(int Slot, bool Argument, bool Store, bool Address);
 
-    readonly record struct Instruction(
-        int Offset,
-        ILOpCode OpCode,
-        int OperandOffset,
-        int NextOffset,
-        ImmutableArray<int> Targets,
-        bool Branches,
-        bool Exits,
-        bool FallsThrough,
-        bool LeavesRegion);
-
-    readonly record struct Block(int Start, int End, BlockEdges Edges);
-
-    readonly record struct ExceptionRegionModel(
-        ExceptionRegionKind Kind,
-        int TryStart,
-        int TryEnd,
-        int HandlerStart,
-        int HandlerEnd,
-        int FilterStart,
-        int FilterEnd)
-    {
-        public bool ContainsTry(int offset) => offset >= TryStart && offset < TryEnd;
-
-        public bool ContainsHandler(int offset) => offset >= HandlerStart && offset < HandlerEnd;
-
-        public bool ContainsFilter(int offset)
-            => Kind == ExceptionRegionKind.Filter && offset >= FilterStart && offset < FilterEnd;
-
-        public bool ContainsAny(int offset)
-            => ContainsTry(offset) || ContainsHandler(offset) || ContainsFilter(offset);
-    }
 }

--- a/src/ILInspector.Instructions/ILInspector.Instructions.csproj
+++ b/src/ILInspector.Instructions/ILInspector.Instructions.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <Authors>Richard Lander</Authors>
-    <Description>Gated Rung 5 typed-stack substrate: decode -> typed instructions -> typed-stack -> EH-aware blocks. SRM-only, no IrNode/structuring/C#. Prototype (issue #1908).</Description>
+    <Description>Shared SRM-only IL decode and exception-handling-aware basic-block substrate (Layer 0) that the analyzer and decompiler converge onto, plus an opt-in, gated typed evaluation stack (Layer 1). No IrNode/structuring/C#/Roslyn; no inspected-assembly loading. See issue #1939.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Cuts **`ReachingDefinitions`** (Analysis) over to the shared
`ILInspector.Instructions` substrate landed in #1982 — the **first consumer
de-dup**. RD now decodes + builds EH-aware blocks via the substrate and keeps
only its reaching-defs dataflow; **~495 lines of duplicate decoder + block-builder
+ region modeling are deleted**.

This is where the substrate's value becomes a *live, measured* change rather than
motivation. Tracker: #1939.

## What changed

- `ReachingDefinitions.AnalyzeCore` now calls `InstructionDecoder.Decode` +
  `BlockGraph.Build` (the **throwing** Layer-0 primitives — preserving RD's
  malformed-IL `BadImageFormatException` contract, not the fail-closed façade)
  and threads the substrate's `InstructionBlock` / `DecodedInstruction` /
  `BlockEdges` through its existing gen/kill dataflow. RD's own
  `DecodeInstructions`/`ReadOpcode`/`SkipOperand`/`BuildBlocks`/region modeling
  are gone (696 → 215 lines).
- `ILInspector.Analysis.csproj` gains the `ILInspector.Instructions` project
  reference.
- Refreshes the stale `ILInspector.Instructions.csproj` `<Description>` (was
  "Rung 5 typed-stack … Prototype (#1908)"; now the #1939 substrate framing) —
  the one nit from the #1939 architecture review.

## Parity (regression-free replacement, not zero-diff)

- **`ILInspector.Analysis.Tests` 265/265** and **`dotnet-inspect.Tests`
  1467/1467** pass **unchanged** — behavioral parity of the reaching-defs results
  (RD feeds the allocation/triage producers, which are covered end-to-end).
- **Block + edge parity over all of `System.Private.CoreLib`** (>10,000 method
  bodies): block spans, successors, external targets, `ExitsMethod`, and
  `LeavesRegion` flags match the old builder **exactly — 0 mismatches**. (Run via
  the pre-cutover differential where both builders coexist; `BlockGraph.Build` is
  unchanged by the #1982 hardening, so this is representative of the merged
  substrate.)

## Perf — now a live change

The substrate's decode+blocks replaces RD's decoder, so the comparison is the
change under test. Measured on an idle 24-core host, Release, over CoreLib
(41,159 method bodies), 5 invocations × 5 passes (±2%), at the pre-cutover commit
where both coexist:

| Path | Old (ReachingDefinitions) | New (substrate) | Change |
| --- | --- | --- | --- |
| decode + blocks | ~77 ms/pass | ~62 ms/pass | **−19% (faster)** |
| decode-only | N/A¹ | 11 ms/pass | N/A |

¹ The old `ReachingDefinitions` fused decode into `Analyze` and exposed no
decode-only entry point; the Layer-0 split is a new capability.

So the cutover is a **perf win**, not a regression — on top of deleting ~495
lines.

## Review

Behavior-sensitive cutover → requesting **3 adversarial reviews** (GPT-5.5,
Gemini 3.1 Pro, Opus 4.8). Attack points: whether the substrate's blocks/edges
are truly identical to what RD's dataflow depended on (especially EH
per-instruction leaders and exception edges); preservation of the malformed-IL
throwing contract; and the gen/kill transfer over the new `InstructionBlock` shape.
