### PR TITLE
Raise guarded union if declaration patterns

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -235,7 +235,7 @@ public class TypeSourceComposerUnionTests
         using var assembly = await CompileWithSdk("""
             namespace UnionFixtures;
 
-            public sealed class Cat { public string Name { get; } = "cat"; }
+            public sealed class Cat { public string Name { get; } = "cat"; public int Age { get; } = 5; }
             public sealed class Dog { }
             public union Pet(Cat, Dog);
 
@@ -246,6 +246,13 @@ public class TypeSourceComposerUnionTests
                 public static string IfDeclaration(Pet pet)
                 {
                     if (pet is Cat cat)
+                        return cat.Name;
+                    return "none";
+                }
+
+                public static string IfGuardedDeclaration(Pet pet)
+                {
+                    if (pet is Cat cat && cat.Age > 3)
                         return cat.Name;
                     return "none";
                 }
@@ -261,6 +268,8 @@ public class TypeSourceComposerUnionTests
         Assert.Equal("return pet is Cat cat && cat.Name.Length > 0;",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "HasNamedCat"));
         Assert.Contains("if (pet is Cat cat)", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IfDeclaration"));
+        Assert.Contains("if (pet is Cat { Age: > 3 } cat)",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "IfGuardedDeclaration"));
         Assert.Equal("""
             if (pet is Cat cat)
             {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2391,7 +2391,8 @@ public sealed partial class CSharpPrinter
             return null;
         }
 
-        return $"{Operand(pattern.Value)} is {TypeText(pattern.Type)} {{ {string.Join(", ", subpatterns.Select(p => $"{p.PropertyName}: {p.Subpattern}"))} }}";
+        string designation = pattern.PreserveLocalInPropertyPattern ? $" {LocalName(pattern.LocalIndex)}" : "";
+        return $"{TypeTestValueText(pattern.Value)} is {TypeText(pattern.Type)} {{ {string.Join(", ", subpatterns.Select(p => $"{p.PropertyName}: {p.Subpattern}"))} }}{designation}";
     }
 
     static void CollectConjuncts(IrExpression expression, List<IrExpression> conjuncts)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -2364,6 +2364,9 @@ public sealed class IsPattern : IrExpression
     /// <summary>The local slot bound by the pattern when the test succeeds.</summary>
     public int LocalIndex { get; }
 
+    /// <summary>When folded into a property pattern, keep the local designation because the guarded scope uses it.</summary>
+    public bool PreserveLocalInPropertyPattern { get; init; }
+
     /// <summary>The value being tested.</summary>
     public IrExpression Value => (IrExpression)Children[0];
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -39,7 +39,7 @@ public sealed class IsPatternPass : IIrPass
 {
     public string Name => "is-pattern";
 
-    sealed record TestSite(IrExpression TestNode, IrNode TrueScope);
+    sealed record TestSite(IrExpression TestNode, IrNode TrueScope, bool PreserveLocalInPropertyPattern = false);
     sealed record RecursivePropertyDeclarationMatch(
         IfStatement NullGuard,
         IfStatement Consumer,
@@ -79,7 +79,8 @@ public sealed class IsPatternPass : IIrPass
                 if (ReferenceOwnership.SubtreeReferencesLocal(asCast.Operand, store.Index) || !IsSideEffectFree(function, asCast.Operand))
                     continue;
 
-                if (FindTest(children[i + 1], store.Index) is not { } site)
+                bool allowStatementConjunction = asCast.Operand is LoadProperty property && IsUnionValueProperty(function, property);
+                if (FindTest(children[i + 1], store.Index, allowStatementConjunction) is not { } site)
                     continue;
 
                 // Soundness: the pattern local must be referenced ONLY by the
@@ -91,7 +92,10 @@ public sealed class IsPatternPass : IIrPass
                     continue;
 
                 var value = (IrExpression)asCast.DetachChildren()[0];
-                var pattern = new IsPattern(value, asCast.Type, store.Index);
+                var pattern = new IsPattern(value, asCast.Type, store.Index)
+                {
+                    PreserveLocalInPropertyPattern = site.PreserveLocalInPropertyPattern
+                };
                 stepper.StepOver("raise as/null-test to is pattern", site.TestNode);
                 site.TestNode.ReplaceWith(pattern);
                 store.Detach();
@@ -374,25 +378,32 @@ public sealed class IsPatternPass : IIrPass
     /// Locates the null test on the pattern local in the statement that follows
     /// the <c>as</c> store, plus the scope that test gates.
     /// </summary>
-    static TestSite? FindTest(IrNode next, int index)
+    static TestSite? FindTest(IrNode next, int index, bool allowStatementConjunction)
     {
+        if (allowStatementConjunction
+            && next is IfStatement { HasElse: false, Condition: LogicalBinary { Kind: LogicalKind.And } condition } andGuard
+            && IsPatternLocalNotNull(LeftmostConjunct(condition), index))
+        {
+            return new TestSite(LeftmostConjunct(condition), andGuard, PreserveLocalInPropertyPattern: true);
+        }
+
         // Short-circuit form: `t != null && rest` — the leading conjunct of the
         // whole && chain is the bare truthy load of the pattern local; the full
         // chain is the scope entered only when the pattern matched.
         foreach (var logical in next.Descendants.OfType<LogicalBinary>())
         {
-            if (logical.Kind == LogicalKind.And
-                && LeftmostConjunct(logical) is LoadLocal andLoad
-                && andLoad.Index == index)
+            if (logical.Kind == LogicalKind.And)
             {
-                return new TestSite(andLoad, logical);
+                var leftmost = LeftmostConjunct(logical);
+                if (IsPatternLocalNotNull(leftmost, index))
+                    return new TestSite(leftmost, logical);
             }
         }
 
         // Statement-guard form: `if (t != null) { ...t... } else { ... }` —
         // only the then-arm is gated by the successful pattern. The caller's
         // LocalReferencesOnlyWithin check rejects any else-arm use of t.
-        if (next is IfStatement { Condition: LoadLocal guardLoad } guard && guardLoad.Index == index)
+        if (next is IfStatement guard && IsPatternLocalNotNull(guard.Condition, index))
             return new TestSite(guard.Condition, guard.Then);
 
         return null;


### PR DESCRIPTION
## Summary

Raises guarded union `if` declaration/property patterns that currently leak the lowered `Value as T` shape.

Simple union declaration patterns already raised, but a statement guard such as `if (pet is Cat cat && cat.Age > 3)` stayed as `Cat cat = pet.Value as Cat; if (cat is not null && cat.Age > 3)`. This PR allows that statement-conjunction shape only when the tested value is a proven union `Value` property, preserving existing non-union manual-`as` negatives.

Fixes #1991.

## Before / After

Source shape:

```csharp
if (pet is Cat cat && cat.Age > 3)
    return cat.Name;
return "none";
```

Before:

```csharp
Cat cat = pet.Value as Cat;
if (cat is not null && cat.Age > 3)
{
    return cat.Name;
}
return "none";
```

After:

```csharp
if (pet is Cat { Age: > 3 } cat)
{
    return cat.Name;
}
return "none";
```

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/UnionDeclarationPattern_RendersAgainstUnion"` — 1 passed.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/IsPatternPassTests/*"` — 22 passed; manual non-union `as` negatives remain flat.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"` — 14 passed.
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet -p:PublishAot=false` — passed. Host default AOT restore currently fails on unavailable preview.6 packs; this is the documented decompiler build gate.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringCoverageTests/*"` — 6 passed.
- Build-event validation-only summary: 278 projects, 0 failed, 0 errors, 0 warnings; event log `20260630T165638.2374273Z-2773927-build-78814778`.

## Review

Decompiler behavior change; adversarial review requested separately before marking ready.
