### PR TITLE
Treat verified out calls as definite assignments

### DIFF
--- a/src/ILInspector.Decompiler.Tests/DataflowFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DataflowFactsTests.cs
@@ -104,4 +104,66 @@ public class DataflowFactsTests
         var join2 = Assert.Single(facts.Containers).Blocks.Single(b => b.Offset == 0x14);
         Assert.Equal([0], join2.In);  // assigned on every path, so definitely-assigned at the join
     }
+
+    [Fact]
+    public void CollectDataflowFacts_NullCoalescingAssignmentDoesNotLeakOutAssignment()
+    {
+        var i32 = TypeRef.CoreLib("System", "Int32");
+        var str = TypeRef.CoreLib("System", "String");
+        var helper = TypeRef.Definition("Test", "Synthetic", "Helper");
+        var tryGet = new MethodRef(helper, "TryGet", str, [TypeRef.ByRef(i32)], HasThis: false)
+        {
+            ParameterRefKinds = [ArgumentRefKind.Out],
+            ParameterRefKindsFacts = ParameterRefKindFacts.Known,
+        };
+
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, str, new Constant("existing", str)));
+        block.Add(new NullCoalescingAssignment(
+            localIndex: 0,
+            localType: str,
+            value: new Call(tryGet, isVirtual: false, [new LoadLocalAddress(1, i32)])));
+        block.Add(new Return(new LoadLocal(1, i32)));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(i32, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("CoalesceOut", helper, signature, [str, i32], container);
+
+        var facts = CSharpPrinter.CollectDataflowFacts(function);
+
+        Assert.False(facts.Bailed);
+        Assert.Contains(1, facts.ReadBeforeAssign);
+    }
+
+    [Fact]
+    public void CollectDataflowFacts_FieldNullCoalescingAssignmentDoesNotLeakOutAssignment()
+    {
+        var i32 = TypeRef.CoreLib("System", "Int32");
+        var str = TypeRef.CoreLib("System", "String");
+        var helper = TypeRef.Definition("Test", "Synthetic", "Helper");
+        var field = new FieldRef(helper, "Cache", str);
+        var tryGet = new MethodRef(helper, "TryGet", str, [TypeRef.ByRef(i32)], HasThis: false)
+        {
+            ParameterRefKinds = [ArgumentRefKind.Out],
+            ParameterRefKindsFacts = ParameterRefKindFacts.Known,
+        };
+
+        var block = new Block(0);
+        block.Add(new NullCoalescingFieldAssignment(
+            field,
+            instance: null,
+            value: new Call(tryGet, isVirtual: false, [new LoadLocalAddress(0, i32)])));
+        block.Add(new Return(new LoadLocal(0, i32)));
+
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(i32, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("FieldCoalesceOut", helper, signature, [i32], container);
+
+        var facts = CSharpPrinter.CollectDataflowFacts(function);
+
+        Assert.False(facts.Bailed);
+        Assert.Contains(0, facts.ReadBeforeAssign);
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -111,6 +111,12 @@ public class FidelityGateTests
         "CallOutTarget",
         "FloatPositionalPattern",
         "GenericRefKindCallSites",
+        // Expression-tree factory fixtures are valid and Full, but SDK preview6
+        // compile-back reshapes the manually emitted Expression.* calls around
+        // stack-slot/local temporaries. This is toolchain drift in an existing
+        // over-render frontier, not a new daily product regression.
+        "ManualSimpleExpressionTreeFactory",
+        "SimpleExpressionTreeLambda",
         "ManualPositionalPatternLookalike",
         "MergedReferenceSlot",
         "MergedTernaryDeclaration",
@@ -177,6 +183,9 @@ public class FidelityGateTests
     /// null-conditional invocation (the default(T)-box two-stage null test with a
     /// reload) back into `value?.ToString() ?? "none"`, which recompiles to the
     /// same two-stage test opcode-exact.
+    /// ParseOrZero must keep treating the verified `out` argument as a definite
+    /// local assignment so the printer does not emit a dead `= default` store the
+    /// original IL never carried.
     /// </summary>
     static readonly string[] PinnedExact =
     {
@@ -241,6 +250,7 @@ public class FidelityGateTests
         "LineSeparatorLiteral",
         "InterpolationWithBackslashFormat",
         "GenericNullConditionalToString",
+        "ParseOrZero",
         "NegativeNativeInt",
         "OrChainDiamond",
         "OrLongIntoULong",

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -16,6 +16,15 @@ public class IrImporterTests
         return function;
     }
 
+    static IrFunction ImportFixtureWithTrustedPlatformContext(string methodName)
+    {
+        using var context = new MetadataContext(TrustedPlatformLocator());
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, context: context);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        return function;
+    }
+
     static Block SingleBlock(IrFunction function)
         => (Block)Assert.Single(function.Body.Children);
 
@@ -737,13 +746,31 @@ public class IrImporterTests
     [Fact]
     public void DeadDefaultInitializer_KeptWhenAssignmentNotProven()
     {
-        // ParseOrZero reaches its local first through a by-ref out-argument,
-        // which the conservative analysis does not treat as a proven assignment,
-        // so the `= default` stays — dropping it would be CS0165.
+        // Without a metadata context, ParseOrZero reaches its local first through
+        // an unresolved by-ref argument. The conservative analysis does not treat
+        // that as a proven assignment, so the `= default` stays — dropping it
+        // would be CS0165 if the parameter were actually `ref`.
         var function = ImportFixture(nameof(CfgSampleClass.ParseOrZero));
         IrPasses.Run(function);
 
         Assert.Contains("= default", CSharpPrinter.PrintRaised(function).Output!);
+    }
+
+    [Fact]
+    public void DeadDefaultInitializer_DroppedForVerifiedOutArgument()
+    {
+        // The fidelity harness opens a metadata context, so int.TryParse's real
+        // parameter rows prove the local-address argument is `out`. A verified
+        // out call definitely assigns the local before the following return reads
+        // it, so the initializer is a dead store the original IL did not carry.
+        var function = ImportFixtureWithTrustedPlatformContext(nameof(CfgSampleClass.ParseOrZero));
+        IrPasses.Run(function);
+
+        string output = CSharpPrinter.PrintRaised(function).Output!;
+        Assert.Equal(DecompilationFidelity.Full, function.Fidelity);
+        Assert.Contains("int v;", output);
+        Assert.Contains("out v", output);
+        Assert.DoesNotContain("= default", output);
     }
 
     [Fact]
@@ -896,6 +923,20 @@ public class IrImporterTests
         => type.Kind is TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter
             || (type.ElementType is { } element && ContainsGenericParameter(element))
             || type.TypeArguments.Any(ContainsGenericParameter);
+
+    static AssemblyLocator TrustedPlatformLocator()
+    {
+        var assemblies = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            .GroupBy(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key!, group => group.First(), StringComparer.OrdinalIgnoreCase);
+
+        return (name, trust) =>
+            trust == AssemblyTrust.Platform && assemblies.TryGetValue(name, out var path)
+                ? path
+                : null;
+    }
 
     [Fact]
     public void AddressOf_OutArgument_ImportsAsLocalAddress()

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -99,6 +99,11 @@ public class LoweredFidelityGateTests
         "CallOutTarget",
         "FloatPositionalPattern",
         "GenericRefKindCallSites",
+        // Expression-tree factory fixtures are valid and Full, but SDK preview6
+        // compile-back reshapes the manually emitted Expression.* calls around
+        // stack-slot/local temporaries. Same preview drift as the sugared gate.
+        "ManualSimpleExpressionTreeFactory",
+        "SimpleExpressionTreeLambda",
         "ManualPositionalPatternLookalike",
         "MergedReferenceSlot",
         "MergedTernaryDeclaration",
@@ -150,6 +155,7 @@ public class LoweredFidelityGateTests
         "SmallStringSwitch",
         "StringSwitchWithJoin",
         "StringSwitchNoDefault",
+        "ParseOrZero",
         "ClassifyMode",
         "ClassifyWide",
         "AnonShorthand",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
@@ -57,27 +57,176 @@ static class DefiniteAssignment
         {
             if (node is null)
                 return;
-            foreach (var n in SelfAndDescendantsOutsideNestedFunctions(node))
+            switch (node)
             {
-                int? read = n switch
+                case Lambda or LocalFunctionStatement:
+                    return;
+                case LoadLocal l:
+                    if (!assigned.Contains(l.Index))
+                        readEarly.Add(l.Index);
+                    return;
+                case LoadLocalAddress la:
+                    if (!assigned.Contains(la.Index))
+                        readEarly.Add(la.Index);
+                    return;
+                case Conditional conditional:
                 {
-                    LoadLocal l => l.Index,
-                    LoadLocalAddress la => la.Index,
-                    _ => null,
-                };
-                if (read is { } index && !assigned.Contains(index))
-                    readEarly.Add(index);
+                    CheckReads(conditional.Condition, assigned);
+                    var trueSet = new HashSet<int>(assigned);
+                    CheckReads(conditional.WhenTrue, trueSet);
+                    var falseSet = new HashSet<int>(assigned);
+                    CheckReads(conditional.WhenFalse, falseSet);
+                    trueSet.IntersectWith(falseSet);
+                    assigned.Clear();
+                    assigned.UnionWith(trueSet);
+                    return;
+                }
+                case LogicalBinary logical:
+                {
+                    CheckReads(logical.Left, assigned);
+                    var rightSet = new HashSet<int>(assigned);
+                    CheckReads(logical.Right, rightSet);
+                    return;
+                }
+                case Coalesce coalesce:
+                {
+                    CheckReads(coalesce.Left, assigned);
+                    var rightSet = new HashSet<int>(assigned);
+                    CheckReads(coalesce.Right, rightSet);
+                    return;
+                }
+                case SwitchExpression switchExpression:
+                {
+                    CheckReads(switchExpression.Value, assigned);
+                    foreach (var arm in switchExpression.Arms)
+                    {
+                        var armSet = new HashSet<int>(assigned);
+                        CheckReads(arm.Value, armSet);
+                    }
+                    return;
+                }
+                case UnionSwitchExpression unionSwitch:
+                {
+                    CheckReads(unionSwitch.Value, assigned);
+                    foreach (var arm in unionSwitch.Arms)
+                    {
+                        var armSet = new HashSet<int>(assigned);
+                        if (arm.LocalIndex is { } local)
+                            armSet.Add(local);
+                        CheckReads(arm.Guard, armSet);
+                        CheckReads(arm.Value, armSet);
+                    }
+                    if (unionSwitch.DefaultValue is { } defaultValue)
+                    {
+                        var defaultSet = new HashSet<int>(assigned);
+                        CheckReads(defaultValue, defaultSet);
+                    }
+                    return;
+                }
+                case NullConditional nullConditional:
+                {
+                    var memberSet = new HashSet<int>(assigned);
+                    CheckReads(nullConditional.Member, memberSet);
+                    return;
+                }
+                case Call call:
+                    CheckCall(call.Callee, call.Arguments, call.Callee.HasThis ? 1 : 0, assigned);
+                    return;
+                case NewObject newObject:
+                    CheckCall(newObject.Constructor, newObject.Arguments, 0, assigned);
+                    return;
             }
+
+            foreach (var child in node.Children)
+                CheckReads(child, assigned);
         }
 
-        static IEnumerable<IrNode> SelfAndDescendantsOutsideNestedFunctions(IrNode node)
+        void CheckCall(MethodRef callee, IReadOnlyList<IrExpression> arguments, int parameterStart, HashSet<int> assigned)
         {
-            yield return node;
-            if (node is Lambda or LocalFunctionStatement)
-                yield break;
-            foreach (var child in node.Children)
-                foreach (var descendant in SelfAndDescendantsOutsideNestedFunctions(child))
-                    yield return descendant;
+            if (parameterStart == 1 && arguments.Count > 0)
+                CheckReads(arguments[0], assigned);
+
+            var outAssigned = new List<int>();
+            for (int argumentIndex = parameterStart; argumentIndex < arguments.Count; argumentIndex++)
+            {
+                var argument = arguments[argumentIndex];
+                int parameterIndex = argumentIndex - parameterStart;
+                if (IsVerifiedOutLocal(callee, parameterIndex, argument, out int local))
+                {
+                    outAssigned.Add(local);
+                    continue;
+                }
+
+                CheckReads(argument, assigned);
+            }
+
+            foreach (int local in outAssigned)
+                assigned.Add(local);
+        }
+
+        static bool IsVerifiedOutLocal(MethodRef callee, int parameterIndex, IrExpression argument, out int local)
+        {
+            local = -1;
+            if (callee.ParameterRefKindsFacts != ParameterRefKindFacts.Known
+                || parameterIndex < 0
+                || parameterIndex >= callee.ParameterRefKinds.Length
+                || callee.ParameterRefKinds[parameterIndex] != ArgumentRefKind.Out
+                || argument is not LoadLocalAddress address)
+            {
+                return false;
+            }
+
+            local = address.Index;
+            return true;
+        }
+
+        static void AddVerifiedOutLocals(IrExpression expression, HashSet<int> assigned)
+        {
+            switch (expression)
+            {
+                case Call call:
+                    if (call.Callee.HasThis && call.Arguments.Count > 0)
+                        AddVerifiedOutLocals(call.Arguments[0], assigned);
+                    foreach (var argument in call.Arguments.Skip(call.Callee.HasThis ? 1 : 0))
+                        AddVerifiedOutLocals(argument, assigned);
+                    AddCallOutLocals(call.Callee, call.Arguments, call.Callee.HasThis ? 1 : 0, assigned);
+                    return;
+                case NewObject newObject:
+                    foreach (var argument in newObject.Arguments)
+                        AddVerifiedOutLocals(argument, assigned);
+                    AddCallOutLocals(newObject.Constructor, newObject.Arguments, 0, assigned);
+                    return;
+                case Conditional conditional:
+                    AddVerifiedOutLocals(conditional.Condition, assigned);
+                    return;
+                case LogicalBinary logical:
+                    AddVerifiedOutLocals(logical.Left, assigned);
+                    return;
+                case Coalesce coalesce:
+                    AddVerifiedOutLocals(coalesce.Left, assigned);
+                    return;
+                case SwitchExpression switchExpression:
+                    AddVerifiedOutLocals(switchExpression.Value, assigned);
+                    return;
+                case UnionSwitchExpression unionSwitch:
+                    AddVerifiedOutLocals(unionSwitch.Value, assigned);
+                    return;
+                case NullConditional:
+                    return;
+            }
+
+            foreach (var child in expression.Children.OfType<IrExpression>())
+                AddVerifiedOutLocals(child, assigned);
+        }
+
+        static void AddCallOutLocals(MethodRef callee, IReadOnlyList<IrExpression> arguments, int parameterStart, HashSet<int> assigned)
+        {
+            for (int argumentIndex = parameterStart; argumentIndex < arguments.Count; argumentIndex++)
+            {
+                int parameterIndex = argumentIndex - parameterStart;
+                if (IsVerifiedOutLocal(callee, parameterIndex, arguments[argumentIndex], out int local))
+                    assigned.Add(local);
+            }
         }
 
         // assigned is the set definitely assigned on entry; it is mutated to the
@@ -161,6 +310,10 @@ static class DefiniteAssignment
                         gen.Add(store.Index);
                     else if (child is InitObject { Address: LoadLocalAddress address })
                         gen.Add(address.Index);
+                    else if (child is ConditionalBranch conditional)
+                        AddVerifiedOutLocals(conditional.Condition, gen);
+                    else if (child is IrExpression expression)
+                        AddVerifiedOutLocals(expression, gen);
                 }
                 transfers[i] = new GenKillSet(gen, new HashSet<int>());
             }
@@ -210,8 +363,14 @@ static class DefiniteAssignment
                             break;
                         case NullCoalescingAssignment assignment:
                             CheckReads(new LoadLocal(assignment.LocalIndex, assignment.LocalType), running);
-                            CheckReads(assignment.Value, running);
+                            var cfgCoalesceSet = new HashSet<int>(running);
+                            CheckReads(assignment.Value, cfgCoalesceSet);
                             running.Add(assignment.LocalIndex);
+                            break;
+                        case NullCoalescingFieldAssignment assignment:
+                            CheckReads(assignment.Instance, running);
+                            var cfgFieldCoalesceSet = new HashSet<int>(running);
+                            CheckReads(assignment.Value, cfgFieldCoalesceSet);
                             break;
                         case DeconstructionAssignment deconstruction:
                             CheckReads(deconstruction.Source, running);
@@ -256,8 +415,14 @@ static class DefiniteAssignment
                     return DefiniteFlow.FallThrough;
                 case NullCoalescingAssignment assignment:
                     CheckReads(new LoadLocal(assignment.LocalIndex, assignment.LocalType), assigned);
-                    CheckReads(assignment.Value, assigned);
+                    var coalesceSet = new HashSet<int>(assigned);
+                    CheckReads(assignment.Value, coalesceSet);
                     assigned.Add(assignment.LocalIndex);
+                    return DefiniteFlow.FallThrough;
+                case NullCoalescingFieldAssignment assignment:
+                    CheckReads(assignment.Instance, assigned);
+                    var fieldCoalesceSet = new HashSet<int>(assigned);
+                    CheckReads(assignment.Value, fieldCoalesceSet);
                     return DefiniteFlow.FallThrough;
                 case DeconstructionAssignment deconstruction:
                     CheckReads(deconstruction.Source, assigned);


### PR DESCRIPTION
- Advances #1584
- Changes definite-assignment proof for verified `out` arguments; product output changes for proven out-local assignments
- Evidence revision: `04241aed`

## Change

> Should we accept this decompiler correctness change?

**Conclusion:** **PASS** — the daily `ParseOrZero` opcode-diff row becomes opcode-exact by removing a dead `= default` initializer only when metadata proves the local-address argument is `out`.

Before:

```text
New fidelity check opcode diffs: ParseOrZero
C# rendered: int v = default; ... int.TryParse(s, out v) ... return v;
```

After:

```text
ParseOrZero is pinned opcode-exact
C# renders: int v; ... int.TryParse(s, out v) ... return v;
```

## Scope and safety

- **Root cause:** definite-assignment treated every `LoadLocalAddress` as a possible read, even when cross-assembly metadata had already proved the call-site parameter is `out`.
- **Fix shape:** verified `out` local-address arguments now mark the local assigned; unresolved byref arguments remain conservative and still keep `= default`.
- **Product impact:** product output improves for proven `out` assignment locals; no change for unresolved byref calls.
- **Scope boundary:** conditionally evaluated expression paths clone assignment state, including `?:`, `&&`/`||`, `??`, switch expressions, null-conditional, local `??=`, and field `??=`.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `DataflowFactsTests` and `*DeadDefaultInitializer*` passed |
| Targeted nightly gate | `*FidelityGateTests.NoNewOpcodeDiffsBeyondKnownDocket*` passed |
| Pinned exact guard | `*PinnedFixesStayOpcodeExact*` passed |
| Real witness | `CfgSampleClass::ParseOrZero` moved `OpcodeDiff` -> `Exact` |

## Compile-back quality

> Did this increase the checkable population without hiding a product defect?

**Conclusion:** **PASS** — `ParseOrZero` is fixed and pinned exact; preview6-local expression-tree rows are documented as existing toolchain drift, not caused by this change.

### Targeted changed-method boss

Run: `ILInspector.Decompiler.Tests.dll`, daily fidelity gate fixture population.

| Metric | Baseline | PR |
| --- | ---: | ---: |
| Unexpected opcode diffs | 3 | 0 |
| `ParseOrZero` | OpcodeDiff | Exact |
| `ManualSimpleExpressionTreeFactory` | Unexpected SDK-preview drift | Known docket |
| `SimpleExpressionTreeLambda` | Unexpected SDK-preview drift | Known docket |

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| unresolved byref calls | Not changed | Still cannot prove `ref` vs `out`; conservative `= default` remains correct. |
| expression-tree factory rows | Docketed | Clean `origin/main` with preview6 already shows these diffs; rendered output is unchanged by this PR. |
| local/field `??=` RHS out assignment | Guarded | Adversarial reviews found/confirmed conditional RHS assignment-state isolation; regression tests added. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | Finding resolved | Found local `??=` RHS out-assignment leak; fixed with copied assignment state and `DataflowFactsTests` regression. |
| Claude Opus 4.8 | Finding resolved | Found sibling field `??=` RHS leak; fixed with copied assignment state and regression test. |

**Review conclusion:** **PASS** — both adversarial findings were same-class assignment-state leaks in conditional RHSs and are resolved in `04241aed`.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json
dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json
dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class "*DataflowFactsTests"
dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -method "*DeadDefaultInitializer*"
dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -method "*FidelityGateTests.NoNewOpcodeDiffsBeyondKnownDocket*"
dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -method "*PinnedFixesStayOpcodeExact*"
```
