### PR TITLE
Raise union pattern conditional returns

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -283,6 +283,32 @@ public class TypeSourceComposerUnionTests
     }
 
     [Fact]
+    public async Task UnionConditionalReturn_RendersPatternConditional()
+    {
+        using var assembly = await CompileWithSdk("""
+            namespace UnionFixtures;
+
+            public sealed class Cat { public string Name { get; } = "cat"; public int Age { get; } = 5; }
+            public sealed class Dog { public string Name { get; } = "dog"; }
+            public union Pet(Cat, Dog);
+
+            public static class Matcher
+            {
+                public static string Ternary(Pet pet) => pet is Cat cat ? cat.Name : "other";
+                public static string TernaryGuard(Pet pet) => pet is Cat cat && cat.Age > 3 ? cat.Name : "other";
+                public static int ConditionalNumber(Pet pet) => pet is Cat cat ? cat.Age : -1;
+            }
+            """);
+
+        Assert.Equal("return pet is Cat cat ? cat.Name : \"other\";",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "Ternary"));
+        Assert.Equal("return pet is Cat { Age: > 3 } cat ? cat.Name : \"other\";",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "TernaryGuard"));
+        Assert.Equal("return pet is Cat cat ? cat.Age : -1;",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "ConditionalNumber"));
+    }
+
+    [Fact]
     public async Task UnionSwitchExpression_RendersTypePatternArms()
     {
         using var assembly = await CompileWithSdk("""

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -297,6 +297,16 @@ public class TypeSourceComposerUnionTests
                 public static string Ternary(Pet pet) => pet is Cat cat ? cat.Name : "other";
                 public static string TernaryGuard(Pet pet) => pet is Cat cat && cat.Age > 3 ? cat.Name : "other";
                 public static int ConditionalNumber(Pet pet) => pet is Cat cat ? cat.Age : -1;
+
+                public static string ManualFallbackUsesLocal(Pet pet)
+                {
+                    Cat cat = pet.Value as Cat;
+                    if (cat is null)
+                        return FormatNull(cat);
+                    return cat.Name;
+                }
+
+                static string FormatNull(Cat? cat) => cat?.Name ?? "null";
             }
             """);
 
@@ -306,6 +316,10 @@ public class TypeSourceComposerUnionTests
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "TernaryGuard"));
         Assert.Equal("return pet is Cat cat ? cat.Age : -1;",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "ConditionalNumber"));
+        var manual = RenderMember(assembly.Path, "UnionFixtures.Matcher", "ManualFallbackUsesLocal");
+        Assert.Contains("Cat cat = pet.Value as Cat;", manual);
+        Assert.Contains("FormatNull(cat)", manual);
+        Assert.DoesNotContain("pet is Cat cat ? cat.Name : FormatNull(cat)", manual);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -58,6 +58,7 @@ public sealed class IsPatternPass : IIrPass
     public void Run(IrFunction function, PassContext context)
     {
         while (TransformOne(function, context.Stepper)
+            || FoldConditionalReturnOne(function, context.Stepper)
             || TransformRecursivePropertyDeclaration(function, context.Stepper)
             || FoldPositionalPatternReturnOne(function, context.Stepper))
         {
@@ -104,6 +105,93 @@ public sealed class IsPatternPass : IIrPass
         }
         return false;
     }
+
+    static bool FoldConditionalReturnOne(IrFunction function, Stepper stepper)
+    {
+        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        {
+            var children = block.Children;
+            for (int i = 0; i + 2 < children.Count; i++)
+            {
+                if (children[i] is not StoreLocal { Value: IsInstance asCast } store
+                    || children[i + 1] is not IfStatement guard
+                    || children[i + 2] is not Return { Value: { } whenTrue }
+                    || !TryUnionConditionalGuard(function, asCast, store.Index, guard, out var condition, out var whenFalse))
+                {
+                    continue;
+                }
+
+                if (ReferenceOwnership.SubtreeReferencesLocal(asCast.Operand, store.Index)
+                    || !IsSideEffectFree(function, asCast.Operand)
+                    || !ReferenceOwnership.LocalReferencesOnlyWithin(function, store.Index, [store, guard.Condition, guard, whenTrue]))
+                {
+                    continue;
+                }
+
+                var conditional = new Conditional(condition, (IrExpression)whenTrue.Clone(), (IrExpression)whenFalse.Clone())
+                {
+                    MergedType = whenTrue.ResultType ?? whenFalse.ResultType
+                };
+                stepper.StepOver("raise union pattern return chain to conditional", guard);
+                children[i + 2].ReplaceWith(new Return(conditional));
+                guard.Detach();
+                store.Detach();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool TryUnionConditionalGuard(
+        IrFunction function,
+        IsInstance asCast,
+        int localIndex,
+        IfStatement guard,
+        out IrExpression condition,
+        out IrExpression whenFalse)
+    {
+        condition = null!;
+        whenFalse = null!;
+        if (guard.HasElse
+            || guard.Then.Children is not [Return { Value: { } fallback }]
+            || asCast.Operand is not LoadProperty property
+            || !IsUnionValueProperty(function, property))
+        {
+            return false;
+        }
+
+        if (IsPatternLocalNull(guard.Condition, localIndex))
+        {
+            condition = new IsPattern((IrExpression)asCast.Operand.Clone(), asCast.Type, localIndex);
+            whenFalse = fallback;
+            return true;
+        }
+
+        if (guard.Condition is LogicalBinary { Kind: LogicalKind.Or } logical
+            && IsPatternLocalNull(logical.Left, localIndex))
+        {
+            var pattern = new IsPattern((IrExpression)asCast.Operand.Clone(), asCast.Type, localIndex)
+            {
+                PreserveLocalInPropertyPattern = true
+            };
+            condition = new LogicalBinary(LogicalKind.And, pattern, Conditions.Negate((IrExpression)logical.Right.Clone()));
+            whenFalse = fallback;
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool IsPatternLocalNull(IrExpression expression, int localIndex) => expression switch
+    {
+        LogicalNot { Operand: LoadLocal load } => load.Index == localIndex,
+        Comparison { Kind: ComparisonKind.Equal, Left: LoadLocal load, Right: Constant { Value: null } }
+            => load.Index == localIndex,
+        Comparison { Kind: ComparisonKind.Equal, Left: Constant { Value: null }, Right: LoadLocal load }
+            => load.Index == localIndex,
+        _ => false,
+    };
 
     static bool TransformRecursivePropertyDeclaration(IrFunction function, Stepper stepper)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -123,7 +123,7 @@ public sealed class IsPatternPass : IIrPass
 
                 if (ReferenceOwnership.SubtreeReferencesLocal(asCast.Operand, store.Index)
                     || !IsSideEffectFree(function, asCast.Operand)
-                    || !ReferenceOwnership.LocalReferencesOnlyWithin(function, store.Index, [store, guard.Condition, guard, whenTrue]))
+                    || !ReferenceOwnership.LocalReferencesOnlyWithin(function, store.Index, [store, guard.Condition, whenTrue]))
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary

Raises union pattern conditional/ternary returns from lowered `Value as T` + null-guard chains into conditional expressions.

This is another N-to-1 source-shape case: the source may be a ternary or an early-return `if`, but for a terminal returned value the expression form is preferred and matches the repo/runtime style of compact expression output.

Fixes #1999.

## Before / After

Source shape:

```csharp
return pet is Cat cat ? cat.Name : "other";
```

Before:

```csharp
Cat cat = pet.Value as Cat;
if (cat is null)
{
    return "other";
}
return cat.Name;
```

After:

```csharp
return pet is Cat cat ? cat.Name : "other";
```

Guarded conditionals are also covered:

```csharp
return pet is Cat { Age: > 3 } cat ? cat.Name : "other";
```

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/UnionConditionalReturn_RendersPatternConditional"` — 1 passed.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/IsPatternPassTests/*"` — 22 passed; non-union manual-`as` negatives remain flat.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"` — 15 passed.
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet -p:PublishAot=false` — passed. Host default AOT restore currently fails on unavailable preview.6 packs; this is the documented decompiler build gate.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringCoverageTests/*"` — 6 passed.
- Build-event validation-only summary: 289 projects, 0 failed, 0 errors, 0 warnings; event log `20260630T174517.6155611Z-2835803-build-77f1ae56`.

## Review

Decompiler behavior change; adversarial review requested separately before marking ready.
