### PR TITLE
Show compile-back failure examples

### DIFF
--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -68,6 +68,8 @@ static class FidelityCheck
 
         int total = 0, full = 0, exact = 0, contextFail = 0, recompileFail = 0, diffCount = 0;
         var diffExamples = new List<string>();
+        var recompileFailExamples = new List<string>();
+        var contextFailExamples = new List<string>();
         var recompileFailCodes = new SortedDictionary<string, int>(StringComparer.Ordinal);
 
         using var metadata = CorpusMetadata.Create(assemblies);
@@ -97,7 +99,8 @@ static class FidelityCheck
                         int effectiveCap = zeroSignal?.EffectiveCap(total) ?? cap;
                         RunType(reader, pe, source, typeHandle, references, parseOptions, compileOptions,
                             effectiveCap, maxExamples, render, ref total, ref full, ref exact, ref contextFail,
-                            ref recompileFail, ref diffCount, diffExamples, recompileFailCodes, phaseTimings);
+                            ref recompileFail, ref diffCount, diffExamples, recompileFailExamples,
+                            contextFailExamples, recompileFailCodes, phaseTimings);
                         zeroSignal?.Observe(total, exact, diffCount, recompileFail, contextFail, recompileFailCodes);
                     }
                 }
@@ -111,7 +114,7 @@ static class FidelityCheck
         }
 
         Report(total, full, exact, contextFail, recompileFail, diffCount,
-            recompileFailCodes, diffExamples, zeroSignal);
+            recompileFailCodes, diffExamples, recompileFailExamples, contextFailExamples, zeroSignal);
         phaseTimings?.Report();
         return 0;
     }
@@ -1618,7 +1621,8 @@ static class FidelityCheck
         Func<IrFunction, DecompilerResult> render,
         ref int total, ref int full, ref int exact, ref int contextFail,
         ref int recompileFail, ref int diffCount,
-        List<string> diffExamples, SortedDictionary<string, int> recompileFailCodes,
+        List<string> diffExamples, List<string> recompileFailExamples, List<string> contextFailExamples,
+        SortedDictionary<string, int> recompileFailCodes,
         FidelityPhaseTimings? timings)
     {
         int remaining = cap - total;
@@ -1655,9 +1659,13 @@ static class FidelityCheck
                 case CompileBackStatus.RecompileFail:
                     recompileFail++;
                     recompileFailCodes[DiagnosticCode(r.Detail)] = recompileFailCodes.GetValueOrDefault(DiagnosticCode(r.Detail)) + 1;
+                    if (recompileFailExamples.Count < maxExamples)
+                        recompileFailExamples.Add(FormatFailureExample(r));
                     break;
                 case CompileBackStatus.ContextFail:
                     contextFail++;
+                    if (contextFailExamples.Count < maxExamples)
+                        contextFailExamples.Add(FormatFailureExample(r));
                     break;
             }
         }
@@ -1665,7 +1673,8 @@ static class FidelityCheck
 
     static void Report(
         int total, int full, int exact, int contextFail, int recompileFail, int diffCount,
-        SortedDictionary<string, int> recompileFailCodes, List<string> diffExamples, ZeroSignalGuard? zeroSignal)
+        SortedDictionary<string, int> recompileFailCodes, List<string> diffExamples,
+        List<string> recompileFailExamples, List<string> contextFailExamples, ZeroSignalGuard? zeroSignal)
     {
         string Pct(int n, int d) => d == 0 ? "0" : $"{100.0 * n / d:F2}%";
         Console.WriteLine($"COMPILE-BACK over {total} rendered methods ({full} Full)");
@@ -1688,7 +1697,26 @@ static class FidelityCheck
             foreach (var e in diffExamples)
                 Console.WriteLine($"  {e}");
         }
+        if (recompileFailExamples.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Recompile-fail examples:");
+            foreach (var e in recompileFailExamples)
+                Console.WriteLine($"  {e}");
+        }
+        if (contextFailExamples.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Context-fail examples:");
+            foreach (var e in contextFailExamples)
+                Console.WriteLine($"  {e}");
+        }
     }
+
+    static string FormatFailureExample(CompileBackResult result)
+        => string.IsNullOrWhiteSpace(result.Detail)
+            ? $"{result.Type}::{result.Method}"
+            : $"{result.Type}::{result.Method}\n    {result.Detail}";
 
     internal static IReadOnlyDictionary<string, FailureBucketSummary> SummarizeFailures(
         IReadOnlyList<CompileBackResult> results, CompileBackStatus status)

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -70,6 +70,11 @@ fidelity coverage series with the same per-bucket failure breakdown for each cap
 uploads the current JSON snapshot as the `decompiler-corpus-snapshot` artifact so
 trends can be compared without scraping logs.
 
+Standalone `--fidelity-check` reports also print bounded examples for every
+non-success bucket: opcode diffs include canonical opcode streams, while
+recompile and context failures include the method and diagnostic detail. Use
+`--max-examples` to widen the triage sample when exploring a new assembly set.
+
 ```bash
 dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
 bash eng/prepare-decompiler-corpus.sh /tmp/corpus-assemblies.txt


### PR DESCRIPTION
- Advances #1584
- Changes standalone compile-back harness reporting; harness-only
- Evidence revision: `0a59474c`

## Change

> Should we accept this harness reporting change?

**Conclusion:** **PASS** — new corpus scans now print bounded method-level examples for recompile and context failures instead of only aggregate diagnostic codes.

Before:

```text
recompile fail     : 25
recompile-fail by code:
  CS0311: 21
  CS1525: 3
  CS1526: 1
```

After:

```text
Recompile-fail examples:
  BuiltInDistributedApplicationEventSubscriptionHandlers::InitializeDcpAnnotations
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' ...
```

## Scope and safety

- **Root cause:** standalone `--fidelity-check` surfaced opcode-diff examples but not recompile/context-failure rows, forcing manual reruns while exploring new corpus candidates.
- **Fix shape:** collect bounded examples for `RecompileFail` and `ContextFail` with the existing `--max-examples` cap; counts and classification are unchanged.
- **Product impact:** none; harness report text only.
- **Scope boundary:** quality-card, JSON snapshot, and targeted-delta summaries are unchanged.

## Evidence

| Check | Result |
| --- | --- |
| Harness build | Pass |
| Markdown lint | Pass |
| #1974 exploratory scan | Pass; recompile examples now identify methods/details |
| Review | Pass; Claude Opus 4.8 and Gemini 3.1 Pro found no significant issues |

## Compile-back quality

> Did this increase the checkable population without hiding a product defect?

**Conclusion:** **ADVISORY** — no compile-back classifications change; the report now makes uncheckable buckets directly actionable for the next fix.

### Broad assembly context

Run: #1974 primary assemblies, cap 25 each.

```text
Aspire.Hosting: 0 exact, 25 recompile fail; examples now show CS0311 generic constraint rows.
System.Text.Json: 19 exact, 5 opcode diff, 1 recompile fail; example shows System.Marvin::GenerateSeed CS1002.
Serilog: 23 exact, 2 recompile fail; examples show Log::CloseAndFlush CS1061 and CloseAndFlushAsync CS1525.
Polly: 19 exact, 6 recompile fail; examples show explicit interface/member syntax rows.
AutoMapper: 17 exact, 2 opcode diff, 6 recompile fail; examples show AddAutoMapper CS1525 rows.
```

**Broad verdict:** **PASS** — this is reporting-only, but it identifies the next fixable corpus bucket.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Aspire `CS0311` | Exposed | Likely skeleton generic/interface constraint issue; left for the next PR. |
| `CS1525` rows across Polly/AutoMapper/Serilog | Exposed | Now visible by method; not fixed in this reporting PR. |
| Opcode-diff rows | Unchanged | Existing opcode example behavior preserved. |

## Build-event validation

**Conclusion:** not applicable — report text only; harness build is the relevant check.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Verified caps, counts, null detail formatting, output guards, and unaffected quality-card paths. |
| Gemini 3.1 Pro | No significant issues | No follow-up changes required. |

**Review conclusion:** **PASS** — no actionable review findings.

## Validation

```bash
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json
npx markdownlint-cli --fix tools/DecompilerHarness/README.md
npx markdownlint-cli tools/DecompilerHarness/README.md
dotnet run --no-restore --project tools/DecompilerHarness -c Release -- /home/rich/.nuget/packages/aspire.hosting/13.4.6/lib/net8.0/Aspire.Hosting.dll --fidelity-check --compile-cap 25 --max-examples 5
# plus six-assembly #1974 exploratory cap-25 scan
```
