### PR TITLE
Label capped compile-back examples

### DIFF
--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1693,25 +1693,28 @@ static class FidelityCheck
         if (diffExamples.Count > 0)
         {
             Console.WriteLine();
-            Console.WriteLine("Opcode-diff examples (Full):");
+            Console.WriteLine(ExampleHeading("Opcode-diff examples (Full)", diffExamples.Count, diffCount));
             foreach (var e in diffExamples)
                 Console.WriteLine($"  {e}");
         }
         if (recompileFailExamples.Count > 0)
         {
             Console.WriteLine();
-            Console.WriteLine("Recompile-fail examples:");
+            Console.WriteLine(ExampleHeading("Recompile-fail examples", recompileFailExamples.Count, recompileFail));
             foreach (var e in recompileFailExamples)
                 Console.WriteLine($"  {e}");
         }
         if (contextFailExamples.Count > 0)
         {
             Console.WriteLine();
-            Console.WriteLine("Context-fail examples:");
+            Console.WriteLine(ExampleHeading("Context-fail examples", contextFailExamples.Count, contextFail));
             foreach (var e in contextFailExamples)
                 Console.WriteLine($"  {e}");
         }
     }
+
+    static string ExampleHeading(string title, int shown, int total)
+        => shown == total ? $"{title} ({total}):" : $"{title} (showing {shown} of {total}):";
 
     static string FormatFailureExample(CompileBackResult result)
         => string.IsNullOrWhiteSpace(result.Detail)

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -73,7 +73,9 @@ trends can be compared without scraping logs.
 Standalone `--fidelity-check` reports also print bounded examples for every
 non-success bucket: opcode diffs include canonical opcode streams, while
 recompile and context failures include the method and diagnostic detail. Use
-`--max-examples` to widen the triage sample when exploring a new assembly set.
+`--max-examples` to widen the triage sample when exploring a new assembly set;
+example headings say whether they show every row or only the first N of the
+bucket.
 
 ```bash
 dotnet build src/dotnet-inspect -c Release -p:PublishAot=false


### PR DESCRIPTION
- Advances #1584
- Changes standalone compile-back harness reporting; harness-only
- Evidence revision: `5ecad0b1`

## Change

> Should we accept this harness reporting change?

**Conclusion:** **PASS** — capped example sections now say whether they are complete or only showing the first N rows.

Before:

```text
Recompile-fail examples:
```

After:

```text
Recompile-fail examples (showing 12 of 25):
```

## Scope and safety

- **Root cause:** #2001 made failure rows actionable, but the headings did not say whether the list was complete or capped by `--max-examples`.
- **Fix shape:** heading text uses the already-counted bucket total and shown example count.
- **Product impact:** none; harness report text only.
- **Scope boundary:** counts, classification, quality cards, targeted reports, and product output are unchanged.

## Validation log

```text
$ dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:04.26

$ npx markdownlint-cli --fix tools/DecompilerHarness/README.md

$ npx markdownlint-cli tools/DecompilerHarness/README.md

$ dotnet run --no-restore --project tools/DecompilerHarness -c Release -- /home/rich/.nuget/packages/aspire.hosting/13.4.6/lib/net8.0/Aspire.Hosting.dll --fidelity-check --compile-cap 25 --max-examples 12
COMPILE-BACK over 25 rendered methods (18 Full)

  exact opcode match : 0 (0.00%)
  opcode diff (Full) : 0 — recompiled to a different stream (the docket)
  context-build fail : 0 — could not emit the type skeleton
  recompile fail     : 25 — skeleton + body did not compile
  recompile-fail by code:
    CS0311: 21
    CS1525: 3
    CS1526: 1

Recompile-fail examples (showing 12 of 25):
  BuiltInDistributedApplicationEventSubscriptionHandlers::InitializeDcpAnnotations
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  BuiltInDistributedApplicationEventSubscriptionHandlers::ExcludeDashboardFromManifestAsync
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  BuiltInDistributedApplicationEventSubscriptionHandlers::MutateHttp2TransportAsync
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  BuiltInDistributedApplicationEventSubscriptionHandlers::UpdateContainerRegistryAsync
    CS1525: Invalid expression term '>'
  BuiltInDistributedApplicationEventSubscriptionHandlers::WarnPersistentContainersWithoutUserSecrets
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  PathLookupHelper::ResolveExecutablePath
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  PathLookupHelper::FindFullPathFromPath
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  PathLookupHelper::FindAllFullPathsFromPath
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  PathLookupHelper::FindFullPathFromPath
    CS1525: Invalid expression term '<'
  PathLookupHelper::FindAllFullPathsFromPath
    CS1525: Invalid expression term '<'
  PathLookupHelper::FindFullPath
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  PathLookupHelper::FindAllFullPaths
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
```

## Compile-back quality

**Conclusion:** **ADVISORY** — no compile-back classifications change; the report is clearer about capped evidence.

The log above is the evidence: Aspire.Hosting cap 25 with `--max-examples 12` now visibly shows that the example list is capped, not complete.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Complete failure export | Not changed | This PR only labels capped console examples; callers can raise `--max-examples` for more rows. |
| Quality cards / targeted reports | Not changed | This applies only to standalone `--fidelity-check` examples. |

## Build-event validation

**Conclusion:** not applicable — report text only; harness build is the relevant check.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No significant issues | Verified zero buckets, `maxExamples=0`, bucket totals, and unchanged counts/classification. |
| Gemini 3.1 Pro | No significant issues | No follow-up changes required. |

**Review conclusion:** **PASS** — no actionable review findings.
