### PR TITLE
Raise class-union conditional returns

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -771,6 +771,10 @@ public class TypeSourceComposerUnionTests
                     Cat otherCat => otherCat.Name.ToUpperInvariant(),
                     Dog dog => dog.Name,
                 };
+
+                public static string Ternary(Pet pet) => pet is Cat cat ? cat.Name : "other";
+
+                public static string TernaryGuard(Pet pet) => pet is Cat cat && cat.Name == "cat" ? cat.Name : "other";
             }
             """);
 
@@ -829,6 +833,10 @@ public class TypeSourceComposerUnionTests
                 Dog dog => dog.Name,
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedExhaustiveBound"));
+        Assert.Equal("return pet is Cat cat ? cat.Name : \"other\";",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "Ternary"));
+        Assert.Equal("return pet is Cat cat && cat.Name == \"cat\" ? cat.Name : \"other\";",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "TernaryGuard"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -775,6 +775,28 @@ public class TypeSourceComposerUnionTests
                 public static string Ternary(Pet pet) => pet is Cat cat ? cat.Name : "other";
 
                 public static string TernaryGuard(Pet pet) => pet is Cat cat && cat.Name == "cat" ? cat.Name : "other";
+
+                public static bool SideEffect() => true;
+
+                public static string GuardedOrSideEffect(Pet pet)
+                {
+                    if (pet is not null)
+                    {
+                        if (pet is Cat cat || SideEffect())
+                            return "cat";
+                    }
+                    return "other";
+                }
+
+                public static string SideEffectBeforePattern(Pet pet)
+                {
+                    if (pet is not null)
+                    {
+                        if (SideEffect() && pet is Cat cat)
+                            return cat.Name;
+                    }
+                    return "other";
+                }
             }
             """);
 
@@ -837,6 +859,14 @@ public class TypeSourceComposerUnionTests
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "Ternary"));
         Assert.Equal("return pet is Cat cat && cat.Name == \"cat\" ? cat.Name : \"other\";",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "TernaryGuard"));
+        var guardedOr = RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedOrSideEffect");
+        Assert.DoesNotContain("pet is Cat cat || SideEffect() ? \"cat\" : \"other\"", guardedOr);
+        Assert.Contains("if (", guardedOr);
+        Assert.Contains("SideEffect()", guardedOr);
+        var sideEffectBefore = RenderMember(assembly.Path, "UnionFixtures.Matcher", "SideEffectBeforePattern");
+        Assert.DoesNotContain("SideEffect() && pet is Cat cat ? cat.Name : \"other\"", sideEffectBefore);
+        Assert.Contains("if (", sideEffectBefore);
+        Assert.Contains("SideEffect()", sideEffectBefore);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -59,6 +59,7 @@ public sealed class IsPatternPass : IIrPass
     {
         while (TransformOne(function, context.Stepper)
             || FoldConditionalReturnOne(function, context.Stepper)
+            || FoldClassUnionNullConditionalReturnOne(function, context.Stepper)
             || TransformRecursivePropertyDeclaration(function, context.Stepper)
             || FoldPositionalPatternReturnOne(function, context.Stepper))
         {
@@ -192,6 +193,62 @@ public sealed class IsPatternPass : IIrPass
             => load.Index == localIndex,
         _ => false,
     };
+
+    static bool FoldClassUnionNullConditionalReturnOne(IrFunction function, Stepper stepper)
+    {
+        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        {
+            var children = block.Children;
+            for (int i = 0; i + 1 < children.Count; i++)
+            {
+                if (children[i] is not IfStatement outer
+                    || outer.HasElse
+                    || outer.Then.Children is not [IfStatement inner]
+                    || inner.HasElse
+                    || inner.Then.Children is not [Return { Value: { } whenTrue }]
+                    || children[i + 1] is not Return { Value: { } whenFalse }
+                    || !TryClassUnionConditionalPattern(function, outer.Condition, inner.Condition, out var pattern))
+                {
+                    continue;
+                }
+
+                if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, pattern.LocalIndex, [inner.Condition, whenTrue]))
+                    continue;
+
+                var conditional = new Conditional((IrExpression)inner.Condition.Clone(), (IrExpression)whenTrue.Clone(), (IrExpression)whenFalse.Clone())
+                {
+                    MergedType = whenTrue.ResultType ?? whenFalse.ResultType
+                };
+                stepper.StepOver("raise class union null-guard return chain to conditional", outer);
+                children[i + 1].ReplaceWith(new Return(conditional));
+                outer.Detach();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool TryClassUnionConditionalPattern(
+        IrFunction function,
+        IrExpression receiver,
+        IrExpression condition,
+        out IsPattern pattern)
+    {
+        pattern = null!;
+        foreach (var candidate in condition.Descendants.Prepend(condition).OfType<IsPattern>())
+        {
+            if (candidate.Value is LoadProperty property
+                && IsUnionValueProperty(function, property)
+                && PlaceIdentity.SameVariable(property.Instance, receiver))
+            {
+                pattern = candidate;
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     static bool TransformRecursivePropertyDeclaration(IrFunction function, Stepper stepper)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -236,18 +236,34 @@ public sealed class IsPatternPass : IIrPass
         out IsPattern pattern)
     {
         pattern = null!;
-        foreach (var candidate in condition.Descendants.Prepend(condition).OfType<IsPattern>())
+        var candidate = LeftmostAndOperand(condition);
+        if (candidate is IsPattern directPattern)
         {
-            if (candidate.Value is LoadProperty property
-                && IsUnionValueProperty(function, property)
-                && PlaceIdentity.SameVariable(property.Instance, receiver))
-            {
-                pattern = candidate;
-                return true;
-            }
+            return TryAccept(directPattern, out pattern);
         }
 
         return false;
+
+        bool TryAccept(IsPattern candidatePattern, out IsPattern accepted)
+        {
+            accepted = null!;
+            if (candidatePattern.Value is LoadProperty property
+                && IsUnionValueProperty(function, property)
+                && PlaceIdentity.SameVariable(property.Instance, receiver))
+            {
+                accepted = candidatePattern;
+                return true;
+            }
+            return false;
+        }
+    }
+
+    static IrExpression LeftmostAndOperand(IrExpression expression)
+    {
+        var current = expression;
+        while (current is LogicalBinary { Kind: LogicalKind.And } and)
+            current = and.Left;
+        return current;
     }
 
     static bool TransformRecursivePropertyDeclaration(IrFunction function, Stepper stepper)


### PR DESCRIPTION
## Summary

Raises terminal class/custom union conditional returns that still had an outer null guard around an already-raised inner union pattern.

Class unions lower `pet is Cat cat ? ... : fallback` as `if (pet is not null) { if (pet is Cat cat) return ... } return fallback;`. This PR collapses that terminal shape to a conditional expression once the outer receiver, inner union pattern, pattern-local ownership, and fallback return all line up.

Fixes #2003.

## Before / After

Before:

```csharp
if (pet is not null)
{
    if (pet is Cat cat)
    {
        return cat.Name;
    }
}
return "other";
```

After:

```csharp
return pet is Cat cat ? cat.Name : "other";
```

Guarded inner patterns are also covered:

```csharp
return pet is Cat cat && cat.Name == "cat" ? cat.Name : "other";
```

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/ClassUnionSwitchExpression_RendersTypePatternArms"` — 1 passed.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/IsPatternPassTests/*"` — 22 passed.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"` — 15 passed.
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet -p:PublishAot=false` — passed. Host default AOT restore currently fails on unavailable preview.6 packs; this is the documented decompiler build gate.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LoweringCoverageTests/*"` — 6 passed.
- Build-event validation-only summary: 289 projects, 0 failed, 0 errors, 0 warnings; event log `20260630T181054.8552865Z-2888945-build-16562ee0`.

## Review

Decompiler behavior change; adversarial review requested separately before marking ready.
