### PR TITLE
Raise union or-pattern bool tests

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -217,13 +217,15 @@ public class TypeSourceComposerUnionTests
             public static class Matcher
             {
                 public static bool IsCat(Pet pet) => pet is Cat;
-                public static bool IsNotNull(Pet pet) => pet is not null;
-                public static bool IsNull(Pet pet) => pet is null;
-                public static Cat? AsCat(Pet pet) => pet.Value as Cat;
-            }
-            """);
+            public static bool IsCatOrDog(Pet pet) => pet is Cat or Dog;
+            public static bool IsNotNull(Pet pet) => pet is not null;
+            public static bool IsNull(Pet pet) => pet is null;
+            public static Cat? AsCat(Pet pet) => pet.Value as Cat;
+        }
+        """);
 
         Assert.Equal("return pet is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCat"));
+        Assert.Equal("return pet is Cat || pet is Dog;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatOrDog"));
         Assert.Equal("return pet is not null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNotNull"));
         Assert.Equal("return pet is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
         Assert.Equal("return pet.Value as Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "AsCat"));
@@ -888,6 +890,7 @@ public class TypeSourceComposerUnionTests
                 public static class Matcher
                 {
                     public static bool IsCat(PetLike pet) => pet.Value is Cat;
+                    public static bool IsCatOrDog(PetLike pet) => pet.Value is Cat or Dog;
                     public static bool IsNull(PetLike pet) => pet.Value is null;
                     public static bool HasCat(PetLike pet)
                     {
@@ -919,6 +922,9 @@ public class TypeSourceComposerUnionTests
             """);
 
         Assert.Equal("return pet.Value is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCat"));
+        var nonUnionOr = RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatOrDog");
+        Assert.Contains("pet.Value", nonUnionOr);
+        Assert.DoesNotContain("return pet is Cat || pet is Dog", nonUnionOr);
         Assert.Equal("return pet.Value is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
         Assert.Equal("return pet.Value is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "HasCat"));
         Assert.DoesNotContain("return pet switch", RenderMember(assembly.Path, "UnionFixtures.Matcher", "Describe"));

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -778,6 +778,8 @@ public class TypeSourceComposerUnionTests
 
                 public static string TernaryGuard(Pet pet) => pet is Cat cat && cat.Name == "cat" ? cat.Name : "other";
 
+                public static bool IsCatOrDog(Pet pet) => pet is Cat or Dog;
+
                 public static bool SideEffect() => true;
 
                 public static string GuardedOrSideEffect(Pet pet)
@@ -861,6 +863,8 @@ public class TypeSourceComposerUnionTests
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "Ternary"));
         Assert.Equal("return pet is Cat cat && cat.Name == \"cat\" ? cat.Name : \"other\";",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "TernaryGuard"));
+        Assert.Equal("return pet is Cat || pet is Dog;",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatOrDog"));
         var guardedOr = RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedOrSideEffect");
         Assert.DoesNotContain("pet is Cat cat || SideEffect() ? \"cat\" : \"other\"", guardedOr);
         Assert.Contains("if (", guardedOr);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -12,6 +12,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
 
     sealed record Arm(TypeRef PatternType, int? LocalIndex, IrExpression Value, IReadOnlyList<IrNode> LocalRoots, IrExpression? Guard = null);
     sealed record Match(int StartIndex, UnionSwitchExpression SwitchExpression);
+    sealed record BoolMatch(int StartIndex, IrExpression Expression);
 
     public void Run(IrFunction function, PassContext context)
     {
@@ -35,6 +36,14 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                     block.Children[i].Detach();
                 context.Stepper.StepOver("raise union type-test dispatch to switch expression", block);
                 continue;
+            }
+
+            if (container.Blocks is [var boolBlock] && TryMatchUnionBoolTypeTest(function, boolBlock, out var boolMatch))
+            {
+                boolBlock.SetChild(boolMatch.StartIndex, new Return(boolMatch.Expression));
+                for (int i = boolBlock.Children.Count - 1; i > boolMatch.StartIndex; i--)
+                    boolBlock.Children[i].Detach();
+                context.Stepper.StepOver("raise union type-test bool dispatch", boolBlock);
             }
         }
     }
@@ -84,6 +93,92 @@ public sealed class UnionSwitchExpressionPass : IIrPass
 
         return false;
     }
+
+    static bool TryMatchUnionBoolTypeTest(IrFunction function, Block block, out BoolMatch match)
+    {
+        match = null!;
+        var children = block.Children;
+        for (int start = 0; start + 2 < children.Count; start++)
+        {
+            if (start + 3 != children.Count
+                || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+                || !IsUnionValueProperty(function, unionValue)
+                || children[start + 1] is not IfStatement ifStatement
+                || ifStatement.Then.Children is not [StoreLocal thenStore]
+                || ifStatement.Else?.Children is not [StoreLocal elseStore]
+                || children[start + 2] is not Return ret
+                || !StoreReturnMatch(thenStore, ret, thenStore.Index)
+                || elseStore.Index != thenStore.Index
+                || !TryBoolConstants(thenStore.Value, elseStore.Value, out bool conditionIsTrueArm)
+                || !TryRewriteTempTypeTestCondition(ifStatement.Condition, valueStore.Index, unionValue, out var condition))
+            {
+                continue;
+            }
+
+            if (!conditionIsTrueArm)
+                condition = Conditions.Negate(condition);
+
+            if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, [valueStore, ifStatement.Condition])
+                || !ReferenceOwnership.LocalReferencesOnlyWithin(function, thenStore.Index, [thenStore, elseStore, ret.Value!]))
+            {
+                continue;
+            }
+
+            match = new BoolMatch(start, condition);
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool TryRewriteTempTypeTestCondition(IrExpression expression, int tempLocal, LoadProperty unionValue, out IrExpression rewritten)
+    {
+        switch (expression)
+        {
+            case IsInstance test when IsTempTypeTest(test, tempLocal):
+                rewritten = new IsInstance(test.Type, (IrExpression)unionValue.Clone());
+                return true;
+            case LogicalBinary logical:
+            {
+                if (!TryRewriteTempTypeTestCondition(logical.Left, tempLocal, unionValue, out var left)
+                    || !TryRewriteTempTypeTestCondition(logical.Right, tempLocal, unionValue, out var right))
+                {
+                    rewritten = null!;
+                    return false;
+                }
+
+                rewritten = new LogicalBinary(logical.Kind, left, right);
+                return true;
+            }
+            default:
+                rewritten = null!;
+                return false;
+        }
+    }
+
+    static bool TryBoolConstants(IrExpression whenTrue, IrExpression whenFalse, out bool conditionIsTrueArm)
+    {
+        if (IsTrueConstant(whenTrue) && IsFalseConstant(whenFalse))
+        {
+            conditionIsTrueArm = true;
+            return true;
+        }
+
+        if (IsFalseConstant(whenTrue) && IsTrueConstant(whenFalse))
+        {
+            conditionIsTrueArm = false;
+            return true;
+        }
+
+        conditionIsTrueArm = false;
+        return false;
+    }
+
+    static bool IsTrueConstant(IrExpression expression)
+        => expression is Constant { Value: true } or Constant { Value: 1 };
+
+    static bool IsFalseConstant(IrExpression expression)
+        => expression is Constant { Value: false } or Constant { Value: 0 };
 
     static bool TryMatchSwitchStatementReturnChainAt(
         IrFunction function,

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -29,6 +29,17 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 continue;
             }
 
+            if (TryMatchClassUnionBoolTypeTestBlocks(function, container, out var classBoolExpression))
+            {
+                int startOffset = container.Blocks[0].StartOffset;
+                container.DetachChildren();
+                var replacementBlock = new Block(startOffset);
+                replacementBlock.Add(new Return(classBoolExpression));
+                container.Add(replacementBlock);
+                context.Stepper.StepOver("raise class union type-test bool dispatch", container);
+                continue;
+            }
+
             if (container.Blocks is [var block] && TryMatch(function, block, out var match))
             {
                 block.SetChild(match.StartIndex, new Return(match.SwitchExpression));
@@ -92,6 +103,44 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         }
 
         return false;
+    }
+
+    static bool TryMatchClassUnionBoolTypeTestBlocks(IrFunction function, BlockContainer container, out IrExpression expression)
+    {
+        expression = null!;
+        var blocks = container.Blocks;
+        if (blocks.Count != 5
+            || blocks[0].Children is not [ConditionalBranch nullBranch]
+            || nullBranch.Condition is not LogicalNot { Operand: var receiver }
+            || blocks[1].Children is not [StoreLocal { Value: LoadProperty unionValue } valueStore, ConditionalBranch testBranch]
+            || !IsUnionValueProperty(function, unionValue)
+            || !PlaceIdentity.SameVariable(unionValue.Instance, receiver)
+            || testBranch.Condition is not LogicalNot { Operand: var directCondition }
+            || !TryRewriteTempTypeTestCondition(directCondition, valueStore.Index, unionValue, out var rewrittenCondition)
+            || blocks[2].Children is not [StoreLocal trueStore, Branch joinBranch]
+            || blocks[3].Children is not [StoreLocal falseStore]
+            || blocks[4].Children is not [Return ret]
+            || nullBranch.TargetOffset != blocks[3].StartOffset
+            || testBranch.TargetOffset != blocks[3].StartOffset
+            || joinBranch.TargetOffset != blocks[4].StartOffset
+            || !StoreReturnMatch(trueStore, ret, trueStore.Index)
+            || falseStore.Index != trueStore.Index
+            || !TryBoolConstants(trueStore.Value, falseStore.Value, out bool conditionIsTrueArm))
+        {
+            return false;
+        }
+
+        if (!conditionIsTrueArm)
+            rewrittenCondition = Conditions.Negate(rewrittenCondition);
+
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, [valueStore, testBranch.Condition])
+            || !ReferenceOwnership.LocalReferencesOnlyWithin(function, trueStore.Index, [trueStore, falseStore, ret.Value!]))
+        {
+            return false;
+        }
+
+        expression = rewrittenCondition;
+        return true;
     }
 
     static bool TryMatchUnionBoolTypeTest(IrFunction function, Block block, out BoolMatch match)


### PR DESCRIPTION
## Summary

Raises union `or` type-test booleans from bool-temp/if scaffolding to direct union type-test expressions.

This covers the terminal lowered shapes for source like `return pet is Cat or Dog;`. Struct unions use a single-block cached-`Value` bool materialization; class/custom unions use a multi-block null-guard shape. Both now normalize to `return pet is Cat || pet is Dog;`, matching the decompiler's existing boolean-expression representation while preserving class null semantics.

Fixes #2006.

## Before / After

Struct union before:

```csharp
bool V_1;

object V_0 = pet.Value;
if (V_0 is Cat || V_0 is Dog)
{
    V_1 = true;
}
else
{
    V_1 = false;
}
return V_1;
```

Class/custom union before:

```csharp
object V_0;
bool V_1;

if (pet is null) goto IL_001E;
V_0 = pet.Value;
if (!(V_0 is Cat || V_0 is Dog)) goto IL_001E;
V_1 = true;
goto IL_0020;
IL_001E:
V_1 = false;
IL_0020:
return V_1;
```

After:

```csharp
return pet is Cat || pet is Dog;
```

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/UnionMatchingTypeAndNullTests_RenderAgainstUnion"` — 1 passed.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/ClassUnionSwitchExpression_RendersTypePatternArms"` — 1 passed.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:WarningsNotAsErrors=NU1507 -- -filter "/*/*/TypeSourceComposerUnionTests/*"` — 15 passed.
- `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet -p:PublishAot=false -p:WarningsNotAsErrors=NU1507` — passed.
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/LoweringCoverageTests/*"` — 6 passed.
- Earlier build-event validation-only for the struct slice: 289 projects, 0 failed, 0 errors, 0 warnings; event log `20260630T183909.3863407Z-2943511-build-3d61b12f`.
- Build-event wrapper is currently blocked locally by an external NuGet source-mapping warning (`NU1507`) in its own prebuild, unrelated to this branch; regular targeted gates are green.

## Review

Decompiler behavior change; adversarial review re-requested after expanding the PR from struct-only to struct + class/custom union OR patterns.
