### PR TITLE
Resolve transitive compile-back package refs

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckNuGetReferenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckNuGetReferenceTests.cs
@@ -8,10 +8,8 @@ public class FidelityCheckNuGetReferenceTests
     public void PackageDependencyReferencePaths_SelectsCompatibleTfmDependencyGroup()
     {
         string root = Directory.CreateTempSubdirectory("dotnet-inspect-nuget-context-").FullName;
-        string? previousRoot = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
         try
         {
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", root);
             string packageDir = Path.Combine(root, "root.package", "1.0.0");
             string targetDir = Path.Combine(packageDir, "lib", "net8.0");
             Directory.CreateDirectory(targetDir);
@@ -39,13 +37,12 @@ public class FidelityCheckNuGetReferenceTests
             string sharedPath = Path.Combine(sharedDir, "Shared.dll");
             File.WriteAllText(sharedPath, "");
 
-            var references = FidelityCheck.PackageDependencyReferencePaths(targetPath);
+            var references = FidelityCheck.PackageDependencyReferencePaths(targetPath, [root]);
 
             Assert.Contains(sharedPath, references);
         }
         finally
         {
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", previousRoot);
             Directory.Delete(root, recursive: true);
         }
     }
@@ -54,10 +51,8 @@ public class FidelityCheckNuGetReferenceTests
     public void PackageDependencyReferencePaths_PrefersExactRefAssetBeforeCompatibleLibFallback()
     {
         string root = Directory.CreateTempSubdirectory("dotnet-inspect-nuget-context-").FullName;
-        string? previousRoot = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
         try
         {
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", root);
             string packageDir = Path.Combine(root, "root.package", "1.0.0");
             string targetDir = Path.Combine(packageDir, "lib", "net8.0");
             Directory.CreateDirectory(targetDir);
@@ -87,14 +82,13 @@ public class FidelityCheckNuGetReferenceTests
             string libPath = Path.Combine(libDir, "Shared.dll");
             File.WriteAllText(libPath, "");
 
-            var references = FidelityCheck.PackageDependencyReferencePaths(targetPath);
+            var references = FidelityCheck.PackageDependencyReferencePaths(targetPath, [root]);
 
             Assert.Contains(refPath, references);
             Assert.DoesNotContain(libPath, references);
         }
         finally
         {
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", previousRoot);
             Directory.Delete(root, recursive: true);
         }
     }
@@ -103,10 +97,8 @@ public class FidelityCheckNuGetReferenceTests
     public void PackageDependencyReferencePaths_IgnoresNonExactRanges()
     {
         string root = Directory.CreateTempSubdirectory("dotnet-inspect-nuget-context-").FullName;
-        string? previousRoot = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
         try
         {
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", root);
             string packageDir = Path.Combine(root, "root.package", "1.0.0");
             string targetDir = Path.Combine(packageDir, "lib", "net8.0");
             Directory.CreateDirectory(targetDir);
@@ -131,14 +123,121 @@ public class FidelityCheckNuGetReferenceTests
             Directory.CreateDirectory(sharedDir);
             File.WriteAllText(Path.Combine(sharedDir, "Shared.dll"), "");
 
-            var references = FidelityCheck.PackageDependencyReferencePaths(targetPath);
+            var references = FidelityCheck.PackageDependencyReferencePaths(targetPath, [root]);
 
             Assert.Empty(references);
         }
         finally
         {
-            Environment.SetEnvironmentVariable("NUGET_PACKAGES", previousRoot);
             Directory.Delete(root, recursive: true);
         }
+    }
+
+    [Fact]
+    public void PackageDependencyReferencePaths_IncludesTransitiveDependencies()
+    {
+        string root = Directory.CreateTempSubdirectory("dotnet-inspect-nuget-context-").FullName;
+        try
+        {
+            string targetPath = CreatePackage(root, "Root.Package", "1.0.0", ("Direct.Package", "1.0.0"));
+            string directPath = CreatePackage(root, "Direct.Package", "1.0.0", ("Transitive.Package", "2.0.0"));
+            string transitivePath = CreatePackage(root, "Transitive.Package", "2.0.0");
+
+            var references = FidelityCheck.PackageDependencyReferencePaths(targetPath, [root]);
+
+            Assert.Contains(directPath, references);
+            Assert.Contains(transitivePath, references);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PackageDependencyReferencePaths_SelectsHighestSemVerDependencyVersion()
+    {
+        string root = Directory.CreateTempSubdirectory("dotnet-inspect-nuget-context-").FullName;
+        try
+        {
+            string targetPath = CreatePackage(
+                root,
+                "Root.Package",
+                "1.0.0",
+                ("Shared.Preview", "1.0.0-preview.2"),
+                ("Shared.Preview", "1.0.0-preview.10"),
+                ("Shared.Stable", "2.0.0-preview.6"),
+                ("Shared.Stable", "2.0.0"));
+            string preview2 = CreatePackage(root, "Shared.Preview", "1.0.0-preview.2");
+            string preview10 = CreatePackage(root, "Shared.Preview", "1.0.0-preview.10");
+            string prerelease = CreatePackage(root, "Shared.Stable", "2.0.0-preview.6");
+            string stable = CreatePackage(root, "Shared.Stable", "2.0.0");
+
+            var references = FidelityCheck.PackageDependencyReferencePaths(targetPath, [root]);
+
+            Assert.Contains(preview10, references);
+            Assert.DoesNotContain(preview2, references);
+            Assert.Contains(stable, references);
+            Assert.DoesNotContain(prerelease, references);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PackageDependencyReferencePaths_DropsDependenciesFromSupersededVersions()
+    {
+        string root = Directory.CreateTempSubdirectory("dotnet-inspect-nuget-context-").FullName;
+        try
+        {
+            string targetPath = CreatePackage(
+                root,
+                "Root.Package",
+                "1.0.0",
+                ("Shared.Parent", "1.0.0"),
+                ("Shared.Parent", "2.0.0"));
+            string lowerParent = CreatePackage(root, "Shared.Parent", "1.0.0", ("Stale.Only", "1.0.0"));
+            string higherParent = CreatePackage(root, "Shared.Parent", "2.0.0");
+            string staleOnly = CreatePackage(root, "Stale.Only", "1.0.0");
+
+            var references = FidelityCheck.PackageDependencyReferencePaths(targetPath, [root]);
+
+            Assert.Contains(higherParent, references);
+            Assert.DoesNotContain(lowerParent, references);
+            Assert.DoesNotContain(staleOnly, references);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    static string CreatePackage(string root, string id, string version, params (string Id, string Version)[] dependencies)
+    {
+        string packageDir = Path.Combine(root, id.ToLowerInvariant(), version.ToLowerInvariant());
+        string assetDir = Path.Combine(packageDir, "lib", "net8.0");
+        Directory.CreateDirectory(assetDir);
+        string assemblyPath = Path.Combine(assetDir, $"{id}.dll");
+        File.WriteAllText(assemblyPath, "");
+
+        var dependencyLines = dependencies
+            .Select(dependency => $"        <dependency id=\"{dependency.Id}\" version=\"{dependency.Version}\" />");
+        File.WriteAllText(
+            Path.Combine(packageDir, $"{id.ToLowerInvariant()}.nuspec"),
+            $$"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <package>
+              <metadata>
+                <dependencies>
+                  <group targetFramework="net8.0">
+            {{string.Join(Environment.NewLine, dependencyLines)}}
+                  </group>
+                </dependencies>
+              </metadata>
+            </package>
+            """);
+        return assemblyPath;
     }
 }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -3141,49 +3141,207 @@ static class FidelityCheck
     }
 
     internal static IReadOnlyList<string> PackageDependencyReferencePaths(string targetPath)
+        => PackageDependencyReferencePaths(targetPath, packageRoots: null);
+
+    internal static IReadOnlyList<string> PackageDependencyReferencePaths(string targetPath, IReadOnlyList<string>? packageRoots)
     {
-        if (NuGetPackageContext(targetPath) is not { } context)
+        if (NuGetPackageContext(targetPath, packageRoots) is not { } context)
             return [];
 
         var nuspec = Directory.EnumerateFiles(context.PackageDirectory, "*.nuspec").FirstOrDefault();
         if (nuspec is null)
             return [];
 
-        var references = new List<string>();
+        var packageDirectories = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+        var dependencyGraph = new Dictionary<string, List<PackageDependency>>(StringComparer.OrdinalIgnoreCase);
+        List<PackageDependency> rootDependencies;
         try
         {
-            var document = XDocument.Load(nuspec);
-            foreach (var dependency in SelectNuGetDependencies(document, context.TargetFramework))
-            {
-                string? id = dependency.Attribute("id")?.Value;
-                string? version = DependencyExactVersion(dependency.Attribute("version")?.Value);
-                if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(version))
-                    continue;
-
-                foreach (var root in NuGetPackageRoots())
-                {
-                    var packageDir = Path.Combine(root, id.ToLowerInvariant(), version.ToLowerInvariant());
-                    foreach (var path in ProbeNuGetPackageVersionDlls(packageDir, context.TargetFramework))
-                        references.Add(path);
-                }
-            }
+            rootDependencies = CollectPackageDependencies(
+                context.PackageDirectory,
+                context.TargetFramework,
+                packageRoots,
+                packageDirectories,
+                dependencyGraph,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase));
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Xml.XmlException)
         {
             return [];
         }
 
+        var selectedVersions = packageDirectories.ToDictionary(
+            kv => kv.Key,
+            kv => kv.Value.Keys.OrderByDescending(version => version, PackageVersionComparer.Instance).First(),
+            StringComparer.OrdinalIgnoreCase);
+        var resolved = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var dependency in rootDependencies)
+            AddResolvedPackage(dependency.Id);
+
+        var references = new List<string>();
+        foreach (string id in resolved.Order(StringComparer.OrdinalIgnoreCase))
+            foreach (var path in ProbeNuGetPackageVersionDlls(packageDirectories[id][selectedVersions[id]], context.TargetFramework))
+                references.Add(path);
         return references;
+
+        void AddResolvedPackage(string id)
+        {
+            if (!selectedVersions.TryGetValue(id, out string? version) || !resolved.Add(id))
+                return;
+            if (!dependencyGraph.TryGetValue(PackageKey(id, version), out var dependencies))
+                return;
+            foreach (var dependency in dependencies)
+                AddResolvedPackage(dependency.Id);
+        }
+    }
+
+    static List<PackageDependency> CollectPackageDependencies(
+        string packageDirectory,
+        string targetFramework,
+        IReadOnlyList<string>? packageRoots,
+        Dictionary<string, Dictionary<string, string>> packageDirectories,
+        Dictionary<string, List<PackageDependency>> dependencyGraph,
+        HashSet<string> visiting)
+    {
+        var nuspec = Directory.EnumerateFiles(packageDirectory, "*.nuspec").FirstOrDefault();
+        if (nuspec is null)
+            return [];
+
+        var document = XDocument.Load(nuspec);
+        var dependencies = new List<PackageDependency>();
+        foreach (var dependency in SelectNuGetDependencies(document, targetFramework))
+        {
+            string? id = dependency.Attribute("id")?.Value;
+            string? version = DependencyExactVersion(dependency.Attribute("version")?.Value);
+            if (string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(version))
+                continue;
+
+            foreach (var root in NuGetPackageRoots(packageRoots))
+            {
+                var dependencyDirectory = Path.Combine(root, id.ToLowerInvariant(), version.ToLowerInvariant());
+                if (!Directory.Exists(dependencyDirectory))
+                    continue;
+
+                if (!packageDirectories.TryGetValue(id, out var versions))
+                    packageDirectories[id] = versions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                versions[version] = dependencyDirectory;
+                dependencies.Add(new PackageDependency(id, version));
+
+                string visitKey = $"{id}/{version}";
+                if (!dependencyGraph.ContainsKey(PackageKey(id, version)) && visiting.Add(visitKey))
+                {
+                    dependencyGraph[PackageKey(id, version)] = CollectPackageDependencies(
+                        dependencyDirectory,
+                        targetFramework,
+                        packageRoots,
+                        packageDirectories,
+                        dependencyGraph,
+                        visiting);
+                    visiting.Remove(visitKey);
+                }
+                break;
+            }
+        }
+        return dependencies;
+    }
+
+    sealed class PackageVersionComparer : IComparer<string>
+    {
+        public static readonly PackageVersionComparer Instance = new();
+
+        public int Compare(string? left, string? right)
+            => string.Equals(left, right, StringComparison.OrdinalIgnoreCase)
+                ? 0
+                : ComparePackageVersion(left ?? "", right ?? "");
+    }
+
+    readonly record struct PackageDependency(string Id, string Version);
+
+    static string PackageKey(string id, string version) => $"{id}/{version}";
+
+    static int ComparePackageVersion(string left, string right)
+    {
+        var leftVersion = PackageVersion.Parse(left);
+        var rightVersion = PackageVersion.Parse(right);
+
+        int releaseLength = Math.Max(leftVersion.Release.Length, rightVersion.Release.Length);
+        for (int i = 0; i < releaseLength; i++)
+        {
+            int leftPart = i < leftVersion.Release.Length ? leftVersion.Release[i] : 0;
+            int rightPart = i < rightVersion.Release.Length ? rightVersion.Release[i] : 0;
+            int comparison = leftPart.CompareTo(rightPart);
+            if (comparison != 0)
+                return comparison;
+        }
+
+        if (leftVersion.Prerelease.Length == 0 || rightVersion.Prerelease.Length == 0)
+            return leftVersion.Prerelease.Length == rightVersion.Prerelease.Length
+                ? 0
+                : leftVersion.Prerelease.Length == 0 ? 1 : -1;
+
+        int prereleaseLength = Math.Max(leftVersion.Prerelease.Length, rightVersion.Prerelease.Length);
+        for (int i = 0; i < prereleaseLength; i++)
+        {
+            if (i >= leftVersion.Prerelease.Length)
+                return -1;
+            if (i >= rightVersion.Prerelease.Length)
+                return 1;
+
+            var leftIdentifier = leftVersion.Prerelease[i];
+            var rightIdentifier = rightVersion.Prerelease[i];
+            int comparison = leftIdentifier.CompareTo(rightIdentifier);
+            if (comparison != 0)
+                return comparison;
+        }
+
+        return 0;
+    }
+
+    readonly record struct PackageVersion(ImmutableArray<int> Release, ImmutableArray<PrereleaseIdentifier> Prerelease)
+    {
+        public static PackageVersion Parse(string version)
+        {
+            string withoutBuild = version.Split('+', 2)[0];
+            var split = withoutBuild.Split('-', 2);
+            var release = split[0]
+                .Split('.', StringSplitOptions.RemoveEmptyEntries)
+                .Select(part => int.TryParse(part, out int value) ? value : 0)
+                .ToImmutableArray();
+            var prerelease = split.Length == 1
+                ? ImmutableArray<PrereleaseIdentifier>.Empty
+                : split[1]
+                    .Split('.', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(PrereleaseIdentifier.Parse)
+                    .ToImmutableArray();
+            return new(release, prerelease);
+        }
+    }
+
+    readonly record struct PrereleaseIdentifier(bool IsNumeric, int NumericValue, string Text)
+    {
+        public static PrereleaseIdentifier Parse(string value)
+            => int.TryParse(value, out int numeric)
+                ? new(true, numeric, "")
+                : new(false, 0, value);
+
+        public int CompareTo(PrereleaseIdentifier other)
+        {
+            if (IsNumeric && other.IsNumeric)
+                return NumericValue.CompareTo(other.NumericValue);
+            if (IsNumeric != other.IsNumeric)
+                return IsNumeric ? -1 : 1;
+            return string.Compare(Text, other.Text, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     sealed record NuGetReferenceContext(
         string PackageDirectory,
         string TargetFramework);
 
-    static NuGetReferenceContext? NuGetPackageContext(string targetPath)
+    static NuGetReferenceContext? NuGetPackageContext(string targetPath, IReadOnlyList<string>? packageRoots = null)
     {
         string fullPath = Path.GetFullPath(targetPath);
-        foreach (var root in NuGetPackageRoots())
+        foreach (var root in NuGetPackageRoots(packageRoots))
         {
             string fullRoot = Path.GetFullPath(root).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
             string prefix = fullRoot + Path.DirectorySeparatorChar;
@@ -3202,8 +3360,15 @@ static class FidelityCheck
         return null;
     }
 
-    static IEnumerable<string> NuGetPackageRoots()
+    static IEnumerable<string> NuGetPackageRoots(IReadOnlyList<string>? packageRoots = null)
     {
+        if (packageRoots is not null)
+        {
+            foreach (var root in packageRoots)
+                yield return root;
+            yield break;
+        }
+
         if (Environment.GetEnvironmentVariable("NUGET_PACKAGES") is { Length: > 0 } envRoot)
             yield return envRoot;
 


### PR DESCRIPTION
- Advances #1584
- Changes standalone compile-back package reference resolution; harness-only
- Evidence revision: `ee9c4063`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — exact NuGet package dependencies are now resolved transitively with one highest-SemVer version per package id, without changing compile-back classification.

Before:

```text
PackageDependencyReferencePaths only added direct dependencies from the target package nuspec.
A larger Aspire prototype later hit a package version conflict:
CS1705: StreamJsonRpc 2.25.0.0 uses Microsoft.VisualStudio.Validation 17.13.0.0 but the harness referenced 17.8.0.0.
```

After:

```text
PackageDependencyReferencePaths walks exact transitive dependencies, selects the highest SemVer version per package id, and emits references only from that selected-version dependency closure.
```

## Scope and safety

- **Root cause:** the compile-back reference context was direct-dependency-only and could keep stale lower-version transitive package references in larger package graphs.
- **Fix shape:** graph exact NuGet dependencies, resolve a single highest SemVer version per package id, then emit references only for the selected-version closure.
- **Product impact:** none; DecompilerHarness reference context only.
- **Scope boundary:** non-exact ranges remain ignored; TFM asset selection stays unchanged.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Harness build | Pass |
| Focused tests | `FidelityCheckNuGetReferenceTests` passed 6/6 |
| Targeted compile-back | Aspire cap-25 unchanged by design: still 0 Exact / 0 OpcodeDiff / 25 RecompileFail |
| Broad compile-back | Not claimed; this is reference-context plumbing for later skeleton fixes |
| Build-event validation | Not applicable |
| Real witness | Aspire remains on `CS0311` skeleton frontier; reference resolver no longer blocks later buckets |

## Compile-back quality

> Did this increase the checkable population without hiding a product defect?

**Conclusion:** **ADVISORY** — no population gain is claimed in this PR; it removes the reference-resolution blocker needed by the next skeleton PR.

### Targeted changed-method boss

Run: synthetic NuGet package graph tests, 6 focused cases.

| Metric | Baseline | PR |
| --- | ---: | ---: |
| Direct dependency refs | Pass | Pass |
| Transitive dependency refs | Missing | Pass |
| Highest SemVer per package id | Missing | Pass |
| Stable release beats prerelease | Missing | Pass |
| Numeric prerelease ordering | Missing | Pass |
| Superseded-version dependency closure | Stale deps possible | Pass |

| Bucket / code | Baseline | PR | Delta | Example |
| --- | ---: | ---: | ---: | --- |
| Transitive refs | 0 | 1 | +1 | `Direct.Package -> Transitive.Package` |
| Version selection | 0 | 2 | +2 | `preview.10 > preview.2`; `stable > preview` |
| Stale closure deps | Possible | 0 | fixed | `Shared.Parent/1.0.0 -> Stale.Only` excluded when `2.0.0` wins |

### Broad assembly context

Run: Aspire.Hosting cap 25, `--max-examples 12`.

```text
$ dotnet run --no-restore --project tools/DecompilerHarness -c Release -- /home/rich/.nuget/packages/aspire.hosting/13.4.6/lib/net8.0/Aspire.Hosting.dll --fidelity-check --compile-cap 25 --max-examples 12
COMPILE-BACK over 25 rendered methods (18 Full)

  exact opcode match : 0 (0.00%)
  opcode diff (Full) : 0 — recompiled to a different stream (the docket)
  context-build fail : 0 — could not emit the type skeleton
  recompile fail     : 25 — skeleton + body did not compile
  recompile-fail by code:
    CS0311: 21
    CS1525: 3
    CS1526: 1

Recompile-fail examples (showing 12 of 25):
  BuiltInDistributedApplicationEventSubscriptionHandlers::InitializeDcpAnnotations
    CS0311: The type 'Aspire.DashboardService.Proto.V1.ApplicationInformationRequest' cannot be used as type parameter 'T' in the generic type or method 'MessageParser<T>'. There is no implicit reference conversion from 'Aspire.DashboardService.Proto.V1.ApplicationInformationRequest' to 'Google.Protobuf.IMessage<Aspire.DashboardService.Proto.V1.ApplicationInformationRequest>'.
  BuiltInDistributedApplicationEventSubscriptionHandlers::ExcludeDashboardFromManifestAsync
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  BuiltInDistributedApplicationEventSubscriptionHandlers::MutateHttp2TransportAsync
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  BuiltInDistributedApplicationEventSubscriptionHandlers::UpdateContainerRegistryAsync
    CS1525: Invalid expression term '>'
  BuiltInDistributedApplicationEventSubscriptionHandlers::WarnPersistentContainersWithoutUserSecrets
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  PathLookupHelper::ResolveExecutablePath
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  PathLookupHelper::FindFullPathFromPath
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  PathLookupHelper::FindAllFullPathsFromPath
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  PathLookupHelper::FindFullPathFromPath
    CS1525: Invalid expression term '<'
  PathLookupHelper::FindAllFullPathsFromPath
    CS1525: Invalid expression term '<'
  PathLookupHelper::FindFullPath
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
  PathLookupHelper::FindAllFullPaths
    CS0311: The type 'Aspire.Hosting.ConnectionStringResource' cannot be used as type parameter 'T' in the generic type or method 'IResourceBuilder<T>'. There is no implicit reference conversion from 'Aspire.Hosting.ConnectionStringResource' to 'Aspire.Hosting.ApplicationModel.IResource'.
```

**Broad verdict:** **ADVISORY** — the real assembly remains blocked by skeleton generic-constraint gaps; that is intentionally left for the next PR.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Aspire `CS0311` generic constraints | Not changed | Next skeleton/base/interface PR owns this. |
| Non-exact NuGet ranges | Not changed | Existing safety behavior preserved. |
| Test package root | Fixed | Tests pass explicit roots; no process-wide `NUGET_PACKAGES` mutation. |
| Diamond dependency graph | Fixed | Recursive traversal memoizes completed `(id, version)` nodes. |

## Build-event validation

> Did the project build health stay stable while the harness evidence changed?

**Conclusion:** not applicable — harness reference-resolution change; product/harness builds are the relevant checks.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | Findings resolved | Flagged process-wide `NUGET_PACKAGES` mutation and missing graph memoization; both fixed. |
| Claude Opus 4.8 | Findings resolved / no remaining issues | Confirmed SemVer ordering, selected-version closure, cycle safety, memoization, and test isolation. |

**Review conclusion:** **PASS** — both review findings were addressed before commit.

## Validation

```text
$ dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json

Build succeeded.
    0 Warning(s)
    0 Error(s)

$ dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class "*FidelityCheckNuGetReferenceTests"
xUnit.net v3 In-Process Runner v3.2.2+728c1dce01 (64-bit .NET 11.0.0-preview.6.26277.111)
  Discovering: ILInspector.Decompiler.Tests
  Discovered:  ILInspector.Decompiler.Tests
  Starting:    ILInspector.Decompiler.Tests
  Finished:    ILInspector.Decompiler.Tests
=== TEST EXECUTION SUMMARY ===
   ILInspector.Decompiler.Tests  Total: 6, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 0.079s

$ dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json

Build succeeded.
    0 Warning(s)
    0 Error(s)

$ dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json

Build succeeded.
    0 Warning(s)
    0 Error(s)
```
