### PR TITLE
Raise class union boolean property patterns

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberIdentityTests.cs
@@ -421,6 +421,7 @@ public class MemberIdentityTests
     public void IsStringEquality_RequiresExactBclStaticSignature()
     {
         Assert.True(MemberIdentity.IsStringEquality(StringEquality(s_string)));
+        Assert.False(MemberIdentity.IsStringEquality(StringInequality(s_string)));
         Assert.False(MemberIdentity.IsStringEquality(StringEquality(TypeRef.Definition("UserAssembly", "System", "String"))));
 
         Assert.False(MemberIdentity.IsStringEquality(new Call(
@@ -440,6 +441,34 @@ public class MemberIdentityTests
 
         Assert.False(MemberIdentity.IsStringEquality(new Call(
             StringEqualityMethod(s_string),
+            isVirtual: false,
+            [new LoadArgument(0, "left", s_string)])));
+    }
+
+    [Fact]
+    public void IsStringInequality_RequiresExactBclStaticSignature()
+    {
+        Assert.True(MemberIdentity.IsStringInequality(StringInequality(s_string)));
+        Assert.False(MemberIdentity.IsStringInequality(StringEquality(s_string)));
+        Assert.False(MemberIdentity.IsStringInequality(StringInequality(TypeRef.Definition("UserAssembly", "System", "String"))));
+
+        Assert.False(MemberIdentity.IsStringInequality(new Call(
+            StringInequalityMethod(s_string) with { ReturnType = s_object },
+            isVirtual: false,
+            [new LoadArgument(0, "left", s_string), new LoadArgument(1, "right", s_string)])));
+
+        Assert.False(MemberIdentity.IsStringInequality(new Call(
+            StringInequalityMethod(s_string) with { ParameterTypes = [s_string, s_object] },
+            isVirtual: false,
+            [new LoadArgument(0, "left", s_string), new LoadArgument(1, "right", s_string)])));
+
+        Assert.False(MemberIdentity.IsStringInequality(new Call(
+            StringInequalityMethod(s_string),
+            isVirtual: true,
+            [new LoadArgument(0, "left", s_string), new LoadArgument(1, "right", s_string)])));
+
+        Assert.False(MemberIdentity.IsStringInequality(new Call(
+            StringInequalityMethod(s_string),
             isVirtual: false,
             [new LoadArgument(0, "left", s_string)])));
     }
@@ -681,9 +710,18 @@ public class MemberIdentityTests
     static MethodRef StringEqualityMethod(TypeRef declaringType)
         => new(declaringType, "op_Equality", TypeRef.CoreLib("System", "Boolean"), [s_string, s_string], HasThis: false);
 
+    static MethodRef StringInequalityMethod(TypeRef declaringType)
+        => new(declaringType, "op_Inequality", TypeRef.CoreLib("System", "Boolean"), [s_string, s_string], HasThis: false);
+
     static Call StringEquality(TypeRef declaringType)
         => new(
             StringEqualityMethod(declaringType),
+            isVirtual: false,
+            [new LoadArgument(0, "left", s_string), new LoadArgument(1, "right", s_string)]);
+
+    static Call StringInequality(TypeRef declaringType)
+        => new(
+            StringInequalityMethod(declaringType),
             isVirtual: false,
             [new LoadArgument(0, "left", s_string), new LoadArgument(1, "right", s_string)]);
 

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -780,6 +780,9 @@ public class TypeSourceComposerUnionTests
 
                 public static bool IsCatOrDog(Pet pet) => pet is Cat or Dog;
 
+                public static bool IsCatWithName(Pet pet) => pet is Cat { Name: "cat" };
+                public static bool IsCatWithOtherName(Pet pet) => pet is Cat { Name: not "dog" };
+
                 public static bool SideEffect() => true;
 
                 public static string GuardedOrSideEffect(Pet pet)
@@ -865,6 +868,10 @@ public class TypeSourceComposerUnionTests
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "TernaryGuard"));
         Assert.Equal("return pet is Cat || pet is Dog;",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatOrDog"));
+        Assert.Equal("return pet is Cat { Name: \"cat\" };",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatWithName"));
+        Assert.Equal("return pet is Cat { Name: not \"dog\" };",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatWithOtherName"));
         var guardedOr = RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedOrSideEffect");
         Assert.DoesNotContain("pet is Cat cat || SideEffect() ? \"cat\" : \"other\"", guardedOr);
         Assert.Contains("if (", guardedOr);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1049,6 +1049,16 @@ public sealed partial class CSharpPrinter
 
     string ConditionalText(Conditional conditional, TypeRef? target)
     {
+        if (IsFalseConstant(conditional.WhenFalse)
+            && IsBooleanLike(conditional)
+            && IsBooleanLike(conditional.WhenTrue))
+        {
+            return Condition(new LogicalBinary(
+                LogicalKind.And,
+                (IrExpression)conditional.Condition.Clone(),
+                (IrExpression)conditional.WhenTrue.Clone()));
+        }
+
         // `?:` is right-associative, so a conditional in the condition position
         // reassociates without parentheses (`(a ? b : c) ? d : e` would reparse
         // as `a ? b : (c ? d : e)`). The arms render through Operand, which
@@ -1058,6 +1068,12 @@ public sealed partial class CSharpPrinter
             : Condition(conditional.Condition);
         return $"{condition} ? {ConditionalArm(conditional.WhenTrue, target)} : {ConditionalArm(conditional.WhenFalse, target)}";
     }
+
+    static bool IsFalseConstant(IrExpression expression)
+        => expression is Constant { Value: false } or Constant { Value: 0 };
+
+    static bool IsBooleanLike(IrExpression expression)
+        => expression.ResultType is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary };
 
     string ConditionalArm(IrExpression arm, TypeRef? target)
         => target is { } charTarget && IsCoreChar(charTarget) && TryCharConstantText(arm, out var charText)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2381,7 +2381,7 @@ public sealed partial class CSharpPrinter
         var subpatterns = new List<(string PropertyName, string Subpattern)>();
         foreach (var conjunct in rest)
         {
-            if (!TryPropertySubpattern(conjunct, pattern.LocalIndex, out var propertyName, out var subpattern))
+            if (!TryPropertySubpattern(conjunct, pattern.LocalIndex, allowStringEquality: !pattern.PreserveLocalInPropertyPattern, out var propertyName, out var subpattern))
                 return null;
             subpatterns.Add((propertyName, subpattern));
         }
@@ -2414,13 +2414,42 @@ public sealed partial class CSharpPrinter
     /// (<c>{ P: &gt; 5 }</c>). Floats are excluded: their unordered (NaN)
     /// comparison semantics are not reproduced by a relational pattern.
     /// </summary>
-    static bool TryPropertySubpattern(IrExpression expression, int patternLocal, out string propertyName, out string subpattern)
+    static bool TryPropertySubpattern(IrExpression expression, int patternLocal, bool allowStringEquality, out string propertyName, out string subpattern)
     {
         propertyName = "";
         subpattern = "";
 
         if (expression is not Comparison comparison)
+        {
+            if (expression is LogicalNot { Operand: Call negatedCall }
+                && allowStringEquality
+                && MemberIdentity.IsStringEquality(negatedCall)
+                && negatedCall.Arguments is [var negatedLeft, var negatedRight]
+                && TryPropertyConstant(negatedLeft, negatedRight, patternLocal, out propertyName, out var negatedConstant))
+            {
+                subpattern = $"not {ConstantText(negatedConstant)}";
+                return true;
+            }
+            if (expression is Call call
+                && allowStringEquality
+                && MemberIdentity.IsStringEquality(call)
+                && call.Arguments is [var left, var right]
+                && TryPropertyConstant(left, right, patternLocal, out propertyName, out var stringConstant))
+            {
+                subpattern = ConstantText(stringConstant);
+                return true;
+            }
+            if (expression is Call inequalityCall
+                && allowStringEquality
+                && MemberIdentity.IsStringInequality(inequalityCall)
+                && inequalityCall.Arguments is [var inequalityLeft, var inequalityRight]
+                && TryPropertyConstant(inequalityLeft, inequalityRight, patternLocal, out propertyName, out var notConstant))
+            {
+                subpattern = $"not {ConstantText(notConstant)}";
+                return true;
+            }
             return false;
+        }
 
         // Orient the comparison so the property is the left operand; mirror the
         // kind when the constant leads (`5 < t.P` reads as `t.P > 5`).
@@ -2467,6 +2496,32 @@ public sealed partial class CSharpPrinter
 
         subpattern = $"{relationalOperator} {ConstantText(constant)}";
         return true;
+    }
+
+    static bool TryPropertyConstant(
+        IrExpression left,
+        IrExpression right,
+        int patternLocal,
+        out string propertyName,
+        out Constant constant)
+    {
+        if (left is LoadProperty leftProperty && IsPatternLocalProperty(leftProperty, patternLocal) && right is Constant rightConstant)
+        {
+            propertyName = leftProperty.PropertyName;
+            constant = rightConstant;
+            return true;
+        }
+
+        if (right is LoadProperty rightProperty && IsPatternLocalProperty(rightProperty, patternLocal) && left is Constant leftConstant)
+        {
+            propertyName = rightProperty.PropertyName;
+            constant = leftConstant;
+            return true;
+        }
+
+        propertyName = "";
+        constant = null!;
+        return false;
     }
 
     static bool IsPatternLocalProperty(LoadProperty property, int patternLocal)

--- a/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MemberIdentity.cs
@@ -552,6 +552,22 @@ public static class MemberIdentity
             && call.Arguments.Count == 2
             && IsCoreLibraryType(call.Callee.DeclaringType, "System", "String");
 
+    public static bool IsStringInequality(Call call)
+        => !call.IsVirtual
+            && call.Callee is
+            {
+                HasThis: false,
+                Name: "op_Inequality",
+                TypeArguments.IsEmpty: true,
+                ParameterTypes: [var left, var right],
+                ReturnType: var returnType,
+            }
+            && returnType.Equals(s_bool)
+            && left.Equals(s_string)
+            && right.Equals(s_string)
+            && call.Arguments.Count == 2
+            && IsCoreLibraryType(call.Callee.DeclaringType, "System", "String");
+
     public static bool IsKnownCoreLibraryOperator(MethodRef method)
     {
         if (method.HasThis || !method.TypeArguments.IsEmpty)


### PR DESCRIPTION
- Fixes/advances #2010
- Changes class-union boolean property tests from synthetic-local conjunctions into property patterns for string constant and not-constant cases.
- Card revision: 483d8f60

## Change

**Conclusion:** **REVIEW** - the focused compiled-fixture shapes now render as direct C# property patterns while preserving existing guarded-pattern output that needs a bound local.

Before:

```csharp
return pet is Cat V_0 && V_0.Name == "cat";
return pet is Cat V_0 && !(V_0.Name == "dog");
```

After:

```csharp
return pet is Cat { Name: "cat" };
return pet is Cat { Name: not "dog" };
```

Near miss preserved:

```csharp
return pet is Cat cat && cat.Name == "cat" ? cat.Name : "other";
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet -p:PublishAot=false -p:WarningsNotAsErrors=NU1507` |
| Focused union fixture | Pass: `TypeSourceComposerUnionTests/ClassUnionSwitchExpression_RendersTypePatternArms` |
| Union fixture class | Pass: `TypeSourceComposerUnionTests/*` |
| Lowering coverage | Pass: `LoweringCoverageTests/*` |
| Identity predicates | Pass: `MemberIdentityTests/IsString*` |

## Decompiler quality

**Conclusion:** **ADVISORY** - this is a compiled preview-union fixture/printer-shape improvement; no real corpus union witnesses are currently known for a generated quality-diff card.

Highest local boss: Stage 6 altitude proof for the targeted union source shapes, backed by Stage 0 build/focused tests.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Pending | Requested after PR open. |
| Gemini Pro | Pending | Requested after PR open. |

**Review conclusion:** **REVIEW** - adversarial review is pending and will be reconciled on the PR before ready-to-merge.
