### PR TITLE
Unblock Aspire compile-back skeleton constraints

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -457,6 +457,159 @@ public class FidelityCheckGeneratedFilterTests
         }
     }
 
+    [Fact]
+    public void Evaluate_RetainsSatisfiedInterfaceBaseClause()
+    {
+        var assemblyPath = CompileFixture("""
+            public interface IResource
+            {
+                string Name { get; }
+            }
+
+            public class Resource : IResource
+            {
+                public virtual string Name => "resource";
+            }
+
+            public sealed class ConnectionStringResource : Resource
+            {
+            }
+
+            public interface IResourceBuilder<T>
+                where T : IResource
+            {
+            }
+
+            public static class ResourceBuilderFactory
+            {
+                public static IResourceBuilder<ConnectionStringResource> Create()
+                    => throw null;
+            }
+            """);
+        try
+        {
+            AssertCheckable(FidelityCheck.Evaluate(assemblyPath), "ResourceBuilderFactory", "Create");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_RetainsProtobufSelfMessageInterfaceClause()
+    {
+        var assemblyPath = CompileFixture("""
+            namespace Google.Protobuf.Reflection
+            {
+                public class MessageDescriptor { }
+            }
+
+            namespace Google.Protobuf
+            {
+                public interface IMessage
+                {
+                    Google.Protobuf.Reflection.MessageDescriptor Descriptor { get; }
+                }
+
+                public interface IMessage<T> : IMessage
+                    where T : IMessage<T>
+                {
+                }
+
+                public class MessageParser<T>
+                    where T : IMessage<T>
+                {
+                }
+            }
+
+            namespace Fixture
+            {
+                public sealed class Request : Google.Protobuf.IMessage<Request>
+                {
+                    public static Google.Protobuf.Reflection.MessageDescriptor Descriptor => throw null;
+                    public Request Clone() => throw null;
+                    public void WriteTo(object output) { }
+                    public int CalculateSize() => 0;
+                    public void MergeFrom(Request other) { }
+                    public void MergeFrom(object input) { }
+                    Google.Protobuf.Reflection.MessageDescriptor Google.Protobuf.IMessage.Descriptor => Descriptor;
+                }
+
+                public static class ParserFactory
+                {
+                    public static Google.Protobuf.MessageParser<Request> Create()
+                        => throw null;
+                }
+            }
+            """);
+        try
+        {
+            AssertCheckable(FidelityCheck.Evaluate(assemblyPath), "Fixture.ParserFactory", "Create");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_RetainsGenericBaseAndStaticMetadataClause()
+    {
+        var assemblyPath = CompileFixture("""
+            namespace Aspire.Hosting.Dcp.Model
+            {
+                public interface IKubernetesStaticMetadata
+                {
+                    string ObjectKind { get; }
+                }
+
+                public class CustomResource { }
+                public class CustomResource<TSpec, TStatus> : CustomResource { }
+                public sealed class ServiceSpec { }
+                public sealed class ServiceStatus { }
+
+                public sealed class Service : CustomResource<ServiceSpec, ServiceStatus>, IKubernetesStaticMetadata
+                {
+                    public static string ObjectKind => "Service";
+                    string IKubernetesStaticMetadata.ObjectKind => ObjectKind;
+                }
+            }
+
+            namespace Aspire.Hosting.Dcp
+            {
+                public class RenderedModelResource<T>
+                    where T : Aspire.Hosting.Dcp.Model.CustomResource, Aspire.Hosting.Dcp.Model.IKubernetesStaticMetadata
+                {
+                }
+            }
+
+            public static class DcpFactory
+            {
+                public static Aspire.Hosting.Dcp.RenderedModelResource<Aspire.Hosting.Dcp.Model.Service> Create()
+                    => throw null;
+            }
+            """);
+        try
+        {
+            AssertCheckable(FidelityCheck.Evaluate(assemblyPath), "DcpFactory", "Create");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    static void AssertCheckable(IReadOnlyList<FidelityCheck.CompileBackResult> results, string type, string method)
+    {
+        var result = Assert.Single(
+            results,
+            result => result.Type == type && result.Method == method);
+        Assert.True(
+            result.Status is FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff,
+            result.Detail);
+    }
+
     static string CompileFixture(string source)
     {
         var directory = Path.Combine(Path.GetTempPath(), $"fidelity-generated-filter-{Guid.NewGuid():N}");

--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -640,16 +640,19 @@ public class FidelityCheckGeneratedFilterTests
             string exact = Path.Combine(root, "11.0.1");
             string sameBandLower = Path.Combine(root, "11.0.0");
             string sameBandHigher = Path.Combine(root, "11.0.3");
+            string preview = Path.Combine(root, "12.0.0-preview.6.1");
             string otherBand = Path.Combine(root, "11.1.9");
             Directory.CreateDirectory(exact);
             Directory.CreateDirectory(sameBandLower);
             Directory.CreateDirectory(sameBandHigher);
+            Directory.CreateDirectory(preview);
             Directory.CreateDirectory(otherBand);
 
             Assert.Equal(exact, FidelityCheck.SelectSharedFrameworkDirectory(root, "11.0.1"));
 
             Directory.Delete(exact);
             Assert.Equal(sameBandHigher, FidelityCheck.SelectSharedFrameworkDirectory(root, "11.0.2"));
+            Assert.Equal(preview, FidelityCheck.SelectSharedFrameworkDirectory(root, "12.0.0-preview.6.2"));
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -600,6 +600,63 @@ public class FidelityCheckGeneratedFilterTests
         }
     }
 
+    [Fact]
+    public void Evaluate_RetainsNestedGenericBaseClause()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Outer
+            {
+                public class Base<T>
+                {
+                }
+
+                public sealed class Derived : Base<int>
+                {
+                }
+            }
+
+            public static class NestedGenericBaseFactory
+            {
+                public static Outer.Derived Create()
+                    => throw null;
+            }
+            """);
+        try
+        {
+            AssertCheckable(FidelityCheck.Evaluate(assemblyPath), "NestedGenericBaseFactory", "Create");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void SelectSharedFrameworkDirectory_PrefersExactThenNearestSameMajorMinor()
+    {
+        string root = Directory.CreateTempSubdirectory("dotnet-inspect-frameworks-").FullName;
+        try
+        {
+            string exact = Path.Combine(root, "11.0.1");
+            string sameBandLower = Path.Combine(root, "11.0.0");
+            string sameBandHigher = Path.Combine(root, "11.0.3");
+            string otherBand = Path.Combine(root, "11.1.9");
+            Directory.CreateDirectory(exact);
+            Directory.CreateDirectory(sameBandLower);
+            Directory.CreateDirectory(sameBandHigher);
+            Directory.CreateDirectory(otherBand);
+
+            Assert.Equal(exact, FidelityCheck.SelectSharedFrameworkDirectory(root, "11.0.1"));
+
+            Directory.Delete(exact);
+            Assert.Equal(sameBandHigher, FidelityCheck.SelectSharedFrameworkDirectory(root, "11.0.2"));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     static void AssertCheckable(IReadOnlyList<FidelityCheck.CompileBackResult> results, string type, string method)
     {
         var result = Assert.Single(

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1919,15 +1919,262 @@ static class FidelityCheck
             if (baseDef.GetGenericParameters().Count != 0)
                 return "";
         }
+        else if (typeDef.BaseType.Kind == HandleKind.TypeSpecification)
+        {
+            return GenericBaseClause(reader, typeDef.BaseType);
+        }
         else if (typeDef.BaseType.Kind != HandleKind.TypeReference || BaseTypeName(reader, typeDef.BaseType) is not "System.Exception")
         {
-            return ""; // TypeSpec / most TypeReference bases — not reliably spellable
+            return ""; // most TypeReference bases — not reliably spellable
         }
 
         string baseName = BaseTypeName(reader, typeDef.BaseType);
         if (baseName is "System.Object")
             return "";
         return $" : {Clean(baseName)}";
+    }
+
+    static string GenericBaseClause(MetadataReader reader, EntityHandle handle)
+    {
+        TypeRef type;
+        try { type = TypeRefDecoder.Instance.GetTypeFromSpecification(reader, GenericScope.Empty, (TypeSpecificationHandle)handle, 0); }
+        catch { return ""; }
+
+        if (type is not
+            {
+                Kind: TypeRefKind.GenericInstance,
+                ElementType:
+                {
+                    Kind: TypeRefKind.Definition
+                } definition
+            }
+            || definition.Assembly != CanonicalAssemblyName(reader)
+            || ContainsGenericParameter(type)
+            || ContainsUnsupportedType(type))
+        {
+            return "";
+        }
+
+        return $" : {Clean(FullyQualifiedTypeName(type))}";
+    }
+
+    static bool ContainsGenericParameter(TypeRef type)
+        => type.Kind is TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter
+           || (type.ElementType is { } element && ContainsGenericParameter(element))
+           || type.TypeArguments.Any(ContainsGenericParameter);
+
+    static bool ContainsUnsupportedType(TypeRef type)
+        => type.Kind == TypeRefKind.Unsupported
+           || (type.ElementType is { } element && ContainsUnsupportedType(element))
+           || type.TypeArguments.Any(ContainsUnsupportedType);
+
+    static string InterfaceClause(MetadataReader reader, TypeDefinition typeDef, TypeKind kind, SignatureAccessibility accessibility)
+    {
+        if (kind != TypeKind.Class)
+            return "";
+
+        var interfaces = new List<string>();
+        foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
+        {
+            var implementation = reader.GetInterfaceImplementation(implementationHandle);
+            if (SameAssemblyNonGenericInterfaceName(reader, implementation.Interface) is { } name
+                && IsSafeClassInterfaceName(name)
+                && InterfaceMembersSatisfied(reader, typeDef, implementation.Interface, accessibility))
+            {
+                interfaces.Add(Clean(name));
+                continue;
+            }
+
+            if (ProtobufSelfMessageInterfaceName(reader, typeDef, implementation.Interface) is { } protobufName)
+                interfaces.Add(Clean(protobufName));
+        }
+
+        return interfaces.Count == 0 ? "" : string.Join(", ", interfaces.Distinct(StringComparer.Ordinal));
+    }
+
+    static string CombineInheritance(string baseClause, string interfaceClause)
+    {
+        if (interfaceClause.Length == 0)
+            return baseClause;
+        if (baseClause.Length == 0)
+            return $" : {interfaceClause}";
+        return $"{baseClause}, {interfaceClause}";
+    }
+
+    static bool IsSafeClassInterfaceName(string name)
+        => name == "IResource"
+           || name.EndsWith(".IResource", StringComparison.Ordinal)
+           || name == "Aspire.Hosting.Dcp.Model.IKubernetesStaticMetadata";
+
+    static string? SameAssemblyNonGenericInterfaceName(MetadataReader reader, EntityHandle handle)
+    {
+        if (handle.Kind != HandleKind.TypeDefinition)
+            return null;
+        var definition = reader.GetTypeDefinition((TypeDefinitionHandle)handle);
+        if ((definition.Attributes & TypeAttributes.Interface) == 0
+            || definition.GetDeclaringType().IsNil == false
+            || definition.GetGenericParameters().Count != 0)
+        {
+            return null;
+        }
+
+        return FullName(reader, definition);
+    }
+
+    static string? ProtobufSelfMessageInterfaceName(MetadataReader reader, TypeDefinition typeDef, EntityHandle handle)
+    {
+        if (handle.Kind != HandleKind.TypeSpecification || !HasProtobufMessageMembers(reader, typeDef))
+            return null;
+
+        TypeRef type;
+        try { type = TypeRefDecoder.Instance.GetTypeFromSpecification(reader, GenericScope.Empty, (TypeSpecificationHandle)handle, 0); }
+        catch { return null; }
+
+        if (type is not
+            {
+                Kind: TypeRefKind.GenericInstance,
+                ElementType:
+                {
+                    Kind: TypeRefKind.Definition,
+                    Assembly: "Google.Protobuf",
+                    Namespace: "Google.Protobuf",
+                    Name: "IMessage`1"
+                },
+                TypeArguments: [{ } argument]
+            }
+            || !IsThisType(reader, typeDef, argument))
+        {
+            return null;
+        }
+
+        return FullyQualifiedTypeName(type);
+    }
+
+    static bool HasProtobufMessageMembers(MetadataReader reader, TypeDefinition typeDef)
+        => HierarchyHasProperty(reader, typeDef, "Descriptor")
+           && HierarchyHasMethod(reader, typeDef, "WriteTo")
+           && HierarchyHasMethod(reader, typeDef, "CalculateSize")
+           && HierarchyHasMethod(reader, typeDef, "MergeFrom");
+
+    static bool IsThisType(MetadataReader reader, TypeDefinition typeDef, TypeRef type)
+    {
+        if (type.Kind != TypeRefKind.Definition)
+            return false;
+        var expected = TypeDefinitionName(reader, typeDef);
+        return type.Assembly == CanonicalAssemblyName(reader)
+            && type.Namespace == expected.Namespace
+            && type.Name == expected.Name;
+    }
+
+    static (string Namespace, string Name) TypeDefinitionName(MetadataReader reader, TypeDefinition typeDef)
+    {
+        if (!typeDef.IsNested)
+            return (reader.GetString(typeDef.Namespace), reader.GetString(typeDef.Name));
+        var declaring = TypeDefinitionName(reader, reader.GetTypeDefinition(typeDef.GetDeclaringType()));
+        return (declaring.Namespace, $"{declaring.Name}+{reader.GetString(typeDef.Name)}");
+    }
+
+    static string CanonicalAssemblyName(MetadataReader reader)
+        => reader.IsAssembly
+            ? TypeRefDecoder.Canonical(reader.GetString(reader.GetAssemblyDefinition().Name))
+            : "";
+
+    static string FullyQualifiedTypeName(TypeRef type) => type.Kind switch
+    {
+        TypeRefKind.Definition => FullyQualifiedDefinitionName(type),
+        TypeRefKind.GenericInstance => FullyQualifiedGenericName(type),
+        _ => type.ToDisplayString(),
+    };
+
+    static string FullyQualifiedDefinitionName(TypeRef type)
+    {
+        string name = StripArity(type.Name).Replace('+', '.');
+        return type.Namespace.Length == 0 ? name : $"{type.Namespace}.{name}";
+    }
+
+    static string FullyQualifiedGenericName(TypeRef type)
+    {
+        var definition = type.ElementType!;
+        string name = StripArity(definition.Name).Replace('+', '.');
+        string qualified = definition.Namespace.Length == 0 ? name : $"{definition.Namespace}.{name}";
+        return $"{qualified}<{string.Join(", ", type.TypeArguments.Select(FullyQualifiedTypeName))}>";
+    }
+
+    static bool InterfaceMembersSatisfied(MetadataReader reader, TypeDefinition typeDef, EntityHandle interfaceHandle, SignatureAccessibility accessibility)
+    {
+        if (interfaceHandle.Kind != HandleKind.TypeDefinition)
+            return false;
+        var interfaceDef = reader.GetTypeDefinition((TypeDefinitionHandle)interfaceHandle);
+        foreach (var inheritedHandle in interfaceDef.GetInterfaceImplementations())
+        {
+            var inherited = reader.GetInterfaceImplementation(inheritedHandle);
+            if (!InterfaceMembersSatisfied(reader, typeDef, inherited.Interface, accessibility))
+                return false;
+        }
+
+        foreach (var propertyHandle in interfaceDef.GetProperties())
+        {
+            var property = reader.GetPropertyDefinition(propertyHandle);
+            if (!accessibility.CanEmitProperty(reader, property, GenericContext.ForType(reader, interfaceDef)))
+                continue;
+            if (!HierarchyHasProperty(reader, typeDef, reader.GetString(property.Name)))
+                return false;
+        }
+
+        var accessorNames = InterfaceAccessorNames(reader, interfaceDef);
+        foreach (var methodHandle in interfaceDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            string name = reader.GetString(method.Name);
+            if (accessorNames.Contains(name))
+                continue;
+            if (!accessibility.CanEmitMethod(reader, method, GenericContext.ForMethod(reader, interfaceDef, method)))
+                continue;
+            if (name.Contains('.') || !HierarchyHasMethod(reader, typeDef, name))
+                return false;
+        }
+
+        return true;
+    }
+
+    static HashSet<string> InterfaceAccessorNames(MetadataReader reader, TypeDefinition interfaceDef)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var propertyHandle in interfaceDef.GetProperties())
+        {
+            var accessors = reader.GetPropertyDefinition(propertyHandle).GetAccessors();
+            if (!accessors.Getter.IsNil)
+                names.Add(reader.GetString(reader.GetMethodDefinition(accessors.Getter).Name));
+            if (!accessors.Setter.IsNil)
+                names.Add(reader.GetString(reader.GetMethodDefinition(accessors.Setter).Name));
+        }
+        return names;
+    }
+
+    static bool HierarchyHasProperty(MetadataReader reader, TypeDefinition typeDef, string propertyName)
+    {
+        for (var current = typeDef; ; )
+        {
+            foreach (var propertyHandle in current.GetProperties())
+                if (reader.GetString(reader.GetPropertyDefinition(propertyHandle).Name) == propertyName)
+                    return true;
+            if (current.BaseType.Kind != HandleKind.TypeDefinition)
+                return false;
+            current = reader.GetTypeDefinition((TypeDefinitionHandle)current.BaseType);
+        }
+    }
+
+    static bool HierarchyHasMethod(MetadataReader reader, TypeDefinition typeDef, string methodName)
+    {
+        for (var current = typeDef; ; )
+        {
+            foreach (var methodHandle in current.GetMethods())
+                if (reader.GetString(reader.GetMethodDefinition(methodHandle).Name) == methodName)
+                    return true;
+            if (current.BaseType.Kind != HandleKind.TypeDefinition)
+                return false;
+            current = reader.GetTypeDefinition((TypeDefinitionHandle)current.BaseType);
+        }
     }
 
     static void EmitType(MetadataReader reader, TypeDefinitionHandle typeHandle,
@@ -1968,6 +2215,10 @@ static class FidelityCheck
             ? (IsByRefLike(reader, typeDef) ? "ref struct" : "struct")
             : IsStaticClass(typeDef) ? "static class" : "class";
         string baseClause = BaseClause(reader, typeDef, kind);
+        string interfaceClause = InterfaceClause(reader, typeDef, kind, accessibility);
+        string inheritanceClause = CombineInheritance(baseClause, interfaceClause);
+        bool implementsProtobufMessage = interfaceClause.Contains("Google.Protobuf.IMessage<", StringComparison.Ordinal);
+        bool implementsKubernetesStaticMetadata = interfaceClause.Contains("Aspire.Hosting.Dcp.Model.IKubernetesStaticMetadata", StringComparison.Ordinal);
         // An [InlineArray(N)] struct must carry the attribute for its span
         // conversions (e.g. `(Span<T>)place`) to bind; the bare reconstructed
         // struct otherwise has no such conversion and the body fails to recompile.
@@ -1980,8 +2231,12 @@ static class FidelityCheck
         var primaryConstructor = primaryConstructorTarget.Value.PrimaryConstructor;
         string primaryParameters = primaryConstructor is null ? "" : $"({primaryConstructor.Parameters})";
         string unsafeModifier = TypeHasAwaitTarget(reader, typeHandle, targets) ? "" : "unsafe ";
-        sb.AppendLine($"{pad}public {unsafeModifier}{keyword} {Identifier(name)}{genParams}{primaryParameters}{baseClause}{whereClauses}");
+        sb.AppendLine($"{pad}public {unsafeModifier}{keyword} {Identifier(name)}{genParams}{primaryParameters}{inheritanceClause}{whereClauses}");
         sb.AppendLine($"{pad}{{");
+        if (implementsProtobufMessage)
+            sb.AppendLine($"{pad}    Google.Protobuf.Reflection.MessageDescriptor Google.Protobuf.IMessage.Descriptor => throw null;");
+        if (implementsKubernetesStaticMetadata)
+            sb.AppendLine($"{pad}    string Aspire.Hosting.Dcp.Model.IKubernetesStaticMetadata.ObjectKind => throw null;");
 
         // Field initializers lifted from a target ctor apply to this type's
         // fields only when this is the type that lifted them.
@@ -2098,7 +2353,8 @@ static class FidelityCheck
         string name, string genParams, string whereClauses, SignatureAccessibility accessibility, StringBuilder sb, string pad, int indent)
     {
         var typeDef = reader.GetTypeDefinition(typeHandle);
-        sb.AppendLine($"{pad}public unsafe interface {Identifier(name)}{genParams}{whereClauses}");
+        string interfaceBaseClause = InterfaceBaseClause(reader, typeDef);
+        sb.AppendLine($"{pad}public unsafe interface {Identifier(name)}{genParams}{interfaceBaseClause}{whereClauses}");
         sb.AppendLine($"{pad}{{");
         string inner = pad + "    ";
 
@@ -2150,6 +2406,21 @@ static class FidelityCheck
         }
 
         sb.AppendLine($"{pad}}}");
+    }
+
+    static string InterfaceBaseClause(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var interfaces = new List<string>();
+        foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
+        {
+            var implementation = reader.GetInterfaceImplementation(implementationHandle);
+            if (SameAssemblyNonGenericInterfaceName(reader, implementation.Interface) is { } name)
+                interfaces.Add(Clean(name));
+        }
+
+        return interfaces.Count == 0
+            ? ""
+            : $" : {string.Join(", ", interfaces.Distinct(StringComparer.Ordinal))}";
     }
 
     static readonly IReadOnlyDictionary<MethodDefinitionHandle, TargetBody> NoTargets =
@@ -2690,6 +2961,12 @@ static class FidelityCheck
 
     static string FullName(MetadataReader reader, TypeDefinition t)
     {
+        if (t.IsNested)
+        {
+            var declaring = reader.GetTypeDefinition(t.GetDeclaringType());
+            return $"{FullName(reader, declaring)}.{StripArity(reader.GetString(t.Name))}";
+        }
+
         string ns = reader.GetString(t.Namespace);
         string n = reader.GetString(t.Name);
         return ns.Length == 0 ? n : $"{ns}.{n}";
@@ -2736,6 +3013,7 @@ static class FidelityCheck
             return "";
 
         var clauses = new List<string>();
+        var genericScope = ConstraintGenericScope(reader, handles);
         int index = 0;
         foreach (var handle in handles)
         {
@@ -2753,7 +3031,7 @@ static class FidelityCheck
             foreach (var constraintHandle in parameter.GetConstraints())
             {
                 var constraint = reader.GetGenericParameterConstraint(constraintHandle);
-                if (ConstraintTypeName(reader, constraint.Type) is not { Name.Length: > 0 } spelled)
+                if (ConstraintTypeName(reader, constraint.Type, genericScope) is not { Name.Length: > 0 } spelled)
                     continue;
                 // System.ValueType/Object are implied by struct or are the
                 // universal base; an explicit clause is invalid or noise.
@@ -2783,6 +3061,26 @@ static class FidelityCheck
         return clauses.Count == 0 ? "" : " " + string.Join(" ", clauses);
     }
 
+    static GenericScope ConstraintGenericScope(MetadataReader reader, GenericParameterHandleCollection handles)
+    {
+        var names = GenericParameterNames(reader, handles);
+        if (handles.Count == 0)
+            return GenericScope.Empty;
+
+        var parent = reader.GetGenericParameter(handles.First()).Parent;
+        if (parent.Kind != HandleKind.MethodDefinition)
+            return new GenericScope(names, []);
+
+        var method = reader.GetMethodDefinition((MethodDefinitionHandle)parent);
+        var declaringType = reader.GetTypeDefinition(method.GetDeclaringType());
+        return new GenericScope(GenericParameterNames(reader, declaringType.GetGenericParameters()), names);
+    }
+
+    static ImmutableArray<string> GenericParameterNames(MetadataReader reader, GenericParameterHandleCollection handles)
+        => handles
+            .Select(handle => Identifier(reader.GetString(reader.GetGenericParameter(handle).Name)))
+            .ToImmutableArray();
+
     /// <summary>
     /// A reliably spellable name for a generic-constraint type and whether it is
     /// an interface, or null to skip it. Only a top-level
@@ -2794,7 +3092,7 @@ static class FidelityCheck
     /// constraint types are interfaces, and a base-class constraint there does not
     /// carry the reference-type flag that would make `class, Base` invalid.
     /// </summary>
-    static (string Name, bool IsInterface)? ConstraintTypeName(MetadataReader reader, EntityHandle handle)
+    static (string Name, bool IsInterface)? ConstraintTypeName(MetadataReader reader, EntityHandle handle, GenericScope genericScope)
     {
         switch (handle.Kind)
         {
@@ -2810,10 +3108,31 @@ static class FidelityCheck
                     or HandleKind.ModuleDefinition or HandleKind.ModuleReference
                     ? (FullName(reader, reference), true)
                     : null;
+            case HandleKind.TypeSpecification:
+                TypeRef type;
+                try { type = TypeRefDecoder.Instance.GetTypeFromSpecification(reader, genericScope, (TypeSpecificationHandle)handle, 0); }
+                catch { return null; }
+                return IsProtobufIMessageConstraint(type)
+                    ? (Clean(FullyQualifiedTypeName(type)), true)
+                    : null;
             default:
                 return null;
         }
     }
+
+    static bool IsProtobufIMessageConstraint(TypeRef type)
+        => type is
+        {
+            Kind: TypeRefKind.GenericInstance,
+            ElementType:
+            {
+                Kind: TypeRefKind.Definition,
+                Assembly: "Google.Protobuf",
+                Namespace: "Google.Protobuf",
+                Name: "IMessage`1"
+            },
+            TypeArguments.Length: 1
+        };
 
     /// <summary>C# keywords that can appear as IL identifiers get an @ escape.</summary>
     static string Identifier(string name) => SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None
@@ -3118,6 +3437,7 @@ static class FidelityCheck
         foreach (var path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
             .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
             Add(path);
+        AddSharedFrameworkReferences("Microsoft.AspNetCore.App", Add);
 
         var dir = Path.GetDirectoryName(Path.GetFullPath(targetPath));
         if (dir is not null && Directory.Exists(dir))
@@ -3138,6 +3458,26 @@ static class FidelityCheck
                 Add(path);
 
         return new ReferenceSet(builder.ToImmutable(), new SignatureAccessibility(referencePaths));
+    }
+
+    static void AddSharedFrameworkReferences(string frameworkName, Action<string> add)
+    {
+        string? runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location);
+        if (runtimeDir is null)
+            return;
+        string? sharedRoot = Directory.GetParent(runtimeDir)?.Parent?.FullName;
+        if (sharedRoot is null)
+            return;
+        string frameworkRoot = Path.Combine(sharedRoot, frameworkName);
+        if (!Directory.Exists(frameworkRoot))
+            return;
+
+        string runtimeVersion = Path.GetFileName(runtimeDir);
+        string exactDirectory = Path.Combine(frameworkRoot, runtimeVersion);
+        if (!Directory.Exists(exactDirectory))
+            return;
+        foreach (var path in Directory.EnumerateFiles(exactDirectory, "*.dll"))
+            add(path);
     }
 
     internal static IReadOnlyList<string> PackageDependencyReferencePaths(string targetPath)

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -3239,8 +3239,11 @@ static class FidelityCheck
 
     /// <summary>Drops the metadata generic-arity suffix (<c>Foo`1</c> → <c>Foo</c>).</summary>
     static string StripArity(string name)
+        => string.Join("+", name.Split('+').Select(StripSegmentArity));
+
+    static string StripSegmentArity(string name)
     {
-        int tick = name.IndexOf('`');
+        int tick = name.LastIndexOf('`');
         return tick < 0 ? name : name[..tick];
     }
 
@@ -3472,12 +3475,32 @@ static class FidelityCheck
         if (!Directory.Exists(frameworkRoot))
             return;
 
-        string runtimeVersion = Path.GetFileName(runtimeDir);
-        string exactDirectory = Path.Combine(frameworkRoot, runtimeVersion);
-        if (!Directory.Exists(exactDirectory))
+        if (SelectSharedFrameworkDirectory(frameworkRoot, Path.GetFileName(runtimeDir)) is not { } selected)
             return;
-        foreach (var path in Directory.EnumerateFiles(exactDirectory, "*.dll"))
+        foreach (var path in Directory.EnumerateFiles(selected, "*.dll"))
             add(path);
+    }
+
+    internal static string? SelectSharedFrameworkDirectory(string frameworkRoot, string runtimeVersion)
+    {
+        string exactDirectory = Path.Combine(frameworkRoot, runtimeVersion);
+        if (Directory.Exists(exactDirectory))
+            return exactDirectory;
+        if (!Version.TryParse(runtimeVersion, out var runtime))
+            return null;
+
+        return Directory.EnumerateDirectories(frameworkRoot)
+            .Select(directory => new
+            {
+                Directory = directory,
+                Version = Version.TryParse(Path.GetFileName(directory), out var version) ? version : null,
+            })
+            .Where(candidate => candidate.Version is not null
+                && candidate.Version.Major == runtime.Major
+                && candidate.Version.Minor == runtime.Minor)
+            .OrderByDescending(candidate => candidate.Version)
+            .Select(candidate => candidate.Directory)
+            .FirstOrDefault();
     }
 
     internal static IReadOnlyList<string> PackageDependencyReferencePaths(string targetPath)

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -3486,14 +3486,14 @@ static class FidelityCheck
         string exactDirectory = Path.Combine(frameworkRoot, runtimeVersion);
         if (Directory.Exists(exactDirectory))
             return exactDirectory;
-        if (!Version.TryParse(runtimeVersion, out var runtime))
+        if (!Version.TryParse(VersionCore(runtimeVersion), out var runtime))
             return null;
 
         return Directory.EnumerateDirectories(frameworkRoot)
             .Select(directory => new
             {
                 Directory = directory,
-                Version = Version.TryParse(Path.GetFileName(directory), out var version) ? version : null,
+                Version = Version.TryParse(VersionCore(Path.GetFileName(directory)), out var version) ? version : null,
             })
             .Where(candidate => candidate.Version is not null
                 && candidate.Version.Major == runtime.Major
@@ -3502,6 +3502,8 @@ static class FidelityCheck
             .Select(candidate => candidate.Directory)
             .FirstOrDefault();
     }
+
+    static string VersionCore(string version) => version.Split('-', 2)[0];
 
     internal static IReadOnlyList<string> PackageDependencyReferencePaths(string targetPath)
         => PackageDependencyReferencePaths(targetPath, packageRoots: null);


### PR DESCRIPTION
- Advances #1584
- Changes compile-back fidelity skeleton and reference context; harness-only
- Evidence revision: `cf12a521`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — Aspire.Hosting cap-25 moves from zero useful compile-back rows to 15 useful rows by preserving the narrow skeleton relationships its generic constraints require.

Before:

```text
COMPILE-BACK over 25 rendered methods (18 Full)

  exact opcode match : 0 (0.00%)
  opcode diff (Full) : 0
  context-build fail : 0
  recompile fail     : 25
  recompile-fail by code:
    CS0311: 21
    CS1525: 3
    CS1526: 1
```

After:

```text
COMPILE-BACK over 25 rendered methods (18 Full)

  exact opcode match : 2 (8.00%)
  opcode diff (Full) : 13
  context-build fail : 0
  recompile fail     : 10
```

## Scope and safety

- **Root cause:** Aspire’s compile-back skeleton dropped type relationships needed by generic constraints: resource interfaces through base classes, protobuf `IMessage<TSelf>`, DCP generated resource bases/static metadata, nested generated base type names, and ASP.NET shared-framework references.
- **Fix shape:** preserve only narrow, proven skeleton relationships: selected same-assembly generic bases, selected class/interface clauses, protobuf/DCP explicit stubs, nested type full names, protobuf `IMessage<T>` TypeSpec constraints, and ASP.NET shared-framework references.
- **Product impact:** none; DecompilerHarness skeleton/reference path only.
- **Scope boundary:** remaining Aspire rows are now real frontiers: `IResourceCollection` enumerable/LINQ surface, syntax rows, incomplete return, and priority-field rows.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Harness build | Pass |
| Focused tests | `FidelityCheckGeneratedFilterTests` passed 16/16 |
| Targeted compile-back | Aspire cap-25 improved 0 useful -> 15 useful rows |
| Broad compile-back | Aspire cap-25 shown below |
| Build-event validation | Not applicable |
| Real witness | Aspire.Hosting moved from generic-constraint zero-signal to Exact/OpcodeDiff rows |

## Compile-back quality

> Did this increase the checkable population without hiding a product defect?

**Conclusion:** **PASS** — the checkable population increases substantially; remaining failures are explicitly surfaced and not hidden.

### Targeted changed-method boss

Run: Aspire.Hosting@13.4.6, cap 25.

| Metric | Baseline | PR |
| --- | ---: | ---: |
| Current sampled methods | 25 | 25 |
| Attempted | 25 | 25 |
| Exact | 0 | 2 |
| OpcodeDiff Full | 0 | 13 |
| Not Full | 0 | 0 |
| RecompileFail | 25 | 10 |
| ContextFail | 0 | 0 |

| Bucket / code | Baseline | PR | Delta | Example |
| --- | ---: | ---: | ---: | --- |
| Exact | 0 | 2 | +2 | Aspire cap sample |
| OpcodeDiff | 0 | 13 | +13 | `PathLookupHelper::ResolveExecutablePath` |
| RecompileFail `CS0311` | 21 | 0 | -21 | `IResourceBuilder<T>` / `MessageParser<T>` constraints cleared |
| RecompileFail other | 4 | 10 | +6 | `IResourceCollection` enumerable/LINQ, syntax, incomplete return |

### Broad assembly context

Run: Aspire.Hosting cap 25, `--max-examples 12`.

```text
$ dotnet run --no-restore --project tools/DecompilerHarness -c Release -- /home/rich/.nuget/packages/aspire.hosting/13.4.6/lib/net8.0/Aspire.Hosting.dll --fidelity-check --compile-cap 25 --max-examples 12
COMPILE-BACK over 25 rendered methods (18 Full)

  exact opcode match : 2 (8.00%)
  opcode diff (Full) : 13 — recompiled to a different stream (the docket)
  context-build fail : 0 — could not emit the type skeleton
  recompile fail     : 10 — skeleton + body did not compile
  recompile-fail by code:
    CS1525: 3
    CS1579: 2
    CS0103: 1
    CS0161: 1
    CS1061: 1
    CS1526: 1
    CS1929: 1

Opcode-diff examples (Full) (showing 12 of 13):
  PathLookupHelper::ResolveExecutablePath
    orig : ldarg call brfalse ldarg ret ldarg call dup ldfld stloc ldfld stloc ldloc dup brtrue pop ldstr call stloc call brtrue ldnull br ldloc dup brtrue pop ldstr call dup brtrue pop ldnull br ldc.i4 ldc.i4 call dup brtrue pop call stloc ldarg ldloc ldsfld ldsfld dup brtrue pop ldnull ldftn newobj dup stsfld ldloc call dup brtrue pop ldstr ldarg ldstr call ldarg newobj throw ret
    recmp: ldarg call brfalse ldarg ret ldarg call dup ldfld stloc ldfld stloc ldloc dup brtrue pop ldstr call stloc ldloc stloc call brtrue ldnull stloc br ldloc dup brtrue pop ldstr call stloc ldloc brtrue ldnull br ldloc ldc.i4 ldc.i4 call stloc ldloc dup brtrue pop call stloc ldloc stloc ldarg stloc ldloc stloc ldsfld stloc ldnull ldftn newobj stloc ldloc ldloc ldloc ldloc ldloc call dup stloc brtrue ldstr ldarg ldstr call ldarg newobj throw ldloc ret
  PathLookupHelper::FindFullPathFromPath
    orig : call brtrue ldnull br ldstr call dup brtrue pop ldnull br ldc.i4 ldc.i4 call dup brtrue pop call stloc ldarg ldstr call ldsfld ldsfld dup brtrue pop ldnull ldftn newobj dup stsfld ldloc call ret
    recmp: call brtrue ldnull stloc br ldstr call dup brtrue pop ldnull br ldc.i4 ldc.i4 call stloc ldloc dup brtrue pop call stloc ldloc stloc ldstr call stloc ldsfld stloc ldnull ldftn newobj stloc ldarg ldloc ldloc ldloc ldloc call ret

Recompile-fail examples (showing 10 of 10):
  BuiltInDistributedApplicationEventSubscriptionHandlers::ExcludeDashboardFromManifestAsync
    CS1929: 'IResourceCollection' does not contain a definition for 'SingleOrDefault' and the best extension method overload 'Queryable.SingleOrDefault<IResource>(IQueryable<IResource>, IResource)' requires a receiver of type 'System.Linq.IQueryable<Aspire.Hosting.ApplicationModel.IResource>'
  BuiltInDistributedApplicationEventSubscriptionHandlers::MutateHttp2TransportAsync
    CS1579: foreach statement cannot operate on variables of type 'IResourceCollection' because 'IResourceCollection' does not contain a public instance or extension definition for 'GetEnumerator'
  BuiltInDistributedApplicationEventSubscriptionHandlers::UpdateContainerRegistryAsync
    CS1525: Invalid expression term '>'
  BuiltInDistributedApplicationEventSubscriptionHandlers::WarnPersistentContainersWithoutUserSecrets
    CS1579: foreach statement cannot operate on variables of type 'IResourceCollection' because 'IResourceCollection' does not contain a public instance or extension definition for 'GetEnumerator'
  PathLookupHelper::FindAllFullPaths
    CS0161: 'PathLookupHelper.FindAllFullPaths(string, string, char, Func<string, bool>, string[])': not all code paths return a value
```

**Broad verdict:** **PASS** — the cap now produces useful compile-back signal and names the next frontier.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `IResourceCollection` enumerable/LINQ rows | Left as frontier | Needs collection/enumerator skeleton surface; separate slice. |
| `CS1525` syntax rows | Left as frontier | Not a reference/constraint issue. |
| `CS0161` incomplete return | Left as frontier | Product/source-shape issue, not skeleton constraint. |
| broad class interface clauses | Not added | Avoids CS0535/CS0736 regressions; only narrow known-safe interfaces are emitted. |

## Build-event validation

**Conclusion:** not applicable — harness-only compile-back skeleton/reference change; product and harness builds are the relevant checks.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | Findings resolved | Fixed nested generic type-name rendering and preview shared-framework fallback. |
| Claude Opus 4.8 | No blocking findings | Confirmed narrow interface/base/protobuf/k8s gates and reviewed the final fixes. |

**Review conclusion:** **PASS** — all actionable review guidance resolved in `41c16a8e` and `cf12a521`.

## Validation

```text
$ dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json
Build succeeded.

$ dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class "*FidelityCheckGeneratedFilterTests"
=== TEST EXECUTION SUMMARY ===
   ILInspector.Decompiler.Tests  Total: 16, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 3.905s

$ dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json
Build succeeded.

$ dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json
Build succeeded.
```
