### PR TITLE
Label compile-back template metric goals

### DIFF
--- a/docs/templates/decompiler-compile-back-harness-pr.md
+++ b/docs/templates/decompiler-compile-back-harness-pr.md
@@ -60,22 +60,22 @@ then broad-cap context in one sentence}.
 
 Run: `{assembly or delta artifact}`, `{method count}` current changed methods.
 
-| Metric | Baseline | PR |
+| Metric (goal) | Baseline | PR |
 | --- | ---: | ---: |
-| Current changed methods | {N} | {N} |
-| Attempted | {N} | {N} |
-| Exact | {count} | {count} |
-| OpcodeDiff Full | {count} | {count} |
-| Not Full | {count} | {count} |
-| RecompileFail | {count} | {count} |
-| ContextFail | {count} | {count} |
+| Current changed methods (context) | {N} | {N} |
+| Attempted (+) | {N} | {N} |
+| Exact (+) | {count} | {count} |
+| OpcodeDiff Full (-) | {count} | {count} |
+| Not Full (-) | {count} | {count} |
+| RecompileFail (-) | {count} | {count} |
+| ContextFail (-) | {count} | {count} |
 
-| Bucket / code | Baseline | PR | Delta | Example |
+| Bucket / code (goal) | Baseline | PR | Delta | Example |
 | --- | ---: | ---: | ---: | --- |
-| Exact | {count} | {count} | {+/-} | `{Type::Method}` |
-| OpcodeDiff | {count} | {count} | {+/-} | `{Type::Method}` |
-| RecompileFail `{CSxxxx}` | {count} | {count} | {+/-} | `{Type::Method}` |
-| ContextFail `{bucket}` | {count} | {count} | {+/-} | `{Type::Method}` |
+| Exact (+) | {count} | {count} | {+/-} | `{Type::Method}` |
+| OpcodeDiff (-) | {count} | {count} | {+/-} | `{Type::Method}` |
+| RecompileFail `{CSxxxx}` (-) | {count} | {count} | {+/-} | `{Type::Method}` |
+| ContextFail `{bucket}` (-) | {count} | {count} | {+/-} | `{Type::Method}` |
 
 ### Broad assembly context
 


### PR DESCRIPTION
## Change

**Conclusion:** PASS — the compile-back harness PR template now follows the general decompiler template convention for metric direction.

Before:

```text
| Metric | Baseline | PR |
| Exact | {count} | {count} |
| RecompileFail | {count} | {count} |
```

After:

```text
| Metric (goal) | Baseline | PR |
| Exact (+) | {count} | {count} |
| RecompileFail (-) | {count} | {count} |
```

## Scope and safety

- Docs-only template change.
- No product or harness behavior changes.
- No adversarial review needed; low-risk documentation-only PR.

## Validation

```text
$ npx markdownlint-cli --fix docs/templates/decompiler-compile-back-harness-pr.md
$ npx markdownlint-cli docs/templates/decompiler-compile-back-harness-pr.md
$ git diff --check
```
