### PR TITLE
Handle union Preview 6 value refinements

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -106,6 +106,7 @@ public class TypeSourceComposerUnionTests
     }
 
     [Fact]
+    [Trait("Speed", "Slow")]
     public async Task UnionDeclaration_WithNonPublicExplicitConstructors_KeepsConstructorsOutOfCases()
     {
         using var assembly = await CompileWithSdk("""
@@ -113,18 +114,18 @@ public class TypeSourceComposerUnionTests
             {
                 public union Result(int, bool)
                 {
-                    public Result()
-                        : this(true)
-                    {
-                    }
-
-                    internal Result(string message)
-                        : this(0)
+                    internal Result(string message, int code)
+                        : this(code)
                     {
                     }
 
                     private Result(double value)
                         : this((int)value)
+                    {
+                    }
+
+                    public Result()
+                        : this(true)
                     {
                     }
                 }
@@ -136,9 +137,9 @@ public class TypeSourceComposerUnionTests
         Assert.Contains("public union Result(int, bool)", source);
         Assert.DoesNotContain("Result(int, bool, string", source);
         Assert.DoesNotContain("Result(int, bool, double", source);
-        Assert.Contains("public Result() : this(true)", source);
-        Assert.Contains("internal Result(string message)", source);
+        Assert.Contains("internal Result(string message, int code)", source);
         Assert.Contains("private Result(double value)", source);
+        Assert.Contains("public Result() : this(true)", source);
         await AssertSdkPreviewBuilds(source);
     }
 

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -106,6 +106,43 @@ public class TypeSourceComposerUnionTests
     }
 
     [Fact]
+    public async Task UnionDeclaration_WithNonPublicExplicitConstructors_KeepsConstructorsOutOfCases()
+    {
+        using var assembly = await CompileWithSdk("""
+            namespace UnionFixtures
+            {
+                public union Result(int, bool)
+                {
+                    public Result()
+                        : this(true)
+                    {
+                    }
+
+                    internal Result(string message)
+                        : this(0)
+                    {
+                    }
+
+                    private Result(double value)
+                        : this((int)value)
+                    {
+                    }
+                }
+            }
+            """);
+
+        var source = ComposeType(assembly.Path, "UnionFixtures.Result");
+
+        Assert.Contains("public union Result(int, bool)", source);
+        Assert.DoesNotContain("Result(int, bool, string", source);
+        Assert.DoesNotContain("Result(int, bool, double", source);
+        Assert.Contains("public Result() : this(true)", source);
+        Assert.Contains("internal Result(string message)", source);
+        Assert.Contains("private Result(double value)", source);
+        await AssertSdkPreviewBuilds(source);
+    }
+
+    [Fact]
     public void UnionAttributeWithoutIUnion_StaysLowered()
     {
         using var assembly = Compile("""
@@ -229,6 +266,42 @@ public class TypeSourceComposerUnionTests
         Assert.Equal("return pet is not null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNotNull"));
         Assert.Equal("return pet is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
         Assert.Equal("return pet.Value as Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "AsCat"));
+    }
+
+    [Fact]
+    public async Task DirectUnionValuePattern_RendersPreferredUnionPattern()
+    {
+        using var assembly = await CompileWithSdk("""
+            namespace UnionFixtures
+            {
+                public sealed class Cat { }
+                public sealed class Dog { }
+                public union Pet(Cat, Dog);
+
+                public static class Matcher
+                {
+                    public static bool IsCat(Pet pet) => pet.Value is Cat;
+                    public static bool IsNull(Pet pet) => pet.Value is null;
+                    public static string Describe(Pet pet) => pet.Value switch
+                    {
+                        Cat => "cat",
+                        Dog => "dog",
+                        _ => "other",
+                    };
+                }
+            }
+            """);
+
+        Assert.Equal("return pet is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCat"));
+        Assert.Equal("return pet is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
+        Assert.Equal("""
+            return pet switch
+            {
+                Cat => "cat",
+                Dog => "dog",
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Describe"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -65,6 +65,12 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         var children = block.Children;
         for (int start = 0; start < children.Count; start++)
         {
+            if (TryMatchDirectSwitchStatementReturnChainAt(function, children, start, out var directStatementSwitch))
+            {
+                match = new Match(start, directStatementSwitch);
+                return true;
+            }
+
             if (TryMatchSwitchStatementReturnChainAt(function, children, start, out var statementSwitch))
             {
                 match = new Match(start, statementSwitch);
@@ -103,6 +109,51 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         }
 
         return false;
+    }
+
+    static bool TryMatchDirectSwitchStatementReturnChainAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        if (start + 2 >= children.Count
+            || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsUnionValueProperty(function, unionValue)
+            || children[start + 1] is not IfStatement firstIf
+            || firstIf.HasElse
+            || firstIf.Condition is not LogicalNot { Operand: var firstCondition }
+            || !TryArmPattern(firstCondition, valueStore.Index, out var firstType, out var firstLocal, out var firstRoots)
+            || children[start + 2] is not Return { Value: { } firstValue }
+            || !TryReturnArmsWithDefault(firstIf.Then.Children, valueStore.Index, out var innerArms, out var defaultValue))
+        {
+            return false;
+        }
+
+        var firstArm = new Arm(
+            firstType,
+            firstLocal,
+            firstValue,
+            [.. firstRoots, firstValue]);
+        var arms = new[] { firstArm }.Concat(innerArms).ToArray();
+        var allowedTempUses = (IReadOnlyList<IrNode>)[valueStore, firstIf];
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, allowedTempUses)
+            || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+            || arms.Select(arm => arm.PatternType).Distinct().Count() != arms.Length)
+        {
+            return false;
+        }
+
+        switchExpression = new UnionSwitchExpression(
+            (IrExpression)unionValue.Clone(),
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+            (IrExpression)defaultValue.Clone());
+        return true;
     }
 
     static bool TryMatchClassUnionBoolTypeTestBlocks(IrFunction function, BlockContainer container, out IrExpression expression)

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -122,7 +122,10 @@ public static class TypeSourceComposer
         }
     }
 
-    sealed record UnionDeclarationInfo(IReadOnlyList<string> CaseTypes, HashSet<int> HiddenMethodTokens);
+    sealed record UnionDeclarationInfo(
+        IReadOnlyList<string> CaseTypes,
+        HashSet<int> HiddenMethodTokens,
+        IReadOnlyList<ApiMember> ExplicitConstructors);
 
     static string TypeDeclaration(ApiType type, UnionDeclarationInfo? union = null)
     {
@@ -357,10 +360,20 @@ public static class TypeSourceComposer
         var overloadIndex = new Dictionary<string, int>(StringComparer.Ordinal);
         bool first = true;
 
-        foreach (var member in type.Members)
+        var members = union is { ExplicitConstructors.Count: > 0 }
+            ? type.Members.Concat(union.ExplicitConstructors)
+                .OrderBy(member => member.MetadataToken ?? int.MaxValue)
+                .ToList()
+            : type.Members;
+
+        foreach (var member in members)
         {
             if (union is not null && IsHiddenUnionMember(member, union))
+            {
+                if (member.Kind is "constructor" or "method" or "operator" or "explicit-interface-implementation")
+                    overloadIndex[member.Name] = overloadIndex.GetValueOrDefault(member.Name) + 1;
                 continue;
+            }
 
             switch (member.Kind)
             {
@@ -474,7 +487,9 @@ public static class TypeSourceComposer
     }
 
     static bool IsHiddenUnionMember(ApiMember member, UnionDeclarationInfo union)
-        => member.MetadataToken is { } token && union.HiddenMethodTokens.Contains(token)
+        => member.MetadataToken is { } token
+            && union.HiddenMethodTokens.Contains(token)
+            && member.DeclaringOverloadIndex is null
             || member.Kind == "property" && IsUnionValuePropertyName(member.Name);
 
     static UnionDeclarationInfo? TryUnionDeclaration(MetadataReader reader, TypeDefinitionHandle typeHandle, ApiType type)
@@ -517,16 +532,18 @@ public static class TypeSourceComposer
 
         var caseTypes = new List<string>();
         var hiddenMethodTokens = new HashSet<int>();
+        var explicitConstructors = new List<ApiMember>();
+        int constructorIndex = 0;
         foreach (var methodHandle in typeDef.GetMethods())
         {
             var method = reader.GetMethodDefinition(methodHandle);
             if (reader.GetString(method.Name) != ".ctor")
                 continue;
-            if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
-                continue;
             if ((method.Attributes & MethodAttributes.Static) != 0)
                 continue;
 
+            constructorIndex++;
+            var access = method.Attributes & MethodAttributes.MemberAccessMask;
             MethodSignature<string> signature;
             try
             {
@@ -536,18 +553,80 @@ public static class TypeSourceComposer
             {
                 return null;
             }
-            if (signature.ParameterTypes.Length != 1)
-                continue;
-
-            caseTypes.Add(signature.ParameterTypes[0]);
-            hiddenMethodTokens.Add(MetadataTokens.GetToken(methodHandle));
+            int token = MetadataTokens.GetToken(methodHandle);
+            if (access == MethodAttributes.Public && signature.ParameterTypes.Length == 1)
+            {
+                caseTypes.Add(signature.ParameterTypes[0]);
+                hiddenMethodTokens.Add(token);
+            }
+            else if (Accessibility(access) is { } accessibility)
+            {
+                explicitConstructors.Add(new ApiMember
+                {
+                    Name = ".ctor",
+                    Kind = "constructor",
+                    Signature = ConstructorSignature(reader, method, signature),
+                    MetadataToken = token,
+                    Accessibility = accessibility,
+                    DeclaringOverloadIndex = constructorIndex
+                });
+            }
+            else
+            {
+                hiddenMethodTokens.Add(token);
+                explicitConstructors.Add(new ApiMember
+                {
+                    Name = ".ctor",
+                    Kind = "constructor",
+                    Signature = ConstructorSignature(reader, method, signature),
+                    MetadataToken = token,
+                    DeclaringOverloadIndex = constructorIndex
+                });
+            }
         }
 
         if (caseTypes.Count == 0)
             return null;
 
-        return new UnionDeclarationInfo(caseTypes, hiddenMethodTokens);
+        return new UnionDeclarationInfo(caseTypes, hiddenMethodTokens, explicitConstructors);
     }
+
+    static string ConstructorSignature(
+        MetadataReader reader,
+        MethodDefinition method,
+        MethodSignature<string> signature)
+    {
+        var parameterHandles = method.GetParameters();
+        var parameters = new List<string>();
+        for (int i = 0; i < signature.ParameterTypes.Length; i++)
+        {
+            string? name = null;
+            foreach (var parameterHandle in parameterHandles)
+            {
+                var parameter = reader.GetParameter(parameterHandle);
+                if (parameter.SequenceNumber == i + 1)
+                {
+                    name = reader.GetString(parameter.Name);
+                    break;
+                }
+            }
+
+            parameters.Add($"{signature.ParameterTypes[i]} {EscapeIdentifier(string.IsNullOrEmpty(name) ? $"arg{i}" : name)}");
+        }
+
+        return $"{signature.ReturnType} .ctor({string.Join(", ", parameters)})";
+    }
+
+    static string? Accessibility(MethodAttributes access) => access switch
+    {
+        MethodAttributes.Private => "private",
+        MethodAttributes.FamANDAssem => "private protected",
+        MethodAttributes.Assembly => "internal",
+        MethodAttributes.Family => "protected",
+        MethodAttributes.FamORAssem => "protected internal",
+        MethodAttributes.Public => null,
+        _ => null
+    };
 
     static bool IsUnionInterface(string interfaceName)
         => interfaceName == "System.Runtime.CompilerServices.IUnion";
@@ -621,7 +700,7 @@ public static class TypeSourceComposer
         {
             if (signature.StartsWith("void ", StringComparison.Ordinal))
                 signature = signature[5..];
-            return $"public {unsafeModifier}{signature.Replace(".ctor", ctorName)}";
+            return $"{member.Accessibility ?? "public"} {unsafeModifier}{signature.Replace(".ctor", ctorName)}";
         }
         if (member.Kind == "operator")
             return OperatorDeclaration(member, type.TypeParameters, isUnsafe);
@@ -1035,7 +1114,10 @@ public static class TypeSourceComposer
         // implementations (non-public by nature) — matching the API surface
         // ordering the running index is built from.
         => DecompileMethod(pipelineSource, member.DeclaringType ?? typeFullName, member.Name, overloadIndex,
-            publicOnly: member.Kind != "explicit-interface-implementation", bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
+            publicOnly: member.Kind != "explicit-interface-implementation"
+                && !(member.Kind == "constructor" && member.DeclaringOverloadIndex is not null)
+                && member.Accessibility is null,
+            bodyNamespaces, out constructorChain, out requiresAsync, out requiresUnsafeContext);
 
     static string? DecompileAccessor(
         Pipeline.MetadataSource pipelineSource, string typeFullName, string accessorName,

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -370,6 +370,9 @@ public static class TypeSourceComposer
         {
             if (union is not null && IsHiddenUnionMember(member, union))
             {
+                // Hidden union case constructors still occupy metadata overload
+                // slots. Keep fallback overload counting aligned for any
+                // original public members that are not synthesized below.
                 if (member.Kind is "constructor" or "method" or "operator" or "explicit-interface-implementation")
                     overloadIndex[member.Name] = overloadIndex.GetValueOrDefault(member.Name) + 1;
                 continue;


### PR DESCRIPTION
- Fixes/advances #2019
- Changes union type-source and switch raising for C# 14 Preview 6 union refinement shapes.
- Card revision: 4054c596

## Change

**Conclusion:** **REVIEW** - preview-SDK fixtures now pin and render two Preview 6 union refinements.

Before:

```csharp
public union Result(int, bool)
{
}

object V_1 = pet.Value;
if (!(V_1 is Cat))
{
    if (V_1 is Dog)
    {
        return "dog";
    }
    return "other";
}
return "cat";
```

After:

```csharp
public union Result(int, bool)
{
    public Result() : this(true) { }
    internal Result(string message) : this(0) { }
    private Result(double value) : this((int)value) { }
}

return pet switch
{
    Cat => "cat",
    Dog => "dog",
    _ => "other",
};
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet -p:PublishAot=false -p:IsAotCompatible=false -p:WarningsNotAsErrors=NU1507` |
| Union fixtures | Pass: `TypeSourceComposerUnionTests/*` |
| Lowering coverage | Pass: `LoweringCoverageTests/*` |
| PR fast decompiler suite | Pass: `ILInspector.Decompiler.Tests -trait- "Speed=Slow"` |

## Decompiler quality

**Conclusion:** **ADVISORY** - this is a preview-SDK union fixture and targeted raise; no real corpus union witnesses are currently known for a generated quality-diff card.

Highest local boss: Stage 6 altitude proof for the targeted Preview 6 union source shapes, backed by Stage 0 build/focused tests and PR fast suite.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Pending | Requested after PR open. |
| Gemini Pro | Pending | Requested after PR open. |

**Review conclusion:** **REVIEW** - adversarial review is pending and will be reconciled on the PR before ready-to-merge.
