### PR TITLE
Align library IL offset output shapes

### DIFF
--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -149,6 +149,66 @@ library MyLib.dll -S "Top Leverage" --count
 member MyType Method:1 --library MyLib.dll -S "Decompiled Source" --bare > Method.cs
 ```
 
+### Case study: IL offset as a shape catalogue
+
+`library --il-offset` is a compact example of the shape ladder because one
+resolved source location can be useful as a human fact sheet, a row, a scalar, a
+URL, a path, or a source-line payload.
+
+The default stays evidence-oriented and renders the singleton location as
+vertical facts:
+
+```bash
+dotnet-inspect library My.dll --il-offset 0x06000002+0x1
+```
+
+```md
+## IL Offset
+
+| Field | Value |
+| ----- | ----- |
+| Method | My.Type.Method |
+| Token | 0x6000002 |
+| IL Offset | 0x1 |
+| File | /_/src/Foo.cs |
+| Line | 42 |
+| Url | https://raw.githubusercontent.com/org/repo/sha/src/Foo.cs#L42 |
+```
+
+The same resolved location then projects cleanly:
+
+```bash
+# Scalar
+dotnet-inspect library My.dll --il-offset 0x06000002+0x1 \
+  -S "IL Offset" --fields Line --value
+# 42
+
+# URL vector (one row)
+dotnet-inspect library My.dll --il-offset 0x06000002+0x1 \
+  -S "IL Offset" --urls
+# https://raw.githubusercontent.com/org/repo/sha/src/Foo.cs#L42
+
+# Path vector (one row)
+dotnet-inspect library My.dll --il-offset 0x06000002+0x1 \
+  -S "IL Offset" --paths
+# /_/src/Foo.cs
+
+# Printable payload: the raw resolved source line
+dotnet-inspect library My.dll --il-offset 0x06000002+0x1 \
+  -S "IL Offset" --print
+#         return JsonSerializer.Serialize(value, options);
+
+# Singleton count
+dotnet-inspect library My.dll --il-offset 0x06000002+0x1 \
+  -S "IL Offset" --count
+# 1
+```
+
+This keeps the concerns separate: the default fact section shows all
+symbolication evidence, `--urls` returns the anchored source location, `--paths`
+returns the PDB document path, and `--print` returns the raw payload at the
+location rather than a decorated snippet.
+
 ## Design discipline for future flags
 
 The stable vocabulary is:

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2,6 +2,7 @@ using System.IO.Compression;
 using System.Text.Json;
 using DotnetInspector.Commands;
 using DotnetInspector.Core;
+using DotnetInspector.Models;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
 using DotnetInspector.Packages;
@@ -4554,7 +4555,10 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.Contains("## IL Offset", output);
-        Assert.Contains("| System.HexConverter.FromChar | 0x6000001 | 0x0 |", output);
+        Assert.Contains("| Field | Value |", output);
+        Assert.Contains("| Method | System.HexConverter.FromChar |", output);
+        Assert.Contains("| Token | 0x6000001 |", output);
+        Assert.Contains("| IL Offset | 0x0 |", output);
         Assert.Contains("HexConverter.cs", output);
     }
 
@@ -4568,8 +4572,113 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.Contains("## IL Offset", output);
-        Assert.Contains("| System.HexConverter.FromChar | 0x6000001 | 0x0 |", output);
+        Assert.Contains("| Field | Value |", output);
+        Assert.Contains("| Method | System.HexConverter.FromChar |", output);
+        Assert.Contains("| Token | 0x6000001 |", output);
+        Assert.Contains("| IL Offset | 0x0 |", output);
         Assert.Contains("HexConverter.cs", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetCount_ReturnsSingletonLocationCount()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x0", "-S", "IL Offset", "--count", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Equal("1", output.Trim());
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetValue_ProjectsResolvedLine()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x0", "-S", "IL Offset", "--fields", "Line", "--value", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Matches(@"^\d+$", output.Trim());
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetPrint_PrintsResolvedSourceLine()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x0", "-S", "IL Offset", "--print", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.DoesNotContain("## IL Offset", output);
+        Assert.Contains("CharToHexLookup", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetPrintJsonArray_EmitsPrintableDocument()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x0", "-S", "IL Offset", "--print-all", "--json-array", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.StartsWith("[", output.Trim());
+        Assert.Contains("\"section\":\"IL Offset\"", output);
+        Assert.Contains("\"label\":\"System.HexConverter.FromChar\"", output);
+        Assert.Contains("CharToHexLookup", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetPrintAllRejectsRow()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x0", "-S", "IL Offset", "--print-all", "--row", "1", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("--print-all cannot be combined with --row", error);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetCountRejectsPrint()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x0", "-S", "IL Offset", "--count", "--print", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("--count cannot be combined with --print", error);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetPrint_DoesNotReadLocalPdbPath()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, "secret-local-file-line", TestContext.Current.CancellationToken);
+            var result = new ILOffsetResult
+            {
+                Method = "Attacker.Method",
+                File = tempFile,
+                Line = 1
+            };
+
+            var (content, error) = await LibraryCommand.ReadILOffsetSourceLineForTestsAsync(result);
+
+            Assert.Null(content);
+            Assert.Contains("no printable source body", error);
+            Assert.DoesNotContain("secret-local-file-line", error);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -153,6 +153,7 @@ public static class InspectionCommandDefinitions
         assemblyCommand.Options.Add(extractResourcesOption);
         opts.AddAllOptionsTo(assemblyCommand);
         opts.AddCountOptionTo(assemblyCommand);
+        opts.AddPrintOptionTo(assemblyCommand);
         opts.AddShapeProjectionOptionsTo(assemblyCommand);
         opts.AddPerformanceTriageOptionsTo(assemblyCommand);
 
@@ -257,10 +258,13 @@ public static class InspectionCommandDefinitions
                 Columns = opts.ParseColumns(parseResult),
                 Fields = opts.ParseFields(parseResult),
                 Count = parseResult.GetValue(opts.Count),
+                Print = parseResult.GetValue(opts.Print),
+                PrintAll = parseResult.GetValue(opts.PrintAll),
                 Value = parseResult.GetValue(opts.Value),
                 Urls = parseResult.GetValue(opts.Urls),
                 Paths = parseResult.GetValue(opts.Paths),
                 JsonArray = parseResult.GetValue(opts.JsonArray),
+                PrintRow = opts.ParsePrintRow(parseResult),
                 ProjectionRow = opts.ParsePrintRow(parseResult),
                 Rows = opts.ParseRows(parseResult),
                 PerformanceTriage = performanceTriage,

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -99,6 +99,12 @@ public class LibraryCommand
         if (options.Count && !CountOutput.ValidateSingleSection(options.IncludeSections))
             return 1;
 
+        if (options.Count && (options.Print || options.PrintAll))
+        {
+            Console.Error.WriteLine("Error: --count cannot be combined with --print or --print-all.");
+            return 1;
+        }
+
         var shapeCount = ShapeProjectionOutput.ActiveShapeCount(options.Value, options.Urls, options.Paths);
         if (shapeCount > 1)
         {
@@ -111,9 +117,9 @@ public class LibraryCommand
             var optionName = options.Value ? "--value" : options.Urls ? "--urls" : "--paths";
             if (!ShapeProjectionOutput.ValidateSingleSection(options.IncludeSections, optionName))
                 return 1;
-            if (options.Count)
+            if (options.Count || options.Print || options.PrintAll)
             {
-                Console.Error.WriteLine($"Error: {optionName} cannot be combined with --count.");
+                Console.Error.WriteLine($"Error: {optionName} cannot be combined with --count, --print, or --print-all.");
                 return 1;
             }
             if (options.Rows is not null)
@@ -123,9 +129,9 @@ public class LibraryCommand
             }
         }
 
-        if (options.JsonArray && shapeCount == 0)
+        if (options.JsonArray && shapeCount == 0 && !options.Print && !options.PrintAll)
         {
-            Console.Error.WriteLine("Error: --json-array requires --value, --urls, or --paths.");
+            Console.Error.WriteLine("Error: --json-array requires --value, --urls, --paths, --print, or --print-all.");
             return 1;
         }
 
@@ -135,9 +141,30 @@ public class LibraryCommand
             return 1;
         }
 
-        if (options.ProjectionRow is not null && shapeCount == 0)
+        if ((options.Print || options.PrintAll) && !ValidateLibraryPrintSelection(options.IncludeSections))
+            return 1;
+
+        if ((options.Print || options.PrintAll) && options.Rows is not null)
         {
-            Console.Error.WriteLine("Error: --row requires --value, --urls, or --paths.");
+            Console.Error.WriteLine("Error: --rows cannot be combined with --print or --print-all; use --row N to choose a printed row.");
+            return 1;
+        }
+
+        if (options.Print && options.PrintAll)
+        {
+            Console.Error.WriteLine("Error: --print cannot be combined with --print-all.");
+            return 1;
+        }
+
+        if (options.PrintAll && options.PrintRow is not null)
+        {
+            Console.Error.WriteLine("Error: --print-all cannot be combined with --row.");
+            return 1;
+        }
+
+        if (options.ProjectionRow is not null && !options.Print && !options.PrintAll && shapeCount == 0)
+        {
+            Console.Error.WriteLine("Error: --row requires --print, --value, --urls, or --paths.");
             return 1;
         }
 
@@ -234,6 +261,10 @@ public class LibraryCommand
                     inspection, resolvedPath!, null, null, isPlatformAssembly: true, options, context.HttpClient, logger);
                 if (ilOffsetExitCode != 0)
                     return ilOffsetExitCode;
+                if (TryWriteLibrarySingletonCount(inspection, options))
+                    return 0;
+                if (options.Print || options.PrintAll)
+                    return await WriteLibraryPrintProjectionAsync(inspection, options);
                 if (options.Value || options.Urls || options.Paths)
                     return WriteLibraryShapeProjection(inspection, options);
                 WarnEmptySections(inspection, options, pipeline);
@@ -297,6 +328,10 @@ public class LibraryCommand
                     options, context.HttpClient, logger);
                 if (ilOffsetExitCode != 0)
                     return ilOffsetExitCode;
+                if (TryWriteLibrarySingletonCount(inspections[0], options))
+                    return 0;
+                if (options.Print || options.PrintAll)
+                    return await WriteLibraryPrintProjectionAsync(inspections[0], options);
                 if (options.Value || options.Urls || options.Paths)
                     return WriteLibraryShapeProjection(inspections[0], options);
                 WarnEmptySections(inspections[0], options, pipeline);
@@ -346,6 +381,10 @@ public class LibraryCommand
                     options, context.HttpClient, logger);
                 if (ilOffsetExitCode != 0)
                     return ilOffsetExitCode;
+                if (TryWriteLibrarySingletonCount(inspection, options))
+                    return 0;
+                if (options.Print || options.PrintAll)
+                    return await WriteLibraryPrintProjectionAsync(inspection, options);
                 if (options.Value || options.Urls || options.Paths)
                     return WriteLibraryShapeProjection(inspection, options);
                 WarnEmptySections(inspection, options, pipeline);
@@ -447,6 +486,28 @@ public class LibraryCommand
         return 0;
     }
 
+    private static bool ValidateLibraryPrintSelection(HashSet<string>? sections)
+    {
+        if (sections is { Count: 1 } && sections.Contains(SectionNames.ILOffset))
+            return true;
+
+        Console.Error.WriteLine("Error: --print requires -S/--select to match exactly one printable section.");
+        return false;
+    }
+
+    private static bool TryWriteLibrarySingletonCount(LibraryInspection inspection, LibraryOptions options)
+    {
+        if (!options.Count
+            || options.IncludeSections is not { Count: 1 } sections
+            || !sections.Contains(SectionNames.ILOffset))
+        {
+            return false;
+        }
+
+        Console.WriteLine(inspection.ILOffset is null ? 0 : 1);
+        return true;
+    }
+
     private static int WriteLibraryShapeProjection(LibraryInspection inspection, LibraryOptions options)
     {
         var kind = ShapeProjectionOutput.GetKind(options.Value, options.Urls, options.Paths);
@@ -470,6 +531,105 @@ public class LibraryCommand
         return ShapeProjectionOutput.Write(
             rows,
             new ShapeProjectionOptions(kind, options.ProjectionRow, options.JsonOutput, options.Jsonl, options.JsonArray));
+    }
+
+    private static async Task<int> WriteLibraryPrintProjectionAsync(LibraryInspection inspection, LibraryOptions options)
+    {
+        var section = options.IncludeSections!.Single();
+        var projection = section switch
+        {
+            SectionNames.ILOffset => await ProjectLibraryILOffsetPrintableAsync(inspection, section),
+            _ => new PrintProjectionResult([])
+        };
+        if (projection.Error is not null)
+        {
+            Console.Error.WriteLine(projection.Error);
+            return 1;
+        }
+
+        if (projection.Documents.Count == 0 && section != SectionNames.ILOffset)
+        {
+            Console.Error.WriteLine($"Error: section '{section}' is not printable.");
+            return 1;
+        }
+
+        return PrintProjectionOutput.Write(
+            projection.Documents,
+            new PrintProjectionOptions(
+                options.PrintAll,
+                options.PrintRow,
+                options.JsonOutput,
+                options.Jsonl,
+                options.JsonArray,
+                Bare: false,
+                OutputPath: null));
+    }
+
+    private sealed record PrintProjectionResult(IReadOnlyList<PrintableDocument> Documents, string? Error = null);
+
+    private static async Task<PrintProjectionResult> ProjectLibraryILOffsetPrintableAsync(
+        LibraryInspection inspection,
+        string section)
+    {
+        if (inspection.ILOffset is not { } result)
+            return new PrintProjectionResult([]);
+
+        var (content, error) = await ReadILOffsetSourceLineAsync(result);
+        if (error is not null)
+            return new PrintProjectionResult([], error);
+        if (content is null)
+            return new PrintProjectionResult([]);
+
+        return new PrintProjectionResult(
+        [
+            new PrintableDocument(1, section, result.Method ?? result.File ?? section, result.File, result.Url, content)
+        ]);
+    }
+
+    internal static Task<(string? Content, string? Error)> ReadILOffsetSourceLineForTestsAsync(ILOffsetResult result)
+        => ReadILOffsetSourceLineAsync(result);
+
+    private static async Task<(string? Content, string? Error)> ReadILOffsetSourceLineAsync(ILOffsetResult result)
+    {
+        if (result.Line is not { } line || line < 1)
+        {
+            return (null, "Error: IL Offset row has no source line to print.");
+        }
+
+        if (string.IsNullOrWhiteSpace(result.Url))
+        {
+            return (null, "Error: IL Offset row has no printable source body. Use --urls or --paths to inspect available payloads.");
+        }
+
+        var rawUrl = StripUrlFragment(GitHubUrlResolver.ConvertBlobToRawUrl(result.Url));
+        var fetcher = new SourceFetcher(DotnetInspector.Core.HttpClientFactory.SharedUntrustedFetch);
+        var source = await fetcher.FetchSourceAsync(rawUrl);
+        if (source is null)
+        {
+            return (null, $"Error: Could not fetch SourceLink source for {rawUrl}.");
+        }
+
+        return ReadLine(source.ReplaceLineEndings("\n").Split('\n'), line);
+    }
+
+    private static (string? Content, string? Error) ReadLine(IEnumerable<string> lines, int line)
+    {
+        var value = lines.Skip(line - 1).FirstOrDefault();
+        if (value is null)
+        {
+            return (null, $"Error: Source line {line} is out of range.");
+        }
+
+        return (value, null);
+    }
+
+    private static string StripUrlFragment(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || string.IsNullOrEmpty(uri.Fragment))
+            return url;
+
+        var builder = new UriBuilder(uri) { Fragment = "" };
+        return builder.Uri.ToString();
     }
 
     private static List<ShapeProjectionRow> ProjectLibrarySourceFiles(LibraryInspection inspection, string section, ShapeProjectionKind kind, LibraryOptions options)

--- a/src/dotnet-inspect/Options/LibraryOptions.cs
+++ b/src/dotnet-inspect/Options/LibraryOptions.cs
@@ -183,6 +183,10 @@ public record LibraryOptions
     /// </summary>
     public bool Count { get; init; }
 
+    public bool Print { get; init; }
+
+    public bool PrintAll { get; init; }
+
     public bool Value { get; init; }
 
     public bool Urls { get; init; }
@@ -190,6 +194,8 @@ public record LibraryOptions
     public bool Paths { get; init; }
 
     public bool JsonArray { get; init; }
+
+    public int? PrintRow { get; init; }
 
     public int? ProjectionRow { get; init; }
 

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -473,7 +473,7 @@ public record PackageSourceFileRow(
 [MarkoutContext(typeof(TargetFrameworkRow))]
 [MarkoutContext(typeof(PackageFileRow))]
 [MarkoutContext(typeof(PackageSourceFileRow))]
-[MarkoutContext(typeof(ILOffsetRow))]
+[MarkoutContext(typeof(ILOffsetSection))]
 [MarkoutContext(typeof(ManifestRow))]
 [MarkoutContext(typeof(RidPackageReferenceView))]
 [MarkoutContext(typeof(EmptyDepsView))]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -481,17 +481,16 @@ public class LibraryInspectionView
     public bool HasILOffset => _data.ILOffset != null;
 
     [MarkoutSection(Name = SectionNames.ILOffset, ShowWhenProperty = nameof(HasILOffset))]
-    public List<ILOffsetRow>? ILOffsetSection => _data.ILOffset is not { } result ? null :
-    [
-        new ILOffsetRow(
-            result.Method,
-            result.Token,
-            result.ILOffset,
-            result.MatchedOffset,
-            result.File,
-            result.Line,
-            result.Url)
-    ];
+    public ILOffsetSection? ILOffsetSection => _data.ILOffset is not { } result ? null : new ILOffsetSection
+    {
+        Method = result.Method,
+        Token = result.Token,
+        ILOffset = result.ILOffset,
+        MatchedOffset = result.MatchedOffset,
+        File = result.File,
+        Line = result.Line,
+        Url = result.Url
+    };
 
     [MarkoutSection(Name = "SourceLink Availability", ShowWhenProperty = nameof(HasSourceLinkAudit))]
     public SourceLinkAuditSection? SourceLinkAuditSection => !HasSourceLinkAudit ? null : new SourceLinkAuditSection
@@ -762,17 +761,20 @@ public record AsyncMethodRow(
     string Kind,
     string Signature);
 
-[MarkoutSerializable]
-public record ILOffsetRow(
-    [property: MarkoutSkipNull] string? Method,
-    [property: MarkoutSkipNull] string? Token,
-    [property: MarkoutPropertyName("IL Offset")]
-    [property: MarkoutSkipNull] string? ILOffset,
-    [property: MarkoutPropertyName("Matched Offset")]
-    [property: MarkoutSkipNull] string? MatchedOffset,
-    [property: MarkoutSkipNull] string? File,
-    [property: MarkoutSkipNull] int? Line,
-    [property: MarkoutSkipNull] string? Url);
+[MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords, FieldLayout = FieldLayout.Table)]
+[MarkoutSkipNull]
+public class ILOffsetSection
+{
+    public string? Method { get; init; }
+    public string? Token { get; init; }
+    [MarkoutPropertyName("IL Offset")]
+    public string? ILOffset { get; init; }
+    [MarkoutPropertyName("Matched Offset")]
+    public string? MatchedOffset { get; init; }
+    public string? File { get; init; }
+    public int? Line { get; init; }
+    public string? Url { get; init; }
+}
 
 [MarkoutSerializable]
 public record ResourceRow(


### PR DESCRIPTION
## Summary

- Render `library --il-offset` as a singleton vertical `IL Offset` fact section instead of a horizontal row.
- Wire `--print` / `--print-all` onto `library` for `IL Offset`; `--print` emits the raw resolved source line, while `--urls`, `--paths`, `--value`, and singleton `--count` keep their shape roles.
- Document `IL Offset` as a shape-catalogue case study in `docs/design/output-shapes.md`.

Closes #2018.

## Validation

- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json --nologo --verbosity quiet`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- -method "*IlOffset*"`
- `npx markdownlint-cli docs/design/output-shapes.md`

## Adversarial review

- Claude Opus 4.8 found validation/UX gaps: `--count --print` silently preferred count, `--print-all --row` produced a misleading error, and source-line read failures could double-report. Fixed in commit 8cc9a947 by adding explicit validation and single-error print projection failures.
- Gemini 3.1 Pro found the same validation/double-error issues and a high-severity local-file disclosure risk from trusting PDB document paths for local reads. Fixed in commit 8cc9a947 by removing local-file fallback from IL-offset print and only materializing source through the SSRF-hardened SourceLink URL fetch path. Added regression tests for local PDB paths and flag conflicts.
- Non-action: Claude noted content-based `--print` assertions are somewhat upstream-source-dependent; kept them because the existing IL-offset test already uses `System.Text.Json` SourceLink resolution and the assertion is limited to a stable line from the resolved method.
