### PR TITLE
Normalize InstructionDecoder malformed-IL exception to BadImageFormatException

### DIFF
--- a/src/ILInspector.Instructions.Tests/SubstrateTests.cs
+++ b/src/ILInspector.Instructions.Tests/SubstrateTests.cs
@@ -162,4 +162,20 @@ public class StackTypeInterpreterTests
         Assert.False(mi.Blocks.IsComplete);
         Assert.NotNull(mi.Blocks.IncompleteReason);
     }
+
+    [Theory]
+    [InlineData(new byte[] { 0x38 })]              // br <int32> with no destination (ILReader path)
+    [InlineData(new byte[] { 0x2B })]              // br.s <int8> with no destination (ILReader path)
+    [InlineData(new byte[] { 0xFE })]              // dangling two-byte opcode prefix (ILReader path)
+    [InlineData(new byte[] { 0x45, 0x01 })]        // switch with a truncated count (ILReader path)
+    [InlineData(new byte[] { 0x28, 0x01, 0x00 })]  // call <token> with a truncated operand (operand path)
+    public void Decode_throws_BadImageFormat_on_truncated_il(byte[] il)
+    {
+        // The substrate exposes a single malformed-IL exception: BadImageFormatException. The
+        // runtime-ported ILReader uses InvalidProgramException internally for truncated
+        // opcode/branch/switch reads, so InstructionDecoder.Decode must normalize it at the
+        // boundary — otherwise consumers (ReachingDefinitions, LibraryBodyIndex) leak the wrong
+        // exception type past their recovery gate.
+        Assert.Throws<BadImageFormatException>(() => InstructionDecoder.Decode(il));
+    }
 }

--- a/src/ILInspector.Instructions/InstructionDecoder.cs
+++ b/src/ILInspector.Instructions/InstructionDecoder.cs
@@ -19,6 +19,25 @@ public static class InstructionDecoder
     public static ImmutableArray<DecodedInstruction> Decode(byte[] il)
     {
         ArgumentNullException.ThrowIfNull(il);
+        try
+        {
+            return DecodeCore(il);
+        }
+        catch (InvalidProgramException ex)
+        {
+            // The runtime-ported ILReader reports a truncated/invalid read (opcode, branch
+            // destination, or switch count) as InvalidProgramException — the JIT/ILVerify
+            // convention. This decoder's documented contract, and every Analysis consumer's
+            // malformed-IL recovery gate, is BadImageFormatException, so normalize at the
+            // substrate boundary. That keeps ILReader a faithful upstream port while presenting
+            // one malformed-IL exception type, so consumers need no per-call-site shim.
+            throw new BadImageFormatException(
+                string.IsNullOrEmpty(ex.Message) ? "Malformed IL" : ex.Message, ex);
+        }
+    }
+
+    static ImmutableArray<DecodedInstruction> DecodeCore(byte[] il)
+    {
         var builder = ImmutableArray.CreateBuilder<DecodedInstruction>();
         var reader = new ILReader(il);
 


### PR DESCRIPTION
## Summary

`InstructionDecoder.Decode` documents *"Malformed IL throws `BadImageFormatException`"*, and every Analysis consumer's per-method recovery gate is built on that contract (`IsRecoverableMethodFailure`, `ReachingDefinitions`, `LibraryBodyIndex`). But `Decode` delegates **opcode, branch-destination, and switch-count** reads to the runtime-ported `ILReader`, which signals truncation with `InvalidProgramException` (the JIT/ILVerify convention). So truncated IL escaped as the **wrong exception type**, violating the decoder's own documented contract.

This fixes it at the root: normalize at the `InstructionDecoder.Decode` boundary so the substrate exposes a single malformed-IL exception type.

## Root cause (proven)

Probing `InstructionDecoder.Decode` on origin/main with truncated bodies:

| Input | Before | Path |
| --- | --- | --- |
| `br <int32>` no destination (`38`) | `InvalidProgramException` | ILReader |
| `br.s <int8>` no destination (`2B`) | `InvalidProgramException` | ILReader |
| dangling `0xFE` prefix (`FE`) | `InvalidProgramException` | ILReader |
| `switch` truncated count (`45 01`) | `InvalidProgramException` | ILReader |
| `call <token>` truncated (`28 01 00`) | `BadImageFormatException` | Decode's own `Slice`/`ReadU8` |

Only the **operand** path honored the contract — which is exactly why the existing fail-closed test (`SubstrateTests.Malformed_il_fails_closed_instead_of_throwing`, a `call`-token case) passed and the leak went unnoticed at the substrate level. It surfaced only **downstream**, where #1990 (ReachingDefinitions) and #2013 (LibraryBodyIndex) each had to add their *own* `InvalidProgramException -> BadImageFormatException` shim. `ReachingDefinitions.cs` even names the cause in a comment: *"InvalidProgramException on a truncated read (opcode / branch operand / switch count)."*

**Why the old system didn't have this:** the old hand-rolled decoders (LibraryBodyIndex's `ReadByte`/`ReadInt32`/`Advance`, RD's equivalent) did inline bounds checks that threw `BadImageFormatException` uniformly. The substrate centralized decoding but inherited dotnet/runtime's `ILReader`, whose `InvalidProgramException` convention is wrong for static inspection (a bad image, not an invalid program at JIT time).

## Fix

- Wrap `Decode` -> `DecodeCore`; catch the ported `ILReader`'s `InvalidProgramException` and rethrow `BadImageFormatException` (preserving message + inner exception).
- This keeps `ILReader` a faithful upstream port (and leaves the decompiler `IrImporter`'s use of it untouched), while presenting one malformed-IL exception type to all consumers.

Alternative considered and rejected: changing `ILReader`'s throws directly. Rejected to preserve its upstream-diffability (it's a one-time port from dotnet/runtime) and to avoid changing the decompiler importer's behavior.

## After

All five truncation classes now throw `BadImageFormatException` (verified by the same probe against this branch). New `Theory` in `SubstrateTests` covers all four `ILReader` paths plus the operand path.

## Validation

- `ILInspector.Instructions.Tests`: 27/27 (5 new cases)
- `ILInspector.Analysis.Tests`: 266/266 (no behavioral change)

## Relationship to other PRs

- **#2013** (LibraryBodyIndex convergence) can rebase onto this and **drop its `DecodeBody` `InvalidProgramException` catch** — it becomes redundant.
- **#1990** (ReachingDefinitions, merged) — its `AnalyzeCore` shim is likewise now redundant; safe to remove as later cleanup (left untouched here to keep this PR surgical).

## Review

Substrate change feeding Analysis. Per the repo's adversarial-review policy this is eligible for two non-Opus reviews (GPT-5.5 / Gemini / MAI), though the change is low-risk: a fully-tested exception-type normalization with behavior proven before/after and no change to the success path.
