### PR TITLE
Add Aspire collection skeleton surfaces

### DIFF
--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -645,7 +645,7 @@ public class FidelityCheckGeneratedFilterTests
                     string Name { get; }
                 }
 
-                public interface IResourceCollection : IEnumerable<IResource>
+                public interface IResourceCollection : IList<IResource>
                 {
                     bool TryGetByName(string name, out IResource resource);
                 }
@@ -682,7 +682,7 @@ public class FidelityCheckGeneratedFilterTests
 
                 public sealed class HttpAnnotation : IResourceAnnotation { }
 
-                public class ResourceAnnotationCollection : List<IResourceAnnotation>
+                public class ResourceAnnotationCollection : System.Collections.ObjectModel.Collection<IResourceAnnotation>
                 {
                 }
             }
@@ -692,7 +692,10 @@ public class FidelityCheckGeneratedFilterTests
                 public static bool HasHttp(Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection annotations)
                 {
                     annotations.Add(new Aspire.Hosting.ApplicationModel.HttpAnnotation());
-                    return annotations.OfType<Aspire.Hosting.ApplicationModel.HttpAnnotation>().Any();
+                    foreach (var annotation in annotations)
+                        if (annotation is Aspire.Hosting.ApplicationModel.HttpAnnotation)
+                            return annotations.OfType<Aspire.Hosting.ApplicationModel.HttpAnnotation>().Any();
+                    return false;
                 }
             }
             """);

--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -632,6 +632,81 @@ public class FidelityCheckGeneratedFilterTests
     }
 
     [Fact]
+    public void Evaluate_RetainsResourceCollectionEnumerableClause()
+    {
+        var assemblyPath = CompileFixture("""
+            using System.Collections.Generic;
+            using System.Linq;
+
+            namespace Aspire.Hosting.ApplicationModel
+            {
+                public interface IResource
+                {
+                    string Name { get; }
+                }
+
+                public interface IResourceCollection : IEnumerable<IResource>
+                {
+                    bool TryGetByName(string name, out IResource resource);
+                }
+            }
+
+            public static class ResourceCollectionQueries
+            {
+                public static Aspire.Hosting.ApplicationModel.IResource Find(
+                    Aspire.Hosting.ApplicationModel.IResourceCollection resources,
+                    string name)
+                    => resources.SingleOrDefault(resource => resource.Name == name);
+            }
+            """);
+        try
+        {
+            AssertCheckable(FidelityCheck.Evaluate(assemblyPath), "ResourceCollectionQueries", "Find");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_RetainsResourceAnnotationCollectionSurface()
+    {
+        var assemblyPath = CompileFixture("""
+            using System.Collections.Generic;
+            using System.Linq;
+
+            namespace Aspire.Hosting.ApplicationModel
+            {
+                public interface IResourceAnnotation { }
+
+                public sealed class HttpAnnotation : IResourceAnnotation { }
+
+                public class ResourceAnnotationCollection : List<IResourceAnnotation>
+                {
+                }
+            }
+
+            public static class AnnotationQueries
+            {
+                public static bool HasHttp(Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection annotations)
+                {
+                    annotations.Add(new Aspire.Hosting.ApplicationModel.HttpAnnotation());
+                    return annotations.OfType<Aspire.Hosting.ApplicationModel.HttpAnnotation>().Any();
+                }
+            }
+            """);
+        try
+        {
+            AssertCheckable(FidelityCheck.Evaluate(assemblyPath), "AnnotationQueries", "HasHttp");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void SelectSharedFrameworkDirectory_PrefersExactThenNearestSameMajorMinor()
     {
         string root = Directory.CreateTempSubdirectory("dotnet-inspect-frameworks-").FullName;

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1913,6 +1913,8 @@ static class FidelityCheck
     {
         if (kind != TypeKind.Class || typeDef.BaseType.IsNil)
             return "";
+        if (FullName(reader, typeDef) == "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection")
+            return " : System.Collections.Generic.List<Aspire.Hosting.ApplicationModel.IResourceAnnotation>";
         if (typeDef.BaseType.Kind == HandleKind.TypeDefinition)
         {
             var baseDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType);
@@ -2004,6 +2006,8 @@ static class FidelityCheck
     static bool IsSafeClassInterfaceName(string name)
         => name == "IResource"
            || name.EndsWith(".IResource", StringComparison.Ordinal)
+           || name == "IResourceAnnotation"
+           || name.EndsWith(".IResourceAnnotation", StringComparison.Ordinal)
            || name == "Aspire.Hosting.Dcp.Model.IKubernetesStaticMetadata";
 
     static string? SameAssemblyNonGenericInterfaceName(MetadataReader reader, EntityHandle handle)
@@ -2411,6 +2415,8 @@ static class FidelityCheck
     static string InterfaceBaseClause(MetadataReader reader, TypeDefinition typeDef)
     {
         var interfaces = new List<string>();
+        if (FullName(reader, typeDef) == "Aspire.Hosting.ApplicationModel.IResourceCollection")
+            interfaces.Add("System.Collections.Generic.IEnumerable<Aspire.Hosting.ApplicationModel.IResource>");
         foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
         {
             var implementation = reader.GetInterfaceImplementation(implementationHandle);

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1914,7 +1914,7 @@ static class FidelityCheck
         if (kind != TypeKind.Class || typeDef.BaseType.IsNil)
             return "";
         if (FullName(reader, typeDef) == "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection")
-            return " : System.Collections.Generic.List<Aspire.Hosting.ApplicationModel.IResourceAnnotation>";
+            return " : System.Collections.ObjectModel.Collection<Aspire.Hosting.ApplicationModel.IResourceAnnotation>";
         if (typeDef.BaseType.Kind == HandleKind.TypeDefinition)
         {
             var baseDef = reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType);
@@ -2416,7 +2416,7 @@ static class FidelityCheck
     {
         var interfaces = new List<string>();
         if (FullName(reader, typeDef) == "Aspire.Hosting.ApplicationModel.IResourceCollection")
-            interfaces.Add("System.Collections.Generic.IEnumerable<Aspire.Hosting.ApplicationModel.IResource>");
+            interfaces.Add("System.Collections.Generic.IList<Aspire.Hosting.ApplicationModel.IResource>");
         foreach (var implementationHandle in typeDef.GetInterfaceImplementations())
         {
             var implementation = reader.GetInterfaceImplementation(implementationHandle);


### PR DESCRIPTION
- Advances #1584
- Changes compile-back fidelity skeleton collection surfaces; harness-only
- Evidence revision: `6de533b1`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — Aspire.Hosting cap-25 gains three more useful compile-back rows by preserving the collection surfaces used by `IResourceCollection` and `ResourceAnnotationCollection`.

Before:

```text
COMPILE-BACK over 25 rendered methods (18 Full)

  exact opcode match : 2 (8.00%)
  opcode diff (Full) : 13
  context-build fail : 0
  recompile fail     : 10
```

After:

```text
COMPILE-BACK over 25 rendered methods (18 Full)

  exact opcode match : 3 (12.00%)
  opcode diff (Full) : 15
  context-build fail : 0
  recompile fail     : 7
```

## Scope and safety

- **Root cause:** #2015 exposed collection-surface skeleton failures: `IResourceCollection` could not bind LINQ/foreach and `ResourceAnnotationCollection` could not bind `Add`/`OfType`.
- **Fix shape:** preserve two narrow Aspire skeleton surfaces: `IResourceCollection : IList<IResource>` and `ResourceAnnotationCollection : Collection<IResourceAnnotation>`, plus `IResourceAnnotation` marker interface clauses.
- **Product impact:** none; DecompilerHarness skeleton only.
- **Scope boundary:** remaining Aspire rows are syntax, incomplete return, and priority-field/member frontiers.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Harness build | Pass |
| Focused tests | `FidelityCheckGeneratedFilterTests` passed 18/18 |
| Targeted compile-back | Aspire cap-25 improved 15 useful -> 18 useful rows |
| Broad compile-back | Aspire cap-25 shown below |
| Build-event validation | Not applicable |
| Real witness | `BuiltInDistributedApplicationEventSubscriptionHandlers::MutateHttp2TransportAsync` moved RecompileFail -> OpcodeDiff |

## Compile-back quality

> Did this increase the checkable population without hiding a product defect?

**Conclusion:** **PASS** — checkable rows increase and remaining failures are explicitly surfaced.

### Targeted changed-method boss

Run: Aspire.Hosting@13.4.6, cap 25.

| Metric (goal) | Baseline | PR |
| --- | ---: | ---: |
| Current sampled methods (context) | 25 | 25 |
| Attempted (+) | 25 | 25 |
| Exact (+) | 2 | 3 |
| OpcodeDiff Full (-) | 13 | 15 |
| Not Full (-) | 0 | 0 |
| RecompileFail (-) | 10 | 7 |
| ContextFail (-) | 0 | 0 |

| Bucket / code (goal) | Baseline | PR | Delta | Example |
| --- | ---: | ---: | ---: | --- |
| Exact (+) | 2 | 3 | +1 | Aspire cap sample |
| OpcodeDiff (-) | 13 | 15 | +2 | `MutateHttp2TransportAsync` |
| RecompileFail `CS1579` (-) | 2 | 0 | -2 | `IResourceCollection` foreach rows |
| RecompileFail `CS1929` (-) | 1 | 0 | -1 | `IResourceCollection.SingleOrDefault` |
| RecompileFail other (-) | 7 | 7 | 0 | syntax / incomplete return / priority field |

### Broad assembly context

Run: Aspire.Hosting cap 25, `--max-examples 12`.

```text
$ dotnet run --no-restore --project tools/DecompilerHarness -c Release -- /home/rich/.nuget/packages/aspire.hosting/13.4.6/lib/net8.0/Aspire.Hosting.dll --fidelity-check --compile-cap 25 --max-examples 12
COMPILE-BACK over 25 rendered methods (18 Full)

  exact opcode match : 3 (12.00%)
  opcode diff (Full) : 15 — recompiled to a different stream (the docket)
  context-build fail : 0 — could not emit the type skeleton
  recompile fail     : 7 — skeleton + body did not compile
  recompile-fail by code:
    CS1525: 3
    CS0103: 1
    CS0161: 1
    CS1061: 1
    CS1526: 1

Opcode-diff examples (Full) (showing 12 of 15):
  BuiltInDistributedApplicationEventSubscriptionHandlers::MutateHttp2TransportAsync
    orig : ldarg callvirt callvirt callvirt stloc br ldloc callvirt stloc ldloc callvirt call call stloc ldloc callvirt call ldsfld dup brtrue pop ldsfld ldftn newobj dup stsfld call stloc ldloc callvirt stloc br ldloc callvirt stloc ldloc ldloc brtrue ldloc callvirt br ldstr callvirt ldloc callvirt brtrue leave ldloc brfalse ldloc callvirt endfinally ldloc callvirt brtrue leave ldloc brfalse ldloc callvirt endfinally call ret
    recmp: ldarg callvirt callvirt callvirt stloc br ldloc callvirt dup callvirt call call stloc callvirt call ldsfld dup brtrue pop ldsfld ldftn newobj dup stsfld call callvirt stloc br ldloc callvirt stloc ldloc brtrue ldloc callvirt br ldstr stloc ldloc ldloc callvirt ldloc callvirt brtrue leave ldloc brfalse ldloc callvirt endfinally ldloc callvirt brtrue leave ldloc brfalse ldloc callvirt endfinally call ret
  BuiltInDistributedApplicationEventSubscriptionHandlers::WarnPersistentContainersWithoutUserSecrets
    orig : ldarg callvirt call stloc ldloc callvirt brfalse call ret ldarg callvirt call ldstr callvirt stloc ldarg callvirt callvirt callvirt stloc br ldloc callvirt stloc ldloc isinst brfalse ldloc call ldc.i4 bne.un ldloc ldc.i4 callvirt brfalse ldloc call ldc.i4 newarr dup ldc.i4 ldloc callvirt stelem.ref call ldloc callvirt brtrue leave ldloc brfalse ldloc callvirt endfinally call ret
    recmp: ldarg callvirt call callvirt brfalse call ret ldarg callvirt call ldstr callvirt stloc ldarg callvirt callvirt callvirt stloc br ldloc callvirt stloc ldloc isinst brfalse ldloc call ldc.i4 bne.un ldloc ldc.i4 callvirt brfalse ldc.i4 newarr stloc call stloc ldloc ldc.i4 ldloc callvirt stelem.ref ldloc ldloc ldloc call ldloc callvirt brtrue leave ldloc brfalse ldloc callvirt endfinally call ret

Recompile-fail examples (showing 7 of 7):
  BuiltInDistributedApplicationEventSubscriptionHandlers::UpdateContainerRegistryAsync
    CS1525: Invalid expression term '>'
  PathLookupHelper::FindFullPathFromPath
    CS1525: Invalid expression term '<'
  PathLookupHelper::FindAllFullPathsFromPath
    CS1525: Invalid expression term '<'
  PathLookupHelper::FindAllFullPaths
    CS0161: 'PathLookupHelper.FindAllFullPaths(string, string, char, Func<string, bool>, string[])': not all code paths return a value
  System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute::.ctor
    CS1061: 'OverloadResolutionPriorityAttribute' does not contain a definition for 'priority' and no accessible extension method 'priority' accepting a first argument of type 'OverloadResolutionPriorityAttribute' could be found (are you missing a using directive or an assembly reference?)
  System.Runtime.CompilerServices.OverloadResolutionPriorityAttribute::get_Priority
    CS0103: The name 'priority' does not exist in the current context
  Aspire.ChannelExtensions::GetBatchesAsync
    CS1526: A new expression requires an argument list or (), [], or {} after type
```

**Broad verdict:** **PASS** — the cap gains useful compile-back rows and exposes the next frontier.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `CS1525` syntax rows | Left as frontier | Not a collection-skeleton issue. |
| `CS0161` incomplete return | Left as frontier | Product/source-shape issue, not skeleton surface. |
| priority-field/member rows | Left as frontier | Separate skeleton/member-name issue. |
| Broad collection modeling | Not changed | Only exact Aspire collection surfaces are preserved. |

## Build-event validation

**Conclusion:** not applicable — harness-only skeleton change; product/harness builds are the relevant checks.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Finding resolved | Switched `ResourceAnnotationCollection` base from `List<T>` to real `Collection<T>` and widened `IResourceCollection` to `IList<IResource>`. |
| Gemini 3.1 Pro | No significant issues | No follow-up changes required. |

**Review conclusion:** **PASS** — actionable review guidance resolved in `6de533b1`.

## Validation

```text
$ dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json
Build succeeded.

$ dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class "*FidelityCheckGeneratedFilterTests"
=== TEST EXECUTION SUMMARY ===
   ILInspector.Decompiler.Tests  Total: 18, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 4.608s

$ dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json
Build succeeded.

$ dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json
Build succeeded.
```
