### PR TITLE
Render union not patterns directly

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -282,19 +282,40 @@ public class TypeSourceComposerUnionTests
                 public static class Matcher
                 {
                     public static bool IsCat(Pet pet) => pet.Value is Cat;
+                    public static bool IsNotCat(Pet pet) => pet is not Cat;
+                    public static bool ValueIsNotCat(Pet pet) => pet.Value is not Cat;
                     public static bool IsNull(Pet pet) => pet.Value is null;
+                    public static bool ValueIsNotNull(Pet pet) => pet.Value is not null;
                     public static string Describe(Pet pet) => pet.Value switch
                     {
                         Cat => "cat",
                         Dog => "dog",
                         _ => "other",
                     };
+                    public static string SwitchNotCat(Pet pet) => pet switch
+                    {
+                        not Cat => "not cat",
+                        Cat => "cat",
+                    };
+                    public static string ValueSwitchNotCat(Pet pet) => pet.Value switch
+                    {
+                        not Cat => "not cat",
+                        Cat => "cat",
+                    };
+                    public static string ValueSwitchNotNull(Pet pet) => pet.Value switch
+                    {
+                        not null => "not null",
+                        _ => "null",
+                    };
                 }
             }
             """);
 
         Assert.Equal("return pet is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCat"));
+        Assert.Equal("return pet is not Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNotCat"));
+        Assert.Equal("return pet is not Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotCat"));
         Assert.Equal("return pet is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
+        Assert.Equal("return pet is not null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotNull"));
         Assert.Equal("""
             return pet switch
             {
@@ -303,6 +324,36 @@ public class TypeSourceComposerUnionTests
                 _ => "other",
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Describe"));
+        Assert.Equal("""
+            if (pet is not Cat)
+            {
+                return "not cat";
+            }
+            else
+            {
+                return "cat";
+            }
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "SwitchNotCat"));
+        Assert.Equal("""
+            if (pet is not Cat)
+            {
+                return "not cat";
+            }
+            else
+            {
+                return "cat";
+            }
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNotCat"));
+        Assert.Equal("""
+            if (pet is not null)
+            {
+                return "not null";
+            }
+            else
+            {
+                return "null";
+            }
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNotNull"));
     }
 
     [Fact]
@@ -854,8 +905,16 @@ public class TypeSourceComposerUnionTests
 
                 public static bool IsCatOrDog(Pet pet) => pet is Cat or Dog;
 
+                public static bool IsNotCat(Pet pet) => pet is not Cat;
+
                 public static bool IsCatWithName(Pet pet) => pet is Cat { Name: "cat" };
                 public static bool IsCatWithOtherName(Pet pet) => pet is Cat { Name: not "dog" };
+
+                public static string ValueSwitchNotNull(Pet pet) => pet.Value switch
+                {
+                    not null => "not null",
+                    _ => "null",
+                };
 
                 public static bool SideEffect() => true;
 
@@ -942,10 +1001,22 @@ public class TypeSourceComposerUnionTests
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "TernaryGuard"));
         Assert.Equal("return pet is Cat || pet is Dog;",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatOrDog"));
+        Assert.Equal("return pet is not null && pet is not Cat;",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNotCat"));
         Assert.Equal("return pet is Cat { Name: \"cat\" };",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatWithName"));
         Assert.Equal("return pet is Cat { Name: not \"dog\" };",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatWithOtherName"));
+        Assert.Equal("""
+            if (pet.Value is not null)
+            {
+                return "not null";
+            }
+            else
+            {
+                return "null";
+            }
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNotNull"));
         var guardedOr = RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedOrSideEffect");
         Assert.DoesNotContain("pet is Cat cat || SideEffect() ? \"cat\" : \"other\"", guardedOr);
         Assert.Contains("if (", guardedOr);

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -906,6 +906,8 @@ public class TypeSourceComposerUnionTests
                 public static bool IsCatOrDog(Pet pet) => pet is Cat or Dog;
 
                 public static bool IsNotCat(Pet pet) => pet is not Cat;
+                public static bool ValueIsNotCat(Pet pet) => pet.Value is not Cat;
+                public static bool ValueIsNotNull(Pet pet) => pet.Value is not null;
 
                 public static bool IsCatWithName(Pet pet) => pet is Cat { Name: "cat" };
                 public static bool IsCatWithOtherName(Pet pet) => pet is Cat { Name: not "dog" };
@@ -1003,6 +1005,8 @@ public class TypeSourceComposerUnionTests
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatOrDog"));
         Assert.Equal("return pet is not null && pet is not Cat;",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNotCat"));
+        Assert.Equal("return pet.Value is not Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotCat"));
+        Assert.Equal("return pet.Value is not null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotNull"));
         Assert.Equal("return pet is Cat { Name: \"cat\" };",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatWithName"));
         Assert.Equal("return pet is Cat { Name: not \"dog\" };",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -713,7 +713,7 @@ public sealed partial class CSharpPrinter
             var operand = right is Constant { Value: null } ? left : right;
             if (IsInstanceNullTestText(operand, isNotNull: kind == ComparisonKind.NotEqual) is { } typeTest)
                 return typeTest;
-            if (UnionValueReceiverText(operand) is { } unionReceiver)
+            if (ValueTypeUnionValueReceiverText(operand) is { } unionReceiver)
             {
                 return kind == ComparisonKind.Equal
                     ? $"{unionReceiver} is null"
@@ -749,7 +749,7 @@ public sealed partial class CSharpPrinter
             var operand = kind is ComparisonKind.GreaterThan or ComparisonKind.LessThanOrEqual ? left : right;
             if (IsInstanceNullTestText(operand, isNotNull: !isNullTest) is { } typeTest)
                 return typeTest;
-            if (UnionValueReceiverText(operand) is { } unionReceiver)
+            if (ValueTypeUnionValueReceiverText(operand) is { } unionReceiver)
                 return $"{unionReceiver} is {(isNullTest ? "" : "not ")}null";
 
             return operand.ResultType is { Kind: TypeRefKind.Pointer }
@@ -821,8 +821,41 @@ public sealed partial class CSharpPrinter
         if (operand is not IsInstance ii)
             return null;
 
-        string test = $"{TypeTestValueText(ii.Operand)} is {TypeText(ii.Type)}";
-        return isNotNull ? test : $"{TypeTestValueText(ii.Operand)} is not {TypeText(ii.Type)}";
+        string valueText = NullTestTypeTestValueText(ii.Operand);
+        string test = $"{valueText} is {TypeText(ii.Type)}";
+        return isNotNull ? test : $"{valueText} is not {TypeText(ii.Type)}";
+    }
+
+    string NullTestTypeTestValueText(IrExpression value)
+    {
+        if (ShouldPreserveClassUnionValueReceiver(value))
+            return Operand(value);
+
+        return TypeTestValueText(value);
+    }
+
+    bool ShouldPreserveClassUnionValueReceiver(IrExpression value)
+    {
+        if (value is not LoadProperty property
+            || property.PropertyName != "Value"
+            || property.IndexArguments.Count != 0
+            || !_function.UnionTypes.Contains(NamedDefinition(property.Accessor.DeclaringType))
+            || IsValueTypeTarget(NamedDefinition(property.Accessor.DeclaringType)))
+        {
+            return false;
+        }
+
+        var receiver = property.Instance;
+        for (IrNode? node = property; node?.Parent is { } parent; node = parent)
+        {
+            if (parent is LogicalBinary { Kind: LogicalKind.And } logical
+                && PlaceIdentity.SameVariable(logical.Left, receiver))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     static bool IsFloatComparison(IrExpression left, IrExpression right)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1751,6 +1751,10 @@ public sealed partial class CSharpPrinter
         // test the condition path spells: `!y` on an object is CS0023, the faithful
         // form is `y is null` (and `x == 0` for an integer). A bool operand returns
         // null from Truthiness and keeps the bare `!operand`.
+        LogicalNot { Operand: Comparison c } => ComparisonText(
+            Conditions.Inverse(c.Kind),
+            IsFloatComparison(c.Left, c.Right) ? !c.IsUnsigned : c.IsUnsigned,
+            c.Left, c.Right),
         LogicalNot { Operand: { } operand } when Truthiness(operand) is { } negated => negated.Inverted,
         LogicalNot n => $"!{Operand(n.Operand)}",
         LogicalBinary l => LogicalText(l),
@@ -1891,6 +1895,12 @@ public sealed partial class CSharpPrinter
     string? UnionValueReceiverText(IrExpression value)
         => value is LoadProperty property ? UnionValueReceiverText(property) : null;
 
+    string? ValueTypeUnionValueReceiverText(IrExpression value)
+        => value is LoadProperty property
+            && IsValueTypeTarget(NamedDefinition(property.Accessor.DeclaringType))
+            ? UnionValueReceiverText(property)
+            : null;
+
     string? UnionValueReceiverText(LoadProperty property)
     {
         if (property.PropertyName != "Value"
@@ -1938,8 +1948,20 @@ public sealed partial class CSharpPrinter
         // in `!= 0` would be `bool != int` (CS0019); the inverse negates it.
         if (operand is IsInstance ii)
         {
-            string test = $"{TypeTestValueText(ii.Operand)} is {TypeText(ii.Type)}";
-            return (test, $"!({test})");
+            string valueText = TypeTestValueText(ii.Operand);
+            string typeText = TypeText(ii.Type);
+            return ($"{valueText} is {typeText}", $"{valueText} is not {typeText}");
+        }
+
+        if (operand is IsPattern pattern)
+        {
+            string valueText = TypeTestValueText(pattern.Value);
+            string typeText = TypeText(pattern.Type);
+            string direct = $"{valueText} is {typeText} {LocalName(pattern.LocalIndex)}";
+            string inverted = ReferenceOwnership.LocalReferencesOnlyWithin(_function, pattern.LocalIndex, [pattern])
+                ? $"{valueText} is not {typeText}"
+                : $"!({direct})";
+            return (direct, inverted);
         }
 
         // A `ref bool`/`bool*` deref loads via `ldind.u1`, so its IR ResultType is
@@ -1953,7 +1975,7 @@ public sealed partial class CSharpPrinter
         if (type is null || type is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary })
             return null;
 
-        string text = Operand(operand);
+        string text = ValueTypeUnionValueReceiverText(operand) ?? Operand(operand);
         (string, string) reference = ($"{text} is not null", $"{text} is null");
         (string, string) integer = ($"{text} != 0", $"{text} == 0");
 


### PR DESCRIPTION
- Fixes/advances #2026
- Changes union `not` pattern rendering so negated type tests and direct `.Value` not/null tests use direct pattern spellings where semantically safe.
- Card revision: 09ae8569

## Change

**Conclusion:** **REVIEW** - Preview SDK fixtures now render direct union `is not` patterns and preserve class-union null-receiver semantics for direct `.Value` truthiness.

Before:

```csharp
return !(pet is Cat);

if (pet.Value is not null)
{
    return "not null";
}
```

After:

```csharp
return pet is not Cat;

if (pet is not null)
{
    return "not null";
}
```

Near miss preserved for class unions:

```csharp
return pet is not null && pet is not Cat;

if (pet.Value is not null)
{
    return "not null";
}
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet -p:PublishAot=false -p:IsAotCompatible=false -p:WarningsNotAsErrors=NU1507` |
| Union fixtures | Pass: `TypeSourceComposerUnionTests/*` |
| Reference/null ordering | Pass: `ReferenceNullOrderingTests/*` |
| Generic type tests | Pass: `GenericIsInstanceNullTestTests/*` |
| Pattern pass | Pass: `IsPatternPassTests/*` |
| Lowering coverage | Pass: `LoweringCoverageTests/*` |
| PR fast decompiler suite | Pass: `ILInspector.Decompiler.Tests -trait- "Speed=Slow"` |

## Decompiler quality

**Conclusion:** **ADVISORY** - this is a preview-SDK union fixture and targeted printer-shape improvement; no real corpus union witnesses are currently known for a generated quality-diff card.

Highest local boss: Stage 6 altitude proof for the targeted Preview 6 union `not` source shapes, backed by Stage 0 build/focused tests and PR fast suite.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Pending | Requested after PR open. |
| Gemini Pro | Pending | Requested after PR open. |

**Review conclusion:** **REVIEW** - adversarial review is pending and will be reconciled on the PR before ready-to-merge.
