### PR TITLE
Raise direct Value negated union property patterns

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -275,7 +275,7 @@ public class TypeSourceComposerUnionTests
         using var assembly = await CompileWithSdk("""
             namespace UnionFixtures
             {
-                public sealed class Cat { }
+                public sealed class Cat { public int Age { get; } = 5; }
                 public sealed class Dog { }
                 public union Pet(Cat, Dog);
 
@@ -284,6 +284,7 @@ public class TypeSourceComposerUnionTests
                     public static bool IsCat(Pet pet) => pet.Value is Cat;
                     public static bool IsNotCat(Pet pet) => pet is not Cat;
                     public static bool ValueIsNotCat(Pet pet) => pet.Value is not Cat;
+                    public static bool ValueIsNotOlderCat(Pet pet) => pet.Value is not Cat { Age: > 3 };
                     public static bool IsNull(Pet pet) => pet.Value is null;
                     public static bool ValueIsNotNull(Pet pet) => pet.Value is not null;
                     public static string Describe(Pet pet) => pet.Value switch
@@ -314,6 +315,7 @@ public class TypeSourceComposerUnionTests
         Assert.Equal("return pet is Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCat"));
         Assert.Equal("return pet is not Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNotCat"));
         Assert.Equal("return pet is not Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotCat"));
+        Assert.Equal("return pet is not Cat { Age: > 3 };", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotOlderCat"));
         Assert.Equal("return pet is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
         Assert.Equal("return pet is not null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotNull"));
         Assert.Equal("""
@@ -907,6 +909,7 @@ public class TypeSourceComposerUnionTests
 
                 public static bool IsNotCat(Pet pet) => pet is not Cat;
                 public static bool ValueIsNotCat(Pet pet) => pet.Value is not Cat;
+                public static bool ValueIsNotNamedCat(Pet pet) => pet.Value is not Cat { Name: "cat" };
                 public static bool ValueIsNotNull(Pet pet) => pet.Value is not null;
 
                 public static bool IsCatWithName(Pet pet) => pet is Cat { Name: "cat" };
@@ -1006,6 +1009,9 @@ public class TypeSourceComposerUnionTests
         Assert.Equal("return pet is not null && pet is not Cat;",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNotCat"));
         Assert.Equal("return pet.Value is not Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotCat"));
+        var classValueNotNamedCat = RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotNamedCat");
+        Assert.Contains("pet.Value as Cat", classValueNotNamedCat);
+        Assert.Contains("V_0.Name == \"cat\"", classValueNotNamedCat);
         Assert.Equal("return pet.Value is not null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotNull"));
         Assert.Equal("return pet is Cat { Name: \"cat\" };",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatWithName"));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1755,6 +1755,7 @@ public sealed partial class CSharpPrinter
             Conditions.Inverse(c.Kind),
             IsFloatComparison(c.Left, c.Right) ? !c.IsUnsigned : c.IsUnsigned,
             c.Left, c.Right),
+        LogicalNot { Operand: LogicalBinary logical } when TryPropertyPatternText(logical, negated: true) is { } negatedPattern => negatedPattern,
         LogicalNot { Operand: { } operand } when Truthiness(operand) is { } negated => negated.Inverted,
         LogicalNot n => $"!{Operand(n.Operand)}",
         LogicalBinary l => LogicalText(l),
@@ -2389,6 +2390,9 @@ public sealed partial class CSharpPrinter
     }
 
     string? TryPropertyPatternText(LogicalBinary logical)
+        => TryPropertyPatternText(logical, negated: false);
+
+    string? TryPropertyPatternText(LogicalBinary logical, bool negated)
     {
         if (logical.Kind != LogicalKind.And)
         {
@@ -2413,8 +2417,12 @@ public sealed partial class CSharpPrinter
             return null;
         }
 
+        if (negated && pattern.PreserveLocalInPropertyPattern)
+            return null;
+
         string designation = pattern.PreserveLocalInPropertyPattern ? $" {LocalName(pattern.LocalIndex)}" : "";
-        return $"{TypeTestValueText(pattern.Value)} is {TypeText(pattern.Type)} {{ {string.Join(", ", subpatterns.Select(p => $"{p.PropertyName}: {p.Subpattern}"))} }}{designation}";
+        string not = negated ? " not" : "";
+        return $"{TypeTestValueText(pattern.Value)} is{not} {TypeText(pattern.Type)} {{ {string.Join(", ", subpatterns.Select(p => $"{p.PropertyName}: {p.Subpattern}"))} }}{designation}";
     }
 
     static void CollectConjuncts(IrExpression expression, List<IrExpression> conjuncts)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -59,6 +59,7 @@ public sealed class IsPatternPass : IIrPass
     {
         while (TransformOne(function, context.Stepper)
             || FoldConditionalReturnOne(function, context.Stepper)
+            || FoldNegatedConditionalPatternReturnOne(function, context.Stepper)
             || FoldClassUnionNullConditionalReturnOne(function, context.Stepper)
             || TransformRecursivePropertyDeclaration(function, context.Stepper)
             || FoldPositionalPatternReturnOne(function, context.Stepper))
@@ -142,6 +143,73 @@ public sealed class IsPatternPass : IIrPass
         }
 
         return false;
+    }
+
+    static bool FoldNegatedConditionalPatternReturnOne(IrFunction function, Stepper stepper)
+    {
+        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        {
+            var children = block.Children;
+            for (int i = 0; i + 1 < children.Count; i++)
+            {
+                if (children[i] is not StoreLocal { Value: IsInstance asCast } store
+                    || children[i + 1] is not Return { Value: LogicalNot { Operand: Conditional conditional } returnNot }
+                    || !TryNegatedConditionalPattern(function, asCast, store.Index, conditional, out var patternCondition))
+                {
+                    continue;
+                }
+
+                if (ReferenceOwnership.SubtreeReferencesLocal(asCast.Operand, store.Index)
+                    || !IsSideEffectFree(function, asCast.Operand)
+                    || !ReferenceOwnership.LocalReferencesOnlyWithin(function, store.Index, [store, returnNot]))
+                {
+                    continue;
+                }
+
+                stepper.StepOver("raise negated union pattern conditional", returnNot);
+                returnNot.ReplaceWith(new LogicalNot(patternCondition));
+                store.Detach();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool TryNegatedConditionalPattern(
+        IrFunction function,
+        IsInstance asCast,
+        int localIndex,
+        Conditional conditional,
+        out IrExpression patternCondition)
+    {
+        patternCondition = null!;
+        if (asCast.Operand is not LoadProperty property
+            || !IsUnionValueProperty(function, property)
+            || function.TypeShapes.GetValueOrDefault(NamedDefinition(property.Accessor.DeclaringType)) != TypeShape.ValueType)
+        {
+            return false;
+        }
+
+        IrExpression valueCondition;
+        if (IsPatternLocalNull(conditional.Condition, localIndex)
+            && IsFalseConstant(conditional.WhenTrue))
+        {
+            valueCondition = conditional.WhenFalse;
+        }
+        else if (IsPatternLocalNotNull(conditional.Condition, localIndex)
+            && IsFalseConstant(conditional.WhenFalse))
+        {
+            valueCondition = conditional.WhenTrue;
+        }
+        else
+        {
+            return false;
+        }
+
+        var pattern = new IsPattern((IrExpression)asCast.Operand.Clone(), asCast.Type, localIndex);
+        patternCondition = new LogicalBinary(LogicalKind.And, pattern, (IrExpression)valueCondition.Clone());
+        return true;
     }
 
     static bool TryUnionConditionalGuard(


### PR DESCRIPTION
- Fixes/advances #2029
- Changes direct `.Value is not T { ... }` on value-type unions from lowered temp/null-conditional output into a direct union-level negated property pattern.
- Card revision: a0129cc4

## Change

**Conclusion:** **REVIEW** - the preview-SDK value-type union shape now renders the intended `is not` property pattern while class-union explicit `.Value` remains flat to preserve null-receiver semantics.

Before:

```csharp
Cat V_0 = pet.Value as Cat;
return !(V_0 is null ? false : (V_0.Age > 3));
```

After:

```csharp
return pet is not Cat { Age: > 3 };
```

Near miss preserved:

```csharp
Cat V_0 = pet.Value as Cat;
return !(V_0 is null ? false : (V_0.Name == "cat"));
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet -p:PublishAot=false -p:IsAotCompatible=false -p:WarningsNotAsErrors=NU1507` |
| Union fixtures | Pass: `TypeSourceComposerUnionTests/*` |
| Pattern pass | Pass: `IsPatternPassTests/*` |
| Lowering coverage | Pass: `LoweringCoverageTests/*` |
| PR fast decompiler suite | Pass: `ILInspector.Decompiler.Tests -trait- "Speed=Slow"` |

## Decompiler quality

**Conclusion:** **ADVISORY** - this is a preview-SDK union fixture and targeted raise; no real corpus union witnesses are currently known for a generated quality-diff card.

Highest local boss: Stage 6 altitude proof for the targeted Preview 6 union `.Value is not T { ... }` shape, backed by Stage 0 build/focused tests and PR fast suite.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Pending | Requested after PR open. |
| Gemini Pro | Pending | Requested after PR open. |

**Review conclusion:** **REVIEW** - adversarial review is pending and will be reconciled on the PR before ready-to-merge.
