### PR TITLE
Add IL offset member context

### DIFF
--- a/src/ILInspector.Metadata/MethodClassificationScanner.cs
+++ b/src/ILInspector.Metadata/MethodClassificationScanner.cs
@@ -101,7 +101,7 @@ public static class MethodClassificationScanner
                 }
 
                 // Check async (runtime async vs classic state-machine async)
-                var asyncClassification = ClassifyAsync(reader, method);
+                var asyncClassification = ClassifyAsyncMethod(reader, method);
                 if (asyncClassification is { } asyncKind)
                 {
                     var signature = FormatSignature(reader, typeDef, method);
@@ -138,7 +138,7 @@ public static class MethodClassificationScanner
     /// MethodImplAttributes.Async (0x2000) flag; classic async by the compiler-emitted
     /// AsyncStateMachineAttribute / AsyncIteratorStateMachineAttribute.
     /// </summary>
-    private static MethodClassification? ClassifyAsync(MetadataReader reader, MethodDefinition method)
+    public static MethodClassification? ClassifyAsyncMethod(MetadataReader reader, MethodDefinition method)
     {
         const MethodImplAttributes AsyncImplFlag = (MethodImplAttributes)0x2000;
         if ((method.ImplAttributes & AsyncImplFlag) != 0)

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -22,6 +22,19 @@ public record SourceDocument(
     byte[]? Checksum = null,
     string? ChecksumAlgorithm = null);
 
+public record ILOffsetMemberContextInfo(
+    string? Assembly,
+    string Type,
+    string TypeKind,
+    string Member,
+    string Signature,
+    string MemberKind,
+    string Visibility,
+    bool Static,
+    string? Async,
+    int MetadataToken,
+    int ILOffset);
+
 /// <summary>
 /// Wraps PE + PDB readers, exposes high-level operations with no SRM in public signatures.
 /// CLI orchestrates PDB acquisition (download via Packages), then calls back into this context.
@@ -216,6 +229,51 @@ public class PdbContext : IDisposable
         return _resolver.ResolveTypeSource(metadataReader, _pdbReader, typeName);
     }
 
+    public ILOffsetMemberContextInfo? ResolveMemberContext(int methodToken, int ilOffset)
+    {
+        if (!_peReader.HasMetadata)
+            return null;
+
+        var handle = MetadataTokens.Handle(methodToken);
+        if (handle.Kind != HandleKind.MethodDefinition)
+            return null;
+
+        try
+        {
+            var reader = _peReader.GetMetadataReader();
+            var methodHandle = (MethodDefinitionHandle)handle;
+            var method = reader.GetMethodDefinition(methodHandle);
+            var type = reader.GetTypeDefinition(method.GetDeclaringType());
+            var assembly = reader.GetAssemblyDefinition();
+            var typeName = reader.GetFullTypeName(type);
+            var methodName = reader.GetString(method.Name);
+            var signature = FormatMemberSignature(reader, type, method, methodName);
+            var async = MethodClassificationScanner.ClassifyAsyncMethod(reader, method) switch
+            {
+                MethodClassification.RuntimeAsync => "Runtime",
+                MethodClassification.StateMachineAsync => "State machine",
+                _ => null
+            };
+
+            return new ILOffsetMemberContextInfo(
+                Assembly: reader.GetString(assembly.Name),
+                Type: typeName,
+                TypeKind: GetTypeKind(reader, type),
+                Member: $"{typeName}.{methodName}",
+                Signature: signature,
+                MemberKind: GetMemberKind(methodName),
+                Visibility: GetVisibility(method.Attributes),
+                Static: (method.Attributes & MethodAttributes.Static) != 0,
+                Async: async,
+                MetadataToken: methodToken,
+                ILOffset: ilOffset);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     /// <summary>
     /// Resolves source file and line range for a specific method overload.
     /// </summary>
@@ -251,6 +309,68 @@ public class PdbContext : IDisposable
 
         return null;
     }
+
+    private static string FormatMemberSignature(
+        MetadataReader reader,
+        TypeDefinition type,
+        MethodDefinition method,
+        string methodName)
+    {
+        try
+        {
+            var context = GenericContext.ForMethod(reader, type, method);
+            var signature = method.DecodeSignature(SignatureDecoder.Instance, context);
+            return SignatureRenderer.RenderDecodedSignature(reader, method, methodName, signature);
+        }
+        catch
+        {
+            return methodName + "(...)";
+        }
+    }
+
+    private static string GetMemberKind(string methodName)
+        => methodName switch
+        {
+            ".ctor" => "constructor",
+            ".cctor" => "static constructor",
+            _ => "method"
+        };
+
+    private static string GetVisibility(MethodAttributes attributes)
+        => (attributes & MethodAttributes.MemberAccessMask) switch
+        {
+            MethodAttributes.Public => "public",
+            MethodAttributes.Private => "private",
+            MethodAttributes.Family => "protected",
+            MethodAttributes.Assembly => "internal",
+            MethodAttributes.FamORAssem => "protected internal",
+            MethodAttributes.FamANDAssem => "private protected",
+            _ => "private"
+        };
+
+    private static string GetTypeKind(MetadataReader reader, TypeDefinition type)
+    {
+        if ((type.Attributes & TypeAttributes.Interface) != 0)
+            return "interface";
+
+        var baseName = GetBaseTypeName(reader, type);
+        if (baseName == "System.Enum")
+            return "enum";
+        if (baseName == "System.ValueType")
+            return "struct";
+        if (baseName == "System.MulticastDelegate")
+            return "delegate";
+
+        return "class";
+    }
+
+    private static string? GetBaseTypeName(MetadataReader reader, TypeDefinition type)
+        => type.BaseType.Kind switch
+        {
+            HandleKind.TypeReference => reader.GetFullTypeName(reader.GetTypeReference((TypeReferenceHandle)type.BaseType)),
+            HandleKind.TypeDefinition => reader.GetFullTypeName(reader.GetTypeDefinition((TypeDefinitionHandle)type.BaseType)),
+            _ => null
+        };
 
     /// <summary>
     /// Finds a type forwarder target assembly name for a given type.

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -27,6 +27,15 @@ public class CommandExecutionTests
         public int Value { get; }
     }
 
+    private sealed class ILOffsetAsyncFixture
+    {
+        public async Task<int> StateMachineAsync()
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+
     private static (string PackagePath, string TempDir) CreateLocalRefPackage(params string[] assemblyNames)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"package-test-{Guid.NewGuid():N}");
@@ -4479,6 +4488,7 @@ public class CommandExecutionTests
                 "Integration Opportunities",
                 "Integrations",
                 "Logging",
+                "Member Context",
                 "OpenAPI",
                 "OpenTelemetry",
                 "Options",
@@ -4577,6 +4587,69 @@ public class CommandExecutionTests
         Assert.Contains("| Token | 0x6000001 |", output);
         Assert.Contains("| IL Offset | 0x0 |", output);
         Assert.Contains("HexConverter.cs", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetDiscovery_IsCoordinateScoped()
+    {
+        var (withoutExit, withoutOutput, withoutError) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json", "-D", "--table", "--tips", "q");
+        var (withExit, withOutput, withError) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x0", "-D", "--table", "--tips", "q");
+
+        Assert.Equal(0, withoutExit);
+        Assert.Equal(0, withExit);
+        Assert.Empty(withoutError);
+        Assert.Empty(withError);
+        Assert.DoesNotContain("IL Offset", withoutOutput);
+        Assert.DoesNotContain("Member Context", withoutOutput);
+        Assert.Contains("IL Offset", withOutput);
+        Assert.Contains("Member Context", withOutput);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetMemberContext_RendersMemberFacts()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x0", "-S", "Member Context", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Member Context", output);
+        Assert.Contains("| Type | System.HexConverter |", output);
+        Assert.Contains("| Type Kind | class |", output);
+        Assert.Contains("| Member | System.HexConverter.FromChar |", output);
+        Assert.Contains("| Signature | int FromChar(int c) |", output);
+        Assert.Contains("| Static | Yes |", output);
+        Assert.Contains("| Metadata Token | 0x6000001 |", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetMemberContext_ValueProjectsType()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x0", "-S", "Member Context", "--fields", "Type", "--value", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Equal("System.HexConverter", output.Trim());
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetMemberContext_ShowsAsyncKind()
+    {
+        var token = typeof(ILOffsetAsyncFixture).GetMethod(nameof(ILOffsetAsyncFixture.StateMachineAsync))!.MetadataToken;
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "--il-offset", $"0x{token:X}+0x0", "-S", "Member Context", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("| Member | DotnetInspector.Tests.CommandExecutionTests.ILOffsetAsyncFixture.StateMachineAsync |", output);
+        Assert.Contains("| Async | Runtime |", output);
     }
 
     [Fact]
@@ -4689,7 +4762,7 @@ public class CommandExecutionTests
             "-S", "IL Offset", "--tips", "q");
 
         Assert.Equal(1, exit);
-        Assert.Contains("IL Offset requires --il-offset", error);
+        Assert.Contains("IL coordinate sections require --il-offset", error);
     }
 
     [Fact]
@@ -4711,7 +4784,7 @@ public class CommandExecutionTests
             "-S", "*", "-n", "8", "--tips", "q");
 
         Assert.Equal(0, exit);
-        Assert.DoesNotContain("IL Offset requires", error);
+        Assert.DoesNotContain("IL coordinate sections require", error);
         Assert.Contains("##", output);
     }
 
@@ -4723,7 +4796,7 @@ public class CommandExecutionTests
             "--il-offset", "0x06000001+0x0", "-S", "Library Info", "--tips", "q");
 
         Assert.Equal(1, exit);
-        Assert.Contains("--il-offset requires the IL Offset section", error);
+        Assert.Contains("--il-offset requires an IL coordinate section", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -251,7 +251,7 @@ public class SectionPipelineTests
     {
         var pipeline = LibrarySections.CreatePipeline();
 
-        Assert.Equal(37, pipeline.AllSectionNames.Length);
+        Assert.Equal(38, pipeline.AllSectionNames.Length);
         Assert.Contains("AI", pipeline.AllSectionNames);
         Assert.Contains("ASP.NET Core", pipeline.AllSectionNames);
         Assert.Contains("Aspire", pipeline.AllSectionNames);
@@ -262,6 +262,7 @@ public class SectionPipelineTests
         Assert.Contains("Hosting", pipeline.AllSectionNames);
         Assert.Contains("HTTP Client", pipeline.AllSectionNames);
         Assert.Contains("IL Offset", pipeline.AllSectionNames);
+        Assert.Contains("Member Context", pipeline.AllSectionNames);
         Assert.Contains("Integration Opportunities", pipeline.AllSectionNames);
         Assert.Contains("Integrations", pipeline.AllSectionNames);
         Assert.Contains("Logging", pipeline.AllSectionNames);
@@ -285,7 +286,10 @@ public class SectionPipelineTests
         string[] registered,
         IReadOnlyCollection<string> discoverable)
     {
-        var missing = registered
+        var expected = command == "library"
+            ? registered.Except(["IL Offset", "Member Context"], StringComparer.OrdinalIgnoreCase)
+            : registered;
+        var missing = expected
             .Where(name => !discoverable.Contains(name, StringComparer.OrdinalIgnoreCase))
             .ToArray();
 
@@ -522,7 +526,7 @@ public class SectionPipelineTests
     }
 
     [Fact]
-    public void LibraryPipeline_ILOffsetDiscovery_UsesMethodBodyApplicability()
+    public void LibraryPipeline_ILCoordinateSections_RequireResolvedCoordinate()
     {
         var pipeline = LibrarySections.CreatePipeline();
         var model = new LibraryInspection
@@ -534,8 +538,23 @@ public class SectionPipelineTests
         var applicable = pipeline.GetApplicableSections(model);
         var renderable = pipeline.GetAvailableSections(model);
 
-        Assert.Contains("IL Offset", applicable);
+        Assert.DoesNotContain("IL Offset", applicable);
+        Assert.DoesNotContain("Member Context", applicable);
         Assert.DoesNotContain("IL Offset", renderable);
+        Assert.DoesNotContain("Member Context", renderable);
+
+        model.ILOffset = new ILOffsetResult
+        {
+            MemberContext = new ILOffsetMemberContext()
+        };
+
+        applicable = pipeline.GetApplicableSections(model);
+        renderable = pipeline.GetAvailableSections(model);
+
+        Assert.Contains("IL Offset", applicable);
+        Assert.Contains("Member Context", applicable);
+        Assert.Contains("IL Offset", renderable);
+        Assert.Contains("Member Context", renderable);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
+++ b/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
@@ -2,6 +2,7 @@ using DotnetInspector.Inspectors;
 using DotnetInspector.Models;
 using DotnetInspector.Options;
 using DotnetInspector.Output;
+using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using ILInspector.Metadata;
 
@@ -34,48 +35,77 @@ internal static class ILOffsetSourceQuery
             return (1, null);
         }
 
-        await SourceEnricher.AcquirePdbAsync(
-            pdbContext,
-            httpClient,
-            packageName,
-            packageVersion,
-            isPlatformAssembly,
-            logger.Log);
-
-        if (!pdbContext.HasPdb)
+        var memberContext = pdbContext.ResolveMemberContext(methodToken, ilOffset);
+        if (memberContext == null)
         {
-            WritePdbWarning(pdbContext);
+            Console.Error.WriteLine($"Error: Could not resolve member context for token 0x{methodToken:X}.");
+            Console.Error.WriteLine("The method token may be invalid or may not identify a MethodDef row.");
             return (1, null);
         }
 
-        if (!service.HasSourceLink)
-            logger.Log("Warning: No SourceLink information found. URLs will not be available.");
-
-        var result = service.ResolveByILOffset(methodToken, ilOffset);
-        if (result == null)
+        SourceLinkResolver.ILOffsetSourceInfo? result = null;
+        if (RequiresSourceLocation(options))
         {
-            Console.Error.WriteLine($"Error: Could not resolve source location for token 0x{methodToken:X}+0x{ilOffset:X}.");
-            Console.Error.WriteLine("The method token may be invalid or the PDB may not contain sequence points for this method.");
-            return (1, null);
+            await SourceEnricher.AcquirePdbAsync(
+                pdbContext,
+                httpClient,
+                packageName,
+                packageVersion,
+                isPlatformAssembly,
+                logger.Log);
+
+            if (!pdbContext.HasPdb)
+            {
+                WritePdbWarning(pdbContext);
+                return (1, null);
+            }
+
+            if (!service.HasSourceLink)
+                logger.Log("Warning: No SourceLink information found. URLs will not be available.");
+
+            result = service.ResolveByILOffset(methodToken, ilOffset);
+            if (result == null)
+            {
+                Console.Error.WriteLine($"Error: Could not resolve source location for token 0x{methodToken:X}+0x{ilOffset:X}.");
+                Console.Error.WriteLine("The method token may be invalid or the PDB may not contain sequence points for this method.");
+                return (1, null);
+            }
         }
 
-        string? url = options.BrowsableUrls ? result.GitHubBrowseUrl : result.SourceUrl;
+        string? url = options.BrowsableUrls ? result?.GitHubBrowseUrl : result?.SourceUrl;
         if (url != null)
-            url += $"#L{result.Line}";
+            url += $"#L{result!.Line}";
 
         var resolved = new ILOffsetResult
         {
-            Method = result.MethodName,
+            Method = result?.MethodName ?? memberContext.Member,
             Token = $"0x{methodToken:X}",
             ILOffset = $"0x{ilOffset:X}",
-            MatchedOffset = result.MatchedOffset != ilOffset ? $"0x{result.MatchedOffset:X}" : null,
-            File = result.FilePath,
-            Line = result.Line,
-            Url = url
+            MatchedOffset = result != null && result.MatchedOffset != ilOffset ? $"0x{result.MatchedOffset:X}" : null,
+            File = result?.FilePath,
+            Line = result?.Line,
+            Url = url,
+            MemberContext = new ILOffsetMemberContext
+            {
+                Assembly = memberContext.Assembly,
+                Type = memberContext.Type,
+                TypeKind = memberContext.TypeKind,
+                Member = memberContext.Member,
+                Signature = memberContext.Signature,
+                MemberKind = memberContext.MemberKind,
+                Visibility = memberContext.Visibility,
+                Static = memberContext.Static ? "Yes" : "No",
+                Async = memberContext.Async,
+                MetadataToken = $"0x{memberContext.MetadataToken:X}",
+                ILOffset = $"0x{memberContext.ILOffset:X}"
+            }
         };
 
         return (0, resolved);
     }
+
+    private static bool RequiresSourceLocation(LibraryOptions options)
+        => options.IncludeSections?.Contains(SectionNames.ILOffset) == true;
 
     public static bool TryParse(string value, out int methodToken, out int ilOffset)
     {

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -71,16 +71,16 @@ public class LibraryCommand
         if (SelectOutput.WriteUnresolved(selectResult)) return 1;
         if (selectResult.Sections != null)
         {
-            if (selectResult.Sections.Contains(SectionNames.ILOffset)
+            if (selectResult.Sections.Overlaps(ILCoordinateSections)
                 && string.IsNullOrWhiteSpace(options.ILOffsetParameter))
             {
-                if (!HasExactILOffsetSelection(options.Select))
+                if (!HasExactILCoordinateSelection(options.Select))
                 {
-                    selectResult.Sections.Remove(SectionNames.ILOffset);
+                    selectResult.Sections.ExceptWith(ILCoordinateSections);
                 }
                 else if (options.Discover == null)
                 {
-                    Console.Error.WriteLine("Error: IL Offset requires --il-offset <token>+<offset>.");
+                    Console.Error.WriteLine("Error: IL coordinate sections require --il-offset <token>+<offset>.");
                     return 1;
                 }
             }
@@ -90,9 +90,9 @@ public class LibraryCommand
 
         if (!string.IsNullOrWhiteSpace(options.ILOffsetParameter)
             && options.IncludeSections is { Count: > 0 }
-            && !options.IncludeSections.Contains(SectionNames.ILOffset))
+            && !options.IncludeSections.Overlaps(ILCoordinateSections))
         {
-            Console.Error.WriteLine("Error: --il-offset requires the IL Offset section. Omit -S or include -S \"IL Offset\".");
+            Console.Error.WriteLine("Error: --il-offset requires an IL coordinate section. Omit -S or include -S \"IL Offset\" or -S \"Member Context\".");
             return 1;
         }
 
@@ -234,7 +234,7 @@ public class LibraryCommand
                 logger.Log($"Using platform runtime library: {framework} {version}");
 
                 // Check effective sections cache before running full inspection
-                if (effectiveDiscovery && options.Discover is { Length: 0 })
+                if (effectiveDiscovery && options.Discover is { Length: 0 } && !HasILOffsetCoordinate(options))
                 {
                     var cached = TryGetCachedEffective(resolvedPath!);
                     if (cached != null)
@@ -255,12 +255,12 @@ public class LibraryCommand
                 inspection.PlatformVersion = version;
                 inspection.LastModified = File.GetLastWriteTimeUtc(resolvedPath!);
 
-                if (effectiveDiscovery)
-                    return WriteEffectiveSections(resolvedPath!, inspection, options, pipeline, userVerbosity);
                 var ilOffsetExitCode = await PopulateILOffsetIfRequestedAsync(
                     inspection, resolvedPath!, null, null, isPlatformAssembly: true, options, context.HttpClient, logger);
                 if (ilOffsetExitCode != 0)
                     return ilOffsetExitCode;
+                if (effectiveDiscovery)
+                    return WriteEffectiveSections(resolvedPath!, inspection, options, pipeline, userVerbosity, cache: !HasILOffsetCoordinate(options));
                 if (TryWriteLibrarySingletonCount(inspection, options))
                     return 0;
                 if (options.Print || options.PrintAll)
@@ -289,7 +289,7 @@ public class LibraryCommand
                 packageVersion = resolvedPackageVersion;
 
                 // Check effective sections cache before running full inspection
-                if (effectiveDiscovery && options.Discover is { Length: 0 } && assemblyPaths.Count > 0)
+                if (effectiveDiscovery && options.Discover is { Length: 0 } && assemblyPaths.Count > 0 && !HasILOffsetCoordinate(options))
                 {
                     var cached = TryGetCachedEffective(assemblyPaths[0]);
                     if (cached != null)
@@ -321,13 +321,13 @@ public class LibraryCommand
                 foreach (var insp in inspections)
                     insp.Source = SourceKind.NuGet;
 
-                if (effectiveDiscovery)
-                    return WriteEffectiveSections(assemblyPaths[0], inspections[0], options, pipeline, userVerbosity);
                 var ilOffsetExitCode = await PopulateILOffsetIfRequestedAsync(
                     inspections[0], assemblyPaths[0], packageName, packageVersion, isPlatformAssembly: false,
                     options, context.HttpClient, logger);
                 if (ilOffsetExitCode != 0)
                     return ilOffsetExitCode;
+                if (effectiveDiscovery)
+                    return WriteEffectiveSections(assemblyPaths[0], inspections[0], options, pipeline, userVerbosity, cache: !HasILOffsetCoordinate(options));
                 if (TryWriteLibrarySingletonCount(inspections[0], options))
                     return 0;
                 if (options.Print || options.PrintAll)
@@ -355,7 +355,7 @@ public class LibraryCommand
                 }
 
                 // Check effective sections cache before running full inspection
-                if (effectiveDiscovery && options.Discover is { Length: 0 })
+                if (effectiveDiscovery && options.Discover is { Length: 0 } && !HasILOffsetCoordinate(options))
                 {
                     var cached = TryGetCachedEffective(assemblyPath!);
                     if (cached != null)
@@ -374,13 +374,13 @@ public class LibraryCommand
 
                 inspection.Source = SourceKind.File;
 
-                if (effectiveDiscovery)
-                    return WriteEffectiveSections(assemblyPath!, inspection, options, pipeline, userVerbosity);
                 var ilOffsetExitCode = await PopulateILOffsetIfRequestedAsync(
                     inspection, assemblyPath!, null, null, isPlatformAssembly: false,
                     options, context.HttpClient, logger);
                 if (ilOffsetExitCode != 0)
                     return ilOffsetExitCode;
+                if (effectiveDiscovery)
+                    return WriteEffectiveSections(assemblyPath!, inspection, options, pipeline, userVerbosity, cache: !HasILOffsetCoordinate(options));
                 if (TryWriteLibrarySingletonCount(inspection, options))
                     return 0;
                 if (options.Print || options.PrintAll)
@@ -447,7 +447,16 @@ public class LibraryCommand
         }, null);
     }
 
-    private static bool HasExactILOffsetSelection(string[]? select)
+    private static readonly string[] ILCoordinateSections =
+    [
+        SectionNames.ILOffset,
+        SectionNames.MemberContext
+    ];
+
+    private static bool HasILOffsetCoordinate(LibraryOptions options)
+        => !string.IsNullOrWhiteSpace(options.ILOffsetParameter);
+
+    private static bool HasExactILCoordinateSelection(string[]? select)
     {
         if (select is not { Length: > 0 })
             return false;
@@ -456,7 +465,7 @@ public class LibraryCommand
         {
             if (value.StartsWith('@'))
                 continue;
-            if (value.Equals(SectionNames.ILOffset, StringComparison.OrdinalIgnoreCase))
+            if (ILCoordinateSections.Contains(value, StringComparer.OrdinalIgnoreCase))
                 return true;
         }
 
@@ -474,7 +483,7 @@ public class LibraryCommand
         VerboseLogger logger)
     {
         if (string.IsNullOrWhiteSpace(options.ILOffsetParameter)
-            || options.IncludeSections?.Contains(SectionNames.ILOffset) != true)
+            || (options.Discover == null && options.IncludeSections?.Overlaps(ILCoordinateSections) != true))
             return 0;
 
         var resolved = await ILOffsetSourceQuery.ResolveAsync(
@@ -517,8 +526,16 @@ public class LibraryCommand
             "Source Files" => ProjectLibrarySourceFiles(inspection, section, kind, options),
             "Library Info" => ProjectLibraryInfo(inspection, section, kind, options),
             SectionNames.ILOffset => ProjectLibraryILOffset(inspection, section, kind, options),
+            SectionNames.MemberContext => ProjectLibraryMemberContext(inspection, section, kind, options),
             _ => []
         };
+
+        if (rows.Count == 0 && section == SectionNames.MemberContext)
+        {
+            if (kind != ShapeProjectionKind.Value)
+                Console.Error.WriteLine($"Error: section '{section}' does not expose {kind.ToString().ToLowerInvariant()} values.");
+            return 1;
+        }
 
         if (rows.Count == 0 && section is not ("Source Files" or "Library Info") && section != SectionNames.ILOffset)
         {
@@ -702,6 +719,49 @@ public class LibraryCommand
         };
     }
 
+    private static List<ShapeProjectionRow> ProjectLibraryMemberContext(
+        LibraryInspection inspection,
+        string section,
+        ShapeProjectionKind kind,
+        LibraryOptions options)
+    {
+        if (kind != ShapeProjectionKind.Value || inspection.ILOffset?.MemberContext is not { } context)
+            return [];
+
+        var field = options.Fields?.SingleOrDefault() ?? options.Columns?.SingleOrDefault();
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            Console.Error.WriteLine("Error: --value for Member Context requires --fields <name>.");
+            return [];
+        }
+
+        var value = SelectMemberContextValue(context, field);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            Console.Error.WriteLine($"Error: field '{field}' has no value in Member Context.");
+            return [];
+        }
+
+        return [new ShapeProjectionRow(1, section, value, Label: field)];
+    }
+
+    private static string? SelectMemberContextValue(ILOffsetMemberContext context, string field)
+        => field.ToLowerInvariant() switch
+        {
+            "assembly" => context.Assembly,
+            "type" => context.Type,
+            "type kind" or "typekind" => context.TypeKind,
+            "member" => context.Member,
+            "signature" => context.Signature,
+            "member kind" or "memberkind" => context.MemberKind,
+            "visibility" => context.Visibility,
+            "static" => context.Static,
+            "async" => context.Async,
+            "metadata token" or "metadatatoken" or "token" => context.MetadataToken,
+            "il offset" or "iloffset" => context.ILOffset,
+            _ => null
+        };
+
     private static List<ShapeProjectionRow> ProjectLibraryInfo(LibraryInspection inspection, string section, ShapeProjectionKind kind, LibraryOptions options)
     {
         if (kind != ShapeProjectionKind.Value)
@@ -774,7 +834,8 @@ public class LibraryCommand
     }
 
     private static int WriteEffectiveSections(string assemblyPath, LibraryInspection inspection,
-        LibraryOptions options, SectionPipeline<LibraryInspection> pipeline, Verbosity userVerbosity = Verbosity.Minimal)
+        LibraryOptions options, SectionPipeline<LibraryInspection> pipeline, Verbosity userVerbosity = Verbosity.Minimal,
+        bool cache = true)
     {
         // Compute all structurally applicable sections for discovery/caching,
         // including opt-in sections whose renderability depends on the section's
@@ -784,7 +845,8 @@ public class LibraryCommand
 
         // Field-level filtering on ALL effective sections (unfiltered) for caching
         var filteredSchema = FilterSchemaToEffectiveFields(inspection, allEffective, schemaMap, pipeline, allEffective.ToArray());
-        CacheEffective(assemblyPath, allEffective, filteredSchema);
+        if (cache)
+            CacheEffective(assemblyPath, allEffective, filteredSchema);
 
         // Apply user filters
         var effective = FilterEffective(allEffective, options);
@@ -853,6 +915,8 @@ public class LibraryCommand
     {
         if (options.IncludeSections is { Count: > 0 })
             sections = sections.Where(s => options.IncludeSections.Contains(s)).ToList();
+        if (!HasILOffsetCoordinate(options))
+            sections = sections.Where(s => !ILCoordinateSections.Contains(s, StringComparer.OrdinalIgnoreCase)).ToList();
         return sections;
     }
 
@@ -900,9 +964,10 @@ public class LibraryCommand
                 continue;
             }
 
-            if (string.Equals(name, "Library Info", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(name, "Library Info", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, SectionNames.MemberContext, StringComparison.OrdinalIgnoreCase))
             {
-                var renderedLabels = GetRenderedFieldLabels(rendered, "Library Info");
+                var renderedLabels = GetRenderedFieldLabels(rendered, name);
                 var effectiveItems = section.Items
                     .Where(item => renderedLabels.Contains(item.Name))
                     .Select(item => item.Name)

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -501,6 +501,22 @@ public class ILOffsetResult
     public string? File { get; init; }
     public int? Line { get; init; }
     public string? Url { get; init; }
+    public ILOffsetMemberContext? MemberContext { get; init; }
+}
+
+public class ILOffsetMemberContext
+{
+    public string? Assembly { get; init; }
+    public string? Type { get; init; }
+    public string? TypeKind { get; init; }
+    public string? Member { get; init; }
+    public string? Signature { get; init; }
+    public string? MemberKind { get; init; }
+    public string? Visibility { get; init; }
+    public string? Static { get; init; }
+    public string? Async { get; init; }
+    public string? MetadataToken { get; init; }
+    public string? ILOffset { get; init; }
 }
 
 public sealed record SourceFileInfo(string Type, string? Url);

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -33,7 +33,8 @@ public static class LibrarySections
     {
         return new SectionPipeline<LibraryInspection>()
             .Add<LibraryInfo>()
-            .Add<ILOffset>(HasILBodies)
+            .Add<ILOffset>()
+            .Add<MemberContext>()
             .Add<SourceFiles>()
             .Add<SourceLinkAudit>(SourceLinkAuditApplicable)
             .Add<MissingSourceFiles>(SourceLinkAuditApplicable)
@@ -131,6 +132,15 @@ public static class LibrarySections
         public static SectionCapabilities Capabilities => SectionCapabilities.MayDownloadPdb;
         public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => model.ILOffset != null;
+    }
+
+    public sealed class MemberContext : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.MemberContext;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(LibraryInspection model) => model.ILOffset?.MemberContext != null;
     }
 
     // ===== Symbol/provenance sections (network-capable, acceptable default cost) =====
@@ -320,9 +330,6 @@ public static class LibrarySections
            && (model.HasSourceLink
                || model.HasEmbeddedPdb
                || !string.IsNullOrWhiteSpace(model.PdbPath));
-
-    private static bool HasILBodies(LibraryInspection model)
-        => model.AssemblyInfo != null && model.HasMethodBodies;
 
     private static bool HasReferenceData(LibraryInspection model)
         => model.AssemblyInfo?.References is { Count: > 0 }

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -105,6 +105,9 @@ public static class SectionNames
     /// <summary>Section for resolving a MethodDef token + IL offset to source.</summary>
     public const string ILOffset = "IL Offset";
 
+    /// <summary>Section for resolving a MethodDef token + IL offset to its owning member/type.</summary>
+    public const string MemberContext = "Member Context";
+
     /// <summary>
     /// Section for the structured hidden-fact table: the same annotations the
     /// Decompiled Source view renders inline, as rows (id, category, detail, IL

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -474,6 +474,7 @@ public record PackageSourceFileRow(
 [MarkoutContext(typeof(PackageFileRow))]
 [MarkoutContext(typeof(PackageSourceFileRow))]
 [MarkoutContext(typeof(ILOffsetSection))]
+[MarkoutContext(typeof(ILOffsetMemberContextSection))]
 [MarkoutContext(typeof(ManifestRow))]
 [MarkoutContext(typeof(RidPackageReferenceView))]
 [MarkoutContext(typeof(EmptyDepsView))]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -492,6 +492,26 @@ public class LibraryInspectionView
         Url = result.Url
     };
 
+    [MarkoutIgnore]
+    public bool HasILOffsetMemberContext => _data.ILOffset?.MemberContext != null;
+
+    [MarkoutSection(Name = SectionNames.MemberContext, ShowWhenProperty = nameof(HasILOffsetMemberContext))]
+    public ILOffsetMemberContextSection? ILOffsetMemberContextSection =>
+        _data.ILOffset?.MemberContext is not { } context ? null : new ILOffsetMemberContextSection
+        {
+            Assembly = context.Assembly,
+            Type = context.Type,
+            TypeKind = context.TypeKind,
+            Member = context.Member,
+            Signature = context.Signature,
+            MemberKind = context.MemberKind,
+            Visibility = context.Visibility,
+            Static = context.Static,
+            Async = context.Async,
+            MetadataToken = context.MetadataToken,
+            ILOffset = context.ILOffset
+        };
+
     [MarkoutSection(Name = "SourceLink Availability", ShowWhenProperty = nameof(HasSourceLinkAudit))]
     public SourceLinkAuditSection? SourceLinkAuditSection => !HasSourceLinkAudit ? null : new SourceLinkAuditSection
     {
@@ -774,6 +794,27 @@ public class ILOffsetSection
     public string? File { get; init; }
     public int? Line { get; init; }
     public string? Url { get; init; }
+}
+
+[MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords, FieldLayout = FieldLayout.Table)]
+[MarkoutSkipNull]
+public class ILOffsetMemberContextSection
+{
+    public string? Assembly { get; init; }
+    public string? Type { get; init; }
+    [MarkoutPropertyName("Type Kind")]
+    public string? TypeKind { get; init; }
+    public string? Member { get; init; }
+    public string? Signature { get; init; }
+    [MarkoutPropertyName("Member Kind")]
+    public string? MemberKind { get; init; }
+    public string? Visibility { get; init; }
+    public string? Static { get; init; }
+    public string? Async { get; init; }
+    [MarkoutPropertyName("Metadata Token")]
+    public string? MetadataToken { get; init; }
+    [MarkoutPropertyName("IL Offset")]
+    public string? ILOffset { get; init; }
 }
 
 [MarkoutSerializable]


### PR DESCRIPTION
## Summary

- Add coordinate-scoped `Member Context` for `library --il-offset`, showing assembly, type/type kind, member/signature, member kind, visibility, static, async model, metadata token, and IL offset.
- Hide IL-coordinate sections from plain `library X -D`; `IL Offset` and `Member Context` appear in effective discovery only when `--il-offset` is supplied.
- Keep this PR code/tests only; the expanded shape-doc case study is intentionally deferred to a follow-up docs PR.

Follow-up to #2018 and #2023.

## Example

```bash
dotnet-inspect library System.Text.Json \
  --il-offset 0x06000001+0x0 \
  -S "Member Context"
```

```md
## Member Context

| Field | Value |
| ----- | ----- |
| Assembly | System.Text.Json |
| Type | System.HexConverter |
| Type Kind | class |
| Member | System.HexConverter.FromChar |
| Signature | int FromChar(int c) |
| Member Kind | method |
| Visibility | public |
| Static | Yes |
| Metadata Token | 0x6000001 |
| IL Offset | 0x0 |
```

With `--il-offset`, discovery also surfaces coordinate-scoped sections:

```bash
dotnet-inspect library System.Text.Json --il-offset 0x06000001+0x0 -D --table
```

```text
IL Offset       section (opt-in)
Member Context  section (opt-in)
```

## Validation

- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json --nologo --verbosity quiet`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- -method "*IlOffset*"`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- -class DotnetInspector.Tests.SectionPipelineTests`

## Adversarial review

- Gemini 3.1 Pro: no blocking findings.
- Claude Opus 4.8: no blocking findings. Non-blocking notes were addressed before opening this PR: removed stale `HasILBodies` helper and added runtime-async Member Context coverage for the `Async` row.
