### PR TITLE
Amortize composition-root performance triage allocations

### DIFF
--- a/src/ILInspector.Analysis.Tests/CompositionRootOptimizationFixtures.cs
+++ b/src/ILInspector.Analysis.Tests/CompositionRootOptimizationFixtures.cs
@@ -1,0 +1,80 @@
+namespace Aspire.Hosting.ApplicationModel
+{
+    public interface IResourceBuilder<T>
+    {
+        void Add(int value);
+    }
+
+    public sealed class TestResource;
+}
+
+namespace ILInspector.Analysis.Tests
+{
+    using Aspire.Hosting.ApplicationModel;
+    using Microsoft.Extensions.Hosting;
+
+    public sealed class NonCompositionBuilder
+    {
+        public void Add(int value)
+        {
+        }
+    }
+
+    public static class CompositionRootOptimizationFixtures
+    {
+        public static IResourceBuilder<T> WithLoopClosure<T>(
+            this IResourceBuilder<T> builder,
+            int[] values,
+            int seed)
+        {
+            foreach (var value in values)
+            {
+                Func<int> projector = () => value + seed;
+                builder.Add(projector());
+            }
+
+            return builder;
+        }
+
+        public static IHostApplicationBuilder ConfigureHost(
+            IHostApplicationBuilder builder,
+            int[] values,
+            int seed)
+        {
+            foreach (var value in values)
+            {
+                Func<int> projector = () => value + seed;
+                _ = projector();
+            }
+
+            return builder;
+        }
+
+        internal static IHostApplicationBuilder InternalConfigureHost(
+            IHostApplicationBuilder builder,
+            int[] values,
+            int seed)
+        {
+            foreach (var value in values)
+            {
+                Func<int> projector = () => value + seed;
+                _ = projector();
+            }
+
+            return builder;
+        }
+
+        public static int HotLoopClosure(NonCompositionBuilder builder, int[] values, int seed)
+        {
+            var total = 0;
+            foreach (var value in values)
+            {
+                Func<int> projector = () => value + seed;
+                total += projector();
+            }
+
+            builder.Add(total);
+            return total;
+        }
+    }
+}

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1561,6 +1561,68 @@ public class LibraryBodyIndexTests
         Assert.False(op.Amortized);
     }
 
+    [Fact]
+    public void OptimizationOpportunities_CompositionRootExtension_IsAmortizedEvenInLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(CompositionRootOptimizationFixtures).Assembly.Location);
+
+        var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.DeclaringType.Name == nameof(CompositionRootOptimizationFixtures)
+            && o.Method.Name == nameof(CompositionRootOptimizationFixtures.WithLoopClosure)
+            && o.Shape == "capturing-delegate"));
+
+        Assert.True(op.InLoop);
+        Assert.Equal("low", op.Confidence);
+        Assert.True(op.Amortized);
+        Assert.Contains("composition-root API", op.SafeFixDirection, StringComparison.Ordinal);
+        Assert.Contains("Amortized setup", op.Caveat, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_CompositionRootReturn_IsAmortizedEvenInLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(CompositionRootOptimizationFixtures).Assembly.Location);
+
+        var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.DeclaringType.Name == nameof(CompositionRootOptimizationFixtures)
+            && o.Method.Name == nameof(CompositionRootOptimizationFixtures.ConfigureHost)
+            && o.Shape == "capturing-delegate"));
+
+        Assert.True(op.InLoop);
+        Assert.Equal("low", op.Confidence);
+        Assert.True(op.Amortized);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_NonCompositionLoopDelegate_RemainsHigh()
+    {
+        var index = LibraryBodyIndex.Open(typeof(CompositionRootOptimizationFixtures).Assembly.Location);
+
+        var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.DeclaringType.Name == nameof(CompositionRootOptimizationFixtures)
+            && o.Method.Name == nameof(CompositionRootOptimizationFixtures.HotLoopClosure)
+            && o.Shape == "capturing-delegate"));
+
+        Assert.True(op.InLoop);
+        Assert.Equal("high", op.Confidence);
+        Assert.False(op.Amortized);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_InternalCompositionReturn_RemainsHigh()
+    {
+        var index = LibraryBodyIndex.Open(typeof(CompositionRootOptimizationFixtures).Assembly.Location);
+
+        var op = Assert.Single(index.OptimizationOpportunities.Where(o =>
+            o.Method.DeclaringType.Name == nameof(CompositionRootOptimizationFixtures)
+            && o.Method.Name == nameof(CompositionRootOptimizationFixtures.InternalConfigureHost)
+            && o.Shape == "capturing-delegate"));
+
+        Assert.True(op.InLoop);
+        Assert.Equal("high", op.Confidence);
+        Assert.False(op.Amortized);
+    }
+
     [Theory]
     [InlineData(nameof(OptimizationOpportunityFixtures.InstanceMethodGroup))]
     [InlineData(nameof(OptimizationOpportunityFixtures.VirtualInstanceMethodGroup))]

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -27,7 +27,8 @@ public sealed class LibraryBodyIndex
         IReadOnlyDictionary<(string Namespace, string Name), bool> inAssemblyTypeIsException,
         IReadOnlySet<int> suppressedOpportunityTokens,
         IReadOnlySet<string> exceptionTypeNames,
-        IReadOnlySet<int> nonHeapNewObjOperandTokens)
+        IReadOnlySet<int> nonHeapNewObjOperandTokens,
+        IReadOnlySet<int> compositionRootApiTokens)
     {
         Path = path;
         Methods = methods;
@@ -45,6 +46,7 @@ public sealed class LibraryBodyIndex
         _suppressedOpportunityTokens = suppressedOpportunityTokens;
         _exceptionTypeNames = exceptionTypeNames;
         _nonHeapNewObjOperandTokens = nonHeapNewObjOperandTokens;
+        _compositionRootApiTokens = compositionRootApiTokens;
     }
 
     public string Path { get; }
@@ -76,22 +78,27 @@ public sealed class LibraryBodyIndex
                 [
                     .. _rawOpportunities.Select(opportunity =>
                     {
-                        int reach = reachByToken.TryGetValue(opportunity.Method.MetadataToken, out int r) ? r : opportunity.RootReach;
-                        var adjusted = reach != opportunity.RootReach ? opportunity with { RootReach = reach } : opportunity;
-                        adjusted = MarkAmortizedSetup(adjusted);
-                        var confidence = IsLowFrequencyOpportunity(adjusted)
-                            ? "low"
-                            : AdjustDelegateConfidenceForReach(adjusted.Shape, adjusted.InLoop, adjusted.Confidence, reach);
-                        return confidence != adjusted.Confidence ? adjusted with { Confidence = confidence } : adjusted;
+                        return AdjustOpportunity(opportunity, reachByToken.TryGetValue(opportunity.Method.MetadataToken, out int r) ? r : opportunity.RootReach);
                     }),
                     .. AllocationHotspots(reachByToken, new HashSet<int>(_rawOpportunities
                         .Where(o => !(o.Shape == "async-state-machine" && o.Amortized))
-                        .Select(o => o.Method.MetadataToken))),
+                        .Select(o => o.Method.MetadataToken)))
+                        .Select(opportunity => AdjustOpportunity(opportunity, reachByToken.TryGetValue(opportunity.Method.MetadataToken, out int r) ? r : opportunity.RootReach)),
                     .. ScanMethodsInvokedInLoops(reachByToken),
                 ];
             }
             return _opportunities;
         }
+    }
+
+    OptimizationOpportunity AdjustOpportunity(OptimizationOpportunity opportunity, int reach)
+    {
+        var adjusted = reach != opportunity.RootReach ? opportunity with { RootReach = reach } : opportunity;
+        adjusted = MarkAmortizedSetup(adjusted);
+        var confidence = IsLowFrequencyOpportunity(adjusted)
+            ? "low"
+            : AdjustDelegateConfidenceForReach(adjusted.Shape, adjusted.InLoop, adjusted.Confidence, reach);
+        return confidence != adjusted.Confidence ? adjusted with { Confidence = confidence } : adjusted;
     }
 
     bool IsExceptionConstruction(TypeRef type)
@@ -136,10 +143,50 @@ public sealed class LibraryBodyIndex
     static bool IsLowFrequencyOpportunity(OptimizationOpportunity opportunity)
         => opportunity.ColdPath || opportunity.Amortized;
 
+    static readonly IReadOnlySet<string> s_compositionRootApiTypeNames = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "Aspire.Hosting.ApplicationModel.IResourceBuilder<T>",
+        "Aspire.Hosting.IDistributedApplicationBuilder",
+        "Microsoft.Extensions.DependencyInjection.IServiceCollection",
+        "Microsoft.Extensions.Hosting.IHostApplicationBuilder",
+    };
+
+    static bool IsWellKnownCompositionRootType(TypeRef type)
+        => s_compositionRootApiTypeNames.Contains(CompositionRootTypeName(type));
+
+    static string CompositionRootTypeName(TypeRef type)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+        if (definition.Kind != TypeRefKind.Definition)
+            return "";
+
+        string name = StripGenericArity(definition.Name);
+        int arity = GenericArity(definition.Name);
+        string qualifiedName = definition.Namespace.Length == 0 ? name : $"{definition.Namespace}.{name}";
+        return arity == 0
+            ? qualifiedName
+            : $"{qualifiedName}<{string.Join(", ", Enumerable.Range(0, arity).Select(i => i == 0 ? "T" : $"T{i + 1}"))}>";
+    }
+
+    static int GenericArity(string name)
+    {
+        int tick = name.IndexOf('`');
+        return tick >= 0 && int.TryParse(name[(tick + 1)..], out int arity) ? arity : 0;
+    }
+
     OptimizationOpportunity MarkAmortizedSetup(OptimizationOpportunity opportunity)
     {
         if (opportunity.Amortized)
             return opportunity;
+        if (_compositionRootApiTokens.Contains(opportunity.Method.MetadataToken))
+        {
+            return opportunity with
+            {
+                Amortized = true,
+                SafeFixDirection = "This allocation is in a composition-root API, not a steady-state per-call path. Optimize only if profiles show app composition itself is hot or repeated unexpectedly.",
+                Caveat = "Amortized setup path: composition-root APIs usually run during application startup/registration, not per steady-state operation.",
+            };
+        }
         if (opportunity.Method.Name is not (".ctor" or ".cctor"))
             return opportunity;
         // Type initializers are exact amortized setup: one execution per type.
@@ -480,6 +527,7 @@ public sealed class LibraryBodyIndex
     readonly IReadOnlySet<int> _suppressedOpportunityTokens;
     readonly IReadOnlySet<string> _exceptionTypeNames;
     readonly IReadOnlySet<int> _nonHeapNewObjOperandTokens;
+    readonly IReadOnlySet<int> _compositionRootApiTokens;
 
     /// <summary>
     /// Per-method analysis signals (allocations, copies, unsafe, reflection,
@@ -621,7 +669,7 @@ public sealed class LibraryBodyIndex
             path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
             index.OptimizationOpportunities, index.UnsafeLeverageMethods, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
             index.BodySignals, index.AllocationOccurrences, index.UnsafetyOccurrences, index.InAssemblyTypeIsException, index.SuppressedOpportunityTokens, index.ExceptionTypeNames,
-            index.NonHeapNewObjOperandTokens);
+            index.NonHeapNewObjOperandTokens, index.CompositionRootApiTokens);
     }
 
     public ImmutableArray<DirectCall> FindCalls(MemberPattern pattern)
@@ -1141,7 +1189,7 @@ public sealed class LibraryBodyIndex
                 && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
         }
 
-        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> AllocationOccurrences, IReadOnlyDictionary<int, ImmutableArray<UnsafetyOccurrence>> UnsafetyOccurrences, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames, IReadOnlySet<int> NonHeapNewObjOperandTokens) Build()
+        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> AllocationOccurrences, IReadOnlyDictionary<int, ImmutableArray<UnsafetyOccurrence>> UnsafetyOccurrences, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames, IReadOnlySet<int> NonHeapNewObjOperandTokens, IReadOnlySet<int> CompositionRootApiTokens) Build()
         {
             var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var unsafeLeverageMethods = ImmutableArray.CreateBuilder<MethodIdentity>();
@@ -1153,6 +1201,7 @@ public sealed class LibraryBodyIndex
             var allocationOccurrences = new Dictionary<int, ImmutableArray<AllocationOccurrence>>();
             var unsafetyOccurrences = new Dictionary<int, ImmutableArray<UnsafetyOccurrence>>();
             var suppressedOpportunityTokens = new HashSet<int>();
+            var compositionRootApiTokens = new HashSet<int>();
             var exceptionTypeNames = ComputeExceptionTypeNames();
             int none = 0, impl = 0, expl = 0;
 
@@ -1198,6 +1247,8 @@ public sealed class LibraryBodyIndex
                         if (unsafety.Length > 0)
                             unsafetyOccurrences[caller.MetadataToken] = unsafety;
                         var methodAttributes = methodDef.GetCustomAttributes();
+                        if (IsCompositionRootApi(caller, typeHandle, methodDef, methodAttributes))
+                            compositionRootApiTokens.Add(caller.MetadataToken);
                         if (!typeSourceGenerated
                             && !HasGeneratedCodeAttribute(methodAttributes)
                             && !HasCompilerGeneratedAttribute(methodAttributes)
@@ -1226,7 +1277,7 @@ public sealed class LibraryBodyIndex
             var nonHeapNewObjOperandTokens = ComputeNonHeapNewObjOperandTokens(directCalls);
             return (methods.ToImmutable(), directCalls, unsafeEvidence.ToImmutable(), diagnostics.ToImmutable(),
                 optimizationOpportunities.ToImmutable(), unsafeLeverageMethods.ToImmutable(), new UnsafeModeBreakdown(none, impl, expl), bodySignals, allocationOccurrences, unsafetyOccurrences,
-                BuildInAssemblyExceptionMap(), suppressedOpportunityTokens, exceptionTypeNames, nonHeapNewObjOperandTokens);
+                BuildInAssemblyExceptionMap(), suppressedOpportunityTokens, exceptionTypeNames, nonHeapNewObjOperandTokens, compositionRootApiTokens);
         }
 
         // The metadata operand tokens of `newobj` instructions that construct a VALUE TYPE
@@ -1474,6 +1525,42 @@ public sealed class LibraryBodyIndex
         // are user-actionable source-shape rewrite targets, so exclude them from collection.
         bool HasCompilerGeneratedAttribute(CustomAttributeHandleCollection attributes)
             => HasAttributeNamed(attributes, "CompilerGeneratedAttribute", "System.Runtime.CompilerServices");
+
+        bool IsCompositionRootApi(MethodIdentity caller, TypeDefinitionHandle typeHandle, MethodDefinition methodDef, CustomAttributeHandleCollection attributes)
+        {
+            bool isExtensionMethod = caller.IsStatic
+                && !caller.ParameterTypes.IsDefaultOrEmpty
+                && HasAttributeNamed(attributes, "ExtensionAttribute", "System.Runtime.CompilerServices");
+            bool isPublicMethod = (methodDef.Attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Public;
+            if (!isPublicMethod && !isExtensionMethod)
+                return false;
+            if (!IsPublicTypeDefinition(typeHandle))
+                return false;
+            if (isPublicMethod && IsWellKnownCompositionRootType(caller.ReturnType))
+                return true;
+            return isExtensionMethod
+                && IsWellKnownCompositionRootType(caller.ParameterTypes[0]);
+        }
+
+        bool IsPublicTypeDefinition(TypeDefinitionHandle typeHandle)
+        {
+            var current = typeHandle;
+            while (!current.IsNil)
+            {
+                var type = _reader.GetTypeDefinition(current);
+                switch (type.Attributes & TypeAttributes.VisibilityMask)
+                {
+                    case TypeAttributes.Public:
+                        return true;
+                    case TypeAttributes.NestedPublic:
+                        current = type.GetDeclaringType();
+                        continue;
+                    default:
+                        return false;
+                }
+            }
+            return false;
+        }
 
         // True when the method is Razor/Blazor-generated render plumbing: any method that
         // takes a Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder parameter


### PR DESCRIPTION
## Summary

Implements #2032 by extending the existing `MarkAmortizedSetup` path in `LibraryBodyIndex` with a curated composition-root type allowlist. Allocation opportunities in public composition APIs and extension `this` methods over the allowlisted builder/DI/host types are now marked amortized and confidence-demoted to low, including loop allocations.

## Demo: Aspire capturing-delegate high band before/after

Commands:

```bash
dnx dotnet-inspect@0.16.0 -y -- library Aspire.Hosting@13.4.6 -S "Performance Triage" --triage-shape capturing-delegate --jsonl
DOTNET_ROLL_FORWARD=LatestMajor dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll library Aspire.Hosting@13.4.6 -S "Performance Triage" --triage-shape capturing-delegate --jsonl
```

| Member | Before high rows | After high rows | Result |
|---|---:|---:|---|
| `Aspire.Hosting.ProjectResourceBuilderExtensions.WithProjectDefaults(...)` | 2 (`IL_0347`, `IL_04D9`) | 0 | left high band; now low/amortized |
| `Aspire.Hosting.Dcp.ResourceSnapshotBuilder.GetEnvironmentVariables(...)` | 1 | 1 | stayed high |
| `Aspire.Hosting.Dcp.ResourceSnapshotBuilder.GetUrls(...)` | 5 | 5 | stayed high |
| all other high-band capturing-delegate members | 9 | 9 | unchanged |

## Six-library favorability (#1974 pinned corpus)

Commands:

```bash
for lib in System.Text.Json@10.0.9 Aspire.Hosting@13.4.6 Newtonsoft.Json@13.0.4 Serilog@4.3.1 Polly@8.7.0 AutoMapper@16.1.1; do
  dnx dotnet-inspect@0.16.0 -y -- library "$lib" -S "Performance Triage" --jsonl > "baseline-$lib.jsonl"
  DOTNET_ROLL_FORWARD=LatestMajor dotnet artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll library "$lib" -S "Performance Triage" --jsonl > "local-$lib.jsonl"
done
```

Per-library delta:

| Library | Confidence changes | New composition amortization | Characterization |
|---|---:|---:|---|
| System.Text.Json@10.0.9 | 0 | 0 | no changes |
| Aspire.Hosting@13.4.6 | 17 | 102 | all are Aspire builder/distributed-app composition APIs (`With*`, `Add*`, event/resource registration); no DCP/resource reconciliation hot-path demotion |
| Newtonsoft.Json@13.0.4 | 0 | 0 | no changes |
| Serilog@4.3.1 | 0 | 0 | no changes |
| Polly@8.7.0 | 0 | 0 | no changes |
| AutoMapper@16.1.1 | 0 | 5 | all are `IServiceCollection.AddAutoMapper` DI-registration overloads; already low, now explicitly amortized |

Confidence-changing rows:

```text
## System.Text.Json@10.0.9
(no confidence changes)
## Aspire.Hosting@13.4.6
medium->low	enumerator-allocation	Aspire.Hosting.ConnectionStringBuilderExtensions.AddConnectionString(Aspire.Hosting.IDistributedApplicationBuilder, string, Aspire.Hosting.ApplicationModel.ReferenceExpression)	IL_0093
medium->low	small-array	Aspire.Hosting.ContainerResourceBuilderExtensions.WithDockerfile(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, string, string)	IL_0028
medium->low	small-array	Aspire.Hosting.ContainerResourceBuilderExtensions.WithDockerfileBuilder(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Func<Aspire.Hosting.ApplicationModel.DockerfileBuilderCallbackContext, System.Threading.Tasks.Task>, string)	IL_0033
medium->low	small-array	Aspire.Hosting.ContainerResourceBuilderExtensions.WithDockerfileFactory(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Func<Aspire.Hosting.ApplicationModel.DockerfileFactoryContext, System.Threading.Tasks.Task<string>>, string)	IL_0033
medium->low	capturing-delegate	Aspire.Hosting.DistributedApplicationEventingExtensions.OnResourceEvent(Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>, System.Func<TResource, TEvent, System.Threading.CancellationToken, System.Threading.Tasks.Task>)	IL_003B
medium->low	small-array	Aspire.Hosting.ParameterResourceBuilderExtensions.AddParameter(Aspire.Hosting.IDistributedApplicationBuilder, T)	IL_0013
high->low	capturing-delegate	Aspire.Hosting.ProjectResourceBuilderExtensions.WithProjectDefaults(Aspire.Hosting.ApplicationModel.IResourceBuilder<TProjectResource>, Aspire.Hosting.ProjectResourceOptions)	IL_0347
high->low	capturing-delegate	Aspire.Hosting.ProjectResourceBuilderExtensions.WithProjectDefaults(Aspire.Hosting.ApplicationModel.IResourceBuilder<TProjectResource>, Aspire.Hosting.ProjectResourceOptions)	IL_04D9
medium->low	enumerator-allocation	Aspire.Hosting.ProjectResourceBuilderExtensions.WithProjectDefaults(Aspire.Hosting.ApplicationModel.IResourceBuilder<TProjectResource>, Aspire.Hosting.ProjectResourceOptions)	IL_02FB
medium->low	capturing-delegate	Aspire.Hosting.ResourceBuilderExtensions.WithArgs(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, System.Action<Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext>)	IL_0030
medium->low	small-array	Aspire.Hosting.ResourceBuilderExtensions.WithHttpCommand(Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>, string, string, string, string, Aspire.Hosting.ApplicationModel.HttpCommandOptions)	IL_001A
medium->low	small-array	Aspire.Hosting.ResourceBuilderExtensions.WithHttpHealthCheck(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Nullable<int>, string)	IL_0022
medium->low	small-array	Aspire.Hosting.ResourceBuilderExtensions.WithHttpProbe(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, Aspire.Hosting.ApplicationModel.ProbeType, string, System.Nullable<int>, System.Nullable<int>, System.Nullable<int>, System.Nullable<int>, System.Nullable<int>, string)	IL_0023
medium->low	box-value-type	Aspire.Hosting.ResourceBuilderExtensions.WithReference(Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ExternalServiceResource>)	IL_0099
medium->low	box-value-type	Aspire.Hosting.ResourceBuilderExtensions.WithReference(Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ExternalServiceResource>)	IL_00DF
medium->low	box-value-type	Aspire.Hosting.ResourceBuilderExtensions.WithReference(Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>, string, System.Uri)	IL_01F2
medium->low	box-value-type	Aspire.Hosting.ResourceBuilderExtensions.WithReference(Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>, string, System.Uri)	IL_0222
## Newtonsoft.Json@13.0.4
(no confidence changes)
## Serilog@4.3.1
(no confidence changes)
## Polly@8.7.0
(no confidence changes)
## AutoMapper@16.1.1
(no confidence changes)
```

<details>
<summary>All rows with new composition-root amortization (107)</summary>

| Library | Confidence | Shape | Member | IL |
|---|---|---|---|---|
| Aspire.Hosting@13.4.6 | low | enumerator-allocation | `Aspire.Hosting.ConnectionStringBuilderExtensions.AddConnectionString(Aspire.Hosting.IDistributedApplicationBuilder, string, Aspire.Hosting.ApplicationModel.ReferenceExpression)` | IL_0093 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ContainerResourceBuilderExtensions.EnsureBuildAndPushPipelineAnnotations(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>)` | IL_001A |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ContainerResourceBuilderExtensions.EnsureBuildAndPushPipelineAnnotations(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>)` | IL_0038 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ContainerResourceBuilderExtensions.PublishAsContainer(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>)` | IL_002A |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ContainerResourceBuilderExtensions.WithContainerFiles(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, string, System.Nullable<int>, System.Nullable<int>, System.Nullable<System.IO.UnixFileMode>)` | IL_0099 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ContainerResourceBuilderExtensions.WithContainerFiles(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Collections.Generic.IEnumerable<Aspire.Hosting.ApplicationModel.ContainerFileSystemItem>, System.Nullable<int>, System.Nullable<int>, System.Nullable<System.IO.UnixFileMode>)` | IL_0047 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ContainerResourceBuilderExtensions.WithContainerRuntimeArgs(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string[])` | IL_0020 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ContainerResourceBuilderExtensions.WithContainerRuntimeArgs(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, System.Action<Aspire.Hosting.ApplicationModel.ContainerRuntimeArgsCallbackContext>)` | IL_0030 |
| Aspire.Hosting@13.4.6 | low | small-array | `Aspire.Hosting.ContainerResourceBuilderExtensions.WithDockerfile(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, string, string)` | IL_0028 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ContainerResourceBuilderExtensions.WithDockerfileBuilder(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Action<Aspire.Hosting.ApplicationModel.DockerfileBuilderCallbackContext>, string)` | IL_0026 |
| Aspire.Hosting@13.4.6 | low | small-array | `Aspire.Hosting.ContainerResourceBuilderExtensions.WithDockerfileBuilder(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Func<Aspire.Hosting.ApplicationModel.DockerfileBuilderCallbackContext, System.Threading.Tasks.Task>, string)` | IL_0033 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ContainerResourceBuilderExtensions.WithDockerfileFactory(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Func<Aspire.Hosting.ApplicationModel.DockerfileFactoryContext, string>, string)` | IL_0031 |
| Aspire.Hosting@13.4.6 | low | small-array | `Aspire.Hosting.ContainerResourceBuilderExtensions.WithDockerfileFactory(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Func<Aspire.Hosting.ApplicationModel.DockerfileFactoryContext, System.Threading.Tasks.Task<string>>, string)` | IL_0033 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.DistributedApplicationBuilderExtensions.CreateResourceBuilder(Aspire.Hosting.IDistributedApplicationBuilder, string)` | IL_0035 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.DistributedApplicationBuilderExtensions.TryCreateResourceBuilder(Aspire.Hosting.IDistributedApplicationBuilder, string, ref Aspire.Hosting.ApplicationModel.IResourceBuilder<T>)` | IL_0035 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.DistributedApplicationEventingExtensions.OnResourceEvent(Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>, System.Func<TResource, TEvent, System.Threading.CancellationToken, System.Threading.Tasks.Task>)` | IL_003B |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.DotnetToolResourceExtensions.AddDotnetTool(Aspire.Hosting.IDistributedApplicationBuilder, T)` | IL_0055 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.DotnetToolResourceExtensions.AddDotnetTool(Aspire.Hosting.IDistributedApplicationBuilder, T)` | IL_006B |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ExecutableResourceBuilderExtensions.AddExecutable(Aspire.Hosting.IDistributedApplicationBuilder, string, string, string, object[])` | IL_0064 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ExecutableResourceBuilderExtensions.PublishAsDockerFile(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, System.Action<Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ContainerResource>>)` | IL_0118 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ExecutableResourceBuilderExtensions.PublishAsDockerFile(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, System.Collections.Generic.IEnumerable<Aspire.Hosting.ApplicationModel.DockerBuildArg>)` | IL_0020 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ExternalServiceBuilderExtensions.WithHttpHealthCheck(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ExternalServiceResource>, string, System.Nullable<int>)` | IL_026C |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ExternalServiceBuilderExtensions.WithHttpHealthCheck(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ExternalServiceResource>, string, System.Nullable<int>)` | IL_02E2 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.McpServerResourceBuilderExtensions.WithMcpServer(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, string)` | IL_0027 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ParameterResourceBuilderExtensions.AddConnectionString(Aspire.Hosting.IDistributedApplicationBuilder, string, string)` | IL_0047 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ParameterResourceBuilderExtensions.AddParameter(Aspire.Hosting.IDistributedApplicationBuilder, string, Aspire.Hosting.ApplicationModel.ParameterDefault, bool, bool)` | IL_00A6 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ParameterResourceBuilderExtensions.AddParameter(Aspire.Hosting.IDistributedApplicationBuilder, string, bool)` | IL_0047 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ParameterResourceBuilderExtensions.AddParameter(Aspire.Hosting.IDistributedApplicationBuilder, string, string, bool, bool)` | IL_003C |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ParameterResourceBuilderExtensions.AddParameter(Aspire.Hosting.IDistributedApplicationBuilder, string, System.Func<string>, bool, bool)` | IL_0052 |
| Aspire.Hosting@13.4.6 | low | small-array | `Aspire.Hosting.ParameterResourceBuilderExtensions.AddParameter(Aspire.Hosting.IDistributedApplicationBuilder, T)` | IL_0013 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ParameterResourceBuilderExtensions.AddParameterFromConfiguration(Aspire.Hosting.IDistributedApplicationBuilder, string, string, bool)` | IL_005E |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ParameterResourceBuilderExtensions.WithCustomInputForPolyglot(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ParameterResource>, Aspire.Hosting.Ats.ParameterCustomInputOptions)` | IL_003A |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.Pipelines.PipelineStepFactoryExtensions.WithPipelineStepFactory(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Func<Aspire.Hosting.Pipelines.PipelineStepContext, System.Threading.Tasks.Task>, string[], string[], string[], string)` | IL_0077 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.AddCSharpApp(Aspire.Hosting.IDistributedApplicationBuilder, string, string, System.Action<Aspire.Hosting.ProjectResourceOptions>)` | IL_007F |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.AddCSharpApp(Aspire.Hosting.IDistributedApplicationBuilder, string, string, System.Action<Aspire.Hosting.ProjectResourceOptions>)` | IL_009E |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.AddCSharpAppForPolyglot(Aspire.Hosting.IDistributedApplicationBuilder, string, string, Aspire.Hosting.ProjectResourceOptions)` | IL_001F |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.AddProject(Aspire.Hosting.IDistributedApplicationBuilder, string, string, string)` | IL_0038 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.AddProject(Aspire.Hosting.IDistributedApplicationBuilder, string, string, System.Action<Aspire.Hosting.ProjectResourceOptions>)` | IL_008D |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.AddProject(Aspire.Hosting.IDistributedApplicationBuilder, string, string)` | IL_002C |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.AddProject(Aspire.Hosting.IDistributedApplicationBuilder, string, System.Action<Aspire.Hosting.ProjectResourceOptions>)` | IL_0060 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.AddProjectForPolyglot(Aspire.Hosting.IDistributedApplicationBuilder, string, string, object)` | IL_006B |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.PublishAsDockerFile(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, System.Action<Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ContainerResource>>)` | IL_016F |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.SetAspNetCoreUrls(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource>)` | IL_001A |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.SetBothPortsEnvVariables(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource>)` | IL_001A |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.SetKestrelUrlOverrideEnvVariables(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource>)` | IL_001A |
| Aspire.Hosting@13.4.6 | low | instance-method-group-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.SetOnePortsEnvVariable(Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource>, Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext, string, string)` | IL_002E |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.WithProjectDefaults(Aspire.Hosting.ApplicationModel.IResourceBuilder<TProjectResource>, Aspire.Hosting.ProjectResourceOptions)` | IL_00B6 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.WithProjectDefaults(Aspire.Hosting.ApplicationModel.IResourceBuilder<TProjectResource>, Aspire.Hosting.ProjectResourceOptions)` | IL_011E |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.WithProjectDefaults(Aspire.Hosting.ApplicationModel.IResourceBuilder<TProjectResource>, Aspire.Hosting.ProjectResourceOptions)` | IL_02C3 |
| Aspire.Hosting@13.4.6 | low | enumerator-allocation | `Aspire.Hosting.ProjectResourceBuilderExtensions.WithProjectDefaults(Aspire.Hosting.ApplicationModel.IResourceBuilder<TProjectResource>, Aspire.Hosting.ProjectResourceOptions)` | IL_02FB |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.WithProjectDefaults(Aspire.Hosting.ApplicationModel.IResourceBuilder<TProjectResource>, Aspire.Hosting.ProjectResourceOptions)` | IL_0347 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.WithProjectDefaults(Aspire.Hosting.ApplicationModel.IResourceBuilder<TProjectResource>, Aspire.Hosting.ProjectResourceOptions)` | IL_04D9 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.WithProjectDefaults(Aspire.Hosting.ApplicationModel.IResourceBuilder<TProjectResource>, Aspire.Hosting.ProjectResourceOptions)` | IL_052A |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ProjectResourceBuilderExtensions.WithProjectDefaults(Aspire.Hosting.ApplicationModel.IResourceBuilder<TProjectResource>, Aspire.Hosting.ProjectResourceOptions)` | IL_0542 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.ApplyEndpoints(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, Aspire.Hosting.ApplicationModel.IResourceWithEndpoints, string, string)` | IL_002D |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.ClearContainerFilesSources(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>)` | IL_0047 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.SubscribeHttpsEndpointsUpdate(Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>, System.Action<Aspire.Hosting.ApplicationModel.HttpsEndpointUpdateCallbackContext>)` | IL_0041 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithArgs(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, object[])` | IL_003C |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithArgs(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string[])` | IL_0030 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithArgs(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, System.Action<Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext>)` | IL_0030 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithCommand(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, string, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult>>, Aspire.Hosting.ApplicationModel.CommandOptions)` | IL_0075 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithCommand(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, string, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult>>, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext, Aspire.Hosting.ApplicationModel.ResourceCommandState>, string, object, string, string, System.Nullable<Aspire.Hosting.ApplicationModel.IconVariant>, bool)` | IL_005E |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithDebugSupport(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, System.Func<string, TLaunchConfiguration>, string, System.Action<Aspire.Hosting.ApplicationModel.CommandLineArgsCallbackContext>)` | IL_0073 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithEndpoint(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Action<Aspire.Hosting.ApplicationModel.EndpointAnnotation>, bool)` | IL_0053 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithEndpoint(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, System.Nullable<int>, System.Nullable<int>, string, string, string, System.Nullable<bool>, System.Nullable<bool>, System.Nullable<System.Net.Sockets.ProtocolType>)` | IL_0061 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithEndpointCallback(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Action<Aspire.Hosting.ApplicationModel.EndpointUpdateContext>, bool)` | IL_003C |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithEnvironment(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, Aspire.Hosting.ApplicationModel.EndpointReference)` | IL_0059 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithEnvironment(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResourceWithConnectionString>)` | IL_0059 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithEnvironment(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ParameterResource>)` | IL_0059 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithEnvironment(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ExternalServiceResource>)` | IL_00AC |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithEnvironment(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, Aspire.Hosting.ApplicationModel.ReferenceExpression)` | IL_0054 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithEnvironment(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, ref Aspire.Hosting.ApplicationModel.ReferenceExpression.ExpressionInterpolatedStringHandler)` | IL_0049 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithEnvironment(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, TValue)` | IL_006C |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithEnvironmentValueProvider(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, object)` | IL_0062 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithHealthCheck(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string)` | IL_0044 |
| Aspire.Hosting@13.4.6 | low | small-array | `Aspire.Hosting.ResourceBuilderExtensions.WithHttpCommand(Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>, string, string, string, string, Aspire.Hosting.ApplicationModel.HttpCommandOptions)` | IL_001A |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithHttpCommand(Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>, string, string, System.Func<Aspire.Hosting.ApplicationModel.EndpointReference>, string, Aspire.Hosting.ApplicationModel.HttpCommandOptions)` | IL_0225 |
| Aspire.Hosting@13.4.6 | low | small-array | `Aspire.Hosting.ResourceBuilderExtensions.WithHttpHealthCheck(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Nullable<int>, string)` | IL_0022 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithHttpHealthCheck(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, System.Func<Aspire.Hosting.ApplicationModel.EndpointReference>, string, System.Nullable<int>)` | IL_0187 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithHttpHealthCheck(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, System.Func<Aspire.Hosting.ApplicationModel.EndpointReference>, string, System.Nullable<int>)` | IL_01A6 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithHttpHealthCheck(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, System.Func<Aspire.Hosting.ApplicationModel.EndpointReference>, string, System.Nullable<int>)` | IL_026C |
| Aspire.Hosting@13.4.6 | low | small-array | `Aspire.Hosting.ResourceBuilderExtensions.WithHttpProbe(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, Aspire.Hosting.ApplicationModel.ProbeType, string, System.Nullable<int>, System.Nullable<int>, System.Nullable<int>, System.Nullable<int>, System.Nullable<int>, string)` | IL_0023 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithProbe(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, Aspire.Hosting.ApplicationModel.ProbeAnnotation)` | IL_002D |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithProcessCommand(Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>, string, string, string, System.Collections.Generic.IReadOnlyList<string>, Aspire.Hosting.ApplicationModel.ProcessCommandOptions)` | IL_0044 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithProcessCommand(Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>, string, string, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext, Aspire.Hosting.ApplicationModel.ProcessCommandSpec>, Aspire.Hosting.ApplicationModel.ProcessCommandOptions)` | IL_0027 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithProcessCommand(Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>, string, string, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext, System.Threading.Tasks.ValueTask<Aspire.Hosting.ApplicationModel.ProcessCommandSpec>>, Aspire.Hosting.ApplicationModel.ProcessCommandOptions)` | IL_0063 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithProcessCommandExport(Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>, string, string, Aspire.Hosting.ApplicationModel.ProcessCommandExportOptions)` | IL_0027 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithProcessCommandFactoryExport(Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>, string, string, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ProcessCommandSpecExportData>>, Aspire.Hosting.ApplicationModel.ProcessCommandResultExportOptions)` | IL_0027 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithReference(Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResourceWithConnectionString>, string, bool)` | IL_008A |
| Aspire.Hosting@13.4.6 | low | box-value-type | `Aspire.Hosting.ResourceBuilderExtensions.WithReference(Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ExternalServiceResource>)` | IL_0099 |
| Aspire.Hosting@13.4.6 | low | box-value-type | `Aspire.Hosting.ResourceBuilderExtensions.WithReference(Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ExternalServiceResource>)` | IL_00DF |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithReference(Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ExternalServiceResource>)` | IL_017E |
| Aspire.Hosting@13.4.6 | low | box-value-type | `Aspire.Hosting.ResourceBuilderExtensions.WithReference(Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>, string, System.Uri)` | IL_01F2 |
| Aspire.Hosting@13.4.6 | low | box-value-type | `Aspire.Hosting.ResourceBuilderExtensions.WithReference(Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>, string, System.Uri)` | IL_0222 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithRemoteImageName(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string)` | IL_0030 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithRemoteImageTag(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string)` | IL_0030 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithUrl(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, Aspire.Hosting.ApplicationModel.ReferenceExpression, string)` | IL_0037 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithUrl(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, string)` | IL_003A |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithUrlForEndpoint(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Action<Aspire.Hosting.ApplicationModel.ResourceUrlAnnotation>)` | IL_0028 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithUrlForEndpoint(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string, System.Func<Aspire.Hosting.ApplicationModel.EndpointReference, Aspire.Hosting.ApplicationModel.ResourceUrlAnnotation>)` | IL_0028 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithWellKnownEndpointCallback(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, System.Action<Aspire.Hosting.ApplicationModel.EndpointUpdateContext>, string, bool, System.Action<Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string>)` | IL_0037 |
| Aspire.Hosting@13.4.6 | low | capturing-delegate | `Aspire.Hosting.ResourceBuilderExtensions.WithWellKnownEndpointCallback(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, System.Action<Aspire.Hosting.ApplicationModel.EndpointUpdateContext>, string, bool, System.Action<Aspire.Hosting.ApplicationModel.IResourceBuilder<T>, string>)` | IL_005F |
| AutoMapper@16.1.1 | low | capturing-delegate | `Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.AddAutoMapper(Microsoft.Extensions.DependencyInjection.IServiceCollection, System.Action<AutoMapper.IMapperConfigurationExpression>, System.Collections.Generic.IEnumerable<System.Reflection.Assembly>, Microsoft.Extensions.DependencyInjection.ServiceLifetime)` | IL_0015 |
| AutoMapper@16.1.1 | low | capturing-delegate | `Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.AddAutoMapper(Microsoft.Extensions.DependencyInjection.IServiceCollection, System.Action<AutoMapper.IMapperConfigurationExpression>, System.Collections.Generic.IEnumerable<System.Type>, Microsoft.Extensions.DependencyInjection.ServiceLifetime)` | IL_0015 |
| AutoMapper@16.1.1 | low | capturing-delegate | `Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.AddAutoMapper(Microsoft.Extensions.DependencyInjection.IServiceCollection, System.Action<AutoMapper.IMapperConfigurationExpression>, System.Reflection.Assembly[])` | IL_0015 |
| AutoMapper@16.1.1 | low | capturing-delegate | `Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.AddAutoMapper(Microsoft.Extensions.DependencyInjection.IServiceCollection, System.Action<AutoMapper.IMapperConfigurationExpression>, System.Type[])` | IL_0015 |
| AutoMapper@16.1.1 | low | capturing-delegate | `Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.AddAutoMapper(Microsoft.Extensions.DependencyInjection.IServiceCollection, System.Action<AutoMapper.IMapperConfigurationExpression>)` | IL_0015 |

</details>

## Validation

- `dotnet build src/dotnet-inspect -c Release`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` (270 passed)
- Aspire before/after demo above
- Six pinned libraries before/after characterization above

## Adversarial review

Requested two false-demotion-focused reviews from Claude Opus 4.8 and Gemini 3.1 Pro. Both identified the same high-severity `MethodAttributes.Public` mask bug; fixed before PR by switching to `MemberAccessMask == Public` and adding an internal-return guard fixture. Opus also suggested amortizing sequence-scan rows; intentionally not broadened because #2032 is the allocation setup-amortization slice. No remaining hot-path false demotion was found in the pinned-corpus run.
