### PR TITLE
Raise direct Value union or-null bool patterns

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -285,6 +285,8 @@ public class TypeSourceComposerUnionTests
                     public static bool IsNotCat(Pet pet) => pet is not Cat;
                     public static bool ValueIsNotCat(Pet pet) => pet.Value is not Cat;
                     public static bool ValueIsNotOlderCat(Pet pet) => pet.Value is not Cat { Age: > 3 };
+                    public static bool ValueIsDogOrNull(Pet pet) => pet.Value is Dog or null;
+                    public static bool ValueIsNotDogOrNull(Pet pet) => pet.Value is not (Dog or null);
                     public static bool IsNull(Pet pet) => pet.Value is null;
                     public static bool ValueIsNotNull(Pet pet) => pet.Value is not null;
                     public static string Describe(Pet pet) => pet.Value switch
@@ -316,6 +318,8 @@ public class TypeSourceComposerUnionTests
         Assert.Equal("return pet is not Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNotCat"));
         Assert.Equal("return pet is not Cat;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotCat"));
         Assert.Equal("return pet is not Cat { Age: > 3 };", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotOlderCat"));
+        Assert.Equal("return pet is Dog || pet is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsDogOrNull"));
+        Assert.Equal("return !(pet is Dog || pet is null);", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotDogOrNull"));
         Assert.Equal("return pet is null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsNull"));
         Assert.Equal("return pet is not null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotNull"));
         Assert.Equal("""
@@ -910,6 +914,7 @@ public class TypeSourceComposerUnionTests
                 public static bool IsNotCat(Pet pet) => pet is not Cat;
                 public static bool ValueIsNotCat(Pet pet) => pet.Value is not Cat;
                 public static bool ValueIsNotNamedCat(Pet pet) => pet.Value is not Cat { Name: "cat" };
+                public static bool ValueIsDogOrNull(Pet pet) => pet.Value is Dog or null;
                 public static bool ValueIsNotNull(Pet pet) => pet.Value is not null;
 
                 public static bool IsCatWithName(Pet pet) => pet is Cat { Name: "cat" };
@@ -1012,6 +1017,9 @@ public class TypeSourceComposerUnionTests
         var classValueNotNamedCat = RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotNamedCat");
         Assert.Contains("pet.Value as Cat", classValueNotNamedCat);
         Assert.Contains("V_0.Name == \"cat\"", classValueNotNamedCat);
+        var classValueDogOrNull = RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsDogOrNull");
+        Assert.Contains("pet.Value", classValueDogOrNull);
+        Assert.DoesNotContain("return pet is Dog || pet is null", classValueDogOrNull);
         Assert.Equal("return pet.Value is not null;", RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueIsNotNull"));
         Assert.Equal("return pet is Cat { Name: \"cat\" };",
             RenderMember(assembly.Path, "UnionFixtures.Matcher", "IsCatWithName"));

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -310,6 +310,16 @@ public class TypeSourceComposerUnionTests
                         not null => "not null",
                         _ => "null",
                     };
+                    public static string ValueSwitchNotOlderCat(Pet pet) => pet.Value switch
+                    {
+                        not Cat { Age: > 3 } => "not older cat",
+                        Cat => "cat",
+                    };
+                    public static string SwitchNotOlderCat(Pet pet) => pet switch
+                    {
+                        not Cat { Age: > 3 } => "not older cat",
+                        Cat => "cat",
+                    };
                 }
             }
             """);
@@ -360,6 +370,26 @@ public class TypeSourceComposerUnionTests
                 return "null";
             }
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNotNull"));
+        Assert.Equal("""
+            if (pet is not Cat { Age: > 3 })
+            {
+                return "not older cat";
+            }
+            else
+            {
+                return "cat";
+            }
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNotOlderCat"));
+        Assert.Equal("""
+            if (pet is not Cat { Age: > 3 })
+            {
+                return "not older cat";
+            }
+            else
+            {
+                return "cat";
+            }
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "SwitchNotOlderCat"));
     }
 
     [Fact]
@@ -925,6 +955,11 @@ public class TypeSourceComposerUnionTests
                     not null => "not null",
                     _ => "null",
                 };
+                public static string ValueSwitchNotNamedCat(Pet pet) => pet.Value switch
+                {
+                    not Cat { Name: "cat" } => "not named cat",
+                    Cat => "cat",
+                };
 
                 public static bool SideEffect() => true;
 
@@ -1035,6 +1070,9 @@ public class TypeSourceComposerUnionTests
                 return "null";
             }
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNotNull"));
+        var classValueSwitchNotNamedCat = RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNotNamedCat");
+        Assert.Contains("pet.Value as Cat", classValueSwitchNotNamedCat);
+        Assert.Contains("V_1.Name == \"cat\"", classValueSwitchNotNamedCat);
         var guardedOr = RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedOrSideEffect");
         Assert.DoesNotContain("pet is Cat cat || SideEffect() ? \"cat\" : \"other\"", guardedOr);
         Assert.Contains("if (", guardedOr);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1875,6 +1875,7 @@ public sealed partial class CSharpPrinter
             Conditions.Inverse(c.Kind),
             IsFloatComparison(c.Left, c.Right) ? !c.IsUnsigned : c.IsUnsigned,
             c.Left, c.Right),
+        LogicalNot { Operand: LogicalBinary logical } when TryPropertyPatternText(logical, negated: true) is { } negatedPattern => negatedPattern,
         LogicalNot { Operand: Call { Callee.Name: "op_True", Arguments: [var value] } } => InvertedUserTruthiness(value),
         LogicalNot { Operand: Call { Callee.Name: "op_False", Arguments: [var value] } } => OperatorOperand(value),
         // brtrue/brfalse test any I4/ref value; C# conditions need bool —

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -58,6 +58,7 @@ public sealed class IsPatternPass : IIrPass
     public void Run(IrFunction function, PassContext context)
     {
         while (TransformOne(function, context.Stepper)
+            || TransformNegatedPropertyPatternGuard(function, context.Stepper)
             || FoldConditionalReturnOne(function, context.Stepper)
             || FoldNegatedConditionalPatternReturnOne(function, context.Stepper)
             || FoldClassUnionNullConditionalReturnOne(function, context.Stepper)
@@ -106,6 +107,71 @@ public sealed class IsPatternPass : IIrPass
             }
         }
         return false;
+    }
+
+    static bool TransformNegatedPropertyPatternGuard(IrFunction function, Stepper stepper)
+    {
+        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        {
+            var children = block.Children;
+            for (int i = 0; i + 1 < children.Count; i++)
+            {
+                if (children[i] is not StoreLocal { Value: IsInstance asCast } store
+                    || children[i + 1] is not IfStatement guard
+                    || !TryNegatedPropertyPatternGuard(function, asCast, store.Index, guard.Condition, out var condition))
+                {
+                    continue;
+                }
+
+                if (ReferenceOwnership.SubtreeReferencesLocal(asCast.Operand, store.Index)
+                    || !IsSideEffectFree(function, asCast.Operand)
+                    || !ReferenceOwnership.LocalReferencesOnlyWithin(function, store.Index, [store, guard.Condition]))
+                {
+                    continue;
+                }
+
+                stepper.StepOver("raise negated union property-pattern guard", guard);
+                guard.Condition.ReplaceWith(condition);
+                store.Detach();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool TryNegatedPropertyPatternGuard(
+        IrFunction function,
+        IsInstance asCast,
+        int localIndex,
+        IrExpression guard,
+        out IrExpression condition)
+    {
+        condition = null!;
+        if (asCast.Operand is not LoadProperty property
+            || !IsValueTypeUnionValueProperty(function, property)
+            || guard is not LogicalBinary { Kind: LogicalKind.Or } logical)
+        {
+            return false;
+        }
+
+        IrExpression other;
+        if (IsPatternLocalNull(logical.Left, localIndex))
+        {
+            other = logical.Right;
+        }
+        else if (IsPatternLocalNull(logical.Right, localIndex))
+        {
+            other = logical.Left;
+        }
+        else
+        {
+            return false;
+        }
+
+        var pattern = new IsPattern((IrExpression)asCast.Operand.Clone(), asCast.Type, localIndex);
+        condition = new LogicalNot(new LogicalBinary(LogicalKind.And, pattern, Conditions.Negate((IrExpression)other.Clone())));
+        return true;
     }
 
     static bool FoldConditionalReturnOne(IrFunction function, Stepper stepper)
@@ -667,6 +733,10 @@ public sealed class IsPatternPass : IIrPass
         => property.PropertyName == "Value"
         && property.IndexArguments.Count == 0
         && function.UnionTypes.Contains(NamedDefinition(property.Accessor.DeclaringType));
+
+    static bool IsValueTypeUnionValueProperty(IrFunction function, LoadProperty property)
+        => IsUnionValueProperty(function, property)
+        && function.TypeShapes.GetValueOrDefault(NamedDefinition(property.Accessor.DeclaringType)) == TypeShape.ValueType;
 
     static bool IsSimpleUnionValueReceiver(IrExpression? receiver) => receiver switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -167,7 +167,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             || !IsUnionValueProperty(function, unionValue)
             || !PlaceIdentity.SameVariable(unionValue.Instance, receiver)
             || testBranch.Condition is not LogicalNot { Operand: var directCondition }
-            || !TryRewriteTempTypeTestCondition(directCondition, valueStore.Index, unionValue, out var rewrittenCondition)
+            || !TryRewriteTempTypeTestCondition(function, directCondition, valueStore.Index, unionValue, out var rewrittenCondition)
             || blocks[2].Children is not [StoreLocal trueStore, Branch joinBranch]
             || blocks[3].Children is not [StoreLocal falseStore]
             || blocks[4].Children is not [Return ret]
@@ -207,15 +207,17 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 || ifStatement.Then.Children is not [StoreLocal thenStore]
                 || ifStatement.Else?.Children is not [StoreLocal elseStore]
                 || children[start + 2] is not Return ret
-                || !StoreReturnMatch(thenStore, ret, thenStore.Index)
+                || !ReturnsBoolLocal(ret, thenStore.Index, out bool returnNegates)
                 || elseStore.Index != thenStore.Index
                 || !TryBoolConstants(thenStore.Value, elseStore.Value, out bool conditionIsTrueArm)
-                || !TryRewriteTempTypeTestCondition(ifStatement.Condition, valueStore.Index, unionValue, out var condition))
+                || !TryRewriteTempTypeTestCondition(function, ifStatement.Condition, valueStore.Index, unionValue, out var condition))
             {
                 continue;
             }
 
             if (!conditionIsTrueArm)
+                condition = Conditions.Negate(condition);
+            if (returnNegates)
                 condition = Conditions.Negate(condition);
 
             if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, [valueStore, ifStatement.Condition])
@@ -231,17 +233,21 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         return false;
     }
 
-    static bool TryRewriteTempTypeTestCondition(IrExpression expression, int tempLocal, LoadProperty unionValue, out IrExpression rewritten)
+    static bool TryRewriteTempTypeTestCondition(IrFunction function, IrExpression expression, int tempLocal, LoadProperty unionValue, out IrExpression rewritten)
     {
         switch (expression)
         {
             case IsInstance test when IsTempTypeTest(test, tempLocal):
                 rewritten = new IsInstance(test.Type, (IrExpression)unionValue.Clone());
                 return true;
+            case LogicalNot { Operand: LoadLocal load }
+                when load.Index == tempLocal && IsValueTypeUnionValueProperty(function, unionValue):
+                rewritten = new LogicalNot((IrExpression)unionValue.Clone());
+                return true;
             case LogicalBinary logical:
             {
-                if (!TryRewriteTempTypeTestCondition(logical.Left, tempLocal, unionValue, out var left)
-                    || !TryRewriteTempTypeTestCondition(logical.Right, tempLocal, unionValue, out var right))
+                if (!TryRewriteTempTypeTestCondition(function, logical.Left, tempLocal, unionValue, out var left)
+                    || !TryRewriteTempTypeTestCondition(function, logical.Right, tempLocal, unionValue, out var right))
                 {
                     rewritten = null!;
                     return false;
@@ -1002,6 +1008,24 @@ public sealed class UnionSwitchExpressionPass : IIrPass
     static bool StoreReturnMatch(StoreLocal store, Return ret, int local)
         => store.Index == local && ReturnsLocal(ret, local);
 
+    static bool ReturnsBoolLocal(Return ret, int local, out bool negates)
+    {
+        if (ReturnsLocal(ret, local))
+        {
+            negates = false;
+            return true;
+        }
+
+        if (ret.Value is LogicalNot { Operand: LoadLocal load } && load.Index == local)
+        {
+            negates = true;
+            return true;
+        }
+
+        negates = false;
+        return false;
+    }
+
     static bool IsTempLocal(Arm arm, int tempLocal)
         => arm.LocalRoots.OfType<StoreLocal>().FirstOrDefault()?.Value is IsInstance test
             && IsTempTypeTest(test, tempLocal);
@@ -1430,6 +1454,10 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         && property.IndexArguments.Count == 0
         && function.UnionTypes.Contains(NamedDefinition(property.Accessor.DeclaringType))
         && IsSimpleUnionValueReceiver(property.Instance);
+
+    static bool IsValueTypeUnionValueProperty(IrFunction function, LoadProperty property)
+        => IsUnionValueProperty(function, property)
+        && function.TypeShapes.GetValueOrDefault(NamedDefinition(property.Accessor.DeclaringType)) == TypeShape.ValueType;
 
     static bool IsSimpleUnionValueReceiver(IrExpression? receiver) => receiver switch
     {


### PR DESCRIPTION
- Fixes/advances #2036 and #2029
- Changes direct `.Value` union bool and negated property-pattern lowerings into direct union-level patterns where safe.
- Card revision: b3e165d3

## Change

**Conclusion:** **REVIEW** - value-type union direct `.Value` OR-null bool patterns and negated property-pattern guards now render at union level, while class-union explicit `.Value` near misses stay flat to preserve null-receiver semantics.

Before:

```csharp
bool V_1;
object V_0 = pet.Value;
if (V_0 is Dog || V_0 is null) { ... }
return V_1;

Cat V_1 = pet.Value as Cat;
if (V_1 is null || V_1.Age <= 3)
{
    return "not older cat";
}
```

After:

```csharp
return pet is Dog || pet is null;
return !(pet is Dog || pet is null);

if (pet is not Cat { Age: > 3 })
{
    return "not older cat";
}
```

Near misses preserved for class unions:

```csharp
// explicit pet.Value stays explicit for class-union .Value checks
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet -p:PublishAot=false -p:IsAotCompatible=false -p:WarningsNotAsErrors=NU1507` |
| Union fixtures | Pass: `TypeSourceComposerUnionTests/*` |
| Pattern pass | Pass: `IsPatternPassTests/*` |
| Lowering coverage | Pass: `LoweringCoverageTests/*` |
| PR fast decompiler suite | Pass: `ILInspector.Decompiler.Tests -trait- "Speed=Slow"` |

## Decompiler quality

**Conclusion:** **ADVISORY** - this is a preview-SDK union fixture and targeted raise; no real corpus union witnesses are currently known for a generated quality-diff card.

Highest local boss: Stage 6 altitude proof for the targeted Preview 6 direct `.Value` union bool/property-pattern shapes, backed by Stage 0 build/focused tests and PR fast suite.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Pending | Requested after final scope update. |
| Gemini Pro | Pending | Requested after final scope update. |

**Review conclusion:** **REVIEW** - adversarial review is pending and will be reconciled on the PR before ready-to-merge.
