### PR TITLE
Decode ILDisassembler through the shared substrate (#1939 consolidation)

### DIFF
--- a/src/ILInspector.Metadata/ILDisassembler.cs
+++ b/src/ILInspector.Metadata/ILDisassembler.cs
@@ -1,7 +1,10 @@
+using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+
+using ILInspector.Instructions;
 
 namespace ILInspector.Metadata;
 
@@ -50,16 +53,13 @@ public static class ILDisassembler
         }
 
         var ilBytes = body.GetILContent().ToArray();
-        List<ILInstruction> instructions = [];
-        int position = 0;
+        var decoded = InstructionDecoder.Decode(ilBytes);
 
-        while (position < ilBytes.Length)
+        var instructions = new List<ILInstruction>(decoded.Length);
+        foreach (var instruction in decoded)
         {
-            int offset = position;
-            var opCode = DecodeOpCode(ilBytes, ref position);
-            string? operand = DecodeOperand(opCode, ilBytes, ref position, reader, syntax);
-
-            instructions.Add(new ILInstruction(offset, GetDisplayName(opCode), operand));
+            instructions.Add(new ILInstruction(
+                instruction.Offset, GetDisplayName(instruction.OpCode), FormatOperand(instruction, reader, syntax)));
         }
 
         return instructions;
@@ -116,148 +116,46 @@ public static class ILDisassembler
         return null;
     }
 
-    static ILOpCode DecodeOpCode(byte[] ilBytes, ref int position)
-    {
-        byte first = ilBytes[position++];
-        if (first == 0xFE && position < ilBytes.Length)
-        {
-            byte second = ilBytes[position++];
-            return (ILOpCode)(0xFE00 | second);
-        }
-        return (ILOpCode)first;
-    }
-
-    static string? DecodeOperand(ILOpCode opCode, byte[] ilBytes, ref int position, MetadataReader reader, ILSyntax syntax = ILSyntax.Display)
+    static string? FormatOperand(DecodedInstruction instruction, MetadataReader reader, ILSyntax syntax)
     {
         bool canonical = syntax == ILSyntax.Canonical;
-        return GetOperandType(opCode) switch
+        int token = (int)instruction.OperandValue;
+        return instruction.Operand switch
         {
             OperandKind.None => null,
-            OperandKind.ShortBrTarget => FormatBranchTarget(ReadSByte(ilBytes, ref position), position),
-            OperandKind.BrTarget => FormatBranchTarget(ReadInt32(ilBytes, ref position), position),
-            OperandKind.ShortI => ReadSByte(ilBytes, ref position).ToString(),
-            OperandKind.I => ReadInt32(ilBytes, ref position).ToString(),
-            OperandKind.I8 => ReadInt64(ilBytes, ref position).ToString(),
+            OperandKind.ShortInlineBrTarget or OperandKind.InlineBrTarget => $"IL_{instruction.BranchTargets[0]:X4}",
+            OperandKind.ShortInlineI => ((sbyte)instruction.OperandValue).ToString(),
+            OperandKind.InlineI => ((int)instruction.OperandValue).ToString(),
+            OperandKind.InlineI8 => instruction.OperandValue.ToString(),
             // Canonical: bit-exact, culture-free ilasm forms (float32/float64 take
             // the raw bits); display keeps the human-readable decimal rendering.
-            OperandKind.ShortR => canonical
-                ? $"float32(0x{BitConverter.SingleToInt32Bits(ReadSingle(ilBytes, ref position)):X8})"
-                : ReadSingle(ilBytes, ref position).ToString(),
-            OperandKind.R => canonical
-                ? $"float64(0x{BitConverter.DoubleToInt64Bits(ReadDouble(ilBytes, ref position)):X16})"
-                : ReadDouble(ilBytes, ref position).ToString(),
-            OperandKind.ShortVariable => ReadByte(ilBytes, ref position).ToString(),
-            OperandKind.Variable => ReadUInt16(ilBytes, ref position).ToString(),
-            OperandKind.String => canonical
-                ? CanonicalIL.ResolveString(reader, ReadInt32(ilBytes, ref position))
-                : ILTokenResolver.ResolveString(reader, ReadInt32(ilBytes, ref position)),
-            OperandKind.Type => canonical
-                ? CanonicalIL.ResolveType(reader, ReadInt32(ilBytes, ref position))
-                : ILTokenResolver.ResolveType(reader, ReadInt32(ilBytes, ref position)),
-            OperandKind.Method => canonical
-                ? CanonicalIL.ResolveMethod(reader, ReadInt32(ilBytes, ref position))
-                : ILTokenResolver.ResolveMethod(reader, ReadInt32(ilBytes, ref position)),
-            OperandKind.Field => canonical
-                ? CanonicalIL.ResolveField(reader, ReadInt32(ilBytes, ref position))
-                : ILTokenResolver.ResolveField(reader, ReadInt32(ilBytes, ref position)),
-            OperandKind.Tok => canonical
-                ? CanonicalIL.ResolveToken(reader, ReadInt32(ilBytes, ref position))
-                : ILTokenResolver.ResolveToken(reader, ReadInt32(ilBytes, ref position)),
-            OperandKind.Sig => $"0x{ReadInt32(ilBytes, ref position):X8}",
-            OperandKind.Switch => DecodeSwitch(ilBytes, ref position),
+            OperandKind.ShortInlineR => canonical
+                ? $"float32(0x{(int)instruction.OperandValue:X8})"
+                : BitConverter.Int32BitsToSingle((int)instruction.OperandValue).ToString(),
+            OperandKind.InlineR => canonical
+                ? $"float64(0x{instruction.OperandValue:X16})"
+                : BitConverter.Int64BitsToDouble(instruction.OperandValue).ToString(),
+            OperandKind.ShortInlineVar => ((byte)instruction.OperandValue).ToString(),
+            OperandKind.InlineVar => ((ushort)instruction.OperandValue).ToString(),
+            OperandKind.InlineString => canonical
+                ? CanonicalIL.ResolveString(reader, token)
+                : ILTokenResolver.ResolveString(reader, token),
+            OperandKind.InlineType => canonical
+                ? CanonicalIL.ResolveType(reader, token)
+                : ILTokenResolver.ResolveType(reader, token),
+            OperandKind.InlineMethod => canonical
+                ? CanonicalIL.ResolveMethod(reader, token)
+                : ILTokenResolver.ResolveMethod(reader, token),
+            OperandKind.InlineField => canonical
+                ? CanonicalIL.ResolveField(reader, token)
+                : ILTokenResolver.ResolveField(reader, token),
+            OperandKind.InlineTok => canonical
+                ? CanonicalIL.ResolveToken(reader, token)
+                : ILTokenResolver.ResolveToken(reader, token),
+            OperandKind.InlineSig => $"0x{token:X8}",
+            OperandKind.InlineSwitch => $"({string.Join(", ", instruction.BranchTargets.Select(t => $"IL_{t:X4}"))})",
             _ => null
         };
-    }
-
-    static string FormatBranchTarget(int delta, int positionAfterOperand)
-    {
-        int target = positionAfterOperand + delta;
-        return $"IL_{target:X4}";
-    }
-
-    static string DecodeSwitch(byte[] ilBytes, ref int position)
-    {
-        int count = ReadInt32(ilBytes, ref position);
-        int baseOffset = position + count * 4;
-        List<string> targets = [];
-        for (int i = 0; i < count; i++)
-        {
-            int delta = ReadInt32(ilBytes, ref position);
-            targets.Add($"IL_{(baseOffset + delta):X4}");
-        }
-        return $"({string.Join(", ", targets)})";
-    }
-
-    // Primitive readers
-
-    static byte ReadByte(byte[] bytes, ref int pos) => bytes[pos++];
-    static sbyte ReadSByte(byte[] bytes, ref int pos) => (sbyte)bytes[pos++];
-
-    static ushort ReadUInt16(byte[] bytes, ref int pos)
-    {
-        var val = BitConverter.ToUInt16(bytes, pos);
-        pos += 2;
-        return val;
-    }
-
-    static int ReadInt32(byte[] bytes, ref int pos)
-    {
-        var val = BitConverter.ToInt32(bytes, pos);
-        pos += 4;
-        return val;
-    }
-
-    static long ReadInt64(byte[] bytes, ref int pos)
-    {
-        var val = BitConverter.ToInt64(bytes, pos);
-        pos += 8;
-        return val;
-    }
-
-    static float ReadSingle(byte[] bytes, ref int pos)
-    {
-        var val = BitConverter.ToSingle(bytes, pos);
-        pos += 4;
-        return val;
-    }
-
-    static double ReadDouble(byte[] bytes, ref int pos)
-    {
-        var val = BitConverter.ToDouble(bytes, pos);
-        pos += 8;
-        return val;
-    }
-
-    // Operand type lookup table and display names from ILSpy (MIT license, Daniel Grunwald).
-    // Index computation: ((opCode & 0x200) >> 1) | (opCode & 0xFF)
-
-    enum OperandKind : byte
-    {
-        BrTarget,
-        Field,
-        I,
-        I8,
-        Method,
-        None,
-        R = 7,
-        Sig = 9,
-        String,
-        Switch,
-        Tok,
-        Type,
-        Variable,
-        ShortBrTarget,
-        ShortI,
-        ShortR,
-        ShortVariable
-    }
-
-    static OperandKind GetOperandType(ILOpCode opCode)
-    {
-        ushort index = (ushort)((((int)opCode & 0x200) >> 1) | ((int)opCode & 0xFF));
-        if (index >= s_operandTypes.Length)
-            return OperandKind.None;
-        return (OperandKind)s_operandTypes[index];
     }
 
     static string GetDisplayName(ILOpCode opCode)
@@ -268,45 +166,6 @@ public static class ILDisassembler
         string name = s_displayNames[index];
         return string.IsNullOrEmpty(name) ? opCode.ToString() : name;
     }
-
-    static readonly byte[] s_operandTypes = [
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.ShortVariable, (byte)OperandKind.ShortVariable,
-        (byte)OperandKind.ShortVariable, (byte)OperandKind.ShortVariable, (byte)OperandKind.ShortVariable, (byte)OperandKind.ShortVariable, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.ShortI,
-        (byte)OperandKind.I, (byte)OperandKind.I8, (byte)OperandKind.ShortR, (byte)OperandKind.R, 255, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.Method,
-        (byte)OperandKind.Method, (byte)OperandKind.Sig, (byte)OperandKind.None, (byte)OperandKind.ShortBrTarget, (byte)OperandKind.ShortBrTarget, (byte)OperandKind.ShortBrTarget, (byte)OperandKind.ShortBrTarget, (byte)OperandKind.ShortBrTarget,
-        (byte)OperandKind.ShortBrTarget, (byte)OperandKind.ShortBrTarget, (byte)OperandKind.ShortBrTarget, (byte)OperandKind.ShortBrTarget, (byte)OperandKind.ShortBrTarget, (byte)OperandKind.ShortBrTarget, (byte)OperandKind.ShortBrTarget, (byte)OperandKind.ShortBrTarget,
-        (byte)OperandKind.BrTarget, (byte)OperandKind.BrTarget, (byte)OperandKind.BrTarget, (byte)OperandKind.BrTarget, (byte)OperandKind.BrTarget, (byte)OperandKind.BrTarget, (byte)OperandKind.BrTarget, (byte)OperandKind.BrTarget,
-        (byte)OperandKind.BrTarget, (byte)OperandKind.BrTarget, (byte)OperandKind.BrTarget, (byte)OperandKind.BrTarget, (byte)OperandKind.BrTarget, (byte)OperandKind.Switch, (byte)OperandKind.None, (byte)OperandKind.None,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.Method,
-        (byte)OperandKind.Type, (byte)OperandKind.Type, (byte)OperandKind.String, (byte)OperandKind.Method, (byte)OperandKind.Type, (byte)OperandKind.Type, (byte)OperandKind.None, 255,
-        255, (byte)OperandKind.Type, (byte)OperandKind.None, (byte)OperandKind.Field, (byte)OperandKind.Field, (byte)OperandKind.Field, (byte)OperandKind.Field, (byte)OperandKind.Field,
-        (byte)OperandKind.Field, (byte)OperandKind.Type, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.Type, (byte)OperandKind.Type, (byte)OperandKind.None, (byte)OperandKind.Type,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.Type, (byte)OperandKind.Type, (byte)OperandKind.Type, 255, 255,
-        255, 255, 255, 255, 255, 255, 255, 255,
-        255, 255, 255, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, 255, 255, 255, 255, 255,
-        255, 255, (byte)OperandKind.Type, (byte)OperandKind.None, 255, 255, (byte)OperandKind.Type, 255,
-        255, 255, 255, 255, 255, 255, 255, 255,
-        (byte)OperandKind.Tok, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.BrTarget, (byte)OperandKind.ShortBrTarget, (byte)OperandKind.None,
-        (byte)OperandKind.None, 255, 255, 255, 255, 255, 255, 255,
-        255, 255, 255, 255, 255, 255, 255, 255,
-        255, 255, 255, 255, 255, 255, 255, 255,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None,
-        (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.Method, (byte)OperandKind.Method,
-        255, (byte)OperandKind.Variable, (byte)OperandKind.Variable, (byte)OperandKind.Variable, (byte)OperandKind.Variable, (byte)OperandKind.Variable, (byte)OperandKind.Variable, (byte)OperandKind.None,
-        255, (byte)OperandKind.None, (byte)OperandKind.ShortI, (byte)OperandKind.None, (byte)OperandKind.None, (byte)OperandKind.Type, (byte)OperandKind.Type, (byte)OperandKind.None,
-        (byte)OperandKind.None, 255, (byte)OperandKind.None, 255, (byte)OperandKind.Type, (byte)OperandKind.None, (byte)OperandKind.None,
-    ];
 
     static readonly string[] s_displayNames = [
         "nop", "break", "ldarg.0", "ldarg.1", "ldarg.2", "ldarg.3", "ldloc.0", "ldloc.1",

--- a/src/ILInspector.Metadata/ILInspector.Metadata.csproj
+++ b/src/ILInspector.Metadata/ILInspector.Metadata.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DotnetInspector.Core\DotnetInspector.Core.csproj" />
+    <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
     <ProjectReference Include="..\ILInspector.MetadataPrimitives\ILInspector.MetadataPrimitives.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

#1939 listed the annotated-IL / disassembly view as a decode **consolidation opportunity**. `ILDisassembler` (in `ILInspector.Metadata`) was a **4th standalone hand-rolled IL decoder** — its own opcode reader, operand reader, read primitives, and an ILSpy-derived operand-size table — independent of the shared `ILInspector.Instructions` substrate.

This swaps its byte-level decode onto `InstructionDecoder.Decode` and formats each `DecodedInstruction`, keeping the display-name table and token resolution.

## Change

- Replace `DecodeOpCode`/`DecodeOperand`/`DecodeSwitch` + primitive readers + `s_operandTypes`/`OperandKind` with a single `FormatOperand(DecodedInstruction, …)` over the substrate's decoded operand value / branch targets / resolved tokens.
- `ILInspector.Metadata` → references `ILInspector.Instructions` (acyclic; the substrate is metadata-free, ControlFlow-only).
- Public API (`Disassemble`/`DisassembleMethod`/`ILInstruction`) unchanged; the ILSpy `s_displayNames` table + `GetDisplayName` + `DisassembleMethod` verified **byte-identical** to origin.

Net **−140 lines** (+41 / −181).

## Behavior-neutral — proven by differential

Disassembled **every method in `System.Private.CoreLib`** (82,024 methods × `Display` + `Canonical` syntax = 1,356,644 lines) with the old and new implementation and compared:

```
✅ BYTE-IDENTICAL disassembly across all 82024 CoreLib methods × 2 syntaxes (1,356,644 lines)
```

CoreLib exercises essentially the full opcode space. Where the two implementations *could* differ, the substrate is strictly **more correct**, and it doesn't surface on real IL:
- the `no.` prefix (`0xFE19`): the old ILSpy table gave it 0 operand bytes and would desync (the #1939 CRITICAL bug); the substrate decodes it as 1 byte. Near-nonexistent in real IL (0 occurrences in CoreLib).
- truncated/malformed IL: old threw `BitConverter` exceptions; new throws `BadImageFormatException`. The sole caller (`MemberCodeProvider`) already wraps `DisassembleMethod` in `catch (Exception)`, so the type change is absorbed.

## Validation

- CoreLib old-vs-new differential: byte-identical (above).
- `dotnet-inspect.Tests`: **1484 / 0 failed** (9 skipped — ildasm-oracle tests need ildasm installed).
- `ILInspector.Metadata.Tests`: **229 / 0 failed**.
- Full `dotnet-inspect` CLI builds clean.

## Context

Fourth and final of the hand-rolled decoders on #1939's list to consolidate (after `ReachingDefinitions` #1990, `LibraryBodyIndex` #2013, decompiler `ILReader` #2028). This one is a clean swap (flat linear decode → format), not a rewrite.
