### PR TITLE
Add IL offset instruction context

### DIFF
--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -155,7 +155,8 @@ member MyType Method:1 --library MyLib.dll -S "Decompiled Source" --bare > Metho
 resolved coordinate can expose multiple sibling sections. The source-location
 section is useful as a human fact sheet, a row, a scalar, a URL, a path, or a
 source-line payload; the member-context section projects the same coordinate to
-the owning type and method.
+the owning type and method; the instruction-context section projects it to the
+exact IL instruction.
 
 The default stays evidence-oriented and renders all applicable coordinate-scoped
 sections:
@@ -191,6 +192,22 @@ dotnet-inspect library My.dll --il-offset 0x06000002+0x1
 | Async | State machine |
 | Metadata Token | 0x6000002 |
 | IL Offset | 0x1 |
+
+## Instruction Context
+
+| Field | Value |
+| ----- | ----- |
+| IL Offset | 0x1 |
+| Boundary | Exact |
+| Opcode | callvirt |
+| Operand Kind | Method |
+| Operand | MyApp.IWorker::DoWork(int) |
+| Operand Token | 0x06000020 |
+| Next Offset | 0x6 |
+| Length | 5 |
+| Block | 0 |
+| Terminates Block | No |
+| Falls Through | Yes |
 ```
 
 Coordinate-scoped sections are discoverable only when the coordinate carrier is
@@ -198,11 +215,12 @@ present:
 
 ```bash
 dotnet-inspect library My.dll -D
-# Source Location and Member Context are omitted.
+# Source Location, Member Context, and Instruction Context are omitted.
 
 dotnet-inspect library My.dll --il-offset 0x06000002+0x1 -D
 # Source Location
 # Member Context
+# Instruction Context
 ```
 
 The source-location section then projects cleanly:
@@ -236,9 +254,9 @@ dotnet-inspect library My.dll --il-offset 0x06000002+0x1 \
 
 This keeps the concerns separate: the default fact section shows all
 symbolication evidence, `Member Context` shows the owning metadata context,
-`--urls` returns the anchored source location, `--paths` returns the PDB
-document path, and `--print` returns the raw payload at the location rather than
-a decorated snippet.
+`Instruction Context` shows the exact IL operation, `--urls` returns the
+anchored source location, `--paths` returns the PDB document path, and `--print`
+returns the raw payload at the location rather than a decorated snippet.
 
 ## Design discipline for future flags
 

--- a/docs/workflows/features.md
+++ b/docs/workflows/features.md
@@ -212,7 +212,7 @@
 | IL (Annotated) section | — | 0.3.x | IL with stack state annotations |
 | Decompiled Source mixed view | — | 0.11.x | Decompiled Source becomes a mixed C#+IL view with hidden-fact comments (allocations, unsafety, lifetime) |
 | Facts section | — | 0.11.x | Structured hidden-fact table for one method (`-S "Facts"` / `--tsv`) |
-| `library --il-offset <token>+<offset>` | — | 0.13.0 | Map MethodDef token + IL offset to source file location through the `Source Location` section |
+| `library --il-offset <token>+<offset>` | — | 0.13.0 | Map MethodDef token + IL offset to coordinate-scoped sections such as `Source Location`, `Member Context`, and `Instruction Context` |
 
 ## Plugin and Integration
 

--- a/docs/workflows/getting-started/lap-around.md
+++ b/docs/workflows/getting-started/lap-around.md
@@ -229,7 +229,7 @@ dotnet-inspect member JsonSerializer --platform System.Text.Json -m Serialize -S
 public static partial class JsonSerializer
 ```
 
-For stack-trace style diagnostics, `library --il-offset` maps a MethodDef token plus IL offset to coordinate-scoped sections such as `Source Location` and `Member Context`.
+For stack-trace style diagnostics, `library --il-offset` maps a MethodDef token plus IL offset to coordinate-scoped sections such as `Source Location`, `Member Context`, and `Instruction Context`.
 
 ```bash
 dotnet-inspect library --platform System.Text.Json --il-offset 0x06000001+0x0 --json

--- a/src/ILInspector.Metadata/ILDisassembler.cs
+++ b/src/ILInspector.Metadata/ILDisassembler.cs
@@ -158,7 +158,7 @@ public static class ILDisassembler
         };
     }
 
-    static string GetDisplayName(ILOpCode opCode)
+    internal static string GetDisplayName(ILOpCode opCode)
     {
         ushort index = (ushort)((((int)opCode & 0x200) >> 1) | ((int)opCode & 0xFF));
         if (index >= s_displayNames.Length)

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
+using System.Globalization;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using ILInspector.Instructions;
 
 namespace ILInspector.Metadata;
 
@@ -34,6 +36,20 @@ public record ILOffsetMemberContextInfo(
     string? Async,
     int MetadataToken,
     int ILOffset);
+
+public record ILOffsetInstructionContextInfo(
+    int ILOffset,
+    string Boundary,
+    string Opcode,
+    string OperandKind,
+    string? Operand,
+    string? OperandToken,
+    string? BranchTargets,
+    int NextOffset,
+    int Length,
+    int? Block,
+    bool TerminatesBlock,
+    bool FallsThrough);
 
 /// <summary>
 /// Wraps PE + PDB readers, exposes high-level operations with no SRM in public signatures.
@@ -274,6 +290,69 @@ public class PdbContext : IDisposable
         }
     }
 
+    public ILOffsetInstructionContextInfo? ResolveInstructionContext(int methodToken, int ilOffset, out string? error)
+    {
+        error = null;
+        if (!_peReader.HasMetadata)
+            return null;
+
+        var handle = MetadataTokens.Handle(methodToken);
+        if (handle.Kind != HandleKind.MethodDefinition)
+        {
+            error = $"Token 0x{methodToken:X} is not a MethodDef token.";
+            return null;
+        }
+
+        try
+        {
+            var reader = _peReader.GetMetadataReader();
+            var method = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+            if (method.RelativeVirtualAddress == 0)
+            {
+                error = $"Method token 0x{methodToken:X} has no IL body.";
+                return null;
+            }
+
+            var body = _peReader.GetMethodBody(method.RelativeVirtualAddress);
+            var instructions = MethodInstructions.Decode(body);
+            if (!instructions.IsComplete)
+            {
+                error = $"Could not decode IL for token 0x{methodToken:X}: {instructions.Blocks.IncompleteReason}";
+                return null;
+            }
+
+            var instruction = instructions.InstructionAt(ilOffset);
+            if (instruction is null)
+            {
+                error = $"IL offset 0x{ilOffset:X} is not an instruction boundary for token 0x{methodToken:X}.";
+                return null;
+            }
+
+            var operand = ResolveInstructionOperand(reader, instruction);
+            var blockIndex = instructions.BlockIndexAt(ilOffset);
+            return new ILOffsetInstructionContextInfo(
+                ILOffset: ilOffset,
+                Boundary: "Exact",
+                Opcode: ILDisassembler.GetDisplayName(instruction.OpCode),
+                OperandKind: operand.Kind,
+                Operand: operand.Value,
+                OperandToken: operand.Token,
+                BranchTargets: instruction.BranchTargets.IsDefaultOrEmpty
+                    ? null
+                    : string.Join(", ", instruction.BranchTargets.Select(FormatILOffset)),
+                NextOffset: instruction.NextOffset,
+                Length: instruction.Length,
+                Block: blockIndex >= 0 ? blockIndex : null,
+                TerminatesBlock: instruction.TerminatesBlock,
+                FallsThrough: instruction.FallsThrough);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentOutOfRangeException)
+        {
+            error = $"Could not resolve instruction context for token 0x{methodToken:X}+0x{ilOffset:X}.";
+            return null;
+        }
+    }
+
     /// <summary>
     /// Resolves source file and line range for a specific method overload.
     /// </summary>
@@ -371,6 +450,51 @@ public class PdbContext : IDisposable
             HandleKind.TypeDefinition => reader.GetFullTypeName(reader.GetTypeDefinition((TypeDefinitionHandle)type.BaseType)),
             _ => null
         };
+
+    private static (string Kind, string? Value, string? Token) ResolveInstructionOperand(
+        MetadataReader reader,
+        DecodedInstruction instruction)
+    {
+        int token = (int)instruction.OperandValue;
+        return instruction.Operand switch
+        {
+            ILInspector.Instructions.OperandKind.None => ("None", null, null),
+            ILInspector.Instructions.OperandKind.InlineMethod => ("Method", ILTokenResolver.ResolveMethod(reader, token), FormatToken(token)),
+            ILInspector.Instructions.OperandKind.InlineField => ("Field", ILTokenResolver.ResolveField(reader, token), FormatToken(token)),
+            ILInspector.Instructions.OperandKind.InlineType => ("Type", ILTokenResolver.ResolveType(reader, token), FormatToken(token)),
+            ILInspector.Instructions.OperandKind.InlineString => ("String", ILTokenResolver.ResolveString(reader, token), FormatToken(token)),
+            ILInspector.Instructions.OperandKind.InlineTok => ("Token", ILTokenResolver.ResolveToken(reader, token), FormatToken(token)),
+            ILInspector.Instructions.OperandKind.InlineSig => ("Signature", FormatToken(token), FormatToken(token)),
+            ILInspector.Instructions.OperandKind.ShortInlineBrTarget or ILInspector.Instructions.OperandKind.InlineBrTarget
+                => ("Branch Target", FormatTargets(instruction), null),
+            ILInspector.Instructions.OperandKind.InlineSwitch => ("Switch Targets", FormatTargets(instruction), null),
+            ILInspector.Instructions.OperandKind.ShortInlineVar or ILInspector.Instructions.OperandKind.InlineVar
+                => (IsArgumentOpcode(instruction.OpCode) ? "Argument" : "Local", instruction.OperandValue.ToString(CultureInfo.InvariantCulture), null),
+            ILInspector.Instructions.OperandKind.ShortInlineI
+                or ILInspector.Instructions.OperandKind.InlineI
+                or ILInspector.Instructions.OperandKind.InlineI8
+                => ("Constant", instruction.OperandValue.ToString(CultureInfo.InvariantCulture), null),
+            ILInspector.Instructions.OperandKind.ShortInlineR
+                => ("Constant", BitConverter.Int32BitsToSingle((int)instruction.OperandValue).ToString(CultureInfo.InvariantCulture), null),
+            ILInspector.Instructions.OperandKind.InlineR
+                => ("Constant", BitConverter.Int64BitsToDouble(instruction.OperandValue).ToString(CultureInfo.InvariantCulture), null),
+            _ => (instruction.Operand.ToString(), instruction.OperandValue.ToString(CultureInfo.InvariantCulture), null)
+        };
+    }
+
+    private static bool IsArgumentOpcode(ILOpCode opcode)
+        => opcode is ILOpCode.Ldarg or ILOpCode.Ldarga or ILOpCode.Starg
+            or ILOpCode.Ldarg_s or ILOpCode.Ldarga_s or ILOpCode.Starg_s
+            or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3;
+
+    private static string? FormatTargets(DecodedInstruction instruction)
+        => instruction.BranchTargets.IsDefaultOrEmpty
+            ? null
+            : string.Join(", ", instruction.BranchTargets.Select(FormatILOffset));
+
+    private static string FormatILOffset(int offset) => $"IL_{offset:X4}";
+
+    private static string FormatToken(int token) => $"0x{token:X8}";
 
     /// <summary>
     /// Finds a type forwarder target assembly name for a given type.

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -36,6 +36,11 @@ public class CommandExecutionTests
         }
     }
 
+    private sealed class ILOffsetFloatFixture
+    {
+        public float FloatConstant() => 1.5f;
+    }
+
     private static (string PackagePath, string TempDir) CreateLocalRefPackage(params string[] assemblyNames)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"package-test-{Guid.NewGuid():N}");
@@ -4484,6 +4489,7 @@ public class CommandExecutionTests
                 "Health Checks",
                 "Hosting",
                 "HTTP Client",
+                "Instruction Context",
                 "Integration Opportunities",
                 "Integrations",
                 "Logging",
@@ -4571,6 +4577,7 @@ public class CommandExecutionTests
         Assert.Contains("| IL Offset | 0x0 |", output);
         Assert.Contains("HexConverter.cs", output);
         Assert.Contains("## Member Context", output);
+        Assert.Contains("## Instruction Context", output);
     }
 
     [Fact]
@@ -4630,8 +4637,10 @@ public class CommandExecutionTests
         Assert.Empty(withError);
         Assert.DoesNotContain("Source Location", withoutOutput);
         Assert.DoesNotContain("Member Context", withoutOutput);
+        Assert.DoesNotContain("Instruction Context", withoutOutput);
         Assert.Contains("Source Location", withOutput);
         Assert.Contains("Member Context", withOutput);
+        Assert.Contains("Instruction Context", withOutput);
     }
 
     [Fact]
@@ -4676,6 +4685,86 @@ public class CommandExecutionTests
         Assert.Empty(error);
         Assert.Contains("| Member | DotnetInspector.Tests.CommandExecutionTests.ILOffsetAsyncFixture.StateMachineAsync |", output);
         Assert.Contains("| Async | Runtime |", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetInstructionContext_RendersInstructionFacts()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x0", "-S", "Instruction Context", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Instruction Context", output);
+        Assert.Contains("| IL Offset | 0x0 |", output);
+        Assert.Contains("| Boundary | Exact |", output);
+        Assert.Contains("| Opcode | ldarg.0 |", output);
+        Assert.Contains("| Operand Kind | None |", output);
+        Assert.Contains("| Next Offset | 0x1 |", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetInstructionContext_ValueProjectsOpcode()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x0", "-S", "Instruction Context", "--fields", "Opcode", "--value", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Equal("ldarg.0", output.Trim());
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetInstructionContext_RequiresInstructionBoundary()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x2", "-S", "Instruction Context", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("not an instruction boundary", error);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetBareReport_RequiresInstructionBoundary()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x2", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("not an instruction boundary", error);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetMemberContext_AllowsNonInstructionBoundary()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x2", "-S", "Member Context", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Member Context", output);
+        Assert.Contains("| Member | System.HexConverter.FromChar |", output);
+        Assert.DoesNotContain("## Instruction Context", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetInstructionContext_FormatsFloatOperands()
+    {
+        var token = typeof(ILOffsetFloatFixture).GetMethod(nameof(ILOffsetFloatFixture.FloatConstant))!.MetadataToken;
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "--il-offset", $"0x{token:X}+0x0", "-S", "Instruction Context", "--fields", "Operand", "--value", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Equal("1.5", output.Trim());
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -251,7 +251,7 @@ public class SectionPipelineTests
     {
         var pipeline = LibrarySections.CreatePipeline();
 
-        Assert.Equal(38, pipeline.AllSectionNames.Length);
+        Assert.Equal(39, pipeline.AllSectionNames.Length);
         Assert.Contains("AI", pipeline.AllSectionNames);
         Assert.Contains("ASP.NET Core", pipeline.AllSectionNames);
         Assert.Contains("Aspire", pipeline.AllSectionNames);
@@ -261,6 +261,7 @@ public class SectionPipelineTests
         Assert.Contains("Health Checks", pipeline.AllSectionNames);
         Assert.Contains("Hosting", pipeline.AllSectionNames);
         Assert.Contains("HTTP Client", pipeline.AllSectionNames);
+        Assert.Contains("Instruction Context", pipeline.AllSectionNames);
         Assert.Contains("Source Location", pipeline.AllSectionNames);
         Assert.Contains("Member Context", pipeline.AllSectionNames);
         Assert.Contains("Integration Opportunities", pipeline.AllSectionNames);
@@ -287,7 +288,7 @@ public class SectionPipelineTests
         IReadOnlyCollection<string> discoverable)
     {
         var expected = command == "library"
-            ? registered.Except(["Source Location", "Member Context"], StringComparer.OrdinalIgnoreCase)
+            ? registered.Except(["Source Location", "Member Context", "Instruction Context"], StringComparer.OrdinalIgnoreCase)
             : registered;
         var missing = expected
             .Where(name => !discoverable.Contains(name, StringComparer.OrdinalIgnoreCase))
@@ -540,12 +541,15 @@ public class SectionPipelineTests
 
         Assert.DoesNotContain("Source Location", applicable);
         Assert.DoesNotContain("Member Context", applicable);
+        Assert.DoesNotContain("Instruction Context", applicable);
         Assert.DoesNotContain("Source Location", renderable);
         Assert.DoesNotContain("Member Context", renderable);
+        Assert.DoesNotContain("Instruction Context", renderable);
 
         model.ILOffset = new ILOffsetResult
         {
-            MemberContext = new ILOffsetMemberContext()
+            MemberContext = new ILOffsetMemberContext(),
+            InstructionContext = new ILOffsetInstructionContext()
         };
 
         applicable = pipeline.GetApplicableSections(model);
@@ -553,8 +557,10 @@ public class SectionPipelineTests
 
         Assert.Contains("Source Location", applicable);
         Assert.Contains("Member Context", applicable);
+        Assert.Contains("Instruction Context", applicable);
         Assert.Contains("Source Location", renderable);
         Assert.Contains("Member Context", renderable);
+        Assert.Contains("Instruction Context", renderable);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
+++ b/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
@@ -43,6 +43,13 @@ internal static class ILOffsetSourceQuery
             return (1, null);
         }
 
+        var instructionContext = pdbContext.ResolveInstructionContext(methodToken, ilOffset, out var instructionError);
+        if (instructionContext == null && RequiresInstructionContext(options))
+        {
+            Console.Error.WriteLine($"Error: {instructionError ?? $"Could not resolve instruction context for token 0x{methodToken:X}+0x{ilOffset:X}."}");
+            return (1, null);
+        }
+
         SourceLinkResolver.ILOffsetSourceInfo? result = null;
         if (RequiresSourceLocation(options))
         {
@@ -98,6 +105,21 @@ internal static class ILOffsetSourceQuery
                 Async = memberContext.Async,
                 MetadataToken = $"0x{memberContext.MetadataToken:X}",
                 ILOffset = $"0x{memberContext.ILOffset:X}"
+            },
+            InstructionContext = instructionContext is null ? null : new ILOffsetInstructionContext
+            {
+                ILOffset = $"0x{instructionContext.ILOffset:X}",
+                Boundary = instructionContext.Boundary,
+                Opcode = instructionContext.Opcode,
+                OperandKind = instructionContext.OperandKind,
+                Operand = instructionContext.Operand,
+                OperandToken = instructionContext.OperandToken,
+                BranchTargets = instructionContext.BranchTargets,
+                NextOffset = $"0x{instructionContext.NextOffset:X}",
+                Length = instructionContext.Length,
+                Block = instructionContext.Block,
+                TerminatesBlock = instructionContext.TerminatesBlock ? "Yes" : "No",
+                FallsThrough = instructionContext.FallsThrough ? "Yes" : "No"
             }
         };
 
@@ -106,6 +128,9 @@ internal static class ILOffsetSourceQuery
 
     private static bool RequiresSourceLocation(LibraryOptions options)
         => options.IncludeSections?.Contains(SectionNames.ILOffset) == true;
+
+    private static bool RequiresInstructionContext(LibraryOptions options)
+        => options.IncludeSections?.Contains(SectionNames.InstructionContext) == true;
 
     public static bool TryParse(string value, out int methodToken, out int ilOffset)
     {

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -92,7 +92,7 @@ public class LibraryCommand
             && options.IncludeSections is { Count: > 0 }
             && !options.IncludeSections.Overlaps(ILCoordinateSections))
         {
-            Console.Error.WriteLine("Error: --il-offset requires an IL coordinate section. Omit -S or include -S \"Source Location\" or -S \"Member Context\".");
+            Console.Error.WriteLine("Error: --il-offset requires an IL coordinate section. Omit -S or include -S \"Source Location\", -S \"Member Context\", or -S \"Instruction Context\".");
             return 1;
         }
 
@@ -440,6 +440,7 @@ public class LibraryCommand
         {
             select.Add(SectionNames.ILOffset);
             select.Add(SectionNames.MemberContext);
+            select.Add(SectionNames.InstructionContext);
         }
 
         return (options with
@@ -452,7 +453,8 @@ public class LibraryCommand
     private static readonly string[] ILCoordinateSections =
     [
         SectionNames.ILOffset,
-        SectionNames.MemberContext
+        SectionNames.MemberContext,
+        SectionNames.InstructionContext
     ];
 
     private static bool HasILOffsetCoordinate(LibraryOptions options)
@@ -511,12 +513,20 @@ public class LibraryCommand
     {
         if (!options.Count
             || options.IncludeSections is not { Count: 1 } sections
-            || !sections.Contains(SectionNames.ILOffset))
+            || !sections.Overlaps(ILCoordinateSections))
         {
             return false;
         }
 
-        Console.WriteLine(inspection.ILOffset is null ? 0 : 1);
+        var section = sections.Single();
+        var hasRow = section switch
+        {
+            SectionNames.ILOffset => inspection.ILOffset != null,
+            SectionNames.MemberContext => inspection.ILOffset?.MemberContext != null,
+            SectionNames.InstructionContext => inspection.ILOffset?.InstructionContext != null,
+            _ => false
+        };
+        Console.WriteLine(hasRow ? 1 : 0);
         return true;
     }
 
@@ -530,10 +540,11 @@ public class LibraryCommand
             "Library Info" => ProjectLibraryInfo(inspection, section, kind, options),
             SectionNames.ILOffset => ProjectLibraryILOffset(inspection, section, kind, options),
             SectionNames.MemberContext => ProjectLibraryMemberContext(inspection, section, kind, options),
+            SectionNames.InstructionContext => ProjectLibraryInstructionContext(inspection, section, kind, options),
             _ => []
         };
 
-        if (rows.Count == 0 && section == SectionNames.MemberContext)
+        if (rows.Count == 0 && section is SectionNames.MemberContext or SectionNames.InstructionContext)
         {
             if (kind != ShapeProjectionKind.Value)
                 Console.Error.WriteLine($"Error: section '{section}' does not expose {kind.ToString().ToLowerInvariant()} values.");
@@ -762,6 +773,50 @@ public class LibraryCommand
             "async" => context.Async,
             "metadata token" or "metadatatoken" or "token" => context.MetadataToken,
             "il offset" or "iloffset" => context.ILOffset,
+            _ => null
+        };
+
+    private static List<ShapeProjectionRow> ProjectLibraryInstructionContext(
+        LibraryInspection inspection,
+        string section,
+        ShapeProjectionKind kind,
+        LibraryOptions options)
+    {
+        if (kind != ShapeProjectionKind.Value || inspection.ILOffset?.InstructionContext is not { } context)
+            return [];
+
+        var field = options.Fields?.SingleOrDefault() ?? options.Columns?.SingleOrDefault();
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            Console.Error.WriteLine("Error: --value for Instruction Context requires --fields <name>.");
+            return [];
+        }
+
+        var value = SelectInstructionContextValue(context, field);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            Console.Error.WriteLine($"Error: field '{field}' has no value in Instruction Context.");
+            return [];
+        }
+
+        return [new ShapeProjectionRow(1, section, value, Label: field)];
+    }
+
+    private static string? SelectInstructionContextValue(ILOffsetInstructionContext context, string field)
+        => field.ToLowerInvariant() switch
+        {
+            "il offset" or "iloffset" => context.ILOffset,
+            "boundary" => context.Boundary,
+            "opcode" => context.Opcode,
+            "operand kind" or "operandkind" => context.OperandKind,
+            "operand" => context.Operand,
+            "operand token" or "operandtoken" or "token" => context.OperandToken,
+            "branch targets" or "branchtargets" => context.BranchTargets,
+            "next offset" or "nextoffset" => context.NextOffset,
+            "length" => context.Length?.ToString(CultureInfo.InvariantCulture),
+            "block" => context.Block?.ToString(CultureInfo.InvariantCulture),
+            "terminates block" or "terminatesblock" => context.TerminatesBlock,
+            "falls through" or "fallsthrough" => context.FallsThrough,
             _ => null
         };
 

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -502,6 +502,7 @@ public class ILOffsetResult
     public int? Line { get; init; }
     public string? Url { get; init; }
     public ILOffsetMemberContext? MemberContext { get; init; }
+    public ILOffsetInstructionContext? InstructionContext { get; init; }
 }
 
 public class ILOffsetMemberContext
@@ -517,6 +518,22 @@ public class ILOffsetMemberContext
     public string? Async { get; init; }
     public string? MetadataToken { get; init; }
     public string? ILOffset { get; init; }
+}
+
+public class ILOffsetInstructionContext
+{
+    public string? ILOffset { get; init; }
+    public string? Boundary { get; init; }
+    public string? Opcode { get; init; }
+    public string? OperandKind { get; init; }
+    public string? Operand { get; init; }
+    public string? OperandToken { get; init; }
+    public string? BranchTargets { get; init; }
+    public string? NextOffset { get; init; }
+    public int? Length { get; init; }
+    public int? Block { get; init; }
+    public string? TerminatesBlock { get; init; }
+    public string? FallsThrough { get; init; }
 }
 
 public sealed record SourceFileInfo(string Type, string? Url);

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -35,6 +35,7 @@ public static class LibrarySections
             .Add<LibraryInfo>()
             .Add<ILOffset>()
             .Add<MemberContext>()
+            .Add<InstructionContext>()
             .Add<SourceFiles>()
             .Add<SourceLinkAudit>(SourceLinkAuditApplicable)
             .Add<MissingSourceFiles>(SourceLinkAuditApplicable)
@@ -141,6 +142,15 @@ public static class LibrarySections
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => model.ILOffset?.MemberContext != null;
+    }
+
+    public sealed class InstructionContext : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.InstructionContext;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(LibraryInspection model) => model.ILOffset?.InstructionContext != null;
     }
 
     // ===== Symbol/provenance sections (network-capable, acceptable default cost) =====

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -108,6 +108,9 @@ public static class SectionNames
     /// <summary>Section for resolving a MethodDef token + IL offset to its owning member/type.</summary>
     public const string MemberContext = "Member Context";
 
+    /// <summary>Section for resolving a MethodDef token + IL offset to its exact IL instruction.</summary>
+    public const string InstructionContext = "Instruction Context";
+
     /// <summary>
     /// Section for the structured hidden-fact table: the same annotations the
     /// Decompiled Source view renders inline, as rows (id, category, detail, IL

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -475,6 +475,7 @@ public record PackageSourceFileRow(
 [MarkoutContext(typeof(PackageSourceFileRow))]
 [MarkoutContext(typeof(ILOffsetSection))]
 [MarkoutContext(typeof(ILOffsetMemberContextSection))]
+[MarkoutContext(typeof(ILOffsetInstructionContextSection))]
 [MarkoutContext(typeof(ManifestRow))]
 [MarkoutContext(typeof(RidPackageReferenceView))]
 [MarkoutContext(typeof(EmptyDepsView))]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -512,6 +512,27 @@ public class LibraryInspectionView
             ILOffset = context.ILOffset
         };
 
+    [MarkoutIgnore]
+    public bool HasILOffsetInstructionContext => _data.ILOffset?.InstructionContext != null;
+
+    [MarkoutSection(Name = SectionNames.InstructionContext, ShowWhenProperty = nameof(HasILOffsetInstructionContext))]
+    public ILOffsetInstructionContextSection? ILOffsetInstructionContextSection =>
+        _data.ILOffset?.InstructionContext is not { } context ? null : new ILOffsetInstructionContextSection
+        {
+            ILOffset = context.ILOffset,
+            Boundary = context.Boundary,
+            Opcode = context.Opcode,
+            OperandKind = context.OperandKind,
+            Operand = context.Operand,
+            OperandToken = context.OperandToken,
+            BranchTargets = context.BranchTargets,
+            NextOffset = context.NextOffset,
+            Length = context.Length,
+            Block = context.Block,
+            TerminatesBlock = context.TerminatesBlock,
+            FallsThrough = context.FallsThrough
+        };
+
     [MarkoutSection(Name = "SourceLink Availability", ShowWhenProperty = nameof(HasSourceLinkAudit))]
     public SourceLinkAuditSection? SourceLinkAuditSection => !HasSourceLinkAudit ? null : new SourceLinkAuditSection
     {
@@ -815,6 +836,31 @@ public class ILOffsetMemberContextSection
     public string? MetadataToken { get; init; }
     [MarkoutPropertyName("IL Offset")]
     public string? ILOffset { get; init; }
+}
+
+[MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords, FieldLayout = FieldLayout.Table)]
+[MarkoutSkipNull]
+public class ILOffsetInstructionContextSection
+{
+    [MarkoutPropertyName("IL Offset")]
+    public string? ILOffset { get; init; }
+    public string? Boundary { get; init; }
+    public string? Opcode { get; init; }
+    [MarkoutPropertyName("Operand Kind")]
+    public string? OperandKind { get; init; }
+    public string? Operand { get; init; }
+    [MarkoutPropertyName("Operand Token")]
+    public string? OperandToken { get; init; }
+    [MarkoutPropertyName("Branch Targets")]
+    public string? BranchTargets { get; init; }
+    [MarkoutPropertyName("Next Offset")]
+    public string? NextOffset { get; init; }
+    public int? Length { get; init; }
+    public int? Block { get; init; }
+    [MarkoutPropertyName("Terminates Block")]
+    public string? TerminatesBlock { get; init; }
+    [MarkoutPropertyName("Falls Through")]
+    public string? FallsThrough { get; init; }
 }
 
 [MarkoutSerializable]


### PR DESCRIPTION
## Summary

- Add coordinate-scoped `Instruction Context` for `library --il-offset`, backed by the shared `ILInspector.Instructions` substrate in the metadata layer.
- Include `Instruction Context` in bare `--il-offset` reports alongside `Source Location` and `Member Context`; `-S` still narrows.
- Enforce exact instruction-boundary behavior for `Instruction Context`, while preserving `Member Context` on non-boundary offsets.

Follow-up to #2005 and #2038.

## Example

```bash
dotnet-inspect library System.Text.Json --il-offset 0x06000001+0x0 -S "Instruction Context"
```

```md
## Instruction Context

| Field | Value |
| ----- | ----- |
| IL Offset | 0x0 |
| Boundary | Exact |
| Opcode | ldarg.0 |
| Operand Kind | None |
| Next Offset | 0x1 |
| Length | 1 |
| Block | 0 |
| Terminates Block | No |
| Falls Through | Yes |
```

A non-boundary offset fails only when `Instruction Context` is required:

```bash
dotnet-inspect library System.Text.Json --il-offset 0x06000001+0x2 -S "Instruction Context"
# Error: IL offset 0x2 is not an instruction boundary for token 0x6000001.
```

## Validation

- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json --nologo --verbosity quiet`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- -method "*IlOffset*"`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- -class DotnetInspector.Tests.SectionPipelineTests`
- `npx markdownlint-cli docs/design/output-shapes.md docs/workflows/features.md docs/workflows/getting-started/lap-around.md`

## Adversarial review

- Gemini 3.1 Pro found two issues before opening: float operands were rendered as integer bit patterns, and instruction-context failures blocked `Member Context` on non-boundary offsets. Fixed both and added regression tests.
- Claude Opus 4.8 found no blocking issues after those fixes; noted the intentional bare `--il-offset` non-boundary failure because bare mode now includes `Instruction Context`. Added an explicit regression test for that contract.
