### PR TITLE
Raise union switches with null arms

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -3354,6 +3354,34 @@ public class RaisingPassTests
     }
 
     [Fact]
+    public void UnionSwitchNullArm_ReadsPreserveDefaultInitializer()
+    {
+        // The null arm is a conditional value path. If it is skipped by the
+        // definite-assignment walk, the printer drops this required initializer.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var petType = TypeRef.Definition("Synthetic", "UnionFixtures", "Pet", ValueTypeHint.ValueType);
+        var catType = TypeRef.Definition("Synthetic", "UnionFixtures", "Cat");
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Return(new UnionSwitchExpression(
+            new LoadArgument(0, "pet", petType),
+            [new UnionSwitchExpressionArm(catType, null, new Constant(1, intType))],
+            nullValue: new LoadLocal(0, intType))));
+        container.Add(block);
+        var signature = new MethodSignature(
+            intType,
+            [new Parameter("pet", petType)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [intType], container);
+
+        string output = CSharpPrinter.Print(function).Output!;
+
+        Assert.Contains("int V_0 = default;", output);
+        Assert.Contains("null => V_0", output);
+    }
+
+    [Fact]
     public void LocalFunctionCall_DemanglesToSourceName()
     {
         // A call to the compiler-generated local function <Outer>g__Helper|0_0

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -322,6 +322,12 @@ public class TypeSourceComposerUnionTests
                         Cat => "cat",
                         Dog => "dog",
                     };
+                    public static string ValueSwitchNullDefault(Pet pet) => pet.Value switch
+                    {
+                        null => "null",
+                        Cat => "cat",
+                        _ => "other",
+                    };
                     public static string ValueSwitchNotOlderCat(Pet pet) => pet.Value switch
                     {
                         not Cat { Age: > 3 } => "not older cat",
@@ -398,6 +404,14 @@ public class TypeSourceComposerUnionTests
                 Dog => "dog",
             };
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "SwitchNull"));
+        Assert.Equal("""
+            return pet switch
+            {
+                null => "null",
+                Cat => "cat",
+                _ => "other",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNullDefault"));
         Assert.Equal("""
             if (pet is not Cat { Age: > 3 })
             {

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -310,6 +310,18 @@ public class TypeSourceComposerUnionTests
                         not null => "not null",
                         _ => "null",
                     };
+                    public static string ValueSwitchNull(Pet pet) => pet.Value switch
+                    {
+                        null => "null",
+                        Cat => "cat",
+                        Dog => "dog",
+                    };
+                    public static string SwitchNull(Pet pet) => pet switch
+                    {
+                        null => "null",
+                        Cat => "cat",
+                        Dog => "dog",
+                    };
                     public static string ValueSwitchNotOlderCat(Pet pet) => pet.Value switch
                     {
                         not Cat { Age: > 3 } => "not older cat",
@@ -370,6 +382,22 @@ public class TypeSourceComposerUnionTests
                 return "null";
             }
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNotNull"));
+        Assert.Equal("""
+            return pet switch
+            {
+                null => "null",
+                Cat => "cat",
+                Dog => "dog",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNull"));
+        Assert.Equal("""
+            return pet switch
+            {
+                null => "null",
+                Cat => "cat",
+                Dog => "dog",
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "SwitchNull"));
         Assert.Equal("""
             if (pet is not Cat { Age: > 3 })
             {
@@ -960,6 +988,13 @@ public class TypeSourceComposerUnionTests
                     not Cat { Name: "cat" } => "not named cat",
                     Cat => "cat",
                 };
+                public static string ValueSwitchNull(Pet pet) => pet.Value switch
+                {
+                    null => "null",
+                    Cat cat => cat.Name,
+                    Dog dog => dog.Name,
+                    _ => "other",
+                };
 
                 public static bool SideEffect() => true;
 
@@ -1073,6 +1108,9 @@ public class TypeSourceComposerUnionTests
         var classValueSwitchNotNamedCat = RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNotNamedCat");
         Assert.Contains("pet.Value as Cat", classValueSwitchNotNamedCat);
         Assert.Contains("V_1.Name == \"cat\"", classValueSwitchNotNamedCat);
+        var classValueSwitchNull = RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNull");
+        Assert.Contains("pet.Value", classValueSwitchNull);
+        Assert.DoesNotContain("return pet switch", classValueSwitchNull);
         var guardedOr = RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedOrSideEffect");
         Assert.DoesNotContain("pet is Cat cat || SideEffect() ? \"cat\" : \"other\"", guardedOr);
         Assert.Contains("if (", guardedOr);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -178,6 +178,8 @@ public sealed partial class CSharpPrinter
     string UnionSwitchExpressionInline(UnionSwitchExpression node, TypeRef? target = null)
     {
         var arms = node.Arms.Select(arm => UnionSwitchArmText(arm, target));
+        if (node.NullValue is { } nullValue)
+            arms = arms.Prepend($"null => {SwitchArmValueText(nullValue, target)}");
         if (node.DefaultValue is { } defaultValue)
             arms = arms.Append($"_ => {SwitchArmValueText(defaultValue, target)}");
         return $"{UnionSwitchReceiverText(node.Value)} switch {{ {string.Join(", ", arms)} }}";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1188,6 +1188,8 @@ public sealed partial class CSharpPrinter
             string inner = pad + "    ";
             sb.Append(pad).Append("return ").Append(UnionSwitchReceiverText(unionSwitch.Value)).AppendLine(" switch");
             sb.Append(pad).AppendLine("{");
+            if (unionSwitch.NullValue is { } nullValue)
+                sb.Append(inner).Append("null => ").Append(SwitchArmValueText(nullValue, _function.Signature.ReturnType)).AppendLine(",");
             foreach (var arm in unionSwitch.Arms)
                 sb.Append(inner).Append(UnionSwitchArmText(arm, _function.Signature.ReturnType)).AppendLine(",");
             if (unionSwitch.DefaultValue is { } defaultValue)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/DefiniteAssignment.cs
@@ -116,6 +116,11 @@ static class DefiniteAssignment
                         CheckReads(arm.Guard, armSet);
                         CheckReads(arm.Value, armSet);
                     }
+                    if (unionSwitch.NullValue is { } nullValue)
+                    {
+                        var nullSet = new HashSet<int>(assigned);
+                        CheckReads(nullValue, nullSet);
+                    }
                     if (unionSwitch.DefaultValue is { } defaultValue)
                     {
                         var defaultSet = new HashSet<int>(assigned);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -697,12 +697,22 @@ public sealed class SwitchExpressionArm : IrNode
 public sealed class UnionSwitchExpression : IrExpression
 {
     readonly bool _hasDefault;
+    readonly bool _hasNullArm;
 
-    public UnionSwitchExpression(IrExpression value, IEnumerable<UnionSwitchExpressionArm> arms, IrExpression? defaultValue = null)
+    public UnionSwitchExpression(
+        IrExpression value,
+        IEnumerable<UnionSwitchExpressionArm> arms,
+        IrExpression? defaultValue = null,
+        IrExpression? nullValue = null)
     {
         AddChild(value);
         foreach (var arm in arms)
             AddChild(arm);
+        if (nullValue is not null)
+        {
+            _hasNullArm = true;
+            AddChild(nullValue);
+        }
         if (defaultValue is not null)
         {
             _hasDefault = true;
@@ -712,13 +722,15 @@ public sealed class UnionSwitchExpression : IrExpression
 
     public IrExpression Value => (IrExpression)Children[0];
     public bool HasDefault => _hasDefault;
+    public bool HasNullArm => _hasNullArm;
     public IReadOnlyList<UnionSwitchExpressionArm> Arms
-        => Children.Skip(1).Take(Children.Count - 1 - (_hasDefault ? 1 : 0)).Cast<UnionSwitchExpressionArm>().ToList();
+        => Children.Skip(1).Take(Children.Count - 1 - (_hasNullArm ? 1 : 0) - (_hasDefault ? 1 : 0)).Cast<UnionSwitchExpressionArm>().ToList();
+    public IrExpression? NullValue => _hasNullArm ? (IrExpression)Children[Children.Count - 1 - (_hasDefault ? 1 : 0)] : null;
     public IrExpression? DefaultValue => _hasDefault ? (IrExpression)Children[^1] : null;
     public override TypeRef? ResultType
-        => Arms.Select(a => a.Value.ResultType).Append(DefaultValue?.ResultType).FirstOrDefault(t => t is not null);
+        => Arms.Select(a => a.Value.ResultType).Append(NullValue?.ResultType).Append(DefaultValue?.ResultType).FirstOrDefault(t => t is not null);
 
-    public override string Describe() => $"UnionSwitchExpression ({Arms.Count} arms{(_hasDefault ? " + default" : "")})";
+    public override string Describe() => $"UnionSwitchExpression ({Arms.Count} arms{(_hasNullArm ? " + null" : "")}{(_hasDefault ? " + default" : "")})";
 }
 
 /// <summary>One type-pattern arm of a <see cref="UnionSwitchExpression"/>.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -181,6 +181,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             || notNullIf.Then.Children.Count < 3
             || notNullIf.Then.Children[^2] is not ExpressionStatement throwStatement
             || !IsThrowSwitchExpression(throwStatement)
+            || !ThrowArgumentMatchesNullArm(throwStatement, valueStore.Index, unionValue.Instance)
             || notNullIf.Then.Children[^1] is not Return throwReturn
             || !ReturnsLocal(throwReturn, nullStore.Index))
         {
@@ -190,6 +191,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         var armNodes = notNullIf.Then.Children.Take(notNullIf.Then.Children.Count - 2).ToArray();
         if (!TryInnerArms(armNodes, valueStore.Index, nullStore.Index, out var arms)
             || !ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, [valueStore, notNullIf])
+            || !ReferenceOwnership.LocalReferencesOnlyWithin(function, nullStore.Index, [notNullIf, nullStore, nullReturn])
             || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
             || !DuplicateTypesAreGuarded(arms))
         {
@@ -1499,6 +1501,22 @@ public sealed class UnionSwitchExpressionPass : IIrPass
     static bool ThrowArgumentMatches(ExpressionStatement statement, IrExpression receiver)
         => statement.Expression is Call { Arguments: [var argument] }
         && PlaceIdentity.SameVariable(argument, receiver);
+
+    static bool ThrowArgumentMatchesNullArm(ExpressionStatement statement, int tempLocal, IrExpression? unionReceiver)
+        => statement.Expression is Call { Arguments: [var argument] }
+        && (argument is LoadLocal local && local.Index == tempLocal
+            || argument is Box { Operand: LoadArgument boxedArgument }
+                && unionReceiver is LoadArgumentAddress receiverArgument
+                && boxedArgument.Index == receiverArgument.Index
+            || argument is Box { Operand: LoadArgument boxedArgumentDirect }
+                && unionReceiver is LoadArgument receiverArgumentDirect
+                && boxedArgumentDirect.Index == receiverArgumentDirect.Index
+            || argument is Box { Operand: LoadLocal boxedLocal }
+                && unionReceiver is LoadLocalAddress receiverLocal
+                && boxedLocal.Index == receiverLocal.Index
+            || argument is Box { Operand: LoadLocal boxedLocalDirect }
+                && unionReceiver is LoadLocal receiverLocalDirect
+                && boxedLocalDirect.Index == receiverLocalDirect.Index);
 
     static bool IsUnionValueProperty(IrFunction function, LoadProperty property)
         => property.PropertyName == "Value"

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -169,12 +169,40 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         out UnionSwitchExpression switchExpression)
     {
         switchExpression = null!;
-        if (start + 4 != children.Count
+        if (start + 2 >= children.Count
             || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
             || !IsValueTypeUnionValueProperty(function, unionValue)
             || children[start + 1] is not IfStatement { HasElse: false } notNullIf
             || notNullIf.Condition is not LoadLocal conditionLocal
-            || conditionLocal.Index != valueStore.Index
+            || conditionLocal.Index != valueStore.Index)
+        {
+            return false;
+        }
+
+        if (start + 3 == children.Count
+            && children[start + 2] is Return { Value: { } directNullValue }
+            && TryReturnArmsWithDefault(notNullIf.Then.Children, valueStore.Index, out var defaultArms, out var defaultValue))
+        {
+            if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, [valueStore, notNullIf])
+                || defaultArms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+                || !DuplicateTypesAreGuarded(defaultArms))
+            {
+                return false;
+            }
+
+            switchExpression = new UnionSwitchExpression(
+                (IrExpression)unionValue.Clone(),
+                defaultArms.Select(arm => new UnionSwitchExpressionArm(
+                    arm.PatternType,
+                    arm.LocalIndex,
+                    (IrExpression)arm.Value.Clone(),
+                    arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+                (IrExpression)defaultValue.Clone(),
+                (IrExpression)directNullValue.Clone());
+            return true;
+        }
+
+        if (start + 4 != children.Count
             || children[start + 2] is not StoreLocal nullStore
             || children[start + 3] is not Return nullReturn
             || !StoreReturnMatch(nullStore, nullReturn, nullStore.Index)
@@ -1508,12 +1536,18 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             || argument is Box { Operand: LoadArgument boxedArgument }
                 && unionReceiver is LoadArgumentAddress receiverArgument
                 && boxedArgument.Index == receiverArgument.Index
+            || argument is Box { Operand: LoadIndirect { Address: LoadArgument boxedArgumentRef } }
+                && unionReceiver is LoadArgument receiverArgumentRef
+                && boxedArgumentRef.Index == receiverArgumentRef.Index
             || argument is Box { Operand: LoadArgument boxedArgumentDirect }
                 && unionReceiver is LoadArgument receiverArgumentDirect
                 && boxedArgumentDirect.Index == receiverArgumentDirect.Index
             || argument is Box { Operand: LoadLocal boxedLocal }
                 && unionReceiver is LoadLocalAddress receiverLocal
                 && boxedLocal.Index == receiverLocal.Index
+            || argument is Box { Operand: LoadIndirect { Address: LoadLocal boxedLocalRef } }
+                && unionReceiver is LoadLocal receiverLocalRef
+                && boxedLocalRef.Index == receiverLocalRef.Index
             || argument is Box { Operand: LoadLocal boxedLocalDirect }
                 && unionReceiver is LoadLocal receiverLocalDirect
                 && boxedLocalDirect.Index == receiverLocalDirect.Index);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -65,6 +65,12 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         var children = block.Children;
         for (int start = 0; start < children.Count; start++)
         {
+            if (TryMatchNullArmSwitchAt(function, children, start, out var nullArmSwitch))
+            {
+                match = new Match(start, nullArmSwitch);
+                return true;
+            }
+
             if (TryMatchDirectSwitchStatementReturnChainAt(function, children, start, out var directStatementSwitch))
             {
                 match = new Match(start, directStatementSwitch);
@@ -153,6 +159,51 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 (IrExpression)arm.Value.Clone(),
                 arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
             (IrExpression)defaultValue.Clone());
+        return true;
+    }
+
+    static bool TryMatchNullArmSwitchAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        if (start + 4 != children.Count
+            || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsValueTypeUnionValueProperty(function, unionValue)
+            || children[start + 1] is not IfStatement { HasElse: false } notNullIf
+            || notNullIf.Condition is not LoadLocal conditionLocal
+            || conditionLocal.Index != valueStore.Index
+            || children[start + 2] is not StoreLocal nullStore
+            || children[start + 3] is not Return nullReturn
+            || !StoreReturnMatch(nullStore, nullReturn, nullStore.Index)
+            || notNullIf.Then.Children.Count < 3
+            || notNullIf.Then.Children[^2] is not ExpressionStatement throwStatement
+            || !IsThrowSwitchExpression(throwStatement)
+            || notNullIf.Then.Children[^1] is not Return throwReturn
+            || !ReturnsLocal(throwReturn, nullStore.Index))
+        {
+            return false;
+        }
+
+        var armNodes = notNullIf.Then.Children.Take(notNullIf.Then.Children.Count - 2).ToArray();
+        if (!TryInnerArms(armNodes, valueStore.Index, nullStore.Index, out var arms)
+            || !ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, [valueStore, notNullIf])
+            || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+            || !DuplicateTypesAreGuarded(arms))
+        {
+            return false;
+        }
+
+        switchExpression = new UnionSwitchExpression(
+            (IrExpression)unionValue.Clone(),
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+            nullValue: (IrExpression)nullStore.Value.Clone());
         return true;
     }
 


### PR DESCRIPTION
- Fixes/advances #2044
- Changes value-type union switch-expression lowerings with explicit `null` arms into direct union-level switches, including `_` default fallbacks.
- Card revision: 6ccf498e

## Change

**Conclusion:** **REVIEW** - value-type union switches with explicit `null =>` arms now render directly, while explicit class-union `.Value` null switches stay flat to preserve null-receiver semantics.

Before:

```csharp
string V_0 = default;
object V_1 = pet.Value;
if (V_1 is not null)
{
    // type arms...
}
V_0 = "null";
return V_0;
```

After:

```csharp
return pet switch
{
    null => "null",
    Cat => "cat",
    _ => "other",
};
```

Also supported:

```csharp
return pet switch
{
    null => "null",
    Cat => "cat",
    Dog => "dog",
};
```

Near miss preserved for class unions:

```csharp
// explicit pet.Value stays explicit and does not become `return pet switch`
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --nologo --verbosity quiet -p:PublishAot=false -p:IsAotCompatible=false -p:WarningsNotAsErrors=NU1507` |
| Union fixtures | Pass: `TypeSourceComposerUnionTests/*` |
| Lowering coverage | Pass: `LoweringCoverageTests/*` |
| PR fast decompiler suite | Pass: `ILInspector.Decompiler.Tests -trait- "Speed=Slow"` |

## Decompiler quality

**Conclusion:** **ADVISORY** - this is a preview-SDK union fixture and targeted switch-expression raise; no real corpus union witnesses are currently known for a generated quality-diff card.

Highest local boss: Stage 6 altitude proof for the targeted Preview 6 explicit-null-arm union switch shape, backed by Stage 0 build/focused tests and PR fast suite.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Pending | Requested after PR open. |
| Gemini Pro | Pending | Requested after PR open. |

**Review conclusion:** **REVIEW** - adversarial review is pending and will be reconciled on the PR before ready-to-merge.
