### PR TITLE
Add IL offset exception context

### DIFF
--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -156,7 +156,8 @@ resolved coordinate can expose multiple sibling sections. The source-location
 section is useful as a human fact sheet, a row, a scalar, a URL, a path, or a
 source-line payload; the member-context section projects the same coordinate to
 the owning type and method; the instruction-context section projects it to the
-exact IL instruction.
+exact IL instruction; the exception-context section appears when the coordinate
+falls inside protected exception-handling regions.
 
 The default stays evidence-oriented and renders all applicable coordinate-scoped
 sections:
@@ -208,6 +209,12 @@ dotnet-inspect library My.dll --il-offset 0x06000002+0x1
 | Block | 0 |
 | Terminates Block | No |
 | Falls Through | Yes |
+
+## Exception Context
+
+| Region | Context | Clause | Try Range | Handler Range | Caught Type |
+| ------ | ------- | ------ | --------- | ------------- | ----------- |
+| 1 | try | catch | IL_0010..IL_0045 | IL_0045..IL_0070 | System.TimeoutException |
 ```
 
 Coordinate-scoped sections are discoverable only when the coordinate carrier is
@@ -215,12 +222,13 @@ present:
 
 ```bash
 dotnet-inspect library My.dll -D
-# Source Location, Member Context, and Instruction Context are omitted.
+# Source Location, Member Context, Instruction Context, and Exception Context are omitted.
 
 dotnet-inspect library My.dll --il-offset 0x06000002+0x1 -D
 # Source Location
 # Member Context
 # Instruction Context
+# Exception Context (only when applicable)
 ```
 
 The source-location section then projects cleanly:
@@ -254,9 +262,10 @@ dotnet-inspect library My.dll --il-offset 0x06000002+0x1 \
 
 This keeps the concerns separate: the default fact section shows all
 symbolication evidence, `Member Context` shows the owning metadata context,
-`Instruction Context` shows the exact IL operation, `--urls` returns the
-anchored source location, `--paths` returns the PDB document path, and `--print`
-returns the raw payload at the location rather than a decorated snippet.
+`Instruction Context` shows the exact IL operation, `Exception Context` shows
+active exception-handling regions, `--urls` returns the anchored source
+location, `--paths` returns the PDB document path, and `--print` returns the raw
+payload at the location rather than a decorated snippet.
 
 ## Design discipline for future flags
 

--- a/docs/workflows/features.md
+++ b/docs/workflows/features.md
@@ -212,7 +212,7 @@
 | IL (Annotated) section | — | 0.3.x | IL with stack state annotations |
 | Decompiled Source mixed view | — | 0.11.x | Decompiled Source becomes a mixed C#+IL view with hidden-fact comments (allocations, unsafety, lifetime) |
 | Facts section | — | 0.11.x | Structured hidden-fact table for one method (`-S "Facts"` / `--tsv`) |
-| `library --il-offset <token>+<offset>` | — | 0.13.0 | Map MethodDef token + IL offset to coordinate-scoped sections such as `Source Location`, `Member Context`, and `Instruction Context` |
+| `library --il-offset <token>+<offset>` | — | 0.13.0 | Map MethodDef token + IL offset to coordinate-scoped sections such as `Source Location`, `Member Context`, `Instruction Context`, and `Exception Context` |
 
 ## Plugin and Integration
 

--- a/docs/workflows/getting-started/lap-around.md
+++ b/docs/workflows/getting-started/lap-around.md
@@ -229,7 +229,7 @@ dotnet-inspect member JsonSerializer --platform System.Text.Json -m Serialize -S
 public static partial class JsonSerializer
 ```
 
-For stack-trace style diagnostics, `library --il-offset` maps a MethodDef token plus IL offset to coordinate-scoped sections such as `Source Location`, `Member Context`, and `Instruction Context`.
+For stack-trace style diagnostics, `library --il-offset` maps a MethodDef token plus IL offset to coordinate-scoped sections such as `Source Location`, `Member Context`, `Instruction Context`, and `Exception Context`.
 
 ```bash
 dotnet-inspect library --platform System.Text.Json --il-offset 0x06000001+0x0 --json

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -51,6 +51,18 @@ public record ILOffsetInstructionContextInfo(
     bool TerminatesBlock,
     bool FallsThrough);
 
+public record ILOffsetExceptionContextInfo(
+    int Region,
+    string Context,
+    string Clause,
+    int TryStart,
+    int TryEnd,
+    int HandlerStart,
+    int HandlerEnd,
+    int? FilterStart,
+    int? FilterEnd,
+    string? CaughtType);
+
 /// <summary>
 /// Wraps PE + PDB readers, exposes high-level operations with no SRM in public signatures.
 /// CLI orchestrates PDB acquisition (download via Packages), then calls back into this context.
@@ -353,6 +365,65 @@ public class PdbContext : IDisposable
         }
     }
 
+    public IReadOnlyList<ILOffsetExceptionContextInfo> ResolveExceptionContext(int methodToken, int ilOffset, out string? error)
+    {
+        error = null;
+        if (!_peReader.HasMetadata)
+            return [];
+
+        var handle = MetadataTokens.Handle(methodToken);
+        if (handle.Kind != HandleKind.MethodDefinition)
+        {
+            error = $"Token 0x{methodToken:X} is not a MethodDef token.";
+            return [];
+        }
+
+        try
+        {
+            var reader = _peReader.GetMetadataReader();
+            var method = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+            if (method.RelativeVirtualAddress == 0)
+            {
+                error = $"Method token 0x{methodToken:X} has no IL body.";
+                return [];
+            }
+
+            var body = _peReader.GetMethodBody(method.RelativeVirtualAddress);
+            List<ILOffsetExceptionContextInfo> rows = [];
+            var regions = body.ExceptionRegions;
+            for (var i = 0; i < regions.Length; i++)
+            {
+                var region = regions[i];
+                var tryEnd = region.TryOffset + region.TryLength;
+                var handlerEnd = region.HandlerOffset + region.HandlerLength;
+                int? filterStart = region.Kind == ExceptionRegionKind.Filter ? region.FilterOffset : null;
+                int? filterEnd = region.Kind == ExceptionRegionKind.Filter ? region.HandlerOffset : null;
+                var context = GetExceptionContext(region, ilOffset, tryEnd, handlerEnd, filterStart, filterEnd);
+                if (context is null)
+                    continue;
+
+                rows.Add(new ILOffsetExceptionContextInfo(
+                    Region: i + 1,
+                    Context: context,
+                    Clause: FormatExceptionClause(region.Kind),
+                    TryStart: region.TryOffset,
+                    TryEnd: tryEnd,
+                    HandlerStart: region.HandlerOffset,
+                    HandlerEnd: handlerEnd,
+                    FilterStart: filterStart,
+                    FilterEnd: filterEnd,
+                    CaughtType: ResolveCatchType(reader, region)));
+            }
+
+            return rows;
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentOutOfRangeException)
+        {
+            error = $"Could not resolve exception context for token 0x{methodToken:X}+0x{ilOffset:X}.";
+            return [];
+        }
+    }
+
     /// <summary>
     /// Resolves source file and line range for a specific method overload.
     /// </summary>
@@ -450,6 +521,45 @@ public class PdbContext : IDisposable
             HandleKind.TypeDefinition => reader.GetFullTypeName(reader.GetTypeDefinition((TypeDefinitionHandle)type.BaseType)),
             _ => null
         };
+
+    private static string? GetExceptionContext(
+        ExceptionRegion region,
+        int offset,
+        int tryEnd,
+        int handlerEnd,
+        int? filterStart,
+        int? filterEnd)
+    {
+        if (filterStart is { } fs && filterEnd is { } fe && offset >= fs && offset < fe)
+            return "filter";
+        if (offset >= region.HandlerOffset && offset < handlerEnd)
+            return region.Kind switch
+            {
+                ExceptionRegionKind.Catch => "catch handler",
+                ExceptionRegionKind.Filter => "filter handler",
+                ExceptionRegionKind.Finally => "finally handler",
+                ExceptionRegionKind.Fault => "fault handler",
+                _ => "handler"
+            };
+        if (offset >= region.TryOffset && offset < tryEnd)
+            return "try";
+        return null;
+    }
+
+    private static string FormatExceptionClause(ExceptionRegionKind kind)
+        => kind switch
+        {
+            ExceptionRegionKind.Catch => "catch",
+            ExceptionRegionKind.Filter => "filter",
+            ExceptionRegionKind.Finally => "finally",
+            ExceptionRegionKind.Fault => "fault",
+            _ => kind.ToString()
+        };
+
+    private static string? ResolveCatchType(MetadataReader reader, ExceptionRegion region)
+        => region.Kind == ExceptionRegionKind.Catch && !region.CatchType.IsNil
+            ? TypeResolver.GetTypeName(reader, region.CatchType)
+            : null;
 
     private static (string Kind, string? Value, string? Token) ResolveInstructionOperand(
         MetadataReader reader,

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -41,6 +41,21 @@ public class CommandExecutionTests
         public float FloatConstant() => 1.5f;
     }
 
+    private sealed class ILOffsetExceptionFixture
+    {
+        public int TryCatch(int value)
+        {
+            try
+            {
+                return 100 / value;
+            }
+            catch (DivideByZeroException)
+            {
+                return -1;
+            }
+        }
+    }
+
     private static (string PackagePath, string TempDir) CreateLocalRefPackage(params string[] assemblyNames)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"package-test-{Guid.NewGuid():N}");
@@ -4485,6 +4500,7 @@ public class CommandExecutionTests
                 "Configuration",
                 "Custom Attributes",
                 "Dependency Injection",
+                "Exception Context",
                 "Extension Methods",
                 "Health Checks",
                 "Hosting",
@@ -4638,6 +4654,7 @@ public class CommandExecutionTests
         Assert.DoesNotContain("Source Location", withoutOutput);
         Assert.DoesNotContain("Member Context", withoutOutput);
         Assert.DoesNotContain("Instruction Context", withoutOutput);
+        Assert.DoesNotContain("Exception Context", withoutOutput);
         Assert.Contains("Source Location", withOutput);
         Assert.Contains("Member Context", withOutput);
         Assert.Contains("Instruction Context", withOutput);
@@ -4765,6 +4782,35 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.Equal("1.5", output.Trim());
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetExceptionContext_RendersContainingRegion()
+    {
+        var token = typeof(ILOffsetExceptionFixture).GetMethod(nameof(ILOffsetExceptionFixture.TryCatch))!.MetadataToken;
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "--il-offset", $"0x{token:X}+0x1", "-S", "Exception Context", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Exception Context", output);
+        Assert.Contains("| Region | Context | Clause | Try Range | Handler Range |", output);
+        Assert.Contains("| 1 | try | catch |", output);
+        Assert.Contains("System.DivideByZeroException", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetExceptionContext_ValueProjectsClause()
+    {
+        var token = typeof(ILOffsetExceptionFixture).GetMethod(nameof(ILOffsetExceptionFixture.TryCatch))!.MetadataToken;
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "--il-offset", $"0x{token:X}+0x1", "-S", "Exception Context", "--fields", "Clause", "--value", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Equal("catch", output.Trim());
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -251,13 +251,14 @@ public class SectionPipelineTests
     {
         var pipeline = LibrarySections.CreatePipeline();
 
-        Assert.Equal(39, pipeline.AllSectionNames.Length);
+        Assert.Equal(40, pipeline.AllSectionNames.Length);
         Assert.Contains("AI", pipeline.AllSectionNames);
         Assert.Contains("ASP.NET Core", pipeline.AllSectionNames);
         Assert.Contains("Aspire", pipeline.AllSectionNames);
         Assert.Contains("Authentication", pipeline.AllSectionNames);
         Assert.Contains("Configuration", pipeline.AllSectionNames);
         Assert.Contains("Dependency Injection", pipeline.AllSectionNames);
+        Assert.Contains("Exception Context", pipeline.AllSectionNames);
         Assert.Contains("Health Checks", pipeline.AllSectionNames);
         Assert.Contains("Hosting", pipeline.AllSectionNames);
         Assert.Contains("HTTP Client", pipeline.AllSectionNames);
@@ -288,7 +289,7 @@ public class SectionPipelineTests
         IReadOnlyCollection<string> discoverable)
     {
         var expected = command == "library"
-            ? registered.Except(["Source Location", "Member Context", "Instruction Context"], StringComparer.OrdinalIgnoreCase)
+            ? registered.Except(["Source Location", "Member Context", "Instruction Context", "Exception Context"], StringComparer.OrdinalIgnoreCase)
             : registered;
         var missing = expected
             .Where(name => !discoverable.Contains(name, StringComparer.OrdinalIgnoreCase))
@@ -542,14 +543,17 @@ public class SectionPipelineTests
         Assert.DoesNotContain("Source Location", applicable);
         Assert.DoesNotContain("Member Context", applicable);
         Assert.DoesNotContain("Instruction Context", applicable);
+        Assert.DoesNotContain("Exception Context", applicable);
         Assert.DoesNotContain("Source Location", renderable);
         Assert.DoesNotContain("Member Context", renderable);
         Assert.DoesNotContain("Instruction Context", renderable);
+        Assert.DoesNotContain("Exception Context", renderable);
 
         model.ILOffset = new ILOffsetResult
         {
             MemberContext = new ILOffsetMemberContext(),
-            InstructionContext = new ILOffsetInstructionContext()
+            InstructionContext = new ILOffsetInstructionContext(),
+            ExceptionContext = [new ILOffsetExceptionContext()]
         };
 
         applicable = pipeline.GetApplicableSections(model);
@@ -558,9 +562,11 @@ public class SectionPipelineTests
         Assert.Contains("Source Location", applicable);
         Assert.Contains("Member Context", applicable);
         Assert.Contains("Instruction Context", applicable);
+        Assert.Contains("Exception Context", applicable);
         Assert.Contains("Source Location", renderable);
         Assert.Contains("Member Context", renderable);
         Assert.Contains("Instruction Context", renderable);
+        Assert.Contains("Exception Context", renderable);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
+++ b/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
@@ -50,6 +50,13 @@ internal static class ILOffsetSourceQuery
             return (1, null);
         }
 
+        var exceptionContext = pdbContext.ResolveExceptionContext(methodToken, ilOffset, out var exceptionError);
+        if (exceptionError is not null && RequiresExceptionContext(options))
+        {
+            Console.Error.WriteLine($"Error: {exceptionError}");
+            return (1, null);
+        }
+
         SourceLinkResolver.ILOffsetSourceInfo? result = null;
         if (RequiresSourceLocation(options))
         {
@@ -120,7 +127,21 @@ internal static class ILOffsetSourceQuery
                 Block = instructionContext.Block,
                 TerminatesBlock = instructionContext.TerminatesBlock ? "Yes" : "No",
                 FallsThrough = instructionContext.FallsThrough ? "Yes" : "No"
-            }
+            },
+            ExceptionContext = exceptionContext
+                .Select(context => new ILOffsetExceptionContext
+                {
+                    Region = context.Region,
+                    Context = context.Context,
+                    Clause = context.Clause,
+                    TryRange = FormatILRange(context.TryStart, context.TryEnd),
+                    HandlerRange = FormatILRange(context.HandlerStart, context.HandlerEnd),
+                    FilterRange = context.FilterStart is { } fs && context.FilterEnd is { } fe
+                        ? FormatILRange(fs, fe)
+                        : null,
+                    CaughtType = context.CaughtType
+                })
+                .ToList()
         };
 
         return (0, resolved);
@@ -131,6 +152,11 @@ internal static class ILOffsetSourceQuery
 
     private static bool RequiresInstructionContext(LibraryOptions options)
         => options.IncludeSections?.Contains(SectionNames.InstructionContext) == true;
+
+    private static bool RequiresExceptionContext(LibraryOptions options)
+        => options.IncludeSections?.Contains(SectionNames.ExceptionContext) == true;
+
+    private static string FormatILRange(int start, int end) => $"IL_{start:X4}..IL_{end:X4}";
 
     public static bool TryParse(string value, out int methodToken, out int ilOffset)
     {

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -92,7 +92,7 @@ public class LibraryCommand
             && options.IncludeSections is { Count: > 0 }
             && !options.IncludeSections.Overlaps(ILCoordinateSections))
         {
-            Console.Error.WriteLine("Error: --il-offset requires an IL coordinate section. Omit -S or include -S \"Source Location\", -S \"Member Context\", or -S \"Instruction Context\".");
+            Console.Error.WriteLine("Error: --il-offset requires an IL coordinate section. Omit -S or include -S \"Source Location\", -S \"Member Context\", -S \"Instruction Context\", or -S \"Exception Context\".");
             return 1;
         }
 
@@ -441,6 +441,7 @@ public class LibraryCommand
             select.Add(SectionNames.ILOffset);
             select.Add(SectionNames.MemberContext);
             select.Add(SectionNames.InstructionContext);
+            select.Add(SectionNames.ExceptionContext);
         }
 
         return (options with
@@ -451,6 +452,14 @@ public class LibraryCommand
     }
 
     private static readonly string[] ILCoordinateSections =
+    [
+        SectionNames.ILOffset,
+        SectionNames.MemberContext,
+        SectionNames.InstructionContext,
+        SectionNames.ExceptionContext
+    ];
+
+    private static readonly string[] ILCoordinateSingletonSections =
     [
         SectionNames.ILOffset,
         SectionNames.MemberContext,
@@ -513,7 +522,7 @@ public class LibraryCommand
     {
         if (!options.Count
             || options.IncludeSections is not { Count: 1 } sections
-            || !sections.Overlaps(ILCoordinateSections))
+            || !sections.Overlaps(ILCoordinateSingletonSections))
         {
             return false;
         }
@@ -541,10 +550,11 @@ public class LibraryCommand
             SectionNames.ILOffset => ProjectLibraryILOffset(inspection, section, kind, options),
             SectionNames.MemberContext => ProjectLibraryMemberContext(inspection, section, kind, options),
             SectionNames.InstructionContext => ProjectLibraryInstructionContext(inspection, section, kind, options),
+            SectionNames.ExceptionContext => ProjectLibraryExceptionContext(inspection, section, kind, options),
             _ => []
         };
 
-        if (rows.Count == 0 && section is SectionNames.MemberContext or SectionNames.InstructionContext)
+        if (rows.Count == 0 && section is SectionNames.MemberContext or SectionNames.InstructionContext or SectionNames.ExceptionContext)
         {
             if (kind != ShapeProjectionKind.Value)
                 Console.Error.WriteLine($"Error: section '{section}' does not expose {kind.ToString().ToLowerInvariant()} values.");
@@ -817,6 +827,49 @@ public class LibraryCommand
             "block" => context.Block?.ToString(CultureInfo.InvariantCulture),
             "terminates block" or "terminatesblock" => context.TerminatesBlock,
             "falls through" or "fallsthrough" => context.FallsThrough,
+            _ => null
+        };
+
+    private static List<ShapeProjectionRow> ProjectLibraryExceptionContext(
+        LibraryInspection inspection,
+        string section,
+        ShapeProjectionKind kind,
+        LibraryOptions options)
+    {
+        if (kind != ShapeProjectionKind.Value || inspection.ILOffset?.ExceptionContext is not { Count: > 0 } rows)
+            return [];
+
+        var field = options.Fields?.SingleOrDefault() ?? options.Columns?.SingleOrDefault();
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            Console.Error.WriteLine("Error: --value for Exception Context requires --fields <name>.");
+            return [];
+        }
+
+        List<ShapeProjectionRow> projected = [];
+        for (var i = 0; i < rows.Count; i++)
+        {
+            var value = SelectExceptionContextValue(rows[i], field);
+            if (!string.IsNullOrWhiteSpace(value))
+                projected.Add(new ShapeProjectionRow(i + 1, section, value, Label: field));
+        }
+
+        if (projected.Count == 0)
+            Console.Error.WriteLine($"Error: field '{field}' has no value in Exception Context.");
+
+        return projected;
+    }
+
+    private static string? SelectExceptionContextValue(ILOffsetExceptionContext context, string field)
+        => field.ToLowerInvariant() switch
+        {
+            "region" => context.Region.ToString(CultureInfo.InvariantCulture),
+            "context" => context.Context,
+            "clause" => context.Clause,
+            "try range" or "tryrange" => context.TryRange,
+            "handler range" or "handlerrange" => context.HandlerRange,
+            "filter range" or "filterrange" => context.FilterRange,
+            "caught type" or "caughttype" => context.CaughtType,
             _ => null
         };
 

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -503,6 +503,7 @@ public class ILOffsetResult
     public string? Url { get; init; }
     public ILOffsetMemberContext? MemberContext { get; init; }
     public ILOffsetInstructionContext? InstructionContext { get; init; }
+    public List<ILOffsetExceptionContext>? ExceptionContext { get; init; }
 }
 
 public class ILOffsetMemberContext
@@ -534,6 +535,17 @@ public class ILOffsetInstructionContext
     public int? Block { get; init; }
     public string? TerminatesBlock { get; init; }
     public string? FallsThrough { get; init; }
+}
+
+public class ILOffsetExceptionContext
+{
+    public int Region { get; init; }
+    public string? Context { get; init; }
+    public string? Clause { get; init; }
+    public string? TryRange { get; init; }
+    public string? HandlerRange { get; init; }
+    public string? FilterRange { get; init; }
+    public string? CaughtType { get; init; }
 }
 
 public sealed record SourceFileInfo(string Type, string? Url);

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -36,6 +36,7 @@ public static class LibrarySections
             .Add<ILOffset>()
             .Add<MemberContext>()
             .Add<InstructionContext>()
+            .Add<ExceptionContext>()
             .Add<SourceFiles>()
             .Add<SourceLinkAudit>(SourceLinkAuditApplicable)
             .Add<MissingSourceFiles>(SourceLinkAuditApplicable)
@@ -151,6 +152,15 @@ public static class LibrarySections
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => model.ILOffset?.InstructionContext != null;
+    }
+
+    public sealed class ExceptionContext : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.ExceptionContext;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(LibraryInspection model) => model.ILOffset?.ExceptionContext is { Count: > 0 };
     }
 
     // ===== Symbol/provenance sections (network-capable, acceptable default cost) =====

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -111,6 +111,9 @@ public static class SectionNames
     /// <summary>Section for resolving a MethodDef token + IL offset to its exact IL instruction.</summary>
     public const string InstructionContext = "Instruction Context";
 
+    /// <summary>Section for resolving a MethodDef token + IL offset to containing exception regions.</summary>
+    public const string ExceptionContext = "Exception Context";
+
     /// <summary>
     /// Section for the structured hidden-fact table: the same annotations the
     /// Decompiled Source view renders inline, as rows (id, category, detail, IL

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -476,6 +476,7 @@ public record PackageSourceFileRow(
 [MarkoutContext(typeof(ILOffsetSection))]
 [MarkoutContext(typeof(ILOffsetMemberContextSection))]
 [MarkoutContext(typeof(ILOffsetInstructionContextSection))]
+[MarkoutContext(typeof(ILOffsetExceptionContextRow))]
 [MarkoutContext(typeof(ManifestRow))]
 [MarkoutContext(typeof(RidPackageReferenceView))]
 [MarkoutContext(typeof(EmptyDepsView))]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -533,6 +533,22 @@ public class LibraryInspectionView
             FallsThrough = context.FallsThrough
         };
 
+    [MarkoutIgnore]
+    public bool HasILOffsetExceptionContext => _data.ILOffset?.ExceptionContext is { Count: > 0 };
+
+    [MarkoutSection(Name = SectionNames.ExceptionContext, ShowWhenProperty = nameof(HasILOffsetExceptionContext))]
+    public List<ILOffsetExceptionContextRow>? ILOffsetExceptionContextSection =>
+        _data.ILOffset?.ExceptionContext?
+            .Select(context => new ILOffsetExceptionContextRow(
+                context.Region,
+                context.Context,
+                context.Clause,
+                context.TryRange,
+                context.HandlerRange,
+                context.FilterRange,
+                context.CaughtType))
+            .ToList();
+
     [MarkoutSection(Name = "SourceLink Availability", ShowWhenProperty = nameof(HasSourceLinkAudit))]
     public SourceLinkAuditSection? SourceLinkAuditSection => !HasSourceLinkAudit ? null : new SourceLinkAuditSection
     {
@@ -862,6 +878,20 @@ public class ILOffsetInstructionContextSection
     [MarkoutPropertyName("Falls Through")]
     public string? FallsThrough { get; init; }
 }
+
+[MarkoutSerializable]
+public record ILOffsetExceptionContextRow(
+    int Region,
+    [property: MarkoutSkipNull] string? Context,
+    [property: MarkoutSkipNull] string? Clause,
+    [property: MarkoutPropertyName("Try Range")]
+    [property: MarkoutSkipNull] string? TryRange,
+    [property: MarkoutPropertyName("Handler Range")]
+    [property: MarkoutSkipNull] string? HandlerRange,
+    [property: MarkoutPropertyName("Filter Range")]
+    [property: MarkoutSkipNull] string? FilterRange,
+    [property: MarkoutPropertyName("Caught Type")]
+    [property: MarkoutSkipNull] string? CaughtType);
 
 [MarkoutSerializable]
 public record ResourceRow(


### PR DESCRIPTION
## Summary

- Add coordinate-scoped `Exception Context` for `library --il-offset`, backed by SRM method-body exception regions.
- Auto-render `Exception Context` only when the coordinate falls inside try/filter/handler/finally/fault regions; `-S` can narrow to it.
- Support row projection for exception fields such as `Clause`, `Context`, ranges, and caught type.

Follow-up to #2005 and #2041.

## Example

```bash
dotnet-inspect library My.dll --il-offset 0x06000042+0x1 -S "Exception Context"
```

```md
## Exception Context

| Region | Context | Clause | Try Range | Handler Range | Caught Type |
| ------ | ------- | ------ | --------- | ------------- | ----------- |
| 1 | try | catch | IL_0001..IL_0009 | IL_0009..IL_000F | System.DivideByZeroException |
```

The same region reports the handler side differently when the queried offset is
inside the catch body:

```md
## Exception Context

| Region | Context | Clause | Try Range | Handler Range | Caught Type |
| ------ | ------- | ------ | --------- | ------------- | ----------- |
| 1 | catch handler | catch | IL_0001..IL_0009 | IL_0009..IL_000F | System.DivideByZeroException |
```

A `finally` is the same protected-region shape with a different clause:

```md
## Exception Context

| Region | Context | Clause | Try Range | Handler Range |
| ------ | ------- | ------ | --------- | ------------- |
| 1 | finally handler | finally | IL_0010..IL_0020 | IL_0020..IL_0028 |
```

`Region` is most useful when multiple EH regions contain the same offset. For
example, an offset inside an inner `try` that is itself protected by an outer
`catch` can produce multiple rows:

```csharp
try
{
    try
    {
        Work();
    }
    finally
    {
        CleanupInner();
    }
}
catch (Exception)
{
    Handle();
}
```

```md
## Exception Context

| Region | Context | Clause | Try Range | Handler Range | Caught Type |
| ------ | ------- | ------ | --------- | ------------- | ----------- |
| 1 | try | catch | IL_0000..IL_0030 | IL_0030..IL_0048 | System.Exception |
| 2 | try | finally | IL_0008..IL_0018 | IL_0018..IL_0028 | |
```

Projection works on the selected row data as usual:

```bash
dotnet-inspect library My.dll --il-offset 0x06000042+0x1 \
  -S "Exception Context" --fields Clause --value
```

```text
catch
```

## Validation

- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json --nologo --verbosity quiet`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- -method "*IlOffset*"`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- -class DotnetInspector.Tests.SectionPipelineTests`
- `npx markdownlint-cli docs/design/output-shapes.md docs/workflows/features.md docs/workflows/getting-started/lap-around.md`

## Adversarial review

- Gemini 3.1 Pro: no significant issues.
- Claude Opus 4.8: found that the new tests used offset `+0x0`, which can be outside the try region in Debug builds, and noted a stale guidance string. Fixed tests to use `+0x1` and updated the guidance to include `Exception Context`.
