### PR TITLE
Add avoidable loop allocation triage shapes

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -6,6 +6,8 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using ILInspector.Analysis;
+using ILInspector.ControlFlow;
+using ILInspector.Instructions;
 
 namespace ILInspector.Analysis.Tests;
 
@@ -1378,6 +1380,39 @@ public class LibraryBodyIndexTests
         Assert.Contains("System.Collections.Generic.List<int>", row.Evidence, StringComparison.Ordinal);
         Assert.Contains("Add", row.Evidence, StringComparison.Ordinal);
         Assert.Contains("Pre-size", row.SafeFixDirection, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_NaturalLoopDetection_HandlesDeepCfgWithoutRecursion()
+    {
+        const int BlockCount = 30_000;
+        var blocks = ImmutableArray.CreateBuilder<InstructionBlock>(BlockCount);
+        for (int i = 0; i < BlockCount; i++)
+        {
+            blocks.Add(new InstructionBlock(
+                i,
+                i,
+                i + 1,
+                new BlockEdges(
+                    i + 1 < BlockCount ? [i + 1] : [],
+                    [],
+                    i + 1 == BlockCount,
+                    LeavesRegion: false)));
+        }
+
+        var graph = new BlockGraph(blocks.ToImmutable(), [], IsComplete: true, IncompleteReason: null);
+        var decodedBodyType = typeof(LibraryBodyIndex)
+            .GetNestedType("IndexBuilder", BindingFlags.NonPublic)!
+            .GetNestedType("DecodedBody", BindingFlags.NonPublic)!;
+        var ctor = decodedBodyType.GetConstructor(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            [typeof(ImmutableArray<DecodedInstruction>), typeof(BlockGraph)],
+            modifiers: null)!;
+
+        var decodedBody = ctor.Invoke([ImmutableArray<DecodedInstruction>.Empty, graph]);
+        var loops = (System.Collections.IEnumerable)decodedBodyType.GetProperty("NaturalLoops")!.GetValue(decodedBody)!;
+        Assert.Empty(loops.Cast<object>());
     }
 
     [Fact]

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1425,6 +1425,37 @@ public class LibraryBodyIndexTests
         Assert.Contains("cold path", row.Caveat, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void OptimizationOpportunities_StringSliceInLoop_Fires()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var row = Assert.Single(StringSliceRows(index, nameof(OptimizationOpportunityFixtures.SubstringInLoop)));
+        Assert.True(row.InLoop);
+        Assert.Equal("medium", row.Confidence);
+        Assert.Contains("System.String::Substring", row.Evidence, StringComparison.Ordinal);
+        Assert.Contains("AsSpan", row.SafeFixDirection, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_StringSliceOutsideLoop_DoesNotFire()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.Empty(StringSliceRows(index, nameof(OptimizationOpportunityFixtures.SubstringOnce)));
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_StringSliceOnThrowHelperPath_IsLowAdvisory()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var row = Assert.Single(StringSliceRows(index, nameof(OptimizationOpportunityFixtures.SubstringInLoopBeforeThrow)));
+        Assert.Equal("low", row.Confidence);
+        Assert.True(row.ColdPath);
+        Assert.Contains("cold path", row.Caveat, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     // Non-loop delegate on a high-reach method -> lifted from low to medium.
     [InlineData("capturing-delegate", false, "low", LibraryBodyIndex.DelegateHotRootReach, "medium")]
@@ -1814,6 +1845,11 @@ public class LibraryBodyIndexTests
     static System.Collections.Generic.List<OptimizationOpportunity> UnsizedCollectionRows(LibraryBodyIndex index, string methodName)
         => index.OptimizationOpportunities
             .Where(o => o.Method.Name == methodName && o.Shape == "unsized-collection-grown")
+            .ToList();
+
+    static System.Collections.Generic.List<OptimizationOpportunity> StringSliceRows(LibraryBodyIndex index, string methodName)
+        => index.OptimizationOpportunities
+            .Where(o => o.Method.Name == methodName && o.Shape == "string-slice-in-loop")
             .ToList();
 
     [Fact]
@@ -2867,6 +2903,25 @@ public class OptimizationOpportunityFixtures
         foreach (var value in values)
             builder.Append(value);
         throw new InvalidOperationException(builder.ToString());
+    }
+
+    public static int SubstringInLoop(string[] values)
+    {
+        var total = 0;
+        foreach (var value in values)
+            total += value.Substring(1).Length;
+        return total;
+    }
+
+    public static int SubstringOnce(string value)
+        => value.Substring(1).Length;
+
+    public static void SubstringInLoopBeforeThrow(string[] values)
+    {
+        var total = 0;
+        foreach (var value in values)
+            total += value.Substring(1).Length;
+        throw new InvalidOperationException(total.ToString());
     }
 
     static void ReplaceSource(ref IEnumerable<int> source, IEnumerable<int> replacement)

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1399,6 +1399,22 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_UnsizedCollectionGrownInLoop_RejectsEnsureCapacityBeforeLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.Empty(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.EnsureCapacityListGrownInLoop)));
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_UnsizedCollectionGrownInLoop_RejectsCapacitySetterBeforeLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.Empty(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.CapacitySetterListGrownInLoop)));
+    }
+
+    [Fact]
     public void OptimizationOpportunities_UnsizedCollectionGrownOutsideLoop_DoesNotFire()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -1446,6 +1462,14 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_NoOpSubstringInLoop_DoesNotFire()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.Empty(StringSliceRows(index, nameof(OptimizationOpportunityFixtures.NoOpSubstringInLoop)));
+    }
+
+    [Fact]
     public void OptimizationOpportunities_StringSliceOnThrowHelperPath_IsLowAdvisory()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -1454,6 +1478,16 @@ public class LibraryBodyIndexTests
         Assert.Equal("low", row.Confidence);
         Assert.True(row.ColdPath);
         Assert.Contains("cold path", row.Caveat, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_StringSliceInFinally_StaysMedium()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var row = Assert.Single(StringSliceRows(index, nameof(OptimizationOpportunityFixtures.SubstringInFinally)));
+        Assert.Equal("medium", row.Confidence);
+        Assert.False(row.ColdPath);
     }
 
     [Theory]
@@ -2876,6 +2910,24 @@ public class OptimizationOpportunityFixtures
         return list;
     }
 
+    public static System.Collections.Generic.List<int> EnsureCapacityListGrownInLoop(int[] values)
+    {
+        var list = new System.Collections.Generic.List<int>();
+        list.EnsureCapacity(values.Length);
+        foreach (var value in values)
+            list.Add(value);
+        return list;
+    }
+
+    public static System.Collections.Generic.List<int> CapacitySetterListGrownInLoop(int[] values)
+    {
+        var list = new System.Collections.Generic.List<int>();
+        list.Capacity = values.Length;
+        foreach (var value in values)
+            list.Add(value);
+        return list;
+    }
+
     public static System.Collections.Generic.List<int> UnsizedListGrownOnce(int value)
     {
         var list = new System.Collections.Generic.List<int>();
@@ -2916,12 +2968,38 @@ public class OptimizationOpportunityFixtures
     public static int SubstringOnce(string value)
         => value.Substring(1).Length;
 
+    public static int NoOpSubstringInLoop(string[] values)
+    {
+        var total = 0;
+        foreach (var value in values)
+        {
+            total += value.Substring(0).Length;
+            total += value.Substring(0, value.Length).Length;
+        }
+        return total;
+    }
+
     public static void SubstringInLoopBeforeThrow(string[] values)
     {
         var total = 0;
         foreach (var value in values)
             total += value.Substring(1).Length;
         throw new InvalidOperationException(total.ToString());
+    }
+
+    public static int SubstringInFinally(string[] values)
+    {
+        var total = 0;
+        try
+        {
+            GC.KeepAlive(values);
+        }
+        finally
+        {
+            foreach (var value in values)
+                total += value.Substring(1).Length;
+        }
+        return total;
     }
 
     static void ReplaceSource(ref IEnumerable<int> source, IEnumerable<int> replacement)

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1415,6 +1415,22 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_UnsizedCollectionGrownInLoop_RejectsTernarySizedOrUnsizedCtor()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.Empty(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.TernarySizedOrUnsizedListGrownInLoop)));
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_UnsizedCollectionGrownInLexicalButNotNaturalLoop_DoesNotFire()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.Empty(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.LexicalButNotNaturalLoop)));
+    }
+
+    [Fact]
     public void OptimizationOpportunities_UnsizedCollectionGrownOutsideLoop_DoesNotFire()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -1435,10 +1451,20 @@ public class LibraryBodyIndexTests
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 
-        var row = Assert.Single(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.UnsizedStringBuilderGrownBeforeThrow)));
+        var row = Assert.Single(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.ThrowUnsizedStringBuilderGrown)));
         Assert.Equal("low", row.Confidence);
         Assert.True(row.ColdPath);
         Assert.Contains("cold path", row.Caveat, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_UnsizedCollectionInInfiniteLoopWithConditionalThrow_StaysMedium()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var row = Assert.Single(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.UnsizedListGrownInInfiniteLoopBeforeConditionalThrow)));
+        Assert.Equal("medium", row.Confidence);
+        Assert.False(row.ColdPath);
     }
 
     [Fact]
@@ -1470,11 +1496,19 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_StringSliceInLexicalButNotNaturalLoop_DoesNotFire()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.Empty(StringSliceRows(index, nameof(OptimizationOpportunityFixtures.LexicalButNotNaturalLoop)));
+    }
+
+    [Fact]
     public void OptimizationOpportunities_StringSliceOnThrowHelperPath_IsLowAdvisory()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 
-        var row = Assert.Single(StringSliceRows(index, nameof(OptimizationOpportunityFixtures.SubstringInLoopBeforeThrow)));
+        var row = Assert.Single(StringSliceRows(index, nameof(OptimizationOpportunityFixtures.ThrowSubstringInLoop)));
         Assert.Equal("low", row.Confidence);
         Assert.True(row.ColdPath);
         Assert.Contains("cold path", row.Caveat, StringComparison.OrdinalIgnoreCase);
@@ -2928,6 +2962,37 @@ public class OptimizationOpportunityFixtures
         return list;
     }
 
+    public static System.Collections.Generic.List<int> TernarySizedOrUnsizedListGrownInLoop(int[] values, bool sized)
+    {
+        var list = sized
+            ? new System.Collections.Generic.List<int>(values.Length)
+            : new System.Collections.Generic.List<int>();
+        foreach (var value in values)
+            list.Add(value);
+        return list;
+    }
+
+    public static int LexicalButNotNaturalLoop(int[] values, string text)
+    {
+        var list = new System.Collections.Generic.List<int>();
+        var total = 0;
+        var i = 0;
+        goto Check;
+    LoopStart:
+        i++;
+        goto Check;
+    OutsideLoop:
+        if (values.Length > 0)
+            list.Add(values[0]);
+        if (text.Length > 1)
+            total += text.Substring(1).Length;
+        return total + list.Count;
+    Check:
+        if (i < values.Length)
+            goto LoopStart;
+        goto OutsideLoop;
+    }
+
     public static System.Collections.Generic.List<int> UnsizedListGrownOnce(int value)
     {
         var list = new System.Collections.Generic.List<int>();
@@ -2949,12 +3014,24 @@ public class OptimizationOpportunityFixtures
 
     static int StaticAdd(int value) => value + 1;
 
-    public static void UnsizedStringBuilderGrownBeforeThrow(string[] values)
+    public static void ThrowUnsizedStringBuilderGrown(string[] values)
     {
         var builder = new System.Text.StringBuilder();
         foreach (var value in values)
             builder.Append(value);
         throw new InvalidOperationException(builder.ToString());
+    }
+
+    public static void UnsizedListGrownInInfiniteLoopBeforeConditionalThrow(bool fatal)
+    {
+        var list = new System.Collections.Generic.List<int>();
+        while (true)
+        {
+            list.Add(42);
+            if (fatal)
+                throw new InvalidOperationException(list.Count.ToString());
+            GC.KeepAlive(list);
+        }
     }
 
     public static int SubstringInLoop(string[] values)
@@ -2979,7 +3056,7 @@ public class OptimizationOpportunityFixtures
         return total;
     }
 
-    public static void SubstringInLoopBeforeThrow(string[] values)
+    public static void ThrowSubstringInLoop(string[] values)
     {
         var total = 0;
         foreach (var value in values)

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1450,6 +1450,24 @@ public class LibraryBodyIndexTests
     }
 
     [Fact]
+    public void OptimizationOpportunities_UnsizedCollectionGrownInLoop_ReportsEnsureCapacityZeroBeforeLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var row = Assert.Single(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.EnsureCapacityZeroListGrownInLoop)));
+        Assert.Equal("medium", row.Confidence);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_UnsizedCollectionGrownInLoop_ReportsCapacitySetterZeroBeforeLoop()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var row = Assert.Single(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.CapacitySetterZeroListGrownInLoop)));
+        Assert.Equal("medium", row.Confidence);
+    }
+
+    [Fact]
     public void OptimizationOpportunities_UnsizedCollectionGrownInLoop_RejectsTernarySizedOrUnsizedCtor()
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -2992,6 +3010,24 @@ public class OptimizationOpportunityFixtures
     {
         var list = new System.Collections.Generic.List<int>();
         list.Capacity = values.Length;
+        foreach (var value in values)
+            list.Add(value);
+        return list;
+    }
+
+    public static System.Collections.Generic.List<int> EnsureCapacityZeroListGrownInLoop(int[] values)
+    {
+        var list = new System.Collections.Generic.List<int>();
+        list.EnsureCapacity(0);
+        foreach (var value in values)
+            list.Add(value);
+        return list;
+    }
+
+    public static System.Collections.Generic.List<int> CapacitySetterZeroListGrownInLoop(int[] values)
+    {
+        var list = new System.Collections.Generic.List<int>();
+        list.Capacity = 0;
         foreach (var value in values)
             list.Add(value);
         return list;

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1414,6 +1414,17 @@ public class LibraryBodyIndexTests
         Assert.Empty(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.StaticAddHelperInLoop)));
     }
 
+    [Fact]
+    public void OptimizationOpportunities_UnsizedCollectionOnThrowHelperPath_IsLowAdvisory()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var row = Assert.Single(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.UnsizedStringBuilderGrownBeforeThrow)));
+        Assert.Equal("low", row.Confidence);
+        Assert.True(row.ColdPath);
+        Assert.Contains("cold path", row.Caveat, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     // Non-loop delegate on a high-reach method -> lifted from low to medium.
     [InlineData("capturing-delegate", false, "low", LibraryBodyIndex.DelegateHotRootReach, "medium")]
@@ -2849,6 +2860,14 @@ public class OptimizationOpportunityFixtures
     }
 
     static int StaticAdd(int value) => value + 1;
+
+    public static void UnsizedStringBuilderGrownBeforeThrow(string[] values)
+    {
+        var builder = new System.Text.StringBuilder();
+        foreach (var value in values)
+            builder.Append(value);
+        throw new InvalidOperationException(builder.ToString());
+    }
 
     static void ReplaceSource(ref IEnumerable<int> source, IEnumerable<int> replacement)
     {

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1367,6 +1367,45 @@ public class LibraryBodyIndexTests
             && o.Shape == "materialize-in-loop");
     }
 
+    [Fact]
+    public void OptimizationOpportunities_UnsizedCollectionGrownInLoop_Fires()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var row = Assert.Single(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.UnsizedListGrownInLoop)));
+        Assert.True(row.InLoop);
+        Assert.Equal("medium", row.Confidence);
+        Assert.Contains("System.Collections.Generic.List<int>", row.Evidence, StringComparison.Ordinal);
+        Assert.Contains("Add", row.Evidence, StringComparison.Ordinal);
+        Assert.Contains("Pre-size", row.SafeFixDirection, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_UnsizedStringBuilderAppendInLoop_Fires()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var row = Assert.Single(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.UnsizedStringBuilderGrownInLoop)));
+        Assert.Contains("System.Text.StringBuilder", row.Evidence, StringComparison.Ordinal);
+        Assert.Contains("Append", row.Evidence, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_UnsizedCollectionGrownInLoop_RejectsCapacityCtor()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.Empty(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.CapacityListGrownInLoop)));
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_UnsizedCollectionGrownOutsideLoop_DoesNotFire()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.Empty(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.UnsizedListGrownOnce)));
+    }
+
     [Theory]
     // Non-loop delegate on a high-reach method -> lifted from low to medium.
     [InlineData("capturing-delegate", false, "low", LibraryBodyIndex.DelegateHotRootReach, "medium")]
@@ -1751,6 +1790,11 @@ public class LibraryBodyIndexTests
     static System.Collections.Generic.List<OptimizationOpportunity> EnumeratorRows(LibraryBodyIndex index, string methodName)
         => index.OptimizationOpportunities
             .Where(o => o.Method.Name == methodName && o.Shape == "enumerator-allocation")
+            .ToList();
+
+    static System.Collections.Generic.List<OptimizationOpportunity> UnsizedCollectionRows(LibraryBodyIndex index, string methodName)
+        => index.OptimizationOpportunities
+            .Where(o => o.Method.Name == methodName && o.Shape == "unsized-collection-grown")
             .ToList();
 
     [Fact]
@@ -2751,6 +2795,37 @@ public class OptimizationOpportunityFixtures
             total += current.ToArray().Length;
         }
         return total;
+    }
+
+    public static System.Collections.Generic.List<int> UnsizedListGrownInLoop(int[] values)
+    {
+        var list = new System.Collections.Generic.List<int>();
+        foreach (var value in values)
+            list.Add(value);
+        return list;
+    }
+
+    public static System.Text.StringBuilder UnsizedStringBuilderGrownInLoop(string[] values)
+    {
+        var builder = new System.Text.StringBuilder();
+        foreach (var value in values)
+            builder.Append(value);
+        return builder;
+    }
+
+    public static System.Collections.Generic.List<int> CapacityListGrownInLoop(int[] values)
+    {
+        var list = new System.Collections.Generic.List<int>(values.Length);
+        foreach (var value in values)
+            list.Add(value);
+        return list;
+    }
+
+    public static System.Collections.Generic.List<int> UnsizedListGrownOnce(int value)
+    {
+        var list = new System.Collections.Generic.List<int>();
+        list.Add(value);
+        return list;
     }
 
     static void ReplaceSource(ref IEnumerable<int> source, IEnumerable<int> replacement)

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1406,6 +1406,14 @@ public class LibraryBodyIndexTests
         Assert.Empty(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.UnsizedListGrownOnce)));
     }
 
+    [Fact]
+    public void OptimizationOpportunities_StaticAddHelperWithCollectionOnStack_DoesNotFire()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.Empty(UnsizedCollectionRows(index, nameof(OptimizationOpportunityFixtures.StaticAddHelperInLoop)));
+    }
+
     [Theory]
     // Non-loop delegate on a high-reach method -> lifted from low to medium.
     [InlineData("capturing-delegate", false, "low", LibraryBodyIndex.DelegateHotRootReach, "medium")]
@@ -2827,6 +2835,20 @@ public class OptimizationOpportunityFixtures
         list.Add(value);
         return list;
     }
+
+    public static int StaticAddHelperInLoop(int[] values)
+    {
+        var list = new System.Collections.Generic.List<int>();
+        var total = 0;
+        foreach (var value in values)
+        {
+            if (list.Contains(StaticAdd(value)))
+                total++;
+        }
+        return total;
+    }
+
+    static int StaticAdd(int value) => value + 1;
 
     static void ReplaceSource(ref IEnumerable<int> source, IEnumerable<int> replacement)
     {

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -2442,7 +2442,8 @@ public sealed class LibraryBodyIndex
                                 null));
                         }
                         else if (IsStringSliceAllocator(callee, out var sliceOp)
-                            && IsInLoopRegion(offset, loopRegions))
+                            && IsInLoopRegion(offset, loopRegions)
+                            && !StringSliceCallIsProvablyNoOp(decodedBody, offset, callee, callerScope))
                         {
                             var coldRegion = ClassifyColdRegion(decodedBody, offset);
                             opportunities.Add(new OptimizationOpportunity(
@@ -2476,7 +2477,7 @@ public sealed class LibraryBodyIndex
                                 "No allocation when the static type has a struct enumerator; worthwhile only if the concrete type is reachable at this call site."));
                         }
                         else if (IsGrowableCollectionMutation(callee, out var growthCall)
-                            && IsInLoopRegion(offset, loopRegions)
+                            && TryGetContainingLoop(offset, loopRegions, out var growthLoop)
                             && TryGetUnsizedCollectionReceiver(
                                 decodedBody,
                                 GetReachingDefinitions(),
@@ -2484,7 +2485,15 @@ public sealed class LibraryBodyIndex
                                 callee,
                                 callerScope,
                                 unsizedCollectionsByDefinition,
-                                out var construction))
+                                out var construction)
+                            && !HasDominatingPreLoopSizingEvent(
+                                decodedBody,
+                                GetReachingDefinitions(),
+                                offset,
+                                growthLoop,
+                                construction,
+                                callerScope,
+                                unsizedCollectionsByDefinition))
                         {
                             var coldRegion = ClassifyColdRegion(decodedBody, offset);
                             opportunities.Add(new OptimizationOpportunity(
@@ -3086,6 +3095,350 @@ public sealed class LibraryBodyIndex
             return found;
         }
 
+        bool StringSliceCallIsProvablyNoOp(DecodedBody decodedBody, int callOffset, MemberRef callee, GenericScope callerScope)
+        {
+            if (callee.Name != "Substring" || !callee.HasThis)
+                return false;
+            int argumentCount = callee.ParameterTypes.Length;
+            if (argumentCount is not (1 or 2))
+                return false;
+
+            int blockIndex = decodedBody.BlockGraph.BlockIndexAt(callOffset);
+            if (blockIndex < 0)
+                return false;
+
+            var block = decodedBody.BlockGraph.Blocks[blockIndex];
+            var stack = new List<StringSliceStackValue>();
+            for (int i = decodedBody.IndexAtOrAfter(block.Start); i < decodedBody.Instructions.Length; i++)
+            {
+                var instruction = decodedBody.Instructions[i];
+                if (instruction.Offset >= callOffset || instruction.Offset >= block.End)
+                    break;
+                if (!ApplyStringSliceStackEffect(instruction, stack, callerScope))
+                    return false;
+            }
+
+            int receiverIndex = stack.Count - argumentCount - 1;
+            if (receiverIndex < 0)
+                return false;
+            var receiver = stack[receiverIndex];
+            var start = stack[receiverIndex + 1];
+            if (!start.IsZero)
+                return false;
+            if (argumentCount == 1)
+                return true;
+
+            var length = stack[receiverIndex + 2];
+            return receiver.IsLocal
+                && length.IsLengthOfLocal
+                && SameSlot(receiver.Access, length.Access);
+        }
+
+        bool ApplyStringSliceStackEffect(DecodedInstruction instruction, List<StringSliceStackValue> stack, GenericScope callerScope)
+        {
+            if (TryReadLocalSlot(instruction, out var access))
+            {
+                if (access.IsStore)
+                    return PopStringSliceTracked(stack, 1);
+                stack.Add(StringSliceStackValue.Local(access));
+                return true;
+            }
+
+            switch (instruction.OpCode)
+            {
+                case ILOpCode.Nop:
+                case ILOpCode.Constrained:
+                case ILOpCode.Readonly:
+                case ILOpCode.Tail:
+                case ILOpCode.Unaligned:
+                case ILOpCode.Volatile:
+                    return true;
+                case ILOpCode.Dup:
+                    if (stack.Count == 0)
+                        return false;
+                    stack.Add(stack[^1]);
+                    return true;
+                case ILOpCode.Pop:
+                    return PopStringSliceTracked(stack, 1);
+                case ILOpCode.Ldc_i4_0:
+                    stack.Add(StringSliceStackValue.Zero);
+                    return true;
+                case ILOpCode.Ldc_i4_s:
+                case ILOpCode.Ldc_i4:
+                    stack.Add(OperandInt32(instruction) == 0 ? StringSliceStackValue.Zero : StringSliceStackValue.Unknown);
+                    return true;
+                case ILOpCode.Ldnull:
+                case ILOpCode.Ldstr:
+                case ILOpCode.Ldc_i4_m1:
+                case ILOpCode.Ldc_i4_1:
+                case ILOpCode.Ldc_i4_2:
+                case ILOpCode.Ldc_i4_3:
+                case ILOpCode.Ldc_i4_4:
+                case ILOpCode.Ldc_i4_5:
+                case ILOpCode.Ldc_i4_6:
+                case ILOpCode.Ldc_i4_7:
+                case ILOpCode.Ldc_i4_8:
+                case ILOpCode.Ldc_i8:
+                case ILOpCode.Ldc_r4:
+                case ILOpCode.Ldc_r8:
+                case ILOpCode.Ldtoken:
+                case ILOpCode.Ldsfld:
+                case ILOpCode.Ldsflda:
+                case ILOpCode.Sizeof:
+                    stack.Add(StringSliceStackValue.Unknown);
+                    return true;
+                case ILOpCode.Ldfld:
+                case ILOpCode.Ldflda:
+                case ILOpCode.Ldlen:
+                case ILOpCode.Box:
+                case ILOpCode.Castclass:
+                case ILOpCode.Isinst:
+                case ILOpCode.Unbox:
+                case ILOpCode.Unbox_any:
+                case ILOpCode.Ldind_i:
+                case ILOpCode.Ldind_i1:
+                case ILOpCode.Ldind_i2:
+                case ILOpCode.Ldind_i4:
+                case ILOpCode.Ldind_i8:
+                case ILOpCode.Ldind_u1:
+                case ILOpCode.Ldind_u2:
+                case ILOpCode.Ldind_u4:
+                case ILOpCode.Ldind_r4:
+                case ILOpCode.Ldind_r8:
+                case ILOpCode.Ldind_ref:
+                case ILOpCode.Conv_i:
+                case ILOpCode.Conv_i1:
+                case ILOpCode.Conv_i2:
+                case ILOpCode.Conv_i4:
+                case ILOpCode.Conv_i8:
+                case ILOpCode.Conv_u:
+                case ILOpCode.Conv_u1:
+                case ILOpCode.Conv_u2:
+                case ILOpCode.Conv_u4:
+                case ILOpCode.Conv_u8:
+                case ILOpCode.Conv_r4:
+                case ILOpCode.Conv_r8:
+                case ILOpCode.Conv_r_un:
+                case ILOpCode.Neg:
+                case ILOpCode.Not:
+                    return ReplaceStringSliceTracked(stack, popCount: 1);
+                case ILOpCode.Stfld:
+                case ILOpCode.Stind_i:
+                case ILOpCode.Stind_i1:
+                case ILOpCode.Stind_i2:
+                case ILOpCode.Stind_i4:
+                case ILOpCode.Stind_i8:
+                case ILOpCode.Stind_r4:
+                case ILOpCode.Stind_r8:
+                case ILOpCode.Stind_ref:
+                case ILOpCode.Stobj:
+                case ILOpCode.Cpobj:
+                    return PopStringSliceTracked(stack, 2);
+                case ILOpCode.Add:
+                case ILOpCode.Add_ovf:
+                case ILOpCode.Add_ovf_un:
+                case ILOpCode.And:
+                case ILOpCode.Ceq:
+                case ILOpCode.Cgt:
+                case ILOpCode.Cgt_un:
+                case ILOpCode.Clt:
+                case ILOpCode.Clt_un:
+                case ILOpCode.Div:
+                case ILOpCode.Div_un:
+                case ILOpCode.Mul:
+                case ILOpCode.Mul_ovf:
+                case ILOpCode.Mul_ovf_un:
+                case ILOpCode.Or:
+                case ILOpCode.Rem:
+                case ILOpCode.Rem_un:
+                case ILOpCode.Shl:
+                case ILOpCode.Shr:
+                case ILOpCode.Shr_un:
+                case ILOpCode.Sub:
+                case ILOpCode.Sub_ovf:
+                case ILOpCode.Sub_ovf_un:
+                case ILOpCode.Xor:
+                    return ReplaceStringSliceTracked(stack, popCount: 2);
+                case ILOpCode.Ldelem:
+                case ILOpCode.Ldelem_i:
+                case ILOpCode.Ldelem_i1:
+                case ILOpCode.Ldelem_i2:
+                case ILOpCode.Ldelem_i4:
+                case ILOpCode.Ldelem_i8:
+                case ILOpCode.Ldelem_u1:
+                case ILOpCode.Ldelem_u2:
+                case ILOpCode.Ldelem_u4:
+                case ILOpCode.Ldelem_r4:
+                case ILOpCode.Ldelem_r8:
+                case ILOpCode.Ldelem_ref:
+                case ILOpCode.Ldelema:
+                    return ReplaceStringSliceTracked(stack, popCount: 2);
+                case ILOpCode.Stelem:
+                case ILOpCode.Stelem_i:
+                case ILOpCode.Stelem_i1:
+                case ILOpCode.Stelem_i2:
+                case ILOpCode.Stelem_i4:
+                case ILOpCode.Stelem_i8:
+                case ILOpCode.Stelem_r4:
+                case ILOpCode.Stelem_r8:
+                case ILOpCode.Stelem_ref:
+                    return PopStringSliceTracked(stack, 3);
+                case ILOpCode.Newarr:
+                case ILOpCode.Localloc:
+                case ILOpCode.Mkrefany:
+                    return ReplaceStringSliceTracked(stack, popCount: 1);
+                case ILOpCode.Initobj:
+                    return PopStringSliceTracked(stack, 1);
+                case ILOpCode.Newobj:
+                {
+                    int token = OperandInt32(instruction);
+                    var member = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
+                    if (member.Kind == MemberKind.Unsupported || !PopStringSliceTracked(stack, member.ParameterTypes.Length))
+                        return false;
+                    stack.Add(StringSliceStackValue.Unknown);
+                    return true;
+                }
+                case ILOpCode.Call:
+                case ILOpCode.Callvirt:
+                {
+                    int token = OperandInt32(instruction);
+                    var member = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
+                    if (member.Kind == MemberKind.Unsupported)
+                        return false;
+                    int popCount = member.ParameterTypes.Length + (member.HasThis ? 1 : 0);
+                    if (IsStringLengthGetter(member))
+                    {
+                        if (stack.Count < 1)
+                            return false;
+                        var receiver = stack[^1];
+                        stack.RemoveAt(stack.Count - 1);
+                        stack.Add(receiver.IsLocal ? StringSliceStackValue.LengthOf(receiver.Access) : StringSliceStackValue.Unknown);
+                        return true;
+                    }
+                    if (!PopStringSliceTracked(stack, popCount))
+                        return false;
+                    if (!ReturnsVoid(member))
+                        stack.Add(StringSliceStackValue.Unknown);
+                    return true;
+                }
+                default:
+                    return false;
+            }
+        }
+
+        static bool PopStringSliceTracked(List<StringSliceStackValue> stack, int count)
+        {
+            if (count == 0)
+                return true;
+            if (stack.Count < count)
+                return false;
+            stack.RemoveRange(stack.Count - count, count);
+            return true;
+        }
+
+        static bool ReplaceStringSliceTracked(List<StringSliceStackValue> stack, int popCount)
+        {
+            if (!PopStringSliceTracked(stack, popCount))
+                return false;
+            stack.Add(StringSliceStackValue.Unknown);
+            return true;
+        }
+
+        static bool IsStringLengthGetter(MemberRef member)
+            => member.Name == "get_Length"
+                && member.HasThis
+                && member.ParameterTypes.Length == 0
+                && FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "String");
+
+        static bool SameSlot(LocalSlotAccess left, LocalSlotAccess right)
+            => left.Slot == right.Slot && left.IsArgument == right.IsArgument;
+
+        bool HasDominatingPreLoopSizingEvent(
+            DecodedBody decodedBody,
+            ReachingDefinitionsResult reachingDefinitions,
+            int growthOffset,
+            (int Start, int End) growthLoop,
+            UnsizedCollectionConstruction construction,
+            GenericScope callerScope,
+            IReadOnlyDictionary<(int Slot, int StoreOffset), UnsizedCollectionConstruction> constructions)
+        {
+            if (!decodedBody.BlockGraph.IsComplete)
+                return false;
+
+            int loopEntryBlock = decodedBody.BlockGraph.BlockIndexAt(growthLoop.Start);
+            if (loopEntryBlock < 0)
+                return false;
+
+            foreach (var instruction in decodedBody.Instructions)
+            {
+                int offset = instruction.Offset;
+                if (offset >= growthLoop.Start || offset >= growthOffset)
+                    break;
+                if (offset <= construction.ConstructorOffset)
+                    continue;
+                if (instruction.OpCode is not (ILOpCode.Call or ILOpCode.Callvirt))
+                    continue;
+
+                int token = OperandInt32(instruction);
+                var callee = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
+                if (!IsGrowableCollectionSizingCall(callee)
+                    || !TryGetUnsizedCollectionReceiver(
+                        decodedBody,
+                        reachingDefinitions,
+                        offset,
+                        callee,
+                        callerScope,
+                        constructions,
+                        out var sizedConstruction)
+                    || sizedConstruction.ConstructorOffset != construction.ConstructorOffset)
+                {
+                    continue;
+                }
+
+                int sizingBlock = decodedBody.BlockGraph.BlockIndexAt(offset);
+                if (sizingBlock < 0)
+                    continue;
+                if (sizingBlock == loopEntryBlock || DominatesBlock(decodedBody.BlockGraph, sizingBlock, loopEntryBlock))
+                    return true;
+            }
+
+            return false;
+        }
+
+        static bool DominatesBlock(BlockGraph graph, int dominatorBlock, int dominatedBlock)
+        {
+            if (dominatorBlock == dominatedBlock)
+                return true;
+            if (!graph.IsComplete || graph.Blocks.Length == 0)
+                return false;
+            if (dominatorBlock == 0)
+                return true;
+
+            var seen = new bool[graph.Blocks.Length];
+            var stack = new Stack<int>();
+            stack.Push(0);
+            seen[0] = true;
+            while (stack.Count > 0)
+            {
+                int block = stack.Pop();
+                foreach (int successor in graph.Blocks[block].Edges.Successors)
+                {
+                    if ((uint)successor >= (uint)seen.Length
+                        || successor == dominatorBlock
+                        || seen[successor])
+                    {
+                        continue;
+                    }
+                    if (successor == dominatedBlock)
+                        return false;
+                    seen[successor] = true;
+                    stack.Push(successor);
+                }
+            }
+
+            return true;
+        }
+
         bool LinqMaterializerSourceIsLoopInvariant(
             DecodedBody decodedBody,
             ReachingDefinitionsResult reachingDefinitions,
@@ -3454,6 +3807,14 @@ public sealed class LibraryBodyIndex
             public static TrackedStackValue Unknown { get; } = new(false, default, -1);
         }
 
+        readonly record struct StringSliceStackValue(bool IsLocal, LocalSlotAccess Access, bool IsZero, bool IsLengthOfLocal)
+        {
+            public static StringSliceStackValue Unknown { get; } = new(false, default, false, false);
+            public static StringSliceStackValue Zero { get; } = new(false, default, true, false);
+            public static StringSliceStackValue Local(LocalSlotAccess access) => new(true, access, false, false);
+            public static StringSliceStackValue LengthOf(LocalSlotAccess access) => new(false, access, false, true);
+        }
+
         static bool TryFindPreviousInstruction(DecodedBody decodedBody, int targetOffset, out DecodedInstruction previousInstruction)
         {
             previousInstruction = default!;
@@ -3616,7 +3977,8 @@ public sealed class LibraryBodyIndex
                 {
                     return true;
                 }
-                if (block.Start >= region.HandlerStart
+                if (region.Kind is HandlerKind.Catch or HandlerKind.Filter or HandlerKind.Fault
+                    && block.Start >= region.HandlerStart
                     && block.End <= region.HandlerEnd)
                 {
                     return true;
@@ -3867,6 +4229,14 @@ public sealed class LibraryBodyIndex
             growthCall = $"{member.DeclaringType.ToQualifiedDisplayString()}::{member.Name}";
             return true;
         }
+
+        static bool IsGrowableCollectionSizingCall(MemberRef member)
+            => member.Kind != MemberKind.Unsupported
+                && member.HasThis
+                && member.ParameterTypes.Length == 1
+                && IsInt32(member.ParameterTypes[0])
+                && member.Name is ("EnsureCapacity" or "set_Capacity" or "Capacity")
+                && IsWellKnownGrowableCollectionType(member.DeclaringType, out _);
 
         static bool IsWellKnownGrowableCollectionType(TypeRef type, out string collectionType)
         {

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -3156,6 +3156,8 @@ public sealed class LibraryBodyIndex
         {
             access = default;
             loadOffset = -1;
+            if (!callee.HasThis)
+                return false;
 
             int blockIndex = decodedBody.BlockGraph.BlockIndexAt(callOffset);
             if (blockIndex < 0)
@@ -3373,7 +3375,7 @@ public sealed class LibraryBodyIndex
                     var member = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
                     if (member.Kind == MemberKind.Unsupported)
                         return false;
-                    int popCount = member.ParameterTypes.Length + (opcode == ILOpCode.Callvirt ? 1 : 0);
+                    int popCount = member.ParameterTypes.Length + (member.HasThis ? 1 : 0);
                     if (!PopTracked(stack, popCount))
                         return false;
                     if (!ReturnsVoid(member))
@@ -3728,7 +3730,11 @@ public sealed class LibraryBodyIndex
             growthCall = "";
             if (member.Kind == MemberKind.Unsupported)
                 return false;
+            if (!member.HasThis)
+                return false;
             if (member.Name is not ("Add" or "AddRange" or "Append" or "AppendLine" or "Enqueue" or "Push"))
+                return false;
+            if (!IsWellKnownGrowableCollectionType(member.DeclaringType, out _))
                 return false;
             growthCall = $"{member.DeclaringType.ToQualifiedDisplayString()}::{member.Name}";
             return true;

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -87,6 +87,7 @@ public sealed class LibraryBodyIndex
                     .. AllocationHotspots(reachByToken, new HashSet<int>(_rawOpportunities
                         .Where(o => !(o.Shape == "async-state-machine" && o.Amortized))
                         .Where(o => o.Shape != "unsized-collection-grown")
+                        .Where(o => o.Shape != "string-slice-in-loop")
                         .Select(o => o.Method.MetadataToken))),
                     .. ScanMethodsInvokedInLoops(reachByToken),
                 ];
@@ -301,6 +302,20 @@ public sealed class LibraryBodyIndex
         => member.Kind != MemberKind.Unsupported
             && member.Name == "Concat"
             && FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "String");
+
+    static bool IsStringSliceAllocator(MemberRef member, out string op)
+    {
+        op = "";
+        if (member.Kind == MemberKind.Unsupported
+            || !FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "String")
+            || member.Name is not ("Substring" or "Split" or "Trim" or "TrimStart" or "TrimEnd"))
+        {
+            return false;
+        }
+
+        op = $"System.String::{member.Name}";
+        return true;
+    }
 
     // A GetEnumerator call that returns a reference-type enumerator — i.e. iterating the
     // sequence allocates an enumerator object on the heap. `foreach` over a concrete type with a
@@ -2425,6 +2440,21 @@ public sealed class LibraryBodyIndex
                                 true,
                                 offset,
                                 null));
+                        }
+                        else if (IsStringSliceAllocator(callee, out var sliceOp)
+                            && IsInLoopRegion(offset, loopRegions))
+                        {
+                            var coldRegion = ClassifyColdRegion(decodedBody, offset);
+                            opportunities.Add(new OptimizationOpportunity(
+                                caller,
+                                "string-slice-in-loop",
+                                $"{sliceOp} allocates a new string each iteration",
+                                "Allocates a new string every iteration; use `AsSpan().Slice(...)` / span-based parsing to avoid the per-iteration allocation.",
+                                coldRegion.IsCold ? "low" : "medium",
+                                true,
+                                offset,
+                                coldRegion.Caveat,
+                                ColdPath: coldRegion.IsCold));
                         }
                         else if (IsInterfaceEnumeratorAllocation(callee) && IsInLoopRegion(offset, loopRegions))
                         {

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1074,11 +1074,13 @@ public sealed class LibraryBodyIndex
                 for (int i = 0; i < instructions.Length; i++)
                     _instructionIndexByOffset[instructions[i].Offset] = i;
                 LoopRegions = CollectLoopRegions();
+                NaturalLoops = CollectNaturalLoops();
             }
 
             public ImmutableArray<DecodedInstruction> Instructions { get; }
             public BlockGraph BlockGraph { get; }
             public IReadOnlyList<(int Start, int End)> LoopRegions { get; }
+            public IReadOnlyList<NaturalLoop> NaturalLoops { get; }
 
             public bool TryGetInstructionAt(int offset, out DecodedInstruction instruction)
             {
@@ -1136,6 +1138,96 @@ public sealed class LibraryBodyIndex
                     }
                 }
                 return regions;
+            }
+
+            IReadOnlyList<NaturalLoop> CollectNaturalLoops()
+            {
+                var loops = new List<NaturalLoop>();
+                if (!BlockGraph.IsComplete || BlockGraph.Blocks.Length == 0)
+                    return loops;
+
+                var predecessors = new List<int>[BlockGraph.Blocks.Length];
+                for (int i = 0; i < predecessors.Length; i++)
+                    predecessors[i] = [];
+                for (int source = 0; source < BlockGraph.Blocks.Length; source++)
+                {
+                    foreach (int successor in BlockGraph.Blocks[source].Edges.Successors)
+                    {
+                        if ((uint)successor < (uint)predecessors.Length)
+                            predecessors[successor].Add(source);
+                    }
+                }
+
+                var indexByBlock = new int[BlockGraph.Blocks.Length];
+                var lowLinkByBlock = new int[BlockGraph.Blocks.Length];
+                var onStack = new bool[BlockGraph.Blocks.Length];
+                Array.Fill(indexByBlock, -1);
+                var stack = new Stack<int>();
+                var nextIndex = 0;
+
+                for (int block = 0; block < BlockGraph.Blocks.Length; block++)
+                {
+                    if (indexByBlock[block] < 0)
+                        Visit(block);
+                }
+
+                return loops;
+
+                void Visit(int block)
+                {
+                    indexByBlock[block] = nextIndex;
+                    lowLinkByBlock[block] = nextIndex;
+                    nextIndex++;
+                    stack.Push(block);
+                    onStack[block] = true;
+
+                    foreach (int successor in BlockGraph.Blocks[block].Edges.Successors)
+                    {
+                        if ((uint)successor >= (uint)BlockGraph.Blocks.Length)
+                            continue;
+                        if (indexByBlock[successor] < 0)
+                        {
+                            Visit(successor);
+                            lowLinkByBlock[block] = Math.Min(lowLinkByBlock[block], lowLinkByBlock[successor]);
+                        }
+                        else if (onStack[successor])
+                        {
+                            lowLinkByBlock[block] = Math.Min(lowLinkByBlock[block], indexByBlock[successor]);
+                        }
+                    }
+
+                    if (lowLinkByBlock[block] != indexByBlock[block])
+                        return;
+
+                    var component = new List<int>();
+                    int member;
+                    do
+                    {
+                        member = stack.Pop();
+                        onStack[member] = false;
+                        component.Add(member);
+                    }
+                    while (member != block);
+
+                    bool cyclic = component.Count > 1
+                        || BlockGraph.Blocks[component[0]].Edges.Successors.Contains(component[0]);
+                    if (!cyclic)
+                        return;
+
+                    var componentSet = component.ToHashSet();
+                    var entries = component
+                        .Where(candidate => candidate == 0 || predecessors[candidate].Any(pred => !componentSet.Contains(pred)))
+                        .Distinct()
+                        .ToArray();
+                    if (entries.Length != 1)
+                        return;
+
+                    int header = entries[0];
+                    if (component.Any(candidate => !DominatesBlock(BlockGraph, header, candidate)))
+                        return;
+
+                    loops.Add(new NaturalLoop(header, LatchBlock: -1, [.. component.Order()]));
+                }
             }
         }
 
@@ -2258,7 +2350,8 @@ public sealed class LibraryBodyIndex
                         int token = OperandInt32(instruction);
                         var constructor = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
                         if (IsNoCapacityGrowableCollectionConstructor(constructor, out var collectionType)
-                            && TryReadStoreLocalDefinition(decodedBody, instruction.NextOffset, out int slot, out int storeOffset))
+                            && TryReadStoreLocalDefinition(decodedBody, instruction.NextOffset, out int slot, out int storeOffset)
+                            && ConstructorDominatesStoreDefinition(decodedBody, offset, storeOffset))
                         {
                             unsizedCollectionsByDefinition[(slot, storeOffset)] =
                                 new UnsizedCollectionConstruction(collectionType, offset);
@@ -2443,9 +2536,10 @@ public sealed class LibraryBodyIndex
                         }
                         else if (IsStringSliceAllocator(callee, out var sliceOp)
                             && IsInLoopRegion(offset, loopRegions)
+                            && TryGetContainingNaturalLoop(decodedBody, offset, out _)
                             && !StringSliceCallIsProvablyNoOp(decodedBody, offset, callee, callerScope))
                         {
-                            var coldRegion = ClassifyColdRegion(decodedBody, offset);
+                            var coldRegion = ClassifyColdRegion(caller, decodedBody, offset);
                             opportunities.Add(new OptimizationOpportunity(
                                 caller,
                                 "string-slice-in-loop",
@@ -2477,7 +2571,8 @@ public sealed class LibraryBodyIndex
                                 "No allocation when the static type has a struct enumerator; worthwhile only if the concrete type is reachable at this call site."));
                         }
                         else if (IsGrowableCollectionMutation(callee, out var growthCall)
-                            && TryGetContainingLoop(offset, loopRegions, out var growthLoop)
+                            && TryGetContainingLoop(offset, loopRegions, out _)
+                            && TryGetContainingNaturalLoop(decodedBody, offset, out var growthLoop)
                             && TryGetUnsizedCollectionReceiver(
                                 decodedBody,
                                 GetReachingDefinitions(),
@@ -2495,7 +2590,7 @@ public sealed class LibraryBodyIndex
                                 callerScope,
                                 unsizedCollectionsByDefinition))
                         {
-                            var coldRegion = ClassifyColdRegion(decodedBody, offset);
+                            var coldRegion = ClassifyColdRegion(caller, decodedBody, offset);
                             opportunities.Add(new OptimizationOpportunity(
                                 caller,
                                 "unsized-collection-grown",
@@ -3025,6 +3120,16 @@ public sealed class LibraryBodyIndex
             return true;
         }
 
+        static bool ConstructorDominatesStoreDefinition(DecodedBody decodedBody, int constructorOffset, int storeOffset)
+        {
+            int constructorBlock = decodedBody.BlockGraph.BlockIndexAt(constructorOffset);
+            int storeBlock = decodedBody.BlockGraph.BlockIndexAt(storeOffset);
+            if (constructorBlock < 0 || storeBlock < 0)
+                return false;
+            return constructorBlock == storeBlock
+                || DominatesBlock(decodedBody.BlockGraph, constructorBlock, storeBlock);
+        }
+
         static bool TryPositionAfterLoadLocal(DecodedBody decodedBody, int offset, int slot, out int positionAfterLoad)
         {
             positionAfterLoad = offset;
@@ -3090,6 +3195,25 @@ public sealed class LibraryBodyIndex
                     continue;
                 if (!found || region.End - region.Start < loop.End - loop.Start)
                     loop = region;
+                found = true;
+            }
+            return found;
+        }
+
+        static bool TryGetContainingNaturalLoop(DecodedBody decodedBody, int offset, out NaturalLoop loop)
+        {
+            loop = default;
+            int blockIndex = decodedBody.BlockGraph.BlockIndexAt(offset);
+            if (blockIndex < 0)
+                return false;
+
+            var found = false;
+            foreach (var candidate in decodedBody.NaturalLoops)
+            {
+                if (!candidate.ContainsBlock(blockIndex))
+                    continue;
+                if (!found || candidate.Blocks.Length < loop.Blocks.Length)
+                    loop = candidate;
                 found = true;
             }
             return found;
@@ -3357,7 +3481,7 @@ public sealed class LibraryBodyIndex
             DecodedBody decodedBody,
             ReachingDefinitionsResult reachingDefinitions,
             int growthOffset,
-            (int Start, int End) growthLoop,
+            NaturalLoop growthLoop,
             UnsizedCollectionConstruction construction,
             GenericScope callerScope,
             IReadOnlyDictionary<(int Slot, int StoreOffset), UnsizedCollectionConstruction> constructions)
@@ -3365,14 +3489,10 @@ public sealed class LibraryBodyIndex
             if (!decodedBody.BlockGraph.IsComplete)
                 return false;
 
-            int loopEntryBlock = decodedBody.BlockGraph.BlockIndexAt(growthLoop.Start);
-            if (loopEntryBlock < 0)
-                return false;
-
             foreach (var instruction in decodedBody.Instructions)
             {
                 int offset = instruction.Offset;
-                if (offset >= growthLoop.Start || offset >= growthOffset)
+                if (offset >= growthOffset)
                     break;
                 if (offset <= construction.ConstructorOffset)
                     continue;
@@ -3398,8 +3518,11 @@ public sealed class LibraryBodyIndex
                 int sizingBlock = decodedBody.BlockGraph.BlockIndexAt(offset);
                 if (sizingBlock < 0)
                     continue;
-                if (sizingBlock == loopEntryBlock || DominatesBlock(decodedBody.BlockGraph, sizingBlock, loopEntryBlock))
+                if (!growthLoop.ContainsBlock(sizingBlock)
+                    && DominatesBlock(decodedBody.BlockGraph, sizingBlock, growthLoop.HeaderBlock))
+                {
                     return true;
+                }
             }
 
             return false;
@@ -3815,6 +3938,12 @@ public sealed class LibraryBodyIndex
             public static StringSliceStackValue LengthOf(LocalSlotAccess access) => new(false, access, false, true);
         }
 
+        readonly record struct NaturalLoop(int HeaderBlock, int LatchBlock, ImmutableArray<int> Blocks)
+        {
+            public bool ContainsBlock(int block)
+                => !Blocks.IsDefaultOrEmpty && Blocks.Contains(block);
+        }
+
         static bool TryFindPreviousInstruction(DecodedBody decodedBody, int targetOffset, out DecodedInstruction previousInstruction)
         {
             previousInstruction = default!;
@@ -3953,14 +4082,18 @@ public sealed class LibraryBodyIndex
         static bool IsInLoopRegion(int offset, IReadOnlyList<(int Start, int End)> regions)
             => regions.Any(region => offset >= region.Start && offset <= region.End);
 
-        ColdRegionClassification ClassifyColdRegion(DecodedBody decodedBody, int offset)
+        ColdRegionClassification ClassifyColdRegion(MethodIdentity caller, DecodedBody decodedBody, int offset)
         {
             if (IsInsideExceptionHandlerBlock(decodedBody, offset))
                 return ColdRegionClassification.Cold;
-            if (MethodUnconditionallyThrows(decodedBody))
+            if (IsThrowHelperMethod(caller) && MethodUnconditionallyThrows(decodedBody, offset))
                 return ColdRegionClassification.Cold;
             return ColdRegionClassification.Warm;
         }
+
+        static bool IsThrowHelperMethod(MethodIdentity caller)
+            => caller.Name.StartsWith("Throw", StringComparison.Ordinal)
+                || StringComparer.Ordinal.Equals(DeclaringTypeLeafName(caller.DeclaringType), "ThrowHelper");
 
         static bool IsInsideExceptionHandlerBlock(DecodedBody decodedBody, int offset)
         {
@@ -3987,10 +4120,11 @@ public sealed class LibraryBodyIndex
             return false;
         }
 
-        static bool MethodUnconditionallyThrows(DecodedBody decodedBody)
+        static bool MethodUnconditionallyThrows(DecodedBody decodedBody, int siteOffset)
         {
             if (!decodedBody.BlockGraph.IsComplete || decodedBody.BlockGraph.Blocks.Length == 0)
                 return false;
+            TryGetContainingNaturalLoop(decodedBody, siteOffset, out var siteLoop);
 
             var reachable = new bool[decodedBody.BlockGraph.Blocks.Length];
             var stack = new Stack<int>();
@@ -4023,6 +4157,8 @@ public sealed class LibraryBodyIndex
                 {
                     return false;
                 }
+                if (siteLoop.ContainsBlock(i))
+                    return false;
                 sawThrowExit = true;
             }
             return sawThrowExit;

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -86,6 +86,7 @@ public sealed class LibraryBodyIndex
                     }),
                     .. AllocationHotspots(reachByToken, new HashSet<int>(_rawOpportunities
                         .Where(o => !(o.Shape == "async-state-machine" && o.Amortized))
+                        .Where(o => o.Shape != "unsized-collection-grown")
                         .Select(o => o.Method.MetadataToken))),
                     .. ScanMethodsInvokedInLoops(reachByToken),
                 ];
@@ -2142,6 +2143,7 @@ public sealed class LibraryBodyIndex
             ReachingDefinitionsResult? reachingDefinitions = null;
             ReachingDefinitionsResult GetReachingDefinitions()
                 => reachingDefinitions ??= ReachingDefinitions.Analyze(il, ArgumentSlotCount(caller), exceptionRegions);
+            var unsizedCollectionsByDefinition = new Dictionary<(int Slot, int StoreOffset), UnsizedCollectionConstruction>();
 
             int? pendingConstant = null;
             // Delegate creation is `<push target>; ldftn/ldvirtftn M; newobj DelegateCtor`.
@@ -2238,6 +2240,14 @@ public sealed class LibraryBodyIndex
                     case ILOpCode.Newobj:
                     {
                         pendingConstant = null;
+                        int token = OperandInt32(instruction);
+                        var constructor = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
+                        if (IsNoCapacityGrowableCollectionConstructor(constructor, out var collectionType)
+                            && TryReadStoreLocalDefinition(decodedBody, instruction.NextOffset, out int slot, out int storeOffset))
+                        {
+                            unsizedCollectionsByDefinition[(slot, storeOffset)] =
+                                new UnsizedCollectionConstruction(collectionType, offset);
+                        }
                         if (pendingDelegateOffset is not null)
                         {
                             // A function pointer was just loaded, so this newobj is the delegate
@@ -2434,6 +2444,27 @@ public sealed class LibraryBodyIndex
                                 true,
                                 offset,
                                 "No allocation when the static type has a struct enumerator; worthwhile only if the concrete type is reachable at this call site."));
+                        }
+                        else if (IsGrowableCollectionMutation(callee, out var growthCall)
+                            && IsInLoopRegion(offset, loopRegions)
+                            && TryGetUnsizedCollectionReceiver(
+                                decodedBody,
+                                GetReachingDefinitions(),
+                                offset,
+                                callee,
+                                callerScope,
+                                unsizedCollectionsByDefinition,
+                                out var construction))
+                        {
+                            opportunities.Add(new OptimizationOpportunity(
+                                caller,
+                                "unsized-collection-grown",
+                                $"{construction.CollectionType} constructed without capacity; grown by {growthCall} in a loop",
+                                "Constructed without capacity and grown in a loop; each growth reallocates and copies the backing store. Pre-size with a capacity when the count is known.",
+                                "medium",
+                                true,
+                                offset,
+                                "Advisory: consider pre-sizing if the size is predictable."));
                         }
                         break;
                     }
@@ -3066,6 +3097,329 @@ public sealed class LibraryBodyIndex
             return true;
         }
 
+        bool TryGetUnsizedCollectionReceiver(
+            DecodedBody decodedBody,
+            ReachingDefinitionsResult reachingDefinitions,
+            int callOffset,
+            MemberRef callee,
+            GenericScope callerScope,
+            IReadOnlyDictionary<(int Slot, int StoreOffset), UnsizedCollectionConstruction> constructions,
+            out UnsizedCollectionConstruction construction)
+        {
+            construction = default;
+            if (!reachingDefinitions.IsComplete)
+                return false;
+            if (!TryFindReceiverLocalAtCall(decodedBody, callOffset, callee, callerScope, out var access, out int loadOffset))
+                return false;
+            if (access.IsArgument || access.IsStore)
+                return false;
+
+            var use = reachingDefinitions.Uses.FirstOrDefault(candidate =>
+                candidate.Offset == loadOffset
+                && !candidate.IsArgument
+                && candidate.Slot == access.Slot
+                && !candidate.Address);
+            if (use is null || use.ReachingDefinitions.Length == 0)
+                return false;
+
+            UnsizedCollectionConstruction? matched = null;
+            foreach (var definition in use.ReachingDefinitions)
+            {
+                if (definition.IsArgument
+                    || !constructions.TryGetValue((definition.Slot, definition.Offset), out var candidate))
+                {
+                    return false;
+                }
+
+                if (matched is { } previous
+                    && !StringComparer.Ordinal.Equals(previous.CollectionType, candidate.CollectionType))
+                {
+                    return false;
+                }
+
+                matched = candidate;
+            }
+
+            if (matched is not { } value)
+                return false;
+            construction = value;
+            return true;
+        }
+
+        bool TryFindReceiverLocalAtCall(
+            DecodedBody decodedBody,
+            int callOffset,
+            MemberRef callee,
+            GenericScope callerScope,
+            out LocalSlotAccess access,
+            out int loadOffset)
+        {
+            access = default;
+            loadOffset = -1;
+
+            int blockIndex = decodedBody.BlockGraph.BlockIndexAt(callOffset);
+            if (blockIndex < 0)
+                return false;
+
+            var block = decodedBody.BlockGraph.Blocks[blockIndex];
+            var stack = new List<TrackedStackValue>();
+            for (int i = decodedBody.IndexAtOrAfter(block.Start); i < decodedBody.Instructions.Length; i++)
+            {
+                var instruction = decodedBody.Instructions[i];
+                if (instruction.Offset >= callOffset || instruction.Offset >= block.End)
+                    break;
+                if (!ApplyTrackedStackEffect(instruction, stack, callerScope))
+                    stack.Clear();
+            }
+
+            int receiverIndex = stack.Count - callee.ParameterTypes.Length - 1;
+            if (receiverIndex < 0)
+                return false;
+
+            var receiver = stack[receiverIndex];
+            if (!receiver.IsLocal)
+                return false;
+
+            access = receiver.Access;
+            loadOffset = receiver.LoadOffset;
+            return true;
+        }
+
+        bool ApplyTrackedStackEffect(DecodedInstruction instruction, List<TrackedStackValue> stack, GenericScope callerScope)
+        {
+            if (TryReadLocalSlot(instruction, out var access))
+            {
+                if (access.IsStore)
+                    return PopTracked(stack, 1);
+                stack.Add(new TrackedStackValue(true, access, instruction.Offset));
+                return true;
+            }
+
+            var opcode = instruction.OpCode;
+            switch (opcode)
+            {
+                case ILOpCode.Nop:
+                case ILOpCode.Constrained:
+                case ILOpCode.Readonly:
+                case ILOpCode.Tail:
+                case ILOpCode.Unaligned:
+                case ILOpCode.Volatile:
+                    return true;
+                case ILOpCode.Dup:
+                    if (stack.Count == 0)
+                        return false;
+                    stack.Add(stack[^1]);
+                    return true;
+                case ILOpCode.Pop:
+                    return PopTracked(stack, 1);
+                case ILOpCode.Ldnull:
+                case ILOpCode.Ldstr:
+                case ILOpCode.Ldc_i4_m1:
+                case ILOpCode.Ldc_i4_0:
+                case ILOpCode.Ldc_i4_1:
+                case ILOpCode.Ldc_i4_2:
+                case ILOpCode.Ldc_i4_3:
+                case ILOpCode.Ldc_i4_4:
+                case ILOpCode.Ldc_i4_5:
+                case ILOpCode.Ldc_i4_6:
+                case ILOpCode.Ldc_i4_7:
+                case ILOpCode.Ldc_i4_8:
+                case ILOpCode.Ldc_i4_s:
+                case ILOpCode.Ldc_i4:
+                case ILOpCode.Ldc_i8:
+                case ILOpCode.Ldc_r4:
+                case ILOpCode.Ldc_r8:
+                case ILOpCode.Ldtoken:
+                case ILOpCode.Ldsfld:
+                case ILOpCode.Ldsflda:
+                case ILOpCode.Sizeof:
+                    stack.Add(TrackedStackValue.Unknown);
+                    return true;
+                case ILOpCode.Ldfld:
+                case ILOpCode.Ldflda:
+                case ILOpCode.Ldlen:
+                case ILOpCode.Box:
+                case ILOpCode.Castclass:
+                case ILOpCode.Isinst:
+                case ILOpCode.Unbox:
+                case ILOpCode.Unbox_any:
+                case ILOpCode.Ldind_i:
+                case ILOpCode.Ldind_i1:
+                case ILOpCode.Ldind_i2:
+                case ILOpCode.Ldind_i4:
+                case ILOpCode.Ldind_i8:
+                case ILOpCode.Ldind_u1:
+                case ILOpCode.Ldind_u2:
+                case ILOpCode.Ldind_u4:
+                case ILOpCode.Ldind_r4:
+                case ILOpCode.Ldind_r8:
+                case ILOpCode.Ldind_ref:
+                case ILOpCode.Conv_i:
+                case ILOpCode.Conv_i1:
+                case ILOpCode.Conv_i2:
+                case ILOpCode.Conv_i4:
+                case ILOpCode.Conv_i8:
+                case ILOpCode.Conv_u:
+                case ILOpCode.Conv_u1:
+                case ILOpCode.Conv_u2:
+                case ILOpCode.Conv_u4:
+                case ILOpCode.Conv_u8:
+                case ILOpCode.Conv_r4:
+                case ILOpCode.Conv_r8:
+                case ILOpCode.Conv_r_un:
+                case ILOpCode.Conv_ovf_i:
+                case ILOpCode.Conv_ovf_i_un:
+                case ILOpCode.Conv_ovf_i1:
+                case ILOpCode.Conv_ovf_i1_un:
+                case ILOpCode.Conv_ovf_i2:
+                case ILOpCode.Conv_ovf_i2_un:
+                case ILOpCode.Conv_ovf_i4:
+                case ILOpCode.Conv_ovf_i4_un:
+                case ILOpCode.Conv_ovf_i8:
+                case ILOpCode.Conv_ovf_i8_un:
+                case ILOpCode.Conv_ovf_u:
+                case ILOpCode.Conv_ovf_u_un:
+                case ILOpCode.Conv_ovf_u1:
+                case ILOpCode.Conv_ovf_u1_un:
+                case ILOpCode.Conv_ovf_u2:
+                case ILOpCode.Conv_ovf_u2_un:
+                case ILOpCode.Conv_ovf_u4:
+                case ILOpCode.Conv_ovf_u4_un:
+                case ILOpCode.Conv_ovf_u8:
+                case ILOpCode.Conv_ovf_u8_un:
+                case ILOpCode.Neg:
+                case ILOpCode.Not:
+                    return ReplaceTracked(stack, popCount: 1);
+                case ILOpCode.Stfld:
+                case ILOpCode.Stind_i:
+                case ILOpCode.Stind_i1:
+                case ILOpCode.Stind_i2:
+                case ILOpCode.Stind_i4:
+                case ILOpCode.Stind_i8:
+                case ILOpCode.Stind_r4:
+                case ILOpCode.Stind_r8:
+                case ILOpCode.Stind_ref:
+                case ILOpCode.Stobj:
+                case ILOpCode.Cpobj:
+                    return PopTracked(stack, 2);
+                case ILOpCode.Add:
+                case ILOpCode.Add_ovf:
+                case ILOpCode.Add_ovf_un:
+                case ILOpCode.And:
+                case ILOpCode.Ceq:
+                case ILOpCode.Cgt:
+                case ILOpCode.Cgt_un:
+                case ILOpCode.Clt:
+                case ILOpCode.Clt_un:
+                case ILOpCode.Div:
+                case ILOpCode.Div_un:
+                case ILOpCode.Mul:
+                case ILOpCode.Mul_ovf:
+                case ILOpCode.Mul_ovf_un:
+                case ILOpCode.Or:
+                case ILOpCode.Rem:
+                case ILOpCode.Rem_un:
+                case ILOpCode.Shl:
+                case ILOpCode.Shr:
+                case ILOpCode.Shr_un:
+                case ILOpCode.Sub:
+                case ILOpCode.Sub_ovf:
+                case ILOpCode.Sub_ovf_un:
+                case ILOpCode.Xor:
+                    return ReplaceTracked(stack, popCount: 2);
+                case ILOpCode.Ldelem:
+                case ILOpCode.Ldelem_i:
+                case ILOpCode.Ldelem_i1:
+                case ILOpCode.Ldelem_i2:
+                case ILOpCode.Ldelem_i4:
+                case ILOpCode.Ldelem_i8:
+                case ILOpCode.Ldelem_u1:
+                case ILOpCode.Ldelem_u2:
+                case ILOpCode.Ldelem_u4:
+                case ILOpCode.Ldelem_r4:
+                case ILOpCode.Ldelem_r8:
+                case ILOpCode.Ldelem_ref:
+                case ILOpCode.Ldelema:
+                    return ReplaceTracked(stack, popCount: 2);
+                case ILOpCode.Stelem:
+                case ILOpCode.Stelem_i:
+                case ILOpCode.Stelem_i1:
+                case ILOpCode.Stelem_i2:
+                case ILOpCode.Stelem_i4:
+                case ILOpCode.Stelem_i8:
+                case ILOpCode.Stelem_r4:
+                case ILOpCode.Stelem_r8:
+                case ILOpCode.Stelem_ref:
+                    return PopTracked(stack, 3);
+                case ILOpCode.Newarr:
+                case ILOpCode.Localloc:
+                case ILOpCode.Mkrefany:
+                    return ReplaceTracked(stack, popCount: 1);
+                case ILOpCode.Initobj:
+                    return PopTracked(stack, 1);
+                case ILOpCode.Newobj:
+                {
+                    int token = OperandInt32(instruction);
+                    var member = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
+                    if (member.Kind == MemberKind.Unsupported || !PopTracked(stack, member.ParameterTypes.Length))
+                        return false;
+                    stack.Add(TrackedStackValue.Unknown);
+                    return true;
+                }
+                case ILOpCode.Call:
+                case ILOpCode.Callvirt:
+                {
+                    int token = OperandInt32(instruction);
+                    var member = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
+                    if (member.Kind == MemberKind.Unsupported)
+                        return false;
+                    int popCount = member.ParameterTypes.Length + (opcode == ILOpCode.Callvirt ? 1 : 0);
+                    if (!PopTracked(stack, popCount))
+                        return false;
+                    if (!ReturnsVoid(member))
+                        stack.Add(TrackedStackValue.Unknown);
+                    return true;
+                }
+                default:
+                    return false;
+            }
+        }
+
+        static bool PopTracked(List<TrackedStackValue> stack, int count)
+        {
+            if (count == 0)
+                return true;
+            if (stack.Count < count)
+                return false;
+            stack.RemoveRange(stack.Count - count, count);
+            return true;
+        }
+
+        static bool ReplaceTracked(List<TrackedStackValue> stack, int popCount)
+        {
+            if (!PopTracked(stack, popCount))
+                return false;
+            stack.Add(TrackedStackValue.Unknown);
+            return true;
+        }
+
+        static bool ReturnsVoid(MemberRef member)
+        {
+            var definition = member.ReturnType.Kind == TypeRefKind.GenericInstance
+                ? member.ReturnType.ElementType ?? member.ReturnType
+                : member.ReturnType;
+            return definition.Assembly == TypeRef.CoreLibrary
+                && definition.Namespace == "System"
+                && definition.Name == "Void";
+        }
+
+        readonly record struct UnsizedCollectionConstruction(string CollectionType, int ConstructorOffset);
+
+        readonly record struct TrackedStackValue(bool IsLocal, LocalSlotAccess Access, int LoadOffset)
+        {
+            public static TrackedStackValue Unknown { get; } = new(false, default, -1);
+        }
+
         static bool TryFindPreviousInstruction(DecodedBody decodedBody, int targetOffset, out DecodedInstruction previousInstruction)
         {
             previousInstruction = default!;
@@ -3357,6 +3711,56 @@ public sealed class LibraryBodyIndex
                 return false;
             receiver = $"System.{name}<T>::ToArray";
             return true;
+        }
+
+        static bool IsNoCapacityGrowableCollectionConstructor(MemberRef member, out string collectionType)
+        {
+            collectionType = "";
+            if (member.Kind != MemberKind.Constructor)
+                return false;
+            if (!IsWellKnownGrowableCollectionType(member.DeclaringType, out collectionType))
+                return false;
+            return !member.ParameterTypes.Any(IsInt32);
+        }
+
+        static bool IsGrowableCollectionMutation(MemberRef member, out string growthCall)
+        {
+            growthCall = "";
+            if (member.Kind == MemberKind.Unsupported)
+                return false;
+            if (member.Name is not ("Add" or "AddRange" or "Append" or "AppendLine" or "Enqueue" or "Push"))
+                return false;
+            growthCall = $"{member.DeclaringType.ToQualifiedDisplayString()}::{member.Name}";
+            return true;
+        }
+
+        static bool IsWellKnownGrowableCollectionType(TypeRef type, out string collectionType)
+        {
+            collectionType = "";
+            var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+            if (definition.Kind == TypeRefKind.Unsupported || !definition.TrustedFrameworkAssembly)
+                return false;
+
+            string name = StripGenericArity(definition.Name);
+            bool match = definition.Namespace switch
+            {
+                "System.Collections.Generic" => name is "List" or "Dictionary" or "HashSet" or "Queue" or "Stack",
+                "System.Text" => name == "StringBuilder",
+                _ => false,
+            };
+            if (!match)
+                return false;
+
+            collectionType = type.ToQualifiedDisplayString();
+            return true;
+        }
+
+        static bool IsInt32(TypeRef type)
+        {
+            var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+            return definition.Assembly == TypeRef.CoreLibrary
+                && definition.Namespace == "System"
+                && definition.Name == "Int32";
         }
 
         static string StripGenericArity(string name)

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1168,65 +1168,82 @@ public sealed class LibraryBodyIndex
                 for (int block = 0; block < BlockGraph.Blocks.Length; block++)
                 {
                     if (indexByBlock[block] < 0)
-                        Visit(block);
+                        VisitIterative(block);
                 }
 
                 return loops;
 
-                void Visit(int block)
+                void VisitIterative(int startBlock)
+                {
+                    StartBlock(startBlock);
+                    var frames = new List<TarjanFrame> { new(startBlock, 0, -1) };
+                    while (frames.Count > 0)
+                    {
+                        var frame = frames[^1];
+                        var successors = BlockGraph.Blocks[frame.Block].Edges.Successors;
+                        if (frame.NextSuccessorIndex < successors.Count)
+                        {
+                            int successor = successors[frame.NextSuccessorIndex];
+                            frames[^1] = frame with { NextSuccessorIndex = frame.NextSuccessorIndex + 1 };
+                            if ((uint)successor >= (uint)BlockGraph.Blocks.Length)
+                                continue;
+                            if (indexByBlock[successor] < 0)
+                            {
+                                StartBlock(successor);
+                                frames.Add(new TarjanFrame(successor, 0, frame.Block));
+                            }
+                            else if (onStack[successor])
+                            {
+                                lowLinkByBlock[frame.Block] = Math.Min(lowLinkByBlock[frame.Block], indexByBlock[successor]);
+                            }
+                            continue;
+                        }
+
+                        frames.RemoveAt(frames.Count - 1);
+                        if (frame.ParentBlock >= 0)
+                            lowLinkByBlock[frame.ParentBlock] = Math.Min(lowLinkByBlock[frame.ParentBlock], lowLinkByBlock[frame.Block]);
+
+                        if (lowLinkByBlock[frame.Block] != indexByBlock[frame.Block])
+                            continue;
+
+                        var component = new List<int>();
+                        int member;
+                        do
+                        {
+                            member = stack.Pop();
+                            onStack[member] = false;
+                            component.Add(member);
+                        }
+                        while (member != frame.Block);
+
+                        bool cyclic = component.Count > 1
+                            || BlockGraph.Blocks[component[0]].Edges.Successors.Contains(component[0]);
+                        if (!cyclic)
+                            continue;
+
+                        var componentSet = component.ToHashSet();
+                        var entries = component
+                            .Where(candidate => candidate == 0 || predecessors[candidate].Any(pred => !componentSet.Contains(pred)))
+                            .Distinct()
+                            .ToArray();
+                        if (entries.Length != 1)
+                            continue;
+
+                        int header = entries[0];
+                        if (component.Any(candidate => !DominatesBlock(BlockGraph, header, candidate)))
+                            continue;
+
+                        loops.Add(new NaturalLoop(header, LatchBlock: -1, [.. component.Order()]));
+                    }
+                }
+
+                void StartBlock(int block)
                 {
                     indexByBlock[block] = nextIndex;
                     lowLinkByBlock[block] = nextIndex;
                     nextIndex++;
                     stack.Push(block);
                     onStack[block] = true;
-
-                    foreach (int successor in BlockGraph.Blocks[block].Edges.Successors)
-                    {
-                        if ((uint)successor >= (uint)BlockGraph.Blocks.Length)
-                            continue;
-                        if (indexByBlock[successor] < 0)
-                        {
-                            Visit(successor);
-                            lowLinkByBlock[block] = Math.Min(lowLinkByBlock[block], lowLinkByBlock[successor]);
-                        }
-                        else if (onStack[successor])
-                        {
-                            lowLinkByBlock[block] = Math.Min(lowLinkByBlock[block], indexByBlock[successor]);
-                        }
-                    }
-
-                    if (lowLinkByBlock[block] != indexByBlock[block])
-                        return;
-
-                    var component = new List<int>();
-                    int member;
-                    do
-                    {
-                        member = stack.Pop();
-                        onStack[member] = false;
-                        component.Add(member);
-                    }
-                    while (member != block);
-
-                    bool cyclic = component.Count > 1
-                        || BlockGraph.Blocks[component[0]].Edges.Successors.Contains(component[0]);
-                    if (!cyclic)
-                        return;
-
-                    var componentSet = component.ToHashSet();
-                    var entries = component
-                        .Where(candidate => candidate == 0 || predecessors[candidate].Any(pred => !componentSet.Contains(pred)))
-                        .Distinct()
-                        .ToArray();
-                    if (entries.Length != 1)
-                        return;
-
-                    int header = entries[0];
-                    if (component.Any(candidate => !DominatesBlock(BlockGraph, header, candidate)))
-                        return;
-
-                    loops.Add(new NaturalLoop(header, LatchBlock: -1, [.. component.Order()]));
                 }
             }
         }
@@ -3943,6 +3960,8 @@ public sealed class LibraryBodyIndex
             public bool ContainsBlock(int block)
                 => !Blocks.IsDefaultOrEmpty && Blocks.Contains(block);
         }
+
+        readonly record struct TarjanFrame(int Block, int NextSuccessorIndex, int ParentBlock);
 
         static bool TryFindPreviousInstruction(DecodedBody decodedBody, int targetOffset, out DecodedInstruction previousInstruction)
         {

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -2456,15 +2456,17 @@ public sealed class LibraryBodyIndex
                                 unsizedCollectionsByDefinition,
                                 out var construction))
                         {
+                            var coldRegion = ClassifyColdRegion(decodedBody, offset);
                             opportunities.Add(new OptimizationOpportunity(
                                 caller,
                                 "unsized-collection-grown",
                                 $"{construction.CollectionType} constructed without capacity; grown by {growthCall} in a loop",
                                 "Constructed without capacity and grown in a loop; each growth reallocates and copies the backing store. Pre-size with a capacity when the count is known.",
-                                "medium",
+                                coldRegion.IsCold ? "low" : "medium",
                                 true,
                                 offset,
-                                "Advisory: consider pre-sizing if the size is predictable."));
+                                coldRegion.Caveat ?? "Advisory: consider pre-sizing if the size is predictable.",
+                                ColdPath: coldRegion.IsCold));
                         }
                         break;
                     }
@@ -3559,6 +3561,102 @@ public sealed class LibraryBodyIndex
 
         static bool IsInLoopRegion(int offset, IReadOnlyList<(int Start, int End)> regions)
             => regions.Any(region => offset >= region.Start && offset <= region.End);
+
+        ColdRegionClassification ClassifyColdRegion(DecodedBody decodedBody, int offset)
+        {
+            if (IsInsideExceptionHandlerBlock(decodedBody, offset))
+                return ColdRegionClassification.Cold;
+            if (MethodUnconditionallyThrows(decodedBody))
+                return ColdRegionClassification.Cold;
+            return ColdRegionClassification.Warm;
+        }
+
+        static bool IsInsideExceptionHandlerBlock(DecodedBody decodedBody, int offset)
+        {
+            int blockIndex = decodedBody.BlockGraph.BlockIndexAt(offset);
+            if (blockIndex < 0)
+                return false;
+
+            var block = decodedBody.BlockGraph.Blocks[blockIndex];
+            foreach (var region in decodedBody.BlockGraph.Regions)
+            {
+                if (region.Kind == HandlerKind.Filter
+                    && block.Start >= region.FilterStart
+                    && block.End <= region.FilterEnd)
+                {
+                    return true;
+                }
+                if (block.Start >= region.HandlerStart
+                    && block.End <= region.HandlerEnd)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        static bool MethodUnconditionallyThrows(DecodedBody decodedBody)
+        {
+            if (!decodedBody.BlockGraph.IsComplete || decodedBody.BlockGraph.Blocks.Length == 0)
+                return false;
+
+            var reachable = new bool[decodedBody.BlockGraph.Blocks.Length];
+            var stack = new Stack<int>();
+            stack.Push(0);
+            reachable[0] = true;
+            while (stack.Count > 0)
+            {
+                int blockIndex = stack.Pop();
+                foreach (int successor in decodedBody.BlockGraph.Blocks[blockIndex].Edges.Successors)
+                {
+                    if ((uint)successor >= (uint)reachable.Length || reachable[successor])
+                        continue;
+                    reachable[successor] = true;
+                    stack.Push(successor);
+                }
+            }
+
+            bool sawThrowExit = false;
+            for (int i = 0; i < decodedBody.BlockGraph.Blocks.Length; i++)
+            {
+                if (!reachable[i])
+                    continue;
+                var block = decodedBody.BlockGraph.Blocks[i];
+                if (block.Edges.ExternalTargets.Count > 0 || block.Edges.LeavesRegion)
+                    return false;
+                if (!block.Edges.ExitsMethod)
+                    continue;
+                if (!TryGetLastInstruction(decodedBody, block, out var last)
+                    || last.OpCode is not (ILOpCode.Throw or ILOpCode.Rethrow))
+                {
+                    return false;
+                }
+                sawThrowExit = true;
+            }
+            return sawThrowExit;
+        }
+
+        static bool TryGetLastInstruction(DecodedBody decodedBody, InstructionBlock block, out DecodedInstruction last)
+        {
+            last = default!;
+            bool found = false;
+            for (int i = decodedBody.IndexAtOrAfter(block.Start); i < decodedBody.Instructions.Length; i++)
+            {
+                var instruction = decodedBody.Instructions[i];
+                if (instruction.Offset >= block.End)
+                    break;
+                last = instruction;
+                found = true;
+            }
+            return found;
+        }
+
+        readonly record struct ColdRegionClassification(bool IsCold, string? Caveat)
+        {
+            const string ColdCaveat = "On an exception/cold path; low steady-state impact.";
+            public static ColdRegionClassification Warm { get; } = new(false, null);
+            public static ColdRegionClassification Cold { get; } = new(true, ColdCaveat);
+        }
 
         // Body-scan signals the call index cannot see: array allocations (newarr),
         // throw/rethrow sites, and exception-handling clauses. Mirrors the loop-region

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -3494,6 +3494,29 @@ public sealed class LibraryBodyIndex
         static bool SameSlot(LocalSlotAccess left, LocalSlotAccess right)
             => left.Slot == right.Slot && left.IsArgument == right.IsArgument;
 
+        bool SizingArgumentIsProvablyZero(DecodedBody decodedBody, int callOffset, MemberRef callee, GenericScope callerScope)
+        {
+            if (callee.ParameterTypes.Length != 1)
+                return false;
+
+            int blockIndex = decodedBody.BlockGraph.BlockIndexAt(callOffset);
+            if (blockIndex < 0)
+                return false;
+
+            var block = decodedBody.BlockGraph.Blocks[blockIndex];
+            var stack = new List<StringSliceStackValue>();
+            for (int i = decodedBody.IndexAtOrAfter(block.Start); i < decodedBody.Instructions.Length; i++)
+            {
+                var instruction = decodedBody.Instructions[i];
+                if (instruction.Offset >= callOffset || instruction.Offset >= block.End)
+                    break;
+                if (!ApplyStringSliceStackEffect(instruction, stack, callerScope))
+                    return false;
+            }
+
+            return stack.Count >= 2 && stack[^1].IsZero;
+        }
+
         bool HasDominatingPreLoopSizingEvent(
             DecodedBody decodedBody,
             ReachingDefinitionsResult reachingDefinitions,
@@ -3519,6 +3542,7 @@ public sealed class LibraryBodyIndex
                 int token = OperandInt32(instruction);
                 var callee = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
                 if (!IsGrowableCollectionSizingCall(callee)
+                    || SizingArgumentIsProvablyZero(decodedBody, offset, callee, callerScope)
                     || !TryGetUnsizedCollectionReceiver(
                         decodedBody,
                         reachingDefinitions,

--- a/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
+++ b/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
@@ -21,6 +21,7 @@ public sealed record PerformanceTriageOptions
         "span-to-array-copy",
         "stackalloc-candidate",
         "string-build-in-loop",
+        "string-slice-in-loop",
         "temporary-byte-array-copy",
         "unsized-collection-grown",
     ];

--- a/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
+++ b/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
@@ -22,6 +22,7 @@ public sealed record PerformanceTriageOptions
         "stackalloc-candidate",
         "string-build-in-loop",
         "temporary-byte-array-copy",
+        "unsized-collection-grown",
     ];
 
     public bool LoopOnly { get; init; }


### PR DESCRIPTION
## Summary

Adds avoidable-loop-allocation family v1 to Performance Triage:

- `unsized-collection-grown`: no-capacity growable collection stored to a local and grown in a loop, linked by reaching definitions.
- `string-slice-in-loop`: trusted `System.String` `Substring` / `Split` / `Trim*` calls inside loop regions.
- Reusable cold-region classifier: EH handler/filter blocks or unconditionally-throwing bodies demote loop-allocation rows to low with "On an exception/cold path; low steady-state impact."

## Evidence

- Build: `dotnet build src/dotnet-inspect -c Release` ✅
- Tests: `dotnet run --project src/ILInspector.Analysis.Tests -c Release` ✅ (275 passed)

### Unsized collection canaries

- STJ `JsonHelpers.TraverseGraphWithTopologicalSort`: 4 rows, all medium.
- STJ ThrowHelper `StringBuilder` rows: low (cold demotion), yielding STJ split 6 low / 5 medium.
- Aspire: 13 rows, all medium/unchanged.

### String slice canaries

- Aspire `DcpLogParser.FormatSystemLog`: `Split` + `Trim` rows.
- Dapper `SqlMapper.GenerateValueTupleDeserializer`: 2 `Substring` rows.
- AutoMapper `TypeDetails.PossibleNames`: `Substring` row.
- Extended #2040-style probe (six pinned + Dapper + Humanizer.Core + RestSharp): 51 `string-slice-in-loop` rows.

### Fixtures

- `unsized-collection-grown`: no-capacity+loop fires; capacity ctor does not; `EnsureCapacity` before loop does not; `Capacity` setter before loop does not; ternary sized/unsized constructor merge does not; lexical-but-not-natural loop does not; non-loop growth does not; static `Add` helper does not; throw-helper path demotes low; infinite-loop work with conditional throw stays medium.
- `string-slice-in-loop`: Substring-in-loop fires; Substring outside loop does not; no-op `Substring(0)` / `Substring(0, s.Length)` in loop does not; lexical-but-not-natural loop does not; Substring-in-loop throw helper demotes low; Substring-in-`finally` stays medium.

## Corpus favorability

Re-verified after GPT-5.5 and Gemini precision fixes: existing rows remain byte-identical to the 0.16.0 baseline after removing the two new shapes. The only baseline deltas are the two new shapes. The strict natural-loop gate intentionally suppresses a few previously reported new-shape rows that could not be confirmed as natural-loop sites (fail-closed precision).

| Library | `string-slice-in-loop` new rows | Other rows |
| --- | ---: | --- |
| System.Text.Json@10.0.9 | 0 | existing unchanged |
| Aspire.Hosting@13.4.6 | 13 | existing unchanged |
| Newtonsoft.Json@13.0.4 | 7 | existing unchanged |
| Serilog@4.3.1 | 2 | existing unchanged |
| Polly@8.7.0 | 0 | existing unchanged |
| AutoMapper@16.1.1 | 2 | existing unchanged |

## Aspire before/after demo

| Shape | `dnx dotnet-inspect@0.16.0` | this PR | Examples |
| --- | ---: | ---: | --- |
| `unsized-collection-grown` | 0 | 13 | `ResourceLoggerService.GetLogger` (`List<ILogger>::Add`), `DrainAppHostStartupEvents` (`List<AppHostStartupEvent>::Add`) |
| `string-slice-in-loop` | 0 | 13 | `DcpLogParser.FormatSystemLog` (`Split`, `Trim`), `ContainerDirectory.GetFileSystemItemsFromPath` (`Substring`, `Split`) |

## Adversarial review

- Claude Opus 4.8: initially found static `Add` and instance-`call` stack receiver hardening issues; fixed in `fcd5d68f`. Latest family review found no significant issues.
- GPT-5.5: found three precision issues; fixed in `d9823aa8` by suppressing dominating pre-loop sizing (`EnsureCapacity` / `Capacity` setter), suppressing provable no-op `Substring`, and keeping `finally` handlers warm.
- Gemini 3.1 Pro: found the same `finally` issue plus lexical loop attribution, branchy constructor-def aliasing, and infinite-loop throw-helper over-demotion; fixed in `042cbd1a` with a new-shapes-only natural-loop gate, constructor/store domination and all-reaching-def fail-closed behavior, and throw-helper-name-gated cold demotion. Confirming re-review found recursive Tarjan stack-overflow risk; fixed in `eb2c572b` by making SCC discovery iterative.
- GPT-5.5 confirming re-review: found zero-capacity pre-size over-suppression; fixed in `0e045ccf` so `EnsureCapacity(0)` / `Capacity = 0` still report while non-zero/unknown sizing suppresses.

Latest local build/tests passed after `0e045ccf`; CI/review still pending, so not marking Ready to merge yet.

Fixes #2042.



