### PR TITLE
Add ReturnToSender compile-back prototype

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -57,6 +57,8 @@
              Link="CorpusSensor.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\FidelityCheck.cs"
              Link="FidelityCheck.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\ReturnToSender.cs"
+             Link="ReturnToSender.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\GeneratedFixtures.cs"
              Link="GeneratedFixtures.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ValidityCheck.cs"

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -57,6 +57,8 @@
              Link="CorpusSensor.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\FidelityCheck.cs"
              Link="FidelityCheck.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\HarnessOpcode.cs"
+             Link="HarnessOpcode.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ReturnToSender.cs"
              Link="ReturnToSender.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\GeneratedFixtures.cs"

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -102,6 +102,45 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    [Fact]
+    public void CompileBackPropertyGetters_EvaluatesSupportedGetterLadderWithCap()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public string Method1 => "Hello World";
+                public int Count => 42;
+                public string this[int index] => index.ToString();
+            }
+
+            public readonly struct SkippedStruct
+            {
+                public int Value => 1;
+            }
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackPropertyGetters(assemblyPath, maxTargets: 2);
+
+            Assert.Collection(
+                results,
+                first =>
+                {
+                    Assert.Equal("get_Method1", first.Plan.TargetMethod.Method);
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, first.Status);
+                },
+                second =>
+                {
+                    Assert.Equal("get_Count", second.Plan.TargetMethod.Method);
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, second.Status);
+                });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     static string CompileFixture(
         string source,
         string? directory = null,

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -67,14 +67,54 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
-    static string CompileFixture(string source)
+    [Fact]
+    public void CompileBackFirstPropertyGetter_UsesDependencyReferencesAndNamespaces()
     {
         var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
         Directory.CreateDirectory(directory);
-        var path = Path.Combine(directory, "fixture.dll");
+        var dependencyPath = CompileFixture("""
+            namespace External;
+
+            public class Greeting
+            {
+                public static Greeting Create() => new Greeting();
+            }
+            """, directory, "ExternalLib");
+        var assemblyPath = CompileFixture("""
+            using External;
+
+            public class Class1
+            {
+                public Greeting Method1 => Greeting.Create();
+            }
+            """, directory, "Fixture", [MetadataReference.CreateFromFile(dependencyPath)]);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("External", result.Plan.Module.Usings);
+            Assert.Contains("public External.Greeting Method1", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    static string CompileFixture(
+        string source,
+        string? directory = null,
+        string assemblyName = "fixture",
+        IReadOnlyList<MetadataReference>? additionalReferences = null)
+    {
+        directory ??= Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, $"{assemblyName}.dll");
         var references = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
             .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-            .Select(path => MetadataReference.CreateFromFile(path));
+            .Select(path => MetadataReference.CreateFromFile(path))
+            .Concat(additionalReferences ?? []);
         var compilation = CSharpCompilation.Create(
             Path.GetFileNameWithoutExtension(path),
             [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -141,6 +141,43 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    [Fact]
+    public void CompileBackPropertyGetters_PreservesSuccessesAfterFailingTarget()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Helper
+            {
+            }
+
+            public class Class1
+            {
+                public Helper SameAssemblyType => new Helper();
+                public string Method1 => "Hello World";
+            }
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackPropertyGetters(assemblyPath, maxTargets: 2);
+
+            Assert.Collection(
+                results,
+                first =>
+                {
+                    Assert.Equal("get_SameAssemblyType", first.Plan.TargetMethod.Method);
+                    Assert.Equal(FidelityCheck.CompileBackStatus.RecompileFail, first.Status);
+                },
+                second =>
+                {
+                    Assert.Equal("get_Method1", second.Plan.TargetMethod.Method);
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, second.Status);
+                });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     static string CompileFixture(
         string source,
         string? directory = null,

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1,0 +1,99 @@
+using ILInspector.DecompilerHarness;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ReturnToSenderPrototypeTests
+{
+    [Fact]
+    public void CompileBackFirstPropertyGetter_RoundTripsMinimalClassProperty()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public string Method1 => "Hello World";
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Equal("Class1", result.Plan.TargetMethod.Type);
+            Assert.Equal("get_Method1", result.Plan.TargetMethod.Method);
+            Assert.Contains("public unsafe class Class1", result.Source);
+            Assert.Contains("public string Method1", result.Source);
+            Assert.Contains("return \"Hello World\";", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackFirstPropertyGetter_ExposesTypedModuleAndTypeShellPlan()
+    {
+        var assemblyPath = CompileFixture("""
+            namespace Fixtures;
+
+            public class Class1
+            {
+                public string Method1 => "Hello World";
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+            var type = Assert.Single(result.Plan.Types);
+            var member = Assert.Single(type.Members);
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Equal("Fixtures", type.Namespace);
+            Assert.Equal("Class1", type.Name);
+            Assert.Equal(ReturnToSender.TypeShellKind.Class, type.Kind);
+            Assert.Equal("Method1", member.Name);
+            Assert.Equal(ReturnToSender.TypeMemberShellKind.PropertyGet, member.Kind);
+            Assert.Equal("string", member.Type);
+            Assert.Contains("System", result.Plan.Module.Usings);
+            Assert.Empty(result.Plan.Module.AssemblyAttributes);
+            Assert.Empty(result.Plan.Module.ModuleAttributes);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    static string CompileFixture(string source)
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, "fixture.dll");
+        var references = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            Path.GetFileNameWithoutExtension(path),
+            [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],
+            references,
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                optimizationLevel: OptimizationLevel.Release,
+                nullableContextOptions: NullableContextOptions.Disable));
+
+        var emit = compilation.Emit(path);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        return path;
+    }
+
+    static void DeleteFixture(string assemblyPath)
+    {
+        var directory = Path.GetDirectoryName(assemblyPath);
+        File.Delete(assemblyPath);
+        if (directory is not null && Path.GetFileName(directory).StartsWith("return-to-sender-", StringComparison.Ordinal))
+            Directory.Delete(directory, recursive: true);
+    }
+}

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -3388,14 +3388,7 @@ static class FidelityCheck
     }
 
     static string CanonicalOpcode(string op)
-    {
-        string trimmed = op.EndsWith(".s", StringComparison.Ordinal) ? op[..^2] : op;
-        if (trimmed.StartsWith("ldarg", StringComparison.Ordinal)) return "ldarg";
-        if (trimmed.StartsWith("ldloc", StringComparison.Ordinal)) return "ldloc";
-        if (trimmed.StartsWith("stloc", StringComparison.Ordinal)) return "stloc";
-        if (trimmed.StartsWith("ldc.i4", StringComparison.Ordinal)) return "ldc.i4";
-        return trimmed;
-    }
+        => HarnessOpcode.Canonicalize(op);
 
     /// <summary>
     /// References for recompilation: the running runtime (TPA), every sibling

--- a/tools/DecompilerHarness/HarnessOpcode.cs
+++ b/tools/DecompilerHarness/HarnessOpcode.cs
@@ -1,0 +1,14 @@
+namespace ILInspector.DecompilerHarness;
+
+static class HarnessOpcode
+{
+    public static string Canonicalize(string op)
+    {
+        string trimmed = op.EndsWith(".s", StringComparison.Ordinal) ? op[..^2] : op;
+        if (trimmed.StartsWith("ldarg", StringComparison.Ordinal)) return "ldarg";
+        if (trimmed.StartsWith("ldloc", StringComparison.Ordinal)) return "ldloc";
+        if (trimmed.StartsWith("stloc", StringComparison.Ordinal)) return "stloc";
+        if (trimmed.StartsWith("ldc.i4", StringComparison.Ordinal)) return "ldc.i4";
+        return trimmed;
+    }
+}

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -184,7 +184,7 @@ static class Program
             return FidelityCheck.Run(assemblies, compileCap, maxExamples, lowered, fidelityTimings, fidelityZeroSignalGuard);
 
         if (returnToSender)
-            return ReturnToSender.Run(assemblies, maxExamples);
+            return ReturnToSender.Run(assemblies, cap, maxExamples);
 
         if (typeCheck)
             return TypeSourceCheck.Run(assemblies, cap, maxExamples);

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -34,6 +34,7 @@ static class Program
         string? emitValidityDefects = null;
         string? diffValidityDefects = null;
         bool fidelityCheck = false;
+        bool returnToSender = false;
         bool fidelityTimings = false;
         int fidelityZeroSignalGuard = 0;
         bool gaps = false;
@@ -101,6 +102,7 @@ static class Program
                 case "--emit-validity-defects": emitValidityDefects = args[++i]; break;
                 case "--diff-validity-defects": diffValidityDefects = args[++i]; break;
                 case "--fidelity-check": fidelityCheck = true; break;
+                case "--return-to-sender": returnToSender = true; break;
                 case "--fidelity-timings": fidelityTimings = true; break;
                 case "--fidelity-zero-signal-guard": fidelityZeroSignalGuard = int.Parse(args[++i]); break;
                 case "--gaps": gaps = true; break;
@@ -180,6 +182,9 @@ static class Program
 
         if (fidelityCheck)
             return FidelityCheck.Run(assemblies, compileCap, maxExamples, lowered, fidelityTimings, fidelityZeroSignalGuard);
+
+        if (returnToSender)
+            return ReturnToSender.Run(assemblies, maxExamples);
 
         if (typeCheck)
             return TypeSourceCheck.Run(assemblies, cap, maxExamples);
@@ -1160,6 +1165,10 @@ static class Program
           --emit-validity-defects <f>    with --validity-check, write per-method defect codes to <f>
           --diff-validity-defects <f>    with --validity-check, diff per-method defects against baseline <f>
           --fidelity-check        decompile, recompile in-context, and compare IL opcodes (semantic fidelity)
+          --return-to-sender      prototype fact-planned compile-back harness:
+                                build module/type shells for the first property
+                                getter in each assembly, compile, and compare IL
+                                opcodes.
           --fidelity-timings      with --fidelity-check: print phase timings for collect/render,
                                 skeleton emit, parse, compilation create, emit, and opcode compare
           --fidelity-zero-signal-guard <n>

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -196,7 +196,7 @@ static class ReturnToSender
                 if (getter.RelativeVirtualAddress == 0)
                     continue;
 
-                results.Add(CompileBackPropertyGetter(assemblyPath, pe, reader, source, typeHandle, propertyHandle, accessors.Getter));
+                results.Add(CompileBackPropertyGetterOrContextFail(assemblyPath, pe, reader, source, typeHandle, propertyHandle, accessors.Getter));
                 if (results.Count >= maxTargets)
                     return results;
             }
@@ -205,6 +205,25 @@ static class ReturnToSender
         if (results.Count == 0)
             throw new InvalidOperationException("No supported property getter with a method body was found.");
         return results;
+    }
+
+    static Result CompileBackPropertyGetterOrContextFail(
+        string assemblyPath,
+        PEReader pe,
+        MetadataReader reader,
+        MetadataSource source,
+        TypeDefinitionHandle typeHandle,
+        PropertyDefinitionHandle propertyHandle,
+        MethodDefinitionHandle getterHandle)
+    {
+        try
+        {
+            return CompileBackPropertyGetter(assemblyPath, pe, reader, source, typeHandle, propertyHandle, getterHandle);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return ContextFailResult(assemblyPath, reader, typeHandle, propertyHandle, getterHandle, ex.Message);
+        }
     }
 
     static Result CompileBackPropertyGetter(
@@ -314,6 +333,55 @@ static class ReturnToSender
             string.Join(" ", originalOps),
             string.Join(" ", recompiledOps),
             null);
+    }
+
+    static Result ContextFailResult(
+        string assemblyPath,
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        PropertyDefinitionHandle propertyHandle,
+        MethodDefinitionHandle getterHandle,
+        string detail)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        var getter = reader.GetMethodDefinition(getterHandle);
+        string fullType = reader.GetFullTypeName(typeDef);
+        string methodName = reader.GetString(getter.Name);
+        int overload = OverloadIndex(reader, typeDef, getterHandle, methodName);
+        string ns = reader.GetString(typeDef.Namespace);
+        string typeName = Identifier(StripArity(reader.GetString(typeDef.Name)));
+        string propertyName = Identifier(reader.GetString(reader.GetPropertyDefinition(propertyHandle).Name));
+
+        var plan = new ReconstructionPlan(
+            AssemblyPath: Path.GetFullPath(assemblyPath),
+            TargetMethod: new MethodIdentity(fullType, methodName, overload, ""),
+            Module: new ModuleRequirement(
+                Usings: ["System"],
+                AssemblyAttributes: [],
+                ModuleAttributes: []),
+            Types:
+            [
+                new TypeShell(
+                    Namespace: ns,
+                    Name: typeName,
+                    Kind: TypeShellKind.Class,
+                    Members:
+                    [
+                        new TypeMemberShell(
+                            Name: propertyName,
+                            Kind: TypeMemberShellKind.PropertyGet,
+                            Type: "",
+                            Body: "")
+                    ])
+            ]);
+
+        return new Result(
+            plan,
+            "",
+            FidelityCheck.CompileBackStatus.ContextFail,
+            "",
+            "",
+            detail);
     }
 
     static int OverloadIndex(MetadataReader reader, TypeDefinition typeDef, MethodDefinitionHandle target, string methodName)

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1,0 +1,441 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text;
+
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Prototype for the ReturnToSender compile-back architecture: build typed shell
+/// records, print them as source, compile with Roslyn, and compare opcodes.
+/// </summary>
+static class ReturnToSender
+{
+    public sealed record ReconstructionPlan(
+        string AssemblyPath,
+        MethodIdentity TargetMethod,
+        ModuleRequirement Module,
+        IReadOnlyList<TypeShell> Types);
+
+    public sealed record MethodIdentity(
+        string Type,
+        string Method,
+        int Overload,
+        string Signature);
+
+    public sealed record ModuleRequirement(
+        IReadOnlyList<string> Usings,
+        IReadOnlyList<AttributeRequirement> AssemblyAttributes,
+        IReadOnlyList<AttributeRequirement> ModuleAttributes);
+
+    public sealed record AttributeRequirement(string Text, string Reason);
+
+    public sealed record TypeShell(
+        string Namespace,
+        string Name,
+        TypeShellKind Kind,
+        IReadOnlyList<TypeMemberShell> Members);
+
+    public enum TypeShellKind
+    {
+        Class,
+    }
+
+    public sealed record TypeMemberShell(
+        string Name,
+        TypeMemberShellKind Kind,
+        string Type,
+        string Body);
+
+    public enum TypeMemberShellKind
+    {
+        PropertyGet,
+    }
+
+    public sealed record Result(
+        ReconstructionPlan Plan,
+        string Source,
+        FidelityCheck.CompileBackStatus Status,
+        string OriginalOpcodes,
+        string RecompiledOpcodes,
+        string? Detail);
+
+    public static int Run(IReadOnlyList<string> assemblies, int maxExamples)
+    {
+        int total = 0, exact = 0, opcodeDiff = 0, recompileFail = 0, contextFail = 0;
+        var examples = new List<string>();
+
+        foreach (var assemblyPath in assemblies)
+        {
+            Result result;
+            try
+            {
+                result = CompileBackFirstPropertyGetter(assemblyPath);
+            }
+            catch (Exception ex) when (ex is IOException or BadImageFormatException or InvalidOperationException)
+            {
+                total++;
+                contextFail++;
+                if (examples.Count < maxExamples)
+                    examples.Add($"{Path.GetFileName(assemblyPath)}\n    ContextFail: {ex.Message}");
+                continue;
+            }
+
+            total++;
+            switch (result.Status)
+            {
+                case FidelityCheck.CompileBackStatus.Exact:
+                    exact++;
+                    break;
+                case FidelityCheck.CompileBackStatus.OpcodeDiff:
+                    opcodeDiff++;
+                    break;
+                case FidelityCheck.CompileBackStatus.RecompileFail:
+                    recompileFail++;
+                    break;
+                default:
+                    contextFail++;
+                    break;
+            }
+
+            if (examples.Count < maxExamples)
+            {
+                examples.Add($"""
+                    {result.Plan.TargetMethod.Type}::{result.Plan.TargetMethod.Method}
+                        status: {result.Status}
+                        layer : module/type shell
+                        detail: {result.Detail ?? "ok"}
+                    """);
+            }
+        }
+
+        Console.WriteLine($"RETURNTOSENDER prototype over {total} assemblies");
+        Console.WriteLine();
+        Console.WriteLine($"  Exact         : {exact}");
+        Console.WriteLine($"  OpcodeDiff    : {opcodeDiff}");
+        Console.WriteLine($"  RecompileFail : {recompileFail}");
+        Console.WriteLine($"  ContextFail   : {contextFail}");
+        if (examples.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Examples:");
+            foreach (var example in examples)
+                Console.WriteLine($"  {example}");
+        }
+
+        return recompileFail + contextFail == 0 ? 0 : 1;
+    }
+
+    public static Result CompileBackFirstPropertyGetter(string assemblyPath)
+    {
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        if (!pe.HasMetadata)
+            throw new InvalidOperationException("Assembly has no metadata.");
+
+        var reader = pe.GetMetadataReader();
+        using var metadata = CorpusMetadata.Create([assemblyPath]);
+        using var source = MetadataSource.Open(assemblyPath, context: metadata);
+
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            if (!typeDef.GetDeclaringType().IsNil || reader.GetString(typeDef.Name) == "<Module>")
+                continue;
+
+            foreach (var propertyHandle in typeDef.GetProperties())
+            {
+                var property = reader.GetPropertyDefinition(propertyHandle);
+                var accessors = property.GetAccessors();
+                if (accessors.Getter.IsNil)
+                    continue;
+
+                var getter = reader.GetMethodDefinition(accessors.Getter);
+                if (getter.RelativeVirtualAddress == 0)
+                    continue;
+
+                return CompileBackPropertyGetter(assemblyPath, pe, reader, source, typeHandle, propertyHandle, accessors.Getter);
+            }
+        }
+
+        throw new InvalidOperationException("No property getter with a method body was found.");
+    }
+
+    static Result CompileBackPropertyGetter(
+        string assemblyPath,
+        PEReader pe,
+        MetadataReader reader,
+        MetadataSource source,
+        TypeDefinitionHandle typeHandle,
+        PropertyDefinitionHandle propertyHandle,
+        MethodDefinitionHandle getterHandle)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        var property = reader.GetPropertyDefinition(propertyHandle);
+        var getter = reader.GetMethodDefinition(getterHandle);
+        string fullType = reader.GetFullTypeName(typeDef);
+        string methodName = reader.GetString(getter.Name);
+        int overload = OverloadIndex(reader, typeDef, getterHandle, methodName);
+
+        var function = IrImporter.Import(source, fullType, methodName, overload)
+            ?? throw new InvalidOperationException($"Could not import {fullType}::{methodName}.");
+        var printed = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+        if (printed.Output is null)
+            throw new InvalidOperationException($"Could not print {fullType}::{methodName}.");
+
+        var original = ILDisassembler.Disassemble(pe, reader, getter)
+            ?? throw new InvalidOperationException($"Could not disassemble {fullType}::{methodName}.");
+        var originalOps = original.Select(instruction => CanonicalOpcode(instruction.OpCodeName)).ToArray();
+
+        var propertySignature = property.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef));
+        string propertyType = Clean(propertySignature.ReturnType);
+        string propertyName = Identifier(reader.GetString(property.Name));
+        string typeName = Identifier(StripArity(reader.GetString(typeDef.Name)));
+        string ns = reader.GetString(typeDef.Namespace);
+
+        var plan = new ReconstructionPlan(
+            AssemblyPath: Path.GetFullPath(assemblyPath),
+            TargetMethod: new MethodIdentity(fullType, methodName, overload, CorpusMethodIdentity.SignatureText(function.Signature)),
+            Module: new ModuleRequirement(
+                Usings: ["System"],
+                AssemblyAttributes: [],
+                ModuleAttributes: []),
+            Types:
+            [
+                new TypeShell(
+                    Namespace: ns,
+                    Name: typeName,
+                    Kind: TypeShellKind.Class,
+                    Members:
+                    [
+                        new TypeMemberShell(
+                            Name: propertyName,
+                            Kind: TypeMemberShellKind.PropertyGet,
+                            Type: propertyType,
+                            Body: printed.Output)
+                    ])
+            ]);
+
+        string unit = ModuleWriter.Write(plan);
+        var tree = CSharpSyntaxTree.ParseText(unit, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "return-to-sender",
+            [tree],
+            TrustedPlatformReferences(),
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                optimizationLevel: OptimizationLevel.Release,
+                nullableContextOptions: NullableContextOptions.Disable,
+                allowUnsafe: true));
+
+        using var ms = new MemoryStream();
+        var emit = compilation.Emit(ms);
+        if (!emit.Success)
+        {
+            var error = emit.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+            return new Result(
+                plan,
+                unit,
+                FidelityCheck.CompileBackStatus.RecompileFail,
+                string.Join(" ", originalOps),
+                "",
+                FormatDiagnostic(error));
+        }
+
+        ms.Position = 0;
+        using var recompiled = new PEReader(ms);
+        var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload)
+            ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
+            .ToArray();
+
+        if (recompiledOps is null)
+        {
+            return new Result(
+                plan,
+                unit,
+                FidelityCheck.CompileBackStatus.ContextFail,
+                string.Join(" ", originalOps),
+                "",
+                "method-not-found");
+        }
+
+        return new Result(
+            plan,
+            unit,
+            originalOps.SequenceEqual(recompiledOps)
+                ? FidelityCheck.CompileBackStatus.Exact
+                : FidelityCheck.CompileBackStatus.OpcodeDiff,
+            string.Join(" ", originalOps),
+            string.Join(" ", recompiledOps),
+            null);
+    }
+
+    static int OverloadIndex(MetadataReader reader, TypeDefinition typeDef, MethodDefinitionHandle target, string methodName)
+    {
+        int overload = 0;
+        foreach (var handle in typeDef.GetMethods())
+        {
+            if (handle == target)
+                return overload;
+            if (reader.GetString(reader.GetMethodDefinition(handle).Name) == methodName)
+                overload++;
+        }
+        return overload;
+    }
+
+    static IReadOnlyList<ILInstruction>? FindAndDisassemble(
+        PEReader pe,
+        string fullType,
+        string methodName,
+        int overload)
+    {
+        if (!pe.HasMetadata)
+            return null;
+
+        var reader = pe.GetMetadataReader();
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            if (reader.GetFullTypeName(typeDef) != fullType)
+                continue;
+
+            int seen = 0;
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) != methodName)
+                    continue;
+                if (seen++ != overload)
+                    continue;
+                return ILDisassembler.Disassemble(pe, reader, method);
+            }
+        }
+
+        return null;
+    }
+
+    static IEnumerable<MetadataReference> TrustedPlatformReferences()
+        => (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Select(path => MetadataReference.CreateFromFile(path));
+
+    static string? FormatDiagnostic(Diagnostic? diagnostic)
+    {
+        if (diagnostic is null)
+            return null;
+
+        string message = diagnostic.GetMessage();
+        return string.IsNullOrWhiteSpace(message)
+            ? diagnostic.Id
+            : $"{diagnostic.Id}: {message}";
+    }
+
+    static string Clean(string type)
+        => type.Replace("modreq(", "", StringComparison.Ordinal)
+            .Replace("modopt(", "", StringComparison.Ordinal)
+            .Replace(")", "", StringComparison.Ordinal)
+            .Replace("System.String", "string", StringComparison.Ordinal)
+            .Replace("System.Int32", "int", StringComparison.Ordinal)
+            .Replace("System.Void", "void", StringComparison.Ordinal);
+
+    static string StripArity(string name)
+    {
+        int tick = name.IndexOf('`');
+        return tick >= 0 ? name[..tick] : name;
+    }
+
+    static string Identifier(string name) => SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None
+        || SyntaxFacts.GetContextualKeywordKind(name) != SyntaxKind.None
+            ? "@" + name
+            : name;
+
+    static string CanonicalOpcode(string op)
+    {
+        string trimmed = op.EndsWith(".s", StringComparison.Ordinal) ? op[..^2] : op;
+        if (trimmed.StartsWith("ldarg", StringComparison.Ordinal)) return "ldarg";
+        if (trimmed.StartsWith("ldloc", StringComparison.Ordinal)) return "ldloc";
+        if (trimmed.StartsWith("stloc", StringComparison.Ordinal)) return "stloc";
+        if (trimmed.StartsWith("ldc.i4", StringComparison.Ordinal)) return "ldc.i4";
+        return trimmed;
+    }
+
+    sealed class ModuleWriter
+    {
+        public static string Write(ReconstructionPlan plan)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("#pragma warning disable");
+            foreach (var attribute in plan.Module.AssemblyAttributes)
+                sb.AppendLine($"[assembly: {attribute.Text}]");
+            foreach (var attribute in plan.Module.ModuleAttributes)
+                sb.AppendLine($"[module: {attribute.Text}]");
+            foreach (var ns in plan.Module.Usings.OrderBy(ns => ns, StringComparer.Ordinal))
+                sb.AppendLine($"using {ns};");
+            foreach (var group in plan.Types.GroupBy(type => type.Namespace, StringComparer.Ordinal))
+            {
+                if (group.Key.Length > 0)
+                {
+                    sb.AppendLine($"namespace {group.Key}");
+                    sb.AppendLine("{");
+                    foreach (var type in group)
+                        TypePrinter.Write(type, sb, indent: 1);
+                    sb.AppendLine("}");
+                }
+                else
+                {
+                    foreach (var type in group)
+                        TypePrinter.Write(type, sb, indent: 0);
+                }
+            }
+            return sb.ToString();
+        }
+    }
+
+    sealed class TypePrinter
+    {
+        public static void Write(TypeShell type, StringBuilder sb, int indent)
+        {
+            string pad = new(' ', indent * 4);
+            string keyword = type.Kind switch
+            {
+                TypeShellKind.Class => "class",
+                _ => throw new NotSupportedException($"Unsupported type shell kind '{type.Kind}'.")
+            };
+
+            sb.AppendLine($"{pad}public unsafe {keyword} {type.Name}");
+            sb.AppendLine($"{pad}{{");
+            foreach (var member in type.Members)
+                WriteMember(member, sb, indent + 1);
+            sb.AppendLine($"{pad}}}");
+        }
+
+        static void WriteMember(TypeMemberShell member, StringBuilder sb, int indent)
+        {
+            string pad = new(' ', indent * 4);
+            switch (member.Kind)
+            {
+                case TypeMemberShellKind.PropertyGet:
+                    sb.AppendLine($"{pad}public {member.Type} {member.Name}");
+                    sb.AppendLine($"{pad}{{");
+                    sb.AppendLine($"{pad}    get");
+                    sb.AppendLine($"{pad}    {{");
+                    foreach (var line in member.Body.Split('\n'))
+                    {
+                        var text = line.TrimEnd('\r');
+                        if (text.Length > 0)
+                            sb.AppendLine($"{pad}        {text}");
+                    }
+                    sb.AppendLine($"{pad}    }}");
+                    sb.AppendLine($"{pad}}}");
+                    break;
+                default:
+                    throw new NotSupportedException($"Unsupported member shell kind '{member.Kind}'.");
+            }
+        }
+    }
+}

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -494,14 +494,7 @@ static class ReturnToSender
             : name;
 
     static string CanonicalOpcode(string op)
-    {
-        string trimmed = op.EndsWith(".s", StringComparison.Ordinal) ? op[..^2] : op;
-        if (trimmed.StartsWith("ldarg", StringComparison.Ordinal)) return "ldarg";
-        if (trimmed.StartsWith("ldloc", StringComparison.Ordinal)) return "ldloc";
-        if (trimmed.StartsWith("stloc", StringComparison.Ordinal)) return "stloc";
-        if (trimmed.StartsWith("ldc.i4", StringComparison.Ordinal)) return "ldc.i4";
-        return trimmed;
-    }
+        => HarnessOpcode.Canonicalize(op);
 
     sealed class ModuleWriter
     {

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -175,7 +175,17 @@ static class ReturnToSender
                 if (reader.GetString(property.Name).Contains('<', StringComparison.Ordinal))
                     continue;
 
-                if (property.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef)).ParameterTypes.Length != 0)
+                MethodSignature<string> propertySignature;
+                try
+                {
+                    propertySignature = property.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef));
+                }
+                catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+                {
+                    continue;
+                }
+
+                if (propertySignature.ParameterTypes.Length != 0)
                     continue;
 
                 var accessors = property.GetAccessors();

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Text;
@@ -66,17 +67,20 @@ static class ReturnToSender
         string RecompiledOpcodes,
         string? Detail);
 
-    public static int Run(IReadOnlyList<string> assemblies, int maxExamples)
+    public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples)
     {
         int total = 0, exact = 0, opcodeDiff = 0, recompileFail = 0, contextFail = 0;
         var examples = new List<string>();
 
         foreach (var assemblyPath in assemblies)
         {
-            Result result;
+            if (total >= cap)
+                break;
+
+            IReadOnlyList<Result> results;
             try
             {
-                result = CompileBackFirstPropertyGetter(assemblyPath);
+                results = CompileBackPropertyGetters(assemblyPath, cap - total);
             }
             catch (Exception ex) when (ex is IOException or BadImageFormatException or InvalidOperationException or UnauthorizedAccessException)
             {
@@ -87,35 +91,41 @@ static class ReturnToSender
                 continue;
             }
 
-            total++;
-            switch (result.Status)
+            foreach (var result in results)
             {
-                case FidelityCheck.CompileBackStatus.Exact:
-                    exact++;
+                if (total >= cap)
                     break;
-                case FidelityCheck.CompileBackStatus.OpcodeDiff:
-                    opcodeDiff++;
-                    break;
-                case FidelityCheck.CompileBackStatus.RecompileFail:
-                    recompileFail++;
-                    break;
-                default:
-                    contextFail++;
-                    break;
-            }
 
-            if (examples.Count < maxExamples)
-            {
-                examples.Add($"""
-                    {result.Plan.TargetMethod.Type}::{result.Plan.TargetMethod.Method}
-                        status: {result.Status}
-                        layer : module/type shell
-                        detail: {result.Detail ?? "ok"}
-                    """);
+                total++;
+                switch (result.Status)
+                {
+                    case FidelityCheck.CompileBackStatus.Exact:
+                        exact++;
+                        break;
+                    case FidelityCheck.CompileBackStatus.OpcodeDiff:
+                        opcodeDiff++;
+                        break;
+                    case FidelityCheck.CompileBackStatus.RecompileFail:
+                        recompileFail++;
+                        break;
+                    default:
+                        contextFail++;
+                        break;
+                }
+
+                if (examples.Count < maxExamples)
+                {
+                    examples.Add($"""
+                        {result.Plan.TargetMethod.Type}::{result.Plan.TargetMethod.Method}
+                            status: {result.Status}
+                            layer : identity transform, module/type shell
+                            detail: {result.Detail ?? "ok"}
+                        """);
+                }
             }
         }
 
-        Console.WriteLine($"RETURNTOSENDER prototype over {total} assemblies");
+        Console.WriteLine($"RETURNTOSENDER prototype over {total} property getters");
         Console.WriteLine();
         Console.WriteLine($"  Exact         : {exact}");
         Console.WriteLine($"  OpcodeDiff    : {opcodeDiff}");
@@ -133,7 +143,14 @@ static class ReturnToSender
     }
 
     public static Result CompileBackFirstPropertyGetter(string assemblyPath)
+        => CompileBackPropertyGetters(assemblyPath, maxTargets: 1).First();
+
+    public static IReadOnlyList<Result> CompileBackPropertyGetters(string assemblyPath, int maxTargets = int.MaxValue)
     {
+        if (maxTargets <= 0)
+            return [];
+
+        var results = new List<Result>();
         using var pe = new PEReader(File.OpenRead(assemblyPath));
         if (!pe.HasMetadata)
             throw new InvalidOperationException("Assembly has no metadata.");
@@ -145,12 +162,22 @@ static class ReturnToSender
         foreach (var typeHandle in reader.TypeDefinitions)
         {
             var typeDef = reader.GetTypeDefinition(typeHandle);
-            if (!typeDef.GetDeclaringType().IsNil || reader.GetString(typeDef.Name) == "<Module>")
+            if (!typeDef.GetDeclaringType().IsNil
+                || reader.GetString(typeDef.Name) == "<Module>"
+                || !IsSupportedClass(reader, typeDef))
+            {
                 continue;
+            }
 
             foreach (var propertyHandle in typeDef.GetProperties())
             {
                 var property = reader.GetPropertyDefinition(propertyHandle);
+                if (reader.GetString(property.Name).Contains('<', StringComparison.Ordinal))
+                    continue;
+
+                if (property.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef)).ParameterTypes.Length != 0)
+                    continue;
+
                 var accessors = property.GetAccessors();
                 if (accessors.Getter.IsNil)
                     continue;
@@ -159,11 +186,15 @@ static class ReturnToSender
                 if (getter.RelativeVirtualAddress == 0)
                     continue;
 
-                return CompileBackPropertyGetter(assemblyPath, pe, reader, source, typeHandle, propertyHandle, accessors.Getter);
+                results.Add(CompileBackPropertyGetter(assemblyPath, pe, reader, source, typeHandle, propertyHandle, accessors.Getter));
+                if (results.Count >= maxTargets)
+                    return results;
             }
         }
 
-        throw new InvalidOperationException("No property getter with a method body was found.");
+        if (results.Count == 0)
+            throw new InvalidOperationException("No supported property getter with a method body was found.");
+        return results;
     }
 
     static Result CompileBackPropertyGetter(
@@ -286,6 +317,36 @@ static class ReturnToSender
                 overload++;
         }
         return overload;
+    }
+
+    static bool IsSupportedClass(MetadataReader reader, TypeDefinition typeDef)
+    {
+        if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
+            return false;
+
+        string baseName = typeDef.BaseType.Kind switch
+        {
+            HandleKind.TypeReference => FullName(reader, reader.GetTypeReference((TypeReferenceHandle)typeDef.BaseType)),
+            HandleKind.TypeDefinition => FullName(reader, reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType)),
+            _ => "",
+        };
+
+        return baseName is not "System.Enum" and not "System.ValueType"
+            and not "System.MulticastDelegate" and not "System.Delegate";
+    }
+
+    static string FullName(MetadataReader reader, TypeReference type)
+    {
+        string ns = reader.GetString(type.Namespace);
+        string name = reader.GetString(type.Name);
+        return ns.Length == 0 ? name : $"{ns}.{name}";
+    }
+
+    static string FullName(MetadataReader reader, TypeDefinition type)
+    {
+        string ns = reader.GetString(type.Namespace);
+        string name = reader.GetString(type.Name);
+        return ns.Length == 0 ? name : $"{ns}.{name}";
     }
 
     static IReadOnlySet<string> RequiredNamespaces(IrFunction function)

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -78,7 +78,7 @@ static class ReturnToSender
             {
                 result = CompileBackFirstPropertyGetter(assemblyPath);
             }
-            catch (Exception ex) when (ex is IOException or BadImageFormatException or InvalidOperationException)
+            catch (Exception ex) when (ex is IOException or BadImageFormatException or InvalidOperationException or UnauthorizedAccessException)
             {
                 total++;
                 contextFail++;
@@ -202,7 +202,7 @@ static class ReturnToSender
             AssemblyPath: Path.GetFullPath(assemblyPath),
             TargetMethod: new MethodIdentity(fullType, methodName, overload, CorpusMethodIdentity.SignatureText(function.Signature)),
             Module: new ModuleRequirement(
-                Usings: ["System"],
+                Usings: RequiredNamespaces(function).Prepend("System").Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray(),
                 AssemblyAttributes: [],
                 ModuleAttributes: []),
             Types:
@@ -226,7 +226,7 @@ static class ReturnToSender
         var compilation = CSharpCompilation.Create(
             "return-to-sender",
             [tree],
-            TrustedPlatformReferences(),
+            CompilationReferences(assemblyPath),
             new CSharpCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary,
                 optimizationLevel: OptimizationLevel.Release,
@@ -249,7 +249,7 @@ static class ReturnToSender
 
         ms.Position = 0;
         using var recompiled = new PEReader(ms);
-        var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload)
+        var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
             ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
             .ToArray();
 
@@ -288,6 +288,41 @@ static class ReturnToSender
         return overload;
     }
 
+    static IReadOnlySet<string> RequiredNamespaces(IrFunction function)
+    {
+        var namespaces = new SortedSet<string>(StringComparer.Ordinal);
+
+        void Add(TypeRef? type)
+        {
+            switch (type?.Kind)
+            {
+                case TypeRefKind.Definition:
+                    if (type.Namespace.Length > 0)
+                        namespaces.Add(type.Namespace);
+                    break;
+                case TypeRefKind.GenericInstance:
+                    Add(type.ElementType);
+                    foreach (var argument in type.TypeArguments)
+                        Add(argument);
+                    break;
+                case TypeRefKind.SzArray or TypeRefKind.Array
+                    or TypeRefKind.ByRef or TypeRefKind.Pointer or TypeRefKind.Pinned:
+                    Add(type.ElementType);
+                    break;
+            }
+        }
+
+        foreach (var node in function.Descendants.Prepend(function))
+        {
+            foreach (var type in node.DirectTypes)
+                Add(type);
+            if (node is IrExpression expression)
+                Add(expression.ResultType);
+        }
+
+        return namespaces;
+    }
+
     static IReadOnlyList<ILInstruction>? FindAndDisassemble(
         PEReader pe,
         string fullType,
@@ -319,10 +354,43 @@ static class ReturnToSender
         return null;
     }
 
-    static IEnumerable<MetadataReference> TrustedPlatformReferences()
-        => (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-            .Select(path => MetadataReference.CreateFromFile(path));
+    static IEnumerable<MetadataReference> CompilationReferences(string targetPath)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        string targetName = Path.GetFileNameWithoutExtension(targetPath);
+
+        IEnumerable<string> paths = FidelityCheck.PackageDependencyReferencePaths(targetPath)
+            .Concat((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+                .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries));
+
+        if (Path.GetDirectoryName(Path.GetFullPath(targetPath)) is { } directory
+            && Directory.Exists(directory))
+            paths = paths.Concat(Directory.EnumerateFiles(directory, "*.dll"));
+
+        foreach (var path in paths)
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                || !File.Exists(path))
+                continue;
+
+            string simpleName = Path.GetFileNameWithoutExtension(path);
+            if (simpleName.Equals(targetName, StringComparison.OrdinalIgnoreCase)
+                || !seen.Add(simpleName))
+                continue;
+
+            MetadataReference reference;
+            try
+            {
+                reference = MetadataReference.CreateFromFile(Path.GetFullPath(path));
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or BadImageFormatException or ArgumentException)
+            {
+                continue;
+            }
+
+            yield return reference;
+        }
+    }
 
     static string? FormatDiagnostic(Diagnostic? diagnostic)
     {


### PR DESCRIPTION
## Summary

- adds the first ReturnToSender prototype inside `tools/DecompilerHarness`
- introduces typed `ReconstructionPlan`, `ModuleRequirement`, `TypeShell`, `TypeMemberShell`, `ModuleWriter`, and `TypePrinter` records/writers
- adds `--return-to-sender` to run the prototype over the first property getter in each input assembly
- proves the minimal `Class1.Method1 => "Hello World"` shape round-trips to exact canonical opcodes

## Scope

This is intentionally a narrow first slice, not a replacement for `--fidelity-check` yet. It exercises the ReturnToSender architecture end-to-end on the smallest useful shape: metadata -> typed plan -> module/type shell -> CSharpPrinter body -> Roslyn compile -> opcode compare.

## Validation

```bash
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json
dotnet build src/ILInspector.Decompiler.Tests -c Release --nologo --verbosity quiet --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json
dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class "*ReturnToSenderPrototypeTests"
# CLI smoke on a temporary Class1 fixture:
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll <fixture.dll> --return-to-sender
```

CLI smoke output:

```text
RETURNTOSENDER prototype over 1 assemblies

  Exact         : 1
  OpcodeDiff    : 0
  RecompileFail : 0
  ContextFail   : 0

Examples:
  Class1::get_Method1
    status: Exact
    layer : module/type shell
    detail: ok
```

A full built `ILInspector.Decompiler.Tests` executable run is still in progress locally as non-blocking extra evidence.

## Review

Adversarial review requested because this starts the new decompiler harness architecture.
