### PR TITLE
Complete union decompiler support

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -632,6 +632,94 @@ public class TypeSourceComposerUnionTests
     }
 
     [Fact]
+    public async Task UnionSwitchExpression_RendersValueTypeCaseArms()
+    {
+        using var assembly = await CompileWithSdk("""
+            namespace UnionFixtures;
+
+            public union Result<T>(T, string);
+            public union Result2(string, int);
+
+            public static class Matcher
+            {
+                public static string Describe(Result<int> result) => result switch
+                {
+                    int value => value.ToString(),
+                    string message => message,
+                    null => "null",
+                };
+
+                public static string DescribeFinalValueType(Result2 result) => result switch
+                {
+                    string message => message,
+                    int value => value.ToString(),
+                    null => "null",
+                };
+            }
+            """);
+
+        Assert.Equal("""
+            return result switch
+            {
+                null => "null",
+                int value => value.ToString(),
+                string message => message,
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "Describe"));
+        Assert.Equal("""
+            return result switch
+            {
+                null => "null",
+                string message => message,
+                int value => value.ToString(),
+            };
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "DescribeFinalValueType"));
+    }
+
+    [Fact]
+    public async Task UnionPatterns_RenderInAndByRefReceiverCanaries()
+    {
+        using var assembly = await CompileWithSdk("""
+            namespace UnionFixtures;
+
+            public sealed class Cat { public int Age { get; } = 5; }
+            public sealed class Dog { }
+            public union Pet(Cat, Dog);
+
+            public static class Matcher
+            {
+                public static bool InReceiver(in Pet pet) => pet is Cat { Age: > 3 };
+                public static bool InValueReceiver(in Pet pet) => pet.Value is Cat { Age: > 3 };
+                public static int InReceiverMixed(in Pet pet) => pet is Cat { Age: > 3 } ? pet.GetHashCode() : 0;
+
+                public static bool RefLocalReceiver(Pet pet)
+                {
+                    ref readonly var alias = ref pet;
+                    return alias is Dog;
+                }
+            }
+            """);
+
+        Assert.Equal("return pet is Cat { Age: > 3 };",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "InReceiver"));
+        Assert.Equal("return pet is Cat { Age: > 3 };",
+            RenderMember(assembly.Path, "UnionFixtures.Matcher", "InValueReceiver"));
+        Assert.Equal("""
+            Pet V_0 = pet;
+            if (V_0 is not Cat { Age: > 3 })
+            {
+                return 0;
+            }
+            V_0 = pet;
+            return V_0.GetHashCode();
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "InReceiverMixed"));
+        Assert.Equal("""
+            Pet V_0 = pet;
+            return V_0 is Dog;
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "RefLocalReceiver"));
+    }
+
+    [Fact]
     public async Task UnionSwitchExpression_RendersGuardedPropertyPatternArms()
     {
         using var assembly = await CompileWithSdk("""

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -677,6 +677,38 @@ public class TypeSourceComposerUnionTests
     }
 
     [Fact]
+    public async Task ClassUnionValueSwitchValueTypeCase_PreservesValueReceiver()
+    {
+        using var assembly = await CompileWithSdk("""
+            using System.Runtime.CompilerServices;
+            namespace UnionFixtures;
+
+            [Union]
+            public sealed class Result : IUnion
+            {
+                public Result(int value) => Value = value;
+                public Result(string value) => Value = value;
+                public object? Value { get; }
+            }
+
+            public static class Matcher
+            {
+                public static string Describe(Result result) => result.Value switch
+                {
+                    int value => value.ToString(),
+                    string message => message,
+                    null => "null",
+                };
+            }
+            """);
+
+        var source = RenderMember(assembly.Path, "UnionFixtures.Matcher", "Describe");
+
+        Assert.Contains("result.Value", source);
+        Assert.DoesNotContain("return result switch", source);
+    }
+
+    [Fact]
     public async Task UnionPatterns_RenderInAndByRefReceiverCanaries()
     {
         using var assembly = await CompileWithSdk("""

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IsPatternPass.cs
@@ -63,7 +63,8 @@ public sealed class IsPatternPass : IIrPass
             || FoldNegatedConditionalPatternReturnOne(function, context.Stepper)
             || FoldClassUnionNullConditionalReturnOne(function, context.Stepper)
             || TransformRecursivePropertyDeclaration(function, context.Stepper)
-            || FoldPositionalPatternReturnOne(function, context.Stepper))
+            || FoldPositionalPatternReturnOne(function, context.Stepper)
+            || FoldUnionValueReceiverCopy(function, context.Stepper))
         {
         }
     }
@@ -108,6 +109,55 @@ public sealed class IsPatternPass : IIrPass
         }
         return false;
     }
+
+    static bool FoldUnionValueReceiverCopy(IrFunction function, Stepper stepper)
+    {
+        foreach (var block in function.Descendants.OfType<Block>().ToList())
+        {
+            var children = block.Children;
+            for (int i = 0; i + 1 < children.Count; i++)
+            {
+                if (children[i] is not StoreLocal copyStore
+                    || TryUnionReceiverCopySource(copyStore.Value) is not { } receiver
+                    || !ReferenceOwnership.LocalReferencesOnlyWithin(function, copyStore.Index, [copyStore, children[i + 1]]))
+                {
+                    continue;
+                }
+
+                var properties = children[i + 1]
+                    .Descendants
+                    .OfType<LoadProperty>()
+                    .Where(property => IsUnionValueProperty(function, property)
+                        && property.Instance is LoadLocalAddress address
+                        && address.Index == copyStore.Index)
+                    .ToList();
+
+                int localReferences = children[i + 1].Descendants.Count(node => node switch
+                {
+                    LoadLocal load => load.Index == copyStore.Index,
+                    LoadLocalAddress address => address.Index == copyStore.Index,
+                    _ => false
+                });
+
+                if (properties.Count == 0 || localReferences != properties.Count)
+                    continue;
+
+                foreach (var property in properties)
+                    property.Instance!.ReplaceWith((IrExpression)receiver.Clone());
+
+                stepper.StepOver("fold union receiver copy into pattern receiver", children[i + 1]);
+                copyStore.Detach();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static IrExpression? TryUnionReceiverCopySource(IrExpression expression)
+        => expression is LoadIndirect { Address: LoadArgument argument }
+            ? (IrExpression)argument.Clone()
+            : null;
 
     static bool TransformNegatedPropertyPatternGuard(IrFunction function, Stepper stepper)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -138,7 +138,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         switchExpression = null!;
         if (start + 4 >= children.Count
             || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
-            || !IsUnionValueProperty(function, unionValue)
+            || !IsValueTypeUnionValueProperty(function, unionValue)
             || children[start + 1] is not StoreLocal { Value: IsInstance firstTest } firstStore
             || !IsTempTypeTest(firstTest, valueStore.Index)
             || children[start + 2] is not IfStatement firstNullGuard
@@ -235,7 +235,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         switchExpression = null!;
         if (start + 5 >= children.Count
             || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
-            || !IsUnionValueProperty(function, unionValue)
+            || !IsValueTypeUnionValueProperty(function, unionValue)
             || children[^4] is not StoreLocal { Value: IsInstance finalTest } finalStore
             || !IsTempTypeTest(finalTest, valueStore.Index)
             || children[^3] is not IfStatement finalNullGuard

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -71,6 +71,18 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 return true;
             }
 
+            if (TryMatchValueTypePrefixNullArmSwitchAt(function, children, start, out var valueTypePrefixSwitch))
+            {
+                match = new Match(start, valueTypePrefixSwitch);
+                return true;
+            }
+
+            if (TryMatchReferencePrefixValueTypeTailNullArmSwitchAt(function, children, start, out var valueTypeTailSwitch))
+            {
+                match = new Match(start, valueTypeTailSwitch);
+                return true;
+            }
+
             if (TryMatchDirectSwitchStatementReturnChainAt(function, children, start, out var directStatementSwitch))
             {
                 match = new Match(start, directStatementSwitch);
@@ -112,6 +124,252 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 match = new Match(start, switchExpression);
                 return true;
             }
+        }
+
+        return false;
+    }
+
+    static bool TryMatchReferencePrefixValueTypeTailNullArmSwitchAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        if (start + 4 >= children.Count
+            || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsUnionValueProperty(function, unionValue)
+            || children[start + 1] is not StoreLocal { Value: IsInstance firstTest } firstStore
+            || !IsTempTypeTest(firstTest, valueStore.Index)
+            || children[start + 2] is not IfStatement firstNullGuard
+            || firstNullGuard.HasElse
+            || !IsNotLocal(firstNullGuard.Condition, firstStore.Index)
+            || children[start + 3] is not StoreLocal firstValueStore
+            || firstValueStore.Value is not LoadLocal firstValueLoad
+            || firstValueLoad.Index != firstStore.Index
+            || children[start + 4] is not Return firstReturn
+            || !ReturnsLocal(firstReturn, firstValueStore.Index)
+            || !TryNestedValueTypeTailNullArms(firstNullGuard.Then.Children, valueStore.Index, firstValueStore.Index, unionValue.Instance, out var tailArms, out var nullValue))
+        {
+            return false;
+        }
+
+        var firstArm = new Arm(
+            firstTest.Type,
+            firstStore.Index,
+            firstValueStore.Value,
+            [firstStore, firstNullGuard.Condition, firstValueStore.Value]);
+        var arms = new[] { firstArm }.Concat(tailArms).ToArray();
+        var consumedNodes = children.Skip(start).Take(5).Concat(firstNullGuard.Then.Children).ToArray();
+
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, consumedNodes)
+            || !ReferenceOwnership.LocalReferencesOnlyWithin(function, firstValueStore.Index, consumedNodes)
+            || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+            || !DuplicateTypesAreGuarded(arms))
+        {
+            return false;
+        }
+
+        switchExpression = new UnionSwitchExpression(
+            (IrExpression)unionValue.Clone(),
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+            nullValue: nullValue is null ? null : (IrExpression)nullValue.Clone());
+        return true;
+    }
+
+    static bool TryNestedValueTypeTailNullArms(
+        IReadOnlyList<IrNode> nodes,
+        int tempLocal,
+        int resultLocal,
+        IrExpression? unionReceiver,
+        out IReadOnlyList<Arm> arms,
+        out IrExpression? nullValue)
+    {
+        arms = [];
+        nullValue = null;
+        if (nodes.Count < 4
+            || nodes[^2] is not ExpressionStatement throwStatement
+            || nodes[^1] is not Return throwReturn
+            || !IsThrowSwitchExpression(throwStatement)
+            || !ThrowArgumentMatchesNullArm(throwStatement, tempLocal, unionReceiver)
+            || !ReturnsLocal(throwReturn, resultLocal)
+            || nodes[^3] is not IfStatement nullIf
+            || nullIf.HasElse
+            || !IsNotLocal(nullIf.Condition, tempLocal)
+            || nullIf.Then.Children is not [StoreLocal nullStore, Return nullReturn]
+            || !StoreReturnMatch(nullStore, nullReturn, resultLocal))
+        {
+            return false;
+        }
+
+        var builder = new List<Arm>();
+        foreach (var node in nodes.Take(nodes.Count - 3))
+        {
+            if (node is not IfStatement armIf
+                || !TryValueTypePrefixArm(armIf, tempLocal, resultLocal, out var arm))
+            {
+                return false;
+            }
+
+            builder.Add(arm);
+        }
+
+        if (builder.Count == 0)
+            return false;
+
+        arms = builder;
+        nullValue = nullStore.Value;
+        return true;
+    }
+
+    static bool TryMatchValueTypePrefixNullArmSwitchAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out UnionSwitchExpression switchExpression)
+    {
+        switchExpression = null!;
+        if (start + 5 >= children.Count
+            || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsUnionValueProperty(function, unionValue)
+            || children[^4] is not StoreLocal { Value: IsInstance finalTest } finalStore
+            || !IsTempTypeTest(finalTest, valueStore.Index)
+            || children[^3] is not IfStatement finalNullGuard
+            || finalNullGuard.HasElse
+            || !IsNotLocal(finalNullGuard.Condition, finalStore.Index)
+            || children[^2] is not StoreLocal finalValueStore
+            || children[^1] is not Return finalValueReturn
+            || !StoreReturnMatch(finalValueStore, finalValueReturn, finalValueStore.Index)
+            || !TryFinalThrowOrNullArm(finalNullGuard.Then.Children, finalValueStore.Index, valueStore.Index, unionValue.Instance, out var nullValue))
+        {
+            return false;
+        }
+
+        var prefixNodes = children.Skip(start + 1).Take(children.Count - start - 5).ToArray();
+        var arms = new List<Arm>();
+        foreach (var node in prefixNodes)
+        {
+            if (node is not IfStatement armIf
+                || !TryValueTypePrefixArm(armIf, valueStore.Index, finalValueStore.Index, out var arm))
+            {
+                return false;
+            }
+
+            arms.Add(arm);
+        }
+
+        if (arms.Count == 0)
+            return false;
+
+        arms.Add(new Arm(
+            finalTest.Type,
+            finalStore.Index,
+            finalValueStore.Value,
+            [finalStore, finalNullGuard.Condition, finalValueStore.Value]));
+
+        var consumedNodes = children.Skip(start).ToArray();
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, consumedNodes)
+            || !ReferenceOwnership.LocalReferencesOnlyWithin(function, finalValueStore.Index, consumedNodes)
+            || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+            || !DuplicateTypesAreGuarded(arms))
+        {
+            return false;
+        }
+
+        switchExpression = new UnionSwitchExpression(
+            (IrExpression)unionValue.Clone(),
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+            nullValue: nullValue is null ? null : (IrExpression)nullValue.Clone());
+        return true;
+    }
+
+    static bool TryValueTypePrefixArm(IfStatement armIf, int tempLocal, int resultLocal, out Arm arm)
+    {
+        arm = null!;
+        if (armIf.HasElse
+            || armIf.Condition is not IsInstance test
+            || !IsTempTypeTest(test, tempLocal))
+        {
+            return false;
+        }
+
+        var body = armIf.Then.Children;
+        if (body.Count == 3
+            && body[0] is StoreLocal boundStore
+            && IsUnboxAnyTemp(boundStore.Value, test.Type, tempLocal)
+            && StoreReturnMatchAt(body, 1, resultLocal, out var boundValue))
+        {
+            arm = new Arm(test.Type, boundStore.Index, boundValue,
+                [armIf.Condition, boundStore, boundValue]);
+            return true;
+        }
+
+        if (body.Count == 2
+            && StoreReturnMatchAt(body, 0, resultLocal, out var value))
+        {
+            arm = new Arm(test.Type, LocalIndex: null, value, [armIf.Condition, value]);
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool StoreReturnMatchAt(IReadOnlyList<IrNode> nodes, int index, int resultLocal, out IrExpression value)
+    {
+        value = null!;
+        if (index + 1 >= nodes.Count
+            || nodes[index] is not StoreLocal store
+            || store.Index != resultLocal
+            || nodes[index + 1] is not Return ret
+            || !ReturnsLocal(ret, resultLocal))
+        {
+            return false;
+        }
+
+        value = store.Value;
+        return true;
+    }
+
+    static bool IsUnboxAnyTemp(IrExpression expression, TypeRef type, int tempLocal)
+        => expression is UnboxAny { Operand: LoadLocal load } unbox
+        && load.Index == tempLocal
+        && unbox.Type.Equals(type);
+
+    static bool TryFinalThrowOrNullArm(
+        IReadOnlyList<IrNode> nodes,
+        int resultLocal,
+        int tempLocal,
+        IrExpression? unionReceiver,
+        out IrExpression? nullValue)
+    {
+        nullValue = null;
+        if (nodes is [ExpressionStatement throwStatement, Return throwReturn]
+            && IsThrowSwitchExpression(throwStatement)
+            && ThrowArgumentMatchesNullArm(throwStatement, tempLocal, unionReceiver)
+            && ReturnsLocal(throwReturn, resultLocal))
+        {
+            return true;
+        }
+
+        if (nodes is [IfStatement nullIf, ExpressionStatement throwStatementWithNull, Return throwReturnWithNull]
+            && nullIf.HasElse == false
+            && IsNotLocal(nullIf.Condition, tempLocal)
+            && nullIf.Then.Children is [StoreLocal nullStore, Return nullReturn]
+            && StoreReturnMatch(nullStore, nullReturn, resultLocal)
+            && IsThrowSwitchExpression(throwStatementWithNull)
+            && ThrowArgumentMatchesNullArm(throwStatementWithNull, tempLocal, unionReceiver)
+            && ReturnsLocal(throwReturnWithNull, resultLocal))
+        {
+            nullValue = nullStore.Value;
+            return true;
         }
 
         return false;


### PR DESCRIPTION
## Summary

- Raise current Preview SDK union switches where value-type case arms lower through `is T` plus `unbox.any`, including value-type arms before or after reference arms.
- Fold owned `in`-receiver union `Value` copies back to the source receiver while leaving mixed/non-owned copies flat.
- Add Preview SDK canaries for value-type union cases, final value-type arms, `in` receivers, mixed receiver copies, and ref-local receiver near misses.

## Evidence

- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*TypeSourceComposerUnionTests*"`: 19 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"`: 1771 passed

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity sampled 25,179 / 89,065 (28.27%); fidelity sampled 36 / 89,065 (0.04%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,398 (88.02%) | -1 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — sampled 25,179 / 89,065 (28.27%) | 74/25,179 — sampled 25,179 / 89,065 (28.27%) | 0 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | 0 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate: Fully raised 88.02% -> 88.02% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 5 (0).

Verdict: corpus sensor matched baseline tolerances.

## Adversarial review

- Claude Opus 4.8: no blocking findings. Verified guards stay flat rather than silently dropping, prefix statements are preserved, `unbox.any` binding is gated by matching type tests, and null/default arm ordering is safe.
- Gemini 3.1 Pro: found two high-confidence issues before push: incomplete receiver-copy rewrites could orphan locals, and final value-type arms were missed. Both were fixed in c62e88c1 and pinned with tests (`InReceiverMixed`, `DescribeFinalValueType`).

## Notes

- Current Roslyn/local csharplang research shows named union member/case syntax is still design/parser-level; this PR does not invent named-case source from metadata.
- The broad corpus card reports one fewer fully raised method but no pinned-subset gate regression, no semantic-defect movement, no fidelity movement, and no pass bugs.
