### PR TITLE
Add IL offset callsite contexts

### DIFF
--- a/docs/design/output-shapes.md
+++ b/docs/design/output-shapes.md
@@ -157,7 +157,8 @@ section is useful as a human fact sheet, a row, a scalar, a URL, a path, or a
 source-line payload; the member-context section projects the same coordinate to
 the owning type and method; the instruction-context section projects it to the
 exact IL instruction; the exception-context section appears when the coordinate
-falls inside protected exception-handling regions.
+falls inside protected exception-handling regions; callsite and return-address
+sections explain call-like operations and stack-frame return addresses.
 
 The default stays evidence-oriented and renders all applicable coordinate-scoped
 sections:
@@ -215,6 +216,33 @@ dotnet-inspect library My.dll --il-offset 0x06000002+0x1
 | Region | Context | Clause | Try Range | Handler Range | Caught Type |
 | ------ | ------- | ------ | --------- | ------------- | ----------- |
 | 1 | try | catch | IL_0010..IL_0045 | IL_0045..IL_0070 | System.TimeoutException |
+
+## Callsite Context
+
+| Field | Value |
+| ----- | ----- |
+| Call Offset | IL_0001 |
+| Opcode | callvirt |
+| Call Kind | virtual |
+| Callee | MyApp.IWorker::DoWork(int) |
+| Operand Token | 0x06000020 |
+| Return Address | IL_0006 |
+```
+
+If the coordinate is the return address after the call, the applicable section
+changes:
+
+```md
+## Return Address Context
+
+| Field | Value |
+| ----- | ----- |
+| IL Offset | IL_0006 |
+| Call Offset | IL_0001 |
+| Opcode | callvirt |
+| Call Kind | virtual |
+| Callee | MyApp.IWorker::DoWork(int) |
+| Operand Token | 0x06000020 |
 ```
 
 Coordinate-scoped sections are discoverable only when the coordinate carrier is
@@ -222,13 +250,16 @@ present:
 
 ```bash
 dotnet-inspect library My.dll -D
-# Source Location, Member Context, Instruction Context, and Exception Context are omitted.
+# Source Location, Member Context, Instruction Context, Exception Context,
+# Callsite Context, and Return Address Context are omitted.
 
 dotnet-inspect library My.dll --il-offset 0x06000002+0x1 -D
 # Source Location
 # Member Context
 # Instruction Context
 # Exception Context (only when applicable)
+# Callsite Context (only when applicable)
+# Return Address Context (only when applicable)
 ```
 
 The source-location section then projects cleanly:
@@ -263,9 +294,11 @@ dotnet-inspect library My.dll --il-offset 0x06000002+0x1 \
 This keeps the concerns separate: the default fact section shows all
 symbolication evidence, `Member Context` shows the owning metadata context,
 `Instruction Context` shows the exact IL operation, `Exception Context` shows
-active exception-handling regions, `--urls` returns the anchored source
-location, `--paths` returns the PDB document path, and `--print` returns the raw
-payload at the location rather than a decorated snippet.
+active exception-handling regions, `Callsite Context` shows the call-like
+operation at the coordinate, `Return Address Context` points back to the prior
+call, `--urls` returns the anchored source location, `--paths` returns the PDB
+document path, and `--print` returns the raw payload at the location rather than
+a decorated snippet.
 
 ## Design discipline for future flags
 

--- a/docs/workflows/features.md
+++ b/docs/workflows/features.md
@@ -212,7 +212,7 @@
 | IL (Annotated) section | — | 0.3.x | IL with stack state annotations |
 | Decompiled Source mixed view | — | 0.11.x | Decompiled Source becomes a mixed C#+IL view with hidden-fact comments (allocations, unsafety, lifetime) |
 | Facts section | — | 0.11.x | Structured hidden-fact table for one method (`-S "Facts"` / `--tsv`) |
-| `library --il-offset <token>+<offset>` | — | 0.13.0 | Map MethodDef token + IL offset to coordinate-scoped sections such as `Source Location`, `Member Context`, `Instruction Context`, and `Exception Context` |
+| `library --il-offset <token>+<offset>` | — | 0.13.0 | Map MethodDef token + IL offset to coordinate-scoped sections such as `Source Location`, `Member Context`, `Instruction Context`, `Exception Context`, `Callsite Context`, and `Return Address Context` |
 
 ## Plugin and Integration
 

--- a/docs/workflows/getting-started/lap-around.md
+++ b/docs/workflows/getting-started/lap-around.md
@@ -229,7 +229,7 @@ dotnet-inspect member JsonSerializer --platform System.Text.Json -m Serialize -S
 public static partial class JsonSerializer
 ```
 
-For stack-trace style diagnostics, `library --il-offset` maps a MethodDef token plus IL offset to coordinate-scoped sections such as `Source Location`, `Member Context`, `Instruction Context`, and `Exception Context`.
+For stack-trace style diagnostics, `library --il-offset` maps a MethodDef token plus IL offset to coordinate-scoped sections such as `Source Location`, `Member Context`, `Instruction Context`, `Exception Context`, `Callsite Context`, and `Return Address Context`.
 
 ```bash
 dotnet-inspect library --platform System.Text.Json --il-offset 0x06000001+0x0 --json

--- a/src/ILInspector.Instructions/MethodInstructions.cs
+++ b/src/ILInspector.Instructions/MethodInstructions.cs
@@ -68,6 +68,29 @@ public sealed record MethodInstructions(
         return null;
     }
 
+    /// <summary>
+    /// The instruction whose <see cref="DecodedInstruction.NextOffset"/> equals
+    /// <paramref name="offset"/>, or null when <paramref name="offset"/> is not the
+    /// return address/fallthrough boundary after an instruction.
+    /// </summary>
+    public DecodedInstruction? InstructionBefore(int offset)
+    {
+        int lo = 0;
+        int hi = Instructions.Length - 1;
+        while (lo <= hi)
+        {
+            int mid = (lo + hi) >>> 1;
+            int next = Instructions[mid].NextOffset;
+            if (next == offset)
+                return Instructions[mid];
+            if (next < offset)
+                lo = mid + 1;
+            else
+                hi = mid - 1;
+        }
+        return null;
+    }
+
     /// <summary>The index of the block containing <paramref name="offset"/>, or -1 if out of range.</summary>
     public int BlockIndexAt(int offset) => Blocks.BlockIndexAt(offset);
 

--- a/src/ILInspector.Metadata/PdbContext.cs
+++ b/src/ILInspector.Metadata/PdbContext.cs
@@ -63,6 +63,22 @@ public record ILOffsetExceptionContextInfo(
     int? FilterEnd,
     string? CaughtType);
 
+public record ILOffsetCallsiteContextInfo(
+    int CallOffset,
+    string Opcode,
+    string CallKind,
+    string Callee,
+    string? OperandToken,
+    int ReturnAddress);
+
+public record ILOffsetReturnAddressContextInfo(
+    int ILOffset,
+    int CallOffset,
+    string Opcode,
+    string CallKind,
+    string Callee,
+    string? OperandToken);
+
 /// <summary>
 /// Wraps PE + PDB readers, exposes high-level operations with no SRM in public signatures.
 /// CLI orchestrates PDB acquisition (download via Packages), then calls back into this context.
@@ -424,6 +440,59 @@ public class PdbContext : IDisposable
         }
     }
 
+    public ILOffsetCallsiteContextInfo? ResolveCallsiteContext(int methodToken, int ilOffset, out string? error)
+    {
+        error = null;
+        if (!TryResolveDecodedMethod(methodToken, out var reader, out var instructions, out error))
+            return null;
+
+        var instruction = instructions!.InstructionAt(ilOffset);
+        if (instruction is null)
+        {
+            error = $"IL offset 0x{ilOffset:X} is not an instruction boundary for token 0x{methodToken:X}.";
+            return null;
+        }
+
+        if (!IsCallLike(instruction.OpCode))
+            return null;
+
+        var operand = ResolveInstructionOperand(reader!, instruction);
+        return new ILOffsetCallsiteContextInfo(
+            CallOffset: instruction.Offset,
+            Opcode: ILDisassembler.GetDisplayName(instruction.OpCode),
+            CallKind: GetCallKind(instruction.OpCode),
+            Callee: operand.Value ?? operand.Token ?? "",
+            OperandToken: operand.Token,
+            ReturnAddress: instruction.NextOffset);
+    }
+
+    public ILOffsetReturnAddressContextInfo? ResolveReturnAddressContext(int methodToken, int ilOffset, out string? error)
+    {
+        error = null;
+        if (!TryResolveDecodedMethod(methodToken, out var reader, out var instructions, out error))
+            return null;
+
+        var current = instructions!.InstructionAt(ilOffset);
+        var previous = instructions.InstructionBefore(ilOffset);
+        if (current is null && previous is null)
+        {
+            error = $"IL offset 0x{ilOffset:X} is not an instruction boundary for token 0x{methodToken:X}.";
+            return null;
+        }
+
+        if (previous is null || !IsCallReturning(previous.OpCode))
+            return null;
+
+        var operand = ResolveInstructionOperand(reader!, previous);
+        return new ILOffsetReturnAddressContextInfo(
+            ILOffset: ilOffset,
+            CallOffset: previous.Offset,
+            Opcode: ILDisassembler.GetDisplayName(previous.OpCode),
+            CallKind: GetCallKind(previous.OpCode),
+            Callee: operand.Value ?? operand.Token ?? "",
+            OperandToken: operand.Token);
+    }
+
     /// <summary>
     /// Resolves source file and line range for a specific method overload.
     /// </summary>
@@ -560,6 +629,71 @@ public class PdbContext : IDisposable
         => region.Kind == ExceptionRegionKind.Catch && !region.CatchType.IsNil
             ? TypeResolver.GetTypeName(reader, region.CatchType)
             : null;
+
+    private bool TryResolveDecodedMethod(
+        int methodToken,
+        out MetadataReader? reader,
+        out MethodInstructions? instructions,
+        out string? error)
+    {
+        reader = null;
+        instructions = null;
+        error = null;
+        if (!_peReader.HasMetadata)
+            return false;
+
+        var handle = MetadataTokens.Handle(methodToken);
+        if (handle.Kind != HandleKind.MethodDefinition)
+        {
+            error = $"Token 0x{methodToken:X} is not a MethodDef token.";
+            return false;
+        }
+
+        try
+        {
+            reader = _peReader.GetMetadataReader();
+            var method = reader.GetMethodDefinition((MethodDefinitionHandle)handle);
+            if (method.RelativeVirtualAddress == 0)
+            {
+                error = $"Method token 0x{methodToken:X} has no IL body.";
+                return false;
+            }
+
+            var body = _peReader.GetMethodBody(method.RelativeVirtualAddress);
+            instructions = MethodInstructions.Decode(body);
+            if (!instructions.IsComplete)
+            {
+                error = $"Could not decode IL for token 0x{methodToken:X}: {instructions.Blocks.IncompleteReason}";
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentOutOfRangeException)
+        {
+            error = $"Could not decode IL for token 0x{methodToken:X}.";
+            return false;
+        }
+    }
+
+    private static bool IsCallLike(ILOpCode opcode)
+        => opcode is ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj
+            or ILOpCode.Calli or ILOpCode.Ldftn or ILOpCode.Ldvirtftn;
+
+    private static bool IsCallReturning(ILOpCode opcode)
+        => opcode is ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj or ILOpCode.Calli;
+
+    private static string GetCallKind(ILOpCode opcode)
+        => opcode switch
+        {
+            ILOpCode.Call => "direct",
+            ILOpCode.Callvirt => "virtual",
+            ILOpCode.Newobj => "constructor",
+            ILOpCode.Calli => "function pointer",
+            ILOpCode.Ldftn => "method pointer",
+            ILOpCode.Ldvirtftn => "virtual method pointer",
+            _ => "call"
+        };
 
     private static (string Kind, string? Value, string? Token) ResolveInstructionOperand(
         MetadataReader reader,

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -56,6 +56,13 @@ public class CommandExecutionTests
         }
     }
 
+    private sealed class ILOffsetFunctionPointerFixture
+    {
+        public Func<int> CreateDelegate() => Target;
+
+        private static int Target() => 1;
+    }
+
     private static (string PackagePath, string TempDir) CreateLocalRefPackage(params string[] assemblyNames)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"package-test-{Guid.NewGuid():N}");
@@ -4497,6 +4504,7 @@ public class CommandExecutionTests
                 "Aspire",
                 "Async Methods",
                 "Authentication",
+                "Callsite Context",
                 "Configuration",
                 "Custom Attributes",
                 "Dependency Injection",
@@ -4515,6 +4523,7 @@ public class CommandExecutionTests
                 "Options",
                 "Performance Triage",
                 "Resources",
+                "Return Address Context",
                 "Source Files",
                 "Source Location",
                 "SourceLink Availability",
@@ -4655,6 +4664,8 @@ public class CommandExecutionTests
         Assert.DoesNotContain("Member Context", withoutOutput);
         Assert.DoesNotContain("Instruction Context", withoutOutput);
         Assert.DoesNotContain("Exception Context", withoutOutput);
+        Assert.DoesNotContain("Callsite Context", withoutOutput);
+        Assert.DoesNotContain("Return Address Context", withoutOutput);
         Assert.Contains("Source Location", withOutput);
         Assert.Contains("Member Context", withOutput);
         Assert.Contains("Instruction Context", withOutput);
@@ -4811,6 +4822,89 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.Equal("catch", output.Trim());
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetCallsiteContext_RendersCallsite()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x1", "-S", "Callsite Context", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Callsite Context", output);
+        Assert.Contains("| Call Offset | IL_0001 |", output);
+        Assert.Contains("| Opcode | call |", output);
+        Assert.Contains("| Call Kind | direct |", output);
+        Assert.Contains("| Callee | System.HexConverter::get_CharToHexLookup() |", output);
+        Assert.Contains("| Return Address | IL_0006 |", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetCallsiteContext_ValueProjectsCallee()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x1", "-S", "Callsite Context", "--fields", "Callee", "--value", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Equal("System.HexConverter::get_CharToHexLookup()", output.Trim());
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetReturnAddressContext_RendersPreviousCall()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x6", "-S", "Return Address Context", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("## Return Address Context", output);
+        Assert.Contains("| IL Offset | IL_0006 |", output);
+        Assert.Contains("| Call Offset | IL_0001 |", output);
+        Assert.Contains("| Opcode | call |", output);
+        Assert.Contains("| Callee | System.HexConverter::get_CharToHexLookup() |", output);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetReturnAddressContext_ValueProjectsCallOffset()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x6", "-S", "Return Address Context", "--fields", "Call Offset", "--value", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Equal("IL_0001", output.Trim());
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetReturnAddressContext_RequiresInstructionBoundary()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", "--platform", "System.Text.Json",
+            "--il-offset", "0x06000001+0x2", "-S", "Return Address Context", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("not an instruction boundary", error);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetReturnAddressContext_IgnoresMethodPointerFallthrough()
+    {
+        var token = typeof(ILOffsetFunctionPointerFixture).GetMethod(nameof(ILOffsetFunctionPointerFixture.CreateDelegate))!.MetadataToken;
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "--il-offset", $"0x{token:X}+0x10", "-S", "Return Address Context", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("# dotnet-inspect.Tests.dll", output);
+        Assert.DoesNotContain("## Return Address Context", output);
+        Assert.Contains("matched section has no data", error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -251,11 +251,12 @@ public class SectionPipelineTests
     {
         var pipeline = LibrarySections.CreatePipeline();
 
-        Assert.Equal(40, pipeline.AllSectionNames.Length);
+        Assert.Equal(42, pipeline.AllSectionNames.Length);
         Assert.Contains("AI", pipeline.AllSectionNames);
         Assert.Contains("ASP.NET Core", pipeline.AllSectionNames);
         Assert.Contains("Aspire", pipeline.AllSectionNames);
         Assert.Contains("Authentication", pipeline.AllSectionNames);
+        Assert.Contains("Callsite Context", pipeline.AllSectionNames);
         Assert.Contains("Configuration", pipeline.AllSectionNames);
         Assert.Contains("Dependency Injection", pipeline.AllSectionNames);
         Assert.Contains("Exception Context", pipeline.AllSectionNames);
@@ -278,6 +279,7 @@ public class SectionPipelineTests
         Assert.Contains("Switches", pipeline.AllSectionNames);
         Assert.Contains("Top Leverage", pipeline.AllSectionNames);
         Assert.Contains("Performance Triage", pipeline.AllSectionNames);
+        Assert.Contains("Return Address Context", pipeline.AllSectionNames);
         Assert.Contains("Union Types", pipeline.AllSectionNames);
     }
 
@@ -289,7 +291,7 @@ public class SectionPipelineTests
         IReadOnlyCollection<string> discoverable)
     {
         var expected = command == "library"
-            ? registered.Except(["Source Location", "Member Context", "Instruction Context", "Exception Context"], StringComparer.OrdinalIgnoreCase)
+            ? registered.Except(["Source Location", "Member Context", "Instruction Context", "Exception Context", "Callsite Context", "Return Address Context"], StringComparer.OrdinalIgnoreCase)
             : registered;
         var missing = expected
             .Where(name => !discoverable.Contains(name, StringComparer.OrdinalIgnoreCase))
@@ -544,16 +546,22 @@ public class SectionPipelineTests
         Assert.DoesNotContain("Member Context", applicable);
         Assert.DoesNotContain("Instruction Context", applicable);
         Assert.DoesNotContain("Exception Context", applicable);
+        Assert.DoesNotContain("Callsite Context", applicable);
+        Assert.DoesNotContain("Return Address Context", applicable);
         Assert.DoesNotContain("Source Location", renderable);
         Assert.DoesNotContain("Member Context", renderable);
         Assert.DoesNotContain("Instruction Context", renderable);
         Assert.DoesNotContain("Exception Context", renderable);
+        Assert.DoesNotContain("Callsite Context", renderable);
+        Assert.DoesNotContain("Return Address Context", renderable);
 
         model.ILOffset = new ILOffsetResult
         {
             MemberContext = new ILOffsetMemberContext(),
             InstructionContext = new ILOffsetInstructionContext(),
-            ExceptionContext = [new ILOffsetExceptionContext()]
+            ExceptionContext = [new ILOffsetExceptionContext()],
+            CallsiteContext = new ILOffsetCallsiteContext(),
+            ReturnAddressContext = new ILOffsetReturnAddressContext()
         };
 
         applicable = pipeline.GetApplicableSections(model);
@@ -563,10 +571,14 @@ public class SectionPipelineTests
         Assert.Contains("Member Context", applicable);
         Assert.Contains("Instruction Context", applicable);
         Assert.Contains("Exception Context", applicable);
+        Assert.Contains("Callsite Context", applicable);
+        Assert.Contains("Return Address Context", applicable);
         Assert.Contains("Source Location", renderable);
         Assert.Contains("Member Context", renderable);
         Assert.Contains("Instruction Context", renderable);
         Assert.Contains("Exception Context", renderable);
+        Assert.Contains("Callsite Context", renderable);
+        Assert.Contains("Return Address Context", renderable);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
+++ b/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
@@ -57,6 +57,20 @@ internal static class ILOffsetSourceQuery
             return (1, null);
         }
 
+        var callsiteContext = pdbContext.ResolveCallsiteContext(methodToken, ilOffset, out var callsiteError);
+        if (callsiteError is not null && RequiresCallsiteContext(options))
+        {
+            Console.Error.WriteLine($"Error: {callsiteError}");
+            return (1, null);
+        }
+
+        var returnAddressContext = pdbContext.ResolveReturnAddressContext(methodToken, ilOffset, out var returnAddressError);
+        if (returnAddressError is not null && RequiresReturnAddressContext(options))
+        {
+            Console.Error.WriteLine($"Error: {returnAddressError}");
+            return (1, null);
+        }
+
         SourceLinkResolver.ILOffsetSourceInfo? result = null;
         if (RequiresSourceLocation(options))
         {
@@ -141,7 +155,25 @@ internal static class ILOffsetSourceQuery
                         : null,
                     CaughtType = context.CaughtType
                 })
-                .ToList()
+                .ToList(),
+            CallsiteContext = callsiteContext is null ? null : new ILOffsetCallsiteContext
+            {
+                CallOffset = FormatILOffset(callsiteContext.CallOffset),
+                Opcode = callsiteContext.Opcode,
+                CallKind = callsiteContext.CallKind,
+                Callee = callsiteContext.Callee,
+                OperandToken = callsiteContext.OperandToken,
+                ReturnAddress = FormatILOffset(callsiteContext.ReturnAddress)
+            },
+            ReturnAddressContext = returnAddressContext is null ? null : new ILOffsetReturnAddressContext
+            {
+                ILOffset = FormatILOffset(returnAddressContext.ILOffset),
+                CallOffset = FormatILOffset(returnAddressContext.CallOffset),
+                Opcode = returnAddressContext.Opcode,
+                CallKind = returnAddressContext.CallKind,
+                Callee = returnAddressContext.Callee,
+                OperandToken = returnAddressContext.OperandToken
+            }
         };
 
         return (0, resolved);
@@ -156,7 +188,15 @@ internal static class ILOffsetSourceQuery
     private static bool RequiresExceptionContext(LibraryOptions options)
         => options.IncludeSections?.Contains(SectionNames.ExceptionContext) == true;
 
+    private static bool RequiresCallsiteContext(LibraryOptions options)
+        => options.IncludeSections?.Contains(SectionNames.CallsiteContext) == true;
+
+    private static bool RequiresReturnAddressContext(LibraryOptions options)
+        => options.IncludeSections?.Contains(SectionNames.ReturnAddressContext) == true;
+
     private static string FormatILRange(int start, int end) => $"IL_{start:X4}..IL_{end:X4}";
+
+    private static string FormatILOffset(int offset) => $"IL_{offset:X4}";
 
     public static bool TryParse(string value, out int methodToken, out int ilOffset)
     {

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -92,7 +92,7 @@ public class LibraryCommand
             && options.IncludeSections is { Count: > 0 }
             && !options.IncludeSections.Overlaps(ILCoordinateSections))
         {
-            Console.Error.WriteLine("Error: --il-offset requires an IL coordinate section. Omit -S or include -S \"Source Location\", -S \"Member Context\", -S \"Instruction Context\", or -S \"Exception Context\".");
+            Console.Error.WriteLine("Error: --il-offset requires an IL coordinate section. Omit -S or include -S \"Source Location\", -S \"Member Context\", -S \"Instruction Context\", -S \"Exception Context\", -S \"Callsite Context\", or -S \"Return Address Context\".");
             return 1;
         }
 
@@ -442,6 +442,8 @@ public class LibraryCommand
             select.Add(SectionNames.MemberContext);
             select.Add(SectionNames.InstructionContext);
             select.Add(SectionNames.ExceptionContext);
+            select.Add(SectionNames.CallsiteContext);
+            select.Add(SectionNames.ReturnAddressContext);
         }
 
         return (options with
@@ -456,14 +458,18 @@ public class LibraryCommand
         SectionNames.ILOffset,
         SectionNames.MemberContext,
         SectionNames.InstructionContext,
-        SectionNames.ExceptionContext
+        SectionNames.ExceptionContext,
+        SectionNames.CallsiteContext,
+        SectionNames.ReturnAddressContext
     ];
 
     private static readonly string[] ILCoordinateSingletonSections =
     [
         SectionNames.ILOffset,
         SectionNames.MemberContext,
-        SectionNames.InstructionContext
+        SectionNames.InstructionContext,
+        SectionNames.CallsiteContext,
+        SectionNames.ReturnAddressContext
     ];
 
     private static bool HasILOffsetCoordinate(LibraryOptions options)
@@ -533,6 +539,8 @@ public class LibraryCommand
             SectionNames.ILOffset => inspection.ILOffset != null,
             SectionNames.MemberContext => inspection.ILOffset?.MemberContext != null,
             SectionNames.InstructionContext => inspection.ILOffset?.InstructionContext != null,
+            SectionNames.CallsiteContext => inspection.ILOffset?.CallsiteContext != null,
+            SectionNames.ReturnAddressContext => inspection.ILOffset?.ReturnAddressContext != null,
             _ => false
         };
         Console.WriteLine(hasRow ? 1 : 0);
@@ -551,10 +559,13 @@ public class LibraryCommand
             SectionNames.MemberContext => ProjectLibraryMemberContext(inspection, section, kind, options),
             SectionNames.InstructionContext => ProjectLibraryInstructionContext(inspection, section, kind, options),
             SectionNames.ExceptionContext => ProjectLibraryExceptionContext(inspection, section, kind, options),
+            SectionNames.CallsiteContext => ProjectLibraryCallsiteContext(inspection, section, kind, options),
+            SectionNames.ReturnAddressContext => ProjectLibraryReturnAddressContext(inspection, section, kind, options),
             _ => []
         };
 
-        if (rows.Count == 0 && section is SectionNames.MemberContext or SectionNames.InstructionContext or SectionNames.ExceptionContext)
+        if (rows.Count == 0 && section is SectionNames.MemberContext or SectionNames.InstructionContext or SectionNames.ExceptionContext
+            or SectionNames.CallsiteContext or SectionNames.ReturnAddressContext)
         {
             if (kind != ShapeProjectionKind.Value)
                 Console.Error.WriteLine($"Error: section '{section}' does not expose {kind.ToString().ToLowerInvariant()} values.");
@@ -870,6 +881,82 @@ public class LibraryCommand
             "handler range" or "handlerrange" => context.HandlerRange,
             "filter range" or "filterrange" => context.FilterRange,
             "caught type" or "caughttype" => context.CaughtType,
+            _ => null
+        };
+
+    private static List<ShapeProjectionRow> ProjectLibraryCallsiteContext(
+        LibraryInspection inspection,
+        string section,
+        ShapeProjectionKind kind,
+        LibraryOptions options)
+    {
+        if (kind != ShapeProjectionKind.Value || inspection.ILOffset?.CallsiteContext is not { } context)
+            return [];
+
+        var field = options.Fields?.SingleOrDefault() ?? options.Columns?.SingleOrDefault();
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            Console.Error.WriteLine("Error: --value for Callsite Context requires --fields <name>.");
+            return [];
+        }
+
+        var value = SelectCallsiteContextValue(context, field);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            Console.Error.WriteLine($"Error: field '{field}' has no value in Callsite Context.");
+            return [];
+        }
+
+        return [new ShapeProjectionRow(1, section, value, Label: field)];
+    }
+
+    private static string? SelectCallsiteContextValue(ILOffsetCallsiteContext context, string field)
+        => field.ToLowerInvariant() switch
+        {
+            "call offset" or "calloffset" or "offset" => context.CallOffset,
+            "opcode" => context.Opcode,
+            "call kind" or "callkind" => context.CallKind,
+            "callee" => context.Callee,
+            "operand token" or "operandtoken" or "token" => context.OperandToken,
+            "return address" or "returnaddress" => context.ReturnAddress,
+            _ => null
+        };
+
+    private static List<ShapeProjectionRow> ProjectLibraryReturnAddressContext(
+        LibraryInspection inspection,
+        string section,
+        ShapeProjectionKind kind,
+        LibraryOptions options)
+    {
+        if (kind != ShapeProjectionKind.Value || inspection.ILOffset?.ReturnAddressContext is not { } context)
+            return [];
+
+        var field = options.Fields?.SingleOrDefault() ?? options.Columns?.SingleOrDefault();
+        if (string.IsNullOrWhiteSpace(field))
+        {
+            Console.Error.WriteLine("Error: --value for Return Address Context requires --fields <name>.");
+            return [];
+        }
+
+        var value = SelectReturnAddressContextValue(context, field);
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            Console.Error.WriteLine($"Error: field '{field}' has no value in Return Address Context.");
+            return [];
+        }
+
+        return [new ShapeProjectionRow(1, section, value, Label: field)];
+    }
+
+    private static string? SelectReturnAddressContextValue(ILOffsetReturnAddressContext context, string field)
+        => field.ToLowerInvariant() switch
+        {
+            "il offset" or "iloffset" or "offset" => context.ILOffset,
+            "call offset" or "calloffset" => context.CallOffset,
+            "opcode" => context.Opcode,
+            "call kind" or "callkind" => context.CallKind,
+            "callee" => context.Callee,
+            "operand token" or "operandtoken" or "token" => context.OperandToken,
             _ => null
         };
 

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -504,6 +504,8 @@ public class ILOffsetResult
     public ILOffsetMemberContext? MemberContext { get; init; }
     public ILOffsetInstructionContext? InstructionContext { get; init; }
     public List<ILOffsetExceptionContext>? ExceptionContext { get; init; }
+    public ILOffsetCallsiteContext? CallsiteContext { get; init; }
+    public ILOffsetReturnAddressContext? ReturnAddressContext { get; init; }
 }
 
 public class ILOffsetMemberContext
@@ -546,6 +548,26 @@ public class ILOffsetExceptionContext
     public string? HandlerRange { get; init; }
     public string? FilterRange { get; init; }
     public string? CaughtType { get; init; }
+}
+
+public class ILOffsetCallsiteContext
+{
+    public string? CallOffset { get; init; }
+    public string? Opcode { get; init; }
+    public string? CallKind { get; init; }
+    public string? Callee { get; init; }
+    public string? OperandToken { get; init; }
+    public string? ReturnAddress { get; init; }
+}
+
+public class ILOffsetReturnAddressContext
+{
+    public string? ILOffset { get; init; }
+    public string? CallOffset { get; init; }
+    public string? Opcode { get; init; }
+    public string? CallKind { get; init; }
+    public string? Callee { get; init; }
+    public string? OperandToken { get; init; }
 }
 
 public sealed record SourceFileInfo(string Type, string? Url);

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -37,6 +37,8 @@ public static class LibrarySections
             .Add<MemberContext>()
             .Add<InstructionContext>()
             .Add<ExceptionContext>()
+            .Add<CallsiteContext>()
+            .Add<ReturnAddressContext>()
             .Add<SourceFiles>()
             .Add<SourceLinkAudit>(SourceLinkAuditApplicable)
             .Add<MissingSourceFiles>(SourceLinkAuditApplicable)
@@ -161,6 +163,24 @@ public static class LibrarySections
         public static bool ExplicitOnly => true;
         public static string? ScannerKey => null;
         public static bool CanRender(LibraryInspection model) => model.ILOffset?.ExceptionContext is { Count: > 0 };
+    }
+
+    public sealed class CallsiteContext : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.CallsiteContext;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(LibraryInspection model) => model.ILOffset?.CallsiteContext != null;
+    }
+
+    public sealed class ReturnAddressContext : ISectionDescriptor<LibraryInspection>
+    {
+        public static string Name => SectionNames.ReturnAddressContext;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(LibraryInspection model) => model.ILOffset?.ReturnAddressContext != null;
     }
 
     // ===== Symbol/provenance sections (network-capable, acceptable default cost) =====

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -114,6 +114,12 @@ public static class SectionNames
     /// <summary>Section for resolving a MethodDef token + IL offset to containing exception regions.</summary>
     public const string ExceptionContext = "Exception Context";
 
+    /// <summary>Section for resolving a MethodDef token + IL offset to a call-like instruction.</summary>
+    public const string CallsiteContext = "Callsite Context";
+
+    /// <summary>Section for resolving a MethodDef token + IL offset to the preceding call instruction.</summary>
+    public const string ReturnAddressContext = "Return Address Context";
+
     /// <summary>
     /// Section for the structured hidden-fact table: the same annotations the
     /// Decompiled Source view renders inline, as rows (id, category, detail, IL

--- a/src/dotnet-inspect/Views/InspectionResultView.cs
+++ b/src/dotnet-inspect/Views/InspectionResultView.cs
@@ -477,6 +477,8 @@ public record PackageSourceFileRow(
 [MarkoutContext(typeof(ILOffsetMemberContextSection))]
 [MarkoutContext(typeof(ILOffsetInstructionContextSection))]
 [MarkoutContext(typeof(ILOffsetExceptionContextRow))]
+[MarkoutContext(typeof(ILOffsetCallsiteContextSection))]
+[MarkoutContext(typeof(ILOffsetReturnAddressContextSection))]
 [MarkoutContext(typeof(ManifestRow))]
 [MarkoutContext(typeof(RidPackageReferenceView))]
 [MarkoutContext(typeof(EmptyDepsView))]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -549,6 +549,36 @@ public class LibraryInspectionView
                 context.CaughtType))
             .ToList();
 
+    [MarkoutIgnore]
+    public bool HasILOffsetCallsiteContext => _data.ILOffset?.CallsiteContext != null;
+
+    [MarkoutSection(Name = SectionNames.CallsiteContext, ShowWhenProperty = nameof(HasILOffsetCallsiteContext))]
+    public ILOffsetCallsiteContextSection? ILOffsetCallsiteContextSection =>
+        _data.ILOffset?.CallsiteContext is not { } context ? null : new ILOffsetCallsiteContextSection
+        {
+            CallOffset = context.CallOffset,
+            Opcode = context.Opcode,
+            CallKind = context.CallKind,
+            Callee = context.Callee,
+            OperandToken = context.OperandToken,
+            ReturnAddress = context.ReturnAddress
+        };
+
+    [MarkoutIgnore]
+    public bool HasILOffsetReturnAddressContext => _data.ILOffset?.ReturnAddressContext != null;
+
+    [MarkoutSection(Name = SectionNames.ReturnAddressContext, ShowWhenProperty = nameof(HasILOffsetReturnAddressContext))]
+    public ILOffsetReturnAddressContextSection? ILOffsetReturnAddressContextSection =>
+        _data.ILOffset?.ReturnAddressContext is not { } context ? null : new ILOffsetReturnAddressContextSection
+        {
+            ILOffset = context.ILOffset,
+            CallOffset = context.CallOffset,
+            Opcode = context.Opcode,
+            CallKind = context.CallKind,
+            Callee = context.Callee,
+            OperandToken = context.OperandToken
+        };
+
     [MarkoutSection(Name = "SourceLink Availability", ShowWhenProperty = nameof(HasSourceLinkAudit))]
     public SourceLinkAuditSection? SourceLinkAuditSection => !HasSourceLinkAudit ? null : new SourceLinkAuditSection
     {
@@ -892,6 +922,38 @@ public record ILOffsetExceptionContextRow(
     [property: MarkoutSkipNull] string? FilterRange,
     [property: MarkoutPropertyName("Caught Type")]
     [property: MarkoutSkipNull] string? CaughtType);
+
+[MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords, FieldLayout = FieldLayout.Table)]
+[MarkoutSkipNull]
+public class ILOffsetCallsiteContextSection
+{
+    [MarkoutPropertyName("Call Offset")]
+    public string? CallOffset { get; init; }
+    public string? Opcode { get; init; }
+    [MarkoutPropertyName("Call Kind")]
+    public string? CallKind { get; init; }
+    public string? Callee { get; init; }
+    [MarkoutPropertyName("Operand Token")]
+    public string? OperandToken { get; init; }
+    [MarkoutPropertyName("Return Address")]
+    public string? ReturnAddress { get; init; }
+}
+
+[MarkoutSerializable(NamingPolicy = NamingPolicy.PascalCaseWords, FieldLayout = FieldLayout.Table)]
+[MarkoutSkipNull]
+public class ILOffsetReturnAddressContextSection
+{
+    [MarkoutPropertyName("IL Offset")]
+    public string? ILOffset { get; init; }
+    [MarkoutPropertyName("Call Offset")]
+    public string? CallOffset { get; init; }
+    public string? Opcode { get; init; }
+    [MarkoutPropertyName("Call Kind")]
+    public string? CallKind { get; init; }
+    public string? Callee { get; init; }
+    [MarkoutPropertyName("Operand Token")]
+    public string? OperandToken { get; init; }
+}
 
 [MarkoutSerializable]
 public record ResourceRow(


### PR DESCRIPTION
## Summary

- Add coordinate-scoped `Callsite Context` for call-like IL operations at an exact offset.
- Add coordinate-scoped `Return Address Context` for offsets immediately after real call-returning instructions.
- Add `MethodInstructions.InstructionBefore(int offset)` to the shared instruction substrate for return-address lookup.

This completes the planned structural-core `--il-offset` set from #2005: Source Location, Member Context, Instruction Context, Exception Context, Callsite Context, and Return Address Context.

## Examples

### Call at the queried offset

```bash
dotnet-inspect library System.Text.Json --il-offset 0x06000001+0x1 -S "Callsite Context"
```

```md
## Callsite Context

| Field | Value |
| ----- | ----- |
| Call Offset | IL_0001 |
| Opcode | call |
| Call Kind | direct |
| Callee | System.HexConverter::get_CharToHexLookup() |
| Operand Token | 0x06000003 |
| Return Address | IL_0006 |
```

### Return address after a call

```bash
dotnet-inspect library System.Text.Json --il-offset 0x06000001+0x6 -S "Return Address Context"
```

```md
## Return Address Context

| Field | Value |
| ----- | ----- |
| IL Offset | IL_0006 |
| Call Offset | IL_0001 |
| Opcode | call |
| Call Kind | direct |
| Callee | System.HexConverter::get_CharToHexLookup() |
| Operand Token | 0x06000003 |
```

### Method pointer fallthrough is not a return address

`ldftn` and `ldvirtftn` are call-like for `Callsite Context`, but they do not transfer control or establish a return address. An offset immediately after `ldftn` omits `Return Address Context` rather than implying a stack-frame return.

### Bare coordinate report

Bare `--il-offset` now auto-renders whichever coordinate sections apply. For a call offset that is not inside an EH region, headings look like:

```text
## Source Location
## Member Context
## Instruction Context
## Callsite Context
```

For a return address after that call:

```text
## Source Location
## Member Context
## Instruction Context
## Return Address Context
```

## Validation

- `dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json --nologo --verbosity quiet`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- -method "*IlOffset*"`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- -class DotnetInspector.Tests.SectionPipelineTests`
- `npx markdownlint-cli docs/design/output-shapes.md docs/workflows/features.md docs/workflows/getting-started/lap-around.md`

## Adversarial review

- Gemini 3.1 Pro found that explicit `Return Address Context` swallowed non-boundary offsets and that `ReturnAddress` was preformatted in the metadata layer. Fixed both and added regression coverage.
- Claude Opus 4.8 noted that `ldftn`/`ldvirtftn` should not produce `Return Address Context` because they do not transfer control. Fixed by restricting return-address matching to `call`/`callvirt`/`newobj`/`calli` while keeping `ldftn`/`ldvirtftn` in `Callsite Context`; added regression coverage.
