### PR TITLE
Add shared C# declaration writer

### DIFF
--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -152,37 +152,16 @@ public static class TypeSourceComposer
             return sb.ToString();
         }
 
-        if (type.Kind == "class")
-        {
-            if (type.IsStatic) sb.Append("static ");
-            else if (type.IsAbstract) sb.Append("abstract ");
-            else if (type.IsSealed) sb.Append("sealed ");
-        }
-        else if (type.Kind == "struct")
-        {
-            if (type.IsReadOnly) sb.Append("readonly ");
-            if (type.IsByRefLike) sb.Append("ref ");
-        }
-        sb.Append(type.Kind == "enum" ? "enum" : type.Kind);
-        sb.Append(' ');
-        sb.Append(DisplayName(type));
-
-        var bases = new List<string>();
-        if (EnumUnderlyingBase(type) is { } enumUnderlyingBase)
-        {
-            bases.Add(enumUnderlyingBase);
-        }
-        else if (type.BaseType is { } baseType
-            && baseType is not ("System.Object" or "object" or "System.ValueType" or "System.Enum"))
-        {
-            bases.Add(EscapeKnownIdentifiers(baseType, type.TypeParameters.Select(p => p.Name)));
-        }
-        bases.AddRange(type.Interfaces.Select(iface => EscapeKnownIdentifiers(iface, type.TypeParameters.Select(p => p.Name))));
-        if (bases.Count > 0)
-            sb.Append($" : {string.Join(", ", bases)}");
-        AppendTypeParameterConstraints(sb, type.TypeParameters);
-        return sb.ToString();
+        return CSharpDeclarationWriter.RenderTypeDeclaration(type, DeclarationOptions());
     }
+
+    static CSharpDeclarationOptions DeclarationOptions(bool forceUnsafe = false, bool forceAsync = false) => new()
+    {
+        ForceAsync = forceAsync,
+        ForceUnsafe = forceUnsafe,
+        IncludeObsoleteAttribute = false,
+        OmitInterfaceMemberModifiers = true
+    };
 
     static string DisplayName(ApiType type)
     {
@@ -215,28 +194,6 @@ public static class TypeSourceComposer
             any = true;
         }
     }
-
-    static string? EnumUnderlyingBase(ApiType type)
-    {
-        if (type.Kind != "enum" || type.EnumUnderlyingType is not { } underlying)
-            return null;
-        return EnumUnderlyingKeyword(underlying) is { } keyword && keyword != "int"
-            ? keyword
-            : null;
-    }
-
-    static string? EnumUnderlyingKeyword(string type) => type switch
-    {
-        "sbyte" or "System.SByte" => "sbyte",
-        "byte" or "System.Byte" => "byte",
-        "short" or "System.Int16" => "short",
-        "ushort" or "System.UInt16" => "ushort",
-        "int" or "System.Int32" => "int",
-        "uint" or "System.UInt32" => "uint",
-        "long" or "System.Int64" => "long",
-        "ulong" or "System.UInt64" => "ulong",
-        _ => null,
-    };
 
     static IEnumerable<string> LayoutAttributes(ApiType type, TypeDefinition typeDef, SortedSet<string> namespaces)
     {
@@ -457,9 +414,10 @@ public static class TypeSourceComposer
                         break;
                     }
 
-                    var declaration = MethodDeclaration(type, member, requiresUnsafeContext);
-                    if (body is not null && requiresAsync && member.Kind is "method" or "extension-method" or "explicit-interface-implementation")
-                        declaration = AddAsyncModifier(declaration);
+                    var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+                        type,
+                        member,
+                        DeclarationOptions(requiresUnsafeContext, requiresAsync));
                     AppendMember(sb, declaration, body, constructorChain);
                     break;
                 }
@@ -472,7 +430,7 @@ public static class TypeSourceComposer
                     foreach (var attribute in AttributeReader.RenderPropertyAttributes(
                         reader, typeHandle, member.Name, bodyNamespaces))
                         sb.AppendLine($"    [{attribute}]");
-                    ComposeProperty(sb, pipelineSource, type.FullName, member, type.TypeParameters, bodyNamespaces);
+                    ComposeProperty(sb, pipelineSource, type, member, bodyNamespaces);
                     break;
                 }
 
@@ -481,10 +439,11 @@ public static class TypeSourceComposer
                     if (!first) sb.AppendLine();
                     first = false;
                     any = true;
-                    string sig = EscapeMemberSignature(member.Signature ?? member.Name, member, type.TypeParameters);
-                    if (!sig.StartsWith("public", StringComparison.Ordinal))
-                        sig = $"public event {sig}";
-                    sb.AppendLine($"    {sig};");
+                    string declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+                        type,
+                        member,
+                        DeclarationOptions() with { TerminateMemberDeclaration = true });
+                    sb.AppendLine($"    {declaration}");
                     break;
                 }
             }
@@ -686,79 +645,6 @@ public static class TypeSourceComposer
         return null;
     }
 
-    /// <summary>
-    /// The extractor's method signatures carry no modifiers (property
-    /// signatures do); synthesize the declaration from the member flags.
-    /// Constructors rename .ctor/.cctor to the type's display name.
-    /// </summary>
-    static string MethodDeclaration(ApiType type, ApiMember member, bool requiresUnsafeContext)
-    {
-        string signature = EscapeMemberSignature(member.Signature ?? member.Name, member, type.TypeParameters);
-        string typeName = DisplayName(type);
-        int tick = typeName.IndexOf('<');
-        string ctorName = tick >= 0 ? typeName[..tick] : typeName;
-        bool isUnsafe = member.IsUnsafe || requiresUnsafeContext;
-        string unsafeModifier = isUnsafe ? "unsafe " : "";
-
-        if (member.Name == ".cctor")
-            return $"static {unsafeModifier}{ctorName}()";
-        if (member.Name == ".ctor")
-        {
-            if (signature.StartsWith("void ", StringComparison.Ordinal))
-                signature = signature[5..];
-            return $"{member.Accessibility ?? "public"} {unsafeModifier}{signature.Replace(".ctor", ctorName)}";
-        }
-        if (member.Kind == "operator")
-            return OperatorDeclaration(member, type.TypeParameters, isUnsafe);
-
-        // Explicit interface implementations take no accessibility/static/virtual
-        // modifiers, but pointer signatures still require unsafe context.
-        if (member.Kind == "explicit-interface-implementation")
-            return isUnsafe ? $"unsafe {signature}" : signature;
-
-        var parts = new List<string> { member.Accessibility ?? "public" };
-        if (isUnsafe)
-            parts.Add("unsafe");
-        if (type.Kind != "interface")
-        {
-            if (member.IsStatic) parts.Add("static");
-            if (member.IsAbstract) parts.Add("abstract");
-            else if (member.IsSealed && member.IsOverride) parts.Add("sealed override");
-            else if (member.IsOverride) parts.Add("override");
-            else if (member.IsVirtual) parts.Add("virtual");
-        }
-        parts.Add(signature);
-        return string.Join(" ", parts);
-    }
-
-    static string OperatorDeclaration(ApiMember member, IReadOnlyList<TypeParameter> typeParameters, bool isUnsafe)
-    {
-        string signature = EscapeMemberSignature(member.Signature ?? member.Name, member, typeParameters);
-        int parenStart = signature.IndexOf('(');
-        if (parenStart <= 0)
-            return signature;
-
-        int nameIndex = signature.LastIndexOf(member.Name, parenStart - 1, StringComparison.Ordinal);
-        if (nameIndex < 0)
-            return signature;
-
-        string returnType = signature[..nameIndex].TrimEnd();
-        string parameters = signature[parenStart..];
-        string modifiers = isUnsafe ? "public static unsafe" : "public static";
-
-        if (member.Name.StartsWith("op_Checked", StringComparison.Ordinal)
-            && OperatorNames.MapBinaryOrUnary(member.Name["op_Checked".Length..]) is { } checkedSymbol)
-            return $"{modifiers} {returnType} operator checked {checkedSymbol}{parameters}";
-
-        return member.Name switch
-        {
-            "op_Implicit" => $"{modifiers} implicit operator {returnType}{parameters}",
-            "op_Explicit" => $"{modifiers} explicit operator {returnType}{parameters}",
-            "op_CheckedExplicit" => $"{modifiers} explicit operator checked {returnType}{parameters}",
-            _ => $"{modifiers} {returnType} {OperatorNames.FormatDisplayName(member.Name)}{parameters}"
-        };
-    }
-
     static void AppendMember(StringBuilder sb, string signature, string? body, string? constructorChain = null)
     {
         // An explicit base(...)/this(...) chain renders as a signature
@@ -780,164 +666,10 @@ public static class TypeSourceComposer
         sb.AppendLine("    }");
     }
 
-    static string AddAsyncModifier(string signature)
-    {
-        var parts = signature.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToList();
-        if (parts.Contains("async"))
-            return signature;
-        int insert = 0;
-        while (insert < parts.Count && parts[insert] is
-               "public" or "private" or "protected" or "internal" or "static" or
-               "virtual" or "override" or "sealed" or "abstract" or "new" or "extern" or "unsafe")
-        {
-            insert++;
-        }
-        parts.Insert(insert, "async");
-        return string.Join(" ", parts);
-    }
-
-    static string InsertModifier(string signature, string modifier)
-    {
-        var parts = signature.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToList();
-        if (parts.Contains(modifier))
-            return signature;
-        int insert = 0;
-        while (insert < parts.Count && parts[insert] is
-               "public" or "private" or "protected" or "internal" or "static" or
-               "virtual" or "override" or "sealed" or "abstract" or "new" or "extern")
-        {
-            insert++;
-        }
-        parts.Insert(insert, modifier);
-        return string.Join(" ", parts);
-    }
-
-    static bool ContainsModifier(string signature, string modifier)
-        => signature.Split(' ', StringSplitOptions.RemoveEmptyEntries).Contains(modifier);
-
     static string TypeParameterDisplayName(TypeParameter typeParameter)
         => typeParameter.Variance is { } variance
             ? $"{variance} {EscapeIdentifier(typeParameter.Name)}"
             : EscapeIdentifier(typeParameter.Name);
-
-    static string EscapeMemberSignature(string signature, ApiMember member, IReadOnlyList<TypeParameter> typeParameters)
-    {
-        signature = EscapeKnownIdentifiers(signature, typeParameters.Select(p => p.Name));
-
-        if (member.Name is not ".ctor" and not ".cctor")
-            signature = ReplaceMemberName(signature, member.Name);
-
-        return EscapeParameterLists(signature);
-    }
-
-    static string ReplaceMemberName(string signature, string metadataName)
-    {
-        if (string.IsNullOrEmpty(metadataName))
-            return signature;
-
-        var escapedName = metadataName.Contains('.')
-            ? EscapeQualifiedName(metadataName)
-            : EscapeIdentifier(metadataName);
-        if (escapedName == metadataName)
-            return signature;
-
-        int searchEnd = signature.IndexOf('(');
-        if (searchEnd < 0)
-            searchEnd = signature.IndexOf('{');
-        if (searchEnd < 0)
-            searchEnd = signature.Length;
-
-        int index = signature.LastIndexOf(metadataName, searchEnd - 1, StringComparison.Ordinal);
-        if (index < 0)
-            return signature;
-
-        return signature[..index] + escapedName + signature[(index + metadataName.Length)..];
-    }
-
-    static string EscapeParameterLists(string signature)
-    {
-        var sb = new StringBuilder(signature.Length);
-        int start = 0;
-        while (true)
-        {
-            int open = signature.IndexOf('(', start);
-            if (open < 0)
-            {
-                sb.Append(signature, start, signature.Length - start);
-                return sb.ToString();
-            }
-            int close = MatchingParen(signature, open);
-            if (close < 0)
-            {
-                sb.Append(signature, start, signature.Length - start);
-                return sb.ToString();
-            }
-
-            sb.Append(signature, start, open - start + 1);
-            sb.Append(EscapeParameters(signature[(open + 1)..close]));
-            sb.Append(')');
-            start = close + 1;
-        }
-    }
-
-    static int MatchingParen(string text, int open)
-    {
-        int depth = 0;
-        for (int i = open; i < text.Length; i++)
-        {
-            if (text[i] == '(') depth++;
-            else if (text[i] == ')' && --depth == 0) return i;
-        }
-        return -1;
-    }
-
-    static string EscapeParameters(string parameterList)
-        => string.Join(", ", SplitTopLevel(parameterList).Select(EscapeParameterName));
-
-    static IEnumerable<string> SplitTopLevel(string text)
-    {
-        if (text.Length == 0)
-            yield break;
-
-        int depth = 0;
-        int start = 0;
-        for (int i = 0; i < text.Length; i++)
-        {
-            char c = text[i];
-            if (c is '<' or '[' or '(') depth++;
-            else if (c is '>' or ']' or ')') depth--;
-            else if (c == ',' && depth == 0)
-            {
-                yield return text[start..i].Trim();
-                start = i + 1;
-            }
-        }
-        yield return text[start..].Trim();
-    }
-
-    static string EscapeParameterName(string parameter)
-    {
-        if (parameter.Length == 0)
-            return parameter;
-
-        int equals = parameter.IndexOf('=');
-        string prefix = equals >= 0 ? parameter[..equals].TrimEnd() : parameter;
-        string suffix = equals >= 0 ? parameter[equals..] : "";
-
-        int end = prefix.Length - 1;
-        while (end >= 0 && char.IsWhiteSpace(prefix[end]))
-            end--;
-        int start = end;
-        while (start >= 0 && (char.IsLetterOrDigit(prefix[start]) || prefix[start] == '_' || prefix[start] == '@'))
-            start--;
-        start++;
-        if (start > end)
-            return parameter;
-
-        string name = prefix[start..(end + 1)];
-        string escaped = name.StartsWith('@') ? name : EscapeIdentifier(name);
-        return prefix[..start] + escaped + prefix[(end + 1)..] + suffix;
-    }
 
     static string EscapeKnownIdentifiers(string text, IEnumerable<string> rawNames)
     {
@@ -980,25 +712,14 @@ public static class TypeSourceComposer
     }
 
     static void ComposeProperty(
-        StringBuilder sb, Pipeline.MetadataSource pipelineSource, string typeFullName, ApiMember member,
-        IReadOnlyList<TypeParameter> typeParameters, SortedSet<string> bodyNamespaces)
+        StringBuilder sb, Pipeline.MetadataSource pipelineSource, ApiType type, ApiMember member,
+        SortedSet<string> bodyNamespaces)
     {
-        string signature = EscapeMemberSignature(member.Signature ?? member.Name, member, typeParameters);
+        string typeFullName = type.FullName;
+        string signature = CSharpDeclarationWriter.RenderMemberDeclaration(type, member, DeclarationOptions());
         int accessorList = signature.IndexOf('{');
         string head = accessorList >= 0 ? signature[..accessorList].TrimEnd() : signature;
         bool requiresUnsafeContext = member.IsUnsafe || signature.Contains('*', StringComparison.Ordinal);
-
-        // The extractor's property signatures sometimes omit modifiers.
-        if (!head.StartsWith("public", StringComparison.Ordinal)
-            && !head.StartsWith("protected", StringComparison.Ordinal)
-            && !head.StartsWith("internal", StringComparison.Ordinal)
-            && !head.StartsWith("private", StringComparison.Ordinal))
-        {
-            string access = member.Accessibility ?? "public";
-            head = member.IsStatic ? $"{access} static {head}" : $"{access} {head}";
-        }
-        if (requiresUnsafeContext && !ContainsModifier(head, "unsafe"))
-            head = InsertModifier(head, "unsafe");
 
         var accessors = new List<(string Keyword, string? Body, bool RequiresUnsafeContext)>();
         if (accessorList >= 0)
@@ -1012,8 +733,12 @@ public static class TypeSourceComposer
                 accessors.Add(("init", DecompileAccessor(pipelineSource, typeFullName, $"set_{member.Name}", bodyNamespaces, out var initRequiresUnsafe), initRequiresUnsafe));
         }
 
-        if (!requiresUnsafeContext && accessors.Any(a => a.RequiresUnsafeContext) && !ContainsModifier(head, "unsafe"))
-            head = InsertModifier(head, "unsafe");
+        if (!requiresUnsafeContext && accessors.Any(a => a.RequiresUnsafeContext))
+        {
+            signature = CSharpDeclarationWriter.RenderMemberDeclaration(type, member, DeclarationOptions(forceUnsafe: true));
+            accessorList = signature.IndexOf('{');
+            head = accessorList >= 0 ? signature[..accessorList].TrimEnd() : signature;
+        }
 
         if (accessors.Count == 0 || member.IsAbstract || accessors.All(a => a.Body is null))
         {

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -1,0 +1,990 @@
+using System.Text;
+
+namespace ILInspector.Metadata;
+
+public enum CSharpTypeNameMode
+{
+    Qualified,
+    ShortWithUsings,
+    ContextualShort
+}
+
+public enum CSharpNamespaceMode
+{
+    Omit,
+    FileScoped
+}
+
+public sealed record CSharpDeclarationOptions
+{
+    public CSharpTypeNameMode TypeNameMode { get; init; } = CSharpTypeNameMode.Qualified;
+    public string? ContainingNamespace { get; init; }
+    public IReadOnlyCollection<string> Usings { get; init; } = [];
+    public CSharpNamespaceMode NamespaceMode { get; init; } = CSharpNamespaceMode.Omit;
+    public bool AbbreviateSignature { get; init; }
+    public bool TerminateMemberDeclaration { get; init; }
+    public bool ForceAsync { get; init; }
+    public bool ForceUnsafe { get; init; }
+    public bool IncludeObsoleteAttribute { get; init; } = true;
+    public bool OmitInterfaceMemberModifiers { get; init; }
+}
+
+public sealed record CSharpRenderedDeclaration(
+    string Source,
+    IReadOnlyList<string> Usings,
+    IReadOnlyList<string> Diagnostics);
+
+/// <summary>
+/// Cheap C# declaration and signature composition over the API metadata model.
+/// It never imports method bodies, opens inspected assemblies, or depends on the decompiler.
+/// </summary>
+public static class CSharpDeclarationWriter
+{
+    public static CSharpRenderedDeclaration RenderMemberUnit(
+        ApiType type,
+        ApiMember member,
+        CSharpDeclarationOptions? options = null,
+        IReadOnlyList<string>? methodParameters = null)
+    {
+        options ??= new CSharpDeclarationOptions();
+        var references = CollectMemberTypeReferences(member);
+        var plan = TypeNamePlan.Create(references, options);
+        var declaration = RenderMemberDeclarationCore(type, member, options, methodParameters);
+        declaration = plan.Apply(declaration);
+
+        if (options.TerminateMemberDeclaration && !declaration.EndsWith(';'))
+            declaration += ";";
+
+        var source = ComposeUnit([declaration], plan.GeneratedUsings, options);
+        return new CSharpRenderedDeclaration(source, plan.GeneratedUsings, plan.Diagnostics);
+    }
+
+    public static string RenderMemberDeclaration(
+        ApiType type,
+        ApiMember member,
+        CSharpDeclarationOptions? options = null,
+        IReadOnlyList<string>? methodParameters = null)
+    {
+        options ??= new CSharpDeclarationOptions();
+        var references = CollectMemberTypeReferences(member);
+        var plan = TypeNamePlan.Create(references, options);
+        var declaration = RenderMemberDeclarationCore(type, member, options, methodParameters);
+        declaration = plan.Apply(declaration);
+        return options.TerminateMemberDeclaration && !declaration.EndsWith(';')
+            ? declaration + ";"
+            : declaration;
+    }
+
+    public static CSharpRenderedDeclaration RenderTypeUnit(
+        ApiType type,
+        IEnumerable<ApiMember>? members = null,
+        CSharpDeclarationOptions? options = null)
+    {
+        options ??= new CSharpDeclarationOptions { NamespaceMode = CSharpNamespaceMode.FileScoped };
+        var memberList = members?.ToList() ?? type.Members;
+        var references = CollectTypeReferences(type)
+            .Concat(memberList.SelectMany(CollectMemberTypeReferences));
+        var plan = TypeNamePlan.Create(references, options);
+
+        List<string> lines = [plan.Apply(RenderTypeDeclarationCore(type))];
+        lines.Add("{");
+        foreach (var member in memberList)
+        {
+            var declaration = RenderMemberDeclarationCore(
+                type,
+                member,
+                options with { TerminateMemberDeclaration = true });
+            if (declaration.Length > 0 && !declaration.EndsWith(';'))
+                declaration += ";";
+            if (declaration.Length > 0)
+                lines.Add("    " + plan.Apply(declaration));
+        }
+        lines.Add("}");
+
+        var source = ComposeUnit(lines, plan.GeneratedUsings, options);
+        return new CSharpRenderedDeclaration(source, plan.GeneratedUsings, plan.Diagnostics);
+    }
+
+    public static string RenderTypeDeclaration(ApiType type, CSharpDeclarationOptions? options = null)
+    {
+        options ??= new CSharpDeclarationOptions();
+        var plan = TypeNamePlan.Create(CollectTypeReferences(type), options);
+        return plan.Apply(RenderTypeDeclarationCore(type));
+    }
+
+    static string ComposeUnit(IReadOnlyList<string> bodyLines, IReadOnlyList<string> usings, CSharpDeclarationOptions options)
+    {
+        var sb = new StringBuilder();
+        foreach (var ns in usings)
+            sb.AppendLine($"using {ns};");
+
+        if (usings.Count > 0)
+            sb.AppendLine();
+
+        if (options.NamespaceMode == CSharpNamespaceMode.FileScoped
+            && !string.IsNullOrWhiteSpace(options.ContainingNamespace))
+        {
+            sb.AppendLine($"namespace {options.ContainingNamespace};");
+            sb.AppendLine();
+        }
+
+        foreach (var line in bodyLines)
+            sb.AppendLine(line);
+
+        return sb.ToString().TrimEnd();
+    }
+
+    static string RenderTypeDeclarationCore(ApiType type)
+    {
+        var parts = new List<string> { "public" };
+        if (type.Kind == "class")
+        {
+            if (type.IsStatic)
+                parts.Add("static");
+            else
+            {
+                if (type.IsAbstract) parts.Add("abstract");
+                if (type.IsSealed) parts.Add("sealed");
+            }
+        }
+        else if (type.Kind == "struct")
+        {
+            if (type.IsReadOnly) parts.Add("readonly");
+            if (type.IsByRefLike) parts.Add("ref");
+        }
+
+        parts.Add(type.Kind == "enum" ? "enum" : type.Kind);
+        parts.Add(FormatTypeDisplayName(type.Name, type.TypeParameters));
+        var declaration = string.Join(" ", parts);
+
+        var bases = new List<string>();
+        if (EnumUnderlyingBase(type) is { } enumUnderlyingBase)
+            bases.Add(enumUnderlyingBase);
+        else if (type.BaseType is { } baseType
+                 && baseType is not ("System.Object" or "object" or "System.ValueType" or "System.Enum"))
+            bases.Add(EscapeKnownIdentifiers(baseType, type.TypeParameters.Select(p => p.Name)));
+        bases.AddRange(type.Interfaces.Select(iface => EscapeKnownIdentifiers(iface, type.TypeParameters.Select(p => p.Name))));
+
+        if (bases.Count > 0)
+            declaration += " : " + string.Join(", ", bases);
+
+        return AppendTypeParameterConstraints(declaration, type.TypeParameters);
+    }
+
+    static string RenderMemberDeclarationCore(
+        ApiType type,
+        ApiMember member,
+        CSharpDeclarationOptions options,
+        IReadOnlyList<string>? methodParameters = null)
+    {
+        var signature = member.Kind == "field" && member.Signature == null && !string.IsNullOrWhiteSpace(member.ReturnType)
+            ? $"{member.ReturnType} {member.Name}"
+            : member.Signature ?? member.ReturnType ?? "";
+        if (string.IsNullOrWhiteSpace(signature))
+        {
+            if (member.Kind == "field" && !string.IsNullOrWhiteSpace(member.ReturnType))
+                signature = $"{member.ReturnType} {member.Name}";
+            else
+                return "";
+        }
+
+        if (options.AbbreviateSignature)
+            signature = AbbreviateSignature(signature);
+        signature = EscapeKnownIdentifiers(signature, type.TypeParameters.Select(p => p.Name));
+
+        if (member.Name == ".cctor")
+        {
+            signature = $"{FormatConstructorTypeName(type.Name)}()";
+        }
+        else if (member.Kind == "constructor")
+        {
+            var typeName = FormatConstructorTypeName(type.Name);
+            signature = $"{typeName}{FormatConstructorCall(signature)}";
+        }
+        else if (member.Name.StartsWith("op_", StringComparison.Ordinal))
+        {
+            signature = FormatOperatorSignature(signature, member.Name);
+        }
+        else if (member.Kind is "method" or "extension-method" or "explicit-interface-implementation")
+        {
+            if (methodParameters is { Count: > 0 })
+                signature = AddMethodGenericParameters(signature, member.Name, methodParameters);
+            if (member.IsExtension)
+                signature = AddExtensionThisModifier(signature);
+            signature = EscapeMemberNameInSignature(signature, member.Name);
+        }
+        else if (member.Kind == "event" && !signature.StartsWith("event ", StringComparison.Ordinal))
+        {
+            signature = $"event {signature}";
+        }
+        if (member.Kind is "property" or "field" or "event")
+        {
+            signature = EscapeMemberNameInSignature(signature, member.Name);
+        }
+
+        signature = EscapeQualifiedKeywordSegments(signature);
+        if (!options.AbbreviateSignature)
+            signature = EscapeParameterLists(signature);
+
+        List<string> parts = [];
+        if (options.IncludeObsoleteAttribute && member.IsObsolete)
+            parts.Add(FormatObsoleteAttribute(member.ObsoleteMessage));
+
+        List<string> modifiers = [];
+        if (member.Name == ".cctor")
+        {
+            modifiers.Add("static");
+            if (member.IsUnsafe || options.ForceUnsafe)
+                modifiers.Add("unsafe");
+        }
+        else if (member.Kind != "explicit-interface-implementation")
+        {
+            var omitInterfaceModifiers = options.OmitInterfaceMemberModifiers
+                && type.Kind == "interface"
+                && member.Kind == "method";
+            modifiers.Add(member.Accessibility ?? "public");
+            if (member.IsConst)
+                modifiers.Add("const");
+            else if (member.IsStatic && !omitInterfaceModifiers)
+                modifiers.Add("static");
+            if (!member.IsConst && member.IsReadOnly)
+                modifiers.Add("readonly");
+            if (!omitInterfaceModifiers)
+            {
+                if (member.IsSealed)
+                    modifiers.Add("sealed");
+                if (member.IsAbstract)
+                    modifiers.Add("abstract");
+                if (member.IsOverride)
+                    modifiers.Add("override");
+                else if (!member.IsAbstract && member.IsVirtual && !member.IsStatic)
+                    modifiers.Add("virtual");
+            }
+            if (member.IsUnsafe || options.ForceUnsafe)
+                modifiers.Add("unsafe");
+        }
+        else if (member.IsUnsafe || options.ForceUnsafe)
+        {
+            modifiers.Add("unsafe");
+        }
+
+        if (options.ForceAsync && member.Kind is "method" or "extension-method" or "explicit-interface-implementation")
+            modifiers.Add("async");
+
+        if (modifiers.Count > 0)
+            parts.Add(string.Join(" ", modifiers));
+        parts.Add(signature);
+
+        return string.Join(" ", parts);
+    }
+
+    static IEnumerable<string> CollectTypeReferences(ApiType type)
+    {
+        if (type.BaseType is { Length: > 0 })
+            yield return type.BaseType;
+        foreach (var iface in type.Interfaces)
+            yield return iface;
+        foreach (var typeParameter in type.TypeParameters)
+        {
+            foreach (var constraint in typeParameter.Constraints)
+            {
+                foreach (var reference in ExtractQualifiedTypeNames(constraint))
+                    yield return reference;
+            }
+        }
+    }
+
+    static IEnumerable<string> CollectMemberTypeReferences(ApiMember member)
+    {
+        foreach (var expression in MemberTypeExpressions(member))
+        {
+            foreach (var reference in ExtractQualifiedTypeNames(expression))
+                yield return reference;
+        }
+    }
+
+    static IEnumerable<string> MemberTypeExpressions(ApiMember member)
+    {
+        if (!string.IsNullOrWhiteSpace(member.ReturnType))
+            yield return member.ReturnType!;
+
+        var signature = member.Signature;
+        if (string.IsNullOrWhiteSpace(signature))
+            yield break;
+
+        if (member.Kind == "property")
+        {
+            foreach (var expression in PropertyTypeExpressions(signature))
+                yield return expression;
+            yield break;
+        }
+
+        if (member.Kind == "field" || member.Kind == "event")
+        {
+            if (TryTypeBeforeName(signature, member.Name, out var type))
+                yield return type;
+            yield break;
+        }
+
+        var parenStart = signature.IndexOf('(');
+        var parenEnd = signature.LastIndexOf(')');
+        if (parenStart < 0 || parenEnd < parenStart)
+            yield break;
+
+        if (member.Kind != "constructor")
+        {
+            var prefix = signature[..parenStart].TrimEnd();
+            var name = member.Name;
+            var nameIndex = prefix.LastIndexOf(name, StringComparison.Ordinal);
+            if (nameIndex > 0)
+                yield return prefix[..nameIndex].TrimEnd();
+        }
+
+        foreach (var parameter in SplitTopLevel(signature[(parenStart + 1)..parenEnd]))
+        {
+            if (TryParameterType(parameter, out var parameterType))
+                yield return parameterType;
+        }
+    }
+
+    static IEnumerable<string> PropertyTypeExpressions(string signature)
+    {
+        if (signature.StartsWith("required ", StringComparison.Ordinal))
+            signature = signature["required ".Length..];
+
+        var indexerStart = signature.IndexOf("this[", StringComparison.Ordinal);
+        if (indexerStart > 0)
+        {
+            yield return signature[..indexerStart].TrimEnd();
+            var close = signature.IndexOf(']', indexerStart);
+            if (close > indexerStart)
+            {
+                foreach (var parameter in SplitTopLevel(signature[(indexerStart + "this[".Length)..close]))
+                {
+                    if (TryParameterType(parameter, out var parameterType))
+                        yield return parameterType;
+                }
+            }
+            yield break;
+        }
+
+        var brace = signature.IndexOf('{');
+        var head = brace >= 0 ? signature[..brace].TrimEnd() : signature.TrimEnd();
+        var lastSpace = LastTopLevelSpace(head);
+        if (lastSpace > 0)
+            yield return head[..lastSpace].TrimEnd();
+    }
+
+    static bool TryTypeBeforeName(string signature, string name, out string type)
+    {
+        type = "";
+        var nameIndex = signature.LastIndexOf(name, StringComparison.Ordinal);
+        if (nameIndex <= 0)
+            return false;
+        type = signature[..nameIndex].TrimEnd();
+        if (type.StartsWith("event ", StringComparison.Ordinal))
+            type = type["event ".Length..];
+        return type.Length > 0;
+    }
+
+    static bool TryParameterType(string parameter, out string type)
+    {
+        type = "";
+        parameter = StripDefaultValue(parameter).Trim();
+        parameter = StripLeadingAttributes(parameter).Trim();
+
+        bool changed;
+        do
+        {
+            changed = false;
+            foreach (var modifier in s_parameterModifiers)
+            {
+                if (parameter.StartsWith(modifier + " ", StringComparison.Ordinal))
+                {
+                    parameter = parameter[(modifier.Length + 1)..].TrimStart();
+                    changed = true;
+                }
+            }
+        } while (changed);
+
+        var lastSpace = LastTopLevelSpace(parameter);
+        if (lastSpace <= 0)
+            return false;
+
+        type = parameter[..lastSpace].TrimEnd();
+        return type.Length > 0;
+    }
+
+    static string StripDefaultValue(string parameter)
+    {
+        var depth = 0;
+        for (var i = 0; i < parameter.Length; i++)
+        {
+            var c = parameter[i];
+            if (c is '<' or '[' or '(') depth++;
+            else if (c is '>' or ']' or ')') depth--;
+            else if (c == '=' && depth == 0)
+                return parameter[..i];
+        }
+
+        return parameter;
+    }
+
+    static string StripLeadingAttributes(string parameter)
+    {
+        while (parameter.StartsWith('['))
+        {
+            var close = Matching(parameter, 0, '[', ']');
+            if (close < 0)
+                return parameter;
+            parameter = parameter[(close + 1)..].TrimStart();
+        }
+
+        return parameter;
+    }
+
+    static IEnumerable<string> ExtractQualifiedTypeNames(string expression)
+    {
+        foreach (var token in DottedIdentifierTokens(expression))
+        {
+            if (token.Contains('.', StringComparison.Ordinal)
+                && !token.StartsWith("global.", StringComparison.Ordinal)
+                && !token.StartsWith("global::", StringComparison.Ordinal))
+                yield return token;
+        }
+    }
+
+    static IEnumerable<string> DottedIdentifierTokens(string text)
+    {
+        for (var i = 0; i < text.Length;)
+        {
+            if (!IsIdentifierStart(text[i]))
+            {
+                i++;
+                continue;
+            }
+
+            var start = i++;
+            while (i < text.Length && (IsIdentifierPart(text[i]) || text[i] is '.' or '+'))
+                i++;
+            yield return text[start..i].TrimEnd('.');
+        }
+    }
+
+    static string AppendTypeParameterConstraints(string declaration, IReadOnlyList<TypeParameter> typeParameters)
+    {
+        foreach (var typeParameter in typeParameters)
+        {
+            if (typeParameter.ConstraintsSummary is { } constraints)
+                declaration += $" where {EscapeIdentifier(typeParameter.Name)} : {EscapeKnownIdentifiers(constraints, typeParameters.Select(p => p.Name))}";
+        }
+
+        return declaration;
+    }
+
+    static string FormatTypeDisplayName(string name, IReadOnlyList<TypeParameter> typeParameters)
+    {
+        var tick = name.IndexOf('`');
+        if (tick >= 0)
+            name = name[..tick];
+        name = EscapeQualifiedIdentifier(name);
+        if (typeParameters.Count > 0)
+            name += $"<{string.Join(", ", typeParameters.Select(TypeParameterDisplayName))}>";
+        return name;
+    }
+
+    static string? EnumUnderlyingBase(ApiType type)
+    {
+        if (type.Kind != "enum" || type.EnumUnderlyingType is not { } underlying)
+            return null;
+        return EnumUnderlyingKeyword(underlying) is { } keyword && keyword != "int"
+            ? keyword
+            : null;
+    }
+
+    static string? EnumUnderlyingKeyword(string type) => type switch
+    {
+        "sbyte" or "System.SByte" => "sbyte",
+        "byte" or "System.Byte" => "byte",
+        "short" or "System.Int16" => "short",
+        "ushort" or "System.UInt16" => "ushort",
+        "int" or "System.Int32" => "int",
+        "uint" or "System.UInt32" => "uint",
+        "long" or "System.Int64" => "long",
+        "ulong" or "System.UInt64" => "ulong",
+        _ => null,
+    };
+
+    static string TypeParameterDisplayName(TypeParameter typeParameter)
+        => typeParameter.Variance is { } variance
+            ? $"{variance} {EscapeIdentifier(typeParameter.Name)}"
+            : EscapeIdentifier(typeParameter.Name);
+
+    static string FormatObsoleteAttribute(string? message)
+        => string.IsNullOrWhiteSpace(message)
+            ? "[Obsolete]"
+            : $"[Obsolete(\"{EscapeCSharpString(message)}\")]";
+
+    static string EscapeCSharpString(string value)
+        => value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\t", "\\t", StringComparison.Ordinal);
+
+    static string FormatOperatorSignature(string signature, string methodName)
+    {
+        var parenStart = signature.IndexOf('(');
+        if (parenStart <= 0)
+            return signature;
+
+        var nameIndex = signature.LastIndexOf(methodName, parenStart - 1, StringComparison.Ordinal);
+        if (nameIndex < 0)
+            return signature;
+
+        var returnType = signature[..nameIndex].TrimEnd();
+        var parameters = signature[parenStart..];
+
+        if (methodName.StartsWith("op_Checked", StringComparison.Ordinal)
+            && OperatorNames.MapBinaryOrUnary(methodName["op_Checked".Length..]) is { } checkedSymbol)
+            return $"{returnType} operator checked {checkedSymbol}{parameters}";
+
+        return methodName switch
+        {
+            "op_Implicit" => $"implicit operator {returnType}{parameters}",
+            "op_Explicit" => $"explicit operator {returnType}{parameters}",
+            "op_CheckedExplicit" => $"explicit operator checked {returnType}{parameters}",
+            _ => $"{returnType} {OperatorNames.FormatDisplayName(methodName)}{parameters}"
+        };
+    }
+
+    static string FormatConstructorTypeName(string name)
+    {
+        var arityIndex = name.IndexOf('`');
+        var typeName = arityIndex < 0 ? name : name[..arityIndex];
+        return EscapeIdentifier(typeName);
+    }
+
+    static string EscapeMemberNameInSignature(string signature, string memberName)
+    {
+        if (string.IsNullOrEmpty(memberName))
+            return signature;
+
+        int searchEnd = signature.IndexOf('(');
+        if (searchEnd < 0)
+            searchEnd = signature.IndexOf('{');
+        if (searchEnd < 0)
+            searchEnd = signature.Length;
+        if (searchEnd <= 0)
+            return signature;
+
+        int nameIndex = signature.LastIndexOf(memberName, searchEnd - 1, StringComparison.Ordinal);
+        if (nameIndex < 0)
+            return signature;
+
+        string escaped = memberName.Contains('.', StringComparison.Ordinal)
+            ? EscapeQualifiedName(memberName)
+            : EscapeIdentifier(memberName);
+        return escaped == memberName
+            ? signature
+            : string.Concat(signature.AsSpan(0, nameIndex), escaped, signature.AsSpan(nameIndex + memberName.Length));
+    }
+
+    static string EscapeQualifiedKeywordSegments(string signature)
+    {
+        var sb = new StringBuilder(signature.Length);
+        bool inString = false;
+        bool inChar = false;
+        bool escapedChar = false;
+        for (int i = 0; i < signature.Length; i++)
+        {
+            char c = signature[i];
+            sb.Append(c);
+            if (inString || inChar)
+            {
+                if (escapedChar)
+                {
+                    escapedChar = false;
+                    continue;
+                }
+                if (c == '\\')
+                {
+                    escapedChar = true;
+                    continue;
+                }
+                if (inString && c == '"')
+                    inString = false;
+                else if (inChar && c == '\'')
+                    inChar = false;
+                continue;
+            }
+            if (c == '"')
+            {
+                inString = true;
+                continue;
+            }
+            if (c == '\'')
+            {
+                inChar = true;
+                continue;
+            }
+            if (c != '.' || i + 1 >= signature.Length || signature[i + 1] == '@' || !IsIdentifierStart(signature[i + 1]))
+                continue;
+
+            int start = i + 1;
+            int end = start + 1;
+            while (end < signature.Length && IsIdentifierPart(signature[end]))
+                end++;
+
+            string segment = signature[start..end];
+            string escaped = EscapeIdentifier(segment);
+            if (escaped != segment)
+            {
+                sb.Append(escaped);
+                i = end - 1;
+            }
+        }
+        return sb.ToString();
+    }
+
+    static string EscapeParameterLists(string signature)
+    {
+        var sb = new StringBuilder(signature.Length);
+        int start = 0;
+        while (true)
+        {
+            int open = signature.IndexOf('(', start);
+            if (open < 0)
+            {
+                sb.Append(signature, start, signature.Length - start);
+                return sb.ToString();
+            }
+            int close = Matching(signature, open, '(', ')');
+            if (close < 0)
+            {
+                sb.Append(signature, start, signature.Length - start);
+                return sb.ToString();
+            }
+
+            sb.Append(signature, start, open - start + 1);
+            sb.Append(string.Join(", ", SplitTopLevel(signature[(open + 1)..close]).Select(EscapeParameterName)));
+            sb.Append(')');
+            start = close + 1;
+        }
+    }
+
+    static string EscapeParameterName(string parameter)
+    {
+        if (parameter.Length == 0)
+            return parameter;
+
+        int equals = parameter.IndexOf('=');
+        string prefix = equals >= 0 ? parameter[..equals] : parameter;
+        string suffix = equals >= 0 ? parameter[equals..] : "";
+
+        int end = prefix.Length - 1;
+        while (end >= 0 && char.IsWhiteSpace(prefix[end]))
+            end--;
+        int start = end;
+        while (start >= 0 && (IsIdentifierPart(prefix[start]) || prefix[start] == '@'))
+            start--;
+        start++;
+        if (start > end)
+            return parameter;
+
+        string name = prefix[start..(end + 1)];
+        string escaped = name.StartsWith('@', StringComparison.Ordinal) ? name : EscapeIdentifier(name);
+        return prefix[..start] + escaped + prefix[(end + 1)..] + suffix;
+    }
+
+    static string EscapeKnownIdentifiers(string text, IEnumerable<string> rawNames)
+    {
+        var names = rawNames.Where(name => EscapeIdentifier(name) != name).ToHashSet(StringComparer.Ordinal);
+        if (names.Count == 0)
+            return text;
+
+        var sb = new StringBuilder(text.Length);
+        for (int i = 0; i < text.Length;)
+        {
+            if (IsIdentifierStart(text[i]))
+            {
+                int start = i++;
+                while (i < text.Length && IsIdentifierPart(text[i]))
+                    i++;
+                string token = text[start..i];
+                sb.Append(names.Contains(token) ? EscapeIdentifier(token) : token);
+                continue;
+            }
+            sb.Append(text[i++]);
+        }
+        return sb.ToString();
+    }
+
+    static string EscapeQualifiedIdentifier(string name)
+        => string.Join("+", name.Split('+').Select(EscapeIdentifier));
+
+    static string EscapeQualifiedName(string name)
+        => string.Join(".", name.Split('.').Select(part => string.Join("+", part.Split('+').Select(EscapeIdentifier))));
+
+    static string EscapeIdentifier(string name)
+        => s_csharpReservedKeywords.Contains(name) || name == "await" ? "@" + name : name;
+
+    static bool IsIdentifierStart(char c) => char.IsLetter(c) || c == '_';
+
+    static bool IsIdentifierPart(char c) => char.IsLetterOrDigit(c) || c == '_';
+
+    static string AddMethodGenericParameters(string signature, string methodName, IReadOnlyList<string> methodParameters)
+    {
+        if (methodParameters.Count == 0 || string.IsNullOrEmpty(methodName))
+            return signature;
+
+        var parenStart = signature.IndexOf('(');
+        if (parenStart <= 0)
+            return signature;
+
+        var nameIndex = signature.LastIndexOf(methodName, parenStart - 1, StringComparison.Ordinal);
+        if (nameIndex < 0)
+            return signature;
+
+        var insertAt = nameIndex + methodName.Length;
+        if (insertAt < parenStart && signature[insertAt] == '<')
+            return signature;
+
+        return signature.Insert(insertAt, $"<{string.Join(", ", methodParameters)}>");
+    }
+
+    static string AddExtensionThisModifier(string signature)
+    {
+        var parenStart = signature.IndexOf('(');
+        var parenEnd = signature.LastIndexOf(')');
+        if (parenStart < 0 || parenEnd <= parenStart + 1)
+            return signature;
+
+        var firstParameterStart = parenStart + 1;
+        while (firstParameterStart < signature.Length && char.IsWhiteSpace(signature[firstParameterStart]))
+            firstParameterStart++;
+
+        if (signature.AsSpan(firstParameterStart).StartsWith("this ".AsSpan(), StringComparison.Ordinal))
+            return signature;
+
+        return signature.Insert(firstParameterStart, "this ");
+    }
+
+    static string AbbreviateSignature(string signature)
+    {
+        int parenStart = signature.IndexOf('(');
+        if (parenStart < 0)
+            return signature;
+
+        int parenEnd = signature.LastIndexOf(')');
+        if (parenEnd < 0)
+            return signature;
+
+        string prefix = signature[..(parenStart + 1)];
+        string suffix = signature[parenEnd..];
+        string paramSection = signature[(parenStart + 1)..parenEnd].Trim();
+        if (string.IsNullOrEmpty(paramSection))
+            return signature;
+
+        var paramTypes = SplitTopLevel(paramSection)
+            .Select(param => TryAbbreviatedParameterType(param, out var type) ? type : param)
+            .ToList();
+
+        return prefix + string.Join(", ", paramTypes) + suffix;
+    }
+
+    static bool TryAbbreviatedParameterType(string parameter, out string type)
+    {
+        type = "";
+        parameter = StripDefaultValue(parameter).Trim();
+
+        var lastSpace = LastTopLevelSpace(parameter);
+        if (lastSpace <= 0)
+            return false;
+
+        type = parameter[..lastSpace].TrimEnd();
+        return type.Length > 0;
+    }
+
+    static string FormatConstructorCall(string signature)
+    {
+        int parenStart = signature.IndexOf('(');
+        return parenStart < 0 ? "()" : signature[parenStart..];
+    }
+
+    static int LastTopLevelSpace(string text)
+    {
+        var depth = 0;
+        var last = -1;
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (c is '<' or '[' or '(') depth++;
+            else if (c is '>' or ']' or ')') depth--;
+            else if (char.IsWhiteSpace(c) && depth == 0)
+                last = i;
+        }
+        return last;
+    }
+
+    static IEnumerable<string> SplitTopLevel(string text)
+    {
+        if (text.Length == 0)
+            yield break;
+
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (c is '<' or '[' or '(') depth++;
+            else if (c is '>' or ']' or ')') depth--;
+            else if (c == ',' && depth == 0)
+            {
+                yield return text[start..i].Trim();
+                start = i + 1;
+            }
+        }
+        yield return text[start..].Trim();
+    }
+
+    static int Matching(string text, int open, char openChar, char closeChar)
+    {
+        int depth = 0;
+        for (int i = open; i < text.Length; i++)
+        {
+            if (text[i] == openChar) depth++;
+            else if (text[i] == closeChar && --depth == 0) return i;
+        }
+        return -1;
+    }
+
+    sealed record TypeNamePlan(
+        IReadOnlyDictionary<string, string> Replacements,
+        IReadOnlyList<string> GeneratedUsings,
+        IReadOnlyList<string> Diagnostics)
+    {
+        public string Apply(string text)
+        {
+            foreach (var (qualified, replacement) in Replacements.OrderByDescending(kvp => kvp.Key.Length))
+                text = ReplaceIdentifierToken(text, qualified, replacement);
+            return text;
+        }
+
+        public static TypeNamePlan Create(IEnumerable<string> references, CSharpDeclarationOptions options)
+        {
+            if (options.TypeNameMode == CSharpTypeNameMode.Qualified)
+                return new TypeNamePlan(new Dictionary<string, string>(), [], []);
+
+            var typeRefs = references
+                .Select(TypeRef.TryCreate)
+                .Where(r => r is not null)
+                .Select(r => r!)
+                .DistinctBy(r => r.FullName, StringComparer.Ordinal)
+                .ToList();
+
+            var collisions = typeRefs
+                .GroupBy(r => r.SimpleName, StringComparer.Ordinal)
+                .Where(g => g.Select(r => r.FullName).Distinct(StringComparer.Ordinal).Count() > 1)
+                .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.Ordinal);
+
+            var contextualUsings = options.Usings.ToHashSet(StringComparer.Ordinal);
+            var generatedUsings = new SortedSet<string>(StringComparer.Ordinal);
+            var diagnostics = new List<string>();
+            var replacements = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            foreach (var typeRef in typeRefs)
+            {
+                if (collisions.ContainsKey(typeRef.SimpleName))
+                {
+                    diagnostics.Add($"Type name '{typeRef.SimpleName}' is ambiguous; kept '{typeRef.FullName}' qualified.");
+                    continue;
+                }
+
+                var isSameNamespace = !string.IsNullOrWhiteSpace(options.ContainingNamespace)
+                    && string.Equals(typeRef.Namespace, options.ContainingNamespace, StringComparison.Ordinal);
+                var isInContext = isSameNamespace || contextualUsings.Contains(typeRef.Namespace);
+
+                if (options.TypeNameMode == CSharpTypeNameMode.ContextualShort && !isInContext)
+                    continue;
+
+                replacements[typeRef.FullName] = typeRef.SimpleName;
+                if (options.TypeNameMode == CSharpTypeNameMode.ShortWithUsings && !isSameNamespace)
+                    generatedUsings.Add(typeRef.Namespace);
+            }
+
+            return new TypeNamePlan(replacements, generatedUsings.ToList(), diagnostics);
+        }
+
+        static string ReplaceIdentifierToken(string text, string token, string replacement)
+        {
+            var sb = new StringBuilder(text.Length);
+            for (var i = 0; i < text.Length;)
+            {
+                if (i + token.Length <= text.Length
+                    && text.AsSpan(i, token.Length).SequenceEqual(token)
+                    && IsStartBoundary(text, i - 1)
+                    && IsEndBoundary(text, i + token.Length))
+                {
+                    sb.Append(replacement);
+                    i += token.Length;
+                    continue;
+                }
+
+                sb.Append(text[i++]);
+            }
+
+            return sb.ToString();
+        }
+
+        static bool IsStartBoundary(string text, int index)
+            => index < 0
+               || index >= text.Length
+               || (!IsIdentifierPart(text[index]) && text[index] is not '.' and not '+');
+
+        static bool IsEndBoundary(string text, int index)
+            => index < 0
+               || index >= text.Length
+               || (!IsIdentifierPart(text[index]) && text[index] != '+');
+    }
+
+    sealed record TypeRef(string FullName, string Namespace, string SimpleName)
+    {
+        public static TypeRef? TryCreate(string value)
+        {
+            value = value.Trim().TrimEnd('?');
+            if (value.Length == 0)
+                return null;
+            var lastDot = value.LastIndexOf('.');
+            if (lastDot <= 0 || lastDot == value.Length - 1)
+                return null;
+            var ns = value[..lastDot];
+            var simple = StripArity(value[(lastDot + 1)..]);
+            if (s_csharpReservedKeywords.Contains(simple))
+                return null;
+            return new TypeRef(value, ns, simple);
+        }
+
+        static string StripArity(string name)
+        {
+            var tick = name.IndexOf('`');
+            return tick < 0 ? name : name[..tick];
+        }
+    }
+
+    static readonly string[] s_parameterModifiers = ["this", "params", "ref", "out", "in", "scoped"];
+
+    static readonly HashSet<string> s_csharpReservedKeywords = new(StringComparer.Ordinal)
+    {
+        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
+        "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else",
+        "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
+        "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
+        "long", "namespace", "new", "null", "object", "operator", "out", "override", "params",
+        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
+        "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
+        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
+        "void", "volatile", "while",
+    };
+}

--- a/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
@@ -1,0 +1,40 @@
+using DotnetInspector.Options;
+using DotnetInspector.Output;
+using ILInspector.Metadata;
+
+namespace DotnetInspector.Tests;
+
+public sealed class CSharpDeclarationFormatterTests
+{
+    [Fact]
+    public void MemberSignatureSection_UsesSharedCSharpDeclarationWriter()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "KeywordHost",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "class",
+                    Kind = "method",
+                    Signature = "int class(int object)"
+                }
+            ]
+        };
+        var view = ApiOutputFormatter.BuildTypeView(
+            type,
+            foundIn: "Test.dll",
+            packageName: null,
+            packageVersion: null,
+            apiSource: "local",
+            selectedTfm: null,
+            new MemberOptions { OverloadIndex = 1 });
+
+        ApiOutputFormatter.PopulateMemberSignature(view, type, new MemberOptions { OverloadIndex = 1 });
+
+        Assert.Contains("public int @class(int @object)", view.SignatureRows![0].Signature);
+    }
+}

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1784,9 +1784,12 @@ public static class ApiOutputFormatter
         bool preferExpressionBodied = false,
         IReadOnlyList<string>? leadingBodyComments = null)
     {
-        var declaration = FormatMemberDeclaration(type, member, abbreviate: false, methodGenericParameters);
-        if (requiresAsyncDeclaration && member.Kind is "method" or "extension-method" or "explicit-interface-implementation")
-            declaration = AddAsyncModifier(declaration);
+        var declaration = FormatMemberDeclaration(
+            type,
+            member,
+            abbreviate: false,
+            methodGenericParameters,
+            forceAsync: requiresAsyncDeclaration);
         var body = lowered.TrimEnd();
 
         // A constructor's base/this initializer is surfaced by the renderer as a
@@ -1820,277 +1823,23 @@ public static class ApiOutputFormatter
         return $"{declaration}{Environment.NewLine}{{{Environment.NewLine}{indentedBody}{Environment.NewLine}}}";
     }
 
-    private static string AddAsyncModifier(string declaration)
-    {
-        var parts = declaration.Split(' ', StringSplitOptions.RemoveEmptyEntries).ToList();
-        if (parts.Contains("async"))
-            return declaration;
-        int insert = 0;
-        while (insert < parts.Count && parts[insert] is
-               "public" or "private" or "protected" or "internal" or "static" or
-               "virtual" or "override" or "sealed" or "abstract" or "new" or "extern" or "unsafe")
-        {
-            insert++;
-        }
-        parts.Insert(insert, "async");
-        return string.Join(" ", parts);
-    }
-
     private static string FormatMemberDeclaration(
         ApiType type,
         ApiMember member,
         bool abbreviate,
-        IReadOnlyList<string>? methodParameters = null)
-    {
-        var signature = member.Kind == "field" && member.Signature == null && !string.IsNullOrWhiteSpace(member.ReturnType)
-            ? $"{member.ReturnType} {member.Name}"
-            : member.Signature ?? member.ReturnType ?? "";
-        if (string.IsNullOrWhiteSpace(signature))
-        {
-            if (member.Kind == "field" && !string.IsNullOrWhiteSpace(member.ReturnType))
-                signature = $"{member.ReturnType} {member.Name}";
-            else
-                return "";
-        }
-
-        if (abbreviate)
-            signature = SignatureParser.AbbreviateSignature(signature);
-
-        if (member.Kind == "constructor")
-        {
-            var typeName = FormatConstructorTypeName(type.Name);
-            signature = $"{typeName}{SignatureParser.FormatConstructorCall(signature)}";
-        }
-        else if (member.Name.StartsWith("op_", StringComparison.Ordinal))
-        {
-            signature = FormatOperatorSignature(signature, member.Name);
-        }
-        else if (member.Kind is "method" or "extension-method")
-        {
-            if (methodParameters is { Count: > 0 })
-                signature = AddMethodGenericParameters(signature, member.Name, methodParameters);
-            if (member.IsExtension)
-                signature = AddExtensionThisModifier(signature);
-            signature = EscapeMemberNameInSignature(signature, member.Name);
-        }
-        else if (member.Kind == "event" && !signature.StartsWith("event ", StringComparison.Ordinal))
-        {
-            signature = $"event {signature}";
-        }
-
-        signature = EscapeQualifiedKeywordSegments(signature);
-
-        List<string> parts = [];
-        if (member.IsObsolete)
-            parts.Add(FormatObsoleteAttribute(member.ObsoleteMessage));
-
-        List<string> modifiers = [];
-        if (member.Kind != "explicit-interface-implementation")
-        {
-            modifiers.Add(member.Accessibility ?? "public");
-            if (member.IsConst)
-                modifiers.Add("const");
-            else if (member.IsStatic)
-                modifiers.Add("static");
-            if (!member.IsConst && member.IsReadOnly)
-                modifiers.Add("readonly");
-            if (member.IsSealed)
-                modifiers.Add("sealed");
-            if (member.IsAbstract)
-                modifiers.Add("abstract");
-            if (member.IsOverride)
-                modifiers.Add("override");
-            else if (!member.IsAbstract && member.IsVirtual && !member.IsStatic)
-                modifiers.Add("virtual");
-            if (member.IsUnsafe)
-                modifiers.Add("unsafe");
-        }
-
-        if (modifiers.Count > 0)
-            parts.Add(string.Join(" ", modifiers));
-        parts.Add(signature);
-
-        return string.Join(" ", parts);
-    }
-
-    private static string FormatObsoleteAttribute(string? message)
-        => string.IsNullOrWhiteSpace(message)
-            ? "[Obsolete]"
-            : $"[Obsolete(\"{EscapeCSharpString(message)}\")]";
-
-    private static string EscapeCSharpString(string value)
-        => value
-            .Replace("\\", "\\\\", StringComparison.Ordinal)
-            .Replace("\"", "\\\"", StringComparison.Ordinal)
-            .Replace("\r", "\\r", StringComparison.Ordinal)
-            .Replace("\n", "\\n", StringComparison.Ordinal)
-            .Replace("\t", "\\t", StringComparison.Ordinal);
-
-    private static string FormatOperatorSignature(string signature, string methodName)
-    {
-        var parenStart = signature.IndexOf('(');
-        if (parenStart <= 0)
-            return signature;
-
-        var nameIndex = signature.LastIndexOf(methodName, parenStart - 1, StringComparison.Ordinal);
-        if (nameIndex < 0)
-            return signature;
-
-        var returnType = signature[..nameIndex].TrimEnd();
-        var parameters = signature[parenStart..];
-
-        if (methodName.StartsWith("op_Checked", StringComparison.Ordinal)
-            && OperatorNames.MapBinaryOrUnary(methodName["op_Checked".Length..]) is { } checkedSymbol)
-            return $"{returnType} operator checked {checkedSymbol}{parameters}";
-
-        return methodName switch
-        {
-            "op_Implicit" => $"implicit operator {returnType}{parameters}",
-            "op_Explicit" => $"explicit operator {returnType}{parameters}",
-            "op_CheckedExplicit" => $"explicit operator checked {returnType}{parameters}",
-            _ => $"{returnType} {OperatorNames.FormatDisplayName(methodName)}{parameters}"
-        };
-    }
-
-    private static string FormatConstructorTypeName(string name)
-    {
-        var arityIndex = name.IndexOf('`');
-        var typeName = arityIndex < 0 ? name : name[..arityIndex];
-        return EscapeCSharpIdentifier(typeName);
-    }
-
-    private static string EscapeMemberNameInSignature(string signature, string memberName)
-    {
-        if (string.IsNullOrEmpty(memberName))
-            return signature;
-
-        int parenStart = signature.IndexOf('(');
-        if (parenStart <= 0)
-            return signature;
-
-        int nameIndex = signature.LastIndexOf(memberName, parenStart - 1, StringComparison.Ordinal);
-        if (nameIndex < 0)
-            return signature;
-
-        string escaped = EscapeCSharpIdentifier(memberName);
-        return escaped == memberName
-            ? signature
-            : string.Concat(signature.AsSpan(0, nameIndex), escaped, signature.AsSpan(nameIndex + memberName.Length));
-    }
-
-    private static string EscapeQualifiedKeywordSegments(string signature)
-    {
-        var sb = new StringBuilder(signature.Length);
-        bool inString = false;
-        bool inChar = false;
-        bool escapedChar = false;
-        for (int i = 0; i < signature.Length; i++)
-        {
-            char c = signature[i];
-            sb.Append(c);
-            if (inString || inChar)
+        IReadOnlyList<string>? methodParameters = null,
+        bool forceAsync = false,
+        bool forceUnsafe = false)
+        => CSharpDeclarationWriter.RenderMemberDeclaration(
+            type,
+            member,
+            new CSharpDeclarationOptions
             {
-                if (escapedChar)
-                {
-                    escapedChar = false;
-                    continue;
-                }
-                if (c == '\\')
-                {
-                    escapedChar = true;
-                    continue;
-                }
-                if (inString && c == '"')
-                    inString = false;
-                else if (inChar && c == '\'')
-                    inChar = false;
-                continue;
-            }
-            if (c == '"')
-            {
-                inString = true;
-                continue;
-            }
-            if (c == '\'')
-            {
-                inChar = true;
-                continue;
-            }
-            if (c != '.' || i + 1 >= signature.Length || signature[i + 1] == '@' || !IsIdentifierStart(signature[i + 1]))
-                continue;
-
-            int start = i + 1;
-            int end = start + 1;
-            while (end < signature.Length && IsIdentifierPart(signature[end]))
-                end++;
-
-            string segment = signature[start..end];
-            string escaped = EscapeCSharpIdentifier(segment);
-            if (escaped != segment)
-            {
-                sb.Append(escaped);
-                i = end - 1;
-            }
-        }
-        return sb.ToString();
-    }
-
-    private static string EscapeCSharpIdentifier(string name)
-        => s_csharpReservedKeywords.Contains(name) || name == "await" ? "@" + name : name;
-
-    private static bool IsIdentifierStart(char c) => char.IsLetter(c) || c == '_';
-
-    private static bool IsIdentifierPart(char c) => char.IsLetterOrDigit(c) || c == '_';
-
-    static readonly HashSet<string> s_csharpReservedKeywords = new(StringComparer.Ordinal)
-    {
-        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
-        "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else",
-        "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
-        "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
-        "long", "namespace", "new", "null", "object", "operator", "out", "override", "params",
-        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
-        "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
-        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
-        "void", "volatile", "while",
-    };
-
-    private static string AddMethodGenericParameters(string signature, string methodName, IReadOnlyList<string> methodParameters)
-    {
-        if (methodParameters.Count == 0 || string.IsNullOrEmpty(methodName))
-            return signature;
-
-        var parenStart = signature.IndexOf('(');
-        if (parenStart <= 0)
-            return signature;
-
-        var nameIndex = signature.LastIndexOf(methodName, parenStart - 1, StringComparison.Ordinal);
-        if (nameIndex < 0)
-            return signature;
-
-        var insertAt = nameIndex + methodName.Length;
-        if (insertAt < parenStart && signature[insertAt] == '<')
-            return signature;
-
-        return signature.Insert(insertAt, $"<{string.Join(", ", methodParameters)}>");
-    }
-
-    private static string AddExtensionThisModifier(string signature)
-    {
-        var parenStart = signature.IndexOf('(');
-        var parenEnd = signature.LastIndexOf(')');
-        if (parenStart < 0 || parenEnd <= parenStart + 1)
-            return signature;
-
-        var firstParameterStart = parenStart + 1;
-        while (firstParameterStart < signature.Length && char.IsWhiteSpace(signature[firstParameterStart]))
-            firstParameterStart++;
-
-        if (signature.AsSpan(firstParameterStart).StartsWith("this ".AsSpan(), StringComparison.Ordinal))
-            return signature;
-
-        return signature.Insert(firstParameterStart, "this ");
-    }
+                AbbreviateSignature = abbreviate,
+                ForceAsync = forceAsync,
+                ForceUnsafe = forceUnsafe
+            },
+            methodParameters);
 
     // ===== Helper Methods =====
 

--- a/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
@@ -1,0 +1,319 @@
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class CSharpDeclarationWriterTests
+{
+    [Fact]
+    public void QualifiedMemberDeclaration_KeepsFullyQualifiedTypeNames()
+    {
+        var type = CreateSampleType();
+        var member = type.Members[0];
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal(
+            "public System.Collections.Generic.Dictionary<string, System.DateTime> GetValues(System.Collections.Generic.List<System.Guid> ids)",
+            declaration);
+    }
+
+    [Fact]
+    public void ShortWithUsingsMemberUnit_GeneratesImportsAndShortensTypes()
+    {
+        var type = CreateSampleType();
+        var member = type.Members[0];
+
+        var rendered = CSharpDeclarationWriter.RenderMemberUnit(
+            type,
+            member,
+            new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ShortWithUsings,
+                TerminateMemberDeclaration = true
+            });
+
+        Assert.Equal(
+            """
+            using System;
+            using System.Collections.Generic;
+
+            public Dictionary<string, DateTime> GetValues(List<Guid> ids);
+            """,
+            rendered.Source);
+        Assert.Equal(["System", "System.Collections.Generic"], rendered.Usings);
+        Assert.Empty(rendered.Diagnostics);
+    }
+
+    [Fact]
+    public void ContextualShort_UsesCallerSuppliedNamespaceContext()
+    {
+        var type = CreateSampleType();
+        var member = type.Members[0];
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+            type,
+            member,
+            new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ContextualShort,
+                Usings = ["System", "System.Collections.Generic"]
+            });
+
+        Assert.Equal("public Dictionary<string, DateTime> GetValues(List<Guid> ids)", declaration);
+    }
+
+    [Fact]
+    public void ContextualShort_LeavesTypesQualifiedWhenImportsAreMissing()
+    {
+        var type = CreateSampleType();
+        var member = type.Members[0];
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+            type,
+            member,
+            new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ContextualShort,
+                Usings = ["System"]
+            });
+
+        Assert.Equal(
+            "public System.Collections.Generic.Dictionary<string, DateTime> GetValues(System.Collections.Generic.List<Guid> ids)",
+            declaration);
+    }
+
+    [Fact]
+    public void ShortWithUsings_KeepsCollidingSimpleNamesQualified()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Sample",
+            Name = "CollisionHost",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Choose",
+                    Kind = "method",
+                    Signature = "Contoso.Models.Widget Choose(Fabrikam.Models.Widget other, System.DateTime when)"
+                }
+            ]
+        };
+
+        var rendered = CSharpDeclarationWriter.RenderMemberUnit(
+            type,
+            type.Members[0],
+            new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ShortWithUsings,
+                TerminateMemberDeclaration = true
+            });
+
+        Assert.Equal(
+            """
+            using System;
+
+            public Contoso.Models.Widget Choose(Fabrikam.Models.Widget other, DateTime when);
+            """,
+            rendered.Source);
+        Assert.Contains("Type name 'Widget' is ambiguous", rendered.Diagnostics[0]);
+    }
+
+    [Fact]
+    public void ShortWithUsings_ShortensEnumDefaultTypePrefix()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Sample",
+            Name = "EnumDefaultHost",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Pick",
+                    Kind = "method",
+                    Signature = "DotnetInspector.Tests.SampleColor Pick(DotnetInspector.Tests.SampleColor color = DotnetInspector.Tests.SampleColor.Green)"
+                }
+            ]
+        };
+
+        var rendered = CSharpDeclarationWriter.RenderMemberUnit(
+            type,
+            type.Members[0],
+            new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ShortWithUsings,
+                TerminateMemberDeclaration = true
+            });
+
+        Assert.Equal(
+            """
+            using DotnetInspector.Tests;
+
+            public SampleColor Pick(SampleColor color = SampleColor.Green);
+            """,
+            rendered.Source);
+    }
+
+    [Fact]
+    public void TypeUnit_ComposesNamespaceTypeAndMemberDeclarations()
+    {
+        var type = CreateSampleType();
+
+        var rendered = CSharpDeclarationWriter.RenderTypeUnit(
+            type,
+            type.Members,
+            new CSharpDeclarationOptions
+            {
+                ContainingNamespace = type.Namespace,
+                NamespaceMode = CSharpNamespaceMode.FileScoped,
+                TypeNameMode = CSharpTypeNameMode.ShortWithUsings
+            });
+
+        Assert.Equal(
+            """
+            using System;
+            using System.Collections.Generic;
+
+            namespace Samples;
+
+            public class Values
+            {
+                public Dictionary<string, DateTime> GetValues(List<Guid> ids);
+            }
+            """,
+            rendered.Source);
+    }
+
+    [Fact]
+    public void DeclarationOptions_InsertAsyncUnsafeAndCanSuppressObsoleteAttribute()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Worker", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Run",
+            Kind = "method",
+            Signature = "System.Threading.Tasks.Task Run()",
+            IsStatic = true,
+            IsObsolete = true,
+            ObsoleteMessage = "Use RunAsync."
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+            type,
+            member,
+            new CSharpDeclarationOptions
+            {
+                ForceAsync = true,
+                ForceUnsafe = true,
+                IncludeObsoleteAttribute = false
+            });
+
+        Assert.Equal("public static unsafe async System.Threading.Tasks.Task Run()", declaration);
+    }
+
+    [Fact]
+    public void StaticConstructorDeclaration_OmitsAccessibility()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Worker", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = ".cctor",
+            Kind = "constructor",
+            Signature = "void .cctor()",
+            IsStatic = true
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("static Worker()", declaration);
+    }
+
+    [Fact]
+    public void AbbreviatedMemberDeclaration_PreservesParameterModifiers()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "RefKinds", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "M",
+            Kind = "method",
+            Signature = "void M(ref int value, out string text, in long source, params byte[] bytes)"
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+            type,
+            member,
+            new CSharpDeclarationOptions { AbbreviateSignature = true });
+
+        Assert.Equal("public void M(ref int, out string, in long, params byte[])", declaration);
+    }
+
+    [Fact]
+    public void ExplicitInterfaceImplementation_WithUnsafeSignature_RetainsUnsafeModifier()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "UnsafeImpl", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "IFoo.Bar",
+            Kind = "explicit-interface-implementation",
+            Signature = "void IFoo.Bar(int* p)",
+            IsUnsafe = true
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("unsafe void IFoo.Bar(int* p)", declaration);
+    }
+
+    [Fact]
+    public void ExplicitInterfaceImplementation_EscapesDottedKeywordSegments()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "KeywordImpl", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "event.class",
+            Kind = "explicit-interface-implementation",
+            Signature = "void event.class()"
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("void @event.@class()", declaration);
+    }
+
+    [Fact]
+    public void TypeDeclaration_EscapesKeywordTypeParametersInInterfaces()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "KeywordGeneric`1",
+            Kind = "class",
+            TypeParameters = [new TypeParameter { Name = "object" }],
+            Interfaces = ["System.Collections.Generic.IEnumerable<object>"]
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderTypeDeclaration(type);
+
+        Assert.Equal("public class KeywordGeneric<@object> : System.Collections.Generic.IEnumerable<@object>", declaration);
+    }
+
+    static ApiType CreateSampleType()
+        => new()
+        {
+            Namespace = "Samples",
+            Name = "Values",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "GetValues",
+                    Kind = "method",
+                    Signature = "System.Collections.Generic.Dictionary<string, System.DateTime> GetValues(System.Collections.Generic.List<System.Guid> ids)"
+                }
+            ]
+        };
+}


### PR DESCRIPTION
- Fixes #2053
- Related: #2057
- Changes C# declaration/signature rendering to flow through a shared API-model-only writer used by CLI signature views and whole-type source composition.
- Card revision: `54bfa799`

## Change

**Conclusion:** **PASS** — this adds the shared declaration seam without moving method-body decompilation into metadata/API-only paths.

Before, declaration rendering was duplicated across CLI signature formatting and `TypeSourceComposer`, including separate modifier, keyword escaping, constructor/operator, and property/event handling.

After, `CSharpDeclarationWriter` owns shared declaration composition and supports qualified, contextual-short, and short-with-usings type spelling:

```csharp
using System;
using System.Collections.Generic;

public Dictionary<string, DateTime> GetValues(List<Guid> ids);
```

`TypeSourceComposer` still owns body composition, constructor-chain lifting, field initializers, attributes, union-specific declarations, and using hoisting for whole-type listings.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507 --nologo --verbosity quiet` |
| Focused decompiler type-source tests | Pass: `dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class '*TypeSourceCheckTests*'` |
| Metadata declaration writer tests | Pass: `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507` |
| CLI formatter regression tests | Pass: `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507` |

## Decompiler quality

**Conclusion:** **PASS** — no method-body raising/structuring pipeline changes are made; validation targeted whole-type declaration/source composition and CLI signature surfaces. The corpus quality-diff card was not run because this is declaration composition infrastructure, not a raise-pass or method-body fidelity change.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | Findings resolved | Found that abbreviated signatures dropped `ref/out/in/params`, and dotted keyword explicit-interface names were not escaped. Both are covered by new `CSharpDeclarationWriterTests` and resolved in `54bfa799`. |
| Claude Opus 4.8 | Findings resolved | Found that unsafe explicit-interface implementations could lose `unsafe`, and keyword generic type parameters in base/interface lists were not escaped. Both are covered by new `CSharpDeclarationWriterTests` and resolved in `54bfa799`. |

**Review conclusion:** **PASS** — both adversarial reviewers found real declaration edge cases; all actionable findings were fixed before opening this PR.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet build src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class '*TypeSourceCheckTests*'
dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507
dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507
```
