### PR TITLE
Simplify decompiler default assembly resolution

### DIFF
--- a/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
+++ b/src/DotnetInspector.Services.Tests/AssemblyDependencyResolverTests.cs
@@ -199,6 +199,89 @@ public class AssemblyDependencyResolverTests
     }
 
     [Fact]
+    public void PackageDependencyReferencePaths_SelectsCurrentTfmDependencyGroup()
+    {
+        string root = Directory.CreateTempSubdirectory("dotnet-inspect-assembly-deps-").FullName;
+        try
+        {
+            string packageDir = Path.Combine(root, "root.package", "1.0.0");
+            string targetDir = Path.Combine(packageDir, "lib", "net8.0");
+            Directory.CreateDirectory(targetDir);
+            string targetPath = Path.Combine(targetDir, "Root.dll");
+            File.WriteAllText(targetPath, "");
+            File.WriteAllText(
+                Path.Combine(packageDir, "root.package.nuspec"),
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+                  <metadata>
+                    <id>Root.Package</id>
+                    <version>1.0.0</version>
+                    <dependencies>
+                      <group targetFramework=".NETStandard2.0">
+                        <dependency id="Shared.Package" version="2.0.0" />
+                      </group>
+                      <group targetFramework="net8.0">
+                        <dependency id="Shared.Package" version="8.0.0" />
+                      </group>
+                    </dependencies>
+                  </metadata>
+                </package>
+                """);
+
+            string netstandardPath = CreatePackageAsset(root, "Shared.Package", "2.0.0", "lib", "netstandard2.0", "Shared.dll");
+            string net8Path = CreatePackageAsset(root, "Shared.Package", "8.0.0", "lib", "net8.0", "Shared.dll");
+
+            var references = AssemblyDependencyResolver.PackageDependencyReferencePaths(targetPath, [root]);
+
+            Assert.Contains(net8Path, references);
+            Assert.DoesNotContain(netstandardPath, references);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PackageDependencyReferencePaths_HandlesBracketExactRangeAndLowercaseVersionDirectory()
+    {
+        string root = Directory.CreateTempSubdirectory("dotnet-inspect-assembly-deps-").FullName;
+        try
+        {
+            string packageDir = Path.Combine(root, "root.package", "1.0.0");
+            string targetDir = Path.Combine(packageDir, "lib", "net8.0");
+            Directory.CreateDirectory(targetDir);
+            string targetPath = Path.Combine(targetDir, "Root.dll");
+            File.WriteAllText(targetPath, "");
+            File.WriteAllText(
+                Path.Combine(packageDir, "root.package.nuspec"),
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <package>
+                  <metadata>
+                    <dependencies>
+                      <group targetFramework="net8.0">
+                        <dependency id="Shared.Package" version="[8.0.0-RC1]" />
+                      </group>
+                    </dependencies>
+                  </metadata>
+                </package>
+                """);
+
+            string dependencyPath = CreatePackageAsset(root, "Shared.Package", "8.0.0-rc1", "lib", "net8.0", "Shared.dll");
+
+            var references = AssemblyDependencyResolver.PackageDependencyReferencePaths(targetPath, [root]);
+
+            Assert.Contains(dependencyPath, references);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Resolve_PlatformTrustFindsTrustedAssemblyWhenPackageCandidateHasSameName()
     {
         string root = Directory.CreateTempSubdirectory("dotnet-inspect-assembly-deps-").FullName;
@@ -251,6 +334,15 @@ public class AssemblyDependencyResolverTests
         {
             Directory.Delete(root, recursive: true);
         }
+    }
+
+    static string CreatePackageAsset(string root, string id, string version, string assetKind, string tfm, string fileName)
+    {
+        string assetDir = Path.Combine(root, id.ToLowerInvariant(), version.ToLowerInvariant(), assetKind, tfm);
+        Directory.CreateDirectory(assetDir);
+        string path = Path.Combine(assetDir, fileName);
+        File.WriteAllText(path, "");
+        return path;
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Reflection;
 
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
@@ -182,72 +181,6 @@ public class CrossAssemblyMethodFactsTests
         Assert.True(call.Callee.IsSpecialNameInferred);
     }
 
-    [Fact]
-    public void NuGetDependencyProbe_SelectsCurrentTfmDependencyGroup()
-    {
-        string directory = Directory.CreateTempSubdirectory("dotnet-inspect-nuspec-deps-").FullName;
-        try
-        {
-            string packageDir = Path.Combine(directory, "root.package", "1.0.0");
-            Directory.CreateDirectory(packageDir);
-            File.WriteAllText(
-                Path.Combine(packageDir, "root.package.nuspec"),
-                """
-                <?xml version="1.0" encoding="utf-8"?>
-                <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
-                  <metadata>
-                    <id>Root.Package</id>
-                    <version>1.0.0</version>
-                    <dependencies>
-                      <group targetFramework=".NETStandard2.0">
-                        <dependency id="Shared.Package" version="2.0.0" />
-                      </group>
-                      <group targetFramework="net8.0">
-                        <dependency id="Shared.Package" version="8.0.0" />
-                      </group>
-                    </dependencies>
-                  </metadata>
-                </package>
-                """);
-
-            var dependencies = ReadNuGetDependencyPackageVersions(packageDir, "Root.Package", "1.0.0", "net8.0");
-
-            Assert.Equal("1.0.0", dependencies["Root.Package"]);
-            Assert.Equal("8.0.0", dependencies["Shared.Package"]);
-        }
-        finally
-        {
-            Directory.Delete(directory, recursive: true);
-        }
-    }
-
-    [Fact]
-    public void NuGetDependencyProbe_HandlesSingleBracketExactRangeAndLowercaseVersionDirectory()
-    {
-        string directory = Directory.CreateTempSubdirectory("dotnet-inspect-nuspec-probe-").FullName;
-        try
-        {
-            string dependencyVersionDir = Path.Combine(directory, "shared.package", "8.0.0-rc1");
-            string dependencyAssetDir = Path.Combine(dependencyVersionDir, "lib", "net8.0");
-            Directory.CreateDirectory(dependencyAssetDir);
-            string dependencyAssembly = Path.Combine(dependencyAssetDir, "Shared.dll");
-            File.WriteAllText(dependencyAssembly, "");
-
-            string? exactVersion = DependencyExactVersion("[8.0.0-RC1]");
-            Assert.Equal("8.0.0-RC1", exactVersion);
-            var versions = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["Shared.Package"] = exactVersion,
-            };
-
-            Assert.Equal(dependencyAssembly, ProbeNuGetPackages(directory, "Shared.dll", versions, "net8.0"));
-        }
-        finally
-        {
-            Directory.Delete(directory, recursive: true);
-        }
-    }
-
     static string Print(MetadataSource source, string methodName)
     {
         var function = ImportFunction(source, methodName);
@@ -279,28 +212,6 @@ public class CrossAssemblyMethodFactsTests
         Assert.NotNull(function);
         function.CheckInvariant();
         return function!;
-    }
-
-    static IReadOnlyDictionary<string, string?> ReadNuGetDependencyPackageVersions(string packageVersionDir, string packageId, string packageVersion, string tfm)
-    {
-        var method = typeof(MetadataSource).GetMethod("NuGetDependencyPackageVersions", BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-        var result = method!.Invoke(null, [packageVersionDir, packageId, packageVersion, tfm]);
-        return Assert.IsAssignableFrom<IReadOnlyDictionary<string, string?>>(result);
-    }
-
-    static string? ProbeNuGetPackages(string root, string fileName, IReadOnlyDictionary<string, string?> packageVersions, string tfm)
-    {
-        var method = typeof(MetadataSource).GetMethod("ProbeNuGetPackages", BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-        return (string?)method!.Invoke(null, [root, fileName, packageVersions, tfm]);
-    }
-
-    static string? DependencyExactVersion(string version)
-    {
-        var method = typeof(MetadataSource).GetMethod("DependencyExactVersion", BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-        return (string?)method!.Invoke(null, [version]);
     }
 
     sealed class CrossAssemblyFixture : IDisposable

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -1,7 +1,6 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
-using System.Xml.Linq;
 using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler.Pipeline;
@@ -130,17 +129,14 @@ public sealed class MetadataSource : IDisposable
     }
 
     /// <summary>
-    /// The decompiler's default "next-by" policy: a referenced assembly is
-    /// expected to sit beside the one being decompiled. Trust is not enforced
-    /// here — the default has no framework directory to fall back to — so a
-    /// platform reference resolves only if its implementation happens to be a
-    /// sibling (as it is when a framework assembly is decompiled in place).
+    /// The decompiler's default "next-by" policy: a non-platform referenced
+    /// assembly is expected to sit beside the one being decompiled. Richer
+    /// resolution (packages, deps.json, projects, shared frameworks) belongs to
+    /// callers that inject a resolver.
     /// </summary>
     static AssemblyLocator SiblingLocator(string path)
     {
         string? dir = System.IO.Path.GetDirectoryName(path);
-        var packageProbe = NuGetPackageProbe(path);
-        var packageCache = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
         return (name, scope) =>
         {
             if (scope == AssemblyResolutionScope.Platform)
@@ -153,225 +149,8 @@ public sealed class MetadataSource : IDisposable
                     return sibling;
             }
 
-            if (packageProbe is null)
-                return null;
-
-            if (!packageCache.TryGetValue(name, out var cached))
-            {
-                cached = packageProbe(name);
-                packageCache[name] = cached;
-            }
-            return cached;
-        };
-    }
-
-    static Func<string, string?>? NuGetPackageProbe(string path)
-    {
-        var roots = NuGetPackageRoots()
-            .Where(Directory.Exists)
-            .Select(root => System.IO.Path.GetFullPath(root).TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        if (roots.Length == 0)
-            return null;
-
-        string fullPath = System.IO.Path.GetFullPath(path);
-        IReadOnlyDictionary<string, string?>? packageVersions = null;
-        string? startingTfm = null;
-        bool isNuGetPackageAsset = false;
-        foreach (string root in roots)
-        {
-            string prefix = root + System.IO.Path.DirectorySeparatorChar;
-            if (!fullPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            var parts = fullPath[prefix.Length..].Split(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar);
-            if (parts.Length >= 5 && (parts[2] == "lib" || parts[2] == "ref"))
-            {
-                string packageId = parts[0];
-                string packageVersion = parts[1];
-                startingTfm = parts[3];
-                isNuGetPackageAsset = true;
-                packageVersions = NuGetDependencyPackageVersions(System.IO.Path.Combine(root, packageId, packageVersion), packageId, packageVersion, startingTfm);
-            }
-            break;
-        }
-        if (!isNuGetPackageAsset || packageVersions is null)
-            return null;
-
-        return assemblyName =>
-        {
-            string fileName = assemblyName + ".dll";
-            foreach (string root in roots)
-            {
-                if (ProbeNuGetPackages(root, fileName, packageVersions, startingTfm) is { } anyVersion)
-                    return anyVersion;
-            }
             return null;
         };
-    }
-
-    static IEnumerable<string> NuGetPackageRoots()
-    {
-        if (Environment.GetEnvironmentVariable("NUGET_PACKAGES") is { Length: > 0 } envRoot)
-            yield return envRoot;
-
-        string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        if (!string.IsNullOrEmpty(home))
-            yield return System.IO.Path.Combine(home, ".nuget", "packages");
-    }
-
-    static IReadOnlyDictionary<string, string?> NuGetDependencyPackageVersions(string packageVersionDir, string packageId, string packageVersion, string? tfm)
-    {
-        var versions = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
-        {
-            [packageId] = packageVersion,
-        };
-
-        try
-        {
-            foreach (string nuspec in Directory.EnumerateFiles(packageVersionDir, "*.nuspec"))
-            {
-                var document = XDocument.Load(nuspec);
-                AddDependencyVersions(versions, SelectNuGetDependencies(document, tfm));
-            }
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Xml.XmlException)
-        {
-        }
-
-        return versions;
-    }
-
-    static IEnumerable<XElement> SelectNuGetDependencies(XDocument document, string? tfm)
-    {
-        var dependencies = document.Descendants().FirstOrDefault(e => e.Name.LocalName == "dependencies");
-        if (dependencies is null)
-            yield break;
-
-        var directDependencies = dependencies.Elements().Where(e => e.Name.LocalName == "dependency").ToArray();
-        var groups = dependencies.Elements().Where(e => e.Name.LocalName == "group").ToArray();
-        string? normalizedTfm = NormalizeNuGetFramework(tfm);
-        var selectedGroup = normalizedTfm is null
-            ? null
-            : groups.FirstOrDefault(g => NormalizeNuGetFramework(g.Attribute("targetFramework")?.Value) == normalizedTfm);
-
-        if (selectedGroup is not null)
-        {
-            foreach (var dependency in selectedGroup.Elements().Where(e => e.Name.LocalName == "dependency"))
-                yield return dependency;
-            yield break;
-        }
-
-        foreach (var dependency in directDependencies)
-            yield return dependency;
-    }
-
-    static void AddDependencyVersions(Dictionary<string, string?> versions, IEnumerable<XElement> dependencies)
-    {
-        foreach (var dependency in dependencies)
-        {
-            string? id = dependency.Attribute("id")?.Value;
-            if (string.IsNullOrWhiteSpace(id))
-                continue;
-            versions.TryAdd(id, DependencyExactVersion(dependency.Attribute("version")?.Value));
-        }
-    }
-
-    static string? NormalizeNuGetFramework(string? tfm)
-    {
-        if (string.IsNullOrWhiteSpace(tfm))
-            return null;
-
-        tfm = tfm.Trim().ToLowerInvariant();
-        if (tfm.StartsWith(".netstandard", StringComparison.Ordinal))
-            return "netstandard" + tfm[".netstandard".Length..];
-        if (tfm.StartsWith(".netcoreapp", StringComparison.Ordinal))
-            return "netcoreapp" + tfm[".netcoreapp".Length..];
-        if (tfm.StartsWith(".netframework", StringComparison.Ordinal))
-            return "net" + tfm[".netframework".Length..].Replace(".", "", StringComparison.Ordinal);
-        return tfm;
-    }
-
-    static string? DependencyExactVersion(string? version)
-    {
-        if (string.IsNullOrWhiteSpace(version))
-            return null;
-
-        version = version.Trim();
-        if (version.Length >= 5 && version[0] == '[' && version[^1] == ']')
-        {
-            string inner = version[1..^1].Trim();
-            var range = inner.Split(',', 2);
-            if (range.Length == 1)
-                return inner;
-            if (range.Length == 2
-                && string.Equals(range[0].Trim(), range[1].Trim(), StringComparison.OrdinalIgnoreCase))
-            {
-                return range[0].Trim();
-            }
-        }
-
-        return version.IndexOfAny(['[', ']', '(', ')', ',']) < 0 ? version : null;
-    }
-
-    static string? ProbeNuGetPackages(string root, string fileName, IReadOnlyDictionary<string, string?> packageVersions, string? tfm)
-    {
-        try
-        {
-            foreach (var (packageId, version) in packageVersions)
-            {
-                string packageDir = System.IO.Path.Combine(root, packageId.ToLowerInvariant());
-                if (!Directory.Exists(packageDir))
-                    continue;
-
-                if (version is not null)
-                {
-                    string versionDir = System.IO.Path.Combine(packageDir, version.ToLowerInvariant());
-                    if (Directory.Exists(versionDir)
-                        && ProbeNuGetPackageVersion(versionDir, fileName, tfm) is { } exact)
-                    {
-                        return exact;
-                    }
-                    continue;
-                }
-
-                foreach (string versionDir in Directory.EnumerateDirectories(packageDir).OrderDescending(StringComparer.OrdinalIgnoreCase))
-                {
-                    if (ProbeNuGetPackageVersion(versionDir, fileName, tfm) is { } found)
-                        return found;
-                }
-            }
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-        }
-        return null;
-    }
-
-    static string? ProbeNuGetPackageVersion(string versionDir, string fileName, string? tfm)
-    {
-        foreach (string assetKind in (string[])["lib", "ref"])
-        {
-            if (tfm is not null)
-            {
-                string candidate = System.IO.Path.Combine(versionDir, assetKind, tfm, fileName);
-                if (File.Exists(candidate))
-                    return candidate;
-            }
-
-            string assetRoot = System.IO.Path.Combine(versionDir, assetKind);
-            if (!Directory.Exists(assetRoot))
-                continue;
-
-            foreach (string tfmDir in Directory.EnumerateDirectories(assetRoot).OrderDescending(StringComparer.OrdinalIgnoreCase))
-            {
-                string candidate = System.IO.Path.Combine(tfmDir, fileName);
-                if (File.Exists(candidate))
-                    return candidate;
-            }
-        }
-        return null;
     }
 
     /// <summary>

--- a/tools/DecompilerHarness/CorpusMetadata.cs
+++ b/tools/DecompilerHarness/CorpusMetadata.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Services;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
 using System.Reflection;
@@ -23,8 +24,15 @@ static class CorpusMetadata
             .Where(d => !string.IsNullOrEmpty(d))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
-        var defaultLocators = assemblyPaths
-            .Select(MetadataSource.DefaultAssemblyLocator)
+        var dependencyResolvers = assemblyPaths
+            .Select(path => new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(path)
+            {
+                IncludeTrustedPlatformAssemblies = false,
+                IncludeAspNetCoreSharedFramework = false,
+                IncludeSiblingAssemblies = false,
+                IncludeDepsJsonAssets = false,
+                PreferImplementationAssemblies = true,
+            }))
             .ToList();
         var platformAssemblies = TrustedPlatformAssemblies();
 
@@ -48,8 +56,8 @@ static class CorpusMetadata
                 if (File.Exists(candidate))
                     return candidate;
             }
-            foreach (var locator in defaultLocators)
-                if (locator(name, trust) is { } resolved)
+            foreach (var resolver in dependencyResolvers)
+                if (resolver.Resolve(new AssemblyReferenceIdentity(name, Version: null, Culture: null, PublicKeyToken: null), trust)?.Path is { } resolved)
                     return resolved;
             return null;
         };


### PR DESCRIPTION
## Summary

- Removes NuGet package-root/dependency probing from `ILInspector.Decompiler`'s default `MetadataSource` assembly locator.
- Leaves Decompiler's default resolver intentionally simple: sibling-only for `AssemblyResolutionScope.Any`, and no local fallback for `Platform`.
- Moves the deleted package-resolution coverage to Services tests and updates DecompilerHarness `CorpusMetadata` to inject `AssemblyDependencyResolver` for package fallback.

Follow-up to #2054, #2061, and #2052.

## Why

After #2061, product decompiler paths already inject `AssemblyDependencyResolver`. The remaining NuGet probing in `MetadataSource.DefaultAssemblyLocator` kept package-cache policy below the intended boundary. This PR removes that policy from Decompiler and keeps rich resolution in Services/injecting callers.

## Behavior

Decompiler default locator now does only this:

```csharp
if (scope == AssemblyResolutionScope.Platform)
    return null;

return siblingDllIfPresent;
```

Richer callers should inject a resolver. The harness now does that in `CorpusMetadata` for package fallback while still preserving corpus-directory and platform-reference behavior.

## Adversarial review

Requested reviews from Claude Opus 4.8 and Gemini 3.1 Pro.

- Claude: no significant issues. Noted that harness corpus sweeps would lose package fallback unless harness injected the Services resolver.
- Gemini: flagged missing Services coverage for the deleted package helper tests and the same harness package-fallback loss.

Resolution:

- Added Services tests for current-TFM dependency group selection and bracket-exact/lowercase version directory resolution.
- Updated `CorpusMetadata` to use `AssemblyDependencyResolver` after corpus-directory probing, with implementation-asset preference and no TPA/shared/deps expansion.

## Validation

- `dotnet run --project src/DotnetInspector.Services.Tests -c Release -p:NoWarn=NU1507`
- `dotnet build src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507`
- `dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class ILInspector.Decompiler.Tests.CrossAssemblyMethodFactsTests`
- `dotnet build tools/DecompilerHarness -c Release -p:NoWarn=NU1507`
- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507`
- `dotnet run --project src/dotnet-inspect -c Release -p:NoWarn=NU1507 -- member String ToString:1 --platform System.Private.CoreLib -S "Decompiled Source" -n 1 --plaintext`
- `git diff --check`
