### PR TITLE
Raise union switch store tails

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SubstratePredicateCensusTests.cs
@@ -30,6 +30,12 @@ public class SubstratePredicateCensusTests
             "Pass-local receiver admissibility: null static receiver or PlaceIdentity.SameVariable only.",
         [new("StructuringPass.cs", "IsInsideFinallyBody")] =
             "Structuring-specific leave-target guard for finally bodies, not a general ancestor/location helper.",
+        [new("UnionSwitchExpressionPass.cs", "SameTailExpression")] =
+            "Union switch store-tail folding compares a pass-owned duplicated tail shape; this is not a reusable re-evaluable-place atom and declines on unlisted expression kinds.",
+        [new("UnionSwitchExpressionPass.cs", "SameTailExpressions")] =
+            "List form of the pass-owned duplicated-tail comparison; kept local with SameTailExpression so the admitted tail expression set stays tied to this rewrite.",
+        [new("UnionSwitchExpressionPass.cs", "SameTailNode")] =
+            "Statement form of the pass-owned duplicated-tail comparison; it accepts only StoreLocal/ExpressionStatement/Return tails for this rewrite.",
     };
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -901,6 +901,159 @@ public class TypeSourceComposerUnionTests
     }
 
     [Fact]
+    public async Task UnionSwitchStatementStoreThenUse_RendersSwitchExpressionAssignment()
+    {
+        using var assembly = await CompileWithSdk("""
+            namespace UnionFixtures;
+
+            public sealed class Cat { public string Name { get; } = "cat"; public int Age { get; } = 5; }
+            public sealed class Dog { public string Name { get; } = "dog"; }
+            public sealed class Bird { public string Name { get; } = "bird"; }
+            public union Pet(Cat, Dog, Bird);
+
+            public static class Matcher
+            {
+                public static string AssignThenUse(Pet pet)
+                {
+                    string result;
+                    switch (pet)
+                    {
+                        case Cat cat:
+                            result = cat.Name;
+                            break;
+                        case Dog dog:
+                            result = dog.Name;
+                            break;
+                        default:
+                            result = "other";
+                            break;
+                    }
+                    return result.ToUpperInvariant();
+                }
+
+                public static string AssignThenUseThree(Pet pet)
+                {
+                    string result;
+                    switch (pet)
+                    {
+                        case Cat cat:
+                            result = cat.Name;
+                            break;
+                        case Dog dog:
+                            result = dog.Name;
+                            break;
+                        case Bird bird:
+                            result = bird.Name;
+                            break;
+                        default:
+                            result = "other";
+                            break;
+                    }
+                    return result.ToUpperInvariant();
+                }
+
+                public static string AssignThenMutate(Pet pet)
+                {
+                    string result;
+                    switch (pet)
+                    {
+                        case Cat cat:
+                            result = cat.Name;
+                            break;
+                        case Dog dog:
+                            result = dog.Name;
+                            break;
+                        default:
+                            result = "other";
+                            break;
+                    }
+                    result += "!";
+                    return result;
+                }
+
+                public static string GuardedStaysFlat(Pet pet)
+                {
+                    string result;
+                    switch (pet)
+                    {
+                        case Cat { Age: > 3 } cat:
+                            result = cat.Name;
+                            break;
+                        case Dog dog:
+                            result = dog.Name;
+                            break;
+                        default:
+                            result = "other";
+                            break;
+                    }
+                    return result.ToUpperInvariant();
+                }
+            }
+            """);
+
+        Assert.Equal("""
+            string result = pet switch { Cat cat => cat.Name, Dog dog => dog.Name, _ => "other" };
+            return result.ToUpperInvariant();
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "AssignThenUse"));
+        Assert.Equal("""
+            string result = pet switch { Cat cat => cat.Name, Dog dog => dog.Name, Bird bird => bird.Name, _ => "other" };
+            return result.ToUpperInvariant();
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "AssignThenUseThree"));
+        Assert.Equal("""
+            string result = pet switch { Cat cat => cat.Name, Dog dog => dog.Name, _ => "other" };
+            result = string.Concat(result, "!");
+            return result;
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "AssignThenMutate"));
+
+        var guarded = RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedStaysFlat");
+        Assert.DoesNotContain("pet switch", guarded);
+        Assert.Contains("cat.Age > 3", guarded);
+    }
+
+    [Fact]
+    public async Task ClassUnionValueSwitchStoreThenUse_PreservesValueReceiver()
+    {
+        using var assembly = await CompileWithSdk("""
+            using System.Runtime.CompilerServices;
+            namespace UnionFixtures;
+
+            [Union]
+            public sealed class Result : IUnion
+            {
+                public Result(int value) => Value = value;
+                public Result(string value) => Value = value;
+                public object? Value { get; }
+            }
+
+            public static class Matcher
+            {
+                public static string AssignThenUse(Result result)
+                {
+                    string text;
+                    switch (result.Value)
+                    {
+                        case int value:
+                            text = value.ToString();
+                            break;
+                        case string message:
+                            text = message;
+                            break;
+                        default:
+                            text = "other";
+                            break;
+                    }
+                    return text.ToUpperInvariant();
+                }
+            }
+            """);
+
+        var source = RenderMember(assembly.Path, "UnionFixtures.Matcher", "AssignThenUse");
+
+        Assert.Contains("result.Value", source);
+        Assert.DoesNotContain("result switch", source);
+    }
+
+    [Fact]
     public async Task UnionSwitchExpression_RendersSameTypeGuardedFallbackArms()
     {
         using var assembly = await CompileWithSdk("""

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -13,6 +13,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
     sealed record Arm(TypeRef PatternType, int? LocalIndex, IrExpression Value, IReadOnlyList<IrNode> LocalRoots, IrExpression? Guard = null);
     sealed record Match(int StartIndex, UnionSwitchExpression SwitchExpression);
     sealed record BoolMatch(int StartIndex, IrExpression Expression);
+    sealed record StoreTailMatch(int StartIndex, StoreLocal SwitchStore, IReadOnlyList<IrNode> Tail);
 
     public void Run(IrFunction function, PassContext context)
     {
@@ -46,6 +47,18 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 for (int i = block.Children.Count - 1; i > match.StartIndex; i--)
                     block.Children[i].Detach();
                 context.Stepper.StepOver("raise union type-test dispatch to switch expression", block);
+                continue;
+            }
+
+            if (container.Blocks is [var storeBlock] && TryMatchStoreTail(function, storeBlock, out var storeMatch))
+            {
+                var oldChildren = storeBlock.DetachChildren();
+                for (int i = 0; i < storeMatch.StartIndex; i++)
+                    storeBlock.Add(oldChildren[i]);
+                storeBlock.Add(storeMatch.SwitchStore);
+                foreach (var tail in storeMatch.Tail)
+                    storeBlock.Add(tail);
+                context.Stepper.StepOver("raise union type-test store dispatch to switch expression", storeBlock);
                 continue;
             }
 
@@ -127,6 +140,200 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         }
 
         return false;
+    }
+
+    static bool TryMatchStoreTail(IrFunction function, Block block, out StoreTailMatch match)
+    {
+        match = null!;
+        var children = block.Children;
+        for (int start = 0; start < children.Count; start++)
+        {
+            if (TryMatchStoreTailAt(function, children, start, out match))
+                return true;
+        }
+
+        return false;
+    }
+
+    static bool TryMatchStoreTailAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out StoreTailMatch match)
+    {
+        match = null!;
+        if (start + 4 >= children.Count
+            || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsValueTypeUnionValueProperty(function, unionValue)
+            || children[start + 1] is not StoreLocal { Value: IsInstance firstTest } firstStore
+            || !IsTempTypeTest(firstTest, valueStore.Index)
+            || children[start + 2] is not IfStatement firstIf
+            || firstIf.HasElse
+            || !IsNotLocal(firstIf.Condition, firstStore.Index)
+            || children[start + 3] is not StoreLocal firstResultStore)
+        {
+            return false;
+        }
+
+        var tail = children.Skip(start + 4).ToArray();
+        if (tail.Length == 0 || !TailShapeIsMovable(tail))
+            return false;
+
+        if (!TryStoreTailArmsWithDefault(firstIf.Then.Children, valueStore.Index, firstResultStore.Index, tail, out var innerArms, out var defaultValue))
+            return false;
+
+        var firstArm = new Arm(
+            firstTest.Type,
+            firstStore.Index,
+            firstResultStore.Value,
+            [firstStore, firstIf.Condition, firstResultStore.Value]);
+        var arms = new[] { firstArm }.Concat(innerArms).ToArray();
+        var consumedNodes = children.Skip(start).ToArray();
+
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, [valueStore, firstStore, firstIf])
+            || !ReferenceOwnership.LocalReferencesOnlyWithin(function, firstResultStore.Index, consumedNodes)
+            || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+            || arms.Select(arm => arm.PatternType).Distinct().Count() != arms.Length)
+        {
+            return false;
+        }
+
+        var switchExpression = new UnionSwitchExpression(
+            (IrExpression)unionValue.Clone(),
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+            (IrExpression)defaultValue.Clone());
+        var switchStore = new StoreLocal(firstResultStore.Index, firstResultStore.Type, switchExpression);
+        match = new StoreTailMatch(start, switchStore, tail.Select(node => node.Clone()).ToArray());
+        return true;
+    }
+
+    static bool TailShapeIsMovable(IReadOnlyList<IrNode> tail)
+        => tail.Count > 0
+        && tail[^1] is Return
+        && !tail.Take(tail.Count - 1).Any(node => node is Return)
+        && tail.All(node => node is StoreLocal or Return or ExpressionStatement);
+
+    static bool TryStoreTailArmsWithDefault(
+        IReadOnlyList<IrNode> nodes,
+        int tempLocal,
+        int resultLocal,
+        IReadOnlyList<IrNode> tail,
+        out IReadOnlyList<Arm> arms,
+        out IrExpression defaultValue)
+    {
+        var builder = new List<Arm>();
+        int i = 0;
+        while (i < nodes.Count)
+        {
+            if (nodes[i] is IfStatement armIf
+                && TryStoreTailArm(armIf, tempLocal, resultLocal, tail, out var arm))
+            {
+                builder.Add(arm);
+                i++;
+                continue;
+            }
+
+            if (nodes[i] is StoreLocal defaultStore
+                && defaultStore.Index == resultLocal
+                && TailMatches(nodes, i + 1, tail))
+            {
+                arms = builder;
+                defaultValue = defaultStore.Value;
+                return arms.Count > 0;
+            }
+
+            break;
+        }
+
+        arms = [];
+        defaultValue = null!;
+        return false;
+    }
+
+    static bool TryStoreTailArm(IfStatement armIf, int tempLocal, int resultLocal, IReadOnlyList<IrNode> tail, out Arm arm)
+    {
+        arm = null!;
+        if (armIf.HasElse
+            || !TryArmPattern(armIf.Condition, tempLocal, out var patternType, out var localIndex, out var patternRoots)
+            || armIf.Then.Children is not [StoreLocal store, ..]
+            || store.Index != resultLocal
+            || !TailMatches(armIf.Then.Children, 1, tail))
+        {
+            return false;
+        }
+
+        var roots = new List<IrNode>(patternRoots) { store.Value };
+        arm = new Arm(patternType, localIndex, store.Value, roots);
+        return true;
+    }
+
+    static bool TailMatches(IReadOnlyList<IrNode> nodes, int start, IReadOnlyList<IrNode> tail)
+    {
+        if (nodes.Count - start != tail.Count)
+            return false;
+
+        for (int i = 0; i < tail.Count; i++)
+        {
+            if (!SameTailNode(nodes[start + i], tail[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    static bool SameTailNode(IrNode left, IrNode right) => (left, right) switch
+    {
+        (Return { Value: var a }, Return { Value: var b }) => SameTailExpression(a, b),
+        (StoreLocal a, StoreLocal b) => a.Index == b.Index && a.Type.Equals(b.Type) && SameTailExpression(a.Value, b.Value),
+        (ExpressionStatement a, ExpressionStatement b) => SameTailExpression(a.Expression, b.Expression),
+        _ => false,
+    };
+
+    static bool SameTailExpression(IrExpression? left, IrExpression? right)
+    {
+        if (left is null || right is null)
+            return left is null && right is null;
+
+        return (left, right) switch
+        {
+            (Constant a, Constant b) => a.Type.Equals(b.Type) && Equals(a.Value, b.Value),
+            (LoadLocal a, LoadLocal b) => a.Index == b.Index && a.Type.Equals(b.Type),
+            (LoadLocalAddress a, LoadLocalAddress b) => a.Index == b.Index && a.Type.Equals(b.Type),
+            (LoadArgument a, LoadArgument b) => a.Index == b.Index && a.Type.Equals(b.Type),
+            (LoadArgumentAddress a, LoadArgumentAddress b) => a.Index == b.Index && a.Type.Equals(b.Type),
+            (LoadProperty a, LoadProperty b) => a.Accessor.Equals(b.Accessor)
+                && a.IsVirtual == b.IsVirtual
+                && SameTailExpression(a.Instance, b.Instance)
+                && SameTailExpressions(a.IndexArguments, b.IndexArguments),
+            (Call a, Call b) => a.Callee.Equals(b.Callee)
+                && a.IsVirtual == b.IsVirtual
+                && Equals(a.ConstrainedTo, b.ConstrainedTo)
+                && SameTailExpressions(a.Arguments, b.Arguments),
+            (CastClass a, CastClass b) => a.Type.Equals(b.Type) && SameTailExpression(a.Operand, b.Operand),
+            (Convert a, Convert b) => a.Target.Equals(b.Target)
+                && a.IsChecked == b.IsChecked
+                && a.IsUnsigned == b.IsUnsigned
+                && SameTailExpression(a.Operand, b.Operand),
+            (Box a, Box b) => SameTailExpression(a.Operand, b.Operand),
+            (UnboxAny a, UnboxAny b) => a.Type.Equals(b.Type) && SameTailExpression(a.Operand, b.Operand),
+            _ => false,
+        };
+    }
+
+    static bool SameTailExpressions(IReadOnlyList<IrExpression> left, IReadOnlyList<IrExpression> right)
+    {
+        if (left.Count != right.Count)
+            return false;
+
+        for (int i = 0; i < left.Count; i++)
+            if (!SameTailExpression(left[i], right[i]))
+                return false;
+
+        return true;
     }
 
     static bool TryMatchReferencePrefixValueTypeTailNullArmSwitchAt(


### PR DESCRIPTION
## Summary

- Raise value-type union switch statements that store every arm into the same local before a duplicated tail into `local = union switch { ... }; tail;`.
- Preserve class/custom union `.Value switch` null-receiver semantics by gating the new matcher to value-type union `Value` properties.
- Add Preview SDK positive and negative canaries for two-case, three-case, mutating-tail, guarded-arm, and class-union near-miss shapes.

## Evidence

- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*TypeSourceComposerUnionTests*"`: 22 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*SubstratePredicateCensusTests*"`: 1 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"`: 1774 passed

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity sampled 25,179 / 89,065 (28.27%); fidelity sampled 36 / 89,065 (0.04%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,398 (88.02%) | -1 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — sampled 25,179 / 89,065 (28.27%) | 73/25,179 — sampled 25,179 / 89,065 (28.27%) | -1 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | 0 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate: Fully raised 88.02% -> 88.02% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 5 (0).

Verdict: corpus sensor matched baseline tolerances.

The aggregate `Fully raised -1` row is the same stale-baseline Roslyn `BindAssignment#0` drift diagnosed in #2055, not a movement from this pass. The pinned-subset gate remains flat, and semantic defects improve by one sampled method.

## Adversarial review

- Claude Opus 4.8: no blocking findings. It verified tail movement preserves order, union `Value` temp ownership is exact, result-local ownership blocks unsafe moves, pattern-local tails are rejected, class-union and guarded shapes stay flat, and rewrite ownership is clean.
- Gemini 3.1 Pro: flagged that the tail structural comparison helpers were hidden from `SubstratePredicateCensusTests`. Resolved before push by restoring `SameTail*` census-visible names and adding explicit pass-local rationale entries.

## Notes

- This is a readability/altitude raise. The shape is analogous to existing switch-store folds: valid and source-recognizable, but not claimed as opcode-exact.
- The pass deliberately declines guarded arms for this slice.
