### PR TITLE
Align analysis UX member and type sections

### DIFF
--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -3165,9 +3165,11 @@ public sealed class LibraryBodyIndex
                             token,
                             PeelToDefinitionToken(token),
                             ToCallKind(opcode),
-                            inLoop,
-                            FormatCallOpcode(opcode),
-                            instruction.NextOffset));
+                            inLoop)
+                        {
+                            Opcode = FormatCallOpcode(opcode),
+                            ReturnAddress = instruction.NextOffset
+                        });
                         if (IsUnsafeCall(callee))
                         {
                             unsafeEvidence.Add(new UnsafeEvidence(
@@ -3190,9 +3192,11 @@ public sealed class LibraryBodyIndex
                             token,
                             token,
                             CallKind.CallIndirect,
-                            IsInLoopRegion(offset, loopRegions),
-                            FormatCallOpcode(opcode),
-                            instruction.NextOffset));
+                            IsInLoopRegion(offset, loopRegions))
+                        {
+                            Opcode = FormatCallOpcode(opcode),
+                            ReturnAddress = instruction.NextOffset
+                        });
                         unsafeEvidence.Add(new UnsafeEvidence(caller, "Unsafe operation", "calli", "calli", offset, token));
                         break;
                     }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -3158,7 +3158,16 @@ public sealed class LibraryBodyIndex
                         int token = OperandInt32(instruction);
                         var callee = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
                         bool inLoop = IsInLoopRegion(offset, loopRegions);
-                        calls.Add(new DirectCall(caller, callee, offset, token, PeelToDefinitionToken(token), ToCallKind(opcode), inLoop));
+                        calls.Add(new DirectCall(
+                            caller,
+                            callee,
+                            offset,
+                            token,
+                            PeelToDefinitionToken(token),
+                            ToCallKind(opcode),
+                            inLoop,
+                            FormatCallOpcode(opcode),
+                            instruction.NextOffset));
                         if (IsUnsafeCall(callee))
                         {
                             unsafeEvidence.Add(new UnsafeEvidence(
@@ -3174,7 +3183,16 @@ public sealed class LibraryBodyIndex
                     case ILOpCode.Calli:
                     {
                         int token = OperandInt32(instruction);
-                        calls.Add(new DirectCall(caller, MemberRef.Unsupported($"calli signature token 0x{token:X8}"), offset, token, token, CallKind.CallIndirect, IsInLoopRegion(offset, loopRegions)));
+                        calls.Add(new DirectCall(
+                            caller,
+                            MemberRef.Unsupported($"calli signature token 0x{token:X8}"),
+                            offset,
+                            token,
+                            token,
+                            CallKind.CallIndirect,
+                            IsInLoopRegion(offset, loopRegions),
+                            FormatCallOpcode(opcode),
+                            instruction.NextOffset));
                         unsafeEvidence.Add(new UnsafeEvidence(caller, "Unsafe operation", "calli", "calli", offset, token));
                         break;
                     }
@@ -3405,6 +3423,16 @@ public sealed class LibraryBodyIndex
             CallKind.LoadFunction => "ldftn",
             CallKind.LoadVirtualFunction => "ldvirtftn",
             _ => "calli",
+        };
+
+        static string FormatCallOpcode(ILOpCode opcode) => opcode switch
+        {
+            ILOpCode.Callvirt => "callvirt",
+            ILOpCode.Newobj => "newobj",
+            ILOpCode.Ldftn => "ldftn",
+            ILOpCode.Ldvirtftn => "ldvirtftn",
+            ILOpCode.Calli => "calli",
+            _ => "call",
         };
 
         static string? UnsafeOpcodeName(ILOpCode opcode, bool includeIndirectOpcodes) => opcode switch

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -129,9 +129,11 @@ public sealed record DirectCall(
     int OperandToken,
     int CalleeDefinitionToken,
     CallKind Kind,
-    bool InLoop = false,
-    string Opcode = "",
-    int? ReturnAddress = null);
+    bool InLoop = false)
+{
+    public string Opcode { get; init; } = "";
+    public int? ReturnAddress { get; init; }
+}
 
 public sealed record UnsafeEvidence(
     MethodIdentity Member,

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -129,7 +129,9 @@ public sealed record DirectCall(
     int OperandToken,
     int CalleeDefinitionToken,
     CallKind Kind,
-    bool InLoop = false);
+    bool InLoop = false,
+    string Opcode = "",
+    int? ReturnAddress = null);
 
 public sealed record UnsafeEvidence(
     MethodIdentity Member,

--- a/src/dotnet-inspect.Tests/MemberCallersSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallersSectionTests.cs
@@ -14,9 +14,10 @@ public class MemberCallersSectionTests
 
         Assert.Equal(0, result.ExitCode);
         Assert.Contains("## Callers", result.Output);
+        Assert.Contains("| Caller | IL Offset | Opcode | Call Kind | Operand Token | Return Address |", result.Output);
         Assert.Equal(1, CountOccurrences(result.Output, $"{nameof(MemberCallersFixture.CallsTargetOnce)}()"));
         Assert.Equal(2, CountOccurrences(result.Output, $"{nameof(MemberCallersFixture.CallsTargetTwice)}()"));
-        Assert.Contains("| call |", result.Output);
+        Assert.Contains("| call | direct |", result.Output);
         Assert.Contains("`IL_", result.Output);
         Assert.Contains("`0x06", result.Output);
     }
@@ -28,7 +29,7 @@ public class MemberCallersSectionTests
 
         Assert.Equal(0, result.ExitCode);
         Assert.Contains($"{nameof(MemberCallersFixture.InvokesSpeak)}(", result.Output);
-        Assert.Contains("| callvirt |", result.Output);
+        Assert.Contains("| callvirt | virtual |", result.Output);
     }
 
     [Fact]
@@ -37,7 +38,7 @@ public class MemberCallersSectionTests
         var result = await RunMemberCallersAsync(typeof(MemberCallersFixture).FullName!, nameof(MemberCallersFixture.Target), tsv: true);
 
         Assert.Equal(0, result.ExitCode);
-        Assert.StartsWith("caller\tkind\til\ttoken", result.Output);
+        Assert.StartsWith("caller\til_offset\topcode\tcall_kind\toperand_token\treturn_address", result.Output);
         Assert.DoesNotContain('`', result.Output);
         Assert.Contains($"{nameof(MemberCallersFixture.CallsTargetOnce)}()", result.Output);
     }
@@ -154,7 +155,7 @@ public class MemberCallersSectionTests
             typeof(MemberCallersFixture).FullName!, nameof(MemberCallersFixture.Target), tsv: true);
 
         Assert.Equal(0, result.ExitCode);
-        Assert.StartsWith("caller\tkind\til\ttoken", result.Output);
+        Assert.StartsWith("caller\til_offset\topcode\tcall_kind\toperand_token\treturn_address", result.Output);
         Assert.DoesNotContain("source\t", result.Output);
     }
 

--- a/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberCallsSectionTests.cs
@@ -14,6 +14,7 @@ public class MemberCallsSectionTests
 
         Assert.Equal(0, result.ExitCode);
         Assert.Contains("## Calls", result.Output);
+        Assert.Contains("| IL Offset | Opcode | Call Kind | Callee | Operand Token | Return Address |", result.Output);
         Assert.Equal(2, CountOccurrences(result.Output, "`System.Console.WriteLine(string)`"));
         Assert.Contains("`IL_", result.Output);
         Assert.Contains("`0x0A", result.Output);
@@ -26,7 +27,7 @@ public class MemberCallsSectionTests
 
         Assert.Equal(0, result.ExitCode);
         Assert.Contains("`System.Collections.Generic.IList<int>.get_Item(int)`", result.Output);
-        Assert.Contains("| callvirt |", result.Output);
+        Assert.Contains("| callvirt | virtual |", result.Output);
     }
 
     [Fact]
@@ -45,7 +46,7 @@ public class MemberCallsSectionTests
         var result = await RunMemberCallsAsync(nameof(MemberCallsFixture.CallsWriteLineTwice), tsv: true);
 
         Assert.Equal(0, result.ExitCode);
-        Assert.StartsWith("callee\tkind\til\ttoken", result.Output);
+        Assert.StartsWith("il_offset\topcode\tcall_kind\tcallee\toperand_token\treturn_address", result.Output);
         Assert.DoesNotContain('`', result.Output);
         Assert.Equal(2, CountOccurrences(result.Output, "System.Console.WriteLine(string)"));
     }

--- a/src/dotnet-inspect.Tests/MemberExceptionRegionsSectionTests.cs
+++ b/src/dotnet-inspect.Tests/MemberExceptionRegionsSectionTests.cs
@@ -50,6 +50,69 @@ public class MemberExceptionRegionsSectionTests
         Assert.Contains("Exception Regions\tsection", result.Output);
     }
 
+    [Fact]
+    public async Task TypeExceptionRegionsSection_RendersMemberIndexedRegions()
+    {
+        var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
+        {
+            TypeName = typeof(MemberExceptionRegionsFixture).FullName,
+            AssemblyPath = typeof(MemberExceptionRegionsFixture).Assembly.Location,
+            IncludeSections = [SectionNames.ExceptionRegions],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            MarkdownExplicitlySet = true,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Exception Regions", result.Output);
+        Assert.Contains("| Member | Region | Clause | Try Range | Handler Range |", result.Output);
+        Assert.Contains("`int TryCatch(int value)`", result.Output);
+        Assert.Contains("| catch | IL_", result.Output);
+        Assert.Contains("`int TryFinally(int value)`", result.Output);
+        Assert.Contains("| finally | IL_", result.Output);
+        Assert.DoesNotContain("Context", result.Output);
+    }
+
+    [Fact]
+    public async Task TypeExceptionRegionsSection_RendersEmptyState_WhenExplicitlySelected()
+    {
+        var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
+        {
+            TypeName = typeof(TypeExceptionRegionsEmptyFixture).FullName,
+            AssemblyPath = typeof(TypeExceptionRegionsEmptyFixture).Assembly.Location,
+            IncludeSections = [SectionNames.ExceptionRegions],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            MarkdownExplicitlySet = true,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Exception Regions", result.Output);
+        Assert.Contains("No exception regions found on this type.", result.Output);
+    }
+
+    [Fact]
+    public async Task TypeEffectiveDiscovery_ListsExceptionRegionsAsOptIn()
+    {
+        var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
+        {
+            TypeName = typeof(MemberExceptionRegionsFixture).FullName,
+            AssemblyPath = typeof(MemberExceptionRegionsFixture).Assembly.Location,
+            Discover = [],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            OneLine = true,
+            Tsv = true,
+            OneLineExplicitlySet = true,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Exception Regions\tsection", result.Output);
+    }
+
     static Task<(int ExitCode, string Output, string Error)> RunExceptionRegionsAsync(string memberName, bool discover = false)
         => ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
         {
@@ -93,5 +156,10 @@ public static class MemberExceptionRegionsFixture
         }
     }
 
+    public static int NoRegions(int value) => value + 1;
+}
+
+public static class TypeExceptionRegionsEmptyFixture
+{
     public static int NoRegions(int value) => value + 1;
 }

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1616,7 +1616,7 @@ public class SectionPipelineTests
     public void ApiMemberPipeline_HasExpectedSectionCount()
     {
         var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
-        Assert.Equal(23, pipeline.AllSectionNames.Length);
+        Assert.Equal(24, pipeline.AllSectionNames.Length);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -313,7 +313,7 @@ public class ApiCommand
         if (detailSchema.GetSection(SectionNames.Calls) == null)
             detailSchema.Add(SectionNames.Calls, "column", "IL Offset", "Opcode", "Call Kind", "Callee", "Operand Token", "Return Address");
         if (detailSchema.GetSection(SectionNames.Callers) == null)
-            detailSchema.Add(SectionNames.Callers, "column", "Caller", "Kind", "IL", "Token");
+            detailSchema.Add(SectionNames.Callers, "column", "Caller", "IL Offset", "Opcode", "Call Kind", "Operand Token", "Return Address");
         if (detailSchema.GetSection(SectionNames.UnsafeOperations) == null)
             detailSchema.Add(SectionNames.UnsafeOperations, "column", "Reason", "Detail", "Kind", "IL", "Token");
         detailSchema.Add(SectionNames.CallGraph, "field",

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -311,7 +311,7 @@ public class ApiCommand
         if (!ApiMemberSectionPipelines.UsesDetailPipeline(options))
             return detailSchema;
         if (detailSchema.GetSection(SectionNames.Calls) == null)
-            detailSchema.Add(SectionNames.Calls, "column", "Callee", "Kind", "IL", "Token");
+            detailSchema.Add(SectionNames.Calls, "column", "IL Offset", "Opcode", "Call Kind", "Callee", "Operand Token", "Return Address");
         if (detailSchema.GetSection(SectionNames.Callers) == null)
             detailSchema.Add(SectionNames.Callers, "column", "Caller", "Kind", "IL", "Token");
         if (detailSchema.GetSection(SectionNames.UnsafeOperations) == null)
@@ -717,6 +717,13 @@ public class ApiCommand
                 && GetRequestedMemberSections(type, options).Contains(SectionNames.UnsafeMembers))
             {
                 ApiOutputFormatter.PopulateUnsafeMembers(view, type, unsafeDllPath);
+            }
+
+            if (options.DllPath is { } exceptionRegionsDllPath
+                && (GetRequestedMemberSections(type, options).Contains(SectionNames.ExceptionRegions)
+                    || options.IncludeSections?.Contains(SectionNames.ExceptionRegions) == true))
+            {
+                ApiOutputFormatter.PopulateTypeExceptionRegions(view, type, exceptionRegionsDllPath, options.IncludeSections);
             }
 
             if (options.DllPath is { } optimizationDllPath
@@ -1319,6 +1326,13 @@ public class ApiCommand
                 && GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.UnsafeMembers))
             {
                 ApiOutputFormatter.PopulateUnsafeMembers(view, type, unsafeDllPath);
+            }
+
+            if (renderOptions.DllPath is { } exceptionRegionsDllPath
+                && (GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.ExceptionRegions)
+                    || renderOptions.IncludeSections?.Contains(SectionNames.ExceptionRegions) == true))
+            {
+                ApiOutputFormatter.PopulateTypeExceptionRegions(view, type, exceptionRegionsDllPath, renderOptions.IncludeSections);
             }
 
             if (renderOptions.DllPath is { } optimizationDllPath

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1177,11 +1177,11 @@ public static class ApiOutputFormatter
 
             // Deduplicate and sort
             rows = rows
-                .GroupBy(row => (row.Source, row.Caller, row.IL, row.Token))
+                .GroupBy(row => (row.Source, row.Caller, row.ILOffset, row.OperandToken))
                 .Select(g => g.First())
                 .OrderBy(row => row.Source, StringComparer.Ordinal)
                 .ThenBy(row => row.Caller, StringComparer.Ordinal)
-                .ThenBy(row => row.IL, StringComparer.Ordinal)
+                .ThenBy(row => row.ILOffset, StringComparer.Ordinal)
                 .ToList();
 
             if (rows.Count > 0 || ExplicitlySelected(SectionNames.Callers))
@@ -1802,9 +1802,13 @@ public static class ApiOutputFormatter
         => new(
             source,
             MarkoutInline.Code(FormatMethod(call.Caller)),
-            FormatCallKind(call.Kind),
             MarkoutInline.Code($"IL_{call.ILOffset:X4}"),
-            MarkoutInline.Code($"0x{call.OperandToken:X8}"));
+            string.IsNullOrEmpty(call.Opcode) ? FormatOpcode(call.Kind) : call.Opcode,
+            FormatCallsiteKind(call.Kind),
+            MarkoutInline.Code($"0x{call.OperandToken:X8}"),
+            call.ReturnAddress is { } returnAddress
+                ? MarkoutInline.Code($"IL_{returnAddress:X4}")
+                : null);
 
     static string FormatMember(Analysis.TypeRef? declaringType, string name, IEnumerable<Analysis.TypeRef> parameterTypes, IEnumerable<Analysis.TypeRef> typeArguments)
     {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1081,10 +1081,14 @@ public static class ApiOutputFormatter
                 .Where(call => call.Caller.MetadataToken == token)
                 .OrderBy(call => call.ILOffset)
                 .Select(call => new CallSiteRow(
-                    MarkoutInline.Code(FormatCallee(call.Callee)),
-                    FormatCallKind(call.Kind),
                     MarkoutInline.Code($"IL_{call.ILOffset:X4}"),
-                    MarkoutInline.Code($"0x{call.OperandToken:X8}")))
+                    string.IsNullOrEmpty(call.Opcode) ? FormatOpcode(call.Kind) : call.Opcode,
+                    FormatCallsiteKind(call.Kind),
+                    MarkoutInline.Code(FormatCallee(call.Callee)),
+                    MarkoutInline.Code($"0x{call.OperandToken:X8}"),
+                    call.ReturnAddress is { } returnAddress
+                        ? MarkoutInline.Code($"IL_{returnAddress:X4}")
+                        : null))
                 .ToList();
             if (rows.Count > 0 || ExplicitlySelected(SectionNames.Calls))
             {
@@ -1443,6 +1447,27 @@ public static class ApiOutputFormatter
         _ => "calli",
     };
 
+    static string FormatOpcode(Analysis.CallKind kind) => kind switch
+    {
+        Analysis.CallKind.CallVirtual => "callvirt",
+        Analysis.CallKind.NewObject => "newobj",
+        Analysis.CallKind.LoadFunction => "ldftn",
+        Analysis.CallKind.LoadVirtualFunction => "ldvirtftn",
+        Analysis.CallKind.CallIndirect => "calli",
+        _ => "call",
+    };
+
+    static string FormatCallsiteKind(Analysis.CallKind kind) => kind switch
+    {
+        Analysis.CallKind.Call => "direct",
+        Analysis.CallKind.CallVirtual => "virtual",
+        Analysis.CallKind.NewObject => "constructor",
+        Analysis.CallKind.LoadFunction => "method pointer",
+        Analysis.CallKind.LoadVirtualFunction => "virtual method pointer",
+        Analysis.CallKind.CallIndirect => "function pointer",
+        _ => "call",
+    };
+
     static string FormatILRange(int start, int end) => $"IL_{start:X4}..IL_{end:X4}";
 
     static bool IsUnsafeApiMemberEvidence(Analysis.UnsafeEvidence evidence)
@@ -1598,6 +1623,35 @@ public static class ApiOutputFormatter
             .ToList();
         if (rows.Count > 0)
             view.UnsafeMemberRows = rows;
+    }
+
+    internal static void PopulateTypeExceptionRegions(
+        TypeView view,
+        ApiType type,
+        string dllPath,
+        IReadOnlySet<string>? explicitSections = null)
+    {
+        using var pdbContext = PdbContext.Open(dllPath);
+        var rows = type.Members
+            .Where(member => member.MetadataToken is not null && ApiMemberSectionDescriptors.IsMethodLike(member))
+            .OrderBy(member => GetMemberSortOrder(member.Kind))
+            .ThenBy(member => member.Name, StringComparer.Ordinal)
+            .ThenBy(GetMemberSignatureSortKey, StringComparer.Ordinal)
+            .SelectMany(member => pdbContext.ResolveExceptionRegions(member.MetadataToken!.Value, out _)
+                .Select(region => new TypeExceptionRegionRow(
+                    MarkoutInline.Code(GetMemberDisplaySignature(type, member)),
+                    region.Region,
+                    region.Clause,
+                    FormatILRange(region.TryStart, region.TryEnd),
+                    FormatILRange(region.HandlerStart, region.HandlerEnd),
+                    region.FilterStart is { } filterStart && region.FilterEnd is { } filterEnd
+                        ? FormatILRange(filterStart, filterEnd)
+                        : null,
+                    region.CaughtType)))
+            .ToList();
+
+        if (rows.Count > 0 || explicitSections is not null && explicitSections.Contains(SectionNames.ExceptionRegions))
+            view.ExceptionRegionRows = rows;
     }
 
     internal static void PopulateOptimizationOpportunities(
@@ -1975,6 +2029,9 @@ public static class ApiOutputFormatter
 
         return signature;
     }
+
+    internal static string GetMemberDisplaySignature(ApiType type, ApiMember member)
+        => member.Signature ?? $"{FormatGenericFullName(type)}.{OperatorNames.FormatDisplayName(member.Name)}";
 
     private static string GetMemberSelectorName(ApiMember member) => member.Kind switch
     {

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -92,6 +92,7 @@ public static class ApiMemberSectionDescriptors
             .Add<Events>()
             .Add<MethodAttributes>()
             .Add<UnsafeMembers>()
+            .Add<ExceptionRegions>()
             .Add<TopLeverage>()
             .Add<OptimizationOpportunities>()
             .Add<SourceFiles>()
@@ -284,6 +285,17 @@ public static class ApiMemberSectionDescriptors
         public static string Name => SectionNames.UnsafeMembers;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Any(IsMethodLike);
+    }
+
+    public sealed class ExceptionRegions : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.ExceptionRegions;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static bool ProbeEffectiveness => false;
         public static string? ScannerKey => null;
         public static bool CanRender(ApiType model)
             => model.Members.Any(IsMethodLike);

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -758,7 +758,15 @@ public record ExceptionRegionRow(
     [property: MarkoutSkipNull] string? CaughtType);
 
 [MarkoutSerializable]
-public record CallerSiteRow(string Source, string Caller, string Kind, string IL, string Token);
+public record CallerSiteRow(
+    string Source,
+    string Caller,
+    [property: MarkoutPropertyName("IL Offset")] string ILOffset,
+    string Opcode,
+    [property: MarkoutPropertyName("Call Kind")] string CallKind,
+    [property: MarkoutPropertyName("Operand Token")] string OperandToken,
+    [property: MarkoutPropertyName("Return Address")]
+    [property: MarkoutSkipNull] string? ReturnAddress);
 
 [MarkoutSerializable]
 public record UnsafeOperationRow(

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -188,6 +188,12 @@ public class TypeView
     [JsonIgnore]
     public List<UnsafeMemberRow>? UnsafeMemberRows { get; set; }
 
+    [MarkoutSection(Name = SectionNames.ExceptionRegions, EmptyText = "No exception regions found on this type.")]
+    [MarkoutIgnoreColumnWhen(nameof(TypeExceptionRegionFilterRangeIsEmpty), nameof(TypeExceptionRegionRow.FilterRange))]
+    [MarkoutIgnoreColumnWhen(nameof(TypeExceptionRegionCaughtTypeIsEmpty), nameof(TypeExceptionRegionRow.CaughtType))]
+    [JsonIgnore]
+    public List<TypeExceptionRegionRow>? ExceptionRegionRows { get; set; }
+
     [MarkoutSection(Name = "Top Leverage", EmptyText = "No intra-assembly call-graph leverage found for this type.")]
     [MarkoutIgnoreColumnWhen(nameof(TopLeverageVisibilityEmpty), nameof(TopLeverageRow.Visibility))]
     [MarkoutIgnoreColumnWhen(nameof(TopLeverageGeneratedEmpty), nameof(TopLeverageRow.Generated))]
@@ -204,6 +210,8 @@ public class TypeView
     public static bool TopLeverageGeneratedEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Generated));
     public static bool TopLeverageStableEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Stable));
     public static bool TopLeverageSelectorEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Selector));
+    public static bool TypeExceptionRegionFilterRangeIsEmpty(List<TypeExceptionRegionRow>? rows) => rows is null || rows.All(row => string.IsNullOrEmpty(row.FilterRange));
+    public static bool TypeExceptionRegionCaughtTypeIsEmpty(List<TypeExceptionRegionRow>? rows) => rows is null || rows.All(row => string.IsNullOrEmpty(row.CaughtType));
 
     [MarkoutSection(Name = "Source Files", EmptyText = "No SourceLink source files found for this type.")]
     [JsonIgnore]
@@ -698,6 +706,7 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(MemberSignatureRow))]
 [MarkoutContext(typeof(MethodAttributeRow))]
 [MarkoutContext(typeof(UnsafeMemberRow))]
+[MarkoutContext(typeof(TypeExceptionRegionRow))]
 [MarkoutContext(typeof(TopLeverageRow))]
 [MarkoutContext(typeof(OptimizationOpportunityRow))]
 [MarkoutContext(typeof(ConstructorOverloadView))]
@@ -716,7 +725,26 @@ public partial class ApiViewContext : MarkoutSerializerContext
 }
 
 [MarkoutSerializable]
-public record CallSiteRow(string Callee, string Kind, string IL, string Token);
+public record CallSiteRow(
+    [property: MarkoutPropertyName("IL Offset")] string ILOffset,
+    string Opcode,
+    [property: MarkoutPropertyName("Call Kind")] string CallKind,
+    string Callee,
+    [property: MarkoutPropertyName("Operand Token")] string OperandToken,
+    [property: MarkoutPropertyName("Return Address")]
+    [property: MarkoutSkipNull] string? ReturnAddress);
+
+[MarkoutSerializable]
+public record TypeExceptionRegionRow(
+    string Member,
+    int Region,
+    string Clause,
+    [property: MarkoutPropertyName("Try Range")] string TryRange,
+    [property: MarkoutPropertyName("Handler Range")] string HandlerRange,
+    [property: MarkoutPropertyName("Filter Range")]
+    [property: MarkoutSkipNull] string? FilterRange,
+    [property: MarkoutPropertyName("Caught Type")]
+    [property: MarkoutSkipNull] string? CaughtType);
 
 [MarkoutSerializable]
 public record ExceptionRegionRow(


### PR DESCRIPTION
## Summary

Batches two coherent follow-up slices from the unified Analysis UX scope model:

- Aligns member `Calls` and `Callers` with offset callsite vocabulary.
- Adds type-scope `Exception Regions` with member identity.

This keeps the shipped offset/member/type surfaces on one lexicon: point views use `* Context`, while wider scopes use container sections such as `Calls` and `Exception Regions`.

Refs #2058.

## Examples

Member `Calls` now mirrors offset `Callsite Context` / `Return Address Context` fields:

```md
## Calls

| IL Offset | Opcode | Call Kind | Callee | Operand Token | Return Address |
| --------- | ------ | --------- | ------ | ------------- | -------------- |
| `IL_0002` | callvirt | virtual | `System.Collections.Generic.IList<int>.get_Item(int)` | `0x0A000347` | `IL_0007` |
```

Member `Callers` uses the same callsite vocabulary from the reverse direction:

```md
## Callers

| Caller | IL Offset | Opcode | Call Kind | Operand Token | Return Address |
| ------ | --------- | ------ | --------- | ------------- | -------------- |
| `DotnetInspector.Tests.MemberCallersFixture.CallsTargetOnce()` | `IL_0000` | call | direct | `0x0600047A` | `IL_0005` |
| `DotnetInspector.Tests.MemberCallersFixture.CallsTargetTwice()` | `IL_0000` | call | direct | `0x0600047A` | `IL_0005` |
| `DotnetInspector.Tests.MemberCallersFixture.CallsTargetTwice()` | `IL_0005` | call | direct | `0x0600047A` | `IL_000A` |
```

Type `Exception Regions` answers "which members on this type contain EH regions?":

```md
## Exception Regions

| Member | Region | Clause | Try Range | Handler Range | Caught Type |
| ------ | ------ | ------ | --------- | ------------- | ----------- |
| `int TryCatch(int value)` | 1 | catch | IL_0000..IL_0007 | IL_0007..IL_000C | System.DivideByZeroException |
| `int TryFinally(int value)` | 1 | finally | IL_0000..IL_0006 | IL_0006..IL_0012 |  |
```

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false \
  --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json \
  --nologo --verbosity quiet
```

```bash
dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- \
  -class DotnetInspector.Tests.MemberCallsSectionTests \
  -class DotnetInspector.Tests.MemberCallersSectionTests \
  -class DotnetInspector.Tests.MemberExceptionRegionsSectionTests \
  -class DotnetInspector.Tests.SectionPipelineTests \
  -class DotnetInspector.Tests.ProjectionDiagnosticsTests
```

```bash
dotnet run --no-restore --project src/ILInspector.Analysis.Tests -c Release -p:PublishAot=false
```

## Adversarial review

Requested per the analysis-change policy.

- Claude Opus 4.8: no blocking findings. Verified DirectCall compatibility by source/test coverage, opcode/return-address recording, call-kind alignment, schema consistency, type-section discovery/default behavior, both type render paths, empty-state behavior, SRM safety, filter ranges, and non-brittle tests.
- Gemini 3.1 Pro: found two actionable issues and one non-actioned architecture concern.
  - Fixed DirectCall binary compatibility by keeping the 7-argument primary constructor and moving `Opcode` / `ReturnAddress` to init properties in commit 4998dd6e.
  - Fixed half-migrated caller UX by aligning `Callers` columns with the same callsite vocabulary in commit 4998dd6e.
  - Did not move type `Exception Regions` population out of the formatter in this PR: the formatter remains a coordinator over reusable `ILInspector.Metadata.PdbContext.ResolveExceptionRegions`; it does not decode IL or load inspected assemblies in the CLI layer.
