### PR TITLE
Add allocation context metadata

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1163,6 +1163,7 @@ public class LibraryBodyIndexTests
     [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), AllocationKind.Box, "boxed System.Guid", AllocationPathContext.StraightLine)]
     [InlineData(nameof(OptimizationOpportunityFixtures.ThrowsInLoop), AllocationKind.Object, "System.InvalidOperationException", AllocationPathContext.ErrorPath)]
     [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesOnceInLoop), AllocationKind.Object, "System.Object", AllocationPathContext.LoopBody)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.FinallyAllocates), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.StraightLine)]
     public void AllocationOccurrences_IncludeRuntimeTypeAndPathContext(string methodName, AllocationKind kind, string expectedRuntimeType, AllocationPathContext expectedPath)
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -1194,11 +1195,35 @@ public class LibraryBodyIndexTests
                 occurrence => occurrence.Method.Name == "SwitchAllocation"
                     && occurrence.Kind == AllocationKind.Object
                     && occurrence.PathContext == AllocationPathContext.SwitchArm);
+            var switchAllocations = index.GetAllocationOccurrences().Values
+                .SelectMany(occurrences => occurrences)
+                .Where(occurrence => occurrence.Method.Name == "SwitchAllocation" && occurrence.Kind == AllocationKind.Object)
+                .ToArray();
+            Assert.Equal(3, switchAllocations.Length);
+            Assert.All(switchAllocations, occurrence => Assert.Equal(AllocationPathContext.SwitchArm, occurrence.PathContext));
+            Assert.Contains(
+                index.GetAllocationOccurrences().Values.SelectMany(occurrences => occurrences),
+                occurrence => occurrence.Method.Name == "AfterIfJoinAllocation"
+                    && occurrence.Kind == AllocationKind.Object
+                    && occurrence.PathContext == AllocationPathContext.StraightLine);
         }
         finally
         {
             Directory.Delete(directory, recursive: true);
         }
+    }
+
+    [Fact]
+    public void AllocationOccurrences_NestedGenericRuntimeTypeKeepsNestedName()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var occurrence = SingleAllocationOccurrence(
+            index,
+            nameof(OptimizationOpportunityFixtures.ReturnsNestedGenericObject),
+            AllocationKind.Object);
+
+        Assert.Contains("+Inner", occurrence.RuntimeAllocationType, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -1859,6 +1884,7 @@ public class LibraryBodyIndexTests
 
         DefineBranchAllocation(type, ctor);
         DefineSwitchAllocation(type, ctor);
+        DefineAfterIfJoinAllocation(type, ctor);
 
         type.CreateType();
         assembly.Save(path);
@@ -1904,6 +1930,23 @@ public class LibraryBodyIndexTests
             EmitNewPlainObject(il, ctor, 1);
             il.MarkLabel(case1);
             EmitNewPlainObject(il, ctor, 2);
+        }
+
+        static void DefineAfterIfJoinAllocation(TypeBuilder type, ConstructorInfo ctor)
+        {
+            var method = type.DefineMethod(
+                "AfterIfJoinAllocation",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(object),
+                [typeof(bool)]);
+            var il = method.GetILGenerator();
+            var join = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Brfalse_S, join);
+            il.Emit(OpCodes.Nop);
+            il.Emit(OpCodes.Br_S, join);
+            il.MarkLabel(join);
+            EmitNewPlainObject(il, ctor, 1);
         }
     }
 
@@ -3086,6 +3129,21 @@ public class OptimizationOpportunityFixtures
         throw exception;
     }
 
+    public static void FinallyAllocates()
+    {
+        try
+        {
+            ConsumeObject(null);
+        }
+        finally
+        {
+            ConsumeObject(new PlainObject(1));
+        }
+    }
+
+    public static object ReturnsNestedGenericObject()
+        => new AllocationMetadataOuter<int>.Inner<string>();
+
     // --- String accumulation (string-build-in-loop) ---
 
     // `s += x` inside a foreach: String.Concat(s, x) stored back to the same local each
@@ -3934,6 +3992,13 @@ public sealed class PlainObject
     public PlainObject(int value) => Value = value;
 
     public int Value { get; }
+}
+
+public sealed class AllocationMetadataOuter<T>
+{
+    public sealed class Inner<U>
+    {
+    }
 }
 
 // An in-assembly value type: `new PlainValue(...)` does not allocate on the heap, so it must

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1158,6 +1158,66 @@ public class LibraryBodyIndexTests
         }
     }
 
+    [Theory]
+    [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), AllocationKind.Array, "System.Int32[]", AllocationPathContext.StraightLine)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), AllocationKind.Box, "boxed System.Guid", AllocationPathContext.StraightLine)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ThrowsInLoop), AllocationKind.Object, "System.InvalidOperationException", AllocationPathContext.ErrorPath)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesOnceInLoop), AllocationKind.Object, "System.Object", AllocationPathContext.LoopBody)]
+    public void AllocationOccurrences_IncludeRuntimeTypeAndPathContext(string methodName, AllocationKind kind, string expectedRuntimeType, AllocationPathContext expectedPath)
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var occurrence = index.GetAllocationOccurrences()
+            .Where(pair => index.Methods.Any(method => method.MetadataToken == pair.Key && method.Name == methodName))
+            .SelectMany(pair => pair.Value)
+            .First(occurrence => occurrence.Kind == kind && occurrence.PathContext == expectedPath);
+
+        Assert.Equal(expectedRuntimeType, occurrence.RuntimeAllocationType);
+        Assert.Equal(expectedPath, occurrence.PathContext);
+    }
+
+    [Fact]
+    public void AllocationOccurrences_IncludeBranchAndSwitchPathContext()
+    {
+        var (path, directory) = BuildPathContextFixture();
+        try
+        {
+            var index = LibraryBodyIndex.Open(path);
+
+            Assert.Contains(
+                index.GetAllocationOccurrences().Values.SelectMany(occurrences => occurrences),
+                occurrence => occurrence.Method.Name == "BranchAllocation"
+                    && occurrence.Kind == AllocationKind.Object
+                    && occurrence.PathContext == AllocationPathContext.Branch);
+            Assert.Contains(
+                index.GetAllocationOccurrences().Values.SelectMany(occurrences => occurrences),
+                occurrence => occurrence.Method.Name == "SwitchAllocation"
+                    && occurrence.Kind == AllocationKind.Object
+                    && occurrence.PathContext == AllocationPathContext.SwitchArm);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), "stackalloc-candidate", "System.Int32[]", "straight-line")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), "box-value-type", "boxed System.Guid", "straight-line")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesInLoop), "box-value-type", "boxed System.Int32", "loop body")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AppendsStringInLoop), "string-build-in-loop", "System.String", "loop body")]
+    public void OptimizationOpportunities_IncludeAllocationAndPathMetadata(string methodName, string shape, string expectedAllocation, string expectedPath)
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var opportunity = Assert.Single(index.OptimizationOpportunities.Where(opportunity =>
+            opportunity.Method.Name == methodName
+            && opportunity.Shape == shape));
+
+        Assert.Equal(expectedAllocation, opportunity.RuntimeAllocationType);
+        Assert.Equal(expectedPath, opportunity.PathContext);
+    }
+
     [Fact]
     public void OptimizationOpportunities_DoesNotFlagListToArrayAsCopy()
     {
@@ -1782,6 +1842,68 @@ public class LibraryBodyIndexTests
             il.Emit(OpCodes.Ldarga, (short)0);
             il.Emit(OpCodes.Pop);
             il.Emit(OpCodes.Ret);
+        }
+    }
+
+    static (string Path, string Directory) BuildPathContextFixture()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "dotnet-inspect-path-context-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "PathContextFixture.dll");
+
+        var assemblyName = new AssemblyName("PathContextFixture");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        var type = module.DefineType("PathContextFixture", TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
+        var ctor = typeof(PlainObject).GetConstructor([typeof(int)])!;
+
+        DefineBranchAllocation(type, ctor);
+        DefineSwitchAllocation(type, ctor);
+
+        type.CreateType();
+        assembly.Save(path);
+        return (path, directory);
+
+        static void EmitNewPlainObject(ILGenerator il, ConstructorInfo ctor, int value)
+        {
+            il.Emit(OpCodes.Ldc_I4, value);
+            il.Emit(OpCodes.Newobj, ctor);
+            il.Emit(OpCodes.Ret);
+        }
+
+        static void DefineBranchAllocation(TypeBuilder type, ConstructorInfo ctor)
+        {
+            var method = type.DefineMethod(
+                "BranchAllocation",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(object),
+                [typeof(bool)]);
+            var il = method.GetILGenerator();
+            var elseLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Brfalse_S, elseLabel);
+            EmitNewPlainObject(il, ctor, 1);
+            il.MarkLabel(elseLabel);
+            EmitNewPlainObject(il, ctor, 2);
+        }
+
+        static void DefineSwitchAllocation(TypeBuilder type, ConstructorInfo ctor)
+        {
+            var method = type.DefineMethod(
+                "SwitchAllocation",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(object),
+                [typeof(int)]);
+            var il = method.GetILGenerator();
+            var case0 = il.DefineLabel();
+            var case1 = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Switch, [case0, case1]);
+            EmitNewPlainObject(il, ctor, 3);
+            il.MarkLabel(case0);
+            EmitNewPlainObject(il, ctor, 1);
+            il.MarkLabel(case1);
+            EmitNewPlainObject(il, ctor, 2);
         }
     }
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1164,6 +1164,7 @@ public class LibraryBodyIndexTests
     [InlineData(nameof(OptimizationOpportunityFixtures.ThrowsInLoop), AllocationKind.Object, "System.InvalidOperationException", AllocationPathContext.ErrorPath)]
     [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesOnceInLoop), AllocationKind.Object, "System.Object", AllocationPathContext.LoopBody)]
     [InlineData(nameof(OptimizationOpportunityFixtures.FinallyAllocates), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.StraightLine)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.CatchAllocatesInLoop), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.ErrorPath)]
     public void AllocationOccurrences_IncludeRuntimeTypeAndPathContext(string methodName, AllocationKind kind, string expectedRuntimeType, AllocationPathContext expectedPath)
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -3141,6 +3142,30 @@ public class OptimizationOpportunityFixtures
         {
             ConsumeObject(new PlainObject(1));
         }
+    }
+
+    public static int CatchAllocatesInLoop(int count)
+    {
+        var total = 0;
+        for (int i = 0; i < count; i++)
+        {
+            try
+            {
+                MaybeThrow(i);
+            }
+            catch (InvalidOperationException)
+            {
+                ConsumeObject(new PlainObject(i));
+                total--;
+            }
+        }
+        return total;
+    }
+
+    static void MaybeThrow(int value)
+    {
+        if (value < 0)
+            throw new InvalidOperationException();
     }
 
     public static object ReturnsNestedGenericObject()

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1231,7 +1231,9 @@ public class LibraryBodyIndexTests
     [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), "box-value-type", "boxed System.Guid", "straight-line")]
     [InlineData(nameof(OptimizationOpportunityFixtures.BoxesInLoop), "box-value-type", "boxed System.Int32", "loop body")]
     [InlineData(nameof(OptimizationOpportunityFixtures.AppendsStringInLoop), "string-build-in-loop", "System.String", "loop body")]
-    public void OptimizationOpportunities_IncludeAllocationAndPathMetadata(string methodName, string shape, string expectedAllocation, string expectedPath)
+    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop), "allocation-hotspot", "newobj/newarr/box", "loop body")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ContainsKey), "scan-method-in-loop-call", null, "loop body")]
+    public void OptimizationOpportunities_IncludeAllocationAndPathMetadata(string methodName, string shape, string? expectedAllocation, string expectedPath)
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 

--- a/src/ILInspector.Analysis/AllocationOccurrence.cs
+++ b/src/ILInspector.Analysis/AllocationOccurrence.cs
@@ -34,6 +34,15 @@ public enum AllocationFactSource
     GetEnumeratorCall,
 }
 
+public enum AllocationPathContext
+{
+    StraightLine,
+    Branch,
+    SwitchArm,
+    LoopBody,
+    ErrorPath,
+}
+
 /// <summary>
 /// One static heap-allocation occurrence, keyed by IL offset. Presentation layers
 /// project this into hidden-fact annotations, method signals, and triage rows.
@@ -49,7 +58,9 @@ public sealed record AllocationOccurrence(
     AllocationFrequency Frequency,
     bool InLoop,
     AllocationEscape Escape,
-    AllocationFactSource Source)
+    AllocationFactSource Source,
+    string? RuntimeAllocationType = null,
+    AllocationPathContext PathContext = AllocationPathContext.StraightLine)
 {
     public string AnnotationId => Kind switch
     {

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -3174,11 +3174,14 @@ public sealed class LibraryBodyIndex
         {
             if (escape == AllocationEscape.ThrowPath)
                 return AllocationPathContext.ErrorPath;
+            int blockIndex = decodedBody.BlockGraph.BlockIndexAt(offset);
+            var blockContext = decodedBody.PathContexts.ContextFor(blockIndex);
+            if (blockContext == AllocationPathContext.ErrorPath)
+                return AllocationPathContext.ErrorPath;
             if (IsInLoopRegion(offset, loopRegions))
                 return AllocationPathContext.LoopBody;
 
-            int blockIndex = decodedBody.BlockGraph.BlockIndexAt(offset);
-            return decodedBody.PathContexts.ContextFor(blockIndex);
+            return blockContext;
         }
 
         // Conservative, sound local-escape check for a freshly created array. Returns true

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1729,7 +1729,7 @@ public sealed class LibraryBodyIndex
                     AllocationFactSource.Newobj);
             }
 
-            static AllocationOccurrence MakeAllocation(
+            AllocationOccurrence MakeAllocation(
                 MethodIdentity method,
                 int offset,
                 int? operandToken,
@@ -1741,7 +1741,20 @@ public sealed class LibraryBodyIndex
                 bool inLoop,
                 AllocationEscape escape,
                 AllocationFactSource source)
-                => new(method, offset, operandToken, kind, allocatedType, detail, countsAsHeapAllocation, frequency, inLoop, escape, source);
+                => new(
+                    method,
+                    offset,
+                    operandToken,
+                    kind,
+                    allocatedType,
+                    detail,
+                    countsAsHeapAllocation,
+                    frequency,
+                    inLoop,
+                    escape,
+                    source,
+                    RuntimeAllocationType(kind, allocatedType),
+                    AllocationPathContextFor(decodedBody, offset, loopRegions, escape));
 
             bool ShouldEmitUnresolvedValueTypeAnnotation(int operandToken, TypeRef type)
             {
@@ -2551,7 +2564,52 @@ public sealed class LibraryBodyIndex
                     previousOpcode = opcode;
             }
 
-            return opportunities.ToImmutable();
+            return [.. opportunities.Select(AnnotateOpportunityMetadata)];
+
+            OptimizationOpportunity AnnotateOpportunityMetadata(OptimizationOpportunity opportunity)
+            {
+                var runtimeAllocation = opportunity.RuntimeAllocationType ?? RuntimeAllocationTypeForOpportunity(opportunity);
+                var pathContext = opportunity.PathContext ?? PathContextForOpportunity(opportunity);
+                return runtimeAllocation != opportunity.RuntimeAllocationType || pathContext != opportunity.PathContext
+                    ? opportunity with { RuntimeAllocationType = runtimeAllocation, PathContext = pathContext }
+                    : opportunity;
+            }
+
+            string? PathContextForOpportunity(OptimizationOpportunity opportunity)
+            {
+                if (opportunity.ColdPath)
+                    return FormatPathContext(AllocationPathContext.ErrorPath);
+                if (opportunity.ILOffset is { } opportunityOffset)
+                    return FormatPathContext(AllocationPathContextFor(decodedBody, opportunityOffset, loopRegions, AllocationEscape.Unknown));
+                return opportunity.InLoop ? FormatPathContext(AllocationPathContext.LoopBody) : null;
+            }
+
+            string? RuntimeAllocationTypeForOpportunity(OptimizationOpportunity opportunity)
+            {
+                if (opportunity.ILOffset is { } opportunityOffset
+                    && allocationByOffset.TryGetValue(opportunityOffset, out var allocation)
+                    && allocation.RuntimeAllocationType is { Length: > 0 } occurrenceRuntime)
+                {
+                    return occurrenceRuntime;
+                }
+
+                return opportunity.Shape switch
+                {
+                    "allocation-hotspot" => "newobj/newarr/box",
+                    "async-state-machine" => "state machine",
+                    "box-value-type" => "boxed T",
+                    "capturing-delegate" => "delegate/display class",
+                    "instance-method-group-delegate" => "delegate",
+                    "enumerator-allocation" => "enumerator",
+                    "linq-scan-in-loop" => null,
+                    "materialize-in-loop" when opportunity.Evidence.Contains(".ToArray", StringComparison.Ordinal) => "T[]",
+                    "materialize-in-loop" when opportunity.Evidence.Contains(".ToList", StringComparison.Ordinal) => "System.Collections.Generic.List<T>",
+                    "small-array" or "stackalloc-candidate" or "span-to-array-copy" => "T[]",
+                    "string-build-in-loop" => "System.String",
+                    "temporary-byte-array-copy" => "System.Byte[]",
+                    _ => null,
+                };
+            }
         }
 
         // True when a delegate's target method is a closure body emitted on a compiler-
@@ -2901,6 +2959,113 @@ public sealed class LibraryBodyIndex
                    or "Int64" or "UInt64" or "Single" or "Double"
                    or "IntPtr" or "UIntPtr";
 
+        static string? RuntimeAllocationType(AllocationKind kind, TypeRef? allocatedType)
+        {
+            if (allocatedType is null)
+                return kind == AllocationKind.Object ? "object" : null;
+            return kind switch
+            {
+                AllocationKind.Box => $"boxed {RuntimeTypeName(allocatedType)}",
+                AllocationKind.Closure => $"display class ({RuntimeTypeName(allocatedType)})",
+                AllocationKind.StateMachine => $"state machine ({RuntimeTypeName(allocatedType)})",
+                _ => RuntimeTypeName(allocatedType),
+            };
+        }
+
+        static string RuntimeTypeName(TypeRef type)
+            => type.Kind switch
+            {
+                TypeRefKind.Definition => type.Namespace.Length == 0 ? StripGenericArity(type.Name) : $"{type.Namespace}.{StripGenericArity(type.Name)}",
+                TypeRefKind.GenericInstance => $"{RuntimeTypeName(type.ElementType ?? type)}<{string.Join(", ", type.TypeArguments.Select(RuntimeTypeName))}>",
+                TypeRefKind.SzArray => $"{RuntimeTypeName(type.ElementType!)}[]",
+                TypeRefKind.Array => $"{RuntimeTypeName(type.ElementType!)}[{new string(',', type.Rank - 1)}]",
+                TypeRefKind.ByRef => $"ref {RuntimeTypeName(type.ElementType!)}",
+                TypeRefKind.Pointer => $"{RuntimeTypeName(type.ElementType!)}*",
+                _ => type.ToQualifiedDisplayString(),
+            };
+
+        public static string FormatPathContext(AllocationPathContext context)
+            => context switch
+            {
+                AllocationPathContext.Branch => "branch",
+                AllocationPathContext.SwitchArm => "switch arm",
+                AllocationPathContext.LoopBody => "loop body",
+                AllocationPathContext.ErrorPath => "error path",
+                _ => "straight-line",
+            };
+
+        static AllocationPathContext AllocationPathContextFor(
+            DecodedBody decodedBody,
+            int offset,
+            IReadOnlyList<(int Start, int End)> loopRegions,
+            AllocationEscape escape)
+        {
+            if (escape == AllocationEscape.ThrowPath || decodedBody.BlockGraph.Regions.Any(region => region.ContainsHandler(offset) || region.ContainsFilter(offset)))
+                return AllocationPathContext.ErrorPath;
+            if (IsInLoopRegion(offset, loopRegions))
+                return AllocationPathContext.LoopBody;
+
+            int blockIndex = decodedBody.BlockGraph.BlockIndexAt(offset);
+            if (blockIndex < 0)
+                return AllocationPathContext.StraightLine;
+
+            var switchTargets = new HashSet<int>();
+            var branchTargets = new HashSet<int>();
+            foreach (var instruction in decodedBody.Instructions)
+            {
+                if (instruction.BranchTargets.Length == 0)
+                    continue;
+                foreach (int target in instruction.BranchTargets)
+                {
+                    int targetBlock = decodedBody.BlockGraph.BlockIndexAt(target);
+                    if (targetBlock < 0)
+                        continue;
+                    branchTargets.Add(targetBlock);
+                    if (instruction.OpCode == ILOpCode.Switch)
+                        switchTargets.Add(targetBlock);
+                }
+            }
+
+            if (switchTargets.Contains(blockIndex))
+                return AllocationPathContext.SwitchArm;
+            if (branchTargets.Contains(blockIndex) || blockIndex > 0 && HasBranchingPredecessor(decodedBody, blockIndex))
+                return AllocationPathContext.Branch;
+            return AllocationPathContext.StraightLine;
+        }
+
+        static bool HasBranchingPredecessor(DecodedBody decodedBody, int blockIndex)
+        {
+            for (int i = 0; i < decodedBody.BlockGraph.Blocks.Length; i++)
+            {
+                if (!decodedBody.BlockGraph.Blocks[i].Edges.Successors.Contains(blockIndex))
+                    continue;
+                if (LastInstructionInBlock(decodedBody, i) is { } predecessor
+                    && predecessor.Branches
+                    && !predecessor.IsUnconditionalBranch)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        static DecodedInstruction? LastInstructionInBlock(DecodedBody decodedBody, int blockIndex)
+        {
+            if ((uint)blockIndex >= (uint)decodedBody.BlockGraph.Blocks.Length)
+                return null;
+            var block = decodedBody.BlockGraph.Blocks[blockIndex];
+            DecodedInstruction? last = null;
+            foreach (var instruction in decodedBody.Instructions)
+            {
+                if (instruction.Offset < block.Start)
+                    continue;
+                if (instruction.Offset >= block.End)
+                    break;
+                last = instruction;
+            }
+            return last;
+        }
+
         // Conservative, sound local-escape check for a freshly created array. Returns true
         // only when the array is stored straight into a local (`newarr; stloc.X`) whose every
         // load is an in-place element access / length read — never returned, stored to a
@@ -2984,7 +3149,13 @@ public sealed class LibraryBodyIndex
                     occurrence.Kind,
                     occurrence.AllocatedType);
 
-                builder.Add(escape == AllocationEscape.Unknown ? occurrence : occurrence with { Escape = escape });
+                builder.Add(escape == AllocationEscape.Unknown
+                    ? occurrence
+                    : occurrence with
+                    {
+                        Escape = escape,
+                        PathContext = escape == AllocationEscape.ThrowPath ? AllocationPathContext.ErrorPath : occurrence.PathContext,
+                    });
             }
             return builder.MoveToImmutable();
         }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -82,12 +82,14 @@ public sealed class LibraryBodyIndex
                         var confidence = IsLowFrequencyOpportunity(adjusted)
                             ? "low"
                             : AdjustDelegateConfidenceForReach(adjusted.Shape, adjusted.InLoop, adjusted.Confidence, reach);
-                        return confidence != adjusted.Confidence ? adjusted with { Confidence = confidence } : adjusted;
+                        adjusted = confidence != adjusted.Confidence ? adjusted with { Confidence = confidence } : adjusted;
+                        return AddFallbackOpportunityMetadata(adjusted);
                     }),
                     .. AllocationHotspots(reachByToken, new HashSet<int>(_rawOpportunities
                         .Where(o => !(o.Shape == "async-state-machine" && o.Amortized))
-                        .Select(o => o.Method.MetadataToken))),
-                    .. ScanMethodsInvokedInLoops(reachByToken),
+                        .Select(o => o.Method.MetadataToken)))
+                        .Select(AddFallbackOpportunityMetadata),
+                    .. ScanMethodsInvokedInLoops(reachByToken).Select(AddFallbackOpportunityMetadata),
                 ];
             }
             return _opportunities;
@@ -135,6 +137,49 @@ public sealed class LibraryBodyIndex
 
     static bool IsLowFrequencyOpportunity(OptimizationOpportunity opportunity)
         => opportunity.ColdPath || opportunity.Amortized;
+
+    static OptimizationOpportunity AddFallbackOpportunityMetadata(OptimizationOpportunity opportunity)
+    {
+        var runtimeAllocation = opportunity.RuntimeAllocationType ?? FallbackRuntimeAllocationType(opportunity);
+        var pathContext = opportunity.PathContext ?? FallbackPathContext(opportunity);
+        return runtimeAllocation != opportunity.RuntimeAllocationType || pathContext != opportunity.PathContext
+            ? opportunity with { RuntimeAllocationType = runtimeAllocation, PathContext = pathContext }
+            : opportunity;
+    }
+
+    static string? FallbackRuntimeAllocationType(OptimizationOpportunity opportunity)
+        => opportunity.Shape switch
+        {
+            "allocation-hotspot" => "newobj/newarr/box",
+            "async-state-machine" => "state machine",
+            "box-value-type" => "boxed T",
+            "capturing-delegate" => "delegate/display class",
+            "instance-method-group-delegate" => "delegate",
+            "enumerator-allocation" => "enumerator",
+            "materialize-in-loop" when opportunity.Evidence.Contains(".ToArray", StringComparison.Ordinal) => "T[]",
+            "materialize-in-loop" when opportunity.Evidence.Contains(".ToList", StringComparison.Ordinal) => "System.Collections.Generic.List<T>",
+            "small-array" or "stackalloc-candidate" or "span-to-array-copy" => "T[]",
+            "string-build-in-loop" => "System.String",
+            "temporary-byte-array-copy" => "System.Byte[]",
+            _ => null,
+        };
+
+    static string? FallbackPathContext(OptimizationOpportunity opportunity)
+    {
+        if (opportunity.ColdPath)
+            return FormatPathContext(AllocationPathContext.ErrorPath);
+        return opportunity.InLoop ? FormatPathContext(AllocationPathContext.LoopBody) : null;
+    }
+
+    static string FormatPathContext(AllocationPathContext context)
+        => context switch
+        {
+            AllocationPathContext.Branch => "branch",
+            AllocationPathContext.SwitchArm => "switch arm",
+            AllocationPathContext.LoopBody => "loop body",
+            AllocationPathContext.ErrorPath => "error path",
+            _ => "straight-line",
+        };
 
     OptimizationOpportunity MarkAmortizedSetup(OptimizationOpportunity opportunity)
     {
@@ -2709,47 +2754,22 @@ public sealed class LibraryBodyIndex
 
             OptimizationOpportunity AnnotateOpportunityMetadata(OptimizationOpportunity opportunity)
             {
-                var runtimeAllocation = opportunity.RuntimeAllocationType ?? RuntimeAllocationTypeForOpportunity(opportunity);
-                var pathContext = opportunity.PathContext ?? PathContextForOpportunity(opportunity);
-                return runtimeAllocation != opportunity.RuntimeAllocationType || pathContext != opportunity.PathContext
-                    ? opportunity with { RuntimeAllocationType = runtimeAllocation, PathContext = pathContext }
-                    : opportunity;
-            }
-
-            string? PathContextForOpportunity(OptimizationOpportunity opportunity)
-            {
-                if (opportunity.ColdPath)
-                    return FormatPathContext(AllocationPathContext.ErrorPath);
+                var annotated = opportunity;
                 if (opportunity.ILOffset is { } opportunityOffset)
-                    return FormatPathContext(AllocationPathContextFor(decodedBody, opportunityOffset, loopRegions, AllocationEscape.Unknown));
-                return opportunity.InLoop ? FormatPathContext(AllocationPathContext.LoopBody) : null;
-            }
-
-            string? RuntimeAllocationTypeForOpportunity(OptimizationOpportunity opportunity)
-            {
-                if (opportunity.ILOffset is { } opportunityOffset
-                    && allocationByOffset.TryGetValue(opportunityOffset, out var allocation)
-                    && allocation.RuntimeAllocationType is { Length: > 0 } occurrenceRuntime)
                 {
-                    return occurrenceRuntime;
+                    string? runtimeAllocation = opportunity.RuntimeAllocationType;
+                    if (allocationByOffset.TryGetValue(opportunityOffset, out var allocation)
+                        && allocation.RuntimeAllocationType is { Length: > 0 } occurrenceRuntime)
+                    {
+                        runtimeAllocation = occurrenceRuntime;
+                    }
+                    annotated = annotated with
+                    {
+                        RuntimeAllocationType = runtimeAllocation,
+                        PathContext = opportunity.PathContext ?? FormatPathContext(AllocationPathContextFor(decodedBody, opportunityOffset, loopRegions, AllocationEscape.Unknown)),
+                    };
                 }
-
-                return opportunity.Shape switch
-                {
-                    "allocation-hotspot" => "newobj/newarr/box",
-                    "async-state-machine" => "state machine",
-                    "box-value-type" => "boxed T",
-                    "capturing-delegate" => "delegate/display class",
-                    "instance-method-group-delegate" => "delegate",
-                    "enumerator-allocation" => "enumerator",
-                    "linq-scan-in-loop" => null,
-                    "materialize-in-loop" when opportunity.Evidence.Contains(".ToArray", StringComparison.Ordinal) => "T[]",
-                    "materialize-in-loop" when opportunity.Evidence.Contains(".ToList", StringComparison.Ordinal) => "System.Collections.Generic.List<T>",
-                    "small-array" or "stackalloc-candidate" or "span-to-array-copy" => "T[]",
-                    "string-build-in-loop" => "System.String",
-                    "temporary-byte-array-copy" => "System.Byte[]",
-                    _ => null,
-                };
+                return AddFallbackOpportunityMetadata(annotated);
             }
         }
 

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1058,11 +1058,13 @@ public sealed class LibraryBodyIndex
                 for (int i = 0; i < instructions.Length; i++)
                     _instructionIndexByOffset[instructions[i].Offset] = i;
                 LoopRegions = CollectLoopRegions();
+                PathContexts = AllocationPathContextIndex.Create(this);
             }
 
             public ImmutableArray<DecodedInstruction> Instructions { get; }
             public BlockGraph BlockGraph { get; }
             public IReadOnlyList<(int Start, int End)> LoopRegions { get; }
+            public AllocationPathContextIndex PathContexts { get; }
 
             public bool TryGetInstructionAt(int offset, out DecodedInstruction instruction)
             {
@@ -1120,6 +1122,145 @@ public sealed class LibraryBodyIndex
                     }
                 }
                 return regions;
+            }
+        }
+
+        sealed class AllocationPathContextIndex
+        {
+            readonly bool[] _branchBlocks;
+            readonly bool[] _switchArmBlocks;
+            readonly bool[] _errorPathBlocks;
+
+            AllocationPathContextIndex(bool[] branchBlocks, bool[] switchArmBlocks, bool[] errorPathBlocks)
+            {
+                _branchBlocks = branchBlocks;
+                _switchArmBlocks = switchArmBlocks;
+                _errorPathBlocks = errorPathBlocks;
+            }
+
+            public static AllocationPathContextIndex Create(DecodedBody decodedBody)
+            {
+                var blockGraph = decodedBody.BlockGraph;
+                var branchBlocks = new bool[blockGraph.Blocks.Length];
+                var switchArmBlocks = new bool[blockGraph.Blocks.Length];
+                var errorPathBlocks = new bool[blockGraph.Blocks.Length];
+                var lastByBlock = LastInstructionsByBlock(decodedBody);
+                var predecessorCounts = PredecessorCounts(blockGraph);
+
+                foreach (var region in blockGraph.Regions)
+                {
+                    switch (region.Kind)
+                    {
+                        case HandlerKind.Catch:
+                        case HandlerKind.Fault:
+                            MarkBlocksInRange(blockGraph, errorPathBlocks, region.HandlerStart, region.HandlerEnd);
+                            break;
+                        case HandlerKind.Filter:
+                            MarkBlocksInRange(blockGraph, errorPathBlocks, region.FilterStart, region.FilterEnd);
+                            MarkBlocksInRange(blockGraph, errorPathBlocks, region.HandlerStart, region.HandlerEnd);
+                            break;
+                    }
+                }
+
+                for (int blockIndex = 0; blockIndex < lastByBlock.Length; blockIndex++)
+                {
+                    var terminator = lastByBlock[blockIndex];
+                    if (terminator is null || !terminator.Branches)
+                        continue;
+
+                    if (terminator.OpCode == ILOpCode.Switch)
+                    {
+                        foreach (int target in terminator.BranchTargets)
+                            MarkSwitchArm(blockGraph, switchArmBlocks, predecessorCounts, target);
+                        if (terminator.FallsThrough)
+                        {
+                            int defaultBlock = blockGraph.BlockIndexAt(terminator.NextOffset);
+                            MarkSwitchArm(blockGraph, switchArmBlocks, predecessorCounts, terminator.NextOffset);
+                            if (defaultBlock >= 0
+                                && lastByBlock[defaultBlock] is { IsUnconditionalBranch: true, BranchTargets.Length: 1 } redirect)
+                            {
+                                MarkSwitchArm(blockGraph, switchArmBlocks, predecessorCounts, redirect.BranchTargets[0]);
+                            }
+                        }
+                        continue;
+                    }
+
+                    if (terminator.IsUnconditionalBranch)
+                        continue;
+
+                    foreach (int target in terminator.BranchTargets)
+                        MarkBranchArm(blockGraph, branchBlocks, predecessorCounts, target);
+                    if (terminator.FallsThrough)
+                        MarkBranchArm(blockGraph, branchBlocks, predecessorCounts, terminator.NextOffset);
+                }
+
+                return new AllocationPathContextIndex(branchBlocks, switchArmBlocks, errorPathBlocks);
+            }
+
+            public AllocationPathContext ContextFor(int blockIndex)
+            {
+                if ((uint)blockIndex >= (uint)_branchBlocks.Length)
+                    return AllocationPathContext.StraightLine;
+                if (_errorPathBlocks[blockIndex])
+                    return AllocationPathContext.ErrorPath;
+                if (_switchArmBlocks[blockIndex])
+                    return AllocationPathContext.SwitchArm;
+                if (_branchBlocks[blockIndex])
+                    return AllocationPathContext.Branch;
+                return AllocationPathContext.StraightLine;
+            }
+
+            static DecodedInstruction?[] LastInstructionsByBlock(DecodedBody decodedBody)
+            {
+                var lastByBlock = new DecodedInstruction?[decodedBody.BlockGraph.Blocks.Length];
+                int cursor = 0;
+                foreach (var instruction in decodedBody.Instructions)
+                {
+                    while (cursor + 1 < decodedBody.BlockGraph.Blocks.Length
+                        && instruction.Offset >= decodedBody.BlockGraph.Blocks[cursor + 1].Start)
+                    {
+                        cursor++;
+                    }
+                    if ((uint)cursor < (uint)lastByBlock.Length)
+                        lastByBlock[cursor] = instruction;
+                }
+                return lastByBlock;
+            }
+
+            static int[] PredecessorCounts(BlockGraph blockGraph)
+            {
+                var counts = new int[blockGraph.Blocks.Length];
+                foreach (var block in blockGraph.Blocks)
+                {
+                    foreach (int successor in block.Edges.Successors)
+                        if ((uint)successor < (uint)counts.Length)
+                            counts[successor]++;
+                }
+                return counts;
+            }
+
+            static void MarkBlocksInRange(BlockGraph blockGraph, bool[] targets, int start, int end)
+            {
+                for (int i = 0; i < blockGraph.Blocks.Length; i++)
+                {
+                    var block = blockGraph.Blocks[i];
+                    if (block.Start < end && block.End > start)
+                        targets[i] = true;
+                }
+            }
+
+            static void MarkSwitchArm(BlockGraph blockGraph, bool[] switchArmBlocks, int[] predecessorCounts, int offset)
+            {
+                int blockIndex = blockGraph.BlockIndexAt(offset);
+                if ((uint)blockIndex < (uint)switchArmBlocks.Length && predecessorCounts[blockIndex] <= 1)
+                    switchArmBlocks[blockIndex] = true;
+            }
+
+            static void MarkBranchArm(BlockGraph blockGraph, bool[] branchBlocks, int[] predecessorCounts, int offset)
+            {
+                int blockIndex = blockGraph.BlockIndexAt(offset);
+                if ((uint)blockIndex < (uint)branchBlocks.Length && predecessorCounts[blockIndex] <= 1)
+                    branchBlocks[blockIndex] = true;
             }
         }
 
@@ -2975,7 +3116,7 @@ public sealed class LibraryBodyIndex
         static string RuntimeTypeName(TypeRef type)
             => type.Kind switch
             {
-                TypeRefKind.Definition => type.Namespace.Length == 0 ? StripGenericArity(type.Name) : $"{type.Namespace}.{StripGenericArity(type.Name)}",
+                TypeRefKind.Definition => type.Namespace.Length == 0 ? StripMetadataGenericArity(type.Name) : $"{type.Namespace}.{StripMetadataGenericArity(type.Name)}",
                 TypeRefKind.GenericInstance => $"{RuntimeTypeName(type.ElementType ?? type)}<{string.Join(", ", type.TypeArguments.Select(RuntimeTypeName))}>",
                 TypeRefKind.SzArray => $"{RuntimeTypeName(type.ElementType!)}[]",
                 TypeRefKind.Array => $"{RuntimeTypeName(type.ElementType!)}[{new string(',', type.Rank - 1)}]",
@@ -2983,6 +3124,17 @@ public sealed class LibraryBodyIndex
                 TypeRefKind.Pointer => $"{RuntimeTypeName(type.ElementType!)}*",
                 _ => type.ToQualifiedDisplayString(),
             };
+
+        static string StripMetadataGenericArity(string name)
+        {
+            if (!name.Contains('`', StringComparison.Ordinal))
+                return name;
+            return string.Join("+", name.Split('+').Select(segment =>
+            {
+                int tick = segment.IndexOf('`');
+                return tick < 0 ? segment : segment[..tick];
+            }));
+        }
 
         public static string FormatPathContext(AllocationPathContext context)
             => context switch
@@ -3000,70 +3152,13 @@ public sealed class LibraryBodyIndex
             IReadOnlyList<(int Start, int End)> loopRegions,
             AllocationEscape escape)
         {
-            if (escape == AllocationEscape.ThrowPath || decodedBody.BlockGraph.Regions.Any(region => region.ContainsHandler(offset) || region.ContainsFilter(offset)))
+            if (escape == AllocationEscape.ThrowPath)
                 return AllocationPathContext.ErrorPath;
             if (IsInLoopRegion(offset, loopRegions))
                 return AllocationPathContext.LoopBody;
 
             int blockIndex = decodedBody.BlockGraph.BlockIndexAt(offset);
-            if (blockIndex < 0)
-                return AllocationPathContext.StraightLine;
-
-            var switchTargets = new HashSet<int>();
-            var branchTargets = new HashSet<int>();
-            foreach (var instruction in decodedBody.Instructions)
-            {
-                if (instruction.BranchTargets.Length == 0)
-                    continue;
-                foreach (int target in instruction.BranchTargets)
-                {
-                    int targetBlock = decodedBody.BlockGraph.BlockIndexAt(target);
-                    if (targetBlock < 0)
-                        continue;
-                    branchTargets.Add(targetBlock);
-                    if (instruction.OpCode == ILOpCode.Switch)
-                        switchTargets.Add(targetBlock);
-                }
-            }
-
-            if (switchTargets.Contains(blockIndex))
-                return AllocationPathContext.SwitchArm;
-            if (branchTargets.Contains(blockIndex) || blockIndex > 0 && HasBranchingPredecessor(decodedBody, blockIndex))
-                return AllocationPathContext.Branch;
-            return AllocationPathContext.StraightLine;
-        }
-
-        static bool HasBranchingPredecessor(DecodedBody decodedBody, int blockIndex)
-        {
-            for (int i = 0; i < decodedBody.BlockGraph.Blocks.Length; i++)
-            {
-                if (!decodedBody.BlockGraph.Blocks[i].Edges.Successors.Contains(blockIndex))
-                    continue;
-                if (LastInstructionInBlock(decodedBody, i) is { } predecessor
-                    && predecessor.Branches
-                    && !predecessor.IsUnconditionalBranch)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        static DecodedInstruction? LastInstructionInBlock(DecodedBody decodedBody, int blockIndex)
-        {
-            if ((uint)blockIndex >= (uint)decodedBody.BlockGraph.Blocks.Length)
-                return null;
-            var block = decodedBody.BlockGraph.Blocks[blockIndex];
-            DecodedInstruction? last = null;
-            foreach (var instruction in decodedBody.Instructions)
-            {
-                if (instruction.Offset < block.Start)
-                    continue;
-                if (instruction.Offset >= block.End)
-                    break;
-                last = instruction;
-            }
-            return last;
+            return decodedBody.PathContexts.ContextFor(blockIndex);
         }
 
         // Conservative, sound local-escape check for a freshly created array. Returns true

--- a/src/ILInspector.Analysis/OptimizationOpportunity.cs
+++ b/src/ILInspector.Analysis/OptimizationOpportunity.cs
@@ -10,7 +10,9 @@ public sealed record OptimizationOpportunity(
     int? ILOffset,
     string? Caveat,
     int RootReach = 0,
-    bool ColdPath = false)
+    bool ColdPath = false,
+    string? RuntimeAllocationType = null,
+    string? PathContext = null)
 {
     public bool Amortized { get; init; }
 }

--- a/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
@@ -39,7 +39,7 @@ public class AllocationOccurrenceFactTests
         var annotations = Classify(nameof(AllocSampleClass.BoxInt));
 
         var box = Assert.Single(annotations, a => a.Descriptor.Id == "alloc.box");
-        Assert.Equal("int", box.Detail);
+        Assert.Equal("int; alloc=boxed System.Int32; path=straight-line; escape=escapes", box.Detail);
         Assert.True(box.SourceOffset >= 0, "the annotation should carry IL provenance");
         Assert.Equal(AnnotationCategory.Allocation, box.Descriptor.Category);
     }
@@ -60,7 +60,7 @@ public class AllocationOccurrenceFactTests
         var annotations = Classify(nameof(AllocSampleClass.MakeRectangularArray));
 
         var array = Assert.Single(annotations, a => a.Descriptor.Id == "alloc.array");
-        Assert.Equal("int[,]", array.Detail);
+        Assert.Equal("int[,]; alloc=System.Int32[,]; path=straight-line; escape=escapes", array.Detail);
         Assert.DoesNotContain(annotations, a => a.Descriptor.Id == "alloc.new");
     }
 

--- a/src/ILInspector.Decompiler.Tests/AnnotatedCSharpRendererTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedCSharpRendererTests.cs
@@ -20,14 +20,14 @@ public class AnnotatedCSharpRendererTests
         // The box is invisible in the source (object BoxInt(int x) => x;) yet the
         // annotated view shows it where it happens.
         var output = Render(nameof(AllocSampleClass.BoxInt));
-        Assert.Contains("return x;  // alloc.box(int)", output);
+        Assert.Contains("return x;  // alloc.box(int; alloc=boxed System.Int32; path=straight-line; escape=escapes)", output);
     }
 
     [Fact]
     public void Array_SurfacesTheAllocatedType()
     {
         var output = Render(nameof(AllocSampleClass.MakeArray));
-        Assert.Contains("// alloc.array(int[])", output);
+        Assert.Contains("// alloc.array(int[]; alloc=System.Int32[]; path=straight-line; escape=escapes)", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/AnnotatedIlFactTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedIlFactTests.cs
@@ -21,7 +21,7 @@ public class AnnotatedIlFactTests
         // opcode, not a statement.
         var output = Render(nameof(AllocSampleClass.BoxInt));
         var line = output.Split('\n').Single(l => l.Contains(": box"));
-        Assert.Contains("alloc.box(int)", line);
+        Assert.Contains("alloc.box(int; alloc=boxed System.Int32; path=straight-line; escape=escapes)", line);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/AnnotationStructuredViewTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationStructuredViewTests.cs
@@ -28,7 +28,7 @@ public class AnnotationStructuredViewTests
         var fact = Assert.Single(doc.RootElement.EnumerateArray());
         Assert.Equal("alloc.box", fact.GetProperty("id").GetString());
         Assert.Equal("Allocation", fact.GetProperty("category").GetString());
-        Assert.Equal("int", fact.GetProperty("detail").GetString());
+        Assert.Equal("int; alloc=boxed System.Int32; path=straight-line; escape=escapes", fact.GetProperty("detail").GetString());
         Assert.Equal("IL_0001", fact.GetProperty("il").GetString());
         Assert.True(fact.GetProperty("offset").GetInt32() >= 0);
     }
@@ -41,7 +41,7 @@ public class AnnotationStructuredViewTests
         var json = AnnotationStructuredView.Json(Collect(nameof(AllocSampleClass.Capture)));
         using var doc = JsonDocument.Parse(json);
         Assert.Contains(doc.RootElement.EnumerateArray(),
-            f => f.GetProperty("detail").GetString() == "Func<int, int>");
+            f => f.GetProperty("detail").GetString() == "Func<int, int>; alloc=System.Func<System.Int32, System.Int32>; path=straight-line; escape=escapes");
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
@@ -37,8 +37,8 @@ public class MixedSourceRendererTests
         var lines = output.Split('\n');
         var cs = lines.Single(l => l.Contains("new int[n]"));
         var il = lines.Single(l => l.Contains("newarr"));
-        Assert.Contains("alloc.array(int[])", cs);
-        Assert.Contains("alloc.array(int[])", il);
+        Assert.Contains("alloc.array(int[]; alloc=System.Int32[]; path=straight-line; escape=escapes)", cs);
+        Assert.Contains("alloc.array(int[]; alloc=System.Int32[]; path=straight-line; escape=escapes)", il);
     }
 
     [Fact]

--- a/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
+++ b/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
@@ -46,7 +46,39 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
             AllocationFrequency.PerIteration => AnnotationConditionality.PerIteration,
             _ => AnnotationConditionality.Always,
         };
-        return new Annotation(descriptor, occurrence.ILOffset, occurrence.Detail, conditionality, Node: null);
+        return new Annotation(descriptor, occurrence.ILOffset, Detail(occurrence), conditionality, Node: null);
     }
+
+    static string? Detail(AllocationOccurrence occurrence)
+    {
+        var parts = new List<string>();
+        if (occurrence.Detail is { Length: > 0 } detail)
+            parts.Add(detail);
+        if (occurrence.RuntimeAllocationType is { Length: > 0 } runtime)
+            parts.Add($"alloc={runtime}");
+        parts.Add($"path={FormatPathContext(occurrence.PathContext)}");
+        if (occurrence.Escape != AllocationEscape.Unknown)
+            parts.Add($"escape={FormatEscape(occurrence.Escape)}");
+        return parts.Count == 0 ? null : string.Join("; ", parts);
+    }
+
+    static string FormatPathContext(AllocationPathContext context)
+        => context switch
+        {
+            AllocationPathContext.Branch => "branch",
+            AllocationPathContext.SwitchArm => "switch-arm",
+            AllocationPathContext.LoopBody => "loop-body",
+            AllocationPathContext.ErrorPath => "error-path",
+            _ => "straight-line",
+        };
+
+    static string FormatEscape(AllocationEscape escape)
+        => escape switch
+        {
+            AllocationEscape.LocalOnly => "local-only",
+            AllocationEscape.Escapes => "escapes",
+            AllocationEscape.ThrowPath => "throw-path",
+            _ => "unknown",
+        };
 
 }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2564,7 +2564,7 @@ public class CommandExecutionTests
         Assert.Contains("| Member | IL | Cs Line | Anchor | Category | Id | Detail | Conditionality |", output);
         Assert.Contains("FactsTableFixture::BoxInt", output);
         Assert.Contains("`IL_", output);
-        Assert.Contains("| offset | Allocation | alloc.box | `int` | Always |", output);
+        Assert.Contains("| offset | Allocation | alloc.box | `int; alloc=boxed System.Int32; path=straight-line; escape=escapes` | Always |", output);
     }
 
     [Fact]
@@ -2577,7 +2577,7 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.Contains("FactsTableFixture::BoxInt\tIL_", output);
-        Assert.Contains("\toffset\tAllocation\talloc.box\tint\tAlways", output);
+        Assert.Contains("\toffset\tAllocation\talloc.box\tint; alloc=boxed System.Int32; path=straight-line; escape=escapes\tAlways", output);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -736,6 +736,8 @@ internal static class LibraryMetadataService
                     Fix = opportunity.SafeFixDirection,
                     Confidence = opportunity.Confidence,
                     Loop = opportunity.InLoop ? "loop" : "",
+                    Allocation = opportunity.RuntimeAllocationType,
+                    Path = opportunity.PathContext,
                     IL = opportunity.ILOffset is { } offset ? $"IL_{offset:X4}" : null,
                 })
                 .ToList();

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -642,6 +642,10 @@ public record class OptimizationOpportunitySummary
     public string Confidence { get; init; } = "";
     public string Loop { get; init; } = "";
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Allocation { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Path { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? IL { get; init; }
 }
 

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1680,6 +1680,8 @@ public static class ApiOutputFormatter
                 opportunity.SafeFixDirection,
                 opportunity.Confidence,
                 opportunity.InLoop ? "loop" : "",
+                opportunity.RuntimeAllocationType is { Length: > 0 } allocation ? MarkoutInline.Code(allocation) : null,
+                opportunity.PathContext,
                 opportunity.ILOffset is { } offset ? MarkoutInline.Code($"IL_{offset:X4}") : null))
             .ToList();
 

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -805,6 +805,8 @@ public record OptimizationOpportunityRow(
     string Fix,
     string Confidence,
     string Loop,
+    [property: MarkoutSkipNull] string? Allocation,
+    [property: MarkoutSkipNull] string? Path,
     [property: MarkoutSkipNull] string? IL);
 
 [MarkoutSerializable]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -702,6 +702,8 @@ public class LibraryInspectionView
                 o.Fix,
                 o.Confidence,
                 o.Loop,
+                o.Allocation is null ? null : MarkoutInline.Code(o.Allocation),
+                o.Path,
                 o.IL is null ? null : MarkoutInline.Code(o.IL)))
             .ToList();
 


### PR DESCRIPTION
## Summary

First PR in the two-PR follow-up split after #2067. This adds static allocation candidate metadata without adding dominance/path-confidence claims.

- Adds `AllocationOccurrence.RuntimeAllocationType` and `AllocationOccurrence.PathContext` (`straight-line`, `branch`, `switch arm`, `loop body`, `error path`).
- Adds optional `RuntimeAllocationType` and `PathContext` metadata to `OptimizationOpportunity` rows.
- Projects the metadata into `Facts` detail and `Performance Triage` rows as `Allocation` and `Path` columns.
- Keeps dominance/path confidence out of scope for the planned second PR.

## Examples

- `LocalArrayStaysLocal` allocation fact: `alloc=System.Int32[]; path=straight-line; escape=local-only`.
- `BoxesGuidValue` occurrence/opportunity: `boxed System.Guid`, `straight-line`.
- `ThrowsInLoop`: `System.InvalidOperationException`, `error path`.
- `BoxesInLoop`: `boxed System.Int32`, `loop body`.
- Reflection.Emit fixtures cover explicit branch and `switch`-target path contexts.

## Validation

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -method '*AllocationOccurrences_IncludeRuntimeTypeAndPathContext*' -method '*AllocationOccurrences_IncludeBranchAndSwitchPathContext*' -method '*OptimizationOpportunities_IncludeAllocationAndPathMetadata*'`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -p:NoWarn=NU1507%3BCS0436`
- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507%3BCS0436 --nologo --verbosity quiet`

## Review status

Adversarial review is required for this analysis PR. I will post reviewer findings and reconciliation as PR comments.
