### PR TITLE
Route metadata resolution through assembly descriptors

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -230,7 +230,7 @@ internal sealed class CrossAssemblyTypeResolver
             if (NamedDefinition(current) is not { } definition)
                 continue;
             if (Locate(definition) is not { } location
-                || _context.Open(location.AssemblyPath) is not { } assembly
+                || _context.Open(location) is not { } assembly
                 || !assembly.TryGetType(location.FullTypeName, out var handle))
             {
                 unresolved = true;
@@ -289,7 +289,7 @@ internal sealed class CrossAssemblyTypeResolver
         {
             if (Locate(type) is not { } location)
                 return null;
-            if (_context.Open(location.AssemblyPath) is not { } assembly)
+            if (_context.Open(location) is not { } assembly)
                 return null;
             if (!assembly.TryGetType(location.FullTypeName, out var handle))
                 return null;
@@ -335,7 +335,7 @@ internal sealed class CrossAssemblyTypeResolver
         {
             if (Locate(type) is not { } location)
                 return null;
-            if (_context.Open(location.AssemblyPath) is not { } assembly)
+            if (_context.Open(location) is not { } assembly)
                 return null;
             if (!assembly.TryGetType(location.FullTypeName, out var handle))
                 return null;
@@ -516,25 +516,26 @@ internal sealed class CrossAssemblyTypeResolver
         {
             foreach (var candidate in CoreLibCandidates)
             {
-                if (_context.Locator(candidate, AssemblyResolutionScope.Platform) is not { } start || !File.Exists(start))
+                var identity = new AssemblyReferenceIdentity(candidate, Version: null, Culture: null, PublicKeyToken: null);
+                if (_context.Resolve(identity, AssemblyResolutionScope.Platform) is not { } candidateAssembly)
                     continue;
-                if (LocateFrom(start, fullName, AssemblyResolutionScope.Platform) is { } located)
+                if (LocateFrom(candidateAssembly, fullName, AssemblyResolutionScope.Platform) is { } located)
                     return located;
             }
             return null;
         }
 
         var scope = ScopeFor(type.Assembly);
-        if (_context.Locator(type.Assembly, scope) is not { } startPath || !File.Exists(startPath))
+        if (_context.Resolve(IdentityFor(type.Assembly), scope) is not { } start)
             return null;
-        return LocateFrom(startPath, fullName, scope);
+        return LocateFrom(start, fullName, scope);
     }
 
-    TypeLocation? LocateFrom(string startPath, string fullName, AssemblyResolutionScope scope)
+    TypeLocation? LocateFrom(ResolvedAssemblyReference start, string fullName, AssemblyResolutionScope scope)
     {
-        if (_context.Open(startPath) is { } assembly && assembly.TryGetType(fullName, out _))
-            return new TypeLocation(startPath, fullName);
-        return TypeForwardResolver.LocateType(startPath, fullName, _context.Locator, scope: scope);
+        if (_context.Open(TypeLocation.From(start, fullName)) is { } assembly && assembly.TryGetType(fullName, out _))
+            return TypeLocation.From(start, fullName);
+        return TypeForwardResolver.LocateType(start, fullName, _context.Resolver, scope: scope);
     }
 
     AssemblyResolutionScope ScopeFor(string simpleName)
@@ -551,9 +552,20 @@ internal sealed class CrossAssemblyTypeResolver
         return AssemblyResolutionScope.Any;
     }
 
+    AssemblyReferenceIdentity IdentityFor(string simpleName)
+    {
+        foreach (var handle in _selfReader.AssemblyReferences)
+        {
+            var identity = AssemblyReferenceIdentity.From(_selfReader, handle);
+            if (string.Equals(identity.Name, simpleName, StringComparison.OrdinalIgnoreCase))
+                return identity;
+        }
+        return new AssemblyReferenceIdentity(simpleName, Version: null, Culture: null, PublicKeyToken: null);
+    }
+
     ValueTypeHint ReadValueTypeHint(TypeLocation location)
     {
-        if (_context.Open(location.AssemblyPath) is not { } assembly)
+        if (_context.Open(location) is not { } assembly)
             return ValueTypeHint.Unknown;
         if (!assembly.TryGetType(location.FullTypeName, out var handle))
             return ValueTypeHint.Unknown;
@@ -569,7 +581,7 @@ internal sealed class CrossAssemblyTypeResolver
 
     MetadataFactState ReadInlineArrayFact(TypeLocation location)
     {
-        if (_context.Open(location.AssemblyPath) is not { } assembly)
+        if (_context.Open(location) is not { } assembly)
             return MetadataFactState.Unknown;
         if (!assembly.TryGetType(location.FullTypeName, out var handle))
             return MetadataFactState.Unknown;

--- a/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
@@ -6,7 +6,7 @@ namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
 /// The multi-assembly resolution environment a decompile session reads through:
-/// an <see cref="AssemblyLocator"/> plus a pool of assemblies opened on demand.
+/// an <see cref="IAssemblyReferenceResolver"/> plus a pool of assemblies opened on demand.
 /// Where <see cref="MetadataSource"/> owns the readers for the ONE assembly being
 /// decompiled, this owns the readers for every OTHER assembly consulted while
 /// recovering cross-assembly facts (value-type-ness of a bare token, interface
@@ -31,11 +31,23 @@ namespace ILInspector.Decompiler.Pipeline;
 public sealed class MetadataContext : IDisposable
 {
     readonly Dictionary<string, OpenedAssembly?> _opened = new(StringComparer.OrdinalIgnoreCase);
+    readonly Dictionary<string, OpenedAssembly?> _openedLocations = new(StringComparer.Ordinal);
 
-    public MetadataContext(AssemblyLocator locator) => Locator = locator;
+    public MetadataContext(AssemblyLocator locator)
+        : this(locator.ToAssemblyReferenceResolver())
+    {
+    }
+
+    public MetadataContext(IAssemblyReferenceResolver resolver)
+    {
+        Resolver = resolver;
+        Locator = resolver.ToAssemblyLocator();
+    }
 
     /// <summary>Resolves a referenced assembly name to an on-disk path.</summary>
     internal AssemblyLocator Locator { get; }
+
+    internal IAssemblyReferenceResolver Resolver { get; }
 
     /// <summary>
     /// Returns the cached reader for an on-disk assembly, opening it on first
@@ -52,11 +64,29 @@ public sealed class MetadataContext : IDisposable
         return opened;
     }
 
+    internal OpenedAssembly? Open(TypeLocation location)
+    {
+        if (location.AssemblyPath is { Length: > 0 } path)
+            return Open(path);
+
+        if (_openedLocations.TryGetValue(location.AssemblyKey, out var cached))
+            return cached;
+        var opened = OpenedAssembly.TryOpen(location.OpenRead);
+        _openedLocations[location.AssemblyKey] = opened;
+        return opened;
+    }
+
+    internal ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+        => Resolver.Resolve(identity, scope);
+
     public void Dispose()
     {
         foreach (var opened in _opened.Values)
             opened?.Dispose();
+        foreach (var opened in _openedLocations.Values)
+            opened?.Dispose();
         _opened.Clear();
+        _openedLocations.Clear();
     }
 }
 
@@ -68,11 +98,11 @@ public sealed class MetadataContext : IDisposable
 /// </summary>
 internal sealed class OpenedAssembly : IDisposable
 {
-    readonly FileStream _stream;
+    readonly Stream _stream;
     readonly PEReader _pe;
     Dictionary<string, TypeDefinitionHandle>? _byFullName;
 
-    OpenedAssembly(FileStream stream, PEReader pe, MetadataReader reader)
+    OpenedAssembly(Stream stream, PEReader pe, MetadataReader reader)
     {
         _stream = stream;
         _pe = pe;
@@ -86,12 +116,15 @@ internal sealed class OpenedAssembly : IDisposable
     /// carries no managed metadata, or cannot be read.
     /// </summary>
     public static OpenedAssembly? TryOpen(string path)
+        => TryOpen(() => File.OpenRead(path));
+
+    public static OpenedAssembly? TryOpen(Func<Stream> openRead)
     {
-        FileStream? stream = null;
+        Stream? stream = null;
         PEReader? pe = null;
         try
         {
-            stream = File.OpenRead(path);
+            stream = openRead();
             pe = new PEReader(stream);
             if (!pe.HasMetadata)
             {

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -17,7 +17,7 @@ public sealed class MetadataSource : IDisposable
 {
     static readonly TypeRef s_enumerable = TypeRef.CoreLib("System.Collections", "IEnumerable");
 
-    readonly FileStream _stream;
+    readonly Stream _stream;
     MetadataReaderProvider? _pdbProvider;
     MetadataReader? _pdbReader;
     bool _pdbProbed;
@@ -25,12 +25,13 @@ public sealed class MetadataSource : IDisposable
     readonly string? _externalPdbPath;
     readonly bool _readSymbols;
     readonly AssemblyLocator _locator;
+    readonly IAssemblyReferenceResolver _resolver;
     readonly MetadataContext? _suppliedContext;
     MetadataContext? _crossContext;
     bool _ownsCrossContext;
     CrossAssemblyTypeResolver? _crossAssembly;
 
-    MetadataSource(string path, FileStream stream, PEReader peReader, MetadataReader reader, string assemblyName, string? externalPdbPath, bool readSymbols, AssemblyLocator locator, MetadataContext? context)
+    MetadataSource(string path, Stream stream, PEReader peReader, MetadataReader reader, string assemblyName, string? externalPdbPath, bool readSymbols, AssemblyLocator locator, IAssemblyReferenceResolver resolver, MetadataContext? context)
     {
         Path = path;
         _stream = stream;
@@ -40,6 +41,7 @@ public sealed class MetadataSource : IDisposable
         _externalPdbPath = externalPdbPath;
         _readSymbols = readSymbols;
         _locator = locator;
+        _resolver = resolver;
         _suppliedContext = context;
     }
 
@@ -87,7 +89,13 @@ public sealed class MetadataSource : IDisposable
     /// borrowed — the caller owns its disposal.
     /// </summary>
     public static MetadataSource Open(string path, string? externalPdbPath = null, AssemblyLocator? locator = null, MetadataContext? context = null)
-        => OpenCore(path, externalPdbPath, readSymbols: true, locator, context);
+        => OpenCore(path, externalPdbPath, readSymbols: true, locator, resolver: null, context);
+
+    public static MetadataSource Open(string path, string? externalPdbPath, IAssemblyReferenceResolver resolver, MetadataContext? context = null)
+        => OpenCore(path, externalPdbPath, readSymbols: true, locator: null, resolver, context);
+
+    public static MetadataSource Open(ResolvedAssemblyReference assembly, string? externalPdbPath, IAssemblyReferenceResolver resolver, MetadataContext? context = null)
+        => OpenCore(assembly, externalPdbPath, readSymbols: true, resolver, context);
 
     /// <summary>
     /// Opens an assembly without consulting any portable PDB, so local names are
@@ -96,7 +104,13 @@ public sealed class MetadataSource : IDisposable
     /// whether or not a PDB happens to be embedded, sidecar, or downloaded.
     /// </summary>
     public static MetadataSource OpenWithoutSymbols(string path, AssemblyLocator? locator = null, MetadataContext? context = null)
-        => OpenCore(path, externalPdbPath: null, readSymbols: false, locator, context);
+        => OpenCore(path, externalPdbPath: null, readSymbols: false, locator, resolver: null, context);
+
+    public static MetadataSource OpenWithoutSymbols(string path, IAssemblyReferenceResolver resolver, MetadataContext? context = null)
+        => OpenCore(path, externalPdbPath: null, readSymbols: false, locator: null, resolver, context);
+
+    public static MetadataSource OpenWithoutSymbols(ResolvedAssemblyReference assembly, IAssemblyReferenceResolver resolver, MetadataContext? context = null)
+        => OpenCore(assembly, externalPdbPath: null, readSymbols: false, resolver, context);
 
     /// <summary>
     /// Default referenced-assembly probing policy for callers that need to share a
@@ -105,7 +119,7 @@ public sealed class MetadataSource : IDisposable
     /// </summary>
     public static AssemblyLocator DefaultAssemblyLocator(string path) => SiblingLocator(path);
 
-    static MetadataSource OpenCore(string path, string? externalPdbPath, bool readSymbols, AssemblyLocator? locator, MetadataContext? context)
+    static MetadataSource OpenCore(string path, string? externalPdbPath, bool readSymbols, AssemblyLocator? locator, IAssemblyReferenceResolver? resolver, MetadataContext? context)
     {
         var stream = File.OpenRead(path);
         PEReader? peReader = null;
@@ -118,7 +132,33 @@ public sealed class MetadataSource : IDisposable
             string assemblyName = reader.IsAssembly
                 ? reader.GetString(reader.GetAssemblyDefinition().Name)
                 : System.IO.Path.GetFileNameWithoutExtension(path);
-            return new MetadataSource(path, stream, peReader, reader, assemblyName, externalPdbPath, readSymbols, locator ?? DefaultAssemblyLocator(path), context);
+            var effectiveLocator = locator ?? DefaultAssemblyLocator(path);
+            var effectiveResolver = resolver ?? effectiveLocator.ToAssemblyReferenceResolver();
+            return new MetadataSource(path, stream, peReader, reader, assemblyName, externalPdbPath, readSymbols, effectiveLocator, effectiveResolver, context);
+        }
+        catch
+        {
+            peReader?.Dispose();
+            stream.Dispose();
+            throw;
+        }
+    }
+
+    static MetadataSource OpenCore(ResolvedAssemblyReference assembly, string? externalPdbPath, bool readSymbols, IAssemblyReferenceResolver resolver, MetadataContext? context)
+    {
+        var stream = assembly.OpenRead();
+        PEReader? peReader = null;
+        try
+        {
+            peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                throw new BadImageFormatException($"No managed metadata: {assembly.Identity.Name}");
+            var reader = peReader.GetMetadataReader();
+            string assemblyName = reader.IsAssembly
+                ? reader.GetString(reader.GetAssemblyDefinition().Name)
+                : assembly.Identity.Name;
+            string path = assembly.Path ?? assembly.Identity.Name;
+            return new MetadataSource(path, stream, peReader, reader, assemblyName, externalPdbPath, readSymbols, resolver.ToAssemblyLocator(), resolver, context);
         }
         catch
         {
@@ -172,7 +212,7 @@ public sealed class MetadataSource : IDisposable
         {
             if (_crossContext is null)
             {
-                _crossContext = _suppliedContext ?? new MetadataContext(_locator);
+                _crossContext = _suppliedContext ?? new MetadataContext(_resolver);
                 _ownsCrossContext = _suppliedContext is null;
             }
             return _crossContext;

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -19,30 +19,55 @@ public static class TypeSourceComposer
 {
     public static string? Compose(ApiType type, string dllPath, string? pdbPath, AssemblyLocator? locateAssembly = null, Pipeline.MetadataContext? context = null)
     {
+        locateAssembly ??= SiblingLocator(dllPath);
+        return ComposeCore(
+            type,
+            dllPath,
+            pdbPath,
+            () => TypeForwardResolver.LocateType(dllPath, type.FullName, locateAssembly),
+            (location, ctx) => location.AssemblyPath is { } path
+                ? Pipeline.MetadataSource.Open(path, pdbPath, locateAssembly, ctx)
+                : Pipeline.MetadataSource.Open(location.ToResolvedAssemblyReference(), pdbPath, locateAssembly.ToAssemblyReferenceResolver(), ctx),
+            context);
+    }
+
+    public static string? Compose(ApiType type, string dllPath, string? pdbPath, IAssemblyReferenceResolver resolver, Pipeline.MetadataContext? context = null)
+    {
+        var start = new ResolvedAssemblyReference(
+            new AssemblyReferenceIdentity(Path.GetFileNameWithoutExtension(dllPath), Version: null, Culture: null, PublicKeyToken: null),
+            dllPath,
+            () => File.OpenRead(dllPath),
+            Provenance: "StartAssembly");
+        return ComposeCore(
+            type,
+            dllPath,
+            pdbPath,
+            () => TypeForwardResolver.LocateType(start, type.FullName, resolver),
+            (location, ctx) => Pipeline.MetadataSource.Open(location.ToResolvedAssemblyReference(), pdbPath, resolver, ctx),
+            context);
+    }
+
+    static string? ComposeCore(
+        ApiType type,
+        string dllPath,
+        string? pdbPath,
+        Func<TypeLocation?> locateType,
+        Func<TypeLocation, Pipeline.MetadataContext?, Pipeline.MetadataSource> openPipelineSource,
+        Pipeline.MetadataContext? context)
+    {
         if (type.Kind is "delegate")
             return null;
 
         try
         {
-            // Follow type forwarders (ref/facade assemblies) to the assembly
-            // that actually defines the type. Default policy: implementations
-            // sit alongside the starting assembly.
-            locateAssembly ??= (name, scope) =>
-            {
-                if (scope == AssemblyResolutionScope.Platform)
-                    return null;
-
-                string sibling = Path.Combine(Path.GetDirectoryName(dllPath)!, name + ".dll");
-                return File.Exists(sibling) ? sibling : null;
-            };
-            if (TypeForwardResolver.LocateType(dllPath, type.FullName, locateAssembly) is not { } location)
+            if (locateType() is not { } location)
                 return null;
 
-            FileStream? stream = null;
+            Stream? stream = null;
             PEReader? peReader = null;
             try
             {
-                stream = File.OpenRead(location.AssemblyPath);
+                stream = location.OpenRead();
                 peReader = new PEReader(stream);
                 MetadataReader reader = peReader.GetMetadataReader();
 
@@ -58,58 +83,58 @@ public static class TypeSourceComposer
                 if (typeHandle.IsNil)
                     return null;
 
-            // Bodies are decompiled from the same on-disk assembly the
-            // forwarder resolved to. The same locator resolves cross-assembly
-            // type facts (value-type-ness of a bare token) during import. A
-            // shared context (when a batch caller supplies one) opens each
-            // referenced assembly once across many composed types.
-            using var pipelineSource = Pipeline.MetadataSource.Open(location.AssemblyPath, locator: locateAssembly, context: context);
-            var union = TryUnionDeclaration(reader, typeHandle, type);
+                    // Bodies are decompiled from the same on-disk assembly the
+                    // forwarder resolved to. The same resolver resolves cross-assembly
+                    // type facts (value-type-ness of a bare token) during import. A
+                    // shared context (when a batch caller supplies one) opens each
+                    // referenced assembly once across many composed types.
+                    using var pipelineSource = openPipelineSource(location, context);
+                    var union = TryUnionDeclaration(reader, typeHandle, type);
 
-            var sb = new StringBuilder();
-            if (!string.IsNullOrEmpty(type.Namespace))
-            {
-                sb.AppendLine($"namespace {type.Namespace};");
-                sb.AppendLine();
-            }
+                    var sb = new StringBuilder();
+                    if (!string.IsNullOrEmpty(type.Namespace))
+                    {
+                        sb.AppendLine($"namespace {type.Namespace};");
+                        sb.AppendLine();
+                    }
 
-            // The printer renders every type with its simple name, so there is
-            // no namespace prefix for HoistUsings to strip into a directive. The
-            // bodies' namespaces are collected straight from the typed IR
-            // instead and seeded into the using block; attribute namespaces
-            // join them so the short attribute names resolve.
-            var bodyNamespaces = new SortedSet<string>(StringComparer.Ordinal);
+                    // The printer renders every type with its simple name, so there is
+                    // no namespace prefix for HoistUsings to strip into a directive. The
+                    // bodies' namespaces are collected straight from the typed IR
+                    // instead and seeded into the using block; attribute namespaces
+                    // join them so the short attribute names resolve.
+                    var bodyNamespaces = new SortedSet<string>(StringComparer.Ordinal);
 
-            if (union is not null)
-                AddTypeNamespaces(bodyNamespaces, union.CaseTypes);
+                    if (union is not null)
+                        AddTypeNamespaces(bodyNamespaces, union.CaseTypes);
 
-            var typeDef = reader.GetTypeDefinition(typeHandle);
-            foreach (var attribute in LayoutAttributes(type, typeDef, bodyNamespaces))
-                sb.AppendLine($"[{attribute}]");
+                    var typeDef = reader.GetTypeDefinition(typeHandle);
+                    foreach (var attribute in LayoutAttributes(type, typeDef, bodyNamespaces))
+                        sb.AppendLine($"[{attribute}]");
 
-            foreach (var attribute in AttributeReader.RenderAttributes(reader, typeDef.GetCustomAttributes(), bodyNamespaces,
-                         union is null ? null : name => name == KnownAttributeNames.UnionAttribute))
-                sb.AppendLine($"[{attribute}]");
+                    foreach (var attribute in AttributeReader.RenderAttributes(reader, typeDef.GetCustomAttributes(), bodyNamespaces,
+                                 union is null ? null : name => name == KnownAttributeNames.UnionAttribute))
+                        sb.AppendLine($"[{attribute}]");
 
-            sb.AppendLine(TypeDeclaration(type, union));
-            sb.AppendLine("{");
+                    sb.AppendLine(TypeDeclaration(type, union));
+                    sb.AppendLine("{");
 
-            bool any = union is not null;
-            if (type.Kind == "enum")
-            {
-                ComposeEnumValues(sb, type, ref any);
-            }
-            else
-            {
-                ComposeFields(sb, reader, typeHandle, bodyNamespaces,
-                    CollectFieldInitializers(pipelineSource, type.FullName, reader, typeHandle), ref any);
-                ComposeMembers(sb, type, pipelineSource, reader, typeHandle, union, bodyNamespaces, ref any);
-            }
+                    bool any = union is not null;
+                    if (type.Kind == "enum")
+                    {
+                        ComposeEnumValues(sb, type, ref any);
+                    }
+                    else
+                    {
+                        ComposeFields(sb, reader, typeHandle, bodyNamespaces,
+                            CollectFieldInitializers(pipelineSource, type.FullName, reader, typeHandle), ref any);
+                        ComposeMembers(sb, type, pipelineSource, reader, typeHandle, union, bodyNamespaces, ref any);
+                    }
 
-            sb.AppendLine("}");
-            if (!any)
-                return null;
-            return HoistUsings(sb.ToString().TrimEnd(), reader, type.Namespace, bodyNamespaces);
+                    sb.AppendLine("}");
+                    if (!any)
+                        return null;
+                    return HoistUsings(sb.ToString().TrimEnd(), reader, type.Namespace, bodyNamespaces);
             }
             finally
             {
@@ -124,6 +149,15 @@ public static class TypeSourceComposer
             return $"// {DiagnosticIds.InternalError}: type source unavailable: {ex.GetType().Name}: {ex.Message}";
         }
     }
+
+    static AssemblyLocator SiblingLocator(string dllPath) => (name, scope) =>
+    {
+        if (scope == AssemblyResolutionScope.Platform)
+            return null;
+
+        string sibling = Path.Combine(Path.GetDirectoryName(dllPath)!, name + ".dll");
+        return File.Exists(sibling) ? sibling : null;
+    };
 
     sealed record UnionDeclarationInfo(
         IReadOnlyList<string> CaseTypes,

--- a/src/ILInspector.Metadata/AssemblyReferenceIdentity.cs
+++ b/src/ILInspector.Metadata/AssemblyReferenceIdentity.cs
@@ -76,4 +76,22 @@ public static class AssemblyReferenceResolverExtensions
                 ? null
                 : throw new NotSupportedException("AssemblyLocator requires a file-backed resolver result."));
         };
+
+    public static IAssemblyReferenceResolver ToAssemblyReferenceResolver(this AssemblyLocator locator)
+        => new AssemblyLocatorReferenceResolver(locator);
+
+    sealed class AssemblyLocatorReferenceResolver(AssemblyLocator locator) : IAssemblyReferenceResolver
+    {
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+        {
+            if (locator(identity.Name, scope) is not { } path)
+                return null;
+
+            return new ResolvedAssemblyReference(
+                identity,
+                path,
+                () => File.OpenRead(path),
+                Provenance: "AssemblyLocator");
+        }
+    }
 }

--- a/src/ILInspector.Metadata/TypeForwardResolver.cs
+++ b/src/ILInspector.Metadata/TypeForwardResolver.cs
@@ -27,7 +27,44 @@ public enum AssemblyResolutionScope
 public delegate string? AssemblyLocator(string assemblyName, AssemblyResolutionScope scope);
 
 /// <summary>Where a type is actually defined after following forwarders.</summary>
-public sealed record TypeLocation(string AssemblyPath, string FullTypeName);
+public sealed record TypeLocation(
+    string? AssemblyPath,
+    string FullTypeName,
+    Func<Stream> OpenRead,
+    string AssemblyKey,
+    AssemblyReferenceIdentity? Identity = null,
+    string? Provenance = null)
+{
+    public TypeLocation(string assemblyPath, string fullTypeName)
+        : this(
+            assemblyPath,
+            fullTypeName,
+            () => File.OpenRead(assemblyPath),
+            Path.GetFullPath(assemblyPath),
+            new AssemblyReferenceIdentity(Path.GetFileNameWithoutExtension(assemblyPath), Version: null, Culture: null, PublicKeyToken: null),
+            Provenance: "Path")
+    {
+    }
+
+    public static TypeLocation From(ResolvedAssemblyReference assembly, string fullTypeName)
+        => new(assembly.Path, fullTypeName, assembly.OpenRead, AssemblyKeyFor(assembly), assembly.Identity, assembly.Provenance);
+
+    public ResolvedAssemblyReference ToResolvedAssemblyReference()
+        => new(
+            Identity ?? new AssemblyReferenceIdentity(
+                AssemblyPath is { Length: > 0 } path ? Path.GetFileNameWithoutExtension(path) : AssemblyKey,
+                Version: null,
+                Culture: null,
+                PublicKeyToken: null),
+            AssemblyPath,
+            OpenRead,
+            Provenance);
+
+    internal static string AssemblyKeyFor(ResolvedAssemblyReference assembly)
+        => assembly.Path is { Length: > 0 } path
+            ? Path.GetFullPath(path)
+            : $"{assembly.Identity.Name}|{assembly.Identity.Version}|{assembly.Identity.Culture}|{assembly.Identity.PublicKeyToken}|{assembly.Provenance}";
+}
 
 /// <summary>
 /// Type-forwarder resolution: the mechanism (ExportedTypes traversal, hop
@@ -71,6 +108,46 @@ public static class TypeForwardResolver
             if (locateAssembly(targetAssembly, scope) is not { } next || !File.Exists(next))
                 return null;
             current = next;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves the assembly that defines <paramref name="fullTypeName"/>,
+    /// starting at a resolved assembly descriptor and following type forwarders
+    /// through <paramref name="resolver"/>. Uses <see cref="ResolvedAssemblyReference.OpenRead"/>
+    /// so callers are not required to expose file paths.
+    /// </summary>
+    public static TypeLocation? LocateType(
+        ResolvedAssemblyReference assembly, string fullTypeName, IAssemblyReferenceResolver resolver,
+        int maxHops = 8, AssemblyResolutionScope scope = AssemblyResolutionScope.Any)
+    {
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var current = assembly;
+
+        for (int hop = 0; hop <= maxHops; hop++)
+        {
+            if (!visited.Add(VisitKey(current)))
+                return null;
+
+            if (TryReadMetadata(current.OpenRead, out var reader, out var peReader, out var stream))
+            {
+                using (stream)
+                using (peReader)
+                {
+                    if (FindTypeDefinition(reader, fullTypeName) is { IsNil: false })
+                        return TypeLocation.From(current, fullTypeName);
+
+                    if (ForwardTargetAssemblyIdentity(reader, fullTypeName) is not { } targetAssembly)
+                        return null;
+                    if (resolver.Resolve(targetAssembly, scope) is not { } next)
+                        return null;
+                    current = next;
+                }
+                continue;
+            }
+
+            return null;
         }
         return null;
     }
@@ -125,6 +202,10 @@ public static class TypeForwardResolver
 
     /// <summary>The assembly-reference simple name a forwarder for <paramref name="fullTypeName"/> points at, or null (exact-name match, one hop).</summary>
     public static string? ForwardTargetAssembly(MetadataReader reader, string fullTypeName)
+        => ForwardTargetAssemblyIdentity(reader, fullTypeName)?.Name;
+
+    /// <summary>The assembly-reference identity a forwarder for <paramref name="fullTypeName"/> points at, or null (exact-name match, one hop).</summary>
+    public static AssemblyReferenceIdentity? ForwardTargetAssemblyIdentity(MetadataReader reader, string fullTypeName)
     {
         foreach (var handle in reader.ExportedTypes)
         {
@@ -135,8 +216,7 @@ public static class TypeForwardResolver
                 continue;
             if (exported.Implementation.Kind == HandleKind.AssemblyReference)
             {
-                var assembly = reader.GetAssemblyReference((AssemblyReferenceHandle)exported.Implementation);
-                return reader.GetString(assembly.Name);
+                return AssemblyReferenceIdentity.From(reader, (AssemblyReferenceHandle)exported.Implementation);
             }
         }
         return null;
@@ -159,4 +239,37 @@ public static class TypeForwardResolver
         string nameText = reader.GetString(name);
         return nsText.Length == 0 ? nameText : $"{nsText}.{nameText}";
     }
+
+    static bool TryReadMetadata(Func<Stream> openRead, out MetadataReader reader, out PEReader peReader, out Stream stream)
+    {
+        reader = null!;
+        peReader = null!;
+        stream = null!;
+        try
+        {
+            stream = openRead();
+            peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+            {
+                peReader.Dispose();
+                stream.Dispose();
+                peReader = null!;
+                stream = null!;
+                return false;
+            }
+            reader = peReader.GetMetadataReader();
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+        {
+            peReader?.Dispose();
+            stream?.Dispose();
+            peReader = null!;
+            stream = null!;
+            return false;
+        }
+    }
+
+    static string VisitKey(ResolvedAssemblyReference assembly)
+        => TypeLocation.AssemblyKeyFor(assembly);
 }

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -492,14 +492,16 @@ public class ApiCommand
     /// they forward to at runtime).
     /// </summary>
     internal static ILInspector.Metadata.AssemblyLocator PlatformAssemblyLocator(string startingDll)
+        => PlatformAssemblyResolver(startingDll).ToAssemblyLocator();
+
+    internal static AssemblyDependencyResolver PlatformAssemblyResolver(string startingDll)
     {
-        var resolver = new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(startingDll)
+        return new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(startingDll)
         {
             IncludeDepsJsonAssets = false,
             IncludeAspNetCoreSharedFramework = false,
             PreferImplementationAssemblies = true,
         });
-        return resolver.ToAssemblyLocator();
     }
 
     internal sealed record ResolvedMethodSource(MethodSourceContext? Source, string? PdbPath);
@@ -763,8 +765,10 @@ public class ApiCommand
             && options.IncludeSections is { Count: > 0 }
             && GetRequestedMemberSections(type, options).Contains(SectionNames.DecompiledSource))
         {
+            var resolver = PlatformAssemblyResolver(typeDllPath);
+            using var metadata = new Decompiler.Pipeline.MetadataContext(resolver);
             var listing = Decompiler.TypeSourceComposer.Compose(
-                type, typeDllPath, options.PdbPath, PlatformAssemblyLocator(typeDllPath));
+                type, typeDllPath, options.PdbPath, resolver, metadata);
             if (listing is not null)
             {
                 view.MemberCode ??= new MemberCodeView();

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -292,7 +292,7 @@ internal static class MemberCodeProvider
                 IncludeAspNetCoreSharedFramework = false,
                 PreferImplementationAssemblies = true,
             });
-            return Decompiler.Pipeline.MetadataSource.Open(dllPath, pdbPath, resolver.ToAssemblyLocator());
+            return Decompiler.Pipeline.MetadataSource.Open(dllPath, pdbPath, resolver);
         }
         catch
         {

--- a/tests/ILInspector.Metadata.Tests/TypeForwardResolverTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeForwardResolverTests.cs
@@ -31,7 +31,26 @@ public class TypeForwardResolverTests
 
         Assert.NotNull(location);
         Assert.NotEqual(NetstandardFacade, location.AssemblyPath);
-        Assert.True(TypeForwardResolver.DefinesType(location.AssemblyPath, "System.Collections.Generic.List`1"));
+        Assert.True(TypeForwardResolver.DefinesType(location.AssemblyPath!, "System.Collections.Generic.List`1"));
+    }
+
+    [Fact]
+    public void LocateType_ResolverOverload_FollowsForwarderThroughOpenReadWithoutPath()
+    {
+        var start = new ResolvedAssemblyReference(
+            new AssemblyReferenceIdentity("netstandard", Version: null, Culture: null, PublicKeyToken: null),
+            Path: null,
+            OpenRead: () => File.OpenRead(NetstandardFacade),
+            Provenance: "test");
+        var resolver = new FrameworkStreamResolver();
+
+        var location = TypeForwardResolver.LocateType(
+            start, "System.Collections.Generic.List`1", resolver);
+
+        Assert.NotNull(location);
+        Assert.Null(location.AssemblyPath);
+        using var stream = location.OpenRead();
+        Assert.True(stream.CanRead);
     }
 
     [Fact]
@@ -71,5 +90,16 @@ public class TypeForwardResolverTests
 
         Assert.False(TypeForwardResolver.DefinesType(NetstandardFacade, "System.String"));
         Assert.True(TypeForwardResolver.ForwardsType(NetstandardFacade, "System.String"));
+    }
+
+    sealed class FrameworkStreamResolver : IAssemblyReferenceResolver
+    {
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+        {
+            string candidate = Path.Combine(FrameworkDir, identity.Name + ".dll");
+            return File.Exists(candidate)
+                ? new ResolvedAssemblyReference(identity, Path: null, OpenRead: () => File.OpenRead(candidate), Provenance: "test")
+                : null;
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds resolver-native type-forwarder resolution using `ResolvedAssemblyReference.OpenRead`.
- Updates `MetadataContext` and `CrossAssemblyTypeResolver` to resolve/open assembly descriptors instead of path-only locator results.
- Adds descriptor-backed `MetadataSource.Open` and a resolver-native `TypeSourceComposer.Compose` overload, then wires product member/whole-type decompiler source paths through the resolver directly.

Follow-up to #2054, #2061, #2066, and #2052.

## Shape

This preserves path-based compatibility:

```csharp
AssemblyLocator(string assemblyName, AssemblyResolutionScope scope) -> string?
```

while adding descriptor-native flow:

```csharp
IAssemblyReferenceResolver.Resolve(identity, scope) -> ResolvedAssemblyReference(Path?, OpenRead, Provenance)
```

`TypeForwardResolver` now has an overload that starts from a `ResolvedAssemblyReference` and follows forwarders by resolving `AssemblyReferenceIdentity` through the resolver. `MetadataContext` keeps path-backed assemblies cached by path and stream-backed assemblies cached by a stable assembly key.

## Examples

### Stream-backed forwarder resolution

`TypeForwardResolver` can now follow a type forwarder without requiring physical paths from the resolver:

```csharp
var location = TypeForwardResolver.LocateType(
    startResolvedAssembly,
    "System.Collections.Generic.List`1",
    resolver);
```

The returned `TypeLocation` carries both `OpenRead` and an optional `AssemblyPath`.

### Product decompiler wiring

Member source now opens `MetadataSource` with the resolver directly:

```csharp
MetadataSource.Open(dllPath, pdbPath, resolver);
```

Whole-type composition now uses a resolver-native overload and a resolver-backed `MetadataContext`:

```csharp
using var metadata = new MetadataContext(resolver);
TypeSourceComposer.Compose(type, typeDllPath, options.PdbPath, resolver, metadata);
```

## Adversarial review

Requested reviews from Claude Opus 4.8 and Gemini 3.1 Pro.

- Claude: no blocking findings. Noted stricter full-identity matching as intended behavior.
- Gemini: found two issues:
  - stream-backed `MetadataContext` cache keyed by full `TypeLocation`, causing per-type/delegate cache misses;
  - whole-type composition still had a path-only requirement.

Resolution:

- Added a stable `AssemblyKey` to `TypeLocation` and cache stream-backed openings by assembly key.
- Added descriptor-backed `MetadataSource.Open` and a resolver-native `TypeSourceComposer.Compose` path used by product whole-type decompilation.

## Validation

- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507`
- `dotnet build src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507`
- `dotnet artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll -class ILInspector.Decompiler.Tests.CrossAssemblyMethodFactsTests`
- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507`
- `dotnet run --project src/dotnet-inspect -c Release -p:NoWarn=NU1507 -- member String ToString:1 --platform System.Private.CoreLib -S "Decompiled Source" -n 1 --plaintext`
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release -p:NoWarn=NU1507`
- `dotnet build tools/DecompilerHarness -c Release -p:NoWarn=NU1507`
- `git diff --check`
