### PR TITLE
Add metadata type-name formatter

### DIFF
--- a/src/ILInspector.Metadata/MetadataTypeNameFormatter.cs
+++ b/src/ILInspector.Metadata/MetadataTypeNameFormatter.cs
@@ -1,0 +1,60 @@
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Metadata-safe type name display helpers: generic arity expansion, namespace
+/// composition, and API-model full names. This deliberately stops short of C#
+/// declaration printing; source-shaped signatures belong to the decompiler.
+/// </summary>
+public static class MetadataTypeNameFormatter
+{
+    public static string FormatFullName(ApiType type)
+        => FormatFullName(type.Namespace, type.Name, type.TypeParameters);
+
+    public static string FormatFullName(string? ns, string name, IReadOnlyList<TypeParameter>? typeParameters = null)
+    {
+        var displayName = FormatGenericTypeName(name, typeParameters);
+        return string.IsNullOrEmpty(ns) ? displayName : $"{ns}.{displayName}";
+    }
+
+    public static string FormatGenericTypeName(string name, IReadOnlyList<TypeParameter>? typeParameters = null)
+    {
+        if (!name.Contains('`', StringComparison.Ordinal))
+            return name;
+
+        var typeParameterIndex = 0;
+        var segments = name.Split('.');
+        for (var i = 0; i < segments.Length; i++)
+            segments[i] = FormatGenericTypeNameSegment(segments[i], typeParameters, ref typeParameterIndex);
+
+        return string.Join(".", segments);
+    }
+
+    static string FormatGenericTypeNameSegment(
+        string name,
+        IReadOnlyList<TypeParameter>? typeParameters,
+        ref int typeParameterIndex)
+    {
+        int backtickIndex = name.IndexOf('`');
+        if (backtickIndex < 0)
+            return name;
+
+        var baseName = name[..backtickIndex];
+        if (!int.TryParse(name[(backtickIndex + 1)..], out int arity) || arity <= 0)
+            return name;
+
+        if (typeParameters is { Count: > 0 } && typeParameterIndex + arity <= typeParameters.Count)
+        {
+            var names = typeParameters
+                .Skip(typeParameterIndex)
+                .Take(arity)
+                .Select(tp => tp.Name);
+            typeParameterIndex += arity;
+            return $"{baseName}<{string.Join(", ", names)}>";
+        }
+
+        var fallbackNames = arity == 1
+            ? "T"
+            : string.Join(", ", Enumerable.Range(1, arity).Select(i => $"T{i}"));
+        return $"{baseName}<{fallbackNames}>";
+    }
+}

--- a/src/ILInspector.Metadata/MetadataTypeNameFormatter.cs
+++ b/src/ILInspector.Metadata/MetadataTypeNameFormatter.cs
@@ -21,40 +21,8 @@ public static class MetadataTypeNameFormatter
         if (!name.Contains('`', StringComparison.Ordinal))
             return name;
 
-        var typeParameterIndex = 0;
-        var segments = name.Split('.');
-        for (var i = 0; i < segments.Length; i++)
-            segments[i] = FormatGenericTypeNameSegment(segments[i], typeParameters, ref typeParameterIndex);
-
-        return string.Join(".", segments);
-    }
-
-    static string FormatGenericTypeNameSegment(
-        string name,
-        IReadOnlyList<TypeParameter>? typeParameters,
-        ref int typeParameterIndex)
-    {
-        int backtickIndex = name.IndexOf('`');
-        if (backtickIndex < 0)
-            return name;
-
-        var baseName = name[..backtickIndex];
-        if (!int.TryParse(name[(backtickIndex + 1)..], out int arity) || arity <= 0)
-            return name;
-
-        if (typeParameters is { Count: > 0 } && typeParameterIndex + arity <= typeParameters.Count)
-        {
-            var names = typeParameters
-                .Skip(typeParameterIndex)
-                .Take(arity)
-                .Select(tp => tp.Name);
-            typeParameterIndex += arity;
-            return $"{baseName}<{string.Join(", ", names)}>";
-        }
-
-        var fallbackNames = arity == 1
-            ? "T"
-            : string.Join(", ", Enumerable.Range(1, arity).Select(i => $"T{i}"));
-        return $"{baseName}<{fallbackNames}>";
+        return typeParameters is { Count: > 0 }
+            ? TypeResolver.ApplyGenericArguments(name, typeParameters.Select(tp => tp.Name).ToArray())
+            : TypeResolver.FormatDisplayName(name);
     }
 }

--- a/src/dotnet-inspect/Inspectors/SourceFileCollector.cs
+++ b/src/dotnet-inspect/Inspectors/SourceFileCollector.cs
@@ -31,7 +31,7 @@ internal static class SourceFileCollector
         {
             foreach (var type in api.Types.OrderBy(t => t.FullName, StringComparer.Ordinal))
             {
-                var typeDisplayName = ApiOutputFormatter.FormatGenericFullName(type);
+                var typeDisplayName = MetadataTypeNameFormatter.FormatFullName(type);
                 if (!string.IsNullOrWhiteSpace(typeFilter)
                     && !TypeMatcher.MatchesTypeFilter(type.FullName, typeFilter)
                     && !TypeMatcher.MatchesTypeFilter(typeDisplayName, typeFilter))

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1946,9 +1946,6 @@ public static class ApiOutputFormatter
             .ToDictionary(g => g.Key, g => g.ToList());
     }
 
-    internal static string FormatGenericTypeName(string name, List<TypeParameter>? typeParameters)
-        => MetadataTypeNameFormatter.FormatGenericTypeName(name, typeParameters);
-
     internal static string FormatGenericFullName(ApiType type)
         => MetadataTypeNameFormatter.FormatFullName(type);
 

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1947,52 +1947,10 @@ public static class ApiOutputFormatter
     }
 
     internal static string FormatGenericTypeName(string name, List<TypeParameter>? typeParameters)
-    {
-        if (!name.Contains('`'))
-            return name;
-
-        var typeParameterIndex = 0;
-        var segments = name.Split('.');
-        for (var i = 0; i < segments.Length; i++)
-            segments[i] = FormatGenericTypeNameSegment(segments[i], typeParameters, ref typeParameterIndex);
-
-        return string.Join(".", segments);
-    }
-
-    private static string FormatGenericTypeNameSegment(
-        string name,
-        List<TypeParameter>? typeParameters,
-        ref int typeParameterIndex)
-    {
-        int backtickIndex = name.IndexOf('`');
-        if (backtickIndex < 0)
-            return name;
-
-        var baseName = name[..backtickIndex];
-        if (!int.TryParse(name[(backtickIndex + 1)..], out int arity) || arity <= 0)
-            return name;
-
-        if (typeParameters is { Count: > 0 } && typeParameterIndex + arity <= typeParameters.Count)
-        {
-            var names = typeParameters
-                .Skip(typeParameterIndex)
-                .Take(arity)
-                .Select(tp => tp.Name);
-            typeParameterIndex += arity;
-            return $"{baseName}<{string.Join(", ", names)}>";
-        }
-
-        var fallbackNames = arity == 1
-            ? "T"
-            : string.Join(", ", Enumerable.Range(1, arity).Select(i => $"T{i}"));
-        return $"{baseName}<{fallbackNames}>";
-    }
+        => MetadataTypeNameFormatter.FormatGenericTypeName(name, typeParameters);
 
     internal static string FormatGenericFullName(ApiType type)
-    {
-        var displayName = FormatGenericTypeName(type.Name, type.TypeParameters);
-        return string.IsNullOrEmpty(type.Namespace) ? displayName : $"{type.Namespace}.{displayName}";
-    }
+        => MetadataTypeNameFormatter.FormatFullName(type);
 
     internal static string GetMemberSignatureSortKey(ApiMember member)
     {

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -343,7 +343,7 @@ public static class SourceResolver
                     else
                     {
                         // Convert backtick notation back to C#-style for display
-                        var displayName = DotnetInspector.Output.ApiOutputFormatter.FormatGenericTypeName(packagePath, null);
+                        var displayName = MetadataTypeNameFormatter.FormatGenericTypeName(packagePath);
                         return new ResolvedSource(
                             packagePath, assemblyPath, platformAssembly, null, null,
                             VersionError: true,

--- a/tests/ILInspector.Metadata.Tests/MetadataTypeNameFormatterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTypeNameFormatterTests.cs
@@ -1,0 +1,51 @@
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class MetadataTypeNameFormatterTests
+{
+    [Fact]
+    public void FormatFullName_UsesApiTypeNamespaceAndGenericParameterNames()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Pair`2",
+            TypeParameters =
+            [
+                new TypeParameter { Name = "TKey" },
+                new TypeParameter { Name = "TValue" }
+            ]
+        };
+
+        Assert.Equal("Samples.Pair<TKey, TValue>", MetadataTypeNameFormatter.FormatFullName(type));
+    }
+
+    [Fact]
+    public void FormatGenericTypeName_ConsumesTypeParametersAcrossNestedSegments()
+    {
+        TypeParameter[] typeParameters =
+        [
+            new() { Name = "TOuter" },
+            new() { Name = "TInnerKey" },
+            new() { Name = "TInnerValue" }
+        ];
+
+        var displayName = MetadataTypeNameFormatter.FormatGenericTypeName("Outer`1.Inner`2", typeParameters);
+
+        Assert.Equal("Outer<TOuter>.Inner<TInnerKey, TInnerValue>", displayName);
+    }
+
+    [Theory]
+    [InlineData("List`1", "List<T>")]
+    [InlineData("Dictionary`2", "Dictionary<T1, T2>")]
+    [InlineData("Outer`1.Inner`2", "Outer<T>.Inner<T1, T2>")]
+    public void FormatGenericTypeName_UsesStableFallbackNamesWhenTypeParametersAreUnavailable(
+        string name,
+        string expected)
+        => Assert.Equal(expected, MetadataTypeNameFormatter.FormatGenericTypeName(name));
+
+    [Fact]
+    public void FormatGenericTypeName_LeavesMalformedArityUnchanged()
+        => Assert.Equal("Bad`x", MetadataTypeNameFormatter.FormatGenericTypeName("Bad`x"));
+}

--- a/tests/ILInspector.Metadata.Tests/MetadataTypeNameFormatterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MetadataTypeNameFormatterTests.cs
@@ -48,4 +48,28 @@ public sealed class MetadataTypeNameFormatterTests
     [Fact]
     public void FormatGenericTypeName_LeavesMalformedArityUnchanged()
         => Assert.Equal("Bad`x", MetadataTypeNameFormatter.FormatGenericTypeName("Bad`x"));
+
+    [Theory]
+    [InlineData("List`1[]", "List<T>[]")]
+    [InlineData("List`1*", "List<T>*")]
+    [InlineData("List`1&", "List<T>&")]
+    public void FormatGenericTypeName_PreservesTypeSuffixesWithoutTypeParameters(
+        string name,
+        string expected)
+        => Assert.Equal(expected, MetadataTypeNameFormatter.FormatGenericTypeName(name));
+
+    [Fact]
+    public void FormatGenericTypeName_PreservesTypeSuffixesWithTypeParameters()
+    {
+        TypeParameter[] typeParameters =
+        [
+            new() { Name = "TOuter" },
+            new() { Name = "TInnerKey" },
+            new() { Name = "TInnerValue" }
+        ];
+
+        var displayName = MetadataTypeNameFormatter.FormatGenericTypeName("Outer`1.Inner`2[]", typeParameters);
+
+        Assert.Equal("Outer<TOuter>.Inner<TInnerKey, TInnerValue>[]", displayName);
+    }
 }


### PR DESCRIPTION
- Advances #2057
- Changes metadata-safe generic type-name display to live in `ILInspector.Metadata`, reducing CLI-owned type-name algorithms.

## Change

**Conclusion:** **PASS** — this is a narrow separation-of-concerns slice: metadata owns generic type-name display/normalization helpers, while C# signature/declaration printing stays out of the CLI.

Before, `ApiOutputFormatter` owned generic `ApiType` display-name logic and non-output services called back into it for type-name rendering.

After, `MetadataTypeNameFormatter` provides metadata-safe type-name display over `ApiType` / `TypeParameter`, delegates generic arity expansion to `TypeResolver`, and is used by:

```text
ApiOutputFormatter
SourceFileCollector
SourceResolver
```

This intentionally does not migrate `SignatureParser` or full signature/declaration printing; those remain follow-up #2057 slices.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507 --nologo --verbosity quiet` |
| Metadata tests | Pass: `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507` |
| CLI tests | Pass: `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Verified behavior preservation, layering, and no C# declaration printing leaked into metadata. |
| Gemini 3.1 Pro | Finding resolved | Found duplicated arity parsing with suffix gaps (`List\`1[]`, pointers, refs) and an unused CLI wrapper. Fixed by delegating to `TypeResolver.FormatDisplayName` / `ApplyGenericArguments`, removing the unused wrapper, and adding suffix tests. |

**Review conclusion:** **PASS** — pre-PR adversarial review found one real robustness issue; it is fixed and covered by tests. A post-PR adversarial review pass is being started as a non-blocking double-check.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507
dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507
```
