### PR TITLE
Add type called types section

### DIFF
--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -645,6 +645,48 @@ public sealed class LibraryBodyIndex
         => MethodLeverageRanking.Top(DirectCalls, Methods, count, scope);
 
     /// <summary>
+    /// Distinct callee types touched by calls from methods in <paramref name="callerScope"/>.
+    /// Callee declaring types are reduced to their open definitions so generic instantiations
+    /// stay bounded and same-type generic self-calls are excluded.
+    /// </summary>
+    public ImmutableArray<CalledTypeSummary> CalledTypes(Func<MethodIdentity, bool> callerScope)
+    {
+        ArgumentNullException.ThrowIfNull(callerScope);
+
+        return
+        [
+            .. DirectCalls
+                .Where(call => callerScope(call.Caller))
+                .Where(call => call.Callee.Kind != MemberKind.Unsupported)
+                .Where(call => !IsObjectConstructor(call.Callee))
+                .Select(call => new
+                {
+                    Call = call,
+                    CalledType = GenericMemberIdentity.OpenDeclaringType(call.Callee.DeclaringType),
+                    CallerType = GenericMemberIdentity.OpenDeclaringType(call.Caller.DeclaringType),
+                    CalleeKey = CallerGraphKey(call.Callee),
+                })
+                .Where(item => !item.CalledType.Equals(item.CallerType))
+                .GroupBy(item => item.CalledType)
+                .Select(group =>
+                {
+                    var type = group.Key;
+                    return new CalledTypeSummary(
+                        type,
+                        FormatCalledTypeAssembly(type.Assembly),
+                        Calls: group.Count(),
+                        Members: group.Select(item => item.CalleeKey).Distinct(StringComparer.Ordinal).Count(),
+                        CallKinds: [.. group
+                            .Select(item => item.Call.Kind)
+                            .Distinct()
+                            .OrderBy(kind => kind)]);
+                })
+                .OrderByDescending(summary => summary.Calls)
+                .ThenBy(summary => summary.Type.ToQualifiedDisplayString(), StringComparer.Ordinal)
+        ];
+    }
+
+    /// <summary>
     /// Requires-unsafe methods whose signature carries no pointer — the unsafe
     /// obligation is visible only via the attribute / <c>unsafe</c> modifier,
     /// hidden from a caller reading the parameter and return types.
@@ -1021,6 +1063,19 @@ public sealed class LibraryBodyIndex
             ? $"{GenericMemberIdentity.KeyFragment(openDeclaring)}|{name}|{parameterTypes.Length}|{GenericMemberIdentity.ErasedParameterShape(openParameterTypes)}|{GenericMemberIdentity.KeyFragment(openReturnType)}"
             : $"{GenericMemberIdentity.KeyFragment(openDeclaring)}|{name}|{parameterTypes.Length}|{string.Join(",", parameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(openReturnType)}";
     }
+
+    static string FormatCalledTypeAssembly(string assembly)
+        => string.IsNullOrEmpty(assembly) || assembly == TypeRef.CoreLibrary ? "" : assembly;
+
+    static bool IsObjectConstructor(MemberRef member)
+        => member is
+        {
+            Name: ".ctor",
+            DeclaringType.Kind: TypeRefKind.Definition,
+            DeclaringType.Assembly: TypeRef.CoreLibrary,
+            DeclaringType.Namespace: "System",
+            DeclaringType.Name: "Object"
+        };
 
     sealed class IndexBuilder
     {

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -135,6 +135,13 @@ public sealed record DirectCall(
     public int? ReturnAddress { get; init; }
 }
 
+public sealed record CalledTypeSummary(
+    TypeRef Type,
+    string Assembly,
+    int Calls,
+    int Members,
+    ImmutableArray<CallKind> CallKinds);
+
 public sealed record UnsafeEvidence(
     MethodIdentity Member,
     string Reason,

--- a/src/dotnet-inspect.Tests/CalledTypesSectionTests.cs
+++ b/src/dotnet-inspect.Tests/CalledTypesSectionTests.cs
@@ -23,6 +23,21 @@ public class CalledTypesSectionTests
     }
 
     [Fact]
+    public async Task TypeCalledTypes_UsesOpenGenericTypesAndExcludesGenericSelfCalls()
+    {
+        var result = await RunCalledTypesAsync(typeof(CalledTypesGenericFixture<>));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Called Types", result.Output);
+        Assert.Contains("`System.Collections.Generic.List`", result.Output);
+        Assert.Contains("| System.Collections | 2 | 1 |", result.Output);
+        Assert.DoesNotContain("`DotnetInspector.Tests.CalledTypesGenericFixture", result.Output);
+        Assert.DoesNotContain("`object`", result.Output);
+        Assert.DoesNotContain("List<int>", result.Output);
+        Assert.DoesNotContain("List<string>", result.Output);
+    }
+
+    [Fact]
     public async Task TypeCalledTypes_TsvUsesPlainAggregateColumns()
     {
         var result = await RunCalledTypesAsync(typeof(CalledTypesFixture), tsv: true);
@@ -91,7 +106,7 @@ public static class CalledTypesFixture
     public static int Second(int value)
     {
         CalledTypesDependency.Touch();
-        CalledTypesDependency.Touch();
+        CalledTypesDependency.TouchOther();
         return Math.Abs(value);
     }
 
@@ -105,9 +120,32 @@ public static class CalledTypesDependency
     public static void Touch()
     {
     }
+
+    public static void TouchOther()
+    {
+    }
 }
 
 public static class CalledTypesEmptyFixture
 {
     public static int Identity(int value) => value;
+}
+
+public sealed class CalledTypesGenericFixture<T>
+{
+    public void First(List<int> values)
+    {
+        values.Add(1);
+        Self();
+    }
+
+    public void Second(List<string> values)
+    {
+        values.Add("x");
+        Self();
+    }
+
+    void Self()
+    {
+    }
 }

--- a/src/dotnet-inspect.Tests/CalledTypesSectionTests.cs
+++ b/src/dotnet-inspect.Tests/CalledTypesSectionTests.cs
@@ -1,0 +1,113 @@
+using DotnetInspector.Commands;
+using DotnetInspector.Options;
+using DotnetInspector.Sections;
+
+namespace DotnetInspector.Tests;
+
+[Collection("Console")]
+public class CalledTypesSectionTests
+{
+    [Fact]
+    public async Task TypeCalledTypes_AggregatesOutboundCalleeTypes()
+    {
+        var result = await RunCalledTypesAsync(typeof(CalledTypesFixture));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Called Types", result.Output);
+        Assert.Contains("| Type | Assembly | Calls | Members | Call Kinds |", result.Output);
+        Assert.Contains("`DotnetInspector.Tests.CalledTypesDependency`", result.Output);
+        Assert.Contains("| dotnet-inspect.Tests | 3 | 2 | direct |", result.Output);
+        Assert.Contains("`System.Console`", result.Output);
+        Assert.Contains("`System.Math`", result.Output);
+        Assert.DoesNotContain("CalledTypesFixture`", result.Output);
+    }
+
+    [Fact]
+    public async Task TypeCalledTypes_TsvUsesPlainAggregateColumns()
+    {
+        var result = await RunCalledTypesAsync(typeof(CalledTypesFixture), tsv: true);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.StartsWith("type\tassembly\tcalls\tmembers\tcall_kinds", result.Output);
+        Assert.DoesNotContain('`', result.Output);
+        Assert.Contains("DotnetInspector.Tests.CalledTypesDependency\tdotnet-inspect.Tests\t3\t2\tdirect", result.Output);
+    }
+
+    [Fact]
+    public async Task TypeCalledTypes_RendersEmptyState_WhenExplicitlySelected()
+    {
+        var result = await RunCalledTypesAsync(typeof(CalledTypesEmptyFixture));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("## Called Types", result.Output);
+        Assert.Contains("No called types found for this type.", result.Output);
+    }
+
+    [Fact]
+    public async Task TypeEffectiveDiscovery_ListsCalledTypesAsOptIn()
+    {
+        var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
+        {
+            TypeName = typeof(CalledTypesFixture).FullName,
+            AssemblyPath = typeof(CalledTypesFixture).Assembly.Location,
+            Discover = [],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            OneLine = true,
+            Tsv = true,
+            OneLineExplicitlySet = true,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Called Types\tsection", result.Output);
+    }
+
+    static Task<(int ExitCode, string Output, string Error)> RunCalledTypesAsync(Type type, bool tsv = false)
+        => ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
+        {
+            TypeName = type.FullName,
+            AssemblyPath = type.Assembly.Location,
+            IncludeSections = [SectionNames.CalledTypes],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            OneLine = tsv,
+            Tsv = tsv,
+            OneLineExplicitlySet = tsv,
+            MarkdownExplicitlySet = !tsv,
+            FormatExplicitlySet = true,
+        }));
+}
+
+public static class CalledTypesFixture
+{
+    public static void First()
+    {
+        CalledTypesDependency.Touch();
+        Console.WriteLine("first");
+        SelfCall();
+    }
+
+    public static int Second(int value)
+    {
+        CalledTypesDependency.Touch();
+        CalledTypesDependency.Touch();
+        return Math.Abs(value);
+    }
+
+    static void SelfCall()
+    {
+    }
+}
+
+public static class CalledTypesDependency
+{
+    public static void Touch()
+    {
+    }
+}
+
+public static class CalledTypesEmptyFixture
+{
+    public static int Identity(int value) => value;
+}

--- a/src/dotnet-inspect.Tests/SectionPipelineTests.cs
+++ b/src/dotnet-inspect.Tests/SectionPipelineTests.cs
@@ -1616,7 +1616,7 @@ public class SectionPipelineTests
     public void ApiMemberPipeline_HasExpectedSectionCount()
     {
         var pipeline = ApiMemberSectionDescriptors.CreatePipeline();
-        Assert.Equal(24, pipeline.AllSectionNames.Length);
+        Assert.Equal(25, pipeline.AllSectionNames.Length);
     }
 
     [Fact]
@@ -1652,6 +1652,7 @@ public class SectionPipelineTests
         Assert.Contains("Decompiled Source", names);
         Assert.Contains("Original Source", names);
         Assert.Contains("Custom Attributes", names);
+        Assert.Contains("Called Types", names);
         Assert.Contains("Top Leverage", names);
     }
 

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -726,6 +726,12 @@ public class ApiCommand
                 ApiOutputFormatter.PopulateTypeExceptionRegions(view, type, exceptionRegionsDllPath, options.IncludeSections);
             }
 
+            if (options.DllPath is { } calledTypesDllPath
+                && GetRequestedMemberSections(type, options).Contains(SectionNames.CalledTypes))
+            {
+                ApiOutputFormatter.PopulateCalledTypes(view, type, calledTypesDllPath, options.IncludeSections);
+            }
+
             if (options.DllPath is { } optimizationDllPath
                 && GetRequestedMemberSections(type, options).Contains(SectionNames.PerformanceTriage))
             {
@@ -1333,6 +1339,12 @@ public class ApiCommand
                     || renderOptions.IncludeSections?.Contains(SectionNames.ExceptionRegions) == true))
             {
                 ApiOutputFormatter.PopulateTypeExceptionRegions(view, type, exceptionRegionsDllPath, renderOptions.IncludeSections);
+            }
+
+            if (renderOptions.DllPath is { } calledTypesDllPath
+                && GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.CalledTypes))
+            {
+                ApiOutputFormatter.PopulateCalledTypes(view, type, calledTypesDllPath, renderOptions.IncludeSections);
             }
 
             if (renderOptions.DllPath is { } optimizationDllPath

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -727,7 +727,8 @@ public class ApiCommand
             }
 
             if (options.DllPath is { } calledTypesDllPath
-                && GetRequestedMemberSections(type, options).Contains(SectionNames.CalledTypes))
+                && (GetRequestedMemberSections(type, options).Contains(SectionNames.CalledTypes)
+                    || options.IncludeSections?.Contains(SectionNames.CalledTypes) == true))
             {
                 ApiOutputFormatter.PopulateCalledTypes(view, type, calledTypesDllPath, options.IncludeSections);
             }
@@ -1342,7 +1343,8 @@ public class ApiCommand
             }
 
             if (renderOptions.DllPath is { } calledTypesDllPath
-                && GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.CalledTypes))
+                && (GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.CalledTypes)
+                    || renderOptions.IncludeSections?.Contains(SectionNames.CalledTypes) == true))
             {
                 ApiOutputFormatter.PopulateCalledTypes(view, type, calledTypesDllPath, renderOptions.IncludeSections);
             }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1661,26 +1661,13 @@ public static class ApiOutputFormatter
         IReadOnlySet<string>? explicitSections = null)
     {
         var index = Analysis.LibraryBodyIndex.Open(dllPath);
-        var rows = index.DirectCalls
-            .Where(call => SameType(call.Caller.DeclaringType, type))
-            .Where(call => call.Callee.Kind != Analysis.MemberKind.Unsupported)
-            .Where(call => !SameType(call.Callee.DeclaringType, type))
-            .GroupBy(call => new
-            {
-                Type = call.Callee.DeclaringType.ToQualifiedDisplayString(),
-                Assembly = FormatCalledTypeAssembly(call.Callee.DeclaringType.Assembly)
-            })
-            .Select(group => new CalledTypeRow(
-                MarkoutInline.Code(group.Key.Type),
-                group.Key.Assembly,
-                group.Count(),
-                group.Select(call => call.Caller.MetadataToken).Distinct().Count(),
-                string.Join(", ", group
-                    .Select(call => FormatCallsiteKind(call.Kind))
-                    .Distinct(StringComparer.Ordinal)
-                    .Order(StringComparer.Ordinal))))
-            .OrderByDescending(row => row.Calls)
-            .ThenBy(row => row.Type, StringComparer.Ordinal)
+        var rows = index.CalledTypes(method => SameType(method.DeclaringType, type))
+            .Select(summary => new CalledTypeRow(
+                MarkoutInline.Code(summary.Type.ToQualifiedDisplayString()),
+                string.IsNullOrEmpty(summary.Assembly) ? null : summary.Assembly,
+                summary.Calls,
+                summary.Members,
+                string.Join(", ", summary.CallKinds.Select(FormatCallsiteKind))))
             .ToList();
 
         if (rows.Count > 0 || explicitSections is not null && explicitSections.Contains(SectionNames.CalledTypes))
@@ -1830,9 +1817,6 @@ public static class ApiOutputFormatter
 
     static string FormatMethod(Analysis.MethodIdentity method)
         => FormatMember(method.DeclaringType, method.Name, method.ParameterTypes, []);
-
-    static string? FormatCalledTypeAssembly(string assembly)
-        => string.IsNullOrEmpty(assembly) || assembly == Analysis.TypeRef.CoreLibrary ? null : assembly;
 
     static CallerSiteRow CreateCallerRow(string source, Analysis.DirectCall call)
         => new(

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1654,6 +1654,39 @@ public static class ApiOutputFormatter
             view.ExceptionRegionRows = rows;
     }
 
+    internal static void PopulateCalledTypes(
+        TypeView view,
+        ApiType type,
+        string dllPath,
+        IReadOnlySet<string>? explicitSections = null)
+    {
+        var index = Analysis.LibraryBodyIndex.Open(dllPath);
+        var rows = index.DirectCalls
+            .Where(call => SameType(call.Caller.DeclaringType, type))
+            .Where(call => call.Callee.Kind != Analysis.MemberKind.Unsupported)
+            .Where(call => !SameType(call.Callee.DeclaringType, type))
+            .GroupBy(call => new
+            {
+                Type = call.Callee.DeclaringType.ToQualifiedDisplayString(),
+                Assembly = FormatCalledTypeAssembly(call.Callee.DeclaringType.Assembly)
+            })
+            .Select(group => new CalledTypeRow(
+                MarkoutInline.Code(group.Key.Type),
+                group.Key.Assembly,
+                group.Count(),
+                group.Select(call => call.Caller.MetadataToken).Distinct().Count(),
+                string.Join(", ", group
+                    .Select(call => FormatCallsiteKind(call.Kind))
+                    .Distinct(StringComparer.Ordinal)
+                    .Order(StringComparer.Ordinal))))
+            .OrderByDescending(row => row.Calls)
+            .ThenBy(row => row.Type, StringComparer.Ordinal)
+            .ToList();
+
+        if (rows.Count > 0 || explicitSections is not null && explicitSections.Contains(SectionNames.CalledTypes))
+            view.CalledTypeRows = rows;
+    }
+
     internal static void PopulateOptimizationOpportunities(
         TypeView view,
         ApiType type,
@@ -1797,6 +1830,9 @@ public static class ApiOutputFormatter
 
     static string FormatMethod(Analysis.MethodIdentity method)
         => FormatMember(method.DeclaringType, method.Name, method.ParameterTypes, []);
+
+    static string? FormatCalledTypeAssembly(string assembly)
+        => string.IsNullOrEmpty(assembly) || assembly == Analysis.TypeRef.CoreLibrary ? null : assembly;
 
     static CallerSiteRow CreateCallerRow(string source, Analysis.DirectCall call)
         => new(

--- a/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
+++ b/src/dotnet-inspect/Sections/ApiSectionDescriptors.cs
@@ -93,6 +93,7 @@ public static class ApiMemberSectionDescriptors
             .Add<MethodAttributes>()
             .Add<UnsafeMembers>()
             .Add<ExceptionRegions>()
+            .Add<CalledTypes>()
             .Add<TopLeverage>()
             .Add<OptimizationOpportunities>()
             .Add<SourceFiles>()
@@ -293,6 +294,17 @@ public static class ApiMemberSectionDescriptors
     public sealed class ExceptionRegions : ISectionDescriptor<ApiType>
     {
         public static string Name => SectionNames.ExceptionRegions;
+        public static bool IsExpensive => false;
+        public static bool ExplicitOnly => true;
+        public static bool ProbeEffectiveness => false;
+        public static string? ScannerKey => null;
+        public static bool CanRender(ApiType model)
+            => model.Members.Any(IsMethodLike);
+    }
+
+    public sealed class CalledTypes : ISectionDescriptor<ApiType>
+    {
+        public static string Name => SectionNames.CalledTypes;
         public static bool IsExpensive => false;
         public static bool ExplicitOnly => true;
         public static bool ProbeEffectiveness => false;

--- a/src/dotnet-inspect/Sections/SectionNames.cs
+++ b/src/dotnet-inspect/Sections/SectionNames.cs
@@ -136,6 +136,9 @@ public static class SectionNames
     /// <summary>Section for callers (reverse call edges) of the selected member within the assembly.</summary>
     public const string Callers = "Callers";
 
+    /// <summary>Type-level aggregate of distinct callee types touched by members on the selected type.</summary>
+    public const string CalledTypes = "Called Types";
+
     /// <summary>Section for the bounded outbound call tree (callees) rooted at the selected member.</summary>
     public const string CallGraph = "Call Graph";
 

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -194,6 +194,10 @@ public class TypeView
     [JsonIgnore]
     public List<TypeExceptionRegionRow>? ExceptionRegionRows { get; set; }
 
+    [MarkoutSection(Name = SectionNames.CalledTypes, EmptyText = "No called types found for this type.")]
+    [JsonIgnore]
+    public List<CalledTypeRow>? CalledTypeRows { get; set; }
+
     [MarkoutSection(Name = "Top Leverage", EmptyText = "No intra-assembly call-graph leverage found for this type.")]
     [MarkoutIgnoreColumnWhen(nameof(TopLeverageVisibilityEmpty), nameof(TopLeverageRow.Visibility))]
     [MarkoutIgnoreColumnWhen(nameof(TopLeverageGeneratedEmpty), nameof(TopLeverageRow.Generated))]
@@ -707,6 +711,7 @@ public partial class TypeViewContext : MarkoutSerializerContext
 [MarkoutContext(typeof(MethodAttributeRow))]
 [MarkoutContext(typeof(UnsafeMemberRow))]
 [MarkoutContext(typeof(TypeExceptionRegionRow))]
+[MarkoutContext(typeof(CalledTypeRow))]
 [MarkoutContext(typeof(TopLeverageRow))]
 [MarkoutContext(typeof(OptimizationOpportunityRow))]
 [MarkoutContext(typeof(ConstructorOverloadView))]
@@ -745,6 +750,14 @@ public record TypeExceptionRegionRow(
     [property: MarkoutSkipNull] string? FilterRange,
     [property: MarkoutPropertyName("Caught Type")]
     [property: MarkoutSkipNull] string? CaughtType);
+
+[MarkoutSerializable]
+public record CalledTypeRow(
+    string Type,
+    [property: MarkoutSkipNull] string? Assembly,
+    int Calls,
+    int Members,
+    [property: MarkoutPropertyName("Call Kinds")] string CallKinds);
 
 [MarkoutSerializable]
 public record ExceptionRegionRow(


### PR DESCRIPTION
## Summary

Adds type-scope `Called Types` as the bounded call overview from the Analysis UX model.

- Answers: "Which other types do members on this type touch?"
- Aggregates outbound member calls by callee type.
- Excludes self-calls, including generic self-calls.
- Collapses constructed generic callees to their open type definition so `List<int>` and `List<string>` stay one bounded row.

Detailed type-scope `Calls` and reverse `Caller Types` are intentionally deferred: `Calls` is noisy drilldown/export surface, while `Caller Types` needs an explicit caller-scope/cost story.

Refs #2058.

## Examples

Type-local outbound aggregate:

```md
## Called Types

| Type | Assembly | Calls | Members | Call Kinds |
| ---- | -------- | ----- | ------- | ---------- |
| `DotnetInspector.Tests.CalledTypesDependency` | dotnet-inspect.Tests | 3 | 2 | direct |
| `System.Console` | System.Console | 1 | 1 | direct |
| `System.Math` |  | 1 | 1 | direct |
```

Generic callees are collapsed to their open type and generic self-calls are excluded:

```md
## Called Types

| Type | Assembly | Calls | Members | Call Kinds |
| ---- | -------- | ----- | ------- | ---------- |
| `System.Collections.Generic.List` | System.Collections | 2 | 1 | virtual |
```

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false \
  --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json \
  --nologo --verbosity quiet
```

```bash
dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- \
  -class DotnetInspector.Tests.CalledTypesSectionTests \
  -class DotnetInspector.Tests.SectionPipelineTests
```

```bash
dotnet run --no-restore --project src/ILInspector.Analysis.Tests -c Release -p:PublishAot=false
```

## Adversarial review

Requested per the analysis-change policy.

- Gemini 3.1 Pro: found three actionable issues.
  - Fixed `Members` to count distinct called target members, not distinct calling members.
  - Fixed generic/open-type grouping and generic self-call exclusion by moving the aggregate into `LibraryBodyIndex.CalledTypes` and normalizing callees through `GenericMemberIdentity.OpenDeclaringType`.
  - Fixed both render paths to include the explicit-section fallback for `Called Types`.
- Claude Opus 4.8: found the same generic/open-type root issue plus missing generic assembly disambiguation.
  - Fixed by using open declaring type definitions for grouping and assembly display.

Follow-up fix commit: f2287020.
