### PR TITLE
Batch union switch store-tail raises

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -911,6 +911,7 @@ public class TypeSourceComposerUnionTests
             public sealed class Bird { public string Name { get; } = "bird"; }
             public union Pet(Cat, Dog, Bird);
             public union MaybeNumber(int, string);
+            public union MaybeNumber2(string, int);
 
             public static class Matcher
             {
@@ -1054,6 +1055,27 @@ public class TypeSourceComposerUnionTests
                     return result;
                 }
 
+                public static string ValueTypeFinalValueType(MaybeNumber2 value)
+                {
+                    string result;
+                    switch (value)
+                    {
+                        case string text:
+                            result = text.Trim();
+                            break;
+                        case int number:
+                            result = number.ToString();
+                            break;
+                        case null:
+                            result = "null";
+                            break;
+                        default:
+                            result = "other";
+                            break;
+                    }
+                    return result.ToUpperInvariant();
+                }
+
                 public static string ValueSwitchNull(Pet pet)
                 {
                     string result;
@@ -1107,6 +1129,10 @@ public class TypeSourceComposerUnionTests
             result = string.Concat(result, "!");
             return result;
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueTypeMutate"));
+        Assert.Equal("""
+            string result = value switch { null => "null", string text => text.Trim(), int number => number.ToString(), _ => "other" };
+            return result.ToUpperInvariant();
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueTypeFinalValueType"));
         Assert.Equal("""
             string result = pet switch { null => "null", Cat cat => cat.Name, Dog dog => dog.Name, _ => "other" };
             return result.ToUpperInvariant();

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -1076,6 +1076,28 @@ public class TypeSourceComposerUnionTests
                     return result.ToUpperInvariant();
                 }
 
+                public static string ValueTypeFinalValueTypeMutate(MaybeNumber2 value)
+                {
+                    string result;
+                    switch (value)
+                    {
+                        case string text:
+                            result = text.Trim();
+                            break;
+                        case int number:
+                            result = number.ToString();
+                            break;
+                        case null:
+                            result = "null";
+                            break;
+                        default:
+                            result = "other";
+                            break;
+                    }
+                    result += "!";
+                    return result;
+                }
+
                 public static string ValueSwitchNull(Pet pet)
                 {
                     string result;
@@ -1133,6 +1155,11 @@ public class TypeSourceComposerUnionTests
             string result = value switch { null => "null", string text => text.Trim(), int number => number.ToString(), _ => "other" };
             return result.ToUpperInvariant();
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueTypeFinalValueType"));
+        Assert.Equal("""
+            string result = value switch { null => "null", string text => text.Trim(), int number => number.ToString(), _ => "other" };
+            result = string.Concat(result, "!");
+            return result;
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueTypeFinalValueTypeMutate"));
         Assert.Equal("""
             string result = pet switch { null => "null", Cat cat => cat.Name, Dog dog => dog.Name, _ => "other" };
             return result.ToUpperInvariant();

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -910,6 +910,7 @@ public class TypeSourceComposerUnionTests
             public sealed class Dog { public string Name { get; } = "dog"; }
             public sealed class Bird { public string Name { get; } = "bird"; }
             public union Pet(Cat, Dog, Bird);
+            public union MaybeNumber(int, string);
 
             public static class Matcher
             {
@@ -988,6 +989,91 @@ public class TypeSourceComposerUnionTests
                     }
                     return result.ToUpperInvariant();
                 }
+
+                public static string ValueTypeCases(MaybeNumber value)
+                {
+                    string result;
+                    switch (value)
+                    {
+                        case int number:
+                            result = number.ToString();
+                            break;
+                        case string text:
+                            result = text;
+                            break;
+                        case null:
+                            result = "null";
+                            break;
+                        default:
+                            result = "other";
+                            break;
+                    }
+                    return result.ToUpperInvariant();
+                }
+
+                public static string ValueTypeFinalExpression(MaybeNumber value)
+                {
+                    string result;
+                    switch (value)
+                    {
+                        case int number:
+                            result = number.ToString();
+                            break;
+                        case string text:
+                            result = text.Trim();
+                            break;
+                        case null:
+                            result = "null";
+                            break;
+                        default:
+                            result = "other";
+                            break;
+                    }
+                    return result.ToUpperInvariant();
+                }
+
+                public static string ValueTypeMutate(MaybeNumber value)
+                {
+                    string result;
+                    switch (value)
+                    {
+                        case int number:
+                            result = number.ToString();
+                            break;
+                        case string text:
+                            result = text;
+                            break;
+                        case null:
+                            result = "null";
+                            break;
+                        default:
+                            result = "other";
+                            break;
+                    }
+                    result += "!";
+                    return result;
+                }
+
+                public static string ValueSwitchNull(Pet pet)
+                {
+                    string result;
+                    switch (pet.Value)
+                    {
+                        case null:
+                            result = "null";
+                            break;
+                        case Cat cat:
+                            result = cat.Name;
+                            break;
+                        case Dog dog:
+                            result = dog.Name;
+                            break;
+                        default:
+                            result = "other";
+                            break;
+                    }
+                    return result.ToUpperInvariant();
+                }
             }
             """);
 
@@ -1008,6 +1094,23 @@ public class TypeSourceComposerUnionTests
         var guarded = RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedStaysFlat");
         Assert.DoesNotContain("pet switch", guarded);
         Assert.Contains("cat.Age > 3", guarded);
+        Assert.Equal("""
+            string result = value switch { null => "null", int number => number.ToString(), string text => text, _ => "other" };
+            return result.ToUpperInvariant();
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueTypeCases"));
+        Assert.Equal("""
+            string result = value switch { null => "null", int number => number.ToString(), string text => text.Trim(), _ => "other" };
+            return result.ToUpperInvariant();
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueTypeFinalExpression"));
+        Assert.Equal("""
+            string result = value switch { null => "null", int number => number.ToString(), string text => text, _ => "other" };
+            result = string.Concat(result, "!");
+            return result;
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueTypeMutate"));
+        Assert.Equal("""
+            string result = pet switch { null => "null", Cat cat => cat.Name, Dog dog => dog.Name, _ => "other" };
+            return result.ToUpperInvariant();
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "ValueSwitchNull"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -150,6 +150,8 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         {
             if (TryMatchNullArmStoreTailAt(function, children, start, out match))
                 return true;
+            if (TryMatchReferencePrefixValueTypeTailStoreTailAt(function, children, start, out match))
+                return true;
             if (TryMatchValueTypePrefixStoreTailAt(function, children, start, out match))
                 return true;
             if (TryMatchStoreTailAt(function, children, start, out match))
@@ -205,6 +207,82 @@ public sealed class UnionSwitchExpressionPass : IIrPass
             (IrExpression)defaultValue.Clone(),
             (IrExpression)nullStore.Value.Clone());
         var switchStore = new StoreLocal(nullStore.Index, nullStore.Type, switchExpression);
+        match = new StoreTailMatch(start, switchStore, tail.Select(node => node.Clone()).ToArray());
+        return true;
+    }
+
+    static bool TryMatchReferencePrefixValueTypeTailStoreTailAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out StoreTailMatch match)
+    {
+        match = null!;
+        if (start + 4 >= children.Count
+            || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsValueTypeUnionValueProperty(function, unionValue)
+            || children[start + 1] is not StoreLocal { Value: IsInstance firstTest } firstStore
+            || !IsTempTypeTest(firstTest, valueStore.Index)
+            || children[start + 2] is not IfStatement firstNullGuard
+            || firstNullGuard.HasElse
+            || !IsNotLocal(firstNullGuard.Condition, firstStore.Index)
+            || children[start + 3] is not StoreLocal firstValueStore)
+        {
+            return false;
+        }
+
+        var tail = children.Skip(start + 4).ToArray();
+        var nestedNodes = firstNullGuard.Then.Children;
+        int armCount = nestedNodes.Count - 3;
+        if (tail.Length == 0
+            || !TailShapeIsMovable(tail)
+            || !TailMatches(children, start + 4, tail)
+            || armCount <= 0
+            || !TryNullAndDefaultStoreTail(nestedNodes.Skip(armCount).ToArray(), valueStore.Index, firstValueStore.Index, tail, out var nullValue, out var defaultValue))
+        {
+            return false;
+        }
+
+        var tailArms = new List<Arm>();
+        foreach (var node in nestedNodes.Take(armCount))
+        {
+            if (node is not IfStatement armIf
+                || !TryValueTypeStoreTailArm(armIf, valueStore.Index, firstValueStore.Index, tail, out var arm))
+            {
+                return false;
+            }
+
+            tailArms.Add(arm);
+        }
+
+        if (tailArms.Count == 0)
+            return false;
+
+        var firstArm = new Arm(
+            firstTest.Type,
+            firstStore.Index,
+            firstValueStore.Value,
+            [firstStore, firstNullGuard.Condition, firstValueStore.Value]);
+        var arms = new[] { firstArm }.Concat(tailArms).ToArray();
+        var consumedNodes = children.Skip(start).ToArray();
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, [valueStore, firstStore, firstNullGuard])
+            || !ReferenceOwnership.LocalReferencesOnlyWithin(function, firstValueStore.Index, consumedNodes)
+            || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+            || !DuplicateTypesAreGuarded(arms))
+        {
+            return false;
+        }
+
+        var switchExpression = new UnionSwitchExpression(
+            (IrExpression)unionValue.Clone(),
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+            (IrExpression)defaultValue.Clone(),
+            (IrExpression)nullValue.Clone());
+        var switchStore = new StoreLocal(firstValueStore.Index, firstValueStore.Type, switchExpression);
         match = new StoreTailMatch(start, switchStore, tail.Select(node => node.Clone()).ToArray());
         return true;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -233,7 +233,7 @@ public sealed class UnionSwitchExpressionPass : IIrPass
 
         var tail = children.Skip(start + 4).ToArray();
         var nestedNodes = firstNullGuard.Then.Children;
-        int armCount = nestedNodes.Count - 3;
+        int armCount = nestedNodes.Count - (2 + tail.Length);
         if (tail.Length == 0
             || !TailShapeIsMovable(tail)
             || !TailMatches(children, start + 4, tail)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -148,11 +148,204 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         var children = block.Children;
         for (int start = 0; start < children.Count; start++)
         {
+            if (TryMatchNullArmStoreTailAt(function, children, start, out match))
+                return true;
+            if (TryMatchValueTypePrefixStoreTailAt(function, children, start, out match))
+                return true;
             if (TryMatchStoreTailAt(function, children, start, out match))
                 return true;
         }
 
         return false;
+    }
+
+    static bool TryMatchNullArmStoreTailAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out StoreTailMatch match)
+    {
+        match = null!;
+        if (start + 3 >= children.Count
+            || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsValueTypeUnionValueProperty(function, unionValue)
+            || children[start + 1] is not IfStatement { HasElse: false } notNullIf
+            || notNullIf.Condition is not LoadLocal conditionLocal
+            || conditionLocal.Index != valueStore.Index
+            || children[start + 2] is not StoreLocal nullStore)
+        {
+            return false;
+        }
+
+        var tail = children.Skip(start + 3).ToArray();
+        if (tail.Length == 0
+            || !TailShapeIsMovable(tail)
+            || !TailMatches(children, start + 3, tail)
+            || !TryStoreTailArmsWithDefault(notNullIf.Then.Children, valueStore.Index, nullStore.Index, tail, out var arms, out var defaultValue))
+        {
+            return false;
+        }
+
+        var consumedNodes = children.Skip(start).ToArray();
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, [valueStore, notNullIf])
+            || !ReferenceOwnership.LocalReferencesOnlyWithin(function, nullStore.Index, consumedNodes)
+            || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+            || !DuplicateTypesAreGuarded(arms))
+        {
+            return false;
+        }
+
+        var switchExpression = new UnionSwitchExpression(
+            (IrExpression)unionValue.Clone(),
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+            (IrExpression)defaultValue.Clone(),
+            (IrExpression)nullStore.Value.Clone());
+        var switchStore = new StoreLocal(nullStore.Index, nullStore.Type, switchExpression);
+        match = new StoreTailMatch(start, switchStore, tail.Select(node => node.Clone()).ToArray());
+        return true;
+    }
+
+    static bool TryMatchValueTypePrefixStoreTailAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out StoreTailMatch match)
+    {
+        match = null!;
+        if (start + 5 >= children.Count
+            || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsValueTypeUnionValueProperty(function, unionValue))
+        {
+            return false;
+        }
+
+        for (int finalIndex = start + 2; finalIndex + 3 < children.Count; finalIndex++)
+        {
+            if (children[finalIndex] is not StoreLocal { Value: IsInstance finalTest } finalStore
+                || !IsTempTypeTest(finalTest, valueStore.Index)
+                || children[finalIndex + 1] is not IfStatement finalNullGuard
+                || finalNullGuard.HasElse
+                || !IsNotLocal(finalNullGuard.Condition, finalStore.Index)
+                || children[finalIndex + 2] is not StoreLocal finalValueStore)
+            {
+                continue;
+            }
+
+            var tail = children.Skip(finalIndex + 3).ToArray();
+            if (tail.Length == 0
+                || !TailShapeIsMovable(tail)
+                || !TailMatches(children, finalIndex + 3, tail)
+                || !TryNullAndDefaultStoreTail(finalNullGuard.Then.Children, valueStore.Index, finalValueStore.Index, tail, out var nullValue, out var defaultValue))
+            {
+                continue;
+            }
+
+            var prefixNodes = children.Skip(start + 1).Take(finalIndex - start - 1).ToArray();
+            var arms = new List<Arm>();
+            bool prefixMatched = true;
+            foreach (var node in prefixNodes)
+            {
+                if (node is not IfStatement armIf
+                    || !TryValueTypeStoreTailArm(armIf, valueStore.Index, finalValueStore.Index, tail, out var arm))
+                {
+                    prefixMatched = false;
+                    break;
+                }
+
+                arms.Add(arm);
+            }
+
+            if (!prefixMatched || arms.Count == 0)
+                continue;
+
+            arms.Add(new Arm(
+                finalTest.Type,
+                finalStore.Index,
+                finalValueStore.Value,
+                [finalStore, finalNullGuard.Condition, finalValueStore.Value]));
+
+            var switchNodes = children.Skip(start).Take(finalIndex + 3 - start).ToArray();
+            var consumedNodes = children.Skip(start).ToArray();
+            if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, switchNodes)
+                || !ReferenceOwnership.LocalReferencesOnlyWithin(function, finalValueStore.Index, consumedNodes)
+                || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+                || !DuplicateTypesAreGuarded(arms))
+            {
+                continue;
+            }
+
+            var switchExpression = new UnionSwitchExpression(
+                (IrExpression)unionValue.Clone(),
+                arms.Select(arm => new UnionSwitchExpressionArm(
+                    arm.PatternType,
+                    arm.LocalIndex,
+                    (IrExpression)arm.Value.Clone(),
+                    arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+                (IrExpression)defaultValue.Clone(),
+                (IrExpression)nullValue.Clone());
+            var switchStore = new StoreLocal(finalValueStore.Index, finalValueStore.Type, switchExpression);
+            match = new StoreTailMatch(start, switchStore, tail.Select(node => node.Clone()).ToArray());
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool TryValueTypeStoreTailArm(
+        IfStatement armIf,
+        int tempLocal,
+        int resultLocal,
+        IReadOnlyList<IrNode> tail,
+        out Arm arm)
+    {
+        arm = null!;
+        if (armIf.HasElse
+            || armIf.Condition is not IsInstance test
+            || !IsTempTypeTest(test, tempLocal)
+            || armIf.Then.Children is not [StoreLocal boundStore, StoreLocal valueStore, ..]
+            || !IsUnboxAnyTemp(boundStore.Value, test.Type, tempLocal)
+            || valueStore.Index != resultLocal
+            || !TailMatches(armIf.Then.Children, 2, tail))
+        {
+            return false;
+        }
+
+        arm = new Arm(test.Type, boundStore.Index, valueStore.Value,
+            [armIf.Condition, boundStore, valueStore.Value]);
+        return true;
+    }
+
+    static bool TryNullAndDefaultStoreTail(
+        IReadOnlyList<IrNode> nodes,
+        int tempLocal,
+        int resultLocal,
+        IReadOnlyList<IrNode> tail,
+        out IrExpression nullValue,
+        out IrExpression defaultValue)
+    {
+        nullValue = null!;
+        defaultValue = null!;
+        if (nodes.Count < 3
+            || nodes[0] is not IfStatement nullIf
+            || nullIf.HasElse
+            || !IsNotLocal(nullIf.Condition, tempLocal)
+            || nullIf.Then.Children is not [StoreLocal nullStore, ..]
+            || nullStore.Index != resultLocal
+            || !TailMatches(nullIf.Then.Children, 1, tail)
+            || nodes[1] is not StoreLocal defaultStore
+            || defaultStore.Index != resultLocal
+            || !TailMatches(nodes, 2, tail))
+        {
+            return false;
+        }
+
+        nullValue = nullStore.Value;
+        defaultValue = defaultStore.Value;
+        return true;
     }
 
     static bool TryMatchStoreTailAt(


### PR DESCRIPTION
## Summary

- Batch two adjacent union store-tail raises:
  - value-type union case arms with `null`/default before a shared tail;
  - direct `.Value` null-arm store-tail over value-type unions.
- Keep class/custom unions gated out to preserve `.Value` null-receiver semantics.
- Keep guarded store-tail shapes flat for this slice.

## Evidence

- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*TypeSourceComposerUnionTests*"`: 22 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"`: 1772 passed

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity sampled 25,179 / 89,065 (28.27%); fidelity sampled 36 / 89,065 (0.04%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,398 (88.02%) | -1 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — sampled 25,179 / 89,065 (28.27%) | 73/25,179 — sampled 25,179 / 89,065 (28.27%) | -1 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | 0 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate: Fully raised 88.02% -> 88.02% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 5 (0).

Verdict: corpus sensor matched baseline tolerances.

The aggregate `Fully raised -1` row is the same stale-baseline Roslyn `BindAssignment#0` drift diagnosed in #2055, not movement from this pass. The pinned-subset gate remains flat, and semantic defects improve by one sampled method.

## Adversarial review

- Claude Opus 4.8: no blocking findings. It verified null/default ordering, class/custom union gating, result-local and union `Value` temp ownership, value-type unbox binding, duplicated-tail movement/order, guarded false-positive rejection, and default-arm shape.
- Gemini 3.1 Pro: found three actionable hardening issues in the value-type case store-tail matcher: end-anchored tail parsing, final-arm value restricted to `LoadLocal`, and union temp ownership including the moved tail. All were resolved before push by forward-scanning the final type arm, allowing arbitrary final-arm expressions, and restricting union-temp ownership to the switch prefix. Tests now pin a final-arm expression (`text.Trim()`) and a multi-statement moved tail (`result += "!"`).

## Notes

- This is a readability/altitude raise, analogous to existing switch-store folds; it is not claimed as opcode-exact.
- Guarded store-tail shapes intentionally remain flat.
