### PR TITLE
Add structured API signature facts

### DIFF
--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -170,6 +170,44 @@ public class TypeParameter
         : null;
 }
 
+public class ApiSignature
+{
+    public string? ReturnType { get; set; }
+    public string? MemberName { get; set; }
+    public bool IsRequired { get; set; }
+    public List<ApiParameter> Parameters { get; set; } = [];
+    public List<ApiAccessor> Accessors { get; set; } = [];
+
+    public int ParameterCount => Parameters.Count;
+
+    public string ParameterTypesSummary => Parameters.Count == 0
+        ? ""
+        : $"({string.Join(", ", Parameters.Select(parameter => parameter.TypeWithModifier))})";
+
+    public string PublicAccessorsSummary => string.Join(", ",
+        Accessors
+            .Where(accessor => string.IsNullOrEmpty(accessor.Accessibility))
+            .Select(accessor => accessor.Kind));
+}
+
+public class ApiParameter
+{
+    public string Name { get; set; } = "";
+    public string Type { get; set; } = "";
+    public string? Modifier { get; set; }
+    public bool HasDefault { get; set; }
+
+    public string TypeWithModifier => string.IsNullOrEmpty(Modifier)
+        ? Type
+        : $"{Modifier} {Type}";
+}
+
+public class ApiAccessor
+{
+    public string Kind { get; set; } = "";
+    public string? Accessibility { get; set; }
+}
+
 public class ApiType
 {
     public string? Namespace { get; set; }
@@ -260,6 +298,9 @@ public class ApiMember
 
     public string? ReturnType { get; set; }
     public string? Signature { get; set; }
+
+    [JsonIgnore]
+    public ApiSignature? SignatureModel { get; set; }
 
     /// <summary>
     /// MethodDef metadata token for method-like members when known.

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -226,9 +226,10 @@ public static class ApiSurfaceExtractor
                     IsAbstract = (methodAttributes & MethodAttributes.Abstract) != 0,
                     IsOverride = isOverride,
                     IsSealed = isOverride && (methodAttributes & MethodAttributes.Final) != 0,
-                    Signature = signature,
+                    Signature = signature.Text,
+                    SignatureModel = signature.Model,
                     MetadataToken = MetadataTokens.GetToken(methodHandle),
-                    IsUnsafe = HasUnsafeSignature(signature)
+                    IsUnsafe = HasUnsafeSignature(signature.Text)
                         || AttributeReader.HasRequiresUnsafeAttribute(reader, method.GetCustomAttributes()),
                     Accessibility = isExplicitInterfaceImplementation && !isOperator ? null : GetAccessibility(methodAccess),
                     IsObsolete = isObsolete,
@@ -302,13 +303,14 @@ public static class ApiSurfaceExtractor
                 {
                     Name = reader.GetString(prop.Name),
                     Kind = "property",
-                    Signature = propertySignature,
+                    Signature = propertySignature.Text,
+                    SignatureModel = propertySignature.Model,
                     IsStatic = isStaticProperty,
                     IsVirtual = isVirtualProperty,
                     IsAbstract = isAbstractProperty,
                     IsOverride = isOverrideProperty,
                     IsSealed = isSealedProperty,
-                    IsUnsafe = HasUnsafeSignature(propertySignature),
+                    IsUnsafe = HasUnsafeSignature(propertySignature.Text),
                     Accessibility = GetAccessibility(bestAccess),
                     IsObsolete = isObsolete,
                     ObsoleteMessage = obsoleteMessage,
@@ -358,6 +360,11 @@ public static class ApiSurfaceExtractor
                     Name = fieldName,
                     Kind = "field",
                     ReturnType = fieldType,
+                    SignatureModel = fieldType is null ? null : new ApiSignature
+                    {
+                        ReturnType = fieldType,
+                        MemberName = fieldName
+                    },
                     IsStatic = (field.Attributes & FieldAttributes.Static) != 0,
                     IsReadOnly = (field.Attributes & FieldAttributes.InitOnly) != 0,
                     IsConst = (field.Attributes & FieldAttributes.Literal) != 0,
@@ -441,6 +448,11 @@ public static class ApiSurfaceExtractor
                     Kind = "event",
                     ReturnType = eventType,
                     Signature = $"{eventType} {reader.GetString(evt.Name)}",
+                    SignatureModel = new ApiSignature
+                    {
+                        ReturnType = eventType,
+                        MemberName = reader.GetString(evt.Name)
+                    },
                     IsStatic = (adderAttributes & MethodAttributes.Static) != 0,
                     IsVirtual = isVirtualEvent,
                     IsAbstract = (adderAttributes & MethodAttributes.Abstract) != 0,
@@ -596,6 +608,7 @@ public static class ApiSurfaceExtractor
                     Kind = "extension-method",
                     ReturnType = extension.ReturnType,
                     Signature = extension.Signature,
+                    SignatureModel = extension.SignatureModel,
                     MetadataToken = extension.MetadataToken,
                     IsStatic = extension.IsStatic,
                     IsVirtual = extension.IsVirtual,
@@ -699,7 +712,7 @@ public static class ApiSurfaceExtractor
         }
     }
 
-    private static string GetMethodSignature(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method, byte typeNullableContext)
+    private static (string Text, ApiSignature Model) GetMethodSignature(MetadataReader reader, TypeDefinition typeDef, MethodDefinition method, byte typeNullableContext)
     {
         string name = reader.GetString(method.Name);
         var context = GenericContext.ForMethod(reader, typeDef, method);
@@ -719,6 +732,7 @@ public static class ApiSurfaceExtractor
         var paramTypes = treeSignature.ParameterTypes;
 
         List<string> parameters = [];
+        List<ApiParameter> parameterModels = [];
         for (int i = 0; i < paramTypes.Length; i++)
         {
             // Apply nullability to this parameter's type tree
@@ -754,6 +768,13 @@ public static class ApiSurfaceExtractor
                 AcceptsNullDefault(paramTypes[i]));
 
             parameters.Add(paramStr);
+            parameterModels.Add(new ApiParameter
+            {
+                Name = paramName,
+                Type = type,
+                Modifier = modifier,
+                HasDefault = hasDefault
+            });
         }
 
         string paramStr2 = string.Join(", ", parameters);
@@ -761,7 +782,12 @@ public static class ApiSurfaceExtractor
         var methodName = context.MethodParameters.Count > 0
             ? $"{name}<{string.Join(", ", context.MethodParameters)}>"
             : name;
-        return $"{returnType} {methodName}({paramStr2})";
+        return ($"{returnType} {methodName}({paramStr2})", new ApiSignature
+        {
+            ReturnType = returnType,
+            MemberName = methodName,
+            Parameters = parameterModels
+        });
     }
 
     private static string FormatMethodReturnType(MetadataReader reader, TypeNode returnType, ParameterHandleCollection paramHandles)
@@ -1191,7 +1217,7 @@ public static class ApiSurfaceExtractor
         }
     }
 
-    private static string GetPropertySignature(MetadataReader reader, TypeDefinition typeDef, PropertyDefinition prop, PropertyAccessors accessors, byte typeNullableContext, bool includeAll = false)
+    private static (string Text, ApiSignature Model) GetPropertySignature(MetadataReader reader, TypeDefinition typeDef, PropertyDefinition prop, PropertyAccessors accessors, byte typeNullableContext, bool includeAll = false)
     {
         string name = reader.GetString(prop.Name);
         var context = GenericContext.ForType(reader, typeDef);
@@ -1225,11 +1251,16 @@ public static class ApiSurfaceExtractor
 
         // Build accessor string
         string accessorStr;
+        var accessorModels = new List<ApiAccessor>();
         if (includeAll)
         {
             // Show explicit access levels for non-public accessors
             var getStr = hasGetter ? FormatAccessor("get", getterAccess, Math.Max((int)getterAccess, (int)setterAccess)) : null;
             var setStr = hasSetter ? FormatAccessor("set", setterAccess, Math.Max((int)getterAccess, (int)setterAccess)) : null;
+            if (hasGetter)
+                accessorModels.Add(new ApiAccessor { Kind = "get", Accessibility = AccessorAccessibility(getterAccess, Math.Max((int)getterAccess, (int)setterAccess)) });
+            if (hasSetter)
+                accessorModels.Add(new ApiAccessor { Kind = "set", Accessibility = AccessorAccessibility(setterAccess, Math.Max((int)getterAccess, (int)setterAccess)) });
             accessorStr = (getStr, setStr) switch
             {
                 (not null, not null) => $"{{ {getStr}; {setStr}; }}",
@@ -1241,20 +1272,38 @@ public static class ApiSurfaceExtractor
         else
         {
             if (hasPublicGetter && hasPublicSetter)
+            {
                 accessorStr = "{ get; set; }";
+                accessorModels.Add(new ApiAccessor { Kind = "get" });
+                accessorModels.Add(new ApiAccessor { Kind = "set" });
+            }
             else if (hasPublicGetter && hasSetter)
+            {
                 accessorStr = "{ get; private set; }";
+                accessorModels.Add(new ApiAccessor { Kind = "get" });
+                accessorModels.Add(new ApiAccessor { Kind = "set", Accessibility = "private" });
+            }
             else if (hasPublicGetter)
+            {
                 accessorStr = "{ get; }";
+                accessorModels.Add(new ApiAccessor { Kind = "get" });
+            }
             else if (hasPublicSetter)
+            {
                 accessorStr = "{ set; }";
+                accessorModels.Add(new ApiAccessor { Kind = "set" });
+            }
             else
+            {
                 accessorStr = "{ get; }"; // Fallback
+                accessorModels.Add(new ApiAccessor { Kind = "get" });
+            }
         }
 
         var requiredPrefix = AttributeReader.HasRequiredMemberAttribute(reader, prop.GetCustomAttributes())
             ? "required "
             : "";
+        var isRequired = requiredPrefix.Length > 0;
 
         var paramHandles = hasGetter
             ? reader.GetMethodDefinition(accessors.Getter).GetParameters()
@@ -1263,6 +1312,7 @@ public static class ApiSurfaceExtractor
                 : default;
         var paramTypes = treeSignature.ParameterTypes;
         List<string> indexerParameters = [];
+        List<ApiParameter> parameterModels = [];
         for (var i = 0; i < paramTypes.Length; i++)
         {
             var paramBytes = NullabilityReader.GetParameterNullableBytes(reader, paramHandles, i + 1);
@@ -1293,13 +1343,29 @@ public static class ApiSurfaceExtractor
                 defaultValue,
                 AcceptsNullDefault(paramTypes[i]));
             indexerParameters.Add(parameter);
+            parameterModels.Add(new ApiParameter
+            {
+                Name = paramName,
+                Type = paramType,
+                Modifier = modifier,
+                HasDefault = hasDefault
+            });
         }
 
         var returnType = FormatMethodReturnType(reader, treeSignature.ReturnType, paramHandles);
-        if (indexerParameters.Count > 0)
-            return $"{requiredPrefix}{returnType} this[{string.Join(", ", indexerParameters)}] {accessorStr}";
+        var model = new ApiSignature
+        {
+            ReturnType = returnType,
+            MemberName = indexerParameters.Count > 0 ? "this[]" : name,
+            IsRequired = isRequired,
+            Parameters = parameterModels,
+            Accessors = accessorModels
+        };
 
-        return $"{requiredPrefix}{returnType} {name} {accessorStr}";
+        if (indexerParameters.Count > 0)
+            return ($"{requiredPrefix}{returnType} this[{string.Join(", ", indexerParameters)}] {accessorStr}", model);
+
+        return ($"{requiredPrefix}{returnType} {name} {accessorStr}", model);
     }
 
     /// <summary>
@@ -1312,6 +1378,9 @@ public static class ApiSurfaceExtractor
         var prefix = GetAccessibility(access);
         return prefix != null ? $"{prefix} {kind}" : kind;
     }
+
+    private static string? AccessorAccessibility(MethodAttributes access, int bestAccess)
+        => (int)access == bestAccess ? null : GetAccessibility(access);
 
     /// <summary>
     /// Gets the first parameter type for extension methods.

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -958,7 +958,7 @@ public static class ApiOutputFormatter
                     var rows = byName.Select(e =>
                         new MethodSummaryRow(
                             OperatorNames.FormatDisplayName(e.members[0].Name),
-                            SignatureParser.ExtractReturnType(e.members[0].Signature),
+                            MemberReturnType(e.members[0]),
                             e.members.Count.ToString())).ToList();
                     if (hasOverloads)
                         methodGroupsView.RowsWithOverloads = rows;
@@ -973,8 +973,8 @@ public static class ApiOutputFormatter
                         var m = e.members[0];
                         return new PropertySummaryRow(
                             m.Name,
-                            SignatureParser.ExtractReturnType(m.Signature),
-                            SignatureParser.ExtractAccessors(m.Signature));
+                            MemberReturnType(m),
+                            MemberAccessors(m));
                     }).ToList();
                     view.PropertySummaryRows = rows;
                     break;
@@ -2173,13 +2173,13 @@ public static class ApiOutputFormatter
             {
                 "constructor" => "",
                 "event" => m.ReturnType ?? m.Signature ?? "",
-                _ => SignatureParser.ExtractReturnType(m.Signature)
+                _ => MemberReturnType(m)
             };
             var detail = e.kind switch
             {
-                "property" => SignatureParser.ExtractAccessors(m.Signature),
+                "property" => MemberAccessors(m),
                 "constructor" or "method" or "operator" or "explicit-interface-implementation" or "extension-method" when e.members.Count > 1 => e.members.Count.ToString(),
-                "constructor" or "method" or "operator" or "explicit-interface-implementation" or "extension-method" when e.members.Count == 1 => SignatureParser.ExtractParamList(m.Signature),
+                "constructor" or "method" or "operator" or "explicit-interface-implementation" or "extension-method" when e.members.Count == 1 => MemberParameterTypes(m),
                 _ => ""
             };
             var kindLabel = m.Accessibility != null ? $"{m.Accessibility} {e.kind}" : e.kind;
@@ -2188,6 +2188,19 @@ public static class ApiOutputFormatter
 
         return (new ApiTypeOneLineView { Rows = rows }, truncated);
     }
+
+    private static string MemberReturnType(ApiMember member)
+        => member.SignatureModel?.ReturnType
+           ?? member.ReturnType
+           ?? SignatureParser.ExtractReturnType(member.Signature);
+
+    private static string MemberAccessors(ApiMember member)
+        => member.SignatureModel?.PublicAccessorsSummary
+           ?? SignatureParser.ExtractAccessors(member.Signature);
+
+    private static string MemberParameterTypes(ApiMember member)
+        => member.SignatureModel?.ParameterTypesSummary
+           ?? SignatureParser.ExtractParamList(member.Signature);
 
     /// <summary>
     /// Builds a unified tabular view for a full API surface (all types).

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -1,0 +1,80 @@
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class ApiSignatureModelTests
+{
+    static readonly ApiSurface Surface;
+
+    static ApiSignatureModelTests()
+    {
+        using var stream = File.OpenRead(typeof(ApiSignatureModelTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        Surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+    }
+
+    [Fact]
+    public void MethodSignatureModel_ExposesReturnTypeParametersAndDefaults()
+    {
+        var member = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.MethodWithRefKinds));
+
+        Assert.NotNull(member.SignatureModel);
+        Assert.Equal("string", member.SignatureModel.ReturnType);
+        Assert.Equal("MethodWithRefKinds", member.SignatureModel.MemberName);
+        Assert.Equal(5, member.SignatureModel.ParameterCount);
+        Assert.Equal("(ref int, out string, in long, int, params byte[])", member.SignatureModel.ParameterTypesSummary);
+        Assert.Equal("value", member.SignatureModel.Parameters[0].Name);
+        Assert.Equal("ref", member.SignatureModel.Parameters[0].Modifier);
+        Assert.Equal("int", member.SignatureModel.Parameters[0].Type);
+        Assert.True(member.SignatureModel.Parameters[3].HasDefault);
+    }
+
+    [Fact]
+    public void PropertySignatureModel_ExposesReturnTypeIndexerParametersAndPublicAccessors()
+    {
+        var member = GetMember(nameof(ApiSignatureFixtures), "Item");
+
+        Assert.NotNull(member.SignatureModel);
+        Assert.Equal("string", member.SignatureModel.ReturnType);
+        Assert.Equal("this[]", member.SignatureModel.MemberName);
+        Assert.Equal("(int)", member.SignatureModel.ParameterTypesSummary);
+        Assert.Equal("get", member.SignatureModel.PublicAccessorsSummary);
+    }
+
+    [Fact]
+    public void FieldAndEventSignatureModels_ExposeReturnType()
+    {
+        var field = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.Count));
+        var evt = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.Changed));
+
+        Assert.Equal("int", field.SignatureModel?.ReturnType);
+        Assert.Equal("System.EventHandler?", evt.SignatureModel?.ReturnType);
+    }
+
+    static ApiMember GetMember(string typeName, string memberName)
+        => Surface.Types
+            .First(type => type.Name == typeName)
+            .Members
+            .First(member => member.Name == memberName);
+}
+
+public sealed class ApiSignatureFixtures
+{
+    public int Count;
+
+    public event EventHandler? Changed;
+
+    public string MethodWithRefKinds(ref int value, out string text, in long source, int count = 1, params byte[] bytes)
+    {
+        Changed?.Invoke(this, EventArgs.Empty);
+        text = count.ToString();
+        return text;
+    }
+
+    public string this[int index]
+    {
+        get => index.ToString();
+        private set { }
+    }
+}


### PR DESCRIPTION
- Advances #2057
- Changes API extraction to expose metadata-owned structured signature facts beside compatibility signature text, then migrates member summaries and one-line rows to query those facts.

## Change

**Conclusion:** **PASS** — this adds queryable metadata signature facts while keeping C# signature/declaration printing out of the CLI.

Before, summary and one-line views parsed rendered `ApiMember.Signature` strings for return types, accessor lists, and parameter type lists.

After, `ApiSurfaceExtractor` populates:

```text
ApiSignature
  ReturnType
  MemberName
  Parameters
  Accessors
```

The CLI asks the model for return type, public accessors, and parameter type summaries, with `SignatureParser` fallback for legacy/unmodeled members. `ApiMember.Signature` remains as compatibility text and `SignatureModel` is `[JsonIgnore]` to avoid JSON schema churn in this slice.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507 --nologo --verbosity quiet` |
| Metadata tests | Pass: `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507` |
| CLI tests | Pass: `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Verified model/text consistency for methods, property accessor behavior, field/event facts, extension projection, JSON compatibility, and layering. Noted model-backed summaries improve return-type handling for shapes `SignatureParser` previously truncated. |
| Gemini 3.1 Pro | No significant issues | No code changes needed. |

**Review conclusion:** **PASS** — adversarial review found no blocking or high-confidence issues.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507
dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507
```
