### PR TITLE
Add allocation path confidence metadata

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1165,6 +1165,7 @@ public class LibraryBodyIndexTests
     [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesOnceInLoop), AllocationKind.Object, "System.Object", AllocationPathContext.LoopBody, AllocationPathConfidence.BehindBranch)]
     [InlineData(nameof(OptimizationOpportunityFixtures.FinallyAllocates), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.StraightLine, AllocationPathConfidence.Unknown)]
     [InlineData(nameof(OptimizationOpportunityFixtures.CatchAllocatesInLoop), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.CatchAllocatesBeforeOnlyReturn), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown)]
     public void AllocationOccurrences_IncludeRuntimeTypePathContextAndConfidence(string methodName, AllocationKind kind, string expectedRuntimeType, AllocationPathContext expectedPath, AllocationPathConfidence expectedConfidence)
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
@@ -1172,7 +1173,9 @@ public class LibraryBodyIndexTests
         var occurrence = index.GetAllocationOccurrences()
             .Where(pair => index.Methods.Any(method => method.MetadataToken == pair.Key && method.Name == methodName))
             .SelectMany(pair => pair.Value)
-            .First(occurrence => occurrence.Kind == kind && occurrence.PathContext == expectedPath);
+            .First(occurrence => occurrence.Kind == kind
+                && occurrence.PathContext == expectedPath
+                && occurrence.RuntimeAllocationType == expectedRuntimeType);
 
         Assert.Equal(expectedRuntimeType, occurrence.RuntimeAllocationType);
         Assert.Equal(expectedPath, occurrence.PathContext);
@@ -3165,6 +3168,20 @@ public class OptimizationOpportunityFixtures
             }
         }
         return total;
+    }
+
+    public static object CatchAllocatesBeforeOnlyReturn()
+    {
+        object? result = null;
+        try
+        {
+            throw new InvalidOperationException();
+        }
+        catch (InvalidOperationException)
+        {
+            result = new PlainObject(1);
+        }
+        return result;
     }
 
     static void MaybeThrow(int value)

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1159,13 +1159,13 @@ public class LibraryBodyIndexTests
     }
 
     [Theory]
-    [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), AllocationKind.Array, "System.Int32[]", AllocationPathContext.StraightLine)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), AllocationKind.Box, "boxed System.Guid", AllocationPathContext.StraightLine)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.ThrowsInLoop), AllocationKind.Object, "System.InvalidOperationException", AllocationPathContext.ErrorPath)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesOnceInLoop), AllocationKind.Object, "System.Object", AllocationPathContext.LoopBody)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.FinallyAllocates), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.StraightLine)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.CatchAllocatesInLoop), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.ErrorPath)]
-    public void AllocationOccurrences_IncludeRuntimeTypeAndPathContext(string methodName, AllocationKind kind, string expectedRuntimeType, AllocationPathContext expectedPath)
+    [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), AllocationKind.Array, "System.Int32[]", AllocationPathContext.StraightLine, AllocationPathConfidence.DominatesReturn)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), AllocationKind.Box, "boxed System.Guid", AllocationPathContext.StraightLine, AllocationPathConfidence.DominatesReturn)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ThrowsInLoop), AllocationKind.Object, "System.InvalidOperationException", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesOnceInLoop), AllocationKind.Object, "System.Object", AllocationPathContext.LoopBody, AllocationPathConfidence.BehindBranch)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.FinallyAllocates), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.StraightLine, AllocationPathConfidence.Unknown)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.CatchAllocatesInLoop), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown)]
+    public void AllocationOccurrences_IncludeRuntimeTypePathContextAndConfidence(string methodName, AllocationKind kind, string expectedRuntimeType, AllocationPathContext expectedPath, AllocationPathConfidence expectedConfidence)
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 
@@ -1176,6 +1176,7 @@ public class LibraryBodyIndexTests
 
         Assert.Equal(expectedRuntimeType, occurrence.RuntimeAllocationType);
         Assert.Equal(expectedPath, occurrence.PathContext);
+        Assert.Equal(expectedConfidence, occurrence.PathConfidence);
     }
 
     [Fact]
@@ -1190,7 +1191,8 @@ public class LibraryBodyIndexTests
                 index.GetAllocationOccurrences().Values.SelectMany(occurrences => occurrences),
                 occurrence => occurrence.Method.Name == "BranchAllocation"
                     && occurrence.Kind == AllocationKind.Object
-                    && occurrence.PathContext == AllocationPathContext.Branch);
+                    && occurrence.PathContext == AllocationPathContext.Branch
+                    && occurrence.PathConfidence == AllocationPathConfidence.BehindBranch);
             Assert.Contains(
                 index.GetAllocationOccurrences().Values.SelectMany(occurrences => occurrences),
                 occurrence => occurrence.Method.Name == "SwitchAllocation"
@@ -1202,11 +1204,13 @@ public class LibraryBodyIndexTests
                 .ToArray();
             Assert.Equal(3, switchAllocations.Length);
             Assert.All(switchAllocations, occurrence => Assert.Equal(AllocationPathContext.SwitchArm, occurrence.PathContext));
+            Assert.All(switchAllocations, occurrence => Assert.Equal(AllocationPathConfidence.BehindBranch, occurrence.PathConfidence));
             Assert.Contains(
                 index.GetAllocationOccurrences().Values.SelectMany(occurrences => occurrences),
                 occurrence => occurrence.Method.Name == "AfterIfJoinAllocation"
                     && occurrence.Kind == AllocationKind.Object
-                    && occurrence.PathContext == AllocationPathContext.StraightLine);
+                    && occurrence.PathContext == AllocationPathContext.StraightLine
+                    && occurrence.PathConfidence == AllocationPathConfidence.DominatesReturn);
         }
         finally
         {
@@ -1228,13 +1232,13 @@ public class LibraryBodyIndexTests
     }
 
     [Theory]
-    [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), "stackalloc-candidate", "System.Int32[]", "straight-line")]
-    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), "box-value-type", "boxed System.Guid", "straight-line")]
-    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesInLoop), "box-value-type", "boxed System.Int32", "loop body")]
-    [InlineData(nameof(OptimizationOpportunityFixtures.AppendsStringInLoop), "string-build-in-loop", "System.String", "loop body")]
-    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop), "allocation-hotspot", "newobj/newarr/box", "loop body")]
-    [InlineData(nameof(OptimizationOpportunityFixtures.ContainsKey), "scan-method-in-loop-call", null, "loop body")]
-    public void OptimizationOpportunities_IncludeAllocationAndPathMetadata(string methodName, string shape, string? expectedAllocation, string expectedPath)
+    [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), "stackalloc-candidate", "System.Int32[]", "straight-line", "dominates-return")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), "box-value-type", "boxed System.Guid", "straight-line", "dominates-return")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesInLoop), "box-value-type", "boxed System.Int32", "loop body", "behind-branch")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AppendsStringInLoop), "string-build-in-loop", "System.String", "loop body", "behind-branch")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop), "allocation-hotspot", "newobj/newarr/box", "loop body", null)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ContainsKey), "scan-method-in-loop-call", null, "loop body", null)]
+    public void OptimizationOpportunities_IncludeAllocationPathAndConfidenceMetadata(string methodName, string shape, string? expectedAllocation, string expectedPath, string? expectedConfidence)
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 
@@ -1244,6 +1248,7 @@ public class LibraryBodyIndexTests
 
         Assert.Equal(expectedAllocation, opportunity.RuntimeAllocationType);
         Assert.Equal(expectedPath, opportunity.PathContext);
+        Assert.Equal(expectedConfidence, opportunity.PathConfidence);
     }
 
     [Fact]

--- a/src/ILInspector.Analysis/AllocationOccurrence.cs
+++ b/src/ILInspector.Analysis/AllocationOccurrence.cs
@@ -43,6 +43,13 @@ public enum AllocationPathContext
     ErrorPath,
 }
 
+public enum AllocationPathConfidence
+{
+    Unknown,
+    DominatesReturn,
+    BehindBranch,
+}
+
 /// <summary>
 /// One static heap-allocation occurrence, keyed by IL offset. Presentation layers
 /// project this into hidden-fact annotations, method signals, and triage rows.
@@ -60,7 +67,8 @@ public sealed record AllocationOccurrence(
     AllocationEscape Escape,
     AllocationFactSource Source,
     string? RuntimeAllocationType = null,
-    AllocationPathContext PathContext = AllocationPathContext.StraightLine)
+    AllocationPathContext PathContext = AllocationPathContext.StraightLine,
+    AllocationPathConfidence PathConfidence = AllocationPathConfidence.Unknown)
 {
     public string AnnotationId => Kind switch
     {

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1398,6 +1398,8 @@ public sealed class LibraryBodyIndex
                 for (int blockIndex = 0; blockIndex < blockGraph.Blocks.Length; blockIndex++)
                 {
                     var pathContext = decodedBody.PathContexts.ContextFor(blockIndex);
+                    if (pathContext == AllocationPathContext.ErrorPath)
+                        continue;
                     if (pathContext is AllocationPathContext.Branch or AllocationPathContext.SwitchArm)
                     {
                         confidenceByBlock[blockIndex] = AllocationPathConfidence.BehindBranch;

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -142,8 +142,11 @@ public sealed class LibraryBodyIndex
     {
         var runtimeAllocation = opportunity.RuntimeAllocationType ?? FallbackRuntimeAllocationType(opportunity);
         var pathContext = opportunity.PathContext ?? FallbackPathContext(opportunity);
-        return runtimeAllocation != opportunity.RuntimeAllocationType || pathContext != opportunity.PathContext
-            ? opportunity with { RuntimeAllocationType = runtimeAllocation, PathContext = pathContext }
+        var pathConfidence = opportunity.PathConfidence;
+        return runtimeAllocation != opportunity.RuntimeAllocationType
+            || pathContext != opportunity.PathContext
+            || pathConfidence != opportunity.PathConfidence
+            ? opportunity with { RuntimeAllocationType = runtimeAllocation, PathContext = pathContext, PathConfidence = pathConfidence }
             : opportunity;
     }
 
@@ -179,6 +182,14 @@ public sealed class LibraryBodyIndex
             AllocationPathContext.LoopBody => "loop body",
             AllocationPathContext.ErrorPath => "error path",
             _ => "straight-line",
+        };
+
+    static string? FormatPathConfidence(AllocationPathConfidence confidence)
+        => confidence switch
+        {
+            AllocationPathConfidence.DominatesReturn => "dominates-return",
+            AllocationPathConfidence.BehindBranch => "behind-branch",
+            _ => null,
         };
 
     OptimizationOpportunity MarkAmortizedSetup(OptimizationOpportunity opportunity)
@@ -1159,12 +1170,14 @@ public sealed class LibraryBodyIndex
                     _instructionIndexByOffset[instructions[i].Offset] = i;
                 LoopRegions = CollectLoopRegions();
                 PathContexts = AllocationPathContextIndex.Create(this);
+                PathConfidences = AllocationPathConfidenceIndex.Create(this);
             }
 
             public ImmutableArray<DecodedInstruction> Instructions { get; }
             public BlockGraph BlockGraph { get; }
             public IReadOnlyList<(int Start, int End)> LoopRegions { get; }
             public AllocationPathContextIndex PathContexts { get; }
+            public AllocationPathConfidenceIndex PathConfidences { get; }
 
             public bool TryGetInstructionAt(int offset, out DecodedInstruction instruction)
             {
@@ -1361,6 +1374,179 @@ public sealed class LibraryBodyIndex
                 int blockIndex = blockGraph.BlockIndexAt(offset);
                 if ((uint)blockIndex < (uint)branchBlocks.Length && predecessorCounts[blockIndex] <= 1)
                     branchBlocks[blockIndex] = true;
+            }
+        }
+
+        sealed class AllocationPathConfidenceIndex
+        {
+            readonly AllocationPathConfidence[] _confidenceByBlock;
+
+            AllocationPathConfidenceIndex(AllocationPathConfidence[] confidenceByBlock)
+            {
+                _confidenceByBlock = confidenceByBlock;
+            }
+
+            public static AllocationPathConfidenceIndex Create(DecodedBody decodedBody)
+            {
+                var blockGraph = decodedBody.BlockGraph;
+                var confidenceByBlock = new AllocationPathConfidence[blockGraph.Blocks.Length];
+                if (blockGraph.Blocks.Length == 0)
+                    return new AllocationPathConfidenceIndex(confidenceByBlock);
+
+                var dominators = DominatorTree.Create(blockGraph);
+                var returnBlocks = ReturnBlocks(decodedBody);
+                for (int blockIndex = 0; blockIndex < blockGraph.Blocks.Length; blockIndex++)
+                {
+                    var pathContext = decodedBody.PathContexts.ContextFor(blockIndex);
+                    if (pathContext is AllocationPathContext.Branch or AllocationPathContext.SwitchArm)
+                    {
+                        confidenceByBlock[blockIndex] = AllocationPathConfidence.BehindBranch;
+                        continue;
+                    }
+
+                    if (returnBlocks.Length > 0
+                        && returnBlocks.All(returnBlock => dominators.Dominates(blockIndex, returnBlock)))
+                    {
+                        confidenceByBlock[blockIndex] = AllocationPathConfidence.DominatesReturn;
+                    }
+                }
+                return new AllocationPathConfidenceIndex(confidenceByBlock);
+            }
+
+            public AllocationPathConfidence ConfidenceFor(int blockIndex)
+                => (uint)blockIndex < (uint)_confidenceByBlock.Length
+                    ? _confidenceByBlock[blockIndex]
+                    : AllocationPathConfidence.Unknown;
+
+            static int[] ReturnBlocks(DecodedBody decodedBody)
+            {
+                var returns = new List<int>();
+                foreach (var instruction in decodedBody.Instructions)
+                {
+                    if (instruction.OpCode != ILOpCode.Ret)
+                        continue;
+                    int blockIndex = decodedBody.BlockGraph.BlockIndexAt(instruction.Offset);
+                    if (blockIndex >= 0)
+                        returns.Add(blockIndex);
+                }
+                return [.. returns.Distinct().Order()];
+            }
+        }
+
+        sealed class DominatorTree
+        {
+            readonly int[] _idom;
+            readonly int _undefined;
+
+            DominatorTree(int[] idom, int undefined)
+            {
+                _idom = idom;
+                _undefined = undefined;
+            }
+
+            public static DominatorTree Create(BlockGraph blockGraph)
+            {
+                int n = blockGraph.Blocks.Length;
+                int undefined = n + 1;
+                var idom = new int[n];
+                Array.Fill(idom, undefined);
+                if (n == 0)
+                    return new DominatorTree(idom, undefined);
+
+                var predecessors = new List<int>[n];
+                for (int i = 0; i < n; i++)
+                    predecessors[i] = [];
+                for (int i = 0; i < n; i++)
+                {
+                    foreach (int successor in blockGraph.Blocks[i].Edges.Successors)
+                        if ((uint)successor < (uint)n)
+                            predecessors[successor].Add(i);
+                }
+
+                var postorder = new int[n];
+                Array.Fill(postorder, -1);
+                var order = new List<int>(n);
+                var visited = new bool[n];
+                var stack = new Stack<(int Block, int Next)>();
+                stack.Push((0, 0));
+                visited[0] = true;
+                while (stack.Count > 0)
+                {
+                    var (block, next) = stack.Pop();
+                    var successors = blockGraph.Blocks[block].Edges.Successors;
+                    if (next < successors.Count)
+                    {
+                        stack.Push((block, next + 1));
+                        int successor = successors[next];
+                        if ((uint)successor < (uint)n && !visited[successor])
+                        {
+                            visited[successor] = true;
+                            stack.Push((successor, 0));
+                        }
+                    }
+                    else
+                    {
+                        postorder[block] = order.Count;
+                        order.Add(block);
+                    }
+                }
+
+                idom[0] = 0;
+                var reversePostorder = new List<int>(order.Count);
+                for (int i = order.Count - 1; i >= 0; i--)
+                    if (order[i] != 0)
+                        reversePostorder.Add(order[i]);
+
+                bool changed = true;
+                while (changed)
+                {
+                    changed = false;
+                    foreach (int block in reversePostorder)
+                    {
+                        int newIdom = undefined;
+                        foreach (int predecessor in predecessors[block])
+                        {
+                            if (idom[predecessor] == undefined)
+                                continue;
+                            newIdom = newIdom == undefined
+                                ? predecessor
+                                : Intersect(predecessor, newIdom, idom, postorder);
+                        }
+                        if (newIdom != undefined && idom[block] != newIdom)
+                        {
+                            idom[block] = newIdom;
+                            changed = true;
+                        }
+                    }
+                }
+
+                return new DominatorTree(idom, undefined);
+            }
+
+            public bool Dominates(int dominator, int block)
+            {
+                if ((uint)dominator >= (uint)_idom.Length || (uint)block >= (uint)_idom.Length)
+                    return false;
+                for (int cursor = block; cursor != _undefined; cursor = _idom[cursor])
+                {
+                    if (cursor == dominator)
+                        return true;
+                    if (cursor == _idom[cursor])
+                        break;
+                }
+                return false;
+            }
+
+            static int Intersect(int a, int b, int[] idom, int[] postorder)
+            {
+                while (a != b)
+                {
+                    while (postorder[a] < postorder[b])
+                        a = idom[a];
+                    while (postorder[b] < postorder[a])
+                        b = idom[b];
+                }
+                return a;
             }
         }
 
@@ -1995,7 +2181,8 @@ public sealed class LibraryBodyIndex
                     escape,
                     source,
                     RuntimeAllocationType(kind, allocatedType),
-                    AllocationPathContextFor(decodedBody, offset, loopRegions, escape));
+                    AllocationPathContextFor(decodedBody, offset, loopRegions, escape),
+                    AllocationPathConfidenceFor(decodedBody, offset, escape));
 
             bool ShouldEmitUnresolvedValueTypeAnnotation(int operandToken, TypeRef type)
             {
@@ -2822,6 +3009,7 @@ public sealed class LibraryBodyIndex
                     {
                         RuntimeAllocationType = runtimeAllocation,
                         PathContext = opportunity.PathContext ?? FormatPathContext(AllocationPathContextFor(decodedBody, opportunityOffset, loopRegions, AllocationEscape.Unknown)),
+                        PathConfidence = opportunity.PathConfidence ?? FormatPathConfidence(AllocationPathConfidenceFor(decodedBody, opportunityOffset, AllocationEscape.Unknown)),
                     };
                 }
                 return AddFallbackOpportunityMetadata(annotated);
@@ -3239,6 +3427,17 @@ public sealed class LibraryBodyIndex
             return blockContext;
         }
 
+        static AllocationPathConfidence AllocationPathConfidenceFor(
+            DecodedBody decodedBody,
+            int offset,
+            AllocationEscape escape)
+        {
+            if (escape == AllocationEscape.ThrowPath)
+                return AllocationPathConfidence.Unknown;
+            int blockIndex = decodedBody.BlockGraph.BlockIndexAt(offset);
+            return decodedBody.PathConfidences.ConfidenceFor(blockIndex);
+        }
+
         // Conservative, sound local-escape check for a freshly created array. Returns true
         // only when the array is stored straight into a local (`newarr; stloc.X`) whose every
         // load is an in-place element access / length read — never returned, stored to a
@@ -3328,6 +3527,7 @@ public sealed class LibraryBodyIndex
                     {
                         Escape = escape,
                         PathContext = escape == AllocationEscape.ThrowPath ? AllocationPathContext.ErrorPath : occurrence.PathContext,
+                        PathConfidence = escape == AllocationEscape.ThrowPath ? AllocationPathConfidence.Unknown : occurrence.PathConfidence,
                     });
             }
             return builder.MoveToImmutable();

--- a/src/ILInspector.Analysis/OptimizationOpportunity.cs
+++ b/src/ILInspector.Analysis/OptimizationOpportunity.cs
@@ -12,7 +12,8 @@ public sealed record OptimizationOpportunity(
     int RootReach = 0,
     bool ColdPath = false,
     string? RuntimeAllocationType = null,
-    string? PathContext = null)
+    string? PathContext = null,
+    string? PathConfidence = null)
 {
     public bool Amortized { get; init; }
 }

--- a/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
@@ -39,7 +39,7 @@ public class AllocationOccurrenceFactTests
         var annotations = Classify(nameof(AllocSampleClass.BoxInt));
 
         var box = Assert.Single(annotations, a => a.Descriptor.Id == "alloc.box");
-        Assert.Equal("int; alloc=boxed System.Int32; path=straight-line; escape=escapes", box.Detail);
+        Assert.Equal("int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; escape=escapes", box.Detail);
         Assert.True(box.SourceOffset >= 0, "the annotation should carry IL provenance");
         Assert.Equal(AnnotationCategory.Allocation, box.Descriptor.Category);
     }
@@ -60,7 +60,7 @@ public class AllocationOccurrenceFactTests
         var annotations = Classify(nameof(AllocSampleClass.MakeRectangularArray));
 
         var array = Assert.Single(annotations, a => a.Descriptor.Id == "alloc.array");
-        Assert.Equal("int[,]; alloc=System.Int32[,]; path=straight-line; escape=escapes", array.Detail);
+        Assert.Equal("int[,]; alloc=System.Int32[,]; path=straight-line; path-confidence=dominates-return; escape=escapes", array.Detail);
         Assert.DoesNotContain(annotations, a => a.Descriptor.Id == "alloc.new");
     }
 

--- a/src/ILInspector.Decompiler.Tests/AnnotatedCSharpRendererTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedCSharpRendererTests.cs
@@ -20,14 +20,14 @@ public class AnnotatedCSharpRendererTests
         // The box is invisible in the source (object BoxInt(int x) => x;) yet the
         // annotated view shows it where it happens.
         var output = Render(nameof(AllocSampleClass.BoxInt));
-        Assert.Contains("return x;  // alloc.box(int; alloc=boxed System.Int32; path=straight-line; escape=escapes)", output);
+        Assert.Contains("return x;  // alloc.box(int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; escape=escapes)", output);
     }
 
     [Fact]
     public void Array_SurfacesTheAllocatedType()
     {
         var output = Render(nameof(AllocSampleClass.MakeArray));
-        Assert.Contains("// alloc.array(int[]; alloc=System.Int32[]; path=straight-line; escape=escapes)", output);
+        Assert.Contains("// alloc.array(int[]; alloc=System.Int32[]; path=straight-line; path-confidence=dominates-return; escape=escapes)", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/AnnotatedIlFactTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedIlFactTests.cs
@@ -21,7 +21,7 @@ public class AnnotatedIlFactTests
         // opcode, not a statement.
         var output = Render(nameof(AllocSampleClass.BoxInt));
         var line = output.Split('\n').Single(l => l.Contains(": box"));
-        Assert.Contains("alloc.box(int; alloc=boxed System.Int32; path=straight-line; escape=escapes)", line);
+        Assert.Contains("alloc.box(int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; escape=escapes)", line);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/AnnotationStructuredViewTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationStructuredViewTests.cs
@@ -28,7 +28,7 @@ public class AnnotationStructuredViewTests
         var fact = Assert.Single(doc.RootElement.EnumerateArray());
         Assert.Equal("alloc.box", fact.GetProperty("id").GetString());
         Assert.Equal("Allocation", fact.GetProperty("category").GetString());
-        Assert.Equal("int; alloc=boxed System.Int32; path=straight-line; escape=escapes", fact.GetProperty("detail").GetString());
+        Assert.Equal("int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; escape=escapes", fact.GetProperty("detail").GetString());
         Assert.Equal("IL_0001", fact.GetProperty("il").GetString());
         Assert.True(fact.GetProperty("offset").GetInt32() >= 0);
     }
@@ -41,7 +41,7 @@ public class AnnotationStructuredViewTests
         var json = AnnotationStructuredView.Json(Collect(nameof(AllocSampleClass.Capture)));
         using var doc = JsonDocument.Parse(json);
         Assert.Contains(doc.RootElement.EnumerateArray(),
-            f => f.GetProperty("detail").GetString() == "Func<int, int>; alloc=System.Func<System.Int32, System.Int32>; path=straight-line; escape=escapes");
+            f => f.GetProperty("detail").GetString() == "Func<int, int>; alloc=System.Func<System.Int32, System.Int32>; path=straight-line; path-confidence=dominates-return; escape=escapes");
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
@@ -37,8 +37,8 @@ public class MixedSourceRendererTests
         var lines = output.Split('\n');
         var cs = lines.Single(l => l.Contains("new int[n]"));
         var il = lines.Single(l => l.Contains("newarr"));
-        Assert.Contains("alloc.array(int[]; alloc=System.Int32[]; path=straight-line; escape=escapes)", cs);
-        Assert.Contains("alloc.array(int[]; alloc=System.Int32[]; path=straight-line; escape=escapes)", il);
+        Assert.Contains("alloc.array(int[]; alloc=System.Int32[]; path=straight-line; path-confidence=dominates-return; escape=escapes)", cs);
+        Assert.Contains("alloc.array(int[]; alloc=System.Int32[]; path=straight-line; path-confidence=dominates-return; escape=escapes)", il);
     }
 
     [Fact]

--- a/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
+++ b/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
@@ -57,6 +57,8 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
         if (occurrence.RuntimeAllocationType is { Length: > 0 } runtime)
             parts.Add($"alloc={runtime}");
         parts.Add($"path={FormatPathContext(occurrence.PathContext)}");
+        if (FormatPathConfidence(occurrence.PathConfidence) is { } confidence)
+            parts.Add($"path-confidence={confidence}");
         if (occurrence.Escape != AllocationEscape.Unknown)
             parts.Add($"escape={FormatEscape(occurrence.Escape)}");
         return parts.Count == 0 ? null : string.Join("; ", parts);
@@ -70,6 +72,14 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
             AllocationPathContext.LoopBody => "loop-body",
             AllocationPathContext.ErrorPath => "error-path",
             _ => "straight-line",
+        };
+
+    static string? FormatPathConfidence(AllocationPathConfidence confidence)
+        => confidence switch
+        {
+            AllocationPathConfidence.DominatesReturn => "dominates-return",
+            AllocationPathConfidence.BehindBranch => "behind-branch",
+            _ => null,
         };
 
     static string FormatEscape(AllocationEscape escape)

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2564,7 +2564,7 @@ public class CommandExecutionTests
         Assert.Contains("| Member | IL | Cs Line | Anchor | Category | Id | Detail | Conditionality |", output);
         Assert.Contains("FactsTableFixture::BoxInt", output);
         Assert.Contains("`IL_", output);
-        Assert.Contains("| offset | Allocation | alloc.box | `int; alloc=boxed System.Int32; path=straight-line; escape=escapes` | Always |", output);
+        Assert.Contains("| offset | Allocation | alloc.box | `int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; escape=escapes` | Always |", output);
     }
 
     [Fact]
@@ -2577,7 +2577,7 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.Contains("FactsTableFixture::BoxInt\tIL_", output);
-        Assert.Contains("\toffset\tAllocation\talloc.box\tint; alloc=boxed System.Int32; path=straight-line; escape=escapes\tAlways", output);
+        Assert.Contains("\toffset\tAllocation\talloc.box\tint; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; escape=escapes\tAlways", output);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -738,6 +738,7 @@ internal static class LibraryMetadataService
                     Loop = opportunity.InLoop ? "loop" : "",
                     Allocation = opportunity.RuntimeAllocationType,
                     Path = opportunity.PathContext,
+                    PathConfidence = opportunity.PathConfidence,
                     IL = opportunity.ILOffset is { } offset ? $"IL_{offset:X4}" : null,
                 })
                 .ToList();

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -646,6 +646,8 @@ public record class OptimizationOpportunitySummary
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Path { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PathConfidence { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? IL { get; init; }
 }
 

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1702,6 +1702,7 @@ public static class ApiOutputFormatter
                 opportunity.InLoop ? "loop" : "",
                 opportunity.RuntimeAllocationType is { Length: > 0 } allocation ? MarkoutInline.Code(allocation) : null,
                 opportunity.PathContext,
+                opportunity.PathConfidence,
                 opportunity.ILOffset is { } offset ? MarkoutInline.Code($"IL_{offset:X4}") : null))
             .ToList();
 

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -820,6 +820,7 @@ public record OptimizationOpportunityRow(
     string Loop,
     [property: MarkoutSkipNull] string? Allocation,
     [property: MarkoutSkipNull] string? Path,
+    [property: MarkoutSkipNull] string? PathConfidence,
     [property: MarkoutSkipNull] string? IL);
 
 [MarkoutSerializable]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -704,6 +704,7 @@ public class LibraryInspectionView
                 o.Loop,
                 o.Allocation is null ? null : MarkoutInline.Code(o.Allocation),
                 o.Path,
+                o.PathConfidence,
                 o.IL is null ? null : MarkoutInline.Code(o.IL)))
             .ToList();
 


### PR DESCRIPTION
## Summary

Second PR in the allocation metadata follow-up split after #2070. This adds evidence-only path-confidence metadata on top of allocation runtime/path context.

- Adds `AllocationPathConfidence` with `dominates-return` and `behind-branch` labels.
- Computes a per-method dominator index over `BlockGraph` to mark allocation blocks that dominate all return blocks.
- Marks conditional/switch arm allocations as `behind-branch`.
- Projects confidence into allocation `Facts` detail and `Performance Triage` as an optional `Path Confidence` column.
- Keeps opportunity detection/ranking unchanged; this is metadata only.

## Examples

- Straight-line `BoxInt` fact: `path=straight-line; path-confidence=dominates-return; escape=escapes`.
- `LocalArrayStaysLocal` / `stackalloc-candidate`: `Path Confidence = dominates-return`.
- Loop-body boxes/string-build rows: `Path Confidence = behind-branch` because the loop body is conditional.
- Branch and switch-arm allocation fixtures: `Path Confidence = behind-branch`.
- Catch/error-path and finally/EH-survivor fixtures remain `Unknown` when dominance is not safe to claim.

## Validation

- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -method '*AllocationOccurrences_IncludeRuntimeTypePathContextAndConfidence*' -method '*AllocationOccurrences_IncludeBranchAndSwitchPathContext*' -method '*OptimizationOpportunities_IncludeAllocationPathAndConfidenceMetadata*'`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -method '*Member_SelectedOverload_SelectFacts*'`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -method '*AllocationOccurrenceFactTests*' -method '*AnnotatedIlFactTests*' -method '*MixedSourceRendererTests.Fact_ShowsOnBoth*' -method '*AnnotatedCSharpRendererTests*' -method '*AnnotationStructuredViewTests.Json*'`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -p:NoWarn=NU1507%3BCS0436`
- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507%3BCS0436 --nologo --verbosity quiet`

## Review status

Adversarial review is required for this analysis PR. I will post reviewer findings and reconciliation as PR comments.
