### PR TITLE
Emit unchecked enum casts for same-assembly unsigned/out-of-range conditional arms

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4359,6 +4359,16 @@ public static class EnumCastSamples
         CfgFlags x = c ? CfgFlags.Top : e;
         return x == CfgFlags.None;
     }
+
+    // #2076 (review): a retyped same-assembly unsigned-enum constant with no named
+    // member — (CfgFlags)uint.MaxValue folds to `ldc.i4.m1` (-1) — must render an
+    // `unchecked` cast in comparison, bitwise, and coalesce positions, not a bare
+    // `(CfgFlags)(-1)` (CS0221).
+    public static bool UnsignedEnumConstantComparison(CfgFlags f) => f == (CfgFlags)uint.MaxValue;
+
+    public static CfgFlags UnsignedEnumConstantBitwise(CfgFlags f) => f & (CfgFlags)uint.MaxValue;
+
+    public static CfgFlags UnsignedEnumConstantCoalesce(CfgFlags? f) => f ?? (CfgFlags)uint.MaxValue;
 }
 
 

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4070,6 +4070,7 @@ public sealed class JoinTypeProvider
 public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }
 
 public enum CfgLongPriority : long { Low = 0, High = 2 }
+public enum CfgULong : ulong { None = 0, All = 18446744073709551615UL }
 
 // uint-underlying with a high-bit member: the value 0x80000000 emits as the
 // signed int -2147483648, the case the member-map key must agree on.
@@ -4376,6 +4377,13 @@ public static class EnumCastSamples
     public static CfgLongPriority[] LongEnumArray() => new[] { CfgLongPriority.High, (CfgLongPriority)5000000000L };
 
     public static System.Enum LongEnumBoxed() => CfgLongPriority.High;
+
+    // #2076 (review): an unsigned long-backed enum value lowers as
+    // `ldc.i4.m1; conv.i8`, so the enum cast's operand is a `Convert(long, ...)`.
+    // The overflow decision must see through it and wrap `unchecked((CfgULong)(...))`.
+    public static System.Enum ULongEnumBoxedMax() => CfgULong.All;
+
+    public static CfgULong[] ULongEnumArrayMax() => new[] { CfgULong.All };
 }
 
 

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4347,6 +4347,18 @@ public static class EnumCastSamples
             0 => CfgPriority.High,
             _ => CfgPriority.Critical,
         };
+
+    // #2076: a conditional whose reused stack slot merges an integer constant and a
+    // same-assembly unsigned-backed enum (CfgFlags : uint). CfgFlags.Top =
+    // 0x80000000u is emitted as `ldc.i4` int.MinValue (negative as a signed int),
+    // so the importer cannot type the slot join. The slot-diamond fold must anchor
+    // the enum type and the printer must emit `unchecked((CfgFlags)(-2147483648))`;
+    // a bare or checked cast is CS0221, and a lost cast is CS0029.
+    public static bool UnsignedEnumConditionalArm(bool c, CfgFlags e)
+    {
+        CfgFlags x = c ? CfgFlags.Top : e;
+        return x == CfgFlags.None;
+    }
 }
 
 

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4384,6 +4384,12 @@ public static class EnumCastSamples
     public static System.Enum ULongEnumBoxedMax() => CfgULong.All;
 
     public static CfgULong[] ULongEnumArrayMax() => new[] { CfgULong.All };
+
+    // #2076 (review): a cross-assembly enum array (StringComparison resolves to
+    // TypeShape.Unknown). The `stelem.i4` storage type must not drop the element
+    // below its enum type — a bare `[0] = 4;` is CS0266.
+    public static System.StringComparison[] CrossAssemblyEnumArray()
+        => new[] { (System.StringComparison)4, System.StringComparison.OrdinalIgnoreCase };
 }
 
 

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4369,6 +4369,13 @@ public static class EnumCastSamples
     public static CfgFlags UnsignedEnumConstantBitwise(CfgFlags f) => f & (CfgFlags)uint.MaxValue;
 
     public static CfgFlags UnsignedEnumConstantCoalesce(CfgFlags? f) => f ?? (CfgFlags)uint.MaxValue;
+
+    // #2076 (review): long-backed enum constants in array-element and box
+    // positions. The `stelem.i8` element type and `box` drop the enum type, so a
+    // long constant printed bare is CS0266/CS0029 unless cast.
+    public static CfgLongPriority[] LongEnumArray() => new[] { CfgLongPriority.High, (CfgLongPriority)5000000000L };
+
+    public static System.Enum LongEnumBoxed() => CfgLongPriority.High;
 }
 
 

--- a/src/ILInspector.Decompiler.Tests/DiamondArmTypeReconciliationTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DiamondArmTypeReconciliationTests.cs
@@ -42,14 +42,25 @@ public class DiamondArmTypeReconciliationTests
     }
 
     [Fact]
-    public void ConflictingArmType_OutOfRangeConstantAndByteBackedEnum_IsUnresolved()
+    public void ConflictingArmType_OutOfRangeConstantAndByteBackedEnum_ResolvesToEnum()
     {
-        // `(Kind)300` where `Kind : byte` is CS0221 — the printer's enum cast is a
-        // constant-expression conversion, so it only compiles in range. Decline
-        // rather than emit invalid C#.
+        // #2076: still anchored even out of the underlying range. The printer wraps
+        // the reinterpret in `unchecked((Kind)300)` (see EnumIntegerCast), which is
+        // valid and faithful, so the fold no longer needs to decline.
         var function = FunctionWithEnum(Byte);
         var enumValue = new Call(new MethodRef(Kind, "Get", Kind, [], HasThis: false), isVirtual: false, []);
-        Assert.Null(DiamondArmTypes.ConflictingArmType(new Constant(300, Int32), enumValue, function));
+        Assert.Equal(Kind, DiamondArmTypes.ConflictingArmType(new Constant(300, Int32), enumValue, function));
+    }
+
+    [Fact]
+    public void ConflictingArmType_NegativeConstantAndUnsignedEnum_ResolvesToEnum()
+    {
+        // #2076: an unsigned-backed enum whose high-bit value is emitted as a
+        // negative `ldc.i4` (e.g. 0x80000000u -> -1). `ConstantFits(-1, uint)` is
+        // false, but the printer renders `unchecked((Kind)(-1))`, so anchor it.
+        var function = FunctionWithEnum(TypeRef.CoreLib("System", "UInt32"));
+        var enumValue = new Call(new MethodRef(Kind, "Get", Kind, [], HasThis: false), isVirtual: false, []);
+        Assert.Equal(Kind, DiamondArmTypes.ConflictingArmType(new Constant(-1, Int32), enumValue, function));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -114,6 +114,38 @@ public class EnumCastPrinterTests
     }
 
     [Fact]
+    public void EnumConditional_SameAssemblyUnsignedEnum_ForcesUncheckedCast()
+    {
+        // #2076: `c ? CfgFlags.Top : e` where CfgFlags : uint. Top (0x80000000u)
+        // is emitted as `ldc.i4` int.MinValue, so the conditional slot's importer
+        // type is unknown; the fold anchors the enum and the printer must wrap the
+        // negative reinterpret in `unchecked`.
+        string body = RenderRaisedFixture(nameof(EnumCastSamples.UnsignedEnumConditionalArm));
+
+        Assert.Contains("unchecked((CfgFlags)(-2147483648))", body);
+        Assert.DoesNotContain(": -2147483648", body);
+        AssertCompiles(
+            "public static bool M(bool c, CfgFlags e)",
+            body,
+            "public enum CfgFlags : uint { None = 0, Top = 0x80000000u }");
+    }
+
+    [Fact]
+    public void KnownEnumPositiveConstantOutOfRange_ForcesUncheckedCast()
+    {
+        // A same-assembly enum with a known narrow underlying type: an out-of-range
+        // constant cast is CS0221 unless wrapped, while an in-range one stays bare.
+        string outOfRange = RenderKnownEnumReturnConstant(300, TypeRef.CoreLib("System", "Byte"));
+        Assert.Contains("return unchecked((Tiny)300);", outOfRange);
+        AssertCompiles("public static Tiny M()", outOfRange, "public enum Tiny : byte { }");
+
+        string inRange = RenderKnownEnumReturnConstant(4, TypeRef.CoreLib("System", "Byte"));
+        Assert.Contains("return (Tiny)4;", inRange);
+        Assert.DoesNotContain("unchecked", inRange);
+        AssertCompiles("public static Tiny M()", inRange, "public enum Tiny : byte { }");
+    }
+
+    [Fact]
     public void UnknownEnumPositiveConstantThatMayOverflow_ForcesUncheckedCast()
     {
         string sbyteBody = RenderUnknownEnumReturnConstant(128);
@@ -169,6 +201,19 @@ public class EnumCastPrinterTests
         return result.Output!;
     }
 
+    // As RenderFixture, but for a body that is only Partial at import (e.g. a slot
+    // whose int/enum join the importer cannot type) and is raised to valid C# by
+    // the pipeline — so it skips the import-time Full precondition.
+    static string RenderRaisedFixture(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(EnumCastSamples).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(EnumCastSamples).FullName!, methodName);
+        Assert.NotNull(function);
+        var result = CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method));
+        Assert.NotNull(result.Output);
+        return result.Output!;
+    }
+
     static string RenderSyntheticSwitchExpression(
         TypeRef returnType,
         IrExpression firstArm,
@@ -207,6 +252,24 @@ public class EnumCastPrinterTests
         container.Add(block);
         var signature = new MethodSignature(enumType, [], HasThis: false, GenericParameterCount: 0);
         var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], container);
+
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    static string RenderKnownEnumReturnConstant(int value, TypeRef underlying)
+    {
+        var enumType = TypeRef.Definition("synthetic", "", "Tiny");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var block = new Block(0);
+        block.Add(new Return(new Constant(value, intType)));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(enumType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], container)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum },
+            EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef> { [enumType] = underlying },
+        };
 
         return CSharpPrinter.Print(function).Output!.Trim();
     }

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -114,6 +114,26 @@ public class EnumCastPrinterTests
     }
 
     [Fact]
+    public void RetypedUnsignedEnumConstant_ForcesUncheckedCast()
+    {
+        // A same-assembly unsigned-enum constant retyped by TypedConstantsPass with
+        // no named member, in comparison / bitwise / coalesce positions.
+        const string declaration = "public enum CfgFlags : uint { None = 0, Top = 0x80000000u }";
+
+        string comparison = RenderFixture(nameof(EnumCastSamples.UnsignedEnumConstantComparison));
+        Assert.Contains("unchecked((CfgFlags)(-1))", comparison);
+        AssertCompiles("public static bool M(CfgFlags f)", comparison, declaration);
+
+        string bitwise = RenderFixture(nameof(EnumCastSamples.UnsignedEnumConstantBitwise));
+        Assert.Contains("unchecked((CfgFlags)(-1))", bitwise);
+        AssertCompiles("public static CfgFlags M(CfgFlags f)", bitwise, declaration);
+
+        string coalesce = RenderFixture(nameof(EnumCastSamples.UnsignedEnumConstantCoalesce));
+        Assert.Contains("unchecked((CfgFlags)(-1))", coalesce);
+        AssertCompiles("public static CfgFlags M(CfgFlags? f)", coalesce, declaration);
+    }
+
+    [Fact]
     public void EnumConditional_SameAssemblyUnsignedEnum_ForcesUncheckedCast()
     {
         // #2076: `c ? CfgFlags.Top : e` where CfgFlags : uint. Top (0x80000000u)

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -166,6 +166,31 @@ public class EnumCastPrinterTests
     }
 
     [Fact]
+    public void EnumWithUnresolvedBackingWidth_AssumesIntBacking()
+    {
+        // An enum classified TypeShape.Enum but whose underlying width is not in the
+        // map (e.g. no value__ field) assumes C#'s default `int` backing: an
+        // int-range negative constant stays a bare cast (matching ExactMember), and
+        // only a genuinely out-of-int value would be wrapped.
+        var enumType = TypeRef.Definition("synthetic", "", "Tiny");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var block = new Block(0);
+        block.Add(new Return(new Constant(-1, intType)));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(enumType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], container)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum },
+            // EnumUnderlyingTypes intentionally left empty.
+        };
+
+        string body = CSharpPrinter.Print(function).Output!.Trim();
+        Assert.Contains("(Tiny)(-1)", body);
+        Assert.DoesNotContain("unchecked", body);
+    }
+
+    [Fact]
     public void UnknownEnumPositiveConstantThatMayOverflow_ForcesUncheckedCast()
     {
         string sbyteBody = RenderUnknownEnumReturnConstant(128);

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -270,6 +270,22 @@ public class EnumCastPrinterTests
     }
 
     [Fact]
+    public void UnsignedLongEnumConstant_ConvertWrapped_ForcesUncheckedCast()
+    {
+        // ulong.MaxValue lowers as `ldc.i4.m1; conv.i8`, so the enum cast operand is
+        // a Convert; the overflow decision must pierce it and wrap `unchecked`.
+        const string declaration = "public enum CfgULong : ulong { None = 0, All = 18446744073709551615UL }";
+
+        string boxed = RenderRaisedFixture(nameof(EnumCastSamples.ULongEnumBoxedMax));
+        Assert.Contains("unchecked((CfgULong)", boxed);
+        AssertCompiles("public static System.Enum M()", boxed, declaration);
+
+        string array = RenderRaisedFixture(nameof(EnumCastSamples.ULongEnumArrayMax));
+        Assert.Contains("unchecked((CfgULong)", array);
+        AssertCompiles("public static CfgULong[] M()", array, declaration);
+    }
+
+    [Fact]
     public void LongBackedEnumConstants_InArrayAndBox_CastOrName()
     {
         // Array elements: long constants render as enum casts, never a bare `long`

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -269,6 +269,31 @@ public class EnumCastPrinterTests
         Assert.DoesNotContain("case 1311768467463790320:", output);
     }
 
+    [Fact]
+    public void LongBackedEnumConstants_InArrayAndBox_CastOrName()
+    {
+        // Array elements: long constants render as enum casts, never a bare `long`
+        // (CS0266). AssertCompiles is the real validity gate.
+        string array = RenderRaisedFixture(nameof(EnumCastSamples.LongEnumArray));
+        Assert.Contains("(CfgLongPriority)5000000000", array);
+        Assert.DoesNotContain("= 5000000000;", array);
+        AssertCompiles(
+            "public static CfgLongPriority[] M()",
+            array,
+            "public enum CfgLongPriority : long { Low = 0, High = 2 }");
+
+        // Box target: the enum value must keep its type (bare long is CS0029 for
+        // System.Enum). A small value arrives as `Convert(long, ...)`, so it casts
+        // rather than names.
+        string boxed = RenderRaisedFixture(nameof(EnumCastSamples.LongEnumBoxed));
+        Assert.Contains("(CfgLongPriority)", boxed);
+        Assert.DoesNotContain("return (long)", boxed);
+        AssertCompiles(
+            "public static System.Enum M()",
+            boxed,
+            "public enum CfgLongPriority : long { Low = 0, High = 2 }");
+    }
+
     static string RenderFixture(string methodName)
     {
         using var source = MetadataSource.Open(typeof(EnumCastSamples).Assembly.Location);

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -270,6 +270,17 @@ public class EnumCastPrinterTests
     }
 
     [Fact]
+    public void CrossAssemblyEnumArray_CastsElementStore()
+    {
+        // A cross-assembly enum array element store must cast to the enum, not emit
+        // a bare `int` (CS0266) off the `stelem.i4` storage type.
+        string body = RenderRaisedFixture(nameof(EnumCastSamples.CrossAssemblyEnumArray));
+        Assert.Contains("(StringComparison)4", body);
+        Assert.DoesNotContain("= 4;", body);
+        AssertCompiles("public static System.StringComparison[] M()", body);
+    }
+
+    [Fact]
     public void UnsignedLongEnumConstant_ConvertWrapped_ForcesUncheckedCast()
     {
         // ulong.MaxValue lowers as `ldc.i4.m1; conv.i8`, so the enum cast operand is

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -235,6 +235,40 @@ public class EnumCastPrinterTests
         AssertCompiles("public static Tiny M(int? value)", body, "public enum Tiny { }");
     }
 
+    [Fact]
+    public void EnumSwitchLabel_LongConstant_CastsInsteadOfBareLiteral()
+    {
+        // #2076 (review): a long case label on a long-backed enum switch must cast
+        // (`case (LEnum)...:`), not render a bare `case 1311768467463790320:`
+        // (CS0266). Member names still win when the value is named.
+        const long value = 1311768467463790320L;
+        var enumType = TypeRef.Definition("synthetic", "", "LEnum");
+        var longType = TypeRef.CoreLib("System", "Int64");
+        var body = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Switch(
+            new LoadArgument(0, "value", enumType),
+            [
+                new SwitchSection(ImmutableArray.Create(new Constant(value, longType)), isDefault: false, SingleReturnContainer()),
+                new SwitchSection(ImmutableArray<Constant>.Empty, isDefault: true, SingleReturnContainer()),
+            ]));
+        body.Add(block);
+        var signature = new MethodSignature(
+            TypeRef.CoreLib("System", "Void"),
+            [new Parameter("value", enumType)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], body)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum },
+            EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef> { [enumType] = longType },
+        };
+
+        string output = CSharpPrinter.Print(function).Output!.Trim();
+        Assert.Contains("case (LEnum)1311768467463790320:", output);
+        Assert.DoesNotContain("case 1311768467463790320:", output);
+    }
+
     static string RenderFixture(string methodName)
     {
         using var source = MetadataSource.Open(typeof(EnumCastSamples).Assembly.Location);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -230,10 +230,13 @@ public sealed partial class CSharpPrinter
                 return true;
             case Convert { Target: { } target } convert
                 when TypeFamilies.IsIntegerLike(target) && TryEnumCastLiteral(convert.Operand, out var inner):
-                // An unsigned widening zero-extends a 32-bit source (`conv.u8` of a
-                // negative int carries its uint bit pattern); a signed widening keeps
-                // the value.
-                literal = convert.IsUnsigned && convert.Operand is Constant { Value: int u } ? (uint)u : inner;
+                // A widening to an unsigned target (`conv.u8`) zero-extends a 32-bit
+                // source, carrying its unsigned bit pattern; a signed widening
+                // (`conv.i8`) keeps the value. `Convert.IsUnsigned` marks a `.un`
+                // overflow opcode, not the target signedness — so key off the target.
+                literal = TypeFamilies.IsUnsignedIntegerPrimitive(target) && convert.Operand is Constant { Value: int u }
+                    ? (uint)u
+                    : inner;
                 return true;
             default:
                 literal = 0;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -202,12 +202,16 @@ public sealed partial class CSharpPrinter
         // needs `unchecked` exactly when the value is out of that width's range.
         if (EnumUnderlyingType(enumType) is { } underlying)
             return !TypeFamilies.ConstantFits(literal, underlying);
-        // A cross-assembly enum has no resolved width; conservatively assume the
-        // narrowest (sbyte) backing, so a negative or a value above sbyte's max may
-        // not fit and is wrapped.
+        // A cross-assembly enum: the width is genuinely unknown and framework enums
+        // are often byte/sbyte-backed [Flags], so conservatively assume the narrowest
+        // (sbyte) backing and wrap a negative or a value above sbyte's max.
         if (_function.TypeShapes.GetValueOrDefault(enumType) == TypeShape.Unknown)
             return literal < 0 || literal > sbyte.MaxValue;
-        return false;
+        // A same-assembly enum shape whose underlying is not in the map (e.g. no
+        // `value__` field): assume C#'s default `int` backing, so an int-range value
+        // (including a negative high-bit constant like int.MinValue) stays a bare
+        // cast and only a genuinely out-of-int value is wrapped.
+        return !TypeFamilies.ConstantFits(literal, TypeRef.CoreLib("System", "Int32"));
     }
 
     string BinaryBody(Binary binary, bool wrap, bool uncheckedOverflow)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -177,20 +177,22 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string EnumIntegerCast(IrExpression value, TypeRef enumType)
     {
+        // A negative literal needs parentheses after the cast (CS0075); whether it
+        // (or an out-of-range positive) also needs `unchecked` is decided entirely
+        // by MayOverflowEnumBackingType against the backing width.
         bool negativeLiteral = value is Constant { Value: int iv } && iv < 0
             || value is Constant { Value: long lv } && lv < 0;
-        bool forceUnchecked = negativeLiteral || MayOverflowEnumBackingType(value, enumType);
-        // A constant can be CS0221 as a plain cast even outside a checked region:
-        // negative into an unsigned-backed enum (`(U)(-1)`) or a positive value that
-        // overflows a narrow backing (`(Tiny)128` for sbyte, `(Tiny)300` for byte),
-        // whether the width is known (from EnumUnderlyingTypes) or only guessed for
-        // a cross-assembly enum. Force `unchecked` in those cases; negative literals
-        // also need parentheses after the cast (CS0075).
+        bool forceUnchecked = MayOverflowEnumBackingType(value, enumType);
         return CheckedSafeCast(
             $"({TypeText(enumType)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}",
             force: forceUnchecked);
     }
 
+    // True when a constant enum cast is CS0221 as a plain (checked) cast, so it must
+    // be wrapped in `unchecked`: a value outside the backing type's range — negative
+    // into an unsigned backing (`(U)(-1)`) or a magnitude a narrow backing cannot
+    // hold (`(Tiny)128` for sbyte, `(Tiny)300` for byte). A value that fits (e.g. a
+    // negative into a signed backing, `(Color)int.MinValue`) stays a bare cast.
     bool MayOverflowEnumBackingType(IrExpression value, TypeRef enumType)
     {
         if (value is not (Constant { Value: int } or Constant { Value: long }))
@@ -201,9 +203,10 @@ public sealed partial class CSharpPrinter
         if (EnumUnderlyingType(enumType) is { } underlying)
             return !TypeFamilies.ConstantFits(literal, underlying);
         // A cross-assembly enum has no resolved width; conservatively assume the
-        // narrowest (sbyte) backing so a value it cannot hold is wrapped.
+        // narrowest (sbyte) backing, so a negative or a value above sbyte's max may
+        // not fit and is wrapped.
         if (_function.TypeShapes.GetValueOrDefault(enumType) == TypeShape.Unknown)
-            return literal > sbyte.MaxValue;
+            return literal < 0 || literal > sbyte.MaxValue;
         return false;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -179,28 +179,32 @@ public sealed partial class CSharpPrinter
     {
         bool negativeLiteral = value is Constant { Value: int iv } && iv < 0
             || value is Constant { Value: long lv } && lv < 0;
-        bool forceUnchecked = negativeLiteral || MayOverflowUnknownEnumBackingType(value, enumType);
+        bool forceUnchecked = negativeLiteral || MayOverflowEnumBackingType(value, enumType);
         // A constant can be CS0221 as a plain cast even outside a checked region:
-        // negative into an unsigned-backed enum (`(U)(-1)`) or positive values that
-        // may overflow a signed- or unsigned-byte-backed unknown enum
-        // (`(Tiny)128` for sbyte, `(Tiny)300` for byte).
-        // Force `unchecked` when the target shape cannot prove the backing width;
-        // negative literals also need parentheses after the cast (CS0075).
+        // negative into an unsigned-backed enum (`(U)(-1)`) or a positive value that
+        // overflows a narrow backing (`(Tiny)128` for sbyte, `(Tiny)300` for byte),
+        // whether the width is known (from EnumUnderlyingTypes) or only guessed for
+        // a cross-assembly enum. Force `unchecked` in those cases; negative literals
+        // also need parentheses after the cast (CS0075).
         return CheckedSafeCast(
             $"({TypeText(enumType)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}",
             force: forceUnchecked);
     }
 
-    bool MayOverflowUnknownEnumBackingType(IrExpression value, TypeRef enumType)
+    bool MayOverflowEnumBackingType(IrExpression value, TypeRef enumType)
     {
-        if (_function.TypeShapes.GetValueOrDefault(enumType) != TypeShape.Unknown)
+        if (value is not (Constant { Value: int } or Constant { Value: long }))
             return false;
-        return value switch
-        {
-            Constant { Value: int iv } => iv > sbyte.MaxValue,
-            Constant { Value: long lv } => lv > sbyte.MaxValue,
-            _ => false,
-        };
+        long literal = value is Constant { Value: int iv } ? iv : (long)((Constant)value).Value!;
+        // A known backing width: the cast is a constant-expression conversion, so it
+        // needs `unchecked` exactly when the value is out of that width's range.
+        if (EnumUnderlyingType(enumType) is { } underlying)
+            return !TypeFamilies.ConstantFits(literal, underlying);
+        // A cross-assembly enum has no resolved width; conservatively assume the
+        // narrowest (sbyte) backing so a value it cannot hold is wrapped.
+        if (_function.TypeShapes.GetValueOrDefault(enumType) == TypeShape.Unknown)
+            return literal > sbyte.MaxValue;
+        return false;
     }
 
     string BinaryBody(Binary binary, bool wrap, bool uncheckedOverflow)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -195,9 +195,8 @@ public sealed partial class CSharpPrinter
     // negative into a signed backing, `(Color)int.MinValue`) stays a bare cast.
     bool MayOverflowEnumBackingType(IrExpression value, TypeRef enumType)
     {
-        if (value is not (Constant { Value: int } or Constant { Value: long }))
+        if (!TryEnumCastLiteral(value, out long literal))
             return false;
-        long literal = value is Constant { Value: int iv } ? iv : (long)((Constant)value).Value!;
         // A known backing width: the cast is a constant-expression conversion, so it
         // needs `unchecked` exactly when the value is out of that width's range.
         if (EnumUnderlyingType(enumType) is { } underlying)
@@ -212,6 +211,34 @@ public sealed partial class CSharpPrinter
         // (including a negative high-bit constant like int.MinValue) stays a bare
         // cast and only a genuinely out-of-int value is wrapped.
         return !TypeFamilies.ConstantFits(literal, TypeRef.CoreLib("System", "Int32"));
+    }
+
+    // The integer literal an enum cast will carry, seeing through a widening
+    // `conv.i8`/`conv.u8` over an integer constant — a long-backed enum's small or
+    // unsigned members lower as `ldc.i4; conv.i8`, so the raw operand is a `Convert`,
+    // not a bare `Constant`. Returns false for a non-constant operand (a runtime
+    // value never needs an out-of-range constant wrap).
+    static bool TryEnumCastLiteral(IrExpression value, out long literal)
+    {
+        switch (value)
+        {
+            case Constant { Value: int i }:
+                literal = i;
+                return true;
+            case Constant { Value: long l }:
+                literal = l;
+                return true;
+            case Convert { Target: { } target } convert
+                when TypeFamilies.IsIntegerLike(target) && TryEnumCastLiteral(convert.Operand, out var inner):
+                // An unsigned widening zero-extends a 32-bit source (`conv.u8` of a
+                // negative int carries its uint bit pattern); a signed widening keeps
+                // the value.
+                literal = convert.IsUnsigned && convert.Operand is Constant { Value: int u } ? (uint)u : inner;
+                return true;
+            default:
+                literal = 0;
+                return false;
+        }
     }
 
     string BinaryBody(Binary binary, bool wrap, bool uncheckedOverflow)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1740,10 +1740,12 @@ public sealed partial class CSharpPrinter
         Constant { Value: int } c when EnumMemberName(c) is { } named => named,
         // A retyped enum constant with no single named member (a composite flag
         // value, or one outside the resolved member map) is still that enum — a
-        // bare int is CS0266. Cast it; naming flag combinations is a later slice.
-        // A negative value must be parenthesized after the cast (else CS0075).
+        // bare int is CS0266. Route it through the overflow-aware enum cast so an
+        // unsigned- or narrow-backed enum's out-of-range/negative value is wrapped
+        // in `unchecked` (e.g. `unchecked((U)(-1))`); naming flag combinations is a
+        // later slice.
         Constant { Value: int value, Type: { } enumType } when _function.TypeShapes.GetValueOrDefault(enumType) == TypeShape.Enum
-            => $"({TypeText(enumType)}){(value < 0 ? $"({value})" : value.ToString(CultureInfo.InvariantCulture))}",
+            => EnumIntegerCast(new Constant(value, TypeRef.CoreLib("System", "Int32")), enumType),
         Constant c => ConstantText(c),
         LoadField f => FieldTarget(f.Field, f.Instance),
         Binary b => BinaryText(b),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3103,9 +3103,9 @@ public sealed partial class CSharpPrinter
     /// the raw integer — naming those is a later slice.
     /// </summary>
     string? EnumMemberName(Constant constant)
-        => constant.Value is int value
+        => constant.Value is int or long
             && _function.EnumMembers.TryGetValue(constant.Type, out var members)
-            && members.TryGetValue(value, out var name)
+            && members.TryGetValue(constant.Value is int i ? i : (long)constant.Value!, out var name)
             ? $"{TypeText(constant.Type)}.{name}"
             : null;
 
@@ -3145,8 +3145,9 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string SwitchLabelText(Constant label, TypeRef? enumType)
     {
-        if (enumType is null || label.Value is not int value)
+        if (enumType is null || label.Value is not (int or long))
             return ConstantText(label);
+        long value = label.Value is int i ? i : (long)label.Value!;
         var typed = new Constant(value, enumType);
         if (EnumMemberName(typed) is { } named)
             return named;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1732,12 +1732,14 @@ public sealed partial class CSharpPrinter
         => store.Accessor.ParameterTypes.Length > 0 ? store.Accessor.ParameterTypes[^1] : null;
 
     // The `stelem` opcode records a storage-primitive element type (e.g. `long` for
-    // a long-backed enum array), which drops an enum-typed integer store below its
-    // real element type and prints a bare literal (CS0266). Prefer the array's own
-    // element type when it resolves to an enum.
+    // a long-backed enum array, or `int` for a cross-assembly enum array), which
+    // drops an enum-typed integer store below its real element type and prints a
+    // bare literal (CS0266). Prefer the array's own element type when it is
+    // enum-like — same-assembly (`TypeShape.Enum`) or cross-assembly (an unresolved
+    // non-primitive definition), matching `CastValue`'s enum-cast reasoning.
     TypeRef? StoreElementTargetType(StoreElement store)
         => store.Array.ResultType is { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element }
-            && _function.TypeShapes.GetValueOrDefault(element) == TypeShape.Enum
+            && IsEnumLikeInteger(element)
             ? element
             : store.ElementType;
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1662,7 +1662,7 @@ public sealed partial class CSharpPrinter
             StorePropertyTargetType(s)),
         EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {CastValue(e.Value, e.Accessor.ParameterTypes[0])};",
         StoreElement s when InlineReceiverTempStoreValue(s) is { } value => $"{Operand(s.Array)}[{Expression(s.Index)}] = {value};",
-        StoreElement s => $"{Operand(s.Array)}[{Expression(s.Index)}] = {CastValue(s.Value, s.ElementType)};",
+        StoreElement s => $"{Operand(s.Array)}[{Expression(s.Index)}] = {CastValue(s.Value, StoreElementTargetType(s))};",
         StoreIndirect s => AssignmentText(
             IndirectTarget(s.Address, IndirectStoreType(s.Address, s.Type)),
             s.Value,
@@ -1731,21 +1731,35 @@ public sealed partial class CSharpPrinter
     static TypeRef? StorePropertyTargetType(StoreProperty store)
         => store.Accessor.ParameterTypes.Length > 0 ? store.Accessor.ParameterTypes[^1] : null;
 
+    // The `stelem` opcode records a storage-primitive element type (e.g. `long` for
+    // a long-backed enum array), which drops an enum-typed integer store below its
+    // real element type and prints a bare literal (CS0266). Prefer the array's own
+    // element type when it resolves to an enum.
+    TypeRef? StoreElementTargetType(StoreElement store)
+        => store.Array.ResultType is { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element }
+            && _function.TypeShapes.GetValueOrDefault(element) == TypeShape.Enum
+            ? element
+            : store.ElementType;
+
     string Expression(IrExpression node) => node switch
     {
         LoadArgument { Index: 0, Name: "this" } => "this",
         LoadArgument a => CSharpNaming.EscapeIdentifier(a.Name),
         LoadLocal l => $"{LocalName(l.Index)}",
         LoadStackSlot s => StackSlotName(s),
-        Constant { Value: int } c when EnumMemberName(c) is { } named => named,
+        Constant { Value: int or long } c when EnumMemberName(c) is { } named => named,
         // A retyped enum constant with no single named member (a composite flag
         // value, or one outside the resolved member map) is still that enum — a
         // bare int is CS0266. Route it through the overflow-aware enum cast so an
         // unsigned- or narrow-backed enum's out-of-range/negative value is wrapped
         // in `unchecked` (e.g. `unchecked((U)(-1))`); naming flag combinations is a
-        // later slice.
-        Constant { Value: int value, Type: { } enumType } when _function.TypeShapes.GetValueOrDefault(enumType) == TypeShape.Enum
-            => EnumIntegerCast(new Constant(value, TypeRef.CoreLib("System", "Int32")), enumType),
+        // later slice. A long-backed enum keeps its `long` payload.
+        Constant { Value: int or long, Type: { } enumType } c when _function.TypeShapes.GetValueOrDefault(enumType) == TypeShape.Enum
+            => EnumIntegerCast(
+                c.Value is int i
+                    ? new Constant(i, TypeRef.CoreLib("System", "Int32"))
+                    : new Constant((long)c.Value!, TypeRef.CoreLib("System", "Int64")),
+                enumType),
         Constant c => ConstantText(c),
         LoadField f => FieldTarget(f.Field, f.Instance),
         Binary b => BinaryText(b),
@@ -1810,7 +1824,7 @@ public sealed partial class CSharpPrinter
         InlineArraySpanConversion c => $"({TypeText(c.SpanType)}){Deref(c.Place)}",
         StackAllocate s => $"stackalloc byte[{Expression(s.Size)}]",
         StackAllocArray s => $"stackalloc {TypeText(s.ElementType)}[{Expression(s.Count)}]",
-        Box b => Expression(b.Operand),
+        Box b => CastValue(b.Operand, b.Type),
         IsInstance i => $"{Operand(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
         IsPattern p => $"{TypeTestValueText(p.Value)} is {TypeText(p.Type)} {LocalName(p.LocalIndex)}",
         RecursivePropertyDeclarationPattern p => $"{Operand(p.Value)} is {{ {p.PropertyName}: {TypeText(p.PatternType)} {LocalName(p.LocalIndex)} }}",

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DiamondArmTypes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DiamondArmTypes.cs
@@ -27,48 +27,29 @@ static class DiamondArmTypes
     /// </summary>
     public static TypeRef? ConflictingArmType(IrExpression whenTrue, IrExpression whenFalse, IrFunction function)
     {
-        if (IsIntegerConstant(whenTrue, out var trueValue) && !IsIntegerConstant(whenFalse, out _) && FitsEnumTarget(trueValue, whenFalse.ResultType, function))
+        if (IsIntegerConstant(whenTrue) && !IsIntegerConstant(whenFalse) && IsKnownUnderlyingEnum(whenFalse.ResultType, function))
             return whenFalse.ResultType;
-        if (IsIntegerConstant(whenFalse, out var falseValue) && !IsIntegerConstant(whenTrue, out _) && FitsEnumTarget(falseValue, whenTrue.ResultType, function))
+        if (IsIntegerConstant(whenFalse) && !IsIntegerConstant(whenTrue) && IsKnownUnderlyingEnum(whenTrue.ResultType, function))
             return whenTrue.ResultType;
         return null;
     }
 
-    static bool IsIntegerConstant(IrExpression expression, out long value)
-    {
-        if (expression is Constant constant && TypeFamilies.IsIntegerLike(constant.Type) && TryToInt64(constant.Value, out value))
-            return true;
-        value = 0;
-        return false;
-    }
+    // An `ldc.i4`/`ldc.i8` constant arm — the shape the printer's enum-cast path
+    // (EnumIntegerCast) recognizes and, when out of the underlying range, wraps in
+    // `unchecked(...)`.
+    static bool IsIntegerConstant(IrExpression expression)
+        => expression is Constant { Value: int or long };
 
-    // Anchors only to an enum whose underlying type can represent the constant. The
-    // printer renders an integer arm of an enum-typed conditional as an explicit
-    // `(EnumType)value` cast; that cast is a constant-expression conversion, so it
-    // only compiles when the value is in the underlying type's range (`(Tiny)300`
-    // for `enum Tiny : byte` is CS0221). A plain (non-enum) integer target is
-    // excluded entirely: the arm printer omits the cast a narrower or out-of-range
-    // constant would need (e.g. `byte b = c ? 300 : x`).
-    static bool FitsEnumTarget(long value, TypeRef? type, IrFunction function)
+    // Anchors to a same-assembly enum with a known underlying type. The printer
+    // renders the integer arm of an enum-typed conditional as an explicit
+    // `(EnumType)value` cast and wraps it in `unchecked(...)` when the value is out
+    // of the underlying type's range (see EnumIntegerCast), so the cast is valid
+    // and faithful for any integer constant — the IL stored that integer into the
+    // same slot, and unchecked truncation matches. A cross-assembly enum has no
+    // resolved underlying type here, and a plain (non-enum) integer target is
+    // excluded because the arm printer only casts toward enum targets.
+    static bool IsKnownUnderlyingEnum(TypeRef? type, IrFunction function)
         => type is not null
             && function.TypeShapes.GetValueOrDefault(type) == TypeShape.Enum
-            && function.EnumUnderlyingTypes.TryGetValue(type, out var underlying)
-            && TypeFamilies.ConstantFits(value, underlying);
-
-    static bool TryToInt64(object? value, out long result)
-    {
-        switch (value)
-        {
-            case int i: result = i; return true;
-            case long l: result = l; return true;
-            case short s: result = s; return true;
-            case sbyte sb: result = sb; return true;
-            case byte b: result = b; return true;
-            case ushort us: result = us; return true;
-            case uint ui: result = ui; return true;
-            case char c: result = c; return true;
-            case ulong ul when ul <= long.MaxValue: result = (long)ul; return true;
-            default: result = 0; return false;
-        }
-    }
+            && function.EnumUnderlyingTypes.ContainsKey(type);
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -107,30 +107,35 @@ public sealed class TypedConstantsPass : IIrPass
         // identity to recover; skip it rather than dereference a null target.
         if (target is null)
             return;
-        if (constant.Value is not int value)
-            return;
-        if (target is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" })
+        if (constant.Value is int value)
         {
-            switch (target.Name)
+            if (target is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" })
             {
-                case "Boolean" when value is 0 or 1:
-                    stepper.StepOver($"retype constant {value} to bool", constant);
-                    constant.ReplaceWith(new Constant(value == 1, target));
-                    return;
-                case "Char" when value >= char.MinValue && value <= char.MaxValue:
-                    stepper.StepOver($"retype constant {value} to char", constant);
-                    constant.ReplaceWith(new Constant((char)value, target));
-                    return;
+                switch (target.Name)
+                {
+                    case "Boolean" when value is 0 or 1:
+                        stepper.StepOver($"retype constant {value} to bool", constant);
+                        constant.ReplaceWith(new Constant(value == 1, target));
+                        return;
+                    case "Char" when value >= char.MinValue && value <= char.MaxValue:
+                        stepper.StepOver($"retype constant {value} to char", constant);
+                        constant.ReplaceWith(new Constant((char)value, target));
+                        return;
+                }
             }
+        }
+        else if (constant.Value is not long)
+        {
+            return;
         }
 
         // An integer flowing into an enum position carries the enum's identity;
         // the printer names it from the resolved member map. The value is kept
-        // (still an int); only the constant's type changes.
+        // (an int, or an ldc.i8 for a long-backed enum); only the type changes.
         if (shapes.GetValueOrDefault(target) == TypeShape.Enum)
         {
-            stepper.StepOver($"retype constant {value} to enum {target.Name}", constant);
-            constant.ReplaceWith(new Constant(value, target));
+            stepper.StepOver($"retype constant to enum {target.Name}", constant);
+            constant.ReplaceWith(new Constant(constant.Value, target));
         }
     }
 }


### PR DESCRIPTION
Fixes #2076.

## Summary

A conditional/slot-diamond whose reused stack slot merges an integer constant with a **same-assembly** enum could still emit invalid C#. The headline case is an unsigned-backed enum whose high-bit value is emitted as a negative `ldc.i4` — `CfgFlags.Top` (`0x80000000u`) becomes `int.MinValue`, so `#2075`'s anchor declined it (`ConstantFits(-1, uint)` is false), leaving the folded conditional's `MergedType` null and the arm rendered as a bare `... : -2147483648` (CS0029).

## Fix (two coupled changes)

- **Printer** (`EnumIntegerCast`): generalize the overflow guard to force `unchecked` when a constant is out of a **known** enum underlying type's range too, not only for cross-assembly (`Unknown`-shape) enums. `(Tiny)300` for `enum Tiny : byte` now renders `unchecked((Tiny)300)`. This is a self-contained printer correctness improvement (the higher-value piece #2076 called out).
- **Anchor** (`DiamondArmTypes.ConflictingArmType`): since the printer now renders any int/long constant into a known-underlying enum validly (in-range bare, negative/out-of-range `unchecked`), anchor any same-assembly known-underlying enum arm instead of range-checking. Fixes the unsigned negative-literal case and keeps in-range cases working.

### Before / after (same-assembly `CfgFlags : uint`)

`main`: `CfgFlags x = !c ? e : -2147483648;`  ← CS0029
This PR: `CfgFlags x = !c ? e : unchecked((CfgFlags)(-2147483648));`  ← valid, faithful (reinterprets to `0x80000000`)

## Out of scope (documented in #2076, issue left open)

- `ulong` values that reach the fold as a `Convert(long, …)` rather than a bare constant (needs the printer to detect negatives/overflow through `Convert`).
- Cross-assembly enums whose underlying type is not loaded (SRM-only product path). Their existing behavior is unchanged (the cross-assembly `Unknown`-shape overflow guard is preserved).

## Evidence

- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*EnumCastPrinterTests*" -class "*DiamondArmTypeReconciliationTests*"`: 21 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"`: 1781 passed
- New tests: a same-assembly unsigned-enum conditional fixture (renders + `AssertCompiles`), a known narrow-enum out-of-range `unchecked` printer test (with in-range bare counter-case), and updated anchor tests. All new render tests go through the product pipeline (`PrintRaised` → `IrPasses.Default`) and compile-check the output.

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity sampled 350 / 89,065 (0.39%); fidelity sampled 36 / 89,065 (0.04%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,399 (88.02%) | 0 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — sampled 25,179 / 89,065 (28.27%) | 1/350 — sampled 350 / 89,065 (0.39%) | -73 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | 0 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate: Fully raised 88.02% -> 88.02% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 5 (0). All flat; the `--compile-cap 25` quick run is why the validity/semantic sample size is smaller (a cap artifact). The printer change touches every `EnumIntegerCast` call site, so the flat card across 89,065 methods is the key regression gate.

## Adversarial review

Requested from GPT-5.5 and Gemini 3.1 Pro (different model families from the author). Results will be reconciled on the PR.
