### PR TITLE
Add project assets source context

### DIFF
--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -129,6 +129,37 @@ public class MemberOptionsParserTests
     }
 
     [Fact]
+    public async Task ProjectWithoutExplicitSource_BecomesSourceContext()
+    {
+        var options = await ParseSuccessAsync(
+            "member", "JsonSerializer", "Serialize",
+            "--project", "App.csproj");
+
+        Assert.Equal("JsonSerializer", options.TypeName);
+        Assert.Equal("App.csproj", options.ProjectPath);
+        Assert.Equal(["Serialize"], options.MemberFilter);
+        Assert.Empty(options.CallerScopeProjects);
+        Assert.False(options.HasCallerScope);
+        Assert.Null(options.PackagePath);
+        Assert.Null(options.AssemblyPath);
+        Assert.Null(options.PlatformAssembly);
+    }
+
+    [Fact]
+    public async Task ProjectWithoutExplicitSource_KeepsAdditionalProjectsAsCallerScope()
+    {
+        var options = await ParseSuccessAsync(
+            "member", "JsonSerializer", "Serialize",
+            "--project", "Source.csproj",
+            "--project", "Caller.csproj");
+
+        Assert.Equal("JsonSerializer", options.TypeName);
+        Assert.Equal("Source.csproj", options.ProjectPath);
+        Assert.Equal(["Caller.csproj"], options.CallerScopeProjects);
+        Assert.True(options.HasCallerScope);
+    }
+
+    [Fact]
     public async Task CallerScope_CallerPackage_PopulatesCallerScopePackages()
     {
         var options = await ParseSuccessAsync(

--- a/src/dotnet-inspect.Tests/Parsers/TypeOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/TypeOptionsParserTests.cs
@@ -1,0 +1,100 @@
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using DotnetInspector.CommandLine;
+using DotnetInspector.Options;
+using DotnetInspector.Services;
+
+namespace DotnetInspector.Tests.Parsers;
+
+public class TypeOptionsParserTests
+{
+    static (Command Root, SharedOptions Opts, TypeOptionsParser.TypeCommandArgs Args) CreateTestCommand()
+    {
+        var opts = new SharedOptions();
+        var typeCommand = new Command("type", "test");
+
+        var argsArg = new Argument<string[]>("args") { Arity = ArgumentArity.ZeroOrMore };
+        var packageOption = new Option<string?>("--package");
+        var assemblyOption = new Option<string?>("--library");
+        var platformOption = new Option<string?>("--platform");
+        var projectOption = new Option<string?>("--project");
+        var frameworkOption = new Option<string?>("--framework");
+        var tfmOption = new Option<string?>("--tfm");
+        var allOption = new Option<bool>("--all");
+        var typeFilterOption = new Option<string?>("-t");
+        var compactOption = new Option<bool>("--compact");
+        var shapeOption = new Option<bool>("--shape");
+        var unsafeOption = new Option<bool>("--unsafe");
+        var memberOption = new Option<string[]>("-m") { AllowMultipleArgumentsPerToken = true };
+        var kindOption = new Option<string[]>("-k") { AllowMultipleArgumentsPerToken = true };
+
+        typeCommand.Arguments.Add(argsArg);
+        typeCommand.Options.Add(packageOption);
+        typeCommand.Options.Add(assemblyOption);
+        typeCommand.Options.Add(platformOption);
+        typeCommand.Options.Add(projectOption);
+        typeCommand.Options.Add(frameworkOption);
+        typeCommand.Options.Add(tfmOption);
+        typeCommand.Options.Add(allOption);
+        typeCommand.Options.Add(typeFilterOption);
+        typeCommand.Options.Add(opts.Json);
+        typeCommand.Options.Add(compactOption);
+        opts.AddTableOptionsTo(typeCommand);
+        typeCommand.Options.Add(shapeOption);
+        typeCommand.Options.Add(unsafeOption);
+        typeCommand.Options.Add(memberOption);
+        typeCommand.Options.Add(kindOption);
+        opts.AddSectionOptionsTo(typeCommand);
+        typeCommand.Options.Add(opts.Markdown);
+        typeCommand.Options.Add(opts.PlainText);
+        opts.AddOutputOptionsTo(typeCommand);
+        opts.AddNuGetOptionsTo(typeCommand);
+
+        typeCommand.SetAction((_, _) => Task.FromResult(0));
+
+        var root = new RootCommand { typeCommand };
+        var args = new TypeOptionsParser.TypeCommandArgs(
+            argsArg, packageOption, assemblyOption, platformOption, projectOption, frameworkOption, tfmOption,
+            allOption, typeFilterOption, compactOption, opts.OneLine, opts.NoHeaders,
+            shapeOption, unsafeOption, memberOption, kindOption);
+
+        return (root, opts, args);
+    }
+
+    static async Task<TypeOptions> ParseSuccessAsync(params string[] args)
+    {
+        ArgumentPreprocessor.Reset();
+        var (root, opts, cmdArgs) = CreateTestCommand();
+        var parseResult = root.Parse(args);
+        Assert.Empty(parseResult.Errors);
+
+        var result = await TypeOptionsParser.ParseAsync(parseResult, opts, cmdArgs);
+        var success = Assert.IsType<TypeOptionsParser.Success>(result);
+        return success.Options;
+    }
+
+    [Fact]
+    public async Task ProjectSource_SetsProjectPathAndTypeName()
+    {
+        var options = await ParseSuccessAsync("type", "Command", "--project", "App.csproj");
+
+        Assert.Equal("Command", options.TypeName);
+        Assert.Equal("App.csproj", options.ProjectPath);
+        Assert.Null(options.PackagePath);
+        Assert.Null(options.AssemblyPath);
+        Assert.Null(options.PlatformAssembly);
+    }
+
+    [Fact]
+    public async Task ProjectCannotCombineWithExplicitSource()
+    {
+        ArgumentPreprocessor.Reset();
+        var (root, opts, cmdArgs) = CreateTestCommand();
+        var parseResult = root.Parse(["type", "Command", "--project", "App.csproj", "--package", "System.CommandLine"]);
+        Assert.Empty(parseResult.Errors);
+
+        var result = await TypeOptionsParser.ParseAsync(parseResult, opts, cmdArgs);
+        var error = Assert.IsType<TypeOptionsParser.VersionError>(result);
+        Assert.Contains("--project cannot be combined", error.Message);
+    }
+}

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -53,6 +53,7 @@ public static class ApiCommandDefinitions
         var packageOption = new Option<string?>("--package") { Description = "Source: package (file, name, or name@version)" };
         var assemblyOption = new Option<string?>("--library") { Description = "Source: library path (local file, or relative within package)" };
         var platformOption = new Option<string?>("--platform") { Description = "Source: platform library (e.g., System.Text.Json)" };
+        var projectOption = new Option<string?>("--project") { Description = "Source: restored project.assets.json context" };
         var frameworkOption = new Option<string?>("--framework") { Description = "Source: platform framework (runtime, aspnetcore, netstandard). @version for specific" };
         var tfmOption = new Option<string?>("--tfm") { Description = "Source: select by TFM (e.g., net8.0)" };
         var allOption = new Option<bool>("--all") { Description = "Include non-public, hidden, and obsolete members" };
@@ -78,6 +79,7 @@ public static class ApiCommandDefinitions
         typeCommand.Options.Add(packageOption);
         typeCommand.Options.Add(assemblyOption);
         typeCommand.Options.Add(platformOption);
+        typeCommand.Options.Add(projectOption);
         typeCommand.Options.Add(frameworkOption);
         typeCommand.Options.Add(tfmOption);
         typeCommand.Options.Add(allOption);
@@ -103,7 +105,7 @@ public static class ApiCommandDefinitions
         opts.AddNuGetOptionsTo(typeCommand);
 
         var commandArgs = new TypeOptionsParser.TypeCommandArgs(
-            argsArg, packageOption, assemblyOption, platformOption, frameworkOption, tfmOption,
+            argsArg, packageOption, assemblyOption, platformOption, projectOption, frameworkOption, tfmOption,
             allOption, typeFilterOption, compactOption, opts.OneLine,
             opts.NoHeaders, shapeOption, unsafeOption, memberOption, kindOption);
 
@@ -187,7 +189,7 @@ public static class ApiCommandDefinitions
         binOption.Aliases.Add("--directory");
         var callerProjectOption = new Option<string[]>("--project")
         {
-            Description = "Scan a project's restored dependencies for inbound callers (Callers section). Can repeat.",
+            Description = "Source: restored project.assets.json context when no other source is supplied; also scans restored dependencies for inbound callers. Can repeat.",
             AllowMultipleArgumentsPerToken = true
         };
         var callerPackageOption = new Option<string[]>("--caller-package")

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -82,9 +82,13 @@ public static class MemberOptionsParser
     {
         var sourceInputs = SharedParsers.ReadSourceSelectionInputs(
             parseResult, args.ArgsArg, args.PackageOption, args.AssemblyOption, args.PlatformOption);
+        var projectValues = parseResult.GetValue(args.ProjectOption) ?? [];
+        var projectSourcePath = !sourceInputs.HasExplicitSource && projectValues.Length > 0
+            ? projectValues[0]
+            : null;
 
         // Handle projection discovery or help
-        if (sourceInputs.Args.Length == 0 && !sourceInputs.HasExplicitSource)
+        if (sourceInputs.Args.Length == 0 && !sourceInputs.HasExplicitSource && projectSourcePath is null)
         {
             if (opts.IsDiscoveryMode(parseResult))
                 return new Discovery(opts.ParseDiscover(parseResult), opts.ParseTree(parseResult));
@@ -93,15 +97,39 @@ public static class MemberOptionsParser
 
         // Extract positional members
         List<string> positionalMembers = [];
-        if (sourceInputs.HasExplicitSource && sourceInputs.Args.Length >= 2)
+        if (projectSourcePath is not null && sourceInputs.Args.Length >= 2)
+            positionalMembers.AddRange(sourceInputs.Args[1..]);
+        else if (sourceInputs.HasExplicitSource && sourceInputs.Args.Length >= 2)
             positionalMembers.AddRange(sourceInputs.Args[1..]);
         else if (!sourceInputs.HasExplicitSource && sourceInputs.Args.Length >= 3)
             positionalMembers.AddRange(sourceInputs.Args[2..]);
 
         // Resolve source
-        var sourceSelection = await SharedParsers.ResolveSourceSelectionAsync(
-            sourceInputs, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: false);
-        var source = sourceSelection.Source;
+        SharedParsers.SourceSelection sourceSelection;
+        SourceResolver.ResolvedSource source;
+        if (projectSourcePath is not null)
+        {
+            source = new SourceResolver.ResolvedSource(
+                PackagePath: null,
+                AssemblyPath: null,
+                PlatformAssembly: null,
+                FrameworkOverride: null,
+                TypeName: sourceInputs.Args.FirstOrDefault());
+            sourceSelection = new SharedParsers.SourceSelection(
+                sourceInputs.Args,
+                sourceInputs.ExplicitPackage,
+                sourceInputs.ExplicitAssembly,
+                sourceInputs.ExplicitPlatform,
+                sourceInputs.IsLibrarySelector,
+                HasExplicitSource: true,
+                source);
+        }
+        else
+        {
+            sourceSelection = await SharedParsers.ResolveSourceSelectionAsync(
+                sourceInputs, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: false);
+            source = sourceSelection.Source;
+        }
 
         if (source.VersionError)
             return new VersionError(source.VersionErrorMessage!);
@@ -231,6 +259,7 @@ public static class MemberOptionsParser
             PackagePath = source.PackagePath,
             AssemblyPath = source.AssemblyPath,
             PlatformAssembly = source.PlatformAssembly,
+            ProjectPath = projectSourcePath,
             PlatformFramework = source.FrameworkOverride ?? parseResult.GetValue(args.FrameworkOption),
             Tfm = parseResult.GetValue(args.TfmOption),
             IncludeAll = parseResult.GetValue(args.AllOption),
@@ -264,7 +293,9 @@ public static class MemberOptionsParser
             MemberDigest = memberDigest,
             ShowMemberIndex = showMemberIndex,
             CallerScopeDirectories = parseResult.GetValue(args.BinOption) ?? [],
-            CallerScopeProjects = parseResult.GetValue(args.ProjectOption) ?? [],
+            CallerScopeProjects = projectSourcePath is null
+                ? projectValues
+                : projectValues.Length > 1 ? projectValues[1..] : [],
             CallerScopePackages = parseResult.GetValue(args.CallerPackageOption) ?? [],
             Discover = opts.ParseDiscover(parseResult),
             Tree = parseResult.GetValue(opts.Tree),

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -21,6 +21,7 @@ public static class TypeOptionsParser
         Option<string?> PackageOption,
         Option<string?> AssemblyOption,
         Option<string?> PlatformOption,
+        Option<string?> ProjectOption,
         Option<string?> FrameworkOption,
         Option<string?> TfmOption,
         Option<bool> AllOption,
@@ -78,14 +79,20 @@ public static class TypeOptionsParser
     {
         var sourceInputs = SharedParsers.ReadSourceSelectionInputs(
             parseResult, args.ArgsArg, args.PackageOption, args.AssemblyOption, args.PlatformOption);
+        var projectPath = parseResult.GetValue(args.ProjectOption);
+        bool hasProjectSource = !string.IsNullOrWhiteSpace(projectPath);
+        bool hasNonProjectSource = sourceInputs.HasExplicitSource;
 
         // Handle projection discovery or help
-        if (sourceInputs.Args.Length == 0 && !sourceInputs.HasExplicitSource)
+        if (sourceInputs.Args.Length == 0 && !sourceInputs.HasExplicitSource && !hasProjectSource)
         {
             if (opts.IsDiscoveryMode(parseResult))
                 return new Discovery(opts.ParseDiscover(parseResult), opts.ParseTree(parseResult));
             return new ShowHelp();
         }
+
+        if (hasProjectSource && hasNonProjectSource)
+            return new VersionError("Error: --project cannot be combined with --package, --library, or --platform.");
 
         // Check for unrecognized options in positional args
         var badOption = sourceInputs.Args.FirstOrDefault(a => a.StartsWith('-'));
@@ -93,9 +100,31 @@ public static class TypeOptionsParser
             return new UnrecognizedOption(badOption);
 
         // Resolve source
-        var sourceSelection = await SharedParsers.ResolveSourceSelectionAsync(
-            sourceInputs, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: true);
-        var source = sourceSelection.Source;
+        SharedParsers.SourceSelection sourceSelection;
+        SourceResolver.ResolvedSource source;
+        if (hasProjectSource)
+        {
+            source = new SourceResolver.ResolvedSource(
+                PackagePath: null,
+                AssemblyPath: null,
+                PlatformAssembly: null,
+                FrameworkOverride: null,
+                TypeName: sourceInputs.Args.FirstOrDefault());
+            sourceSelection = new SharedParsers.SourceSelection(
+                sourceInputs.Args,
+                sourceInputs.ExplicitPackage,
+                sourceInputs.ExplicitAssembly,
+                sourceInputs.ExplicitPlatform,
+                sourceInputs.IsLibrarySelector,
+                HasExplicitSource: true,
+                source);
+        }
+        else
+        {
+            sourceSelection = await SharedParsers.ResolveSourceSelectionAsync(
+                sourceInputs, parseResult.GetValue(opts.Verbose), tryQualifiedTypeName: true);
+            source = sourceSelection.Source;
+        }
 
         if (source.VersionError)
             return new VersionError(source.VersionErrorMessage!);
@@ -123,6 +152,7 @@ public static class TypeOptionsParser
             PackagePath = source.PackagePath,
             AssemblyPath = source.AssemblyPath,
             PlatformAssembly = source.PlatformAssembly,
+            ProjectPath = projectPath,
             PlatformFramework = source.FrameworkOverride ?? parseResult.GetValue(args.FrameworkOption),
             Tfm = parseResult.GetValue(args.TfmOption),
             IncludeAll = parseResult.GetValue(args.AllOption),

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -494,10 +494,12 @@ public class ApiCommand
     internal static ILInspector.Metadata.AssemblyLocator PlatformAssemblyLocator(string startingDll)
         => PlatformAssemblyResolver(startingDll).ToAssemblyLocator();
 
-    internal static AssemblyDependencyResolver PlatformAssemblyResolver(string startingDll)
+    internal static AssemblyDependencyResolver PlatformAssemblyResolver(string startingDll, string? projectAssetsPath = null, string? targetFramework = null)
     {
         return new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(startingDll)
         {
+            ProjectAssetsPath = projectAssetsPath,
+            TargetFramework = targetFramework,
             IncludeDepsJsonAssets = false,
             IncludeAspNetCoreSharedFramework = false,
             PreferImplementationAssemblies = true,
@@ -772,7 +774,7 @@ public class ApiCommand
             && options.IncludeSections is { Count: > 0 }
             && GetRequestedMemberSections(type, options).Contains(SectionNames.DecompiledSource))
         {
-            var resolver = PlatformAssemblyResolver(typeDllPath);
+            var resolver = PlatformAssemblyResolver(typeDllPath, options.ProjectAssetsPath, options.Tfm);
             using var metadata = new Decompiler.Pipeline.MetadataContext(resolver);
             var listing = Decompiler.TypeSourceComposer.Compose(
                 type, typeDllPath, options.PdbPath, resolver, metadata);

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -50,10 +50,13 @@ public static class MemberCommand
         var packageVersion = source.PackageVersion;
         var apiSource = source.ApiSource;
         var selectedTfm = source.SelectedTfm;
+        var projectAssetsPath = source.ProjectAssetsPath;
         var tempDir = source.TempDir;
         var typeName = source.TypeName;
         var context = source.Context;
         var logger = context.Logger;
+
+        options = options with { ProjectAssetsPath = projectAssetsPath };
 
         try
         {

--- a/src/dotnet-inspect/Commands/TypeCommand.cs
+++ b/src/dotnet-inspect/Commands/TypeCommand.cs
@@ -60,11 +60,14 @@ public static class TypeCommand
         var apiSource = source.ApiSource;
         var apiVersion = source.ApiVersion;
         var selectedTfm = source.SelectedTfm;
+        var projectAssetsPath = source.ProjectAssetsPath;
         var tempDir = source.TempDir;
         var typeName = source.TypeName;
         var originalTypeQuery = options.OriginalTypeQuery ?? options.TypeName;
         var context = source.Context;
         var logger = context.Logger;
+
+        options = options with { ProjectAssetsPath = projectAssetsPath };
 
         try
         {

--- a/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
+++ b/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
@@ -15,6 +15,7 @@ internal sealed record ApiSourceResult(
     string? ApiSource,
     string? ApiVersion,
     string? SelectedTfm,
+    string? ProjectAssetsPath,
     string? TempDir,
     string? TypeName,
     CommandContext Context);
@@ -34,6 +35,7 @@ internal static class ApiSourceResolver
         string? packageVersion = null;
         string? apiSource = null;
         string? apiVersion = null;
+        string? projectAssetsPath = null;
         var typeName = options.TypeName;
 
         if (!string.IsNullOrEmpty(options.PackagePath))
@@ -96,6 +98,45 @@ internal static class ApiSourceResolver
             }
             searchPath = options.AssemblyPath;
             apiSource = SourceKind.Library;
+        }
+        else if (!string.IsNullOrEmpty(options.ProjectPath))
+        {
+            projectAssetsPath = ProjectAssetsParser.FindAssets(options.ProjectPath);
+            if (projectAssetsPath is null)
+            {
+                Console.Error.WriteLine($"Error: project.assets.json not found for '{options.ProjectPath}'. Run 'dotnet restore'.");
+                return (null!, 1);
+            }
+
+            if (string.IsNullOrWhiteSpace(typeName))
+            {
+                Console.Error.WriteLine("Error: --project requires a type name for type/member resolution.");
+                return (null!, 1);
+            }
+
+            logger.Log($"Using assets: {projectAssetsPath}");
+            var assemblies = ProjectAssetsParser.Parse(projectAssetsPath, options.Tfm, logger.Log);
+            foreach (var (asmPath, projectPackageName, projectPackageVersion) in assemblies)
+            {
+                var (apiType, _, dllPath, _) = ApiServices.FindType(typeName, asmPath, logger, options.IncludeAll);
+                if (apiType is null || dllPath is null)
+                    continue;
+
+                searchPath = dllPath;
+                packageName = projectPackageName;
+                packageVersion = projectPackageVersion;
+                apiSource = SourceKind.Project;
+                apiVersion = projectPackageVersion;
+                selectedTfm = options.Tfm;
+                logger.Log($"Resolved type '{typeName}' to {Path.GetFileName(searchPath)} from {projectPackageName} {projectPackageVersion}");
+                goto ProjectResolved;
+            }
+
+            Console.Error.WriteLine($"Error: Type '{typeName}' not found in project assets '{projectAssetsPath}'.");
+            return (null!, 1);
+
+        ProjectResolved:
+            ;
         }
         else if (!string.IsNullOrEmpty(options.PlatformAssembly))
         {
@@ -248,6 +289,6 @@ internal static class ApiSourceResolver
         }
 
         return (new ApiSourceResult(searchPath, runtimeAssemblyPath, packageName, packageVersion,
-            apiSource, apiVersion, selectedTfm, tempDir, typeName, context), null);
+            apiSource, apiVersion, selectedTfm, projectAssetsPath, tempDir, typeName, context), null);
     }
 }

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -17,7 +17,7 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 internal static class MemberCodeProvider
 {
-    internal sealed record Request(bool DecompiledSource, bool AnnotatedSource, bool CostOverlay, bool SemanticsOverlay, bool IL, bool Attributes, bool Calls, bool Callers, bool CallGraph, bool UnsafeOperations, bool Facts = false);
+    internal sealed record Request(bool DecompiledSource, bool AnnotatedSource, bool CostOverlay, bool SemanticsOverlay, bool IL, bool Attributes, bool Calls, bool Callers, bool CallGraph, bool UnsafeOperations, bool Facts = false, string? ProjectAssetsPath = null, string? TargetFramework = null);
 
     /// <summary>
     /// Code content for one member. Body and diagnostic are mutually
@@ -288,6 +288,8 @@ internal static class MemberCodeProvider
         {
             var resolver = new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(dllPath)
             {
+                ProjectAssetsPath = request.ProjectAssetsPath,
+                TargetFramework = request.TargetFramework,
                 IncludeDepsJsonAssets = false,
                 IncludeAspNetCoreSharedFramework = false,
                 PreferImplementationAssemblies = true,

--- a/src/dotnet-inspect/Models/SourceKind.cs
+++ b/src/dotnet-inspect/Models/SourceKind.cs
@@ -9,4 +9,5 @@ public static class SourceKind
     public const string NuGet = "NuGet";
     public const string File = "File";
     public const string Library = "Library";
+    public const string Project = "Project";
 }

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -18,6 +18,8 @@ public partial record ApiOptions
     public string? PackagePath { get; init; }
     public string? AssemblyPath { get; init; }
     public string? PlatformAssembly { get; init; }
+    public string? ProjectPath { get; init; }
+    public string? ProjectAssetsPath { get; init; }
     public string? PlatformFramework { get; init; }
     public string? Tfm { get; init; }
     public bool IncludeAll { get; init; }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1051,7 +1051,9 @@ public static class ApiOutputFormatter
             Callers: requestedSections.Contains(SectionNames.Callers),
             CallGraph: requestedSections.Contains(SectionNames.CallGraph),
             UnsafeOperations: requestedSections.Contains(SectionNames.UnsafeOperations),
-            Facts: requestedSections.Contains(SectionNames.Facts));
+            Facts: requestedSections.Contains(SectionNames.Facts),
+            ProjectAssetsPath: options?.ProjectAssetsPath,
+            TargetFramework: options?.Tfm);
 
         // An index-backed section that is explicitly selected (via -S or a category like
         // @Audit) renders an empty-state note instead of vanishing when it yields no rows.


### PR DESCRIPTION
## Summary

- Adds `--project` as a restored `project.assets.json` source context for `type`.
- Adds `--project` as a restored assets source context for `member` when no package/library/platform source is supplied.
- Keeps explicit-source `member ... --package/--library/--platform ... --project ...` as caller-scope behavior.
- Threads the resolved `project.assets.json` into decompiler resolver context for source sections.

Docs and SKILL updates are intentionally deferred to a follow-up PR.

## Semantics

This PR treats `--project` as **existing project.assets.json restored-assets context**:

- `.csproj`, directory, or `project.assets.json` inputs are accepted by `ProjectAssetsParser.FindAssets`.
- Missing `project.assets.json` is a hard error for source resolution.
- No restore/build/MSBuild evaluation is attempted.
- Source resolution searches restored package compile assets for the requested type.

Examples:

```bash
dotnet-inspect type Command --project src/dotnet-inspect/dotnet-inspect.csproj
dotnet-inspect member Command --project src/dotnet-inspect/dotnet-inspect.csproj --show-index
```

## Member command split

`member` already used `--project` for caller scope. This keeps that behavior when an explicit source is present:

```bash
dotnet-inspect member Command --package System.CommandLine --project App.csproj
```

When no explicit source is present, the first `--project` is the source context:

```bash
dotnet-inspect member Command Add --project App.csproj
```

Repeated project values after the source project remain caller scopes:

```bash
dotnet-inspect member MyType MyMethod --project Source.csproj --project Caller.csproj
```

## Adversarial review

Requested reviews from Claude Opus 4.8 and Gemini 3.1 Pro.

- Claude found no significant issues and verified source/caller-scope split, missing-assets error behavior, no fallback, parser positional logic, resolver threading, and non-project compatibility.
- Gemini found one issue: repeated `--project` values in member source mode dropped later caller-scope projects. Fixed by keeping `projectValues[1..]` as `CallerScopeProjects` when the first project is used as source context, with parser coverage.

## Validation

After review fix and rebase onto latest `origin/main`:

- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -class "*Parser*"`
- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507`
- `dotnet run --project src/dotnet-inspect -c Release -p:NoWarn=NU1507 -- type Command --project src/dotnet-inspect/dotnet-inspect.csproj --markdown -v:q -n 20`
- `dotnet run --project src/dotnet-inspect -c Release -p:NoWarn=NU1507 -- member Command --project src/dotnet-inspect/dotnet-inspect.csproj --show-index -n 20`
- missing-assets smoke with `! dotnet run ... -- type Command --project /tmp/no-assets-proj/no-assets.csproj --markdown -v:q`
- `dotnet build src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507`
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release -p:NoWarn=NU1507`
- `git diff --check`
