### PR TITLE
Implement Performance Triage row queries

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -317,10 +317,13 @@ public class CommandExecutionTests
 
         var baseline = await RunAppAsync(BaseArgs());
         var filtered = await RunAppAsync([.. BaseArgs(), "--loop"]);
+        var whereFiltered = await RunAppAsync([.. BaseArgs(), "--where", "Shape=box-value-type"]);
 
         Assert.Equal(0, baseline.Exit);
         Assert.Equal(0, filtered.Exit);
+        Assert.Equal(0, whereFiltered.Exit);
         Assert.Equal(baseline.Output, filtered.Output);
+        Assert.Equal(baseline.Output, whereFiltered.Output);
     }
 
     [Fact]
@@ -332,6 +335,89 @@ public class CommandExecutionTests
         Assert.Empty(output);
         Assert.Contains("Unknown Performance Triage shape 'typo-shape'", error);
         Assert.Contains("capturing-delegate", error);
+    }
+
+    [Fact]
+    public async Task PerformanceTriageWhere_FiltersRowsByField()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Performance Triage",
+            "--where", "Allocation=boxed *",
+            "--where", "Path=straight-line",
+            "--tsv",
+            "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("\tbox-value-type\t", output);
+        Assert.Contains("\tboxed System.Int32\tstraight-line\t", output);
+        Assert.DoesNotContain("\tstackalloc-candidate\t", output);
+    }
+
+    [Fact]
+    public async Task PerformanceTriageOrderBy_OrdersBeforeTop()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Performance Triage",
+            "--where", "Shape=box-value-type",
+            "--order-by", "RootReach desc",
+            "--top", "1",
+            "--tsv",
+            "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        var rows = output.TrimEnd().Split('\n');
+        Assert.Single(rows.Skip(1));
+        Assert.Contains("\tbox-value-type\t", rows[1]);
+    }
+
+    [Fact]
+    public async Task PerformanceTriageCount_AppliesWhereBeforeTop()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Performance Triage",
+            "--where", "Shape=box-value-type",
+            "--top", "1",
+            "--count",
+            "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.True(int.TryParse(output.Trim(), out var count), output);
+        Assert.True(count > 1, $"expected post-filter count before --top, got {count}");
+    }
+
+    [Fact]
+    public async Task PerformanceTriageWhere_UnknownFieldReportsSuggestion()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "--where", "Allocaton=boxed *",
+            "--tsv",
+            "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("Field 'Allocaton' is not filterable", error);
+        Assert.Contains("Allocation", error);
+    }
+
+    [Fact]
+    public async Task PerformanceTriageOrderBy_TriageCompositeMustBeStandalone()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "--order-by", "Triage desc,RootReach desc",
+            "--tsv",
+            "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("Triage is a composite order", error);
     }
 
     [Theory]
@@ -4554,6 +4640,10 @@ public class CommandExecutionTests
         Assert.Contains("| Fix | column |", output);
         Assert.Contains("| Confidence | column |", output);
         Assert.Contains("| Loop | column |", output);
+        Assert.Contains("| Triage desc | default-order |", output);
+        Assert.Contains("| Loop desc | order-step |", output);
+        Assert.Contains("| Allocation | filterable |", output);
+        Assert.Contains("| RootReach | sortable |", output);
         Assert.Contains("| IL | column |", output);
     }
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -356,6 +356,23 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task PerformanceTriageWhere_MemberAcceptsDisplayedShortSignature()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "type", nameof(FactsTableFixture),
+            "--library", TestAssemblyPath,
+            "-S", "Performance Triage",
+            "--where", "Member=BoxInt(int)",
+            "--tsv",
+            "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("BoxInt(int)", output);
+        Assert.Contains("\tbox-value-type\t", output);
+    }
+
+    [Fact]
     public async Task PerformanceTriageOrderBy_OrdersBeforeTop()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -452,6 +469,20 @@ public class CommandExecutionTests
         Assert.Equal(1, exit);
         Assert.Empty(output);
         Assert.Contains("Triage is a composite order", error);
+    }
+
+    [Fact]
+    public async Task PerformanceTriageOrderBy_EmptyTermsReportDiagnostic()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "--order-by", ",",
+            "--tsv",
+            "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("--order-by requires at least one field", error);
     }
 
     [Theory]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -375,6 +375,24 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task PerformanceTriageOrderBy_AcceptsHumanColumnNames()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Performance Triage",
+            "--where", "Path Confidence=dominates-return",
+            "--order-by", "Root Reach desc",
+            "--top", "1",
+            "--tsv",
+            "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        var rows = output.TrimEnd().Split('\n');
+        Assert.Single(rows.Skip(1));
+    }
+
+    [Fact]
     public async Task PerformanceTriageCount_AppliesWhereBeforeTop()
     {
         var (exit, output, error) = await RunAppAsync(
@@ -404,6 +422,22 @@ public class CommandExecutionTests
         Assert.Empty(output);
         Assert.Contains("Field 'Allocaton' is not filterable", error);
         Assert.Contains("Allocation", error);
+    }
+
+    [Theory]
+    [InlineData("RootReach>=abc", "expects an integer")]
+    [InlineData("Confidence>=bogus", "expects one of low, medium, high")]
+    public async Task PerformanceTriageWhere_InvalidValuesReportDiagnostics(string predicate, string expected)
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "--where", predicate,
+            "--tsv",
+            "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains(expected, error);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -365,6 +365,33 @@ public class OutputFormatterTests
     }
 
     [Fact]
+    public void FilterAndOrderTriageOpportunities_AllowsOperatorsInsidePredicateValues()
+    {
+        var opportunities = new[]
+        {
+            Opp("ComparisonEvidence", inLoop: false, confidence: "medium", rootReach: 1, shape: "small-array") with
+            {
+                Evidence = "value >= threshold",
+            },
+            Opp("OtherEvidence", inLoop: false, confidence: "medium", rootReach: 1, shape: "small-array") with
+            {
+                Evidence = "plain value",
+            },
+        };
+
+        var filtered = LibraryMetadataService.FilterAndOrderTriageOpportunities(
+                opportunities,
+                new PerformanceTriageOptions
+                {
+                    Where = ["Evidence=*>=*"],
+                })
+            .Select(opportunity => opportunity.Method.Name)
+            .ToList();
+
+        Assert.Equal(["ComparisonEvidence"], filtered);
+    }
+
+    [Fact]
     public void FilterAndOrderTriageOpportunities_AppliesExplicitOrderBeforeTop()
     {
         var opportunities = new[]

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -415,6 +415,27 @@ public class OutputFormatterTests
         Assert.Equal(["HighReach"], filtered);
     }
 
+    [Fact]
+    public void FilterAndOrderTriageOpportunities_OrdersIlNumerically()
+    {
+        var opportunities = new[]
+        {
+            Opp("OffsetLarge", inLoop: false, confidence: "medium", rootReach: 1, shape: "small-array") with { ILOffset = 0x10000 },
+            Opp("OffsetSmall", inLoop: false, confidence: "medium", rootReach: 1, shape: "small-array") with { ILOffset = 0x2000 },
+        };
+
+        var filtered = LibraryMetadataService.FilterAndOrderTriageOpportunities(
+                opportunities,
+                new PerformanceTriageOptions
+                {
+                    OrderBy = "IL asc",
+                })
+            .Select(opportunity => opportunity.Method.Name)
+            .ToList();
+
+        Assert.Equal(["OffsetSmall", "OffsetLarge"], filtered);
+    }
+
     static ILInspector.Analysis.OptimizationOpportunity Opp(string name, bool inLoop, string confidence, int rootReach, string shape)
     {
         var declaring = ILInspector.Analysis.TypeRef.Definition("Asm", "Ns", "Type");

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -325,6 +325,69 @@ public class OutputFormatterTests
         Assert.Equal(["LoopHighDelegateLowReach"], filtered);
     }
 
+    [Fact]
+    public void FilterAndOrderTriageOpportunities_AppliesWherePredicates()
+    {
+        var opportunities = new[]
+        {
+            Opp("BoxLoop", inLoop: true, confidence: "high", rootReach: 1, shape: "box-value-type") with
+            {
+                RuntimeAllocationType = "boxed System.Int32",
+                PathContext = "loop body",
+            },
+            Opp("ArrayLoop", inLoop: true, confidence: "high", rootReach: 100, shape: "small-array") with
+            {
+                RuntimeAllocationType = "System.Int32[]",
+                PathContext = "loop body",
+            },
+            Opp("BoxCold", inLoop: false, confidence: "medium", rootReach: 1000, shape: "box-value-type") with
+            {
+                RuntimeAllocationType = "boxed System.Guid",
+                PathContext = "straight-line",
+            },
+        };
+
+        var filtered = LibraryMetadataService.FilterAndOrderTriageOpportunities(
+                opportunities,
+                new PerformanceTriageOptions
+                {
+                    Where =
+                    [
+                        "Allocation=boxed *",
+                        "Path=loop body",
+                        "Confidence>=medium",
+                    ],
+                })
+            .Select(opportunity => opportunity.Method.Name)
+            .ToList();
+
+        Assert.Equal(["BoxLoop"], filtered);
+    }
+
+    [Fact]
+    public void FilterAndOrderTriageOpportunities_AppliesExplicitOrderBeforeTop()
+    {
+        var opportunities = new[]
+        {
+            Opp("LowReach", inLoop: true, confidence: "high", rootReach: 1, shape: "box-value-type"),
+            Opp("HighReach", inLoop: false, confidence: "low", rootReach: 100, shape: "box-value-type"),
+            Opp("MediumReach", inLoop: true, confidence: "medium", rootReach: 50, shape: "small-array"),
+        };
+
+        var filtered = LibraryMetadataService.FilterAndOrderTriageOpportunities(
+                opportunities,
+                new PerformanceTriageOptions
+                {
+                    Where = ["Shape=box-value-type"],
+                    OrderBy = "RootReach desc",
+                    Top = 1,
+                })
+            .Select(opportunity => opportunity.Method.Name)
+            .ToList();
+
+        Assert.Equal(["HighReach"], filtered);
+    }
+
     static ILInspector.Analysis.OptimizationOpportunity Opp(string name, bool inLoop, string confidence, int rootReach, string shape)
     {
         var declaring = ILInspector.Analysis.TypeRef.Definition("Asm", "Ns", "Type");

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -215,7 +215,7 @@ public static class InspectionCommandDefinitions
             var typeFilter = parseResult.GetValue(typeFilterOption);
             var select = opts.ParseSelect(parseResult);
             var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
-            if (!PerformanceTriageOptions.TryValidateShapes(performanceTriage, out var triageShapeError))
+            if (!PerformanceTriageOptions.TryValidate(performanceTriage, out var triageShapeError))
             {
                 Console.Error.WriteLine(triageShapeError);
                 return 1;

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -220,7 +220,7 @@ public static class MemberOptionsParser
         if (showMemberIndex)
             select = [.. select ?? [], SectionNames.MemberIndex];
         var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
-        if (!PerformanceTriageOptions.TryValidateShapes(performanceTriage, out var triageShapeError))
+        if (!PerformanceTriageOptions.TryValidate(performanceTriage, out var triageShapeError))
             return new VersionError(triageShapeError);
         if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult))
             select = [.. select ?? [], SectionNames.PerformanceTriage];

--- a/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/TypeOptionsParser.cs
@@ -111,7 +111,7 @@ public static class TypeOptionsParser
         var kindFilter = SharedParsers.ParseKindFilter(kindValues);
         var routePolicy = TypeRoutePolicy.Resolve(sourceSelection.Args, sourceSelection.HasExplicitSource, source);
         var performanceTriage = opts.ParsePerformanceTriageOptions(parseResult);
-        if (!PerformanceTriageOptions.TryValidateShapes(performanceTriage, out var triageShapeError))
+        if (!PerformanceTriageOptions.TryValidate(performanceTriage, out var triageShapeError))
             return new VersionError(triageShapeError);
         var select = opts.ParseSelect(parseResult);
         if (performanceTriage.HasFilters && !opts.IsDiscoveryMode(parseResult))

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -856,6 +856,20 @@ internal static class LibraryMetadataService
             return MatchCompare(compare, predicate.Operator);
         }
 
+        if (predicate.Field == "Member")
+        {
+            var full = FormatMethod(opportunity.Method);
+            var shortSignature = ShortMemberSignature(opportunity.Method);
+            bool memberMatches = WildcardMatch(full, predicate.Value)
+                || WildcardMatch(shortSignature, predicate.Value);
+            return predicate.Operator switch
+            {
+                PerformanceTriageOptions.RowOperator.Equals => memberMatches,
+                PerformanceTriageOptions.RowOperator.NotEquals => !memberMatches,
+                _ => false,
+            };
+        }
+
         var actual = TriageFieldValue(opportunity, predicate.Field) ?? "";
         bool match = WildcardMatch(actual, predicate.Value);
         return predicate.Operator switch
@@ -884,6 +898,8 @@ internal static class LibraryMetadataService
             return ConfidenceRank(left.Confidence).CompareTo(ConfidenceRank(right.Confidence));
         if (field == "Loop")
             return left.InLoop.CompareTo(right.InLoop);
+        if (field == "IL")
+            return (left.ILOffset ?? -1).CompareTo(right.ILOffset ?? -1);
         return string.Compare(
             TriageFieldValue(left, field) ?? "",
             TriageFieldValue(right, field) ?? "",
@@ -906,6 +922,9 @@ internal static class LibraryMetadataService
             "RootReach" => opportunity.RootReach.ToString(CultureInfo.InvariantCulture),
             _ => null,
         };
+
+    static string ShortMemberSignature(Analysis.MethodIdentity method)
+        => $"{method.Name}({string.Join(", ", method.ParameterTypes.Select(p => p.ToQualifiedDisplayString()))})";
 
     static bool WildcardMatch(string actual, string pattern)
     {

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -1,5 +1,6 @@
 using DotnetInspector.Core;
 using DotnetInspector.Models;
+using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -794,9 +795,159 @@ internal static class LibraryMetadataService
             var shapes = options.Shapes.ToHashSet(StringComparer.OrdinalIgnoreCase);
             filtered = filtered.Where(opportunity => shapes.Contains(opportunity.Shape));
         }
+        if (options.TryGetPredicates(out var predicates, out _))
+        {
+            foreach (var predicate in predicates)
+                filtered = filtered.Where(opportunity => MatchesTriagePredicate(opportunity, predicate));
+        }
 
-        var ordered = OrderByTriagePriority(filtered);
+        var ordered = options.TryGetOrderTerms(out var orderTerms, out _)
+            ? OrderTriageRows(filtered, orderTerms)
+            : OrderByTriagePriority(filtered);
         return options.Top is { } top ? ordered.Take(top) : ordered;
+    }
+
+    static IEnumerable<Analysis.OptimizationOpportunity> OrderTriageRows(
+        IEnumerable<Analysis.OptimizationOpportunity> opportunities,
+        IReadOnlyList<PerformanceTriageOptions.OrderTerm> orderTerms)
+    {
+        if (orderTerms.Count == 1
+            && orderTerms[0].Field.Equals("Triage", StringComparison.OrdinalIgnoreCase))
+        {
+            var ordered = OrderByTriagePriority(opportunities);
+            return orderTerms[0].Descending ? ordered : ordered.Reverse();
+        }
+
+        return opportunities.OrderBy(opportunity => opportunity, Comparer<Analysis.OptimizationOpportunity>.Create((left, right) =>
+        {
+            foreach (var term in orderTerms)
+            {
+                int compare = CompareTriageField(left, right, term.Field);
+                if (compare != 0)
+                    return term.Descending ? -compare : compare;
+            }
+
+            int memberCompare = string.Compare(FormatMethod(left.Method), FormatMethod(right.Method), StringComparison.OrdinalIgnoreCase);
+            if (memberCompare != 0)
+                return memberCompare;
+            int ilCompare = (left.ILOffset ?? -1).CompareTo(right.ILOffset ?? -1);
+            if (ilCompare != 0)
+                return ilCompare;
+            return string.Compare(left.Shape, right.Shape, StringComparison.OrdinalIgnoreCase);
+        }));
+    }
+
+    static bool MatchesTriagePredicate(Analysis.OptimizationOpportunity opportunity, PerformanceTriageOptions.RowPredicate predicate)
+    {
+        if (predicate.Field == "RootReach")
+        {
+            if (!int.TryParse(predicate.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value))
+                return false;
+            int compare = opportunity.RootReach.CompareTo(value);
+            return MatchCompare(compare, predicate.Operator);
+        }
+
+        if (predicate.Field == "Confidence")
+        {
+            int expected = ConfidenceRank(predicate.Value);
+            if (expected == 0 && !predicate.Value.Equals("low", StringComparison.OrdinalIgnoreCase))
+                return false;
+            int compare = ConfidenceRank(opportunity.Confidence).CompareTo(expected);
+            return MatchCompare(compare, predicate.Operator);
+        }
+
+        var actual = TriageFieldValue(opportunity, predicate.Field) ?? "";
+        bool match = WildcardMatch(actual, predicate.Value);
+        return predicate.Operator switch
+        {
+            PerformanceTriageOptions.RowOperator.Equals => match,
+            PerformanceTriageOptions.RowOperator.NotEquals => !match,
+            _ => false,
+        };
+    }
+
+    static bool MatchCompare(int compare, PerformanceTriageOptions.RowOperator op)
+        => op switch
+        {
+            PerformanceTriageOptions.RowOperator.Equals => compare == 0,
+            PerformanceTriageOptions.RowOperator.NotEquals => compare != 0,
+            PerformanceTriageOptions.RowOperator.GreaterOrEqual => compare >= 0,
+            PerformanceTriageOptions.RowOperator.LessOrEqual => compare <= 0,
+            _ => false,
+        };
+
+    static int CompareTriageField(Analysis.OptimizationOpportunity left, Analysis.OptimizationOpportunity right, string field)
+    {
+        if (field == "RootReach")
+            return left.RootReach.CompareTo(right.RootReach);
+        if (field == "Confidence")
+            return ConfidenceRank(left.Confidence).CompareTo(ConfidenceRank(right.Confidence));
+        if (field == "Loop")
+            return left.InLoop.CompareTo(right.InLoop);
+        return string.Compare(
+            TriageFieldValue(left, field) ?? "",
+            TriageFieldValue(right, field) ?? "",
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    static string? TriageFieldValue(Analysis.OptimizationOpportunity opportunity, string field)
+        => field switch
+        {
+            "Member" => FormatMethod(opportunity.Method),
+            "Shape" => opportunity.Shape,
+            "Evidence" => opportunity.Evidence,
+            "Fix" => opportunity.SafeFixDirection,
+            "Confidence" => opportunity.Confidence,
+            "Loop" => opportunity.InLoop ? "loop" : "",
+            "Allocation" => opportunity.RuntimeAllocationType,
+            "Path" => opportunity.PathContext,
+            "PathConfidence" => opportunity.PathConfidence,
+            "IL" => opportunity.ILOffset is { } offset ? $"IL_{offset:X4}" : null,
+            "RootReach" => opportunity.RootReach.ToString(CultureInfo.InvariantCulture),
+            _ => null,
+        };
+
+    static bool WildcardMatch(string actual, string pattern)
+    {
+        if (!pattern.Contains('*') && !pattern.Contains('?'))
+            return string.Equals(actual, pattern, StringComparison.OrdinalIgnoreCase);
+
+        return WildcardMatch(actual.AsSpan(), pattern.AsSpan());
+
+        static bool WildcardMatch(ReadOnlySpan<char> text, ReadOnlySpan<char> pattern)
+        {
+            int textIndex = 0;
+            int patternIndex = 0;
+            int starIndex = -1;
+            int matchIndex = 0;
+            while (textIndex < text.Length)
+            {
+                if (patternIndex < pattern.Length
+                    && (pattern[patternIndex] == '?' || char.ToUpperInvariant(pattern[patternIndex]) == char.ToUpperInvariant(text[textIndex])))
+                {
+                    textIndex++;
+                    patternIndex++;
+                }
+                else if (patternIndex < pattern.Length && pattern[patternIndex] == '*')
+                {
+                    starIndex = patternIndex++;
+                    matchIndex = textIndex;
+                }
+                else if (starIndex >= 0)
+                {
+                    patternIndex = starIndex + 1;
+                    textIndex = ++matchIndex;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            while (patternIndex < pattern.Length && pattern[patternIndex] == '*')
+                patternIndex++;
+            return patternIndex == pattern.Length;
+        }
     }
 
     internal static List<IntegrationSignal>? ScanOpenTelemetry(string path, VerboseLogger logger)

--- a/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
+++ b/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
@@ -144,6 +144,11 @@ public sealed record PerformanceTriageOptions
         }
 
         orderTerms = [.. terms];
+        if (orderTerms.Length == 0)
+        {
+            error = "Error: --order-by requires at least one field.";
+            return false;
+        }
         if (orderTerms.Length > 1 && orderTerms.Any(term => term.Field == "Triage"))
         {
             error = "Error: Triage is a composite order and must be used alone, e.g. --order-by \"Triage desc\".";

--- a/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
+++ b/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
@@ -5,7 +5,48 @@ namespace DotnetInspector.Options;
 /// </summary>
 public sealed record PerformanceTriageOptions
 {
+    public enum RowOperator
+    {
+        Equals,
+        NotEquals,
+        GreaterOrEqual,
+        LessOrEqual,
+    }
+
+    public sealed record RowPredicate(string Field, RowOperator Operator, string Value);
+
+    public sealed record OrderTerm(string Field, bool Descending);
+
     public static PerformanceTriageOptions Default { get; } = new();
+    public static readonly string[] FilterableFields =
+    [
+        "Member",
+        "RootReach",
+        "Shape",
+        "Evidence",
+        "Fix",
+        "Confidence",
+        "Loop",
+        "Allocation",
+        "Path",
+        "PathConfidence",
+        "IL",
+    ];
+
+    public static readonly string[] SortableFields =
+    [
+        "Triage",
+        "RootReach",
+        "Confidence",
+        "Loop",
+        "Member",
+        "Shape",
+        "IL",
+        "Allocation",
+        "Path",
+        "PathConfidence",
+    ];
+
     public static readonly string[] KnownShapes =
     [
         "allocation-hotspot",
@@ -28,12 +69,95 @@ public sealed record PerformanceTriageOptions
     public string? MinConfidence { get; init; }
     public string[] Shapes { get; init; } = [];
     public int? Top { get; init; }
+    public string[] Where { get; init; } = [];
+    public string? OrderBy { get; init; }
 
     public bool HasFilters =>
         LoopOnly
         || !string.IsNullOrWhiteSpace(MinConfidence)
         || Shapes.Length > 0
-        || Top.HasValue;
+        || Top.HasValue
+        || Where.Length > 0
+        || !string.IsNullOrWhiteSpace(OrderBy);
+
+    public bool TryGetPredicates(out RowPredicate[] predicates, out string error)
+    {
+        var builder = new List<RowPredicate>();
+        foreach (var expression in Where)
+        {
+            if (!TryParsePredicate(expression, out var predicate, out error))
+            {
+                predicates = [];
+                return false;
+            }
+            builder.Add(predicate);
+        }
+        predicates = [.. builder];
+        error = "";
+        return true;
+    }
+
+    public bool TryGetOrderTerms(out OrderTerm[] orderTerms, out string error)
+    {
+        if (string.IsNullOrWhiteSpace(OrderBy))
+        {
+            orderTerms = [new OrderTerm("Triage", Descending: true)];
+            error = "";
+            return true;
+        }
+
+        var terms = new List<OrderTerm>();
+        foreach (var raw in OrderBy.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var parts = raw.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length is < 1 or > 2)
+            {
+                orderTerms = [];
+                error = $"Error: Invalid --order-by term '{raw}'. Use forms like 'RootReach desc' or 'Confidence desc,RootReach desc'.";
+                return false;
+            }
+
+            var field = NormalizeField(parts[0], SortableFields);
+            if (field is null)
+            {
+                orderTerms = [];
+                error = UnknownFieldError(parts[0], "sortable", SortableFields);
+                return false;
+            }
+
+            bool descending = false;
+            if (parts.Length == 2)
+            {
+                if (parts[1].Equals("desc", StringComparison.OrdinalIgnoreCase)
+                    || parts[1].Equals("descending", StringComparison.OrdinalIgnoreCase))
+                {
+                    descending = true;
+                }
+                else if (parts[1].Equals("asc", StringComparison.OrdinalIgnoreCase)
+                    || parts[1].Equals("ascending", StringComparison.OrdinalIgnoreCase))
+                {
+                    descending = false;
+                }
+                else
+                {
+                    orderTerms = [];
+                    error = $"Error: Invalid --order-by direction '{parts[1]}'. Valid directions: asc, desc.";
+                    return false;
+                }
+            }
+
+            terms.Add(new OrderTerm(field, descending));
+        }
+
+        orderTerms = [.. terms];
+        if (orderTerms.Length > 1 && orderTerms.Any(term => term.Field == "Triage"))
+        {
+            error = "Error: Triage is a composite order and must be used alone, e.g. --order-by \"Triage desc\".";
+            return false;
+        }
+        error = "";
+        return true;
+    }
 
     public static bool TryValidateShapes(PerformanceTriageOptions options, out string error)
     {
@@ -48,5 +172,114 @@ public sealed record PerformanceTriageOptions
         var quotedInvalid = string.Join(", ", invalid.Select(shape => $"'{shape}'"));
         error = $"Error: Unknown Performance Triage shape{(invalid.Length == 1 ? "" : "s")} {quotedInvalid}. Valid shapes: {string.Join(", ", KnownShapes)}.";
         return false;
+    }
+
+    public static bool TryValidate(PerformanceTriageOptions options, out string error)
+    {
+        if (!TryValidateShapes(options, out error))
+            return false;
+        if (!options.TryGetPredicates(out _, out error))
+            return false;
+        if (!options.TryGetOrderTerms(out _, out error))
+            return false;
+        return true;
+    }
+
+    static bool TryParsePredicate(string expression, out RowPredicate predicate, out string error)
+    {
+        predicate = default!;
+        expression = expression.Trim();
+        if (expression.Length == 0)
+        {
+            error = "Error: Empty --where predicate.";
+            return false;
+        }
+
+        foreach (var (token, op) in new[]
+        {
+            (">=", RowOperator.GreaterOrEqual),
+            ("<=", RowOperator.LessOrEqual),
+            ("!=", RowOperator.NotEquals),
+            ("=", RowOperator.Equals),
+        })
+        {
+            int index = expression.IndexOf(token, StringComparison.Ordinal);
+            if (index <= 0)
+                continue;
+
+            var field = NormalizeField(expression[..index].Trim(), FilterableFields);
+            if (field is null)
+            {
+                error = UnknownFieldError(expression[..index].Trim(), "filterable", FilterableFields);
+                return false;
+            }
+
+            var value = expression[(index + token.Length)..].Trim();
+            if (value.Length == 0)
+            {
+                error = $"Error: Missing value in --where predicate '{expression}'.";
+                return false;
+            }
+
+            if (op is RowOperator.GreaterOrEqual or RowOperator.LessOrEqual
+                && field is not ("RootReach" or "Confidence"))
+            {
+                error = $"Error: Field '{field}' supports only = and != predicates.";
+                return false;
+            }
+
+            predicate = new RowPredicate(field, op, value);
+            error = "";
+            return true;
+        }
+
+        error = $"Error: Invalid --where predicate '{expression}'. Use forms like 'Field=value', 'Field!=value', 'RootReach>=10', or 'Confidence>=medium'.";
+        return false;
+    }
+
+    static string? NormalizeField(string field, IReadOnlyList<string> knownFields)
+    {
+        var normalized = NormalizeName(field);
+        foreach (var known in knownFields)
+            if (NormalizeName(known).Equals(normalized, StringComparison.OrdinalIgnoreCase))
+                return known;
+        return null;
+    }
+
+    static string NormalizeName(string value)
+        => value.Replace(" ", "", StringComparison.Ordinal)
+            .Replace("-", "", StringComparison.Ordinal)
+            .Replace("_", "", StringComparison.Ordinal);
+
+    static string UnknownFieldError(string field, string kind, IReadOnlyList<string> knownFields)
+    {
+        var suggestion = knownFields
+            .OrderBy(candidate => EditDistance(NormalizeName(field).ToLowerInvariant(), NormalizeName(candidate).ToLowerInvariant()))
+            .ThenBy(candidate => candidate, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+        return suggestion is null
+            ? $"Error: Field '{field}' is not {kind} in section 'Performance Triage'."
+            : $"Error: Field '{field}' is not {kind} in section 'Performance Triage'.{Environment.NewLine}{Environment.NewLine}Did you mean:{Environment.NewLine}  {suggestion}";
+    }
+
+    static int EditDistance(string left, string right)
+    {
+        var previous = new int[right.Length + 1];
+        var current = new int[right.Length + 1];
+        for (int j = 0; j <= right.Length; j++)
+            previous[j] = j;
+        for (int i = 1; i <= left.Length; i++)
+        {
+            current[0] = i;
+            for (int j = 1; j <= right.Length; j++)
+            {
+                var cost = left[i - 1] == right[j - 1] ? 0 : 1;
+                current[j] = Math.Min(
+                    Math.Min(current[j - 1] + 1, previous[j] + 1),
+                    previous[j - 1] + cost);
+            }
+            (previous, current) = (current, previous);
+        }
+        return previous[right.Length];
     }
 }

--- a/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
+++ b/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
@@ -238,7 +238,8 @@ public sealed record PerformanceTriageOptions
                 error = $"Error: Field '{field}' supports only = and != predicates.";
                 return false;
             }
-            if (field == "RootReach" && !int.TryParse(value, out _))
+            if (field == "RootReach"
+                && !int.TryParse(value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out _))
             {
                 error = $"Error: Field 'RootReach' expects an integer value in --where predicate '{expression}'.";
                 return false;

--- a/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
+++ b/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
@@ -109,39 +109,33 @@ public sealed record PerformanceTriageOptions
         var terms = new List<OrderTerm>();
         foreach (var raw in OrderBy.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
         {
-            var parts = raw.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            if (parts.Length is < 1 or > 2)
-            {
-                orderTerms = [];
-                error = $"Error: Invalid --order-by term '{raw}'. Use forms like 'RootReach desc' or 'Confidence desc,RootReach desc'.";
-                return false;
-            }
+            var (fieldText, directionText) = SplitOrderTerm(raw);
 
-            var field = NormalizeField(parts[0], SortableFields);
+            var field = NormalizeField(fieldText, SortableFields);
             if (field is null)
             {
                 orderTerms = [];
-                error = UnknownFieldError(parts[0], "sortable", SortableFields);
+                error = UnknownFieldError(fieldText, "sortable", SortableFields);
                 return false;
             }
 
             bool descending = false;
-            if (parts.Length == 2)
+            if (directionText is { Length: > 0 })
             {
-                if (parts[1].Equals("desc", StringComparison.OrdinalIgnoreCase)
-                    || parts[1].Equals("descending", StringComparison.OrdinalIgnoreCase))
+                if (directionText.Equals("desc", StringComparison.OrdinalIgnoreCase)
+                    || directionText.Equals("descending", StringComparison.OrdinalIgnoreCase))
                 {
                     descending = true;
                 }
-                else if (parts[1].Equals("asc", StringComparison.OrdinalIgnoreCase)
-                    || parts[1].Equals("ascending", StringComparison.OrdinalIgnoreCase))
+                else if (directionText.Equals("asc", StringComparison.OrdinalIgnoreCase)
+                    || directionText.Equals("ascending", StringComparison.OrdinalIgnoreCase))
                 {
                     descending = false;
                 }
                 else
                 {
                     orderTerms = [];
-                    error = $"Error: Invalid --order-by direction '{parts[1]}'. Valid directions: asc, desc.";
+                    error = $"Error: Invalid --order-by direction '{directionText}'. Valid directions: asc, desc.";
                     return false;
                 }
             }
@@ -157,6 +151,25 @@ public sealed record PerformanceTriageOptions
         }
         error = "";
         return true;
+    }
+
+    static (string Field, string? Direction) SplitOrderTerm(string raw)
+    {
+        raw = raw.Trim();
+        int lastSpace = raw.LastIndexOf(' ');
+        if (lastSpace < 0)
+            return (raw, null);
+
+        var maybeDirection = raw[(lastSpace + 1)..].Trim();
+        if (maybeDirection.Equals("asc", StringComparison.OrdinalIgnoreCase)
+            || maybeDirection.Equals("ascending", StringComparison.OrdinalIgnoreCase)
+            || maybeDirection.Equals("desc", StringComparison.OrdinalIgnoreCase)
+            || maybeDirection.Equals("descending", StringComparison.OrdinalIgnoreCase))
+        {
+            return (raw[..lastSpace].Trim(), maybeDirection);
+        }
+
+        return (raw, null);
     }
 
     public static bool TryValidateShapes(PerformanceTriageOptions options, out string error)
@@ -195,17 +208,10 @@ public sealed record PerformanceTriageOptions
             return false;
         }
 
-        foreach (var (token, op) in new[]
+        var match = FindPredicateOperator(expression);
+        if (match is { } found)
         {
-            (">=", RowOperator.GreaterOrEqual),
-            ("<=", RowOperator.LessOrEqual),
-            ("!=", RowOperator.NotEquals),
-            ("=", RowOperator.Equals),
-        })
-        {
-            int index = expression.IndexOf(token, StringComparison.Ordinal);
-            if (index <= 0)
-                continue;
+            var (index, token, op) = found;
 
             var field = NormalizeField(expression[..index].Trim(), FilterableFields);
             if (field is null)
@@ -227,6 +233,16 @@ public sealed record PerformanceTriageOptions
                 error = $"Error: Field '{field}' supports only = and != predicates.";
                 return false;
             }
+            if (field == "RootReach" && !int.TryParse(value, out _))
+            {
+                error = $"Error: Field 'RootReach' expects an integer value in --where predicate '{expression}'.";
+                return false;
+            }
+            if (field == "Confidence" && !IsKnownConfidence(value))
+            {
+                error = $"Error: Field 'Confidence' expects one of low, medium, high in --where predicate '{expression}'.";
+                return false;
+            }
 
             predicate = new RowPredicate(field, op, value);
             error = "";
@@ -236,6 +252,35 @@ public sealed record PerformanceTriageOptions
         error = $"Error: Invalid --where predicate '{expression}'. Use forms like 'Field=value', 'Field!=value', 'RootReach>=10', or 'Confidence>=medium'.";
         return false;
     }
+
+    static (int Index, string Token, RowOperator Operator)? FindPredicateOperator(string expression)
+    {
+        (int Index, string Token, RowOperator Operator)? best = null;
+        foreach (var candidate in new[]
+        {
+            (Token: ">=", Operator: RowOperator.GreaterOrEqual),
+            (Token: "<=", Operator: RowOperator.LessOrEqual),
+            (Token: "!=", Operator: RowOperator.NotEquals),
+            (Token: "=", Operator: RowOperator.Equals),
+        })
+        {
+            int index = expression.IndexOf(candidate.Token, StringComparison.Ordinal);
+            if (index <= 0)
+                continue;
+            if (best is null
+                || index < best.Value.Index
+                || index == best.Value.Index && candidate.Token.Length > best.Value.Token.Length)
+            {
+                best = (index, candidate.Token, candidate.Operator);
+            }
+        }
+        return best;
+    }
+
+    static bool IsKnownConfidence(string value)
+        => value.Equals("low", StringComparison.OrdinalIgnoreCase)
+           || value.Equals("medium", StringComparison.OrdinalIgnoreCase)
+           || value.Equals("high", StringComparison.OrdinalIgnoreCase);
 
     static string? NormalizeField(string field, IReadOnlyList<string> knownFields)
     {

--- a/src/dotnet-inspect/Output/DiscoverOutput.cs
+++ b/src/dotnet-inspect/Output/DiscoverOutput.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using DotnetInspector.Options;
 using DotnetInspector.Sections;
 using DotnetInspector.Views;
 using Markout;
@@ -355,9 +356,32 @@ public static class DiscoverOutput
                 foreach (var item in items)
                     rows.Add(new DiscoveryRow(item.Name, item.Kind));
             }
+            if (string.Equals(resolved, SectionNames.PerformanceTriage, StringComparison.OrdinalIgnoreCase))
+                rows.AddRange(PerformanceTriageQueryRows());
         }
 
         return rows;
+    }
+
+    static IEnumerable<DiscoveryRow> PerformanceTriageQueryRows()
+    {
+        yield return new DiscoveryRow("Triage desc", "default-order");
+        foreach (var step in new[]
+        {
+            "Loop desc",
+            "Confidence desc (high > medium > low)",
+            "RootReach desc",
+            "Member asc",
+            "IL asc",
+            "Shape asc",
+        })
+        {
+            yield return new DiscoveryRow(step, "order-step");
+        }
+        foreach (var field in PerformanceTriageOptions.FilterableFields)
+            yield return new DiscoveryRow(field, "filterable");
+        foreach (var field in PerformanceTriageOptions.SortableFields)
+            yield return new DiscoveryRow(field, "sortable");
     }
 
     private static int ResolvedSectionCount(

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -65,6 +65,15 @@ public class SharedOptions
         AllowMultipleArgumentsPerToken = true
     };
     public Option<int?> PerformanceTriageTop { get; } = new("--top") { Description = "Performance Triage: show the top N ranked rows" };
+    public Option<string[]> RowWhere { get; } = new("--where")
+    {
+        Description = "Filter selected section rows with a field predicate, e.g. --where \"Allocation=boxed *\" or --where \"RootReach>=10\"",
+        AllowMultipleArgumentsPerToken = false
+    };
+    public Option<string?> RowOrderBy { get; } = new("--order-by")
+    {
+        Description = "Order selected section rows by field(s), e.g. --order-by \"RootReach desc,Confidence desc\""
+    };
 
     // NuGet source options
     public Option<string[]> Source { get; } = new("--source")
@@ -192,6 +201,8 @@ public class SharedOptions
         command.Options.Add(PerformanceTriageMinConfidence);
         command.Options.Add(PerformanceTriageShape);
         command.Options.Add(PerformanceTriageTop);
+        command.Options.Add(RowWhere);
+        command.Options.Add(RowOrderBy);
     }
 
     /// <summary>
@@ -228,13 +239,15 @@ public class SharedOptions
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-        var top = parseResult.GetValue(PerformanceTriageTop);
+        var top = parseResult.GetValue(Count) ? null : parseResult.GetValue(PerformanceTriageTop);
         return new PerformanceTriageOptions
         {
             LoopOnly = parseResult.GetValue(PerformanceTriageLoop),
             MinConfidence = parseResult.GetValue(PerformanceTriageMinConfidence),
             Shapes = shapes,
-            Top = top is > 0 ? top : null
+            Top = top is > 0 ? top : null,
+            Where = parseResult.GetValue(RowWhere) ?? [],
+            OrderBy = parseResult.GetValue(RowOrderBy)
         };
     }
 


### PR DESCRIPTION
## Summary

Implements the first row-query/order slice from #2081 for the `Performance Triage` section.

- Adds `--where "Field=value"` row predicates for `Performance Triage` fields.
- Adds `--order-by` for explicit row ordering.
- Keeps `--top` as a semantic cap after filtering/ordering.
- Makes `--count` count post-filter rows before `--top` by suppressing `Top` while counting.
- Keeps existing focused flags (`--loop`, `--min-confidence`, `--triage-shape`) and lowers them through the same `PerformanceTriageOptions` pipeline.
- Extends `-D "Performance Triage" --schema` with default-order, order-step, filterable, and sortable rows.

## Examples

```bash
dotnet-inspect library MyApp.dll -S "Performance Triage" \
  --where "Allocation=boxed *" \
  --where "Path=straight-line" \
  --order-by "RootReach desc" \
  --top 10
```

```bash
dotnet-inspect library MyApp.dll -S "Performance Triage" \
  --where "Shape=box-value-type" \
  --top 1 \
  --count
```

## Validation

- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -method '*PerformanceTriagePredicates_DoNotAlterDiscovery*' -method '*FilterAndOrderTriageOpportunities*' -method '*PerformanceTriageWhere*' -method '*PerformanceTriageOrderBy*' -method '*PerformanceTriageCount*' -method '*LibraryCommand_DiscoverPerformanceTriage_ListsRenderableColumns*'`
- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507%3BCS0436 --nologo --verbosity quiet`

Note: a full local `src/dotnet-inspect.Tests` run still hits the pre-existing `CliDiscoverySections_AreSelectable` / `SourceLink Integrity` failure in this environment; the targeted row-query tests above pass.

## Review status

Adversarial review is required for this behavior PR. I will post reviewer findings and reconciliation as PR comments.
