### PR TITLE
Use structured member identity for Member Index

### DIFF
--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -1,0 +1,49 @@
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Metadata-owned API identity helpers for durable member selectors. These
+/// helpers compose identity strings from queryable metadata facts, not from C#
+/// declaration text.
+/// </summary>
+public static class ApiMemberIdentity
+{
+    public static bool TryGetCanonicalSignature(ApiType type, ApiMember member, out string canonicalSignature)
+    {
+        var declaringType = string.IsNullOrWhiteSpace(member.DeclaringType)
+            ? MetadataTypeNameFormatter.FormatFullName(type)
+            : member.DeclaringType!;
+
+        var kindCode = member.Kind switch
+        {
+            "property" => "P",
+            "field" => "F",
+            "event" => "E",
+            _ => "M"
+        };
+
+        if (member.Kind is "property" or "field" or "event")
+        {
+            canonicalSignature = $"{kindCode}:{declaringType}.{member.Name}";
+            return true;
+        }
+
+        if (member.SignatureModel is not { } signature)
+        {
+            canonicalSignature = "";
+            return false;
+        }
+
+        var memberName = member.Kind == "constructor"
+            ? "#ctor"
+            : string.IsNullOrWhiteSpace(signature.MemberName)
+                ? member.Name
+                : signature.MemberName!;
+        canonicalSignature = $"{kindCode}:{declaringType}.{memberName}{NormalizeCanonicalParameters(signature.ParameterTypesSummary)}";
+        return true;
+    }
+
+    static string NormalizeCanonicalParameters(string parameterTypesSummary)
+        => string.IsNullOrEmpty(parameterTypesSummary)
+            ? "()"
+            : parameterTypesSummary.Replace(", ", ",", StringComparison.Ordinal).Trim();
+}

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -38,6 +38,7 @@ public static class ApiMemberIdentity
             : string.IsNullOrWhiteSpace(signature.MemberName)
                 ? member.Name
                 : signature.MemberName!;
+        memberName = NormalizeCanonicalCommas(memberName);
         canonicalSignature = $"{kindCode}:{declaringType}.{memberName}{NormalizeCanonicalParameters(signature.ParameterTypesSummary)}";
         return true;
     }
@@ -45,5 +46,8 @@ public static class ApiMemberIdentity
     static string NormalizeCanonicalParameters(string parameterTypesSummary)
         => string.IsNullOrEmpty(parameterTypesSummary)
             ? "()"
-            : parameterTypesSummary.Replace(", ", ",", StringComparison.Ordinal).Trim();
+            : NormalizeCanonicalCommas(parameterTypesSummary);
+
+    static string NormalizeCanonicalCommas(string value)
+        => value.Replace(", ", ",", StringComparison.Ordinal).Trim();
 }

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -35,12 +35,50 @@ public static class ApiMemberIdentity
 
         var memberName = member.Kind == "constructor"
             ? "#ctor"
-            : string.IsNullOrWhiteSpace(signature.MemberName)
-                ? member.Name
-                : signature.MemberName!;
+            : LegacyCanonicalMemberName(member.Signature, member.Name)
+              ?? (string.IsNullOrWhiteSpace(signature.MemberName)
+                  ? member.Name
+                  : signature.MemberName!);
         memberName = NormalizeCanonicalCommas(memberName);
         canonicalSignature = $"{kindCode}:{declaringType}.{memberName}{NormalizeCanonicalParameters(signature.ParameterTypesSummary)}";
         return true;
+    }
+
+    // Preserve the v1 Member Index digest contract for members that already have
+    // compatibility signature text. The legacy parser had edge-case behavior
+    // around method names inside generic parameter names, and published stable
+    // selectors hash that exact canonical string.
+    static string? LegacyCanonicalMemberName(string? signature, string memberName)
+    {
+        if (string.IsNullOrEmpty(signature))
+            return null;
+
+        var parenStart = signature.IndexOf('(');
+        if (parenStart < 0)
+            return null;
+
+        var nameIndex = signature.LastIndexOf(memberName, parenStart - 1, StringComparison.Ordinal);
+        if (nameIndex < 0)
+            return null;
+
+        var end = nameIndex + memberName.Length;
+        if (end < parenStart && signature[end] == '<')
+        {
+            var depth = 0;
+            for (var i = end; i < parenStart; i++)
+            {
+                if (signature[i] == '<')
+                    depth++;
+                else if (signature[i] == '>')
+                {
+                    depth--;
+                    if (depth == 0)
+                        return signature[nameIndex..(i + 1)];
+                }
+            }
+        }
+
+        return memberName;
     }
 
     static string NormalizeCanonicalParameters(string parameterTypesSummary)

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2159,6 +2159,9 @@ public static class ApiOutputFormatter
 
     internal static string GetCanonicalSignature(ApiType type, ApiMember member)
     {
+        if (ApiMemberIdentity.TryGetCanonicalSignature(type, member, out var structuredCanonicalSignature))
+            return structuredCanonicalSignature;
+
         var declaringType = member.DeclaringType;
         if (string.IsNullOrWhiteSpace(declaringType))
             declaringType = FormatGenericFullName(type);

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -52,9 +52,51 @@ public sealed class ApiSignatureModelTests
         Assert.Equal("System.EventHandler?", evt.SignatureModel?.ReturnType);
     }
 
+    [Fact]
+    public void CanonicalSignature_UsesStructuredSignatureModel()
+    {
+        var type = GetType(nameof(ApiSignatureFixtures));
+        var source = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.MethodWithRefKinds));
+        var member = new ApiMember
+        {
+            Name = source.Name,
+            Kind = source.Kind,
+            Signature = "BROKEN",
+            SignatureModel = source.SignatureModel
+        };
+
+        Assert.True(ApiMemberIdentity.TryGetCanonicalSignature(type, member, out var canonical));
+
+        Assert.Equal(
+            "M:ILInspector.Metadata.Tests.ApiSignatureFixtures.MethodWithRefKinds(ref int,out string,in long,int,params byte[])",
+            canonical);
+    }
+
+    [Fact]
+    public void CanonicalSignature_UsesGenericMethodNameFromStructuredModel()
+    {
+        var type = GetType(nameof(ApiSignatureFixtures));
+        var source = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.GenericMethod));
+        var member = new ApiMember
+        {
+            Name = source.Name,
+            Kind = source.Kind,
+            Signature = "BROKEN",
+            SignatureModel = source.SignatureModel
+        };
+
+        Assert.True(ApiMemberIdentity.TryGetCanonicalSignature(type, member, out var canonical));
+
+        Assert.Equal(
+            "M:ILInspector.Metadata.Tests.ApiSignatureFixtures.GenericMethod<T>(T)",
+            canonical);
+    }
+
+    static ApiType GetType(string typeName)
+        => Surface.Types.First(type => type.Name == typeName);
+
     static ApiMember GetMember(string typeName, string memberName)
-        => Surface.Types
-            .First(type => type.Name == typeName)
+        => GetType(typeName)
             .Members
             .First(member => member.Name == memberName);
 }
@@ -71,6 +113,8 @@ public sealed class ApiSignatureFixtures
         text = count.ToString();
         return text;
     }
+
+    public T GenericMethod<T>(T value) => value;
 
     public string this[int index]
     {

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -112,6 +112,19 @@ public sealed class ApiSignatureModelTests
             canonical);
     }
 
+    [Fact]
+    public void CanonicalSignature_PreservesLegacyGenericNameSubstringDigestContract()
+    {
+        var type = GetType(nameof(ApiSignatureFixtures));
+        var source = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.Validate));
+
+        Assert.True(ApiMemberIdentity.TryGetCanonicalSignature(type, source, out var canonical));
+
+        Assert.Equal(
+            "M:ILInspector.Metadata.Tests.ApiSignatureFixtures.Validate()",
+            canonical);
+    }
+
     static ApiType GetType(string typeName)
         => Surface.Types.First(type => type.Name == typeName);
 
@@ -138,6 +151,10 @@ public sealed class ApiSignatureFixtures
 
     public (TLeft Left, TRight Right) PairGenericMethod<TLeft, TRight>(TLeft left, TRight right)
         => (left, right);
+
+    public void Validate<TValidateOptions>()
+    {
+    }
 
     public string this[int index]
     {

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -92,6 +92,26 @@ public sealed class ApiSignatureModelTests
             canonical);
     }
 
+    [Fact]
+    public void CanonicalSignature_NormalizesMultiGenericMethodNameWhitespace()
+    {
+        var type = GetType(nameof(ApiSignatureFixtures));
+        var source = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.PairGenericMethod));
+        var member = new ApiMember
+        {
+            Name = source.Name,
+            Kind = source.Kind,
+            Signature = "BROKEN",
+            SignatureModel = source.SignatureModel
+        };
+
+        Assert.True(ApiMemberIdentity.TryGetCanonicalSignature(type, member, out var canonical));
+
+        Assert.Equal(
+            "M:ILInspector.Metadata.Tests.ApiSignatureFixtures.PairGenericMethod<TLeft,TRight>(TLeft,TRight)",
+            canonical);
+    }
+
     static ApiType GetType(string typeName)
         => Surface.Types.First(type => type.Name == typeName);
 
@@ -115,6 +135,9 @@ public sealed class ApiSignatureFixtures
     }
 
     public T GenericMethod<T>(T value) => value;
+
+    public (TLeft Left, TRight Right) PairGenericMethod<TLeft, TRight>(TLeft left, TRight right)
+        => (left, right);
 
     public string this[int index]
     {


### PR DESCRIPTION
- Advances #2057
- Changes Member Index canonical identity to prefer structured `ApiSignature` facts while preserving the v1 stable-selector digest contract.

## Change

**Conclusion:** **PASS** — Member Index now queries metadata-owned identity facts without moving C# declaration printing into the CLI, and compatibility fallbacks preserve existing stable selectors.

Before, Member Index canonical signatures parsed rendered `ApiMember.Signature` text directly.

After, `ApiMemberIdentity` composes canonical signatures from structured metadata facts when available:

```text
M:Namespace.Type.Member<T>(T,string)
```

The legacy parser path remains as a fallback for unmodeled members, and the structured path intentionally preserves v1 digest behavior for published stable selectors.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507 --nologo --verbosity quiet` |
| Metadata tests | Pass: `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507` |
| CLI tests | Pass: `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Findings resolved, final pass clean | Found two digest-contract gaps: multi-generic method name comma spacing and generic type-parameter names containing the method name. Fixed in `32259980`, `02bd3f46`, and `f1634a4f`; final pass verified zero digest churn across ~700 types in 10 assemblies. |
| Gemini 3.1 Pro | Findings resolved, final pass clean | Found missing regression-test coverage after the first fix. Fixed in `02bd3f46`; final pass found no significant issues and confirmed prior findings were covered. |

**Review conclusion:** **PASS** — repeated adversarial review is clean after fixes.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507
dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507
```
