### PR TITLE
Teach skills project context source selection

### DIFF
--- a/skills/decompiler/SKILL.md
+++ b/skills/decompiler/SKILL.md
@@ -32,6 +32,7 @@ calls matter. Use `--bare` for a whole-type listing.
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json Serialize:1 -S @Source
 dnx dotnet-inspect -y -- member JsonSerializer --platform System.Text.Json Serialize:1 -S "Annotated Source"
 dnx dotnet-inspect -y -- type JsonSerializer --platform System.Text.Json -S "Decompiled Source" --bare
+dnx dotnet-inspect -y -- member Command --project ./src/App Add:1 -S @Source
 ```
 
 ## Fidelity model

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -18,7 +18,7 @@ dnx dotnet-inspect -y -- <command>
 
 | Goal | Command |
 | ---- | ------- |
-| Find an API | `find Pattern`, then reuse the reported `--platform`, `--package`, or `--library`. |
+| Find an API | In a repo, start with `find Pattern --project path/to/project`; otherwise `find Pattern`, then reuse the reported `--platform`, `--package`, or `--library`. |
 | Inspect a type | `type Type --package Foo`; add `--all` for non-public/hidden members. |
 | Inspect overloads | `member Type --platform Lib -m Name -S "Member Index"` |
 | Select an overload | `member Type --platform Lib Name:1` or `Name~digest` |
@@ -45,6 +45,6 @@ dnx dotnet-inspect -y -- member System.Text.Json.JsonSerializer.Serialize -S "Me
 
 - Default output is Markdown; for formats, `-D`/`-S` discovery, projection, and
   limits, load `dotnet-inspect skill query`.
-- Common BCL types resolve without scope: `type string`, `type 'List<T>'`. Quote
-  generics and patterns: `member 'Dictionary<TKey,TValue>'`, `-S "Async*"`.
+- In repos, prefer `--project <csproj|dir|project.assets.json>` for API/type/member questions; use `--bin <dir>` for built DLLs.
+- Common BCL types resolve without scope: `type string`, `type 'List<T>'`. Quote generics and patterns: `member 'Dictionary<TKey,TValue>'`, `-S "Async*"`.
 - Unpinned packages use latest stable; add `--preview` for prerelease APIs.

--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -18,7 +18,7 @@ dnx dotnet-inspect -y -- <command>
 
 | Goal | Command |
 | ---- | ------- |
-| Find an API | In a repo, start with `find Pattern --project path/to/project`; otherwise `find Pattern`, then reuse the reported `--platform`, `--package`, or `--library`. |
+| Find an API | `find Pattern` includes platform/BCL types; add `--project path/to/project` when project references should be in scope. |
 | Inspect a type | `type Type --package Foo`; add `--all` for non-public/hidden members. |
 | Inspect overloads | `member Type --platform Lib -m Name -S "Member Index"` |
 | Select an overload | `member Type --platform Lib Name:1` or `Name~digest` |
@@ -45,6 +45,6 @@ dnx dotnet-inspect -y -- member System.Text.Json.JsonSerializer.Serialize -S "Me
 
 - Default output is Markdown; for formats, `-D`/`-S` discovery, projection, and
   limits, load `dotnet-inspect skill query`.
-- In repos, prefer `--project <csproj|dir|project.assets.json>` for API/type/member questions; use `--bin <dir>` for built DLLs.
+- Add `--project <csproj|dir|project.assets.json>` when APIs from project-referenced packages should be in scope.
 - Common BCL types resolve without scope: `type string`, `type 'List<T>'`. Quote generics and patterns: `member 'Dictionary<TKey,TValue>'`, `-S "Async*"`.
 - Unpinned packages use latest stable; add `--preview` for prerelease APIs.

--- a/skills/relationships/SKILL.md
+++ b/skills/relationships/SKILL.md
@@ -15,9 +15,10 @@ dnx dotnet-inspect -y -- <command>
 ```
 
 Scope any of these commands the same way: `--package Foo` (repeatable),
-`--library path.dll`, `--platform` (all in-box frameworks), `--extensions` or
-`--aspnetcore` (curated Microsoft.* sets), `--package-prefix Azure.AI` (every
-package under a NuGet ID prefix), and `--tfm net9.0`.
+`--library path.dll`, `--platform` (all in-box frameworks), `--project App.csproj`
+(restored project assets), `--extensions` or `--aspnetcore` (curated Microsoft.*
+sets), `--package-prefix Azure.AI` (every package under a NuGet ID prefix), and
+`--tfm net9.0`.
 
 ## What implements or extends it?
 
@@ -44,9 +45,11 @@ dnx dotnet-inspect -y -- depends MyType --library MyLib.dll --mermaid
 
 ## Who calls it? (reverse edges)
 
-`member Type Method:1 -S Calls` lists what a method calls; `-S Callers` lists the
-call sites that reach it. Widen the caller search with `--bin`, `--project`, or
-`--caller-package`.
+`member Type Method:1 -S Calls` lists what a method calls; `-S Callers` lists
+the call sites that reach it. With an explicit source, widen the caller search
+with `--bin`, `--project`, or `--caller-package`. With no explicit source, the
+first `--project` is the source context; repeated `--project` values after it
+remain caller scopes.
 
 ```bash
 dnx dotnet-inspect -y -- member Type Method:1 -S Calls

--- a/skills/relationships/SKILL.md
+++ b/skills/relationships/SKILL.md
@@ -16,9 +16,9 @@ dnx dotnet-inspect -y -- <command>
 
 Scope any of these commands the same way: `--package Foo` (repeatable),
 `--library path.dll`, `--platform` (all in-box frameworks), `--project App.csproj`
-(restored project assets), `--extensions` or `--aspnetcore` (curated Microsoft.*
-sets), `--package-prefix Azure.AI` (every package under a NuGet ID prefix), and
-`--tfm net9.0`.
+(project-referenced packages), `--extensions` or `--aspnetcore` (curated
+Microsoft.* sets), `--package-prefix Azure.AI` (every package under a NuGet ID
+prefix), and `--tfm net9.0`.
 
 ## What implements or extends it?
 


### PR DESCRIPTION
## Summary

- Updates the base `dotnet-inspect` skill to prefer `--project` for API/type/member questions when working in a repo.
- Updates the relationships skill to include `--project` as a scope and clarify the member source-vs-caller-scope split.
- Adds a project-context decompiler example to the decompiler skill.

Follow-up to #2082.

## Validation

- `npx markdownlint-cli skills/dotnet-inspect/SKILL.md skills/relationships/SKILL.md skills/decompiler/SKILL.md`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -class "*SkillCommandTests"`
