### PR TITLE
Use structured facts for constructor emphasis

### DIFF
--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1013,13 +1013,13 @@ public static class ApiOutputFormatter
         if (constructors.Count == 0) return;
 
         var sorted = constructors
-            .OrderBy(c => SignatureParser.CountParameters(c.Signature))
+            .OrderBy(ConstructorParameterCount)
             .ToList();
 
         view.ConstructorOverloads = sorted.Select((ctor, i) =>
         {
-            var paramCount = SignatureParser.CountParameters(ctor.Signature);
-            var paramInfo = SignatureParser.ExtractParameterInfo(ctor.Signature);
+            var paramCount = ConstructorParameterCount(ctor);
+            var paramInfo = ConstructorParameterInfo(ctor);
 
             var overloadView = new ConstructorOverloadView
             {
@@ -1037,6 +1037,17 @@ public static class ApiOutputFormatter
             return overloadView;
         }).ToList();
     }
+
+    private static int ConstructorParameterCount(ApiMember constructor)
+        => constructor.SignatureModel?.ParameterCount
+           ?? SignatureParser.CountParameters(constructor.Signature);
+
+    private static List<(string name, string type, bool hasDefault)> ConstructorParameterInfo(ApiMember constructor)
+        => constructor.SignatureModel is { } signature
+            ? signature.Parameters
+                .Select(parameter => (parameter.Name, parameter.TypeWithModifier, parameter.HasDefault))
+                .ToList()
+            : SignatureParser.ExtractParameterInfo(constructor.Signature);
 
     internal static void PopulateIndexSections(TypeView view, ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex, IReadOnlySet<string> requestedSections, string? pdbPath = null, IReadOnlySet<string>? explicitSections = null, IReadOnlyList<string>? callerScopeAssemblies = null, ApiOptions? options = null)
     {

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -53,6 +53,25 @@ public sealed class ApiSignatureModelTests
     }
 
     [Fact]
+    public void ConstructorSignatureModel_ExposesParameterFacts()
+    {
+        var ctor = GetType(nameof(ApiSignatureFixtures)).Members
+            .Where(member => member.Kind == "constructor")
+            .Single(member => member.SignatureModel?.ParameterCount == 2);
+
+        Assert.NotNull(ctor.SignatureModel);
+        Assert.Equal(".ctor", ctor.SignatureModel.MemberName);
+        Assert.Equal(2, ctor.SignatureModel.ParameterCount);
+        Assert.Equal("(string, int)", ctor.SignatureModel.ParameterTypesSummary);
+        Assert.Equal("name", ctor.SignatureModel.Parameters[0].Name);
+        Assert.Equal("string", ctor.SignatureModel.Parameters[0].Type);
+        Assert.False(ctor.SignatureModel.Parameters[0].HasDefault);
+        Assert.Equal("count", ctor.SignatureModel.Parameters[1].Name);
+        Assert.Equal("int", ctor.SignatureModel.Parameters[1].Type);
+        Assert.True(ctor.SignatureModel.Parameters[1].HasDefault);
+    }
+
+    [Fact]
     public void CanonicalSignature_UsesStructuredSignatureModel()
     {
         var type = GetType(nameof(ApiSignatureFixtures));
@@ -139,6 +158,15 @@ public sealed class ApiSignatureFixtures
     public int Count;
 
     public event EventHandler? Changed;
+
+    public ApiSignatureFixtures()
+    {
+    }
+
+    public ApiSignatureFixtures(string name, int count = 1)
+    {
+        Count = name.Length + count;
+    }
 
     public string MethodWithRefKinds(ref int value, out string text, in long source, int count = 1, params byte[] bytes)
     {


### PR DESCRIPTION
- Advances #2057
- Changes constructor emphasis (`member ... --ctor`) to query structured `ApiSignature` facts for parameter counts and parameter table rows.

## Change

**Conclusion:** **PASS** — constructor emphasis now uses metadata-owned signature facts for queryable components while leaving source-shaped C# constructor-call rendering on the existing compatibility path for a later decompiler-printer slice.

Before, `PopulateConstructorOverloads` parsed rendered constructor signatures for:

- overload ordering by parameter count;
- overload title parameter count;
- parameter table name/type/default notes.

After, modeled constructors use:

```text
ApiSignature.ParameterCount
ApiSignature.Parameters[*].Name
ApiParameter.TypeWithModifier
ApiParameter.HasDefault
```

`SignatureParser` remains as fallback for unmodeled members.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507 --nologo --verbosity quiet` |
| Metadata tests | Pass: `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507` |
| CLI tests | Pass: `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No significant issues | Verified overload ordering, parameter mapping, optional/required notes, fallback, and that no new C# printing moved into CLI. |
| Gemini 3.1 Pro | No significant issues | No code changes needed. |

**Review conclusion:** **PASS** — adversarial review found no blocking or high-confidence issues.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507
dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507
```
