### PR TITLE
Prototype IL coordinate batch workflows

### DIFF
--- a/docs/design/il-coordinate-workflows.md
+++ b/docs/design/il-coordinate-workflows.md
@@ -18,13 +18,12 @@ summary:
 dotnet-inspect library My.dll --il-offsets coords.txt
 ```
 
-```md
+```text
 ## IL Coordinates
 
-| Coordinate | Label | Member | IL Offset | Meaning | Evidence |
-| ---------- | ----- | ------ | --------- | ------- | -------- |
-| 0x06000042+0x2F | profiler-sample | My.Type.M1 | IL_002F | return address | call at IL_002A to M2 |
-| 0x06000051+0x10 | debugger-frame | My.Type.M2 | IL_0010 | allocation | array int[] |
+Coordinate      Label            Member      IL Offset  Meaning         Evidence
+0x06000042+0x2F profiler-sample  My.Type.M1  IL_002F    return address  call at IL_002A to M2
+0x06000051+0x10 debugger-frame   My.Type.M2  IL_0010    allocation      array int[]
 ```
 
 ## Prototype producer workflows
@@ -39,6 +38,8 @@ likely the collection and normalization step, not the `dotnet-inspect` query.
 2. Normalize frames to `0x06000000+0x0` coordinates in a text file.
 3. Run `library --il-offsets` to explain return addresses, callsites, exception
    regions, and semantic context rows.
+4. Malformed lines are kept as `error` rows so partially-clean artifacts can
+   still produce a useful summary.
 
 ### Profiler / trace workflow
 

--- a/docs/design/il-coordinate-workflows.md
+++ b/docs/design/il-coordinate-workflows.md
@@ -1,0 +1,64 @@
+# IL coordinate workflows
+
+`library --il-offsets <file>` is a prototype for explaining sparse runtime
+coordinates. It assumes another tool has already collected MethodDef token + IL
+offset pairs and normalizes them into a simple text file:
+
+```text
+# label coordinate
+profiler-sample 0x06000042+0x2F
+debugger-frame 0x06000051+0x10
+analyzer-hit 0x06000060+0x08
+```
+
+The command resolves each coordinate against one assembly and prints a compact
+summary:
+
+```bash
+dotnet-inspect library My.dll --il-offsets coords.txt
+```
+
+```md
+## IL Coordinates
+
+| Coordinate | Label | Member | IL Offset | Meaning | Evidence |
+| ---------- | ----- | ------ | --------- | ------- | -------- |
+| 0x06000042+0x2F | profiler-sample | My.Type.M1 | IL_002F | return address | call at IL_002A to M2 |
+| 0x06000051+0x10 | debugger-frame | My.Type.M2 | IL_0010 | allocation | array int[] |
+```
+
+## Prototype producer workflows
+
+These workflows are intentionally producer-agnostic. The skill-worthy part is
+likely the collection and normalization step, not the `dotnet-inspect` query.
+
+### Debugger / dump workflow
+
+1. Use a debugger, SOS, or dump inspection tool to collect stack frames that
+   include a method identity and IL offset.
+2. Normalize frames to `0x06000000+0x0` coordinates in a text file.
+3. Run `library --il-offsets` to explain return addresses, callsites, exception
+   regions, and semantic context rows.
+
+### Profiler / trace workflow
+
+1. Use a profiler or EventPipe trace tool to identify hot methods and offsets.
+2. Symbolize native/IP data to method token + IL offset when needed.
+3. Run `library --il-offsets` with labels such as `hot-sample` or
+   `alloc-sample` to summarize what each sparse coordinate represents.
+
+### Analyzer / CI artifact workflow
+
+1. A static analyzer or test harness emits method tokens and IL offsets for
+   suspicious points.
+2. The agent turns the artifact into the coordinate file format.
+3. `library --il-offsets` produces the shared explanation table used in PR or
+   issue triage.
+
+## Deferrals
+
+- This prototype does not parse debugger, dump, profiler, or trace formats
+  directly.
+- It does not join coordinates across multiple assemblies in one invocation.
+- Those adapters belong in a future debugging skill once the highest-value
+  producer workflow is clear.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -38,6 +38,7 @@ Agents working in this repo should preserve these principles:
 - [Progressive disclosure](design/progressive-disclosure.md): verbosity, `-D`/`-S`, opt-in sections, `-S @All`, and limiter behavior.
 - [Row query and ordering](design/row-query-order.md): proposed field-scoped row predicates, ordering, `--top`, and schema-discoverable defaults.
 - [Analysis UX scopes](design/analysis-ux-scopes.md): shared analysis vocabulary across offset, member, type, and library scopes.
+- [IL coordinate workflows](design/il-coordinate-workflows.md): prototype workflows for explaining sparse runtime coordinates from debugger, profiler, or analyzer artifacts.
 - [Integrations](design/integrations.md): library ecosystem integration roll-ups and focused API currency.
 - [Section model](design/section-model.md): section selection and query behavior.
 - [Hidden-fact annotations](design/hidden-fact-annotations.md): offset-keyed fact overlay semantics, validation, and projections.

--- a/docs/workflows/debugging/il-coordinate-artifacts.md
+++ b/docs/workflows/debugging/il-coordinate-artifacts.md
@@ -1,0 +1,187 @@
+---
+id: il-coordinate-artifacts
+description: Explain sparse IL coordinates from debugger, profiler, and analyzer-style artifacts
+commands: [library]
+areas: [debugging, analysis, il-offset, workflow]
+---
+
+# Debugging: IL Coordinate Artifacts
+
+> Prototype workflows for an agent that receives runtime or analyzer artifacts
+> containing sparse method-token + IL-offset coordinates. The agent performs the
+> "sneakernet" normalization step, then asks `dotnet-inspect` to explain the
+> coordinates.
+
+## Preconditions
+
+Build the CLI and test assembly used by the demo scenarios.
+
+```bash
+dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+dotnet build src/dotnet-inspect.Tests -c Release -p:PublishAot=false
+```
+
+Generate three coordinate artifact files from the test assembly:
+
+- `debugger.coords`: a callsite and its return address, like a debugger or dump
+  stack frame might provide.
+- `profiler.coords`: hot call and allocation coordinates, like a profiler or
+  trace postprocessor might provide.
+- `analyzer.coords`: safety/allocation coordinates plus a malformed line, like a
+  static analyzer or CI artifact might provide.
+
+```bash
+mkdir -p /tmp/dotnet-inspect-coordinate-demo
+cat > /tmp/dotnet-inspect-coordinate-demo/create.cs <<EOF
+using System.Reflection;
+
+var assemblyPath = Path.GetFullPath("artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll");
+var assembly = Assembly.LoadFile(assemblyPath);
+
+MethodInfo Method(string typeName, string methodName)
+{
+    var type = assembly.GetType(typeName) ?? throw new InvalidOperationException(typeName);
+    return type.GetMethod(
+        methodName,
+        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+        ?? throw new InvalidOperationException($"{typeName}.{methodName}");
+}
+
+int FindOpcode(MethodInfo method, byte opcode)
+{
+    var il = method.GetMethodBody()?.GetILAsByteArray() ?? throw new InvalidOperationException(method.Name);
+    for (var i = 0; i < il.Length; i++)
+    {
+        if (il[i] == opcode)
+            return i;
+    }
+    throw new InvalidOperationException($"opcode 0x{opcode:X2} not found in {method.Name}");
+}
+
+var memberCalls = Method("DotnetInspector.Tests.MemberCallsFixture", "CallsInterfaceItem");
+var memberCallsToken = memberCalls.MetadataToken;
+var interfaceCallOffset = FindOpcode(memberCalls, 0x6F); // callvirt
+var interfaceReturnAddress = interfaceCallOffset + 5;
+
+var semantic = Method("DotnetInspector.Tests.SemanticFactsFixture", "AllSignals");
+var semanticToken = semantic.MetadataToken;
+var allocationOffset = FindOpcode(semantic, 0x8D); // newarr
+var virtualCallOffset = FindOpcode(semantic, 0x6F); // callvirt
+
+var unsafeMethod = Method("DotnetInspector.Tests.SemanticFactsFixture", "UnsafeAs");
+var unsafeToken = unsafeMethod.MetadataToken;
+var unsafeCallOffset = FindOpcode(unsafeMethod, 0x28); // call
+
+string C(int token, int offset) => $"0x{token:X8}+0x{offset:X}";
+
+File.WriteAllLines("/tmp/dotnet-inspect-coordinate-demo/debugger.coords",
+[
+    "# debugger/dump-style normalized frames",
+    $"caller-frame {C(memberCallsToken, interfaceCallOffset)}",
+    $"return-address {C(memberCallsToken, interfaceReturnAddress)}",
+]);
+
+File.WriteAllLines("/tmp/dotnet-inspect-coordinate-demo/profiler.coords",
+[
+    "# profiler/trace-style hot sparse samples",
+    $"hot-virtual-call {C(semanticToken, virtualCallOffset)}",
+    $"alloc-sample {C(semanticToken, allocationOffset)}",
+]);
+
+File.WriteAllLines("/tmp/dotnet-inspect-coordinate-demo/analyzer.coords",
+[
+    "# analyzer/CI-style suspicious coordinates",
+    $"unsafe-call {C(unsafeToken, unsafeCallOffset)}",
+    $"allocation {C(semanticToken, allocationOffset)}",
+    "unparsed analyzer line",
+]);
+EOF
+dotnet run /tmp/dotnet-inspect-coordinate-demo/create.cs
+```
+
+## 1. Explain debugger or dump frames
+
+> Goal: Given a sparse frame artifact with a callsite and return address, explain
+> where the caller is and what call it corresponds to.
+
+```prompt
+Explain these debugger IL coordinates from my crash dump.
+```
+
+```bash
+dotnet run --project src/dotnet-inspect -c Release -- \
+  library artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll \
+  --il-offsets /tmp/dotnet-inspect-coordinate-demo/debugger.coords \
+  --markdown --tips q
+```
+
+```expect
+## IL Coordinates
+caller-frame
+callsite
+return-address
+return address
+```
+
+## 2. Explain profiler or trace samples
+
+> Goal: Given sparse profiler coordinates, separate objective code shapes such
+> as dispatch and allocation without running a ranked triage.
+
+```prompt
+Explain these profiler sample coordinates without doing a full triage.
+```
+
+```bash
+dotnet run --project src/dotnet-inspect -c Release -- \
+  library artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll \
+  --il-offsets /tmp/dotnet-inspect-coordinate-demo/profiler.coords \
+  --markdown --tips q
+```
+
+```expect
+hot-virtual-call
+virtual dispatch
+alloc-sample
+allocation
+```
+
+```expect-not
+Performance Triage
+```
+
+## 3. Explain analyzer or CI artifact coordinates
+
+> Goal: Given a mixed artifact, preserve malformed rows as visible errors while
+> still explaining coordinates that can be normalized.
+
+```prompt
+Explain this analyzer artifact and keep bad lines visible.
+```
+
+```bash
+dotnet run --project src/dotnet-inspect -c Release -- \
+  library artifacts/bin/dotnet-inspect.Tests/release/dotnet-inspect.Tests.dll \
+  --il-offsets /tmp/dotnet-inspect-coordinate-demo/analyzer.coords \
+  --markdown --tips q
+```
+
+```expect-error
+unsafe-call
+safety
+allocation
+error
+expected a MethodDef token + IL offset coordinate
+```
+
+## Skill candidate
+
+The eventual debugging skill should focus on the artifact-to-coordinate
+normalization step:
+
+1. Identify the producer format (debugger/dump, profiler/trace, analyzer/CI).
+2. Extract or symbolize method identity + IL offset.
+3. Write the neutral coordinate file.
+4. Run `library --il-offsets`.
+5. Decide whether the output is enough or whether to drill into individual
+   sections with `--il-offset -S "<Context>"`.

--- a/docs/workflows/debugging/il-coordinate-artifacts.md
+++ b/docs/workflows/debugging/il-coordinate-artifacts.md
@@ -123,7 +123,150 @@ return-address
 return address
 ```
 
-## 2. Explain profiler or trace samples
+## 2. Collect a crash dump, normalize frames, and explain them
+
+> Goal: Show the end-to-end agent workflow: run an app, collect a crash dump,
+> use a debugger-style tool to extract method/offset data, normalize it into the
+> neutral coordinate file, and then ask `dotnet-inspect` to explain the static
+> context.
+
+This scenario intentionally leaves the dump-symbolication command as a
+producer-specific step. The important workflow contract is the handoff from a
+debugger/SOS-like artifact to the neutral coordinate file.
+
+```prompt
+I have a crash dump. Normalize the stack frame IL offsets and explain them with dotnet-inspect.
+```
+
+Create a small app that throws after going through a callsite we can explain:
+
+```bash
+mkdir -p /tmp/dotnet-inspect-coordinate-demo/CrashApp
+cat > /tmp/dotnet-inspect-coordinate-demo/CrashApp/CrashApp.csproj <<'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+EOF
+cat > /tmp/dotnet-inspect-coordinate-demo/CrashApp/Program.cs <<'EOF'
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    public static void Main()
+    {
+        try
+        {
+            Entry();
+        }
+        catch
+        {
+            EmitCoordinates();
+            throw;
+        }
+    }
+
+    public static void Entry() => Caller();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Caller() => CrashTarget(42);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void CrashTarget(int value)
+    {
+        var values = new int[value];
+        throw new InvalidOperationException(values.Length.ToString());
+    }
+
+    static void EmitCoordinates()
+    {
+        var caller = typeof(Program).GetMethod(
+            "Caller",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        var crashTarget = typeof(Program).GetMethod(
+            "CrashTarget",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var callOffset = FindOpcode(caller, 0x28); // call
+        var returnAddress = callOffset + 5;
+        var allocationOffset = FindOpcode(crashTarget, 0x8D); // newarr
+
+        File.WriteAllLines("/tmp/dotnet-inspect-coordinate-demo/crash.coords",
+        [
+            "# normalized from crash stack / dump frames",
+            $"caller-callsite 0x{caller.MetadataToken:X8}+0x{callOffset:X}",
+            $"caller-return-address 0x{caller.MetadataToken:X8}+0x{returnAddress:X}",
+            $"crash-allocation 0x{crashTarget.MetadataToken:X8}+0x{allocationOffset:X}",
+        ]);
+    }
+
+    static int FindOpcode(MethodInfo method, byte opcode)
+    {
+        var il = method.GetMethodBody()!.GetILAsByteArray()!;
+        for (var i = 0; i < il.Length; i++)
+        {
+            if (il[i] == opcode)
+                return i;
+        }
+        throw new InvalidOperationException($"opcode 0x{opcode:X2} not found in {method.Name}");
+    }
+}
+EOF
+dotnet build /tmp/dotnet-inspect-coordinate-demo/CrashApp -c Release
+```
+
+Run the app and collect a dump. This uses `dotnet-dump` if available; the app
+also writes `crash.coords` so the workflow remains executable without requiring
+dump tooling in CI:
+
+```bash
+set +e
+dotnet /tmp/dotnet-inspect-coordinate-demo/CrashApp/bin/Release/net10.0/CrashApp.dll
+app_exit=$?
+set -e
+test "$app_exit" -ne 0
+
+# Optional real collection step when a process is still alive or a dump is needed:
+# dotnet-dump collect --process-id <pid> --output /tmp/dotnet-inspect-coordinate-demo/crash.dmp
+```
+
+In a real dump workflow, the agent would run a debugger/SOS command here and
+normalize the frames:
+
+```text
+# Example shape of external debugger output (tool-specific, not parsed by dotnet-inspect):
+#   Program.Caller() + IL_0000
+#   Program.CrashTarget(int) + IL_0004
+#
+# Agent normalization result:
+#   caller-callsite 0x06000002+0x0
+#   crash-allocation 0x06000003+0x4
+```
+
+Then run `dotnet-inspect` on the normalized coordinate file:
+
+```bash
+dotnet run --project src/dotnet-inspect -c Release -- \
+  library /tmp/dotnet-inspect-coordinate-demo/CrashApp/bin/Release/net10.0/CrashApp.dll \
+  --il-offsets /tmp/dotnet-inspect-coordinate-demo/crash.coords \
+  --markdown --tips q
+```
+
+```expect
+caller-callsite
+callsite
+caller-return-address
+return address
+crash-allocation
+allocation
+```
+
+## 3. Explain profiler or trace samples
 
 > Goal: Given sparse profiler coordinates, separate objective code shapes such
 > as dispatch and allocation without running a ranked triage.
@@ -150,7 +293,7 @@ allocation
 Performance Triage
 ```
 
-## 3. Explain analyzer or CI artifact coordinates
+## 4. Explain analyzer or CI artifact coordinates
 
 > Goal: Given a mixed artifact, preserve malformed rows as visible errors while
 > still explaining coordinates that can be normalized.

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4646,15 +4646,46 @@ public class CommandExecutionTests
     public async Task LibraryCommand_IlOffsetsFile_RejectsBadCoordinateLine()
     {
         var path = Path.Combine(Path.GetTempPath(), $"coords-{Guid.NewGuid():N}.txt");
-        await File.WriteAllTextAsync(path, "not-a-coordinate", TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(path,
+            """
+            bad debugger frame
+            good 0x06000001+0x1
+            """,
+            TestContext.Current.CancellationToken);
         try
         {
             var (exit, output, error) = await RunAppAsync(
                 "library", TestAssemblyPath, "--il-offsets", path, "--tips", "q");
 
             Assert.Equal(1, exit);
-            Assert.Empty(output);
-            Assert.Contains("expected a MethodDef token + IL offset coordinate", error);
+            Assert.Empty(error);
+            Assert.Contains(Path.GetFileName(path), output);
+            Assert.Contains("expected a MethodDef token + IL offset coordinate", output);
+            Assert.Contains("good", output);
+            Assert.Contains("callsite", output);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetsFile_JsonUsesSnakeCaseEnvelope()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"coords-{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(path, "sample 0x06000001+0x1", TestContext.Current.CancellationToken);
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "library", TestAssemblyPath, "--il-offsets", path, "--json", "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.Contains("\"rows\"", output);
+            Assert.Contains("\"il_offset\"", output);
+            Assert.DoesNotContain("\"ILOffset\"", output);
+            Assert.DoesNotContain("\"Coordinate\"", output);
         }
         finally
         {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -4609,6 +4609,60 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task LibraryCommand_IlOffsetsFile_RendersCoordinateSummary()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"coords-{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(path,
+            """
+            # label coordinate
+            profiler-sample 0x06000001+0x1
+            return-address 0x06000001+0x6
+            """,
+            TestContext.Current.CancellationToken);
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "library", TestAssemblyPath, "--il-offsets", path, "--tips", "q");
+
+            Assert.Equal(0, exit);
+            Assert.Empty(error);
+            Assert.Contains("## IL Coordinates", output);
+            Assert.Contains("Coordinate", output);
+            Assert.Contains("IL Offset", output);
+            Assert.Contains("Meaning", output);
+            Assert.Contains("Evidence", output);
+            Assert.Contains("profiler-sample", output);
+            Assert.Contains("callsite", output);
+            Assert.Contains("return-address", output);
+            Assert.Contains("return address", output);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task LibraryCommand_IlOffsetsFile_RejectsBadCoordinateLine()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"coords-{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(path, "not-a-coordinate", TestContext.Current.CancellationToken);
+        try
+        {
+            var (exit, output, error) = await RunAppAsync(
+                "library", TestAssemblyPath, "--il-offsets", path, "--tips", "q");
+
+            Assert.Equal(1, exit);
+            Assert.Empty(output);
+            Assert.Contains("expected a MethodDef token + IL offset coordinate", error);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public async Task LibraryCommand_SourceLocationSectionSelector_UsesFlagParameter()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -136,6 +136,7 @@ public static class InspectionCommandDefinitions
         var typeFilterOption = new Option<string?>("-t") { Description = "Filter Source Files rows by type glob/name (e.g., *Json*)" };
         typeFilterOption.Aliases.Add("--type");
         var ilOffsetOption = new Option<string?>("--il-offset") { Description = "MethodDef token + IL offset for coordinate-scoped sections (e.g., 0x06000001+0x5)" };
+        var ilOffsetsOption = new Option<string?>("--il-offsets") { Description = "Text file of sparse MethodDef token + IL offset coordinates to explain" };
         var extractResourcesOption = new Option<string?>("--extract-resources") { Description = "Extract embedded resources to a directory" };
         assemblyCommand.Arguments.Add(assemblyPathArg);
         assemblyCommand.Options.Add(referencesOption);
@@ -148,6 +149,7 @@ public static class InspectionCommandDefinitions
         assemblyCommand.Options.Add(asmTfmOption);
         assemblyCommand.Options.Add(typeFilterOption);
         assemblyCommand.Options.Add(ilOffsetOption);
+        assemblyCommand.Options.Add(ilOffsetsOption);
         assemblyCommand.Options.Add(opts.RawUrls);
         assemblyCommand.Options.Add(opts.BrowsableUrls);
         assemblyCommand.Options.Add(extractResourcesOption);
@@ -239,6 +241,7 @@ public static class InspectionCommandDefinitions
                 Tfm = parseResult.GetValue(asmTfmOption),
                 TypeFilter = typeFilter,
                 ILOffsetParameter = parseResult.GetValue(ilOffsetOption),
+                ILOffsetsPath = parseResult.GetValue(ilOffsetsOption),
                 BrowsableUrls = parseResult.GetValue(opts.BrowsableUrls)
                     && !parseResult.GetValue(opts.RawUrls),
                 JsonOutput = parseResult.GetValue(opts.Json),

--- a/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
+++ b/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
@@ -20,55 +20,81 @@ internal static class ILOffsetSourceQuery
         HttpClient httpClient,
         VerboseLogger logger)
     {
+        using var service = SourceLinkService.Open(dllPath, logger.Log);
+        return await ResolveAsync(service, packageName, packageVersion, isPlatformAssembly, options, httpClient, logger, writeErrors: true);
+    }
+
+    internal static async Task<(int ExitCode, ILOffsetResult? Result, string? Error)> ResolveBatchAsync(
+        SourceLinkService service,
+        string? packageName,
+        string? packageVersion,
+        bool isPlatformAssembly,
+        LibraryOptions options,
+        HttpClient httpClient,
+        VerboseLogger logger)
+    {
+        var (exitCode, result) = await ResolveAsync(service, packageName, packageVersion, isPlatformAssembly, options, httpClient, logger, writeErrors: false);
+        return (exitCode, result, exitCode == 0 ? null : "could not resolve");
+    }
+
+    private static async Task<(int ExitCode, ILOffsetResult? Result)> ResolveAsync(
+        SourceLinkService service,
+        string? packageName,
+        string? packageVersion,
+        bool isPlatformAssembly,
+        LibraryOptions options,
+        HttpClient httpClient,
+        VerboseLogger logger,
+        bool writeErrors)
+    {
         if (!TryParse(options.ILOffsetParameter!, out var methodToken, out var ilOffset))
         {
-            Console.Error.WriteLine($"Error: Invalid --il-offset value '{options.ILOffsetParameter}'.");
-            Console.Error.WriteLine("Expected format: 0x6000001+0x5 (method token + IL offset)");
+            WriteError(writeErrors, $"Error: Invalid --il-offset value '{options.ILOffsetParameter}'.");
+            WriteError(writeErrors, "Expected format: 0x6000001+0x5 (method token + IL offset)");
             return (1, null);
         }
 
-        using var service = SourceLinkService.Open(dllPath, logger.Log);
         var pdbContext = service.Context;
 
         if (!pdbContext.HasMetadata)
         {
-            Console.Error.WriteLine("Error: No metadata in library.");
+            WriteError(writeErrors, "Error: No metadata in library.");
             return (1, null);
         }
 
         var memberContext = pdbContext.ResolveMemberContext(methodToken, ilOffset);
         if (memberContext == null)
         {
-            Console.Error.WriteLine($"Error: Could not resolve member context for token 0x{methodToken:X}.");
-            Console.Error.WriteLine("The method token may be invalid or may not identify a MethodDef row.");
+            WriteError(writeErrors, $"Error: Could not resolve member context for token 0x{methodToken:X}.");
+            WriteError(writeErrors, "The method token may be invalid or may not identify a MethodDef row.");
             return (1, null);
         }
 
         var instructionContext = pdbContext.ResolveInstructionContext(methodToken, ilOffset, out var instructionError);
         if (instructionContext == null && RequiresInstructionContext(options))
         {
-            Console.Error.WriteLine($"Error: {instructionError ?? $"Could not resolve instruction context for token 0x{methodToken:X}+0x{ilOffset:X}."}");
+            WriteError(writeErrors, $"Error: {instructionError ?? $"Could not resolve instruction context for token 0x{methodToken:X}+0x{ilOffset:X}."}");
             return (1, null);
         }
 
         var exceptionContext = pdbContext.ResolveExceptionContext(methodToken, ilOffset, out var exceptionError);
         if (exceptionError is not null && RequiresExceptionContext(options))
         {
-            Console.Error.WriteLine($"Error: {exceptionError}");
+            WriteError(writeErrors, $"Error: {exceptionError}");
             return (1, null);
         }
 
         var callsiteContext = pdbContext.ResolveCallsiteContext(methodToken, ilOffset, out var callsiteError);
         if (callsiteError is not null && RequiresCallsiteContext(options))
         {
-            Console.Error.WriteLine($"Error: {callsiteError}");
+            WriteError(writeErrors, $"Error: {callsiteError}");
             return (1, null);
         }
 
         var returnAddressContext = pdbContext.ResolveReturnAddressContext(methodToken, ilOffset, out var returnAddressError);
         if (returnAddressError is not null && RequiresReturnAddressContext(options))
         {
-            Console.Error.WriteLine($"Error: {returnAddressError}");
+            WriteError(writeErrors, $"Error: {returnAddressError}");
             return (1, null);
         }
 
@@ -98,7 +124,8 @@ internal static class ILOffsetSourceQuery
 
             if (!pdbContext.HasPdb)
             {
-                WritePdbWarning(pdbContext);
+                if (writeErrors)
+                    WritePdbWarning(pdbContext);
                 return (1, null);
             }
 
@@ -108,8 +135,8 @@ internal static class ILOffsetSourceQuery
             result = service.ResolveByILOffset(methodToken, ilOffset);
             if (result == null)
             {
-                Console.Error.WriteLine($"Error: Could not resolve source location for token 0x{methodToken:X}+0x{ilOffset:X}.");
-                Console.Error.WriteLine("The method token may be invalid or the PDB may not contain sequence points for this method.");
+                WriteError(writeErrors, $"Error: Could not resolve source location for token 0x{methodToken:X}+0x{ilOffset:X}.");
+                WriteError(writeErrors, "The method token may be invalid or the PDB may not contain sequence points for this method.");
                 return (1, null);
             }
         }
@@ -194,6 +221,12 @@ internal static class ILOffsetSourceQuery
         };
 
         return (0, resolved);
+    }
+
+    private static void WriteError(bool enabled, string message)
+    {
+        if (enabled)
+            Console.Error.WriteLine(message);
     }
 
     private static bool RequiresSourceLocation(LibraryOptions options)

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -14,6 +14,8 @@ using DotnetInspector.Views;
 using Markout;
 using System.Globalization;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace DotnetInspector.Commands;
 
@@ -93,6 +95,13 @@ public class LibraryCommand
             && !options.IncludeSections.Overlaps(ILCoordinateSections))
         {
             Console.Error.WriteLine("Error: --il-offset requires an IL coordinate section. Omit -S or include -S \"Source Location\", -S \"Member Context\", -S \"Instruction Context\", -S \"Exception Context\", -S \"Callsite Context\", or -S \"Return Address Context\".");
+            return 1;
+        }
+
+        if (!string.IsNullOrWhiteSpace(options.ILOffsetParameter)
+            && !string.IsNullOrWhiteSpace(options.ILOffsetsPath))
+        {
+            Console.Error.WriteLine("Error: --il-offset cannot be combined with --il-offsets.");
             return 1;
         }
 
@@ -233,6 +242,9 @@ public class LibraryCommand
 
                 logger.Log($"Using platform runtime library: {framework} {version}");
 
+                if (!string.IsNullOrWhiteSpace(options.ILOffsetsPath))
+                    return await WriteILCoordinateBatchAsync(resolvedPath!, null, null, isPlatformAssembly: true, options, context.HttpClient, logger);
+
                 // Check effective sections cache before running full inspection
                 if (effectiveDiscovery && options.Discover is { Length: 0 } && !HasILOffsetCoordinate(options))
                 {
@@ -321,6 +333,9 @@ public class LibraryCommand
                 foreach (var insp in inspections)
                     insp.Source = SourceKind.NuGet;
 
+                if (!string.IsNullOrWhiteSpace(options.ILOffsetsPath))
+                    return await WriteILCoordinateBatchAsync(assemblyPaths[0], packageName, packageVersion, isPlatformAssembly: false, options, context.HttpClient, logger);
+
                 var ilOffsetExitCode = await PopulateILOffsetIfRequestedAsync(
                     inspections[0], assemblyPaths[0], packageName, packageVersion, isPlatformAssembly: false,
                     options, context.HttpClient, logger);
@@ -353,6 +368,9 @@ public class LibraryCommand
                     Console.Error.WriteLine($"Error: File not found: {assemblyPath}");
                     return 1;
                 }
+
+                if (!string.IsNullOrWhiteSpace(options.ILOffsetsPath))
+                    return await WriteILCoordinateBatchAsync(assemblyPath!, null, null, isPlatformAssembly: false, options, context.HttpClient, logger);
 
                 // Check effective sections cache before running full inspection
                 if (effectiveDiscovery && options.Discover is { Length: 0 } && !HasILOffsetCoordinate(options))
@@ -418,6 +436,199 @@ public class LibraryCommand
     private static int IntegrityExitCode(params LibraryInspection[] inspections)
     {
         return inspections.Any(insp => insp.SourceIntegrityMismatches is { Count: > 0 }) ? 1 : 0;
+    }
+
+    private static async Task<int> WriteILCoordinateBatchAsync(
+        string assemblyPath,
+        string? packageName,
+        string? packageVersion,
+        bool isPlatformAssembly,
+        LibraryOptions options,
+        HttpClient httpClient,
+        VerboseLogger logger)
+    {
+        if (!File.Exists(options.ILOffsetsPath))
+        {
+            Console.Error.WriteLine($"Error: IL offsets file not found: {options.ILOffsetsPath}");
+            return 1;
+        }
+
+        if (!TryReadILCoordinates(options.ILOffsetsPath!, out var coordinates, out var error))
+        {
+            Console.Error.WriteLine(error);
+            return 1;
+        }
+
+        HashSet<string> sections = options.IncludeSections is { Count: > 0 }
+            ? [.. options.IncludeSections]
+            : [.. BatchCoordinateSections];
+
+        var rows = new List<ILCoordinateBatchRow>();
+        foreach (var coordinate in coordinates)
+        {
+            var queryOptions = options with
+            {
+                ILOffsetParameter = coordinate.Coordinate,
+                IncludeSections = sections,
+                Select = [.. sections],
+                Discover = null,
+                Print = false,
+                PrintAll = false,
+                Count = false,
+                Value = false,
+                Urls = false,
+                Paths = false
+            };
+            var resolved = await ILOffsetSourceQuery.ResolveAsync(
+                assemblyPath,
+                packageName,
+                packageVersion,
+                isPlatformAssembly,
+                queryOptions,
+                httpClient,
+                logger);
+            rows.Add(resolved.Result is { } result
+                ? BuildILCoordinateBatchRow(coordinate, result)
+                : new ILCoordinateBatchRow(coordinate.Coordinate, coordinate.Label, null, null, "error", "could not resolve"));
+        }
+
+        WriteILCoordinateBatchRows(rows, options);
+        return rows.Any(row => row.Meaning == "error") ? 1 : 0;
+    }
+
+    private static readonly string[] BatchCoordinateSections =
+    [
+        SectionNames.MemberContext,
+        SectionNames.InstructionContext,
+        SectionNames.ExceptionContext,
+        SectionNames.CallsiteContext,
+        SectionNames.ReturnAddressContext,
+        SectionNames.AllocationContext,
+        SectionNames.SafetyContext,
+        SectionNames.CostContext
+    ];
+
+    private static bool TryReadILCoordinates(string path, out List<ILCoordinateInput> coordinates, out string? error)
+    {
+        coordinates = [];
+        error = null;
+        var lineNumber = 0;
+        foreach (var rawLine in File.ReadLines(path))
+        {
+            lineNumber++;
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith('#'))
+                continue;
+            var tokens = line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            var coordinateIndex = Array.FindIndex(tokens, token => ILOffsetSourceQuery.TryParse(token, out _, out _));
+            if (coordinateIndex < 0)
+            {
+                error = $"Error: {path}:{lineNumber}: expected a MethodDef token + IL offset coordinate like 0x06000001+0x5.";
+                return false;
+            }
+
+            var labelTokens = tokens
+                .Where((_, index) => index != coordinateIndex)
+                .ToArray();
+            coordinates.Add(new ILCoordinateInput(
+                tokens[coordinateIndex],
+                labelTokens.Length == 0 ? null : string.Join(' ', labelTokens)));
+        }
+
+        if (coordinates.Count == 0)
+        {
+            error = $"Error: {path} did not contain any IL coordinates.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static ILCoordinateBatchRow BuildILCoordinateBatchRow(ILCoordinateInput input, ILOffsetResult result)
+    {
+        var (meaning, evidence) = ExplainILCoordinate(result);
+        return new ILCoordinateBatchRow(
+            input.Coordinate,
+            input.Label,
+            result.Method,
+            FormatBatchOffset(result),
+            meaning,
+            evidence);
+    }
+
+    private static (string Meaning, string Evidence) ExplainILCoordinate(ILOffsetResult result)
+    {
+        if (result.ReturnAddressContext is { } returnAddress)
+            return ("return address", $"call at {returnAddress.CallOffset} to {returnAddress.Callee}");
+        if (result.CallsiteContext is { } callsite)
+            return ("callsite", $"{callsite.Opcode} {callsite.Callee}");
+        if (result.AllocationContext is { Count: > 0 } allocations)
+        {
+            var allocation = allocations[0];
+            return ("allocation", $"{allocation.AllocationKind} {allocation.AllocatedType}".Trim());
+        }
+        if (result.SafetyContext is { Count: > 0 } safetyFacts)
+        {
+            var safety = safetyFacts[0];
+            return ("safety", $"{safety.SafetyKind} {safety.Operation}".Trim());
+        }
+        if (result.CostContext is { Count: > 0 } costFacts)
+        {
+            var cost = costFacts[0];
+            return ("cost", $"{cost.CostKind} {cost.Operation}".Trim());
+        }
+        if (result.ExceptionContext is { Count: > 0 } exceptions)
+            return ("exception", string.Join(", ", exceptions.Select(e => $"{e.Context} {e.Clause}".Trim())));
+        if (result.InstructionContext is { } instruction)
+            return ("instruction", $"{instruction.Opcode} {instruction.Operand}".Trim());
+        return ("member", result.MemberContext?.Signature ?? result.Method ?? "");
+    }
+
+    private static string? FormatBatchOffset(ILOffsetResult result)
+        => result.InstructionContext?.ILOffset is { } offset
+            ? FormatHexOffset(offset)
+            : result.MemberContext?.ILOffset is { } memberOffset
+                ? FormatHexOffset(memberOffset)
+                : result.ILOffset;
+
+    private static string FormatHexOffset(string value)
+        => value.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+            && int.TryParse(value[2..], NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var offset)
+            ? $"IL_{offset:X4}"
+            : value;
+
+    private static void WriteILCoordinateBatchRows(List<ILCoordinateBatchRow> rows, LibraryOptions options)
+    {
+        if (options.JsonOutput)
+        {
+            Console.WriteLine(JsonSerializer.Serialize(rows, ILCoordinateBatchJsonContext.Default.ListILCoordinateBatchRow));
+            return;
+        }
+
+        if (!options.OneLine && !options.Tsv && !options.Jsonl && !options.NoHeader)
+        {
+            Console.WriteLine("## IL Coordinates");
+            Console.WriteLine();
+        }
+
+        OutputFormatter.WriteTable(Console.Out, !options.NoHeader, (writer, formatter) =>
+        {
+            var writerOptions = OutputFormatter.CreateTableWriterOptions(options.Tsv, options.Jsonl);
+            var markoutWriter = new MarkoutWriter(writer, formatter, writerOptions);
+            markoutWriter.WriteTable(
+                ["Coordinate", "Label", "Member", "IL Offset", "Meaning", "Evidence"],
+                ["coordinate", "label", "member", "il_offset", "meaning", "evidence"],
+                rows.Select(row => new[]
+                {
+                    row.Coordinate,
+                    row.Label ?? "",
+                    row.Member ?? "",
+                    row.ILOffset ?? "",
+                    row.Meaning,
+                    row.Evidence
+                }).ToArray());
+            markoutWriter.Flush();
+        }, options.Rows);
     }
 
     private static (LibraryOptions Options, string? Error) NormalizeILOffsetSelection(LibraryOptions options)
@@ -1549,4 +1760,21 @@ public class LibraryCommand
         try { Directory.Delete(tempDir, recursive: true); } catch { }
     }
 
+}
+
+internal sealed record ILCoordinateInput(string Coordinate, string? Label);
+
+[MarkoutSerializable]
+internal sealed record ILCoordinateBatchRow(
+    string Coordinate,
+    [property: MarkoutSkipNull] string? Label,
+    [property: MarkoutSkipNull] string? Member,
+    [property: MarkoutPropertyName("IL Offset")]
+    [property: MarkoutSkipNull] string? ILOffset,
+    string Meaning,
+    string Evidence);
+
+[JsonSerializable(typeof(List<ILCoordinateBatchRow>))]
+internal partial class ILCoordinateBatchJsonContext : JsonSerializerContext
+{
 }

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -300,6 +300,9 @@ public class LibraryCommand
                 packageName = resolvedPackageName;
                 packageVersion = resolvedPackageVersion;
 
+                if (!string.IsNullOrWhiteSpace(options.ILOffsetsPath))
+                    return await WriteILCoordinateBatchAsync(assemblyPaths[0], packageName, packageVersion, isPlatformAssembly: false, options, context.HttpClient, logger);
+
                 // Check effective sections cache before running full inspection
                 if (effectiveDiscovery && options.Discover is { Length: 0 } && assemblyPaths.Count > 0 && !HasILOffsetCoordinate(options))
                 {
@@ -332,9 +335,6 @@ public class LibraryCommand
 
                 foreach (var insp in inspections)
                     insp.Source = SourceKind.NuGet;
-
-                if (!string.IsNullOrWhiteSpace(options.ILOffsetsPath))
-                    return await WriteILCoordinateBatchAsync(assemblyPaths[0], packageName, packageVersion, isPlatformAssembly: false, options, context.HttpClient, logger);
 
                 var ilOffsetExitCode = await PopulateILOffsetIfRequestedAsync(
                     inspections[0], assemblyPaths[0], packageName, packageVersion, isPlatformAssembly: false,
@@ -453,7 +453,7 @@ public class LibraryCommand
             return 1;
         }
 
-        if (!TryReadILCoordinates(options.ILOffsetsPath!, out var coordinates, out var error))
+        if (!TryReadILCoordinates(options.ILOffsetsPath!, out var coordinates, out var readErrors, out var error))
         {
             Console.Error.WriteLine(error);
             return 1;
@@ -463,7 +463,10 @@ public class LibraryCommand
             ? [.. options.IncludeSections]
             : [.. BatchCoordinateSections];
 
-        var rows = new List<ILCoordinateBatchRow>();
+        var rows = readErrors
+            .Select(errorRow => new ILCoordinateBatchRow(null, errorRow.Label, null, null, "error", errorRow.Error))
+            .ToList();
+        using var service = SourceLinkService.Open(assemblyPath, logger.Log);
         foreach (var coordinate in coordinates)
         {
             var queryOptions = options with
@@ -479,8 +482,8 @@ public class LibraryCommand
                 Urls = false,
                 Paths = false
             };
-            var resolved = await ILOffsetSourceQuery.ResolveAsync(
-                assemblyPath,
+            var resolved = await ILOffsetSourceQuery.ResolveBatchAsync(
+                service,
                 packageName,
                 packageVersion,
                 isPlatformAssembly,
@@ -489,7 +492,7 @@ public class LibraryCommand
                 logger);
             rows.Add(resolved.Result is { } result
                 ? BuildILCoordinateBatchRow(coordinate, result)
-                : new ILCoordinateBatchRow(coordinate.Coordinate, coordinate.Label, null, null, "error", "could not resolve"));
+                : new ILCoordinateBatchRow(coordinate.Coordinate, coordinate.Label, null, null, "error", resolved.Error ?? "could not resolve"));
         }
 
         WriteILCoordinateBatchRows(rows, options);
@@ -508,9 +511,10 @@ public class LibraryCommand
         SectionNames.CostContext
     ];
 
-    private static bool TryReadILCoordinates(string path, out List<ILCoordinateInput> coordinates, out string? error)
+    private static bool TryReadILCoordinates(string path, out List<ILCoordinateInput> coordinates, out List<ILCoordinateReadError> readErrors, out string? error)
     {
         coordinates = [];
+        readErrors = [];
         error = null;
         var lineNumber = 0;
         foreach (var rawLine in File.ReadLines(path))
@@ -523,8 +527,8 @@ public class LibraryCommand
             var coordinateIndex = Array.FindIndex(tokens, token => ILOffsetSourceQuery.TryParse(token, out _, out _));
             if (coordinateIndex < 0)
             {
-                error = $"Error: {path}:{lineNumber}: expected a MethodDef token + IL offset coordinate like 0x06000001+0x5.";
-                return false;
+                readErrors.Add(new ILCoordinateReadError($"{path}:{lineNumber}", "expected a MethodDef token + IL offset coordinate"));
+                continue;
             }
 
             var labelTokens = tokens
@@ -535,7 +539,7 @@ public class LibraryCommand
                 labelTokens.Length == 0 ? null : string.Join(' ', labelTokens)));
         }
 
-        if (coordinates.Count == 0)
+        if (coordinates.Count == 0 && readErrors.Count == 0)
         {
             error = $"Error: {path} did not contain any IL coordinates.";
             return false;
@@ -560,8 +564,6 @@ public class LibraryCommand
     {
         if (result.ReturnAddressContext is { } returnAddress)
             return ("return address", $"call at {returnAddress.CallOffset} to {returnAddress.Callee}");
-        if (result.CallsiteContext is { } callsite)
-            return ("callsite", $"{callsite.Opcode} {callsite.Callee}");
         if (result.AllocationContext is { Count: > 0 } allocations)
         {
             var allocation = allocations[0];
@@ -577,6 +579,8 @@ public class LibraryCommand
             var cost = costFacts[0];
             return ("cost", $"{cost.CostKind} {cost.Operation}".Trim());
         }
+        if (result.CallsiteContext is { } callsite)
+            return ("callsite", $"{callsite.Opcode} {callsite.Callee}");
         if (result.ExceptionContext is { Count: > 0 } exceptions)
             return ("exception", string.Join(", ", exceptions.Select(e => $"{e.Context} {e.Clause}".Trim())));
         if (result.InstructionContext is { } instruction)
@@ -601,7 +605,7 @@ public class LibraryCommand
     {
         if (options.JsonOutput)
         {
-            Console.WriteLine(JsonSerializer.Serialize(rows, ILCoordinateBatchJsonContext.Default.ListILCoordinateBatchRow));
+            Console.WriteLine(JsonSerializer.Serialize(new ILCoordinateBatchResult(rows), ILCoordinateBatchJsonContext.Default.ILCoordinateBatchResult));
             return;
         }
 
@@ -620,7 +624,7 @@ public class LibraryCommand
                 ["coordinate", "label", "member", "il_offset", "meaning", "evidence"],
                 rows.Select(row => new[]
                 {
-                    row.Coordinate,
+                    row.Coordinate ?? "",
                     row.Label ?? "",
                     row.Member ?? "",
                     row.ILOffset ?? "",
@@ -1764,9 +1768,13 @@ public class LibraryCommand
 
 internal sealed record ILCoordinateInput(string Coordinate, string? Label);
 
+internal sealed record ILCoordinateReadError(string Label, string Error);
+
+internal sealed record ILCoordinateBatchResult(List<ILCoordinateBatchRow> Rows);
+
 [MarkoutSerializable]
 internal sealed record ILCoordinateBatchRow(
-    string Coordinate,
+    [property: MarkoutSkipNull] string? Coordinate,
     [property: MarkoutSkipNull] string? Label,
     [property: MarkoutSkipNull] string? Member,
     [property: MarkoutPropertyName("IL Offset")]
@@ -1774,7 +1782,8 @@ internal sealed record ILCoordinateBatchRow(
     string Meaning,
     string Evidence);
 
-[JsonSerializable(typeof(List<ILCoordinateBatchRow>))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(ILCoordinateBatchResult))]
 internal partial class ILCoordinateBatchJsonContext : JsonSerializerContext
 {
 }

--- a/src/dotnet-inspect/Options/LibraryOptions.cs
+++ b/src/dotnet-inspect/Options/LibraryOptions.cs
@@ -72,6 +72,11 @@ public record LibraryOptions
     public string? ILOffsetParameter { get; init; }
 
     /// <summary>
+    /// Path to a text file containing sparse MethodDef token + IL offset coordinates.
+    /// </summary>
+    public string? ILOffsetsPath { get; init; }
+
+    /// <summary>
     /// Use GitHub /blob/ URLs for browser viewing instead of raw source URLs.
     /// </summary>
     public bool BrowsableUrls { get; init; }


### PR DESCRIPTION
## Summary

Prototypes sparse IL coordinate batch explanation for agent/debugging workflows:

- Adds `library <assembly> --il-offsets <file>`.
- Reads a text file of MethodDef token + IL offset coordinates with optional labels.
- Emits a compact `IL Coordinates` summary table.
- Documents producer workflows for debugger/dump, profiler/trace, and analyzer/CI artifacts.

This intentionally does not parse debugger, dump, trace, or profiler formats directly. Those producer-specific adapters are deferred until we know which workflow is skill-worthy.

Refs #2005.

## Coordinate file

```text
# label coordinate
profiler-sample 0x06000042+0x2F
debugger-frame 0x06000051+0x10
analyzer-hit 0x06000060+0x08
```

## Example output

```text
## IL Coordinates

Coordinate      Label            Member      IL Offset  Meaning         Evidence
0x06000042+0x2F profiler-sample  My.Type.M1  IL_002F    return address  call at IL_002A to M2
0x06000051+0x10 debugger-frame   My.Type.M2  IL_0010    allocation      array int[]
```

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false \
  --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json \
  --nologo --verbosity quiet
```

```bash
dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:PublishAot=false -- \
  -method '*LibraryCommand_IlOffsetsFile*'
```

```bash
npx markdownlint-cli --fix docs/design/il-coordinate-workflows.md docs/overview.md
npx markdownlint-cli docs/design/il-coordinate-workflows.md docs/overview.md
```

## Adversarial review

Requested per the analysis-change policy.

- Gemini 3.1 Pro found issues and they were fixed in `5e6421e9`:
  - hoisted `SourceLinkService` so a batch does not reopen metadata/PDB state per coordinate,
  - moved package `--il-offsets` handling before full package inspection,
  - prioritized semantic meanings over generic callsite meanings,
  - changed malformed lines into error rows instead of aborting the whole batch,
  - suppressed per-coordinate stderr noise in batch resolution,
  - changed JSON output to a snake_case envelope.
- Claude Opus 4.8 found JSON naming and documentation mismatch/stderr concerns:
  - JSON now uses source-generated snake_case,
  - docs now show the actual aligned table style,
  - batch resolver suppresses redundant stderr and renders error rows.
