### PR TITLE
Clarify project context skill scope

### DIFF
--- a/skills/dotnet-inspect/SKILL.md
+++ b/skills/dotnet-inspect/SKILL.md
@@ -45,6 +45,6 @@ dnx dotnet-inspect -y -- member System.Text.Json.JsonSerializer.Serialize -S "Me
 
 - Default output is Markdown; for formats, `-D`/`-S` discovery, projection, and
   limits, load `dotnet-inspect skill query`.
-- Add `--project <csproj|dir|project.assets.json>` when APIs from project-referenced packages should be in scope.
+- Add `--project <csproj|dir|project.assets.json>` when project-referenced packages should be in scope; it reads existing restored assets, so restore/build first if dependencies changed.
 - Common BCL types resolve without scope: `type string`, `type 'List<T>'`. Quote generics and patterns: `member 'Dictionary<TKey,TValue>'`, `-S "Async*"`.
 - Unpinned packages use latest stable; add `--preview` for prerelease APIs.

--- a/skills/relationships/SKILL.md
+++ b/skills/relationships/SKILL.md
@@ -15,10 +15,9 @@ dnx dotnet-inspect -y -- <command>
 ```
 
 Scope any of these commands the same way: `--package Foo` (repeatable),
-`--library path.dll`, `--platform` (all in-box frameworks), `--project App.csproj`
-(project-referenced packages), `--extensions` or `--aspnetcore` (curated
-Microsoft.* sets), `--package-prefix Azure.AI` (every package under a NuGet ID
-prefix), and `--tfm net9.0`.
+`--library path.dll`, `--platform` (all in-box frameworks), `--extensions` or
+`--aspnetcore` (curated Microsoft.* sets), `--package-prefix Azure.AI` (every
+package under a NuGet ID prefix), and `--tfm net9.0`.
 
 ## What implements or extends it?
 
@@ -30,6 +29,7 @@ to include extensions on types reachable through properties and methods.
 dnx dotnet-inspect -y -- implements IDisposable --platform
 dnx dotnet-inspect -y -- extensions HttpClient --platform --reachable
 dnx dotnet-inspect -y -- implements ILogger --package-prefix Microsoft.Extensions
+dnx dotnet-inspect -y -- implements IMarkoutFormatter --package Markout
 ```
 
 ## What does it depend on?


### PR DESCRIPTION
## Summary

- Clarifies that unscoped `find` covers platform/BCL types and `--project` adds project-referenced packages to API/type/member lookup scope.
- Removes wording that implied `implements`/`extensions` support `--project` today.
- Adds a package-scoped Markout `implements IMarkoutFormatter` example for type-relationship discovery.

Follow-up to #2086 after validating `implements --project` is not currently supported.

## Validation

- `npx markdownlint-cli skills/dotnet-inspect/SKILL.md skills/relationships/SKILL.md skills/decompiler/SKILL.md`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -class "*SkillCommandTests"`
- `dotnet run --no-build --project src/dotnet-inspect -c Release -- implements IMarkoutFormatter --package Markout -v:q -n 80`
