### PR TITLE
Add value-typed emission design note (the coercion choke point)

### DIFF
--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -1,0 +1,249 @@
+# Value-typed emission: the coercion choke point
+
+This document scopes a major investment in the decompiler's **value-flow** layer,
+the sibling of [control-flow-structuring.md](control-flow-structuring.md). Where
+that doc governs how blocks become nested `if`/`else`, this one governs how a
+*value* is rendered into a *typed position* — and argues that the decompiler is
+missing a first-class abstraction the compiler family it belongs to has always
+had.
+
+Read [decompiler.md](../decompiler.md) first for the pipeline shape and the
+recognizability goal.
+
+## The missing member of the type system
+
+The decompiler has a rich vocabulary for **what a value is**: `TypeRef`
+(structural semantic identity), the per-node `ResultType`, and the join-merged
+`Conditional.MergedType`. That is the *natural type*, in Roslyn's terms.
+
+It has **no representation of two things**:
+
+1. **What a *position* requires** — the *target type* of a value-consuming sink:
+   a `return`, a call argument, a field/array-element store, a `box`, a
+   conditional arm, a `switch` label. Every sink has an expected type, but that
+   type is implicit and re-derived at each print site.
+2. **The coercion that bridges them** — "render a value of natural type `N` into a
+   context that requires `T`." This is not a *thing* in the IR. It is *emergent
+   behavior*: a string synthesized ad hoc inside the printer — `(T)x`,
+   `unchecked((T)x)`, or nothing — at roughly a dozen independent render branches.
+
+So the decompiler built **half of target-typing and stopped**. It has the
+natural-type half; it never built the target-type half or the conversion node that
+consumes both. "Target-typing without the target or the conversion" necessarily
+degrades into *the printer guessing* — which is the single root cause behind a long
+tail of invalid-C# defects, none of them a bug in any one pass.
+
+The missing member is a first-class **coercion**: a node, inserted during raising,
+that already knows "I am the conversion of this value to type `T`," so the printer
+renders a node instead of *deciding* to be a cast. Roslyn calls it
+`BoundConversion`; ILSpy calls its result `.ConvertTo(T)`.
+
+### Why a node, not a helper
+
+The decompiler already has coercion *helpers* — `CastValue`
+(`CSharpPrinter.Numerics.cs:925`) and `EnumIntegerCast`
+(`CSharpPrinter.Numerics.cs:178`). They are not enough, because a helper the
+printer *may* call is not an invariant. Because the coercion is a transient string
+and not a node, it is invisible to the rest of the architecture:
+
+- `CheckInvariant()` cannot assert "no value reaches a sink un-coerced."
+- Fidelity cannot treat an unresolved coercion as an honest `Partial` signal, the
+  way an unknown join type already is.
+- No other pass can see, move, or reason about it.
+
+Making the coercion a node — computed once, rendered by one rule, checked by one
+invariant — is what converts *"discipline in every printer branch"* into *"one node
+type."* The alternative is what we have: the same missing rule rediscovered one
+render context at a time.
+
+## Where we are — the leak surface, measured
+
+The cast/coercion decision is spread across the printer, each site re-deriving
+"an integer flowing into an enum position needs an explicit cast, and an
+out-of-range constant needs `unchecked`":
+
+| Site | File | What it decides locally |
+| --- | --- | --- |
+| enum-typed conditional arm | `CSharpPrinter.Numerics.cs` `ConditionalArm` | cast each integer arm to the enum target |
+| retyped enum constant | `CSharpPrinter.cs:1745` | `(Enum)value`, **`int`-only** |
+| `switch` case label | `CSharpPrinter.cs:3144` | `SwitchLabelText`, **`int`-only** |
+| array-element store | `CSharpPrinter.cs:1665` | `CastValue(value, ElementType)` — uses the `stelem` storage type |
+| `box` operand | `CSharpPrinter.cs:1811` | drops the boxed type entirely |
+| enum bitwise / comparison | `CSharpPrinter.Numerics.cs` | cast the integer operand to the enum |
+| overflow / `unchecked` | `CSharpPrinter.Numerics.cs:194` | `MayOverflow…`, **`Unknown`-shape only**, raw `Constant` only |
+| constant typing | `TypedConstantsPass.cs:110` | retypes **`int`-only**, does not pierce `Convert` |
+
+The italicised limits are the leak: each is a place the missing rule is
+*partially* implemented. The consequence is a recurring, pre-existing defect class.
+Six consecutive adversarial-review rounds on one PR (a fix originally scoped to a
+single conditional-arm shape) each surfaced the *same* class in a *new* sink —
+none a regression, all latent:
+
+1. narrow-enum out-of-range constant → `(Tiny)300` (CS0221)
+2. unsigned-enum negative high-bit constant → `... : -2147483648` (CS0029)
+3. retyped enum constant in comparison / bitwise / `??` → `(E)(-1)` (CS0221)
+4. `long` enum `switch` label → `case 1311768467463790320:` (CS0266)
+5. `long`-backed enum in array element / `box` → bare `long` (CS0266 / CS0029)
+6. unsigned `long`-backed enum via `conv.i8(ldc.i4.m1)` → `(UE)((long)-1)` (CS0221)
+
+Every fix was correct and local; every next round found the next sink. That slope
+— *N* near-identical fixes converging on nothing — is the value-flow analogue of
+the control-flow "normalizer treadmill" that
+[control-flow-structuring.md](control-flow-structuring.md) diagnoses. The two are
+**orthogonal axes**: the adversarial review of that redesign
+([gist](https://gist.github.com/richlander/a6f12e0ca8c426ee034be29a01b3f7a2))
+explicitly found that the value-flow diamonds "move *data* across a join, not
+control flow … those passes survive any structuring rewrite." A post-dominator
+structurer does not touch this. This is the second lane, and it has not been
+written down until now.
+
+## Prior art — every compiler in the family solves this
+
+The .NET compiler ecosystem resolves conversions **once, into typed IR, via a
+single classifier**, and treats the back-end as a *total function* of typed input.
+The decompiler is the only member that pushed the decision into its back-end.
+
+### Roslyn — the forward direction, and the exact precedent
+
+Roslyn faces the forward problem (source → IL): where does a conversion go, and is
+it implicit, explicit, or an error?
+
+- **Conversions are nodes, inserted at bind time.** One classifier
+  (`Conversions.ClassifyConversionFromExpression`) decides; `Binder.CreateConversion`
+  materialises a `BoundConversion` into the tree. Lowering and emit never *decide* a
+  cast — they render already-typed nodes.
+- **Constant conversions and `checked`/`unchecked` legality are folded in one
+  place** (the binder's constant-conversion folding), which is exactly what the
+  scattered `MayOverflow…` heuristic re-implements.
+- **Target-typed conditional / `switch` expressions (C# 9) are our bug, verbatim.**
+  Roslyn used to give `a ? b : c` a *best common type* and error (CS0173) when none
+  existed. It was reworked so a `BoundUnconvertedConditionalOperator` stays
+  **untyped** until a target type is applied, then one conversion resolves it. The
+  decompiler's `Conditional.MergedType`-is-null-so-fall-back-to-the-first-arm
+  failure is *precisely* the "best common type is insufficient; carry it unconverted
+  and target-type it" lesson.
+
+The decompiler's job is Roslyn's binder **in reverse**: given a typed value and a
+target type, spell the *minimal* C# conversion that `ClassifyConversion` maps back to
+the original IL. "Invert the conversion classifier" is a real north star.
+
+### RyuJIT — the type-propagation prerequisite
+
+The JIT (IL → machine code) never spells C#, but it *does* reconstruct types from
+IL's loosely-typed stack, which is our prerequisite:
+
+- The importer normalises the `int32`/`int64`/`native int` stack into a typed
+  `GenTree`, inserting explicit `GT_CAST` nodes; conversions become IR at import,
+  never re-decided at codegen.
+- At join points it **merges stack types to a common supertype and spills to typed
+  temps** — the same operation as our slot-merge-at-join, which today drops to
+  `Unknown` and taints fidelity. The JIT's spill-temp typing is the model for doing
+  it completely.
+
+### ILSpy — the same-domain existence proof
+
+ILSpy raises IL → C# and has exactly the abstraction we lack: a
+**`TranslatedExpression`** that carries the expression *and* its resolved type, with
+a single `.ConvertTo(targetType, …)` method that is *the* coercion site. Its
+`ExpressionBuilder` never open-codes a cast; it produces a translated expression and
+converts it. This is the closest working reference and the most convincing proof the
+choke point is achievable under the IL→C# constraint.
+
+### Ghidra — the non-.NET cross-check
+
+Ghidra's decompiler propagates data types through P-code as a dataflow lattice and
+inserts casts through a single `CastStrategy`. Different language, same shape:
+propagation feeds one cast-insertion policy.
+
+## The capability — two halves of one type
+
+### 1. Target type on every sink
+
+Each value-consuming position declares the type it expects. Most IR nodes already
+carry it structurally (a `StoreElement` knows its array's element type; a `Box`
+knows the boxed type; a `Return` has the method's return type) — the gap is that
+the printer sometimes reads the *storage-opcode* type instead of the *semantic*
+type (the `stelem.i8` → `long` defect). Where a sink's target is genuinely
+implicit, it is derived once and attached, not re-derived per print.
+
+### 2. `Coerce(value, targetType)` — the node
+
+A single C#-surface coercion node, distinct from the existing `Convert` node.
+This distinction is load-bearing: `Convert` models the value's **IL history**
+(`conv.i8`); `Coerce` models the **C# rendering conversion** needed at a target. The
+new node is inserted during raising (or synthesised at the emission boundary) and
+owns, in one place, the rules the printer currently spreads around:
+
+- implicit vs. explicit conversion (only literal `0` converts to an enum bare);
+- `unchecked(...)` for a constant that overflows the *backing* width, whether the
+  backing is known, cross-assembly-`Unknown` (conservative), or an
+  `Enum`-shape-without-`value__` (assume C#'s default `int`);
+- enum ↔ underlying, numeric widening, `null`-literal typing;
+- seeing through a widening `conv.i8`/`conv.u8` over an integer constant (small and
+  unsigned `long`-backed enum members lower this way).
+
+The rendering rule is one total function of `(value, targetType)`; the printer
+calls it and never open-codes `(T)x` again.
+
+### The invariant
+
+With the node in place, well-formedness becomes checkable: **no value may occupy a
+typed sink except through a `Coerce`** (or be provably already at the target type).
+`CheckInvariant()` asserts it; a violation fails at the pass level, in a unit test,
+instead of being discovered by recompiling corpus output. The compile-back oracle
+stops being the *only* place this class is caught.
+
+## Scope and constraints
+
+This stays inside the decompiler's deliberate ceilings:
+
+- **SRM-only, no assembly loading.** A cross-assembly enum resolves to
+  `TypeShape.Unknown` and its backing width is not available. `Coerce` must render a
+  faithful, conservative cast for that case (it cannot become a member name), never
+  load the defining assembly. This is a permanent input, not a gap to close.
+- **Not SSA, not Hindley-Milner.** The prerequisite is *propagation* over the
+  existing shallow-stack IR — retype constants (including `long` and
+  `Convert`-wrapped) into every typed sink, complete the join-merge typing — not a
+  general inference engine. The IR stays the readable-output-first model ILSpy uses.
+- **Faithfulness over prettiness.** A valid cast that recompiles to the same IL is
+  the floor; a member name is a bonus the node can add when the value is a named,
+  non-`Convert`-wrapped constant.
+
+## Migration — incremental, with coverage proven
+
+The redesign is landable in slices *because* the invariant makes coverage
+measurable, unlike the control-flow rewrite's all-or-nothing invariant relaxation.
+
+1. **Introduce `Coerce` and the one rendering function.** Fold `CastValue`,
+   `EnumIntegerCast`, `SwitchLabelText`, the retyped-constant branch, `Box`, and
+   `StoreElement` into it. No behavior change intended; the corpus fidelity card is
+   the guard.
+2. **Complete constant typing.** Extend `TypedConstantsPass` to retype `int`,
+   `long`, and `Convert`-wrapped integer constants into every enum-typed sink, so
+   the printer sees enum-typed values uniformly.
+3. **Turn the invariant on.** Assert every typed sink routes through `Coerce`;
+   burn down the violations it flags (these are the remaining leak sites, now
+   enumerated by the checker rather than by adversarial review).
+4. **Complete join typing** where the importer drops to `Unknown` but a sound
+   common type exists (the JIT spill-temp model), reducing `Partial`-by-unknown-join.
+
+Each slice reports the standard decompiler-affecting-PR evidence: focused tests,
+the corpus quality-diff card, and improved/still-flat examples.
+
+## Acceptance and start-trigger
+
+Consistent with [control-flow-structuring.md](control-flow-structuring.md)'s
+insistence on a falsifiable trigger rather than a standing intention:
+
+- **Start** slice 1 when the value-flow treadmill is confirmed — which the six-round
+  history above already demonstrates. This lane is *ready to start*, not deferred.
+- **Done** when the invariant (step 3) is enforced in `CheckInvariant()` and green
+  across the corpus: at that point the class cannot recur silently, because a new
+  un-coerced sink fails a unit test, not a recompile.
+- **Explicitly out of scope** and tracked separately: member-naming of
+  `Convert`-wrapped constants (a naming nicety, not a validity gap) and any
+  cross-assembly enum backing that would require loading the defining assembly.
+
+The measure of success is not a fully-raised delta — it is that "run adversarial
+review until clean" would converge in **one** round, because there is one place to
+get right instead of a dozen.

--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -1,16 +1,54 @@
-# Value-typed emission: the coercion choke point
+# The thin writer: value-typed emission
 
-This document scopes a major investment in the decompiler's **value-flow** layer,
-the sibling of [control-flow-structuring.md](control-flow-structuring.md). Where
-that doc governs how blocks become nested `if`/`else`, this one governs how a
-*value* is rendered into a *typed position* — and argues that the decompiler is
-missing a first-class abstraction the compiler family it belongs to has always
-had.
+This document scopes a major investment in how the decompiler's **writer** — the
+`CSharpPrinter` that turns raised IR into C# text — earns its keep. The thesis: the
+writer is **too thick**. It does not merely *spell* a decided tree; it makes
+semantic decisions the IR never recorded, and rediscovers each one — wrongly — one
+render context at a time. This doc defines the end state (a **thin writer**: a total
+function of a fully-typed IR), the invariant that enforces it, and the instances of
+thickness to remove under it, largest first.
+
+It is the value-flow sibling of
+[control-flow-structuring.md](control-flow-structuring.md). Where that doc governs
+how blocks become nested `if`/`else`, this one governs how a *decided* value reaches
+the page.
 
 Read [decompiler.md](../decompiler.md) first for the pipeline shape and the
 recognizability goal.
 
-## The missing member of the type system
+## The thin-writer invariant
+
+A thin writer makes **zero semantic decisions**. It renders a tree that has already
+been decided — every value carries its resolved type, every conversion is a node,
+every local is materialized — and its only job is **surface spelling**: precedence
+and parenthesization, identifier escaping, layout, and the C# text of an
+already-decided node. Those stay; *thin is not logicless*.
+
+What must leave the writer is every place it *decides* rather than *spells*. Each is
+the same illness — the writer inferring, at print time, something the typed IR
+should already carry — and each has leaked the same way: correct in the context it
+was written for, wrong in the next one.
+
+| Instance | The writer currently decides… | It should be… | Field evidence |
+| --- | --- | --- | --- |
+| **1. Coercion** (flagship) | whether/how to cast a value to a target type, and when to wrap `unchecked` | a `Coerce` node + one renderer | the six-round enum-cast history below |
+| **2. Stack-slot materialization** | which locals exist, their types, and when to split one slot into two | typed local IR nodes from type propagation | #2075 — the `S_0`/`S_256` collapse |
+| **3. Definite assignment** (later) | which locals need `= default` | a pre-print flow pass handing over a decided tree | #631 (partial) |
+
+Precedence, escaping, layout, node-spelling are deliberately *not* on this list —
+they are the writer's real job.
+
+The invariant that makes "thin" checkable: **no value reaches the writer un-decided**
+— every typed sink routes through a `Coerce` (instance 1) and every rendered local is
+a materialized, typed IR node (instance 2) — asserted by `CheckInvariant()`. A
+violation fails a unit test, not a recompile.
+
+The rest of this document details **instance 1 (coercion)** in full — it is the
+largest, most bug-dense, and the template for the others — then **instance 2 (slot
+typing)**, which the same type-propagation prerequisite removes almost for free.
+Instance 3 is noted where it sits and deferred.
+
+## Instance 1 — coercion: the missing member of the type system
 
 The decompiler has a rich vocabulary for **what a value is**: `TypeRef`
 (structural semantic identity), the per-node `ResultType`, and the join-merged
@@ -163,7 +201,7 @@ Ghidra's decompiler runs **monotone type propagation over its data-type ordering
 `CastStrategyJava`). Different language, same shape: propagation feeds one
 cast-insertion policy per target language.
 
-## The capability — two halves of one type
+## The coercion capability — two halves of one type
 
 ### 1. Target type on every sink
 
@@ -227,6 +265,41 @@ the coercion function's own unit tests and the compile-back oracle. The win is t
 the oracle stops being the *only* place an un-coerced sink is caught, and a new sink
 can no longer silently bypass the rule.
 
+## Instance 2 — stack-slot materialization and typing
+
+The same illness, a different organ. The writer does not only decide *conversions*;
+it decides *which locals exist and what type they are*. `TryChooseUnifiedStackSlotType`
+and `StackSlotName` invent the `S_0`/`S_256` variables from IL stack-slot positions
+and, at print time, **unify or split** their types — picking one C# type for a slot
+reused across live ranges, or splitting it into two variables when the types
+conflict. That is a semantic decision (SSA-value identity and typing) made in the
+writer, from opcode-stack bookkeeping the IR never resolved into locals.
+
+It fails the same way coercion does. **#2075** was exactly this: a stack slot reused
+for an `int` value and a `BindValueKind` (enum) value; the writer's unifier collapsed
+both onto one `int` local, and the enum use then rendered without a cast — invalid
+C#. The shape that produced the enum-cast leaks produced a *variable-identity* leak,
+because the same component was guessing.
+
+The fix is the coercion redesign's own prerequisite, reused: once **type propagation**
+(instance-1 migration step 4 — the RyuJIT typed-temp model) materializes each slot's
+live ranges as **typed local IR nodes** before printing, there is nothing left to
+unify. The writer stops inventing variables; `TryChooseUnifiedStackSlotType` is
+deleted, and the thin-writer invariant extends to "every rendered local is a
+materialized IR node," checkable the same way. This is why instance 2 rides on
+instance 1: they share the type-propagation spine, so instance 2 is *mostly the
+deletion* of print-time typing once propagation exists — not a second engine.
+
+## Instance 3 — definite assignment (noted, deferred)
+
+The writer also decides which locals need `= default` to satisfy C# definite
+assignment (the `#631` flow walk over the printer's `_facts`). This is a third
+flow analysis — the sibling of control-flow structuring and type flow — and it is
+*thin-writer-adjacent*: defensible where it is, but strictly it could run as a
+pre-print pass that hands the writer a decided tree. It is the lowest-priority
+instance and is called out here only so the umbrella is complete; it is not
+sequenced below.
+
 ## Scope and constraints
 
 This stays inside the decompiler's deliberate ceilings:
@@ -248,13 +321,18 @@ This stays inside the decompiler's deliberate ceilings:
 The redesign is landable in slices *because* the invariant makes coverage
 measurable, unlike the control-flow rewrite's all-or-nothing invariant relaxation.
 
-1. **Introduce `Coerce` and the one rendering function.** Fold `CastValue`,
-   `EnumIntegerCast`, `SwitchLabelText`, the retyped-constant branch, `Box`, and
-   `StoreElement` into it. This is **not** behavior-neutral: those sites have
-   *different* partial behaviors today (`int`-only here, `Unknown`-shape-only there),
-   so unifying them will move outputs at the margins — that is the point. Expect and
-   *measure* net-positive validity movement on the corpus quality-diff card; a
-   fidelity regression on any already-`Full` method is the stop signal.
+1. **Promote `CastValue` into `Coerce`, one rendering function.** `CastValue` is
+   already the embryonic choke point (it renders a value at a target type and
+   delegates the enum case to `EnumIntegerCast`); this *consolidates*, it does not
+   rewrite. The hard-won rules in `EnumIntegerCast`/`MayOverflow…` become the private
+   internals of the one renderer, and the scattered cast *decisions* at `Box`,
+   `StoreElement`, `SwitchLabelText`, and the retyped-constant branch are replaced by
+   a `Coerce` call — the sinks remain, the decisions leave. This is **not**
+   behavior-neutral: those sites have *different* partial behaviors today (`int`-only
+   here, `Unknown`-shape-only there), so unifying them moves outputs at the margins —
+   that is the point. Expect and *measure* net-positive validity movement on the
+   corpus quality-diff card; a fidelity regression on any already-`Full` method is the
+   stop signal.
 2. **Complete constant typing.** Extend `TypedConstantsPass` to retype `int`,
    `long`, and `Convert`-wrapped integer constants into every enum-typed sink, so
    the printer sees enum-typed values uniformly.
@@ -262,10 +340,17 @@ measurable, unlike the control-flow rewrite's all-or-nothing invariant relaxatio
    burn down the violations it flags (these are the remaining leak sites, now
    enumerated by the checker rather than by adversarial review). Slices 1–3 deliver
    the coercion choke point and can land without step 4.
-4. **Complete join typing** (a semi-separate axis, worth its own slice/issue) where
-   the importer drops to `Unknown` but a sound common type exists — type
-   *propagation* at joins (the RyuJIT typed-temp model), the sibling of type
-   *coercion* at sinks, reducing `Partial`-by-unknown-join.
+4. **Complete join typing — the shared type-propagation spine** (worth its own
+   slice/issue). Where the importer drops to `Unknown` but a sound common type
+   exists, propagate types at joins (the RyuJIT typed-temp model), reducing
+   `Partial`-by-unknown-join. This is the prerequisite *both* instances lean on:
+   it feeds instance 1's constant/`Convert` typing and is what instance 2 needs to
+   materialize locals.
+5. **Materialize stack-slot locals (instance 2).** On the step-4 propagation, emit
+   each slot's live ranges as typed local IR nodes and **delete
+   `TryChooseUnifiedStackSlotType`** — the writer stops inventing and unifying
+   variables. Extend the invariant to "every rendered local is a materialized IR
+   node." Mostly a deletion once step 4 lands.
 
 Each slice reports the standard decompiler-affecting-PR evidence: focused tests,
 the corpus quality-diff card, and improved/still-flat examples.
@@ -277,13 +362,19 @@ insistence on a falsifiable trigger rather than a standing intention:
 
 - **Start** slice 1 when the value-flow treadmill is confirmed — which the six-round
   history above already demonstrates. This lane is *ready to start*, not deferred.
-- **Done** when the invariant (step 3) is enforced in `CheckInvariant()` and green
-  across the corpus: at that point the class cannot recur silently, because a new
-  un-coerced sink fails a unit test, not a recompile.
+- **Instance 1 done** when the coercion invariant (step 3) is enforced in
+  `CheckInvariant()` and green across the corpus: at that point the cast class cannot
+  recur silently, because a new un-coerced sink fails a unit test, not a recompile.
+- **Thin writer done** when the invariant covers both instances — every typed sink
+  through a `Coerce`, every rendered local a materialized IR node (steps 4–5) — so the
+  writer is a total function of a decided, fully-typed IR. Instance 3 remains an
+  optional later slice.
 - **Explicitly out of scope** and tracked separately: member-naming of
   `Convert`-wrapped constants (a naming nicety, not a validity gap) and any
   cross-assembly enum backing that would require loading the defining assembly.
 
-The measure of success is not a fully-raised delta — it is that "run adversarial
-review until clean" would converge in **one** round, because there is one place to
-get right instead of a dozen.
+The measure of success is not a fully-raised delta — it is that the writer stops
+being a place bugs can hide: "run adversarial review until clean" converges in **one**
+round, because there is one place to get each decision right instead of a dozen, and
+`CheckInvariant()` — not a recompile of corpus output — is where a regression is
+caught.

--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -133,39 +133,50 @@ The JIT (IL → machine code) never spells C#, but it *does* reconstruct types f
 IL's loosely-typed stack, which is our prerequisite:
 
 - The importer normalises the `int32`/`int64`/`native int` stack into a typed
-  `GenTree`, inserting explicit `GT_CAST` nodes; conversions become IR at import,
-  never re-decided at codegen.
-- At join points it **merges the entry-state stack types to a common supertype** and
-  (separately) **spills mismatched entries to typed temps** — two related but
-  distinct mechanisms. Together they are the analogue of our slot-merge-at-join,
-  which today drops to `Unknown` and taints fidelity; the JIT's typed-temp model is
-  how to do it completely.
+  `GenTree` — retagging integer constants in place and inserting `GT_CAST` for other
+  narrowing/sign-changing inputs; conversions become IR at import, never re-decided
+  at codegen.
+- At join points it **spills non-empty stack slots to shared typed temps**, and for
+  a few supported conflicts (`int`/native-int/byref, `float`/`double`) it upgrades
+  the temp and reimports the clique or inserts casts on the narrower inputs. This is
+  *targeted* conflict repair, not a general supertype algorithm — but it is the same
+  operation as our slot-merge-at-join, which today drops to `Unknown` and taints
+  fidelity, and the typed-temp model is how to do it more completely.
 
 ### ILSpy — the same-domain existence proof
 
 ILSpy raises IL → C# and has exactly the abstraction we lack: a
 **`TranslatedExpression`** that carries the expression *and* its resolved type, with
-a single `.ConvertTo(targetType, …)` method that is *the* coercion site. Its
-`ExpressionBuilder` never open-codes a cast; it produces a translated expression and
-converts it. This is the closest working reference and the most convincing proof the
-choke point is achievable under the IL→C# constraint.
+`.ConvertTo(targetType, …)` as its **primary, de-facto coercion choke point**.
+`ExpressionBuilder` defers casts to it pervasively and only open-codes a
+`CastExpression` in a few genuinely semantic cases (delegate/lambda, some
+unbox-related paths), and there is a sibling `ConvertToBoolean` for the truthiness
+case. It is not literally one method — but the discipline (a typed expression with a
+single dominant conversion entry point) is exactly the shape we want, and it is the
+most convincing proof the choke point is achievable under the IL→C# constraint.
 
 ### Ghidra — the non-.NET cross-check
 
-Ghidra's decompiler propagates data types through P-code as a dataflow lattice and
-inserts casts through a single `CastStrategy`. Different language, same shape:
-propagation feeds one cast-insertion policy.
+Ghidra's decompiler runs **monotone type propagation over its data-type ordering**
+(`ActionInferTypes`, not a formal meet/join lattice) and inserts casts through a
+**language-selected `CastStrategy` implementation** (`CastStrategyC`,
+`CastStrategyJava`). Different language, same shape: propagation feeds one
+cast-insertion policy per target language.
 
 ## The capability — two halves of one type
 
 ### 1. Target type on every sink
 
-Each value-consuming position declares the type it expects. Most IR nodes already
-carry it structurally (a `StoreElement` knows its array's element type; a `Box`
-knows the boxed type; a `Return` has the method's return type) — the gap is that
-the printer sometimes reads the *storage-opcode* type instead of the *semantic*
-type (the `stelem.i8` → `long` defect). Where a sink's target is genuinely
-implicit, it is derived once and attached, not re-derived per print.
+Each value-consuming position declares the type it expects. Some sinks carry it
+directly (a `Box` knows the boxed type; a `Return` has the method's return type),
+but others **do not, and this is part of the work**: `StoreElement.ElementType` is
+often the `stelem.*` *storage* type (`Int64` for `stelem.i8` into an enum array,
+because the importer only prefers the array element when widths match), so the
+semantic target must be *derived* from `array.ResultType`'s element type, distinct
+from the opcode storage type. The rule is: every sink resolves a *semantic* target
+type once — from the array/field/parameter/return type, not the storage opcode —
+and attaches it, rather than the printer re-deriving (and sometimes mis-reading) it
+per print.
 
 ### 2. `Coerce(value, targetType)` — the node
 
@@ -181,10 +192,16 @@ owns, in one place, the rules the printer currently spreads around:
   `Enum`-shape-without-`value__` (assume C#'s default `int`);
 - enum ↔ underlying, numeric widening, `null`-literal typing;
 - seeing through a widening `conv.i8`/`conv.u8` over an integer constant (small and
-  unsigned `long`-backed enum members lower this way).
+  unsigned `long`-backed enum members lower this way);
+- **lexical `checked`/`unchecked` context.** The same value and target need a bare
+  `(T)x` outside a `checked` region but `unchecked((T)x)` inside one — otherwise a
+  narrowing/sign-changing constant cast silently recompiles to `conv.ovf.*` the IL
+  never had (today handled by `CheckedSafeCast` / `_checkedContext`). So the render
+  is not total on `(value, targetType)` alone.
 
-The rendering rule is one total function of `(value, targetType)`; the printer
-calls it and never open-codes `(T)x` again.
+The rendering rule is one function of `(value, targetType, checkedContext)` — the
+checked context either threaded in or captured on the node — and the printer calls
+it and never open-codes `(T)x` again.
 
 **`Convert` and `Coerce` compose; they do not merge.** At a sink where the value
 already carries a `Convert` (an IL `conv.i8`) *and* the target type mismatches,

--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -135,10 +135,11 @@ IL's loosely-typed stack, which is our prerequisite:
 - The importer normalises the `int32`/`int64`/`native int` stack into a typed
   `GenTree`, inserting explicit `GT_CAST` nodes; conversions become IR at import,
   never re-decided at codegen.
-- At join points it **merges stack types to a common supertype and spills to typed
-  temps** — the same operation as our slot-merge-at-join, which today drops to
-  `Unknown` and taints fidelity. The JIT's spill-temp typing is the model for doing
-  it completely.
+- At join points it **merges the entry-state stack types to a common supertype** and
+  (separately) **spills mismatched entries to typed temps** — two related but
+  distinct mechanisms. Together they are the analogue of our slot-merge-at-join,
+  which today drops to `Unknown` and taints fidelity; the JIT's typed-temp model is
+  how to do it completely.
 
 ### ILSpy — the same-domain existence proof
 
@@ -185,13 +186,29 @@ owns, in one place, the rules the printer currently spreads around:
 The rendering rule is one total function of `(value, targetType)`; the printer
 calls it and never open-codes `(T)x` again.
 
+**`Convert` and `Coerce` compose; they do not merge.** At a sink where the value
+already carries a `Convert` (an IL `conv.i8`) *and* the target type mismatches,
+raising **wraps** the `Convert` in a `Coerce` — it does not rewrite one into the
+other. Leak case #6 is exactly this: `Coerce(Convert(long, ldc.i4.m1), UE)` renders
+`unchecked((UE)((long)-1))`, where the inner `Convert` keeps the value's IL history
+(`(long)-1`) and the outer `Coerce` owns the surface conversion to the enum and the
+overflow decision. Keeping them as separate, nesting nodes — rather than folding the
+IL conversion into the rendering one — is what lets the overflow rule see through the
+`Convert` to the literal without losing the faithful IL spelling.
+
 ### The invariant
 
 With the node in place, well-formedness becomes checkable: **no value may occupy a
 typed sink except through a `Coerce`** (or be provably already at the target type).
 `CheckInvariant()` asserts it; a violation fails at the pass level, in a unit test,
-instead of being discovered by recompiling corpus output. The compile-back oracle
-stops being the *only* place this class is caught.
+instead of being discovered by recompiling corpus output.
+
+This proves **routing, not rendering**: the invariant guarantees every sink *reaches*
+the one coercion function, collapsing the leak surface from ~12 sites to one — but it
+does not prove that function's *output* is correct. That output is still validated by
+the coercion function's own unit tests and the compile-back oracle. The win is that
+the oracle stops being the *only* place an un-coerced sink is caught, and a new sink
+can no longer silently bypass the rule.
 
 ## Scope and constraints
 
@@ -216,16 +233,22 @@ measurable, unlike the control-flow rewrite's all-or-nothing invariant relaxatio
 
 1. **Introduce `Coerce` and the one rendering function.** Fold `CastValue`,
    `EnumIntegerCast`, `SwitchLabelText`, the retyped-constant branch, `Box`, and
-   `StoreElement` into it. No behavior change intended; the corpus fidelity card is
-   the guard.
+   `StoreElement` into it. This is **not** behavior-neutral: those sites have
+   *different* partial behaviors today (`int`-only here, `Unknown`-shape-only there),
+   so unifying them will move outputs at the margins — that is the point. Expect and
+   *measure* net-positive validity movement on the corpus quality-diff card; a
+   fidelity regression on any already-`Full` method is the stop signal.
 2. **Complete constant typing.** Extend `TypedConstantsPass` to retype `int`,
    `long`, and `Convert`-wrapped integer constants into every enum-typed sink, so
    the printer sees enum-typed values uniformly.
 3. **Turn the invariant on.** Assert every typed sink routes through `Coerce`;
    burn down the violations it flags (these are the remaining leak sites, now
-   enumerated by the checker rather than by adversarial review).
-4. **Complete join typing** where the importer drops to `Unknown` but a sound
-   common type exists (the JIT spill-temp model), reducing `Partial`-by-unknown-join.
+   enumerated by the checker rather than by adversarial review). Slices 1–3 deliver
+   the coercion choke point and can land without step 4.
+4. **Complete join typing** (a semi-separate axis, worth its own slice/issue) where
+   the importer drops to `Unknown` but a sound common type exists — type
+   *propagation* at joins (the RyuJIT typed-temp model), the sibling of type
+   *coercion* at sinks, reducing `Partial`-by-unknown-join.
 
 Each slice reports the standard decompiler-affecting-PR evidence: focused tests,
 the corpus quality-diff card, and improved/still-flat examples.


### PR DESCRIPTION
## Summary

A design note for the decompiler's **value-flow / emission** axis — the sibling of `control-flow-structuring.md`, on the orthogonal axis that (per that redesign's own adversarial review) a post-dominator structurer does **not** touch.

Thesis: the decompiler is missing a first-class **coercion** abstraction — Roslyn's `BoundConversion`, ILSpy's `TranslatedExpression.ConvertTo(T)`. It built *half* of target-typing (natural types via `ResultType`/`MergedType`) and never built the **target-type-on-sinks** half or the **`Coerce(value, targetType)` node**, so cast/`unchecked` decisions are spread across ~12 printer branches and leak one sink at a time.

## Why now

This is the field-evidence write-up for a real, painful loop: a fix originally scoped to one conditional-arm shape drew **six consecutive adversarial-review rounds**, each surfacing the *same* invalid-C# class in a *new* sink (narrow-enum overflow, unsigned negative high-bit, comparison/bitwise/`??`, `long` switch labels, array-element/`box`, `ulong` via `conv.i8`). None were regressions; every fix was correct and local; every next round found the next sink. That slope is the value-flow analogue of the control-flow "normalizer treadmill."

## What the doc proposes

- **Target type on every sink** + a **`Coerce` node** (distinct from the IL-history `Convert` node), rendered by one total function of `(value, targetType)`.
- A checkable **well-formedness invariant** — "no value occupies a typed sink except through `Coerce`" — so the class is caught in a unit test, not by recompiling corpus output.
- An incremental migration whose coverage is *provable* (unlike the control-flow all-or-nothing relaxation), with a falsifiable start-trigger.

Grounded in prior art: Roslyn (`ClassifyConversion`, `BoundConversion`, and the C# 9 **target-typed conditional** — which is our `Conditional.MergedType` bug verbatim), RyuJIT (importer `GT_CAST` + stack-merge spill temps = the type-propagation prerequisite), ILSpy (`ConvertTo` — same-domain existence proof), Ghidra (`CastStrategy`).

## Scope

Docs-only. No behavior change. Respects the SRM-only / no-assembly-loading / not-SSA ceilings. Markdownlint clean.

## Review

Requesting adversarial review focused on **technical accuracy of the compiler prior-art claims** and the soundness of the diagnosis/design, from two model families different from the author's.
