### PR TITLE
Add allocation post-dominance metadata

### DIFF
--- a/docs/design/row-query-order.md
+++ b/docs/design/row-query-order.md
@@ -8,9 +8,9 @@ describe behavior that exists today.
 ## Problem
 
 Table sections are becoming richer. `Performance Triage` now has columns such as
-`Allocation`, `Path`, and `Path Confidence`, and future sections will add more
-domain-specific columns. Adding one flag per column, such as `--allocation` or
-`--path-confidence`, does not scale:
+`Allocation`, `Path`, `Path Confidence`, and `Post Dominance`, and future
+sections will add more domain-specific columns. Adding one flag per column, such
+as `--allocation` or `--path-confidence`, does not scale:
 
 - the command surface grows without bound;
 - field names become less discoverable than table schemas;
@@ -112,6 +112,7 @@ Examples:
 --where "Allocation=boxed *"
 --where "Path=loop body"
 --where "PathConfidence=dominates-return"
+--where "PostDominance=return-post-dominates"
 --where "RootReach>=10"
 --where "Confidence>=medium"
 ```
@@ -158,11 +159,11 @@ Default order:
 
 Filterable fields:
   Member, RootReach, Shape, Evidence, Fix, Confidence, Loop, Allocation, Path,
-  PathConfidence, IL
+  PathConfidence, PostDominance, IL
 
 Sortable fields:
   Triage, RootReach, Confidence, Loop, Member, Shape, IL, Allocation, Path,
-  PathConfidence
+  PathConfidence, PostDominance
 ```
 
 This makes the default sort order visible exactly where users and agents already
@@ -195,7 +196,7 @@ dotnet-inspect library MyApp.dll -S "Performance Triage" \
   --where "Path=loop body" \
   --order-by "RootReach desc" \
   --top 10 \
-  --columns "Member,Shape,Allocation,Path,PathConfidence,RootReach,IL"
+  --columns "Member,Shape,Allocation,Path,PathConfidence,PostDominance,RootReach,IL"
 ```
 
 Compact note in human output when `--top` is used:
@@ -284,7 +285,7 @@ rendered rows.
 1. Should `--where "Field=glob *"` use glob matching automatically when `*` or
    `?` appears, or require an explicit glob operator?
 2. Should field names normalize aliases such as `PathConfidence` and
-   `Path Confidence`?
+   `Path Confidence`, or `PostDominance` and `Post Dominance`?
 3. Should `--order-by Confidence` default to descending for ranked fields?
 4. Should a selected section with no default order allow `--top`, or should
    `--top` require a default or explicit order?

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1162,7 +1162,7 @@ public class LibraryBodyIndexTests
     [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), AllocationKind.Array, "System.Int32[]", AllocationPathContext.StraightLine, AllocationPathConfidence.DominatesReturn, AllocationPostDominance.ReturnPostDominates)]
     [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), AllocationKind.Box, "boxed System.Guid", AllocationPathContext.StraightLine, AllocationPathConfidence.DominatesReturn, AllocationPostDominance.ReturnPostDominates)]
     [InlineData(nameof(OptimizationOpportunityFixtures.ThrowsInLoop), AllocationKind.Object, "System.InvalidOperationException", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown, AllocationPostDominance.Unknown)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesOnceInLoop), AllocationKind.Object, "System.Object", AllocationPathContext.LoopBody, AllocationPathConfidence.BehindBranch, AllocationPostDominance.ReturnPostDominates)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesOnceInLoop), AllocationKind.Object, "System.Object", AllocationPathContext.LoopBody, AllocationPathConfidence.BehindBranch, AllocationPostDominance.Unknown)]
     [InlineData(nameof(OptimizationOpportunityFixtures.FinallyAllocates), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.StraightLine, AllocationPathConfidence.Unknown, AllocationPostDominance.Unknown)]
     [InlineData(nameof(OptimizationOpportunityFixtures.CatchAllocatesInLoop), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown, AllocationPostDominance.Unknown)]
     [InlineData(nameof(OptimizationOpportunityFixtures.CatchAllocatesBeforeOnlyReturn), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown, AllocationPostDominance.Unknown)]
@@ -1225,6 +1225,13 @@ public class LibraryBodyIndexTests
                     && occurrence.PathContext == AllocationPathContext.StraightLine
                     && occurrence.PathConfidence == AllocationPathConfidence.DominatesReturn
                     && occurrence.PostDominance == AllocationPostDominance.Unknown);
+            Assert.Contains(
+                index.GetAllocationOccurrences().Values.SelectMany(occurrences => occurrences),
+                occurrence => occurrence.Method.Name == "InternalReturnLoopAllocation"
+                    && occurrence.Kind == AllocationKind.Object
+                    && occurrence.PathContext == AllocationPathContext.StraightLine
+                    && occurrence.PathConfidence == AllocationPathConfidence.DominatesReturn
+                    && occurrence.PostDominance == AllocationPostDominance.Unknown);
         }
         finally
         {
@@ -1248,8 +1255,8 @@ public class LibraryBodyIndexTests
     [Theory]
     [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), "stackalloc-candidate", "System.Int32[]", "straight-line", "dominates-return", "return-post-dominates")]
     [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), "box-value-type", "boxed System.Guid", "straight-line", "dominates-return", "return-post-dominates")]
-    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesInLoop), "box-value-type", "boxed System.Int32", "loop body", "behind-branch", "return-post-dominates")]
-    [InlineData(nameof(OptimizationOpportunityFixtures.AppendsStringInLoop), "string-build-in-loop", "System.String", "loop body", "behind-branch", "return-post-dominates")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesInLoop), "box-value-type", "boxed System.Int32", "loop body", "behind-branch", null)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AppendsStringInLoop), "string-build-in-loop", "System.String", "loop body", "behind-branch", null)]
     [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop), "allocation-hotspot", "newobj/newarr/box", "loop body", null, null)]
     [InlineData(nameof(OptimizationOpportunityFixtures.ContainsKey), "scan-method-in-loop-call", null, "loop body", null, null)]
     public void OptimizationOpportunities_IncludeAllocationPathConfidenceAndPostDominanceMetadata(string methodName, string shape, string? expectedAllocation, string expectedPath, string? expectedConfidence, string? expectedPostDominance)
@@ -1909,6 +1916,7 @@ public class LibraryBodyIndexTests
         DefineSwitchAllocation(type, ctor);
         DefineAfterIfJoinAllocation(type, ctor);
         DefineReturnOrInfiniteLoopAllocation(type, ctor);
+        DefineInternalReturnLoopAllocation(type, ctor);
 
         type.CreateType();
         assembly.Save(path);
@@ -1992,6 +2000,29 @@ public class LibraryBodyIndexTests
             il.Emit(OpCodes.Ret);
             il.MarkLabel(loop);
             il.Emit(OpCodes.Br_S, loop);
+        }
+
+        static void DefineInternalReturnLoopAllocation(TypeBuilder type, ConstructorInfo ctor)
+        {
+            var method = type.DefineMethod(
+                "InternalReturnLoopAllocation",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(object),
+                [typeof(bool)]);
+            var il = method.GetILGenerator();
+            var header = il.DefineLabel();
+            var ret = il.DefineLabel();
+            var value = il.DeclareLocal(typeof(object));
+            il.Emit(OpCodes.Ldc_I4, 1);
+            il.Emit(OpCodes.Newobj, ctor);
+            il.Emit(OpCodes.Stloc, value);
+            il.MarkLabel(header);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Brtrue_S, ret);
+            il.Emit(OpCodes.Br_S, header);
+            il.MarkLabel(ret);
+            il.Emit(OpCodes.Ldloc, value);
+            il.Emit(OpCodes.Ret);
         }
     }
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1218,6 +1218,13 @@ public class LibraryBodyIndexTests
                     && occurrence.PathContext == AllocationPathContext.StraightLine
                     && occurrence.PathConfidence == AllocationPathConfidence.DominatesReturn
                     && occurrence.PostDominance == AllocationPostDominance.ReturnPostDominates);
+            Assert.Contains(
+                index.GetAllocationOccurrences().Values.SelectMany(occurrences => occurrences),
+                occurrence => occurrence.Method.Name == "ReturnOrInfiniteLoopAllocation"
+                    && occurrence.Kind == AllocationKind.Object
+                    && occurrence.PathContext == AllocationPathContext.StraightLine
+                    && occurrence.PathConfidence == AllocationPathConfidence.DominatesReturn
+                    && occurrence.PostDominance == AllocationPostDominance.Unknown);
         }
         finally
         {
@@ -1901,6 +1908,7 @@ public class LibraryBodyIndexTests
         DefineBranchAllocation(type, ctor);
         DefineSwitchAllocation(type, ctor);
         DefineAfterIfJoinAllocation(type, ctor);
+        DefineReturnOrInfiniteLoopAllocation(type, ctor);
 
         type.CreateType();
         assembly.Save(path);
@@ -1963,6 +1971,27 @@ public class LibraryBodyIndexTests
             il.Emit(OpCodes.Br_S, join);
             il.MarkLabel(join);
             EmitNewPlainObject(il, ctor, 1);
+        }
+
+        static void DefineReturnOrInfiniteLoopAllocation(TypeBuilder type, ConstructorInfo ctor)
+        {
+            var method = type.DefineMethod(
+                "ReturnOrInfiniteLoopAllocation",
+                MethodAttributes.Public | MethodAttributes.Static,
+                typeof(object),
+                [typeof(bool)]);
+            var il = method.GetILGenerator();
+            var loop = il.DefineLabel();
+            var value = il.DeclareLocal(typeof(object));
+            il.Emit(OpCodes.Ldc_I4, 1);
+            il.Emit(OpCodes.Newobj, ctor);
+            il.Emit(OpCodes.Stloc, value);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Brtrue_S, loop);
+            il.Emit(OpCodes.Ldloc, value);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(loop);
+            il.Emit(OpCodes.Br_S, loop);
         }
     }
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1159,14 +1159,14 @@ public class LibraryBodyIndexTests
     }
 
     [Theory]
-    [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), AllocationKind.Array, "System.Int32[]", AllocationPathContext.StraightLine, AllocationPathConfidence.DominatesReturn)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), AllocationKind.Box, "boxed System.Guid", AllocationPathContext.StraightLine, AllocationPathConfidence.DominatesReturn)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.ThrowsInLoop), AllocationKind.Object, "System.InvalidOperationException", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesOnceInLoop), AllocationKind.Object, "System.Object", AllocationPathContext.LoopBody, AllocationPathConfidence.BehindBranch)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.FinallyAllocates), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.StraightLine, AllocationPathConfidence.Unknown)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.CatchAllocatesInLoop), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.CatchAllocatesBeforeOnlyReturn), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown)]
-    public void AllocationOccurrences_IncludeRuntimeTypePathContextAndConfidence(string methodName, AllocationKind kind, string expectedRuntimeType, AllocationPathContext expectedPath, AllocationPathConfidence expectedConfidence)
+    [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), AllocationKind.Array, "System.Int32[]", AllocationPathContext.StraightLine, AllocationPathConfidence.DominatesReturn, AllocationPostDominance.ReturnPostDominates)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), AllocationKind.Box, "boxed System.Guid", AllocationPathContext.StraightLine, AllocationPathConfidence.DominatesReturn, AllocationPostDominance.ReturnPostDominates)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ThrowsInLoop), AllocationKind.Object, "System.InvalidOperationException", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown, AllocationPostDominance.Unknown)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesOnceInLoop), AllocationKind.Object, "System.Object", AllocationPathContext.LoopBody, AllocationPathConfidence.BehindBranch, AllocationPostDominance.ReturnPostDominates)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.FinallyAllocates), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.StraightLine, AllocationPathConfidence.Unknown, AllocationPostDominance.Unknown)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.CatchAllocatesInLoop), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown, AllocationPostDominance.Unknown)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.CatchAllocatesBeforeOnlyReturn), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown, AllocationPostDominance.Unknown)]
+    public void AllocationOccurrences_IncludeRuntimeTypePathContextConfidenceAndPostDominance(string methodName, AllocationKind kind, string expectedRuntimeType, AllocationPathContext expectedPath, AllocationPathConfidence expectedConfidence, AllocationPostDominance expectedPostDominance)
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 
@@ -1180,6 +1180,7 @@ public class LibraryBodyIndexTests
         Assert.Equal(expectedRuntimeType, occurrence.RuntimeAllocationType);
         Assert.Equal(expectedPath, occurrence.PathContext);
         Assert.Equal(expectedConfidence, occurrence.PathConfidence);
+        Assert.Equal(expectedPostDominance, occurrence.PostDominance);
     }
 
     [Fact]
@@ -1195,7 +1196,8 @@ public class LibraryBodyIndexTests
                 occurrence => occurrence.Method.Name == "BranchAllocation"
                     && occurrence.Kind == AllocationKind.Object
                     && occurrence.PathContext == AllocationPathContext.Branch
-                    && occurrence.PathConfidence == AllocationPathConfidence.BehindBranch);
+                    && occurrence.PathConfidence == AllocationPathConfidence.BehindBranch
+                    && occurrence.PostDominance == AllocationPostDominance.ReturnPostDominates);
             Assert.Contains(
                 index.GetAllocationOccurrences().Values.SelectMany(occurrences => occurrences),
                 occurrence => occurrence.Method.Name == "SwitchAllocation"
@@ -1208,12 +1210,14 @@ public class LibraryBodyIndexTests
             Assert.Equal(3, switchAllocations.Length);
             Assert.All(switchAllocations, occurrence => Assert.Equal(AllocationPathContext.SwitchArm, occurrence.PathContext));
             Assert.All(switchAllocations, occurrence => Assert.Equal(AllocationPathConfidence.BehindBranch, occurrence.PathConfidence));
+            Assert.All(switchAllocations, occurrence => Assert.Equal(AllocationPostDominance.ReturnPostDominates, occurrence.PostDominance));
             Assert.Contains(
                 index.GetAllocationOccurrences().Values.SelectMany(occurrences => occurrences),
                 occurrence => occurrence.Method.Name == "AfterIfJoinAllocation"
                     && occurrence.Kind == AllocationKind.Object
                     && occurrence.PathContext == AllocationPathContext.StraightLine
-                    && occurrence.PathConfidence == AllocationPathConfidence.DominatesReturn);
+                    && occurrence.PathConfidence == AllocationPathConfidence.DominatesReturn
+                    && occurrence.PostDominance == AllocationPostDominance.ReturnPostDominates);
         }
         finally
         {
@@ -1235,13 +1239,13 @@ public class LibraryBodyIndexTests
     }
 
     [Theory]
-    [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), "stackalloc-candidate", "System.Int32[]", "straight-line", "dominates-return")]
-    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), "box-value-type", "boxed System.Guid", "straight-line", "dominates-return")]
-    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesInLoop), "box-value-type", "boxed System.Int32", "loop body", "behind-branch")]
-    [InlineData(nameof(OptimizationOpportunityFixtures.AppendsStringInLoop), "string-build-in-loop", "System.String", "loop body", "behind-branch")]
-    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop), "allocation-hotspot", "newobj/newarr/box", "loop body", null)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.ContainsKey), "scan-method-in-loop-call", null, "loop body", null)]
-    public void OptimizationOpportunities_IncludeAllocationPathAndConfidenceMetadata(string methodName, string shape, string? expectedAllocation, string expectedPath, string? expectedConfidence)
+    [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), "stackalloc-candidate", "System.Int32[]", "straight-line", "dominates-return", "return-post-dominates")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), "box-value-type", "boxed System.Guid", "straight-line", "dominates-return", "return-post-dominates")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.BoxesInLoop), "box-value-type", "boxed System.Int32", "loop body", "behind-branch", "return-post-dominates")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AppendsStringInLoop), "string-build-in-loop", "System.String", "loop body", "behind-branch", "return-post-dominates")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesManyObjectsInLoop), "allocation-hotspot", "newobj/newarr/box", "loop body", null, null)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ContainsKey), "scan-method-in-loop-call", null, "loop body", null, null)]
+    public void OptimizationOpportunities_IncludeAllocationPathConfidenceAndPostDominanceMetadata(string methodName, string shape, string? expectedAllocation, string expectedPath, string? expectedConfidence, string? expectedPostDominance)
     {
         var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
 
@@ -1252,6 +1256,7 @@ public class LibraryBodyIndexTests
         Assert.Equal(expectedAllocation, opportunity.RuntimeAllocationType);
         Assert.Equal(expectedPath, opportunity.PathContext);
         Assert.Equal(expectedConfidence, opportunity.PathConfidence);
+        Assert.Equal(expectedPostDominance, opportunity.PostDominance);
     }
 
     [Fact]

--- a/src/ILInspector.Analysis/AllocationOccurrence.cs
+++ b/src/ILInspector.Analysis/AllocationOccurrence.cs
@@ -50,6 +50,12 @@ public enum AllocationPathConfidence
     BehindBranch,
 }
 
+public enum AllocationPostDominance
+{
+    Unknown,
+    ReturnPostDominates,
+}
+
 /// <summary>
 /// One static heap-allocation occurrence, keyed by IL offset. Presentation layers
 /// project this into hidden-fact annotations, method signals, and triage rows.
@@ -68,7 +74,8 @@ public sealed record AllocationOccurrence(
     AllocationFactSource Source,
     string? RuntimeAllocationType = null,
     AllocationPathContext PathContext = AllocationPathContext.StraightLine,
-    AllocationPathConfidence PathConfidence = AllocationPathConfidence.Unknown)
+    AllocationPathConfidence PathConfidence = AllocationPathConfidence.Unknown,
+    AllocationPostDominance PostDominance = AllocationPostDominance.Unknown)
 {
     public string AnnotationId => Kind switch
     {

--- a/src/ILInspector.Analysis/AllocationOccurrence.cs
+++ b/src/ILInspector.Analysis/AllocationOccurrence.cs
@@ -74,9 +74,10 @@ public sealed record AllocationOccurrence(
     AllocationFactSource Source,
     string? RuntimeAllocationType = null,
     AllocationPathContext PathContext = AllocationPathContext.StraightLine,
-    AllocationPathConfidence PathConfidence = AllocationPathConfidence.Unknown,
-    AllocationPostDominance PostDominance = AllocationPostDominance.Unknown)
+    AllocationPathConfidence PathConfidence = AllocationPathConfidence.Unknown)
 {
+    public AllocationPostDominance PostDominance { get; init; }
+
     public string AnnotationId => Kind switch
     {
         AllocationKind.Box => "alloc.box",

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1550,61 +1550,58 @@ public sealed class LibraryBodyIndex
 
             static IEnumerable<int> CyclicBlocks(IReadOnlyList<BlockEdges> edges)
             {
-                var indexByBlock = new int[edges.Count];
-                var lowlinkByBlock = new int[edges.Count];
-                Array.Fill(indexByBlock, -1);
-                var onStack = new bool[edges.Count];
-                var stack = new Stack<int>();
+                var state = new byte[edges.Count]; // 0 = unvisited, 1 = active, 2 = done
+                var activePath = new List<int>();
+                var activePosition = new int[edges.Count];
+                Array.Fill(activePosition, -1);
                 var cyclic = new bool[edges.Count];
-                int nextIndex = 0;
 
-                for (int block = 0; block < edges.Count; block++)
-                    if (indexByBlock[block] < 0)
-                        Visit(block);
+                for (int root = 0; root < edges.Count; root++)
+                {
+                    if (state[root] != 0)
+                        continue;
+
+                    var frames = new Stack<(int Block, int NextSuccessor)>();
+                    Enter(root, frames);
+                    while (frames.Count > 0)
+                    {
+                        var (block, nextSuccessor) = frames.Pop();
+                        var successors = edges[block].Successors;
+                        if (nextSuccessor >= successors.Count)
+                        {
+                            state[block] = 2;
+                            activePosition[block] = -1;
+                            activePath.RemoveAt(activePath.Count - 1);
+                            continue;
+                        }
+
+                        frames.Push((block, nextSuccessor + 1));
+                        int successor = successors[nextSuccessor];
+                        if ((uint)successor >= (uint)edges.Count)
+                            continue;
+
+                        if (state[successor] == 0)
+                        {
+                            Enter(successor, frames);
+                            continue;
+                        }
+
+                        if (state[successor] == 1 && activePosition[successor] >= 0)
+                        {
+                            for (int i = activePosition[successor]; i < activePath.Count; i++)
+                                cyclic[activePath[i]] = true;
+                        }
+                    }
+                }
 
                 return Enumerable.Range(0, cyclic.Length).Where(block => cyclic[block]).ToArray();
 
-                void Visit(int block)
+                void Enter(int block, Stack<(int Block, int NextSuccessor)> frames)
                 {
-                    indexByBlock[block] = nextIndex;
-                    lowlinkByBlock[block] = nextIndex;
-                    nextIndex++;
-                    stack.Push(block);
-                    onStack[block] = true;
-
-                    foreach (int successor in edges[block].Successors)
-                    {
-                        if ((uint)successor >= (uint)edges.Count)
-                            continue;
-                        if (indexByBlock[successor] < 0)
-                        {
-                            Visit(successor);
-                            lowlinkByBlock[block] = Math.Min(lowlinkByBlock[block], lowlinkByBlock[successor]);
-                        }
-                        else if (onStack[successor])
-                        {
-                            lowlinkByBlock[block] = Math.Min(lowlinkByBlock[block], indexByBlock[successor]);
-                        }
-                    }
-
-                    if (lowlinkByBlock[block] != indexByBlock[block])
-                        return;
-
-                    var component = new List<int>();
-                    int member;
-                    do
-                    {
-                        member = stack.Pop();
-                        onStack[member] = false;
-                        component.Add(member);
-                    }
-                    while (member != block);
-
-                    if (component.Count > 1 || edges[block].Successors.Contains(block))
-                    {
-                        foreach (int memberBlock in component)
-                            cyclic[memberBlock] = true;
-                    }
+                    state[block] = 1;
+                    activePosition[block] = activePath.Count;
+                    activePath.Add(block);
+                    frames.Push((block, 0));
                 }
             }
         }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1490,6 +1490,7 @@ public sealed class LibraryBodyIndex
                             || edges[block].LeavesRegion)));
                 var reachesNonExitingBlock = BackwardReachable(edges, Enumerable.Range(0, edges.Length)
                     .Where(block => postDominators.ImmediatePostDominator(block) == PostDominators.None));
+                var reachesCycle = BackwardReachable(edges, CyclicBlocks(edges));
 
                 for (int blockIndex = 0; blockIndex < blockGraph.Blocks.Length; blockIndex++)
                 {
@@ -1497,7 +1498,8 @@ public sealed class LibraryBodyIndex
                         continue;
                     if (reachesReturn[blockIndex]
                         && !reachesNonReturnExit[blockIndex]
-                        && !reachesNonExitingBlock[blockIndex])
+                        && !reachesNonExitingBlock[blockIndex]
+                        && !reachesCycle[blockIndex])
                     {
                         postDominanceByBlock[blockIndex] = AllocationPostDominance.ReturnPostDominates;
                     }
@@ -1544,6 +1546,66 @@ public sealed class LibraryBodyIndex
                 }
 
                 return reachable;
+            }
+
+            static IEnumerable<int> CyclicBlocks(IReadOnlyList<BlockEdges> edges)
+            {
+                var indexByBlock = new int[edges.Count];
+                var lowlinkByBlock = new int[edges.Count];
+                Array.Fill(indexByBlock, -1);
+                var onStack = new bool[edges.Count];
+                var stack = new Stack<int>();
+                var cyclic = new bool[edges.Count];
+                int nextIndex = 0;
+
+                for (int block = 0; block < edges.Count; block++)
+                    if (indexByBlock[block] < 0)
+                        Visit(block);
+
+                return Enumerable.Range(0, cyclic.Length).Where(block => cyclic[block]).ToArray();
+
+                void Visit(int block)
+                {
+                    indexByBlock[block] = nextIndex;
+                    lowlinkByBlock[block] = nextIndex;
+                    nextIndex++;
+                    stack.Push(block);
+                    onStack[block] = true;
+
+                    foreach (int successor in edges[block].Successors)
+                    {
+                        if ((uint)successor >= (uint)edges.Count)
+                            continue;
+                        if (indexByBlock[successor] < 0)
+                        {
+                            Visit(successor);
+                            lowlinkByBlock[block] = Math.Min(lowlinkByBlock[block], lowlinkByBlock[successor]);
+                        }
+                        else if (onStack[successor])
+                        {
+                            lowlinkByBlock[block] = Math.Min(lowlinkByBlock[block], indexByBlock[successor]);
+                        }
+                    }
+
+                    if (lowlinkByBlock[block] != indexByBlock[block])
+                        return;
+
+                    var component = new List<int>();
+                    int member;
+                    do
+                    {
+                        member = stack.Pop();
+                        onStack[member] = false;
+                        component.Add(member);
+                    }
+                    while (member != block);
+
+                    if (component.Count > 1 || edges[block].Successors.Contains(block))
+                    {
+                        foreach (int memberBlock in component)
+                            cyclic[memberBlock] = true;
+                    }
+                }
             }
         }
 

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -4,6 +4,7 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 
+using ILInspector.ControlFlow;
 using ILInspector.Instructions;
 
 namespace ILInspector.Analysis;
@@ -145,10 +146,12 @@ public sealed class LibraryBodyIndex
         var runtimeAllocation = opportunity.RuntimeAllocationType ?? FallbackRuntimeAllocationType(opportunity);
         var pathContext = opportunity.PathContext ?? FallbackPathContext(opportunity);
         var pathConfidence = opportunity.PathConfidence;
+        var postDominance = opportunity.PostDominance;
         return runtimeAllocation != opportunity.RuntimeAllocationType
             || pathContext != opportunity.PathContext
             || pathConfidence != opportunity.PathConfidence
-            ? opportunity with { RuntimeAllocationType = runtimeAllocation, PathContext = pathContext, PathConfidence = pathConfidence }
+            || postDominance != opportunity.PostDominance
+            ? opportunity with { RuntimeAllocationType = runtimeAllocation, PathContext = pathContext, PathConfidence = pathConfidence, PostDominance = postDominance }
             : opportunity;
     }
 
@@ -191,6 +194,13 @@ public sealed class LibraryBodyIndex
         {
             AllocationPathConfidence.DominatesReturn => "dominates-return",
             AllocationPathConfidence.BehindBranch => "behind-branch",
+            _ => null,
+        };
+
+    static string? FormatPostDominance(AllocationPostDominance postDominance)
+        => postDominance switch
+        {
+            AllocationPostDominance.ReturnPostDominates => "return-post-dominates",
             _ => null,
         };
 
@@ -1183,6 +1193,7 @@ public sealed class LibraryBodyIndex
                 LoopRegions = CollectLoopRegions();
                 PathContexts = AllocationPathContextIndex.Create(this);
                 PathConfidences = AllocationPathConfidenceIndex.Create(this);
+                PostDominances = AllocationPostDominanceIndex.Create(this);
             }
 
             public ImmutableArray<DecodedInstruction> Instructions { get; }
@@ -1190,6 +1201,7 @@ public sealed class LibraryBodyIndex
             public IReadOnlyList<(int Start, int End)> LoopRegions { get; }
             public AllocationPathContextIndex PathContexts { get; }
             public AllocationPathConfidenceIndex PathConfidences { get; }
+            public AllocationPostDominanceIndex PostDominances { get; }
 
             public bool TryGetInstructionAt(int offset, out DecodedInstruction instruction)
             {
@@ -1389,6 +1401,20 @@ public sealed class LibraryBodyIndex
             }
         }
 
+        static int[] ReturnBlocks(DecodedBody decodedBody)
+        {
+            var returns = new List<int>();
+            foreach (var instruction in decodedBody.Instructions)
+            {
+                if (instruction.OpCode != ILOpCode.Ret)
+                    continue;
+                int blockIndex = decodedBody.BlockGraph.BlockIndexAt(instruction.Offset);
+                if (blockIndex >= 0)
+                    returns.Add(blockIndex);
+            }
+            return [.. returns.Distinct().Order()];
+        }
+
         sealed class AllocationPathConfidenceIndex
         {
             readonly AllocationPathConfidence[] _confidenceByBlock;
@@ -1431,20 +1457,44 @@ public sealed class LibraryBodyIndex
                 => (uint)blockIndex < (uint)_confidenceByBlock.Length
                     ? _confidenceByBlock[blockIndex]
                     : AllocationPathConfidence.Unknown;
+        }
 
-            static int[] ReturnBlocks(DecodedBody decodedBody)
+        sealed class AllocationPostDominanceIndex
+        {
+            readonly AllocationPostDominance[] _postDominanceByBlock;
+
+            AllocationPostDominanceIndex(AllocationPostDominance[] postDominanceByBlock)
             {
-                var returns = new List<int>();
-                foreach (var instruction in decodedBody.Instructions)
-                {
-                    if (instruction.OpCode != ILOpCode.Ret)
-                        continue;
-                    int blockIndex = decodedBody.BlockGraph.BlockIndexAt(instruction.Offset);
-                    if (blockIndex >= 0)
-                        returns.Add(blockIndex);
-                }
-                return [.. returns.Distinct().Order()];
+                _postDominanceByBlock = postDominanceByBlock;
             }
+
+            public static AllocationPostDominanceIndex Create(DecodedBody decodedBody)
+            {
+                var blockGraph = decodedBody.BlockGraph;
+                var postDominanceByBlock = new AllocationPostDominance[blockGraph.Blocks.Length];
+                if (blockGraph.Blocks.Length == 0)
+                    return new AllocationPostDominanceIndex(postDominanceByBlock);
+
+                var postDominators = PostDominators.Of(blockGraph.Blocks.Select(static block => block.Edges).ToArray());
+                var returnBlocks = ReturnBlocks(decodedBody);
+                if (returnBlocks.Length == 0)
+                    return new AllocationPostDominanceIndex(postDominanceByBlock);
+
+                for (int blockIndex = 0; blockIndex < blockGraph.Blocks.Length; blockIndex++)
+                {
+                    if (decodedBody.PathContexts.ContextFor(blockIndex) == AllocationPathContext.ErrorPath)
+                        continue;
+                    if (returnBlocks.Any(returnBlock => postDominators.PostDominates(returnBlock, blockIndex)))
+                        postDominanceByBlock[blockIndex] = AllocationPostDominance.ReturnPostDominates;
+                }
+
+                return new AllocationPostDominanceIndex(postDominanceByBlock);
+            }
+
+            public AllocationPostDominance PostDominanceFor(int blockIndex)
+                => (uint)blockIndex < (uint)_postDominanceByBlock.Length
+                    ? _postDominanceByBlock[blockIndex]
+                    : AllocationPostDominance.Unknown;
         }
 
         sealed class DominatorTree
@@ -2196,7 +2246,8 @@ public sealed class LibraryBodyIndex
                     source,
                     RuntimeAllocationType(kind, allocatedType),
                     AllocationPathContextFor(decodedBody, offset, loopRegions, escape),
-                    AllocationPathConfidenceFor(decodedBody, offset, escape));
+                    AllocationPathConfidenceFor(decodedBody, offset, escape),
+                    AllocationPostDominanceFor(decodedBody, offset, escape));
 
             bool ShouldEmitUnresolvedValueTypeAnnotation(int operandToken, TypeRef type)
             {
@@ -3024,6 +3075,7 @@ public sealed class LibraryBodyIndex
                         RuntimeAllocationType = runtimeAllocation,
                         PathContext = opportunity.PathContext ?? FormatPathContext(AllocationPathContextFor(decodedBody, opportunityOffset, loopRegions, AllocationEscape.Unknown)),
                         PathConfidence = opportunity.PathConfidence ?? FormatPathConfidence(AllocationPathConfidenceFor(decodedBody, opportunityOffset, AllocationEscape.Unknown)),
+                        PostDominance = opportunity.PostDominance ?? FormatPostDominance(AllocationPostDominanceFor(decodedBody, opportunityOffset, AllocationEscape.Unknown)),
                     };
                 }
                 return AddFallbackOpportunityMetadata(annotated);
@@ -3452,6 +3504,17 @@ public sealed class LibraryBodyIndex
             return decodedBody.PathConfidences.ConfidenceFor(blockIndex);
         }
 
+        static AllocationPostDominance AllocationPostDominanceFor(
+            DecodedBody decodedBody,
+            int offset,
+            AllocationEscape escape)
+        {
+            if (escape == AllocationEscape.ThrowPath)
+                return AllocationPostDominance.Unknown;
+            int blockIndex = decodedBody.BlockGraph.BlockIndexAt(offset);
+            return decodedBody.PostDominances.PostDominanceFor(blockIndex);
+        }
+
         // Conservative, sound local-escape check for a freshly created array. Returns true
         // only when the array is stored straight into a local (`newarr; stloc.X`) whose every
         // load is an in-place element access / length read — never returned, stored to a
@@ -3542,6 +3605,7 @@ public sealed class LibraryBodyIndex
                         Escape = escape,
                         PathContext = escape == AllocationEscape.ThrowPath ? AllocationPathContext.ErrorPath : occurrence.PathContext,
                         PathConfidence = escape == AllocationEscape.ThrowPath ? AllocationPathConfidence.Unknown : occurrence.PathConfidence,
+                        PostDominance = escape == AllocationEscape.ThrowPath ? AllocationPostDominance.Unknown : occurrence.PostDominance,
                     });
             }
             return builder.MoveToImmutable();

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -1475,17 +1475,32 @@ public sealed class LibraryBodyIndex
                 if (blockGraph.Blocks.Length == 0)
                     return new AllocationPostDominanceIndex(postDominanceByBlock);
 
-                var postDominators = PostDominators.Of(blockGraph.Blocks.Select(static block => block.Edges).ToArray());
+                var edges = blockGraph.Blocks.Select(static block => block.Edges).ToArray();
+                var postDominators = PostDominators.Of(edges);
                 var returnBlocks = ReturnBlocks(decodedBody);
                 if (returnBlocks.Length == 0)
                     return new AllocationPostDominanceIndex(postDominanceByBlock);
+
+                var reachesReturn = BackwardReachable(edges, returnBlocks);
+                var returnSet = returnBlocks.ToHashSet();
+                var reachesNonReturnExit = BackwardReachable(edges, Enumerable.Range(0, edges.Length)
+                    .Where(block => !returnSet.Contains(block)
+                        && (edges[block].ExitsMethod
+                            || edges[block].ExternalTargets.Count > 0
+                            || edges[block].LeavesRegion)));
+                var reachesNonExitingBlock = BackwardReachable(edges, Enumerable.Range(0, edges.Length)
+                    .Where(block => postDominators.ImmediatePostDominator(block) == PostDominators.None));
 
                 for (int blockIndex = 0; blockIndex < blockGraph.Blocks.Length; blockIndex++)
                 {
                     if (decodedBody.PathContexts.ContextFor(blockIndex) == AllocationPathContext.ErrorPath)
                         continue;
-                    if (returnBlocks.Any(returnBlock => postDominators.PostDominates(returnBlock, blockIndex)))
+                    if (reachesReturn[blockIndex]
+                        && !reachesNonReturnExit[blockIndex]
+                        && !reachesNonExitingBlock[blockIndex])
+                    {
                         postDominanceByBlock[blockIndex] = AllocationPostDominance.ReturnPostDominates;
+                    }
                 }
 
                 return new AllocationPostDominanceIndex(postDominanceByBlock);
@@ -1495,6 +1510,41 @@ public sealed class LibraryBodyIndex
                 => (uint)blockIndex < (uint)_postDominanceByBlock.Length
                     ? _postDominanceByBlock[blockIndex]
                     : AllocationPostDominance.Unknown;
+
+            static bool[] BackwardReachable(IReadOnlyList<BlockEdges> edges, IEnumerable<int> seeds)
+            {
+                var reachable = new bool[edges.Count];
+                var predecessors = new List<int>[edges.Count];
+                for (int i = 0; i < predecessors.Length; i++)
+                    predecessors[i] = [];
+                for (int from = 0; from < edges.Count; from++)
+                    foreach (int to in edges[from].Successors)
+                        if ((uint)to < (uint)predecessors.Length)
+                            predecessors[to].Add(from);
+
+                var stack = new Stack<int>();
+                foreach (int seed in seeds)
+                {
+                    if ((uint)seed >= (uint)reachable.Length || reachable[seed])
+                        continue;
+                    reachable[seed] = true;
+                    stack.Push(seed);
+                }
+
+                while (stack.Count > 0)
+                {
+                    int block = stack.Pop();
+                    foreach (int predecessor in predecessors[block])
+                    {
+                        if (reachable[predecessor])
+                            continue;
+                        reachable[predecessor] = true;
+                        stack.Push(predecessor);
+                    }
+                }
+
+                return reachable;
+            }
         }
 
         sealed class DominatorTree
@@ -2246,8 +2296,10 @@ public sealed class LibraryBodyIndex
                     source,
                     RuntimeAllocationType(kind, allocatedType),
                     AllocationPathContextFor(decodedBody, offset, loopRegions, escape),
-                    AllocationPathConfidenceFor(decodedBody, offset, escape),
-                    AllocationPostDominanceFor(decodedBody, offset, escape));
+                    AllocationPathConfidenceFor(decodedBody, offset, escape))
+                {
+                    PostDominance = AllocationPostDominanceFor(decodedBody, offset, escape),
+                };
 
             bool ShouldEmitUnresolvedValueTypeAnnotation(int operandToken, TypeRef type)
             {

--- a/src/ILInspector.Analysis/OptimizationOpportunity.cs
+++ b/src/ILInspector.Analysis/OptimizationOpportunity.cs
@@ -13,7 +13,8 @@ public sealed record OptimizationOpportunity(
     bool ColdPath = false,
     string? RuntimeAllocationType = null,
     string? PathContext = null,
-    string? PathConfidence = null)
+    string? PathConfidence = null,
+    string? PostDominance = null)
 {
     public bool Amortized { get; init; }
 }

--- a/src/ILInspector.Analysis/OptimizationOpportunity.cs
+++ b/src/ILInspector.Analysis/OptimizationOpportunity.cs
@@ -13,8 +13,8 @@ public sealed record OptimizationOpportunity(
     bool ColdPath = false,
     string? RuntimeAllocationType = null,
     string? PathContext = null,
-    string? PathConfidence = null,
-    string? PostDominance = null)
+    string? PathConfidence = null)
 {
     public bool Amortized { get; init; }
+    public string? PostDominance { get; init; }
 }

--- a/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
@@ -39,7 +39,7 @@ public class AllocationOccurrenceFactTests
         var annotations = Classify(nameof(AllocSampleClass.BoxInt));
 
         var box = Assert.Single(annotations, a => a.Descriptor.Id == "alloc.box");
-        Assert.Equal("int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; escape=escapes", box.Detail);
+        Assert.Equal("int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes", box.Detail);
         Assert.True(box.SourceOffset >= 0, "the annotation should carry IL provenance");
         Assert.Equal(AnnotationCategory.Allocation, box.Descriptor.Category);
     }
@@ -60,7 +60,7 @@ public class AllocationOccurrenceFactTests
         var annotations = Classify(nameof(AllocSampleClass.MakeRectangularArray));
 
         var array = Assert.Single(annotations, a => a.Descriptor.Id == "alloc.array");
-        Assert.Equal("int[,]; alloc=System.Int32[,]; path=straight-line; path-confidence=dominates-return; escape=escapes", array.Detail);
+        Assert.Equal("int[,]; alloc=System.Int32[,]; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes", array.Detail);
         Assert.DoesNotContain(annotations, a => a.Descriptor.Id == "alloc.new");
     }
 

--- a/src/ILInspector.Decompiler.Tests/AnnotatedCSharpRendererTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedCSharpRendererTests.cs
@@ -20,14 +20,14 @@ public class AnnotatedCSharpRendererTests
         // The box is invisible in the source (object BoxInt(int x) => x;) yet the
         // annotated view shows it where it happens.
         var output = Render(nameof(AllocSampleClass.BoxInt));
-        Assert.Contains("return x;  // alloc.box(int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; escape=escapes)", output);
+        Assert.Contains("return x;  // alloc.box(int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes)", output);
     }
 
     [Fact]
     public void Array_SurfacesTheAllocatedType()
     {
         var output = Render(nameof(AllocSampleClass.MakeArray));
-        Assert.Contains("// alloc.array(int[]; alloc=System.Int32[]; path=straight-line; path-confidence=dominates-return; escape=escapes)", output);
+        Assert.Contains("// alloc.array(int[]; alloc=System.Int32[]; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes)", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/AnnotatedIlFactTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotatedIlFactTests.cs
@@ -21,7 +21,7 @@ public class AnnotatedIlFactTests
         // opcode, not a statement.
         var output = Render(nameof(AllocSampleClass.BoxInt));
         var line = output.Split('\n').Single(l => l.Contains(": box"));
-        Assert.Contains("alloc.box(int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; escape=escapes)", line);
+        Assert.Contains("alloc.box(int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes)", line);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/AnnotationStructuredViewTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AnnotationStructuredViewTests.cs
@@ -28,7 +28,7 @@ public class AnnotationStructuredViewTests
         var fact = Assert.Single(doc.RootElement.EnumerateArray());
         Assert.Equal("alloc.box", fact.GetProperty("id").GetString());
         Assert.Equal("Allocation", fact.GetProperty("category").GetString());
-        Assert.Equal("int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; escape=escapes", fact.GetProperty("detail").GetString());
+        Assert.Equal("int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes", fact.GetProperty("detail").GetString());
         Assert.Equal("IL_0001", fact.GetProperty("il").GetString());
         Assert.True(fact.GetProperty("offset").GetInt32() >= 0);
     }
@@ -41,7 +41,7 @@ public class AnnotationStructuredViewTests
         var json = AnnotationStructuredView.Json(Collect(nameof(AllocSampleClass.Capture)));
         using var doc = JsonDocument.Parse(json);
         Assert.Contains(doc.RootElement.EnumerateArray(),
-            f => f.GetProperty("detail").GetString() == "Func<int, int>; alloc=System.Func<System.Int32, System.Int32>; path=straight-line; path-confidence=dominates-return; escape=escapes");
+            f => f.GetProperty("detail").GetString() == "Func<int, int>; alloc=System.Func<System.Int32, System.Int32>; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes");
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
@@ -37,8 +37,8 @@ public class MixedSourceRendererTests
         var lines = output.Split('\n');
         var cs = lines.Single(l => l.Contains("new int[n]"));
         var il = lines.Single(l => l.Contains("newarr"));
-        Assert.Contains("alloc.array(int[]; alloc=System.Int32[]; path=straight-line; path-confidence=dominates-return; escape=escapes)", cs);
-        Assert.Contains("alloc.array(int[]; alloc=System.Int32[]; path=straight-line; path-confidence=dominates-return; escape=escapes)", il);
+        Assert.Contains("alloc.array(int[]; alloc=System.Int32[]; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes)", cs);
+        Assert.Contains("alloc.array(int[]; alloc=System.Int32[]; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes)", il);
     }
 
     [Fact]

--- a/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
+++ b/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
@@ -59,6 +59,8 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
         parts.Add($"path={FormatPathContext(occurrence.PathContext)}");
         if (FormatPathConfidence(occurrence.PathConfidence) is { } confidence)
             parts.Add($"path-confidence={confidence}");
+        if (FormatPostDominance(occurrence.PostDominance) is { } postDominance)
+            parts.Add($"post-dominance={postDominance}");
         if (occurrence.Escape != AllocationEscape.Unknown)
             parts.Add($"escape={FormatEscape(occurrence.Escape)}");
         return parts.Count == 0 ? null : string.Join("; ", parts);
@@ -79,6 +81,13 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
         {
             AllocationPathConfidence.DominatesReturn => "dominates-return",
             AllocationPathConfidence.BehindBranch => "behind-branch",
+            _ => null,
+        };
+
+    static string? FormatPostDominance(AllocationPostDominance postDominance)
+        => postDominance switch
+        {
+            AllocationPostDominance.ReturnPostDominates => "return-post-dominates",
             _ => null,
         };
 

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -2715,7 +2715,7 @@ public class CommandExecutionTests
         Assert.Contains("| Member | IL | Cs Line | Anchor | Category | Id | Detail | Conditionality |", output);
         Assert.Contains("FactsTableFixture::BoxInt", output);
         Assert.Contains("`IL_", output);
-        Assert.Contains("| offset | Allocation | alloc.box | `int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; escape=escapes` | Always |", output);
+        Assert.Contains("| offset | Allocation | alloc.box | `int; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes` | Always |", output);
     }
 
     [Fact]
@@ -2728,7 +2728,7 @@ public class CommandExecutionTests
         Assert.Equal(0, exit);
         Assert.Empty(error);
         Assert.Contains("FactsTableFixture::BoxInt\tIL_", output);
-        Assert.Contains("\toffset\tAllocation\talloc.box\tint; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; escape=escapes\tAlways", output);
+        Assert.Contains("\toffset\tAllocation\talloc.box\tint; alloc=boxed System.Int32; path=straight-line; path-confidence=dominates-return; post-dominance=return-post-dominates; escape=escapes\tAlways", output);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -740,6 +740,7 @@ internal static class LibraryMetadataService
                     Allocation = opportunity.RuntimeAllocationType,
                     Path = opportunity.PathContext,
                     PathConfidence = opportunity.PathConfidence,
+                    PostDominance = opportunity.PostDominance,
                     IL = opportunity.ILOffset is { } offset ? $"IL_{offset:X4}" : null,
                 })
                 .ToList();

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -681,6 +681,8 @@ public record class OptimizationOpportunitySummary
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? PathConfidence { get; init; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PostDominance { get; init; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? IL { get; init; }
 }
 

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1813,6 +1813,7 @@ public static class ApiOutputFormatter
                 opportunity.RuntimeAllocationType is { Length: > 0 } allocation ? MarkoutInline.Code(allocation) : null,
                 opportunity.PathContext,
                 opportunity.PathConfidence,
+                opportunity.PostDominance,
                 opportunity.ILOffset is { } offset ? MarkoutInline.Code($"IL_{offset:X4}") : null))
             .ToList();
 

--- a/src/dotnet-inspect/Views/ApiViews.cs
+++ b/src/dotnet-inspect/Views/ApiViews.cs
@@ -888,6 +888,8 @@ public record OptimizationOpportunityRow(
     [property: MarkoutSkipNull] string? Allocation,
     [property: MarkoutSkipNull] string? Path,
     [property: MarkoutSkipNull] string? PathConfidence,
+    [property: MarkoutPropertyName("Post Dominance")]
+    [property: MarkoutSkipNull] string? PostDominance,
     [property: MarkoutSkipNull] string? IL);
 
 [MarkoutSerializable]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -750,6 +750,7 @@ public class LibraryInspectionView
                 o.Allocation is null ? null : MarkoutInline.Code(o.Allocation),
                 o.Path,
                 o.PathConfidence,
+                o.PostDominance,
                 o.IL is null ? null : MarkoutInline.Code(o.IL)))
             .ToList();
 


### PR DESCRIPTION
## Summary

Adds evidence-only allocation post-dominance metadata without changing Performance Triage ranking/scoring or shape confidence.

- Adds `AllocationPostDominance.ReturnPostDominates` as non-positional metadata on allocation occurrences and optimization opportunities.
- Computes post-dominance from the shared `ILInspector.ControlFlow.PostDominators` kernel over instruction `BlockGraph` edges.
- Projects the evidence as `post-dominance=return-post-dominates` in Facts annotations and as `Post Dominance` in Performance Triage rows / JSONL.
- Keeps the predicate conservative: unknown for non-return exits, EH leaves, external targets, non-exiting blocks, and any reachable cycle.
- Updates row-query design docs to include the new `PostDominance` field.

## Validation

- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config -p:NoWarn=NU1507`
- `dotnet run --no-restore --project src/ILInspector.Analysis.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -method '*AllocationOccurrences_IncludeRuntimeTypePathContextConfidenceAndPostDominance*' -method '*AllocationOccurrences_IncludeBranchAndSwitchPathContext*' -method '*OptimizationOpportunities_IncludeAllocationPathConfidenceAndPostDominanceMetadata*'`
- `dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -class '*AllocationOccurrenceFactTests' -class '*AnnotatedCSharpRendererTests' -class '*AnnotatedIlFactTests' -class '*AnnotationStructuredViewTests' -class '*MixedSourceRendererTests'`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -method '*Member_SelectedOverload_SelectFacts_RendersStructuredResearchRows*' -method '*Member_SelectedOverload_SelectFacts_TsvIncludesStructuredColumns*'`
- `npx markdownlint-cli docs/design/row-query-order.md`
- CLI probe: `dotnet-inspect library artifacts/bin/ILInspector.Analysis/release/ILInspector.Analysis.dll -S "Performance Triage" --jsonl --fields "Shape,Path,Path Confidence,Post Dominance" --top 2`

## Adversarial review

Required analysis-PR adversarial review was completed with non-GPT model families.

- Round 1: Claude Opus 4.8 found public record constructor compatibility risk and a terminal infinite-loop false positive; Gemini 3.1 Pro returned clean. Fixed in `814bc842` by moving new metadata to init-only properties and disqualifying non-return/non-exiting paths.
- Round 2: Claude Opus 4.8 returned clean; MAI Code found an internal conditional-return loop false positive. Fixed in `82048b2b` by conservatively suppressing post-dominance when any reachable cycle exists, with regression fixtures.
- Round 3: Gemini 3.1 Pro returned clean; MAI Code found recursive cycle detection could stack-overflow on deep CFGs. Fixed in `d1c85210` by replacing recursion with iterative DFS cycle marking.
- Round 4: Claude Opus 4.8 and Gemini 3.1 Pro both returned clean after the fixes.
