### PR TITLE
Raise guarded union switch store tails

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -991,6 +991,27 @@ public class TypeSourceComposerUnionTests
                     return result.ToUpperInvariant();
                 }
 
+                public static string SameTypeGuardedFallback(Pet pet)
+                {
+                    string result;
+                    switch (pet)
+                    {
+                        case Cat { Name: "cat" } cat:
+                            result = cat.Name;
+                            break;
+                        case Cat:
+                            result = "other cat";
+                            break;
+                        case Dog dog:
+                            result = dog.Name;
+                            break;
+                        default:
+                            result = "other";
+                            break;
+                    }
+                    return result.ToUpperInvariant();
+                }
+
                 public static string ValueTypeCases(MaybeNumber value)
                 {
                     string result;
@@ -1135,9 +1156,14 @@ public class TypeSourceComposerUnionTests
             return result;
             """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "AssignThenMutate"));
 
-        var guarded = RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedStaysFlat");
-        Assert.DoesNotContain("pet switch", guarded);
-        Assert.Contains("cat.Age > 3", guarded);
+        Assert.Equal("""
+            string result = pet switch { Cat cat when cat.Age > 3 => cat.Name, Dog dog => dog.Name, _ => "other" };
+            return result.ToUpperInvariant();
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "GuardedStaysFlat"));
+        Assert.Equal("""
+            string result = pet switch { Cat cat when cat.Name == "cat" => cat.Name, Cat => "other cat", Dog dog => dog.Name, _ => "other" };
+            return result.ToUpperInvariant();
+            """, RenderMember(assembly.Path, "UnionFixtures.Matcher", "SameTypeGuardedFallback"));
         Assert.Equal("""
             string result = value switch { null => "null", int number => number.ToString(), string text => text, _ => "other" };
             return result.ToUpperInvariant();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UnionSwitchExpressionPass.cs
@@ -154,6 +154,8 @@ public sealed class UnionSwitchExpressionPass : IIrPass
                 return true;
             if (TryMatchValueTypePrefixStoreTailAt(function, children, start, out match))
                 return true;
+            if (TryMatchGuardedPrefixStoreTailAt(function, children, start, out match))
+                return true;
             if (TryMatchStoreTailAt(function, children, start, out match))
                 return true;
         }
@@ -285,6 +287,105 @@ public sealed class UnionSwitchExpressionPass : IIrPass
         var switchStore = new StoreLocal(firstValueStore.Index, firstValueStore.Type, switchExpression);
         match = new StoreTailMatch(start, switchStore, tail.Select(node => node.Clone()).ToArray());
         return true;
+    }
+
+    static bool TryMatchGuardedPrefixStoreTailAt(
+        IrFunction function,
+        IReadOnlyList<IrNode> children,
+        int start,
+        out StoreTailMatch match)
+    {
+        match = null!;
+        if (start + 5 >= children.Count
+            || children[start] is not StoreLocal { Value: LoadProperty unionValue } valueStore
+            || !IsValueTypeUnionValueProperty(function, unionValue)
+            || children[start + 1] is not IfStatement firstIf
+            || firstIf.HasElse
+            || !TryArmPattern(firstIf.Condition, valueStore.Index, out var firstType, out var firstLocal, out var firstRoots)
+            || children[start + 2] is not StoreLocal { Value: IsInstance finalTest } finalStore
+            || !IsTempTypeTest(finalTest, valueStore.Index)
+            || children[start + 3] is not IfStatement finalNullGuard
+            || finalNullGuard.HasElse
+            || !IsNotLocal(finalNullGuard.Condition, finalStore.Index)
+            || finalNullGuard.Then.Children is not [StoreLocal defaultStore, ..]
+            || children[start + 4] is not StoreLocal finalValueStore
+            || finalValueStore.Index != defaultStore.Index)
+        {
+            return false;
+        }
+
+        var tail = children.Skip(start + 5).ToArray();
+        if (tail.Length == 0
+            || !TailShapeIsMovable(tail)
+            || !TailMatches(finalNullGuard.Then.Children, 1, tail)
+            || !TailMatches(children, start + 5, tail)
+            || !TryGuardedStoreTailSplit(firstIf.Then.Children, finalValueStore.Index, tail, defaultStore.Value, firstType, firstLocal, firstRoots, out var firstArms))
+        {
+            return false;
+        }
+
+        var finalArm = new Arm(
+            finalTest.Type,
+            finalStore.Index,
+            finalValueStore.Value,
+            [finalStore, finalNullGuard.Condition, finalValueStore.Value]);
+        var arms = firstArms.Append(finalArm).ToArray();
+        var switchNodes = children.Skip(start).Take(5).Concat(firstIf.Then.Children).Concat(finalNullGuard.Then.Children).ToArray();
+        var consumedNodes = children.Skip(start).ToArray();
+
+        if (!ReferenceOwnership.LocalReferencesOnlyWithin(function, valueStore.Index, switchNodes)
+            || !ReferenceOwnership.LocalReferencesOnlyWithin(function, finalValueStore.Index, consumedNodes)
+            || arms.Any(arm => !ArmLocalReferencesAreOwned(function, arm))
+            || !DuplicateTypesAreGuarded(arms))
+        {
+            return false;
+        }
+
+        var switchExpression = new UnionSwitchExpression(
+            (IrExpression)unionValue.Clone(),
+            arms.Select(arm => new UnionSwitchExpressionArm(
+                arm.PatternType,
+                arm.LocalIndex,
+                (IrExpression)arm.Value.Clone(),
+                arm.Guard is null ? null : (IrExpression)arm.Guard.Clone())),
+            (IrExpression)defaultStore.Value.Clone());
+        var switchStore = new StoreLocal(finalValueStore.Index, finalValueStore.Type, switchExpression);
+        match = new StoreTailMatch(start, switchStore, tail.Select(node => node.Clone()).ToArray());
+        return true;
+    }
+
+    static bool TryGuardedStoreTailSplit(
+        IReadOnlyList<IrNode> nodes,
+        int resultLocal,
+        IReadOnlyList<IrNode> tail,
+        IrExpression defaultValue,
+        TypeRef patternType,
+        int? localIndex,
+        IReadOnlyList<IrNode> patternRoots,
+        out IReadOnlyList<Arm> arms)
+    {
+        arms = [];
+        if (nodes is not [IfStatement guardIf, StoreLocal fallbackStore, ..]
+            || localIndex is not { } local
+            || guardIf.HasElse
+            || guardIf.Then.Children is not [StoreLocal guardedStore, ..]
+            || guardedStore.Index != resultLocal
+            || fallbackStore.Index != resultLocal
+            || !TailMatches(guardIf.Then.Children, 1, tail)
+            || !TailMatches(nodes, 2, tail))
+        {
+            return false;
+        }
+
+        arms = BuildSplitArms(
+            patternType,
+            local,
+            patternRoots,
+            guardedStore.Value,
+            guardIf.Condition,
+            fallbackStore.Value,
+            defaultValue);
+        return arms.Count > 0;
     }
 
     static bool TryMatchValueTypePrefixStoreTailAt(


### PR DESCRIPTION
## Summary

- Raise guarded value-type union switch store-tail shapes into switch-expression assignments before the shared tail.
- Cover same-type guarded fallback (`Cat when ...`, then `Cat`, then other cases) using the existing split-arm logic.
- Preserve class/custom union `.Value` semantics by keeping the matcher gated to value-type union `Value` properties.

## Evidence

- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*TypeSourceComposerUnionTests*"`: 22 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"`: 1778 passed

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity sampled 25,179 / 89,065 (28.27%); fidelity sampled 36 / 89,065 (0.04%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,399 (88.02%) | 0 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — sampled 25,179 / 89,065 (28.27%) | 73/25,179 — sampled 25,179 / 89,065 (28.27%) | -1 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | 0 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate: Fully raised 88.02% -> 88.02% (0 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 5 (0).

Verdict: corpus sensor matched baseline tolerances.

## Adversarial review

- Gemini 3.1 Pro: no blocking findings. It verified guarded arm local ownership, duplicated-tail movement/order, side-effecting guard order, class-union gating, and same-type fallback/default semantics.
- Claude Opus 4.8: no blocking findings. It verified fallback-equals-default equivalence with execution-level probes, ownership proofs, side-effect guard order, guard referencing dropped union temp rejection, duplicate-type handling, class-union gating, and matcher precedence.

## Notes

- This is a readability/altitude raise, not claimed as opcode-exact.
- The corpus card has no fully-raised drift after #2075's baseline/current fix.
