### PR TITLE
Add project scope to relationship commands

### DIFF
--- a/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
+++ b/src/dotnet-inspect.Tests/ExtensionsCommandTests.cs
@@ -233,6 +233,42 @@ public class ExtensionsCommandTests
         Assert.Equal("TSource First(this IEnumerable<TSource> source)", entry.Signature);
     }
 
+    [Fact]
+    public void CollapseOverloads_DuplicateSameSignature_DoesNotInflateOverloadCount()
+    {
+        var results = new List<ExtensionMethodResult>
+        {
+            new()
+            {
+                MethodName = "UnicodeToOctetString",
+                Kind = "method",
+                ExtensionClass = "Internal.Cryptography.PkcsHelpers",
+                Assembly = "System.Security.Cryptography.Pkcs",
+                Signature = "byte[] UnicodeToOctetString(this string s)",
+                Source = "System.Security.Cryptography.Pkcs",
+                SourceVersion = "9.0.4"
+            },
+            new()
+            {
+                MethodName = "UnicodeToOctetString",
+                Kind = "method",
+                ExtensionClass = "Internal.Cryptography.PkcsHelpers",
+                Assembly = "System.Security.Cryptography.Pkcs",
+                Signature = "byte[] UnicodeToOctetString(this string s)",
+                Source = "System.Security.Cryptography.Pkcs",
+                SourceVersion = "9.0.4"
+            }
+        };
+
+        var collapsed = ExtensionsCommand.CollapseOverloads(results);
+
+        Assert.Single(collapsed);
+        var entry = collapsed[0];
+        Assert.Null(entry.Overloads);
+        Assert.Null(entry.Signatures);
+        Assert.Equal("byte[] UnicodeToOctetString(this string s)", entry.Signature);
+    }
+
     private static List<ExtensionMethodResult> CreateOverloadResults() =>
     [
         new()

--- a/src/dotnet-inspect.Tests/RelationshipProjectScopeOptionsTests.cs
+++ b/src/dotnet-inspect.Tests/RelationshipProjectScopeOptionsTests.cs
@@ -1,0 +1,14 @@
+using DotnetInspector.Options;
+
+namespace DotnetInspector.Tests;
+
+public class RelationshipProjectScopeOptionsTests
+{
+    [Fact]
+    public void ProjectScope_CountsAsAssemblySourceScope()
+    {
+        Assert.True(new ImplementsOptions { Projects = ["App.csproj"] }.HasAnyScope);
+        Assert.True(new ExtensionsOptions { Projects = ["App.csproj"] }.HasAnyScope);
+        Assert.True(new DependsOptions { Projects = ["App.csproj"] }.HasAnyScope);
+    }
+}

--- a/src/dotnet-inspect/CommandLine/Commands/SearchCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/SearchCommandDefinitions.cs
@@ -143,6 +143,11 @@ public static class SearchCommandDefinitions
         var extensionsOption = new Option<bool>("--extensions") { Description = "Search curated Microsoft.Extensions.* packages" };
         var aspnetcoreOption = new Option<bool>("--aspnetcore") { Description = "Search curated Microsoft.AspNetCore.* packages" };
         var curatedOption = new Option<bool>("--curated") { Description = "Use default curated scope explicitly", Hidden = true };
+        var projectOption = new Option<string[]>("--project")
+        {
+            Description = "Search project dependencies via project.assets.json. Can repeat.",
+            AllowMultipleArgumentsPerToken = true
+        };
         var tfmOption = new Option<string?>("--tfm") { Description = "Target framework (e.g., net8.0)" };
         var allOption = new Option<bool>("--all") { Description = "Include non-public, hidden, and obsolete types" };
         var compactOption = new Option<bool>("--compact") { Description = "Minified JSON (use with --json)" };
@@ -158,6 +163,7 @@ public static class SearchCommandDefinitions
         implCommand.Options.Add(extensionsOption);
         implCommand.Options.Add(aspnetcoreOption);
         implCommand.Options.Add(curatedOption);
+        implCommand.Options.Add(projectOption);
         implCommand.Options.Add(tfmOption);
         implCommand.Options.Add(allOption);
         implCommand.Options.Add(typeFilterOption);
@@ -191,6 +197,7 @@ public static class SearchCommandDefinitions
             var packages = await CommandLineHelpers.MergeWithPrefixPackagesAsync(
                 parseResult.GetValue(packageOption) ?? [], packagePrefix, parseResult.GetValue(opts.Verbose));
             var assemblies = parseResult.GetValue(assemblyOption) ?? [];
+            var projects = parseResult.GetValue(projectOption) ?? [];
 
             var (allPlatformFrameworks, platformAssemblies) = CommandLineHelpers.ParsePlatformSearchOption(
                 parseResult,
@@ -202,7 +209,8 @@ public static class SearchCommandDefinitions
                 Extensions: parseResult.GetValue(extensionsOption),
                 AspNetCore: parseResult.GetValue(aspnetcoreOption),
                 Curated: parseResult.GetValue(curatedOption));
-            var scope = ScopeResolver.Resolve(scopeFlags, packages, assemblies, packagePrefix, platformAssemblies.Length > 0);
+            var scope = ScopeResolver.Resolve(scopeFlags, packages, assemblies, packagePrefix,
+                hasOtherScopeIndicators: projects.Length > 0 || platformAssemblies.Length > 0);
 
             var options = new ImplementsOptions
             {
@@ -211,6 +219,7 @@ public static class SearchCommandDefinitions
                 Assemblies = assemblies,
                 PlatformAssemblies = platformAssemblies,
                 PlatformFrameworks = scope.Frameworks,
+                Projects = projects,
                 Tfm = parseResult.GetValue(tfmOption),
                 IncludeAll = parseResult.GetValue(allOption),
                 Limit = CommandLineHelpers.ParseTypeLimit(parseResult.GetValue(typeFilterOption)),
@@ -262,6 +271,11 @@ public static class SearchCommandDefinitions
         var extensionsOption = new Option<bool>("--extensions") { Description = "Search curated Microsoft.Extensions.* packages" };
         var aspnetcoreOption = new Option<bool>("--aspnetcore") { Description = "Search curated Microsoft.AspNetCore.* packages" };
         var curatedOption = new Option<bool>("--curated") { Description = "Use default curated scope explicitly", Hidden = true };
+        var projectOption = new Option<string[]>("--project")
+        {
+            Description = "Search project dependencies via project.assets.json. Can repeat.",
+            AllowMultipleArgumentsPerToken = true
+        };
         var reachableOption = new Option<bool>("--reachable")
         {
             Description = "Include extensions on types reachable via properties/methods"
@@ -286,6 +300,7 @@ public static class SearchCommandDefinitions
         extCommand.Options.Add(extensionsOption);
         extCommand.Options.Add(aspnetcoreOption);
         extCommand.Options.Add(curatedOption);
+        extCommand.Options.Add(projectOption);
         extCommand.Options.Add(reachableOption);
         extCommand.Options.Add(depthOption);
         extCommand.Options.Add(tfmOption);
@@ -318,6 +333,7 @@ public static class SearchCommandDefinitions
             var packages = await CommandLineHelpers.MergeWithPrefixPackagesAsync(
                 parseResult.GetValue(packageOption) ?? [], packagePrefix, parseResult.GetValue(opts.Verbose));
             var assemblies = parseResult.GetValue(assemblyOption) ?? [];
+            var projects = parseResult.GetValue(projectOption) ?? [];
 
             var (allPlatformFrameworks, platformAssemblies) = CommandLineHelpers.ParsePlatformSearchOption(
                 parseResult,
@@ -329,7 +345,8 @@ public static class SearchCommandDefinitions
                 Extensions: parseResult.GetValue(extensionsOption),
                 AspNetCore: parseResult.GetValue(aspnetcoreOption),
                 Curated: parseResult.GetValue(curatedOption));
-            var scope = ScopeResolver.Resolve(scopeFlags, packages, assemblies, packagePrefix, platformAssemblies.Length > 0);
+            var scope = ScopeResolver.Resolve(scopeFlags, packages, assemblies, packagePrefix,
+                hasOtherScopeIndicators: projects.Length > 0 || platformAssemblies.Length > 0);
 
             var options = new ExtensionsOptions
             {
@@ -338,6 +355,7 @@ public static class SearchCommandDefinitions
                 Assemblies = assemblies,
                 PlatformAssemblies = platformAssemblies,
                 PlatformFrameworks = scope.Frameworks,
+                Projects = projects,
                 Reachable = parseResult.GetValue(reachableOption),
                 Depth = parseResult.GetValue(depthOption),
                 Tfm = parseResult.GetValue(tfmOption),
@@ -384,6 +402,11 @@ public static class SearchCommandDefinitions
         var extensionsOption = new Option<bool>("--extensions") { Description = "Search curated Microsoft.Extensions.* packages" };
         var aspnetcoreOption = new Option<bool>("--aspnetcore") { Description = "Search curated Microsoft.AspNetCore.* packages" };
         var curatedOption = new Option<bool>("--curated") { Description = "Use default curated scope explicitly", Hidden = true };
+        var projectOption = new Option<string[]>("--project")
+        {
+            Description = "Search project dependencies via project.assets.json. Can repeat.",
+            AllowMultipleArgumentsPerToken = true
+        };
         var tfmOption = new Option<string?>("--tfm") { Description = "Target framework (e.g., net8.0)" };
         var compactOption = new Option<bool>("--compact") { Description = "Minified JSON (use with --json)" };
 
@@ -395,6 +418,7 @@ public static class SearchCommandDefinitions
         dependsCommand.Options.Add(extensionsOption);
         dependsCommand.Options.Add(aspnetcoreOption);
         dependsCommand.Options.Add(curatedOption);
+        dependsCommand.Options.Add(projectOption);
         dependsCommand.Options.Add(tfmOption);
         dependsCommand.Options.Add(opts.Json);
         dependsCommand.Options.Add(compactOption);
@@ -409,6 +433,7 @@ public static class SearchCommandDefinitions
             var targetType = parseResult.GetValue(targetTypeArg);
             var packages = parseResult.GetValue(packageOption) ?? [];
             var assemblies = parseResult.GetValue(assemblyOption) ?? [];
+            var projects = parseResult.GetValue(projectOption) ?? [];
 
             // Mode detection: no type arg → library or package dependency mode
             if (string.IsNullOrEmpty(targetType))
@@ -426,10 +451,10 @@ public static class SearchCommandDefinitions
                     SourceOptions = opts.ParseNuGetSourceOptions(parseResult)
                 };
 
-                if (assemblies.Length == 1 && packages.Length == 0)
+                if (assemblies.Length == 1 && packages.Length == 0 && projects.Length == 0)
                     return await DependsCommand.ExecuteLibraryDependsAsync(commonOptions with { LibraryName = assemblies[0] });
 
-                if (packages.Length == 1 && assemblies.Length == 0)
+                if (packages.Length == 1 && assemblies.Length == 0 && projects.Length == 0)
                     return await DependsCommand.ExecutePackageDependsAsync(commonOptions with { PackageName = packages[0] });
 
                 return TipWriter.MissingArgumentWithTips(dependsCommand,
@@ -449,7 +474,8 @@ public static class SearchCommandDefinitions
                 Extensions: parseResult.GetValue(extensionsOption),
                 AspNetCore: parseResult.GetValue(aspnetcoreOption),
                 Curated: parseResult.GetValue(curatedOption));
-            var scope = ScopeResolver.Resolve(scopeFlags, packages, assemblies, hasOtherScopeIndicators: platformAssemblies.Length > 0);
+            var scope = ScopeResolver.Resolve(scopeFlags, packages, assemblies,
+                hasOtherScopeIndicators: projects.Length > 0 || platformAssemblies.Length > 0);
 
             var options = new DependsOptions
             {
@@ -458,6 +484,7 @@ public static class SearchCommandDefinitions
                 Assemblies = assemblies,
                 PlatformAssemblies = platformAssemblies,
                 PlatformFrameworks = scope.Frameworks,
+                Projects = projects,
                 Tfm = parseResult.GetValue(tfmOption),
                 JsonOutput = parseResult.GetValue(opts.Json),
                 CompactJson = parseResult.GetValue(compactOption),

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -203,7 +203,7 @@ public class ExtensionsCommand
             {
                 var first = g.First();
                 var signatures = g.Select(r => r.Signature).Where(s => s != null).Distinct().Cast<string>().ToList();
-                var count = g.Count();
+                var count = signatures.Count > 0 ? signatures.Count : g.Count();
                 return first with
                 {
                     Overloads = count > 1 ? count : null,

--- a/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
@@ -81,7 +81,22 @@ public static class AssemblyCollector
             assemblyPaths.Add(new AssemblyInfo(asmPath, Path.GetFileName(asmPath), null));
         }
 
-        // 3. Platform assemblies
+        // 3. Project assets
+        foreach (var projectPath in options.Projects)
+        {
+            var assetsPath = ProjectAssetsParser.FindAssets(projectPath);
+            if (assetsPath == null)
+            {
+                Console.Error.WriteLine($"Warning: project.assets.json not found for '{projectPath}'. Run 'dotnet restore'.");
+                continue;
+            }
+
+            logger.Log($"Using assets: {assetsPath}");
+            foreach (var (asmPath, packageName, packageVersion) in ProjectAssetsParser.Parse(assetsPath, options.Tfm, logger.Log))
+                assemblyPaths.Add(new AssemblyInfo(asmPath, packageName, packageVersion));
+        }
+
+        // 4. Platform assemblies
         foreach (var platformAsm in options.PlatformAssemblies)
         {
             var (assemblyPath, resolvedFramework, version, error) = await PlatformResolver.ResolveAssemblyAsync(platformAsm, httpClient, logger.Log);
@@ -93,7 +108,7 @@ public static class AssemblyCollector
             assemblyPaths.Add(new AssemblyInfo(assemblyPath!, resolvedFramework ?? "platform", version));
         }
 
-        // 4. Platform frameworks (download ref packs only if not locally available)
+        // 5. Platform frameworks (download ref packs only if not locally available)
         if (options.PlatformFrameworks.Length > 0)
         {
             var requests = PlatformPackService.GetMissingPackRequests(options.PlatformFrameworks);

--- a/src/dotnet-inspect/Inspectors/CallerScopeResolver.cs
+++ b/src/dotnet-inspect/Inspectors/CallerScopeResolver.cs
@@ -125,6 +125,7 @@ public static class CallerScopeResolver
         public string[] Assemblies { get; } = [];
         public string[] PlatformAssemblies { get; } = [];
         public string[] PlatformFrameworks { get; } = [];
+        public string[] Projects { get; } = [];
         public string? Tfm { get; }
         
         NuGetSourceOptions? IAssemblySourceOptions.SourceOptions => null;

--- a/src/dotnet-inspect/Options/DependsOptions.cs
+++ b/src/dotnet-inspect/Options/DependsOptions.cs
@@ -43,6 +43,11 @@ public record DependsOptions : IAssemblySourceOptions
     public string[] PlatformFrameworks { get; init; } = [];
 
     /// <summary>
+    /// Project files, directories, or project.assets.json paths to search via restored assets.
+    /// </summary>
+    public string[] Projects { get; init; } = [];
+
+    /// <summary>
     /// Target framework moniker (e.g., net8.0).
     /// </summary>
     public string? Tfm { get; init; }
@@ -94,7 +99,8 @@ public record DependsOptions : IAssemblySourceOptions
         Packages.Length > 0 ||
         Assemblies.Length > 0 ||
         PlatformAssemblies.Length > 0 ||
-        PlatformFrameworks.Length > 0;
+        PlatformFrameworks.Length > 0 ||
+        Projects.Length > 0;
 
     /// <summary>
     /// True when output is raw text (not rendered markdown).

--- a/src/dotnet-inspect/Options/ExtensionsOptions.cs
+++ b/src/dotnet-inspect/Options/ExtensionsOptions.cs
@@ -33,6 +33,11 @@ public record ExtensionsOptions : IAssemblySourceOptions
     public string[] PlatformFrameworks { get; init; } = [];
 
     /// <summary>
+    /// Project files, directories, or project.assets.json paths to search via restored assets.
+    /// </summary>
+    public string[] Projects { get; init; } = [];
+
+    /// <summary>
     /// Include extensions on types reachable via properties/methods.
     /// </summary>
     public bool Reachable { get; init; }
@@ -105,6 +110,7 @@ public record ExtensionsOptions : IAssemblySourceOptions
         Assemblies.Length > 0 ||
         PlatformAssemblies.Length > 0 ||
         PlatformFrameworks.Length > 0 ||
+        Projects.Length > 0 ||
         PackagePrefix != null;
 
     /// <summary>

--- a/src/dotnet-inspect/Options/IAssemblySourceOptions.cs
+++ b/src/dotnet-inspect/Options/IAssemblySourceOptions.cs
@@ -28,6 +28,11 @@ public interface IAssemblySourceOptions
     string[] PlatformFrameworks { get; }
 
     /// <summary>
+    /// Project files, directories, or project.assets.json paths to search via restored assets.
+    /// </summary>
+    string[] Projects { get; }
+
+    /// <summary>
     /// Target framework moniker filter.
     /// </summary>
     string? Tfm { get; }

--- a/src/dotnet-inspect/Options/ImplementsOptions.cs
+++ b/src/dotnet-inspect/Options/ImplementsOptions.cs
@@ -33,6 +33,11 @@ public record ImplementsOptions : IAssemblySourceOptions
     public string[] PlatformFrameworks { get; init; } = [];
 
     /// <summary>
+    /// Project files, directories, or project.assets.json paths to search via restored assets.
+    /// </summary>
+    public string[] Projects { get; init; } = [];
+
+    /// <summary>
     /// Target framework moniker (e.g., net8.0).
     /// </summary>
     public string? Tfm { get; init; }
@@ -130,6 +135,7 @@ public record ImplementsOptions : IAssemblySourceOptions
         Assemblies.Length > 0 ||
         PlatformAssemblies.Length > 0 ||
         PlatformFrameworks.Length > 0 ||
+        Projects.Length > 0 ||
         PackagePrefix != null;
 
     /// <summary>


### PR DESCRIPTION
## Summary

- Adds `--project` restored-assets scope to `implements`, `extensions`, and type-mode `depends`.
- Expands projects through shared `AssemblyCollector` using existing `project.assets.json`, preserving package/version provenance.
- Keeps existing `find --project` and member caller-scope project paths separate.

Follow-up to #2082.

## Examples

Cross-library type relationship from project-referenced packages:

```bash
dotnet-inspect implements IEquatable --project src/dotnet-inspect/dotnet-inspect.csproj -v:q -n 40
```

Representative sources include `Markout@0.14.0`, `NuGet.Versioning@7.3.0`, `NuGetFetch@0.6.2`, `SourceLinkFetch@0.1.0`, and `System.CommandLine@3.0.0-preview.5.26302.115`.

Project-scoped extensions:

```bash
dotnet-inspect extensions string --project src/dotnet-inspect/dotnet-inspect.csproj -v:n -n 40
```

Project-scoped type dependencies:

```bash
dotnet-inspect depends Command --project src/dotnet-inspect/dotnet-inspect.csproj -v:q -n 40
```

## Adversarial review

Requested reviews from Claude Opus 4.8 and Gemini 3.1 Pro.

Both found no significant issues. They verified:

- all `IAssemblySourceOptions` implementers expose `Projects`;
- project scope prevents relationship commands from defaulting to platform scope;
- `depends` no-argument package/library modes are not confused by `--project`;
- `find --project` and member caller-scope paths are not double-processed;
- project assembly provenance is stamped as package/version.

## Validation

- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -class "*RelationshipProjectScopeOptionsTests"`
- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507`
- `dotnet run --project src/dotnet-inspect -c Release -p:NoWarn=NU1507 -- implements IEquatable --project src/dotnet-inspect/dotnet-inspect.csproj -v:q -n 40`
- `dotnet run --project src/dotnet-inspect -c Release -p:NoWarn=NU1507 -- extensions string --project src/dotnet-inspect/dotnet-inspect.csproj -v:n -n 40`
- `dotnet run --project src/dotnet-inspect -c Release -p:NoWarn=NU1507 -- depends Command --project src/dotnet-inspect/dotnet-inspect.csproj -v:q -n 40`
- `git diff --check`
