### PR TITLE
Make post-dominance queryable in Performance Triage

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -410,6 +410,24 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task PerformanceTriageWhere_FiltersByPostDominance()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "library", TestAssemblyPath,
+            "-S", "Performance Triage",
+            "--where", "Post Dominance=return-post-dominates",
+            "--order-by", "PostDominance desc,RootReach desc",
+            "--tsv",
+            "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        var rows = output.TrimEnd().Split('\n').Skip(1).ToArray();
+        Assert.NotEmpty(rows);
+        Assert.All(rows, row => Assert.Contains("\treturn-post-dominates\t", row));
+    }
+
+    [Fact]
     public async Task PerformanceTriageCount_AppliesWhereBeforeTop()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -919,6 +919,7 @@ internal static class LibraryMetadataService
             "Allocation" => opportunity.RuntimeAllocationType,
             "Path" => opportunity.PathContext,
             "PathConfidence" => opportunity.PathConfidence,
+            "PostDominance" => opportunity.PostDominance,
             "IL" => opportunity.ILOffset is { } offset ? $"IL_{offset:X4}" : null,
             "RootReach" => opportunity.RootReach.ToString(CultureInfo.InvariantCulture),
             _ => null,

--- a/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
+++ b/src/dotnet-inspect/Options/PerformanceTriageOptions.cs
@@ -30,6 +30,7 @@ public sealed record PerformanceTriageOptions
         "Allocation",
         "Path",
         "PathConfidence",
+        "PostDominance",
         "IL",
     ];
 
@@ -45,6 +46,7 @@ public sealed record PerformanceTriageOptions
         "Allocation",
         "Path",
         "PathConfidence",
+        "PostDominance",
     ];
 
     public static readonly string[] KnownShapes =


### PR DESCRIPTION
## Summary

Follow-up to #2091: registers `PostDominance` as a Performance Triage row-query field.

- Adds `PostDominance` to Performance Triage filterable and sortable field metadata.
- Maps `PostDominance` in row predicate/order value extraction.
- Adds a command test for `--where "Post Dominance=return-post-dominates"` and `--order-by "PostDominance desc,RootReach desc"`.

## Validation

- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config -p:NoWarn=NU1507`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -method '*PerformanceTriageWhere_FiltersByPostDominance*'`
- CLI probe: `dotnet-inspect library artifacts/bin/ILInspector.Analysis/release/ILInspector.Analysis.dll -S "Performance Triage" --where "Post Dominance=return-post-dominates" --order-by "PostDominance desc,RootReach desc" --jsonl --fields "Member,Shape,Path,Path Confidence,Post Dominance,RootReach,IL" --top 3`

Low-risk CLI query metadata follow-up; no analysis semantics changed.
