### PR TITLE
Document allocation metadata readout guidance

### DIFF
--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -67,6 +67,33 @@ times out, or whose diagnostics increase) exits nonzero; signal-count DRIFT is r
 failed. Each assembly is bounded by a per-assembly timeout so one pathological input cannot hang
 the sweep.
 
+Allocation metadata readout is a measurement-only companion for deciding whether
+path/escape evidence is strong enough to inform future confidence or ranking work:
+
+```bash
+bash eng/prepare-decompiler-corpus.sh /tmp/corpus-assemblies.txt
+dotnet run --project tools/AnalysisHarness -c Release -- \
+  --allocation-readout /tmp/corpus-assemblies.txt --top 12
+dotnet run --project tools/AnalysisHarness -c Release -- \
+  --allocation-readout /tmp/corpus-assemblies.txt --json
+```
+
+The readout aggregates occurrence buckets (`kind`, `allocation`, `path`,
+`path-confidence`, `post-dominance`, `escape`) and opportunity buckets (`shape`,
+`allocation`, `path`, `path-confidence`, `post-dominance`, `confidence`), plus
+cross-tabs. Text output caps each bucket with `--top`; JSON keeps all buckets.
+Use it before changing confidence/ranking so the proposal names its measured
+population.
+
+A 2026-07-01 fixed-corpus run (`14/14` assemblies opened) showed 41,890
+allocation occurrences and 6,587 optimization opportunities. `return-post-dominates`
+was common (29,175 occurrences; 4,817 opportunities), but not selective by
+itself: it appears heavily in `small-array`, `box-value-type`, and delegate
+rows. `local-only` escape evidence was sparse (133 occurrences, ~0.3%), so
+`LocalOnly + post-dominance` is not yet broad enough to justify global confidence
+or ranking changes. Treat this as a query/example signal first; behavior changes
+should remain shape-specific and cite the measured bucket they target.
+
 Layer 3 (sampled precision/recall) splits by oracle: recall is mechanical once curated, precision
 needs judgement.
 


### PR DESCRIPTION
## Summary

Documents how to use the merged allocation metadata readout before changing confidence or ranking.

- Adds the `--allocation-readout` command shape to `tools/AnalysisHarness/README.md`.
- Records the 2026-07-01 fixed-corpus readout summary: 14/14 assemblies opened, 41,890 allocation occurrences, 6,587 optimization opportunities.
- Captures the conclusion that `return-post-dominates` is common but not selective by itself, and `local-only` escape evidence is too sparse for global confidence/ranking changes.

## Validation

- `npx markdownlint-cli tools/AnalysisHarness/README.md`

Docs-only measurement note; no product behavior changes.
