### PR TITLE
Document ReturnToSender compile-back PR template evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,9 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
 
 For decompiler-affecting PRs, follow this evidence and review contract:
 
-- Use `docs/templates/decompiler-pr.md` for general decompiler PR bodies and
+- Use `docs/templates/decompiler-pr.md` for general decompiler PR bodies,
+  `docs/templates/decompiler-compile-back-harness-pr.md` for DecompilerHarness /
+  ReturnToSender / compile-back coverage PRs, and
   `docs/templates/decompiler-burndown-fix-pr.md` for focused invalid-`Full` /
   burndown row fixes. Keep the human summary terse and conclusion-first.
 - Include the tool-generated quality-diff card; do not hand-construct or re-key

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -501,7 +501,11 @@ drill-down. To reproduce the full row set behind a capped card, follow
 [Reproducing decompiler corpus deltas](decompiler-corpus-delta-repro.md).
 Use the terse PR body shape in
 [docs/templates/decompiler-pr.md](templates/decompiler-pr.md) when writing the
-human summary around the generated card.
+human summary around the generated card. For DecompilerHarness,
+ReturnToSender, fidelity skeleton, or compile-back coverage PRs, use
+[docs/templates/decompiler-compile-back-harness-pr.md](templates/decompiler-compile-back-harness-pr.md)
+instead so the PR records the targeted checked population and RTS/current A/B
+evidence.
 
 Rate deltas in card prose use **percentage points** (`pp`): `+0.49 pp` means
 the rate increased from, for example, `82.17%` to `82.66%`. Counts still use raw

--- a/docs/templates/decompiler-compile-back-harness-pr.md
+++ b/docs/templates/decompiler-compile-back-harness-pr.md
@@ -1,10 +1,10 @@
 # Decompiler compile-back harness PR template
 
 <!--
-Use this for DecompilerHarness / fidelity skeleton / compile-back coverage PRs.
-The center of gravity is the checkable population: what was uncheckable before,
-what became Exact or OpcodeDiff after, and which frontier remains. Delete
-sections that do not apply.
+Use this for DecompilerHarness / fidelity skeleton / ReturnToSender (RTS) /
+compile-back coverage PRs. The center of gravity is the checkable population:
+what was uncheckable before, what became Exact or OpcodeDiff after, and which
+frontier remains. Delete sections that do not apply.
 -->
 
 - Advances #{issue-or-track}
@@ -33,9 +33,11 @@ After:
 ## Scope and safety
 
 - **Root cause:** {why compile-back could not check the method population}.
-- **Fix shape:** {skeleton/context/metadata/reference/fixture change}.
+- **Fix shape:** {skeleton/context/metadata/reference/fixture/RTS orchestration change}.
 - **Product impact:** {none, or explain any product-output behavior change}.
 - **Scope boundary:** {nearby failure intentionally left as a frontier or future issue}.
+- **RTS boundary:** {not applicable / RTS only orchestrates closure + Roslyn +
+  opcode compare; product/shared code owns C# source generation}.
 
 ## Evidence
 
@@ -45,6 +47,7 @@ After:
 | Focused tests | `{test class or method}` passed |
 | Decompiler fast suite | Pass |
 | Targeted compile-back | `{target population}` improved `{before}` -> `{after}` |
+| ReturnToSender A/B | `{same target set}` `{rescued/same/worse/current-missing}` |
 | Broad compile-back | `{assembly/cap}` `{summary}` |
 | Build-event validation | Pass / not applicable |
 | Real witness | `{Type::Method}` moved `{before bucket}` -> `{after bucket}` |
@@ -93,6 +96,41 @@ COMPILE-BACK over {cap} rendered methods ({Full} Full)
 **Broad verdict:** **PASS/ADVISORY/BLOCKED** — {one-line context; explain if
 the broad cap should be unchanged because the fix is targeted-path-only}.
 
+### ReturnToSender A/B
+
+Use this section for RTS PRs. The A/B card must compare RTS against the current
+compile-back path on the same intended population. If the current side is capped
+or missing rows, say that plainly; `CurrentMissing` is coverage context, not a
+rescue.
+
+Run: `{assembly}`, `{cap}`, `{max examples}`.
+
+```text
+RETURNTOSENDER A/B over {N} property getters
+
+  Rescued       : {count}
+  Same          : {count}
+  Changed       : {count}
+  Worse         : {count}
+  CurrentMissing: {count}
+```
+
+| Delta | Count | Interpretation | Example |
+| --- | ---: | --- | --- |
+| Rescued (+) | {count} | RTS checked a row current compile-back could not | `{Type::Method}` |
+| Same (=) | {count} | RTS matched current status | `{Type::Method}` |
+| Worse (-) | {count} | RTS lost current checked fidelity | `{Type::Method}` |
+| CurrentMissing (?) | {count} | Current comparison did not reach this RTS target | `{Type::Method}` |
+
+**RTS verdict:** **PASS/ADVISORY/BLOCKED** — {whether this crosses, approaches,
+or fails the Rubicon for the claimed row}.
+
+Known product-shell frontiers:
+
+| Frontier | Status | Next owner |
+| --- | --- | --- |
+| `{auto/record property shell}` | `{Worse / RecompileFail / not touched}` | `{product declaration API / RTS orchestration / filed issue}` |
+
 ## Frontiers and non-actions
 
 | Item | Status | Reason |
@@ -140,6 +178,8 @@ dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet
 
 dotnet run --project tools/DecompilerHarness -c Release --no-build -- {assembly} --fidelity-check --fidelity-method-delta {delta-json} --max-examples {N}
 /usr/bin/time -f 'elapsed=%E cpu=%P maxrss=%MKB' dotnet run --project tools/DecompilerHarness -c Release --no-build -- {assembly} --fidelity-check --compile-cap {N} --max-examples {N} --fidelity-timings
+dotnet run --project tools/DecompilerHarness -c Release --no-build -- {assembly} --return-to-sender --cap {N} --max-examples {N}
+dotnet run --project tools/DecompilerHarness -c Release --no-build -- {assembly} --return-to-sender-ab --cap {N} --max-examples {N}
 
 /home/rich/git/dotnet-build-events-vmr-preview5-events/artifacts/preview5-events-sdk-test/dotnet build tools/DecompilerHarness --no-incremental --view types --event-log-stderr -c Release --nologo --verbosity quiet
 dotnet run --project /home/rich/git/dotnet-inspect-build-event-query/src/dotnet-inspect -c Release --no-build -- build {before-log} -S Compare --compare {after-log} --tsv


### PR DESCRIPTION
## Summary

- Reuses the existing compile-back harness PR template for ReturnToSender work.
- Adds an RTS A/B section, RTS boundary prompt, and validation commands.
- Links the template from AGENTS and decompiler quality guidance.

## Validation

```bash
npx markdownlint-cli --fix AGENTS.md docs/decompiler-quality.md docs/templates/decompiler-compile-back-harness-pr.md
npx markdownlint-cli AGENTS.md docs/decompiler-quality.md docs/templates/decompiler-compile-back-harness-pr.md
```

Docs-only; no product behavior change.
