### PR TITLE
Emit auto-property shells for RTS compile-back

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -422,6 +422,29 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackPropertyGetters_UsesAutoPropertyShellForRecordPropertyGetter()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed record Snapshot(string Assembly, int Count);
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackPropertyGetters(assemblyPath, maxTargets: 8)
+                .Single(item => item.Plan.TargetMethod.Method == "get_Assembly");
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            var member = Assert.Single(Assert.Single(result.Plan.Types).Members, member => member.Name == "Assembly");
+            Assert.Equal(CompileBackStubBodyKind.AutoProperty, member.StubBody);
+            Assert.Contains("public string Assembly { get; }", result.Source);
+            Assert.DoesNotContain("return this.Assembly;", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_PreservesStaticTargetPropertyShape()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -214,6 +214,7 @@ public enum CompileBackStubBodyKind
     None,
     Throw,
     TargetBody,
+    AutoProperty,
 }
 
 public sealed record CompileBackFact(string Producer, string Id, string Detail);
@@ -259,6 +260,7 @@ public static class CompileBackSourceComposer
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         string propertyName = Identifier(reader.GetString(property.Name));
         var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
+        bool targetIsAutoProperty = IsAutoProperty(reader, targetTypeDef, property, targetGetter, returnType.DisplayName);
 
         var diagnostics = new List<CompileBackPlanningDiagnostic>();
         var targetRoot = TopLevelRootOf(reader, targetType);
@@ -281,9 +283,14 @@ public static class CompileBackSourceComposer
                         reader.GetMethodDefinition(targetGetter).Attributes.HasFlag(MethodAttributes.Static),
                         [],
                         returnType,
-                        CompileBackStubBodyKind.TargetBody,
-                        targetBody,
-                        [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))])
+                        targetIsAutoProperty ? CompileBackStubBodyKind.AutoProperty : CompileBackStubBodyKind.TargetBody,
+                        targetIsAutoProperty ? null : targetBody,
+                        targetIsAutoProperty
+                            ? [
+                                new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name)),
+                                new CompileBackFact("metadata", "auto-property", propertyName)
+                            ]
+                            : [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))])
                 ],
                 targetFacts)
         };
@@ -440,6 +447,11 @@ public static class CompileBackSourceComposer
                     sb.AppendLine($"{pad}{declaration}");
                     return;
                 }
+                if (member.StubBody == CompileBackStubBodyKind.AutoProperty)
+                {
+                    sb.AppendLine($"{pad}{declaration} {{ get; }}");
+                    break;
+                }
 
                 sb.AppendLine($"{pad}{declaration}");
                 sb.AppendLine($"{pad}{{");
@@ -516,6 +528,46 @@ public static class CompileBackSourceComposer
             IsStatic = member.IsStatic,
             Accessibility = null,
         };
+    }
+
+    static bool IsAutoProperty(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        PropertyDefinition property,
+        MethodDefinitionHandle getterHandle,
+        string propertyType)
+    {
+        var accessors = property.GetAccessors();
+        if (accessors.Getter.IsNil || accessors.Getter != getterHandle)
+            return false;
+        var getter = reader.GetMethodDefinition(getterHandle);
+        if (!MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, getter.GetCustomAttributes()))
+            return false;
+
+        string propertyName = reader.GetString(property.Name);
+        string backingName = $"<{propertyName}>k__BackingField";
+        bool isStatic = getter.Attributes.HasFlag(MethodAttributes.Static);
+        var context = GenericContext.ForType(reader, typeDef);
+        foreach (var fieldHandle in typeDef.GetFields())
+        {
+            var field = reader.GetFieldDefinition(fieldHandle);
+            if (reader.GetString(field.Name) != backingName)
+                continue;
+            if (field.Attributes.HasFlag(FieldAttributes.Static) != isStatic)
+                continue;
+            if (!MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, field.GetCustomAttributes()))
+                return false;
+            try
+            {
+                return CompileBackTypeSignature.Display(field.DecodeSignature(SignatureDecoder.Instance, context)).DisplayName == propertyType;
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        return false;
     }
 
     static CompileBackTypeKind ShellKind(MetadataReader reader, TypeDefinition typeDef)


### PR DESCRIPTION
- Advances #2049 and #2050
- Changes product compile-back source generation: auto-property accessors use declaration shells instead of accessor body shells.
- Evidence revision: `ca6d2a39`

## Change

> Should we accept this harness/product-shell change?

**Conclusion:** **PASS** — it removes the known RTS A/B `Worse` rows for record/auto-property getters by letting product compile-back source generation emit the correct auto-property shell.

Before:

```csharp
public string Assembly
{
    get
    {
        return this.Assembly;
    }
}
```

After:

```csharp
public string Assembly { get; }
```

## Scope and safety

- **Root cause:** RTS composed a target getter body into a property declaration, so record/auto-property getters recompiled as recursive property calls (`ldarg call ret`) instead of backing-field loads (`ldarg ldfld ret`).
- **Fix shape:** product `CompileBackSourceComposer` detects compiler-generated backing-field-backed target getters and emits an `AutoProperty` declaration shell.
- **Product impact:** product compile-back source generation improves; no user-facing decompiler output behavior is claimed.
- **Scope boundary:** this handles getter fidelity only; richer source declaration shape (`init`, record positional syntax, setters) remains future product declaration work.
- **RTS boundary:** RTS only orchestrates closure + Roslyn + opcode compare; product/shared code owns C# source generation.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `ReturnToSenderPrototypeTests` 15/15 passed |
| Decompiler fast suite | Not run |
| Targeted compile-back | record positional getter exact via `AutoProperty` shell |
| ReturnToSender A/B | `Worse` 3 -> 0; `Same` 1 -> 4 on harness sample |
| Broad compile-back | Not run |
| Build-event validation | Not applicable |
| Real witness | `CorpusMethodSnapshot::{get_Assembly,get_AssemblyPath,get_Type}` no longer reported as Worse in the 10-row RTS A/B smoke |

## Compile-back quality

> Did this increase the checkable population without hiding a product defect?

**Conclusion:** **PASS** — it preserves getter opcode fidelity for compiler auto-properties and improves the RTS/current A/B card without changing product decompiler output.

### Targeted changed-method boss

Run: reduced record positional property fixture.

| Metric (goal) | Baseline | PR |
| --- | ---: | ---: |
| Current changed methods (context) | 1 | 1 |
| Attempted (+) | 1 | 1 |
| Exact (+) | 0 | 1 |
| OpcodeDiff Full (-) | 1 | 0 |
| Not Full (-) | 0 | 0 |
| RecompileFail (-) | 0 | 0 |
| ContextFail (-) | 0 | 0 |

| Bucket / code (goal) | Baseline | PR | Delta | Example |
| --- | ---: | ---: | ---: | --- |
| Exact (+) | 0 | 1 | +1 | `Snapshot::get_Assembly` |
| OpcodeDiff (-) | 1 | 0 | -1 | `Snapshot::get_Assembly` |

### Broad assembly context

Not run. This is a targeted RTS/product-shell fix.

### ReturnToSender A/B

Run: `ILInspector.Decompiler.Tests.dll`, cap 10, max examples 5.

```text
RETURNTOSENDER A/B over 10 property getters

  Rescued       : 0
  Same          : 4
  Changed       : 0
  Worse         : 0
  CurrentMissing: 6
```

| Delta | Count | Interpretation | Example |
| --- | ---: | --- | --- |
| Rescued (+) | 0 | RTS checked a row current compile-back could not | - |
| Same (=) | 4 | RTS matched current status | `CorpusMethodSnapshot::get_Assembly` |
| Worse (-) | 0 | RTS lost current checked fidelity | - |
| CurrentMissing (?) | 6 | Current comparison did not reach this RTS target | `CorpusMethodSnapshot::get_Method` |

**RTS verdict:** **PASS** — this fixes the first observed product-shell A/B regression; RTS still has `CurrentMissing` comparison coverage limitations.

Known product-shell frontiers:

| Frontier | Status | Next owner |
| --- | --- | --- |
| Setter/init/record declaration spelling | Not changed | Product declaration API |
| Broader exact target A/B matching | `CurrentMissing` remains | Harness A/B targeting |

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `{ get; init; }` spelling | Not changed | Getter IL fidelity is identical; source-shape spelling is separate product declaration work. |
| Non-auto property getters | Not changed | Must continue to use body shell and opcode comparison. |

## Build-event validation

**Conclusion:** **not applicable** — this PR is covered by product/harness builds and RTS compile-back tests.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Verified no false-Exact risk, detection breadth, record/init semantics, static/keyword/generic safety, and Roslyn-free product boundary. |
| Gemini 3.1 Pro | No blocking findings | Verified getter IL identity for get/init/set forms, static/struct/generic/explicit-interface/keyword cases, and architecture boundary. |

**Review conclusion:** **PASS** — both reviewers reported no blocking findings.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet -p:NoWarn=NU1507
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -method "*AutoPropertyShellForRecordPropertyGetter"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 10 --max-examples 5
```
