### PR TITLE
Thread assembly resolver into the Analysis metadata path (#2098 slice 1)

### DIFF
--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\DiffAsmFixtures.Target\DiffAsmFixtures.Target.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffAsmFixtures.Caller\DiffAsmFixtures.Caller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
+    <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
     <ProjectReference Include="..\..\tools\AnalysisHarness\AnalysisHarness.csproj" />
   </ItemGroup>
 

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -2,10 +2,13 @@ using System.Collections.Immutable;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+using DotnetInspector.Services;
 using ILInspector.Analysis;
+using ILInspector.Metadata;
 
 namespace ILInspector.Analysis.Tests;
 
@@ -22,6 +25,108 @@ public class LibraryBodyIndexTests
         Assert.Equal(CallKind.Call, call.Kind);
         Assert.Equal(TypeRef.CoreLib("System", "String"), Assert.Single(call.Callee.ParameterTypes));
         Assert.Empty(index.Diagnostics);
+    }
+
+    [Fact]
+    public void CrossAssemblyMetadataResolver_ResolvesFrameworkTypeDefinition()
+    {
+        string targetPath = typeof(Console).Assembly.Location;
+        var resolver = new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(targetPath)
+        {
+            IncludeDepsJsonAssets = false,
+            IncludeAspNetCoreSharedFramework = false,
+            PreferImplementationAssemblies = true,
+        });
+
+        using var stream = File.OpenRead(targetPath);
+        using var peReader = new PEReader(stream);
+        Assert.True(peReader.HasMetadata);
+        var reader = peReader.GetMetadataReader();
+        using var builder = new LibraryBodyIndex.IndexBuilder(targetPath, reader, peReader, resolver);
+
+        bool resolvedFrameworkType = false;
+        foreach (var handle in reader.TypeReferences)
+        {
+            var typeReference = reader.GetTypeReference(handle);
+            if (typeReference.ResolutionScope.Kind != HandleKind.AssemblyReference)
+                continue;
+            var assemblyReference = (AssemblyReferenceHandle)typeReference.ResolutionScope;
+            if (!FrameworkAssemblyKeys.IsFrameworkReference(reader, assemblyReference))
+                continue;
+
+            var resolved = builder.TryResolveExternalTypeDefinition(handle);
+            if (resolved is not { } definition)
+                continue;
+
+            var definingType = definition.DefiningReader.GetTypeDefinition(definition.Definition);
+            Assert.Equal(reader.GetString(typeReference.Name), definition.DefiningReader.GetString(definingType.Name));
+            Assert.True(
+                !definingType.BaseType.IsNil || definingType.GetFields().Count > 0 || definingType.GetMethods().Count > 0,
+                "resolved type metadata should be readable");
+            resolvedFrameworkType = true;
+            break;
+        }
+
+        Assert.True(resolvedFrameworkType, "expected at least one framework TypeRef to resolve to readable metadata");
+    }
+
+    [Fact]
+    public void CrossAssemblyMetadataResolver_NullResolverFailsHonest()
+    {
+        string targetPath = typeof(Console).Assembly.Location;
+        using var stream = File.OpenRead(targetPath);
+        using var peReader = new PEReader(stream);
+        Assert.True(peReader.HasMetadata);
+        var reader = peReader.GetMetadataReader();
+        var externalType = FirstExternalTypeReference(reader);
+        using var builder = new LibraryBodyIndex.IndexBuilder(targetPath, reader, peReader, resolver: null);
+
+        Assert.Null(builder.TryResolveExternalTypeDefinition(externalType));
+
+        var oneArg = LibraryBodyIndex.Open(targetPath);
+        var nullResolver = LibraryBodyIndex.Open(targetPath, resolver: null);
+        Assert.Equal(oneArg.Methods.Length, nullResolver.Methods.Length);
+        Assert.Equal(oneArg.DirectCalls.Length, nullResolver.DirectCalls.Length);
+        Assert.Equal(oneArg.UnsafeEvidence.Length, nullResolver.UnsafeEvidence.Length);
+        Assert.Equal(oneArg.Diagnostics.Length, nullResolver.Diagnostics.Length);
+    }
+
+    [Fact]
+    public void Open_WithResolverDoesNotChangeIndexShape()
+    {
+        string targetPath = typeof(CallSiteFixtures).Assembly.Location;
+        var resolver = new CountingResolver();
+
+        var oneArg = LibraryBodyIndex.Open(targetPath);
+        var withResolver = LibraryBodyIndex.Open(targetPath, resolver);
+
+        Assert.Equal(oneArg.Methods.Length, withResolver.Methods.Length);
+        Assert.Equal(oneArg.DirectCalls.Length, withResolver.DirectCalls.Length);
+        Assert.Equal(oneArg.UnsafeEvidence.Length, withResolver.UnsafeEvidence.Length);
+        Assert.Equal(oneArg.Diagnostics.Length, withResolver.Diagnostics.Length);
+        Assert.Equal(0, resolver.ResolveCalls);
+    }
+
+    static TypeReferenceHandle FirstExternalTypeReference(MetadataReader reader)
+    {
+        foreach (var handle in reader.TypeReferences)
+        {
+            if (reader.GetTypeReference(handle).ResolutionScope.Kind == HandleKind.AssemblyReference)
+                return handle;
+        }
+
+        throw new InvalidOperationException("Expected at least one external TypeRef.");
+    }
+
+    sealed class CountingResolver : IAssemblyReferenceResolver
+    {
+        public int ResolveCalls { get; private set; }
+
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+        {
+            ResolveCalls++;
+            return null;
+        }
     }
 
     [Fact]

--- a/src/ILInspector.Analysis/ILInspector.Analysis.csproj
+++ b/src/ILInspector.Analysis/ILInspector.Analysis.csproj
@@ -16,8 +16,13 @@
   <!-- System.Reflection.Metadata is part of net10.0 BCL -->
 
   <ItemGroup>
+    <InternalsVisibleTo Include="ILInspector.Analysis.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ILInspector.ControlFlow\ILInspector.ControlFlow.csproj" />
     <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
+    <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -6,6 +6,7 @@ using System.Reflection.PortableExecutable;
 
 using ILInspector.ControlFlow;
 using ILInspector.Instructions;
+using ILInspector.Metadata;
 
 namespace ILInspector.Analysis;
 
@@ -687,13 +688,16 @@ public sealed class LibraryBodyIndex
     }
 
     public static LibraryBodyIndex Open(string path)
+        => Open(path, resolver: null);
+
+    public static LibraryBodyIndex Open(string path, IAssemblyReferenceResolver? resolver = null)
     {
         using var stream = File.OpenRead(path);
         using var peReader = new PEReader(stream);
         if (!peReader.HasMetadata)
             throw new BadImageFormatException($"No managed metadata: {path}");
         var reader = peReader.GetMetadataReader();
-        var builder = new IndexBuilder(path, reader, peReader);
+        using var builder = new IndexBuilder(path, reader, peReader, resolver);
         var index = builder.Build();
         return new LibraryBodyIndex(
             path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
@@ -1155,29 +1159,188 @@ public sealed class LibraryBodyIndex
             DeclaringType.Name: "Object"
         };
 
-    sealed class IndexBuilder
+    internal sealed class IndexBuilder : IDisposable
     {
         readonly string _path;
         readonly MetadataReader _reader;
         readonly PEReader _peReader;
+        readonly IAssemblyReferenceResolver? _resolver;
+        readonly Dictionary<AssemblyReferenceIdentity, ReferencedAssemblyMetadata?> _referencedAssemblyCache = new();
         readonly string _assemblyName;
         readonly Guid _mvid;
         readonly bool _memorySafetyRulesEnabled;
 
-        public IndexBuilder(string path, MetadataReader reader, PEReader peReader)
+        internal IndexBuilder(string path, MetadataReader reader, PEReader peReader, IAssemblyReferenceResolver? resolver = null)
         {
             _path = path;
             _reader = reader;
             _peReader = peReader;
+            _resolver = resolver;
             _assemblyName = reader.IsAssembly ? reader.GetString(reader.GetAssemblyDefinition().Name) : System.IO.Path.GetFileNameWithoutExtension(path);
             _mvid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
             _memorySafetyRulesEnabled = DetectMemorySafetyRules();
+        }
+
+        public void Dispose()
+        {
+            foreach (var assembly in _referencedAssemblyCache.Values)
+                assembly?.Dispose();
+            _referencedAssemblyCache.Clear();
         }
 
         // Roslyn's ModuleSymbol.UseUpdatedMemorySafetyRules: the module opted in
         // when MemorySafetyRulesAttribute is applied (emitted [module:], like
         // RefSafetyRulesAttribute). Check the module and assembly scopes.
         public bool MemorySafetyRulesEnabled => _memorySafetyRulesEnabled;
+
+        sealed class ReferencedAssemblyMetadata(Stream stream, PEReader peReader) : IDisposable
+        {
+            public MetadataReader Reader { get; } = peReader.GetMetadataReader();
+
+            public void Dispose()
+            {
+                peReader.Dispose();
+                stream.Dispose();
+            }
+        }
+
+        internal (MetadataReader DefiningReader, TypeDefinitionHandle Definition)? TryResolveExternalTypeDefinition(TypeReferenceHandle handle)
+            => TryResolveExternalTypeDefinition(handle, new HashSet<TypeReferenceHandle>());
+
+        (MetadataReader DefiningReader, TypeDefinitionHandle Definition)? TryResolveExternalTypeDefinition(
+            TypeReferenceHandle handle,
+            HashSet<TypeReferenceHandle> visited)
+        {
+            if (handle.IsNil || !visited.Add(handle))
+                return null;
+
+            var typeRef = _reader.GetTypeReference(handle);
+            string name = _reader.GetString(typeRef.Name);
+            string ns = _reader.GetString(typeRef.Namespace);
+            return typeRef.ResolutionScope.Kind switch
+            {
+                HandleKind.AssemblyReference => TryResolveTopLevelExternalType(
+                    (AssemblyReferenceHandle)typeRef.ResolutionScope,
+                    ns,
+                    name),
+                HandleKind.TypeReference => TryResolveNestedExternalType(
+                    (TypeReferenceHandle)typeRef.ResolutionScope,
+                    ns,
+                    name,
+                    visited),
+                _ => null,
+            };
+        }
+
+        (MetadataReader DefiningReader, TypeDefinitionHandle Definition)? TryResolveTopLevelExternalType(
+            AssemblyReferenceHandle assemblyReference,
+            string ns,
+            string name)
+        {
+            var metadata = ResolveReferencedAssembly(assemblyReference);
+            if (metadata is null)
+                return null;
+
+            foreach (var candidateHandle in metadata.Reader.TypeDefinitions)
+            {
+                var candidate = metadata.Reader.GetTypeDefinition(candidateHandle);
+                if (candidate.IsNested)
+                    continue;
+                if (metadata.Reader.StringComparer.Equals(candidate.Namespace, ns)
+                    && metadata.Reader.StringComparer.Equals(candidate.Name, name))
+                    return (metadata.Reader, candidateHandle);
+            }
+
+            return null;
+        }
+
+        (MetadataReader DefiningReader, TypeDefinitionHandle Definition)? TryResolveNestedExternalType(
+            TypeReferenceHandle declaringReference,
+            string ns,
+            string name,
+            HashSet<TypeReferenceHandle> visited)
+        {
+            var declaring = TryResolveExternalTypeDefinition(declaringReference, visited);
+            if (declaring is not { } resolvedDeclaring)
+                return null;
+
+            var declaringDefinition = resolvedDeclaring.DefiningReader.GetTypeDefinition(resolvedDeclaring.Definition);
+            foreach (var nestedHandle in declaringDefinition.GetNestedTypes())
+            {
+                var nested = resolvedDeclaring.DefiningReader.GetTypeDefinition(nestedHandle);
+                if ((ns.Length == 0 || resolvedDeclaring.DefiningReader.StringComparer.Equals(nested.Namespace, ns))
+                    && resolvedDeclaring.DefiningReader.StringComparer.Equals(nested.Name, name))
+                    return (resolvedDeclaring.DefiningReader, nestedHandle);
+            }
+
+            return null;
+        }
+
+        ReferencedAssemblyMetadata? ResolveReferencedAssembly(AssemblyReferenceHandle handle)
+        {
+            var identity = AssemblyReferenceIdentity.From(_reader, handle);
+            if (_referencedAssemblyCache.TryGetValue(identity, out var cached))
+                return cached;
+
+            var resolved = OpenReferencedAssembly(identity, ScopeForReference(handle));
+            _referencedAssemblyCache[identity] = resolved;
+            return resolved;
+        }
+
+        ReferencedAssemblyMetadata? OpenReferencedAssembly(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+        {
+            if (_resolver is null)
+                return null;
+
+            ResolvedAssemblyReference? resolved;
+            try
+            {
+                resolved = _resolver.Resolve(identity, scope);
+            }
+            catch (Exception ex) when (IsRecoverableReferenceResolutionFailure(ex))
+            {
+                return null;
+            }
+
+            if (resolved?.Path is not { Length: > 0 } path || !File.Exists(path))
+                return null;
+
+            Stream? stream = null;
+            PEReader? peReader = null;
+            try
+            {
+                stream = File.OpenRead(path);
+                peReader = new PEReader(stream);
+                if (!peReader.HasMetadata)
+                    return null;
+                var metadata = new ReferencedAssemblyMetadata(stream, peReader);
+                stream = null;
+                peReader = null;
+                return metadata;
+            }
+            catch (Exception ex) when (IsRecoverableReferenceResolutionFailure(ex))
+            {
+                return null;
+            }
+            finally
+            {
+                peReader?.Dispose();
+                stream?.Dispose();
+            }
+        }
+
+        AssemblyResolutionScope ScopeForReference(AssemblyReferenceHandle handle)
+            => FrameworkAssemblyKeys.IsFrameworkReference(_reader, handle)
+                ? AssemblyResolutionScope.Platform
+                : AssemblyResolutionScope.Any;
+
+        static bool IsRecoverableReferenceResolutionFailure(Exception ex)
+            => ex is IOException
+                or UnauthorizedAccessException
+                or BadImageFormatException
+                or InvalidOperationException
+                or NotSupportedException
+                or ArgumentException;
 
         sealed class DecodedBody
         {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Inspectors;
+using DotnetInspector.Commands;
 using DotnetInspector.Core;
 using ILInspector.Metadata;
 using System.Security.Cryptography;
@@ -19,6 +20,9 @@ namespace DotnetInspector.Output;
 /// </summary>
 public static class ApiOutputFormatter
 {
+    static IAssemblyReferenceResolver AnalysisReferenceResolver(string dllPath, ApiOptions? options = null)
+        => ApiCommand.PlatformAssemblyResolver(dllPath, options?.ProjectAssetsPath, options?.Tfm);
+
     // ===== Full API View Model Factory =====
 
     internal static (CliApiSurface view, int truncatedCount) BuildFullApiView(ApiSurface api, ApiOptions options)
@@ -1074,6 +1078,7 @@ public static class ApiOutputFormatter
 
         var memberCode = new MemberCodeView();
         bool hasCode = false;
+        var assemblyResolver = AnalysisReferenceResolver(dllPath, options);
 
         // For sections that require a single selected method (Calls, CallGraph, decompiled source, etc.),
         // filter to that specific overload. Callers can aggregate across all overloads.
@@ -1089,7 +1094,7 @@ public static class ApiOutputFormatter
         if (request.Calls && singleMethodList is [{ MetadataToken: { } token } callsMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.calls", callsMethod.Name);
-            var index = Analysis.LibraryBodyIndex.Open(dllPath);
+            var index = Analysis.LibraryBodyIndex.Open(dllPath, assemblyResolver);
             var rows = index.DirectCalls
                 .Where(call => call.Caller.MetadataToken == token)
                 .OrderBy(call => call.ILOffset)
@@ -1135,7 +1140,7 @@ public static class ApiOutputFormatter
         if (request.Callers && methods.Count > 0)
         {
             RequestTelemetry.Breadcrumb("il-analysis.callers", $"{methods.Count} member(s)");
-            var index = Analysis.LibraryBodyIndex.Open(dllPath);
+            var index = Analysis.LibraryBodyIndex.Open(dllPath, assemblyResolver);
             var ownSource = Path.GetFileNameWithoutExtension(dllPath);
             var rows = new List<CallerSiteRow>();
 
@@ -1169,7 +1174,7 @@ public static class ApiOutputFormatter
                         Analysis.LibraryBodyIndex scopeIndex;
                         try
                         {
-                            scopeIndex = Analysis.LibraryBodyIndex.Open(scopePath);
+                            scopeIndex = Analysis.LibraryBodyIndex.Open(scopePath, AnalysisReferenceResolver(scopePath, options));
                         }
                         catch
                         {
@@ -1207,7 +1212,7 @@ public static class ApiOutputFormatter
         if (request.CallGraph && singleMethodList is [{ MetadataToken: { } graphToken } graphMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.call-graph", graphMethod.Name);
-            var index = Analysis.LibraryBodyIndex.Open(dllPath);
+            var index = Analysis.LibraryBodyIndex.Open(dllPath, assemblyResolver);
             var root = ToCallGraphNode(index.BuildCallTree(graphToken), GetRequestedCallGraphFields(options));
             if (root.Children is { Count: > 0 })
             {
@@ -1225,7 +1230,7 @@ public static class ApiOutputFormatter
         if (requestedSections.Contains(SectionNames.CallerGraph) && singleMethodList is [{ MetadataToken: { } callerGraphToken } callerGraphMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.caller-graph", callerGraphMethod.Name);
-            var index = Analysis.LibraryBodyIndex.Open(dllPath);
+            var index = Analysis.LibraryBodyIndex.Open(dllPath, assemblyResolver);
             // Extend the reverse graph across the caller scope (--bin/--project/--caller-package)
             // so a dependency member surfaces the product entry points and callers that reach it.
             var scopeIndexes = new List<Analysis.LibraryBodyIndex>();
@@ -1235,7 +1240,7 @@ public static class ApiOutputFormatter
                 {
                     try
                     {
-                        scopeIndexes.Add(Analysis.LibraryBodyIndex.Open(scopePath));
+                        scopeIndexes.Add(Analysis.LibraryBodyIndex.Open(scopePath, AnalysisReferenceResolver(scopePath, options)));
                     }
                     catch
                     {
@@ -1257,7 +1262,7 @@ public static class ApiOutputFormatter
         if (request.UnsafeOperations && singleMethodList is [{ MetadataToken: { } unsafeToken } unsafeMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.unsafe", unsafeMethod.Name);
-            var index = Analysis.LibraryBodyIndex.Open(dllPath);
+            var index = Analysis.LibraryBodyIndex.Open(dllPath, assemblyResolver);
             var evidence = index.UnsafeEvidence
                 .Where(evidence => evidence.Member.MetadataToken == unsafeToken)
                 .OrderBy(evidence => evidence.ILOffset ?? -1)
@@ -1299,7 +1304,7 @@ public static class ApiOutputFormatter
         if (requestedSections.Overlaps(SemanticFactSections) && singleMethodList is [{ MetadataToken: { } semanticToken } semanticMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.semantic-facts", semanticMethod.Name);
-            var index = Analysis.LibraryBodyIndex.Open(dllPath);
+            var index = Analysis.LibraryBodyIndex.Open(dllPath, assemblyResolver);
 
             if (requestedSections.Contains(SectionNames.AllocationFacts))
             {
@@ -1674,7 +1679,7 @@ public static class ApiOutputFormatter
 
     internal static void PopulateUnsafeMembers(TypeView view, ApiType type, string dllPath)
     {
-        var index = Analysis.LibraryBodyIndex.Open(dllPath);
+        var index = Analysis.LibraryBodyIndex.Open(dllPath, AnalysisReferenceResolver(dllPath));
         var rows = index.UnsafeEvidence
             .Where(evidence => SameType(evidence.Member.DeclaringType, type))
             .OrderBy(evidence => evidence.Member.Name, StringComparer.Ordinal)
@@ -1722,7 +1727,7 @@ public static class ApiOutputFormatter
         string dllPath,
         IReadOnlySet<string>? explicitSections = null)
     {
-        var index = Analysis.LibraryBodyIndex.Open(dllPath);
+        var index = Analysis.LibraryBodyIndex.Open(dllPath, AnalysisReferenceResolver(dllPath));
         var rows = index.CalledTypes(method => SameType(method.DeclaringType, type))
             .Select(summary => new CalledTypeRow(
                 MarkoutInline.Code(summary.Type.ToQualifiedDisplayString()),
@@ -1743,7 +1748,7 @@ public static class ApiOutputFormatter
         IReadOnlySet<string>? requestedSections,
         IReadOnlySet<string>? explicitSections = null)
     {
-        var index = Analysis.LibraryBodyIndex.Open(dllPath);
+        var index = Analysis.LibraryBodyIndex.Open(dllPath, AnalysisReferenceResolver(dllPath));
         var methodTokens = type.Members
             .Where(member => member.MetadataToken is not null && ApiMemberSectionDescriptors.IsMethodLike(member))
             .Select(member => member.MetadataToken!.Value)
@@ -1792,7 +1797,7 @@ public static class ApiOutputFormatter
         PerformanceTriageOptions? options = null,
         bool restrictToModelMembers = false)
     {
-        var index = Analysis.LibraryBodyIndex.Open(dllPath);
+        var index = Analysis.LibraryBodyIndex.Open(dllPath, AnalysisReferenceResolver(dllPath));
         HashSet<int>? memberTokens = restrictToModelMembers
             ? type.Members.Where(m => m.MetadataToken is not null).Select(m => m.MetadataToken!.Value).ToHashSet()
             : null;
@@ -1884,7 +1889,7 @@ public static class ApiOutputFormatter
 
     internal static void PopulateTopLeverage(TypeView view, ApiType type, string dllPath, bool restrictToModelMembers = false)
     {
-        var index = Analysis.LibraryBodyIndex.Open(dllPath);
+        var index = Analysis.LibraryBodyIndex.Open(dllPath, AnalysisReferenceResolver(dllPath));
         var drillByToken = BuildMemberDrillMap(type);
 
         // Rank every method declared on this type; fanin is still measured across all


### PR DESCRIPTION
## Summary

Implements slice 1 of #2098: threads an `IAssemblyReferenceResolver` into the
Analysis metadata path so cross-assembly type metadata can be read on demand. This
is the **seam only** — a shared enabler for cross-assembly allocation sizing (#2096),
escape/type backing (#2064), and referenced-enum shape. **No perf-shape behavior
change.**

Per #2066, reading a referenced assembly's *metadata* via an injected resolver is
permitted and is **not** runtime assembly loading; the product stays NativeAOT- and
Roslyn-free and never loads/executes inspected code.

## What changed

- `LibraryBodyIndex.Open(string path, IAssemblyReferenceResolver? resolver = null)`
  overload (the 1-arg overload delegates with `resolver: null`).
- Resolver-aware `IndexBuilder` with a lazy, per-identity cache of referenced
  `MetadataReader`s (`AssemblyReferenceIdentity -> ReferencedAssemblyMetadata`),
  opened via `resolver.Resolve(...)`.
- Internal `TryResolveExternalTypeDefinition(TypeReferenceHandle)` resolving a
  cross-assembly type ref to `(definingReader, TypeDefinitionHandle)`, handling
  top-level + nested types with a recursion guard. **Internal only** (test-visible
  via `InternalsVisibleTo`); it is not exposed to shape code, and slice 2 will
  replace it with typed value-extractors so no live reader escapes (see #2098).
- Product wiring: `ApiOutputFormatter` passes `ApiCommand.PlatformAssemblyResolver`.

## Lifetime model

`Build()` is a one-shot eager pass returning immutable data; `LibraryBodyIndex`
holds no live reader. All `MetadataReader`s (target and cross-assembly) are disposed
when `Open()` returns — the cross-assembly readers share the target reader's existing
lifetime exactly. The `IDisposable` builder owns and disposes every opened
`PEReader`/stream (including the failure path). Consumers extract values during Build
and store only the extracted values — the pre-existing contract.

## Fail-honest

Null resolver, an unresolvable reference, or a reference without managed metadata
all yield `null` (negative results cached, not retried) — behavior identical to the
single-reader path.

## Validation

- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507` — clean.
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` — 298/298 pass,
  including: cross-assembly framework-type resolution reads readable metadata;
  null-resolver fail-honest + index-shape parity; resolver-does-not-change-shape.
- End-to-end `library System.Text.Json@10.0.9 -S "Performance Triage"` — 132 rows,
  shapes/metadata identical to `main` (the new cross-assembly reader is provably
  unconsumed in `Build`, so output is byte-identical).

## Review

Touches `LibraryBodyIndex`; requesting adversarial review (two model families) on
disposal/lifetime correctness and the fail-honest resolution paths. Additive enabler,
so favorability risk is low. Slice 2 (typed extractors + first consumer) follows per
#2098.
