### PR TITLE
Render constructor declarations from ApiSignature

### DIFF
--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -179,7 +179,9 @@ public static class CSharpDeclarationWriter
     {
         var signature = member.Kind == "field" && member.Signature == null && !string.IsNullOrWhiteSpace(member.ReturnType)
             ? $"{member.ReturnType} {member.Name}"
-            : member.Signature ?? member.ReturnType ?? "";
+            : TryRenderSignatureModel(type, member, methodParameters, out var modelSignature)
+                ? modelSignature
+                : member.Signature ?? member.ReturnType ?? "";
         if (string.IsNullOrWhiteSpace(signature))
         {
             if (member.Kind == "field" && !string.IsNullOrWhiteSpace(member.ReturnType))
@@ -307,6 +309,14 @@ public static class CSharpDeclarationWriter
     {
         if (!string.IsNullOrWhiteSpace(member.ReturnType))
             yield return member.ReturnType!;
+        if (member.SignatureModel is { } signatureModel)
+        {
+            if (!string.IsNullOrWhiteSpace(signatureModel.ReturnType))
+                yield return signatureModel.ReturnType!;
+            foreach (var parameter in signatureModel.Parameters)
+                if (!string.IsNullOrWhiteSpace(parameter.Type))
+                    yield return parameter.Type;
+        }
 
         var signature = member.Signature;
         if (string.IsNullOrWhiteSpace(signature))
@@ -480,6 +490,48 @@ public static class CSharpDeclarationWriter
         }
 
         return declaration;
+    }
+
+    static bool TryRenderSignatureModel(
+        ApiType type,
+        ApiMember member,
+        IReadOnlyList<string>? methodParameters,
+        out string signature)
+    {
+        signature = "";
+        if (member.SignatureModel is not { } model)
+            return false;
+
+        // ApiParameter tracks whether a default exists but not its source text.
+        // Keep the compatibility signature for optional parameters until default
+        // value text is modeled.
+        if (model.Parameters.Any(static parameter => parameter.HasDefault))
+            return false;
+
+        var parameters = string.Join(", ", model.Parameters.Select(ParameterDeclaration));
+        if (member.Name == ".cctor")
+        {
+            signature = $"{FormatConstructorTypeName(type.Name)}()";
+            return true;
+        }
+        if (member.Kind == "constructor")
+        {
+            signature = $"{FormatConstructorTypeName(type.Name)}({parameters})";
+            return true;
+        }
+
+        // Keep method/property/event rendering on compatibility text until
+        // generic parameters, constraints, attributes, and default-value text are
+        // represented in ApiSignature.
+        return false;
+
+        static string ParameterDeclaration(ApiParameter parameter)
+        {
+            var type = parameter.TypeWithModifier;
+            return string.IsNullOrWhiteSpace(parameter.Name)
+                ? type
+                : $"{type} {parameter.Name}";
+        }
     }
 
     static string FormatTypeDisplayName(string name, IReadOnlyList<TypeParameter> typeParameters)

--- a/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
@@ -232,6 +232,74 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void ConstructorDeclaration_CanRenderFromStructuredSignatureModel()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = ".ctor",
+            Kind = "constructor",
+            SignatureModel = new ApiSignature
+            {
+                Parameters =
+                [
+                    new ApiParameter
+                    {
+                        Type = "System.Collections.Generic.List<System.Guid>",
+                        Name = "items"
+                    }
+                ]
+            }
+        };
+
+        var rendered = CSharpDeclarationWriter.RenderMemberUnit(
+            type,
+            member,
+            new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ShortWithUsings,
+                TerminateMemberDeclaration = true
+            });
+
+        Assert.Equal(
+            """
+            using System;
+            using System.Collections.Generic;
+
+            public Widget(List<Guid> items);
+            """,
+            rendered.Source);
+    }
+
+    [Fact]
+    public void ConstructorDeclaration_WithDefaultParameterKeepsCompatibilitySignature()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = ".ctor",
+            Kind = "constructor",
+            Signature = "void .ctor(int count = 42)",
+            SignatureModel = new ApiSignature
+            {
+                Parameters =
+                [
+                    new ApiParameter
+                    {
+                        Type = "int",
+                        Name = "count",
+                        HasDefault = true
+                    }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("public Widget(int count = 42)", declaration);
+    }
+
+    [Fact]
     public void AbbreviatedMemberDeclaration_PreservesParameterModifiers()
     {
         var type = new ApiType { Namespace = "Samples", Name = "RefKinds", Kind = "class" };


### PR DESCRIPTION
## Summary

Advances #2057 by making `CSharpDeclarationWriter` consume structured `ApiSignature` facts for constructor declarations when the model is complete enough.

- Renders constructor declarations from `ApiSignature.Parameters` when no default-value text is needed.
- Keeps compatibility signature fallback for optional/default parameters because `ApiParameter` currently tracks `HasDefault` but not the default value text.
- Adds signature-model parameter types to declaration-writer type-reference collection so short-name/import planning works without reparsing compatibility signatures.
- Leaves methods/properties/events on the existing compatibility string path until generic parameters, constraints, attributes, and default-value text are modeled.

## Why this shape

This is the top-down #2057 declaration-writer slice, not the #2090 value-flow/coercion lane. It also relates to RTS because `ReturnToSender` goes through `CSharpDeclarationWriter`; targeted RTS prototype tests stay green.

## Validation

- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config -p:NoWarn=NU1507`
- `dotnet run --no-restore --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -class '*CSharpDeclarationWriterTests'`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -class '*CSharpDeclarationFormatterTests'`
- `dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -class '*ReturnToSenderPrototypeTests'`
