### PR TITLE
Add ApiParameter default value text

### DIFF
--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -196,10 +196,24 @@ public class ApiParameter
     public string Type { get; set; } = "";
     public string? Modifier { get; set; }
     public bool HasDefault { get; set; }
+    public string? DefaultValueText { get; set; }
 
     public string TypeWithModifier => string.IsNullOrEmpty(Modifier)
         ? Type
         : $"{Modifier} {Type}";
+
+    public string Declaration
+    {
+        get
+        {
+            var head = string.IsNullOrWhiteSpace(Name)
+                ? TypeWithModifier
+                : $"{TypeWithModifier} {Name}";
+            return HasDefault && DefaultValueText is { Length: > 0 }
+                ? $"{head} = {DefaultValueText}"
+                : head;
+        }
+    }
 }
 
 public class ApiAccessor

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -773,7 +773,8 @@ public static class ApiSurfaceExtractor
                 Name = paramName,
                 Type = type,
                 Modifier = modifier,
-                HasDefault = hasDefault
+                HasDefault = hasDefault,
+                DefaultValueText = DefaultValueText(reader, defaultValue, type, hasDefault, AcceptsNullDefault(paramTypes[i]))
             });
         }
 
@@ -1012,6 +1013,13 @@ public static class ApiSurfaceExtractor
             double d => d.ToString("G"),
             _ => value.ToString() ?? "default"
         };
+    }
+
+    private static string? DefaultValueText(MetadataReader reader, object? value, string typeName, bool hasDefault, bool acceptsNullDefault)
+    {
+        if (!hasDefault || value is DateTimeConstantDefault)
+            return null;
+        return FormatDefaultValue(reader, value, typeName, acceptsNullDefault);
     }
 
     private static string EscapeCharLiteral(char c) => c switch
@@ -1348,7 +1356,8 @@ public static class ApiSurfaceExtractor
                 Name = paramName,
                 Type = paramType,
                 Modifier = modifier,
-                HasDefault = hasDefault
+                HasDefault = hasDefault,
+                DefaultValueText = DefaultValueText(reader, defaultValue, paramType, hasDefault, AcceptsNullDefault(paramTypes[i]))
             });
         }
 

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -502,10 +502,9 @@ public static class CSharpDeclarationWriter
         if (member.SignatureModel is not { } model)
             return false;
 
-        // ApiParameter tracks whether a default exists but not its source text.
-        // Keep the compatibility signature for optional parameters until default
-        // value text is modeled.
-        if (model.Parameters.Any(static parameter => parameter.HasDefault))
+        // Keep compatibility text when a default exists but has no source-level
+        // spelling in the structured model (for example DateTimeConstantAttribute).
+        if (model.Parameters.Any(static parameter => parameter.HasDefault && string.IsNullOrWhiteSpace(parameter.DefaultValueText)))
             return false;
 
         var parameters = string.Join(", ", model.Parameters.Select(ParameterDeclaration));
@@ -527,10 +526,10 @@ public static class CSharpDeclarationWriter
 
         static string ParameterDeclaration(ApiParameter parameter)
         {
-            var type = parameter.TypeWithModifier;
-            return string.IsNullOrWhiteSpace(parameter.Name)
-                ? type
-                : $"{type} {parameter.Name}";
+            var declaration = string.IsNullOrWhiteSpace(parameter.Name)
+                ? parameter.TypeWithModifier
+                : parameter.Declaration;
+            return declaration;
         }
     }
 

--- a/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
@@ -37,4 +37,49 @@ public sealed class CSharpDeclarationFormatterTests
 
         Assert.Contains("public int @class(int @object)", view.SignatureRows![0].Signature);
     }
+
+    [Fact]
+    public void ConstructorOverloadSnippet_UsesStructuredDefaultValueText()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = ".ctor",
+                    Kind = "constructor",
+                    Signature = "BROKEN",
+                    SignatureModel = new ApiSignature
+                    {
+                        Parameters =
+                        [
+                            new ApiParameter
+                            {
+                                Type = "int",
+                                Name = "count",
+                                HasDefault = true,
+                                DefaultValueText = "42"
+                            }
+                        ]
+                    }
+                }
+            ]
+        };
+        var view = ApiOutputFormatter.BuildTypeView(
+            type,
+            foundIn: "Test.dll",
+            packageName: null,
+            packageVersion: null,
+            apiSource: "local",
+            selectedTfm: null,
+            new TypeOptions());
+
+        ApiOutputFormatter.PopulateConstructorOverloads(view, type, new TypeOptions());
+
+        Assert.Equal("new Widget(int count = 42)", view.ConstructorOverloads![0].Signature.Content);
+    }
 }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1028,7 +1028,7 @@ public static class ApiOutputFormatter
             var overloadView = new ConstructorOverloadView
             {
                 Title = $"Overload {i + 1}: {paramCount} parameter{(paramCount != 1 ? "s" : "")}",
-                Signature = new CodeSection("csharp", $"new {type.Name}{SignatureParser.FormatConstructorCall(ctor.Signature)}")
+                Signature = new CodeSection("csharp", $"new {type.Name}{ConstructorCall(type, ctor)}")
             };
 
             if (paramInfo.Count > 0)
@@ -1052,6 +1052,19 @@ public static class ApiOutputFormatter
                 .Select(parameter => (parameter.Name, parameter.TypeWithModifier, parameter.HasDefault))
                 .ToList()
             : SignatureParser.ExtractParameterInfo(constructor.Signature);
+
+    private static string ConstructorCall(ApiType type, ApiMember constructor)
+    {
+        if (constructor.SignatureModel is { } signature
+            && signature.Parameters.All(static parameter => !parameter.HasDefault || !string.IsNullOrWhiteSpace(parameter.DefaultValueText)))
+        {
+            var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, constructor);
+            if (!string.IsNullOrWhiteSpace(declaration))
+                return SignatureParser.FormatConstructorCall(declaration);
+        }
+
+        return SignatureParser.FormatConstructorCall(constructor.Signature);
+    }
 
     internal static void PopulateIndexSections(TypeView view, ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex, IReadOnlySet<string> requestedSections, string? pdbPath = null, IReadOnlySet<string>? explicitSections = null, IReadOnlyList<string>? callerScopeAssemblies = null, ApiOptions? options = null)
     {

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -28,6 +28,7 @@ public sealed class ApiSignatureModelTests
         Assert.Equal("ref", member.SignatureModel.Parameters[0].Modifier);
         Assert.Equal("int", member.SignatureModel.Parameters[0].Type);
         Assert.True(member.SignatureModel.Parameters[3].HasDefault);
+        Assert.Equal("1", member.SignatureModel.Parameters[3].DefaultValueText);
     }
 
     [Fact]
@@ -69,6 +70,7 @@ public sealed class ApiSignatureModelTests
         Assert.Equal("count", ctor.SignatureModel.Parameters[1].Name);
         Assert.Equal("int", ctor.SignatureModel.Parameters[1].Type);
         Assert.True(ctor.SignatureModel.Parameters[1].HasDefault);
+        Assert.Equal("1", ctor.SignatureModel.Parameters[1].DefaultValueText);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
@@ -272,14 +272,13 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
-    public void ConstructorDeclaration_WithDefaultParameterKeepsCompatibilitySignature()
+    public void ConstructorDeclaration_WithDefaultParameterUsesStructuredDefaultText()
     {
         var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
         var member = new ApiMember
         {
             Name = ".ctor",
             Kind = "constructor",
-            Signature = "void .ctor(int count = 42)",
             SignatureModel = new ApiSignature
             {
                 Parameters =
@@ -288,7 +287,8 @@ public sealed class CSharpDeclarationWriterTests
                     {
                         Type = "int",
                         Name = "count",
-                        HasDefault = true
+                        HasDefault = true,
+                        DefaultValueText = "42"
                     }
                 ]
             }
@@ -297,6 +297,34 @@ public sealed class CSharpDeclarationWriterTests
         var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
 
         Assert.Equal("public Widget(int count = 42)", declaration);
+    }
+
+    [Fact]
+    public void ConstructorDeclaration_WithUnmodeledDefaultKeepsCompatibilitySignature()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Widget", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = ".ctor",
+            Kind = "constructor",
+            Signature = "void .ctor([System.Runtime.InteropServices.Optional, System.Runtime.CompilerServices.DateTimeConstant(42L)] System.DateTime when)",
+            SignatureModel = new ApiSignature
+            {
+                Parameters =
+                [
+                    new ApiParameter
+                    {
+                        Type = "System.DateTime",
+                        Name = "when",
+                        HasDefault = true
+                    }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Contains("DateTimeConstant(42L)", declaration);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/DefaultValueRenderingTests.cs
+++ b/tests/ILInspector.Metadata.Tests/DefaultValueRenderingTests.cs
@@ -27,12 +27,17 @@ public sealed class DefaultValueRenderingTests
         .First(t => t.Name == nameof(DefaultValueFixtures))
         .Members.First(m => m.Name == method).Signature;
 
+    static ApiParameter Parameter(string method, int index = 0) => Surface.Types
+        .First(t => t.Name == nameof(DefaultValueFixtures))
+        .Members.First(m => m.Name == method).SignatureModel!.Parameters[index];
+
     [Fact]
     public void ValueTypeStruct_Default_RendersDefaultNotNull()
     {
         var sig = Signature(nameof(DefaultValueFixtures.ValueTypeStructDefault));
         Assert.Contains("ct = default", sig);
         Assert.DoesNotContain("ct = null", sig);
+        Assert.Equal("default", Parameter(nameof(DefaultValueFixtures.ValueTypeStructDefault)).DefaultValueText);
     }
 
     [Fact]
@@ -60,11 +65,15 @@ public sealed class DefaultValueRenderingTests
         var sig = Signature(nameof(DefaultValueFixtures.NullableValueNull));
         Assert.Contains("n = null", sig);
         Assert.DoesNotContain("n = default", sig);
+        Assert.Equal("null", Parameter(nameof(DefaultValueFixtures.NullableValueNull)).DefaultValueText);
     }
 
     [Fact]
     public void Int_Default_Unchanged()
-        => Assert.Contains("i = 5", Signature(nameof(DefaultValueFixtures.IntDefault)));
+    {
+        Assert.Contains("i = 5", Signature(nameof(DefaultValueFixtures.IntDefault)));
+        Assert.Equal("5", Parameter(nameof(DefaultValueFixtures.IntDefault)).DefaultValueText);
+    }
 
     [Fact]
     public void Bool_Default_Unchanged()
@@ -76,6 +85,9 @@ public sealed class DefaultValueRenderingTests
         var sig = Signature(nameof(DefaultValueFixtures.EnumNonZeroDefault));
         Assert.Contains("color = ILInspector.Metadata.Tests.DefaultValueFixtures.SampleColor.Green", sig);
         Assert.DoesNotContain("color = 1", sig);
+        Assert.Equal(
+            "ILInspector.Metadata.Tests.DefaultValueFixtures.SampleColor.Green",
+            Parameter(nameof(DefaultValueFixtures.EnumNonZeroDefault)).DefaultValueText);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Advances #2057 by modeling parameter default-value text and using it to move constructor overload snippets onto structured `ApiSignature` facts.

- Adds `ApiParameter.DefaultValueText` plus a structured `Declaration` helper.
- Populates default-value text from existing metadata/default rendering logic for methods and indexers.
- Keeps compatibility fallback for defaults that still require attributes/source text outside the model (for example `DateTimeConstantAttribute`).
- Updates `CSharpDeclarationWriter` constructor rendering to use structured defaults when available.
- Updates constructor overload snippets (`new Type(...)`) to use the structured declaration path instead of `SignatureParser.FormatConstructorCall` when the model is complete.

## Validation

- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config -p:NoWarn=NU1507`
- `dotnet run --no-restore --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -class '*CSharpDeclarationWriterTests' -class '*ApiSignatureModelTests' -class '*DefaultValueRenderingTests'`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -class '*CSharpDeclarationFormatterTests'`
