### PR TITLE
Harden ReturnToSender exact-target A/B and closure shells

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -575,11 +575,103 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    [Fact]
+    public void CompileBackFirstPropertyGetter_DoesNotSurfaceOuterMembersForTypeOnlyNestedClosure()
+    {
+        var assemblyPath = CompileFixture("""
+            internal class Hidden
+            {
+            }
+
+            public class Outer
+            {
+                public class Inner
+                {
+                }
+
+                internal static Hidden Leak() => new Hidden();
+            }
+
+            public class Class1
+            {
+                public Outer.Inner FromNested => new Outer.Inner();
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("public class Inner", result.Source);
+            Assert.DoesNotContain("Leak", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackFirstPropertyGetter_SurfacesReferencedInstanceField()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                private readonly string _value = "Hello";
+
+                public string Value => _value;
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("public string _value;", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackFirstPropertyGetter_EmitsUnsafePointerTargetAndField()
+    {
+        var assemblyPath = CompileFixture("""
+            public unsafe class Class1
+            {
+                private int* _pointer;
+
+                public int* Pointer => _pointer;
+            }
+            """, allowUnsafe: true);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("public unsafe int* Pointer", result.Source);
+            Assert.Contains("public unsafe int* _pointer;", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     static string CompileFixture(
         string source,
         string? directory = null,
         string assemblyName = "fixture",
-        IReadOnlyList<MetadataReference>? additionalReferences = null)
+        IReadOnlyList<MetadataReference>? additionalReferences = null,
+        bool allowUnsafe = false)
     {
         directory ??= Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
         Directory.CreateDirectory(directory);
@@ -595,7 +687,8 @@ public class ReturnToSenderPrototypeTests
             new CSharpCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary,
                 optimizationLevel: OptimizationLevel.Release,
-                nullableContextOptions: NullableContextOptions.Disable));
+                nullableContextOptions: NullableContextOptions.Disable,
+                allowUnsafe: allowUnsafe));
 
         var emit = compilation.Emit(path);
         Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace ILInspector.Decompiler.Tests;
 
+[Trait("Speed", "Slow")]
 public class ReturnToSenderPrototypeTests
 {
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -587,6 +587,7 @@ public class ReturnToSenderPrototypeTests
             {
                 public class Inner
                 {
+                    internal static Hidden LeakNested() => new Hidden();
                 }
 
                 internal static Hidden Leak() => new Hidden();
@@ -606,6 +607,7 @@ public class ReturnToSenderPrototypeTests
                 $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             Assert.Contains("public class Inner", result.Source);
             Assert.DoesNotContain("Leak", result.Source);
+            Assert.DoesNotContain("LeakNested", result.Source);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -445,6 +445,51 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void RunComparison_UsesExactCurrentTargetsPastPerTypeSampleCap()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public int P0 => 0;
+                public int P1 => 1;
+                public int P2 => 2;
+                public int P3 => 3;
+                public int P4 => 4;
+                public int P5 => 5;
+                public int P6 => 6;
+                public int P7 => 7;
+                public int P8 => 8;
+                public int P9 => 9;
+            }
+            """);
+        try
+        {
+            var oldOut = Console.Out;
+            using var writer = new StringWriter();
+            try
+            {
+                Console.SetOut(writer);
+                var exitCode = ReturnToSender.RunComparison([assemblyPath], cap: 10, maxExamples: 10);
+
+                Assert.Equal(0, exitCode);
+            }
+            finally
+            {
+                Console.SetOut(oldOut);
+            }
+
+            var output = writer.ToString();
+            Assert.Contains("RETURNTOSENDER A/B over 10 property getters", output);
+            Assert.Contains("  Same          : 10", output);
+            Assert.Contains("  CurrentMissing: 0", output);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_PreservesStaticTargetPropertyShape()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -643,6 +643,38 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_EmitsClosureConstFieldsWithInitializers()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Helper
+            {
+                public const int ConstValue = 42;
+                public int Value => ConstValue;
+                public static Helper Create() => new Helper();
+            }
+
+            public class Class1
+            {
+                public int FromHelper => Helper.Create().Value;
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackPropertyGetters(assemblyPath, maxTargets: 2)
+                .Single(item => item.Plan.TargetMethod.Method == "get_FromHelper");
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("public const int ConstValue = 42;", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_EmitsUnsafePointerTargetAndField()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -668,6 +668,38 @@ public class ReturnToSenderPrototypeTests
         }
     }
 
+    [Fact]
+    public void CompileBackFirstPropertyGetter_SurfacesUnsafeNestedClosureMember()
+    {
+        var assemblyPath = CompileFixture("""
+            public unsafe class Outer
+            {
+                public class Inner
+                {
+                    public static int* GetPointer() => null;
+                }
+            }
+
+            public unsafe class Class1
+            {
+                public int* Pointer => Outer.Inner.GetPointer();
+            }
+            """, allowUnsafe: true);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("public static unsafe int* GetPointer()", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
     static string CompileFixture(
         string source,
         string? directory = null,

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -675,6 +675,40 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_EmitsNonFiniteClosureConstFields()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Helper
+            {
+                public const float FloatNaN = float.NaN;
+                public const double DoubleInfinity = double.PositiveInfinity;
+                public int Value => 42;
+                public static Helper Create() => new Helper();
+            }
+
+            public class Class1
+            {
+                public int FromHelper => Helper.Create().Value;
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackPropertyGetters(assemblyPath, maxTargets: 2)
+                .Single(item => item.Plan.TargetMethod.Method == "get_FromHelper");
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("public const float FloatNaN = float.NaN;", result.Source);
+            Assert.Contains("public const double DoubleInfinity = double.PositiveInfinity;", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_EmitsUnsafePointerTargetAndField()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -823,7 +823,11 @@ public static class CompileBackSourceComposer
                     Interfaces: InterfaceSignatures(reader, typeDef),
                     members,
                     requirement.SourceFacts,
-                    NestedTypes(reader, typeDef, diagnostics)));
+                    NestedTypes(
+                        reader,
+                        typeDef,
+                        includeMemberSurface: requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member"),
+                        diagnostics)));
             }
 
             return shells;
@@ -832,6 +836,7 @@ public static class CompileBackSourceComposer
         static IReadOnlyList<CompileBackTypeDeclaration> NestedTypes(
             MetadataReader reader,
             TypeDefinition typeDef,
+            bool includeMemberSurface,
             List<CompileBackPlanningDiagnostic> diagnostics)
         {
             var nestedTypes = new List<CompileBackTypeDeclaration>();
@@ -854,7 +859,8 @@ public static class CompileBackSourceComposer
                     RequiredMembers: [],
                     SourceFacts: [new CompileBackFact("metadata", "nested-closure-type", identity.FullName)]);
                 var members = new List<CompileBackMemberDeclaration>();
-                AddClosureMemberSurface(reader, nestedDef, requirement, members, diagnostics);
+                if (includeMemberSurface)
+                    AddClosureMemberSurface(reader, nestedDef, requirement, members, diagnostics);
                 nestedTypes.Add(new CompileBackTypeDeclaration(
                     identity,
                     kind,
@@ -863,7 +869,7 @@ public static class CompileBackSourceComposer
                     Interfaces: InterfaceSignatures(reader, nestedDef),
                     members,
                     requirement.SourceFacts,
-                    NestedTypes(reader, nestedDef, diagnostics)));
+                    NestedTypes(reader, nestedDef, includeMemberSurface, diagnostics)));
             }
 
             return nestedTypes;
@@ -901,7 +907,8 @@ public static class CompileBackSourceComposer
             if (requirement.RequiredKind == CompileBackTypeKind.Enum)
                 return;
 
-            bool allowUnsafeSurface = requirement.RequiredMembers.Count != 0;
+            bool allowUnsafeSurface = requirement.RequiredMembers.Count != 0
+                || requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
             var accessorMethods = new HashSet<MethodDefinitionHandle>();
             var typeContext = GenericContext.ForType(reader, typeDef);
             foreach (var fieldHandle in typeDef.GetFields())

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -160,6 +160,7 @@ public enum CompileBackMemberKind
     PropertyGet,
     Constructor,
     Method,
+    Field,
 }
 
 public enum CompileBackAccessibility
@@ -436,9 +437,19 @@ public static class CompileBackSourceComposer
     static void WriteMember(StringBuilder sb, CompileBackTypeDeclaration type, CompileBackMemberDeclaration member, int indent)
     {
         string pad = new(' ', indent * 4);
+        if (member.Kind == CompileBackMemberKind.Field)
+        {
+            string staticText = member.IsStatic ? " static" : "";
+            string unsafeText = RequiresUnsafe(member) ? " unsafe" : "";
+            sb.AppendLine($"{pad}public{staticText}{unsafeText} {member.ReturnType?.DisplayName ?? "object"} {member.Name};");
+            return;
+        }
+
         var apiType = ToApiType(type);
         var apiMember = ToApiMember(type, member);
         string declaration = CSharpDeclarationWriter.RenderMemberDeclaration(apiType, apiMember);
+        if (RequiresUnsafe(member))
+            declaration = AddUnsafeModifier(declaration);
         switch (member.Kind)
         {
             case CompileBackMemberKind.PropertyGet:
@@ -514,6 +525,7 @@ public static class CompileBackSourceComposer
                 CompileBackMemberKind.PropertyGet => "property",
                 CompileBackMemberKind.Constructor => "constructor",
                 CompileBackMemberKind.Method => "method",
+                CompileBackMemberKind.Field => "field",
                 _ => throw new NotSupportedException($"Unsupported member declaration kind '{member.Kind}'."),
             },
             ReturnType = returnType,
@@ -523,11 +535,30 @@ public static class CompileBackSourceComposer
                 CompileBackMemberKind.PropertyGet => $"{returnType ?? "void"} {member.Name}",
                 CompileBackMemberKind.Constructor => $"void .ctor({parameterList})",
                 CompileBackMemberKind.Method => $"{returnType ?? "void"} {member.Name}({parameterList})",
+                CompileBackMemberKind.Field => $"{returnType ?? "object"} {member.Name}",
                 _ => null,
             },
             IsStatic = member.IsStatic,
             Accessibility = null,
         };
+    }
+
+    static bool RequiresUnsafe(CompileBackMemberDeclaration member)
+        => member.ReturnType?.DisplayName.Contains('*', StringComparison.Ordinal) == true
+            || member.Parameters.Any(parameter => parameter.Type.DisplayName.Contains('*', StringComparison.Ordinal));
+
+    static string AddUnsafeModifier(string declaration)
+    {
+        if (declaration.Contains(" unsafe ", StringComparison.Ordinal))
+            return declaration;
+
+        foreach (var prefix in new[] { "public static ", "internal static ", "public ", "internal ", "static " })
+        {
+            if (declaration.StartsWith(prefix, StringComparison.Ordinal))
+                return prefix + "unsafe " + declaration[prefix.Length..];
+        }
+
+        return "unsafe " + declaration;
     }
 
     static bool IsAutoProperty(
@@ -781,8 +812,7 @@ public static class CompileBackSourceComposer
                         member.SourceFacts));
                 }
 
-                if (requirement.RequiredMembers.Count == 0
-                    || requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-root"))
+                if (requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member"))
                     AddClosureMemberSurface(reader, typeDef, requirement, members, diagnostics);
 
                 shells.Add(new CompileBackTypeDeclaration(
@@ -871,8 +901,48 @@ public static class CompileBackSourceComposer
             if (requirement.RequiredKind == CompileBackTypeKind.Enum)
                 return;
 
+            bool allowUnsafeSurface = requirement.RequiredMembers.Count != 0;
             var accessorMethods = new HashSet<MethodDefinitionHandle>();
             var typeContext = GenericContext.ForType(reader, typeDef);
+            foreach (var fieldHandle in typeDef.GetFields())
+            {
+                var field = reader.GetFieldDefinition(fieldHandle);
+                string fieldName = reader.GetString(field.Name);
+                if (fieldName.Contains('<', StringComparison.Ordinal)
+                    || fieldName.Contains('>', StringComparison.Ordinal)
+                    || fieldName.Contains('.', StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                if (members.Any(member => member.Kind == CompileBackMemberKind.Field && member.Name == Identifier(fieldName)))
+                    continue;
+
+                string fieldType;
+                try
+                {
+                    fieldType = field.DecodeSignature(SignatureDecoder.Instance, typeContext);
+                }
+                catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+                {
+                    diagnostics.Add(new CompileBackPlanningDiagnostic("member surface", "field-signature-decode-failed", fieldName));
+                    continue;
+                }
+                if (IsUnsupportedSurfaceSignature(fieldType)
+                    || (!allowUnsafeSurface && IsPointerSignature(fieldType)))
+                    continue;
+
+                members.Add(new CompileBackMemberDeclaration(
+                    new CompileBackMethodIdentity(requirement.Type.FullName, Identifier(fieldName), 0, $"field {fieldType}"),
+                    CompileBackMemberKind.Field,
+                    CompileBackAccessibility.Public,
+                    field.Attributes.HasFlag(FieldAttributes.Static),
+                    CompileBackTypeSignature.Display(fieldType),
+                    Parameters: [],
+                    CompileBackStubBodyKind.None,
+                    TargetBody: null,
+                    [new CompileBackFact("metadata", "closure-field", fieldName)]));
+            }
+
             foreach (var propertyHandle in typeDef.GetProperties())
             {
                 var property = reader.GetPropertyDefinition(propertyHandle);
@@ -903,6 +973,9 @@ public static class CompileBackSourceComposer
                 }
 
                 if (signature.ParameterTypes.Length != 0)
+                    continue;
+                if (IsUnsupportedSurfaceSignature(signature.ReturnType)
+                    || (!allowUnsafeSurface && IsPointerSignature(signature.ReturnType)))
                     continue;
 
                 var accessor = accessors.Getter.IsNil ? accessors.Setter : accessors.Getter;
@@ -962,6 +1035,14 @@ public static class CompileBackSourceComposer
                 }
 
                 var parameters = Parameters(reader, method, signature);
+                if (IsUnsupportedSurfaceSignature(signature.ReturnType)
+                    || parameters.Any(parameter => IsUnsupportedSurfaceSignature(parameter.Type.DisplayName))
+                    || (!allowUnsafeSurface
+                        && (IsPointerSignature(signature.ReturnType)
+                            || parameters.Any(parameter => IsPointerSignature(parameter.Type.DisplayName)))))
+                {
+                    continue;
+                }
                 members.Add(new CompileBackMemberDeclaration(
                     new CompileBackMethodIdentity(requirement.Type.FullName, identifierName, overload++, MethodSignatureText(name, signature)),
                     isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method,
@@ -990,6 +1071,13 @@ public static class CompileBackSourceComposer
                     [new CompileBackFact("metadata", "synthetic-parameterless-ctor", "same-assembly closure root")]));
             }
         }
+
+        static bool IsUnsupportedSurfaceSignature(string signature)
+            => signature.Contains("delegate*", StringComparison.Ordinal)
+                || signature.Contains("@delegate*", StringComparison.Ordinal);
+
+        static bool IsPointerSignature(string signature)
+            => signature.Contains('*', StringComparison.Ordinal);
 
         static IReadOnlyList<CompileBackParameter> Parameters(
             MetadataReader reader,

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -1121,14 +1121,36 @@ public static class CompileBackSourceComposer
                 ConstantTypeCode.UInt32 => blob.ReadUInt32().ToString(CultureInfo.InvariantCulture),
                 ConstantTypeCode.Int64 => blob.ReadInt64().ToString(CultureInfo.InvariantCulture) + "L",
                 ConstantTypeCode.UInt64 => blob.ReadUInt64().ToString(CultureInfo.InvariantCulture) + "UL",
-                ConstantTypeCode.Single => blob.ReadSingle().ToString("R", CultureInfo.InvariantCulture) + "f",
-                ConstantTypeCode.Double => blob.ReadDouble().ToString("R", CultureInfo.InvariantCulture),
+                ConstantTypeCode.Single => FormatSingleConstant(blob.ReadSingle()),
+                ConstantTypeCode.Double => FormatDoubleConstant(blob.ReadDouble()),
                 ConstantTypeCode.String => StringLiteral(blob.ReadUTF16(blob.Length)),
                 ConstantTypeCode.NullReference => "null",
                 _ => null,
             };
 
             return constant is not null;
+        }
+
+        static string FormatSingleConstant(float value)
+        {
+            if (float.IsNaN(value))
+                return "float.NaN";
+            if (float.IsPositiveInfinity(value))
+                return "float.PositiveInfinity";
+            if (float.IsNegativeInfinity(value))
+                return "float.NegativeInfinity";
+            return value.ToString("R", CultureInfo.InvariantCulture) + "f";
+        }
+
+        static string FormatDoubleConstant(double value)
+        {
+            if (double.IsNaN(value))
+                return "double.NaN";
+            if (double.IsPositiveInfinity(value))
+                return "double.PositiveInfinity";
+            if (double.IsNegativeInfinity(value))
+                return "double.NegativeInfinity";
+            return value.ToString("R", CultureInfo.InvariantCulture);
         }
 
         static string StringLiteral(string value)

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -860,7 +860,7 @@ public static class CompileBackSourceComposer
                     SourceFacts: [new CompileBackFact("metadata", "nested-closure-type", identity.FullName)]);
                 var members = new List<CompileBackMemberDeclaration>();
                 if (includeMemberSurface)
-                    AddClosureMemberSurface(reader, nestedDef, requirement, members, diagnostics);
+                    AddClosureMemberSurface(reader, nestedDef, requirement, members, diagnostics, allowUnsafeSurface: true);
                 nestedTypes.Add(new CompileBackTypeDeclaration(
                     identity,
                     kind,
@@ -902,12 +902,14 @@ public static class CompileBackSourceComposer
             TypeDefinition typeDef,
             CompileBackTypeRequirement requirement,
             List<CompileBackMemberDeclaration> members,
-            List<CompileBackPlanningDiagnostic> diagnostics)
+            List<CompileBackPlanningDiagnostic> diagnostics,
+            bool allowUnsafeSurface = false)
         {
             if (requirement.RequiredKind == CompileBackTypeKind.Enum)
                 return;
 
-            bool allowUnsafeSurface = requirement.RequiredMembers.Count != 0
+            allowUnsafeSurface = allowUnsafeSurface
+                || requirement.RequiredMembers.Count != 0
                 || requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
             var accessorMethods = new HashSet<MethodDefinitionHandle>();
             var typeContext = GenericContext.ForType(reader, typeDef);

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -441,6 +442,12 @@ public static class CompileBackSourceComposer
         {
             string staticText = member.IsStatic ? " static" : "";
             string unsafeText = RequiresUnsafe(member) ? " unsafe" : "";
+            if (member.StubBody == CompileBackStubBodyKind.TargetBody && member.TargetBody is { } initializer)
+            {
+                sb.AppendLine($"{pad}public const {member.ReturnType?.DisplayName ?? "object"} {member.Name} = {initializer};");
+                return;
+            }
+
             sb.AppendLine($"{pad}public{staticText}{unsafeText} {member.ReturnType?.DisplayName ?? "object"} {member.Name};");
             return;
         }
@@ -947,8 +954,10 @@ public static class CompileBackSourceComposer
                     field.Attributes.HasFlag(FieldAttributes.Static),
                     CompileBackTypeSignature.Display(fieldType),
                     Parameters: [],
-                    CompileBackStubBodyKind.None,
-                    TargetBody: null,
+                    TryFormatConstantField(reader, field, out var constant)
+                        ? CompileBackStubBodyKind.TargetBody
+                        : CompileBackStubBodyKind.None,
+                    TargetBody: constant,
                     [new CompileBackFact("metadata", "closure-field", fieldName)]));
             }
 
@@ -1087,6 +1096,68 @@ public static class CompileBackSourceComposer
 
         static bool IsPointerSignature(string signature)
             => signature.Contains('*', StringComparison.Ordinal);
+
+        static bool TryFormatConstantField(MetadataReader reader, FieldDefinition field, out string? constant)
+        {
+            constant = null;
+            if (!field.Attributes.HasFlag(FieldAttributes.Literal))
+                return false;
+
+            var constantHandle = field.GetDefaultValue();
+            if (constantHandle.IsNil)
+                return false;
+
+            var value = reader.GetConstant(constantHandle);
+            var blob = reader.GetBlobReader(value.Value);
+            constant = value.TypeCode switch
+            {
+                ConstantTypeCode.Boolean => blob.ReadBoolean() ? "true" : "false",
+                ConstantTypeCode.Char => $"'{EscapeCharLiteral(blob.ReadChar())}'",
+                ConstantTypeCode.SByte => blob.ReadSByte().ToString(CultureInfo.InvariantCulture),
+                ConstantTypeCode.Byte => blob.ReadByte().ToString(CultureInfo.InvariantCulture),
+                ConstantTypeCode.Int16 => blob.ReadInt16().ToString(CultureInfo.InvariantCulture),
+                ConstantTypeCode.UInt16 => blob.ReadUInt16().ToString(CultureInfo.InvariantCulture),
+                ConstantTypeCode.Int32 => blob.ReadInt32().ToString(CultureInfo.InvariantCulture),
+                ConstantTypeCode.UInt32 => blob.ReadUInt32().ToString(CultureInfo.InvariantCulture),
+                ConstantTypeCode.Int64 => blob.ReadInt64().ToString(CultureInfo.InvariantCulture) + "L",
+                ConstantTypeCode.UInt64 => blob.ReadUInt64().ToString(CultureInfo.InvariantCulture) + "UL",
+                ConstantTypeCode.Single => blob.ReadSingle().ToString("R", CultureInfo.InvariantCulture) + "f",
+                ConstantTypeCode.Double => blob.ReadDouble().ToString("R", CultureInfo.InvariantCulture),
+                ConstantTypeCode.String => StringLiteral(blob.ReadUTF16(blob.Length)),
+                ConstantTypeCode.NullReference => "null",
+                _ => null,
+            };
+
+            return constant is not null;
+        }
+
+        static string StringLiteral(string value)
+        {
+            var sb = new StringBuilder(value.Length + 2);
+            sb.Append('"');
+            foreach (char ch in value)
+                sb.Append(EscapeCharLiteral(ch));
+            sb.Append('"');
+            return sb.ToString();
+        }
+
+        static string EscapeCharLiteral(char ch)
+            => ch switch
+            {
+                '\'' => "\\'",
+                '"' => "\\\"",
+                '\\' => "\\\\",
+                '\0' => "\\0",
+                '\a' => "\\a",
+                '\b' => "\\b",
+                '\f' => "\\f",
+                '\n' => "\\n",
+                '\r' => "\\r",
+                '\t' => "\\t",
+                '\v' => "\\v",
+                _ when char.IsControl(ch) => $"\\u{(int)ch:x4}",
+                _ => ch.ToString(),
+            };
 
         static IReadOnlyList<CompileBackParameter> Parameters(
             MetadataReader reader,

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -256,6 +256,13 @@ static class FidelityCheck
         string OriginalOpcodes, string RecompiledOpcodes, string? Detail,
         CaptureMode Capture = CaptureMode.WholeModule);
 
+    internal sealed record CompileBackTarget(
+        string AssemblyPath,
+        string Type,
+        string Method,
+        int Overload,
+        string Signature);
+
     /// <summary>
     /// Runs the fidelity check loop over one assembly and returns a structured result
     /// per rendered method, without printing. This is the testable entry point the
@@ -646,6 +653,27 @@ static class FidelityCheck
 
     static string TargetKey(MethodTarget target)
         => $"{target.AssemblyPath}!{target.Type}::{target.Method}{target.Signature}";
+
+    internal static IReadOnlyList<CompileBackResult> EvaluateTargets(
+        IReadOnlyList<string> assemblies,
+        IReadOnlyList<CompileBackTarget> targets,
+        bool lowered = false)
+    {
+        var methodTargets = targets
+            .Select(target => new MethodTarget(
+                Assembly: Path.GetFileNameWithoutExtension(target.AssemblyPath),
+                AssemblyPath: PortablePath(target.AssemblyPath),
+                Type: target.Type,
+                Method: target.Method,
+                Overload: target.Overload,
+                Signature: target.Signature,
+                DisplayMethod: $"{target.Type}::{target.Method}"))
+            .ToArray();
+
+        return EvaluateTargets(assemblies, methodTargets, lowered)
+            .Select(row => row.Result)
+            .ToArray();
+    }
 
     static IReadOnlyList<TargetedCompileBackResult> EvaluateTargets(IReadOnlyList<string> assemblies, IReadOnlyList<MethodTarget> targets, bool lowered)
     {

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -182,7 +182,16 @@ static class ReturnToSender
             IReadOnlyDictionary<string, FidelityCheck.CompileBackResult> current;
             try
             {
-                current = FidelityCheck.Evaluate([assemblyPath], Math.Max(1, rtsResults.Count * 4), lowered: false, includeAllResults: true)
+                var currentTargets = rtsResults
+                    .Select(result => new FidelityCheck.CompileBackTarget(
+                        assemblyPath,
+                        result.Plan.TargetMethod.Type,
+                        result.Plan.TargetMethod.Method,
+                        result.Plan.TargetMethod.Overload,
+                        result.Plan.TargetMethod.Signature))
+                    .Distinct()
+                    .ToArray();
+                current = FidelityCheck.EvaluateTargets([assemblyPath], currentTargets)
                     .GroupBy(CurrentKey, StringComparer.Ordinal)
                     .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
             }

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -514,7 +514,7 @@ static class ReturnToSender
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
             firstError ??= errors.FirstOrDefault();
-            bool grew = AddClosureRoots(errors, indexes, reader.GetString(typeDef.Namespace), closureRoots, closureFacts);
+            bool grew = AddClosureRoots(errors, indexes, reader.GetString(typeDef.Namespace), TopLevelRootOf(reader, typeHandle), closureRoots, closureFacts);
             if (!grew || closureRoots.Count > maxRoots)
             {
                 string reason = closureRoots.Count > maxRoots ? "closure-root-budget" : "closure-stalled";
@@ -755,6 +755,8 @@ static class ReturnToSender
         Dictionary<string, List<TypeDefinitionHandle>> Types,
         Dictionary<string, List<TypeDefinitionHandle>> FullTypes,
         Dictionary<string, List<TypeDefinitionHandle>> Methods,
+        Dictionary<string, List<TypeDefinitionHandle>> Properties,
+        Dictionary<string, List<TypeDefinitionHandle>> Fields,
         Dictionary<string, List<TypeDefinitionHandle>> Namespaces,
         Dictionary<TypeDefinitionHandle, string> RootNamespaces);
 
@@ -763,6 +765,8 @@ static class ReturnToSender
         var types = new Dictionary<string, List<TypeDefinitionHandle>>(StringComparer.Ordinal);
         var fullTypes = new Dictionary<string, List<TypeDefinitionHandle>>(StringComparer.Ordinal);
         var methods = new Dictionary<string, List<TypeDefinitionHandle>>(StringComparer.Ordinal);
+        var properties = new Dictionary<string, List<TypeDefinitionHandle>>(StringComparer.Ordinal);
+        var fields = new Dictionary<string, List<TypeDefinitionHandle>>(StringComparer.Ordinal);
         var namespaces = new Dictionary<string, List<TypeDefinitionHandle>>(StringComparer.Ordinal);
         var rootNamespaces = new Dictionary<TypeDefinitionHandle, string>();
 
@@ -791,39 +795,73 @@ static class ReturnToSender
                 Add(namespaces, reader.GetString(typeDef.Namespace), handle);
             foreach (var methodHandle in typeDef.GetMethods())
                 Add(methods, reader.GetString(reader.GetMethodDefinition(methodHandle).Name), root);
+            foreach (var propertyHandle in typeDef.GetProperties())
+                Add(properties, reader.GetString(reader.GetPropertyDefinition(propertyHandle).Name), root);
+            foreach (var fieldHandle in typeDef.GetFields())
+                Add(fields, reader.GetString(reader.GetFieldDefinition(fieldHandle).Name), root);
         }
 
-        return new ClosureIndex(types, fullTypes, methods, namespaces, rootNamespaces);
+        return new ClosureIndex(types, fullTypes, methods, properties, fields, namespaces, rootNamespaces);
     }
 
     static bool AddClosureRoots(
         IReadOnlyList<Diagnostic> diagnostics,
         ClosureIndex indexes,
         string targetNamespace,
+        TypeDefinitionHandle preferredRoot,
         HashSet<TypeDefinitionHandle> closureRoots,
         Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts)
     {
         bool grew = false;
         foreach (var diagnostic in diagnostics)
         {
-            if (diagnostic.Id is "CS0246" or "CS0234" or "CS0103")
+            if (diagnostic.Id is "CS0246" or "CS0234" or "CS0103" or "CS0122")
             {
                 var names = QuotedNames(diagnostic.GetMessage()).ToList();
                 foreach (var name in names)
                 {
                     var index = name.Contains('.', StringComparison.Ordinal) ? indexes.FullTypes : indexes.Types;
                     var key = name.Contains('.', StringComparison.Ordinal) ? name : NormalizeTypeName(name);
-                    grew |= AddRoots(indexes, index, key, diagnostic, name, targetNamespace, closureRoots, closureFacts);
+                    grew |= AddRoots(indexes, index, key, diagnostic, name, targetNamespace, preferredRoot, addMemberSurfaceFact: false, closureRoots, closureFacts);
                     if (diagnostic.Id is "CS0103")
-                        grew |= AddRoots(indexes, indexes.Methods, NormalizeTypeName(name), diagnostic, name, targetNamespace, closureRoots, closureFacts);
+                    {
+                        grew |= AddRoots(indexes, indexes.Methods, NormalizeTypeName(name), diagnostic, name, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                        grew |= AddRoots(indexes, indexes.Properties, NormalizeTypeName(name), diagnostic, name, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                        grew |= AddRoots(indexes, indexes.Fields, name, diagnostic, name, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                    }
                 }
                 if (diagnostic.Id is "CS0234" && names.Count == 2)
-                    grew |= AddRoots(indexes, indexes.Namespaces, $"{names[1]}.{names[0]}", diagnostic, $"{names[1]}.{names[0]}", targetNamespace, closureRoots, closureFacts);
+                    grew |= AddRoots(indexes, indexes.Namespaces, $"{names[1]}.{names[0]}", diagnostic, $"{names[1]}.{names[0]}", targetNamespace, preferredRoot, addMemberSurfaceFact: false, closureRoots, closureFacts);
             }
             else if (diagnostic.Id is "CS1061")
             {
-                foreach (var name in QuotedNames(diagnostic.GetMessage()))
-                    grew |= AddRoots(indexes, indexes.Methods, NormalizeTypeName(name), diagnostic, name, targetNamespace, closureRoots, closureFacts);
+                var names = QuotedNames(diagnostic.GetMessage()).ToList();
+                if (names.Count >= 2)
+                {
+                    var typeName = names[0];
+                    var index = typeName.Contains('.', StringComparison.Ordinal) ? indexes.FullTypes : indexes.Types;
+                    var key = typeName.Contains('.', StringComparison.Ordinal) ? typeName : NormalizeTypeName(typeName);
+                    grew |= AddRoots(indexes, index, key, diagnostic, $"{typeName}.{names[1]}", targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                }
+                else
+                {
+                    foreach (var name in names)
+                    {
+                        grew |= AddRoots(indexes, indexes.Methods, NormalizeTypeName(name), diagnostic, name, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                        grew |= AddRoots(indexes, indexes.Properties, NormalizeTypeName(name), diagnostic, name, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                    }
+                }
+            }
+            else if (diagnostic.Id is "CS0117")
+            {
+                var names = QuotedNames(diagnostic.GetMessage()).ToList();
+                if (names.Count >= 2)
+                {
+                    var typeName = names[0];
+                    var index = typeName.Contains('.', StringComparison.Ordinal) ? indexes.FullTypes : indexes.Types;
+                    var key = typeName.Contains('.', StringComparison.Ordinal) ? typeName : NormalizeTypeName(typeName);
+                    grew |= AddRoots(indexes, index, key, diagnostic, $"{typeName}.{names[1]}", targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                }
             }
         }
 
@@ -837,6 +875,8 @@ static class ReturnToSender
         Diagnostic diagnostic,
         string detail,
         string targetNamespace,
+        TypeDefinitionHandle preferredRoot,
+        bool addMemberSurfaceFact,
         HashSet<TypeDefinitionHandle> closureRoots,
         Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts)
     {
@@ -845,13 +885,20 @@ static class ReturnToSender
 
         if (!key.Contains('.', StringComparison.Ordinal) && roots.Count > 1)
         {
-            var sameNamespace = roots
+            if (roots.Contains(preferredRoot))
+            {
+                roots = [preferredRoot];
+            }
+            else
+            {
+                var sameNamespace = roots
                 .Where(root => indexes.RootNamespaces.TryGetValue(root, out var ns) && ns == targetNamespace)
                 .ToList();
-            if (sameNamespace.Count == 1)
-                roots = sameNamespace;
-            else
-                return false;
+                if (sameNamespace.Count == 1)
+                    roots = sameNamespace;
+                else
+                    return false;
+            }
         }
 
         bool changed = false;
@@ -861,11 +908,20 @@ static class ReturnToSender
 
             if (!closureFacts.TryGetValue(root, out var facts))
                 closureFacts[root] = facts = [];
-            var fact = new CompileBackFact("roslyn", "closure-root", $"{diagnostic.Id}: {detail}");
-            if (!facts.Contains(fact))
+            var rootFact = new CompileBackFact("roslyn", "closure-root", $"{diagnostic.Id}: {detail}");
+            if (!facts.Contains(rootFact))
             {
-                facts.Add(fact);
+                facts.Add(rootFact);
                 changed = true;
+            }
+            if (addMemberSurfaceFact)
+            {
+                var memberFact = new CompileBackFact("roslyn", "closure-member", $"{diagnostic.Id}: {detail}");
+                if (!facts.Contains(memberFact))
+                {
+                    facts.Add(memberFact);
+                    changed = true;
+                }
             }
         }
 

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -841,7 +841,15 @@ static class ReturnToSender
                     var typeName = names[0];
                     var index = typeName.Contains('.', StringComparison.Ordinal) ? indexes.FullTypes : indexes.Types;
                     var key = typeName.Contains('.', StringComparison.Ordinal) ? typeName : NormalizeTypeName(typeName);
-                    grew |= AddRoots(indexes, index, key, diagnostic, $"{typeName}.{names[1]}", targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                    var typeGrew = AddRoots(indexes, index, key, diagnostic, $"{typeName}.{names[1]}", targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts, out var typeResolved);
+                    grew |= typeGrew;
+                    if (!typeResolved)
+                    {
+                        string memberName = names[1];
+                        grew |= AddRoots(indexes, indexes.Methods, NormalizeTypeName(memberName), diagnostic, memberName, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                        grew |= AddRoots(indexes, indexes.Properties, NormalizeTypeName(memberName), diagnostic, memberName, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                        grew |= AddRoots(indexes, indexes.Fields, memberName, diagnostic, memberName, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                    }
                 }
                 else
                 {
@@ -860,7 +868,15 @@ static class ReturnToSender
                     var typeName = names[0];
                     var index = typeName.Contains('.', StringComparison.Ordinal) ? indexes.FullTypes : indexes.Types;
                     var key = typeName.Contains('.', StringComparison.Ordinal) ? typeName : NormalizeTypeName(typeName);
-                    grew |= AddRoots(indexes, index, key, diagnostic, $"{typeName}.{names[1]}", targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                    var typeGrew = AddRoots(indexes, index, key, diagnostic, $"{typeName}.{names[1]}", targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts, out var typeResolved);
+                    grew |= typeGrew;
+                    if (!typeResolved)
+                    {
+                        string memberName = names[1];
+                        grew |= AddRoots(indexes, indexes.Methods, NormalizeTypeName(memberName), diagnostic, memberName, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                        grew |= AddRoots(indexes, indexes.Properties, NormalizeTypeName(memberName), diagnostic, memberName, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                        grew |= AddRoots(indexes, indexes.Fields, memberName, diagnostic, memberName, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
+                    }
                 }
             }
         }
@@ -879,7 +895,33 @@ static class ReturnToSender
         bool addMemberSurfaceFact,
         HashSet<TypeDefinitionHandle> closureRoots,
         Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts)
+        => AddRoots(
+            indexes,
+            index,
+            key,
+            diagnostic,
+            detail,
+            targetNamespace,
+            preferredRoot,
+            addMemberSurfaceFact,
+            closureRoots,
+            closureFacts,
+            out _);
+
+    static bool AddRoots(
+        ClosureIndex indexes,
+        IReadOnlyDictionary<string, List<TypeDefinitionHandle>> index,
+        string key,
+        Diagnostic diagnostic,
+        string detail,
+        string targetNamespace,
+        TypeDefinitionHandle preferredRoot,
+        bool addMemberSurfaceFact,
+        HashSet<TypeDefinitionHandle> closureRoots,
+        Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
+        out bool resolved)
     {
+        resolved = false;
         if (!index.TryGetValue(key, out var roots))
             return false;
 
@@ -901,6 +943,7 @@ static class ReturnToSender
             }
         }
 
+        resolved = true;
         bool changed = false;
         foreach (var root in roots)
         {


### PR DESCRIPTION
- Advances #2049 and #2050
- Changes ReturnToSender A/B to compare exact targets and hardens product-side compile-back source composition for RTS closure/member surfaces.
- Evidence revision: `6c516261`

## Change

> Should we accept this RTS compile-back architecture step?

**Conclusion:** **PASS** — RTS now compares against the exact current compile-back target population and the measured property-getter population is clean across both the decompiler test assembly and the harness assembly.

Before:

```text
RETURNTOSENDER A/B over 80 property getters

  Same          : 70
  Worse         : 10
  CurrentMissing: 0
```

After:

```text
RETURNTOSENDER A/B over 217 property getters

  Rescued       : 0
  Same          : 217
  Changed       : 0
  Worse         : 0
  CurrentMissing: 0
```

## Scope and safety

- **Root cause:** RTS was comparing against a capped nearby current-side sample, and product-side source composition lacked enough declaration/member surface for real closure diagnostics.
- **Fix shape:** Exact-target current compile-back comparison plus product-owned field, const, unsafe, nested, and closure-member declaration generation. RTS still only orchestrates closure growth, Roslyn compile, opcode compare, and reporting.
- **Product impact:** Compile-back source composition only; no normal decompiler output behavior is intended to change.
- **Scope boundary:** This keeps the target population to supported property getters. Generic/indexer target expansion and richer structured signatures remain future work; #2057 should help that next layer.
- **RTS boundary:** RTS does not write C# shells; product/shared code owns C# source/declaration generation.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Harness build | Pass |
| Focused tests | `ReturnToSenderPrototypeTests` `22/22` passed |
| Decompiler fast suite | `1782/1782` passed with `-trait- "Speed=Slow"` |
| ReturnToSender A/B | `ILInspector.Decompiler.Tests.dll` `217 Same / 0 Worse / 0 CurrentMissing` |
| Broad RTS A/B | `decompiler-harness.dll` `248 Same / 0 Worse / 0 CurrentMissing` |
| Build-event validation | Not applicable |

### ReturnToSender A/B

Run: `artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll`, `--cap 500`, `--max-examples 40`.

```text
RETURNTOSENDER A/B over 217 property getters

  Rescued       : 0
  Same          : 217
  Changed       : 0
  Worse         : 0
  CurrentMissing: 0
```

Run: `tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll`, `--cap 300`, `--max-examples 40`.

```text
RETURNTOSENDER A/B over 248 property getters

  Rescued       : 0
  Same          : 248
  Changed       : 0
  Worse         : 0
  CurrentMissing: 0
```

| Delta | Count | Interpretation | Example |
| --- | ---: | --- | --- |
| Rescued (+) | 0 | No sampled row where RTS improved over current | n/a |
| Same (=) | 217 / 248 | RTS matched current status on exact target sets | property-getter populations |
| Worse (-) | 0 | RTS did not lose current checked fidelity | n/a |
| CurrentMissing (?) | 0 | Current comparison reached every RTS target | n/a |

**RTS verdict:** **PASS** — exact-target A/B removes the prior sampling artifact, and the current measured RTS property-getter population is no worse than current compile-back.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Generic/indexer RTS targets | Left as frontier | Target enumeration remains intentionally property-getter focused. |
| Function-pointer broad closure surface | Left as frontier | Unsupported for broad non-target surface; unsafe target and closure-member pointer cases are covered. |
| Structured signature model (#2057) | Future architecture help | Should reduce string-based declaration risk for harder shapes. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Initial review clean; delayed follow-up clean for the first review-resolution delta. |
| Gemini 3.1 Pro | Findings resolved, final clean | Found nested unsafe closure-member gap; fixed in `6c20b745`; final latest-HEAD review clean. |
| MAI Code Flash | Findings resolved, final clean | Found const-field and non-finite const-literal issues; fixed in `d8fbbf72` and `6c516261`; final pass clean. |

**Review conclusion:** **PASS** — all blocking/high-confidence review findings were resolved, and final Gemini + MAI latest-HEAD reviews reported no blocking findings.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet -p:NoWarn=NU1507
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 40
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-ab --cap 300 --max-examples 40
```
