### PR TITLE
Use metadata identity for XML doc lookup

### DIFF
--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -144,7 +144,7 @@ public static class ApiMemberIdentity
         IReadOnlyDictionary<string, int> typeParameterMap,
         IReadOnlyDictionary<string, int> methodParameterMap)
     {
-        var type = parameter.Trim();
+        var type = StripLeadingAttributes(parameter.Trim());
         var isByRef = false;
         foreach (var prefix in (string[])["ref ", "out ", "in ", "params ", "this "])
         {
@@ -161,10 +161,24 @@ public static class ApiMemberIdentity
             isByRef = true;
             type = type.TrimEnd('@');
         }
-        type = type.Replace("?", "", StringComparison.Ordinal);
+        var nullableValueType = false;
+        if (type.EndsWith("?", StringComparison.Ordinal))
+        {
+            var unwrapped = type[..^1];
+            if (PrimitiveTypeNames.TryToClrFullName(unwrapped, out var primitive)
+                && primitive is not ("System.String" or "System.Object" or "System.Void"))
+            {
+                type = $"System.Nullable<{primitive}>";
+                nullableValueType = true;
+            }
+            else
+            {
+                type = unwrapped;
+            }
+        }
 
         string normalized;
-        if (TryNormalizeGenericParameterReference(type, typeParameterMap, methodParameterMap, out var genericParameter))
+        if (!nullableValueType && TryNormalizeGenericParameterReference(type, typeParameterMap, methodParameterMap, out var genericParameter))
         {
             normalized = genericParameter;
         }
@@ -389,11 +403,12 @@ public static class ApiMemberIdentity
             return false;
 
         var rankSpec = type[(open + 1)..^1];
-        if (rankSpec.Any(c => c != ',' && !char.IsWhiteSpace(c)))
+        if (rankSpec.Length == 0)
             return false;
 
         elementType = type[..open];
-        suffix = type[open..];
+        var rank = rankSpec.Count(c => c == ',') + 1;
+        suffix = "[" + new string(',', rank - 1) + "]";
         return true;
     }
 }

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -7,7 +7,10 @@ namespace ILInspector.Metadata;
 /// </summary>
 public static class ApiMemberIdentity
 {
-    public sealed record XmlDocMemberIdentity(string LookupKey, IReadOnlyList<string> NormalizedParameters);
+    public sealed record XmlDocMemberIdentity(
+        string LookupKey,
+        IReadOnlyList<string> NormalizedParameters,
+        string? NormalizedReturnType = null);
 
     public static bool TryGetCanonicalSignature(ApiType type, ApiMember member, out string canonicalSignature)
     {
@@ -94,7 +97,7 @@ public static class ApiMemberIdentity
     public static bool TryGetXmlDocMemberIdentity(ApiType type, ApiMember member, out XmlDocMemberIdentity identity)
     {
         var typeXmlName = ToXmlDocName(type.FullName);
-        var memberName = member.Name == ".ctor" ? "#ctor" : member.Name;
+        var memberName = member.Name == ".ctor" ? "#ctor" : ToXmlDocMemberName(member.Name);
         var prefix = member.Kind switch
         {
             "property" => "P",
@@ -117,7 +120,10 @@ public static class ApiMemberIdentity
         var parameters = signature.Parameters
             .Select(parameter => NormalizeXmlDocParameterType(parameter.TypeWithModifier, typeParameterMap, methodParameterMap))
             .ToList();
-        identity = new XmlDocMemberIdentity(lookupKey, parameters);
+        var returnType = IsConversionOperator(member.Name) && !string.IsNullOrWhiteSpace(signature.ReturnType)
+            ? NormalizeXmlDocParameterType(signature.ReturnType!, typeParameterMap, methodParameterMap)
+            : null;
+        identity = new XmlDocMemberIdentity(lookupKey, parameters, returnType);
         return true;
     }
 
@@ -139,34 +145,50 @@ public static class ApiMemberIdentity
         IReadOnlyDictionary<string, int> methodParameterMap)
     {
         var type = parameter.Trim();
+        var isByRef = false;
         foreach (var prefix in (string[])["ref ", "out ", "in ", "params ", "this "])
         {
             if (type.StartsWith(prefix, StringComparison.Ordinal))
             {
+                isByRef = prefix is "ref " or "out " or "in ";
                 type = type[prefix.Length..].TrimStart();
                 break;
             }
         }
 
-        type = type.TrimEnd('@');
+        if (type.EndsWith('@'))
+        {
+            isByRef = true;
+            type = type.TrimEnd('@');
+        }
         type = type.Replace("?", "", StringComparison.Ordinal);
 
+        string normalized;
         if (TryNormalizeGenericParameterReference(type, typeParameterMap, methodParameterMap, out var genericParameter))
-            return genericParameter;
-
-        if (type.EndsWith("[]", StringComparison.Ordinal))
-            return $"{NormalizeXmlDocParameterType(type[..^2], typeParameterMap, methodParameterMap)}[]";
-
-        var genericStart = IndexOfAny(type, '<', '{');
-        if (genericStart >= 0 && TryGetGenericParts(type, genericStart, out var genericType, out var genericArgs))
         {
-            var normalizedType = PrimitiveTypeNames.ToClrFullName(genericType);
-            var normalizedArgs = SplitParameters(genericArgs)
-                .Select(p => NormalizeXmlDocParameterType(p, typeParameterMap, methodParameterMap));
-            return $"{normalizedType}{{{string.Join(",", normalizedArgs)}}}";
+            normalized = genericParameter;
+        }
+        else if (type.EndsWith("[]", StringComparison.Ordinal))
+        {
+            normalized = $"{NormalizeXmlDocParameterType(type[..^2], typeParameterMap, methodParameterMap)}[]";
+        }
+        else
+        {
+            var genericStart = IndexOfAny(type, '<', '{');
+            if (genericStart >= 0 && TryGetGenericParts(type, genericStart, out var genericType, out var genericArgs))
+            {
+                var normalizedType = PrimitiveTypeNames.ToClrFullName(genericType);
+                var normalizedArgs = SplitParameters(genericArgs)
+                    .Select(p => NormalizeXmlDocParameterType(p, typeParameterMap, methodParameterMap));
+                normalized = $"{normalizedType}{{{string.Join(",", normalizedArgs)}}}";
+            }
+            else
+            {
+                normalized = PrimitiveTypeNames.ToClrFullName(type);
+            }
         }
 
-        return PrimitiveTypeNames.ToClrFullName(type);
+        return isByRef ? $"{normalized}@" : normalized;
     }
 
     static string ExtractSignatureParameterType(string parameter)
@@ -174,6 +196,7 @@ public static class ApiMemberIdentity
         var eqIndex = parameter.IndexOf('=');
         if (eqIndex >= 0)
             parameter = parameter[..eqIndex].Trim();
+        parameter = StripLeadingAttributes(parameter.TrimStart());
 
         var depth = 0;
         var lastSpace = -1;
@@ -187,6 +210,34 @@ public static class ApiMemberIdentity
         }
 
         return lastSpace > 0 ? parameter[..lastSpace] : parameter;
+    }
+
+    static string StripLeadingAttributes(string parameter)
+    {
+        while (parameter.StartsWith('['))
+        {
+            var depth = 0;
+            var end = -1;
+            for (var i = 0; i < parameter.Length; i++)
+            {
+                if (parameter[i] == '[') depth++;
+                else if (parameter[i] == ']')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        end = i;
+                        break;
+                    }
+                }
+            }
+
+            if (end < 0)
+                return parameter;
+            parameter = parameter[(end + 1)..].TrimStart();
+        }
+
+        return parameter;
     }
 
     static Dictionary<string, int> GetMethodGenericParameterMap(string? memberName)
@@ -304,4 +355,10 @@ public static class ApiMemberIdentity
 
     static string ToXmlDocName(string typeName)
         => typeName.Replace('+', '.');
+
+    static string ToXmlDocMemberName(string memberName)
+        => memberName is ".cctor" ? memberName : memberName.Replace('.', '#');
+
+    static bool IsConversionOperator(string memberName)
+        => memberName is "op_Implicit" or "op_Explicit" or "op_CheckedExplicit";
 }

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -124,6 +124,12 @@ public static class ApiMemberIdentity
     public static string NormalizeXmlDocParameterType(string parameter)
         => NormalizeXmlDocParameterType(parameter, EmptyParameterMap, EmptyParameterMap);
 
+    internal static string NormalizeXmlDocSignatureParameter(
+        string parameter,
+        IReadOnlyDictionary<string, int> typeParameterMap,
+        IReadOnlyDictionary<string, int> methodParameterMap)
+        => NormalizeXmlDocParameterType(ExtractSignatureParameterType(parameter), typeParameterMap, methodParameterMap);
+
     static readonly IReadOnlyDictionary<string, int> EmptyParameterMap =
         new Dictionary<string, int>(StringComparer.Ordinal);
 
@@ -161,6 +167,26 @@ public static class ApiMemberIdentity
         }
 
         return PrimitiveTypeNames.ToClrFullName(type);
+    }
+
+    static string ExtractSignatureParameterType(string parameter)
+    {
+        var eqIndex = parameter.IndexOf('=');
+        if (eqIndex >= 0)
+            parameter = parameter[..eqIndex].Trim();
+
+        var depth = 0;
+        var lastSpace = -1;
+        for (var i = 0; i < parameter.Length; i++)
+        {
+            var c = parameter[i];
+            if (c == '<') depth++;
+            else if (c == '>') depth--;
+            else if (c == ' ' && depth == 0)
+                lastSpace = i;
+        }
+
+        return lastSpace > 0 ? parameter[..lastSpace] : parameter;
     }
 
     static Dictionary<string, int> GetMethodGenericParameterMap(string? memberName)

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -7,6 +7,8 @@ namespace ILInspector.Metadata;
 /// </summary>
 public static class ApiMemberIdentity
 {
+    public sealed record XmlDocMemberIdentity(string LookupKey, IReadOnlyList<string> NormalizedParameters);
+
     public static bool TryGetCanonicalSignature(ApiType type, ApiMember member, out string canonicalSignature)
     {
         var declaringType = string.IsNullOrWhiteSpace(member.DeclaringType)
@@ -88,4 +90,198 @@ public static class ApiMemberIdentity
 
     static string NormalizeCanonicalCommas(string value)
         => value.Replace(", ", ",", StringComparison.Ordinal).Trim();
+
+    public static bool TryGetXmlDocMemberIdentity(ApiType type, ApiMember member, out XmlDocMemberIdentity identity)
+    {
+        var typeXmlName = ToXmlDocName(type.FullName);
+        var memberName = member.Name == ".ctor" ? "#ctor" : member.Name;
+        var prefix = member.Kind switch
+        {
+            "property" => "P",
+            "field" => "F",
+            "event" => "E",
+            _ => "M"
+        };
+
+        var lookupKey = $"{prefix}:{typeXmlName}.{memberName}";
+        if (member.SignatureModel is not { } signature)
+        {
+            if (member.Kind is "property" or "field" or "event")
+            {
+                identity = new XmlDocMemberIdentity(lookupKey, []);
+                return true;
+            }
+
+            identity = new XmlDocMemberIdentity("", []);
+            return false;
+        }
+
+        var typeParameterMap = type.TypeParameters
+            .Select((p, i) => (p.Name, Index: i))
+            .ToDictionary(p => p.Name, p => p.Index, StringComparer.Ordinal);
+        var methodParameterMap = GetMethodGenericParameterMap(signature.MemberName);
+        var parameters = signature.Parameters
+            .Select(parameter => NormalizeXmlDocParameterType(parameter.TypeWithModifier, typeParameterMap, methodParameterMap))
+            .ToList();
+        identity = new XmlDocMemberIdentity(lookupKey, parameters);
+        return true;
+    }
+
+    public static string NormalizeXmlDocParameterType(string parameter)
+        => NormalizeXmlDocParameterType(parameter, EmptyParameterMap, EmptyParameterMap);
+
+    static readonly IReadOnlyDictionary<string, int> EmptyParameterMap =
+        new Dictionary<string, int>(StringComparer.Ordinal);
+
+    static string NormalizeXmlDocParameterType(
+        string parameter,
+        IReadOnlyDictionary<string, int> typeParameterMap,
+        IReadOnlyDictionary<string, int> methodParameterMap)
+    {
+        var type = parameter.Trim();
+        foreach (var prefix in (string[])["ref ", "out ", "in ", "params ", "this "])
+        {
+            if (type.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                type = type[prefix.Length..].TrimStart();
+                break;
+            }
+        }
+
+        type = type.TrimEnd('@');
+        type = type.Replace("?", "", StringComparison.Ordinal);
+
+        if (TryNormalizeGenericParameterReference(type, typeParameterMap, methodParameterMap, out var genericParameter))
+            return genericParameter;
+
+        if (type.EndsWith("[]", StringComparison.Ordinal))
+            return $"{NormalizeXmlDocParameterType(type[..^2], typeParameterMap, methodParameterMap)}[]";
+
+        var genericStart = IndexOfAny(type, '<', '{');
+        if (genericStart >= 0 && TryGetGenericParts(type, genericStart, out var genericType, out var genericArgs))
+        {
+            var normalizedType = PrimitiveTypeNames.ToClrFullName(genericType);
+            var normalizedArgs = SplitParameters(genericArgs)
+                .Select(p => NormalizeXmlDocParameterType(p, typeParameterMap, methodParameterMap));
+            return $"{normalizedType}{{{string.Join(",", normalizedArgs)}}}";
+        }
+
+        return PrimitiveTypeNames.ToClrFullName(type);
+    }
+
+    static Dictionary<string, int> GetMethodGenericParameterMap(string? memberName)
+    {
+        if (string.IsNullOrWhiteSpace(memberName))
+            return new Dictionary<string, int>(StringComparer.Ordinal);
+
+        var genericStart = memberName.IndexOf('<');
+        if (genericStart < 0)
+            return new Dictionary<string, int>(StringComparer.Ordinal);
+
+        if (!TryGetGenericParts(memberName, genericStart, out _, out var parameters))
+            return new Dictionary<string, int>(StringComparer.Ordinal);
+
+        return SplitParameters(parameters)
+            .Select((name, index) => (Name: name.Trim(), Index: index))
+            .Where(p => p.Name.Length > 0)
+            .ToDictionary(p => p.Name, p => p.Index, StringComparer.Ordinal);
+    }
+
+    static IEnumerable<string> SplitParameters(string parameters)
+    {
+        var depth = 0;
+        var lastSplit = 0;
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            var c = parameters[i];
+            if (c is '<' or '{' or '(')
+                depth++;
+            else if (c is '>' or '}' or ')')
+                depth--;
+            else if (c == ',' && depth == 0)
+            {
+                yield return parameters[lastSplit..i].Trim();
+                lastSplit = i + 1;
+            }
+        }
+
+        yield return parameters[lastSplit..].Trim();
+    }
+
+    static int IndexOfAny(string value, char first, char second)
+    {
+        var firstIndex = value.IndexOf(first);
+        var secondIndex = value.IndexOf(second);
+        return (firstIndex, secondIndex) switch
+        {
+            (< 0, < 0) => -1,
+            (< 0, _) => secondIndex,
+            (_, < 0) => firstIndex,
+            _ => Math.Min(firstIndex, secondIndex)
+        };
+    }
+
+    static bool TryGetGenericParts(string type, int genericStart, out string genericType, out string genericArgs)
+    {
+        genericType = type[..genericStart];
+        genericArgs = "";
+
+        var open = type[genericStart];
+        var close = open == '<' ? '>' : '}';
+        var depth = 0;
+        for (var i = genericStart; i < type.Length; i++)
+        {
+            var c = type[i];
+            if (c == open)
+                depth++;
+            else if (c == close)
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    genericArgs = type[(genericStart + 1)..i];
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    static bool TryNormalizeGenericParameterReference(
+        string type,
+        IReadOnlyDictionary<string, int> typeParameterMap,
+        IReadOnlyDictionary<string, int> methodParameterMap,
+        out string normalized)
+    {
+        normalized = "";
+        if (type.StartsWith("``", StringComparison.Ordinal) && int.TryParse(type[2..], out var methodIndex))
+        {
+            normalized = $"M{methodIndex}";
+            return true;
+        }
+
+        if (type.StartsWith('`') && int.TryParse(type[1..], out var typeIndex))
+        {
+            normalized = $"T{typeIndex}";
+            return true;
+        }
+
+        if (methodParameterMap.TryGetValue(type, out methodIndex))
+        {
+            normalized = $"M{methodIndex}";
+            return true;
+        }
+
+        if (typeParameterMap.TryGetValue(type, out typeIndex))
+        {
+            normalized = $"T{typeIndex}";
+            return true;
+        }
+
+        return false;
+    }
+
+    static string ToXmlDocName(string typeName)
+        => typeName.Replace('+', '.');
 }

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -172,6 +172,14 @@ public static class ApiMemberIdentity
         {
             normalized = $"{NormalizeXmlDocParameterType(type[..^2], typeParameterMap, methodParameterMap)}[]";
         }
+        else if (type.EndsWith("*", StringComparison.Ordinal))
+        {
+            normalized = $"{NormalizeXmlDocParameterType(type[..^1], typeParameterMap, methodParameterMap)}*";
+        }
+        else if (TryGetArraySuffix(type, out var arrayElementType, out var arraySuffix))
+        {
+            normalized = $"{NormalizeXmlDocParameterType(arrayElementType, typeParameterMap, methodParameterMap)}{arraySuffix}";
+        }
         else
         {
             var genericStart = IndexOfAny(type, '<', '{');
@@ -193,10 +201,10 @@ public static class ApiMemberIdentity
 
     static string ExtractSignatureParameterType(string parameter)
     {
+        parameter = StripLeadingAttributes(parameter.TrimStart());
         var eqIndex = parameter.IndexOf('=');
         if (eqIndex >= 0)
             parameter = parameter[..eqIndex].Trim();
-        parameter = StripLeadingAttributes(parameter.TrimStart());
 
         var depth = 0;
         var lastSpace = -1;
@@ -245,11 +253,13 @@ public static class ApiMemberIdentity
         if (string.IsNullOrWhiteSpace(memberName))
             return new Dictionary<string, int>(StringComparer.Ordinal);
 
-        var genericStart = memberName.IndexOf('<');
+        var memberSegmentStart = memberName.LastIndexOf('.');
+        var memberSegment = memberSegmentStart >= 0 ? memberName[(memberSegmentStart + 1)..] : memberName;
+        var genericStart = memberSegment.IndexOf('<');
         if (genericStart < 0)
             return new Dictionary<string, int>(StringComparer.Ordinal);
 
-        if (!TryGetGenericParts(memberName, genericStart, out _, out var parameters))
+        if (!TryGetGenericParts(memberSegment, genericStart, out _, out var parameters))
             return new Dictionary<string, int>(StringComparer.Ordinal);
 
         return SplitParameters(parameters)
@@ -357,8 +367,33 @@ public static class ApiMemberIdentity
         => typeName.Replace('+', '.');
 
     static string ToXmlDocMemberName(string memberName)
-        => memberName is ".cctor" ? memberName : memberName.Replace('.', '#');
+        => memberName is ".cctor"
+            ? memberName
+            : memberName
+                .Replace('.', '#')
+                .Replace('<', '{')
+                .Replace('>', '}');
 
     static bool IsConversionOperator(string memberName)
         => memberName is "op_Implicit" or "op_Explicit" or "op_CheckedExplicit";
+
+    static bool TryGetArraySuffix(string type, out string elementType, out string suffix)
+    {
+        elementType = "";
+        suffix = "";
+        if (!type.EndsWith("]", StringComparison.Ordinal))
+            return false;
+
+        var open = type.LastIndexOf('[');
+        if (open <= 0)
+            return false;
+
+        var rankSpec = type[(open + 1)..^1];
+        if (rankSpec.Any(c => c != ',' && !char.IsWhiteSpace(c)))
+            return false;
+
+        elementType = type[..open];
+        suffix = type[open..];
+        return true;
+    }
 }

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -106,12 +106,6 @@ public static class ApiMemberIdentity
         var lookupKey = $"{prefix}:{typeXmlName}.{memberName}";
         if (member.SignatureModel is not { } signature)
         {
-            if (member.Kind is "property" or "field" or "event")
-            {
-                identity = new XmlDocMemberIdentity(lookupKey, []);
-                return true;
-            }
-
             identity = new XmlDocMemberIdentity("", []);
             return false;
         }
@@ -133,7 +127,7 @@ public static class ApiMemberIdentity
     static readonly IReadOnlyDictionary<string, int> EmptyParameterMap =
         new Dictionary<string, int>(StringComparer.Ordinal);
 
-    static string NormalizeXmlDocParameterType(
+    internal static string NormalizeXmlDocParameterType(
         string parameter,
         IReadOnlyDictionary<string, int> typeParameterMap,
         IReadOnlyDictionary<string, int> methodParameterMap)

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -139,6 +139,17 @@ public static class ApiMemberIdentity
     static readonly IReadOnlyDictionary<string, int> EmptyParameterMap =
         new Dictionary<string, int>(StringComparer.Ordinal);
 
+    static readonly HashSet<string> KnownNullableValueTypes = new(StringComparer.Ordinal)
+    {
+        "System.DateTime",
+        "System.DateTimeOffset",
+        "System.Decimal",
+        "System.Guid",
+        "System.TimeSpan",
+        "System.IntPtr",
+        "System.UIntPtr"
+    };
+
     internal static string NormalizeXmlDocParameterType(
         string parameter,
         IReadOnlyDictionary<string, int> typeParameterMap,
@@ -169,6 +180,11 @@ public static class ApiMemberIdentity
                 && primitive is not ("System.String" or "System.Object" or "System.Void"))
             {
                 type = $"System.Nullable<{primitive}>";
+                nullableValueType = true;
+            }
+            else if (KnownNullableValueTypes.Contains(unwrapped))
+            {
+                type = $"System.Nullable<{unwrapped}>";
                 nullableValueType = true;
             }
             else

--- a/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
+++ b/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
@@ -145,8 +145,9 @@ public class XmlDocFileParser
         if (!_loaded)
             return null;
 
-        if (ApiMemberIdentity.TryGetXmlDocMemberIdentity(apiType, member, out var identity))
-            return GetMemberDocumentation(identity);
+        if (ApiMemberIdentity.TryGetXmlDocMemberIdentity(apiType, member, out var identity)
+            && GetMemberDocumentation(identity) is { } structuredMatch)
+            return structuredMatch;
 
         var typeXmlName = ConvertToXmlDocName(apiType.FullName);
         var xmlMemberName = member.Name == ".ctor" ? "#ctor" : member.Name;

--- a/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
+++ b/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
@@ -270,6 +270,7 @@ public class XmlDocFileParser
         IReadOnlyDictionary<string, int> methodParameterMap)
     {
         var paramList = SignatureParser.ExtractParamList(signature);
+        var stripParameterNames = false;
         if (string.IsNullOrEmpty(paramList) && !string.IsNullOrEmpty(signature))
         {
             var indexerStart = signature.IndexOf("this[", StringComparison.Ordinal);
@@ -278,7 +279,10 @@ public class XmlDocFileParser
                 var bracketStart = indexerStart + "this".Length;
                 var bracketEnd = signature.IndexOf(']', bracketStart);
                 if (bracketEnd > bracketStart)
+                {
                     paramList = $"({signature[(bracketStart + 1)..bracketEnd]})";
+                    stripParameterNames = true;
+                }
             }
         }
         if (string.IsNullOrEmpty(paramList))
@@ -291,7 +295,9 @@ public class XmlDocFileParser
             return [];
 
         return SplitParameters(inner)
-            .Select(p => ApiMemberIdentity.NormalizeXmlDocParameterType(p, typeParameterMap, methodParameterMap))
+            .Select(p => stripParameterNames
+                ? ApiMemberIdentity.NormalizeXmlDocSignatureParameter(p, typeParameterMap, methodParameterMap)
+                : ApiMemberIdentity.NormalizeXmlDocParameterType(p, typeParameterMap, methodParameterMap))
             .ToList();
     }
 

--- a/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
+++ b/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
@@ -145,6 +145,9 @@ public class XmlDocFileParser
         if (!_loaded)
             return null;
 
+        if (ApiMemberIdentity.TryGetXmlDocMemberIdentity(apiType, member, out var identity))
+            return GetMemberDocumentation(identity);
+
         var typeXmlName = ConvertToXmlDocName(apiType.FullName);
         var xmlMemberName = member.Name == ".ctor" ? "#ctor" : member.Name;
         var prefix = member.Kind switch
@@ -209,6 +212,58 @@ public class XmlDocFileParser
             : null;
     }
 
+    private DocCommentParser.DocComment? GetMemberDocumentation(ApiMemberIdentity.XmlDocMemberIdentity identity)
+    {
+        var xmlKey = identity.LookupKey;
+        var prefix = xmlKey.Length > 0 ? xmlKey[0].ToString() : "";
+
+        if (prefix != "M")
+        {
+            if (identity.NormalizedParameters.Count > 0)
+            {
+                var parameterizedCandidates = CandidateKeys(xmlKey)
+                    .Where(k => k.StartsWith($"{xmlKey}(", StringComparison.Ordinal))
+                    .ToList();
+                var matchingKey = parameterizedCandidates.FirstOrDefault(key =>
+                    TryGetXmlDocParameters(key, out var xmlParameters)
+                    && ParametersMatch(identity.NormalizedParameters, xmlParameters));
+                return matchingKey != null && _members.TryGetValue(matchingKey, out var matchingNode)
+                    ? ParseMemberNode(matchingNode)
+                    : null;
+            }
+
+            return _members.TryGetValue(xmlKey, out var node)
+                ? ParseMemberNode(node)
+                : null;
+        }
+
+        var candidates = CandidateKeys(xmlKey)
+            .Where(k =>
+                k == xmlKey
+                || k.StartsWith($"{xmlKey}(", StringComparison.Ordinal)
+                || k.StartsWith($"{xmlKey}``", StringComparison.Ordinal))
+            .ToList();
+        if (candidates.Count == 0)
+            return null;
+
+        if (identity.NormalizedParameters.Count > 0)
+        {
+            var matchingKey = candidates.FirstOrDefault(key =>
+                TryGetXmlDocParameters(key, out var xmlParameters)
+                && ParametersMatch(identity.NormalizedParameters, xmlParameters));
+            if (matchingKey != null && _members.TryGetValue(matchingKey, out var matchingNode))
+                return ParseMemberNode(matchingNode);
+
+            return null;
+        }
+
+        var fallbackKey = candidates.FirstOrDefault(key => key == xmlKey)
+            ?? candidates.FirstOrDefault();
+        return fallbackKey != null && _members.TryGetValue(fallbackKey, out var fallbackNode)
+            ? ParseMemberNode(fallbackNode)
+            : null;
+    }
+
     private static List<string> GetNormalizedSignatureParameters(
         string? signature,
         IReadOnlyDictionary<string, int> typeParameterMap,
@@ -252,7 +307,7 @@ public class XmlDocFileParser
         parameters = string.IsNullOrWhiteSpace(inner)
             ? []
             : SplitParameters(inner)
-                .Select(p => NormalizeParameterType(p, EmptyTypeParameterMap, EmptyTypeParameterMap))
+                .Select(ApiMemberIdentity.NormalizeXmlDocParameterType)
                 .ToList();
         return true;
     }

--- a/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
+++ b/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
@@ -291,7 +291,7 @@ public class XmlDocFileParser
             return [];
 
         return SplitParameters(inner)
-            .Select(p => NormalizeParameterType(p, typeParameterMap, methodParameterMap))
+            .Select(p => ApiMemberIdentity.NormalizeXmlDocParameterType(p, typeParameterMap, methodParameterMap))
             .ToList();
     }
 
@@ -382,47 +382,6 @@ public class XmlDocFileParser
             .ToDictionary(p => p.Name, p => p.Index, StringComparer.Ordinal);
     }
 
-    private static string NormalizeParameterType(
-        string parameter,
-        IReadOnlyDictionary<string, int> typeParameterMap,
-        IReadOnlyDictionary<string, int> methodParameterMap)
-    {
-        var type = SignatureParser.ExtractParamType(parameter.Trim());
-        foreach (var prefix in new[] { "ref ", "out ", "in ", "params ", "this " })
-        {
-            if (type.StartsWith(prefix, StringComparison.Ordinal))
-            {
-                type = type[prefix.Length..].TrimStart();
-                break;
-            }
-        }
-
-        type = type.TrimEnd('@');
-        type = RemoveNullableAnnotations(type);
-
-        if (TryNormalizeGenericParameterReference(type, typeParameterMap, methodParameterMap, out var genericParameter))
-            return genericParameter;
-
-        if (type.EndsWith("[]", StringComparison.Ordinal))
-            return $"{NormalizeParameterType(type[..^2], typeParameterMap, methodParameterMap)}[]";
-
-        var genericStart = IndexOfAny(type, '<', '{');
-        if (genericStart >= 0 && TryGetGenericParts(type, genericStart, out var genericType, out var genericArgs))
-        {
-            var normalizedType = NormalizeSimpleTypeName(genericType);
-            var normalizedArgs = SplitParameters(genericArgs)
-                .Select(p => NormalizeParameterType(p, typeParameterMap, methodParameterMap));
-            return $"{normalizedType}{{{string.Join(",", normalizedArgs)}}}";
-        }
-
-        return NormalizeSimpleTypeName(type);
-    }
-
-    private static string NormalizeSimpleTypeName(string type) => PrimitiveTypeNames.ToClrFullName(type);
-
-    private static string RemoveNullableAnnotations(string type)
-        => type.Replace("?", "", StringComparison.Ordinal);
-
     private static bool TryGetGenericParts(string type, int genericStart, out string genericType, out string genericArgs)
     {
         genericType = type[..genericStart];
@@ -448,53 +407,6 @@ public class XmlDocFileParser
         }
 
         return false;
-    }
-
-    private static bool TryNormalizeGenericParameterReference(
-        string type,
-        IReadOnlyDictionary<string, int> typeParameterMap,
-        IReadOnlyDictionary<string, int> methodParameterMap,
-        out string normalized)
-    {
-        normalized = "";
-        if (type.StartsWith("``", StringComparison.Ordinal) && int.TryParse(type[2..], out var methodIndex))
-        {
-            normalized = $"M{methodIndex}";
-            return true;
-        }
-
-        if (type.StartsWith('`') && int.TryParse(type[1..], out var typeIndex))
-        {
-            normalized = $"T{typeIndex}";
-            return true;
-        }
-
-        if (methodParameterMap.TryGetValue(type, out methodIndex))
-        {
-            normalized = $"M{methodIndex}";
-            return true;
-        }
-
-        if (typeParameterMap.TryGetValue(type, out typeIndex))
-        {
-            normalized = $"T{typeIndex}";
-            return true;
-        }
-
-        return false;
-    }
-
-    private static int IndexOfAny(string value, char first, char second)
-    {
-        var firstIndex = value.IndexOf(first);
-        var secondIndex = value.IndexOf(second);
-        return (firstIndex, secondIndex) switch
-        {
-            (< 0, < 0) => -1,
-            (< 0, _) => secondIndex,
-            (_, < 0) => firstIndex,
-            _ => Math.Min(firstIndex, secondIndex)
-        };
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
+++ b/src/dotnet-inspect/Inspectors/XmlDocFileParser.cs
@@ -226,7 +226,8 @@ public class XmlDocFileParser
                     .ToList();
                 var matchingKey = parameterizedCandidates.FirstOrDefault(key =>
                     TryGetXmlDocParameters(key, out var xmlParameters)
-                    && ParametersMatch(identity.NormalizedParameters, xmlParameters));
+                    && ParametersMatch(identity.NormalizedParameters, xmlParameters)
+                    && ReturnTypeMatches(identity.NormalizedReturnType, key));
                 return matchingKey != null && _members.TryGetValue(matchingKey, out var matchingNode)
                     ? ParseMemberNode(matchingNode)
                     : null;
@@ -250,7 +251,8 @@ public class XmlDocFileParser
         {
             var matchingKey = candidates.FirstOrDefault(key =>
                 TryGetXmlDocParameters(key, out var xmlParameters)
-                && ParametersMatch(identity.NormalizedParameters, xmlParameters));
+                && ParametersMatch(identity.NormalizedParameters, xmlParameters)
+                && ReturnTypeMatches(identity.NormalizedReturnType, key));
             if (matchingKey != null && _members.TryGetValue(matchingKey, out var matchingNode))
                 return ParseMemberNode(matchingNode);
 
@@ -316,6 +318,19 @@ public class XmlDocFileParser
                 .Select(ApiMemberIdentity.NormalizeXmlDocParameterType)
                 .ToList();
         return true;
+    }
+
+    private static bool ReturnTypeMatches(string? normalizedReturnType, string key)
+    {
+        if (normalizedReturnType is null)
+            return true;
+
+        var suffixStart = key.LastIndexOf('~');
+        if (suffixStart < 0 || suffixStart == key.Length - 1)
+            return false;
+
+        var keyReturnType = ApiMemberIdentity.NormalizeXmlDocParameterType(key[(suffixStart + 1)..]);
+        return string.Equals(normalizedReturnType, keyReturnType, StringComparison.Ordinal);
     }
 
     private static bool ParametersMatch(IReadOnlyList<string> signatureParameters, IReadOnlyList<string> xmlParameters)

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -184,6 +184,43 @@ public sealed class ApiSignatureModelTests
         Assert.Equal(["System.Int32"], identity.NormalizedParameters);
     }
 
+    [Fact]
+    public void XmlDocIdentity_FallsBackWhenSignatureModelIsMissing()
+    {
+        var type = GetType(nameof(ApiSignatureFixtures));
+        var source = GetMember(nameof(ApiSignatureFixtures), "Item");
+        var member = new ApiMember
+        {
+            Name = source.Name,
+            Kind = source.Kind,
+            Signature = source.Signature
+        };
+
+        Assert.False(ApiMemberIdentity.TryGetXmlDocMemberIdentity(type, member, out _));
+    }
+
+    [Fact]
+    public void XmlDocParameterNormalization_UsesGenericMaps()
+    {
+        Dictionary<string, int> typeParameters = new(StringComparer.Ordinal)
+        {
+            ["TType"] = 0
+        };
+        Dictionary<string, int> methodParameters = new(StringComparer.Ordinal)
+        {
+            ["TMethod"] = 0
+        };
+
+        Assert.Equal("T0", ApiMemberIdentity.NormalizeXmlDocParameterType("TType", typeParameters, methodParameters));
+        Assert.Equal("M0", ApiMemberIdentity.NormalizeXmlDocParameterType("TMethod", typeParameters, methodParameters));
+        Assert.Equal(
+            "System.Collections.Generic.Dictionary{T0,M0}",
+            ApiMemberIdentity.NormalizeXmlDocParameterType(
+                "System.Collections.Generic.Dictionary<TType, TMethod>",
+                typeParameters,
+                methodParameters));
+    }
+
     static ApiType GetType(string typeName)
         => Surface.Types.First(type => type.Name == typeName);
 

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -325,6 +325,7 @@ public sealed class ApiSignatureModelTests
     [InlineData("int[,]", "System.Int32[,]")]
     [InlineData("System.Int32[0:,0:]", "System.Int32[,]")]
     [InlineData("int?", "System.Nullable{System.Int32}")]
+    [InlineData("System.DateTime?", "System.Nullable{System.DateTime}")]
     [InlineData("string?", "System.String")]
     public void XmlDocParameterNormalization_PreservesByRefMarkers(string input, string expected)
     {

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -146,6 +146,44 @@ public sealed class ApiSignatureModelTests
             canonical);
     }
 
+    [Fact]
+    public void XmlDocIdentity_UsesStructuredMethodParameters()
+    {
+        var type = GetType(nameof(ApiSignatureFixtures));
+        var source = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.MethodWithRefKinds));
+
+        Assert.True(ApiMemberIdentity.TryGetXmlDocMemberIdentity(type, source, out var identity));
+
+        Assert.Equal("M:ILInspector.Metadata.Tests.ApiSignatureFixtures.MethodWithRefKinds", identity.LookupKey);
+        Assert.Equal(
+            ["System.Int32", "System.String", "System.Int64", "System.Int32", "System.Byte[]"],
+            identity.NormalizedParameters);
+    }
+
+    [Fact]
+    public void XmlDocIdentity_MapsGenericTypeAndMethodParameters()
+    {
+        var type = GetType(nameof(ApiSignatureFixtures));
+        var source = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.PairGenericMethod));
+
+        Assert.True(ApiMemberIdentity.TryGetXmlDocMemberIdentity(type, source, out var identity));
+
+        Assert.Equal("M:ILInspector.Metadata.Tests.ApiSignatureFixtures.PairGenericMethod", identity.LookupKey);
+        Assert.Equal(["M0", "M1"], identity.NormalizedParameters);
+    }
+
+    [Fact]
+    public void XmlDocIdentity_UsesIndexerParametersForProperties()
+    {
+        var type = GetType(nameof(ApiSignatureFixtures));
+        var source = GetMember(nameof(ApiSignatureFixtures), "Item");
+
+        Assert.True(ApiMemberIdentity.TryGetXmlDocMemberIdentity(type, source, out var identity));
+
+        Assert.Equal("P:ILInspector.Metadata.Tests.ApiSignatureFixtures.Item", identity.LookupKey);
+        Assert.Equal(["System.Int32"], identity.NormalizedParameters);
+    }
+
     static ApiType GetType(string typeName)
         => Surface.Types.First(type => type.Name == typeName);
 

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -156,7 +156,7 @@ public sealed class ApiSignatureModelTests
 
         Assert.Equal("M:ILInspector.Metadata.Tests.ApiSignatureFixtures.MethodWithRefKinds", identity.LookupKey);
         Assert.Equal(
-            ["System.Int32", "System.String", "System.Int64", "System.Int32", "System.Byte[]"],
+            ["System.Int32@", "System.String@", "System.Int64@", "System.Int32", "System.Byte[]"],
             identity.NormalizedParameters);
     }
 
@@ -182,6 +182,44 @@ public sealed class ApiSignatureModelTests
 
         Assert.Equal("P:ILInspector.Metadata.Tests.ApiSignatureFixtures.Item", identity.LookupKey);
         Assert.Equal(["System.Int32"], identity.NormalizedParameters);
+    }
+
+    [Fact]
+    public void XmlDocIdentity_UsesHashForExplicitInterfaceMembers()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Impl" };
+        var member = new ApiMember
+        {
+            Name = "IFoo.Bar",
+            Kind = "explicit-interface-implementation",
+            SignatureModel = new ApiSignature { MemberName = "IFoo.Bar" }
+        };
+
+        Assert.True(ApiMemberIdentity.TryGetXmlDocMemberIdentity(type, member, out var identity));
+
+        Assert.Equal("M:Samples.Impl.IFoo#Bar", identity.LookupKey);
+    }
+
+    [Fact]
+    public void XmlDocIdentity_IncludesConversionOperatorReturnType()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Number" };
+        var member = new ApiMember
+        {
+            Name = "op_Implicit",
+            Kind = "operator",
+            SignatureModel = new ApiSignature
+            {
+                MemberName = "op_Implicit",
+                ReturnType = "int",
+                Parameters = [new ApiParameter { Name = "value", Type = "Samples.Number" }]
+            }
+        };
+
+        Assert.True(ApiMemberIdentity.TryGetXmlDocMemberIdentity(type, member, out var identity));
+
+        Assert.Equal("System.Int32", identity.NormalizedReturnType);
+        Assert.Equal(["Samples.Number"], identity.NormalizedParameters);
     }
 
     [Fact]
@@ -236,6 +274,23 @@ public sealed class ApiSignatureModelTests
                 "System.Collections.Generic.Dictionary<string, int> values = null",
                 new Dictionary<string, int>(StringComparer.Ordinal),
                 new Dictionary<string, int>(StringComparer.Ordinal)));
+        Assert.Equal(
+            "System.Int32@",
+            ApiMemberIdentity.NormalizeXmlDocSignatureParameter(
+                "[System.Runtime.InteropServices.In] ref int value",
+                new Dictionary<string, int>(StringComparer.Ordinal),
+                new Dictionary<string, int>(StringComparer.Ordinal)));
+    }
+
+    [Theory]
+    [InlineData("ref int", "System.Int32@")]
+    [InlineData("out int", "System.Int32@")]
+    [InlineData("in int", "System.Int32@")]
+    [InlineData("System.Int32@", "System.Int32@")]
+    [InlineData("params int[]", "System.Int32[]")]
+    public void XmlDocParameterNormalization_PreservesByRefMarkers(string input, string expected)
+    {
+        Assert.Equal(expected, ApiMemberIdentity.NormalizeXmlDocParameterType(input));
     }
 
     static ApiType GetType(string typeName)

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -221,6 +221,23 @@ public sealed class ApiSignatureModelTests
                 methodParameters));
     }
 
+    [Fact]
+    public void XmlDocSignatureParameterNormalization_StripsParameterNamesForFallback()
+    {
+        Assert.Equal(
+            "System.Int32",
+            ApiMemberIdentity.NormalizeXmlDocSignatureParameter(
+                "int index",
+                new Dictionary<string, int>(StringComparer.Ordinal),
+                new Dictionary<string, int>(StringComparer.Ordinal)));
+        Assert.Equal(
+            "System.Collections.Generic.Dictionary{System.String,System.Int32}",
+            ApiMemberIdentity.NormalizeXmlDocSignatureParameter(
+                "System.Collections.Generic.Dictionary<string, int> values = null",
+                new Dictionary<string, int>(StringComparer.Ordinal),
+                new Dictionary<string, int>(StringComparer.Ordinal)));
+    }
+
     static ApiType GetType(string typeName)
         => Surface.Types.First(type => type.Name == typeName);
 

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -296,6 +296,12 @@ public sealed class ApiSignatureModelTests
                 new Dictionary<string, int>(StringComparer.Ordinal),
                 new Dictionary<string, int>(StringComparer.Ordinal)));
         Assert.Equal(
+            "System.Int32",
+            ApiMemberIdentity.NormalizeXmlDocSignatureParameter(
+                """[System.ComponentModel.DefaultValue("=")] int value = 0""",
+                new Dictionary<string, int>(StringComparer.Ordinal),
+                new Dictionary<string, int>(StringComparer.Ordinal)));
+        Assert.Equal(
             "System.Int32@",
             ApiMemberIdentity.NormalizeXmlDocSignatureParameter(
                 "[System.Runtime.InteropServices.In] ref int value",
@@ -317,6 +323,9 @@ public sealed class ApiSignatureModelTests
     [InlineData("params int[]", "System.Int32[]")]
     [InlineData("int*", "System.Int32*")]
     [InlineData("int[,]", "System.Int32[,]")]
+    [InlineData("System.Int32[0:,0:]", "System.Int32[,]")]
+    [InlineData("int?", "System.Nullable{System.Int32}")]
+    [InlineData("string?", "System.String")]
     public void XmlDocParameterNormalization_PreservesByRefMarkers(string input, string expected)
     {
         Assert.Equal(expected, ApiMemberIdentity.NormalizeXmlDocParameterType(input));

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -201,6 +201,27 @@ public sealed class ApiSignatureModelTests
     }
 
     [Fact]
+    public void XmlDocIdentity_UsesBracesForGenericExplicitInterfaceMembers()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Impl" };
+        var member = new ApiMember
+        {
+            Name = "System.IEquatable<System.String>.Equals",
+            Kind = "explicit-interface-implementation",
+            SignatureModel = new ApiSignature
+            {
+                MemberName = "System.IEquatable<System.String>.Equals",
+                Parameters = [new ApiParameter { Name = "other", Type = "System.String" }]
+            }
+        };
+
+        Assert.True(ApiMemberIdentity.TryGetXmlDocMemberIdentity(type, member, out var identity));
+
+        Assert.Equal("M:Samples.Impl.System#IEquatable{System#String}#Equals", identity.LookupKey);
+        Assert.Equal(["System.String"], identity.NormalizedParameters);
+    }
+
+    [Fact]
     public void XmlDocIdentity_IncludesConversionOperatorReturnType()
     {
         var type = new ApiType { Namespace = "Samples", Name = "Number" };
@@ -280,6 +301,12 @@ public sealed class ApiSignatureModelTests
                 "[System.Runtime.InteropServices.In] ref int value",
                 new Dictionary<string, int>(StringComparer.Ordinal),
                 new Dictionary<string, int>(StringComparer.Ordinal)));
+        Assert.Equal(
+            "System.Int32",
+            ApiMemberIdentity.NormalizeXmlDocSignatureParameter(
+                """[System.ComponentModel.DefaultValue("=")] int value = 0""",
+                new Dictionary<string, int>(StringComparer.Ordinal),
+                new Dictionary<string, int>(StringComparer.Ordinal)));
     }
 
     [Theory]
@@ -288,6 +315,8 @@ public sealed class ApiSignatureModelTests
     [InlineData("in int", "System.Int32@")]
     [InlineData("System.Int32@", "System.Int32@")]
     [InlineData("params int[]", "System.Int32[]")]
+    [InlineData("int*", "System.Int32*")]
+    [InlineData("int[,]", "System.Int32[,]")]
     public void XmlDocParameterNormalization_PreservesByRefMarkers(string input, string expected)
     {
         Assert.Equal(expected, ApiMemberIdentity.NormalizeXmlDocParameterType(input));


### PR DESCRIPTION
- Advances #2057
- Changes XML documentation lookup to prefer metadata-owned member identity translation instead of parsing rendered signatures.

## Change

**Conclusion:** **PASS** — this moves a correctness-sensitive identity bridge into metadata while preserving the legacy XML-doc fallback path.

Scenario: dotnet-inspect has an `ApiType` + `ApiMember` from metadata and an XML docs file from the inspected library/package. To attach the right `<member name="...">` node, the tool must translate structured metadata facts into XML doc member IDs:

```text
ApiType + ApiMember + ApiSignature
  -> M:Namespace.Type.Method(System.String)
  -> XML <member name="...">
  -> member.Documentation
```

This PR adds one-way metadata-to-XML-doc identity translation and wires `XmlDocFileParser.GetMemberDocumentation(ApiType, ApiMember)` to prefer it. The legacy signature-string fallback remains for unmodeled members and for structured misses.

Covered XML doc identity cases include:

- methods, constructors, properties, fields, events, and indexers;
- generic method/type parameters (`M0` / `T0`);
- explicit interface member names (`#`) and generic interface braces (`{}`);
- conversion operator `~ReturnType`;
- byref `@`, pointers, arrays, multidimensional array bounds, nullable value/reference types;
- leading parameter attributes in legacy fallback text.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507 --nologo --verbosity quiet` |
| Metadata tests | Pass: `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507` |
| CLI tests | Pass: `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507` |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Findings resolved, final pass clean | Found/followed several XML-doc edge cases during repeated review; final pass found no blocking/high-confidence issues. |
| Gemini 3.1 Pro | Findings resolved, final pass clean | Found fallback, explicit-interface, conversion, byref, array, nullable, and attribute parsing issues during repeated review; all fixed and final pass found no significant issues. |

**Review conclusion:** **PASS** — repeated adversarial review loop is clean after fixes through `8547d50a`.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507
dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507
```
