### PR TITLE
Centralize project.assets.json resolution and diagnostics (#2052)

### DIFF
--- a/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
@@ -313,6 +313,86 @@ public class ProjectAssetsParserTests
         }
     }
 
+    [Fact]
+    public void TryFindAssets_DirectAssetsJsonPath_ReturnsFound()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"pa-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var assets = Path.Combine(dir, "project.assets.json");
+        File.WriteAllText(assets, "{}");
+        try
+        {
+            Assert.True(ProjectAssetsParser.TryFindAssets(assets, out var found, out var status));
+            Assert.Equal(ProjectAssetsStatus.Found, status);
+            Assert.Equal(Path.GetFullPath(assets), found);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryFindAssets_DirectoryWithObjAssets_ReturnsFound()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"pa-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(dir, "obj"));
+        File.WriteAllText(Path.Combine(dir, "Sample.csproj"), "<Project/>");
+        var assets = Path.Combine(dir, "obj", "project.assets.json");
+        File.WriteAllText(assets, "{}");
+        try
+        {
+            Assert.True(ProjectAssetsParser.TryFindAssets(dir, out var found, out var status));
+            Assert.Equal(ProjectAssetsStatus.Found, status);
+            Assert.Equal(Path.GetFullPath(assets), found);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryFindAssets_ProjectWithoutRestore_ReturnsAssetsNotRestored()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"pa-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var csproj = Path.Combine(dir, "Sample.csproj");
+        File.WriteAllText(csproj, "<Project/>");
+        try
+        {
+            Assert.False(ProjectAssetsParser.TryFindAssets(csproj, out var found, out var status));
+            Assert.Null(found);
+            Assert.Equal(ProjectAssetsStatus.AssetsNotRestored, status);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryFindAssets_NonexistentPath_ReturnsProjectNotFound()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"pa-missing-{Guid.NewGuid():N}", "Sample.csproj");
+
+        Assert.False(ProjectAssetsParser.TryFindAssets(missing, out var found, out var status));
+        Assert.Null(found);
+        Assert.Equal(ProjectAssetsStatus.ProjectNotFound, status);
+    }
+
+    [Fact]
+    public void DescribeMissingAssets_ProducesDistinctMessages()
+    {
+        var notFound = ProjectAssetsParser.DescribeMissingAssets("x.csproj", ProjectAssetsStatus.ProjectNotFound);
+        var notRestored = ProjectAssetsParser.DescribeMissingAssets("x.csproj", ProjectAssetsStatus.AssetsNotRestored);
+
+        Assert.Contains("Project not found", notFound);
+        Assert.Contains("dotnet restore", notRestored);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => ProjectAssetsParser.DescribeMissingAssets("x", ProjectAssetsStatus.Found));
+    }
+
     private static string CreateTempAssetsFile(object content)
     {
         var json = JsonSerializer.Serialize(content);

--- a/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/ProjectAssetsParserTests.cs
@@ -393,6 +393,43 @@ public class ProjectAssetsParserTests
             () => ProjectAssetsParser.DescribeMissingAssets("x", ProjectAssetsStatus.Found));
     }
 
+    [Fact]
+    public void TryFindAssets_ExistingDirectoryWithoutProject_ReturnsProjectNotFound()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"pa-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "readme.txt"), "no project here");
+        try
+        {
+            Assert.False(ProjectAssetsParser.TryFindAssets(dir, out var found, out var status));
+            Assert.Null(found);
+            Assert.Equal(ProjectAssetsStatus.ProjectNotFound, status);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryFindAssets_ExistingNonProjectFile_ReturnsProjectNotFound()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"pa-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, "notes.txt");
+        File.WriteAllText(file, "not a project");
+        try
+        {
+            Assert.False(ProjectAssetsParser.TryFindAssets(file, out var found, out var status));
+            Assert.Null(found);
+            Assert.Equal(ProjectAssetsStatus.ProjectNotFound, status);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
     private static string CreateTempAssetsFile(object content)
     {
         var json = JsonSerializer.Serialize(content);

--- a/src/DotnetInspector.Services/ProjectAssetsParser.cs
+++ b/src/DotnetInspector.Services/ProjectAssetsParser.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using DotnetInspector.Packages;
 using NuGetFetch;
@@ -11,10 +12,58 @@ public sealed record ProjectPackageReference(
     string TargetFramework);
 
 /// <summary>
+/// Outcome of locating a project's <c>project.assets.json</c>.
+/// </summary>
+public enum ProjectAssetsStatus
+{
+    /// <summary>The assets file was located.</summary>
+    Found,
+
+    /// <summary>The supplied project path does not exist as a file or directory.</summary>
+    ProjectNotFound,
+
+    /// <summary>The project exists but no <c>project.assets.json</c> was found (needs <c>dotnet restore</c>).</summary>
+    AssetsNotRestored,
+}
+
+/// <summary>
 /// Parses project.assets.json to discover NuGet package assemblies in a project.
 /// </summary>
 public static class ProjectAssetsParser
 {
+    /// <summary>
+    /// Locates a project's <c>project.assets.json</c> and reports why discovery failed.
+    /// Accepts a directory, a project file, or a direct <c>project.assets.json</c> path.
+    /// Returns <see langword="true"/> and a non-null <paramref name="assetsPath"/> when found.
+    /// </summary>
+    public static bool TryFindAssets(string projectPath, [NotNullWhen(true)] out string? assetsPath, out ProjectAssetsStatus status)
+    {
+        assetsPath = FindAssets(projectPath);
+        if (assetsPath is not null)
+        {
+            status = ProjectAssetsStatus.Found;
+            return true;
+        }
+
+        var fullPath = Path.GetFullPath(string.IsNullOrWhiteSpace(projectPath) ? "." : projectPath);
+        status = File.Exists(fullPath) || Directory.Exists(fullPath)
+            ? ProjectAssetsStatus.AssetsNotRestored
+            : ProjectAssetsStatus.ProjectNotFound;
+        return false;
+    }
+
+    /// <summary>
+    /// Returns a human-readable, severity-free explanation for a failed
+    /// <see cref="TryFindAssets"/> lookup. Callers prepend their own
+    /// <c>Warning:</c>/<c>Error:</c> prefix per their control flow.
+    /// </summary>
+    public static string DescribeMissingAssets(string projectPath, ProjectAssetsStatus status) => status switch
+    {
+        ProjectAssetsStatus.ProjectNotFound => $"Project not found '{projectPath}'.",
+        ProjectAssetsStatus.AssetsNotRestored => $"project.assets.json not found for '{projectPath}'. Run 'dotnet restore'.",
+        _ => throw new ArgumentOutOfRangeException(nameof(status), status, "Status does not describe a failure."),
+    };
+
     public static string? FindAssets(string projectPath)
     {
         var fullPath = Path.GetFullPath(string.IsNullOrWhiteSpace(projectPath) ? "." : projectPath);

--- a/src/DotnetInspector.Services/ProjectAssetsParser.cs
+++ b/src/DotnetInspector.Services/ProjectAssetsParser.cs
@@ -45,10 +45,29 @@ public static class ProjectAssetsParser
             return true;
         }
 
-        var fullPath = Path.GetFullPath(string.IsNullOrWhiteSpace(projectPath) ? "." : projectPath);
-        status = File.Exists(fullPath) || Directory.Exists(fullPath)
+        status = HasProject(projectPath)
             ? ProjectAssetsStatus.AssetsNotRestored
             : ProjectAssetsStatus.ProjectNotFound;
+        return false;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="projectPath"/> points at a project file or a directory
+    /// containing one. Used to distinguish "not a project" from "project exists but not
+    /// restored" once <see cref="FindAssets"/> has failed.
+    /// </summary>
+    static bool HasProject(string projectPath)
+    {
+        var fullPath = Path.GetFullPath(string.IsNullOrWhiteSpace(projectPath) ? "." : projectPath);
+        if (File.Exists(fullPath))
+            return Path.GetExtension(fullPath).EndsWith("proj", StringComparison.OrdinalIgnoreCase);
+
+        if (Directory.Exists(fullPath))
+        {
+            foreach (var _ in Directory.EnumerateFiles(fullPath, "*.*proj", SearchOption.TopDirectoryOnly))
+                return true;
+        }
+
         return false;
     }
 

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -125,10 +125,9 @@ public class ProjectCommand
 
         var context = new CommandContext(options.Verbose);
         var logger = context.Logger;
-        var assetsPath = ProjectAssetsParser.FindAssets(options.ProjectPath);
-        if (assetsPath == null)
+        if (!ProjectAssetsParser.TryFindAssets(options.ProjectPath, out var assetsPath, out var assetsStatus))
         {
-            Console.Error.WriteLine($"Error: project.assets.json not found for '{options.ProjectPath}'. Run 'dotnet restore'.");
+            Console.Error.WriteLine($"Error: {ProjectAssetsParser.DescribeMissingAssets(options.ProjectPath, assetsStatus)}");
             return 1;
         }
 

--- a/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
+++ b/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
@@ -101,10 +101,9 @@ internal static class ApiSourceResolver
         }
         else if (!string.IsNullOrEmpty(options.ProjectPath))
         {
-            projectAssetsPath = ProjectAssetsParser.FindAssets(options.ProjectPath);
-            if (projectAssetsPath is null)
+            if (!ProjectAssetsParser.TryFindAssets(options.ProjectPath, out projectAssetsPath, out var assetsStatus))
             {
-                Console.Error.WriteLine($"Error: project.assets.json not found for '{options.ProjectPath}'. Run 'dotnet restore'.");
+                Console.Error.WriteLine($"Error: {ProjectAssetsParser.DescribeMissingAssets(options.ProjectPath, assetsStatus)}");
                 return (null!, 1);
             }
 

--- a/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
+++ b/src/dotnet-inspect/Inspectors/AssemblyCollector.cs
@@ -84,10 +84,9 @@ public static class AssemblyCollector
         // 3. Project assets
         foreach (var projectPath in options.Projects)
         {
-            var assetsPath = ProjectAssetsParser.FindAssets(projectPath);
-            if (assetsPath == null)
+            if (!ProjectAssetsParser.TryFindAssets(projectPath, out var assetsPath, out var status))
             {
-                Console.Error.WriteLine($"Warning: project.assets.json not found for '{projectPath}'. Run 'dotnet restore'.");
+                Console.Error.WriteLine($"Warning: {ProjectAssetsParser.DescribeMissingAssets(projectPath, status)}");
                 continue;
             }
 

--- a/src/dotnet-inspect/Inspectors/CallerScopeResolver.cs
+++ b/src/dotnet-inspect/Inspectors/CallerScopeResolver.cs
@@ -53,10 +53,9 @@ public static class CallerScopeResolver
         // Projects: restored dependencies via project.assets.json
         foreach (var projectPath in projects)
         {
-            var assetsPath = ProjectAssetsParser.FindAssets(projectPath);
-            if (assetsPath == null)
+            if (!ProjectAssetsParser.TryFindAssets(projectPath, out var assetsPath, out var status))
             {
-                Console.Error.WriteLine($"Warning: project.assets.json not found for '{projectPath}'. Run 'dotnet restore'.");
+                Console.Error.WriteLine($"Warning: {ProjectAssetsParser.DescribeMissingAssets(projectPath, status)}");
                 continue;
             }
 

--- a/src/dotnet-inspect/Inspectors/CallerScopeResolver.cs
+++ b/src/dotnet-inspect/Inspectors/CallerScopeResolver.cs
@@ -53,7 +53,7 @@ public static class CallerScopeResolver
         // Projects: restored dependencies via project.assets.json
         foreach (var projectPath in projects)
         {
-            var assetsPath = FindProjectAssets(projectPath);
+            var assetsPath = ProjectAssetsParser.FindAssets(projectPath);
             if (assetsPath == null)
             {
                 Console.Error.WriteLine($"Warning: project.assets.json not found for '{projectPath}'. Run 'dotnet restore'.");
@@ -79,35 +79,6 @@ public static class CallerScopeResolver
         }
 
         return result;
-    }
-
-    static string? FindProjectAssets(string projectPath)
-    {
-        var fullPath = Path.GetFullPath(projectPath);
-        var projectDir = Path.GetDirectoryName(fullPath);
-        var projectName = Path.GetFileNameWithoutExtension(fullPath);
-
-        if (projectDir == null || !File.Exists(fullPath))
-        {
-            Console.Error.WriteLine($"Warning: Project not found '{projectPath}', skipping.");
-            return null;
-        }
-
-        var candidates = new[]
-        {
-            Path.Combine(projectDir, "obj", "project.assets.json"),
-            Path.Combine(projectDir, "..", "..", "artifacts", "obj", projectName, "project.assets.json"),
-            Path.Combine(projectDir, "artifacts", "obj", projectName, "project.assets.json")
-        };
-
-        foreach (var candidate in candidates)
-        {
-            var normalized = Path.GetFullPath(candidate);
-            if (File.Exists(normalized))
-                return normalized;
-        }
-
-        return null;
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Inspectors/TypeSearchService.cs
+++ b/src/dotnet-inspect/Inspectors/TypeSearchService.cs
@@ -414,10 +414,9 @@ internal static class TypeSearchService
         {
             if (ReachedLimit()) break;
 
-            var assetsPath = ProjectAssetsParser.FindAssets(projectPath);
-            if (assetsPath == null)
+            if (!ProjectAssetsParser.TryFindAssets(projectPath, out var assetsPath, out var status))
             {
-                Console.Error.WriteLine($"Warning: project.assets.json not found for '{projectPath}'. Run 'dotnet restore'.");
+                Console.Error.WriteLine($"Warning: {ProjectAssetsParser.DescribeMissingAssets(projectPath, status)}");
                 continue;
             }
 

--- a/src/dotnet-inspect/Inspectors/TypeSearchService.cs
+++ b/src/dotnet-inspect/Inspectors/TypeSearchService.cs
@@ -420,7 +420,9 @@ internal static class TypeSearchService
                 continue;
             }
 
-            var projectName = Path.GetFileNameWithoutExtension(projectPath);
+            var projectName = Directory.Exists(projectPath)
+                ? new DirectoryInfo(Path.GetFullPath(projectPath)).Name
+                : Path.GetFileNameWithoutExtension(projectPath);
             logger.Log($"Using assets: {assetsPath}");
             var assemblies = ProjectAssetsParser.Parse(assetsPath, options.Tfm, logger.Log);
             logger.Log($"Searching {assemblies.Count} libraries from {projectName}");

--- a/src/dotnet-inspect/Inspectors/TypeSearchService.cs
+++ b/src/dotnet-inspect/Inspectors/TypeSearchService.cs
@@ -414,40 +414,14 @@ internal static class TypeSearchService
         {
             if (ReachedLimit()) break;
 
-            var fullPath = Path.GetFullPath(projectPath);
-            var projectDir = Path.GetDirectoryName(fullPath);
-            var projectName = Path.GetFileNameWithoutExtension(fullPath);
-
-            if (projectDir == null || !File.Exists(fullPath))
-            {
-                Console.Error.WriteLine($"Warning: Project not found '{projectPath}', skipping.");
-                continue;
-            }
-
-            var candidatePaths = new[]
-            {
-                Path.Combine(projectDir, "obj", "project.assets.json"),
-                Path.Combine(projectDir, "..", "..", "artifacts", "obj", projectName, "project.assets.json"),
-                Path.Combine(projectDir, "artifacts", "obj", projectName, "project.assets.json")
-            };
-
-            string? assetsPath = null;
-            foreach (var candidate in candidatePaths)
-            {
-                var normalized = Path.GetFullPath(candidate);
-                if (File.Exists(normalized))
-                {
-                    assetsPath = normalized;
-                    break;
-                }
-            }
-
+            var assetsPath = ProjectAssetsParser.FindAssets(projectPath);
             if (assetsPath == null)
             {
                 Console.Error.WriteLine($"Warning: project.assets.json not found for '{projectPath}'. Run 'dotnet restore'.");
                 continue;
             }
 
+            var projectName = Path.GetFileNameWithoutExtension(projectPath);
             logger.Log($"Using assets: {assetsPath}");
             var assemblies = ProjectAssetsParser.Parse(assetsPath, options.Tfm, logger.Log);
             logger.Log($"Searching {assemblies.Count} libraries from {projectName}");


### PR DESCRIPTION
## Summary

Finishes the last "duplicate shapes to collapse" item in #2052: `project.assets.json`
resolution is now fully centralized in `DotnetInspector.Services`. Discovery was already
shared (`ProjectAssetsParser.FindAssets`), but every caller hand-rolled its own
missing-assets warning string, and the two inline callers additionally distinguished
"project not found" from "not restored" — a distinction the naive dedup would have dropped.

## Changes

- **Shared discovery**: `CallerScopeResolver` and `TypeSearchService` stop hand-rolling the
  `obj/` + `artifacts/obj/` candidate-path list and call the canonical
  `ProjectAssetsParser.FindAssets`.
- **Shared diagnostics**: new `ProjectAssetsParser.TryFindAssets` (bool Try-pattern with
  `[NotNullWhen(true)]`) reporting `ProjectAssetsStatus { Found, ProjectNotFound,
  AssetsNotRestored }`, plus `DescribeMissingAssets` for severity-free message text.
- **All five callers converge** on it — `CallerScopeResolver`, `TypeSearchService`,
  `AssemblyCollector` (`Warning:` + continue) and `ApiSourceResolver`, `ProjectCommand`
  (`Error:` + return) — each keeping its own severity and control flow.
- **Accurate classification**: `AssetsNotRestored` (i.e. "run `dotnet restore`") is reported
  only when a project actually exists (`*.*proj` file, or a directory containing one);
  otherwise `ProjectNotFound`. This restores the richer diagnostic for the two inline
  callers and upgrades the other three, which previously only ever said "not restored" —
  even when the path did not exist or was not a project.

Net: `FindAssets` remains the low-level primitive; `TryFindAssets` is the single shared
entry for callers.

## Validation

- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507` — 0 warnings.
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release -p:NoWarn=NU1507 -- -class DotnetInspector.Services.Tests.ProjectAssetsParserTests` — 16/16 (7 new `TryFindAssets`/`DescribeMissingAssets` tests, incl. 2 regression tests).
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -class DotnetInspector.Tests.RelationshipProjectScopeOptionsTests -class DotnetInspector.Tests.MemberCallersSectionTests` — 12/12.
- Rebased on latest `origin/main`; re-verified.

## Adversarial review

Two independent reviewers per round; at least one reviewer rotated each round.

| Round | Reviewers | Result |
| --- | --- | --- |
| R1 (discovery collapse) | GPT-5.5, Gemini 3.1 Pro | APPROVE / APPROVE (1 benign cosmetic log note) |
| R2 (centralized diagnostics) | GPT-5.5, MAI-Code-1-Flash | APPROVE / REQUEST-CHANGES |
| R3 (after fix) | Gemini 3.1 Pro, MAI-Code-1-Flash | APPROVE / APPROVE |

- **Divergence**: only MAI-Code-1-Flash (R2) caught that `TryFindAssets` classified *any*
  existing path as `AssetsNotRestored`, so a non-project directory/file produced a wrong
  "run `dotnet restore`" hard-fail in `ProjectCommand`/`ApiSourceResolver`. GPT-5.5 and
  Gemini had judged the classifier acceptable.
- **Resolution**: fixed by the `HasProject` check (commit "Only report AssetsNotRestored
  when a project actually exists") plus two regression tests. Both R3 reviewers
  independently confirmed the fix with real build/test runs.
- **Dismissed/non-actioned**: Gemini's R1 cosmetic note (empty `projectName` in a verbose
  log line for a trailing-slash directory input) — log-only, no correctness impact, left
  as-is. No other findings outstanding.

Closes #2052.
