### PR TITLE
Render simple method declarations from ApiSignature

### DIFF
--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -518,10 +518,19 @@ public static class CSharpDeclarationWriter
             signature = $"{FormatConstructorTypeName(type.Name)}({parameters})";
             return true;
         }
+        if (member.Kind == "method"
+            && methodParameters is not { Count: > 0 }
+            && model.MemberName is { Length: > 0 } memberName
+            && !memberName.Contains('<', StringComparison.Ordinal)
+            && model.ReturnType is { Length: > 0 } returnType)
+        {
+            signature = $"{returnType} {memberName}({parameters})";
+            return true;
+        }
 
-        // Keep method/property/event rendering on compatibility text until
-        // generic parameters, constraints, attributes, and default-value text are
-        // represented in ApiSignature.
+        // Keep generic methods, extension methods, explicit implementations,
+        // operators, properties, and events on compatibility text until the
+        // remaining declaration-level facts are represented in ApiSignature.
         return false;
 
         static string ParameterDeclaration(ApiParameter parameter)

--- a/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
@@ -39,6 +39,54 @@ public sealed class CSharpDeclarationFormatterTests
     }
 
     [Fact]
+    public void MemberSignatureSection_CanRenderMethodFromStructuredSignature()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "StructuredHost",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "GetValues",
+                    Kind = "method",
+                    Signature = "BROKEN",
+                    SignatureModel = new ApiSignature
+                    {
+                        ReturnType = "System.Collections.Generic.Dictionary<string, System.DateTime>",
+                        MemberName = "GetValues",
+                        Parameters =
+                        [
+                            new ApiParameter
+                            {
+                                Type = "System.Collections.Generic.List<System.Guid>",
+                                Name = "ids"
+                            }
+                        ]
+                    }
+                }
+            ]
+        };
+        var view = ApiOutputFormatter.BuildTypeView(
+            type,
+            foundIn: "Test.dll",
+            packageName: null,
+            packageVersion: null,
+            apiSource: "local",
+            selectedTfm: null,
+            new MemberOptions { OverloadIndex = 1 });
+
+        ApiOutputFormatter.PopulateMemberSignature(view, type, new MemberOptions { OverloadIndex = 1 });
+
+        Assert.Contains("public System.Collections.Generic.Dictionary", view.SignatureRows![0].Signature);
+        Assert.Contains("GetValues", view.SignatureRows[0].Signature);
+        Assert.Contains("System.Collections.Generic.List", view.SignatureRows[0].Signature);
+        Assert.DoesNotContain("BROKEN", view.SignatureRows[0].Signature);
+    }
+
+    [Fact]
     public void ConstructorOverloadSnippet_UsesStructuredDefaultValueText()
     {
         var type = new ApiType

--- a/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
@@ -83,6 +83,73 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void MethodDeclaration_CanRenderFromStructuredSignatureModel()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "GetValues",
+            Kind = "method",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.Collections.Generic.Dictionary<string, System.DateTime>",
+                MemberName = "GetValues",
+                Parameters =
+                [
+                    new ApiParameter
+                    {
+                        Type = "System.Collections.Generic.List<System.Guid>",
+                        Name = "ids"
+                    }
+                ]
+            }
+        };
+
+        var rendered = CSharpDeclarationWriter.RenderMemberUnit(
+            type,
+            member,
+            new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ShortWithUsings,
+                TerminateMemberDeclaration = true
+            });
+
+        Assert.Equal(
+            """
+            using System;
+            using System.Collections.Generic;
+
+            public Dictionary<string, DateTime> GetValues(List<Guid> ids);
+            """,
+            rendered.Source);
+    }
+
+    [Fact]
+    public void GenericMethodDeclaration_KeepsCompatibilitySignature()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Echo",
+            Kind = "method",
+            Signature = "T Echo<T>(T value)",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "T",
+                MemberName = "Echo<T>",
+                Parameters =
+                [
+                    new ApiParameter { Type = "T", Name = "value" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("public T Echo<T>(T value)", declaration);
+    }
+
+    [Fact]
     public void ShortWithUsings_KeepsCollidingSimpleNamesQualified()
     {
         var type = new ApiType


### PR DESCRIPTION
## Summary

Advances #2057 by making `CSharpDeclarationWriter` render simple non-generic method declarations from structured `ApiSignature` facts.

- Renders normal, non-generic method declarations from `ApiSignature.ReturnType`, `MemberName`, and `Parameters`.
- Keeps generic methods, extension methods, explicit interface implementations, operators, properties, and events on the existing compatibility string path until their declaration-level facts are modeled.
- Adds focused metadata writer and CLI signature-section tests proving method declarations can render without reparsing compatibility signature text.

## Validation

- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config -p:NoWarn=NU1507`
- `dotnet run --no-restore --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -class '*CSharpDeclarationWriterTests'`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -class '*CSharpDeclarationFormatterTests'`
