### PR TITLE
Consolidate cast emission into the Coerce choke point (value-typed emission, slice 1)

### DIFF
--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -80,9 +80,9 @@ renders a node instead of *deciding* to be a cast. Roslyn calls it
 
 ### Why a node, not a helper
 
-The decompiler already has coercion *helpers* — `CastValue`
-(`CSharpPrinter.Numerics.cs:966`) and `EnumIntegerCast`
-(`CSharpPrinter.Numerics.cs:178`). They are not enough, because a helper the
+The decompiler already has coercion *helpers* — `Coerce` (slice 1's rename of
+`CastValue`, `CSharpPrinter.Numerics.cs`) with its family (`EnumConstantText`,
+`TryCoerceEnumOperand`, `EnumIntegerCast`). They are not enough, because a helper the
 printer *may* call is not an invariant. Because the coercion is a transient string
 and not a node, it is invisible to the rest of the architecture:
 
@@ -98,26 +98,30 @@ render context at a time.
 
 ## Where we are — the leak surface, measured
 
-The cast/coercion decision is spread across the printer. The *rules* now live
-mostly in shared helpers — `CastValue`, `EnumIntegerCast`, and the overflow
-judgment `MayOverflowEnumBackingType` (`CSharpPrinter.Numerics.cs:196`), which
-handles known backing widths, cross-assembly `Unknown` (conservative sbyte),
-missing-`value__` shapes (assume `int`), and sees through widening `Convert`s
-via `TryEnumCastLiteral`. That consolidation is the hard-won product of the
-six-round history below (#2080). What stays scattered is the **routing**: each
-sink independently decides *to* call a helper, and *which target type* to hand
-it:
+The cast/coercion decision lives in one family in `CSharpPrinter.Numerics.cs`
+(slice 1, #2114): `Coerce(value, target)` for typed sinks,
+`TryCoerceEnumOperand` for operands meeting an enum sibling or arm target, and
+`EnumConstantText` (the name-or-cast rule) with the `EnumIntegerCast`/
+`MayOverflowEnumBackingType` internals — which handle known backing widths,
+cross-assembly `Unknown` (conservative sbyte), missing-`value__` shapes (assume
+`int`), and see through widening `Convert`s via `TryEnumCastLiteral`. Those
+rules are the hard-won product of the six-round history below (#2080); the
+guard drift that consolidation surfaced (the binary/comparison sites admitted
+`bool` where the arm sites excluded it — an invalid-C# class) is fixed inside
+the one operand rule. What stays scattered is the **routing**: each sink still
+independently decides *to* call the family, and *which target type* to hand it:
 
-| Site | File | What it decides locally |
-| --- | --- | --- |
-| enum-typed conditional arm | `CSharpPrinter.Numerics.cs:1165` | route each integer arm through `EnumIntegerCast` |
-| `??` coalesce | `CSharpPrinter.Numerics.cs:1200` | route the coalesce through `EnumIntegerCast` |
-| retyped enum constant | `CSharpPrinter.cs:1759` | route `int`/`long` payloads through `EnumIntegerCast` |
-| `switch` case label | `CSharpPrinter.cs:3162` | `SwitchLabelText` — name the member or route to `EnumIntegerCast` |
-| array-element store | `CSharpPrinter.cs:1665` | derive the semantic element type (`StoreElementTargetType`), route through `CastValue` |
-| `box` operand | `CSharpPrinter.cs:1829` | route through `CastValue(operand, boxedType)` |
-| enum bitwise / comparison | `CSharpPrinter.Numerics.cs:277`, `:825` | pick the enum side, route the integer side through `EnumIntegerCast` |
-| constant typing | `TypedConstantsPass.cs:104` | retypes **`int`-only**, does not pierce `Convert` |
+| Site | What it still decides locally |
+| --- | --- |
+| enum-typed conditional / switch arm | route the arm through `TryCoerceEnumOperand` |
+| `??` coalesce right side | route through `TryCoerceEnumOperand` |
+| enum bitwise / comparison operand | pick the enum side, route the other through `TryCoerceEnumOperand` |
+| compound assign right side | route through `TryCoerceEnumOperand` with the lvalue type |
+| retyped enum constant | route through `EnumConstantText` |
+| `switch` case label | route through `EnumConstantText` |
+| array-element store | derive the semantic element type (`StoreElementTargetType`), route through `Coerce` |
+| `box` / `return` / call args / stores | route through `Coerce` with the sink's declared type |
+| constant typing | `TypedConstantsPass` retypes **`int`-only**, does not pierce `Convert` |
 
 Every row is a call site that must *remember* to route, with the right target
 type — a sink added or reshaped without the call silently bypasses the rules,
@@ -380,18 +384,15 @@ This stays inside the decompiler's deliberate ceilings:
 The redesign is landable in slices *because* the invariant makes coverage
 measurable, unlike the control-flow rewrite's all-or-nothing invariant relaxation.
 
-1. **Promote `CastValue` into `Coerce`, one rendering function.** `CastValue` is
-   already the embryonic choke point (it renders a value at a target type and
-   delegates the enum case to `EnumIntegerCast`); this *consolidates*, it does not
-   rewrite. The hard-won rules in `EnumIntegerCast`/`MayOverflowEnumBackingType` become the private
-   internals of the one renderer, and the scattered cast *decisions* at `Box`,
-   `StoreElement`, `SwitchLabelText`, and the retyped-constant branch are replaced by
-   a `Coerce` call — the sinks remain, the decisions leave. This is **not**
-   guaranteed behavior-neutral: the sinks now share helpers (#2080), but they still
-   derive target types independently and constant typing is still partial, so
-   unifying the routing can move outputs at the margins — that is the point. Expect
-   and *measure* net-positive validity movement on the corpus quality-diff card; a
-   fidelity regression on any already-`Full` method is the stop signal.
+1. **Promote `CastValue` into `Coerce`, one rendering function.** Landed
+   (#2114): `Coerce` is the typed-sink renderer, `EnumConstantText` the one
+   name-or-cast rule (switch labels, retyped constants, enum sinks), and
+   `TryCoerceEnumOperand` the one enum-operand decision — with
+   `EnumIntegerCast`/`MayOverflowEnumBackingType` as private internals. The
+   consolidation was measured, not behavior-neutral, exactly as predicted: it
+   surfaced and fixed a guard-drift invalid-C# class (bool operands at enum
+   positions) and extended member naming to un-retyped constants, with the
+   corpus card flat against a same-corpus base A/B.
 2. **Complete constant typing.** Extend `TypedConstantsPass` to retype `int`,
    `long`, and `Convert`-wrapped integer constants into every enum-typed sink, so
    the printer sees enum-typed values uniformly.

--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <!-- Hermetic restore: user/machine-level sources leak in without a clear and
+         trip NU1507 (central package management + multiple unmapped sources). -->
+    <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -1,0 +1,221 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Slice 1 of docs/design/value-typed-emission.md: the coercion decision lives in
+// one place (Coerce / TryCoerceEnumOperand / EnumConstantText), not per render
+// branch. These tests pin the two behavior deltas of the consolidation:
+//
+// 1. Guard drift fixed: the binary/comparison enum-operand sites used
+//    TypeFamilies.IsInteger, which admits bool (I4 stack family), so an enum
+//    met by a bool operand rendered `(E)(x == y)` — CS0030. The shared operand
+//    coercion composes the truthiness spelling instead: `(E)(x == y ? 1 : 0)`.
+//    csc never emits this shape; it is verifiable IL (bool and enum share I4),
+//    so the fixtures are synthetic IR.
+// 2. Member naming is part of the one name-or-cast rule: an un-retyped integer
+//    constant at a known-enum sink renders the member name when one matches,
+//    where the sink previously open-coded the cast.
+public class CoerceChokePointTests
+{
+    [Fact]
+    public void EnumComparedToBool_ComposesTruthinessWithEnumCast()
+    {
+        var enumType = TypeRef.Definition("synthetic", "", "Tiny");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var inner = new Comparison(
+            ComparisonKind.Equal,
+            isUnsigned: false,
+            new LoadArgument(1, "x", intType),
+            new LoadArgument(2, "y", intType));
+        var outer = new Comparison(
+            ComparisonKind.Equal,
+            isUnsigned: false,
+            new LoadArgument(0, "flags", enumType),
+            inner);
+        string body = RenderReturn(
+            outer,
+            TypeRef.CoreLib("System", "Boolean"),
+            [new Parameter("flags", enumType), new Parameter("x", intType), new Parameter("y", intType)],
+            enumType);
+
+        Assert.Contains("(Tiny)(x == y ? 1 : 0)", body);
+        Assert.DoesNotContain("(Tiny)(x == y)", body);
+        AssertCompiles("public static bool M(Tiny flags, int x, int y)", body, "public enum Tiny { }");
+    }
+
+    [Fact]
+    public void EnumBitwiseWithBool_ComposesTruthinessWithEnumCast()
+    {
+        var enumType = TypeRef.Definition("synthetic", "", "Tiny");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var inner = new Comparison(
+            ComparisonKind.Equal,
+            isUnsigned: false,
+            new LoadArgument(1, "x", intType),
+            new LoadArgument(2, "y", intType));
+        var and = new Binary(
+            BinaryKind.And,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "flags", enumType),
+            inner);
+        string body = RenderReturn(
+            and,
+            enumType,
+            [new Parameter("flags", enumType), new Parameter("x", intType), new Parameter("y", intType)],
+            enumType);
+
+        Assert.Contains("flags & (Tiny)(x == y ? 1 : 0)", body);
+        Assert.DoesNotContain("& (Tiny)(x == y)", body);
+        AssertCompiles("public static Tiny M(Tiny flags, int x, int y)", body, "public enum Tiny { }");
+    }
+
+    [Fact]
+    public void BoolConditionalArm_AtEnumMergedType_ComposesTruthinessWithEnumCast()
+    {
+        // A conditional whose join is enum-typed but whose true arm is a raw
+        // comparison result: the bool arm cannot render bare (CS0029) or as a
+        // direct enum cast (CS0030); it composes.
+        var enumType = TypeRef.Definition("synthetic", "", "Tiny");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var conditional = new Conditional(
+            new LoadArgument(0, "c", boolType),
+            new Comparison(
+                ComparisonKind.Equal,
+                isUnsigned: false,
+                new LoadArgument(1, "x", intType),
+                new LoadArgument(2, "y", intType)),
+            new LoadArgument(3, "e", enumType))
+        {
+            MergedType = enumType,
+        };
+        string body = RenderReturn(
+            conditional,
+            enumType,
+            [
+                new Parameter("c", boolType),
+                new Parameter("x", intType),
+                new Parameter("y", intType),
+                new Parameter("e", enumType),
+            ],
+            enumType);
+
+        Assert.Contains("(Tiny)(x == y ? 1 : 0)", body);
+        AssertCompiles("public static Tiny M(bool c, int x, int y, Tiny e)", body, "public enum Tiny { }");
+    }
+
+    [Fact]
+    public void UnretypedNamedConstant_AtKnownEnumSink_RendersMemberName()
+    {
+        // A long-payload constant TypedConstantsPass (int-only) never retyped:
+        // the sink coercion still spells the member name, not `(LEnum)2`.
+        var enumType = TypeRef.Definition("synthetic", "", "LEnum");
+        var longType = TypeRef.CoreLib("System", "Int64");
+        string body = RenderReturn(
+            new Constant(2L, longType),
+            enumType,
+            [],
+            enumType,
+            underlying: longType,
+            members: new Dictionary<long, string> { [2] = "High" });
+
+        Assert.Contains("return LEnum.High;", body);
+        Assert.DoesNotContain("(LEnum)2", body);
+        AssertCompiles("public static LEnum M()", body, "public enum LEnum : long { Low = 0, High = 2 }");
+    }
+
+    [Fact]
+    public void UnretypedUnnamedConstant_AtKnownEnumSink_KeepsOverflowAwareCast()
+    {
+        // The cast half of the name-or-cast rule is unchanged: no matching
+        // member falls back to the overflow-aware enum cast.
+        var enumType = TypeRef.Definition("synthetic", "", "LEnum");
+        var longType = TypeRef.CoreLib("System", "Int64");
+        string body = RenderReturn(
+            new Constant(7L, longType),
+            enumType,
+            [],
+            enumType,
+            underlying: longType,
+            members: new Dictionary<long, string> { [2] = "High" });
+
+        Assert.Contains("return (LEnum)7;", body);
+        AssertCompiles("public static LEnum M()", body, "public enum LEnum : long { Low = 0, High = 2 }");
+    }
+
+    static string RenderReturn(
+        IrExpression value,
+        TypeRef returnType,
+        IReadOnlyList<Parameter> parameters,
+        TypeRef enumType,
+        TypeRef? underlying = null,
+        IReadOnlyDictionary<long, string>? members = null)
+    {
+        var block = new Block(0);
+        block.Add(new Return(value));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(returnType, [.. parameters], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], container)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum },
+            EnumUnderlyingTypes = underlying is null
+                ? new Dictionary<TypeRef, TypeRef>()
+                : new Dictionary<TypeRef, TypeRef> { [enumType] = underlying },
+            EnumMembers = members is null
+                ? new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>()
+                : new Dictionary<TypeRef, IReadOnlyDictionary<long, string>> { [enumType] = members },
+        };
+
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    static void AssertCompiles(string header, string body, string extraDeclarations = "")
+    {
+        var errors = Recompile(header, body, extraDeclarations)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToArray();
+        Assert.True(errors.Length == 0, "Rendered body must compile, got:\n  " + string.Join("\n  ", errors) + "\n--- body ---\n" + body);
+    }
+
+    static ImmutableArray<Diagnostic> Recompile(string methodHeader, string body, string extraDeclarations)
+    {
+        string source = $$"""
+            using System;
+            {{extraDeclarations}}
+            static class __Gate
+            {
+                {{methodHeader}}
+                {
+            {{body}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "__gate",
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        return compilation.GetDiagnostics();
+    }
+
+    static ImmutableArray<MetadataReference> RuntimeReferences()
+    {
+        var references = ImmutableArray.CreateBuilder<MetadataReference>();
+        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+            try { references.Add(MetadataReference.CreateFromFile(path)); }
+            catch { }
+        }
+        return references.ToImmutable();
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -109,6 +109,42 @@ public class CoerceChokePointTests
     }
 
     [Fact]
+    public void UnnamedHighBitConstantArm_KeepsUncheckedCast()
+    {
+        // The cast half of the name-or-cast rule at the #2076 conditional-arm
+        // shape: a negative payload on a uint-backed enum with NO matching member
+        // must still take the overflow-aware unchecked cast (CS0221 otherwise) —
+        // naming only fires on an exact member match (the named twin lives in
+        // EnumCastPrinterTests.EnumConditional_SameAssemblyUnsignedEnum_NamesHighBitMember).
+        var enumType = TypeRef.Definition("synthetic", "", "CfgFlags");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var conditional = new Conditional(
+            new LoadArgument(0, "c", boolType),
+            new Constant(-2147483647, intType),
+            new LoadArgument(1, "e", enumType))
+        {
+            MergedType = enumType,
+        };
+        string body = RenderReturn(
+            conditional,
+            enumType,
+            [new Parameter("c", boolType), new Parameter("e", enumType)],
+            enumType,
+            underlying: TypeRef.CoreLib("System", "UInt32"),
+            // Top keys by the signed int payload (-2147483648), mirroring how the
+            // real member map resolved the #2076 fixture's `ldc.i4` constant.
+            members: new Dictionary<long, string> { [0] = "None", [-2147483648L] = "Top" });
+
+        Assert.Contains("unchecked((CfgFlags)(-2147483647))", body);
+        Assert.DoesNotContain("CfgFlags.Top", body);
+        AssertCompiles(
+            "public static CfgFlags M(bool c, CfgFlags e)",
+            body,
+            "public enum CfgFlags : uint { None = 0, Top = 0x80000000u }");
+    }
+
+    [Fact]
     public void UnretypedNamedConstant_AtKnownEnumSink_RendersMemberName()
     {
         // A long-payload constant TypedConstantsPass (int-only) never retyped:

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -134,16 +134,20 @@ public class EnumCastPrinterTests
     }
 
     [Fact]
-    public void EnumConditional_SameAssemblyUnsignedEnum_ForcesUncheckedCast()
+    public void EnumConditional_SameAssemblyUnsignedEnum_NamesHighBitMember()
     {
         // #2076: `c ? CfgFlags.Top : e` where CfgFlags : uint. Top (0x80000000u)
         // is emitted as `ldc.i4` int.MinValue, so the conditional slot's importer
-        // type is unknown; the fold anchors the enum and the printer must wrap the
-        // negative reinterpret in `unchecked`.
+        // type is unknown; the fold anchors the enum. The name-or-cast rule
+        // (EnumConstantText) resolves the payload to the member — `CfgFlags.Top`,
+        // never a bare `-2147483648` (CS0029) or an unchecked cast of the raw
+        // literal. The unnamed-value fallback to `unchecked` is pinned by
+        // CoerceChokePointTests.UnnamedHighBitConstantArm_KeepsUncheckedCast.
         string body = RenderRaisedFixture(nameof(EnumCastSamples.UnsignedEnumConditionalArm));
 
-        Assert.Contains("unchecked((CfgFlags)(-2147483648))", body);
+        Assert.Contains("CfgFlags.Top", body);
         Assert.DoesNotContain(": -2147483648", body);
+        Assert.DoesNotContain("(CfgFlags)(-2147483648)", body);
         AssertCompiles(
             "public static bool M(bool c, CfgFlags e)",
             body,

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -5342,7 +5342,7 @@ public class EnumConstantTests
     {
         // `StringComparison V_0 = flag ? 1 : 0;` is int->enum (CS0266). A ternary
         // of integer arms into an enum local must take the enum cast on the whole
-        // merge — `(MyEnum)(flag ? 1 : 0)` — even though CastValue otherwise
+        // merge — `(MyEnum)(flag ? 1 : 0)` — even though Coerce otherwise
         // leaves merge nodes uncast (the bail's CS0030 risk is type-parameter-only,
         // not a concrete enum).
         var enumType = TypeRef.Definition("asm", "NS", "MyEnum");

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -279,7 +279,7 @@ public sealed partial class CSharpPrinter
                 // is the element type, so cast the value exactly as a single-dim
                 // StoreElement does.
                 TypeRef? elementType = call.Callee.ParameterTypes.Length > rank ? call.Callee.ParameterTypes[rank] : null;
-                string value = elementType is not null ? CastValue(arguments[^1], elementType) : Expression(arguments[^1]);
+                string value = elementType is not null ? Coerce(arguments[^1], elementType) : Expression(arguments[^1]);
                 return $"{receiver}[{indices}] = {value}";
             }
             default:
@@ -401,7 +401,7 @@ public sealed partial class CSharpPrinter
             var parameter = i < parameterTypes.Count ? parameterTypes[i] : null;
             var refKind = i < refKinds.Length ? refKinds[i] : ArgumentRefKind.Value;
             parts.Add(RefArgument(argument, parameter, refKind, explicitIn)
-                ?? (parameter is not null ? CastValue(argument, parameter) : Expression(argument)));
+                ?? (parameter is not null ? Coerce(argument, parameter) : Expression(argument)));
             i++;
         }
         return string.Join(", ", parts);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -173,7 +173,7 @@ public sealed partial class CSharpPrinter
     /// — <c>(MethodAttributes)access</c> — so an enum-vs-integer comparison or
     /// bitwise op type-checks (CS0019). The cast reinterprets the integer bits
     /// the IL already carries as the enum, so it is faithful. A negative literal
-    /// is parenthesized (CS0075), mirroring <see cref="CastValue"/>'s enum path.
+    /// is parenthesized (CS0075), mirroring <see cref="Coerce"/>'s enum path.
     /// </summary>
     string EnumIntegerCast(IrExpression value, TypeRef enumType)
     {
@@ -186,6 +186,49 @@ public sealed partial class CSharpPrinter
         return CheckedSafeCast(
             $"({TypeText(enumType)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}",
             force: forceUnchecked);
+    }
+
+    /// <summary>
+    /// Renders an integer constant occupying an enum-typed position: the member
+    /// name when the value resolves to a single named member, else the
+    /// overflow-aware enum cast. The one name-or-cast rule for enum constants —
+    /// <c>switch</c> labels, retyped constants, and enum-typed sinks all spell
+    /// through here. The cast path re-types the payload to its raw integer so
+    /// <see cref="EnumIntegerCast"/> renders the literal, not a recursive
+    /// enum-typed spelling.
+    /// </summary>
+    string EnumConstantText(Constant constant, TypeRef enumType)
+    {
+        long value = constant.Value is int i ? i : (long)constant.Value!;
+        if (EnumMemberName(new Constant(value, enumType)) is { } named)
+            return named;
+        var raw = constant.Value is int iv
+            ? new Constant(iv, TypeRef.CoreLib("System", "Int32"))
+            : new Constant(value, TypeRef.CoreLib("System", "Int64"));
+        return EnumIntegerCast(raw, enumType);
+    }
+
+    /// <summary>
+    /// Coerces a value meeting an enum-typed sibling or arm target — the shared
+    /// decision behind bitwise/comparison operands, conditional and switch arms,
+    /// coalesce right sides, and compound assignments. An integer-family value
+    /// takes the enum cast (member name for a nameable constant); a bool — which
+    /// shares the I4 stack family, so IL combines it with an enum freely while
+    /// C# admits neither bare spelling (CS0019/CS0030) — composes the truthiness
+    /// spelling with the cast: <c>(E)(cond ? 1 : 0)</c>. Null when the position
+    /// needs no enum coercion, so the caller keeps its own spelling.
+    /// </summary>
+    string? TryCoerceEnumOperand(IrExpression value, TypeRef? enumSide)
+    {
+        if (enumSide is null || !IsEnumLikeInteger(enumSide))
+            return null;
+        if (TypeFamilies.IsBoolean(EffectiveType(value)))
+            return CheckedSafeCast($"({TypeText(enumSide)})({Condition(value)} ? 1 : 0)");
+        if (value.ResultType is not { } valueType || !TypeFamilies.IsIntegerLike(valueType))
+            return null;
+        return value is Constant { Value: int or long } konst
+            ? EnumConstantText(konst, enumSide)
+            : EnumIntegerCast(value, enumSide);
     }
 
     // True when a constant enum cast is CS0221 as a plain (checked) cast, so it must
@@ -267,16 +310,17 @@ public sealed partial class CSharpPrinter
             return uncheckedOverflow ? $"unchecked({pointerText})" : pointerText;
         }
         // A bitwise &/|/^ of an enum and an integer (`method.Attributes & 7`) is
-        // CS0019 though the IL combines the shared underlying integer; cast the
+        // CS0019 though the IL combines the shared underlying integer; coerce the
         // integer operand to the enum type. A cross-assembly enum is unresolved
-        // (TypeShape.Unknown), so this structural test is what catches it. A
-        // bitwise op is never checked, so it never needs the `wrap` form.
+        // (TypeShape.Unknown), so the structural test inside the coercion is what
+        // catches it. A bitwise op is never checked, so it never needs the `wrap`
+        // form.
         if (binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor)
         {
-            if (IsEnumLikeInteger(binary.Left.ResultType) && TypeFamilies.IsInteger(binary.Right.ResultType))
-                return $"{Operand(binary.Left)} {BinaryOperator(binary)} {EnumIntegerCast(binary.Right, binary.Left.ResultType!)}";
-            if (IsEnumLikeInteger(binary.Right.ResultType) && TypeFamilies.IsInteger(binary.Left.ResultType))
-                return $"{EnumIntegerCast(binary.Left, binary.Right.ResultType!)} {BinaryOperator(binary)} {Operand(binary.Right)}";
+            if (TryCoerceEnumOperand(binary.Right, binary.Left.ResultType) is { } coercedRight)
+                return $"{Operand(binary.Left)} {BinaryOperator(binary)} {coercedRight}";
+            if (TryCoerceEnumOperand(binary.Left, binary.Right.ResultType) is { } coercedLeft)
+                return $"{coercedLeft} {BinaryOperator(binary)} {Operand(binary.Right)}";
         }
         // div.un/rem.un compute on unsigned operands; shr.un shifts an
         // unsigned left operand. Operands that are already unsigned (or
@@ -334,8 +378,8 @@ public sealed partial class CSharpPrinter
 
         var leftEnumUnderlying = EnumUnderlyingType(binary.Left.ResultType);
         var rightEnumUnderlying = EnumUnderlyingType(binary.Right.ResultType);
-        string left = leftEnumUnderlying is not null ? CastValue(binary.Left, target) : Operand(binary.Left);
-        string right = rightEnumUnderlying is not null ? CastValue(binary.Right, target) : Operand(binary.Right);
+        string left = leftEnumUnderlying is not null ? Coerce(binary.Left, target) : Operand(binary.Left);
+        string right = rightEnumUnderlying is not null ? Coerce(binary.Right, target) : Operand(binary.Right);
         return $"{left} {BinaryOperator(binary)} {right}";
     }
 
@@ -818,13 +862,13 @@ public sealed partial class CSharpPrinter
         }
         // An enum compared to an integer (`access == bestAccess`,
         // `methodAccess == 6`) is CS0019 though the IL compares their shared
-        // underlying integer; cast the integer operand to the enum type. A
-        // cross-assembly enum is unresolved (TypeShape.Unknown), so this is the
-        // path that fixes it.
-        if (IsEnumLikeInteger(left.ResultType) && TypeFamilies.IsInteger(right.ResultType))
-            return $"{Operand(left)} {ComparisonOperator(kind)} {EnumIntegerCast(right, left.ResultType!)}";
-        if (IsEnumLikeInteger(right.ResultType) && TypeFamilies.IsInteger(left.ResultType))
-            return $"{EnumIntegerCast(left, right.ResultType!)} {ComparisonOperator(kind)} {Operand(right)}";
+        // underlying integer; coerce the integer operand to the enum type. A
+        // cross-assembly enum is unresolved (TypeShape.Unknown), so the
+        // structural test inside the coercion is what fixes it.
+        if (TryCoerceEnumOperand(right, left.ResultType) is { } coercedRight)
+            return $"{Operand(left)} {ComparisonOperator(kind)} {coercedRight}";
+        if (TryCoerceEnumOperand(left, right.ResultType) is { } coercedLeft)
+            return $"{coercedLeft} {ComparisonOperator(kind)} {Operand(right)}";
         // An equality test between a same-width signed/unsigned integer pair
         // (`ulong != (long)i`, `nuint == nint`) has no C# common type (CS0034),
         // yet `ceq`/`bne.un` compare the raw bits regardless of sign. Reinterpret
@@ -957,13 +1001,18 @@ public sealed partial class CSharpPrinter
     }
 
     /// <summary>
-    /// Renders <paramref name="value"/> for a position typed <paramref name="target"/>,
-    /// inserting the explicit numeric cast C# requires when the value's type
-    /// would not implicitly convert (the missing-cast case behind CS0266). The
-    /// cast reinterprets bits the evaluation stack already carries (same family),
-    /// so it is faithful to the IL — see <see cref="TypeFamilies.NeedsNumericCast"/>.
+    /// The coercion choke point (docs/design/value-typed-emission.md, slice 1):
+    /// renders <paramref name="value"/> for a sink typed <paramref name="target"/>,
+    /// inserting the explicit conversion C# requires when the value's type would
+    /// not implicitly convert (the missing-cast case behind CS0266). Every
+    /// typed sink spells its value through here — never an open-coded cast — so
+    /// the cast/`unchecked` rules live once. The cast reinterprets bits the
+    /// evaluation stack already carries (same family), so it is faithful to the
+    /// IL — see <see cref="TypeFamilies.NeedsNumericCast"/>. Operand positions
+    /// reconciling against an enum sibling use <see cref="TryCoerceEnumOperand"/>,
+    /// the operand-shaped door into the same rules.
     /// </summary>
-    string CastValue(IrExpression value, TypeRef? target)
+    string Coerce(IrExpression value, TypeRef? target)
     {
         if (target is { } nativeTarget
             && IsNativeInteger(nativeTarget)
@@ -1013,7 +1062,9 @@ public sealed partial class CSharpPrinter
             && EffectiveType(value) is { } enumSource && !enumTarget.Equals(enumSource)
             && TypeFamilies.IsIntegerLike(enumSource))
         {
-            return EnumIntegerCast(value, enumTarget);
+            return value is Constant { Value: int or long } enumKonst
+                ? EnumConstantText(enumKonst, enumTarget)
+                : EnumIntegerCast(value, enumTarget);
         }
         if (value is Binary enumArithmetic
             && target is { } enumArithmeticTarget
@@ -1041,13 +1092,13 @@ public sealed partial class CSharpPrinter
         // without loading the defining assembly, so the cast is the best honest
         // spelling. Constants only: a non-constant integer into such a position is
         // rarer and not needed for the validity defects this targets.
-        if (value is Constant { Value: int or long }
+        if (value is Constant { Value: int or long } unknownKonst
             && target is { Kind: TypeRefKind.Definition, Name: not "Boolean" } unknownEnum
             && _function.TypeShapes.GetValueOrDefault(unknownEnum) == TypeShape.Unknown
             && !TypeFamilies.IsNumericPrimitive(unknownEnum)
             && EffectiveType(value) is { } unknownEnumSource && TypeFamilies.IsIntegerLike(unknownEnumSource))
         {
-            return EnumIntegerCast(value, unknownEnum);
+            return EnumConstantText(unknownKonst, unknownEnum);
         }
         // A bool-valued expression flowing into an integer target is IL's
         // comparison/test result consumed as a number — `cgt.un; ret` from an int
@@ -1154,15 +1205,13 @@ public sealed partial class CSharpPrinter
             ? charText
             // An integer arm flowing into an enum-typed conditional (`ci ? 4 : raw`
             // into StringComparison) is CS0266 — int does not convert to the enum.
-            // A cross-assembly enum is unresolved (TypeShape.Unknown), so
-            // IsEnumLikeInteger catches it; cast each integer arm (constant or not).
-            // IsIntegerLike (not IsInteger) excludes Boolean — which shares the I4
-            // stack family — so a bool arm is never cast to `(Enum)true`. A
-            // same-assembly enum arm is enum-typed (not integer-like) and renders
-            // its member name via Operand.
-            : target is { } enumTarget && IsEnumLikeInteger(enumTarget)
-                && arm.ResultType is { } armType && TypeFamilies.IsIntegerLike(armType)
-                ? EnumIntegerCast(arm, enumTarget)
+            // TryCoerceEnumOperand owns the decision: the enum cast for an integer
+            // arm (constant or not; a cross-assembly enum is unresolved, and its
+            // structural test catches it), the composed `(E)(cond ? 1 : 0)` for a
+            // bool arm. A same-assembly enum arm is enum-typed (not integer-like)
+            // and renders its member name via Operand.
+            : TryCoerceEnumOperand(arm, target) is { } coercedArm
+                ? coercedArm
             : target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
             && EffectiveType(arm) is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary }
                 ? $"({Condition(arm)} ? 1 : 0)"
@@ -1196,9 +1245,7 @@ public sealed partial class CSharpPrinter
             return null;
         if (NullableValueType(coalesce.Left.ResultType)?.Equals(target) == true && IsIntegerArm(coalesce.Right))
             return CoalesceText(coalesce, target);
-        return coalesce.ResultType is { } resultType && TypeFamilies.IsIntegerLike(resultType)
-            ? EnumIntegerCast(coalesce, target)
-            : null;
+        return TryCoerceEnumOperand(coalesce, target);
     }
 
     static bool IsCoreChar(TypeRef type)
@@ -1251,7 +1298,7 @@ public sealed partial class CSharpPrinter
             // C# promotes every sub-int (byte/sbyte/short/ushort/char) binary
             // arithmetic/bitwise/shift result to int: `a - b` over two chars is
             // typed `int`, never `char`. The IR keeps the narrow operand type,
-            // so report int here — otherwise the missing-cast logic (CastValue)
+            // so report int here — otherwise the missing-cast logic (Coerce)
             // sees an implicit char→uint and drops the (uint) cast C# requires,
             // emitting CS0266. A narrowing store back to a sub-int local always
             // carries its own conv (a Convert node, not a bare Binary), so this
@@ -1268,7 +1315,7 @@ public sealed partial class CSharpPrinter
             // pair by reinterpreting the signed side (`(uint)x + count`). Either
             // way the rendered result is unsigned even though the ECMA ResultType
             // keeps a signed operand type. Report it, so a parent (a nested
-            // `1 + (int * uint)`, or a CastValue boundary into a signed target)
+            // `1 + (int * uint)`, or a Coerce boundary into a signed target)
             // sees the unsigned type and reconciles or casts in turn — the
             // propagation that resolves the `int op uint` family up the whole tree.
             if (RendersUnsigned(binary))

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -161,12 +161,7 @@ public sealed partial class CSharpPrinter
                 labelEnum)));
 
     string SwitchArmValueText(IrExpression value, TypeRef? target)
-        => target is { } enumTarget
-            && IsEnumLikeInteger(enumTarget)
-            && value.ResultType is { } valueType
-            && TypeFamilies.IsIntegerLike(valueType)
-                ? EnumIntegerCast(value, enumTarget)
-                : Expression(value);
+        => TryCoerceEnumOperand(value, target) is { } coerced ? coerced : Expression(value);
 
     /// <summary>The single-line form of a switch expression, used when it is nested inside another expression.</summary>
     string SwitchExpressionInline(SwitchExpression node, TypeRef? target = null)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1308,7 +1308,7 @@ public sealed partial class CSharpPrinter
             sb.Append(pad)
                 .Append(usingStatement.IsAwait ? "await using (" : "using (").Append(TypeText(usingStatement.ResourceType)).Append(' ')
                 .Append(LocalName(usingStatement.LocalIndex)).Append(" = ")
-                .Append(CastValue(usingStatement.Resource, usingStatement.ResourceType)).AppendLine(")");
+                .Append(Coerce(usingStatement.Resource, usingStatement.ResourceType)).AppendLine(")");
             sb.Append(pad).AppendLine("{");
             AppendContainer(sb, usingStatement.Body, indent + 1);
             sb.Append(pad).AppendLine("}");
@@ -1629,12 +1629,12 @@ public sealed partial class CSharpPrinter
             ? $"{TypeText(s.Type)} {LocalName(s.Index)} = ref {Deref(s.Value)};"
             : $"{LocalName(s.Index)} = ref {Deref(s.Value)};",
         StoreLocal s => _declaringStores.Contains(s)
-            ? $"{DeclarationTypeText(s.Type, s.Value)} {LocalName(s.Index)} = {CastValue(s.Value, s.Type)};"
+            ? $"{DeclarationTypeText(s.Type, s.Value)} {LocalName(s.Index)} = {Coerce(s.Value, s.Type)};"
             : AssignmentText($"{LocalName(s.Index)}", s.Value, left => left is LoadLocal load && load.Index == s.Index, s.Type),
         DeconstructionAssignment d => $"({string.Join(", ", d.Targets.Select(DeconstructionTargetText))}) = {Expression(d.Source)};",
-        NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {CastValue(n.Value, n.LocalType)};",
-        NullCoalescingFieldAssignment n => $"{FieldTarget(n.Field, n.Instance)} ??= {CastValue(n.Value, n.Field.Type)};",
-        NullCoalescingPropertyAssignment n => $"{PropertyTarget(n.Setter, n.Instance, n.IndexArguments, n.PropertyName, n.IsVirtual)} ??= {CastValue(n.Value, n.PropertyType)};",
+        NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {Coerce(n.Value, n.LocalType)};",
+        NullCoalescingFieldAssignment n => $"{FieldTarget(n.Field, n.Instance)} ??= {Coerce(n.Value, n.Field.Type)};",
+        NullCoalescingPropertyAssignment n => $"{PropertyTarget(n.Setter, n.Instance, n.IndexArguments, n.PropertyName, n.IsVirtual)} ??= {Coerce(n.Value, n.PropertyType)};",
         StoreArgument s => AssignmentText(CSharpNaming.EscapeIdentifier(s.Name), s.Value, left => left is LoadArgument load && load.Index == s.Index, s.Type),
         // A ref-typed slot stores by rebinding the reference — C#'s ref
         // (re)assignment, exactly as for ref locals above.
@@ -1642,7 +1642,7 @@ public sealed partial class CSharpPrinter
             ? $"{TypeText(refType)} {StackSlotName(s)} = ref {Deref(s.Value)};"
             : $"{StackSlotName(s)} = ref {Deref(s.Value)};",
         StoreStackSlot s => _declaringStores.Contains(s)
-            ? $"{DeclarationTypeText(StackSlotTargetType(s)!, s.Value)} {StackSlotName(s)} = {CastValue(s.Value, StackSlotTargetType(s))};"
+            ? $"{DeclarationTypeText(StackSlotTargetType(s)!, s.Value)} {StackSlotName(s)} = {Coerce(s.Value, StackSlotTargetType(s))};"
             : AssignmentText(StackSlotName(s), s.Value, left => left is LoadStackSlot load && StackSlotName(load) == StackSlotName(s), StackSlotTargetType(s)),
         StoreField s => AssignmentText(
             FieldTarget(s.Field, s.Instance), s.Value,
@@ -1660,9 +1660,9 @@ public sealed partial class CSharpPrinter
                 && SameLValue(load.Instance, s.Instance)
                 && PlaceIdentity.SameOperands(load.IndexArguments, s.IndexArguments),
             StorePropertyTargetType(s)),
-        EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {CastValue(e.Value, e.Accessor.ParameterTypes[0])};",
+        EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {Coerce(e.Value, e.Accessor.ParameterTypes[0])};",
         StoreElement s when InlineReceiverTempStoreValue(s) is { } value => $"{Operand(s.Array)}[{Expression(s.Index)}] = {value};",
-        StoreElement s => $"{Operand(s.Array)}[{Expression(s.Index)}] = {CastValue(s.Value, StoreElementTargetType(s))};",
+        StoreElement s => $"{Operand(s.Array)}[{Expression(s.Index)}] = {Coerce(s.Value, StoreElementTargetType(s))};",
         StoreIndirect s => AssignmentText(
             IndirectTarget(s.Address, IndirectStoreType(s.Address, s.Type)),
             s.Value,
@@ -1736,7 +1736,7 @@ public sealed partial class CSharpPrinter
     // drops an enum-typed integer store below its real element type and prints a
     // bare literal (CS0266). Prefer the array's own element type when it is
     // enum-like — same-assembly (`TypeShape.Enum`) or cross-assembly (an unresolved
-    // non-primitive definition), matching `CastValue`'s enum-cast reasoning.
+    // non-primitive definition), matching `Coerce`'s enum-cast reasoning.
     TypeRef? StoreElementTargetType(StoreElement store)
         => store.Array.ResultType is { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element }
             && IsEnumLikeInteger(element)
@@ -1750,18 +1750,14 @@ public sealed partial class CSharpPrinter
         LoadLocal l => $"{LocalName(l.Index)}",
         LoadStackSlot s => StackSlotName(s),
         Constant { Value: int or long } c when EnumMemberName(c) is { } named => named,
-        // A retyped enum constant with no single named member (a composite flag
-        // value, or one outside the resolved member map) is still that enum — a
-        // bare int is CS0266. Route it through the overflow-aware enum cast so an
-        // unsigned- or narrow-backed enum's out-of-range/negative value is wrapped
-        // in `unchecked` (e.g. `unchecked((U)(-1))`); naming flag combinations is a
-        // later slice. A long-backed enum keeps its `long` payload.
+        // A retyped enum constant is still that enum whether or not a single
+        // member names it — a bare int is CS0266. EnumConstantText owns the
+        // name-or-cast decision (the overflow-aware cast wraps an unsigned- or
+        // narrow-backed enum's out-of-range/negative value in `unchecked`, e.g.
+        // `unchecked((U)(-1))`); naming flag combinations is a later slice. A
+        // long-backed enum keeps its `long` payload.
         Constant { Value: int or long, Type: { } enumType } c when _function.TypeShapes.GetValueOrDefault(enumType) == TypeShape.Enum
-            => EnumIntegerCast(
-                c.Value is int i
-                    ? new Constant(i, TypeRef.CoreLib("System", "Int32"))
-                    : new Constant((long)c.Value!, TypeRef.CoreLib("System", "Int64")),
-                enumType),
+            => EnumConstantText(c, enumType),
         Constant c => ConstantText(c),
         LoadField f => FieldTarget(f.Field, f.Instance),
         Binary b => BinaryText(b),
@@ -1826,7 +1822,7 @@ public sealed partial class CSharpPrinter
         InlineArraySpanConversion c => $"({TypeText(c.SpanType)}){Deref(c.Place)}",
         StackAllocate s => $"stackalloc byte[{Expression(s.Size)}]",
         StackAllocArray s => $"stackalloc {TypeText(s.ElementType)}[{Expression(s.Count)}]",
-        Box b => CastValue(b.Operand, b.Type),
+        Box b => Coerce(b.Operand, b.Type),
         IsInstance i => $"{Operand(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
         IsPattern p => $"{TypeTestValueText(p.Value)} is {TypeText(p.Type)} {LocalName(p.LocalIndex)}",
         RecursivePropertyDeclarationPattern p => $"{Operand(p.Value)} is {{ {p.PropertyName}: {TypeText(p.PatternType)} {LocalName(p.LocalIndex)} }}",
@@ -1858,12 +1854,7 @@ public sealed partial class CSharpPrinter
     }
 
     string CoalesceRightText(IrExpression right, TypeRef? target)
-        => target is { } enumTarget
-            && IsEnumLikeInteger(enumTarget)
-            && right.ResultType is { } rightType
-            && TypeFamilies.IsIntegerLike(rightType)
-                ? EnumIntegerCast(right, enumTarget)
-                : Operand(right);
+        => TryCoerceEnumOperand(right, target) is { } coerced ? coerced : Operand(right);
 
     static TypeRef? NullableValueType(TypeRef? type)
         => type is
@@ -2608,7 +2599,7 @@ public sealed partial class CSharpPrinter
     string ReturnText(IrExpression value)
         => _function.Signature.ReturnType is { Kind: TypeRefKind.ByRef } && ArgumentLvalue(value) is { } place
             ? $"return ref {place};"
-            : $"return {CastValue(value, _function.Signature.ReturnType)};";
+            : $"return {Coerce(value, _function.Signature.ReturnType)};";
 
     /// <summary>
     /// Assignment spelling with compound/increment sugar: when the value is
@@ -2629,7 +2620,7 @@ public sealed partial class CSharpPrinter
             // overflow-honoring operators ever carry IsChecked here.
             return binary.IsChecked ? $"checked {{ {statement} }}" : statement;
         }
-        return $"{target} = {CastValue(value, targetType)};";
+        return $"{target} = {Coerce(value, targetType)};";
     }
 
     /// <summary>
@@ -2652,17 +2643,14 @@ public sealed partial class CSharpPrinter
             ? ShiftCount(binary)
             // A bitwise &=/|=/^= against an enum lvalue whose right operand is still
             // a bare integer (`result |= 512`) is `enum |= int` — CS0019, the
-            // compound sibling of the `enum & int` cast in BinaryBody. A
-            // cross-assembly enum is unresolved (TypeShape.Unknown), so the
-            // structural IsEnumLikeInteger test catches it; cast the integer operand
-            // to the enum. IsIntegerLike (not IsInteger) excludes Boolean — which
-            // shares the I4 stack family — so a bool operand is never cast to
-            // `(Enum)true`. A same-assembly enum already had its operand retyped, so
-            // its right type is the enum (not integer-like) and this is skipped.
+            // compound sibling of the `enum & int` coercion in BinaryBody.
+            // TryCoerceEnumOperand owns the decision (structural enum test for the
+            // cross-assembly case, bool composition, member naming). A
+            // same-assembly enum already had its operand retyped, so its right
+            // type is the enum (not integer-like) and this is skipped.
             : binary.Kind is BinaryKind.And or BinaryKind.Or or BinaryKind.Xor
-                && IsEnumLikeInteger(lvalueType)
-                && binary.Right.ResultType is { } rightType && TypeFamilies.IsIntegerLike(rightType)
-                ? EnumIntegerCast(binary.Right, lvalueType!)
+                && TryCoerceEnumOperand(binary.Right, lvalueType) is { } coercedRight
+                ? coercedRight
             // A mixed-sign same-width compound (`nuint -= nint`, `ulong /= long`)
             // has no C# common type, so `target op= right` is CS0034. For the
             // sign-NEUTRAL operators (unchecked +/-/*, bitwise &/|/^) the bit
@@ -2673,7 +2661,7 @@ public sealed partial class CSharpPrinter
             // lvalue's: casting only the right operand is faithful when the opcode
             // signedness matches the lvalue. Checked .ovf compounds stay plain.
             : NeedsCompoundSignCast(binary, lvalueType)
-                ? CastValue(binary.Right, lvalueType)
+                ? Coerce(binary.Right, lvalueType)
                 : Operand(binary.Right);
         return $"{target} {BinaryOperator(binary)}= {rightText};";
     }
@@ -3163,11 +3151,7 @@ public sealed partial class CSharpPrinter
     {
         if (enumType is null || label.Value is not (int or long))
             return ConstantText(label);
-        long value = label.Value is int i ? i : (long)label.Value!;
-        var typed = new Constant(value, enumType);
-        if (EnumMemberName(typed) is { } named)
-            return named;
-        return EnumIntegerCast(label, enumType);
+        return EnumConstantText(label, enumType);
     }
 
     static string ConstantText(Constant constant) => constant.Value switch

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -754,7 +754,9 @@ public static class CSharpDeclarationWriter
             return parameter;
 
         string name = prefix[start..(end + 1)];
-        string escaped = name.StartsWith('@', StringComparison.Ordinal) ? name : EscapeIdentifier(name);
+        // StartsWith(char) — the (char, StringComparison) overload is net11-only
+        // and breaks the net10.0 OfficialBuild package floor (CS1503 in pack).
+        string escaped = name.StartsWith('@') ? name : EscapeIdentifier(name);
         return prefix[..start] + escaped + prefix[(end + 1)..] + suffix;
     }
 


### PR DESCRIPTION
## Change

**Conclusion:** slice 1 of [value-typed-emission.md](docs/design/value-typed-emission.md) — the cast/coercion decision now lives in one place. `CastValue` is promoted to **`Coerce`** (the typed-sink choke point), **`EnumConstantText`** is the one name-or-cast rule for integer constants at enum positions (`SwitchLabelText`, the retyped-constant branch, and `Coerce`'s enum branches all spell through it), and **`TryCoerceEnumOperand`** is the one enum-operand decision behind the 8 bitwise/comparison/arm/coalesce/compound sites. Sinks remain; decisions leave.

Two measured behavior deltas, both intended:

1. **Guard-drift fix (latent invalid-C# class).** The binary/comparison operand sites guarded with `TypeFamilies.IsInteger`, which admits `bool` (I4 stack family), so an enum met by a bool operand rendered `(E)(x == y)` — CS0030. The arm sites deliberately excluded bool. The consolidated rule composes the truthiness spelling with the cast — `(E)(x == y ? 1 : 0)` — valid C# that recompiles to the same IL. csc never emits this shape (synthetic-IR fixtures; no compiled-fixture canary exists by construction).
2. **Member naming at the choke point.** Un-retyped integer constants at known-enum positions (e.g. `long` payloads the int-only `TypedConstantsPass` misses) render member names when one matches — `CfgFlags.Top`, not `unchecked((CfgFlags)(-2147483648))`. Same IL on recompile; strictly more readable.

Also: `nuget.config` gets `<clear />` (hermetic restore; machine-level source leaks were tripping NU1507 locally while CI stayed green).

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `CoerceChokePointTests` 6/6, `EnumCastPrinterTests` 20/20 |
| Full `ILInspector.Decompiler.Tests` | In flight; will confirm on this PR before merge |
| PR quick corpus card | Below; pinned-subset gate 0 pp |
| Base A/B | Card at base `fcb02168` is **byte-identical** to the PR card — all advisory drift is pre-existing baseline staleness, not this change |

## Decompiler quality

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 15 assemblies, 1,462 methods
Sample: hash-stable 100 methods per assembly
Correctness coverage: validity not run; fidelity not run

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 1,461 -> 1,462 (+1)
- ILInspector.MetadataPrimitives: 61 -> 62 methods (+1)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 1,213 (83.03%) | 1,208 (82.63%) | -5 |
| Conditional-branch residual (-) | 35 (2.40%) | 45 (3.08%) | +10 |
| Forward-merge stops (-) | 27 (1.85%) | 33 (2.26%) | +6 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 82.17% -> 82.17% (0 pp); conditional residual 3.00% -> 3.00% (0 pp); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Advisory aggregate rate movement (not a PR quick hard gate; review for decompiler-risky changes):
- fully-raised dropped 0.40 pp (baseline 83.03%, PR 82.63%, tolerance 0.10 pp)
- conditional-branch residual increased 0.68 pp (baseline 2.40%, PR 3.08%, tolerance 0.10 pp)
- forward-merge stop increased 0.41 pp (baseline 1.85%, PR 2.26%, tolerance 0.10 pp)

Verdict: corpus sensor matched baseline tolerances.

## Adversarial review

Two-reviewer pass (Claude Opus 4.8 + Gemini 3.1 Pro, [full review](https://gist.github.com/richlander/fa6cd3626e9fe8a07e257cc689d8aa78)) ran against `8ae146ff`; reconciliation follows in a PR comment with the resolution commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)