### PR TITLE
Report ReturnToSender generated fixture frontier

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -436,6 +436,41 @@ public class GeneratedFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderCatalogReport_ClassifiesSupportedAndSkippedTargets()
+    {
+        var run = GeneratedFixtureRunner.RunReturnToSenderCatalog(
+            [
+                GeneratedFixtureCatalog.MinimalPropertyLiteral,
+                GeneratedFixtureCatalog.MinimalMethodCallSameType,
+            ]);
+        string report = GeneratedFixtureRunner.FormatReturnToSenderCatalogReport(run, maxExamples: 10);
+
+        Assert.True(run.Passed, report);
+        Assert.Contains("RETURNTOSENDER GENERATED FIXTURE FRONTIER", report);
+        Assert.Contains("Passed : 1", report);
+        Assert.Contains("Skipped: 1", report);
+        Assert.Contains("not-property-getter: 4", report);
+
+        var propertyGetter = Assert.Single(run.Results, result =>
+            result.FixtureId == "minimal.property.literal"
+            && result.Method == "get_Method1");
+        Assert.Equal(GeneratedFixtureReturnToSenderStatus.Pass, propertyGetter.Status);
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, propertyGetter.ActualStatus);
+
+        Assert.All(
+            run.Results.Where(result => result.FixtureId == "minimal.method-call.same-type"),
+            result => Assert.Equal(GeneratedFixtureReturnToSenderStatus.Skip, result.Status));
+
+        string json = GeneratedFixtureRunner.FormatReturnToSenderCatalogJson(run);
+        using var document = JsonDocument.Parse(json);
+        Assert.True(document.RootElement.GetProperty("Passed").GetBoolean());
+        Assert.Contains(document.RootElement.GetProperty("Results").EnumerateArray(),
+            result => result.GetProperty("Status").GetString() == "Pass");
+        Assert.Contains(document.RootElement.GetProperty("Results").EnumerateArray(),
+            result => result.GetProperty("Reason").GetString() == "not-property-getter");
+    }
+
+    [Fact]
     public void CompilerLoweringFrontiers_AreSelectableButNotInDefaultRun()
     {
         var switchRun = GeneratedFixtureRunner.Run(GeneratedFixtureCatalog.Select("minimal.switch-two-case-lowers-if"));

--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -447,9 +447,9 @@ public class GeneratedFixtureCatalogTests
 
         Assert.True(run.Passed, report);
         Assert.Contains("RETURNTOSENDER GENERATED FIXTURE FRONTIER", report);
-        Assert.Contains("Passed : 1", report);
-        Assert.Contains("Skipped: 1", report);
-        Assert.Contains("not-property-getter: 4", report);
+        Assert.Contains("Passed : 2", report);
+        Assert.Contains("Skipped: 0", report);
+        Assert.Contains("constructor-target: 2", report);
 
         var propertyGetter = Assert.Single(run.Results, result =>
             result.FixtureId == "minimal.property.literal"
@@ -457,9 +457,14 @@ public class GeneratedFixtureCatalogTests
         Assert.Equal(GeneratedFixtureReturnToSenderStatus.Pass, propertyGetter.Status);
         Assert.Equal(FidelityCheck.CompileBackStatus.Exact, propertyGetter.ActualStatus);
 
-        Assert.All(
-            run.Results.Where(result => result.FixtureId == "minimal.method-call.same-type"),
-            result => Assert.Equal(GeneratedFixtureReturnToSenderStatus.Skip, result.Status));
+        Assert.Contains(run.Results, result =>
+            result.FixtureId == "minimal.method-call.same-type"
+            && result.Method == "Method1"
+            && result.Status == GeneratedFixtureReturnToSenderStatus.Pass);
+        Assert.Contains(run.Results, result =>
+            result.FixtureId == "minimal.method-call.same-type"
+            && result.Method == "Method2"
+            && result.Status == GeneratedFixtureReturnToSenderStatus.Pass);
 
         string json = GeneratedFixtureRunner.FormatReturnToSenderCatalogJson(run);
         using var document = JsonDocument.Parse(json);
@@ -467,7 +472,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(document.RootElement.GetProperty("Results").EnumerateArray(),
             result => result.GetProperty("Status").GetString() == "Pass");
         Assert.Contains(document.RootElement.GetProperty("Results").EnumerateArray(),
-            result => result.GetProperty("Reason").GetString() == "not-property-getter");
+            result => result.GetProperty("Reason").GetString() == "constructor-target");
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -736,6 +736,33 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_UsesMetadataMethodOverloadIndex()
+    {
+        var assemblyPath = CompileFixture("""
+            public abstract class Class1
+            {
+                public abstract int Method1();
+
+                public int Method1(int value) => value + 1;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "Method1", 1)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Equal(1, result.Plan.TargetMethod.Overload);
+            Assert.Contains("public int Method1(int value)", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_SurfacesUnsafeNestedClosureMember()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -337,6 +337,94 @@ public static class CompileBackSourceComposer
         return new CompileBackSourceResult(plan, WriteCompilationUnit(plan));
     }
 
+    public static CompileBackSourceResult ComposeMethod(
+        string assemblyPath,
+        MetadataReader reader,
+        IrFunction function,
+        TypeDefinitionHandle targetType,
+        MethodDefinitionHandle targetMethod,
+        string targetBody,
+        string fullType,
+        string methodName,
+        int overload,
+        string signatureText,
+        IReadOnlySet<TypeDefinitionHandle> closureRoots,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts)
+    {
+        var targetTypeDef = reader.GetTypeDefinition(targetType);
+        var method = reader.GetMethodDefinition(targetMethod);
+        var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, targetTypeDef, method));
+        var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
+        string targetMethodName = Identifier(methodName);
+
+        var diagnostics = new List<CompileBackPlanningDiagnostic>();
+        var targetRoot = TopLevelRootOf(reader, targetType);
+        var targetFacts = new List<CompileBackFact>
+        {
+            new("metadata", "target-type", targetIdentity.FullName),
+        };
+        if (closureFacts.TryGetValue(targetRoot, out var targetClosureFacts))
+            targetFacts.AddRange(targetClosureFacts);
+
+        var requirements = new List<CompileBackTypeRequirement>
+        {
+            new(
+                targetIdentity,
+                ShellKind(reader, targetTypeDef),
+                [
+                    new CompileBackMemberRequirement(
+                        new CompileBackMethodIdentity(targetIdentity.FullName, targetMethodName, overload, signatureText),
+                        CompileBackMemberKind.Method,
+                        method.Attributes.HasFlag(MethodAttributes.Static),
+                        MethodParameters(reader, method, signature),
+                        CompileBackTypeSignature.Display(signature.ReturnType),
+                        CompileBackStubBodyKind.TargetBody,
+                        targetBody,
+                        [new CompileBackFact("metadata", "target-method", reader.GetString(method.Name))])
+                ],
+                targetFacts)
+        };
+
+        foreach (var dependency in closureRoots.OrderBy(handle => MetadataTokens.GetToken(handle)))
+        {
+            if (dependency == targetRoot)
+                continue;
+
+            var dependencyDef = reader.GetTypeDefinition(dependency);
+            var dependencyIdentity = CompileBackTypeIdentity.FromDefinition(reader, dependencyDef);
+            if (requirements.Any(requirement => requirement.Type.MetadataFullName == dependencyIdentity.MetadataFullName))
+                continue;
+
+            requirements.Add(new CompileBackTypeRequirement(
+                dependencyIdentity,
+                ShellKind(reader, dependencyDef),
+                RequiredMembers: [],
+                SourceFacts: closureFacts.TryGetValue(dependency, out var facts)
+                    ? facts.ToArray()
+                    : [new CompileBackFact("closure", "closure-root", dependencyIdentity.FullName)]));
+        }
+
+        var declarations = TypeProducer.Produce(reader, requirements, diagnostics);
+        var module = new CompileBackModuleRequirement(
+            Usings: RequiredNamespaces(function)
+                .Concat(DeclarationNamespaces(declarations))
+                .Prepend("System")
+                .Select(CompileBackCSharpNames.EscapeNamespace)
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal)
+                .ToArray(),
+            AssemblyAttributes: [],
+            ModuleAttributes: []);
+        var plan = new CompileBackReconstructionPlan(
+            assemblyPath,
+            new CompileBackMethodIdentity(fullType, methodName, overload, signatureText),
+            module,
+            declarations,
+            requirements,
+            diagnostics);
+        return new CompileBackSourceResult(plan, WriteCompilationUnit(plan));
+    }
+
     static string WriteCompilationUnit(CompileBackReconstructionPlan plan)
     {
         var sb = new StringBuilder();
@@ -495,9 +583,25 @@ public static class CompileBackSourceComposer
                 sb.AppendLine($"{pad}{declaration} {{ throw null; }}");
                 break;
             case CompileBackMemberKind.Method:
-                sb.AppendLine(type.Kind == CompileBackTypeKind.Interface
-                    ? $"{pad}{(declaration.EndsWith(';') ? declaration : declaration + ";")}"
-                    : $"{pad}{declaration} {{ throw null; }}");
+                if (type.Kind == CompileBackTypeKind.Interface)
+                {
+                    sb.AppendLine($"{pad}{(declaration.EndsWith(';') ? declaration : declaration + ";")}");
+                    break;
+                }
+                if (member.StubBody == CompileBackStubBodyKind.TargetBody)
+                {
+                    sb.AppendLine($"{pad}{declaration}");
+                    sb.AppendLine($"{pad}{{");
+                    foreach (var line in member.Body.Split('\n'))
+                    {
+                        var text = line.TrimEnd('\r');
+                        if (text.Length > 0)
+                            sb.AppendLine($"{pad}    {text}");
+                    }
+                    sb.AppendLine($"{pad}}}");
+                    break;
+                }
+                sb.AppendLine($"{pad}{declaration} {{ throw null; }}");
                 break;
             default:
                 throw new NotSupportedException($"Unsupported member declaration kind '{member.Kind}'.");
@@ -566,6 +670,26 @@ public static class CompileBackSourceComposer
         }
 
         return "unsafe " + declaration;
+    }
+
+    static IReadOnlyList<CompileBackParameter> MethodParameters(
+        MetadataReader reader,
+        MethodDefinition method,
+        MethodSignature<string> signature)
+    {
+        var names = new Dictionary<int, string>();
+        foreach (var parameterHandle in method.GetParameters())
+        {
+            var parameter = reader.GetParameter(parameterHandle);
+            if (parameter.SequenceNumber > 0)
+                names[parameter.SequenceNumber - 1] = reader.GetString(parameter.Name);
+        }
+
+        return signature.ParameterTypes
+            .Select((type, index) => new CompileBackParameter(
+                Identifier(names.TryGetValue(index, out var name) && name.Length > 0 ? name : $"arg{index}"),
+                CompileBackTypeSignature.Display(type)))
+            .ToArray();
     }
 
     static bool IsAutoProperty(

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -730,27 +730,25 @@ internal static class GeneratedFixtureRunner
     {
         return RunWithMaterializedFixtures(fixtures, options, (root, assemblyPath) =>
         {
-            IReadOnlyDictionary<string, ReturnToSender.Result> rtsResults;
-            try
-            {
-                rtsResults = ReturnToSender.CompileBackPropertyGetters(assemblyPath)
-                    .ToDictionary(result => Key(
-                        result.Plan.TargetMethod.Type,
-                        result.Plan.TargetMethod.Method,
-                        result.Plan.TargetMethod.Overload), StringComparer.Ordinal);
-            }
-            catch (InvalidOperationException ex) when (ex.Message.Contains("No supported property getter", StringComparison.Ordinal))
-            {
-                rtsResults = new Dictionary<string, ReturnToSender.Result>(StringComparer.Ordinal);
-            }
+            var requestedTargets = fixtures
+                .SelectMany(fixture => fixture.Targets)
+                .Where(target => target.Method != ".ctor")
+                .Select(target => new ReturnToSender.RequestedTarget(target.Type, target.Method, target.Overload))
+                .Distinct()
+                .ToArray();
+            IReadOnlyDictionary<string, ReturnToSender.Result> rtsResults = ReturnToSender.CompileBackTargets(assemblyPath, requestedTargets)
+                .ToDictionary(result => Key(
+                    result.Plan.TargetMethod.Type,
+                    result.Plan.TargetMethod.Method,
+                    result.Plan.TargetMethod.Overload), StringComparer.Ordinal);
             var results = new List<GeneratedFixtureReturnToSenderResult>();
             foreach (var fixture in fixtures)
             {
                 foreach (var target in fixture.Targets)
                 {
-                    if (!target.Method.StartsWith("get_", StringComparison.Ordinal))
+                    if (target.Method == ".ctor")
                     {
-                        results.Add(Skipped(fixture, target, "not-property-getter"));
+                        results.Add(Skipped(fixture, target, "constructor-target"));
                         continue;
                     }
 

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -626,6 +626,36 @@ internal sealed record GeneratedFixtureResult(
     public string DisplayMember => $"{Type}::{Method}#{Overload}";
 }
 
+internal enum GeneratedFixtureReturnToSenderStatus
+{
+    Pass,
+    Skip,
+    Fail,
+}
+
+internal sealed record GeneratedFixtureReturnToSenderRunResult(
+    string ProjectDirectory,
+    string AssemblyPath,
+    IReadOnlyList<GeneratedFixtureReturnToSenderResult> Results)
+{
+    public bool Passed => Results.All(result => result.Status != GeneratedFixtureReturnToSenderStatus.Fail);
+}
+
+internal sealed record GeneratedFixtureReturnToSenderResult(
+    string FixtureId,
+    string Type,
+    string Method,
+    int Overload,
+    GeneratedFixtureReturnToSenderStatus Status,
+    FidelityCheck.CompileBackStatus? ActualStatus,
+    string Reason,
+    string? Detail,
+    bool IsFrontier,
+    string? Note)
+{
+    public string DisplayMember => $"{Type}::{Method}#{Overload}";
+}
+
 internal sealed record GeneratedFixtureRender(string DecompilerFidelity, string? Body);
 
 internal static class GeneratedFixtureRunner
@@ -659,29 +689,8 @@ internal static class GeneratedFixtureRunner
         IReadOnlyList<GeneratedFixtureDefinition> fixtures,
         GeneratedFixtureRunOptions? options = null)
     {
-        if (fixtures.Count == 0)
-            throw new ArgumentException("At least one generated fixture is required.", nameof(fixtures));
-
-        options ??= GeneratedFixtureRunOptions.Default;
-        var root = Path.Combine(Path.GetTempPath(), "dotnet-inspect-generated-fixtures", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(root);
-        try
+        return RunWithMaterializedFixtures(fixtures, options, (root, assemblyPath) =>
         {
-            string projectPath = Path.Combine(root, "GeneratedDecompilerFixtures.csproj");
-            File.WriteAllText(projectPath, ProjectFile(options.TargetFramework ?? CurrentTargetFramework()));
-
-            for (int i = 0; i < fixtures.Count; i++)
-            {
-                string sourcePath = Path.Combine(root, $"{i:000}_{SafeFileName(fixtures[i].Id)}.cs");
-                File.WriteAllText(sourcePath, fixtures[i].Source);
-            }
-
-            Build(root);
-            string assemblyPath = Path.Combine(root, "bin", "Release",
-                options.TargetFramework ?? CurrentTargetFramework(), "GeneratedDecompilerFixtures.dll");
-            if (!File.Exists(assemblyPath))
-                throw new InvalidOperationException($"Generated fixture assembly was not produced: {assemblyPath}");
-
             var compileBack = FidelityCheck.Evaluate(assemblyPath)
                 .ToDictionary(result => Key(result.Type, result.Method, result.Overload), StringComparer.Ordinal);
             var renders = DecompilerRenders(assemblyPath, fixtures);
@@ -712,6 +721,117 @@ internal static class GeneratedFixtureRunner
             }
 
             return new GeneratedFixtureRunResult(root, assemblyPath, results);
+        });
+    }
+
+    public static GeneratedFixtureReturnToSenderRunResult RunReturnToSenderCatalog(
+        IReadOnlyList<GeneratedFixtureDefinition> fixtures,
+        GeneratedFixtureRunOptions? options = null)
+    {
+        return RunWithMaterializedFixtures(fixtures, options, (root, assemblyPath) =>
+        {
+            IReadOnlyDictionary<string, ReturnToSender.Result> rtsResults;
+            try
+            {
+                rtsResults = ReturnToSender.CompileBackPropertyGetters(assemblyPath)
+                    .ToDictionary(result => Key(
+                        result.Plan.TargetMethod.Type,
+                        result.Plan.TargetMethod.Method,
+                        result.Plan.TargetMethod.Overload), StringComparer.Ordinal);
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("No supported property getter", StringComparison.Ordinal))
+            {
+                rtsResults = new Dictionary<string, ReturnToSender.Result>(StringComparer.Ordinal);
+            }
+            var results = new List<GeneratedFixtureReturnToSenderResult>();
+            foreach (var fixture in fixtures)
+            {
+                foreach (var target in fixture.Targets)
+                {
+                    if (!target.Method.StartsWith("get_", StringComparison.Ordinal))
+                    {
+                        results.Add(Skipped(fixture, target, "not-property-getter"));
+                        continue;
+                    }
+
+                    if (!rtsResults.TryGetValue(Key(target.Type, target.Method, target.Overload), out var actual))
+                    {
+                        results.Add(Skipped(fixture, target, "unsupported-rts-target"));
+                        continue;
+                    }
+
+                    var status = actual.Status == FidelityCheck.CompileBackStatus.Exact
+                        ? GeneratedFixtureReturnToSenderStatus.Pass
+                        : GeneratedFixtureReturnToSenderStatus.Fail;
+                    results.Add(new GeneratedFixtureReturnToSenderResult(
+                        fixture.Id,
+                        target.Type,
+                        target.Method,
+                        target.Overload,
+                        status,
+                        actual.Status,
+                        status == GeneratedFixtureReturnToSenderStatus.Pass ? "exact" : FailureReason(actual),
+                        actual.Detail,
+                        target.IsFrontier,
+                        target.Note));
+                }
+            }
+
+            return new GeneratedFixtureReturnToSenderRunResult(root, assemblyPath, results);
+        });
+    }
+
+    static GeneratedFixtureReturnToSenderResult Skipped(GeneratedFixtureDefinition fixture, GeneratedFixtureTarget target, string reason)
+        => new(
+            fixture.Id,
+            target.Type,
+            target.Method,
+            target.Overload,
+            GeneratedFixtureReturnToSenderStatus.Skip,
+            ActualStatus: null,
+            reason,
+            Detail: null,
+            target.IsFrontier,
+            target.Note);
+
+    static string FailureReason(ReturnToSender.Result result)
+        => result.Status switch
+        {
+            FidelityCheck.CompileBackStatus.RecompileFail => DiagnosticCode(result.Detail),
+            FidelityCheck.CompileBackStatus.ContextFail => string.IsNullOrWhiteSpace(result.Detail) ? "context-fail" : result.Detail,
+            FidelityCheck.CompileBackStatus.OpcodeDiff => "opcode-diff",
+            _ => result.Status.ToString(),
+        };
+
+    static T RunWithMaterializedFixtures<T>(
+        IReadOnlyList<GeneratedFixtureDefinition> fixtures,
+        GeneratedFixtureRunOptions? options,
+        Func<string, string, T> run)
+    {
+        if (fixtures.Count == 0)
+            throw new ArgumentException("At least one generated fixture is required.", nameof(fixtures));
+
+        options ??= GeneratedFixtureRunOptions.Default;
+        var root = Path.Combine(Path.GetTempPath(), "dotnet-inspect-generated-fixtures", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            string projectPath = Path.Combine(root, "GeneratedDecompilerFixtures.csproj");
+            File.WriteAllText(projectPath, ProjectFile(options.TargetFramework ?? CurrentTargetFramework()));
+
+            for (int i = 0; i < fixtures.Count; i++)
+            {
+                string sourcePath = Path.Combine(root, $"{i:000}_{SafeFileName(fixtures[i].Id)}.cs");
+                File.WriteAllText(sourcePath, fixtures[i].Source);
+            }
+
+            Build(root);
+            string assemblyPath = Path.Combine(root, "bin", "Release",
+                options.TargetFramework ?? CurrentTargetFramework(), "GeneratedDecompilerFixtures.dll");
+            if (!File.Exists(assemblyPath))
+                throw new InvalidOperationException($"Generated fixture assembly was not produced: {assemblyPath}");
+
+            return run(root, assemblyPath);
         }
         finally
         {
@@ -750,7 +870,121 @@ internal static class GeneratedFixtureRunner
         return sb.ToString();
     }
 
+    public static string FormatReturnToSenderCatalogReport(GeneratedFixtureReturnToSenderRunResult run, int maxExamples)
+    {
+        var sb = new StringBuilder();
+        var fixtureRows = run.Results
+            .GroupBy(result => result.FixtureId, StringComparer.Ordinal)
+            .Select(group =>
+            {
+                var rows = group.ToArray();
+                GeneratedFixtureReturnToSenderStatus status =
+                    rows.Any(row => row.Status == GeneratedFixtureReturnToSenderStatus.Fail)
+                        ? GeneratedFixtureReturnToSenderStatus.Fail
+                        : rows.Any(row => row.Status == GeneratedFixtureReturnToSenderStatus.Pass)
+                            ? GeneratedFixtureReturnToSenderStatus.Pass
+                            : GeneratedFixtureReturnToSenderStatus.Skip;
+                return new { FixtureId = group.Key, Status = status, Rows = rows };
+            })
+            .OrderBy(row => row.FixtureId, StringComparer.Ordinal)
+            .ToArray();
+
+        int passedFixtures = fixtureRows.Count(row => row.Status == GeneratedFixtureReturnToSenderStatus.Pass);
+        int skippedFixtures = fixtureRows.Count(row => row.Status == GeneratedFixtureReturnToSenderStatus.Skip);
+        int failedFixtures = fixtureRows.Count(row => row.Status == GeneratedFixtureReturnToSenderStatus.Fail);
+        int passedTargets = run.Results.Count(row => row.Status == GeneratedFixtureReturnToSenderStatus.Pass);
+        int skippedTargets = run.Results.Count(row => row.Status == GeneratedFixtureReturnToSenderStatus.Skip);
+        int failedTargets = run.Results.Count(row => row.Status == GeneratedFixtureReturnToSenderStatus.Fail);
+
+        sb.AppendLine($"RETURNTOSENDER GENERATED FIXTURE FRONTIER over {fixtureRows.Length} fixture(s), {run.Results.Count} target(s)");
+        sb.AppendLine();
+        sb.AppendLine("Fixtures:");
+        sb.AppendLine($"  Passed : {passedFixtures}");
+        sb.AppendLine($"  Skipped: {skippedFixtures}");
+        sb.AppendLine($"  Failed : {failedFixtures}");
+        sb.AppendLine();
+        sb.AppendLine("Targets:");
+        sb.AppendLine($"  Passed : {passedTargets}");
+        sb.AppendLine($"  Skipped: {skippedTargets}");
+        sb.AppendLine($"  Failed : {failedTargets}");
+
+        var skipBuckets = run.Results
+            .Where(row => row.Status == GeneratedFixtureReturnToSenderStatus.Skip)
+            .GroupBy(row => row.Reason, StringComparer.Ordinal)
+            .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key, StringComparer.Ordinal)
+            .ToArray();
+        if (skipBuckets.Length != 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Skipped target reasons:");
+            foreach (var group in skipBuckets)
+                sb.AppendLine($"  {group.Key}: {group.Count()}");
+        }
+
+        var failureBuckets = run.Results
+            .Where(row => row.Status == GeneratedFixtureReturnToSenderStatus.Fail)
+            .GroupBy(row => row.Reason, StringComparer.Ordinal)
+            .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key, StringComparer.Ordinal)
+            .ToArray();
+        if (failureBuckets.Length != 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Failed target buckets:");
+            foreach (var group in failureBuckets)
+                sb.AppendLine($"  {group.Key}: {group.Count()}");
+        }
+
+        var failedFixturesToShow = fixtureRows
+            .Where(row => row.Status == GeneratedFixtureReturnToSenderStatus.Fail)
+            .Take(maxExamples)
+            .ToArray();
+        if (failedFixturesToShow.Length != 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"Failed fixtures (first {failedFixturesToShow.Length} of {failedFixtures}):");
+            foreach (var fixture in failedFixturesToShow)
+            {
+                sb.AppendLine($"  {fixture.FixtureId}");
+                foreach (var row in fixture.Rows.Where(row => row.Status == GeneratedFixtureReturnToSenderStatus.Fail))
+                {
+                    string actual = row.ActualStatus?.ToString() ?? "Missing";
+                    sb.AppendLine($"      {row.DisplayMember}  rts={actual}  bucket={row.Reason}");
+                    if (!string.IsNullOrWhiteSpace(row.Detail))
+                        sb.AppendLine($"      detail: {row.Detail}");
+                }
+            }
+        }
+
+        var passedFixturesToShow = fixtureRows
+            .Where(row => row.Status == GeneratedFixtureReturnToSenderStatus.Pass)
+            .Take(maxExamples)
+            .ToArray();
+        if (passedFixturesToShow.Length != 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"Passed fixtures (first {passedFixturesToShow.Length} of {passedFixtures}):");
+            foreach (var fixture in passedFixturesToShow)
+                sb.AppendLine($"  {fixture.FixtureId}");
+        }
+
+        return sb.ToString();
+    }
+
     public static string FormatJson(GeneratedFixtureRunResult run)
+    {
+        var payload = new
+        {
+            ProjectDirectory = Directory.Exists(run.ProjectDirectory) ? run.ProjectDirectory : null,
+            AssemblyPath = File.Exists(run.AssemblyPath) ? run.AssemblyPath : null,
+            run.Results,
+            run.Passed,
+        };
+        return JsonSerializer.Serialize(payload, s_jsonOptions);
+    }
+
+    public static string FormatReturnToSenderCatalogJson(GeneratedFixtureReturnToSenderRunResult run)
     {
         var payload = new
         {
@@ -805,6 +1039,27 @@ internal static class GeneratedFixtureRunner
     }
 
     static string Key(string type, string method, int overload) => $"{type}::{method}#{overload}";
+
+    static string DiagnosticCode(string? detail)
+    {
+        if (string.IsNullOrWhiteSpace(detail))
+            return "recompile-fail";
+
+        for (int i = 0; i <= detail.Length - 6; i++)
+        {
+            if (detail[i] == 'C'
+                && detail[i + 1] == 'S'
+                && char.IsDigit(detail[i + 2])
+                && char.IsDigit(detail[i + 3])
+                && char.IsDigit(detail[i + 4])
+                && char.IsDigit(detail[i + 5]))
+            {
+                return detail.Substring(i, 6);
+            }
+        }
+
+        return "recompile-fail";
+    }
 
     static string ProjectFile(string targetFramework) =>
         $$"""

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -36,6 +36,7 @@ static class Program
         bool fidelityCheck = false;
         bool returnToSender = false;
         bool returnToSenderAb = false;
+        bool returnToSenderCatalog = false;
         bool fidelityTimings = false;
         int fidelityZeroSignalGuard = 0;
         bool gaps = false;
@@ -64,6 +65,7 @@ static class Program
         bool classifyDec0009 = false;
         bool generatedFixtures = false;
         string? generatedFixtureSelector = null;
+        string? returnToSenderCatalogSelector = null;
         bool keepGeneratedFixtures = false;
         string? emitCorpusSnapshot = null;
         string? diffCorpusBaseline = null;
@@ -105,6 +107,13 @@ static class Program
                 case "--fidelity-check": fidelityCheck = true; break;
                 case "--return-to-sender": returnToSender = true; break;
                 case "--return-to-sender-ab": returnToSenderAb = true; break;
+                case "--return-to-sender-catalog":
+                    returnToSenderCatalog = true;
+                    if (i + 1 < args.Length && !args[i + 1].StartsWith('-')
+                        && !File.Exists(args[i + 1]) && !Directory.Exists(args[i + 1])
+                        && !LooksLikePath(args[i + 1]))
+                        returnToSenderCatalogSelector = args[++i];
+                    break;
                 case "--fidelity-timings": fidelityTimings = true; break;
                 case "--fidelity-zero-signal-guard": fidelityZeroSignalGuard = int.Parse(args[++i]); break;
                 case "--gaps": gaps = true; break;
@@ -166,6 +175,13 @@ static class Program
             if (inputs.Count > 0)
                 return Fail("--generated-fixtures generates its own temporary input assembly; do not pass assembly paths.");
             return GeneratedFixtures(generatedFixtureSelector, keepGeneratedFixtures, json);
+        }
+
+        if (returnToSenderCatalog)
+        {
+            if (inputs.Count > 0)
+                return Fail("--return-to-sender-catalog generates its own temporary input assembly; do not pass assembly paths.");
+            return ReturnToSenderCatalog(returnToSenderCatalogSelector, keepGeneratedFixtures, json, maxExamples);
         }
 
         var assemblies = ResolveAssemblies(inputs);
@@ -279,6 +295,41 @@ static class Program
         else
         {
             Console.Write(GeneratedFixtureRunner.FormatReport(run));
+        }
+        if (keepArtifacts && !json)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"Generated fixture project: {run.ProjectDirectory}");
+            Console.WriteLine($"Generated fixture assembly: {run.AssemblyPath}");
+        }
+        return run.Passed ? 0 : 1;
+    }
+
+    static int ReturnToSenderCatalog(string? selector, bool keepArtifacts, bool json, int maxExamples)
+    {
+        var fixtures = GeneratedFixtureCatalog.Select(selector);
+        if (selector == "list")
+        {
+            if (json)
+                Console.WriteLine(GeneratedFixtureRunner.FormatListJson(GeneratedFixtureCatalog.Catalog));
+            else
+                Console.Write(GeneratedFixtureRunner.FormatList(GeneratedFixtureCatalog.Catalog));
+            return 0;
+        }
+
+        if (fixtures.Count == 0)
+            return Fail($"No generated fixture IDs match '{selector}'. Use '--return-to-sender-catalog list'.");
+
+        var run = GeneratedFixtureRunner.RunReturnToSenderCatalog(
+            fixtures,
+            new GeneratedFixtureRunOptions(KeepArtifacts: keepArtifacts));
+        if (json)
+        {
+            Console.WriteLine(GeneratedFixtureRunner.FormatReturnToSenderCatalogJson(run));
+        }
+        else
+        {
+            Console.Write(GeneratedFixtureRunner.FormatReturnToSenderCatalogReport(run, maxExamples));
         }
         if (keepArtifacts && !json)
         {
@@ -1176,6 +1227,12 @@ static class Program
                                 opcodes.
           --return-to-sender-ab   compare current compile-back and ReturnToSender
                                 over the same ReturnToSender property-getter targets.
+          --return-to-sender-catalog [selector]
+                                compile the generated fixture catalog, run
+                                ReturnToSender over supported property getters,
+                                and report pass/skip/fail frontier buckets.
+                                Use selector prefix or "list"; supports --json
+                                and --keep-generated-fixtures.
           --fidelity-timings      with --fidelity-check: print phase timings for collect/render,
                                 skeleton emit, parse, compilation create, emit, and opcode compare
           --fidelity-zero-signal-guard <n>

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -28,6 +28,8 @@ static class ReturnToSender
         string RecompiledOpcodes,
         string? Detail);
 
+    public sealed record RequestedTarget(string Type, string Method, int Overload);
+
     sealed class NoSupportedReturnToSenderTargetsException(string message) : InvalidOperationException(message);
 
     enum ComparisonDelta
@@ -386,6 +388,112 @@ static class ReturnToSender
         return results;
     }
 
+    public static IReadOnlyList<Result> CompileBackTargets(string assemblyPath, IReadOnlyList<RequestedTarget> targets)
+    {
+        if (targets.Count == 0)
+            return [];
+
+        var results = new List<Result>();
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        if (!pe.HasMetadata)
+            throw new InvalidOperationException("Assembly has no metadata.");
+
+        var reader = pe.GetMetadataReader();
+        using var metadata = CorpusMetadata.Create([assemblyPath]);
+        using var source = MetadataSource.Open(assemblyPath, context: metadata);
+        var typeHandles = reader.TypeDefinitions
+            .Select(handle => (Handle: handle, Definition: reader.GetTypeDefinition(handle)))
+            .Where(item => reader.GetFullTypeName(item.Definition) is { } fullName
+                && fullName.Length != 0
+                && item.Definition.GetDeclaringType().IsNil)
+            .ToDictionary(item => reader.GetFullTypeName(item.Definition), item => item.Handle, StringComparer.Ordinal);
+
+        foreach (var target in targets)
+        {
+            if (!typeHandles.TryGetValue(target.Type, out var typeHandle))
+                continue;
+
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            string typeName = reader.GetString(typeDef.Name);
+            if (!typeDef.GetDeclaringType().IsNil
+                || typeName == "<Module>"
+                || typeName.Contains('<', StringComparison.Ordinal)
+                || typeName.Contains('`', StringComparison.Ordinal)
+                || !IsSupportedClass(reader, typeDef))
+            {
+                continue;
+            }
+
+            if (TryFindPropertyGetter(reader, typeDef, target.Method, target.Overload) is { } propertyTarget)
+            {
+                results.Add(CompileBackPropertyGetterOrContextFail(
+                    assemblyPath,
+                    pe,
+                    reader,
+                    source,
+                    typeHandle,
+                    propertyTarget.Property,
+                    propertyTarget.Getter));
+                continue;
+            }
+
+            if (target.Method == ".ctor")
+                continue;
+            if (TryFindMethod(reader, typeDef, target.Method, target.Overload) is { } methodHandle)
+                results.Add(CompileBackMethodOrContextFail(assemblyPath, pe, reader, source, typeHandle, methodHandle));
+        }
+
+        return results;
+    }
+
+    static (PropertyDefinitionHandle Property, MethodDefinitionHandle Getter)? TryFindPropertyGetter(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string methodName,
+        int overload)
+    {
+        int seen = 0;
+        foreach (var propertyHandle in typeDef.GetProperties())
+        {
+            var property = reader.GetPropertyDefinition(propertyHandle);
+            var accessors = property.GetAccessors();
+            if (accessors.Getter.IsNil)
+                continue;
+
+            var getter = reader.GetMethodDefinition(accessors.Getter);
+            if (reader.GetString(getter.Name) != methodName || getter.RelativeVirtualAddress == 0)
+                continue;
+            if (seen++ == overload)
+                return (propertyHandle, accessors.Getter);
+        }
+
+        return null;
+    }
+
+    static MethodDefinitionHandle? TryFindMethod(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string methodName,
+        int overload)
+    {
+        int seen = 0;
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != methodName
+                || method.RelativeVirtualAddress == 0
+                || method.GetGenericParameters().Count != 0)
+            {
+                continue;
+            }
+
+            if (seen++ == overload)
+                return methodHandle;
+        }
+
+        return null;
+    }
+
     static Result CompileBackPropertyGetterOrContextFail(
         string assemblyPath,
         PEReader pe,
@@ -402,6 +510,24 @@ static class ReturnToSender
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
             return ContextFailResult(assemblyPath, reader, typeHandle, propertyHandle, getterHandle, $"{ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    static Result CompileBackMethodOrContextFail(
+        string assemblyPath,
+        PEReader pe,
+        MetadataReader reader,
+        MetadataSource source,
+        TypeDefinitionHandle typeHandle,
+        MethodDefinitionHandle methodHandle)
+    {
+        try
+        {
+            return CompileBackMethod(assemblyPath, pe, reader, source, typeHandle, methodHandle);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return ContextFailResult(assemblyPath, reader, typeHandle, methodHandle, $"{ex.GetType().Name}: {ex.Message}");
         }
     }
 
@@ -555,6 +681,152 @@ static class ReturnToSender
         }
     }
 
+    static Result CompileBackMethod(
+        string assemblyPath,
+        PEReader pe,
+        MetadataReader reader,
+        MetadataSource source,
+        TypeDefinitionHandle typeHandle,
+        MethodDefinitionHandle methodHandle)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        var method = reader.GetMethodDefinition(methodHandle);
+        string fullType = reader.GetFullTypeName(typeDef);
+        string methodName = reader.GetString(method.Name);
+        int overload = OverloadIndex(reader, typeDef, methodHandle, methodName);
+
+        var function = IrImporter.Import(source, fullType, methodName, overload)
+            ?? throw new InvalidOperationException($"Could not import {fullType}::{methodName}.");
+        var printed = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+        if (printed.Output is null)
+            throw new InvalidOperationException($"Could not print {fullType}::{methodName}.");
+
+        var original = ILDisassembler.Disassemble(pe, reader, method)
+            ?? throw new InvalidOperationException($"Could not disassemble {fullType}::{methodName}.");
+        var originalOps = original.Select(instruction => CanonicalOpcode(instruction.OpCodeName)).ToArray();
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+        var compileOptions = new CSharpCompilationOptions(
+            OutputKind.DynamicallyLinkedLibrary,
+            optimizationLevel: OptimizationLevel.Release,
+            nullableContextOptions: NullableContextOptions.Disable,
+            allowUnsafe: true);
+        var references = CompilationReferences(assemblyPath).ToArray();
+        var indexes = ClosureIndexes(reader);
+        var closureRoots = new HashSet<TypeDefinitionHandle>
+        {
+            TopLevelRootOf(reader, typeHandle),
+        };
+        var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
+        const int maxRoots = 200;
+        const int maxIterations = 80;
+        Diagnostic? firstError = null;
+
+        for (int iteration = 0; iteration < maxIterations; iteration++)
+        {
+            var sourceResult = CompileBackSourceComposer.ComposeMethod(
+                assemblyPath,
+                reader,
+                function,
+                typeHandle,
+                methodHandle,
+                printed.Output,
+                fullType,
+                methodName,
+                overload,
+                CorpusMethodIdentity.SignatureText(function.Signature),
+                closureRoots,
+                closureFacts);
+            var plan = sourceResult.Plan;
+
+            if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
+            {
+                return new Result(
+                    plan,
+                    "",
+                    FidelityCheck.CompileBackStatus.ContextFail,
+                    string.Join(" ", originalOps),
+                    "",
+                    $"{identityDiagnostic.Reason}: {identityDiagnostic.Detail}");
+            }
+
+            string unit = sourceResult.Source;
+            var tree = CSharpSyntaxTree.ParseText(unit, parseOptions);
+            var compilation = CSharpCompilation.Create("return-to-sender", [tree], references, compileOptions);
+            using var ms = new MemoryStream();
+            var emit = compilation.Emit(ms);
+            if (emit.Success)
+            {
+                ms.Position = 0;
+                using var recompiled = new PEReader(ms);
+                var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
+                    ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
+                    .ToArray();
+
+                if (recompiledOps is null)
+                {
+                    return new Result(
+                        plan,
+                        unit,
+                        FidelityCheck.CompileBackStatus.ContextFail,
+                        string.Join(" ", originalOps),
+                        "",
+                        "method-not-found");
+                }
+
+                return new Result(
+                    plan,
+                    unit,
+                    originalOps.SequenceEqual(recompiledOps)
+                        ? FidelityCheck.CompileBackStatus.Exact
+                        : FidelityCheck.CompileBackStatus.OpcodeDiff,
+                    string.Join(" ", originalOps),
+                    string.Join(" ", recompiledOps),
+                    null);
+            }
+
+            var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
+            firstError ??= errors.FirstOrDefault();
+            bool grew = AddClosureRoots(errors, indexes, reader.GetString(typeDef.Namespace), TopLevelRootOf(reader, typeHandle), closureRoots, closureFacts);
+            if (!grew || closureRoots.Count > maxRoots)
+            {
+                string reason = closureRoots.Count > maxRoots ? "closure-root-budget" : "closure-stalled";
+                var error = errors.FirstOrDefault() ?? firstError;
+                return new Result(
+                    plan,
+                    unit,
+                    FidelityCheck.CompileBackStatus.RecompileFail,
+                    string.Join(" ", originalOps),
+                    "",
+                    $"{reason}: {FormatDiagnostic(error)}");
+            }
+        }
+
+        {
+            var sourceResult = CompileBackSourceComposer.ComposeMethod(
+                assemblyPath,
+                reader,
+                function,
+                typeHandle,
+                methodHandle,
+                printed.Output,
+                fullType,
+                methodName,
+                overload,
+                CorpusMethodIdentity.SignatureText(function.Signature),
+                closureRoots,
+                closureFacts);
+            var plan = sourceResult.Plan;
+            return new Result(
+                plan,
+                sourceResult.Source,
+                FidelityCheck.CompileBackStatus.RecompileFail,
+                string.Join(" ", originalOps),
+                "",
+                $"closure-iteration-budget: {FormatDiagnostic(firstError)}");
+        }
+    }
+
     static Result ContextFailResult(
         string assemblyPath,
         MetadataReader reader,
@@ -609,6 +881,28 @@ static class ReturnToSender
             "",
             "",
             detail);
+    }
+
+    static Result ContextFailResult(
+        string assemblyPath,
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        MethodDefinitionHandle methodHandle,
+        string detail)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        var method = reader.GetMethodDefinition(methodHandle);
+        string fullType = reader.GetFullTypeName(typeDef);
+        string methodName = reader.GetString(method.Name);
+        int overload = OverloadIndex(reader, typeDef, methodHandle, methodName);
+        var plan = new CompileBackReconstructionPlan(
+            assemblyPath,
+            new CompileBackMethodIdentity(fullType, methodName, overload, ""),
+            new CompileBackModuleRequirement(["System"], [], []),
+            [],
+            [],
+            []);
+        return new Result(plan, "", FidelityCheck.CompileBackStatus.ContextFail, "", "", detail);
     }
 
     static int OverloadIndex(MetadataReader reader, TypeDefinition typeDef, MethodDefinitionHandle target, string methodName)

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -452,19 +452,19 @@ static class ReturnToSender
         string methodName,
         int overload)
     {
-        int seen = 0;
+        var getterToProperty = new Dictionary<MethodDefinitionHandle, PropertyDefinitionHandle>();
         foreach (var propertyHandle in typeDef.GetProperties())
         {
             var property = reader.GetPropertyDefinition(propertyHandle);
             var accessors = property.GetAccessors();
-            if (accessors.Getter.IsNil)
-                continue;
+            if (!accessors.Getter.IsNil)
+                getterToProperty[accessors.Getter] = propertyHandle;
+        }
 
-            var getter = reader.GetMethodDefinition(accessors.Getter);
-            if (reader.GetString(getter.Name) != methodName || getter.RelativeVirtualAddress == 0)
-                continue;
-            if (seen++ == overload)
-                return (propertyHandle, accessors.Getter);
+        if (TryFindMethod(reader, typeDef, methodName, overload) is { } getterHandle
+            && getterToProperty.TryGetValue(getterHandle, out var foundPropertyHandle))
+        {
+            return (foundPropertyHandle, getterHandle);
         }
 
         return null;
@@ -480,15 +480,17 @@ static class ReturnToSender
         foreach (var methodHandle in typeDef.GetMethods())
         {
             var method = reader.GetMethodDefinition(methodHandle);
-            if (reader.GetString(method.Name) != methodName
-                || method.RelativeVirtualAddress == 0
-                || method.GetGenericParameters().Count != 0)
+            if (reader.GetString(method.Name) != methodName)
             {
                 continue;
             }
 
-            if (seen++ == overload)
+            if (seen++ == overload
+                && method.RelativeVirtualAddress != 0
+                && method.GetGenericParameters().Count == 0)
+            {
                 return methodHandle;
+            }
         }
 
         return null;


### PR DESCRIPTION
- Advances #2049 and #2050
- Changes DecompilerHarness catalog evidence for ReturnToSender; product output is unchanged.
- Evidence revision: `bf10c219`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — the generated fixture catalog is now an RTS frontier selector, and RTS can check the default catalog's non-constructor targets with no failures.

Before:

```text
RTS catalog frontier was implicit: fixture #23 had to be chosen manually.
```

After:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 19 fixture(s), 40 target(s)

Fixtures:
  Passed : 19
  Skipped: 0
  Failed : 0

Targets:
  Passed : 21
  Skipped: 19
  Failed : 0

Skipped target reasons:
  constructor-target: 19
```

## Scope and safety

- **Root cause:** RTS had no catalog-backed way to distinguish passed, skipped, and failed generated fixtures, and only enumerated property getters.
- **Fix shape:** Add `--return-to-sender-catalog [selector]`, reuse the generated fixture catalog, and let RTS compile selected normal method targets as well as property getters. Constructors remain skipped.
- **Product impact:** None intended; this is DecompilerHarness/compile-back evidence only.
- **Scope boundary:** Constructor targets remain a named skip bucket. The known `minimal.switch-two-case-lowers-if` frontier remains an `opcode-diff` when explicitly selected.
- **RTS boundary:** RTS still orchestrates target selection, closure growth, Roslyn compile, opcode compare, and reporting. Product-side `CompileBackSourceComposer` owns generated C# source/declarations.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Harness build | Pass |
| Focused generated fixture tests | `GeneratedFixtureCatalogTests` `8/8` passed |
| Focused RTS tests | `ReturnToSenderPrototypeTests` `23/23` passed |
| Decompiler fast suite | `1782/1782` passed with `-trait- "Speed=Slow"` |
| ReturnToSender A/B | `ILInspector.Decompiler.Tests.dll` `234 Same / 0 Worse / 0 CurrentMissing` |
| RTS catalog default | `19 passed / 0 failed`, `21 target passes`, `19 constructor skips` |
| RTS catalog with frontiers | `20 passed / 1 failed`, expected `minimal.switch-two-case-lowers-if` `opcode-diff` |
| Build-event validation | Not applicable |

### ReturnToSender catalog

Run: default generated fixture catalog.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 19 fixture(s), 40 target(s)

Fixtures:
  Passed : 19
  Skipped: 0
  Failed : 0

Targets:
  Passed : 21
  Skipped: 19
  Failed : 0

Skipped target reasons:
  constructor-target: 19
```

Run: `--return-to-sender-catalog minimal --max-examples 20`.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 21 fixture(s), 44 target(s)

Fixtures:
  Passed : 20
  Skipped: 0
  Failed : 1

Targets:
  Passed : 22
  Skipped: 21
  Failed : 1

Skipped target reasons:
  constructor-target: 21

Failed target buckets:
  opcode-diff: 1

Failed fixtures (first 1 of 1):
  minimal.switch-two-case-lowers-if
      GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1::Method1#0  rts=OpcodeDiff  bucket=opcode-diff
```

**RTS verdict:** **PASS** — the default catalog has no RTS failures, and the explicit frontier selector surfaces the known compiler-lowering opcode-diff bucket.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Constructor targets | Skipped | RTS does not yet compose constructor targets. |
| `minimal.switch-two-case-lowers-if` | Left as frontier | Known compiler-lowering/source-shape frontier; explicit selector reports `opcode-diff`. |
| Generic/indexer/explicit interface expansion | Future work | Catalog/reporting path now gives a place to measure these when added. |
| Generic structured signature work (#2057) | Future architecture help | Should reduce declaration risk for harder target shapes. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Reviewed current HEAD including `bf10c219`. |
| Gemini 3.1 Pro | Finding resolved, follow-up clean | Found overload-index mismatch; fixed in `bf10c219`; follow-up reported no blocking findings. |

**Review conclusion:** **PASS** — the one high-confidence review finding was resolved with a targeted regression, and both reviewers are clean on current HEAD.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet -p:NoWarn=NU1507
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog --max-examples 20
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog minimal --max-examples 20
```
