### PR TITLE
Render property declarations from ApiSignature

### DIFF
--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -532,7 +532,9 @@ public static class CSharpDeclarationWriter
         }
         if (member.Kind == "property"
             && model.ReturnType is { Length: > 0 } propertyType
-            && model.Accessors.Count > 0)
+            && model.Accessors.Count > 0
+            && IsOrdinaryPropertyName(member.Name)
+            && IsOrdinaryPropertyName(model.MemberName))
         {
             var head = model.IsRequired ? $"required {propertyType}" : propertyType;
             var propertyMemberName = model.MemberName == "this[]"
@@ -564,6 +566,11 @@ public static class CSharpDeclarationWriter
             => string.IsNullOrWhiteSpace(accessor.Accessibility)
                 ? $"{accessor.Kind};"
                 : $"{accessor.Accessibility} {accessor.Kind};";
+
+        static bool IsOrdinaryPropertyName(string? name)
+            => string.IsNullOrWhiteSpace(name)
+               || name == "this[]"
+               || !name.Contains('.', StringComparison.Ordinal);
     }
 
     static string FormatTypeDisplayName(string name, IReadOnlyList<TypeParameter> typeParameters)

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -551,10 +551,13 @@ public static class CSharpDeclarationWriter
 
         static string ParameterDeclaration(ApiParameter parameter)
         {
+            var head = parameter.TypeWithModifier;
             var declaration = string.IsNullOrWhiteSpace(parameter.Name)
-                ? parameter.TypeWithModifier
-                : parameter.Declaration;
-            return declaration;
+                ? head
+                : $"{head} {EscapeIdentifier(parameter.Name)}";
+            return parameter.HasDefault && parameter.DefaultValueText is { Length: > 0 }
+                ? $"{declaration} = {parameter.DefaultValueText}"
+                : declaration;
         }
 
         static string AccessorDeclaration(ApiAccessor accessor)

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -52,7 +52,7 @@ public static class CSharpDeclarationWriter
         var declaration = RenderMemberDeclarationCore(type, member, options, methodParameters);
         declaration = plan.Apply(declaration);
 
-        if (options.TerminateMemberDeclaration && !declaration.EndsWith(';'))
+        if (options.TerminateMemberDeclaration && NeedsTerminator(declaration))
             declaration += ";";
 
         var source = ComposeUnit([declaration], plan.GeneratedUsings, options);
@@ -70,7 +70,7 @@ public static class CSharpDeclarationWriter
         var plan = TypeNamePlan.Create(references, options);
         var declaration = RenderMemberDeclarationCore(type, member, options, methodParameters);
         declaration = plan.Apply(declaration);
-        return options.TerminateMemberDeclaration && !declaration.EndsWith(';')
+        return options.TerminateMemberDeclaration && NeedsTerminator(declaration)
             ? declaration + ";"
             : declaration;
     }
@@ -94,7 +94,7 @@ public static class CSharpDeclarationWriter
                 type,
                 member,
                 options with { TerminateMemberDeclaration = true });
-            if (declaration.Length > 0 && !declaration.EndsWith(';'))
+            if (declaration.Length > 0 && NeedsTerminator(declaration))
                 declaration += ";";
             if (declaration.Length > 0)
                 lines.Add("    " + plan.Apply(declaration));
@@ -170,6 +170,9 @@ public static class CSharpDeclarationWriter
 
         return AppendTypeParameterConstraints(declaration, type.TypeParameters);
     }
+
+    static bool NeedsTerminator(string declaration)
+        => !declaration.EndsWith(';') && !declaration.EndsWith('}');
 
     static string RenderMemberDeclarationCore(
         ApiType type,
@@ -527,10 +530,23 @@ public static class CSharpDeclarationWriter
             signature = $"{returnType} {memberName}({parameters})";
             return true;
         }
+        if (member.Kind == "property"
+            && model.ReturnType is { Length: > 0 } propertyType
+            && model.Accessors.Count > 0)
+        {
+            var head = model.IsRequired ? $"required {propertyType}" : propertyType;
+            var propertyMemberName = model.MemberName == "this[]"
+                ? $"this[{parameters}]"
+                : string.IsNullOrWhiteSpace(model.MemberName)
+                    ? member.Name
+                    : model.MemberName!;
+            signature = $"{head} {propertyMemberName} {{ {string.Join(" ", model.Accessors.Select(AccessorDeclaration))} }}";
+            return true;
+        }
 
-        // Keep generic methods, extension methods, explicit implementations,
-        // operators, properties, and events on compatibility text until the
-        // remaining declaration-level facts are represented in ApiSignature.
+        // Keep generic methods, extension projections, explicit implementations,
+        // operators, and events on compatibility text until the remaining
+        // declaration-level facts are represented in ApiSignature.
         return false;
 
         static string ParameterDeclaration(ApiParameter parameter)
@@ -540,6 +556,11 @@ public static class CSharpDeclarationWriter
                 : parameter.Declaration;
             return declaration;
         }
+
+        static string AccessorDeclaration(ApiAccessor accessor)
+            => string.IsNullOrWhiteSpace(accessor.Accessibility)
+                ? $"{accessor.Kind};"
+                : $"{accessor.Accessibility} {accessor.Kind};";
     }
 
     static string FormatTypeDisplayName(string name, IReadOnlyList<TypeParameter> typeParameters)

--- a/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
@@ -87,6 +87,51 @@ public sealed class CSharpDeclarationFormatterTests
     }
 
     [Fact]
+    public void MemberSignatureSection_CanRenderPropertyFromStructuredSignature()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "StructuredHost",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Current",
+                    Kind = "property",
+                    Signature = "BROKEN",
+                    SignatureModel = new ApiSignature
+                    {
+                        ReturnType = "System.Collections.Generic.List<System.Guid>",
+                        MemberName = "Current",
+                        Accessors =
+                        [
+                            new ApiAccessor { Kind = "get" },
+                            new ApiAccessor { Kind = "set", Accessibility = "private" }
+                        ]
+                    }
+                }
+            ]
+        };
+        var view = ApiOutputFormatter.BuildTypeView(
+            type,
+            foundIn: "Test.dll",
+            packageName: null,
+            packageVersion: null,
+            apiSource: "local",
+            selectedTfm: null,
+            new MemberOptions { OverloadIndex = 1 });
+
+        ApiOutputFormatter.PopulateMemberSignature(view, type, new MemberOptions { OverloadIndex = 1 });
+
+        Assert.Contains("public System.Collections.Generic.List", view.SignatureRows![0].Signature);
+        Assert.Contains("Current", view.SignatureRows[0].Signature);
+        Assert.Contains("private set", view.SignatureRows[0].Signature);
+        Assert.DoesNotContain("BROKEN", view.SignatureRows[0].Signature);
+    }
+
+    [Fact]
     public void ConstructorOverloadSnippet_UsesStructuredDefaultValueText()
     {
         var type = new ApiType

--- a/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
@@ -150,6 +150,99 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void PropertyDeclaration_CanRenderFromStructuredSignatureModel()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Current",
+            Kind = "property",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.Collections.Generic.List<System.Guid>",
+                MemberName = "Current",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" },
+                    new ApiAccessor { Kind = "set", Accessibility = "private" }
+                ]
+            }
+        };
+
+        var rendered = CSharpDeclarationWriter.RenderMemberUnit(
+            type,
+            member,
+            new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ShortWithUsings,
+                TerminateMemberDeclaration = true
+            });
+
+        Assert.Equal(
+            """
+            using System;
+            using System.Collections.Generic;
+
+            public List<Guid> Current { get; private set; }
+            """,
+            rendered.Source);
+    }
+
+    [Fact]
+    public void RequiredPropertyDeclaration_UsesStructuredRequiredFact()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Name",
+            Kind = "property",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "string",
+                MemberName = "Name",
+                IsRequired = true,
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" },
+                    new ApiAccessor { Kind = "set" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("public required string Name { get; set; }", declaration);
+    }
+
+    [Fact]
+    public void IndexerDeclaration_CanRenderFromStructuredSignatureModel()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Item",
+            Kind = "property",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "string",
+                MemberName = "this[]",
+                Parameters =
+                [
+                    new ApiParameter { Type = "int", Name = "index" }
+                ],
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("public string this[int index] { get; }", declaration);
+    }
+
+    [Fact]
     public void ShortWithUsings_KeepsCollidingSimpleNamesQualified()
     {
         var type = new ApiType

--- a/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
@@ -295,6 +295,31 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void ExplicitPropertyDeclaration_KeepsCompatibilitySignature()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "ITest.Prop",
+            Kind = "property",
+            Signature = "string ITest.Prop { get; }",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "string",
+                MemberName = "ITest.Prop",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("public string ITest.Prop { get; }", declaration);
+    }
+
+    [Fact]
     public void ShortWithUsings_KeepsCollidingSimpleNamesQualified()
     {
         var type = new ApiType

--- a/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
@@ -243,6 +243,58 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void PropertyDeclaration_EscapesStructuredKeywordMemberName()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "event",
+            Kind = "property",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "string",
+                MemberName = "event",
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("public string @event { get; }", declaration);
+    }
+
+    [Fact]
+    public void IndexerDeclaration_EscapesStructuredKeywordParameterName()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Item",
+            Kind = "property",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "string",
+                MemberName = "this[]",
+                Parameters =
+                [
+                    new ApiParameter { Type = "int", Name = "event" }
+                ],
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("public string this[int @event] { get; }", declaration);
+    }
+
+    [Fact]
     public void ShortWithUsings_KeepsCollidingSimpleNamesQualified()
     {
         var type = new ApiType


### PR DESCRIPTION
## Summary

Advances #2057 by making `CSharpDeclarationWriter` render property and indexer declarations from structured `ApiSignature` facts.

- Renders properties from `ApiSignature.ReturnType`, `MemberName`, `IsRequired`, and `Accessors`.
- Renders indexers from `ApiSignature.Parameters` and accessors.
- Keeps events, operators, explicit implementations, and unsupported/generic surfaces on compatibility strings.
- Makes declaration termination kind-aware so property/indexer declarations do not gain an invalid trailing semicolon.
- Adds focused metadata writer and CLI signature-section tests proving property declarations can render without reparsing compatibility signature text.

## Validation

- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config -p:NoWarn=NU1507`
- `dotnet run --no-build --no-restore --project tests/ILInspector.Metadata.Tests -c Release -- -class '*CSharpDeclarationWriterTests'`
- `dotnet run --no-build --no-restore --project src/dotnet-inspect.Tests -c Release -- -class '*CSharpDeclarationFormatterTests'`
