### PR TITLE
Fix small-array/stackalloc misfire on conditional-length arrays (#2117)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1161,6 +1161,8 @@ public class LibraryBodyIndexTests
     }
 
     [Theory]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ReturnsIntArray5))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ReturnsIntArray5AfterUnrelatedBranch))]
     [InlineData(nameof(OptimizationOpportunityFixtures.ReturnsSmallArray))]
     [InlineData(nameof(OptimizationOpportunityFixtures.StoresArrayToField))]
     [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayPassedToCall))]
@@ -1171,6 +1173,16 @@ public class LibraryBodyIndexTests
 
         var shape = Assert.Single(ArrayShapes(index, methodName));
         Assert.Equal("small-array", shape);
+    }
+
+    [Theory]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ReturnsConditionalSmallOrHugeArray))]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ReturnsConditionalHugeOrSmallArray))]
+    public void OptimizationOpportunities_DoesNotTreatConditionalLengthArraysAsSmallArrays(string methodName)
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        Assert.Empty(ArrayShapes(index, methodName));
     }
 
     [Theory]

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -2978,7 +2978,12 @@ public sealed class LibraryBodyIndex
             ReachingDefinitionsResult GetReachingDefinitions()
                 => reachingDefinitions ??= ReachingDefinitions.Analyze(il, ArgumentSlotCount(caller), exceptionRegions);
 
+            var branchTargetOffsets = decodedBody.Instructions
+                .SelectMany(static instruction => instruction.BranchTargets)
+                .ToArray();
             int? pendingConstant = null;
+            int pendingConstantOffset = -1;
+            int pendingConstantBlock = -1;
             // Delegate creation is `<push target>; ldftn/ldvirtftn M; newobj DelegateCtor`.
             // Track the pending function-pointer load so a single row is emitted at the
             // newobj (one row per delegate allocation), classified by the target.
@@ -3014,32 +3019,34 @@ public sealed class LibraryBodyIndex
                     case ILOpCode.Ldc_i4_6:
                     case ILOpCode.Ldc_i4_7:
                     case ILOpCode.Ldc_i4_8:
-                        pendingConstant = opcode switch
-                        {
-                            ILOpCode.Ldc_i4_m1 => -1,
-                            ILOpCode.Ldc_i4_0 => 0,
-                            ILOpCode.Ldc_i4_1 => 1,
-                            ILOpCode.Ldc_i4_2 => 2,
-                            ILOpCode.Ldc_i4_3 => 3,
-                            ILOpCode.Ldc_i4_4 => 4,
-                            ILOpCode.Ldc_i4_5 => 5,
-                            ILOpCode.Ldc_i4_6 => 6,
-                            ILOpCode.Ldc_i4_7 => 7,
-                            _ => 8,
-                        };
+                        SetPendingConstant(
+                            opcode switch
+                            {
+                                ILOpCode.Ldc_i4_m1 => -1,
+                                ILOpCode.Ldc_i4_0 => 0,
+                                ILOpCode.Ldc_i4_1 => 1,
+                                ILOpCode.Ldc_i4_2 => 2,
+                                ILOpCode.Ldc_i4_3 => 3,
+                                ILOpCode.Ldc_i4_4 => 4,
+                                ILOpCode.Ldc_i4_5 => 5,
+                                ILOpCode.Ldc_i4_6 => 6,
+                                ILOpCode.Ldc_i4_7 => 7,
+                                _ => 8,
+                            },
+                            offset);
                         break;
                     case ILOpCode.Ldc_i4_s:
-                        pendingConstant = (int)instruction.OperandValue;
+                        SetPendingConstant((int)instruction.OperandValue, offset);
                         break;
                     case ILOpCode.Ldc_i4:
-                        pendingConstant = OperandInt32(instruction);
+                        SetPendingConstant(OperandInt32(instruction), offset);
                         break;
                     case ILOpCode.Newarr:
                     {
                         int elementToken = OperandInt32(instruction);
                         if (allocationByOffset.TryGetValue(offset, out var arrayAllocation)
                             && arrayAllocation.Kind == AllocationKind.Array
-                            && pendingConstant is int length && length >= 0 && length <= 8)
+                            && ValidPendingConstant(offset) is int length && length >= 0 && length <= 8)
                         {
                             // Promote to a confident stackalloc recommendation only when the
                             // array provably stays local AND its element type is stackalloc-
@@ -3067,12 +3074,12 @@ public sealed class LibraryBodyIndex
                                     offset,
                                     "Escape not analyzed; confirm the array stays local before replacing."));
                         }
-                        pendingConstant = null;
+                        ClearPendingConstant();
                         break;
                     }
                     case ILOpCode.Newobj:
                     {
-                        pendingConstant = null;
+                        ClearPendingConstant();
                         if (pendingDelegateOffset is not null)
                         {
                             // A function pointer was just loaded, so this newobj is the delegate
@@ -3152,7 +3159,7 @@ public sealed class LibraryBodyIndex
                     case ILOpCode.Call:
                     case ILOpCode.Callvirt:
                     {
-                        pendingConstant = null;
+                        ClearPendingConstant();
                         int token = OperandInt32(instruction);
                         var callee = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
                         // When the delegate just allocated flows straight into a lazy LINQ
@@ -3275,7 +3282,7 @@ public sealed class LibraryBodyIndex
                     case ILOpCode.Ldftn:
                     case ILOpCode.Ldvirtftn:
                     {
-                        pendingConstant = null;
+                        ClearPendingConstant();
                         int token = OperandInt32(instruction);
                         // Defer emission to the following newobj (de-dup). Capture is decided
                         // by the target method's declaring type: a lambda that closes over state
@@ -3296,22 +3303,22 @@ public sealed class LibraryBodyIndex
                         break;
                     }
                     case ILOpCode.Ldarg_0:
-                        pendingConstant = null;
+                        ClearPendingConstant();
                         break;
                     case ILOpCode.Ldarg:
-                        pendingConstant = null;
+                        ClearPendingConstant();
                         break;
                     case ILOpCode.Ldarg_s:
-                        pendingConstant = null;
+                        ClearPendingConstant();
                         break;
                     case ILOpCode.Ldfld:
                     case ILOpCode.Ldflda:
                     case ILOpCode.Stfld:
-                        pendingConstant = null;
+                        ClearPendingConstant();
                         break;
                     case ILOpCode.Box:
                     {
-                        pendingConstant = null;
+                        ClearPendingConstant();
                         int token = OperandInt32(instruction);
                         var boxed = ResolveTypeToken(token, callerScope);
                         // ECMA-335 permits `box` on reference types (a no-op) and generic
@@ -3337,7 +3344,7 @@ public sealed class LibraryBodyIndex
                         break;
                     }
                     default:
-                        pendingConstant = null;
+                        ClearPendingConstant();
                         break;
                 }
 
@@ -3382,6 +3389,34 @@ public sealed class LibraryBodyIndex
             }
 
             return [.. opportunities.Select(AnnotateOpportunityMetadata)];
+
+            void SetPendingConstant(int value, int instructionOffset)
+            {
+                pendingConstant = value;
+                pendingConstantOffset = instructionOffset;
+                pendingConstantBlock = decodedBody.BlockGraph.BlockIndexAt(instructionOffset);
+            }
+
+            void ClearPendingConstant()
+            {
+                pendingConstant = null;
+                pendingConstantOffset = -1;
+                pendingConstantBlock = -1;
+            }
+
+            int? ValidPendingConstant(int newarrOffset)
+                => pendingConstant is { } value
+                    && decodedBody.BlockGraph.IsComplete
+                    && pendingConstantBlock >= 0
+                    // EH-aware blocks can split protected regions at every instruction; only a
+                    // real branch target between the constant and newarr makes the length joined.
+                    && (pendingConstantBlock == decodedBody.BlockGraph.BlockIndexAt(newarrOffset)
+                        || !HasBranchTargetBetween(pendingConstantOffset, newarrOffset))
+                    ? value
+                    : null;
+
+            bool HasBranchTargetBetween(int startExclusive, int endInclusive)
+                => branchTargetOffsets.Any(target => target > startExclusive && target <= endInclusive);
 
             OptimizationOpportunity AnnotateOpportunityMetadata(OptimizationOpportunity opportunity)
             {


### PR DESCRIPTION
## Summary

Fixes #2117: the `small-array` (stackalloc-candidate) shape used a linear
`pendingConstant` scan that, like the size scan fixed in #2110, mis-read a
ternary/branch-join array length as an unconditional constant — so a **dynamic-length
array (`new int[cond ? 5 : 1000000]`) could be classified as a small stackalloc
candidate**. Following that advice risks a `StackOverflowException`.

Applies the **same** same-basic-block `BlockGraph` guard used for the size scan in
#2110 (reused, not reinvented): a `pendingConstant` length is only valid when the
`ldc.i4*` and the `newarr` are in the same basic block; otherwise the length isn't a
provable constant and `small-array` does not fire.

## Verification

- Ternary `new int[c ? 5 : 1000000]` (both orderings) no longer fires `small-array`;
  straight-line `new int[5]` still does; a same-block const after an unrelated earlier
  branch still fires (no over-suppression). 316 analysis tests pass.

## Honest paydirt note (a maintainer decision)

This is a **defensive soundness fix with zero corpus paydirt.** Before→after on the
6 pinned libraries (Aspire.Hosting@13.4.6, System.Text.Json@10.0.9,
Newtonsoft.Json@13.0.4, Serilog@4.3.1, Polly@8.7.0, AutoMapper@16.1.1): **0
`small-array` rows removed** — the conditional-length pattern does not occur in any
of them. The bug is real and dangerous, but absent from our corpus (mature libraries
rarely write `new int[cond ? a : b]`; application code is likelier to).

So the land decision is a **safety-vs-evidence tradeoff**: the fix prevents a
genuinely unsafe recommendation but has no demonstrated corpus impact. Per the
corpus-paydirt gate this is a legitimate "your call" — I'm surfacing it rather than
asserting it clears the bar. It's a Performance Triage *judgment* change (removes a
false-positive class), mechanism already proven two-clean in #2110.

Requesting adversarial review (rotated reviewers) focused on over-suppression risk.
