### PR TITLE
Complete TypedConstantsPass: Convert folding, sink coverage, late run (value-typed emission, slice 2)

### DIFF
--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -393,9 +393,15 @@ measurable, unlike the control-flow rewrite's all-or-nothing invariant relaxatio
    surfaced and fixed a guard-drift invalid-C# class (bool operands at enum
    positions) and extended member naming to un-retyped constants, with the
    corpus card flat against a same-corpus base A/B.
-2. **Complete constant typing.** Extend `TypedConstantsPass` to retype `int`,
-   `long`, and `Convert`-wrapped integer constants into every enum-typed sink, so
-   the printer sees enum-typed values uniformly.
+2. **Complete constant typing.** Landed (#2120): `TypedConstantsPass` retypes
+   `int`, `long`, and unchecked 8-byte-widening `Convert`-wrapped constants into
+   enum-typed sinks (semantic array-element targets, either-side comparisons,
+   `??=`/property stores, enum-merged conditional arms), with a third pipeline
+   run after reconstruction for late-created sinks. The `ldc.i4; conv.i8`
+   lowering of long/ulong-backed enum constants now names its member —
+   `CfgULong.All`, not `unchecked((CfgULong)((long)(-1)))`. Switch labels stay
+   printer-spelled (`EnumConstantText`): `SwitchSection` holds them outside the
+   rewritable tree.
 3. **Turn the invariant on.** Assert every typed sink routes through `Coerce`;
    burn down the violations it flags (these are the remaining leak sites, now
    enumerated by the checker rather than by adversarial review). Slices 1–3 deliver

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -285,26 +285,31 @@ public class EnumCastPrinterTests
     }
 
     [Fact]
-    public void UnsignedLongEnumConstant_ConvertWrapped_ForcesUncheckedCast()
+    public void UnsignedLongEnumMaxConstant_ConvertWrapped_NamesMember()
     {
-        // ulong.MaxValue lowers as `ldc.i4.m1; conv.i8`, so the enum cast operand is
-        // a Convert; the overflow decision must pierce it and wrap `unchecked`.
+        // ulong.MaxValue lowers as `ldc.i4.m1; conv.i8`; TypedConstantsPass folds
+        // the widening into an enum-typed constant (sign-extended payload -1
+        // matches the member map's keying), so the value renders by name — the
+        // ideal spelling for leak case #6, replacing
+        // `unchecked((CfgULong)((long)(-1)))`. The unnamed-value unchecked
+        // fallback stays pinned by the Unknown-enum and CoerceChokePoint tests.
         const string declaration = "public enum CfgULong : ulong { None = 0, All = 18446744073709551615UL }";
 
         string boxed = RenderRaisedFixture(nameof(EnumCastSamples.ULongEnumBoxedMax));
-        Assert.Contains("unchecked((CfgULong)", boxed);
+        Assert.Contains("CfgULong.All", boxed);
+        Assert.DoesNotContain("(long)(-1)", boxed);
         AssertCompiles("public static System.Enum M()", boxed, declaration);
 
         string array = RenderRaisedFixture(nameof(EnumCastSamples.ULongEnumArrayMax));
-        Assert.Contains("unchecked((CfgULong)", array);
+        Assert.Contains("CfgULong.All", array);
         AssertCompiles("public static CfgULong[] M()", array, declaration);
     }
 
     [Fact]
     public void LongBackedEnumConstants_InArrayAndBox_CastOrName()
     {
-        // Array elements: long constants render as enum casts, never a bare `long`
-        // (CS0266). AssertCompiles is the real validity gate.
+        // Array elements: an unnamed long payload renders as the enum cast, never
+        // a bare `long` (CS0266). AssertCompiles is the real validity gate.
         string array = RenderRaisedFixture(nameof(EnumCastSamples.LongEnumArray));
         Assert.Contains("(CfgLongPriority)5000000000", array);
         Assert.DoesNotContain("= 5000000000;", array);
@@ -314,10 +319,10 @@ public class EnumCastPrinterTests
             "public enum CfgLongPriority : long { Low = 0, High = 2 }");
 
         // Box target: the enum value must keep its type (bare long is CS0029 for
-        // System.Enum). A small value arrives as `Convert(long, ...)`, so it casts
-        // rather than names.
+        // System.Enum). The small value arrives as `Convert(long, ...)`;
+        // TypedConstantsPass folds it, so the named member renders.
         string boxed = RenderRaisedFixture(nameof(EnumCastSamples.LongEnumBoxed));
-        Assert.Contains("(CfgLongPriority)", boxed);
+        Assert.Contains("CfgLongPriority.High", boxed);
         Assert.DoesNotContain("return (long)", boxed);
         AssertCompiles(
             "public static System.Enum M()",

--- a/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
@@ -1,5 +1,6 @@
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
+using Convert = ILInspector.Decompiler.Pipeline.Convert;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -50,6 +51,162 @@ public class TypedConstantsPassTests
         Assert.Contains("return S_256[index] ? 1 : 0;", output);
         Assert.DoesNotContain("visited[index] = 1;", output);
         Assert.DoesNotContain("visited[index] == 0", output);
+    }
+
+    // --- Slice 2 (value-typed-emission.md): Convert folding, semantic element
+    // targets, either-side comparisons, and late-created sinks. ---
+
+    static readonly TypeRef LongEnum = TypeRef.Definition("synthetic", "", "LEnum");
+    static readonly TypeRef Int32Type = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Int64Type = TypeRef.CoreLib("System", "Int64");
+
+    static IrFunction EnumFunction(BlockContainer body, TypeRef returnType, params Parameter[] parameters)
+        => new("M", TypeRef.Definition("synthetic", "", "Holder"),
+            new MethodSignature(returnType, [.. parameters], HasThis: false, GenericParameterCount: 0), [], body)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [LongEnum] = TypeShape.Enum },
+            EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef> { [LongEnum] = Int64Type },
+            EnumMembers = new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>
+            {
+                [LongEnum] = new Dictionary<long, string> { [2] = "High" },
+            },
+        };
+
+    static BlockContainer SingleStatement(IrNode statement)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(statement);
+        container.Add(block);
+        return container;
+    }
+
+    [Fact]
+    public void WideningConvertConstant_AtEnumReturn_FoldsAndNames()
+    {
+        // A long-backed enum constant lowers `ldc.i4 2; conv.i8`; the fold turns
+        // the Convert into a typed constant, and the printer names it.
+        var body = SingleStatement(new Return(
+            new Convert(Int64Type, isChecked: false, isUnsigned: false, new Constant(2, Int32Type))));
+        var function = EnumFunction(body, LongEnum);
+
+        new TypedConstantsPass().Run(function, PassContext.None);
+
+        var constant = Assert.IsType<Constant>(Assert.Single(function.Descendants.OfType<Return>()).Value);
+        Assert.Equal(2L, constant.Value);
+        Assert.Equal(LongEnum, constant.Type);
+        Assert.Contains("return LEnum.High;", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void UnsignedWideningConvertConstant_ZeroExtendsPayload()
+    {
+        // conv.u8 zero-extends a 32-bit payload: -1 carries 4294967295, not -1
+        // (keyed off the convert target, mirroring TryEnumCastLiteral).
+        var body = SingleStatement(new Return(
+            new Convert(TypeRef.CoreLib("System", "UInt64"), isChecked: false, isUnsigned: false, new Constant(-1, Int32Type))));
+        var function = EnumFunction(body, LongEnum);
+
+        new TypedConstantsPass().Run(function, PassContext.None);
+
+        var constant = Assert.IsType<Constant>(Assert.Single(function.Descendants.OfType<Return>()).Value);
+        Assert.Equal(4294967295L, constant.Value);
+    }
+
+    [Fact]
+    public void CheckedOrNarrowingConvertConstant_DoesNotFold()
+    {
+        // conv.ovf traps on out-of-range values and a narrowing truncates —
+        // neither is a pure retype, so both keep their Convert.
+        var check = SingleStatement(new Return(
+            new Convert(Int64Type, isChecked: true, isUnsigned: false, new Constant(-1, Int32Type))));
+        var checkedFunction = EnumFunction(check, LongEnum);
+        new TypedConstantsPass().Run(checkedFunction, PassContext.None);
+        Assert.IsType<Convert>(Assert.Single(checkedFunction.Descendants.OfType<Return>()).Value);
+
+        var narrow = SingleStatement(new Return(
+            new Convert(TypeRef.CoreLib("System", "UInt32"), isChecked: false, isUnsigned: false, new Constant(300, Int32Type))));
+        var narrowFunction = EnumFunction(narrow, LongEnum);
+        new TypedConstantsPass().Run(narrowFunction, PassContext.None);
+        Assert.IsType<Convert>(Assert.Single(narrowFunction.Descendants.OfType<Return>()).Value);
+    }
+
+    [Fact]
+    public void StoreElement_PrefersSemanticElementType()
+    {
+        // stelem.i8 into LEnum[] carries ElementType Int64 (the storage width);
+        // the array's element type is the semantic target, so the Convert-wrapped
+        // payload folds to the enum.
+        var array = new LoadArgument(0, "values", TypeRef.SzArray(LongEnum));
+        var store = new StoreElement(
+            Int64Type,
+            array,
+            new Constant(0, Int32Type),
+            new Convert(Int64Type, isChecked: false, isUnsigned: false, new Constant(2, Int32Type)));
+        var function = EnumFunction(SingleStatement(store), TypeRef.CoreLib("System", "Void"),
+            new Parameter("values", TypeRef.SzArray(LongEnum)));
+
+        new TypedConstantsPass().Run(function, PassContext.None);
+
+        var constant = Assert.IsType<Constant>(Assert.Single(function.Descendants.OfType<StoreElement>()).Value);
+        Assert.Equal(LongEnum, constant.Type);
+    }
+
+    [Fact]
+    public void ComparisonConstantOnLeft_RetypesAgainstRightSide()
+    {
+        var comparison = new Comparison(
+            ComparisonKind.Equal,
+            isUnsigned: false,
+            new Constant(2, Int32Type),
+            new LoadArgument(0, "e", LongEnum));
+        var function = EnumFunction(
+            SingleStatement(new Return(comparison)),
+            TypeRef.CoreLib("System", "Boolean"),
+            new Parameter("e", LongEnum));
+
+        new TypedConstantsPass().Run(function, PassContext.None);
+
+        var retyped = Assert.IsType<Constant>(Assert.Single(function.Descendants.OfType<Comparison>()).Left);
+        Assert.Equal(LongEnum, retyped.Type);
+    }
+
+    [Fact]
+    public void EnumMergedConditionalArm_RetypesConstantArm()
+    {
+        // The join sinks only exist after structuring/diamond folds, which is
+        // why the pipeline gained a late run; enum-merged only (bool joins
+        // belong to BooleanFoldingPass).
+        var conditional = new Conditional(
+            new LoadArgument(0, "c", TypeRef.CoreLib("System", "Boolean")),
+            new Constant(2, Int32Type),
+            new LoadArgument(1, "e", LongEnum))
+        {
+            MergedType = LongEnum,
+        };
+        var function = EnumFunction(
+            SingleStatement(new Return(conditional)),
+            LongEnum,
+            new Parameter("c", TypeRef.CoreLib("System", "Boolean")),
+            new Parameter("e", LongEnum));
+
+        new TypedConstantsPass().Run(function, PassContext.None);
+
+        var arm = Assert.IsType<Constant>(Assert.Single(function.Descendants.OfType<Conditional>()).WhenTrue);
+        Assert.Equal(LongEnum, arm.Type);
+        Assert.Contains("LEnum.High", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void CoalescingAssignment_RetypesValue()
+    {
+        var assign = new NullCoalescingAssignment(0, LongEnum, new Constant(2, Int32Type));
+        var function = EnumFunction(SingleStatement(assign), TypeRef.CoreLib("System", "Void"));
+
+        new TypedConstantsPass().Run(function, PassContext.None);
+
+        var constant = Assert.IsType<Constant>(Assert.Single(function.Descendants.OfType<NullCoalescingAssignment>()).Value);
+        Assert.Equal(LongEnum, constant.Type);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -300,6 +300,12 @@ public static class IrPasses
         // earlier IncrementDecrementPass run (before reconstruction) never saw.
         // Re-run it to fold those back into `i++`/`i--` on the rebuilt body.
         new IncrementDecrementPass(),
+        // Structuring, sugar, and reconstruction create typed sinks that did not
+        // exist at the first two runs — enum-merged conditional arms, ??= and
+        // property stores, reconstructed bodies. The late run retypes (and
+        // Convert-folds) constants into those positions so the printer sees
+        // enum-typed values uniformly (value-typed-emission.md, slice 2).
+        new TypedConstantsPass(),
         // After post-reconstruction cleanup, verify the recovered iterator still has
         // a safe structured shape; otherwise degrade honestly instead of claiming Full.
         new IteratorReconstructionSafetyPass(),

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -18,17 +18,29 @@ public sealed class TypedConstantsPass : IIrPass
         {
             switch (node)
             {
-                case Return { Value: Constant constant }:
-                    Retype(constant, function.Signature.ReturnType, shapes, stepper);
+                case Return { Value: { } value }:
+                    Retype(value, function.Signature.ReturnType, shapes, stepper);
                     break;
-                case StoreLocal { Value: Constant constant } store:
-                    Retype(constant, store.Type, shapes, stepper);
+                case StoreLocal { Value: { } value } store:
+                    Retype(value, store.Type, shapes, stepper);
                     break;
-                case StoreArgument { Value: Constant constant } store:
-                    Retype(constant, store.Type, shapes, stepper);
+                case StoreArgument { Value: { } value } store:
+                    Retype(value, store.Type, shapes, stepper);
                     break;
-                case StoreField { Value: Constant constant } store:
-                    Retype(constant, store.Field.Type, shapes, stepper);
+                case StoreField { Value: { } value } store:
+                    Retype(value, store.Field.Type, shapes, stepper);
+                    break;
+                case StoreProperty { Value: { } value } store:
+                    Retype(value, store.Accessor.ParameterTypes is { IsDefault: false, Length: > 0 } setter ? setter[^1] : null, shapes, stepper);
+                    break;
+                case NullCoalescingAssignment { Value: { } value } assign:
+                    Retype(value, assign.LocalType, shapes, stepper);
+                    break;
+                case NullCoalescingFieldAssignment { Value: { } value } assign:
+                    Retype(value, assign.Field.Type, shapes, stepper);
+                    break;
+                case NullCoalescingPropertyAssignment { Value: { } value } assign:
+                    Retype(value, assign.PropertyType, shapes, stepper);
                     break;
                 case Call call:
                     RetypeArguments(call.Callee, call.Arguments, call.Callee.HasThis ? 1 : 0, shapes, stepper);
@@ -36,37 +48,64 @@ public sealed class TypedConstantsPass : IIrPass
                 case NewObject ctor:
                     RetypeArguments(ctor.Constructor, ctor.Arguments, 0, shapes, stepper);
                     break;
-                case Comparison { Left: { } left, Right: Constant constant }
-                    when left is not Constant && left.ResultType is { } leftType:
-                    Retype(constant, leftType, shapes, stepper);
+                // Either side: a constant compared against a typed non-constant
+                // carries that side's identity (`5 == e` occurs in IL as readily
+                // as `e == 5`).
+                case Comparison { Left: { } left, Right: { } right }:
+                    if (left is not Constant && left.ResultType is { } leftType)
+                        Retype(right, leftType, shapes, stepper);
+                    else if (right is not Constant && right.ResultType is { } rightType)
+                        Retype(left, rightType, shapes, stepper);
                     break;
-                case Box { Operand: Constant constant } box:
-                    Retype(constant, box.Type, shapes, stepper);
+                case Box { Operand: { } operand } box:
+                    Retype(operand, box.Type, shapes, stepper);
                     break;
-                case StoreElement { Value: Constant constant, ElementType: { } elementType }:
-                    Retype(constant, elementType, shapes, stepper);
+                // The stelem opcode carries only a storage width (`stelem.i8` says
+                // Int64, not the long-backed enum), so the semantic target is the
+                // array's element type when it resolves — the same
+                // storage-vs-semantic split the printer's StoreElementTargetType
+                // makes.
+                case StoreElement { Value: { } value } store:
+                    Retype(value, ElementTargetType(store), shapes, stepper);
                     break;
                 // `stind.i1`/`stind.i2` carry only a storage width (sbyte/short), so a
                 // `bool`/`char` location stored through a managed ref or pointer keeps
                 // the opcode's integer type. The address's pointee type is the real
                 // target — `ref bool wasSymlink = 0` is `wasSymlink = false`.
-                case StoreIndirect { Value: Constant constant } store
+                case StoreIndirect { Value: { } value } store
                     when (PointeeType(store.Address.ResultType) ?? store.Type) is { } indirectType:
-                    Retype(constant, indirectType, shapes, stepper);
+                    Retype(value, indirectType, shapes, stepper);
                     break;
                 // `flags & 16` is `BindingFlags & int` — CS0019. The bitwise
                 // operators are the enum-flag idiom; an int constant beside an
                 // enum operand carries that enum's identity, so retype it (the
                 // printer then names the member or casts).
                 case Binary { Kind: BinaryKind.And or BinaryKind.Or or BinaryKind.Xor } binary:
-                    if (EnumOperandType(binary.Left, shapes) is { } leftEnum && binary.Right is Constant rightConst)
-                        Retype(rightConst, leftEnum, shapes, stepper);
-                    else if (EnumOperandType(binary.Right, shapes) is { } rightEnum && binary.Left is Constant leftConst)
-                        Retype(leftConst, rightEnum, shapes, stepper);
+                    if (EnumOperandType(binary.Left, shapes) is { } leftEnum && binary.Right is Constant or Convert)
+                        Retype(binary.Right, leftEnum, shapes, stepper);
+                    else if (EnumOperandType(binary.Right, shapes) is { } rightEnum && binary.Left is Constant or Convert)
+                        Retype(binary.Left, rightEnum, shapes, stepper);
                     break;
+                // An enum-typed join (set by the diamond/store-chain folds) types
+                // both arms. Enum only: bool/char conditionals belong to
+                // BooleanFoldingPass, whose 0/1-arm reconciliation must not be
+                // preempted here.
+                case Conditional { MergedType: { } merged } conditional
+                    when shapes.GetValueOrDefault(merged) == TypeShape.Enum:
+                    Retype(conditional.WhenTrue, merged, shapes, stepper);
+                    Retype(conditional.WhenFalse, merged, shapes, stepper);
+                    break;
+                // Switch case labels are deliberately not retyped: SwitchSection
+                // holds them outside the child tree (ReplaceWith cannot reach
+                // them) and the printer spells labels through EnumConstantText.
             }
         }
     }
+
+    static TypeRef? ElementTargetType(StoreElement store)
+        => store.Array.ResultType is { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element }
+            ? element
+            : store.ElementType;
 
     static TypeRef? PointeeType(TypeRef? type)
         => type is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer } ? type.ElementType : null;
@@ -95,18 +134,46 @@ public sealed class TypedConstantsPass : IIrPass
         if (callee.ParameterTypes.IsDefault)
             return;
         for (int i = 0; i < callee.ParameterTypes.Length && i + receiverOffset < arguments.Count; i++)
-        {
-            if (arguments[i + receiverOffset] is Constant constant)
-                Retype(constant, callee.ParameterTypes[i], shapes, stepper);
-        }
+            Retype(arguments[i + receiverOffset], callee.ParameterTypes[i], shapes, stepper);
     }
 
-    static void Retype(Constant constant, TypeRef target, IReadOnlyDictionary<TypeRef, TypeShape> shapes, Stepper stepper)
+    static void Retype(IrExpression expression, TypeRef? target, IReadOnlyDictionary<TypeRef, TypeShape> shapes, Stepper stepper)
     {
         // A retype position whose target type did not resolve carries no
         // identity to recover; skip it rather than dereference a null target.
         if (target is null)
             return;
+        switch (expression)
+        {
+            case Constant constant:
+                RetypeConstant(constant, target, shapes, stepper);
+                return;
+            // A long/ulong-backed enum constant lowers as `ldc.i4 N; conv.i8`
+            // (or `conv.u8`), so at the sink the payload is a Convert over the
+            // int constant, not a constant — and it never names or retypes.
+            // Fold the widening into a typed constant: the value survives (a
+            // conv.u8 target zero-extends the 32-bit payload, a conv.i8 target
+            // sign-extends — keyed off the target, as in TryEnumCastLiteral)
+            // and csc regenerates the identical ldc.i4/conv pair from the
+            // member name or cast on recompile. Unchecked 8-byte widenings
+            // only: a conv.ovf traps on an out-of-range value and a narrowing
+            // truncates, so neither folds; enum targets only, where the
+            // recovered identity pays for erasing the IL-history node.
+            case Convert
+            {
+                IsChecked: false,
+                Target: { Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Int64" or "UInt64" } convertTarget,
+                Operand: Constant { Value: int payload },
+            } convert when shapes.GetValueOrDefault(target) == TypeShape.Enum:
+                long widened = convertTarget.Name == "UInt64" ? (uint)payload : payload;
+                stepper.StepOver($"fold widening conv into enum {target.Name} constant", convert);
+                convert.ReplaceWith(new Constant(widened, target));
+                return;
+        }
+    }
+
+    static void RetypeConstant(Constant constant, TypeRef target, IReadOnlyDictionary<TypeRef, TypeShape> shapes, Stepper stepper)
+    {
         if (constant.Value is int value)
         {
             if (target is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" })
@@ -132,7 +199,9 @@ public sealed class TypedConstantsPass : IIrPass
         // An integer flowing into an enum position carries the enum's identity;
         // the printer names it from the resolved member map. The value is kept
         // (an int, or an ldc.i8 for a long-backed enum); only the type changes.
-        if (shapes.GetValueOrDefault(target) == TypeShape.Enum)
+        // Idempotent: a constant already carrying the target (an earlier run of
+        // this pass) is left alone rather than re-replaced on every run.
+        if (shapes.GetValueOrDefault(target) == TypeShape.Enum && constant.Type?.Equals(target) != true)
         {
             stepper.StepOver($"retype constant to enum {target.Name}", constant);
             constant.ReplaceWith(new Constant(constant.Value, target));


### PR DESCRIPTION
## Change

**Conclusion:** slice 2 of [value-typed-emission.md](docs/design/value-typed-emission.md) — constants reach the printer enum-typed uniformly. Builds directly on slice 1's choke point (#2114).

- **`Convert` folding.** The `ldc.i4 N; conv.i8/u8` lowering of long/ulong-backed enum constants folds into a typed constant at enum sinks: `conv.u8` zero-extends, `conv.i8` sign-extends (keyed off the target, mirroring `TryEnumCastLiteral`). Checked converts (trap on out-of-range) and narrowings (truncate) are excluded — neither is a pure retype. Headline delta: **`return CfgULong.All;`** where the pipeline rendered `unchecked((CfgULong)((long)(-1)))` — leak case #6 at its ideal spelling. Recompiles to the identical `ldc.i4.m1; conv.i8`.
- **Semantic element targets.** `StoreElement` retypes against the array's element type, not the `stelem` storage width — the pass-side twin of the printer's `StoreElementTargetType` split.
- **Sink coverage.** Comparison constants on either side; `Convert`-wrapped call/ctor arguments; `StoreProperty`; `??=` (local/field/property); enum-merged `Conditional` arms (enum-only — bool joins belong to `BooleanFoldingPass`'s 0/1-arm reconciliation, deliberately not preempted).
- **Third pipeline run** after reconstruction so late-created sinks (structuring joins, sugar stores, rebuilt bodies) see the same rules; enum retyping is idempotent across runs. Switch labels stay out with a documented reason (`SwitchSection` holds them outside the child tree; the printer spells them via `EnumConstantText`).

Two existing fixture expectations updated **deliberately** (the cast spellings for foldable constants are now member names — `CfgLongPriority.High`, `CfgULong.All`); the cast/`unchecked` fallback proofs remain pinned by the Unknown-enum, `CoerceChokePointTests`, and new pass tests.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Full `ILInspector.Decompiler.Tests` | **1847/1847 pass** (local, this branch) |
| New pass tests | `TypedConstantsPassTests` +7 (fold/zero-extend/no-fold guards/semantic element/either-side comparison/late sinks) |
| PR quick corpus card | Below; pinned-subset gate 0 pp |
| Base A/B | Card at merge-base `a758694b` is **byte-identical** to the PR card — structuring metrics unmoved |

## Decompiler quality

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 15 assemblies, 1,462 methods
Sample: hash-stable 100 methods per assembly
Correctness coverage: validity not run; fidelity not run

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 1,461 -> 1,462 (+1)
- ILInspector.MetadataPrimitives: 61 -> 62 methods (+1)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 1,213 (83.03%) | 1,210 (82.76%) | -3 |
| Conditional-branch residual (-) | 35 (2.40%) | 44 (3.01%) | +9 |
| Forward-merge stops (-) | 27 (1.85%) | 33 (2.26%) | +6 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 82.17% -> 82.17% (0 pp); conditional residual 3.00% -> 3.00% (0 pp); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Advisory aggregate rate movement (not a PR quick hard gate; review for decompiler-risky changes):
- fully-raised dropped 0.27 pp (baseline 83.03%, PR 82.76%, tolerance 0.10 pp)
- conditional-branch residual increased 0.61 pp (baseline 2.40%, PR 3.01%, tolerance 0.10 pp)
- forward-merge stop increased 0.41 pp (baseline 1.85%, PR 2.26%, tolerance 0.10 pp)

Verdict: corpus sensor matched baseline tolerances.

## Adversarial review

Requesting the standard two-reviewer cross-model pass (per AGENTS.md) with these attack points: (1) the fold's value semantics — zero- vs sign-extension keying, the checked/narrowing exclusions, payloads at exactly int.MinValue/uint.MaxValue; (2) the third pass run's interaction with BooleanFoldingPass and reconstruction-created bodies; (3) whether erasing the `Convert` node loses any IL-history fidelity the compile-back oracle would catch. Evidence from real runs required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)