### PR TITLE
Enable ReturnToSender constructor catalog targets

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -449,7 +449,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("RETURNTOSENDER GENERATED FIXTURE FRONTIER", report);
         Assert.Contains("Passed : 2", report);
         Assert.Contains("Skipped: 0", report);
-        Assert.Contains("constructor-target: 2", report);
+        Assert.DoesNotContain("constructor-target", report);
 
         var propertyGetter = Assert.Single(run.Results, result =>
             result.FixtureId == "minimal.property.literal"
@@ -471,7 +471,7 @@ public class GeneratedFixtureCatalogTests
         Assert.True(document.RootElement.GetProperty("Passed").GetBoolean());
         Assert.Contains(document.RootElement.GetProperty("Results").EnumerateArray(),
             result => result.GetProperty("Status").GetString() == "Pass");
-        Assert.Contains(document.RootElement.GetProperty("Results").EnumerateArray(),
+        Assert.DoesNotContain(document.RootElement.GetProperty("Results").EnumerateArray(),
             result => result.GetProperty("Reason").GetString() == "constructor-target");
     }
 

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -3,6 +3,7 @@ using ILInspector.Decompiler;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using System.Reflection;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -816,6 +817,19 @@ public class ReturnToSenderPrototypeTests
         {
             DeleteFixture(assemblyPath);
         }
+    }
+
+    [Fact]
+    public void CompileBackSourceComposer_PrimaryConstructorParametersPrecedeGenericConstraints()
+    {
+        var method = typeof(CompileBackSourceComposer).GetMethod(
+            "AddPrimaryConstructorParameters",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        var result = Assert.IsType<string>(method?.Invoke(
+            null,
+            ["public class Class1<T> where T : class", "string message"]));
+
+        Assert.Equal("public class Class1<T>(string message) where T : class", result);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -763,6 +763,62 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RoundTripsConstructorAssigningGetOnlyAutoProperty()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public Class1(string message)
+                {
+                    Message = message;
+                }
+
+                public string Message { get; }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", ".ctor", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public string Message { get; }", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_UsesPrimaryConstructorForFieldInitializerPrologue()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1(string message)
+            {
+                private readonly string _message = message;
+
+                public string Message => _message;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", ".ctor", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public class Class1(string message)", result.Source);
+            Assert.Contains("public string _message = message;", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_SurfacesUnsafeNestedClosureMember()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -663,7 +663,7 @@ public static class CompileBackSourceComposer
 
     static ApiMember ToApiMember(CompileBackTypeDeclaration type, CompileBackMemberDeclaration member)
     {
-        string parameterList = string.Join(", ", member.Parameters.Select(parameter => $"{parameter.Type.DisplayName} {parameter.Name}"));
+        string parameterList = string.Join(", ", member.Parameters.Select(RenderParameter));
         string? returnType = member.ReturnType?.DisplayName;
         return new ApiMember
         {
@@ -711,10 +711,13 @@ public static class CompileBackSourceComposer
 
     static string AddPrimaryConstructorParameters(string declaration, string parameters)
     {
-        int inheritance = declaration.IndexOf(" : ", StringComparison.Ordinal);
+        int constraints = declaration.IndexOf(" where ", StringComparison.Ordinal);
+        string head = constraints >= 0 ? declaration[..constraints] : declaration;
+        string tail = constraints >= 0 ? declaration[constraints..] : "";
+        int inheritance = head.IndexOf(" : ", StringComparison.Ordinal);
         return inheritance >= 0
-            ? declaration[..inheritance] + $"({parameters})" + declaration[inheritance..]
-            : $"{declaration}({parameters})";
+            ? head[..inheritance] + $"({parameters})" + head[inheritance..] + tail
+            : $"{head}({parameters}){tail}";
     }
 
     static IReadOnlyList<CompileBackParameter> MethodParameters(
@@ -827,9 +830,12 @@ public static class CompileBackSourceComposer
             return null;
 
         string parameters = string.Join(", ", MethodParameters(reader, method, method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, declaringType, method)))
-            .Select(parameter => $"{parameter.Type.DisplayName} {parameter.Name}"));
+            .Select(RenderParameter));
         return new CompileBackPrimaryConstructor(parameters, fieldInitializers);
     }
+
+    static string RenderParameter(CompileBackParameter parameter)
+        => $"{parameter.Type.DisplayName} {parameter.Name}";
 
     static Dictionary<int, string> ParameterNames(MetadataReader reader, MethodDefinition method)
     {

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -123,6 +123,7 @@ public sealed record CompileBackTypeDeclaration(
     CompileBackTypeKind Kind,
     CompileBackAccessibility Accessibility,
     CompileBackTypeSignature? BaseType,
+    string? PrimaryConstructorParameters,
     IReadOnlyList<CompileBackTypeSignature> Interfaces,
     IReadOnlyList<CompileBackMemberDeclaration> Members,
     IReadOnlyList<CompileBackFact> SourceFacts,
@@ -217,14 +218,20 @@ public enum CompileBackStubBodyKind
     Throw,
     TargetBody,
     AutoProperty,
+    FieldInitializer,
 }
 
 public sealed record CompileBackFact(string Producer, string Id, string Detail);
+
+public sealed record CompileBackPrimaryConstructor(
+    string Parameters,
+    IReadOnlyList<CompileBackMemberRequirement> FieldInitializers);
 
 public sealed record CompileBackTypeRequirement(
     CompileBackTypeIdentity Type,
     CompileBackTypeKind RequiredKind,
     IReadOnlyList<CompileBackMemberRequirement> RequiredMembers,
+    CompileBackPrimaryConstructor? PrimaryConstructor,
     IReadOnlyList<CompileBackFact> SourceFacts);
 
 public sealed record CompileBackMemberRequirement(
@@ -294,6 +301,7 @@ public static class CompileBackSourceComposer
                             ]
                             : [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))])
                 ],
+                PrimaryConstructor: null,
                 targetFacts)
         };
 
@@ -311,6 +319,7 @@ public static class CompileBackSourceComposer
                 dependencyIdentity,
                 ShellKind(reader, dependencyDef),
                 RequiredMembers: [],
+                PrimaryConstructor: null,
                 SourceFacts: closureFacts.TryGetValue(dependency, out var facts)
                     ? facts.ToArray()
                     : [new CompileBackFact("closure", "closure-root", dependencyIdentity.FullName)]));
@@ -356,6 +365,10 @@ public static class CompileBackSourceComposer
         var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, targetTypeDef, method));
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         string targetMethodName = Identifier(methodName);
+        bool isConstructor = methodName == ".ctor";
+        var primaryConstructor = isConstructor
+            ? PrimaryConstructorFromPrologue(reader, method, function, targetBody)
+            : null;
 
         var diagnostics = new List<CompileBackPlanningDiagnostic>();
         var targetRoot = TopLevelRootOf(reader, targetType);
@@ -371,17 +384,19 @@ public static class CompileBackSourceComposer
             new(
                 targetIdentity,
                 ShellKind(reader, targetTypeDef),
+                primaryConstructor?.FieldInitializers ??
                 [
                     new CompileBackMemberRequirement(
                         new CompileBackMethodIdentity(targetIdentity.FullName, targetMethodName, overload, signatureText),
-                        CompileBackMemberKind.Method,
+                        isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method,
                         method.Attributes.HasFlag(MethodAttributes.Static),
                         MethodParameters(reader, method, signature),
-                        CompileBackTypeSignature.Display(signature.ReturnType),
+                        isConstructor ? null : CompileBackTypeSignature.Display(signature.ReturnType),
                         CompileBackStubBodyKind.TargetBody,
                         targetBody,
-                        [new CompileBackFact("metadata", "target-method", reader.GetString(method.Name))])
+                        [new CompileBackFact("metadata", isConstructor ? "target-constructor" : "target-method", reader.GetString(method.Name))])
                 ],
+                primaryConstructor,
                 targetFacts)
         };
 
@@ -399,6 +414,7 @@ public static class CompileBackSourceComposer
                 dependencyIdentity,
                 ShellKind(reader, dependencyDef),
                 RequiredMembers: [],
+                PrimaryConstructor: null,
                 SourceFacts: closureFacts.TryGetValue(dependency, out var facts)
                     ? facts.ToArray()
                     : [new CompileBackFact("closure", "closure-root", dependencyIdentity.FullName)]));
@@ -514,7 +530,10 @@ public static class CompileBackSourceComposer
     static void WriteType(StringBuilder sb, CompileBackTypeDeclaration type, int indent)
     {
         string pad = new(' ', indent * 4);
-        sb.AppendLine($"{pad}{CSharpDeclarationWriter.RenderTypeDeclaration(ToApiType(type))}");
+        var declaration = CSharpDeclarationWriter.RenderTypeDeclaration(ToApiType(type));
+        if (type.PrimaryConstructorParameters is { Length: > 0 } parameters)
+            declaration = AddPrimaryConstructorParameters(declaration, parameters);
+        sb.AppendLine($"{pad}{declaration}");
         sb.AppendLine($"{pad}{{");
         foreach (var member in type.Members)
             WriteMember(sb, type, member, indent + 1);
@@ -533,6 +552,11 @@ public static class CompileBackSourceComposer
             if (member.StubBody == CompileBackStubBodyKind.TargetBody && member.TargetBody is { } initializer)
             {
                 sb.AppendLine($"{pad}public const {member.ReturnType?.DisplayName ?? "object"} {member.Name} = {initializer};");
+                return;
+            }
+            if (member.StubBody == CompileBackStubBodyKind.FieldInitializer && member.TargetBody is { } fieldInitializer)
+            {
+                sb.AppendLine($"{pad}public{staticText}{unsafeText} {member.ReturnType?.DisplayName ?? "object"} {member.Name} = {fieldInitializer};");
                 return;
             }
 
@@ -580,6 +604,19 @@ public static class CompileBackSourceComposer
                 sb.AppendLine($"{pad}}}");
                 break;
             case CompileBackMemberKind.Constructor:
+                if (member.StubBody == CompileBackStubBodyKind.TargetBody)
+                {
+                    sb.AppendLine($"{pad}{declaration}");
+                    sb.AppendLine($"{pad}{{");
+                    foreach (var line in member.Body.Split('\n'))
+                    {
+                        var text = line.TrimEnd('\r');
+                        if (text.Length > 0)
+                            sb.AppendLine($"{pad}    {text}");
+                    }
+                    sb.AppendLine($"{pad}}}");
+                    break;
+                }
                 sb.AppendLine($"{pad}{declaration} {{ throw null; }}");
                 break;
             case CompileBackMemberKind.Method:
@@ -672,6 +709,14 @@ public static class CompileBackSourceComposer
         return "unsafe " + declaration;
     }
 
+    static string AddPrimaryConstructorParameters(string declaration, string parameters)
+    {
+        int inheritance = declaration.IndexOf(" : ", StringComparison.Ordinal);
+        return inheritance >= 0
+            ? declaration[..inheritance] + $"({parameters})" + declaration[inheritance..]
+            : $"{declaration}({parameters})";
+    }
+
     static IReadOnlyList<CompileBackParameter> MethodParameters(
         MetadataReader reader,
         MethodDefinition method,
@@ -690,6 +735,188 @@ public static class CompileBackSourceComposer
                 Identifier(names.TryGetValue(index, out var name) && name.Length > 0 ? name : $"arg{index}"),
                 CompileBackTypeSignature.Display(type)))
             .ToArray();
+    }
+
+    static CompileBackPrimaryConstructor? PrimaryConstructorFromPrologue(
+        MetadataReader reader,
+        MethodDefinition method,
+        IrFunction function,
+        string renderedBody)
+    {
+        if (reader.GetString(method.Name) != ".ctor"
+            || method.Attributes.HasFlag(MethodAttributes.Static))
+            return null;
+        var declaringHandle = method.GetDeclaringType();
+        var declaringType = reader.GetTypeDefinition(declaringHandle);
+        if (CountInstanceConstructors(reader, declaringType) != 1
+            || HasInAssemblyDerivedType(reader, declaringHandle))
+            return null;
+        if (function.Body.Blocks is not [{ } entry, ..])
+            return null;
+
+        int? chainIndex = null;
+        for (int i = 0; i < entry.Children.Count; i++)
+        {
+            if (entry.Children[i] is ExpressionStatement
+                {
+                    Expression: Call { Callee: { Name: ".ctor", HasThis: true }, Arguments: [LoadArgument { Index: 0 }] }
+                })
+            {
+                chainIndex = i;
+                break;
+            }
+        }
+
+        if (chainIndex is not > 0)
+            return null;
+        if (entry.Children.Skip(chainIndex.Value + 1).Any(node => node is not Return))
+            return null;
+
+        var parameterNames = ParameterNames(reader, method);
+        if (parameterNames.Count == 0)
+            return null;
+
+        var fieldInitializers = new List<CompileBackMemberRequirement>();
+        var initializerTexts = new List<(string Field, string Value)>();
+        foreach (var node in entry.Children.Take(chainIndex.Value))
+        {
+            if (node is not StoreField
+                {
+                    HasInstance: true,
+                    Instance: LoadArgument { Index: 0 },
+                    Value: LoadArgument { Index: > 0 } value
+                } store)
+                return null;
+            if (!parameterNames.TryGetValue(value.Index - 1, out string? parameterName))
+                return null;
+            if (FindField(reader, declaringType, store.Field.Name) is not { } fieldHandle)
+                return null;
+
+            var field = reader.GetFieldDefinition(fieldHandle);
+            string fieldType;
+            try
+            {
+                fieldType = field.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, declaringType));
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return null;
+            }
+
+            string fieldName = AutoPropertyNameForBackingField(reader, declaringType, store.Field.Name)
+                ?? store.Field.Name;
+            initializerTexts.Add((fieldName, parameterName));
+            fieldInitializers.Add(new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(
+                    CompileBackTypeIdentity.FromDefinition(reader, declaringType).FullName,
+                    Identifier(fieldName),
+                    0,
+                    $"field {fieldType}"),
+                CompileBackMemberKind.Field,
+                field.Attributes.HasFlag(FieldAttributes.Static),
+                Parameters: [],
+                CompileBackTypeSignature.Display(fieldType),
+                CompileBackStubBodyKind.FieldInitializer,
+                parameterName,
+                [new CompileBackFact("metadata", "primary-constructor-field-initializer", fieldName)]));
+        }
+
+        if (fieldInitializers.Count == 0)
+            return null;
+        if (!RenderedBodyMatchesPrimaryConstructorInitializers(renderedBody, initializerTexts))
+            return null;
+
+        string parameters = string.Join(", ", MethodParameters(reader, method, method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, declaringType, method)))
+            .Select(parameter => $"{parameter.Type.DisplayName} {parameter.Name}"));
+        return new CompileBackPrimaryConstructor(parameters, fieldInitializers);
+    }
+
+    static Dictionary<int, string> ParameterNames(MetadataReader reader, MethodDefinition method)
+    {
+        var names = new Dictionary<int, string>();
+        foreach (var parameterHandle in method.GetParameters())
+        {
+            var parameter = reader.GetParameter(parameterHandle);
+            if (parameter.SequenceNumber >= 1)
+                names[parameter.SequenceNumber - 1] = Identifier(reader.GetString(parameter.Name));
+        }
+        return names;
+    }
+
+    static bool RenderedBodyMatchesPrimaryConstructorInitializers(
+        string renderedBody,
+        IReadOnlyList<(string Field, string Value)> initializers)
+    {
+        var lines = renderedBody
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(line => line.TrimEnd('\r'))
+            .Where(line => line.Length > 0)
+            .ToArray();
+        if (lines.Length != initializers.Count)
+            return false;
+
+        for (int i = 0; i < initializers.Count; i++)
+        {
+            var (field, value) = initializers[i];
+            string fieldName = Identifier(field);
+            string expectedBare = $"{fieldName} = {value};";
+            string expectedThis = $"this.{fieldName} = {value};";
+            if (lines[i] != expectedBare && lines[i] != expectedThis)
+                return false;
+        }
+        return true;
+    }
+
+    static FieldDefinitionHandle? FindField(MetadataReader reader, TypeDefinition typeDef, string name)
+    {
+        foreach (var fieldHandle in typeDef.GetFields())
+        {
+            if (reader.GetString(reader.GetFieldDefinition(fieldHandle).Name) == name)
+                return fieldHandle;
+        }
+        return null;
+    }
+
+    static string? AutoPropertyNameForBackingField(MetadataReader reader, TypeDefinition typeDef, string fieldName)
+    {
+        if (!fieldName.StartsWith('<', StringComparison.Ordinal) || !fieldName.EndsWith(">k__BackingField", StringComparison.Ordinal))
+            return null;
+
+        string propertyName = fieldName[1..^">k__BackingField".Length];
+        foreach (var propertyHandle in typeDef.GetProperties())
+        {
+            var property = reader.GetPropertyDefinition(propertyHandle);
+            if (reader.GetString(property.Name) == propertyName)
+                return propertyName;
+        }
+        return null;
+    }
+
+    static int CountInstanceConstructors(MetadataReader reader, TypeDefinition typeDef)
+    {
+        int count = 0;
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) == ".ctor"
+                && !method.Attributes.HasFlag(MethodAttributes.Static))
+                count++;
+        }
+        return count;
+    }
+
+    static bool HasInAssemblyDerivedType(MetadataReader reader, TypeDefinitionHandle baseHandle)
+    {
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            if (typeHandle == baseHandle)
+                continue;
+            var type = reader.GetTypeDefinition(typeHandle);
+            if (type.BaseType.Kind == HandleKind.TypeDefinition
+                && (TypeDefinitionHandle)type.BaseType == baseHandle)
+                return true;
+        }
+        return false;
     }
 
     static bool IsAutoProperty(
@@ -951,6 +1178,7 @@ public static class CompileBackSourceComposer
                     requirement.RequiredKind,
                     CompileBackAccessibility.Public,
                     BaseType: null,
+                    PrimaryConstructorParameters: requirement.PrimaryConstructor?.Parameters,
                     Interfaces: InterfaceSignatures(reader, typeDef),
                     members,
                     requirement.SourceFacts,
@@ -988,6 +1216,7 @@ public static class CompileBackSourceComposer
                     identity,
                     kind,
                     RequiredMembers: [],
+                    PrimaryConstructor: null,
                     SourceFacts: [new CompileBackFact("metadata", "nested-closure-type", identity.FullName)]);
                 var members = new List<CompileBackMemberDeclaration>();
                 if (includeMemberSurface)
@@ -997,6 +1226,7 @@ public static class CompileBackSourceComposer
                     kind,
                     CompileBackAccessibility.Public,
                     BaseType: null,
+                    PrimaryConstructorParameters: null,
                     Interfaces: InterfaceSignatures(reader, nestedDef),
                     members,
                     requirement.SourceFacts,
@@ -1124,14 +1354,21 @@ public static class CompileBackSourceComposer
                 bool isStatic = !accessor.IsNil && reader.GetMethodDefinition(accessor).Attributes.HasFlag(MethodAttributes.Static);
                 if (requirement.RequiredKind == CompileBackTypeKind.Interface && isStatic)
                     continue;
+                var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
+                bool isAutoProperty = !accessors.Getter.IsNil
+                    && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnType.DisplayName);
                 members.Add(new CompileBackMemberDeclaration(
                     new CompileBackMethodIdentity(requirement.Type.FullName, Identifier(propertyName), 0, $"property {signature.ReturnType}"),
                     CompileBackMemberKind.PropertyGet,
                     CompileBackAccessibility.Public,
                     isStatic,
-                    CompileBackTypeSignature.Display(signature.ReturnType),
+                    returnType,
                     Parameters: [],
-                    requirement.RequiredKind == CompileBackTypeKind.Interface ? CompileBackStubBodyKind.None : CompileBackStubBodyKind.Throw,
+                    requirement.RequiredKind == CompileBackTypeKind.Interface
+                        ? CompileBackStubBodyKind.None
+                        : isAutoProperty
+                            ? CompileBackStubBodyKind.AutoProperty
+                            : CompileBackStubBodyKind.Throw,
                     TargetBody: null,
                     [new CompileBackFact("metadata", "closure-property", propertyName)]));
             }
@@ -1198,6 +1435,7 @@ public static class CompileBackSourceComposer
             }
 
             if (requirement.RequiredKind == CompileBackTypeKind.Class
+                && requirement.PrimaryConstructor is null
                 && !members.Any(member => member.Kind == CompileBackMemberKind.Constructor && member.Parameters.Count == 0)
                 && !HasParameterlessInstanceConstructor(reader, typeDef))
             {

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -732,7 +732,6 @@ internal static class GeneratedFixtureRunner
         {
             var requestedTargets = fixtures
                 .SelectMany(fixture => fixture.Targets)
-                .Where(target => target.Method != ".ctor")
                 .Select(target => new ReturnToSender.RequestedTarget(target.Type, target.Method, target.Overload))
                 .Distinct()
                 .ToArray();
@@ -746,12 +745,6 @@ internal static class GeneratedFixtureRunner
             {
                 foreach (var target in fixture.Targets)
                 {
-                    if (target.Method == ".ctor")
-                    {
-                        results.Add(Skipped(fixture, target, "constructor-target"));
-                        continue;
-                    }
-
                     if (!rtsResults.TryGetValue(Key(target.Type, target.Method, target.Overload), out var actual))
                     {
                         results.Add(Skipped(fixture, target, "unsupported-rts-target"));

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -437,8 +437,6 @@ static class ReturnToSender
                 continue;
             }
 
-            if (target.Method == ".ctor")
-                continue;
             if (TryFindMethod(reader, typeDef, target.Method, target.Overload) is { } methodHandle)
                 results.Add(CompileBackMethodOrContextFail(assemblyPath, pe, reader, source, typeHandle, methodHandle));
         }
@@ -856,6 +854,7 @@ static class ReturnToSender
                     CompileBackTypeKind.Class,
                     CompileBackAccessibility.Public,
                     BaseType: null,
+                    PrimaryConstructorParameters: null,
                     Interfaces: [],
                     Members:
                     [


### PR DESCRIPTION
- Advances #2049 and #2050
- Changes RTS catalog coverage for constructor targets; product output is unchanged.
- Evidence revision: `4ecd380c`

## Change

> Should we accept this RTS compile-back coverage step?

**Conclusion:** **PASS** — constructors are no longer a default RTS catalog skip bucket, and the default generated fixture catalog now passes every RTS target.

Before:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 19 fixture(s), 40 target(s)

Fixtures:
  Passed : 19
  Skipped: 0
  Failed : 0

Targets:
  Passed : 21
  Skipped: 19
  Failed : 0

Skipped target reasons:
  constructor-target: 19
```

After:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 19 fixture(s), 40 target(s)

Fixtures:
  Passed : 19
  Skipped: 0
  Failed : 0

Targets:
  Passed : 40
  Skipped: 0
  Failed : 0
```

## Scope and safety

- **Root cause:** RTS catalog reported constructors as skipped. Enabling them exposed two source-shape buckets: get-only auto-property assignment and primary-constructor field-initializer prologue order.
- **Fix shape:** Product-side `CompileBackSourceComposer` now composes constructor target bodies, emits auto-property shells for closure properties, and models the safe primary-constructor field-initializer prologue as `class C(args)` plus initialized fields.
- **Product impact:** Compile-back source composition only; no shipped decompiler output behavior is intended to change.
- **Scope boundary:** The known `minimal.switch-two-case-lowers-if` compiler-lowering frontier remains an explicit `opcode-diff` when selected. Broader constructor shapes remain catalog-expandable future work.
- **RTS boundary:** RTS remains orchestration only: target selection, closure growth, Roslyn compile, opcode compare, and reporting. Product/shared code owns generated C# source/declarations.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Harness build | Pass |
| Focused RTS tests | `ReturnToSenderPrototypeTests` `26/26` passed |
| Focused generated fixture tests | `GeneratedFixtureCatalogTests` `8/8` passed |
| Decompiler fast suite | `1788/1788` passed with `-trait- "Speed=Slow"` |
| ReturnToSender A/B | `ILInspector.Decompiler.Tests.dll` `234 Same / 0 Worse / 0 CurrentMissing` |
| RTS catalog default | `19/19 fixtures`, `40/40 targets`, `0 skipped`, `0 failed` |
| RTS catalog with frontiers | `20 passed / 1 failed`, expected `minimal.switch-two-case-lowers-if` `opcode-diff` |
| Build-event validation | Not applicable |

### ReturnToSender catalog

Run: default generated fixture catalog.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 19 fixture(s), 40 target(s)

Fixtures:
  Passed : 19
  Skipped: 0
  Failed : 0

Targets:
  Passed : 40
  Skipped: 0
  Failed : 0
```

Run: `--return-to-sender-catalog minimal --max-examples 20`.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 21 fixture(s), 44 target(s)

Fixtures:
  Passed : 20
  Skipped: 0
  Failed : 1

Targets:
  Passed : 43
  Skipped: 0
  Failed : 1

Failed target buckets:
  opcode-diff: 1

Failed fixtures (first 1 of 1):
  minimal.switch-two-case-lowers-if
      GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1::Method1#0  rts=OpcodeDiff  bucket=opcode-diff
```

**RTS verdict:** **PASS** — constructor targets are now checked in the default catalog, and the only explicit selector failure is the known compiler-lowering frontier.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `minimal.switch-two-case-lowers-if` | Left as frontier | Known source/compiler-lowering opcode-diff frontier. |
| Generic primary-constructor target types | Guarded; not claimed | Product insertion bug was fixed, but RTS still skips generic target types today. |
| Wider constructor shapes | Future catalog work | This PR covers the measured default catalog constructor buckets. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Initial constructor-target review clean. |
| Gemini 3.1 Pro | Findings resolved, follow-up clean | Found primary-constructor `where` insertion and parameter-rendering concerns; fixed in `03d6c477`; follow-up reported no blocking findings. |

**Review conclusion:** **PASS** — all blocking/high-confidence review findings were resolved and follow-up review is clean.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet -p:NoWarn=NU1507
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog --max-examples 20
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog minimal --max-examples 20
```
