### PR TITLE
Model method generic signature constraints

### DIFF
--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -175,6 +175,7 @@ public class ApiSignature
     public string? ReturnType { get; set; }
     public string? MemberName { get; set; }
     public bool IsRequired { get; set; }
+    public List<TypeParameter> TypeParameters { get; set; } = [];
     public List<ApiParameter> Parameters { get; set; } = [];
     public List<ApiAccessor> Accessors { get; set; } = [];
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -97,64 +97,7 @@ public static class ApiSurfaceExtractor
             // Get type's generic context for resolving interface type parameters
             var typeContext = GenericContext.ForType(reader, typeDef);
 
-            // Get generic type parameters with constraints
-            var genericParams = typeDef.GetGenericParameters();
-            if (genericParams.Count > 0)
-            {
-                apiType.TypeParameters = [];
-                foreach (var paramHandle in genericParams)
-                {
-                    var param = reader.GetGenericParameter(paramHandle);
-                    var typeParam = new TypeParameter
-                    {
-                        Name = reader.GetString(param.Name)
-                    };
-
-                    // Get variance (only applies to interfaces and delegates)
-                    var attrs = param.Attributes;
-                    if ((attrs & GenericParameterAttributes.Covariant) != 0)
-                        typeParam.Variance = "out";
-                    else if ((attrs & GenericParameterAttributes.Contravariant) != 0)
-                        typeParam.Variance = "in";
-
-                    var nullable = GetEffectiveNullable(reader, param.GetCustomAttributes(), typeNullableContext);
-                    var hasReferenceTypeConstraint = (attrs & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
-                    var hasValueTypeConstraint = (attrs & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
-                    var hasDefaultConstructorConstraint = (attrs & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
-                    var isUnmanaged = AttributeReader.HasAttribute(reader, param.GetCustomAttributes(),
-                        KnownAttributeNames.IsUnmanagedAttribute);
-
-                    // Get primary constraints.
-                    if (hasReferenceTypeConstraint)
-                        typeParam.Constraints.Add(nullable == 2 ? "class?" : "class");
-                    else if (isUnmanaged)
-                        typeParam.Constraints.Add("unmanaged");
-                    else if (hasValueTypeConstraint)
-                        typeParam.Constraints.Add("struct");
-                    else if (nullable == 1)
-                        typeParam.Constraints.Add("notnull");
-
-                    // Get type constraints (interfaces and base class)
-                    foreach (var constraintHandle in param.GetConstraints())
-                    {
-                        var constraint = reader.GetGenericParameterConstraint(constraintHandle);
-                        string? constraintTypeName = TypeResolver.GetTypeName(reader, constraint.Type, typeContext);
-                        if (constraintTypeName != null)
-                        {
-                            // Skip System.ValueType (shown as 'struct' above) and System.Object
-                            if (constraintTypeName != "System.ValueType" && constraintTypeName != "System.Object")
-                                typeParam.Constraints.Add(FormatConstraintType(reader, constraint, constraintTypeName, typeNullableContext));
-                        }
-                    }
-
-                    if (hasDefaultConstructorConstraint && !hasValueTypeConstraint)
-                        typeParam.Constraints.Add("new()");
-                    if ((attrs & GenericParameterAttributes.AllowByRefLike) != 0)
-                        typeParam.Constraints.Add("allows ref struct");
-
-                    apiType.TypeParameters.Add(typeParam);
-                }
-            }
+            apiType.TypeParameters = GenericParameters(reader, typeDef.GetGenericParameters(), typeContext, typeNullableContext, includeVariance: true);
 
             // Get interfaces
             var interfaces = typeDef.GetInterfaceImplementations();
@@ -512,6 +455,69 @@ public static class ApiSurfaceExtractor
         return nullableContext != 0 ? nullableContext : null;
     }
 
+    private static List<TypeParameter> GenericParameters(
+        MetadataReader reader,
+        GenericParameterHandleCollection handles,
+        GenericContext context,
+        byte nullableContext,
+        bool includeVariance)
+    {
+        var parameters = new List<TypeParameter>();
+        foreach (var paramHandle in handles)
+        {
+            var param = reader.GetGenericParameter(paramHandle);
+            var typeParam = new TypeParameter
+            {
+                Name = reader.GetString(param.Name)
+            };
+
+            var attrs = param.Attributes;
+            if (includeVariance)
+            {
+                if ((attrs & GenericParameterAttributes.Covariant) != 0)
+                    typeParam.Variance = "out";
+                else if ((attrs & GenericParameterAttributes.Contravariant) != 0)
+                    typeParam.Variance = "in";
+            }
+
+            var nullable = GetEffectiveNullable(reader, param.GetCustomAttributes(), nullableContext);
+            var hasReferenceTypeConstraint = (attrs & GenericParameterAttributes.ReferenceTypeConstraint) != 0;
+            var hasValueTypeConstraint = (attrs & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
+            var hasDefaultConstructorConstraint = (attrs & GenericParameterAttributes.DefaultConstructorConstraint) != 0;
+            var isUnmanaged = AttributeReader.HasAttribute(reader, param.GetCustomAttributes(),
+                KnownAttributeNames.IsUnmanagedAttribute);
+
+            if (hasReferenceTypeConstraint)
+                typeParam.Constraints.Add(nullable == 2 ? "class?" : "class");
+            else if (isUnmanaged)
+                typeParam.Constraints.Add("unmanaged");
+            else if (hasValueTypeConstraint)
+                typeParam.Constraints.Add("struct");
+            else if (nullable == 1)
+                typeParam.Constraints.Add("notnull");
+
+            foreach (var constraintHandle in param.GetConstraints())
+            {
+                var constraint = reader.GetGenericParameterConstraint(constraintHandle);
+                string? constraintTypeName = TypeResolver.GetTypeName(reader, constraint.Type, context);
+                if (constraintTypeName is null)
+                    continue;
+                if (constraintTypeName is "System.ValueType" or "System.Object")
+                    continue;
+                typeParam.Constraints.Add(FormatConstraintType(reader, constraint, constraintTypeName, nullableContext));
+            }
+
+            if (hasDefaultConstructorConstraint && !hasValueTypeConstraint)
+                typeParam.Constraints.Add("new()");
+            if ((attrs & GenericParameterAttributes.AllowByRefLike) != 0)
+                typeParam.Constraints.Add("allows ref struct");
+
+            parameters.Add(typeParam);
+        }
+
+        return parameters;
+    }
+
     private static string FormatConstraintType(
         MetadataReader reader, GenericParameterConstraint constraint, string constraintTypeName, byte nullableContext)
     {
@@ -780,13 +786,15 @@ public static class ApiSurfaceExtractor
 
         string paramStr2 = string.Join(", ", parameters);
         var returnType = FormatMethodReturnType(reader, treeSignature.ReturnType, paramHandles);
+        var methodTypeParameters = GenericParameters(reader, method.GetGenericParameters(), context, nullableDefault, includeVariance: false);
         var methodName = context.MethodParameters.Count > 0
-            ? $"{name}<{string.Join(", ", context.MethodParameters)}>"
+            ? $"{name}<{string.Join(", ", methodTypeParameters.Select(parameter => parameter.Name))}>"
             : name;
         return ($"{returnType} {methodName}({paramStr2})", new ApiSignature
         {
             ReturnType = returnType,
             MemberName = methodName,
+            TypeParameters = methodTypeParameters,
             Parameters = parameterModels
         });
     }

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -195,7 +195,7 @@ public static class CSharpDeclarationWriter
 
         if (options.AbbreviateSignature)
             signature = AbbreviateSignature(signature);
-        signature = EscapeKnownIdentifiers(signature, type.TypeParameters.Select(p => p.Name));
+        signature = EscapeKnownIdentifiers(signature, type.TypeParameters.Concat(member.SignatureModel?.TypeParameters ?? []).Select(p => p.Name));
 
         if (member.Name == ".cctor")
         {
@@ -319,6 +319,10 @@ public static class CSharpDeclarationWriter
             foreach (var parameter in signatureModel.Parameters)
                 if (!string.IsNullOrWhiteSpace(parameter.Type))
                     yield return parameter.Type;
+            foreach (var typeParameter in signatureModel.TypeParameters)
+                foreach (var constraint in typeParameter.Constraints)
+                    foreach (var reference in ExtractQualifiedTypeNames(constraint))
+                        yield return reference;
         }
 
         var signature = member.Signature;
@@ -524,10 +528,11 @@ public static class CSharpDeclarationWriter
         if (member.Kind == "method"
             && methodParameters is not { Count: > 0 }
             && model.MemberName is { Length: > 0 } memberName
-            && !memberName.Contains('<', StringComparison.Ordinal)
             && model.ReturnType is { Length: > 0 } returnType)
         {
-            signature = $"{returnType} {memberName}({parameters})";
+            if (memberName.Contains('<', StringComparison.Ordinal) && model.TypeParameters.Count == 0)
+                return false;
+            signature = AppendTypeParameterConstraints($"{returnType} {memberName}({parameters})", model.TypeParameters);
             return true;
         }
         if (member.Kind == "property"
@@ -546,9 +551,9 @@ public static class CSharpDeclarationWriter
             return true;
         }
 
-        // Keep generic methods, extension projections, explicit implementations,
-        // operators, and events on compatibility text until the remaining
-        // declaration-level facts are represented in ApiSignature.
+        // Keep extension projections, explicit implementations, operators, and
+        // events on compatibility text until the remaining declaration-level
+        // facts are represented in ApiSignature.
         return false;
 
         static string ParameterDeclaration(ApiParameter parameter)

--- a/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
@@ -87,6 +87,56 @@ public sealed class CSharpDeclarationFormatterTests
     }
 
     [Fact]
+    public void MemberSignatureSection_CanRenderGenericMethodFromStructuredSignature()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "StructuredHost",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Map",
+                    Kind = "method",
+                    Signature = "BROKEN",
+                    SignatureModel = new ApiSignature
+                    {
+                        ReturnType = "TResult",
+                        MemberName = "Map<TSource, TResult>",
+                        TypeParameters =
+                        [
+                            new TypeParameter { Name = "TSource", Constraints = ["unmanaged"] },
+                            new TypeParameter { Name = "TResult", Constraints = ["System.IComparable<TResult>", "new()"] }
+                        ],
+                        Parameters =
+                        [
+                            new ApiParameter { Type = "TSource", Name = "source" }
+                        ]
+                    }
+                }
+            ]
+        };
+        var view = ApiOutputFormatter.BuildTypeView(
+            type,
+            foundIn: "Test.dll",
+            packageName: null,
+            packageVersion: null,
+            apiSource: "local",
+            selectedTfm: null,
+            new MemberOptions { OverloadIndex = 1 });
+
+        ApiOutputFormatter.PopulateMemberSignature(view, type, new MemberOptions { OverloadIndex = 1 });
+
+        Assert.Contains("Map", view.SignatureRows![0].Signature);
+        Assert.Contains("TSource", view.SignatureRows[0].Signature);
+        Assert.Contains("TResult", view.SignatureRows[0].Signature);
+        Assert.Contains("IComparable", view.SignatureRows[0].Signature);
+        Assert.DoesNotContain("BROKEN", view.SignatureRows[0].Signature);
+    }
+
+    [Fact]
     public void MemberSignatureSection_CanRenderPropertyFromStructuredSignature()
     {
         var type = new ApiType

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -111,6 +111,22 @@ public sealed class ApiSignatureModelTests
         Assert.Equal(
             "M:ILInspector.Metadata.Tests.ApiSignatureFixtures.GenericMethod<T>(T)",
             canonical);
+        Assert.Equal("T", source.SignatureModel!.TypeParameters.Single().Name);
+    }
+
+    [Fact]
+    public void MethodSignatureModel_ExposesGenericParameterConstraints()
+    {
+        var member = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.ConstrainedGenericMethod));
+
+        Assert.NotNull(member.SignatureModel);
+        Assert.Equal("ConstrainedGenericMethod<TSource, TResult>", member.SignatureModel.MemberName);
+        Assert.Equal("TResult", member.SignatureModel.ReturnType);
+        Assert.Equal(2, member.SignatureModel.TypeParameters.Count);
+        Assert.Equal("TSource", member.SignatureModel.TypeParameters[0].Name);
+        Assert.Equal(["unmanaged"], member.SignatureModel.TypeParameters[0].Constraints);
+        Assert.Equal("TResult", member.SignatureModel.TypeParameters[1].Name);
+        Assert.Equal(["notnull", "System.IComparable<TResult>", "new()"], member.SignatureModel.TypeParameters[1].Constraints);
     }
 
     [Fact]
@@ -367,6 +383,11 @@ public sealed class ApiSignatureFixtures
 
     public (TLeft Left, TRight Right) PairGenericMethod<TLeft, TRight>(TLeft left, TRight right)
         => (left, right);
+
+    public TResult ConstrainedGenericMethod<TSource, TResult>(TSource source)
+        where TSource : unmanaged
+        where TResult : IComparable<TResult>, new()
+        => new();
 
     public void Validate<TValidateOptions>()
     {

--- a/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
@@ -125,7 +125,49 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
-    public void GenericMethodDeclaration_KeepsCompatibilitySignature()
+    public void GenericMethodDeclaration_CanRenderFromStructuredSignatureModel()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Map",
+            Kind = "method",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "TResult",
+                MemberName = "Map<TSource, TResult>",
+                TypeParameters =
+                [
+                    new TypeParameter { Name = "TSource", Constraints = ["unmanaged"] },
+                    new TypeParameter { Name = "TResult", Constraints = ["System.IComparable<TResult>", "new()"] }
+                ],
+                Parameters =
+                [
+                    new ApiParameter { Type = "TSource", Name = "source" }
+                ]
+            }
+        };
+
+        var rendered = CSharpDeclarationWriter.RenderMemberUnit(
+            type,
+            member,
+            new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ShortWithUsings,
+                TerminateMemberDeclaration = true
+            });
+
+        Assert.Equal(
+            """
+            using System;
+
+            public TResult Map<TSource, TResult>(TSource source) where TSource : unmanaged where TResult : IComparable<TResult>, new();
+            """,
+            rendered.Source);
+    }
+
+    [Fact]
+    public void GenericMethodDeclaration_WithoutGenericParameterFactsKeepsCompatibilitySignature()
     {
         var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
         var member = new ApiMember


### PR DESCRIPTION
## Summary

Advances #2057 by modeling method generic parameters/constraints and using them for generic method declarations.

- Adds method-level `TypeParameters` to `ApiSignature`.
- Reuses the generic-parameter/constraint extraction logic for both type and method generic parameters.
- Includes method generic constraints in declaration-writer type-reference planning.
- Lets `CSharpDeclarationWriter` render generic methods from structured facts when the generic parameter facts are present.
- Keeps extension projections, explicit implementations, operators, and events on compatibility text.

## Validation

- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config -p:NoWarn=NU1507`
- `dotnet run --no-restore --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -class '*ApiSignatureModelTests' -class '*CSharpDeclarationWriterTests'`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507%3BCS0436 -- -class '*CSharpDeclarationFormatterTests'`
