### PR TITLE
Collapse nuspec discovery into parser service

### DIFF
--- a/src/DotnetInspector.Services.Tests/NuspecParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/NuspecParserTests.cs
@@ -313,4 +313,64 @@ public class NuspecParserTests : IDisposable
         Assert.Equal("NoNamespacePackage", result.PackageName);
         Assert.Equal("2.0.0", result.Version);
     }
+
+    [Fact]
+    public void FindNuspec_NoNuspecInPackageDirectory_ReturnsNull()
+    {
+        Assert.Null(NuspecParser.FindNuspec(_tempDir));
+    }
+
+    [Fact]
+    public void FindNuspec_NuspecInPackageDirectory_ReturnsPath()
+    {
+        var nuspec = WriteNuspec("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <package>
+              <metadata>
+                <id>FindMe</id>
+                <version>1.0.0</version>
+              </metadata>
+            </package>
+            """);
+
+        Assert.Equal(nuspec, NuspecParser.FindNuspec(_tempDir));
+    }
+
+    [Fact]
+    public void FindNuspec_NuspecOnlyInNestedDirectory_ReturnsNull()
+    {
+        var nestedDir = Path.Combine(_tempDir, "nested");
+        Directory.CreateDirectory(nestedDir);
+        File.WriteAllText(Path.Combine(nestedDir, "nested.nuspec"), """
+            <?xml version="1.0" encoding="utf-8"?>
+            <package>
+              <metadata>
+                <id>Nested</id>
+                <version>1.0.0</version>
+              </metadata>
+            </package>
+            """);
+
+        Assert.Null(NuspecParser.FindNuspec(_tempDir));
+    }
+
+    [Fact]
+    public void FindAndParse_NuspecInPackageDirectory_ParsesMetadata()
+    {
+        WriteNuspec("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <package>
+              <metadata>
+                <id>ParsedFromDirectory</id>
+                <version>2.3.4</version>
+              </metadata>
+            </package>
+            """);
+
+        var result = NuspecParser.FindAndParse(_tempDir);
+
+        Assert.NotNull(result);
+        Assert.Equal("ParsedFromDirectory", result.PackageName);
+        Assert.Equal("2.3.4", result.Version);
+    }
 }

--- a/src/DotnetInspector.Services/NuspecParser.cs
+++ b/src/DotnetInspector.Services/NuspecParser.cs
@@ -15,6 +15,24 @@ public static class NuspecParser
     public static NuspecData Parse(string nuspecPath) => ParseDocument(HardenedXml.LoadXDocument(nuspecPath));
 
     /// <summary>
+    /// Finds the first nuspec file directly under a package directory.
+    /// </summary>
+    public static string? FindNuspec(string packageDir)
+    {
+        var nuspecFiles = Directory.GetFiles(packageDir, "*.nuspec", SearchOption.TopDirectoryOnly);
+        return nuspecFiles.Length == 0 ? null : nuspecFiles[0];
+    }
+
+    /// <summary>
+    /// Finds and parses the first nuspec file directly under a package directory.
+    /// </summary>
+    public static NuspecData? FindAndParse(string packageDir)
+    {
+        var nuspecPath = FindNuspec(packageDir);
+        return nuspecPath == null ? null : Parse(nuspecPath);
+    }
+
+    /// <summary>
     /// Parses nuspec metadata from raw XML content (e.g. a nuspec fetched directly from a feed
     /// without downloading the full package).
     /// </summary>

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -1751,9 +1751,7 @@ public class LibraryCommand
 
     private static string? GetNuspecVersion(string extractPath)
     {
-        var nuspec = Directory.GetFiles(extractPath, "*.nuspec", SearchOption.TopDirectoryOnly)
-            .FirstOrDefault();
-        return nuspec == null ? null : NuspecParser.Parse(nuspec).Version;
+        return NuspecParser.FindAndParse(extractPath)?.Version;
     }
 
     private static void DeleteTempDir(string? tempDir)

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -339,10 +339,7 @@ public class PackageCommand
             }
 
             // Parse nuspec (needed for --readme and --dependencies early exits, and full inspection)
-            NuspecData? nuspec = null;
-            string[] nuspecFiles = Directory.GetFiles(extractPath, "*.nuspec", SearchOption.TopDirectoryOnly);
-            if (nuspecFiles.Length > 0)
-                nuspec = Services.NuspecParser.Parse(nuspecFiles[0]);
+            var nuspec = Services.NuspecParser.FindAndParse(extractPath);
 
             // Handle file content modes and exit early.
             if (options.ShowContent)
@@ -1143,10 +1140,7 @@ public class PackageCommand
             extractPath = resolution.ExtractPath;
             version = resolution.Version ?? version;
 
-            NuspecData? nuspec = null;
-            string[] nuspecFiles = Directory.GetFiles(extractPath, "*.nuspec", SearchOption.TopDirectoryOnly);
-            if (nuspecFiles.Length > 0)
-                nuspec = Services.NuspecParser.Parse(nuspecFiles[0]);
+            var nuspec = Services.NuspecParser.FindAndParse(extractPath);
 
             var packageId = nuspec?.PackageName ?? target.PackageName;
             var packageVersion = nuspec?.Version ?? version;
@@ -1201,10 +1195,7 @@ public class PackageCommand
             extractPath = resolution.ExtractPath;
             version = resolution.Version ?? version;
 
-            NuspecData? nuspec = null;
-            string[] nuspecFiles = Directory.GetFiles(extractPath, "*.nuspec", SearchOption.TopDirectoryOnly);
-            if (nuspecFiles.Length > 0)
-                nuspec = Services.NuspecParser.Parse(nuspecFiles[0]);
+            var nuspec = Services.NuspecParser.FindAndParse(extractPath);
 
             long? packageSize = null;
             if (resolution.NupkgPath != null && File.Exists(resolution.NupkgPath))

--- a/src/dotnet-inspect/Commands/ProjectCommand.cs
+++ b/src/dotnet-inspect/Commands/ProjectCommand.cs
@@ -660,10 +660,7 @@ public class ProjectCommand
 
     private static string? ReadDeclaredReadme(string packagePath)
     {
-        var nuspecFiles = Directory.GetFiles(packagePath, "*.nuspec", SearchOption.TopDirectoryOnly);
-        return nuspecFiles.Length == 0
-            ? null
-            : NuspecParser.Parse(nuspecFiles[0]).ReadmeFile;
+        return NuspecParser.FindAndParse(packagePath)?.ReadmeFile;
     }
 
     private static void WriteOutput(string output, string? outputPath)

--- a/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
+++ b/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
@@ -131,11 +131,10 @@ internal static class DependencyGraphService
 
             var version = extracted.Version ?? "";
 
-            string[] nuspecFiles = Directory.GetFiles(extracted.ExtractPath, "*.nuspec", SearchOption.TopDirectoryOnly);
-            if (nuspecFiles.Length == 0)
+            var nuspec = NuspecParser.FindAndParse(extracted.ExtractPath);
+            if (nuspec == null)
                 return new PackageDependencyGraphResult.Empty("No dependencies declared in package.");
 
-            var nuspec = NuspecParser.Parse(nuspecFiles[0]);
             if (nuspec.DependencyGroups is not { Count: > 0 })
                 return new PackageDependencyGraphResult.Empty("No dependencies declared in package.");
 


### PR DESCRIPTION
## Summary

- Adds shared `NuspecParser.FindNuspec` / `FindAndParse` helpers in `DotnetInspector.Services`.
- Routes the duplicated CLI nuspec discovery/parse call sites through the shared parser service.
- Adds focused tests for missing, top-level, nested-only, and parse-from-directory behavior.

Refs #2122.

## Validation

- `dotnet run --project src/DotnetInspector.Services.Tests -c Release --no-restore`
- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config`

## Review

Low-risk service deduplication slice; no decompiler/analysis behavior or heuristic changes, so adversarial review is not required by AGENTS.md.