### PR TITLE
Move SourceResolver type lookup into metadata

### DIFF
--- a/src/ILInspector.Metadata/AssemblyReader.cs
+++ b/src/ILInspector.Metadata/AssemblyReader.cs
@@ -55,6 +55,67 @@ public static class AssemblyReader
     }
 
     /// <summary>
+    /// Finds the unique public type matching a full, simple, or generic-aware type query.
+    /// Returns null when the assembly cannot be read, has no metadata, has no match,
+    /// or has multiple matches.
+    /// </summary>
+    public static string? FindUniquePublicType(string dllPath, string typeName)
+    {
+        try
+        {
+            using var stream = File.OpenRead(dllPath);
+            using var peReader = new PEReader(stream);
+
+            if (!peReader.HasMetadata)
+                return null;
+
+            return FindUniquePublicType(peReader.GetMetadataReader(), typeName);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? FindUniquePublicType(MetadataReader reader, string typeName)
+    {
+        var normalized = TypeMatcher.Normalize(typeName);
+
+        List<string> publicTypes = [];
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            if (!typeDef.IsPublic)
+                continue;
+
+            publicTypes.Add(reader.GetFullTypeName(typeDef));
+        }
+
+        var exactMatches = publicTypes.Where(fullName =>
+            fullName.Equals(normalized, StringComparison.OrdinalIgnoreCase)
+            || TypeMatcher.GetSimpleName(fullName).Equals(normalized, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (exactMatches.Count == 1)
+            return exactMatches[0];
+        if (exactMatches.Count > 1)
+            return null;
+
+        string? match = null;
+        foreach (var fullName in publicTypes)
+        {
+            if (!TypeMatcher.Matches(fullName, normalized))
+                continue;
+
+            if (match != null)
+                return null;
+
+            match = fullName;
+        }
+
+        return match;
+    }
+
+    /// <summary>
     /// Finds all types in an assembly that implement or extend the target type.
     /// </summary>
     public static IEnumerable<TypeRelationship> FindImplementers(string dllPath, string targetType, bool includeHidden = false)

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -1,5 +1,3 @@
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using DotnetInspector.CommandLine;
 using DotnetInspector.Core;
 using ILInspector.Metadata;
@@ -194,7 +192,7 @@ public static class SourceResolver
         if (assemblyPath == null || error != null)
             return null;
 
-        var match = FindUniquePublicType(assemblyPath, typeName);
+        var match = AssemblyReader.FindUniquePublicType(assemblyPath, typeName);
         return match != null
             ? new LocalProbeResult(CoreLibAssemblyName, match, LocalSourceKind.Platform)
             : null;
@@ -207,53 +205,6 @@ public static class SourceResolver
         return ILInspector.Metadata.PrimitiveTypeNames.TryToClrFullName(trimmed.ToLowerInvariant(), out var full)
             ? full
             : trimmed;
-    }
-
-    private static string? FindUniquePublicType(string assemblyPath, string typeName)
-    {
-        var normalized = ILInspector.Metadata.TypeMatcher.Normalize(typeName);
-
-        using var stream = File.OpenRead(assemblyPath);
-        using var peReader = new PEReader(stream);
-        if (!peReader.HasMetadata)
-            return null;
-
-        var reader = peReader.GetMetadataReader();
-        List<string> publicTypes = [];
-        foreach (var handle in reader.TypeDefinitions)
-        {
-            var typeDef = reader.GetTypeDefinition(handle);
-            if (!typeDef.IsPublic)
-                continue;
-
-            var name = reader.GetString(typeDef.Name);
-            var ns = reader.GetString(typeDef.Namespace);
-            var fullName = string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
-            publicTypes.Add(fullName);
-        }
-
-        var exactMatches = publicTypes.Where(fullName =>
-            fullName.Equals(normalized, StringComparison.OrdinalIgnoreCase)
-            || ILInspector.Metadata.TypeMatcher.GetSimpleName(fullName).Equals(normalized, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-        if (exactMatches.Count == 1)
-            return exactMatches[0];
-        if (exactMatches.Count > 1)
-            return null;
-
-        string? match = null;
-        foreach (var fullName in publicTypes)
-        {
-            if (!ILInspector.Metadata.TypeMatcher.Matches(fullName, normalized))
-                continue;
-
-            if (match != null)
-                return null;
-
-            match = fullName;
-        }
-
-        return match;
     }
 
     /// <summary>

--- a/tests/ILInspector.Metadata.Tests/AssemblyReaderTests.cs
+++ b/tests/ILInspector.Metadata.Tests/AssemblyReaderTests.cs
@@ -1,0 +1,64 @@
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests
+{
+    public sealed class AssemblyReaderTests
+    {
+        [Fact]
+        public void FindUniquePublicType_matches_simple_public_type_name()
+        {
+            var match = AssemblyReader.FindUniquePublicType(
+                typeof(PublicTypeLookupFixture).Assembly.Location,
+                nameof(PublicTypeLookupFixture));
+
+            Assert.Equal(typeof(PublicTypeLookupFixture).FullName, match);
+        }
+
+        [Fact]
+        public void FindUniquePublicType_matches_nested_public_type_name()
+        {
+            var match = AssemblyReader.FindUniquePublicType(
+                typeof(PublicTypeLookupFixture).Assembly.Location,
+                $"{nameof(PublicTypeLookupFixture)}.{nameof(PublicTypeLookupFixture.Nested)}");
+
+            Assert.Equal(typeof(PublicTypeLookupFixture.Nested).FullName!.Replace('+', '.'), match);
+        }
+
+        [Fact]
+        public void FindUniquePublicType_returns_null_for_non_public_type()
+        {
+            var match = AssemblyReader.FindUniquePublicType(
+                typeof(InternalTypeLookupFixture).Assembly.Location,
+                nameof(InternalTypeLookupFixture));
+
+            Assert.Null(match);
+        }
+
+        [Fact]
+        public void FindUniquePublicType_returns_null_for_ambiguous_simple_name()
+        {
+            var match = AssemblyReader.FindUniquePublicType(
+                typeof(PublicTypeLookupFixture).Assembly.Location,
+                "AmbiguousTypeLookupFixture");
+
+            Assert.Null(match);
+        }
+    }
+
+    public sealed class PublicTypeLookupFixture
+    {
+        public sealed class Nested;
+    }
+
+    internal sealed class InternalTypeLookupFixture;
+}
+
+namespace ILInspector.Metadata.Tests.AmbiguousOne
+{
+    public sealed class AmbiguousTypeLookupFixture;
+}
+
+namespace ILInspector.Metadata.Tests.AmbiguousTwo
+{
+    public sealed class AmbiguousTypeLookupFixture;
+}


### PR DESCRIPTION
## Summary
- add ILInspector.Metadata AssemblyReader.FindUniquePublicType for unique public type lookup
- route SourceResolver bare CoreLib type resolution through the metadata API instead of opening PE metadata in the CLI
- add metadata tests for exact, nested, non-public, and ambiguous lookup behavior

## Validation
- dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -class "*AssemblyReaderTests*"
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class "*SourceResolverTests*"
- dotnet build src/dotnet-inspect -c Release --configfile ./nuget.config --nologo --verbosity minimal

## Adversarial review
- Claude Opus 4.8: no blocking or high-confidence correctness issues; verified top-level behavior preservation, nested-type qualification improvement, and SRM-only layering.
- Gemini 3.1 Pro: no significant issues found.

Fixes part of #2122.
