### PR TITLE
Expand ReturnToSender generated fixture catalog coverage

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -124,6 +124,83 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.static-constructor",
+            "GeneratedFixtures.MinimalStaticConstructor.Class1",
+            ".cctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.static-constructor",
+            "GeneratedFixtures.MinimalStaticConstructor.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.static-constructor",
+            "GeneratedFixtures.MinimalStaticConstructor.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.interface-implementation",
+            "GeneratedFixtures.MinimalInterfaceImplementation.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.interface-implementation",
+            "GeneratedFixtures.MinimalInterfaceImplementation.Class1",
+            "GetValue",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.object-initializer",
+            "GeneratedFixtures.MinimalObjectInitializer.Helper",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.object-initializer",
+            "GeneratedFixtures.MinimalObjectInitializer.Helper",
+            "get_Value",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.object-initializer",
+            "GeneratedFixtures.MinimalObjectInitializer.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.object-initializer",
+            "GeneratedFixtures.MinimalObjectInitializer.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.collection-initializer",
+            "GeneratedFixtures.MinimalCollectionInitializer.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.collection-initializer",
+            "GeneratedFixtures.MinimalCollectionInitializer.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.if-else",
             "GeneratedFixtures.MinimalIfElse.Class1",
             ".ctor",
@@ -176,6 +253,20 @@ public class GeneratedFixtureCatalogTests
             "minimal.array-length",
             "GeneratedFixtures.MinimalArrayLength.Class1",
             "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.indexer.getter",
+            "GeneratedFixtures.MinimalIndexerGetter.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.indexer.getter",
+            "GeneratedFixtures.MinimalIndexerGetter.Class1",
+            "get_Item",
             FidelityCheck.CompileBackStatus.Exact,
             frontier: false);
         AssertTarget(
@@ -310,10 +401,15 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.auto-property.getter", report);
         Assert.Contains("minimal.method-call.same-type", report);
         Assert.Contains("minimal.static-method-call", report);
+        Assert.Contains("minimal.static-constructor", report);
+        Assert.Contains("minimal.interface-implementation", report);
+        Assert.Contains("minimal.object-initializer", report);
+        Assert.Contains("minimal.collection-initializer", report);
         Assert.Contains("minimal.if-else", report);
         Assert.Contains("minimal.integer-addition", report);
         Assert.Contains("minimal.array-index", report);
         Assert.Contains("minimal.array-length", report);
+        Assert.Contains("minimal.indexer.getter", report);
         Assert.Contains("minimal.string-length", report);
         Assert.Contains("minimal.null-coalesce", report);
         Assert.Contains("minimal.try-finally", report);
@@ -355,17 +451,22 @@ public class GeneratedFixtureCatalogTests
                 "minimal.array-index",
                 "minimal.array-length",
                 "minimal.auto-property.getter",
+                "minimal.collection-initializer",
                 "minimal.conditional-expression-shape-frontier",
                 "minimal.ctor-field.getter",
                 "minimal.do-while",
                 "minimal.for-loop",
                 "minimal.foreach-array",
                 "minimal.if-else",
+                "minimal.indexer.getter",
                 "minimal.integer-addition",
+                "minimal.interface-implementation",
                 "minimal.method-call.same-type",
                 "minimal.null-coalesce",
+                "minimal.object-initializer",
                 "minimal.primary-ctor.field-init",
                 "minimal.property.literal",
+                "minimal.static-constructor",
                 "minimal.static-method-call",
                 "minimal.string-length",
                 "minimal.switch-int",
@@ -397,10 +498,15 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.conditional-expression-shape-frontier");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.method-call.same-type");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.static-method-call");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.static-constructor");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.interface-implementation");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.object-initializer");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.collection-initializer");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.integer-addition");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-index");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-length");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.indexer.getter");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.string-length");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.null-coalesce");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.try-finally");

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -218,6 +218,7 @@ public enum CompileBackStubBodyKind
     Throw,
     TargetBody,
     AutoProperty,
+    AutoPropertyGetSet,
     FieldInitializer,
 }
 
@@ -265,7 +266,9 @@ public static class CompileBackSourceComposer
     {
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var property = reader.GetPropertyDefinition(targetProperty);
+        var getter = reader.GetMethodDefinition(targetGetter);
         var signature = property.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, targetTypeDef));
+        var getterSignature = getter.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, targetTypeDef, getter));
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         string propertyName = Identifier(reader.GetString(property.Name));
         var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
@@ -289,8 +292,8 @@ public static class CompileBackSourceComposer
                     new CompileBackMemberRequirement(
                         new CompileBackMethodIdentity(targetIdentity.FullName, propertyName, overload, signatureText),
                         CompileBackMemberKind.PropertyGet,
-                        reader.GetMethodDefinition(targetGetter).Attributes.HasFlag(MethodAttributes.Static),
-                        [],
+                        getter.Attributes.HasFlag(MethodAttributes.Static),
+                        MethodParameters(reader, getter, getterSignature),
                         returnType,
                         targetIsAutoProperty ? CompileBackStubBodyKind.AutoProperty : CompileBackStubBodyKind.TargetBody,
                         targetIsAutoProperty ? null : targetBody,
@@ -365,7 +368,7 @@ public static class CompileBackSourceComposer
         var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, targetTypeDef, method));
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         string targetMethodName = Identifier(methodName);
-        bool isConstructor = methodName == ".ctor";
+        bool isConstructor = methodName is ".ctor" or ".cctor";
         var primaryConstructor = isConstructor
             ? PrimaryConstructorFromPrologue(reader, method, function, targetBody)
             : null;
@@ -582,7 +585,13 @@ public static class CompileBackSourceComposer
                     sb.AppendLine($"{pad}{declaration} {{ get; }}");
                     break;
                 }
+                if (member.StubBody == CompileBackStubBodyKind.AutoPropertyGetSet)
+                {
+                    sb.AppendLine($"{pad}{declaration} {{ get; set; }}");
+                    break;
+                }
 
+                declaration = StripPropertyAccessorBlock(declaration);
                 sb.AppendLine($"{pad}{declaration}");
                 sb.AppendLine($"{pad}{{");
                 sb.AppendLine($"{pad}    get");
@@ -679,6 +688,7 @@ public static class CompileBackSourceComposer
             ReturnType = returnType,
             Signature = member.Kind switch
             {
+                CompileBackMemberKind.PropertyGet when member.Parameters.Count > 0 => $"{returnType ?? "void"} this[{parameterList}] {{ get; }}",
                 CompileBackMemberKind.PropertyGet when type.Kind == CompileBackTypeKind.Interface => $"{returnType ?? "void"} {member.Name} {{ get; }}",
                 CompileBackMemberKind.PropertyGet => $"{returnType ?? "void"} {member.Name}",
                 CompileBackMemberKind.Constructor => $"void .ctor({parameterList})",
@@ -718,6 +728,14 @@ public static class CompileBackSourceComposer
         return inheritance >= 0
             ? head[..inheritance] + $"({parameters})" + head[inheritance..] + tail
             : $"{head}({parameters}){tail}";
+    }
+
+    static string StripPropertyAccessorBlock(string declaration)
+    {
+        const string getOnly = " { get; }";
+        return declaration.EndsWith(getOnly, StringComparison.Ordinal)
+            ? declaration[..^getOnly.Length]
+            : declaration;
     }
 
     static IReadOnlyList<CompileBackParameter> MethodParameters(
@@ -1363,6 +1381,7 @@ public static class CompileBackSourceComposer
                 var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
                 bool isAutoProperty = !accessors.Getter.IsNil
                     && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnType.DisplayName);
+                bool hasSetter = !accessors.Setter.IsNil;
                 members.Add(new CompileBackMemberDeclaration(
                     new CompileBackMethodIdentity(requirement.Type.FullName, Identifier(propertyName), 0, $"property {signature.ReturnType}"),
                     CompileBackMemberKind.PropertyGet,
@@ -1372,9 +1391,11 @@ public static class CompileBackSourceComposer
                     Parameters: [],
                     requirement.RequiredKind == CompileBackTypeKind.Interface
                         ? CompileBackStubBodyKind.None
-                        : isAutoProperty
-                            ? CompileBackStubBodyKind.AutoProperty
-                            : CompileBackStubBodyKind.Throw,
+                        : hasSetter
+                            ? CompileBackStubBodyKind.AutoPropertyGetSet
+                            : isAutoProperty
+                                ? CompileBackStubBodyKind.AutoProperty
+                                : CompileBackStubBodyKind.Throw,
                     TargetBody: null,
                     [new CompileBackFact("metadata", "closure-property", propertyName)]));
             }

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -152,6 +152,102 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "static", "method-call"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalStaticConstructor = new(
+        "minimal.static-constructor",
+        """
+        namespace GeneratedFixtures.MinimalStaticConstructor;
+
+        public class Class1
+        {
+            private static int s_value;
+
+            static Class1()
+            {
+                s_value = 42;
+            }
+
+            public static int Method1() => s_value;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalStaticConstructor.Class1", ".cctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalStaticConstructor.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalStaticConstructor.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "static", "constructor", "field"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalInterfaceImplementation = new(
+        "minimal.interface-implementation",
+        """
+        namespace GeneratedFixtures.MinimalInterfaceImplementation;
+
+        public interface IValue
+        {
+            int GetValue();
+        }
+
+        public class Class1 : IValue
+        {
+            public int GetValue() => 42;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalInterfaceImplementation.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalInterfaceImplementation.Class1", "GetValue",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "interface", "implementation"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalObjectInitializer = new(
+        "minimal.object-initializer",
+        """
+        namespace GeneratedFixtures.MinimalObjectInitializer;
+
+        public class Helper
+        {
+            public int Value { get; set; }
+        }
+
+        public class Class1
+        {
+            public Helper Method1(int value) => new Helper { Value = value };
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalObjectInitializer.Helper", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalObjectInitializer.Helper", "get_Value",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalObjectInitializer.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalObjectInitializer.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "object-initializer", "property", "setter"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalCollectionInitializer = new(
+        "minimal.collection-initializer",
+        """
+        namespace GeneratedFixtures.MinimalCollectionInitializer;
+
+        public class Class1
+        {
+            public System.Collections.Generic.List<int> Method1(int value)
+                => new System.Collections.Generic.List<int> { value };
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalCollectionInitializer.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalCollectionInitializer.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "collection", "initializer", "generic"]);
+
     public static readonly GeneratedFixtureDefinition MinimalIfElse = new(
         "minimal.if-else",
         """
@@ -231,6 +327,24 @@ internal static class GeneratedFixtureCatalog
                 ExpectedShape: SyntaxKind.SimpleMemberAccessExpression),
         ],
         ["minimal", "array", "length"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalIndexerGetter = new(
+        "minimal.indexer.getter",
+        """
+        namespace GeneratedFixtures.MinimalIndexerGetter;
+
+        public class Class1
+        {
+            public int this[int index] => index + 1;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalIndexerGetter.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalIndexerGetter.Class1", "get_Item",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "indexer", "property"]);
 
     public static readonly GeneratedFixtureDefinition MinimalStringLength = new(
         "minimal.string-length",
@@ -529,10 +643,15 @@ internal static class GeneratedFixtureCatalog
         MinimalAutoPropertyGetter,
         MinimalMethodCallSameType,
         MinimalStaticMethodCall,
+        MinimalStaticConstructor,
+        MinimalInterfaceImplementation,
+        MinimalObjectInitializer,
+        MinimalCollectionInitializer,
         MinimalIfElse,
         MinimalIntegerAddition,
         MinimalArrayIndex,
         MinimalArrayLength,
+        MinimalIndexerGetter,
         MinimalStringLength,
         MinimalNullCoalesce,
         MinimalTryFinally,


### PR DESCRIPTION
- Advances #2049 and #2050
- Changes RTS generated-fixture catalog coverage; product output is unchanged.
- Evidence revision: `68f2ee6b`

## Change

> Should we accept this RTS catalog coverage slice?

**Conclusion:** **PASS** — the default generated fixture catalog grows to 24 fixtures / 53 RTS targets with no skips or failures.

Before:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 19 fixture(s), 40 target(s)

Fixtures:
  Passed : 19
  Skipped: 0
  Failed : 0

Targets:
  Passed : 40
  Skipped: 0
  Failed : 0
```

After:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 24 fixture(s), 53 target(s)

Fixtures:
  Passed : 24
  Skipped: 0
  Failed : 0

Targets:
  Passed : 53
  Skipped: 0
  Failed : 0
```

## Scope and safety

- **Root cause:** After constructor support, the default catalog had no active frontier; the next useful step was broadening catalog shapes and fixing the first measured declaration/body issues.
- **Fix shape:** Add generated fixtures for indexer getter, static constructor, interface implementation, object initializer, and collection initializer. Product-side `CompileBackSourceComposer` now handles indexer getter declarations, static constructor target classification, and settable closure-property shells.
- **Product impact:** Compile-back source composition only; no shipped decompiler output behavior is intended to change.
- **Scope boundary:** The known `minimal.switch-two-case-lowers-if` frontier remains an explicit `opcode-diff` when selected.
- **RTS boundary:** RTS remains orchestration only; product/shared code owns generated C# declarations/source.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Harness build | Pass |
| Focused generated fixture tests | `GeneratedFixtureCatalogTests` `8/8` passed |
| Focused RTS tests | `ReturnToSenderPrototypeTests` `26/26` passed |
| Decompiler fast suite | `1788/1788` passed with `-trait- "Speed=Slow"` |
| ReturnToSender A/B | `ILInspector.Decompiler.Tests.dll` `234 Same / 0 Worse / 0 CurrentMissing` |
| RTS catalog default | `24/24 fixtures`, `53/53 targets`, `0 skipped`, `0 failed` |
| RTS catalog with frontiers | `25 passed / 1 failed`, expected `minimal.switch-two-case-lowers-if` `opcode-diff` |
| Build-event validation | Not applicable |

### ReturnToSender catalog

Run: default generated fixture catalog.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 24 fixture(s), 53 target(s)

Fixtures:
  Passed : 24
  Skipped: 0
  Failed : 0

Targets:
  Passed : 53
  Skipped: 0
  Failed : 0
```

Run: `--return-to-sender-catalog minimal --max-examples 30`.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 26 fixture(s), 57 target(s)

Fixtures:
  Passed : 25
  Skipped: 0
  Failed : 1

Targets:
  Passed : 56
  Skipped: 0
  Failed : 1

Failed target buckets:
  opcode-diff: 1

Failed fixtures (first 1 of 1):
  minimal.switch-two-case-lowers-if
      GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1::Method1#0  rts=OpcodeDiff  bucket=opcode-diff
```

**RTS verdict:** **PASS** — the default catalog expands without introducing skips/failures, and explicit frontier selection still reports the known opcode-diff bucket.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `minimal.switch-two-case-lowers-if` | Left as frontier | Known source/compiler-lowering opcode-diff frontier. |
| Setter targets | Not added as RTS targets | Object initializer exercises setter binding through closure surface; direct setter target support remains future work. |
| Wider generic/indexer setter shapes | Future catalog work | This PR covers the measured indexer getter and settable closure-property bucket. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Static review traced indexer, static constructor, setter surface, catalog expectations, and boundary. |
| Gemini 3.1 Pro | No blocking findings | Confirmed generated C# validity and RTS/product boundary. |

**Review conclusion:** **PASS** — both adversarial reviews reported no blocking or high-confidence issues.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet -p:NoWarn=NU1507
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog --max-examples 30
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog minimal --max-examples 30
```
