### PR TITLE
Render event declarations from ApiSignature

### DIFF
--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -550,10 +550,21 @@ public static class CSharpDeclarationWriter
             signature = $"{head} {propertyMemberName} {{ {string.Join(" ", model.Accessors.Select(AccessorDeclaration))} }}";
             return true;
         }
+        if (member.Kind == "event"
+            && model.ReturnType is { Length: > 0 } eventType
+            && IsOrdinaryPropertyName(member.Name)
+            && IsOrdinaryPropertyName(model.MemberName))
+        {
+            var eventMemberName = string.IsNullOrWhiteSpace(model.MemberName)
+                ? member.Name
+                : model.MemberName!;
+            signature = $"{eventType} {eventMemberName}";
+            return true;
+        }
 
         // Keep extension projections, explicit implementations, operators, and
-        // events on compatibility text until the remaining declaration-level
-        // facts are represented in ApiSignature.
+        // unsupported event shapes on compatibility text until the remaining
+        // declaration-level facts are represented in ApiSignature.
         return false;
 
         static string ParameterDeclaration(ApiParameter parameter)

--- a/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
@@ -182,6 +182,45 @@ public sealed class CSharpDeclarationFormatterTests
     }
 
     [Fact]
+    public void MemberSignatureSection_CanRenderEventFromStructuredSignature()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "StructuredHost",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Changed",
+                    Kind = "event",
+                    Signature = "BROKEN",
+                    SignatureModel = new ApiSignature
+                    {
+                        ReturnType = "System.EventHandler",
+                        MemberName = "Changed"
+                    }
+                }
+            ]
+        };
+        var view = ApiOutputFormatter.BuildTypeView(
+            type,
+            foundIn: "Test.dll",
+            packageName: null,
+            packageVersion: null,
+            apiSource: "local",
+            selectedTfm: null,
+            new MemberOptions { OverloadIndex = 1 });
+
+        ApiOutputFormatter.PopulateMemberSignature(view, type, new MemberOptions { OverloadIndex = 1 });
+
+        Assert.Contains("event System.EventHandler", view.SignatureRows![0].Signature);
+        Assert.Contains("Changed", view.SignatureRows[0].Signature);
+        Assert.DoesNotContain("BROKEN", view.SignatureRows[0].Signature);
+    }
+
+    [Fact]
     public void ConstructorOverloadSnippet_UsesStructuredDefaultValueText()
     {
         var type = new ApiType

--- a/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
@@ -362,6 +362,80 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void EventDeclaration_CanRenderFromStructuredSignatureModel()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Changed",
+            Kind = "event",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.EventHandler",
+                MemberName = "Changed"
+            }
+        };
+
+        var rendered = CSharpDeclarationWriter.RenderMemberUnit(
+            type,
+            member,
+            new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ShortWithUsings,
+                TerminateMemberDeclaration = true
+            });
+
+        Assert.Equal(
+            """
+            using System;
+
+            public event EventHandler Changed;
+            """,
+            rendered.Source);
+    }
+
+    [Fact]
+    public void EventDeclaration_EscapesStructuredKeywordMemberName()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "event",
+            Kind = "event",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.EventHandler",
+                MemberName = "event"
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("public event System.EventHandler @event", declaration);
+    }
+
+    [Fact]
+    public void ExplicitEventDeclaration_KeepsCompatibilitySignature()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "ITest.Changed",
+            Kind = "event",
+            Signature = "System.EventHandler ITest.Changed",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "System.EventHandler",
+                MemberName = "ITest.Changed"
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("public event System.EventHandler ITest.Changed", declaration);
+    }
+
+    [Fact]
     public void ShortWithUsings_KeepsCollidingSimpleNamesQualified()
     {
         var type = new ApiType


### PR DESCRIPTION
## Summary
- render ordinary event declarations from ApiSignature in CSharpDeclarationWriter
- keep explicit/unsupported dotted event shapes on compatibility text
- add writer and CLI signature-section coverage for structured event rendering

## Validation
- dotnet build src/dotnet-inspect -c Release --configfile nuget.config -p:NoWarn=NU1507
- dotnet build tests/ILInspector.Metadata.Tests -c Release --configfile nuget.config -p:NoWarn=NU1507%3BCS0436
- dotnet run --no-build --no-restore --project tests/ILInspector.Metadata.Tests -c Release -- -class '*CSharpDeclarationWriterTests'
- dotnet build src/dotnet-inspect.Tests -c Release --configfile nuget.config -p:NoWarn=NU1507%3BCS0436
- dotnet run --no-build --no-restore --project src/dotnet-inspect.Tests -c Release -- -class '*CSharpDeclarationFormatterTests'

Adversarial review pending.