### PR TITLE
Extract DotnetToolSettings.xml parsing into a service (#2122)

### DIFF
--- a/src/DotnetInspector.Services.Tests/DotnetToolSettingsParserTests.cs
+++ b/src/DotnetInspector.Services.Tests/DotnetToolSettingsParserTests.cs
@@ -1,0 +1,181 @@
+namespace DotnetInspector.Services.Tests;
+
+public class DotnetToolSettingsParserTests
+{
+    [Fact]
+    public void ParseContent_Version2_IsRidSpecificPointerWithCommandsAndRidPackages()
+    {
+        const string xml = """
+            <DotNetCliTool Version="2">
+              <Commands>
+                <Command Name="mytool" EntryPoint="mytool.dll" Runner="dotnet" />
+              </Commands>
+              <RuntimeIdentifierPackages>
+                <RuntimeIdentifierPackage RuntimeIdentifier="win-x64" Id="MyTool.win-x64" />
+                <RuntimeIdentifierPackage RuntimeIdentifier="linux-x64" Id="MyTool.linux-x64" />
+              </RuntimeIdentifierPackages>
+            </DotNetCliTool>
+            """;
+
+        var settings = DotnetToolSettingsParser.ParseContent(xml);
+
+        Assert.NotNull(settings);
+        Assert.Equal("2", settings!.Version);
+        Assert.True(settings.IsRidSpecificPointerPackage);
+        Assert.Equal(["mytool"], settings.Commands);
+        Assert.NotNull(settings.RuntimeIdentifierPackages);
+        Assert.Collection(settings.RuntimeIdentifierPackages!,
+            r => { Assert.Equal("win-x64", r.RuntimeIdentifier); Assert.Equal("MyTool.win-x64", r.PackageId); },
+            r => { Assert.Equal("linux-x64", r.RuntimeIdentifier); Assert.Equal("MyTool.linux-x64", r.PackageId); });
+    }
+
+    [Fact]
+    public void ParseContent_Version1_IsPortableWithNoRidPackages()
+    {
+        const string xml = """
+            <DotNetCliTool Version="1">
+              <Commands>
+                <Command Name="portabletool" EntryPoint="portabletool.dll" Runner="dotnet" />
+              </Commands>
+            </DotNetCliTool>
+            """;
+
+        var settings = DotnetToolSettingsParser.ParseContent(xml);
+
+        Assert.NotNull(settings);
+        Assert.Equal("1", settings!.Version);
+        Assert.False(settings.IsRidSpecificPointerPackage);
+        Assert.Equal(["portabletool"], settings.Commands);
+        Assert.Null(settings.RuntimeIdentifierPackages);
+    }
+
+    [Fact]
+    public void ParseContent_NoVersionAttribute_TreatedAsPortable()
+    {
+        const string xml = """
+            <DotNetCliTool>
+              <Commands>
+                <Command Name="legacy" />
+              </Commands>
+            </DotNetCliTool>
+            """;
+
+        var settings = DotnetToolSettingsParser.ParseContent(xml);
+
+        Assert.NotNull(settings);
+        Assert.Null(settings!.Version);
+        Assert.False(settings.IsRidSpecificPointerPackage);
+        Assert.Equal(["legacy"], settings.Commands);
+    }
+
+    [Fact]
+    public void ParseContent_UnrecognizedVersion_ReturnsNull()
+    {
+        const string xml = """<DotNetCliTool Version="99" />""";
+
+        Assert.Null(DotnetToolSettingsParser.ParseContent(xml));
+    }
+
+    [Fact]
+    public void ParseContent_MalformedXml_ReturnsNullWithoutThrowing()
+    {
+        Assert.Null(DotnetToolSettingsParser.ParseContent("<DotNetCliTool Version=\"2\"><Commands>"));
+    }
+
+    [Fact]
+    public void FindSettings_LocatesFileAtRootOneAndTwoLevelsDeep()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"tool-settings-{Guid.NewGuid():N}");
+        try
+        {
+            // root level
+            Directory.CreateDirectory(root);
+            var atRoot = Path.Combine(root, "DotnetToolSettings.xml");
+            File.WriteAllText(atRoot, "<DotNetCliTool Version=\"1\" />");
+            Assert.Equal(atRoot, DotnetToolSettingsParser.FindSettings(root));
+
+            // one level deep (tools/{tfm}/)
+            var root1 = Path.Combine(Path.GetTempPath(), $"tool-settings-{Guid.NewGuid():N}");
+            var tfmDir = Path.Combine(root1, "net8.0");
+            Directory.CreateDirectory(tfmDir);
+            var atLevel1 = Path.Combine(tfmDir, "DotnetToolSettings.xml");
+            File.WriteAllText(atLevel1, "<DotNetCliTool Version=\"1\" />");
+            Assert.Equal(atLevel1, DotnetToolSettingsParser.FindSettings(root1));
+
+            // two levels deep (tools/{tfm}/{rid}/)
+            var root2 = Path.Combine(Path.GetTempPath(), $"tool-settings-{Guid.NewGuid():N}");
+            var ridDir = Path.Combine(root2, "net8.0", "any");
+            Directory.CreateDirectory(ridDir);
+            var atLevel2 = Path.Combine(ridDir, "DotnetToolSettings.xml");
+            File.WriteAllText(atLevel2, "<DotNetCliTool Version=\"1\" />");
+            Assert.Equal(atLevel2, DotnetToolSettingsParser.FindSettings(root2));
+
+            Directory.Delete(root1, recursive: true);
+            Directory.Delete(root2, recursive: true);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FindSettings_NotPresent_ReturnsNull()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"tool-settings-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(root, "net8.0"));
+        try
+        {
+            Assert.Null(DotnetToolSettingsParser.FindSettings(root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FindAndParse_EndToEnd_ReturnsParsedSettings()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"tool-settings-{Guid.NewGuid():N}");
+        var tfmDir = Path.Combine(root, "net8.0");
+        Directory.CreateDirectory(tfmDir);
+        File.WriteAllText(Path.Combine(tfmDir, "DotnetToolSettings.xml"), """
+            <DotNetCliTool Version="2">
+              <Commands><Command Name="mytool" /></Commands>
+              <RuntimeIdentifierPackages>
+                <RuntimeIdentifierPackage RuntimeIdentifier="win-x64" Id="MyTool.win-x64" />
+              </RuntimeIdentifierPackages>
+            </DotNetCliTool>
+            """);
+        try
+        {
+            var settings = DotnetToolSettingsParser.FindAndParse(root);
+
+            Assert.NotNull(settings);
+            Assert.True(settings!.IsRidSpecificPointerPackage);
+            Assert.Equal(["mytool"], settings.Commands);
+            Assert.Single(settings.RuntimeIdentifierPackages!);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void FindAndParse_NoManifest_ReturnsNull()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"tool-settings-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        try
+        {
+            Assert.Null(DotnetToolSettingsParser.FindAndParse(root));
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/src/DotnetInspector.Services/DotnetToolSettingsData.cs
+++ b/src/DotnetInspector.Services/DotnetToolSettingsData.cs
@@ -1,0 +1,16 @@
+namespace DotnetInspector.Services;
+
+/// <summary>
+/// A RID-specific payload package referenced by a <c>DotnetToolSettings.xml</c> v2 manifest.
+/// </summary>
+public sealed record ToolRidPackage(string RuntimeIdentifier, string PackageId);
+
+/// <summary>
+/// Parsed contents of a NuGet tool package's <c>DotnetToolSettings.xml</c> manifest.
+/// </summary>
+public sealed record DotnetToolSettingsData(
+    string? Version,
+    string? ToolFormat,
+    bool IsRidSpecificPointerPackage,
+    IReadOnlyList<string>? Commands,
+    IReadOnlyList<ToolRidPackage>? RuntimeIdentifierPackages);

--- a/src/DotnetInspector.Services/DotnetToolSettingsParser.cs
+++ b/src/DotnetInspector.Services/DotnetToolSettingsParser.cs
@@ -1,0 +1,133 @@
+using System.Xml.Linq;
+using DotnetInspector.Core;
+
+namespace DotnetInspector.Services;
+
+/// <summary>
+/// Locates and parses a NuGet tool package's <c>DotnetToolSettings.xml</c> manifest.
+/// Sibling to <see cref="NuspecParser"/> / <c>DepsJsonParser</c>: the CLI orchestration
+/// layer maps the returned data onto its own inspection models.
+/// </summary>
+public static class DotnetToolSettingsParser
+{
+    private const string SettingsFileName = "DotnetToolSettings.xml";
+
+    /// <summary>
+    /// Searches for <c>DotnetToolSettings.xml</c> at the root of <paramref name="toolsDir"/>
+    /// or up to two levels deep (<c>tools/</c>, <c>tools/{tfm}/</c>, <c>tools/{tfm}/{rid}/</c>).
+    /// Returns the manifest path, or <see langword="null"/> if none is found.
+    /// </summary>
+    public static string? FindSettings(string toolsDir)
+    {
+        var path = Path.Combine(toolsDir, SettingsFileName);
+        if (File.Exists(path))
+            return path;
+
+        foreach (var level1 in Directory.GetDirectories(toolsDir))
+        {
+            path = Path.Combine(level1, SettingsFileName);
+            if (File.Exists(path))
+                return path;
+
+            foreach (var level2 in Directory.GetDirectories(level1))
+            {
+                path = Path.Combine(level2, SettingsFileName);
+                if (File.Exists(path))
+                    return path;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Locates and parses the manifest under <paramref name="toolsDir"/>, or
+    /// <see langword="null"/> if none is found or it cannot be parsed.
+    /// </summary>
+    public static DotnetToolSettingsData? FindAndParse(string toolsDir)
+    {
+        var settingsFile = FindSettings(toolsDir);
+        return settingsFile == null ? null : Parse(settingsFile);
+    }
+
+    /// <summary>
+    /// Parses a <c>DotnetToolSettings.xml</c> file, or <see langword="null"/> on error or an
+    /// unrecognized manifest version.
+    /// </summary>
+    public static DotnetToolSettingsData? Parse(string settingsFile)
+    {
+        try
+        {
+            return ParseDocument(HardenedXml.LoadXDocument(settingsFile));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Parses <c>DotnetToolSettings.xml</c> from raw XML content, or <see langword="null"/> on
+    /// error or an unrecognized manifest version.
+    /// </summary>
+    public static DotnetToolSettingsData? ParseContent(string xml)
+    {
+        try
+        {
+            return ParseDocument(HardenedXml.ParseXDocument(xml));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static DotnetToolSettingsData? ParseDocument(XDocument doc)
+    {
+        var root = doc.Root;
+        var version = root?.Attribute("Version")?.Value;
+
+        return version switch
+        {
+            "2" => new DotnetToolSettingsData(
+                version,
+                "DotNetCliTool Version=\"2\" (RID-specific)",
+                IsRidSpecificPointerPackage: true,
+                ParseCommands(root),
+                ParseRidPackages(root)),
+            "1" or null => new DotnetToolSettingsData(
+                version,
+                "DotNetCliTool Version=\"1\" (portable)",
+                IsRidSpecificPointerPackage: false,
+                ParseCommands(root),
+                RuntimeIdentifierPackages: null),
+            _ => null,
+        };
+    }
+
+    private static List<string>? ParseCommands(XElement? root)
+    {
+        var commands = root?.Element("Commands")?.Elements("Command");
+        if (commands == null)
+            return null;
+
+        return commands
+            .Select(c => c.Attribute("Name")?.Value)
+            .Where(n => n != null)
+            .Cast<string>()
+            .ToList();
+    }
+
+    private static List<ToolRidPackage>? ParseRidPackages(XElement? root)
+    {
+        var ridPackages = root?.Element("RuntimeIdentifierPackages")?.Elements("RuntimeIdentifierPackage");
+        if (ridPackages == null)
+            return null;
+
+        return ridPackages
+            .Select(r => new ToolRidPackage(
+                r.Attribute("RuntimeIdentifier")?.Value ?? "",
+                r.Attribute("Id")?.Value ?? ""))
+            .ToList();
+    }
+}

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -1702,7 +1702,7 @@ public class LibraryCommand
         var toolsDir = Path.Combine(extractPath, "tools");
         if (Directory.Exists(toolsDir))
         {
-            var settings = ToolsAnalyzer.ReadToolSettings(toolsDir);
+            var settings = DotnetToolSettingsParser.FindAndParse(toolsDir);
             var anyPayload = settings?.RuntimeIdentifierPackages?
                 .FirstOrDefault(r => r.RuntimeIdentifier.Equals("any", StringComparison.OrdinalIgnoreCase));
             if (!string.IsNullOrWhiteSpace(anyPayload?.PackageId))

--- a/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
+++ b/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
@@ -9,18 +9,11 @@ namespace DotnetInspector.Inspectors;
 /// </summary>
 public static class ToolsAnalyzer
 {
-    public sealed record ToolSettings(
-        string? Version,
-        string? ToolFormat,
-        bool IsRidSpecificPointerPackage,
-        List<string>? Commands,
-        List<RidPackageReference>? RuntimeIdentifierPackages);
-
     public static void AnalyzeToolsDirectory(string toolsDir, InspectionResult result)
     {
         // Check for DotnetToolSettings.xml: root, one level deep, or two levels deep
         // Standard locations: tools/, tools/{tfm}/, or tools/{tfm}/{rid}/
-        var settings = ReadToolSettings(toolsDir);
+        var settings = DotnetToolSettingsParser.FindAndParse(toolsDir);
         if (settings != null)
         {
             ApplyToolSettings(settings, result);
@@ -149,117 +142,26 @@ public static class ToolsAnalyzer
     }
 
     /// <summary>
-    /// Searches for DotnetToolSettings.xml up to 2 levels deep in tools/.
+    /// Applies parsed tool-settings manifest data onto the inspection result.
     /// </summary>
-    private static string? FindSettingsFile(string toolsDir)
-    {
-        const string fileName = "DotnetToolSettings.xml";
-        var path = Path.Combine(toolsDir, fileName);
-        if (File.Exists(path)) return path;
-
-        foreach (var level1 in Directory.GetDirectories(toolsDir))
-        {
-            path = Path.Combine(level1, fileName);
-            if (File.Exists(path)) return path;
-
-            foreach (var level2 in Directory.GetDirectories(level1))
-            {
-                path = Path.Combine(level2, fileName);
-                if (File.Exists(path)) return path;
-            }
-        }
-
-        return null;
-    }
-
-    public static ToolSettings? ReadToolSettings(string toolsDir)
-    {
-        var settingsFile = FindSettingsFile(toolsDir);
-        return settingsFile == null ? null : ParseToolSettings(settingsFile);
-    }
-
-    private static ToolSettings? ParseToolSettings(string settingsFile)
-    {
-        try
-        {
-            var doc = DotnetInspector.Core.HardenedXml.LoadXDocument(settingsFile);
-            var root = doc.Root;
-
-            string? version = root?.Attribute("Version")?.Value;
-            if (version == "2")
-            {
-                var commands = root?.Element("Commands")?.Elements("Command");
-                List<string>? commandNames = null;
-                if (commands != null)
-                {
-                    commandNames = commands
-                        .Select(c => c.Attribute("Name")?.Value)
-                        .Where(n => n != null)
-                        .Cast<string>()
-                        .ToList();
-                }
-
-                var ridPackages = root?.Element("RuntimeIdentifierPackages")?.Elements("RuntimeIdentifierPackage");
-                List<RidPackageReference>? runtimeIdentifierPackages = null;
-                if (ridPackages != null)
-                {
-                    runtimeIdentifierPackages = ridPackages
-                        .Select(r => new RidPackageReference
-                        {
-                            RuntimeIdentifier = r.Attribute("RuntimeIdentifier")?.Value ?? "",
-                            PackageId = r.Attribute("Id")?.Value ?? ""
-                        })
-                        .ToList();
-                }
-
-                return new ToolSettings(
-                    version,
-                    "DotNetCliTool Version=\"2\" (RID-specific)",
-                    IsRidSpecificPointerPackage: true,
-                    commandNames,
-                    runtimeIdentifierPackages);
-            }
-            else if (version == "1" || version == null)
-            {
-                var commands = root?.Element("Commands")?.Elements("Command");
-                List<string>? commandNames = null;
-                if (commands != null)
-                {
-                    commandNames = commands
-                        .Select(c => c.Attribute("Name")?.Value)
-                        .Where(n => n != null)
-                        .Cast<string>()
-                        .ToList();
-                }
-
-                return new ToolSettings(
-                    version,
-                    "DotNetCliTool Version=\"1\" (portable)",
-                    IsRidSpecificPointerPackage: false,
-                    commandNames,
-                    RuntimeIdentifierPackages: null);
-            }
-        }
-        catch
-        {
-            // Ignore parse errors
-        }
-
-        return null;
-    }
-
-    private static void ApplyToolSettings(ToolSettings settings, InspectionResult result)
+    private static void ApplyToolSettings(DotnetToolSettingsData settings, InspectionResult result)
     {
         result.ManifestVersion = settings.Version;
         result.ToolFormat = settings.ToolFormat;
-        result.ToolCommands = settings.Commands;
+        result.ToolCommands = settings.Commands?.ToList();
 
         if (settings.IsRidSpecificPointerPackage)
         {
             result.IsRidSpecificPointerPackage = true;
             result.IsFrameworkDependent = false;
             result.HasRidSpecificAssets = true;
-            result.RuntimeIdentifierPackages = settings.RuntimeIdentifierPackages;
+            result.RuntimeIdentifierPackages = settings.RuntimeIdentifierPackages?
+                .Select(r => new RidPackageReference
+                {
+                    RuntimeIdentifier = r.RuntimeIdentifier,
+                    PackageId = r.PackageId
+                })
+                .ToList();
             result.SupportedRids = settings.RuntimeIdentifierPackages?
                 .Select(r => r.RuntimeIdentifier)
                 .ToList();


### PR DESCRIPTION
## Summary

Slice of #2122 (thin out the CLI layer). `ToolsAnalyzer` hand-parsed
`DotnetToolSettings.xml` inline — locate up to two levels deep, XML parse, and
version/command/RID-package extraction — a package-structure parser with **no service**,
unlike its siblings `NuspecParser` and `DepsJsonParser`.

## Changes

- New `DotnetInspector.Services.DotnetToolSettingsParser`: `FindSettings` /
  `Parse` / `ParseContent` / `FindAndParse`, returning a Services-owned
  `DotnetToolSettingsData` (with `ToolRidPackage`). Mirrors `NuspecParser`'s shape and uses
  the shared `HardenedXml` loader.
- `ToolsAnalyzer` keeps only the directory-structure analysis and maps the parsed data onto
  its CLI models (`InspectionResult`, `RidPackageReference`). ~110 lines of parsing removed.
- `LibraryCommand`'s tool-payload lookup routes through the service (the one external caller
  of the removed `ReadToolSettings`).

Services can't depend on the CLI `Models` project, so the parser returns Services-side types
and the CLI maps them — same pattern as `NuspecData`.

## Behavior preservation

`ToolFormat` strings, version handling (v2 → RID-specific pointer, v1/null → portable,
other → null), and command/RID-package extraction are unchanged.

## Validation

- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507` — 0 warnings.
- `dotnet run --project src/DotnetInspector.Services.Tests -c Release -p:NoWarn=NU1507` —
  187/187 (incl. 9 new `DotnetToolSettingsParser` tests).
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -class DotnetInspector.Tests.ToolsAnalyzerTests` —
  14/14 (unchanged; the behavior-preservation regression gate).

## Adversarial review

Per `AGENTS.md`: two reviewers requested (below). Low/med risk, behavior-preserving move.

Part of #2122.
