### PR TITLE
Move union type scanning into metadata

### DIFF
--- a/src/ILInspector.Metadata/UnionTypeScanner.cs
+++ b/src/ILInspector.Metadata/UnionTypeScanner.cs
@@ -1,0 +1,93 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata;
+
+public record UnionTypeInfo(
+    string TypeName,
+    string Kind,
+    bool ImplementsIUnion,
+    List<string> CaseTypes);
+
+/// <summary>
+/// Scans assemblies for C# union-shaped types.
+/// </summary>
+public static class UnionTypeScanner
+{
+    private const string IUnionTypeName = "System.Runtime.CompilerServices.IUnion";
+
+    public static List<UnionTypeInfo> Scan(PEReader peReader)
+    {
+        if (!peReader.HasMetadata)
+            return [];
+
+        var reader = peReader.GetMetadataReader();
+        List<UnionTypeInfo> results = [];
+
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            if (!AttributeReader.HasAttribute(reader, typeDef.GetCustomAttributes(), KnownAttributeNames.UnionAttribute))
+                continue;
+
+            var context = GenericContext.ForType(reader, typeDef);
+            results.Add(new UnionTypeInfo(
+                reader.GetFullTypeName(typeDef),
+                GetTypeKind(reader, typeDef),
+                ImplementsIUnion(reader, typeDef, context),
+                GetUnionCaseTypes(reader, typeDef).ToList()));
+        }
+
+        return results;
+    }
+
+    private static bool ImplementsIUnion(MetadataReader reader, TypeDefinition typeDef, GenericContext context)
+    {
+        foreach (var interfaceHandle in typeDef.GetInterfaceImplementations())
+        {
+            var iface = reader.GetInterfaceImplementation(interfaceHandle);
+            if (TypeResolver.GetTypeName(reader, iface.Interface, context) == IUnionTypeName)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> GetUnionCaseTypes(MetadataReader reader, TypeDefinition typeDef)
+    {
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != ".ctor")
+                continue;
+            if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
+                continue;
+            if ((method.Attributes & MethodAttributes.Static) != 0)
+                continue;
+
+            MethodSignature<string> signature;
+            try
+            {
+                signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (signature.ParameterTypes.Length == 1)
+                yield return signature.ParameterTypes[0];
+        }
+    }
+
+    private static string GetTypeKind(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var attrs = typeDef.Attributes;
+        if ((attrs & TypeAttributes.Interface) != 0)
+            return "interface";
+        if (TypeResolver.GetTypeName(reader, typeDef.BaseType) == "System.ValueType")
+            return "struct";
+        return "class";
+    }
+}

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -2,7 +2,6 @@ using DotnetInspector.Core;
 using DotnetInspector.Models;
 using System.Globalization;
 using System.Reflection;
-using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using DotnetInspector.Inspectors;
 using ILInspector.Metadata;
@@ -1231,84 +1230,22 @@ internal static class LibraryMetadataService
     {
         try
         {
-            var reader = peReader.GetMetadataReader();
-            var results = new List<UnionTypeSummary>();
-
-            foreach (var typeHandle in reader.TypeDefinitions)
-            {
-                var typeDef = reader.GetTypeDefinition(typeHandle);
-                if (!AttributeReader.HasAttribute(reader, typeDef.GetCustomAttributes(), KnownAttributeNames.UnionAttribute))
-                    continue;
-
-                var context = GenericContext.ForType(reader, typeDef);
-                bool implementsIUnion = ImplementsIUnion(reader, typeDef, context);
-                var caseTypes = UnionCaseTypes(reader, typeDef).ToList();
-
-                results.Add(new UnionTypeSummary
+            var results = UnionTypeScanner.Scan(peReader);
+            return results.Count == 0
+                ? null
+                : results.Select(t => new UnionTypeSummary
                 {
-                    TypeName = reader.GetFullTypeName(typeDef),
-                    Kind = TypeKind(reader, typeDef),
-                    ImplementsIUnion = implementsIUnion,
-                    CaseTypes = caseTypes
-                });
-            }
-
-            return results.Count == 0 ? null : results;
+                    TypeName = t.TypeName,
+                    Kind = t.Kind,
+                    ImplementsIUnion = t.ImplementsIUnion,
+                    CaseTypes = t.CaseTypes.ToList()
+                }).ToList();
         }
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning union types in {path}: {ex.Message}");
             return null;
         }
-    }
-
-    static bool ImplementsIUnion(MetadataReader reader, TypeDefinition typeDef, GenericContext context)
-    {
-        foreach (var interfaceHandle in typeDef.GetInterfaceImplementations())
-        {
-            var iface = reader.GetInterfaceImplementation(interfaceHandle);
-            if (TypeResolver.GetTypeName(reader, iface.Interface, context) == "System.Runtime.CompilerServices.IUnion")
-                return true;
-        }
-
-        return false;
-    }
-
-    static IEnumerable<string> UnionCaseTypes(MetadataReader reader, TypeDefinition typeDef)
-    {
-        foreach (var methodHandle in typeDef.GetMethods())
-        {
-            var method = reader.GetMethodDefinition(methodHandle);
-            if (reader.GetString(method.Name) != ".ctor")
-                continue;
-            if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
-                continue;
-            if ((method.Attributes & MethodAttributes.Static) != 0)
-                continue;
-
-            MethodSignature<string> signature;
-            try
-            {
-                signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
-            }
-            catch
-            {
-                continue;
-            }
-
-            if (signature.ParameterTypes.Length == 1)
-                yield return signature.ParameterTypes[0];
-        }
-    }
-
-    static string TypeKind(MetadataReader reader, TypeDefinition typeDef)
-    {
-        var attrs = typeDef.Attributes;
-        if ((attrs & TypeAttributes.Interface) != 0)
-            return "interface";
-        if (TypeResolver.GetTypeName(reader, typeDef.BaseType) == "System.ValueType")
-            return "struct";
-        return "class";
     }
 
     /// <summary>

--- a/tests/ILInspector.Metadata.Tests/UnionTypeScannerTests.cs
+++ b/tests/ILInspector.Metadata.Tests/UnionTypeScannerTests.cs
@@ -1,0 +1,61 @@
+using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+public sealed class UnionTypeScannerTests
+{
+    [Fact]
+    public void Scan_finds_union_attribute_types_and_cases()
+    {
+        using var stream = File.OpenRead(typeof(MetadataUnionFixture).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var union = Assert.Single(
+            UnionTypeScanner.Scan(peReader),
+            t => t.TypeName == typeof(MetadataUnionFixture).FullName);
+
+        Assert.Equal("struct", union.Kind);
+        Assert.True(union.ImplementsIUnion);
+        Assert.Equal(
+            [typeof(MetadataUnionCat).FullName!, typeof(MetadataUnionDog).FullName!],
+            union.CaseTypes);
+    }
+
+    [Fact]
+    public void Scan_keeps_union_attribute_lookalike_but_marks_missing_iunion()
+    {
+        using var stream = File.OpenRead(typeof(MetadataUnionLookalike).Assembly.Location);
+        using var peReader = new PEReader(stream);
+
+        var union = Assert.Single(
+            UnionTypeScanner.Scan(peReader),
+            t => t.TypeName == typeof(MetadataUnionLookalike).FullName);
+
+        Assert.Equal("class", union.Kind);
+        Assert.False(union.ImplementsIUnion);
+        Assert.Equal([typeof(MetadataUnionCat).FullName!], union.CaseTypes);
+    }
+}
+
+public sealed class MetadataUnionCat;
+public sealed class MetadataUnionDog;
+
+[Union]
+public readonly struct MetadataUnionFixture : IUnion
+{
+    public MetadataUnionFixture(MetadataUnionCat value) => Value = value;
+    public MetadataUnionFixture(MetadataUnionDog value) => Value = value;
+    private MetadataUnionFixture(string ignored) => Value = ignored;
+
+    public object? Value { get; }
+}
+
+[Union]
+public sealed class MetadataUnionLookalike
+{
+    public MetadataUnionLookalike(MetadataUnionCat value) => Value = value;
+
+    public object? Value { get; }
+}


### PR DESCRIPTION
## Summary
- add ILInspector.Metadata UnionTypeScanner for union attribute, IUnion, kind, and case-type detection
- route LibraryMetadataService union section scanning through the shared metadata scanner
- add focused metadata tests for real IUnion-backed unions and union-shaped non-IUnion types

## Validation
- dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -class "*UnionTypeScannerTests*"
- dotnet run --project src/dotnet-inspect.Tests -c Release -- -class "*UnionTypesSectionTests*"
- dotnet build src/dotnet-inspect -c Release --configfile ./nuget.config --nologo --verbosity minimal

## Adversarial review
- Claude Opus 4.8: no significant issues found; verified behavior preservation, empty/null contract, SRM-only layering, additive API shape, and test coverage.
- Gemini 3.1 Pro: no significant issues found; verified the refactor preserves type resolution/signature decoding/context behavior and remains NativeAOT/Roslyn-free.

Fixes part of #2122.
