### PR TITLE
Model parameter attributes in ApiSignature

### DIFF
--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -193,6 +193,7 @@ public class ApiSignature
 
 public class ApiParameter
 {
+    public List<string> Attributes { get; set; } = [];
     public string Name { get; set; } = "";
     public string Type { get; set; } = "";
     public string? Modifier { get; set; }
@@ -207,12 +208,16 @@ public class ApiParameter
     {
         get
         {
+            var attributes = Attributes.Count == 0
+                ? ""
+                : $"[{string.Join(", ", Attributes)}] ";
             var head = string.IsNullOrWhiteSpace(Name)
                 ? TypeWithModifier
                 : $"{TypeWithModifier} {Name}";
-            return HasDefault && DefaultValueText is { Length: > 0 }
+            var declaration = HasDefault && DefaultValueText is { Length: > 0 }
                 ? $"{head} = {DefaultValueText}"
                 : head;
+            return attributes + declaration;
         }
     }
 }

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -749,7 +749,7 @@ public static class ApiSurfaceExtractor
 
             // Parameter handles may include return parameter at SequenceNumber 0
             // Actual parameters have SequenceNumber 1, 2, 3...
-            var (paramName, isParams, refKind, hasDefault, defaultValue) = GetParameterInfo(reader, paramHandles, i + 1);
+            var (paramName, isParams, refKind, hasDefault, defaultValue, attributes) = GetParameterInfo(reader, paramHandles, i + 1);
             paramName ??= $"arg{i}";
 
             var isByRef = type.StartsWith("ref ", StringComparison.Ordinal);
@@ -776,6 +776,7 @@ public static class ApiSurfaceExtractor
             parameters.Add(paramStr);
             parameterModels.Add(new ApiParameter
             {
+                Attributes = attributes,
                 Name = paramName,
                 Type = type,
                 Modifier = modifier,
@@ -829,7 +830,7 @@ public static class ApiSurfaceExtractor
         => AttributeReader.HasAttribute(reader, attributes, KnownAttributeNames.IsReadOnlyAttribute)
             || AttributeReader.HasAttribute(reader, attributes, "System.Runtime.CompilerServices.RequiresLocationAttribute");
 
-    private static (string? name, bool isParams, string? refKind, bool hasDefault, object? defaultValue) GetParameterInfo(
+    private static (string? name, bool isParams, string? refKind, bool hasDefault, object? defaultValue, List<string> attributes) GetParameterInfo(
         MetadataReader reader, ParameterHandleCollection handles, int sequenceNumber)
     {
         foreach (var handle in handles)
@@ -840,6 +841,7 @@ public static class ApiSurfaceExtractor
                 string name = reader.GetString(param.Name);
                 var attributes = param.GetCustomAttributes();
                 bool isParams = AttributeReader.HasAttribute(reader, attributes, "System.ParamArrayAttribute");
+                var renderedAttributes = AttributeReader.RenderParameterAttributes(reader, handle);
                 string? refKind = (param.Attributes & System.Reflection.ParameterAttributes.Out) != 0
                     ? "out"
                     : (param.Attributes & System.Reflection.ParameterAttributes.In) != 0
@@ -864,11 +866,11 @@ public static class ApiSurfaceExtractor
                     }
                 }
 
-                return (name, isParams, refKind, hasDefault, defaultValue);
+                return (name, isParams, refKind, hasDefault, defaultValue, renderedAttributes);
             }
         }
 
-        return (null, false, null, false, null);
+        return (null, false, null, false, null, []);
     }
 
     private sealed record DateTimeConstantDefault(long Ticks);
@@ -1335,7 +1337,7 @@ public static class ApiSurfaceExtractor
             pos = 0;
             paramTypes[i].ApplyNullability(paramBytes, ref pos, typeNullableContext);
             var paramType = paramTypes[i].Render();
-            var (paramName, isParams, refKind, hasDefault, defaultValue) = GetParameterInfo(reader, paramHandles, i + 1);
+            var (paramName, isParams, refKind, hasDefault, defaultValue, attributes) = GetParameterInfo(reader, paramHandles, i + 1);
             paramName ??= $"arg{i}";
 
             var isByRef = paramType.StartsWith("ref ", StringComparison.Ordinal);
@@ -1361,6 +1363,7 @@ public static class ApiSurfaceExtractor
             indexerParameters.Add(parameter);
             parameterModels.Add(new ApiParameter
             {
+                Attributes = attributes,
                 Name = paramName,
                 Type = paramType,
                 Modifier = modifier,

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -840,7 +840,8 @@ public static class ApiSurfaceExtractor
             {
                 string name = reader.GetString(param.Name);
                 var attributes = param.GetCustomAttributes();
-                bool isParams = AttributeReader.HasAttribute(reader, attributes, "System.ParamArrayAttribute");
+                bool isParams = AttributeReader.HasAttribute(reader, attributes, "System.ParamArrayAttribute")
+                    || AttributeReader.HasAttribute(reader, attributes, KnownAttributeNames.ParamCollectionAttribute);
                 var renderedAttributes = AttributeReader.RenderParameterAttributes(reader, handle);
                 string? refKind = (param.Attributes & System.Reflection.ParameterAttributes.Out) != 0
                     ? "out"

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -527,6 +527,7 @@ public static class AttributeReader
     static bool IsParameterSyntaxAttribute(string name) => name switch
     {
         "System.ParamArrayAttribute" => true,
+        KnownAttributeNames.ParamCollectionAttribute => true,
         KnownAttributeNames.DecimalConstantAttribute => true,
         KnownAttributeNames.DateTimeConstantAttribute => true,
         _ => false,

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -391,9 +391,15 @@ public static class AttributeReader
     }
 
     static string GetQualifiedAttributeName(string fullName)
-        => fullName.EndsWith("Attribute", StringComparison.Ordinal)
-            ? fullName[..^9]
-            : fullName;
+    {
+        if (!fullName.EndsWith("Attribute", StringComparison.Ordinal))
+            return fullName;
+
+        var trimmed = fullName[..^9];
+        return trimmed.Length == 0 || trimmed.EndsWith('.', StringComparison.Ordinal)
+            ? fullName
+            : trimmed;
+    }
 
     /// <summary>Renders one attribute-argument value, or null when its shape is not faithfully spellable (arrays, unknown).</summary>
     static string? RenderArgument(string type, object? value) => value switch
@@ -404,7 +410,7 @@ public static class AttributeReader
         _ when type == "System.Type" && value is string typeName => RenderTypeArgument(typeName),
         string s => "\"" + EscapeStringLiteral(s) + "\"",
         bool b => b ? "true" : "false",
-        char c => $"'{c}'",
+        char c => $"'{EscapeCharLiteral(c)}'",
         // A primitive keyword type came from the provider; render the literal.
         _ when type is "byte" or "sbyte" or "short" or "ushort" or "int" or "uint" or "double" => value.ToString(),
         _ when type == "long" => value + "L",
@@ -424,27 +430,72 @@ public static class AttributeReader
         return $"typeof({typeName.Replace('+', '.')})";
     }
 
+    static string EscapeCharLiteral(char value) => value switch
+    {
+        '\\' => "\\\\",
+        '\'' => "\\'",
+        '\0' => "\\0",
+        '\a' => "\\a",
+        '\b' => "\\b",
+        '\f' => "\\f",
+        '\n' => "\\n",
+        '\r' => "\\r",
+        '\t' => "\\t",
+        '\v' => "\\v",
+        '\u0085' or '\u2028' or '\u2029' => $"\\u{(int)value:x4}",
+        _ when char.IsControl(value) => $"\\u{(int)value:x4}",
+        _ => value.ToString()
+    };
+
     static string EscapeStringLiteral(string value)
     {
         var builder = new StringBuilder(value.Length);
         foreach (var c in value)
         {
-            builder.Append(c switch
+            switch (c)
             {
-                '\\' => "\\\\",
-                '"' => "\\\"",
-                '\0' => "\\0",
-                '\a' => "\\a",
-                '\b' => "\\b",
-                '\f' => "\\f",
-                '\n' => "\\n",
-                '\r' => "\\r",
-                '\t' => "\\t",
-                '\v' => "\\v",
-                '\u0085' or '\u2028' or '\u2029' => $"\\u{(int)c:x4}",
-                _ when char.IsControl(c) => $"\\u{(int)c:x4}",
-                _ => c
-            });
+                case '\\':
+                    builder.Append("\\\\");
+                    break;
+                case '"':
+                    builder.Append("\\\"");
+                    break;
+                case '\0':
+                    builder.Append("\\0");
+                    break;
+                case '\a':
+                    builder.Append("\\a");
+                    break;
+                case '\b':
+                    builder.Append("\\b");
+                    break;
+                case '\f':
+                    builder.Append("\\f");
+                    break;
+                case '\n':
+                    builder.Append("\\n");
+                    break;
+                case '\r':
+                    builder.Append("\\r");
+                    break;
+                case '\t':
+                    builder.Append("\\t");
+                    break;
+                case '\v':
+                    builder.Append("\\v");
+                    break;
+                case '\u0085':
+                case '\u2028':
+                case '\u2029':
+                    builder.Append($"\\u{(int)c:x4}");
+                    break;
+                default:
+                    if (char.IsControl(c))
+                        builder.Append($"\\u{(int)c:x4}");
+                    else
+                        builder.Append(c);
+                    break;
+            }
         }
 
         return builder.ToString();

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -284,7 +284,8 @@ public static class AttributeReader
     /// </summary>
     public static List<string> RenderAttributes(
         MetadataReader reader, CustomAttributeHandleCollection attributes, SortedSet<string>? namespaces = null,
-        Func<string, bool>? skipAttribute = null)
+        Func<string, bool>? skipAttribute = null,
+        bool qualifyNames = false)
     {
         var result = new List<string>();
         foreach (var attrHandle in attributes)
@@ -295,7 +296,7 @@ public static class AttributeReader
                 continue;
             if (skipAttribute?.Invoke(typeName) == true)
                 continue;
-            if (TryRenderAttribute(reader, attr) is not { } rendered)
+            if (TryRenderAttribute(reader, attr, qualifyNames) is not { } rendered)
                 continue;
             int lastDot = typeName.LastIndexOf('.');
             if (lastDot > 0)
@@ -333,6 +334,14 @@ public static class AttributeReader
     public static List<string> RenderAttributes(MetadataReader reader, ParameterHandle parameter, SortedSet<string>? namespaces = null)
         => RenderAttributes(reader, reader.GetParameter(parameter).GetCustomAttributes(), namespaces);
 
+    public static List<string> RenderParameterAttributes(MetadataReader reader, ParameterHandle parameter, SortedSet<string>? namespaces = null)
+        => RenderAttributes(
+            reader,
+            reader.GetParameter(parameter).GetCustomAttributes(),
+            namespaces,
+            IsParameterSyntaxAttribute,
+            qualifyNames: true);
+
     /// <summary>
     /// Renders the attributes on a method, resolved by the same name + public-only
     /// overload counting the decompiler uses to select the body, so the attributes
@@ -358,11 +367,12 @@ public static class AttributeReader
         return [];
     }
 
-    static string? TryRenderAttribute(MetadataReader reader, CustomAttribute attr)
+    static string? TryRenderAttribute(MetadataReader reader, CustomAttribute attr, bool qualifyName)
     {
         if (AttributeDecoder.TryDecode(reader, attr) is not { } value)
             return null;
-        string name = TypeMatcher.GetShortAttributeName(GetAttributeTypeName(reader, attr.Constructor)!);
+        var typeName = GetAttributeTypeName(reader, attr.Constructor)!;
+        string name = qualifyName ? GetQualifiedAttributeName(typeName) : TypeMatcher.GetShortAttributeName(typeName);
         var args = new List<string>();
         foreach (var arg in value.FixedArguments)
         {
@@ -378,6 +388,11 @@ public static class AttributeReader
         }
         return args.Count == 0 ? name : $"{name}({string.Join(", ", args)})";
     }
+
+    static string GetQualifiedAttributeName(string fullName)
+        => fullName.EndsWith("Attribute", StringComparison.Ordinal)
+            ? fullName[..^9]
+            : fullName;
 
     /// <summary>Renders one attribute-argument value, or null when its shape is not faithfully spellable (arrays, unknown).</summary>
     static string? RenderArgument(string type, object? value) => value switch
@@ -419,6 +434,14 @@ public static class AttributeReader
         KnownAttributeNames.AsyncStateMachineAttribute => true,
         KnownAttributeNames.IteratorStateMachineAttribute => true,
         "System.Reflection.DefaultMemberAttribute" => true,
+        _ => false,
+    };
+
+    static bool IsParameterSyntaxAttribute(string name) => name switch
+    {
+        "System.ParamArrayAttribute" => true,
+        KnownAttributeNames.DecimalConstantAttribute => true,
+        KnownAttributeNames.DateTimeConstantAttribute => true,
         _ => false,
     };
 

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -399,8 +399,9 @@ public static class AttributeReader
     static string? RenderArgument(string type, object? value) => value switch
     {
         null => "null",
-        // A Type argument decodes to its name string; spell it typeof(...).
-        _ when type == "System.Type" && value is string typeName => $"typeof({typeName})",
+        // A Type argument decodes to its name string; spell only simple source
+        // type names we can render faithfully.
+        _ when type == "System.Type" && value is string typeName => RenderTypeArgument(typeName),
         string s => "\"" + EscapeStringLiteral(s) + "\"",
         bool b => b ? "true" : "false",
         char c => $"'{c}'",
@@ -415,6 +416,13 @@ public static class AttributeReader
             => $"({type}){value}",
         _ => null,
     };
+
+    static string? RenderTypeArgument(string typeName)
+    {
+        if (typeName.IndexOfAny(['`', '[', ',']) >= 0)
+            return null;
+        return $"typeof({typeName.Replace('+', '.')})";
+    }
 
     static string EscapeStringLiteral(string value)
     {

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Text;
 
 namespace ILInspector.Metadata;
 
@@ -398,11 +399,11 @@ public static class AttributeReader
     static string? RenderArgument(string type, object? value) => value switch
     {
         null => "null",
-        string s => "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"",
-        bool b => b ? "true" : "false",
-        char c => $"'{c}'",
         // A Type argument decodes to its name string; spell it typeof(...).
         _ when type == "System.Type" && value is string typeName => $"typeof({typeName})",
+        string s => "\"" + EscapeStringLiteral(s) + "\"",
+        bool b => b ? "true" : "false",
+        char c => $"'{c}'",
         // A primitive keyword type came from the provider; render the literal.
         _ when type is "byte" or "sbyte" or "short" or "ushort" or "int" or "uint" or "double" => value.ToString(),
         _ when type == "long" => value + "L",
@@ -415,6 +416,32 @@ public static class AttributeReader
         _ => null,
     };
 
+    static string EscapeStringLiteral(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        foreach (var c in value)
+        {
+            builder.Append(c switch
+            {
+                '\\' => "\\\\",
+                '"' => "\\\"",
+                '\0' => "\\0",
+                '\a' => "\\a",
+                '\b' => "\\b",
+                '\f' => "\\f",
+                '\n' => "\\n",
+                '\r' => "\\r",
+                '\t' => "\\t",
+                '\v' => "\\v",
+                '\u0085' or '\u2028' or '\u2029' => $"\\u{(int)c:x4}",
+                _ when char.IsControl(c) => $"\\u{(int)c:x4}",
+                _ => c
+            });
+        }
+
+        return builder.ToString();
+    }
+
     /// <summary>Attributes the C# compiler re-synthesizes from syntax — emitting them in source is redundant or a duplicate-attribute error.</summary>
     static bool IsReEmittedAttribute(string name) => name switch
     {
@@ -423,6 +450,7 @@ public static class AttributeReader
         KnownAttributeNames.NullableAttribute => true,
         KnownAttributeNames.NullableContextAttribute => true,
         KnownAttributeNames.IsReadOnlyAttribute => true,
+        KnownAttributeNames.RequiresLocationAttribute => true,
         KnownAttributeNames.IsByRefLikeAttribute => true,
         KnownAttributeNames.IsUnmanagedAttribute => true,
         KnownAttributeNames.RefSafetyRulesAttribute => true,

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -479,6 +479,16 @@ public static class CSharpDeclarationWriter
     {
         for (var i = 0; i < text.Length;)
         {
+            if (IsStringLiteralStart(text, i))
+            {
+                i = SkipStringLiteral(text, i);
+                continue;
+            }
+            if (text[i] == '\'')
+            {
+                i = SkipCharLiteral(text, i);
+                continue;
+            }
             if (!IsIdentifierStart(text[i]))
             {
                 i++;
@@ -1038,6 +1048,20 @@ public static class CSharpDeclarationWriter
             var sb = new StringBuilder(text.Length);
             for (var i = 0; i < text.Length;)
             {
+                if (IsStringLiteralStart(text, i))
+                {
+                    var end = SkipStringLiteral(text, i);
+                    sb.Append(text.AsSpan(i, end - i));
+                    i = end;
+                    continue;
+                }
+                if (text[i] == '\'')
+                {
+                    var end = SkipCharLiteral(text, i);
+                    sb.Append(text.AsSpan(i, end - i));
+                    i = end;
+                    continue;
+                }
                 if (i + token.Length <= text.Length
                     && text.AsSpan(i, token.Length).SequenceEqual(token)
                     && IsStartBoundary(text, i - 1)
@@ -1063,6 +1087,78 @@ public static class CSharpDeclarationWriter
             => index < 0
                || index >= text.Length
                || (!IsIdentifierPart(text[index]) && text[index] != '+');
+    }
+
+    static bool IsStringLiteralStart(string text, int index)
+        => text[index] == '"'
+           || (text[index] == '@' && index + 1 < text.Length && text[index + 1] == '"')
+           || (text[index] == '$' && index + 1 < text.Length && text[index + 1] == '"')
+           || (text[index] == '$' && index + 2 < text.Length && text[index + 1] == '@' && text[index + 2] == '"')
+           || (text[index] == '@' && index + 2 < text.Length && text[index + 1] == '$' && text[index + 2] == '"');
+
+    static int SkipStringLiteral(string text, int start)
+    {
+        var i = start;
+        var verbatim = false;
+        if (text[i] == '$')
+        {
+            i++;
+            if (i < text.Length && text[i] == '@')
+            {
+                verbatim = true;
+                i++;
+            }
+        }
+        else if (text[i] == '@')
+        {
+            i++;
+            if (i < text.Length && text[i] == '$')
+                i++;
+            verbatim = true;
+        }
+
+        if (i >= text.Length || text[i] != '"')
+            return start + 1;
+
+        i++;
+        while (i < text.Length)
+        {
+            if (text[i] == '"' && verbatim && i + 1 < text.Length && text[i + 1] == '"')
+            {
+                i += 2;
+                continue;
+            }
+            if (text[i] == '"')
+                return i + 1;
+            if (text[i] == '\\' && !verbatim && i + 1 < text.Length)
+            {
+                i += 2;
+                continue;
+            }
+
+            i++;
+        }
+
+        return text.Length;
+    }
+
+    static int SkipCharLiteral(string text, int start)
+    {
+        var i = start + 1;
+        while (i < text.Length)
+        {
+            if (text[i] == '\'')
+                return i + 1;
+            if (text[i] == '\\' && i + 1 < text.Length)
+            {
+                i += 2;
+                continue;
+            }
+
+            i++;
+        }
+
+        return text.Length;
     }
 
     sealed record TypeRef(string FullName, string Namespace, string SimpleName)

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -317,8 +317,12 @@ public static class CSharpDeclarationWriter
             if (!string.IsNullOrWhiteSpace(signatureModel.ReturnType))
                 yield return signatureModel.ReturnType!;
             foreach (var parameter in signatureModel.Parameters)
+            {
                 if (!string.IsNullOrWhiteSpace(parameter.Type))
                     yield return parameter.Type;
+                foreach (var attribute in parameter.Attributes)
+                    yield return attribute;
+            }
             foreach (var typeParameter in signatureModel.TypeParameters)
                 foreach (var constraint in typeParameter.Constraints)
                     foreach (var reference in ExtractQualifiedTypeNames(constraint))
@@ -573,9 +577,12 @@ public static class CSharpDeclarationWriter
             var declaration = string.IsNullOrWhiteSpace(parameter.Name)
                 ? head
                 : $"{head} {EscapeIdentifier(parameter.Name)}";
-            return parameter.HasDefault && parameter.DefaultValueText is { Length: > 0 }
+            declaration = parameter.HasDefault && parameter.DefaultValueText is { Length: > 0 }
                 ? $"{declaration} = {parameter.DefaultValueText}"
                 : declaration;
+            return parameter.Attributes.Count == 0
+                ? declaration
+                : $"[{string.Join(", ", parameter.Attributes)}] {declaration}";
         }
 
         static string AccessorDeclaration(ApiAccessor accessor)

--- a/src/ILInspector.Metadata/KnownAttributeNames.cs
+++ b/src/ILInspector.Metadata/KnownAttributeNames.cs
@@ -33,6 +33,7 @@ public static class KnownAttributeNames
     public const string NullablePublicOnlyAttribute = Prefix + "NullablePublicOnlyAttribute";
     public const string RefSafetyRulesAttribute = Prefix + "RefSafetyRulesAttribute";
     public const string RequiredMemberAttribute = Prefix + "RequiredMemberAttribute";
+    public const string RequiresLocationAttribute = Prefix + "RequiresLocationAttribute";
 
     // RequiresUnsafeAttribute is emitted in System.Diagnostics.CodeAnalysis (the
     // metadata form of the member `unsafe`/`extern` modifier under the updated

--- a/src/ILInspector.Metadata/KnownAttributeNames.cs
+++ b/src/ILInspector.Metadata/KnownAttributeNames.cs
@@ -31,6 +31,7 @@ public static class KnownAttributeNames
     public const string NullableAttribute = Prefix + "NullableAttribute";
     public const string NullableContextAttribute = Prefix + "NullableContextAttribute";
     public const string NullablePublicOnlyAttribute = Prefix + "NullablePublicOnlyAttribute";
+    public const string ParamCollectionAttribute = Prefix + "ParamCollectionAttribute";
     public const string RefSafetyRulesAttribute = Prefix + "RefSafetyRulesAttribute";
     public const string RequiredMemberAttribute = Prefix + "RequiredMemberAttribute";
     public const string RequiresLocationAttribute = Prefix + "RequiresLocationAttribute";

--- a/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
@@ -137,6 +137,53 @@ public sealed class CSharpDeclarationFormatterTests
     }
 
     [Fact]
+    public void MemberSignatureSection_CanRenderParameterAttributesFromStructuredSignature()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "StructuredHost",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = "Validate",
+                    Kind = "method",
+                    Signature = "BROKEN",
+                    SignatureModel = new ApiSignature
+                    {
+                        ReturnType = "void",
+                        MemberName = "Validate",
+                        Parameters =
+                        [
+                            new ApiParameter
+                            {
+                                Attributes = ["System.Diagnostics.CodeAnalysis.StringSyntax(\"Regex\")"],
+                                Type = "string",
+                                Name = "pattern"
+                            }
+                        ]
+                    }
+                }
+            ]
+        };
+        var view = ApiOutputFormatter.BuildTypeView(
+            type,
+            foundIn: "Test.dll",
+            packageName: null,
+            packageVersion: null,
+            apiSource: "local",
+            selectedTfm: null,
+            new MemberOptions { OverloadIndex = 1 });
+
+        ApiOutputFormatter.PopulateMemberSignature(view, type, new MemberOptions { OverloadIndex = 1 });
+
+        Assert.Contains("[System.Diagnostics.CodeAnalysis.StringSyntax(\"Regex\")] string pattern", view.SignatureRows![0].Signature);
+        Assert.DoesNotContain("BROKEN", view.SignatureRows[0].Signature);
+    }
+
+    [Fact]
     public void MemberSignatureSection_CanRenderPropertyFromStructuredSignature()
     {
         var type = new ApiType

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3245,7 +3245,7 @@ public class CommandExecutionTests
         Assert.Contains("public class Stack<T>", output);
         Assert.Contains("private T[] _array;", output);
         Assert.Contains("public void Push(T item)", output);
-        Assert.Contains("public bool TryPop(out T result)", output);
+        Assert.Contains("public bool TryPop([System.Diagnostics.CodeAnalysis.MaybeNullWhen(false)] out T result)", output);
         // Using hoisting: qualified names shorten against the metadata
         // namespace tables; the directives appear at the top.
         Assert.Contains("using System.Runtime.CompilerServices;", output);
@@ -3408,7 +3408,7 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        Assert.Contains("TryGetBytesFromBase64\tpublic bool TryGetBytesFromBase64(out byte[]? value)", output);
+        Assert.Contains("TryGetBytesFromBase64\tpublic bool TryGetBytesFromBase64([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out byte[]? value)", output);
     }
 
     [Fact]
@@ -3435,8 +3435,8 @@ public class CommandExecutionTests
 
         Assert.Equal(0, exit);
         Assert.Empty(error);
-        Assert.Contains("public static string Join(char separator, System.ReadOnlySpan<object?> values)\tConcatenates the string representations of a span of objects", output);
-        Assert.Contains("public static string Join(char separator, System.ReadOnlySpan<string?> value)\tConcatenates a span of strings", output);
+        Assert.Contains("public static string Join(char separator, params System.ReadOnlySpan<object?> values)\tConcatenates the string representations of a span of objects", output);
+        Assert.Contains("public static string Join(char separator, params System.ReadOnlySpan<string?> value)\tConcatenates a span of strings", output);
         Assert.Contains("public static string Join(char separator, string?[] value, int startIndex, int count)\tConcatenates an array of strings", output);
     }
 

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -181,6 +181,24 @@ public sealed class ApiSignatureModelTests
     }
 
     [Fact]
+    public void MethodSignatureModel_EscapesCharArguments()
+    {
+        var quote = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.MethodWithQuoteCharAttribute));
+        var backslash = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.MethodWithBackslashCharAttribute));
+        var newline = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.MethodWithNewlineCharAttribute));
+
+        Assert.Equal(
+            ["ILInspector.Metadata.Tests.ParameterCharMarker('\\'')"],
+            quote.SignatureModel?.Parameters[0].Attributes);
+        Assert.Equal(
+            ["ILInspector.Metadata.Tests.ParameterCharMarker('\\\\')"],
+            backslash.SignatureModel?.Parameters[0].Attributes);
+        Assert.Equal(
+            ["ILInspector.Metadata.Tests.ParameterCharMarker('\\n')"],
+            newline.SignatureModel?.Parameters[0].Attributes);
+    }
+
+    [Fact]
     public void CanonicalSignature_NormalizesMultiGenericMethodNameWhitespace()
     {
         var type = GetType(nameof(ApiSignatureFixtures));
@@ -464,6 +482,18 @@ public sealed class ApiSignatureFixtures
     {
     }
 
+    public void MethodWithQuoteCharAttribute([ParameterCharMarker('\'')] string value)
+    {
+    }
+
+    public void MethodWithBackslashCharAttribute([ParameterCharMarker('\\')] string value)
+    {
+    }
+
+    public void MethodWithNewlineCharAttribute([ParameterCharMarker('\n')] string value)
+    {
+    }
+
     public sealed class Nested
     {
     }
@@ -497,4 +527,15 @@ public sealed class ParameterTypeMarkerAttribute : Attribute
 
     public Type Type { get; }
     public string? Text { get; set; }
+}
+
+[AttributeUsage(AttributeTargets.Parameter)]
+public sealed class ParameterCharMarkerAttribute : Attribute
+{
+    public ParameterCharMarkerAttribute(char value)
+    {
+        Value = value;
+    }
+
+    public char Value { get; }
 }

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -152,6 +152,26 @@ public sealed class ApiSignatureModelTests
     }
 
     [Fact]
+    public void MethodSignatureModel_RendersNestedTypeParameterAttributeArguments()
+    {
+        var member = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.MethodWithNestedTypeParameterAttribute));
+
+        Assert.NotNull(member.SignatureModel);
+        Assert.Equal(
+            ["ILInspector.Metadata.Tests.ParameterTypeMarker(typeof(ILInspector.Metadata.Tests.ApiSignatureFixtures.Nested))"],
+            member.SignatureModel.Parameters[0].Attributes);
+    }
+
+    [Fact]
+    public void MethodSignatureModel_SkipsUnspellableGenericTypeParameterAttributeArguments()
+    {
+        var member = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.MethodWithGenericTypeParameterAttribute));
+
+        Assert.NotNull(member.SignatureModel);
+        Assert.Empty(member.SignatureModel.Parameters[0].Attributes);
+    }
+
+    [Fact]
     public void MethodSignatureModel_SuppressesCompilerReservedRefReadonlyParameterAttributes()
     {
         var member = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.MethodWithRefReadonlyParameter));
@@ -432,7 +452,19 @@ public sealed class ApiSignatureFixtures
     {
     }
 
+    public void MethodWithNestedTypeParameterAttribute([ParameterTypeMarker(typeof(Nested))] string value)
+    {
+    }
+
+    public void MethodWithGenericTypeParameterAttribute([ParameterTypeMarker(typeof(List<int>))] string value)
+    {
+    }
+
     public void MethodWithRefReadonlyParameter(ref readonly int value)
+    {
+    }
+
+    public sealed class Nested
     {
     }
 

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -130,6 +130,17 @@ public sealed class ApiSignatureModelTests
     }
 
     [Fact]
+    public void MethodSignatureModel_ExposesSourceRenderableParameterAttributes()
+    {
+        var member = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.MethodWithParameterAttribute));
+
+        Assert.NotNull(member.SignatureModel);
+        Assert.Equal(
+            ["ILInspector.Metadata.Tests.ParameterMarker(\"id\", Order = 2)"],
+            member.SignatureModel.Parameters[0].Attributes);
+    }
+
+    [Fact]
     public void CanonicalSignature_NormalizesMultiGenericMethodNameWhitespace()
     {
         var type = GetType(nameof(ApiSignatureFixtures));
@@ -393,9 +404,25 @@ public sealed class ApiSignatureFixtures
     {
     }
 
+    public void MethodWithParameterAttribute([ParameterMarker("id", Order = 2)] string id)
+    {
+    }
+
     public string this[int index]
     {
         get => index.ToString();
         private set { }
     }
+}
+
+[AttributeUsage(AttributeTargets.Parameter)]
+public sealed class ParameterMarkerAttribute : Attribute
+{
+    public ParameterMarkerAttribute(string name)
+    {
+        Name = name;
+    }
+
+    public string Name { get; }
+    public int Order { get; set; }
 }

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -141,6 +141,26 @@ public sealed class ApiSignatureModelTests
     }
 
     [Fact]
+    public void MethodSignatureModel_RendersParameterAttributeTypeAndEscapedStringArguments()
+    {
+        var member = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.MethodWithTypeParameterAttribute));
+
+        Assert.NotNull(member.SignatureModel);
+        Assert.Equal(
+            ["ILInspector.Metadata.Tests.ParameterTypeMarker(typeof(System.Int32), Text = \"System.String\\\\Path\\nNext\")"],
+            member.SignatureModel.Parameters[0].Attributes);
+    }
+
+    [Fact]
+    public void MethodSignatureModel_SuppressesCompilerReservedRefReadonlyParameterAttributes()
+    {
+        var member = GetMember(nameof(ApiSignatureFixtures), nameof(ApiSignatureFixtures.MethodWithRefReadonlyParameter));
+
+        Assert.NotNull(member.SignatureModel);
+        Assert.Empty(member.SignatureModel.Parameters[0].Attributes);
+    }
+
+    [Fact]
     public void CanonicalSignature_NormalizesMultiGenericMethodNameWhitespace()
     {
         var type = GetType(nameof(ApiSignatureFixtures));
@@ -408,6 +428,14 @@ public sealed class ApiSignatureFixtures
     {
     }
 
+    public void MethodWithTypeParameterAttribute([ParameterTypeMarker(typeof(int), Text = "System.String\\Path\nNext")] string value)
+    {
+    }
+
+    public void MethodWithRefReadonlyParameter(ref readonly int value)
+    {
+    }
+
     public string this[int index]
     {
         get => index.ToString();
@@ -425,4 +453,16 @@ public sealed class ParameterMarkerAttribute : Attribute
 
     public string Name { get; }
     public int Order { get; set; }
+}
+
+[AttributeUsage(AttributeTargets.Parameter)]
+public sealed class ParameterTypeMarkerAttribute : Attribute
+{
+    public ParameterTypeMarkerAttribute(Type type)
+    {
+        Type = type;
+    }
+
+    public Type Type { get; }
+    public string? Text { get; set; }
 }

--- a/tests/ILInspector.Metadata.Tests/AttributeReaderTests.cs
+++ b/tests/ILInspector.Metadata.Tests/AttributeReaderTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 
@@ -60,5 +61,20 @@ public class AttributeReaderTests
             return;
         }
         Assert.Fail("CLSCompliant attribute not found on CoreLib");
+    }
+
+    [Theory]
+    [InlineData("Attribute", "Attribute")]
+    [InlineData("Samples.Attribute", "Samples.Attribute")]
+    [InlineData("Samples.WidgetAttribute", "Samples.Widget")]
+    [InlineData("Samples.AttributeAttribute", "Samples.Attribute")]
+    public void QualifiedAttributeName_DoesNotStripToInvalidName(string fullName, string expected)
+    {
+        var method = typeof(AttributeReader).GetMethod(
+            "GetQualifiedAttributeName",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(method);
+        Assert.Equal(expected, method!.Invoke(null, [fullName]));
     }
 }

--- a/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
@@ -167,6 +167,48 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void MethodDeclaration_CanRenderStructuredParameterAttributes()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Validate",
+            Kind = "method",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "void",
+                MemberName = "Validate",
+                Parameters =
+                [
+                    new ApiParameter
+                    {
+                        Attributes = ["System.Diagnostics.CodeAnalysis.StringSyntax(\"Regex\")"],
+                        Type = "string",
+                        Name = "pattern"
+                    }
+                ]
+            }
+        };
+
+        var rendered = CSharpDeclarationWriter.RenderMemberUnit(
+            type,
+            member,
+            new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ShortWithUsings,
+                TerminateMemberDeclaration = true
+            });
+
+        Assert.Equal(
+            """
+            using System.Diagnostics.CodeAnalysis;
+
+            public void Validate([StringSyntax("Regex")] string pattern);
+            """,
+            rendered.Source);
+    }
+
+    [Fact]
     public void GenericMethodDeclaration_WithoutGenericParameterFactsKeepsCompatibilitySignature()
     {
         var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
@@ -334,6 +376,39 @@ public sealed class CSharpDeclarationWriterTests
         var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
 
         Assert.Equal("public string this[int @event] { get; }", declaration);
+    }
+
+    [Fact]
+    public void IndexerDeclaration_CanRenderStructuredParameterAttributes()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Item",
+            Kind = "property",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "string",
+                MemberName = "this[]",
+                Parameters =
+                [
+                    new ApiParameter
+                    {
+                        Attributes = ["System.Diagnostics.CodeAnalysis.StringSyntax(\"Uri\")"],
+                        Type = "string",
+                        Name = "key"
+                    }
+                ],
+                Accessors =
+                [
+                    new ApiAccessor { Kind = "get" }
+                ]
+            }
+        };
+
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, member);
+
+        Assert.Equal("public string this[[System.Diagnostics.CodeAnalysis.StringSyntax(\"Uri\")] string key] { get; }", declaration);
     }
 
     [Fact]

--- a/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
+++ b/tests/ILInspector.Metadata.Tests/CSharpDeclarationWriterTests.cs
@@ -209,6 +209,48 @@ public sealed class CSharpDeclarationWriterTests
     }
 
     [Fact]
+    public void MethodDeclaration_DoesNotShortenTypeNamesInsideParameterAttributeStringLiterals()
+    {
+        var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };
+        var member = new ApiMember
+        {
+            Name = "Validate",
+            Kind = "method",
+            SignatureModel = new ApiSignature
+            {
+                ReturnType = "void",
+                MemberName = "Validate",
+                Parameters =
+                [
+                    new ApiParameter
+                    {
+                        Attributes = ["System.Diagnostics.CodeAnalysis.StringSyntax(\"System.String\")"],
+                        Type = "string",
+                        Name = "pattern"
+                    }
+                ]
+            }
+        };
+
+        var rendered = CSharpDeclarationWriter.RenderMemberUnit(
+            type,
+            member,
+            new CSharpDeclarationOptions
+            {
+                TypeNameMode = CSharpTypeNameMode.ShortWithUsings,
+                TerminateMemberDeclaration = true
+            });
+
+        Assert.Equal(
+            """
+            using System.Diagnostics.CodeAnalysis;
+
+            public void Validate([StringSyntax("System.String")] string pattern);
+            """,
+            rendered.Source);
+    }
+
+    [Fact]
     public void GenericMethodDeclaration_WithoutGenericParameterFactsKeepsCompatibilitySignature()
     {
         var type = new ApiType { Namespace = "Samples", Name = "Values", Kind = "class" };


### PR DESCRIPTION
## Summary
- add source-renderable parameter attributes to ApiParameter
- populate method and indexer parameter attributes from metadata while skipping syntax attributes already represented by modifiers/defaults
- render structured parameter attributes in CSharpDeclarationWriter and CLI signature sections

## Validation
- dotnet build src/dotnet-inspect -c Release --configfile nuget.config -p:NoWarn=NU1507
- dotnet build tests/ILInspector.Metadata.Tests -c Release --configfile nuget.config -p:NoWarn=NU1507%3BCS0436
- dotnet run --no-build --no-restore --project tests/ILInspector.Metadata.Tests -c Release -- -class '*ApiSignatureModelTests' -class '*CSharpDeclarationWriterTests'
- dotnet build src/dotnet-inspect.Tests -c Release --configfile nuget.config -p:NoWarn=NU1507%3BCS0436
- dotnet run --no-build --no-restore --project src/dotnet-inspect.Tests -c Release -- -class '*CSharpDeclarationFormatterTests'

Adversarial review pending.