### PR TITLE
Move method-source reconstruction into SourceLinkResolver (#2122)

### DIFF
--- a/src/ILInspector.Metadata/SourceLinkResolver.cs
+++ b/src/ILInspector.Metadata/SourceLinkResolver.cs
@@ -71,6 +71,78 @@ public class SourceLinkResolver
         int EndLine
     );
 
+    /// <summary>
+    /// Reconstructs a method's source text from the full file <paramref name="sourceText"/> and the
+    /// sequence-point line range (<paramref name="startLine"/>..<paramref name="endLine"/>, 1-based).
+    /// Sequence points cover the body, so this scans backward to capture the signature (skipping
+    /// doc comments, attributes, and preprocessor lines) and forward to include the closing brace,
+    /// then dedents the block. Line numbers outside the file bounds surface as an
+    /// <see cref="IndexOutOfRangeException"/>, which callers already handle by treating the source
+    /// as unavailable.
+    /// </summary>
+    public static string ExtractMethodBody(string sourceText, int startLine, int endLine, string methodName)
+    {
+        var lines = sourceText.Split('\n');
+        int start = startLine;
+        int end = Math.Min(endLine, lines.Length);
+
+        // Scan backward from the first sequence point to capture the method signature.
+        int sigStart = start;
+        for (int i = start - 2; i >= Math.Max(0, start - 15); i--)
+        {
+            var trimmed = lines[i].TrimStart();
+            if (trimmed.Length == 0 || trimmed.StartsWith("///") || trimmed.StartsWith("//")
+                || trimmed.StartsWith("[") || trimmed.StartsWith("#"))
+                continue;
+            if (trimmed == "{")
+                continue;
+            if (trimmed.StartsWith("}"))
+            {
+                sigStart = i + 2;
+                break;
+            }
+
+            sigStart = i + 1;
+            if (trimmed.StartsWith("public") || trimmed.StartsWith("private")
+                || trimmed.StartsWith("protected") || trimmed.StartsWith("internal")
+                || trimmed.StartsWith("static") || trimmed.Contains(methodName))
+                break;
+        }
+
+        int from = sigStart - 1;
+        int to = end;
+
+        // Scan forward to include the closing brace.
+        for (int i = to; i < Math.Min(to + 3, lines.Length); i++)
+        {
+            var trimmed = lines[i].TrimStart();
+            if (trimmed.StartsWith("}"))
+            {
+                to = i + 1;
+                break;
+            }
+            if (trimmed.Length > 0)
+                break;
+        }
+
+        if (from < 0) from = 0;
+        if (to > lines.Length) to = lines.Length;
+
+        while (from < to && lines[from].TrimStart().Length == 0)
+            from++;
+
+        var methodLines = lines[from..to];
+
+        int minIndent = methodLines
+            .Where(l => l.TrimStart().Length > 0)
+            .Select(l => l.Length - l.TrimStart().Length)
+            .DefaultIfEmpty(0)
+            .Min();
+
+        var dedented = methodLines.Select(l => l.Length >= minIndent ? l[minIndent..] : l);
+        return string.Join('\n', dedented).TrimEnd();
+    }
+
     private SourceLinkResolver(SLF.SourceLinkResolver slfResolver)
     {
         _slfResolver = slfResolver;

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -546,65 +546,8 @@ public class ApiCommand
             if (content == null)
                 return new ResolvedMethodSource(null, pdbPath);
 
-            var lines = content.Split('\n');
-            int startLine = methodInfo.StartLine;
-            int endLine = Math.Min(methodInfo.EndLine, lines.Length);
-
-            // Scan backward from first sequence point to capture method signature
-            int sigStart = startLine;
-            for (int i = startLine - 2; i >= Math.Max(0, startLine - 15); i--)
-            {
-                var trimmed = lines[i].TrimStart();
-                if (trimmed.Length == 0 || trimmed.StartsWith("///") || trimmed.StartsWith("//")
-                    || trimmed.StartsWith("[") || trimmed.StartsWith("#"))
-                    continue;
-                if (trimmed == "{")
-                    continue;
-                if (trimmed.StartsWith("}"))
-                {
-                    sigStart = i + 2;
-                    break;
-                }
-
-                sigStart = i + 1;
-                if (trimmed.StartsWith("public") || trimmed.StartsWith("private")
-                    || trimmed.StartsWith("protected") || trimmed.StartsWith("internal")
-                    || trimmed.StartsWith("static") || trimmed.Contains(methodName))
-                    break;
-            }
-
-            int from = sigStart - 1;
-            int to = endLine;
-
-            // Scan forward to include the closing brace
-            for (int i = to; i < Math.Min(to + 3, lines.Length); i++)
-            {
-                var trimmed = lines[i].TrimStart();
-                if (trimmed.StartsWith("}"))
-                {
-                    to = i + 1;
-                    break;
-                }
-                if (trimmed.Length > 0)
-                    break;
-            }
-
-            if (from < 0) from = 0;
-            if (to > lines.Length) to = lines.Length;
-
-            while (from < to && lines[from].TrimStart().Length == 0)
-                from++;
-
-            var methodLines = lines[from..to];
-
-            int minIndent = methodLines
-                .Where(l => l.TrimStart().Length > 0)
-                .Select(l => l.Length - l.TrimStart().Length)
-                .DefaultIfEmpty(0)
-                .Min();
-
-            var dedented = methodLines.Select(l => l.Length >= minIndent ? l[minIndent..] : l);
-            var sourceCode = string.Join('\n', dedented).TrimEnd();
+            var sourceCode = SourceLinkResolver.ExtractMethodBody(
+                content, methodInfo.StartLine, methodInfo.EndLine, methodName);
 
             return new ResolvedMethodSource(new MethodSourceContext(sourceCode, methodInfo.SourceUrl), pdbPath);
         }

--- a/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ExtractMethodBodyTests.cs
@@ -1,0 +1,94 @@
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Characterization tests for <see cref="SourceLinkResolver.ExtractMethodBody"/>, the
+/// signature-boundary reconstruction heuristic moved out of the CLI. These lock in the
+/// existing behavior (line numbers are 1-based sequence-point ranges).
+/// </summary>
+public class ExtractMethodBodyTests
+{
+    private static string Lines(params string[] lines) => string.Join('\n', lines);
+
+    [Fact]
+    public void SimpleMethod_ReconstructsSignatureThroughClosingBrace_Dedented()
+    {
+        var source = Lines(
+            "class C",                              // 1
+            "{",                                    // 2
+            "    public int Add(int a, int b)",     // 3
+            "    {",                                // 4  <- StartLine
+            "        return a + b;",                // 5
+            "    }",                                // 6  <- EndLine
+            "",                                     // 7
+            "    public int Sub() => 0;",           // 8
+            "}");                                   // 9
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 4, endLine: 6, methodName: "Add");
+
+        Assert.Equal("public int Add(int a, int b)\n{\n    return a + b;\n}", body);
+    }
+
+    [Fact]
+    public void MultiLineSignature_WalksBackwardToSignatureStart()
+    {
+        var source = Lines(
+            "class C",                              // 1
+            "{",                                    // 2
+            "    /// <summary>M.</summary>",        // 3
+            "    public int Add(",                  // 4
+            "        int a,",                       // 5
+            "        int b)",                       // 6
+            "    {",                                // 7  <- StartLine
+            "        return a + b;",                // 8
+            "    }",                                // 9  <- EndLine
+            "",                                     // 10
+            "    public int X() => 0;",             // 11
+            "}");                                   // 12
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 7, endLine: 9, methodName: "Add");
+
+        Assert.Equal(
+            "public int Add(\n    int a,\n    int b)\n{\n    return a + b;\n}",
+            body);
+    }
+
+    [Fact]
+    public void DocCommentsAndAttributesAboveSignature_AreExcluded()
+    {
+        var source = Lines(
+            "class C",                              // 1
+            "{",                                    // 2
+            "    /// <summary>Adds.</summary>",     // 3
+            "    [Obsolete]",                       // 4
+            "    public int Add(int a, int b)",     // 5
+            "    {",                                // 6  <- StartLine
+            "        return a + b;",                // 7
+            "    }",                                // 8  <- EndLine
+            "",                                     // 9
+            "    public int X() => 0;",             // 10
+            "}");                                   // 11
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 6, endLine: 8, methodName: "Add");
+
+        Assert.Equal("public int Add(int a, int b)\n{\n    return a + b;\n}", body);
+    }
+
+    [Fact]
+    public void ForwardScan_IncludesClosingBrace_WhenEndLineStopsAtLastStatement()
+    {
+        var source = Lines(
+            "class C",                              // 1
+            "{",                                    // 2
+            "    public int Add(int a, int b)",     // 3
+            "    {",                                // 4  <- StartLine
+            "        return a + b;",                // 5  <- EndLine (last statement, not the brace)
+            "    }",                                // 6
+            "",                                     // 7
+            "    void Y() {}",                      // 8
+            "}");                                   // 9
+
+        var body = SourceLinkResolver.ExtractMethodBody(source, startLine: 4, endLine: 5, methodName: "Add");
+
+        Assert.Equal("public int Add(int a, int b)\n{\n    return a + b;\n}", body);
+    }
+}


### PR DESCRIPTION
## Summary

Slice of #2122 (thin out the CLI layer). `ApiCommand.ResolveMethodSourceAsync` hand-reconstructed
a method's source text from fetched SourceLink content — scanning backward from the first sequence
point to capture the signature (skipping doc comments, attributes, preprocessor lines), forward to
include the closing brace, then slicing and dedenting. That reconstruction is source/metadata-layer
logic, not CLI orchestration.

## Changes

- New pure API `ILInspector.Metadata.SourceLinkResolver.ExtractMethodBody(sourceText, startLine,
  endLine, methodName)`, co-located with `MethodSourceInfo`. The heuristic is moved **verbatim**.
- `ApiCommand` keeps the orchestration it owns — SourceLink resolve, PDB acquisition, source fetch,
  and the surrounding `try/catch` (which still handles the documented out-of-bounds line case) — and
  calls the new API. ~59 lines removed from the CLI.

## Behavior preservation

The reconstruction logic is unchanged (same backward/forward scans, dedent, `TrimEnd`, and
`Split('\n')` semantics). The `try/catch` around the call is retained, so the prior
"source unavailable on any failure" behavior is identical.

## Validation

- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507` — 0 warnings.
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507` — 305/305,
  incl. 4 new `ExtractMethodBodyTests` characterization tests (simple, multi-line signature,
  docs/attributes excluded, forward-scan brace inclusion).

## Adversarial review

Per `AGENTS.md`: two reviewers requested below. Medium risk (output-affecting), but the move is
verbatim and covered by characterization tests.

Part of #2122.
