### PR TITLE
Render constructor snippets from ApiSignature parameters

### DIFF
--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -40,9 +40,6 @@ public sealed record CSharpRenderedDeclaration(
 /// </summary>
 public static class CSharpDeclarationWriter
 {
-    public static string RenderParameterDeclaration(ApiParameter parameter)
-        => ParameterDeclaration(parameter);
-
     public static CSharpRenderedDeclaration RenderMemberUnit(
         ApiType type,
         ApiMember member,

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -40,6 +40,9 @@ public sealed record CSharpRenderedDeclaration(
 /// </summary>
 public static class CSharpDeclarationWriter
 {
+    public static string RenderParameterDeclaration(ApiParameter parameter)
+        => ParameterDeclaration(parameter);
+
     public static CSharpRenderedDeclaration RenderMemberUnit(
         ApiType type,
         ApiMember member,
@@ -581,20 +584,6 @@ public static class CSharpDeclarationWriter
         // declaration-level facts are represented in ApiSignature.
         return false;
 
-        static string ParameterDeclaration(ApiParameter parameter)
-        {
-            var head = parameter.TypeWithModifier;
-            var declaration = string.IsNullOrWhiteSpace(parameter.Name)
-                ? head
-                : $"{head} {EscapeIdentifier(parameter.Name)}";
-            declaration = parameter.HasDefault && parameter.DefaultValueText is { Length: > 0 }
-                ? $"{declaration} = {parameter.DefaultValueText}"
-                : declaration;
-            return parameter.Attributes.Count == 0
-                ? declaration
-                : $"[{string.Join(", ", parameter.Attributes)}] {declaration}";
-        }
-
         static string AccessorDeclaration(ApiAccessor accessor)
             => string.IsNullOrWhiteSpace(accessor.Accessibility)
                 ? $"{accessor.Kind};"
@@ -604,6 +593,20 @@ public static class CSharpDeclarationWriter
             => string.IsNullOrWhiteSpace(name)
                || name == "this[]"
                || !name.Contains('.', StringComparison.Ordinal);
+    }
+
+    static string ParameterDeclaration(ApiParameter parameter)
+    {
+        var head = parameter.TypeWithModifier;
+        var declaration = string.IsNullOrWhiteSpace(parameter.Name)
+            ? head
+            : $"{head} {EscapeIdentifier(parameter.Name)}";
+        declaration = parameter.HasDefault && parameter.DefaultValueText is { Length: > 0 }
+            ? $"{declaration} = {parameter.DefaultValueText}"
+            : declaration;
+        return parameter.Attributes.Count == 0
+            ? declaration
+            : $"[{string.Join(", ", parameter.Attributes)}] {declaration}";
     }
 
     static string FormatTypeDisplayName(string name, IReadOnlyList<TypeParameter> typeParameters)

--- a/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
@@ -355,4 +355,49 @@ public sealed class CSharpDeclarationFormatterTests
 
         Assert.Equal("new Widget([System.Diagnostics.CodeAnalysis.NotNull] string @event)", view.ConstructorOverloads![0].Signature.Content);
     }
+
+    [Fact]
+    public void ConstructorOverloadSnippet_IgnoresObsoleteAttributePrefix()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = ".ctor",
+                    Kind = "constructor",
+                    IsObsolete = true,
+                    ObsoleteMessage = "Use Widget()",
+                    Signature = "BROKEN",
+                    SignatureModel = new ApiSignature
+                    {
+                        Parameters =
+                        [
+                            new ApiParameter
+                            {
+                                Type = "int",
+                                Name = "count"
+                            }
+                        ]
+                    }
+                }
+            ]
+        };
+        var view = ApiOutputFormatter.BuildTypeView(
+            type,
+            foundIn: "Test.dll",
+            packageName: null,
+            packageVersion: null,
+            apiSource: "local",
+            selectedTfm: null,
+            new TypeOptions());
+
+        ApiOutputFormatter.PopulateConstructorOverloads(view, type, new TypeOptions());
+
+        Assert.Equal("new Widget(int count)", view.ConstructorOverloads![0].Signature.Content);
+    }
 }

--- a/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
@@ -311,4 +311,48 @@ public sealed class CSharpDeclarationFormatterTests
 
         Assert.Equal("new Widget(int count = 42)", view.ConstructorOverloads![0].Signature.Content);
     }
+
+    [Fact]
+    public void ConstructorOverloadSnippet_UsesStructuredParameterDeclarations()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class",
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = ".ctor",
+                    Kind = "constructor",
+                    Signature = "BROKEN",
+                    SignatureModel = new ApiSignature
+                    {
+                        Parameters =
+                        [
+                            new ApiParameter
+                            {
+                                Attributes = ["System.Diagnostics.CodeAnalysis.NotNull"],
+                                Type = "string",
+                                Name = "event"
+                            }
+                        ]
+                    }
+                }
+            ]
+        };
+        var view = ApiOutputFormatter.BuildTypeView(
+            type,
+            foundIn: "Test.dll",
+            packageName: null,
+            packageVersion: null,
+            apiSource: "local",
+            selectedTfm: null,
+            new TypeOptions());
+
+        ApiOutputFormatter.PopulateConstructorOverloads(view, type, new TypeOptions());
+
+        Assert.Equal("new Widget([System.Diagnostics.CodeAnalysis.NotNull] string @event)", view.ConstructorOverloads![0].Signature.Content);
+    }
 }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1028,7 +1028,7 @@ public static class ApiOutputFormatter
             var overloadView = new ConstructorOverloadView
             {
                 Title = $"Overload {i + 1}: {paramCount} parameter{(paramCount != 1 ? "s" : "")}",
-                Signature = new CodeSection("csharp", $"new {type.Name}{ConstructorCall(ctor)}")
+                Signature = new CodeSection("csharp", $"new {type.Name}{ConstructorCall(type, ctor)}")
             };
 
             if (paramInfo.Count > 0)
@@ -1053,18 +1053,25 @@ public static class ApiOutputFormatter
                 .ToList()
             : SignatureParser.ExtractParameterInfo(constructor.Signature);
 
-    private static string ConstructorCall(ApiMember constructor)
+    private static string ConstructorCall(ApiType type, ApiMember constructor)
     {
         if (constructor.SignatureModel is { } signature
             && signature.Parameters.All(static parameter => !parameter.HasDefault || !string.IsNullOrWhiteSpace(parameter.DefaultValueText)))
         {
-            var parameters = string.Join(", ", signature.Parameters.Select(CSharpDeclarationWriter.RenderParameterDeclaration));
-            return $"({parameters})";
+            var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, constructor);
+            if (!string.IsNullOrWhiteSpace(declaration))
+                return ConstructorCallFromDeclaration(declaration);
         }
 
         // Compatibility-only fallback for legacy signatures without complete
         // structured default-value facts.
         return SignatureParser.FormatConstructorCall(constructor.Signature);
+    }
+
+    private static string ConstructorCallFromDeclaration(string declaration)
+    {
+        var parenStart = declaration.IndexOf('(');
+        return parenStart < 0 ? "()" : declaration[parenStart..];
     }
 
     internal static void PopulateIndexSections(TypeView view, ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex, IReadOnlySet<string> requestedSections, string? pdbPath = null, IReadOnlySet<string>? explicitSections = null, IReadOnlyList<string>? callerScopeAssemblies = null, ApiOptions? options = null)

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1058,7 +1058,10 @@ public static class ApiOutputFormatter
         if (constructor.SignatureModel is { } signature
             && signature.Parameters.All(static parameter => !parameter.HasDefault || !string.IsNullOrWhiteSpace(parameter.DefaultValueText)))
         {
-            var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, constructor);
+            var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+                type,
+                constructor,
+                new CSharpDeclarationOptions { IncludeObsoleteAttribute = false });
             if (!string.IsNullOrWhiteSpace(declaration))
                 return ConstructorCallFromDeclaration(declaration);
         }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1028,7 +1028,7 @@ public static class ApiOutputFormatter
             var overloadView = new ConstructorOverloadView
             {
                 Title = $"Overload {i + 1}: {paramCount} parameter{(paramCount != 1 ? "s" : "")}",
-                Signature = new CodeSection("csharp", $"new {type.Name}{ConstructorCall(type, ctor)}")
+                Signature = new CodeSection("csharp", $"new {type.Name}{ConstructorCall(ctor)}")
             };
 
             if (paramInfo.Count > 0)
@@ -1053,16 +1053,17 @@ public static class ApiOutputFormatter
                 .ToList()
             : SignatureParser.ExtractParameterInfo(constructor.Signature);
 
-    private static string ConstructorCall(ApiType type, ApiMember constructor)
+    private static string ConstructorCall(ApiMember constructor)
     {
         if (constructor.SignatureModel is { } signature
             && signature.Parameters.All(static parameter => !parameter.HasDefault || !string.IsNullOrWhiteSpace(parameter.DefaultValueText)))
         {
-            var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(type, constructor);
-            if (!string.IsNullOrWhiteSpace(declaration))
-                return SignatureParser.FormatConstructorCall(declaration);
+            var parameters = string.Join(", ", signature.Parameters.Select(CSharpDeclarationWriter.RenderParameterDeclaration));
+            return $"({parameters})";
         }
 
+        // Compatibility-only fallback for legacy signatures without complete
+        // structured default-value facts.
         return SignatureParser.FormatConstructorCall(constructor.Signature);
     }
 


### PR DESCRIPTION
## Summary
- expose CSharpDeclarationWriter.RenderParameterDeclaration for structured parameter rendering
- build constructor overload snippets directly from ApiSignature parameters when default facts are complete
- keep SignatureParser.FormatConstructorCall only as the compatibility fallback for legacy/unmodeled default signatures

## Validation
- dotnet build src/dotnet-inspect -c Release --configfile nuget.config -p:NoWarn=NU1507
- dotnet build src/dotnet-inspect.Tests -c Release --configfile nuget.config -p:NoWarn=NU1507%3BCS0436
- dotnet run --no-build --no-restore --project src/dotnet-inspect.Tests -c Release -- -class '*CSharpDeclarationFormatterTests'
- dotnet build tests/ILInspector.Metadata.Tests -c Release --configfile nuget.config -p:NoWarn=NU1507%3BCS0436
- dotnet run --no-build --no-restore --project tests/ILInspector.Metadata.Tests -c Release -- -class '*CSharpDeclarationWriterTests' -class '*ApiSignatureModelTests'

Adversarial review pending.