### PR TITLE
Centralize dependency group selection

### DIFF
--- a/src/DotnetInspector.Services.Tests/DependencyResolutionServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/DependencyResolutionServiceTests.cs
@@ -159,6 +159,97 @@ public class DependencyResolutionServiceTests
     }
 
     [Fact]
+    public void SelectDependencyGroup_NoGroups_ReturnsNoDependencyGroups()
+    {
+        var result = DependencyResolutionService.SelectDependencyGroup(null, null);
+
+        Assert.Equal(DependencyResolutionService.DependencyGroupSelectionStatus.NoDependencyGroups, result.Status);
+        Assert.Null(result.Group);
+        Assert.Empty(result.AvailableTargetFrameworks);
+    }
+
+    [Fact]
+    public void SelectDependencyGroup_NoRequestedTfm_SelectsHighestTfm()
+    {
+        var groups = new List<DotnetInspector.Packages.DependencyGroup>
+        {
+            new() { TargetFramework = "netstandard2.0" },
+            new() { TargetFramework = "net8.0" },
+            new() { TargetFramework = "net472" }
+        };
+
+        var result = DependencyResolutionService.SelectDependencyGroup(groups, null);
+
+        Assert.True(result.IsSelected);
+        Assert.Equal("net8.0", result.Group?.TargetFramework);
+        Assert.Equal("net8.0", result.TargetFramework);
+    }
+
+    [Fact]
+    public void SelectDependencyGroup_RequestedTfm_AllowsCompatibleFallbackAndPreservesRequestedTarget()
+    {
+        var groups = new List<DotnetInspector.Packages.DependencyGroup>
+        {
+            new() { TargetFramework = "net6.0" },
+            new() { TargetFramework = "net8.0" }
+        };
+
+        var result = DependencyResolutionService.SelectDependencyGroup(groups, "net9.0");
+
+        Assert.True(result.IsSelected);
+        Assert.Equal("net8.0", result.Group?.TargetFramework);
+        Assert.Equal("net9.0", result.TargetFramework);
+    }
+
+    [Fact]
+    public void SelectDependencyGroup_RequestedTfm_NoMatch_ReturnsAvailableTfms()
+    {
+        var groups = new List<DotnetInspector.Packages.DependencyGroup>
+        {
+            new() { TargetFramework = "net8.0" },
+            new() { TargetFramework = "net9.0" }
+        };
+
+        var result = DependencyResolutionService.SelectDependencyGroup(groups, "net6.0");
+
+        Assert.Equal(DependencyResolutionService.DependencyGroupSelectionStatus.NoMatchingTargetFramework, result.Status);
+        Assert.Null(result.Group);
+        Assert.Equal("net6.0", result.TargetFramework);
+        Assert.Equal(["net8.0", "net9.0"], result.AvailableTargetFrameworks);
+    }
+
+    [Fact]
+    public void SelectDependencyGroup_ExactMode_DoesNotFallbackForRequestedTfm()
+    {
+        var groups = new List<DotnetInspector.Packages.DependencyGroup>
+        {
+            new() { TargetFramework = "net8.0" }
+        };
+
+        var result = DependencyResolutionService.SelectDependencyGroup(
+            groups,
+            "net9.0",
+            allowCompatibleFallbackForRequestedTfm: false);
+
+        Assert.Equal(DependencyResolutionService.DependencyGroupSelectionStatus.NoMatchingTargetFramework, result.Status);
+        Assert.Null(result.Group);
+    }
+
+    [Fact]
+    public void SelectDependencyGroup_EmptyDependencyGroup_IsStillSelected()
+    {
+        var groups = new List<DotnetInspector.Packages.DependencyGroup>
+        {
+            new() { TargetFramework = "net8.0", Dependencies = [] }
+        };
+
+        var result = DependencyResolutionService.SelectDependencyGroup(groups, null);
+
+        Assert.True(result.IsSelected);
+        Assert.Empty(result.Group!.Dependencies);
+    }
+
+    [Fact]
     public void DependencyNode_Record_Properties()
     {
         var child = new DependencyNode("ChildPkg", "1.0.0", "Author1", []);

--- a/src/DotnetInspector.Services.Tests/DependencyResolutionServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/DependencyResolutionServiceTests.cs
@@ -202,6 +202,41 @@ public class DependencyResolutionServiceTests
     }
 
     [Fact]
+    public void SelectDependencyGroup_EmptyRequestedTfm_SelectsEmptyTfmGroup()
+    {
+        var groups = new List<DotnetInspector.Packages.DependencyGroup>
+        {
+            new() { TargetFramework = "net8.0" },
+            new() { TargetFramework = "" }
+        };
+
+        var result = DependencyResolutionService.SelectDependencyGroup(groups, "");
+
+        Assert.True(result.IsSelected);
+        Assert.Equal("", result.Group?.TargetFramework);
+        Assert.Equal("", result.TargetFramework);
+    }
+
+    [Fact]
+    public void SelectDependencyGroup_ExactMode_EmptyRequestedTfm_SelectsEmptyTfmGroup()
+    {
+        var groups = new List<DotnetInspector.Packages.DependencyGroup>
+        {
+            new() { TargetFramework = "net8.0" },
+            new() { TargetFramework = "" }
+        };
+
+        var result = DependencyResolutionService.SelectDependencyGroup(
+            groups,
+            "",
+            allowCompatibleFallbackForRequestedTfm: false);
+
+        Assert.True(result.IsSelected);
+        Assert.Equal("", result.Group?.TargetFramework);
+        Assert.Equal("", result.TargetFramework);
+    }
+
+    [Fact]
     public void SelectDependencyGroup_RequestedTfm_NoMatch_ReturnsAvailableTfms()
     {
         var groups = new List<DotnetInspector.Packages.DependencyGroup>

--- a/src/DotnetInspector.Services/DependencyResolutionService.cs
+++ b/src/DotnetInspector.Services/DependencyResolutionService.cs
@@ -82,7 +82,7 @@ public static class DependencyResolutionService
         }
 
         var availableTfms = groups.Select(g => g.TargetFramework).ToArray();
-        if (!string.IsNullOrEmpty(requestedTfm))
+        if (requestedTfm != null)
         {
             var group = allowCompatibleFallbackForRequestedTfm
                 ? FindBestMatchingTfmGroup(groups, requestedTfm)

--- a/src/DotnetInspector.Services/DependencyResolutionService.cs
+++ b/src/DotnetInspector.Services/DependencyResolutionService.cs
@@ -8,6 +8,22 @@ namespace DotnetInspector.Services;
 /// </summary>
 public static class DependencyResolutionService
 {
+    public enum DependencyGroupSelectionStatus
+    {
+        Selected,
+        NoDependencyGroups,
+        NoMatchingTargetFramework
+    }
+
+    public sealed record DependencyGroupSelection(
+        DependencyGroup? Group,
+        string? TargetFramework,
+        DependencyGroupSelectionStatus Status,
+        IReadOnlyList<string> AvailableTargetFrameworks)
+    {
+        public bool IsSelected => Status == DependencyGroupSelectionStatus.Selected && Group != null;
+    }
+
     /// <summary>
     /// Resolves the full transitive dependency tree for a set of direct dependencies.
     /// </summary>
@@ -52,6 +68,36 @@ public static class DependencyResolutionService
             .FirstOrDefault();
     }
 
+    /// <summary>
+    /// Selects the dependency group to use for a package dependency tree.
+    /// </summary>
+    public static DependencyGroupSelection SelectDependencyGroup(
+        List<DependencyGroup>? groups,
+        string? requestedTfm,
+        bool allowCompatibleFallbackForRequestedTfm = true)
+    {
+        if (groups is not { Count: > 0 })
+        {
+            return new DependencyGroupSelection(null, requestedTfm, DependencyGroupSelectionStatus.NoDependencyGroups, []);
+        }
+
+        var availableTfms = groups.Select(g => g.TargetFramework).ToArray();
+        if (!string.IsNullOrEmpty(requestedTfm))
+        {
+            var group = allowCompatibleFallbackForRequestedTfm
+                ? FindBestMatchingTfmGroup(groups, requestedTfm)
+                : groups.FirstOrDefault(g => g.TargetFramework.Equals(requestedTfm, StringComparison.OrdinalIgnoreCase));
+
+            return group == null
+                ? new DependencyGroupSelection(null, requestedTfm, DependencyGroupSelectionStatus.NoMatchingTargetFramework, availableTfms)
+                : new DependencyGroupSelection(group, requestedTfm, DependencyGroupSelectionStatus.Selected, availableTfms);
+        }
+
+        var highest = TfmSelector.OrderByTfmPriorityDescending(groups, g => g.TargetFramework)
+            .First();
+        return new DependencyGroupSelection(highest, highest.TargetFramework, DependencyGroupSelectionStatus.Selected, availableTfms);
+    }
+
     private static async Task<(List<DependencyNode> Children, string? Author)> ResolveChildDependenciesAsync(
         HttpClient client, string packageId, string versionRange, string tfm,
         HashSet<string> globalSeen, Action<string>? log)
@@ -72,10 +118,10 @@ public static class DependencyResolutionService
 
             if (nuspec.DependencyGroups is not { Count: > 0 }) return ([], nuspec.Authors);
 
-            var group = FindBestMatchingTfmGroup(nuspec.DependencyGroups, tfm);
-            if (group?.Dependencies is not { Count: > 0 }) return ([], nuspec.Authors);
+            var selection = SelectDependencyGroup(nuspec.DependencyGroups, tfm);
+            if (selection.Group?.Dependencies is not { Count: > 0 }) return ([], nuspec.Authors);
 
-            var children = await ResolveDependencyTreeAsync(client, group.Dependencies, tfm, globalSeen, log).ConfigureAwait(false);
+            var children = await ResolveDependencyTreeAsync(client, selection.Group.Dependencies, selection.TargetFramework ?? tfm, globalSeen, log).ConfigureAwait(false);
             return (children, nuspec.Authors);
         }
         catch (Exception ex)

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -2750,32 +2750,25 @@ public class PackageCommand
     private static async Task<int> ShowDependencyTreeAsync(
         HttpClient client, InspectionResult result, InspectionOptions options, VerboseLogger logger)
     {
-        if (result.DependencyGroups is not { Count: > 0 })
+        var selection = DependencyResolutionService.SelectDependencyGroup(
+            result.DependencyGroups,
+            options.Tfm,
+            allowCompatibleFallbackForRequestedTfm: false);
+        if (selection.Status == DependencyResolutionService.DependencyGroupSelectionStatus.NoDependencyGroups)
         {
             Console.Error.WriteLine("No dependencies declared in package.");
             return 0;
         }
 
-        // Pick TFM: explicit --tfm, or highest available
-        var tfm = options.Tfm;
-        DependencyGroup? group;
-        if (!string.IsNullOrEmpty(tfm))
+        if (selection.Status == DependencyResolutionService.DependencyGroupSelectionStatus.NoMatchingTargetFramework)
         {
-            group = result.DependencyGroups.FirstOrDefault(g =>
-                g.TargetFramework.Equals(tfm, StringComparison.OrdinalIgnoreCase));
-            if (group == null)
-            {
-                Console.Error.WriteLine($"Error: No dependencies found for TFM '{tfm}'.");
-                Console.Error.WriteLine("Available TFMs: " + string.Join(", ", result.DependencyGroups.Select(g => g.TargetFramework)));
-                return 1;
-            }
+            Console.Error.WriteLine($"Error: No dependencies found for TFM '{selection.TargetFramework}'.");
+            Console.Error.WriteLine("Available TFMs: " + string.Join(", ", selection.AvailableTargetFrameworks));
+            return 1;
         }
-        else
-        {
-            group = TfmSelector.OrderByTfmPriorityDescending(result.DependencyGroups, g => g.TargetFramework)
-                .First();
-            tfm = group.TargetFramework;
-        }
+
+        var group = selection.Group!;
+        var tfm = selection.TargetFramework ?? group.TargetFramework;
 
         if (group.Dependencies.Count == 0)
         {

--- a/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
+++ b/src/dotnet-inspect/Inspectors/DependencyGraphService.cs
@@ -135,29 +135,18 @@ internal static class DependencyGraphService
             if (nuspec == null)
                 return new PackageDependencyGraphResult.Empty("No dependencies declared in package.");
 
-            if (nuspec.DependencyGroups is not { Count: > 0 })
+            var selection = DependencyResolutionService.SelectDependencyGroup(nuspec.DependencyGroups, requestedTfm);
+            if (selection.Status == DependencyResolutionService.DependencyGroupSelectionStatus.NoDependencyGroups)
                 return new PackageDependencyGraphResult.Empty("No dependencies declared in package.");
-
-            var tfm = requestedTfm;
-            DependencyGroup? group;
-            if (!string.IsNullOrEmpty(tfm))
+            if (selection.Status == DependencyResolutionService.DependencyGroupSelectionStatus.NoMatchingTargetFramework)
             {
-                group = DependencyResolutionService.FindBestMatchingTfmGroup(nuspec.DependencyGroups, tfm);
-                if (group == null)
-                {
-                    return new PackageDependencyGraphResult.Error(
-                        $"No dependencies found for TFM '{tfm}'.",
-                        "Available TFMs: " + string.Join(", ",
-                            nuspec.DependencyGroups.Select(g => g.TargetFramework)));
-                }
-            }
-            else
-            {
-                group = TfmSelector.OrderByTfmPriorityDescending(nuspec.DependencyGroups, g => g.TargetFramework)
-                    .First();
-                tfm = group.TargetFramework;
+                return new PackageDependencyGraphResult.Error(
+                    $"No dependencies found for TFM '{selection.TargetFramework}'.",
+                    "Available TFMs: " + string.Join(", ", selection.AvailableTargetFrameworks));
             }
 
+            var group = selection.Group!;
+            var tfm = selection.TargetFramework ?? group.TargetFramework;
             if (group.Dependencies.Count == 0)
                 return new PackageDependencyGraphResult.Empty($"No additional dependencies for {tfm}.");
 


### PR DESCRIPTION
## Summary

- Adds `DependencyResolutionService.SelectDependencyGroup(...)` to centralize package dependency-group / TFM selection and selection status reporting.
- Routes package dependency-tree rendering and `depends --package` dependency graph selection through the shared service helper while preserving package command exact-TFM behavior.
- Adds focused service coverage for no groups, highest-TFM selection, compatible fallback, exact-mode no-fallback, no-match available TFMs, and empty dependency groups.

Refs #2122.

## Validation

- `dotnet run --project src/DotnetInspector.Services.Tests -c Release -p:RestoreConfigFile=nuget.config -- -class "*DependencyResolutionServiceTests*"`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:RestoreConfigFile=nuget.config -- -class "*DependencyGraphServiceTests*"`
- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config`

## Review

Adversarial review required because this centralizes dependency-tree TFM selection across service and CLI callers. Results will be posted as a PR comment.