### PR TITLE
Add method body inspection design doc (#2122)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Hidden-Fact Annotations](design/hidden-fact-annotations.md) | Allocation/unsafety/lifetime annotation model and the static IL pair-agreement oracle strategy. |
 | [Decompiler Inspection & Oracle](design/decompiler-inspection-oracle.md) | Unifies single-method inspection (dump/stages) with the corpus-wide fidelity check oracle; product-vs-tool scoping. |
 | [ReturnToSender: Fact-Planned Compile-Back Harness](design/fact-planned-compile-back-harness.md) | Spec for a fresh tools-side compile-back harness with fact-planned TypeProducer/TypePrinter shells. |
+| [Method Body Inspection](design/method-body-inspection.md) | Target service seam for shared `member` and `library --il-offset` method-body facts and coordinate inspection. |
 | [NuGet API](design/nuget.md) | NuGet API endpoints used by the tool. |
 | [Version Resolution](design/version-resolution.md) | Package/platform version and cache behavior. |
 | [Assembly Inspection Query Model](design/assembly-inspection-query.md) | Target boundary where the CLI forms a query and the metadata/service layer resolves, opens, and returns the final shape (why the CLI should not hold a `PEReader`). |

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -2,9 +2,9 @@
 
 > Design north-star for raising `member` body sections and `library --il-offset`
 > onto one service model. This complements the assembly acquisition/session seam
-> in the #2122 inspection-query work: assembly inspection opens and identifies
-> an assembly; method-body inspection explains one method body or one IL
-> coordinate inside it.
+> in the [assembly inspection query model](https://github.com/richlander/dotnet-inspect/pull/2138):
+> assembly inspection opens and identifies an assembly; method-body inspection
+> explains one method body or one IL coordinate inside it.
 
 ## Problem
 
@@ -98,7 +98,7 @@ CLI section name. Section selection maps to lenses at the command boundary.
 | `Source` | source file, line, SourceLink URL, browsable URL | Metadata / SourceLink |
 | `ExceptionRegions` | region, clause, try/handler/filter ranges, caught type | Metadata / PDB context |
 | `Calls` | direct call sites, call kind, callee, operand token, return address | Analysis |
-| `Callers` | inbound caller sites and caller-scope provenance | Analysis / Services |
+| `Callers` | inbound caller sites and caller-scope provenance | Analysis / composition |
 | `Graphs` | call graph and caller graph nodes with signal annotations | Analysis |
 | `Unsafe` | unsafe API/member evidence and unsafe operations | Analysis |
 | `AllocationFacts` | allocation facts at method or coordinate scope | Analysis |
@@ -188,7 +188,7 @@ Owns offset-keyed overlays that join Analysis (R1) and Decompiler (R2):
 Research remains the bridge. Analysis should not depend on Decompiler or
 Research.
 
-### `DotnetInspector.Services`
+### Composition layer
 
 Owns composition:
 
@@ -197,7 +197,18 @@ Owns composition:
 - coordinate metadata, analysis, source acquisition, and Research
 - return `MethodBodyInspection`
 
-This is the natural home for caching and lazy lens execution.
+This layer must sit **above** Metadata, Analysis, Decompiler, and Research. It
+must not be `DotnetInspector.Services`, because that project is a lower-level
+shared services layer used by package/source/TFM infrastructure. Putting
+Research or Decompiler orchestration there would invert the dependency graph and
+pull R2 concerns into lower-layer consumers.
+
+Initial implementations may live in `src/dotnet-inspect/Inspectors/` while the
+service shape proves out. If this grows beyond CLI-local orchestration, prefer a
+new high-level inspection/composition project over expanding
+`DotnetInspector.Services`.
+
+This composition layer is the natural home for caching and lazy lens execution.
 
 ### CLI
 
@@ -222,6 +233,12 @@ assembly session design settles, but the target constructor should consume the
 assembly session or its `ResolvedAssemblyReference`, not introduce another
 string-only seam.
 
+This depends on the sibling assembly acquisition design in
+[PR #2138](https://github.com/richlander/dotnet-inspect/pull/2138). Treat the
+two docs as one program of work under #2122: assembly inspection owns resolution
+and PE lifetime; method-body inspection owns member/coordinate facts inside the
+resolved assembly.
+
 ## Migration
 
 Move in reviewable slices.
@@ -229,8 +246,10 @@ Move in reviewable slices.
 1. **Design the shared model.** Land this doc and agree on the lens ownership
    table.
 2. **Add a path-backed adapter.** Add `MethodBodyInspectionSession.Open(path)`
-   or an internal service equivalent that can be swapped later for
-   `AssemblyInspectionSession`.
+   or an internal composition-layer equivalent that can be swapped later for
+   `AssemblyInspectionSession`. Keep this above Metadata, Analysis, Decompiler,
+   and Research; do not add Research/Decompiler dependencies to
+   `DotnetInspector.Services`.
 3. **Raise semantic facts first.** Move `ILOffsetSourceQuery` allocation,
    safety, and cost construction to Analysis-backed method/coordinate APIs.
    Preserve the current instruction-only fallback behavior deliberately or

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -114,6 +114,16 @@ The important rule: a facet has one canonical owner. CLI sections such as
 render different projections, but they should not compute the underlying facts
 independently.
 
+Facet identity is typed here (a `MethodBodyFacetSet` over named facets), which suits a
+closed, product-owned catalog — see the *facet-identity design axis* (string vs typed
+vs generic type-as-key) in the
+[Assembly Inspection Query Model](assembly-inspection-query.md) for when each applies.
+This service is also a **producer registry**: it delegates each facet to its one owning
+layer and composes the results, exactly the pattern `ILInspector.Research`'s
+`IResearchFactProducer` / `ResearchFactRegistry` already use over a build-once context
+(the *prior art* section of that same doc). Prefer generalizing that pattern over a
+green-field mechanism.
+
 ## Service shape
 
 ```csharp
@@ -228,16 +238,27 @@ I open it once, and what assembly-level scanners are requested?"
 The method-body session answers: "inside that assembly, which method body or IL
 coordinate am I explaining, and which facets are requested?"
 
-Method-body inspection should be able to start from today's `dllPath` while the
-assembly session design settles, but the target constructor should consume the
-assembly session or its `ResolvedAssemblyReference`, not introduce another
-string-only seam.
+Method-body inspection can start from today's `dllPath` for early slices, but the
+target constructor consumes the assembly session or its `ResolvedAssemblyReference`,
+not another string-only seam. That assembly session is **no longer pending**:
+`AssemblyInspectionSession` and its `AssemblyImage` shipped in #2156–#2162 (see the
+[Assembly Inspection Query Model](assembly-inspection-query.md)), so the method-body
+session can consume the real type from the start rather than a placeholder.
+
+One caveat on "open the image once": true single-open convergence — sharing the
+assembly's `AssemblyImage` with `PdbContext`, `MetadataSource`, and `LibraryBodyIndex`
+— depends on the shared-PE-owner composition that is **still pending** (the `PdbContext`
+/ `MetadataSource` work called out as Symptom 3 in the assembly design). Until it lands,
+early method-body slices will still open their own readers for the decompiler/analysis
+paths; the single-open convergence arrives with that composition, not this doc.
 
 This depends on the sibling assembly acquisition design in
 [Assembly Inspection Query Model](assembly-inspection-query.md). Treat the
 two docs as one program of work under #2122: assembly inspection owns resolution
 and PE lifetime; method-body inspection owns member/coordinate facts inside the
-resolved assembly.
+resolved assembly. In request terms, the CLI builds one `InspectionQuery` whose
+`Target.Selector` is a `MemberQuery` / `ILCoordinateQuery`; it hands that selector
+plus the requested facets to the method-body session.
 
 ## Migration
 
@@ -245,10 +266,10 @@ Move in reviewable slices.
 
 1. **Design the shared model.** Land this doc and agree on the facet ownership
    table.
-2. **Add a path-backed adapter.** Add `MethodBodyInspectionSession.Open(path)`
-   or an internal composition-layer equivalent that can be swapped later for
-   `AssemblyInspectionSession`. Keep this above Metadata, Analysis, Decompiler,
-   and Research; do not add Research/Decompiler dependencies to
+2. **Add a session-backed adapter.** Add `MethodBodyInspectionSession` that consumes
+   the existing `AssemblyInspectionSession` (or a `ResolvedAssemblyReference`), with a
+   `dllPath` convenience entry for early slices. Keep this above Metadata, Analysis,
+   Decompiler, and Research; do not add Research/Decompiler dependencies to
    `DotnetInspector.Services`.
 3. **Raise semantic facts first.** Move `ILOffsetSourceQuery` allocation,
    safety, and cost construction to Analysis-backed method/coordinate APIs.

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -44,25 +44,24 @@ The shared abstraction is **method body inspection**:
 ResolvedAssemblyReference
   -> AssemblyInspectionSession
       -> MethodBodyInspectionSession
-          -> MemberQuery
-          -> ILCoordinateQuery
-          -> MethodBodyInspection
+          Inspect(MemberSelector | ILCoordinateSelector, facets)
+              -> MethodBodyInspection
 ```
 
-The command chooses a selector and requested facets. The service returns
-section-ready inspection facts. Renderers format those facts; they do not open
-indexes, classify opcodes, or assemble semantic rows.
+The command chooses a **selector** (member or IL coordinate) and the requested
+**facets**. The service returns section-ready inspection facts. Renderers format
+those facts; they do not open indexes, classify opcodes, or assemble semantic rows.
 
-## Query shapes
+## Selector shapes
 
 There are two entry points into the same method-body system.
 
-### `MemberQuery`
+### `MemberSelector`
 
 Identifies a method by API identity:
 
 ```csharp
-public sealed record MemberQuery(
+public sealed record MemberSelector(
     string TypeName,
     string MemberName,
     int OverloadIndex,
@@ -72,12 +71,12 @@ public sealed record MemberQuery(
 This is the `member` command shape. It is selected from `ApiType`/`ApiMember`
 and stable member selectors.
 
-### `ILCoordinateQuery`
+### `ILCoordinateSelector`
 
 Identifies a method-body selector by metadata coordinates:
 
 ```csharp
-public sealed record ILCoordinateQuery(
+public sealed record ILCoordinateSelector(
     int MethodToken,
     int ILOffset);
 ```
@@ -129,8 +128,8 @@ green-field mechanism.
 ```csharp
 public sealed class MethodBodyInspectionSession
 {
-    public MethodBodyInspection Inspect(MemberQuery query, MethodBodyFacetSet facets);
-    public MethodBodyInspection Inspect(ILCoordinateQuery query, MethodBodyFacetSet facets);
+    public MethodBodyInspection Inspect(MemberSelector selector, MethodBodyFacetSet facets);
+    public MethodBodyInspection Inspect(ILCoordinateSelector selector, MethodBodyFacetSet facets);
 }
 
 public sealed record MethodBodyInspection(
@@ -257,7 +256,7 @@ This depends on the sibling assembly acquisition design in
 two docs as one program of work under #2122: assembly inspection owns resolution
 and PE lifetime; method-body inspection owns member/coordinate facts inside the
 resolved assembly. In request terms, the CLI builds one `InspectionQuery` whose
-`Target.Selector` is a `MemberQuery` / `ILCoordinateQuery`; it hands that selector
+`Target.Selector` is a `MemberSelector` / `ILCoordinateSelector`; it hands that selector
 plus the requested facets to the method-body session.
 
 ## Migration
@@ -278,7 +277,7 @@ Move in reviewable slices.
 4. **Raise metadata coordinate facts.** Move member, instruction, exception,
    callsite, and return-address context behind the shared method-body service.
 5. **Delete `ILOffsetSourceQuery`.** Route `library --il-offset` through the
-   service with `ILCoordinateQuery`.
+   service with `ILCoordinateSelector`.
 6. **Raise member sections.** Move the fact construction currently in
    `ApiOutputFormatter.PopulateIndexSections` into the service. Leave the
    formatter as projection/rendering only.

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -1,0 +1,277 @@
+# Method Body Inspection
+
+> Design north-star for raising `member` body sections and `library --il-offset`
+> onto one service model. This complements the assembly acquisition/session seam
+> in the #2122 inspection-query work: assembly inspection opens and identifies
+> an assembly; method-body inspection explains one method body or one IL
+> coordinate inside it.
+
+## Problem
+
+`member` and `library --il-offset` now expose peer facts about method bodies:
+
+- source and decompiled source
+- IL
+- exception regions
+- calls, callers, call graphs, and return addresses
+- allocation, safety, and cost facts
+- hidden facts and overlays
+
+They reached that capability from different directions.
+
+`member` is integrated into the API pipeline. It resolves a type/member/overload,
+then `ApiOutputFormatter.PopulateIndexSections` opens analysis indexes and PDB
+contexts to fill `MemberCodeView` sections. `MemberCodeProvider` separately
+opens metadata/decompiler state for source, IL, attributes, overlays, and hidden
+facts.
+
+`library --il-offset` started as a one-off source lookup. `ILOffsetSourceQuery`
+now resolves member, instruction, exception, callsite, return-address,
+allocation, safety, and cost context, builds CLI model rows, and owns fallback
+opcode heuristics. It is no longer just a source query.
+
+Both paths have useful pieces, but neither is the target architecture:
+
+- `member` uses the normal command pipeline, but its formatter constructs facts.
+- `library --il-offset` has a standalone query/helper file that should disappear.
+- Both paths construct overlapping method-body facts differently.
+
+## Target
+
+The shared abstraction is **method body inspection**:
+
+```text
+ResolvedAssemblyReference
+  -> AssemblyInspectionSession
+      -> MethodBodyInspectionSession
+          -> MemberQuery
+          -> ILCoordinateQuery
+          -> MethodBodyInspection
+```
+
+The command chooses a query and requested lenses. The service returns
+section-ready inspection facts. Renderers format those facts; they do not open
+indexes, classify opcodes, or assemble semantic rows.
+
+## Query shapes
+
+There are two entry points into the same method-body system.
+
+### `MemberQuery`
+
+Identifies a method by API identity:
+
+```csharp
+public sealed record MemberQuery(
+    string TypeName,
+    string MemberName,
+    int OverloadIndex,
+    bool PublicOnly);
+```
+
+This is the `member` command shape. It is selected from `ApiType`/`ApiMember`
+and stable member selectors.
+
+### `ILCoordinateQuery`
+
+Identifies a method location by metadata coordinates:
+
+```csharp
+public sealed record ILCoordinateQuery(
+    int MethodToken,
+    int ILOffset);
+```
+
+This is the `library --il-offset` shape. It should not be a separate command
+architecture. It is another locator for the same method-body inspection
+pipeline.
+
+## Lenses
+
+Both query shapes request the same lenses. A lens is a product capability, not a
+CLI section name. Section selection maps to lenses at the command boundary.
+
+| Lens | Facts returned | Owner |
+| --- | --- | --- |
+| `Member` | assembly, type, member, signature, visibility, async, selected token | Metadata |
+| `Instruction` | IL offset, opcode, operand, block, branches, next offset | Metadata / Instructions |
+| `Source` | source file, line, SourceLink URL, browsable URL | Metadata / SourceLink |
+| `ExceptionRegions` | region, clause, try/handler/filter ranges, caught type | Metadata / PDB context |
+| `Calls` | direct call sites, call kind, callee, operand token, return address | Analysis |
+| `Callers` | inbound caller sites and caller-scope provenance | Analysis / Services |
+| `Graphs` | call graph and caller graph nodes with signal annotations | Analysis |
+| `Unsafe` | unsafe API/member evidence and unsafe operations | Analysis |
+| `AllocationFacts` | allocation facts at method or coordinate scope | Analysis |
+| `SafetyFacts` | safety facts at method or coordinate scope | Analysis |
+| `CostFacts` | dispatch/delegate/function-pointer cost facts | Analysis |
+| `HiddenFacts` | offset-keyed annotations used by Facts/overlays | Research |
+| `DecompiledSource` | raised/lowered source and diagnostics | Decompiler / Research |
+| `AnnotatedSource` | raised source plus hidden facts and IL | Research |
+| `OriginalSource` | fetched source slice | Metadata / SourceLink |
+
+The important rule: a lens has one canonical owner. CLI sections such as
+`Allocation Facts`, `Allocation Context`, `Facts`, or `Annotated Source` may
+render different projections, but they should not compute the underlying facts
+independently.
+
+## Service shape
+
+```csharp
+public sealed class MethodBodyInspectionSession
+{
+    public MethodBodyInspection Inspect(MemberQuery query, MethodBodyLensSet lenses);
+    public MethodBodyInspection Inspect(ILCoordinateQuery query, MethodBodyLensSet lenses);
+}
+
+public sealed record MethodBodyInspection(
+    MethodBodyIdentity Method,
+    InstructionFact? Instruction,
+    SourceLocationFact? Source,
+    IReadOnlyList<ExceptionRegionFact> ExceptionRegions,
+    IReadOnlyList<CallSiteFact> Calls,
+    IReadOnlyList<CallerSiteFact> Callers,
+    CallGraphFact? CallGraph,
+    CallGraphFact? CallerGraph,
+    IReadOnlyList<UnsafeFact> Unsafe,
+    IReadOnlyList<AllocationFact> Allocations,
+    IReadOnlyList<SafetyFact> Safety,
+    IReadOnlyList<CostFact> Cost,
+    IReadOnlyList<HiddenFact> HiddenFacts,
+    SourceBodyFact? DecompiledSource,
+    SourceBodyFact? AnnotatedSource,
+    SourceBodyFact? OriginalSource);
+```
+
+The exact record names can change. The boundary should not:
+
+- input is a member identity or IL coordinate plus requested lenses
+- output is a product-model inspection shape
+- the CLI does not open `LibraryBodyIndex`, `PdbContext`, `MetadataSource`, or
+  `PEReader`
+- the formatter does not construct facts
+
+## Layer ownership
+
+### `ILInspector.Metadata`
+
+Owns metadata-local method-body facts:
+
+- MethodDef token and overload resolution
+- instruction context
+- exception regions
+- SourceLink/source-line coordinate resolution
+- original-source body/slice acquisition helper APIs
+
+It stays SRM-only and does not load inspected assemblies.
+
+### `ILInspector.Analysis`
+
+Owns IL analysis facts:
+
+- direct calls and return addresses
+- callers and caller graphs
+- allocation, safety, and cost facts
+- unsafe operations and unsafe API evidence
+
+The existing `LibraryBodyIndex` and `SemanticFactProjection` are the right
+substrates. Coordinate scope should be added there, not rebuilt in CLI code.
+
+### `ILInspector.Research`
+
+Owns offset-keyed overlays that join Analysis (R1) and Decompiler (R2):
+
+- hidden fact registry
+- Facts rows
+- annotated source
+- cost and semantics overlays
+
+Research remains the bridge. Analysis should not depend on Decompiler or
+Research.
+
+### `DotnetInspector.Services`
+
+Owns composition:
+
+- open or receive the assembly inspection session
+- build/reuse `LibraryBodyIndex`
+- coordinate metadata, analysis, source acquisition, and Research
+- return `MethodBodyInspection`
+
+This is the natural home for caching and lazy lens execution.
+
+### CLI
+
+Owns only:
+
+- parse command options
+- map section selection to lenses
+- call the service
+- render the returned shape
+- write command-line diagnostics for invalid user input
+
+## Relationship to assembly inspection
+
+The assembly inspection session answers: "what assembly am I inspecting, how do
+I open it once, and what assembly-level scanners are requested?"
+
+The method-body session answers: "inside that assembly, which method body or IL
+coordinate am I explaining, and which lenses are requested?"
+
+Method-body inspection should be able to start from today's `dllPath` while the
+assembly session design settles, but the target constructor should consume the
+assembly session or its `ResolvedAssemblyReference`, not introduce another
+string-only seam.
+
+## Migration
+
+Move in reviewable slices.
+
+1. **Design the shared model.** Land this doc and agree on the lens ownership
+   table.
+2. **Add a path-backed adapter.** Add `MethodBodyInspectionSession.Open(path)`
+   or an internal service equivalent that can be swapped later for
+   `AssemblyInspectionSession`.
+3. **Raise semantic facts first.** Move `ILOffsetSourceQuery` allocation,
+   safety, and cost construction to Analysis-backed method/coordinate APIs.
+   Preserve the current instruction-only fallback behavior deliberately or
+   remove it with an explicit behavior note.
+4. **Raise metadata coordinate facts.** Move member, instruction, exception,
+   callsite, and return-address context behind the shared method-body service.
+5. **Delete `ILOffsetSourceQuery`.** Route `library --il-offset` through the
+   service with `ILCoordinateQuery`.
+6. **Raise member sections.** Move the fact construction currently in
+   `ApiOutputFormatter.PopulateIndexSections` into the service. Leave the
+   formatter as projection/rendering only.
+7. **Unify overlays.** Keep `MemberCodeProvider` only as an adapter if needed,
+   then route source/IL/decompiler/Research-backed sections through the same
+   method-body session.
+
+## Acceptance tests for the architecture
+
+- Adding a new method-body fact requires changing one producer/service, not both
+  `member` and `library --il-offset`.
+- `library --il-offset` has no bespoke query/helper file.
+- `ApiOutputFormatter` does not open `LibraryBodyIndex` or `PdbContext`.
+- Member-level and coordinate-level allocation/safety/cost rows agree for the
+  same method and offset.
+- The CLI has no `System.Reflection.Metadata` or
+  `System.Reflection.PortableExecutable` dependency for method-body inspection.
+- Analysis remains SRM-only, NativeAOT-friendly, Roslyn-free, and free of
+  decompiler dependencies.
+- Research remains the only R1/R2 overlay bridge.
+
+## Open questions
+
+- Should `MethodBodyInspection` return all facts as canonical records with the
+  CLI adapting to existing view rows, or should the service return
+  view-compatible section records? Prefer canonical product records first, with
+  thin render adapters.
+- Should missing facts be represented as empty lists, diagnostics, or
+  unavailable-lens reasons? `member` sections often render empty-state notes;
+  `library --il-offset` currently returns command errors for required contexts.
+- How much of caller-scope resolution belongs in this service versus the
+  command? The scope is user input, but resolving assemblies for the scope is a
+  service concern.
+- Should `OriginalSource` be a method-body lens or remain a SourceLink service
+  call that the method-body service composes? It is a lens from the user's
+  perspective, even if SourceLink owns the fetch.

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -2,7 +2,7 @@
 
 > Design north-star for raising `member` body sections and `library --il-offset`
 > onto one service model. This complements the assembly acquisition/session seam
-> in the [assembly inspection query model](https://github.com/richlander/dotnet-inspect/pull/2138):
+> in the [assembly inspection query model](assembly-inspection-query.md):
 > assembly inspection opens and identifies an assembly; method-body inspection
 > explains one method body or one IL coordinate inside it.
 
@@ -49,7 +49,7 @@ ResolvedAssemblyReference
           -> MethodBodyInspection
 ```
 
-The command chooses a query and requested lenses. The service returns
+The command chooses a selector and requested facets. The service returns
 section-ready inspection facts. Renderers format those facts; they do not open
 indexes, classify opcodes, or assemble semantic rows.
 
@@ -74,7 +74,7 @@ and stable member selectors.
 
 ### `ILCoordinateQuery`
 
-Identifies a method location by metadata coordinates:
+Identifies a method-body selector by metadata coordinates:
 
 ```csharp
 public sealed record ILCoordinateQuery(
@@ -83,15 +83,15 @@ public sealed record ILCoordinateQuery(
 ```
 
 This is the `library --il-offset` shape. It should not be a separate command
-architecture. It is another locator for the same method-body inspection
+architecture. It is another selector for the same method-body inspection
 pipeline.
 
-## Lenses
+## Facets
 
-Both query shapes request the same lenses. A lens is a product capability, not a
-CLI section name. Section selection maps to lenses at the command boundary.
+Both query shapes request the same facets. A facet is a product capability, not a
+CLI section name. Section selection maps to facets at the command boundary.
 
-| Lens | Facts returned | Owner |
+| Facet | Facts returned | Owner |
 | --- | --- | --- |
 | `Member` | assembly, type, member, signature, visibility, async, selected token | Metadata |
 | `Instruction` | IL offset, opcode, operand, block, branches, next offset | Metadata / Instructions |
@@ -109,7 +109,7 @@ CLI section name. Section selection maps to lenses at the command boundary.
 | `AnnotatedSource` | raised source plus hidden facts and IL | Research |
 | `OriginalSource` | fetched source slice | Metadata / SourceLink |
 
-The important rule: a lens has one canonical owner. CLI sections such as
+The important rule: a facet has one canonical owner. CLI sections such as
 `Allocation Facts`, `Allocation Context`, `Facts`, or `Annotated Source` may
 render different projections, but they should not compute the underlying facts
 independently.
@@ -119,8 +119,8 @@ independently.
 ```csharp
 public sealed class MethodBodyInspectionSession
 {
-    public MethodBodyInspection Inspect(MemberQuery query, MethodBodyLensSet lenses);
-    public MethodBodyInspection Inspect(ILCoordinateQuery query, MethodBodyLensSet lenses);
+    public MethodBodyInspection Inspect(MemberQuery query, MethodBodyFacetSet facets);
+    public MethodBodyInspection Inspect(ILCoordinateQuery query, MethodBodyFacetSet facets);
 }
 
 public sealed record MethodBodyInspection(
@@ -144,7 +144,7 @@ public sealed record MethodBodyInspection(
 
 The exact record names can change. The boundary should not:
 
-- input is a member identity or IL coordinate plus requested lenses
+- input is a member identity or IL coordinate plus requested facets
 - output is a product-model inspection shape
 - the CLI does not open `LibraryBodyIndex`, `PdbContext`, `MetadataSource`, or
   `PEReader`
@@ -208,14 +208,14 @@ service shape proves out. If this grows beyond CLI-local orchestration, prefer a
 new high-level inspection/composition project over expanding
 `DotnetInspector.Services`.
 
-This composition layer is the natural home for caching and lazy lens execution.
+This composition layer is the natural home for caching and lazy facet execution.
 
 ### CLI
 
 Owns only:
 
 - parse command options
-- map section selection to lenses
+- map section selection to facets
 - call the service
 - render the returned shape
 - write command-line diagnostics for invalid user input
@@ -226,7 +226,7 @@ The assembly inspection session answers: "what assembly am I inspecting, how do
 I open it once, and what assembly-level scanners are requested?"
 
 The method-body session answers: "inside that assembly, which method body or IL
-coordinate am I explaining, and which lenses are requested?"
+coordinate am I explaining, and which facets are requested?"
 
 Method-body inspection should be able to start from today's `dllPath` while the
 assembly session design settles, but the target constructor should consume the
@@ -234,7 +234,7 @@ assembly session or its `ResolvedAssemblyReference`, not introduce another
 string-only seam.
 
 This depends on the sibling assembly acquisition design in
-[PR #2138](https://github.com/richlander/dotnet-inspect/pull/2138). Treat the
+[Assembly Inspection Query Model](assembly-inspection-query.md). Treat the
 two docs as one program of work under #2122: assembly inspection owns resolution
 and PE lifetime; method-body inspection owns member/coordinate facts inside the
 resolved assembly.
@@ -243,7 +243,7 @@ resolved assembly.
 
 Move in reviewable slices.
 
-1. **Design the shared model.** Land this doc and agree on the lens ownership
+1. **Design the shared model.** Land this doc and agree on the facet ownership
    table.
 2. **Add a path-backed adapter.** Add `MethodBodyInspectionSession.Open(path)`
    or an internal composition-layer equivalent that can be swapped later for
@@ -286,11 +286,11 @@ Move in reviewable slices.
   view-compatible section records? Prefer canonical product records first, with
   thin render adapters.
 - Should missing facts be represented as empty lists, diagnostics, or
-  unavailable-lens reasons? `member` sections often render empty-state notes;
+  unavailable-facet reasons? `member` sections often render empty-state notes;
   `library --il-offset` currently returns command errors for required contexts.
 - How much of caller-scope resolution belongs in this service versus the
   command? The scope is user input, but resolving assemblies for the scope is a
   service concern.
-- Should `OriginalSource` be a method-body lens or remain a SourceLink service
-  call that the method-body service composes? It is a lens from the user's
+- Should `OriginalSource` be a method-body facet or remain a SourceLink service
+  call that the method-body service composes? It is a facet from the user's
   perspective, even if SourceLink owns the fetch.

--- a/docs/design/method-body-inspection.md
+++ b/docs/design/method-body-inspection.md
@@ -126,7 +126,7 @@ public sealed class MethodBodyInspectionSession
 public sealed record MethodBodyInspection(
     MethodBodyIdentity Method,
     InstructionFact? Instruction,
-    SourceLocationFact? Source,
+    SourceCoordinateFact? Source,
     IReadOnlyList<ExceptionRegionFact> ExceptionRegions,
     IReadOnlyList<CallSiteFact> Calls,
     IReadOnlyList<CallerSiteFact> Callers,


### PR DESCRIPTION
## Summary
- add a method-body inspection design note for converging member body sections and library --il-offset
- define shared selector shapes, facets, layer ownership, migration steps, and architecture acceptance tests
- align terminology with the merged Assembly Inspection Query Model: location = assembly, selector = member/IL coordinate, facet = capability
- clarify that method-body composition must sit above Metadata/Analysis/Decompiler/Research, not in DotnetInspector.Services
- link the design from docs/README.md

## Validation
- npx markdownlint-cli docs/design/method-body-inspection.md docs/README.md

## Adversarial review
- Claude Opus 4.8: no significant issues found; verified layering, current architecture claims, facet ownership, terminology alignment, and buildable migration path.
- Gemini 3.1 Pro: found a high-confidence terminology leak (`SourceLocationFact` overloaded location). Addressed in cade8c4e by renaming it to `SourceCoordinateFact`.
- Earlier review rounds found and resolved missing #2138 cross-reference and incorrect DotnetInspector.Services ownership; addressed in 35d38962.

Docs-only; no behavior change.

Part of #2122.
