### PR TITLE
Add ReturnToSender setter catalog coverage

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -174,6 +174,13 @@ public class GeneratedFixtureCatalogTests
         AssertTarget(
             run,
             "minimal.object-initializer",
+            "GeneratedFixtures.MinimalObjectInitializer.Helper",
+            "set_Value",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.object-initializer",
             "GeneratedFixtures.MinimalObjectInitializer.Class1",
             ".ctor",
             FidelityCheck.CompileBackStatus.Exact,
@@ -267,6 +274,27 @@ public class GeneratedFixtureCatalogTests
             "minimal.indexer.getter",
             "GeneratedFixtures.MinimalIndexerGetter.Class1",
             "get_Item",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.indexer.setter",
+            "GeneratedFixtures.MinimalIndexerSetter.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.indexer.setter",
+            "GeneratedFixtures.MinimalIndexerSetter.Class1",
+            "get_Item",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.indexer.setter",
+            "GeneratedFixtures.MinimalIndexerSetter.Class1",
+            "set_Item",
             FidelityCheck.CompileBackStatus.Exact,
             frontier: false);
         AssertTarget(
@@ -410,6 +438,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.array-index", report);
         Assert.Contains("minimal.array-length", report);
         Assert.Contains("minimal.indexer.getter", report);
+        Assert.Contains("minimal.indexer.setter", report);
         Assert.Contains("minimal.string-length", report);
         Assert.Contains("minimal.null-coalesce", report);
         Assert.Contains("minimal.try-finally", report);
@@ -459,6 +488,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.foreach-array",
                 "minimal.if-else",
                 "minimal.indexer.getter",
+                "minimal.indexer.setter",
                 "minimal.integer-addition",
                 "minimal.interface-implementation",
                 "minimal.method-call.same-type",
@@ -507,6 +537,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-index");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-length");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.indexer.getter");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.indexer.setter");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.string-length");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.null-coalesce");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.try-finally");

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -893,6 +893,50 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_OverloadedIndexerSetterComparesSingleShellAccessor()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                private readonly int[] _values;
+                private readonly string[] _names;
+
+                public Class1()
+                {
+                    _values = new int[4];
+                    _names = new string[4];
+                }
+
+                public int this[int index]
+                {
+                    get => _values[index];
+                    set => _values[index] = value;
+                }
+
+                public string this[string key]
+                {
+                    get => _names[key.Length];
+                    set => _names[key.Length] = value;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "set_Item", 1)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Equal(1, result.Plan.TargetMethod.Overload);
+            Assert.Contains("public string this[string key]", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_DoesNotDuplicateBodyBackedSetterDuringClosureSurface()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -833,6 +833,66 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RoundTripsAutoPropertySetter()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public int Value { get; set; }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "set_Value", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public int Value { get; set; }", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RoundTripsIndexerSetter()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                private readonly int[] _values;
+
+                public Class1()
+                {
+                    _values = new int[4];
+                }
+
+                public int this[int index]
+                {
+                    get => _values[index];
+                    set => _values[index] = value;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "set_Item", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public int this[int index]", result.Source);
+            Assert.Contains("set", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_SurfacesUnsafeNestedClosureMember()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -923,6 +923,42 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_EmitsGetterStubForSetterBodyThatReadsProperty()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                private int _value;
+
+                public int Value
+                {
+                    get => _value;
+                    set
+                    {
+                        if (Value != value)
+                            _value = value;
+                    }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "set_Value", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("get", result.Source);
+            Assert.Contains("throw null", result.Source);
+            Assert.Contains("Value != value", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_SurfacesUnsafeNestedClosureMember()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -893,6 +893,36 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_DoesNotDuplicateBodyBackedSetterDuringClosureSurface()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                private int _value;
+
+                public int Value
+                {
+                    set => _value = value;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "set_Value", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public int Value", result.Source);
+            Assert.DoesNotContain("throw null", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_SurfacesUnsafeNestedClosureMember()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -1526,7 +1526,9 @@ public static class CompileBackSourceComposer
                 {
                     continue;
                 }
-                if (members.Any(member => member.Kind == CompileBackMemberKind.PropertyGet && member.Name == Identifier(propertyName)))
+                if (members.Any(member =>
+                        member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet
+                        && member.Name == Identifier(propertyName)))
                     continue;
 
                 MethodSignature<string> signature;

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -160,6 +160,7 @@ public sealed record CompileBackMemberDeclaration(
 public enum CompileBackMemberKind
 {
     PropertyGet,
+    PropertySet,
     Constructor,
     Method,
     Field,
@@ -303,6 +304,107 @@ public static class CompileBackSourceComposer
                                 new CompileBackFact("metadata", "auto-property", propertyName)
                             ]
                             : [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))])
+                ],
+                PrimaryConstructor: null,
+                targetFacts)
+        };
+
+        foreach (var dependency in closureRoots.OrderBy(handle => MetadataTokens.GetToken(handle)))
+        {
+            if (dependency == targetRoot)
+                continue;
+
+            var dependencyDef = reader.GetTypeDefinition(dependency);
+            var dependencyIdentity = CompileBackTypeIdentity.FromDefinition(reader, dependencyDef);
+            if (requirements.Any(requirement => requirement.Type.MetadataFullName == dependencyIdentity.MetadataFullName))
+                continue;
+
+            requirements.Add(new CompileBackTypeRequirement(
+                dependencyIdentity,
+                ShellKind(reader, dependencyDef),
+                RequiredMembers: [],
+                PrimaryConstructor: null,
+                SourceFacts: closureFacts.TryGetValue(dependency, out var facts)
+                    ? facts.ToArray()
+                    : [new CompileBackFact("closure", "closure-root", dependencyIdentity.FullName)]));
+        }
+
+        var declarations = TypeProducer.Produce(reader, requirements, diagnostics);
+        var module = new CompileBackModuleRequirement(
+            Usings: RequiredNamespaces(function)
+                .Concat(DeclarationNamespaces(declarations))
+                .Prepend("System")
+                .Select(CompileBackCSharpNames.EscapeNamespace)
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal)
+                .ToArray(),
+            AssemblyAttributes: [],
+            ModuleAttributes: []);
+        var plan = new CompileBackReconstructionPlan(
+            assemblyPath,
+            new CompileBackMethodIdentity(fullType, methodName, overload, signatureText),
+            module,
+            declarations,
+            requirements,
+            diagnostics);
+        return new CompileBackSourceResult(plan, WriteCompilationUnit(plan));
+    }
+
+    public static CompileBackSourceResult ComposePropertySetter(
+        string assemblyPath,
+        MetadataReader reader,
+        IrFunction function,
+        TypeDefinitionHandle targetType,
+        PropertyDefinitionHandle targetProperty,
+        MethodDefinitionHandle targetSetter,
+        string targetBody,
+        string fullType,
+        string methodName,
+        int overload,
+        string signatureText,
+        IReadOnlySet<TypeDefinitionHandle> closureRoots,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts)
+    {
+        var targetTypeDef = reader.GetTypeDefinition(targetType);
+        var property = reader.GetPropertyDefinition(targetProperty);
+        var setter = reader.GetMethodDefinition(targetSetter);
+        var propertySignature = property.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, targetTypeDef));
+        var setterSignature = setter.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, targetTypeDef, setter));
+        var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
+        string propertyName = Identifier(reader.GetString(property.Name));
+        var returnType = CompileBackTypeSignature.Display(propertySignature.ReturnType);
+        bool targetIsAutoProperty = IsAutoPropertySetter(reader, targetTypeDef, property, targetSetter, returnType.DisplayName);
+
+        var diagnostics = new List<CompileBackPlanningDiagnostic>();
+        var targetRoot = TopLevelRootOf(reader, targetType);
+        var targetFacts = new List<CompileBackFact>
+        {
+            new("metadata", "target-type", targetIdentity.FullName),
+        };
+        if (closureFacts.TryGetValue(targetRoot, out var targetClosureFacts))
+            targetFacts.AddRange(targetClosureFacts);
+
+        var indexerParameterCount = propertySignature.ParameterTypes.Length;
+        var requirements = new List<CompileBackTypeRequirement>
+        {
+            new(
+                targetIdentity,
+                ShellKind(reader, targetTypeDef),
+                [
+                    new CompileBackMemberRequirement(
+                        new CompileBackMethodIdentity(targetIdentity.FullName, propertyName, overload, signatureText),
+                        CompileBackMemberKind.PropertySet,
+                        setter.Attributes.HasFlag(MethodAttributes.Static),
+                        MethodParameters(reader, setter, setterSignature).Take(indexerParameterCount).ToArray(),
+                        returnType,
+                        targetIsAutoProperty ? CompileBackStubBodyKind.AutoPropertyGetSet : CompileBackStubBodyKind.TargetBody,
+                        targetIsAutoProperty ? null : targetBody,
+                        targetIsAutoProperty
+                            ? [
+                                new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name)),
+                                new CompileBackFact("metadata", "auto-property", propertyName)
+                            ]
+                            : [new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name))])
                 ],
                 PrimaryConstructor: null,
                 targetFacts)
@@ -587,6 +689,7 @@ public static class CompileBackSourceComposer
                 }
                 if (member.StubBody == CompileBackStubBodyKind.AutoPropertyGetSet)
                 {
+                    declaration = StripPropertyAccessorBlock(declaration);
                     sb.AppendLine($"{pad}{declaration} {{ get; set; }}");
                     break;
                 }
@@ -608,6 +711,28 @@ public static class CompileBackSourceComposer
                         if (text.Length > 0)
                             sb.AppendLine($"{pad}        {text}");
                     }
+                }
+                sb.AppendLine($"{pad}    }}");
+                sb.AppendLine($"{pad}}}");
+                break;
+            case CompileBackMemberKind.PropertySet:
+                if (member.StubBody == CompileBackStubBodyKind.AutoPropertyGetSet)
+                {
+                    declaration = StripPropertyAccessorBlock(declaration);
+                    sb.AppendLine($"{pad}{declaration} {{ get; set; }}");
+                    break;
+                }
+
+                declaration = StripPropertyAccessorBlock(declaration);
+                sb.AppendLine($"{pad}{declaration}");
+                sb.AppendLine($"{pad}{{");
+                sb.AppendLine($"{pad}    set");
+                sb.AppendLine($"{pad}    {{");
+                foreach (var line in member.Body.Split('\n'))
+                {
+                    var text = line.TrimEnd('\r');
+                    if (text.Length > 0)
+                        sb.AppendLine($"{pad}        {text}");
                 }
                 sb.AppendLine($"{pad}    }}");
                 sb.AppendLine($"{pad}}}");
@@ -680,6 +805,7 @@ public static class CompileBackSourceComposer
             Kind = member.Kind switch
             {
                 CompileBackMemberKind.PropertyGet => "property",
+                CompileBackMemberKind.PropertySet => "property",
                 CompileBackMemberKind.Constructor => "constructor",
                 CompileBackMemberKind.Method => "method",
                 CompileBackMemberKind.Field => "field",
@@ -691,6 +817,8 @@ public static class CompileBackSourceComposer
                 CompileBackMemberKind.PropertyGet when member.Parameters.Count > 0 => $"{returnType ?? "void"} this[{parameterList}] {{ get; }}",
                 CompileBackMemberKind.PropertyGet when type.Kind == CompileBackTypeKind.Interface => $"{returnType ?? "void"} {member.Name} {{ get; }}",
                 CompileBackMemberKind.PropertyGet => $"{returnType ?? "void"} {member.Name}",
+                CompileBackMemberKind.PropertySet when member.Parameters.Count > 0 => $"{returnType ?? "void"} this[{parameterList}] {{ set; }}",
+                CompileBackMemberKind.PropertySet => $"{returnType ?? "void"} {member.Name} {{ set; }}",
                 CompileBackMemberKind.Constructor => $"void .ctor({parameterList})",
                 CompileBackMemberKind.Method => $"{returnType ?? "void"} {member.Name}({parameterList})",
                 CompileBackMemberKind.Field => $"{returnType ?? "object"} {member.Name}",
@@ -732,10 +860,13 @@ public static class CompileBackSourceComposer
 
     static string StripPropertyAccessorBlock(string declaration)
     {
-        const string getOnly = " { get; }";
-        return declaration.EndsWith(getOnly, StringComparison.Ordinal)
-            ? declaration[..^getOnly.Length]
-            : declaration;
+        foreach (var suffix in new[] { " { get; }", " { set; }" })
+        {
+            if (declaration.EndsWith(suffix, StringComparison.Ordinal))
+                return declaration[..^suffix.Length];
+        }
+
+        return declaration;
     }
 
     static IReadOnlyList<CompileBackParameter> MethodParameters(
@@ -960,6 +1091,47 @@ public static class CompileBackSourceComposer
         string propertyName = reader.GetString(property.Name);
         string backingName = $"<{propertyName}>k__BackingField";
         bool isStatic = getter.Attributes.HasFlag(MethodAttributes.Static);
+        var context = GenericContext.ForType(reader, typeDef);
+        foreach (var fieldHandle in typeDef.GetFields())
+        {
+            var field = reader.GetFieldDefinition(fieldHandle);
+            if (reader.GetString(field.Name) != backingName)
+                continue;
+            if (field.Attributes.HasFlag(FieldAttributes.Static) != isStatic)
+                continue;
+            if (!MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, field.GetCustomAttributes()))
+                return false;
+            try
+            {
+                return CompileBackTypeSignature.Display(field.DecodeSignature(SignatureDecoder.Instance, context)).DisplayName == propertyType;
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return false;
+            }
+
+        }
+
+        return false;
+    }
+
+    static bool IsAutoPropertySetter(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        PropertyDefinition property,
+        MethodDefinitionHandle setterHandle,
+        string propertyType)
+    {
+        var accessors = property.GetAccessors();
+        if (accessors.Setter.IsNil || accessors.Setter != setterHandle)
+            return false;
+        var setter = reader.GetMethodDefinition(setterHandle);
+        if (!MethodDefinitionFacts.HasCompilerGeneratedAttribute(reader, setter.GetCustomAttributes()))
+            return false;
+
+        string propertyName = reader.GetString(property.Name);
+        string backingName = $"<{propertyName}>k__BackingField";
+        bool isStatic = setter.Attributes.HasFlag(MethodAttributes.Static);
         var context = GenericContext.ForType(reader, typeDef);
         foreach (var fieldHandle in typeDef.GetFields())
         {

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -218,6 +218,8 @@ public enum CompileBackStubBodyKind
     None,
     Throw,
     TargetBody,
+    TargetGetterWithSetter,
+    TargetSetterWithGetter,
     AutoProperty,
     AutoPropertyGetSet,
     FieldInitializer,
@@ -270,6 +272,7 @@ public static class CompileBackSourceComposer
         var getter = reader.GetMethodDefinition(targetGetter);
         var signature = property.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, targetTypeDef));
         var getterSignature = getter.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, targetTypeDef, getter));
+        var accessors = property.GetAccessors();
         var targetIdentity = CompileBackTypeIdentity.FromDefinition(reader, targetTypeDef);
         string propertyName = Identifier(reader.GetString(property.Name));
         var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
@@ -296,7 +299,11 @@ public static class CompileBackSourceComposer
                         getter.Attributes.HasFlag(MethodAttributes.Static),
                         MethodParameters(reader, getter, getterSignature),
                         returnType,
-                        targetIsAutoProperty ? CompileBackStubBodyKind.AutoProperty : CompileBackStubBodyKind.TargetBody,
+                        targetIsAutoProperty
+                            ? CompileBackStubBodyKind.AutoProperty
+                            : accessors.Setter.IsNil
+                                ? CompileBackStubBodyKind.TargetBody
+                                : CompileBackStubBodyKind.TargetGetterWithSetter,
                         targetIsAutoProperty ? null : targetBody,
                         targetIsAutoProperty
                             ? [
@@ -397,7 +404,11 @@ public static class CompileBackSourceComposer
                         setter.Attributes.HasFlag(MethodAttributes.Static),
                         MethodParameters(reader, setter, setterSignature).Take(indexerParameterCount).ToArray(),
                         returnType,
-                        targetIsAutoProperty ? CompileBackStubBodyKind.AutoPropertyGetSet : CompileBackStubBodyKind.TargetBody,
+                        targetIsAutoProperty
+                            ? CompileBackStubBodyKind.AutoPropertyGetSet
+                            : property.GetAccessors().Getter.IsNil
+                                ? CompileBackStubBodyKind.TargetBody
+                                : CompileBackStubBodyKind.TargetSetterWithGetter,
                         targetIsAutoProperty ? null : targetBody,
                         targetIsAutoProperty
                             ? [
@@ -713,6 +724,13 @@ public static class CompileBackSourceComposer
                     }
                 }
                 sb.AppendLine($"{pad}    }}");
+                if (member.StubBody == CompileBackStubBodyKind.TargetGetterWithSetter)
+                {
+                    sb.AppendLine($"{pad}    set");
+                    sb.AppendLine($"{pad}    {{");
+                    sb.AppendLine($"{pad}        throw null;");
+                    sb.AppendLine($"{pad}    }}");
+                }
                 sb.AppendLine($"{pad}}}");
                 break;
             case CompileBackMemberKind.PropertySet:
@@ -726,6 +744,13 @@ public static class CompileBackSourceComposer
                 declaration = StripPropertyAccessorBlock(declaration);
                 sb.AppendLine($"{pad}{declaration}");
                 sb.AppendLine($"{pad}{{");
+                if (member.StubBody == CompileBackStubBodyKind.TargetSetterWithGetter)
+                {
+                    sb.AppendLine($"{pad}    get");
+                    sb.AppendLine($"{pad}    {{");
+                    sb.AppendLine($"{pad}        throw null;");
+                    sb.AppendLine($"{pad}    }}");
+                }
                 sb.AppendLine($"{pad}    set");
                 sb.AppendLine($"{pad}    {{");
                 foreach (var line in member.Body.Split('\n'))

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -222,6 +222,8 @@ internal static class GeneratedFixtureCatalog
                 FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalObjectInitializer.Helper", "get_Value",
                 FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalObjectInitializer.Helper", "set_Value",
+                FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalObjectInitializer.Class1", ".ctor",
                 FidelityCheck.CompileBackStatus.Exact),
             new("GeneratedFixtures.MinimalObjectInitializer.Class1", "Method1",
@@ -345,6 +347,37 @@ internal static class GeneratedFixtureCatalog
                 FidelityCheck.CompileBackStatus.Exact),
         ],
         ["minimal", "indexer", "property"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalIndexerSetter = new(
+        "minimal.indexer.setter",
+        """
+        namespace GeneratedFixtures.MinimalIndexerSetter;
+
+        public class Class1
+        {
+            private readonly int[] _values;
+
+            public Class1()
+            {
+                _values = new int[4];
+            }
+
+            public int this[int index]
+            {
+                get => _values[index];
+                set => _values[index] = value;
+            }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalIndexerSetter.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalIndexerSetter.Class1", "get_Item",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalIndexerSetter.Class1", "set_Item",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "indexer", "property", "setter"]);
 
     public static readonly GeneratedFixtureDefinition MinimalStringLength = new(
         "minimal.string-length",
@@ -652,6 +685,7 @@ internal static class GeneratedFixtureCatalog
         MinimalArrayIndex,
         MinimalArrayLength,
         MinimalIndexerGetter,
+        MinimalIndexerSetter,
         MinimalStringLength,
         MinimalNullCoalesce,
         MinimalTryFinally,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -437,6 +437,19 @@ static class ReturnToSender
                 continue;
             }
 
+            if (TryFindPropertySetter(reader, typeDef, target.Method, target.Overload) is { } setterTarget)
+            {
+                results.Add(CompileBackPropertySetterOrContextFail(
+                    assemblyPath,
+                    pe,
+                    reader,
+                    source,
+                    typeHandle,
+                    setterTarget.Property,
+                    setterTarget.Setter));
+                continue;
+            }
+
             if (TryFindMethod(reader, typeDef, target.Method, target.Overload) is { } methodHandle)
                 results.Add(CompileBackMethodOrContextFail(assemblyPath, pe, reader, source, typeHandle, methodHandle));
         }
@@ -463,6 +476,30 @@ static class ReturnToSender
             && getterToProperty.TryGetValue(getterHandle, out var foundPropertyHandle))
         {
             return (foundPropertyHandle, getterHandle);
+        }
+
+        return null;
+    }
+
+    static (PropertyDefinitionHandle Property, MethodDefinitionHandle Setter)? TryFindPropertySetter(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        string methodName,
+        int overload)
+    {
+        var setterToProperty = new Dictionary<MethodDefinitionHandle, PropertyDefinitionHandle>();
+        foreach (var propertyHandle in typeDef.GetProperties())
+        {
+            var property = reader.GetPropertyDefinition(propertyHandle);
+            var accessors = property.GetAccessors();
+            if (!accessors.Setter.IsNil)
+                setterToProperty[accessors.Setter] = propertyHandle;
+        }
+
+        if (TryFindMethod(reader, typeDef, methodName, overload) is { } setterHandle
+            && setterToProperty.TryGetValue(setterHandle, out var foundPropertyHandle))
+        {
+            return (foundPropertyHandle, setterHandle);
         }
 
         return null;
@@ -528,6 +565,25 @@ static class ReturnToSender
         catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
         {
             return ContextFailResult(assemblyPath, reader, typeHandle, methodHandle, $"{ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    static Result CompileBackPropertySetterOrContextFail(
+        string assemblyPath,
+        PEReader pe,
+        MetadataReader reader,
+        MetadataSource source,
+        TypeDefinitionHandle typeHandle,
+        PropertyDefinitionHandle propertyHandle,
+        MethodDefinitionHandle setterHandle)
+    {
+        try
+        {
+            return CompileBackPropertySetter(assemblyPath, pe, reader, source, typeHandle, propertyHandle, setterHandle);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            return ContextFailResult(assemblyPath, reader, typeHandle, propertyHandle, setterHandle, $"{ex.GetType().Name}: {ex.Message}");
         }
     }
 
@@ -809,6 +865,155 @@ static class ReturnToSender
                 function,
                 typeHandle,
                 methodHandle,
+                printed.Output,
+                fullType,
+                methodName,
+                overload,
+                CorpusMethodIdentity.SignatureText(function.Signature),
+                closureRoots,
+                closureFacts);
+            var plan = sourceResult.Plan;
+            return new Result(
+                plan,
+                sourceResult.Source,
+                FidelityCheck.CompileBackStatus.RecompileFail,
+                string.Join(" ", originalOps),
+                "",
+                $"closure-iteration-budget: {FormatDiagnostic(firstError)}");
+        }
+    }
+
+    static Result CompileBackPropertySetter(
+        string assemblyPath,
+        PEReader pe,
+        MetadataReader reader,
+        MetadataSource source,
+        TypeDefinitionHandle typeHandle,
+        PropertyDefinitionHandle propertyHandle,
+        MethodDefinitionHandle setterHandle)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        var setter = reader.GetMethodDefinition(setterHandle);
+        string fullType = reader.GetFullTypeName(typeDef);
+        string methodName = reader.GetString(setter.Name);
+        int overload = OverloadIndex(reader, typeDef, setterHandle, methodName);
+
+        var function = IrImporter.Import(source, fullType, methodName, overload)
+            ?? throw new InvalidOperationException($"Could not import {fullType}::{methodName}.");
+        var printed = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+        if (printed.Output is null)
+            throw new InvalidOperationException($"Could not print {fullType}::{methodName}.");
+
+        var original = ILDisassembler.Disassemble(pe, reader, setter)
+            ?? throw new InvalidOperationException($"Could not disassemble {fullType}::{methodName}.");
+        var originalOps = original.Select(instruction => CanonicalOpcode(instruction.OpCodeName)).ToArray();
+
+        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+        var compileOptions = new CSharpCompilationOptions(
+            OutputKind.DynamicallyLinkedLibrary,
+            optimizationLevel: OptimizationLevel.Release,
+            nullableContextOptions: NullableContextOptions.Disable,
+            allowUnsafe: true);
+        var references = CompilationReferences(assemblyPath).ToArray();
+        var indexes = ClosureIndexes(reader);
+        var closureRoots = new HashSet<TypeDefinitionHandle>
+        {
+            TopLevelRootOf(reader, typeHandle),
+        };
+        var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
+        const int maxRoots = 200;
+        const int maxIterations = 80;
+        Diagnostic? firstError = null;
+
+        for (int iteration = 0; iteration < maxIterations; iteration++)
+        {
+            var sourceResult = CompileBackSourceComposer.ComposePropertySetter(
+                assemblyPath,
+                reader,
+                function,
+                typeHandle,
+                propertyHandle,
+                setterHandle,
+                printed.Output,
+                fullType,
+                methodName,
+                overload,
+                CorpusMethodIdentity.SignatureText(function.Signature),
+                closureRoots,
+                closureFacts);
+            var plan = sourceResult.Plan;
+
+            if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
+            {
+                return new Result(
+                    plan,
+                    "",
+                    FidelityCheck.CompileBackStatus.ContextFail,
+                    string.Join(" ", originalOps),
+                    "",
+                    $"{identityDiagnostic.Reason}: {identityDiagnostic.Detail}");
+            }
+
+            string unit = sourceResult.Source;
+            var tree = CSharpSyntaxTree.ParseText(unit, parseOptions);
+            var compilation = CSharpCompilation.Create("return-to-sender", [tree], references, compileOptions);
+            using var ms = new MemoryStream();
+            var emit = compilation.Emit(ms);
+            if (emit.Success)
+            {
+                ms.Position = 0;
+                using var recompiled = new PEReader(ms);
+                var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
+                    ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
+                    .ToArray();
+
+                if (recompiledOps is null)
+                {
+                    return new Result(
+                        plan,
+                        unit,
+                        FidelityCheck.CompileBackStatus.ContextFail,
+                        string.Join(" ", originalOps),
+                        "",
+                        "method-not-found");
+                }
+
+                return new Result(
+                    plan,
+                    unit,
+                    originalOps.SequenceEqual(recompiledOps)
+                        ? FidelityCheck.CompileBackStatus.Exact
+                        : FidelityCheck.CompileBackStatus.OpcodeDiff,
+                    string.Join(" ", originalOps),
+                    string.Join(" ", recompiledOps),
+                    null);
+            }
+
+            var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
+            firstError ??= errors.FirstOrDefault();
+            bool grew = AddClosureRoots(errors, indexes, reader.GetString(typeDef.Namespace), TopLevelRootOf(reader, typeHandle), closureRoots, closureFacts);
+            if (!grew || closureRoots.Count > maxRoots)
+            {
+                string reason = closureRoots.Count > maxRoots ? "closure-root-budget" : "closure-stalled";
+                var error = errors.FirstOrDefault() ?? firstError;
+                return new Result(
+                    plan,
+                    unit,
+                    FidelityCheck.CompileBackStatus.RecompileFail,
+                    string.Join(" ", originalOps),
+                    "",
+                    $"{reason}: {FormatDiagnostic(error)}");
+            }
+        }
+
+        {
+            var sourceResult = CompileBackSourceComposer.ComposePropertySetter(
+                assemblyPath,
+                reader,
+                function,
+                typeHandle,
+                propertyHandle,
+                setterHandle,
                 printed.Output,
                 fullType,
                 methodName,


### PR DESCRIPTION
- Advances #2049 and #2050
- Changes RTS setter/indexer catalog coverage; product output is unchanged.
- Evidence revision: `63b38fbf`

## Change

> Should we accept this RTS catalog coverage slice?

**Conclusion:** **PASS** — RTS now checks direct property setter targets, including indexer setters, while the default catalog stays fully green.

Before:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 24 fixture(s), 53 target(s)

Fixtures:
  Passed : 24
  Skipped: 0
  Failed : 0

Targets:
  Passed : 53
  Skipped: 0
  Failed : 0
```

After:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 25 fixture(s), 57 target(s)

Fixtures:
  Passed : 25
  Skipped: 0
  Failed : 0

Targets:
  Passed : 57
  Skipped: 0
  Failed : 0
```

## Scope and safety

- **Root cause:** The catalog had settable property surfaces only as closure support; direct setter targets, especially indexer setters and body-backed setters with sibling accessors, were not covered.
- **Fix shape:** Product-side `CompileBackSourceComposer` now composes `PropertySet` members, including scalar setters, indexer setters, auto-property get/set shells, and sibling accessor stubs. RTS dispatch now recognizes setter accessors as first-class requested targets.
- **Product impact:** Compile-back source composition only; no shipped decompiler output behavior is intended to change.
- **Scope boundary:** The known `minimal.switch-two-case-lowers-if` compiler-lowering frontier remains an explicit `opcode-diff` when selected.
- **RTS boundary:** RTS remains orchestration only; product/shared code owns generated C# declarations/source.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Harness build | Pass |
| Focused generated fixture tests | `GeneratedFixtureCatalogTests` `8/8` passed |
| Focused RTS tests | `ReturnToSenderPrototypeTests` `31/31` passed |
| Decompiler fast suite | `1795/1795` passed with `-trait- "Speed=Slow"` |
| ReturnToSender A/B | `ILInspector.Decompiler.Tests.dll` `234 Same / 0 Worse / 0 CurrentMissing` |
| RTS catalog default | `25/25 fixtures`, `57/57 targets`, `0 skipped`, `0 failed` |
| RTS catalog with frontiers | `26 passed / 1 failed`, expected `minimal.switch-two-case-lowers-if` `opcode-diff` |
| Build-event validation | Not applicable |

### ReturnToSender catalog

Run: default generated fixture catalog.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 25 fixture(s), 57 target(s)

Fixtures:
  Passed : 25
  Skipped: 0
  Failed : 0

Targets:
  Passed : 57
  Skipped: 0
  Failed : 0
```

Run: `--return-to-sender-catalog minimal --max-examples 50`.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 27 fixture(s), 61 target(s)

Fixtures:
  Passed : 26
  Skipped: 0
  Failed : 1

Targets:
  Passed : 60
  Skipped: 0
  Failed : 1

Failed target buckets:
  opcode-diff: 1

Failed fixtures (first 1 of 1):
  minimal.switch-two-case-lowers-if
      GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1::Method1#0  rts=OpcodeDiff  bucket=opcode-diff
```

**RTS verdict:** **PASS** — direct setter targets are now catalog-checkable, and the only explicit selector failure is the known compiler-lowering frontier.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `minimal.switch-two-case-lowers-if` | Left as frontier | Known source/compiler-lowering opcode-diff frontier. |
| Broader setter/operator/event shapes | Future catalog work | This PR covers measured scalar setters, indexer setters, auto-property setters, and sibling accessor stubs. |
| Original-overload recompiled lookup concern | Not changed | RTS composes a single-accessor shell; regression `CompileBackTargets_OverloadedIndexerSetterComparesSingleShellAccessor` proves original overload 1 compares against recompiled shell overload 0 correctly. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Initial and final reviews clean. |
| Gemini 3.1 Pro | Findings resolved, final clean | Found duplicate setter-surface and missing sibling-accessor issues; fixed in `e1bd2ec8` and `65fdb909`; final pass clean. |
| MAI Code Flash | Concern resolved by regression | Raised original/recompiled overload concern; `93196be0` adds overloaded indexer setter regression proving the single-accessor shell behavior. |

**Review conclusion:** **PASS** — all high-confidence review findings were resolved or pinned with targeted regression coverage, and final Claude/Gemini reviews are clean.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet -p:NoWarn=NU1507
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog --max-examples 50
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog minimal --max-examples 50
```
