### PR TITLE
Deduplicate compile-back C# name cleanup

### DIFF
--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -1079,88 +1079,11 @@ public static class CompileBackSourceComposer
         return namespaces;
     }
 
-    static string Clean(string type)
-    {
-        if (type.Contains('!'))
-            return "object";
+    static string Clean(string type) => CompileBackCSharpNames.Clean(type);
 
-        type = type.Replace("modreq(", "", StringComparison.Ordinal)
-            .Replace("modopt(", "", StringComparison.Ordinal)
-            .Replace(")", "", StringComparison.Ordinal)
-            .Trim();
+    static string StripArity(string name) => CompileBackCSharpNames.StripArity(name);
 
-        type = type switch
-        {
-            "System.String" => "string",
-            "System.Int32" => "int",
-            "System.Void" => "void",
-            _ => type,
-        };
-
-        return EscapeTypeKeywords(type);
-    }
-
-    static string EscapeTypeKeywords(string type)
-    {
-        var sb = new StringBuilder(type.Length);
-        int i = 0;
-        while (i < type.Length)
-        {
-            char c = type[i];
-            if (char.IsLetter(c) || c == '_')
-            {
-                int start = i;
-                while (i < type.Length && (char.IsLetterOrDigit(type[i]) || type[i] == '_'))
-                    i++;
-
-                string word = type[start..i];
-                bool alreadyEscaped = start > 0 && type[start - 1] == '@';
-                bool qualifiedSegment = start > 0 && type[start - 1] == '.';
-                bool bareSpelling = (word is "void" or "ref" || IsPrimitiveTypeName(word)) && !qualifiedSegment;
-                if (!alreadyEscaped && !bareSpelling && IsCSharpKeyword(word))
-                {
-                    sb.Append('@');
-                }
-                sb.Append(word);
-            }
-            else
-            {
-                sb.Append(c);
-                i++;
-            }
-        }
-
-        return sb.ToString();
-    }
-
-    static bool IsPrimitiveTypeName(string name)
-        => name is "bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
-            or "float" or "int" or "uint" or "nint" or "nuint" or "long" or "ulong"
-            or "object" or "short" or "ushort" or "string";
-
-    static string StripArity(string name)
-    {
-        int tick = name.IndexOf('`');
-        return tick >= 0 ? name[..tick] : name;
-    }
-
-    static string Identifier(string name) => IsCSharpKeyword(name) ? "@" + name : name;
-
-    static bool IsCSharpKeyword(string word)
-        => word is "abstract" or "as" or "base" or "bool" or "break" or "byte"
-            or "case" or "catch" or "char" or "checked" or "class" or "const"
-            or "continue" or "decimal" or "default" or "delegate" or "do"
-            or "double" or "else" or "enum" or "event" or "explicit" or "extern"
-            or "false" or "finally" or "fixed" or "float" or "for" or "foreach"
-            or "goto" or "if" or "implicit" or "in" or "int" or "interface"
-            or "internal" or "is" or "lock" or "long" or "namespace" or "new"
-            or "null" or "object" or "operator" or "out" or "override" or "params"
-            or "private" or "protected" or "public" or "readonly" or "ref"
-            or "return" or "sbyte" or "sealed" or "short" or "sizeof" or "stackalloc"
-            or "static" or "string" or "struct" or "switch" or "this" or "throw"
-            or "true" or "try" or "typeof" or "uint" or "ulong" or "unchecked"
-            or "unsafe" or "ushort" or "using" or "virtual" or "void" or "volatile"
-            or "while" or "record" or "required" or "init" or "file" or "scoped";
+    static string Identifier(string name) => CompileBackCSharpNames.Identifier(name);
 
     sealed class TypeProducer
     {


### PR DESCRIPTION
## Summary
- collapse duplicate CompileBackSourceComposer C# name cleanup helpers onto CompileBackCSharpNames
- preserve existing compile-back type cleanup, arity stripping, and keyword escaping behavior
- leave shared CLI/metadata declaration writer paths unchanged

## Validation
- dotnet build src/dotnet-inspect -c Release --configfile nuget.config -p:NoWarn=NU1507
- dotnet build src/ILInspector.Decompiler.Tests -c Release --configfile nuget.config -p:NoWarn=NU1507
- dotnet run --no-build --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -class '*CSharpNamingTests'

Note: broader compile-back-focused test runs were started but remained running after several minutes and were stopped; this PR is a no-behavior helper deduplication.

Adversarial review pending.