### PR TITLE
Add ReturnToSender value and static catalog coverage

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -145,6 +145,27 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.static-class",
+            "GeneratedFixtures.MinimalStaticClass.Class1",
+            ".cctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.static-class",
+            "GeneratedFixtures.MinimalStaticClass.Class1",
+            "get_Value",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.static-class",
+            "GeneratedFixtures.MinimalStaticClass.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.interface-implementation",
             "GeneratedFixtures.MinimalInterfaceImplementation.Class1",
             ".ctor",
@@ -232,6 +253,27 @@ public class GeneratedFixtureCatalogTests
             "minimal.integer-addition",
             "GeneratedFixtures.MinimalIntegerAddition.Class1",
             "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.struct-members",
+            "GeneratedFixtures.MinimalStructMembers.Counter",
+            "get_Value",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.struct-members",
+            "GeneratedFixtures.MinimalStructMembers.Counter",
+            "set_Value",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.struct-members",
+            "GeneratedFixtures.MinimalStructMembers.Counter",
+            "Add",
             FidelityCheck.CompileBackStatus.Exact,
             frontier: false);
         AssertTarget(
@@ -429,12 +471,14 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.auto-property.getter", report);
         Assert.Contains("minimal.method-call.same-type", report);
         Assert.Contains("minimal.static-method-call", report);
+        Assert.Contains("minimal.static-class", report);
         Assert.Contains("minimal.static-constructor", report);
         Assert.Contains("minimal.interface-implementation", report);
         Assert.Contains("minimal.object-initializer", report);
         Assert.Contains("minimal.collection-initializer", report);
         Assert.Contains("minimal.if-else", report);
         Assert.Contains("minimal.integer-addition", report);
+        Assert.Contains("minimal.struct-members", report);
         Assert.Contains("minimal.array-index", report);
         Assert.Contains("minimal.array-length", report);
         Assert.Contains("minimal.indexer.getter", report);
@@ -496,9 +540,12 @@ public class GeneratedFixtureCatalogTests
                 "minimal.object-initializer",
                 "minimal.primary-ctor.field-init",
                 "minimal.property.literal",
+                "minimal.static-class",
                 "minimal.static-constructor",
                 "minimal.static-method-call",
                 "minimal.string-length",
+                "minimal.struct-constructor-field-init-frontier",
+                "minimal.struct-members",
                 "minimal.switch-int",
                 "minimal.switch-two-case-lowers-if",
                 "minimal.try-finally",
@@ -528,12 +575,15 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.conditional-expression-shape-frontier");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.method-call.same-type");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.static-method-call");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.static-class");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.static-constructor");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.interface-implementation");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.object-initializer");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.collection-initializer");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.integer-addition");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.struct-members");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.struct-constructor-field-init-frontier");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-index");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-length");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.indexer.getter");
@@ -666,6 +716,9 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(GeneratedFixtureCatalog.Frontiers, fixture =>
             fixture.Id == "minimal.conditional-expression-shape-frontier" &&
             fixture.Tags.Contains("shape"));
+        Assert.Contains(GeneratedFixtureCatalog.Frontiers, fixture =>
+            fixture.Id == "minimal.struct-constructor-field-init-frontier" &&
+            fixture.Tags.Contains("value-type"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -937,6 +937,81 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RoundTripsStructPropertyTargets()
+    {
+        var assemblyPath = CompileFixture("""
+            public struct Counter
+            {
+                private int _value;
+
+                public int Value
+                {
+                    get => _value;
+                    set => _value = value;
+                }
+
+                public int Add(int value) => _value + value;
+            }
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Counter", "get_Value", 0),
+                    new ReturnToSender.RequestedTarget("Counter", "set_Value", 0),
+                    new ReturnToSender.RequestedTarget("Counter", "Add", 0),
+                ]);
+
+            Assert.Collection(
+                results,
+                result => Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status),
+                result => Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status),
+                result => Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status));
+            Assert.All(results, result => Assert.Contains("public struct Counter", result.Source));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RoundTripsStaticClassTargets()
+    {
+        var assemblyPath = CompileFixture("""
+            public static class Class1
+            {
+                private static int s_value = 42;
+
+                public static int Value => s_value;
+
+                public static int Method1(int value) => value + s_value;
+            }
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Class1", ".cctor", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "get_Value", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "Method1", 0),
+                ]);
+
+            Assert.Collection(
+                results,
+                result => Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status),
+                result => Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status),
+                result => Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_DoesNotDuplicateBodyBackedSetterDuringClosureSurface()
     {
         var assemblyPath = CompileFixture("""

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -179,6 +179,30 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "static", "constructor", "field"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalStaticClass = new(
+        "minimal.static-class",
+        """
+        namespace GeneratedFixtures.MinimalStaticClass;
+
+        public static class Class1
+        {
+            private static int s_value = 42;
+
+            public static int Value => s_value;
+
+            public static int Method1(int value) => value + s_value;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalStaticClass.Class1", ".cctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalStaticClass.Class1", "get_Value",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalStaticClass.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "static", "class", "field"]);
+
     public static readonly GeneratedFixtureDefinition MinimalInterfaceImplementation = new(
         "minimal.interface-implementation",
         """
@@ -291,6 +315,70 @@ internal static class GeneratedFixtureCatalog
                 ExpectedShape: SyntaxKind.AddExpression),
         ],
         ["minimal", "integer", "arithmetic", "addition"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalStructMembers = new(
+        "minimal.struct-members",
+        """
+        namespace GeneratedFixtures.MinimalStructMembers;
+
+        public struct Counter
+        {
+            private int _value;
+
+            public Counter(int value)
+            {
+                _value = value;
+            }
+
+            public int Value
+            {
+                get => _value;
+                set => _value = value;
+            }
+
+            public int Add(int value) => _value + value;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalStructMembers.Counter", "get_Value",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalStructMembers.Counter", "set_Value",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalStructMembers.Counter", "Add",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "struct", "value-type", "property", "setter"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalStructConstructorFieldInitFrontier = new(
+        "minimal.struct-constructor-field-init-frontier",
+        """
+        namespace GeneratedFixtures.MinimalStructConstructorFieldInitFrontier;
+
+        public struct Counter
+        {
+            private int _value;
+
+            public Counter(int value)
+            {
+                _value = value;
+            }
+
+            public int Value
+            {
+                get => _value;
+                set => _value = value;
+            }
+        }
+        """,
+        [
+            new(
+                "GeneratedFixtures.MinimalStructConstructorFieldInitFrontier.Counter",
+                ".ctor",
+                FidelityCheck.CompileBackStatus.OpcodeDiff,
+                IsFrontier: true,
+                Note: "RTS currently broad-surfaces sibling auto-properties after field-closure growth, introducing a backing-field initialization before the target struct constructor body."),
+        ],
+        ["minimal", "struct", "constructor", "frontier", "value-type"]);
 
     public static readonly GeneratedFixtureDefinition MinimalArrayIndex = new(
         "minimal.array-index",
@@ -677,11 +765,13 @@ internal static class GeneratedFixtureCatalog
         MinimalMethodCallSameType,
         MinimalStaticMethodCall,
         MinimalStaticConstructor,
+        MinimalStaticClass,
         MinimalInterfaceImplementation,
         MinimalObjectInitializer,
         MinimalCollectionInitializer,
         MinimalIfElse,
         MinimalIntegerAddition,
+        MinimalStructMembers,
         MinimalArrayIndex,
         MinimalArrayLength,
         MinimalIndexerGetter,
@@ -701,6 +791,7 @@ internal static class GeneratedFixtureCatalog
     [
         MinimalSwitchTwoCaseLowersIf,
         MinimalConditionalExpressionShapeFrontier,
+        MinimalStructConstructorFieldInitFrontier,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> Catalog { get; } =

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -419,7 +419,7 @@ static class ReturnToSender
                 || typeName == "<Module>"
                 || typeName.Contains('<', StringComparison.Ordinal)
                 || typeName.Contains('`', StringComparison.Ordinal)
-                || !IsSupportedClass(reader, typeDef))
+                || !IsSupportedTargetType(reader, typeDef))
             {
                 continue;
             }
@@ -1138,6 +1138,21 @@ static class ReturnToSender
 
         return baseName is not "System.Enum" and not "System.ValueType"
             and not "System.MulticastDelegate" and not "System.Delegate";
+    }
+
+    static bool IsSupportedTargetType(MetadataReader reader, TypeDefinition typeDef)
+    {
+        if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
+            return false;
+
+        string baseName = typeDef.BaseType.Kind switch
+        {
+            HandleKind.TypeReference => FullName(reader, reader.GetTypeReference((TypeReferenceHandle)typeDef.BaseType)),
+            HandleKind.TypeDefinition => FullName(reader, reader.GetTypeDefinition((TypeDefinitionHandle)typeDef.BaseType)),
+            _ => "",
+        };
+
+        return baseName is not "System.Enum" and not "System.MulticastDelegate" and not "System.Delegate";
     }
 
     static bool IsSupportedClosureRoot(MetadataReader reader, TypeDefinition typeDef)


### PR DESCRIPTION
- Advances #2049 and #2050
- Changes RTS explicit target coverage for static classes and value types; product output is unchanged.
- Evidence revision: `270bdc97`

## Change

> Should we accept this RTS catalog coverage slice?

**Conclusion:** **PASS** — RTS now checks explicit static-class targets and struct member targets while keeping broad A/B property enumeration class-only.

Before:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 25 fixture(s), 57 target(s)

Fixtures:
  Passed : 25
  Skipped: 0
  Failed : 0

Targets:
  Passed : 57
  Skipped: 0
  Failed : 0
```

After:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 27 fixture(s), 63 target(s)

Fixtures:
  Passed : 27
  Skipped: 0
  Failed : 0

Targets:
  Passed : 63
  Skipped: 0
  Failed : 0
```

## Scope and safety

- **Root cause:** Catalog target selection still treated explicit value-type targets as unsupported. Static-class target shapes were not represented in the catalog either.
- **Fix shape:** Add an explicit-target admission gate that permits value types but still rejects interfaces, enums, and delegates. Broad property-getter enumeration continues to use the class-only gate. Add static-class and struct member fixtures.
- **Product impact:** Harness/catalog target coverage only; no shipped decompiler output behavior is intended to change.
- **Scope boundary:** Struct constructor field-initializer remains an explicit opcode-diff frontier because broad sibling auto-property surface introduces a backing-field initialization before the target struct constructor body.
- **RTS boundary:** RTS remains orchestration only; product/shared code owns generated C# declarations/source.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Harness build | Pass |
| Focused generated fixture tests | `GeneratedFixtureCatalogTests` `8/8` passed |
| Focused RTS tests | `ReturnToSenderPrototypeTests` `33/33` passed |
| Decompiler fast suite | `1795/1795` passed with `-trait- "Speed=Slow"` |
| ReturnToSender A/B | `ILInspector.Decompiler.Tests.dll` `234 Same / 0 Worse / 0 CurrentMissing` |
| RTS catalog default | `27/27 fixtures`, `63/63 targets`, `0 skipped`, `0 failed` |
| RTS catalog with frontiers | `28 passed / 2 failed`, expected opcode-diff frontiers |
| Build-event validation | Not applicable |

### ReturnToSender catalog

Run: default generated fixture catalog.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 27 fixture(s), 63 target(s)

Fixtures:
  Passed : 27
  Skipped: 0
  Failed : 0

Targets:
  Passed : 63
  Skipped: 0
  Failed : 0
```

Run: `--return-to-sender-catalog minimal --max-examples 50`.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 30 fixture(s), 68 target(s)

Fixtures:
  Passed : 28
  Skipped: 0
  Failed : 2

Targets:
  Passed : 66
  Skipped: 0
  Failed : 2

Failed target buckets:
  opcode-diff: 2

Failed fixtures (first 2 of 2):
  minimal.struct-constructor-field-init-frontier
      GeneratedFixtures.MinimalStructConstructorFieldInitFrontier.Counter::.ctor#0  rts=OpcodeDiff  bucket=opcode-diff
  minimal.switch-two-case-lowers-if
      GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1::Method1#0  rts=OpcodeDiff  bucket=opcode-diff
```

**RTS verdict:** **PASS** — explicit value-type/static catalog targets are now checkable, and the default catalog remains fully green.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `minimal.switch-two-case-lowers-if` | Left as frontier | Known source/compiler-lowering opcode-diff frontier. |
| `minimal.struct-constructor-field-init-frontier` | Left as frontier | Struct constructor field-init currently differs because broad sibling auto-property surface introduces a backing-field initialization before the target constructor body. |
| Broad A/B struct enumeration | Not changed | Broad property getter A/B intentionally remains class-only to avoid changing the measured population in this slice. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Confirmed explicit value-type admission, A/B boundary preservation, catalog keying, and frontier classification. |
| Gemini 3.1 Pro | No blocking findings | Confirmed value-type/static target handling, struct constructor frontier, broad A/B boundary, and architecture boundary. |

**Review conclusion:** **PASS** — both adversarial reviews reported no blocking findings.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet -p:NoWarn=NU1507
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog --max-examples 50
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog minimal --max-examples 50
```
