### PR TITLE
Turn on the coercion invariant: Coerce node, insertion pass, checker (value-typed emission, slice 3)

### DIFF
--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -268,17 +268,26 @@ IL conversion into the rendering one — is what lets the overflow rule see thro
 
 ### The invariant
 
-With the node in place, well-formedness becomes checkable: **no value may occupy a
-typed sink except through a `Coerce`** (or be provably already at the target type).
-`CheckInvariant()` asserts it; a violation fails at the pass level, in a unit test,
-instead of being discovered by recompiling corpus output.
+With the node in place, well-formedness is checkable: **no value may occupy a
+typed sink except through a `Coerce`** (or be provably already at the target
+type). `CoercionInvariant.Check` asserts it; a violation fails at the pass
+level, in a unit test, instead of being discovered by recompiling corpus
+output. Three structural guarantees keep the assertion honest:
 
-The exemption is itself a choke point. "Provably already at the target type"
-must be **one shared type-identity predicate**, not a per-sink judgment —
-otherwise the scattered-partial-rule problem reappears one level up, as
-identity checks with per-sink blind spots (`int`-only here, `Unknown`-blind
-there) exempting exactly the sinks that need coercion. One `Coerce` renderer,
-one identity predicate that gates skipping it.
+- **One sink model.** `CoercionSinks.Enumerate` is the single enumeration of
+  typed sinks and their semantic targets; the insertion pass wraps through it
+  and the checker asserts through it, so the two cannot disagree about what a
+  sink is. The sink set grows in one reviewed place.
+- **One exemption predicate.** "Provably already at the target type" is
+  `CoercionTyping.IsAtTarget` — never a per-sink judgment, or the
+  scattered-partial-rule problem reappears one level up as identity checks
+  with per-sink blind spots exempting exactly the sinks that need coercion.
+- **A declared domain.** The invariant owns the value-flow class this lane
+  treats — integer-family primitives, `bool`/`char`, and resolved enums
+  (`CoercionTyping.InDomain`). Reference and struct conversions join when an
+  inverse conversion-classifier exists; a cross-assembly `Unknown` definition
+  cannot be *proven* an enum, so it stays render-time-handled and outside the
+  checkable domain.
 
 This proves **routing, not rendering**: the invariant guarantees every sink *reaches*
 the one coercion function, collapsing the leak surface from ~12 sites to one — but it
@@ -402,10 +411,17 @@ measurable, unlike the control-flow rewrite's all-or-nothing invariant relaxatio
    `CfgULong.All`, not `unchecked((CfgULong)((long)(-1)))`. Switch labels stay
    printer-spelled (`EnumConstantText`): `SwitchSection` holds them outside the
    rewritable tree.
-3. **Turn the invariant on.** Assert every typed sink routes through `Coerce`;
-   burn down the violations it flags (these are the remaining leak sites, now
-   enumerated by the checker rather than by adversarial review). Slices 1–3 deliver
-   the coercion choke point and can land without step 4.
+3. **Turn the invariant on.** Landed (#TBD): the `Coerce` node,
+   `CoercionInsertionPass` (pipeline-last, wraps every in-domain sink value not
+   provably at target, output-neutral by construction), and
+   `CoercionInvariant.Check`. First corpus sweep: 15 assemblies, 134,373
+   methods — 0 violations, with 9,072 `Coerce` nodes routed across 3,749
+   methods, so the assertion is active, not vacuous. Declared residuals for
+   later burn-down: `StoreIndirect` targets (printer's `IndirectStoreType`
+   derivation not yet shared), non-enum conditional merges, `switch` labels
+   (held outside the rewritable tree), and operand positions
+   (`TryCoerceEnumOperand` — reconciliation, not sinks). Slices 1–3 deliver
+   the coercion choke point; step 4 is independent.
 4. **Complete join typing — the shared type-propagation spine** (worth its own
    slice/issue). Where the importer drops to `Unknown` but a sound common type
    exists, propagate types at joins (the RyuJIT typed-temp model), reducing

--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -411,17 +411,30 @@ measurable, unlike the control-flow rewrite's all-or-nothing invariant relaxatio
    `CfgULong.All`, not `unchecked((CfgULong)((long)(-1)))`. Switch labels stay
    printer-spelled (`EnumConstantText`): `SwitchSection` holds them outside the
    rewritable tree.
-3. **Turn the invariant on.** Landed (#TBD): the `Coerce` node,
-   `CoercionInsertionPass` (pipeline-last, wraps every in-domain sink value not
-   provably at target, output-neutral by construction), and
-   `CoercionInvariant.Check`. First corpus sweep: 15 assemblies, 134,373
-   methods — 0 violations, with 9,072 `Coerce` nodes routed across 3,749
-   methods, so the assertion is active, not vacuous. Declared residuals for
-   later burn-down: `StoreIndirect` targets (printer's `IndirectStoreType`
-   derivation not yet shared), non-enum conditional merges, `switch` labels
-   (held outside the rewritable tree), and operand positions
-   (`TryCoerceEnumOperand` — reconciliation, not sinks). Slices 1–3 deliver
-   the coercion choke point; step 4 is independent.
+3. **Turn the invariant on.** Landed: the `Coerce` node,
+   `CoercionInsertionPass` (pipeline-last), and `CoercionInvariant.Check`, with
+   one shared `RequiresCoercion` decision so pass and checker cannot drift.
+   Corpus evidence: 15 assemblies, 134,373 methods — 0 violations, 7,954
+   `Coerce` nodes routed across 3,225 methods (active, not vacuous), and a
+   **render-text A/B against the merge base** in which every one of the 17
+   changed methods is a verified fidelity fix (wrong `op_Implicit`
+   overloads/values at call arguments, CS1929 extension receivers, CS0266
+   iterator yields) — neutral on common sinks, correcting
+   previously-unfaithful casts at call-argument sinks. The insertion domain is
+   deliberately "sinks whose printer rendering is provably CoerceText with the
+   same target"; everything else is an enumerated residual for the burn-down:
+   slot-carried values (the unifier owns their type until instance 2), lambda
+   returns (delegate `Invoke` signature not yet resolved), merge-node values
+   (CoerceText's own targeted branches render them, statement-position
+   formatting included), `Box` operands (the unbox-over-box spelling renders
+   through `ConvertText`, and a bare constant under `(object)` boxes the
+   literal's own type), `StoreIndirect` targets (printer's `IndirectStoreType`
+   not yet shared), `switch` labels (outside the rewritable tree), and operand
+   positions (`TryCoerceEnumOperand` — reconciliation, not sinks). Slices 1–3
+   deliver the coercion choke point; step 4 is independent — and the
+   longer-term end state is Roslyn's: establish the invariant **at
+   construction** (importer emits coerced trees) rather than by a
+   pipeline-last mutating pass.
 4. **Complete join typing — the shared type-propagation spine** (worth its own
    slice/issue). Where the importer drops to `Unknown` but a sound common type
    exists, propagate types at joins (the RyuJIT typed-temp model), reducing

--- a/src/ILInspector.Decompiler.Tests/CoercionInvariantTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoercionInvariantTests.cs
@@ -1,0 +1,170 @@
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using Convert = ILInspector.Decompiler.Pipeline.Convert;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Slice 3 of docs/design/value-typed-emission.md: the Coerce node, the
+// insertion pass, and the invariant. The insertion is output-neutral by
+// construction (sinks already render through CoerceText; the node renders
+// through the same function with the same target) — the full suite is that
+// proof. These tests pin the routing machinery itself.
+public class CoercionInvariantTests
+{
+    static readonly TypeRef Enum32 = TypeRef.Definition("synthetic", "", "E32");
+    static readonly TypeRef Int32Type = TypeRef.CoreLib("System", "Int32");
+
+    static IrFunction Function(BlockContainer body, TypeRef returnType, params Parameter[] parameters)
+        => new("M", TypeRef.Definition("synthetic", "", "Holder"),
+            new MethodSignature(returnType, [.. parameters], HasThis: false, GenericParameterCount: 0), [], body)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [Enum32] = TypeShape.Enum },
+            EnumMembers = new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>
+            {
+                [Enum32] = new Dictionary<long, string> { [1] = "One" },
+            },
+        };
+
+    static BlockContainer Returning(IrExpression value)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Return(value));
+        container.Add(block);
+        return container;
+    }
+
+    [Fact]
+    public void UncoercedEnumSink_IsAViolation_AndInsertionClearsIt()
+    {
+        // A non-constant integer at an enum return: not provably at target, so
+        // the invariant flags it; the insertion pass wraps it and the invariant
+        // goes green — the burn-down loop in miniature.
+        var function = Function(
+            Returning(new LoadArgument(0, "raw", Int32Type)),
+            Enum32,
+            new Parameter("raw", Int32Type));
+
+        var before = CoercionInvariant.Check(function);
+        Assert.Single(before);
+        Assert.Contains("E32", before[0]);
+
+        new CoercionInsertionPass().Run(function, PassContext.None);
+
+        Assert.Empty(CoercionInvariant.Check(function));
+        var coerce = Assert.IsType<Coerce>(Assert.Single(function.Descendants.OfType<Return>()).Value);
+        Assert.Equal(Enum32, coerce.Target);
+        Assert.Contains("return (E32)raw;", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void AtTargetValue_IsExemptThroughTheOnePredicate()
+    {
+        // The exemption ("provably already at the target type") is
+        // CoercionTyping.IsAtTarget — one predicate, no per-sink judgment.
+        var function = Function(
+            Returning(new LoadArgument(0, "e", Enum32)),
+            Enum32,
+            new Parameter("e", Enum32));
+
+        Assert.Empty(CoercionInvariant.Check(function));
+        new CoercionInsertionPass().Run(function, PassContext.None);
+        Assert.Empty(function.Descendants.OfType<Coerce>());
+    }
+
+    [Fact]
+    public void OutOfDomainSink_IsNotChecked()
+    {
+        // Reference-typed sinks are outside the invariant's domain until an
+        // inverse conversion-classifier exists.
+        var stringType = TypeRef.CoreLib("System", "String");
+        var function = Function(
+            Returning(new LoadArgument(0, "o", TypeRef.CoreLib("System", "Object"))),
+            stringType,
+            new Parameter("o", TypeRef.CoreLib("System", "Object")));
+
+        Assert.Empty(CoercionInvariant.Check(function));
+        new CoercionInsertionPass().Run(function, PassContext.None);
+        Assert.Empty(function.Descendants.OfType<Coerce>());
+    }
+
+    [Fact]
+    public void CoerceComposesOverConvert_KeepingIlHistory()
+    {
+        // Leak case #6's composition: Coerce(Convert(long, m1), UE) — the inner
+        // Convert keeps the IL history when folding is not applicable (checked
+        // conv), the outer Coerce owns the surface conversion.
+        var convert = new Convert(TypeRef.CoreLib("System", "Int64"), isChecked: true, isUnsigned: false,
+            new LoadArgument(0, "raw", Int32Type));
+        var function = Function(
+            Returning(convert),
+            Enum32,
+            new Parameter("raw", Int32Type));
+
+        new CoercionInsertionPass().Run(function, PassContext.None);
+
+        var coerce = Assert.IsType<Coerce>(Assert.Single(function.Descendants.OfType<Return>()).Value);
+        Assert.IsType<Convert>(coerce.Operand);
+        Assert.Empty(CoercionInvariant.Check(function));
+    }
+
+    [Fact]
+    public void NestedSinks_WrapDeepestFirst_LiveTreeStaysCoerced()
+    {
+        // A conditional (enum-merged) whose arm needs coercion, itself sitting
+        // in an int-typed... rather: enum return whose conditional arms mix — the
+        // arm wrap must land in the LIVE tree even though the outer wrap clones.
+        var conditional = new Conditional(
+            new LoadArgument(0, "c", TypeRef.CoreLib("System", "Boolean")),
+            new LoadArgument(1, "raw", Int32Type),
+            new LoadArgument(2, "e", Enum32))
+        {
+            MergedType = Enum32,
+        };
+        var function = Function(
+            Returning(conditional),
+            Enum32,
+            new Parameter("c", TypeRef.CoreLib("System", "Boolean")),
+            new Parameter("raw", Int32Type),
+            new Parameter("e", Enum32));
+
+        new CoercionInsertionPass().Run(function, PassContext.None);
+
+        // The conditional is at-target (MergedType == return type), so only the
+        // raw arm wraps — and it must wrap in the live tree.
+        var live = Assert.Single(function.Descendants.OfType<Conditional>());
+        Assert.IsType<Coerce>(live.WhenTrue);
+        Assert.IsType<LoadArgument>(live.WhenFalse);
+        Assert.Empty(CoercionInvariant.Check(function));
+        Assert.Contains("(E32)raw", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void FullPipeline_LeavesFixturesInvariantClean()
+    {
+        // The standing assertion: after the real pipeline (which ends in the
+        // insertion pass), every method in the enum-heavy fixture set satisfies
+        // the invariant. This is where a future pass reshaping sink values
+        // without coercion fails a unit test instead of a recompile.
+        using var source = MetadataSource.Open(typeof(EnumCastSamples).Assembly.Location);
+        foreach (var method in new[]
+        {
+            nameof(EnumCastSamples.EnumConditional),
+            nameof(EnumCastSamples.EnumFlagsCompound),
+            nameof(EnumCastSamples.EnumCoalesce),
+            nameof(EnumCastSamples.LongEnumArray),
+            nameof(EnumCastSamples.LongEnumBoxed),
+            nameof(EnumCastSamples.ULongEnumBoxedMax),
+            nameof(EnumCastSamples.UnsignedEnumConditionalArm),
+            nameof(EnumCastSamples.CrossAssemblyEnumArray),
+        })
+        {
+            var function = IrImporter.Import(source, typeof(EnumCastSamples).FullName!, method);
+            Assert.NotNull(function);
+            IrPasses.Run(function!);
+            var violations = CoercionInvariant.Check(function!);
+            Assert.True(violations.Count == 0,
+                $"{method}: " + string.Join("; ", violations));
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CoercionInvariantTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoercionInvariantTests.cs
@@ -5,10 +5,11 @@ using Convert = ILInspector.Decompiler.Pipeline.Convert;
 namespace ILInspector.Decompiler.Tests;
 
 // Slice 3 of docs/design/value-typed-emission.md: the Coerce node, the
-// insertion pass, and the invariant. The insertion is output-neutral by
-// construction (sinks already render through CoerceText; the node renders
-// through the same function with the same target) — the full suite is that
-// proof. These tests pin the routing machinery itself.
+// insertion pass, and the invariant. Neutrality is proven empirically by the
+// corpus render-text A/B (adversarial review: "by construction" held only for
+// pure-CoerceText sinks — lambda returns and slot-carried values needed
+// scope exclusions), plus the full suite. These tests pin the routing
+// machinery itself.
 public class CoercionInvariantTests
 {
     static readonly TypeRef Enum32 = TypeRef.Definition("synthetic", "", "E32");
@@ -61,7 +62,7 @@ public class CoercionInvariantTests
     public void AtTargetValue_IsExemptThroughTheOnePredicate()
     {
         // The exemption ("provably already at the target type") is
-        // CoercionTyping.IsAtTarget — one predicate, no per-sink judgment.
+        // CoercionDomain.IsAtTarget — one predicate, no per-sink judgment.
         var function = Function(
             Returning(new LoadArgument(0, "e", Enum32)),
             Enum32,
@@ -137,6 +138,58 @@ public class CoercionInvariantTests
         Assert.IsType<LoadArgument>(live.WhenFalse);
         Assert.Empty(CoercionInvariant.Check(function));
         Assert.Contains("(E32)raw", CSharpPrinter.Print(function).Output);
+    }
+
+    [Fact]
+    public void SlotCarriedValue_IsExcluded_UntilInstanceTwoTypesIt()
+    {
+        // Review finding #1: wrapping a LoadStackSlot breaks the printer's slot
+        // unifier's structural pattern matches (phantom split locals in
+        // ApiSurfaceExtractor::Extract). Slot-carried values stay excluded from
+        // both wrap and check until instance 2 materializes typed locals.
+        var function = Function(
+            Returning(new LoadStackSlot(0, Int32Type)),
+            TypeRef.CoreLib("System", "Boolean"));
+
+        Assert.Empty(CoercionInvariant.Check(function));
+        new CoercionInsertionPass().Run(function, PassContext.None);
+        Assert.Empty(function.Descendants.OfType<Coerce>());
+    }
+
+    [Fact]
+    public void LambdaBodyReturn_IsNotAttributedToTheOuterSignature()
+    {
+        // Review finding #2: a bool predicate return inside a lambda embedded in
+        // an int-returning method must not be coerced to the outer return type
+        // (`t => t.Type != 4` became `t => t.Type != 4 ? 1 : 0`).
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var lambdaBody = Returning(new Comparison(
+            ComparisonKind.NotEqual,
+            isUnsigned: false,
+            new LoadArgument(0, "t", Int32Type),
+            new Constant(4, Int32Type)));
+        var lambda = new Lambda(
+            TypeRef.Definition("System.Private.CoreLib", "System", "Func`2"),
+            [new Parameter("t", Int32Type)],
+            [], [], usesUpdatedMemorySafetyRules: false, skipLocalsInit: false,
+            lambdaBody);
+        var function = Function(
+            SingleStatementBody(new StoreLocal(0, TypeRef.Definition("System.Private.CoreLib", "System", "Func`2"), lambda)),
+            Int32Type);
+
+        new CoercionInsertionPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Coerce>());
+        Assert.Empty(CoercionInvariant.Check(function));
+    }
+
+    static BlockContainer SingleStatementBody(IrNode statement)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(statement);
+        container.Add(block);
+        return container;
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -279,7 +279,7 @@ public sealed partial class CSharpPrinter
                 // is the element type, so cast the value exactly as a single-dim
                 // StoreElement does.
                 TypeRef? elementType = call.Callee.ParameterTypes.Length > rank ? call.Callee.ParameterTypes[rank] : null;
-                string value = elementType is not null ? Coerce(arguments[^1], elementType) : Expression(arguments[^1]);
+                string value = elementType is not null ? CoerceText(arguments[^1], elementType) : Expression(arguments[^1]);
                 return $"{receiver}[{indices}] = {value}";
             }
             default:
@@ -401,7 +401,7 @@ public sealed partial class CSharpPrinter
             var parameter = i < parameterTypes.Count ? parameterTypes[i] : null;
             var refKind = i < refKinds.Length ? refKinds[i] : ArgumentRefKind.Value;
             parts.Add(RefArgument(argument, parameter, refKind, explicitIn)
-                ?? (parameter is not null ? Coerce(argument, parameter) : Expression(argument)));
+                ?? (parameter is not null ? CoerceText(argument, parameter) : Expression(argument)));
             i++;
         }
         return string.Join(", ", parts);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -173,7 +173,7 @@ public sealed partial class CSharpPrinter
     /// — <c>(MethodAttributes)access</c> — so an enum-vs-integer comparison or
     /// bitwise op type-checks (CS0019). The cast reinterprets the integer bits
     /// the IL already carries as the enum, so it is faithful. A negative literal
-    /// is parenthesized (CS0075), mirroring <see cref="Coerce"/>'s enum path.
+    /// is parenthesized (CS0075), mirroring <see cref="CoerceText"/>'s enum path.
     /// </summary>
     string EnumIntegerCast(IrExpression value, TypeRef enumType)
     {
@@ -378,8 +378,8 @@ public sealed partial class CSharpPrinter
 
         var leftEnumUnderlying = EnumUnderlyingType(binary.Left.ResultType);
         var rightEnumUnderlying = EnumUnderlyingType(binary.Right.ResultType);
-        string left = leftEnumUnderlying is not null ? Coerce(binary.Left, target) : Operand(binary.Left);
-        string right = rightEnumUnderlying is not null ? Coerce(binary.Right, target) : Operand(binary.Right);
+        string left = leftEnumUnderlying is not null ? CoerceText(binary.Left, target) : Operand(binary.Left);
+        string right = rightEnumUnderlying is not null ? CoerceText(binary.Right, target) : Operand(binary.Right);
         return $"{left} {BinaryOperator(binary)} {right}";
     }
 
@@ -1012,7 +1012,7 @@ public sealed partial class CSharpPrinter
     /// reconciling against an enum sibling use <see cref="TryCoerceEnumOperand"/>,
     /// the operand-shaped door into the same rules.
     /// </summary>
-    string Coerce(IrExpression value, TypeRef? target)
+    string CoerceText(IrExpression value, TypeRef? target)
     {
         if (target is { } nativeTarget
             && IsNativeInteger(nativeTarget)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1308,7 +1308,7 @@ public sealed partial class CSharpPrinter
             sb.Append(pad)
                 .Append(usingStatement.IsAwait ? "await using (" : "using (").Append(TypeText(usingStatement.ResourceType)).Append(' ')
                 .Append(LocalName(usingStatement.LocalIndex)).Append(" = ")
-                .Append(Coerce(usingStatement.Resource, usingStatement.ResourceType)).AppendLine(")");
+                .Append(CoerceText(usingStatement.Resource, usingStatement.ResourceType)).AppendLine(")");
             sb.Append(pad).AppendLine("{");
             AppendContainer(sb, usingStatement.Body, indent + 1);
             sb.Append(pad).AppendLine("}");
@@ -1629,12 +1629,12 @@ public sealed partial class CSharpPrinter
             ? $"{TypeText(s.Type)} {LocalName(s.Index)} = ref {Deref(s.Value)};"
             : $"{LocalName(s.Index)} = ref {Deref(s.Value)};",
         StoreLocal s => _declaringStores.Contains(s)
-            ? $"{DeclarationTypeText(s.Type, s.Value)} {LocalName(s.Index)} = {Coerce(s.Value, s.Type)};"
+            ? $"{DeclarationTypeText(s.Type, s.Value)} {LocalName(s.Index)} = {CoerceText(s.Value, s.Type)};"
             : AssignmentText($"{LocalName(s.Index)}", s.Value, left => left is LoadLocal load && load.Index == s.Index, s.Type),
         DeconstructionAssignment d => $"({string.Join(", ", d.Targets.Select(DeconstructionTargetText))}) = {Expression(d.Source)};",
-        NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {Coerce(n.Value, n.LocalType)};",
-        NullCoalescingFieldAssignment n => $"{FieldTarget(n.Field, n.Instance)} ??= {Coerce(n.Value, n.Field.Type)};",
-        NullCoalescingPropertyAssignment n => $"{PropertyTarget(n.Setter, n.Instance, n.IndexArguments, n.PropertyName, n.IsVirtual)} ??= {Coerce(n.Value, n.PropertyType)};",
+        NullCoalescingAssignment n => $"{LocalName(n.LocalIndex)} ??= {CoerceText(n.Value, n.LocalType)};",
+        NullCoalescingFieldAssignment n => $"{FieldTarget(n.Field, n.Instance)} ??= {CoerceText(n.Value, n.Field.Type)};",
+        NullCoalescingPropertyAssignment n => $"{PropertyTarget(n.Setter, n.Instance, n.IndexArguments, n.PropertyName, n.IsVirtual)} ??= {CoerceText(n.Value, n.PropertyType)};",
         StoreArgument s => AssignmentText(CSharpNaming.EscapeIdentifier(s.Name), s.Value, left => left is LoadArgument load && load.Index == s.Index, s.Type),
         // A ref-typed slot stores by rebinding the reference — C#'s ref
         // (re)assignment, exactly as for ref locals above.
@@ -1642,7 +1642,7 @@ public sealed partial class CSharpPrinter
             ? $"{TypeText(refType)} {StackSlotName(s)} = ref {Deref(s.Value)};"
             : $"{StackSlotName(s)} = ref {Deref(s.Value)};",
         StoreStackSlot s => _declaringStores.Contains(s)
-            ? $"{DeclarationTypeText(StackSlotTargetType(s)!, s.Value)} {StackSlotName(s)} = {Coerce(s.Value, StackSlotTargetType(s))};"
+            ? $"{DeclarationTypeText(StackSlotTargetType(s)!, s.Value)} {StackSlotName(s)} = {CoerceText(s.Value, StackSlotTargetType(s))};"
             : AssignmentText(StackSlotName(s), s.Value, left => left is LoadStackSlot load && StackSlotName(load) == StackSlotName(s), StackSlotTargetType(s)),
         StoreField s => AssignmentText(
             FieldTarget(s.Field, s.Instance), s.Value,
@@ -1660,9 +1660,9 @@ public sealed partial class CSharpPrinter
                 && SameLValue(load.Instance, s.Instance)
                 && PlaceIdentity.SameOperands(load.IndexArguments, s.IndexArguments),
             StorePropertyTargetType(s)),
-        EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {Coerce(e.Value, e.Accessor.ParameterTypes[0])};",
+        EventSubscription e => $"{PropertyTarget(e.Accessor, e.HasInstance ? e.Instance : null, [], e.EventName, e.IsVirtual)} {(e.IsAdd ? "+=" : "-=")} {CoerceText(e.Value, e.Accessor.ParameterTypes[0])};",
         StoreElement s when InlineReceiverTempStoreValue(s) is { } value => $"{Operand(s.Array)}[{Expression(s.Index)}] = {value};",
-        StoreElement s => $"{Operand(s.Array)}[{Expression(s.Index)}] = {Coerce(s.Value, StoreElementTargetType(s))};",
+        StoreElement s => $"{Operand(s.Array)}[{Expression(s.Index)}] = {CoerceText(s.Value, StoreElementTargetType(s))};",
         StoreIndirect s => AssignmentText(
             IndirectTarget(s.Address, IndirectStoreType(s.Address, s.Type)),
             s.Value,
@@ -1784,6 +1784,9 @@ public sealed partial class CSharpPrinter
         Unary u => $"~{Operand(u.Operand)}",
         AwaitExpression aw => $"await {Operand(aw.Operand)}",
         IncrementDecrement id => IncrementDecrementText(id),
+        // The coercion node renders through the one rule — the node IS the
+        // routing guarantee; CoerceText decides cast, unchecked, name, or bare.
+        Coerce co => CoerceText(co.Operand, co.Target),
         Convert v => ConvertText(v),
         Call c when MultiDimArrayAccessText(c) is { } text => text,
         Call c => CallText(c),
@@ -1822,7 +1825,7 @@ public sealed partial class CSharpPrinter
         InlineArraySpanConversion c => $"({TypeText(c.SpanType)}){Deref(c.Place)}",
         StackAllocate s => $"stackalloc byte[{Expression(s.Size)}]",
         StackAllocArray s => $"stackalloc {TypeText(s.ElementType)}[{Expression(s.Count)}]",
-        Box b => Coerce(b.Operand, b.Type),
+        Box b => CoerceText(b.Operand, b.Type),
         IsInstance i => $"{Operand(i.Operand)} {(IsValueTypeTarget(i.Type) ? "is" : "as")} {TypeText(i.Type)}",
         IsPattern p => $"{TypeTestValueText(p.Value)} is {TypeText(p.Type)} {LocalName(p.LocalIndex)}",
         RecursivePropertyDeclarationPattern p => $"{Operand(p.Value)} is {{ {p.PropertyName}: {TypeText(p.PatternType)} {LocalName(p.LocalIndex)} }}",
@@ -2599,7 +2602,7 @@ public sealed partial class CSharpPrinter
     string ReturnText(IrExpression value)
         => _function.Signature.ReturnType is { Kind: TypeRefKind.ByRef } && ArgumentLvalue(value) is { } place
             ? $"return ref {place};"
-            : $"return {Coerce(value, _function.Signature.ReturnType)};";
+            : $"return {CoerceText(value, _function.Signature.ReturnType)};";
 
     /// <summary>
     /// Assignment spelling with compound/increment sugar: when the value is
@@ -2620,7 +2623,7 @@ public sealed partial class CSharpPrinter
             // overflow-honoring operators ever carry IsChecked here.
             return binary.IsChecked ? $"checked {{ {statement} }}" : statement;
         }
-        return $"{target} = {Coerce(value, targetType)};";
+        return $"{target} = {CoerceText(value, targetType)};";
     }
 
     /// <summary>
@@ -2661,7 +2664,7 @@ public sealed partial class CSharpPrinter
             // lvalue's: casting only the right operand is faithful when the opcode
             // signedness matches the lvalue. Checked .ovf compounds stay plain.
             : NeedsCompoundSignCast(binary, lvalueType)
-                ? Coerce(binary.Right, lvalueType)
+                ? CoerceText(binary.Right, lvalueType)
                 : Operand(binary.Right);
         return $"{target} {BinaryOperator(binary)}= {rightText};";
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1738,10 +1738,7 @@ public sealed partial class CSharpPrinter
     // enum-like — same-assembly (`TypeShape.Enum`) or cross-assembly (an unresolved
     // non-primitive definition), matching `Coerce`'s enum-cast reasoning.
     TypeRef? StoreElementTargetType(StoreElement store)
-        => store.Array.ResultType is { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element }
-            && IsEnumLikeInteger(element)
-            ? element
-            : store.ElementType;
+        => CoercionSinks.StoreElementTarget(store, _function.TypeShapes);
 
     string Expression(IrExpression node) => node switch
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2127,14 +2127,36 @@ public sealed partial class CSharpPrinter
             // span the ENTIRE text — a child cast can contribute a leading
             // `unchecked(` (`unchecked((uint)b) / unchecked((uint)c)`) without
             // bracketing the whole expression, and dropping its parens would misbind.
-            || node is Binary or Convert
-                && (IsWholeExpressionWrapper(text, "checked(") || IsWholeExpressionWrapper(text, "unchecked("));
+            || node is Binary or Convert or Coerce
+                && (IsWholeExpressionWrapper(text, "checked(") || IsWholeExpressionWrapper(text, "unchecked("))
+            // A Coerce that rendered as a member name or bare literal is an
+            // atom; its cast and `cond ? 1 : 0` forms are NOT — a cast as a
+            // member-access receiver misbinds onto the call result
+            // (`(E)x.M()` is `(E)(x.M())`), so those keep Operand's parens.
+            || node is Coerce && IsSimpleAtomText(text);
         atomic = atomic || node is LoadIndirect load && PointerElementAccessText(load) is not null;
         return atomic ? text : $"({text})";
     }
 
     string CollectionElementText(IrExpression element)
         => element is CollectionSpreadElement spread ? $"..{Expression(spread.Source)}" : Expression(element);
+
+    /// <summary>
+    /// True when rendered text is a bare identifier chain or numeric literal
+    /// (`LEnum.High`, `10`, `-1`) — safe unparenthesized in any operand
+    /// position, including as a member-access receiver.
+    /// </summary>
+    static bool IsSimpleAtomText(string text)
+    {
+        if (text.Length == 0)
+            return false;
+        foreach (char c in text)
+        {
+            if (!char.IsLetterOrDigit(c) && c is not ('.' or '_' or '@' or '-'))
+                return false;
+        }
+        return true;
+    }
 
     /// <summary>
     /// True when <paramref name="text"/> is a single <paramref name="prefix"/>-wrapped

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1219,6 +1219,32 @@ public sealed class IncrementDecrement : IrExpression
         => $"{(IsPrefix ? "Pre" : "Post")}{(IsIncrement ? "Increment" : "Decrement")}";
 }
 
+/// <summary>
+/// The C#-surface coercion of a value into a typed sink
+/// (docs/design/value-typed-emission.md): "render this value into a position
+/// that requires <see cref="Target"/>". Distinct from <see cref="Convert"/>,
+/// which models the value's IL history (a conv.* opcode); the two compose —
+/// a Convert-wrapped value at a mismatched sink is wrapped, not rewritten.
+/// Inserted by CoercionInsertionPass; rendered by the printer's one
+/// CoerceText rule; asserted by CoercionInvariant. Roslyn's BoundConversion,
+/// in reverse.
+/// </summary>
+public sealed class Coerce : IrExpression
+{
+    public Coerce(TypeRef target, IrExpression operand)
+    {
+        Target = target;
+        AddChild(operand);
+    }
+
+    public TypeRef Target { get; }
+    public IrExpression Operand => (IrExpression)Children[0];
+    public override TypeRef? ResultType => Target;
+    public override IEnumerable<TypeRef> DirectTypes => [Target];
+
+    public override string Describe() => $"Coerce {Target.ToDisplayString()}";
+}
+
 /// <summary>A numeric conversion (the conv.* family).</summary>
 public sealed class Convert : IrExpression
 {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
@@ -14,14 +14,68 @@ public static class CoercionSinks
 {
     public readonly record struct TypedSink(IrExpression Value, TypeRef Target);
 
+    /// <summary>
+    /// One shared decision for pass and checker: an enumerated sink requires a
+    /// <see cref="Coerce"/> when its target is in the invariant's domain, the
+    /// value is not provably at the target, and the value's type is not owned
+    /// by a later decider — a <see cref="LoadStackSlot"/>'s C# type belongs to
+    /// the printer's slot unifier until instance 2 materializes typed locals,
+    /// and wrapping it breaks the unifier's structural pattern matches
+    /// (review finding: phantom split locals).
+    /// </summary>
+    public static bool RequiresCoercion(TypedSink sink, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+        => sink.Value is not (Coerce or LoadStackSlot)
+            && CoercionDomain.InDomain(sink.Target, shapes)
+            && !CoercionDomain.IsAtTarget(sink.Value, sink.Target);
+
+    /// <summary>
+    /// The one semantic target for an array-element store, shared by the
+    /// printer's cast decision and this sink model: the stelem opcode carries a
+    /// storage width (`stelem.i8` says Int64, not the long-backed enum), so the
+    /// array's element type wins exactly when it is an enum-like definition —
+    /// a named type with no primitive stack family that the shape map does not
+    /// class as a reference or non-enum struct. TypedConstantsPass's ungated
+    /// preference is a different question (identity recovery for bool/char,
+    /// where the storage width is never the semantic type).
+    /// </summary>
+    public static TypeRef? StoreElementTarget(StoreElement store, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+        => store.Array.ResultType is { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element }
+            && element is { Kind: TypeRefKind.Definition }
+            && TypeFamilies.Of(element) is null
+            && shapes.GetValueOrDefault(element) is not (TypeShape.Reference or TypeShape.ValueType)
+            ? element
+            : store.ElementType;
+
     public static IEnumerable<TypedSink> Enumerate(IrFunction function)
+        => Enumerate(function.Body, function.Signature.ReturnType, function);
+
+    /// <summary>
+    /// Walks one body scope. Nested bodies carry their own return types: a
+    /// <see cref="LocalFunctionStatement"/> declares its, a <see cref="Lambda"/>
+    /// does not expose one (the delegate's Invoke signature is not resolved
+    /// here), so lambda returns are skipped rather than mis-attributed to the
+    /// outer signature (review finding: a bool predicate return coerced to the
+    /// outer method's int).
+    /// </summary>
+    static IEnumerable<TypedSink> Enumerate(IrNode scope, TypeRef? returnType, IrFunction function)
     {
-        foreach (var node in function.Descendants)
+        foreach (var child in scope.Children)
         {
-            switch (node)
+            switch (child)
             {
-                case Return { Value: { } value } when function.Signature.ReturnType is { } returnType:
-                    yield return new(value, returnType);
+                case Lambda lambda:
+                    foreach (var nested in Enumerate(lambda, returnType: null, function))
+                        yield return nested;
+                    continue;
+                case LocalFunctionStatement local:
+                    foreach (var nested in Enumerate(local, local.ReturnType, function))
+                        yield return nested;
+                    continue;
+            }
+            switch (child)
+            {
+                case Return { Value: { } value } when returnType is { } scopeReturn:
+                    yield return new(value, scopeReturn);
                     break;
                 case StoreLocal { Value: { } value, Type: { } type }:
                     yield return new(value, type);
@@ -48,15 +102,9 @@ public static class CoercionSinks
                 case Box { Operand: { } operand, Type: { } type }:
                     yield return new(operand, type);
                     break;
-                // The stelem opcode carries a storage width; the array's element
-                // type is the semantic target (the printer's
-                // StoreElementTargetType split, and TypedConstantsPass's).
-                case StoreElement { Value: { } value } store:
-                    var element = store.Array.ResultType is { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } semantic }
-                        ? semantic
-                        : store.ElementType;
-                    if (element is { } elementType)
-                        yield return new(value, elementType);
+                case StoreElement store when store.Value is { } value
+                    && StoreElementTarget(store, function.TypeShapes) is { } elementType:
+                    yield return new(value, elementType);
                     break;
                 // StoreIndirect is deliberately absent: the printer's target
                 // derivation (IndirectStoreType) carries special cases this
@@ -82,18 +130,24 @@ public static class CoercionSinks
                     yield return new(conditional.WhenTrue, merged);
                     yield return new(conditional.WhenFalse, merged);
                     break;
+                // Switch case labels are deliberately not enumerated:
+                // SwitchSection holds them outside the child tree (ReplaceWith
+                // cannot reach them) and the printer spells labels through
+                // EnumConstantText.
             }
+            foreach (var nested in Enumerate(child, returnType, function))
+                yield return nested;
         }
     }
 }
 
 /// <summary>
-/// The one type-identity predicate gating the coercion invariant's exemption:
-/// "provably already at the target type" is decided here, never per sink —
-/// otherwise the scattered-partial-judgment problem reappears one level up as
-/// per-sink identity checks with blind spots.
+/// The invariant's declared domain and its one type-identity exemption
+/// predicate. "Provably already at the target type" is decided here, never per
+/// sink — otherwise the scattered-partial-judgment problem reappears one level
+/// up as per-sink identity checks with blind spots.
 /// </summary>
-public static class CoercionTyping
+public static class CoercionDomain
 {
     /// <summary>
     /// The value-flow class the invariant owns: integer-family primitives,
@@ -106,7 +160,6 @@ public static class CoercionTyping
     public static bool InDomain(TypeRef target, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
         => TypeFamilies.IsNumericPrimitive(target)
             || TypeFamilies.IsBoolean(target)
-            || target is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Char" }
             || shapes.GetValueOrDefault(target) == TypeShape.Enum;
 
     public static bool IsAtTarget(IrExpression value, TypeRef target)
@@ -114,11 +167,12 @@ public static class CoercionTyping
 }
 
 /// <summary>
-/// Wraps every in-domain typed-sink value that is not provably at its target in
-/// a <see cref="Coerce"/> node (value-typed-emission.md, slice 3). Runs last:
-/// the tree the printer receives is the decided tree. Output-neutral by
-/// construction — sinks already render through CoerceText(value, target), and
-/// the node renders through the same function with the same target.
+/// Wraps every typed-sink value that requires coercion in a
+/// <see cref="Coerce"/> node (value-typed-emission.md, slice 3). Runs last: the
+/// tree the printer receives is the decided tree. Output-neutral for sinks that
+/// render through CoerceText — the node renders through the same function with
+/// the same target; the render-text corpus A/B is the empirical gate on that
+/// claim.
 /// </summary>
 public sealed class CoercionInsertionPass : IIrPass
 {
@@ -132,9 +186,7 @@ public sealed class CoercionInsertionPass : IIrPass
         // original (the same stale-match hazard BitwiseBoolOperandPass reverses
         // for).
         var sinks = CoercionSinks.Enumerate(function)
-            .Where(s => s.Value is not Coerce
-                && CoercionTyping.InDomain(s.Target, shapes)
-                && !CoercionTyping.IsAtTarget(s.Value, s.Target))
+            .Where(s => CoercionSinks.RequiresCoercion(s, shapes))
             .OrderByDescending(s => Depth(s.Value))
             .ToList();
         foreach (var (value, target) in sinks)
@@ -167,12 +219,12 @@ public static class CoercionInvariant
     {
         var shapes = function.TypeShapes;
         List<string>? violations = null;
-        foreach (var (value, target) in CoercionSinks.Enumerate(function))
+        foreach (var sink in CoercionSinks.Enumerate(function))
         {
-            if (value is Coerce || !CoercionTyping.InDomain(target, shapes) || CoercionTyping.IsAtTarget(value, target))
+            if (!CoercionSinks.RequiresCoercion(sink, shapes))
                 continue;
             (violations ??= []).Add(
-                $"{function.Name}: {value.Describe()} occupies a {target.ToDisplayString()} sink without a Coerce");
+                $"{function.Name}: {sink.Value.Describe()} occupies a {sink.Target.ToDisplayString()} sink without a Coerce");
         }
         return violations ?? [];
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
@@ -1,0 +1,179 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// The one enumeration of typed sinks and their semantic target types
+/// (docs/design/value-typed-emission.md, capability 1: "target type on every
+/// sink"). CoercionInsertionPass wraps through it and CoercionInvariant asserts
+/// through it, so the two cannot disagree about what a sink is. Growth of the
+/// sink set happens here, in one reviewed place. TypedConstantsPass keeps its
+/// own traversal deliberately: it also covers non-sink positions (bitwise and
+/// comparison operands) where identity recovery, not sink typing, is the
+/// concern.
+/// </summary>
+public static class CoercionSinks
+{
+    public readonly record struct TypedSink(IrExpression Value, TypeRef Target);
+
+    public static IEnumerable<TypedSink> Enumerate(IrFunction function)
+    {
+        foreach (var node in function.Descendants)
+        {
+            switch (node)
+            {
+                case Return { Value: { } value } when function.Signature.ReturnType is { } returnType:
+                    yield return new(value, returnType);
+                    break;
+                case StoreLocal { Value: { } value, Type: { } type }:
+                    yield return new(value, type);
+                    break;
+                case StoreArgument { Value: { } value, Type: { } type }:
+                    yield return new(value, type);
+                    break;
+                case StoreField { Value: { } value, Field.Type: { } type }:
+                    yield return new(value, type);
+                    break;
+                case StoreProperty { Value: { } value } store
+                    when store.Accessor.ParameterTypes is { IsDefault: false, Length: > 0 } setter:
+                    yield return new(value, setter[^1]);
+                    break;
+                case NullCoalescingAssignment { Value: { } value, LocalType: { } type }:
+                    yield return new(value, type);
+                    break;
+                case NullCoalescingFieldAssignment { Value: { } value, Field.Type: { } type }:
+                    yield return new(value, type);
+                    break;
+                case NullCoalescingPropertyAssignment { Value: { } value, PropertyType: { } type }:
+                    yield return new(value, type);
+                    break;
+                case Box { Operand: { } operand, Type: { } type }:
+                    yield return new(operand, type);
+                    break;
+                // The stelem opcode carries a storage width; the array's element
+                // type is the semantic target (the printer's
+                // StoreElementTargetType split, and TypedConstantsPass's).
+                case StoreElement { Value: { } value } store:
+                    var element = store.Array.ResultType is { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } semantic }
+                        ? semantic
+                        : store.ElementType;
+                    if (element is { } elementType)
+                        yield return new(value, elementType);
+                    break;
+                // StoreIndirect is deliberately absent: the printer's target
+                // derivation (IndirectStoreType) carries special cases this
+                // enumeration would drift from; TypedConstantsPass still retypes
+                // its constants. Residual for the burn-down.
+                case Call call when !call.Callee.ParameterTypes.IsDefault:
+                    for (int i = 0, offset = call.Callee.HasThis ? 1 : 0;
+                        i < call.Callee.ParameterTypes.Length && i + offset < call.Arguments.Count; i++)
+                    {
+                        yield return new(call.Arguments[i + offset], call.Callee.ParameterTypes[i]);
+                    }
+                    break;
+                case NewObject ctor when !ctor.Constructor.ParameterTypes.IsDefault:
+                    for (int i = 0; i < ctor.Constructor.ParameterTypes.Length && i < ctor.Arguments.Count; i++)
+                        yield return new(ctor.Arguments[i], ctor.Constructor.ParameterTypes[i]);
+                    break;
+                // An enum-typed join types both arms. Enum merges only: bool
+                // joins belong to BooleanFoldingPass's 0/1 reconciliation, and
+                // int-merge arm rendering (bool arms as `(cond ? 1 : 0)`) is
+                // still a printer rule — residual for the burn-down.
+                case Conditional { MergedType: { } merged } conditional
+                    when function.TypeShapes.GetValueOrDefault(merged) == TypeShape.Enum:
+                    yield return new(conditional.WhenTrue, merged);
+                    yield return new(conditional.WhenFalse, merged);
+                    break;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// The one type-identity predicate gating the coercion invariant's exemption:
+/// "provably already at the target type" is decided here, never per sink —
+/// otherwise the scattered-partial-judgment problem reappears one level up as
+/// per-sink identity checks with blind spots.
+/// </summary>
+public static class CoercionTyping
+{
+    /// <summary>
+    /// The value-flow class the invariant owns: integer-family primitives,
+    /// bool/char, and resolved enums. Reference and struct conversions stay
+    /// outside until an inverse conversion-classifier exists; a cross-assembly
+    /// <see cref="TypeShape.Unknown"/> definition cannot be proven an enum, so
+    /// it is out of the checkable domain (the printer's structural constant
+    /// rule still covers it at render time).
+    /// </summary>
+    public static bool InDomain(TypeRef target, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+        => TypeFamilies.IsNumericPrimitive(target)
+            || TypeFamilies.IsBoolean(target)
+            || target is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Char" }
+            || shapes.GetValueOrDefault(target) == TypeShape.Enum;
+
+    public static bool IsAtTarget(IrExpression value, TypeRef target)
+        => value.ResultType is { } resultType && resultType.Equals(target);
+}
+
+/// <summary>
+/// Wraps every in-domain typed-sink value that is not provably at its target in
+/// a <see cref="Coerce"/> node (value-typed-emission.md, slice 3). Runs last:
+/// the tree the printer receives is the decided tree. Output-neutral by
+/// construction — sinks already render through CoerceText(value, target), and
+/// the node renders through the same function with the same target.
+/// </summary>
+public sealed class CoercionInsertionPass : IIrPass
+{
+    public string Name => "coercion-insertion";
+
+    public void Run(IrFunction function, PassContext context)
+    {
+        var shapes = function.TypeShapes;
+        // Deepest-first: wrapping an outer sink clones its subtree, so a nested
+        // sink recorded in the snapshot would otherwise edit the discarded
+        // original (the same stale-match hazard BitwiseBoolOperandPass reverses
+        // for).
+        var sinks = CoercionSinks.Enumerate(function)
+            .Where(s => s.Value is not Coerce
+                && CoercionTyping.InDomain(s.Target, shapes)
+                && !CoercionTyping.IsAtTarget(s.Value, s.Target))
+            .OrderByDescending(s => Depth(s.Value))
+            .ToList();
+        foreach (var (value, target) in sinks)
+        {
+            context.Stepper.StepOver($"coerce sink value to {target.Name}", value);
+            // Clone so the wrapper owns a detached copy before the in-place
+            // replace swaps the original out of its slot.
+            value.ReplaceWith(new Coerce(target, (IrExpression)value.Clone()));
+        }
+    }
+
+    static int Depth(IrNode node)
+    {
+        int depth = 0;
+        for (var parent = node.Parent; parent is not null; parent = parent.Parent)
+            depth++;
+        return depth;
+    }
+}
+
+/// <summary>
+/// The thin-writer well-formedness assertion: no value occupies an in-domain
+/// typed sink except through a <see cref="Coerce"/> (or provably already at the
+/// target type). Violations are returned, not thrown, so tests and gates fail
+/// with the full list.
+/// </summary>
+public static class CoercionInvariant
+{
+    public static IReadOnlyList<string> Check(IrFunction function)
+    {
+        var shapes = function.TypeShapes;
+        List<string>? violations = null;
+        foreach (var (value, target) in CoercionSinks.Enumerate(function))
+        {
+            if (value is Coerce || !CoercionTyping.InDomain(target, shapes) || CoercionTyping.IsAtTarget(value, target))
+                continue;
+            (violations ??= []).Add(
+                $"{function.Name}: {value.Describe()} occupies a {target.ToDisplayString()} sink without a Coerce");
+        }
+        return violations ?? [];
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
@@ -24,7 +24,12 @@ public static class CoercionSinks
     /// (review finding: phantom split locals).
     /// </summary>
     public static bool RequiresCoercion(TypedSink sink, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
-        => sink.Value is not (Coerce or LoadStackSlot)
+        // Merge nodes (conditional/coalesce/switch expressions) are excluded
+        // like slot loads: CoerceText owns their target-aware rendering via its
+        // own branches (TryConditionalTextForTarget and siblings), and wrapping
+        // them re-routes statement-position spellings into the inline forms
+        // (a multi-line switch expression collapsing to one line).
+        => sink.Value is not (Coerce or LoadStackSlot or Conditional or Coalesce or SwitchExpression or UnionSwitchExpression)
             && CoercionDomain.InDomain(sink.Target, shapes)
             && !CoercionDomain.IsAtTarget(sink.Value, sink.Target);
 
@@ -99,9 +104,13 @@ public static class CoercionSinks
                 case NullCoalescingPropertyAssignment { Value: { } value, PropertyType: { } type }:
                     yield return new(value, type);
                     break;
-                case Box { Operand: { } operand, Type: { } type }:
-                    yield return new(operand, type);
-                    break;
+                // Box is deliberately absent: the unbox-over-box spelling
+                // (`(T)(object)x`) renders the operand through ConvertText, not
+                // CoerceText, and a bare constant under `(object)` boxes the
+                // literal's own type regardless of the box token — the coercion
+                // needs the explicit type spelling there. Residual for the
+                // burn-down; the plain-Box printer branch still coerces via its
+                // own CoerceText call.
                 case StoreElement store when store.Value is { } value
                     && StoreElementTarget(store, function.TypeShapes) is { } elementType:
                     yield return new(value, elementType);
@@ -158,6 +167,8 @@ public static class CoercionDomain
     /// rule still covers it at render time).
     /// </summary>
     public static bool InDomain(TypeRef target, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+        // Char and the native ints ride IsNumericPrimitive; only bool needs the
+        // explicit disjunct (it is deliberately not a numeric primitive).
         => TypeFamilies.IsNumericPrimitive(target)
             || TypeFamilies.IsBoolean(target)
             || shapes.GetValueOrDefault(target) == TypeShape.Enum;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -321,6 +321,11 @@ public static class IrPasses
         // mismatch) renders an honest marker instead of an uncompilable fp(x).
         new CallIndirectSpellabilityPass(),
         new RefKindDiagnosticsPass(),
+        // Last: wrap every in-domain typed-sink value not provably at its
+        // target in a Coerce node, so the printer receives a decided tree and
+        // CoercionInvariant is checkable (value-typed-emission.md, slice 3).
+        // Nothing may reshape sink values after this.
+        new CoercionInsertionPass(),
     ];
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NativePasses.cs
@@ -83,6 +83,8 @@ internal static class NativePasses
     // ───────── IlErasure — reconstruct information the IL type system dropped ─────────
     [Native(NativeCategory.IlErasure, "int constants re-typed to bool/char/enum at typed positions")]
     public static TypedConstantsPass TypedConstants => new();
+    [Native(NativeCategory.IlErasure, "typed-sink values wrapped in explicit Coerce nodes — the sink type IL erased, re-established as IR so the printer renders a decided tree")]
+    public static CoercionInsertionPass CoercionInsertion => new();
     [Native(NativeCategory.IlErasure, "bool marshalled as int (cgt against 0) normalized")]
     public static BoolToIntNormalizationPass BoolToIntNormalization => new();
     [Native(NativeCategory.IlErasure, "a bool operand of integer arithmetic (erased to i4 on the IL stack) materialized back to (cond ? 1 : 0) so the mix is not CS0019 int + bool")]


### PR DESCRIPTION
## Change

**Conclusion:** slice 3 of [value-typed-emission.md](docs/design/value-typed-emission.md) — the `Coerce` **node** exists, every in-domain typed sink routes through it or is provably at target, and the invariant is a standing unit-test assertion instead of a recompile discovery.

- **`Coerce` node** — the C#-surface coercion as IR, distinct from `Convert` (IL history); the two compose. Slice 1's renderer (now `CoerceText`) is the node's one rendering rule.
- **`CoercionSinks`** — THE enumeration of typed sinks and semantic targets, consumed by both the insertion pass and the checker (one shared `RequiresCoercion`, one shared `StoreElementTarget` also used by the printer) — they cannot drift.
- **`CoercionDomain`** — the declared domain (integer/bool/char/resolved-enum; reference conversions wait for an inverse classifier) and the one `IsAtTarget` exemption predicate.
- **`CoercionInsertionPass`** (pipeline-last, registered in `NativePasses` under IlErasure) — wraps sink values under a sharp principle the two adversarial rounds forged: **wrap only where the printer's rendering is provably CoerceText-with-the-same-target**. Everything else is an enumerated residual (slot-carried values, lambda returns, merge nodes, `Box` operands, `StoreIndirect`, switch labels, operand positions — each with its reason in the doc).
- **`CoercionInvariant.Check`** — no value occupies an in-domain typed sink except through `Coerce` or the at-target exemption; pinned by unit tests including a pipeline-wide fixture sweep.

## Evidence

| Check | Result |
| --- | --- |
| Full `ILInspector.Decompiler.Tests` | **1858/1858 pass** |
| Invariant corpus sweep | 15 assemblies, **134,373 methods, 0 violations**; 7,954 `Coerce` nodes across 3,225 methods (active, not vacuous) |
| **Render-text A/B vs merge base** (full corpus) | **17 changed methods — every one a verified base fidelity fix**; zero noise, zero regressions |
| PR quick corpus card | Below; pinned-subset gate 0 pp |

### The 17 changed methods (all fixes)

| Class | Methods | Defect fixed |
| --- | --- | --- |
| Wrong `op_Implicit` overload/value at call arguments | `Int128/UInt32/UInt64/UIntPtr` saturation guards, `NFloat.TryConvertTo`, `UInt128.LeadingZeroCount`, `CSharpPrinter.TryGetIntegerRange` | base emitted `(Int128)(-1)` where the IL calls `op_Implicit(uint)` — wrong value AND wrong method token (reviewer-verified against `--dump --il`) |
| CS1929 extension receivers | `MethodTypeInferrer.GetResults`, `CSharpSemanticModel` ×3, `TryGetNullableContext` ×3 | int/byte receiver on an enum extension method, now coerced (parenthesized cast receiver) |
| CS0266 returns/yields | `toHex` local function, `SyntaxFacts` iterators ×2 | `(ushort)` payload at a `char`/`SyntaxKind` position, now correctly cast |

Honest framing per review: **neutral on common sinks; corrects previously-unfaithful casts at call-argument sinks.**

## Decompiler quality

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 15 assemblies, 1,462 methods
Sample: hash-stable 100 methods per assembly
Correctness coverage: validity not run; fidelity not run

Baseline staleness: corpus drifted from the pinned baseline (generated 2026-06-26). Aggregate count deltas below include this corpus change and are not a clean PR signal; rebaseline against current main (--emit-corpus-baseline) before trusting count-based regressions.
- total methods 1,461 -> 1,462 (+1)
- ILInspector.MetadataPrimitives: 61 -> 62 methods (+1)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 1,213 (83.03%) | 1,207 (82.56%) | -6 |
| Conditional-branch residual (-) | 35 (2.40%) | 44 (3.01%) | +9 |
| Forward-merge stops (-) | 27 (1.85%) | 33 (2.26%) | +6 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 82.17% -> 82.17% (0 pp); conditional residual 3.00% -> 3.00% (0 pp); fidelity ungated (no pinned fidelity sample; rely on changed-method fidelity).

Advisory aggregate rate movement (not a PR quick hard gate; review for decompiler-risky changes):
- fully-raised dropped 0.47 pp (baseline 83.03%, PR 82.56%, tolerance 0.10 pp)
- conditional-branch residual increased 0.61 pp (baseline 2.40%, PR 3.01%, tolerance 0.10 pp)
- forward-merge stop increased 0.41 pp (baseline 1.85%, PR 2.26%, tolerance 0.10 pp)

Verdict: corpus sensor matched baseline tolerances.

## Adversarial review

Two rounds, both by Claude Opus 4.8 ([round 1](https://gist.github.com/richlander/acc6b6985366c42db0894fd8e7593ed1), [round 2 re-review](https://gist.github.com/richlander/51b7704771e3a467ca7213d90ba2d201)); reconciliation in a PR comment. Round 2 verdict: findings resolved root-cause, independently verified, "ready to merge on my axis" — and its adversarial extra found the branch **fixing** latent wrong-overload bugs outside the claimed set. Requesting the second-family review (GPT-5.5 or Gemini) per AGENTS.md to complete the two-model contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)