### PR TITLE
Promote RTS struct constructor field-init fixture

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -278,6 +278,13 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.struct-constructor.field-init",
+            "GeneratedFixtures.MinimalStructConstructorFieldInit.Counter",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.array-index",
             "GeneratedFixtures.MinimalArrayIndex.Class1",
             ".ctor",
@@ -479,6 +486,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.if-else", report);
         Assert.Contains("minimal.integer-addition", report);
         Assert.Contains("minimal.struct-members", report);
+        Assert.Contains("minimal.struct-constructor.field-init", report);
         Assert.Contains("minimal.array-index", report);
         Assert.Contains("minimal.array-length", report);
         Assert.Contains("minimal.indexer.getter", report);
@@ -544,7 +552,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.static-constructor",
                 "minimal.static-method-call",
                 "minimal.string-length",
-                "minimal.struct-constructor-field-init-frontier",
+                "minimal.struct-constructor.field-init",
                 "minimal.struct-members",
                 "minimal.switch-int",
                 "minimal.switch-two-case-lowers-if",
@@ -583,7 +591,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.integer-addition");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.struct-members");
-        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.struct-constructor-field-init-frontier");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.struct-constructor.field-init");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-index");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.array-length");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.indexer.getter");
@@ -716,9 +724,6 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(GeneratedFixtureCatalog.Frontiers, fixture =>
             fixture.Id == "minimal.conditional-expression-shape-frontier" &&
             fixture.Tags.Contains("shape"));
-        Assert.Contains(GeneratedFixtureCatalog.Frontiers, fixture =>
-            fixture.Id == "minimal.struct-constructor-field-init-frontier" &&
-            fixture.Tags.Contains("value-type"));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -977,6 +977,42 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_SurfacesStructNonAutoPropertyWithoutBackingField()
+    {
+        var assemblyPath = CompileFixture("""
+            public struct Counter
+            {
+                private int _value;
+
+                public int Value
+                {
+                    get => _value;
+                    set => _value = value;
+                }
+            }
+
+            public class Class1
+            {
+                public int Read(Counter counter) => counter.Value;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "Read", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public int Value", result.Source);
+            Assert.Contains("throw null", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsStaticClassTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -217,6 +217,7 @@ public enum CompileBackStubBodyKind
 {
     None,
     Throw,
+    ThrowGetSet,
     TargetBody,
     TargetGetterWithSetter,
     TargetSetterWithGetter,
@@ -702,6 +703,22 @@ public static class CompileBackSourceComposer
                 {
                     declaration = StripPropertyAccessorBlock(declaration);
                     sb.AppendLine($"{pad}{declaration} {{ get; set; }}");
+                    break;
+                }
+                if (member.StubBody == CompileBackStubBodyKind.ThrowGetSet)
+                {
+                    declaration = StripPropertyAccessorBlock(declaration);
+                    sb.AppendLine($"{pad}{declaration}");
+                    sb.AppendLine($"{pad}{{");
+                    sb.AppendLine($"{pad}    get");
+                    sb.AppendLine($"{pad}    {{");
+                    sb.AppendLine($"{pad}        throw null;");
+                    sb.AppendLine($"{pad}    }}");
+                    sb.AppendLine($"{pad}    set");
+                    sb.AppendLine($"{pad}    {{");
+                    sb.AppendLine($"{pad}        throw null;");
+                    sb.AppendLine($"{pad}    }}");
+                    sb.AppendLine($"{pad}}}");
                     break;
                 }
 
@@ -1503,8 +1520,6 @@ public static class CompileBackSourceComposer
                 var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
                 bool isAutoProperty = !accessors.Getter.IsNil
                     && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnType.DisplayName);
-                if (requirement.RequiredKind == CompileBackTypeKind.Struct && !isAutoProperty)
-                    continue;
                 bool hasSetter = !accessors.Setter.IsNil;
                 members.Add(new CompileBackMemberDeclaration(
                     new CompileBackMethodIdentity(requirement.Type.FullName, Identifier(propertyName), 0, $"property {signature.ReturnType}"),
@@ -1515,10 +1530,12 @@ public static class CompileBackSourceComposer
                     Parameters: [],
                     requirement.RequiredKind == CompileBackTypeKind.Interface
                         ? CompileBackStubBodyKind.None
-                        : hasSetter
+                        : hasSetter && isAutoProperty
                             ? CompileBackStubBodyKind.AutoPropertyGetSet
                             : isAutoProperty
                                 ? CompileBackStubBodyKind.AutoProperty
+                                : hasSetter
+                                    ? CompileBackStubBodyKind.ThrowGetSet
                                 : CompileBackStubBodyKind.Throw,
                     TargetBody: null,
                     [new CompileBackFact("metadata", "closure-property", propertyName)]));

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -1503,6 +1503,8 @@ public static class CompileBackSourceComposer
                 var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
                 bool isAutoProperty = !accessors.Getter.IsNil
                     && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnType.DisplayName);
+                if (requirement.RequiredKind == CompileBackTypeKind.Struct && !isAutoProperty)
+                    continue;
                 bool hasSetter = !accessors.Setter.IsNil;
                 members.Add(new CompileBackMemberDeclaration(
                     new CompileBackMethodIdentity(requirement.Type.FullName, Identifier(propertyName), 0, $"property {signature.ReturnType}"),

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -349,10 +349,10 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "struct", "value-type", "property", "setter"]);
 
-    public static readonly GeneratedFixtureDefinition MinimalStructConstructorFieldInitFrontier = new(
-        "minimal.struct-constructor-field-init-frontier",
+    public static readonly GeneratedFixtureDefinition MinimalStructConstructorFieldInit = new(
+        "minimal.struct-constructor.field-init",
         """
-        namespace GeneratedFixtures.MinimalStructConstructorFieldInitFrontier;
+        namespace GeneratedFixtures.MinimalStructConstructorFieldInit;
 
         public struct Counter
         {
@@ -372,13 +372,11 @@ internal static class GeneratedFixtureCatalog
         """,
         [
             new(
-                "GeneratedFixtures.MinimalStructConstructorFieldInitFrontier.Counter",
+                "GeneratedFixtures.MinimalStructConstructorFieldInit.Counter",
                 ".ctor",
-                FidelityCheck.CompileBackStatus.OpcodeDiff,
-                IsFrontier: true,
-                Note: "RTS currently broad-surfaces sibling auto-properties after field-closure growth, introducing a backing-field initialization before the target struct constructor body."),
+                FidelityCheck.CompileBackStatus.Exact),
         ],
-        ["minimal", "struct", "constructor", "frontier", "value-type"]);
+        ["minimal", "struct", "constructor", "value-type"]);
 
     public static readonly GeneratedFixtureDefinition MinimalArrayIndex = new(
         "minimal.array-index",
@@ -772,6 +770,7 @@ internal static class GeneratedFixtureCatalog
         MinimalIfElse,
         MinimalIntegerAddition,
         MinimalStructMembers,
+        MinimalStructConstructorFieldInit,
         MinimalArrayIndex,
         MinimalArrayLength,
         MinimalIndexerGetter,
@@ -791,7 +790,6 @@ internal static class GeneratedFixtureCatalog
     [
         MinimalSwitchTwoCaseLowersIf,
         MinimalConditionalExpressionShapeFrontier,
-        MinimalStructConstructorFieldInitFrontier,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> Catalog { get; } =


### PR DESCRIPTION
- Advances #2049 and #2050
- Changes RTS struct constructor catalog frontier; product output is unchanged.
- Evidence revision: `152e7883`

## Change

> Should we accept this RTS compile-back frontier fix?

**Conclusion:** **PASS** — the struct constructor field-init fixture moves from explicit opcode-diff frontier into the default Exact catalog.

Before:

```text
Failed fixtures (first 2 of 2):
  minimal.struct-constructor-field-init-frontier
      GeneratedFixtures.MinimalStructConstructorFieldInitFrontier.Counter::.ctor#0  rts=OpcodeDiff  bucket=opcode-diff
  minimal.switch-two-case-lowers-if
      GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1::Method1#0  rts=OpcodeDiff  bucket=opcode-diff
```

After:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 28 fixture(s), 64 target(s)

Fixtures:
  Passed : 28
  Skipped: 0
  Failed : 0

Targets:
  Passed : 64
  Skipped: 0
  Failed : 0
```

## Scope and safety

- **Root cause:** Broad struct closure-property surfacing emitted non-auto settable properties as auto-properties, introducing hidden backing-field initialization before the target struct constructor body and causing an opcode diff.
- **Fix shape:** Product-side `CompileBackSourceComposer` now surfaces non-auto struct properties as throwing get/set accessors rather than auto-properties. This preserves binding without generating backing fields.
- **Product impact:** Compile-back source composition only; no shipped decompiler output behavior is intended to change.
- **Scope boundary:** The known `minimal.switch-two-case-lowers-if` compiler-lowering frontier remains an explicit `opcode-diff` when selected.
- **RTS boundary:** RTS remains orchestration only; product/shared code owns generated C# declarations/source.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Harness build | Pass |
| Focused generated fixture tests | `GeneratedFixtureCatalogTests` `8/8` passed |
| Focused RTS tests | `ReturnToSenderPrototypeTests` `34/34` passed |
| Decompiler fast suite | `1795/1795` passed with `-trait- "Speed=Slow"` |
| ReturnToSender A/B | `ILInspector.Decompiler.Tests.dll` `234 Same / 0 Worse / 0 CurrentMissing` |
| RTS catalog default | `28/28 fixtures`, `64/64 targets`, `0 skipped`, `0 failed` |
| RTS catalog with frontiers | `29 passed / 1 failed`, expected `minimal.switch-two-case-lowers-if` `opcode-diff` |
| Build-event validation | Not applicable |

### ReturnToSender catalog

Run: default generated fixture catalog.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 28 fixture(s), 64 target(s)

Fixtures:
  Passed : 28
  Skipped: 0
  Failed : 0

Targets:
  Passed : 64
  Skipped: 0
  Failed : 0
```

Run: `--return-to-sender-catalog minimal --max-examples 50`.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 30 fixture(s), 68 target(s)

Fixtures:
  Passed : 29
  Skipped: 0
  Failed : 1

Targets:
  Passed : 67
  Skipped: 0
  Failed : 1

Failed target buckets:
  opcode-diff: 1

Failed fixtures (first 1 of 1):
  minimal.switch-two-case-lowers-if
      GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1::Method1#0  rts=OpcodeDiff  bucket=opcode-diff
```

**RTS verdict:** **PASS** — the struct constructor field-init shape is now checkable and Exact in the default catalog.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `minimal.switch-two-case-lowers-if` | Left as frontier | Known source/compiler-lowering opcode-diff frontier. |
| Auto-property-like struct constructor field initialization | Fixed | Non-auto struct properties no longer create hidden backing fields in closure surface. |
| Direct broad struct A/B enumeration | Not changed | Broad A/B remains class-only; this PR affects explicit catalog targets. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Confirmed the fix is scoped to struct closure surface and does not alter broad A/B target admission. |
| Gemini 3.1 Pro | Finding resolved, follow-up clean | Found that skipping non-auto struct properties would break binding; fixed in `152e7883`; follow-up reported no blocking findings. |

**Review conclusion:** **PASS** — all high-confidence review findings were resolved and follow-up review is clean.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet -p:NoWarn=NU1507
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog --max-examples 50
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog minimal --max-examples 50
```
