### PR TITLE
Docs: clarify coercion-invariant scope and fix CoercionDomain class-name drift

### DIFF
--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -272,22 +272,34 @@ With the node in place, well-formedness is checkable: **no value may occupy a
 typed sink except through a `Coerce`** (or be provably already at the target
 type). `CoercionInvariant.Check` asserts it; a violation fails at the pass
 level, in a unit test, instead of being discovered by recompiling corpus
-output. Three structural guarantees keep the assertion honest:
+output. Three structural properties fix what the assertion covers:
 
 - **One sink model.** `CoercionSinks.Enumerate` is the single enumeration of
   typed sinks and their semantic targets; the insertion pass wraps through it
   and the checker asserts through it, so the two cannot disagree about what a
   sink is. The sink set grows in one reviewed place.
 - **One exemption predicate.** "Provably already at the target type" is
-  `CoercionTyping.IsAtTarget` — never a per-sink judgment, or the
+  `CoercionDomain.IsAtTarget` — never a per-sink judgment, or the
   scattered-partial-rule problem reappears one level up as identity checks
   with per-sink blind spots exempting exactly the sinks that need coercion.
 - **A declared domain.** The invariant owns the value-flow class this lane
   treats — integer-family primitives, `bool`/`char`, and resolved enums
-  (`CoercionTyping.InDomain`). Reference and struct conversions join when an
+  (`CoercionDomain.InDomain`). Reference and struct conversions join when an
   inverse conversion-classifier exists; a cross-assembly `Unknown` definition
   cannot be *proven* an enum, so it stays render-time-handled and outside the
   checkable domain.
+
+The assertion's reach is bounded on purpose, and reading "0 violations" as
+"every sink renders faithfully" over-claims it. `CoercionInvariant.Check`
+shares the pass's `CoercionSinks.RequiresCoercion` decision, so the same
+enumerated residuals the pass skips — merge-node values (`Conditional`,
+`Coalesce`, switch expressions), slot loads, `Box` operands, `StoreIndirect`
+targets, `switch` labels, and lambda returns — are outside the checkable set by
+construction, not merely unviolated within it. What the checker guarantees is
+**routing agreement**: for an in-domain, non-residual sink, the pass and the
+checker cannot drift on whether a `Coerce` is required. Each residual stays
+printer-owned — rendered by its own `CoerceText` branch — until it graduates
+into the enumeration.
 
 This proves **routing, not rendering**: the invariant guarantees every sink *reaches*
 the one coercion function, collapsing the leak surface from ~12 sites to one — but it


### PR DESCRIPTION
## Change

Docs-only. Sharpens the coercion invariant's scope in
`docs/design/value-typed-emission.md` and fixes a class-name drift.

Follow-up from the second-family adversarial review of #2143 — item 1 of #2145.

- **Scope clarification.** Adds a paragraph making the invariant's reach
  explicit: `CoercionInvariant.Check` shares the pass's
  `CoercionSinks.RequiresCoercion` decision, so the enumerated residuals the
  pass skips (merge nodes, slot loads, `Box` operands, `StoreIndirect`, `switch`
  labels, lambda returns) are outside the checkable set *by construction*. The
  guarantee is **routing agreement** between pass and checker for in-domain,
  non-residual sinks — not rendering fidelity for the residuals. This states
  the limit directly so "0 violations" is not misread as "every sink renders
  faithfully"; the compile-back oracle remains the faithfulness check for
  residuals (already described in the following paragraph).
- **Class-name fix.** The doc referenced `CoercionTyping.IsAtTarget` and
  `CoercionTyping.InDomain`; the actual type shipped in #2143 is
  `CoercionDomain`. Corrected both.
- Reworded one sentence to drop "honest" framing.

## Why

The adversarial review observed the invariant is intentionally silent on the
excluded residuals — a correct, disclosed design choice, but the prose could be
read as a stronger fidelity claim than the checker makes. This closes that gap
in the doc; no behavior changes.

## Evidence

Docs-only, no measured behavior claims. `markdownlint` passes on the changed
file.
