### PR TITLE
Inverse architecture: the annotation infrastructure (system, no product annotations)

### DIFF
--- a/docs/design/inverse-ledger.generated.md
+++ b/docs/design/inverse-ledger.generated.md
@@ -1,0 +1,9 @@
+# Inverse node ledger (generated)
+
+Generated from the `[InverseOf]` annotations in `ILInspector.Decompiler` by the
+test reflector; drift-gated by a test. Do not edit by hand. See
+[inverse-architecture.md](inverse-architecture.md) for the framing.
+
+| Node | Forward construct | Naming | Precondition | Witness |
+| --- | --- | --- | --- | --- |
+| _(none yet)_ | — | — | — | — |

--- a/docs/design/inverse-ledger.generated.md
+++ b/docs/design/inverse-ledger.generated.md
@@ -1,9 +1,17 @@
 # Inverse node ledger (generated)
 
-Generated from the `[InverseOf]` annotations in `ILInspector.Decompiler` by the
-test reflector; drift-gated by a test. Do not edit by hand. See
-[inverse-architecture.md](inverse-architecture.md) for the framing.
+Generated from the `[InverseOf]` / `[NotInverted]` annotations in
+`ILInspector.Decompiler` by the test reflector; drift-gated by a test. Do not
+edit by hand. See [inverse-architecture.md](inverse-architecture.md) for the framing.
+
+## Type assertions
 
 | Node | Forward construct | Naming | Precondition | Witness |
 | --- | --- | --- | --- | --- |
 | _(none yet)_ | — | — | — | — |
+
+## Declared non-inverse boundaries
+
+| Node | Reason |
+| --- | --- |
+| _(none yet)_ | — |

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Decompiler.Pipeline.InverseArchitecture;
@@ -48,6 +47,20 @@ public class InverseArchitectureTests
         var unannotated = InverseLedger.Unannotated(TestAssembly);
         Assert.Contains(nameof(SampleUnannotatedNode), unannotated);
         Assert.DoesNotContain(nameof(SampleInverseNode), unannotated);
+        Assert.DoesNotContain(nameof(SampleBoundaryNode), unannotated);
+    }
+
+    [Fact]
+    public void Reflector_RendersBoundary()
+    {
+        var boundary = Assert.Single(
+            InverseLedger.Boundaries(TestAssembly),
+            b => b.Node == nameof(SampleBoundaryNode));
+        Assert.Equal("sample: outside the checkable domain", boundary.Reason);
+
+        var markdown = InverseLedger.RenderMarkdown(TestAssembly);
+        Assert.Contains("## Declared non-inverse boundaries", markdown);
+        Assert.Contains("| `SampleBoundaryNode` | sample: outside the checkable domain |", markdown);
     }
 
     // Rule #4: every [InverseOf(assumes: ...)] must name a runnable, release-capable
@@ -112,12 +125,16 @@ public class InverseArchitectureTests
     [Fact]
     public void GeneratedProductLedger_MatchesCommittedFile()
     {
-        var generated = InverseLedger.RenderMarkdown(ProductAssembly);
-        var path = Path.Combine(RepoRoot(), "docs", "design", "inverse-ledger.generated.md");
+        var root = FindRepoRoot();
+        Assert.SkipUnless(root is not null,
+            "Repo source tree is not co-located with the test binary; the drift gate is a source-tree check.");
 
+        var path = Path.Combine(root!, "docs", "design", "inverse-ledger.generated.md");
         Assert.True(File.Exists(path),
             $"Missing {path}. Regenerate it from InverseLedger.RenderMarkdown(ProductAssembly).");
-        Assert.Equal(Normalize(generated), Normalize(File.ReadAllText(path)));
+        Assert.Equal(
+            Normalize(InverseLedger.RenderMarkdown(ProductAssembly)),
+            Normalize(File.ReadAllText(path)));
     }
 
     static IrFunction EmptyProbeFunction()
@@ -134,8 +151,17 @@ public class InverseArchitectureTests
 
     static string Normalize(string text) => text.Replace("\r\n", "\n").TrimEnd() + "\n";
 
-    static string RepoRoot([CallerFilePath] string thisFile = "")
-        => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "..", ".."));
+    // Walk up from the running binary's location to the repo root (identified by the
+    // framing doc). Runtime-relative, not [CallerFilePath]: a built exe executed on a
+    // different machine than it was built keeps working, and when the source tree is
+    // absent the drift gate skips rather than false-failing.
+    static string? FindRepoRoot()
+    {
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir is not null; dir = dir.Parent)
+            if (File.Exists(Path.Combine(dir.FullName, "docs", "design", "inverse-architecture.md")))
+                return dir.FullName;
+        return null;
+    }
 }
 
 // A stand-in IR node exercising the full annotation pipeline (reflection, ledger
@@ -152,6 +178,14 @@ sealed class SampleInverseNode : IrExpression
 {
     public override TypeRef? ResultType => null;
     public override string Describe() => nameof(SampleInverseNode);
+}
+
+// A stand-in boundary node: proves [NotInverted] renders in the generated ledger.
+[NotInverted("sample: outside the checkable domain")]
+sealed class SampleBoundaryNode : IrExpression
+{
+    public override TypeRef? ResultType => null;
+    public override string Describe() => nameof(SampleBoundaryNode);
 }
 
 // Deliberately unannotated: proves the coverage backlog detection.

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
@@ -1,0 +1,162 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Decompiler.Pipeline.InverseArchitecture;
+
+using Xunit;
+
+namespace ILInspector.Decompiler.Tests.InverseArchitecture;
+
+// Machinery for the inverse architecture (docs/design/inverse-architecture.md):
+// proves the [InverseOf]/[NotInverted] annotations, the InverseAssumptions
+// predicates, the ledger reflector, and the coverage/drift gates work end to end
+// — without annotating any product node, so this change touches no IrNodes.cs and
+// the value-typed-emission owner applies the real annotations in their own flow.
+// The sample nodes below stand in for real IR nodes to exercise the pipeline.
+public class InverseArchitectureTests
+{
+    readonly ITestOutputHelper _output;
+
+    public InverseArchitectureTests(ITestOutputHelper output) => _output = output;
+
+    // In-domain product nodes that MUST carry [InverseOf] or [NotInverted]. Empty
+    // for now: this machinery-only change adds no product annotations (no
+    // IrNodes.cs churn). The set grows as the ledger's declared domain grows.
+    static readonly string[] EnforcedProductNodes = [];
+
+    static Assembly ProductAssembly => typeof(IrFunction).Assembly;
+    Assembly TestAssembly => GetType().Assembly;
+
+    [Fact]
+    public void Reflector_RendersAnnotatedNode()
+    {
+        var sample = Assert.Single(
+            InverseLedger.Rows(TestAssembly),
+            row => row.Node == nameof(SampleInverseNode));
+
+        Assert.Equal("BoundConversion (sample)", sample.ForwardName);
+        Assert.Equal(NameProvenance.Native, sample.Naming);
+
+        var markdown = InverseLedger.RenderMarkdown(TestAssembly);
+        Assert.Contains("| `SampleInverseNode` | BoundConversion (sample) | Native |", markdown);
+    }
+
+    [Fact]
+    public void Coverage_DetectsAnnotatedAndUnannotated()
+    {
+        var unannotated = InverseLedger.Unannotated(TestAssembly);
+        Assert.Contains(nameof(SampleUnannotatedNode), unannotated);
+        Assert.DoesNotContain(nameof(SampleInverseNode), unannotated);
+    }
+
+    // Rule #4: every [InverseOf(assumes: ...)] must name a runnable, release-capable
+    // predicate on InverseAssumptions, and the coverage test invokes it over a
+    // fixture corpus. This binds the attribute's claim to an executable check.
+    [Fact]
+    public void EveryAssumes_ResolvesToARunnablePredicate()
+    {
+        var probes = new[] { EmptyProbeFunction() };
+        int validated = 0;
+
+        foreach (var assembly in new[] { ProductAssembly, TestAssembly })
+        {
+            foreach (var nodeType in InverseLedger.NodeTypes(assembly))
+            {
+                if (nodeType.GetCustomAttribute<InverseOfAttribute>() is not { Assumes: { } assumes })
+                    continue;
+
+                var predicate = typeof(InverseAssumptions).GetMethod(
+                    assumes, BindingFlags.Public | BindingFlags.Static, [typeof(IrFunction)]);
+
+                Assert.True(predicate is not null,
+                    $"{nodeType.Name}: assumes '{assumes}' has no InverseAssumptions.{assumes}(IrFunction).");
+                Assert.True(typeof(IReadOnlyList<string>).IsAssignableFrom(predicate!.ReturnType),
+                    $"{nodeType.Name}: assumes '{assumes}' must return IReadOnlyList<string>.");
+
+                foreach (var probe in probes)
+                    Assert.IsAssignableFrom<IReadOnlyList<string>>(predicate.Invoke(null, [probe]));
+
+                validated++;
+            }
+        }
+
+        Assert.True(validated > 0, "Expected at least one assumes: predicate to validate (the sample node).");
+    }
+
+    [Fact]
+    public void EnforcedProductNodes_AreAnnotated()
+    {
+        var annotated = InverseLedger.NodeTypes(ProductAssembly)
+            .Where(t => t.GetCustomAttribute<InverseOfAttribute>() is not null
+                     || t.GetCustomAttribute<NotInvertedAttribute>() is not null)
+            .Select(t => t.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var node in EnforcedProductNodes)
+            Assert.True(annotated.Contains(node),
+                $"In-domain node '{node}' must carry [InverseOf] or [NotInverted].");
+    }
+
+    // Advisory only: surface the annotation backlog. Never fails — new nodes added
+    // by other work show up here but must not red this gate.
+    [Fact]
+    public void ProductBacklog_IsReported()
+    {
+        var backlog = InverseLedger.Unannotated(ProductAssembly);
+        _output.WriteLine($"Inverse ledger backlog: {backlog.Count} IR node(s) await [InverseOf]/[NotInverted].");
+        foreach (var node in backlog)
+            _output.WriteLine($"  - {node}");
+    }
+
+    [Fact]
+    public void GeneratedProductLedger_MatchesCommittedFile()
+    {
+        var generated = InverseLedger.RenderMarkdown(ProductAssembly);
+        var path = Path.Combine(RepoRoot(), "docs", "design", "inverse-ledger.generated.md");
+
+        Assert.True(File.Exists(path),
+            $"Missing {path}. Regenerate it from InverseLedger.RenderMarkdown(ProductAssembly).");
+        Assert.Equal(Normalize(generated), Normalize(File.ReadAllText(path)));
+    }
+
+    static IrFunction EmptyProbeFunction()
+    {
+        var container = new BlockContainer();
+        container.Add(new Block(0));
+        return new IrFunction(
+            "Probe",
+            TypeRef.Definition("synthetic", "", "Holder"),
+            new MethodSignature(TypeRef.CoreLib("System", "Int32"), [], HasThis: false, GenericParameterCount: 0),
+            [],
+            container);
+    }
+
+    static string Normalize(string text) => text.Replace("\r\n", "\n").TrimEnd() + "\n";
+
+    static string RepoRoot([CallerFilePath] string thisFile = "")
+        => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "..", ".."));
+}
+
+// A stand-in IR node exercising the full annotation pipeline (reflection, ledger
+// rendering, assumes resolution + invocation) without touching a product node.
+[InverseOf(
+    Forward.RoslynBoundConversion,
+    naming: NameProvenance.Native,
+    oracle: Oracle.RyuJitStackNormalization,
+    forwardName: "BoundConversion (sample)",
+    precondition: "sample: sink distinguishable from stack",
+    assumes: nameof(InverseAssumptions.SinkDistinguishableFromStack),
+    witness: "InverseArchitectureTests")]
+sealed class SampleInverseNode : IrExpression
+{
+    public override TypeRef? ResultType => null;
+    public override string Describe() => nameof(SampleInverseNode);
+}
+
+// Deliberately unannotated: proves the coverage backlog detection.
+sealed class SampleUnannotatedNode : IrExpression
+{
+    public override TypeRef? ResultType => null;
+    public override string Describe() => nameof(SampleUnannotatedNode);
+}

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseLedger.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseLedger.cs
@@ -1,0 +1,71 @@
+using System.Reflection;
+using System.Text;
+
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Decompiler.Pipeline.InverseArchitecture;
+
+namespace ILInspector.Decompiler.Tests.InverseArchitecture;
+
+/// <summary>
+/// Reflects <see cref="InverseOfAttribute"/> / <see cref="NotInvertedAttribute"/>
+/// on <see cref="IrExpression"/> subclasses and renders the node ledger
+/// (docs/design/inverse-architecture.md). Test/tooling only — never the shipped
+/// decompiler. The generated markdown is the single source of truth for the
+/// ledger table; the committed copy is drift-gated by a test.
+/// </summary>
+public static class InverseLedger
+{
+    /// <summary>One generated ledger row: the type assertion an inverse node makes.</summary>
+    public sealed record Row(
+        string Node,
+        string ForwardName,
+        NameProvenance Naming,
+        string Precondition,
+        string Witness);
+
+    /// <summary>Concrete, non-abstract IR expression node types in the given assembly, name-ordered.</summary>
+    public static IReadOnlyList<Type> NodeTypes(Assembly assembly)
+        => [.. assembly.GetTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: false } && typeof(IrExpression).IsAssignableFrom(t))
+            .OrderBy(t => t.Name, StringComparer.Ordinal)];
+
+    /// <summary>The annotated node rows — the generated ledger content.</summary>
+    public static IReadOnlyList<Row> Rows(Assembly assembly)
+        => [.. NodeTypes(assembly)
+            .Select(t => (Node: t, Inverse: t.GetCustomAttribute<InverseOfAttribute>()))
+            .Where(x => x.Inverse is not null)
+            .Select(x => new Row(
+                x.Node.Name,
+                x.Inverse!.ForwardName ?? x.Inverse.Forward.ToString(),
+                x.Inverse.Naming,
+                x.Inverse.Precondition ?? "—",
+                x.Inverse.Witness ?? "—"))];
+
+    /// <summary>IR node types carrying neither attribute — the advisory annotation backlog.</summary>
+    public static IReadOnlyList<string> Unannotated(Assembly assembly)
+        => [.. NodeTypes(assembly)
+            .Where(t => t.GetCustomAttribute<InverseOfAttribute>() is null
+                     && t.GetCustomAttribute<NotInvertedAttribute>() is null)
+            .Select(t => t.Name)];
+
+    /// <summary>Renders the node ledger as deterministic, markdownlint-clean Markdown for the committed generated file.</summary>
+    public static string RenderMarkdown(Assembly assembly)
+    {
+        var sb = new StringBuilder();
+        sb.Append("# Inverse node ledger (generated)\n\n");
+        sb.Append("Generated from the `[InverseOf]` annotations in `ILInspector.Decompiler` by the\n");
+        sb.Append("test reflector; drift-gated by a test. Do not edit by hand. See\n");
+        sb.Append("[inverse-architecture.md](inverse-architecture.md) for the framing.\n\n");
+        sb.Append("| Node | Forward construct | Naming | Precondition | Witness |\n");
+        sb.Append("| --- | --- | --- | --- | --- |\n");
+
+        var rows = Rows(assembly);
+        if (rows.Count == 0)
+            sb.Append("| _(none yet)_ | — | — | — | — |\n");
+        else
+            foreach (var row in rows)
+                sb.Append($"| `{row.Node}` | {row.ForwardName} | {row.Naming} | {row.Precondition} | {row.Witness} |\n");
+
+        return sb.ToString();
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseLedger.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseLedger.cs
@@ -41,6 +41,16 @@ public static class InverseLedger
                 x.Inverse.Precondition ?? "—",
                 x.Inverse.Witness ?? "—"))];
 
+    /// <summary>One declared non-inverse boundary: a node deliberately outside the checkable domain.</summary>
+    public sealed record Boundary(string Node, string Reason);
+
+    /// <summary>IR node types marked <see cref="NotInvertedAttribute"/> — declared non-inverse boundaries.</summary>
+    public static IReadOnlyList<Boundary> Boundaries(Assembly assembly)
+        => [.. NodeTypes(assembly)
+            .Select(t => (Node: t, NotInverted: t.GetCustomAttribute<NotInvertedAttribute>()))
+            .Where(x => x.NotInverted is not null)
+            .Select(x => new Boundary(x.Node.Name, x.NotInverted!.Reason))];
+
     /// <summary>IR node types carrying neither attribute — the advisory annotation backlog.</summary>
     public static IReadOnlyList<string> Unannotated(Assembly assembly)
         => [.. NodeTypes(assembly)
@@ -53,9 +63,10 @@ public static class InverseLedger
     {
         var sb = new StringBuilder();
         sb.Append("# Inverse node ledger (generated)\n\n");
-        sb.Append("Generated from the `[InverseOf]` annotations in `ILInspector.Decompiler` by the\n");
-        sb.Append("test reflector; drift-gated by a test. Do not edit by hand. See\n");
-        sb.Append("[inverse-architecture.md](inverse-architecture.md) for the framing.\n\n");
+        sb.Append("Generated from the `[InverseOf]` / `[NotInverted]` annotations in\n");
+        sb.Append("`ILInspector.Decompiler` by the test reflector; drift-gated by a test. Do not\n");
+        sb.Append("edit by hand. See [inverse-architecture.md](inverse-architecture.md) for the framing.\n\n");
+        sb.Append("## Type assertions\n\n");
         sb.Append("| Node | Forward construct | Naming | Precondition | Witness |\n");
         sb.Append("| --- | --- | --- | --- | --- |\n");
 
@@ -65,6 +76,17 @@ public static class InverseLedger
         else
             foreach (var row in rows)
                 sb.Append($"| `{row.Node}` | {row.ForwardName} | {row.Naming} | {row.Precondition} | {row.Witness} |\n");
+
+        sb.Append("\n## Declared non-inverse boundaries\n\n");
+        sb.Append("| Node | Reason |\n");
+        sb.Append("| --- | --- |\n");
+
+        var boundaries = Boundaries(assembly);
+        if (boundaries.Count == 0)
+            sb.Append("| _(none yet)_ | — |\n");
+        else
+            foreach (var boundary in boundaries)
+                sb.Append($"| `{boundary.Node}` | {boundary.Reason} |\n");
 
         return sb.ToString();
     }

--- a/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseArchitecture.cs
+++ b/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseArchitecture.cs
@@ -1,0 +1,136 @@
+using System;
+
+namespace ILInspector.Decompiler.Pipeline.InverseArchitecture;
+
+// The co-located half of the inverse architecture
+// (docs/design/inverse-architecture.md). These attributes and enums annotate IR
+// nodes with the forward construct they invert and the assumption that makes the
+// inverse sound; a test/tooling reflector turns them into the generated node
+// ledger, and the coverage test enforces that they stay honest. This is metadata
+// only — it adds no product-path behavior and keeps the shipped decompiler
+// SRM-only and NativeAOT-friendly.
+
+/// <summary>
+/// The forward-compiler construct an inverse IR node undoes. The decompiler is
+/// the confident inverse of Roslyn's IL emission and a sibling of RyuJIT's
+/// importer; a node names the forward construct it is the inverse of.
+/// </summary>
+public enum Forward
+{
+    /// <summary>No forward construct — a decompiler-native node.</summary>
+    None,
+
+    /// <summary>Roslyn's <c>BoundConversion</c> (the bound-tree conversion node).</summary>
+    RoslynBoundConversion,
+
+    /// <summary>RyuJIT's <c>GT_CAST</c>.</summary>
+    RyuJitCast,
+
+    /// <summary>RyuJIT's <c>GT_BOX</c>.</summary>
+    RyuJitBox,
+}
+
+/// <summary>
+/// The soundness oracle a node's type recovery is bounded by. RyuJIT's importer
+/// solves the same erased-type recovery problem from the same IL, so it bounds
+/// what the decompiler may soundly assert.
+/// </summary>
+public enum Oracle
+{
+    /// <summary>No oracle bound declared.</summary>
+    None,
+
+    /// <summary>RyuJIT's ECMA-335 stack normalization (<c>bool</c>/<c>byte</c>/<c>short</c> widened to <c>int32</c>).</summary>
+    RyuJitStackNormalization,
+
+    /// <summary>RyuJIT's IL-importer type reconstruction, generally.</summary>
+    RyuJitImporter,
+}
+
+/// <summary>
+/// Whether an inverse node's name follows, inverts, or is native to the forward
+/// vocabulary. Native names carry the highest drift risk — no forward anchor —
+/// and form the standing rename-review queue.
+/// </summary>
+public enum NameProvenance
+{
+    /// <summary>Deliberately follows a forward name (e.g. <c>Convert</c> ← <c>BoundConversion</c>).</summary>
+    Inherited,
+
+    /// <summary>A deliberate antonym of the forward name (e.g. <c>raise</c> ← <c>lower</c>).</summary>
+    Inverted,
+
+    /// <summary>No forward analog — decompiler-born; must carry its own rationale.</summary>
+    Native,
+}
+
+/// <summary>
+/// Marks an IR node as the inverse of a forward-compiler construct (the node
+/// ledger of docs/design/inverse-architecture.md). The reflector reads these to
+/// generate the ledger; the coverage test enforces that every declared in-domain
+/// node carries this or <see cref="NotInvertedAttribute"/>, and that any
+/// <see cref="Assumes"/> resolves to a runnable predicate on
+/// <see cref="InverseAssumptions"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class InverseOfAttribute : Attribute
+{
+    public InverseOfAttribute(
+        Forward forward,
+        NameProvenance naming = NameProvenance.Native,
+        Oracle oracle = Oracle.None,
+        string? forwardName = null,
+        string? precondition = null,
+        string? assumes = null,
+        string? witness = null)
+    {
+        Forward = forward;
+        Naming = naming;
+        Oracle = oracle;
+        ForwardName = forwardName;
+        Precondition = precondition;
+        Assumes = assumes;
+        Witness = witness;
+    }
+
+    /// <summary>The forward construct this node is the inverse of.</summary>
+    public Forward Forward { get; }
+
+    /// <summary>Whether this node's name follows, inverts, or is native to the forward vocabulary.</summary>
+    public NameProvenance Naming { get; }
+
+    /// <summary>The soundness oracle bounding this node's type recovery.</summary>
+    public Oracle Oracle { get; }
+
+    /// <summary>The forward construct's own name — the ledger's forward-construct column.</summary>
+    public string? ForwardName { get; }
+
+    /// <summary>Descriptive precondition under which the inverse is exact — the ledger's Precondition column.</summary>
+    public string? Precondition { get; }
+
+    /// <summary>
+    /// Name of the runnable assumption predicate on <see cref="InverseAssumptions"/>
+    /// that verifies <see cref="Precondition"/>. When set it must resolve to a
+    /// release-capable <c>Check(IrFunction)</c>; the coverage test enforces this
+    /// and invokes it over a fixture corpus.
+    /// </summary>
+    public string? Assumes { get; }
+
+    /// <summary>Descriptive witnesses that prove the inverse — the ledger's Witness column (fixtures, tests, harness modes).</summary>
+    public string? Witness { get; }
+}
+
+/// <summary>
+/// Marks an IR node as deliberately outside the inverse's checkable domain
+/// (docs/design/inverse-architecture.md, "Declared non-inverse boundaries"). It
+/// satisfies the coverage rule without asserting an inverse, so a boundary is
+/// visible rather than an unexplained gap.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class NotInvertedAttribute : Attribute
+{
+    public NotInvertedAttribute(string reason) => Reason = reason;
+
+    /// <summary>Why this node is outside the checkable inverse domain.</summary>
+    public string Reason { get; }
+}

--- a/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseAssumptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseAssumptions.cs
@@ -1,0 +1,25 @@
+namespace ILInspector.Decompiler.Pipeline.InverseArchitecture;
+
+/// <summary>
+/// The runnable assumption predicates named by <c>[InverseOf(assumes: ...)]</c>.
+/// Each is a release-capable check over an <see cref="IrFunction"/> that returns
+/// violation messages (empty = the assumption holds on that function). The
+/// inverse-architecture rule: an <c>assumes:</c> must name one of these, and the
+/// coverage test invokes it over a fixture corpus
+/// (docs/design/inverse-architecture.md, "Two levels"). Binding the attribute's
+/// claim to a runnable check is the residual-drift guard — an assumption that
+/// cannot be spelled as a predicate stays in prose behind a
+/// <see cref="NotInvertedAttribute"/> marker instead.
+/// </summary>
+public static class InverseAssumptions
+{
+    /// <summary>
+    /// A coercion sink is distinguishable from the value's stack type: every
+    /// in-domain typed sink routes through a <c>Coerce</c> or is provably at its
+    /// target. The executable form of the assumption the value-typed-emission
+    /// slice-3 review turned on; reuses <see cref="CoercionInvariant.Check"/> so
+    /// the ledger's assertion and the shipped invariant cannot diverge.
+    /// </summary>
+    public static IReadOnlyList<string> SinkDistinguishableFromStack(IrFunction function)
+        => CoercionInvariant.Check(function);
+}


### PR DESCRIPTION
## What

Stands up the **co-located annotation infrastructure** for the inverse architecture (`docs/design/inverse-architecture.md`, merged in #2135) — step 3 of the agreed relay. **New files only; zero edits to `IrNodes.cs` / `CSharpPrinter` / passes**, so the value-typed-emission owner applies the real node annotations in their own flow without concurrent churn on those hot files.

## The system

**Product** (`ILInspector.Decompiler` — metadata + one predicate; no product-path behavior, stays SRM-only / NativeAOT-friendly):

- `InverseArchitecture.cs` — the `Forward` / `Oracle` / `NameProvenance` enums and the `[InverseOf]` / `[NotInverted]` attributes.
- `InverseAssumptions.cs` — the runnable predicates named by `[InverseOf(assumes: ...)]`. `SinkDistinguishableFromStack` **reuses `CoercionInvariant.Check`**, so the ledger's assertion and the shipped invariant cannot diverge.

**Test/tooling** (`ILInspector.Decompiler.Tests`):

- `InverseLedger.cs` — reflects the attributes over `IrExpression` subclasses and renders the generated node ledger.
- `InverseArchitectureTests.cs` — proves the pipeline end-to-end with **test-only sample nodes** (so no product node is touched): reflector rendering, annotated/unannotated coverage, **rule #4** (every `assumes:` resolves to a runnable release-capable predicate, invoked over a fixture), an enforced-product allowlist (empty for now), an **advisory** backlog report, and the generated-ledger **drift gate**.
- `docs/design/inverse-ledger.generated.md` — the committed generated ledger (empty; annotations pending), drift-gated by the test.

## Why it can't collide with the other agent

- All five files are new; SDK globbing means no `.csproj` edits; xUnit auto-discovers, so no central registration.
- **Coverage is allowlist-scoped and the backlog is advisory** — new nodes added by value-typed-emission slices 4–5 show up as advisory backlog but **never red this gate**.
- Real annotations (`Convert`/`Coerce`/`Box`, …) land later, applied by whoever owns the `IrNodes.cs` churn; the allowlist flips them from advisory to enforced then.

## Validation

- Build clean; **1809** decompiler tests pass (`ILInspector.Decompiler.Tests`, fast suite); the 6 new tests green.
- markdownlint clean on the generated ledger.

## Risk

Low — additive metadata + test tooling, **no IR/render/behavior change** (the corpus and fidelity are untouched by construction). Requesting two adversarial reviews per policy anyway (all decompiler PRs); attack points below.

<details><summary>Adversarial attack points for reviewers</summary>

- Does the `[InverseOf]` metadata leak into the product path or fight NativeAOT? (It shouldn't — attributes + one predicate reusing `CoercionInvariant`.)
- Is the coverage gate genuinely non-blocking for newly-added nodes? (Allowlist empty; backlog advisory.)
- Does `EveryAssumes_ResolvesToARunnablePredicate` actually invoke the predicate, or only resolve it?
- Is the drift test's `CallerFilePath` repo-root resolution sound under CI?
- Could `InverseAssumptions.SinkDistinguishableFromStack` drift from `CoercionInvariant`? (It delegates.)
</details>
