### PR TITLE
Use ApiSignature for RTS generic methods

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -229,6 +229,48 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.generic-methods",
+            "GeneratedFixtures.MinimalGenericMethods.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.generic-methods",
+            "GeneratedFixtures.MinimalGenericMethods.Class1",
+            "Echo",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.generic-methods",
+            "GeneratedFixtures.MinimalGenericMethods.Class1",
+            "Choose",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.generic-methods",
+            "GeneratedFixtures.MinimalGenericMethods.Class1",
+            "Create",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.generic-methods",
+            "GeneratedFixtures.MinimalGenericMethods.Class1",
+            "DefaultValue",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.generic-methods",
+            "GeneratedFixtures.MinimalGenericMethods.Class1",
+            "Comparable",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.if-else",
             "GeneratedFixtures.MinimalIfElse.Class1",
             ".ctor",
@@ -483,6 +525,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.interface-implementation", report);
         Assert.Contains("minimal.object-initializer", report);
         Assert.Contains("minimal.collection-initializer", report);
+        Assert.Contains("minimal.generic-methods", report);
         Assert.Contains("minimal.if-else", report);
         Assert.Contains("minimal.integer-addition", report);
         Assert.Contains("minimal.struct-members", report);
@@ -538,6 +581,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.do-while",
                 "minimal.for-loop",
                 "minimal.foreach-array",
+                "minimal.generic-methods",
                 "minimal.if-else",
                 "minimal.indexer.getter",
                 "minimal.indexer.setter",
@@ -588,6 +632,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.interface-implementation");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.object-initializer");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.collection-initializer");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.generic-methods");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.integer-addition");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.struct-members");

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -937,6 +937,69 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RoundTripsGenericMethodSignatures()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public T Echo<T>(T value) => value;
+
+                public T Choose<T>(T left, T right) where T : class => left;
+
+                public T Create<T>() where T : new() => new T();
+
+                public T DefaultValue<T>() where T : struct => default;
+
+                public T Comparable<T>(T value) where T : System.IComparable<T> => value;
+            }
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Class1", "Echo", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "Choose", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "Create", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "DefaultValue", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "Comparable", 0),
+                ]);
+
+            Assert.Collection(
+                results,
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("public T Echo<T>(T value)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("public T Choose<T>(T left, T right) where T : class", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("public T Create<T>() where T : new()", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("public T DefaultValue<T>() where T : struct", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("public T Comparable<T>(T value) where T : System.IComparable<T>", result.Source);
+                });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsStructPropertyTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -23,7 +23,7 @@ public class ReturnToSenderPrototypeTests
         {
             var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
 
-            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.True(result.Status == FidelityCheck.CompileBackStatus.Exact, $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             Assert.Equal("Class1", result.Plan.TargetMethod.Type);
             Assert.Equal("get_Method1", result.Plan.TargetMethod.Method);
             Assert.Contains("public class Class1", result.Source);
@@ -97,7 +97,9 @@ public class ReturnToSenderPrototypeTests
         {
             var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
 
-            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             Assert.Contains("External", result.Plan.Module.Usings);
             Assert.Contains("public External.Greeting Method1", result.Source);
         }
@@ -240,7 +242,9 @@ public class ReturnToSenderPrototypeTests
         {
             var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
 
-            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             var type = Assert.Single(result.Plan.Types);
             Assert.Contains(type.SourceFacts, fact =>
                 fact.Producer == "roslyn"

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -988,7 +988,7 @@ public static class CompileBackSourceComposer
 
             parameters.Add(new TypeParameter
             {
-                Name = CompileBackCSharpNames.Identifier(reader.GetString(parameter.Name)),
+                Name = reader.GetString(parameter.Name),
                 Constraints = constraints,
             });
         }

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -148,6 +148,7 @@ public sealed record CompileBackMemberDeclaration(
     bool IsStatic,
     CompileBackTypeSignature? ReturnType,
     IReadOnlyList<CompileBackParameter> Parameters,
+    IReadOnlyList<TypeParameter> TypeParameters,
     CompileBackStubBodyKind StubBody,
     string? TargetBody,
     IReadOnlyList<CompileBackFact> SourceFacts)
@@ -245,6 +246,7 @@ public sealed record CompileBackMemberRequirement(
     bool IsStatic,
     IReadOnlyList<CompileBackParameter> Parameters,
     CompileBackTypeSignature? ReturnType,
+    IReadOnlyList<TypeParameter> TypeParameters,
     CompileBackStubBodyKind StubBody,
     string? TargetBody,
     IReadOnlyList<CompileBackFact> SourceFacts);
@@ -300,6 +302,7 @@ public static class CompileBackSourceComposer
                         getter.Attributes.HasFlag(MethodAttributes.Static),
                         MethodParameters(reader, getter, getterSignature),
                         returnType,
+                        TypeParameters: [],
                         targetIsAutoProperty
                             ? CompileBackStubBodyKind.AutoProperty
                             : accessors.Setter.IsNil
@@ -405,6 +408,7 @@ public static class CompileBackSourceComposer
                         setter.Attributes.HasFlag(MethodAttributes.Static),
                         MethodParameters(reader, setter, setterSignature).Take(indexerParameterCount).ToArray(),
                         returnType,
+                        TypeParameters: [],
                         targetIsAutoProperty
                             ? CompileBackStubBodyKind.AutoPropertyGetSet
                             : property.GetAccessors().Getter.IsNil
@@ -509,6 +513,7 @@ public static class CompileBackSourceComposer
                         method.Attributes.HasFlag(MethodAttributes.Static),
                         MethodParameters(reader, method, signature),
                         isConstructor ? null : CompileBackTypeSignature.Display(signature.ReturnType),
+                        MethodTypeParameters(reader, method),
                         CompileBackStubBodyKind.TargetBody,
                         targetBody,
                         [new CompileBackFact("metadata", isConstructor ? "target-constructor" : "target-method", reader.GetString(method.Name))])
@@ -841,7 +846,7 @@ public static class CompileBackSourceComposer
     {
         string parameterList = string.Join(", ", member.Parameters.Select(RenderParameter));
         string? returnType = member.ReturnType?.DisplayName;
-        return new ApiMember
+        var apiMember = new ApiMember
         {
             Name = member.Name,
             Kind = member.Kind switch
@@ -869,6 +874,26 @@ public static class CompileBackSourceComposer
             IsStatic = member.IsStatic,
             Accessibility = null,
         };
+        if (member.Kind == CompileBackMemberKind.Method)
+        {
+            apiMember.SignatureModel = new ApiSignature
+            {
+                ReturnType = returnType,
+                MemberName = member.TypeParameters.Count == 0
+                    ? member.Name
+                    : $"{member.Name}<{string.Join(", ", member.TypeParameters.Select(parameter => parameter.Name))}>",
+                TypeParameters = member.TypeParameters.ToList(),
+                Parameters = member.Parameters
+                    .Select(parameter => new ApiParameter
+                    {
+                        Name = parameter.Name,
+                        Type = parameter.Type.DisplayName,
+                    })
+                    .ToList(),
+            };
+        }
+
+        return apiMember;
     }
 
     static bool RequiresUnsafe(CompileBackMemberDeclaration member)
@@ -930,6 +955,55 @@ public static class CompileBackSourceComposer
                 CompileBackTypeSignature.Display(type)))
             .ToArray();
     }
+
+    static IReadOnlyList<TypeParameter> MethodTypeParameters(MetadataReader reader, MethodDefinition method)
+    {
+        var declaringType = reader.GetTypeDefinition(method.GetDeclaringType());
+        var context = GenericContext.ForMethod(reader, declaringType, method);
+        var parameters = new List<TypeParameter>();
+        foreach (var handle in method.GetGenericParameters())
+        {
+            var parameter = reader.GetGenericParameter(handle);
+            var constraints = new List<string>();
+            var attributes = parameter.Attributes;
+            bool isStruct = (attributes & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0;
+            if (isStruct)
+                constraints.Add("struct");
+            else if ((attributes & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
+                constraints.Add("class");
+
+            foreach (var constraintHandle in parameter.GetConstraints())
+            {
+                var constraint = reader.GetGenericParameterConstraint(constraintHandle);
+                if (ConstraintTypeName(reader, constraint.Type, context) is { Length: > 0 } constraintName)
+                {
+                    if (isStruct && constraintName is "System.ValueType" or "ValueType")
+                        continue;
+                    constraints.Add(constraintName);
+                }
+            }
+
+            if (!isStruct && (attributes & GenericParameterAttributes.DefaultConstructorConstraint) != 0)
+                constraints.Add("new()");
+
+            parameters.Add(new TypeParameter
+            {
+                Name = CompileBackCSharpNames.Identifier(reader.GetString(parameter.Name)),
+                Constraints = constraints,
+            });
+        }
+
+        return parameters;
+    }
+
+    static string? ConstraintTypeName(MetadataReader reader, EntityHandle handle, GenericContext context)
+        => handle.Kind switch
+        {
+            HandleKind.TypeDefinition => CompileBackTypeIdentity.FromDefinition(reader, reader.GetTypeDefinition((TypeDefinitionHandle)handle)).FullName,
+            HandleKind.TypeReference => FullName(reader, reader.GetTypeReference((TypeReferenceHandle)handle)),
+            HandleKind.TypeSpecification => reader.GetTypeSpecification((TypeSpecificationHandle)handle).DecodeSignature(SignatureDecoder.Instance, context),
+            _ => null,
+        };
 
     static CompileBackPrimaryConstructor? PrimaryConstructorFromPrologue(
         MetadataReader reader,
@@ -1010,6 +1084,7 @@ public static class CompileBackSourceComposer
                 field.Attributes.HasFlag(FieldAttributes.Static),
                 Parameters: [],
                 CompileBackTypeSignature.Display(fieldType),
+                TypeParameters: [],
                 CompileBackStubBodyKind.FieldInitializer,
                 parameterName,
                 [new CompileBackFact("metadata", "primary-constructor-field-initializer", fieldName)]));
@@ -1326,6 +1401,7 @@ public static class CompileBackSourceComposer
                         member.IsStatic,
                         member.ReturnType,
                         member.Parameters,
+                        member.TypeParameters,
                         member.StubBody,
                         member.TargetBody,
                         member.SourceFacts));
@@ -1469,6 +1545,7 @@ public static class CompileBackSourceComposer
                     field.Attributes.HasFlag(FieldAttributes.Static),
                     CompileBackTypeSignature.Display(fieldType),
                     Parameters: [],
+                    TypeParameters: [],
                     TryFormatConstantField(reader, field, out var constant)
                         ? CompileBackStubBodyKind.TargetBody
                         : CompileBackStubBodyKind.None,
@@ -1528,6 +1605,7 @@ public static class CompileBackSourceComposer
                     isStatic,
                     returnType,
                     Parameters: [],
+                    TypeParameters: [],
                     requirement.RequiredKind == CompileBackTypeKind.Interface
                         ? CompileBackStubBodyKind.None
                         : hasSetter && isAutoProperty
@@ -1597,6 +1675,7 @@ public static class CompileBackSourceComposer
                     method.Attributes.HasFlag(MethodAttributes.Static),
                     isConstructor ? null : CompileBackTypeSignature.Display(signature.ReturnType),
                     parameters,
+                    TypeParameters: [],
                     requirement.RequiredKind == CompileBackTypeKind.Interface ? CompileBackStubBodyKind.None : CompileBackStubBodyKind.Throw,
                     TargetBody: null,
                     [new CompileBackFact("metadata", isConstructor ? "closure-constructor" : "closure-method", name)]));
@@ -1614,6 +1693,7 @@ public static class CompileBackSourceComposer
                     IsStatic: false,
                     ReturnType: null,
                     Parameters: [],
+                    TypeParameters: [],
                     CompileBackStubBodyKind.Throw,
                     TargetBody: null,
                     [new CompileBackFact("metadata", "synthetic-parameterless-ctor", "same-assembly closure root")]));

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -148,7 +148,7 @@ public sealed record CompileBackMemberDeclaration(
     bool IsStatic,
     CompileBackTypeSignature? ReturnType,
     IReadOnlyList<CompileBackParameter> Parameters,
-    IReadOnlyList<TypeParameter> TypeParameters,
+    IReadOnlyList<CompileBackTypeParameter> TypeParameters,
     CompileBackStubBodyKind StubBody,
     string? TargetBody,
     IReadOnlyList<CompileBackFact> SourceFacts)
@@ -214,6 +214,8 @@ public sealed record CompileBackTypeSignature(CompileBackTypeSignatureKind Kind,
 
 public sealed record CompileBackParameter(string Name, CompileBackTypeSignature Type);
 
+public sealed record CompileBackTypeParameter(string Name, IReadOnlyList<string> Constraints);
+
 public enum CompileBackStubBodyKind
 {
     None,
@@ -246,7 +248,7 @@ public sealed record CompileBackMemberRequirement(
     bool IsStatic,
     IReadOnlyList<CompileBackParameter> Parameters,
     CompileBackTypeSignature? ReturnType,
-    IReadOnlyList<TypeParameter> TypeParameters,
+    IReadOnlyList<CompileBackTypeParameter> TypeParameters,
     CompileBackStubBodyKind StubBody,
     string? TargetBody,
     IReadOnlyList<CompileBackFact> SourceFacts);
@@ -882,7 +884,13 @@ public static class CompileBackSourceComposer
                 MemberName = member.TypeParameters.Count == 0
                     ? member.Name
                     : $"{member.Name}<{string.Join(", ", member.TypeParameters.Select(parameter => parameter.Name))}>",
-                TypeParameters = member.TypeParameters.ToList(),
+                TypeParameters = member.TypeParameters
+                    .Select(parameter => new TypeParameter
+                    {
+                        Name = parameter.Name,
+                        Constraints = parameter.Constraints.ToList(),
+                    })
+                    .ToList(),
                 Parameters = member.Parameters
                     .Select(parameter => new ApiParameter
                     {
@@ -956,11 +964,11 @@ public static class CompileBackSourceComposer
             .ToArray();
     }
 
-    static IReadOnlyList<TypeParameter> MethodTypeParameters(MetadataReader reader, MethodDefinition method)
+    static IReadOnlyList<CompileBackTypeParameter> MethodTypeParameters(MetadataReader reader, MethodDefinition method)
     {
         var declaringType = reader.GetTypeDefinition(method.GetDeclaringType());
         var context = GenericContext.ForMethod(reader, declaringType, method);
-        var parameters = new List<TypeParameter>();
+        var parameters = new List<CompileBackTypeParameter>();
         foreach (var handle in method.GetGenericParameters())
         {
             var parameter = reader.GetGenericParameter(handle);
@@ -986,11 +994,7 @@ public static class CompileBackSourceComposer
             if (!isStruct && (attributes & GenericParameterAttributes.DefaultConstructorConstraint) != 0)
                 constraints.Add("new()");
 
-            parameters.Add(new TypeParameter
-            {
-                Name = reader.GetString(parameter.Name),
-                Constraints = constraints,
-            });
+            parameters.Add(new CompileBackTypeParameter(reader.GetString(parameter.Name), constraints));
         }
 
         return parameters;

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -274,6 +274,40 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "collection", "initializer", "generic"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalGenericMethods = new(
+        "minimal.generic-methods",
+        """
+        namespace GeneratedFixtures.MinimalGenericMethods;
+
+        public class Class1
+        {
+            public T Echo<T>(T value) => value;
+
+            public T Choose<T>(T left, T right) where T : class => left;
+
+            public T Create<T>() where T : new() => new T();
+
+            public T DefaultValue<T>() where T : struct => default;
+
+            public T Comparable<T>(T value) where T : System.IComparable<T> => value;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalGenericMethods.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalGenericMethods.Class1", "Echo",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalGenericMethods.Class1", "Choose",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalGenericMethods.Class1", "Create",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalGenericMethods.Class1", "DefaultValue",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalGenericMethods.Class1", "Comparable",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "generic", "method", "constraints"]);
+
     public static readonly GeneratedFixtureDefinition MinimalIfElse = new(
         "minimal.if-else",
         """
@@ -767,6 +801,7 @@ internal static class GeneratedFixtureCatalog
         MinimalInterfaceImplementation,
         MinimalObjectInitializer,
         MinimalCollectionInitializer,
+        MinimalGenericMethods,
         MinimalIfElse,
         MinimalIntegerAddition,
         MinimalStructMembers,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -521,8 +521,7 @@ static class ReturnToSender
             }
 
             if (seen++ == overload
-                && method.RelativeVirtualAddress != 0
-                && method.GetGenericParameters().Count == 0)
+                && method.RelativeVirtualAddress != 0)
             {
                 return methodHandle;
             }
@@ -1070,6 +1069,7 @@ static class ReturnToSender
                             IsStatic: false,
                             ReturnType: null,
                             Parameters: [],
+                            TypeParameters: [],
                             CompileBackStubBodyKind.TargetBody,
                             TargetBody: "",
                             SourceFacts: [])


### PR DESCRIPTION
- Advances #2057, #2049, and #2050
- Changes RTS compile-back source composition to use structured `ApiSignature` for generic method declarations.
- Evidence revision: `50a7399d`

## Change

> Should we accept this RTS structured-signature slice?

**Conclusion:** **PASS** — RTS now checks generic method targets in the generated fixture catalog, with method type parameters and constraints rendered through product-side `ApiSignature` / `CSharpDeclarationWriter`.

Before:

```text
Generic method targets were not returned by ReturnToSender.CompileBackTargets.
```

After:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 29 fixture(s), 70 target(s)

Fixtures:
  Passed : 29
  Skipped: 0
  Failed : 0

Targets:
  Passed : 70
  Skipped: 0
  Failed : 0
```

## Scope and safety

- **Root cause:** RTS target lookup filtered out generic methods, and compile-back source composition rendered method declarations from string fragments instead of the structured signature model.
- **Fix shape:** Allow explicit RTS generic method targets; carry method type parameters and constraints into `ApiSignature`; let `CSharpDeclarationWriter` render generic method declarations and constraints.
- **Product impact:** Compile-back source composition only; no shipped decompiler output behavior is intended to change.
- **Scope boundary:** This covers generic methods and common method constraints (`class`, `new()`, `struct`, interface type constraints). Broader #2057 work remains for defaults, attributes, explicit interface members, operators, events, and keyword-named generic parameter edge cases.
- **RTS boundary:** RTS remains orchestration only; product/shared code owns generated C# declarations/source.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Harness build | Pass |
| Focused generated fixture tests | `GeneratedFixtureCatalogTests` `8/8` passed |
| Focused RTS tests | `ReturnToSenderPrototypeTests` `35/35` passed |
| Decompiler fast suite | `1803/1803` passed with `-trait- "Speed=Slow"` |
| ReturnToSender A/B | `ILInspector.Decompiler.Tests.dll` `234 Same / 0 Worse / 0 CurrentMissing` |
| RTS catalog default | `29/29 fixtures`, `70/70 targets`, `0 skipped`, `0 failed` |
| RTS catalog with frontiers | `30 passed / 1 failed`, expected `minimal.switch-two-case-lowers-if` `opcode-diff` |
| Build-event validation | Not applicable |

### ReturnToSender catalog

Run: default generated fixture catalog.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 29 fixture(s), 70 target(s)

Fixtures:
  Passed : 29
  Skipped: 0
  Failed : 0

Targets:
  Passed : 70
  Skipped: 0
  Failed : 0
```

Run: `--return-to-sender-catalog minimal --max-examples 50`.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 31 fixture(s), 74 target(s)

Fixtures:
  Passed : 30
  Skipped: 0
  Failed : 1

Targets:
  Passed : 73
  Skipped: 0
  Failed : 1

Failed target buckets:
  opcode-diff: 1

Failed fixtures (first 1 of 1):
  minimal.switch-two-case-lowers-if
      GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1::Method1#0  rts=OpcodeDiff  bucket=opcode-diff
```

**RTS verdict:** **PASS** — generic method targets become checkable through the product structured-signature path, and the default catalog remains fully green.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `minimal.switch-two-case-lowers-if` | Left as frontier | Known source/compiler-lowering opcode-diff frontier. |
| Keyword-named generic parameters | Left as declaration-writer frontier | Raw parameter names are now passed to `CSharpDeclarationWriter`; a separate writer edge remains around double-escaping already-escaped constraint text. |
| Wider #2057 signature families | Future work | Defaults, parameter attributes, explicit interface members, operators, events, and generic type target families remain out of scope. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Confirmed overload stability, constraint rendering, structured signature plumbing, catalog expectations, and architecture boundary. |
| Gemini 3.1 Pro | Finding resolved, follow-up clean | Found premature generic parameter escaping; fixed in `f6a77ec1`; follow-up reported no blocking findings. |

**Review conclusion:** **PASS** — initial reviews were reconciled; an additional Gemini review is requested on this PR-ready head.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet -p:NoWarn=NU1507
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog --max-examples 50
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog minimal --max-examples 50
```
