### PR TITLE
Centralize package TFM assembly selection

### DIFF
--- a/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
@@ -118,6 +118,38 @@ public class TfmSelectorTests : IDisposable
         Assert.Equal([root], paths);
     }
 
+    [Fact]
+    public void FindAssemblyByTfm_UsesPackageNameMatch()
+    {
+        WriteDll("lib/net8.0/Companion.dll");
+        var primary = WriteDll("lib/net8.0/MyPackage.dll");
+
+        var result = TfmSelector.FindAssemblyByTfm(_tempDir, "net8.0", "MyPackage");
+
+        Assert.Equal(primary, result);
+    }
+
+    [Fact]
+    public void FindAssemblyByTfm_FiltersResourceAssemblies()
+    {
+        var primary = WriteDll("tools/net8.0/any/MyTool.dll");
+        WriteDll("tools/net8.0/any/MyTool.resources.dll");
+
+        var result = TfmSelector.FindAssemblyByTfm(_tempDir, "net8.0");
+
+        Assert.Equal(primary, result);
+    }
+
+    [Fact]
+    public void FindAssemblyByTfm_HandlesRuntimeSpecificLibLayout()
+    {
+        var runtimeAssembly = WriteDll("runtimes/linux-x64/lib/net8.0/MyRuntime.dll");
+
+        var result = TfmSelector.FindAssemblyByTfm(_tempDir, "net8.0");
+
+        Assert.Equal(runtimeAssembly, result);
+    }
+
     private string WriteDll(string relativePath)
     {
         var path = Path.Combine(_tempDir, relativePath.Replace('/', Path.DirectorySeparatorChar));

--- a/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
@@ -48,6 +48,30 @@ public class TfmSelectorTests : IDisposable
     }
 
     [Fact]
+    public void SelectHighestAssembliesFromPackage_ToolsLayoutExplicitTfm_SelectsMatchingAssemblies()
+    {
+        var tool = WriteDll("tools/net8.0/any/MyTool.dll");
+        WriteDll("tools/net6.0/any/MyTool.dll");
+
+        var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir, "net8.0");
+
+        Assert.Equal("net8.0", tfm);
+        Assert.Equal([tool], paths);
+    }
+
+    [Fact]
+    public void SelectHighestAssembliesFromPackage_RefLayoutExplicitTfm_SelectsMatchingAssemblies()
+    {
+        var referenceAssembly = WriteDll("ref/net8.0/MyLib.dll");
+        WriteDll("ref/net6.0/MyLib.dll");
+
+        var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir, "net8.0");
+
+        Assert.Equal("net8.0", tfm);
+        Assert.Equal([referenceAssembly], paths);
+    }
+
+    [Fact]
     public void SelectHighestAssembliesFromPackage_ExplicitTfmWithoutMatches_ReturnsEmptySelection()
     {
         WriteDll("lib/net8.0/MyLib.dll");

--- a/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
@@ -1,0 +1,104 @@
+namespace DotnetInspector.Services.Tests;
+
+public class TfmSelectorTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public TfmSelectorTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"tfm-selector-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SelectHighestAssembliesFromPackage_SelectsHighestTfmAssemblies()
+    {
+        var netstandard = WriteDll("lib/netstandard2.0/MyLib.dll");
+        var net8 = WriteDll("lib/net8.0/MyLib.dll");
+        var net8Companion = WriteDll("lib/net8.0/MyLib.Companion.dll");
+        WriteDll("lib/net8.0/fr/MyLib.resources.dll");
+
+        var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir);
+
+        Assert.Equal("net8.0", tfm);
+        Assert.Equal(2, paths.Count);
+        Assert.Contains(net8, paths);
+        Assert.Contains(net8Companion, paths);
+        Assert.DoesNotContain(netstandard, paths);
+    }
+
+    [Fact]
+    public void SelectHighestAssembliesFromPackage_ExplicitTfm_SelectsMatchingAssemblies()
+    {
+        var net6 = WriteDll("lib/net6.0/MyLib.dll");
+        WriteDll("lib/net8.0/MyLib.dll");
+
+        var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir, "net6.0");
+
+        Assert.Equal("net6.0", tfm);
+        Assert.Equal([net6], paths);
+    }
+
+    [Fact]
+    public void SelectHighestAssembliesFromPackage_ExplicitTfmWithoutMatches_ReturnsEmptySelection()
+    {
+        WriteDll("lib/net8.0/MyLib.dll");
+
+        var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir, "net6.0");
+
+        Assert.Equal("net6.0", tfm);
+        Assert.Empty(paths);
+    }
+
+    [Fact]
+    public void SelectHighestAssembliesFromPackage_AllTfms_ReturnsAllNonResourceAssemblies()
+    {
+        var net6 = WriteDll("lib/net6.0/MyLib.dll");
+        var net8 = WriteDll("lib/net8.0/MyLib.dll");
+        WriteDll("lib/net8.0/fr/MyLib.resources.dll");
+
+        var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir, "all");
+
+        Assert.Null(tfm);
+        Assert.Equal([net6, net8], paths);
+    }
+
+    [Fact]
+    public void GetPackageTfms_ReturnsDistinctTfmsInPriorityOrder()
+    {
+        WriteDll("lib/netstandard2.0/MyLib.dll");
+        WriteDll("lib/net8.0/MyLib.dll");
+        WriteDll("lib/net8.0/MyLib.Companion.dll");
+
+        var tfms = TfmSelector.GetPackageTfms(_tempDir);
+
+        Assert.Equal(["net8.0", "netstandard2.0"], tfms);
+    }
+
+    [Fact]
+    public void SelectHighestAssembliesFromPackage_NoTfmLayout_ReturnsPackageAssemblies()
+    {
+        var root = WriteDll("MyLib.dll");
+
+        var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir);
+
+        Assert.Null(tfm);
+        Assert.Equal([root], paths);
+    }
+
+    private string WriteDll(string relativePath)
+    {
+        var path = Path.Combine(_tempDir, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllBytes(path, []);
+        return path;
+    }
+}

--- a/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
@@ -36,6 +36,17 @@ public class TfmSelectorTests : IDisposable
     }
 
     [Fact]
+    public void SelectHighestAssembliesFromPackage_KeepsPrimaryAssemblyEndingInResources()
+    {
+        var resourcesAssembly = WriteDll("lib/net8.0/MyCompany.Resources.dll");
+
+        var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir);
+
+        Assert.Equal("net8.0", tfm);
+        Assert.Equal([resourcesAssembly], paths);
+    }
+
+    [Fact]
     public void SelectHighestAssembliesFromPackage_ExplicitTfm_SelectsMatchingAssemblies()
     {
         var net6 = WriteDll("lib/net6.0/MyLib.dll");
@@ -143,6 +154,39 @@ public class TfmSelectorTests : IDisposable
     [Fact]
     public void FindAssemblyByTfm_HandlesRuntimeSpecificLibLayout()
     {
+        var runtimeAssembly = WriteDll("runtimes/linux-x64/lib/net8.0/MyRuntime.dll");
+
+        var result = TfmSelector.FindAssemblyByTfm(_tempDir, "net8.0");
+
+        Assert.Equal(runtimeAssembly, result);
+    }
+
+    [Fact]
+    public void FindAssemblyByTfm_PrefersLibPackageNameMatchOverToolsAssembly()
+    {
+        WriteDll("tools/net8.0/MyTool.dll");
+        var libraryAssembly = WriteDll("lib/net8.0/MyLib.dll");
+
+        var result = TfmSelector.FindAssemblyByTfm(_tempDir, "net8.0", "MyLib");
+
+        Assert.Equal(libraryAssembly, result);
+    }
+
+    [Fact]
+    public void FindAssemblyByTfm_FindsLibTfmWhenToolsHasDifferentTfm()
+    {
+        WriteDll("tools/net472/MyTool.dll");
+        var libraryAssembly = WriteDll("lib/net8.0/MyLib.dll");
+
+        var result = TfmSelector.FindAssemblyByTfm(_tempDir, "net8.0");
+
+        Assert.Equal(libraryAssembly, result);
+    }
+
+    [Fact]
+    public void FindAssemblyByTfm_FindsRuntimeSpecificLibWhenLibHasDifferentTfm()
+    {
+        WriteDll("lib/net6.0/MyLib.dll");
         var runtimeAssembly = WriteDll("runtimes/linux-x64/lib/net8.0/MyRuntime.dll");
 
         var result = TfmSelector.FindAssemblyByTfm(_tempDir, "net8.0");

--- a/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
@@ -38,9 +38,20 @@ public class TfmSelectorTests : IDisposable
     [Fact]
     public void SelectHighestAssembliesFromPackage_KeepsPrimaryAssemblyEndingInResources()
     {
-        var resourcesAssembly = WriteDll("lib/net8.0/MyCompany.Resources.dll");
+        var resourcesAssembly = WriteDll("lib/net472/MyCompany.Resources.dll");
 
         var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir);
+
+        Assert.Equal("net472", tfm);
+        Assert.Equal([resourcesAssembly], paths);
+    }
+
+    [Fact]
+    public void SelectHighestAssembliesFromPackage_KeepsToolPrimaryAssemblyEndingInResources()
+    {
+        var resourcesAssembly = WriteDll("tools/net8.0/any/MyTool.Resources.dll");
+
+        var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir, "net8.0");
 
         Assert.Equal("net8.0", tfm);
         Assert.Equal([resourcesAssembly], paths);
@@ -80,6 +91,19 @@ public class TfmSelectorTests : IDisposable
 
         Assert.Equal("net8.0", tfm);
         Assert.Equal([referenceAssembly], paths);
+    }
+
+    [Fact]
+    public void SelectHighestAssembliesFromPackage_ExplicitTfmScansAllLayouts()
+    {
+        WriteDll("tools/net472/MyTool.dll");
+        var libraryAssembly = WriteDll("lib/net8.0/MyLib.dll");
+        var companionAssembly = WriteDll("runtimes/linux-x64/lib/net8.0/MyRuntime.dll");
+
+        var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir, "net8.0");
+
+        Assert.Equal("net8.0", tfm);
+        Assert.Equal([libraryAssembly, companionAssembly], paths);
     }
 
     [Fact]
@@ -138,6 +162,18 @@ public class TfmSelectorTests : IDisposable
         var result = TfmSelector.FindAssemblyByTfm(_tempDir, "net8.0", "MyPackage");
 
         Assert.Equal(primary, result);
+    }
+
+    [Fact]
+    public void FindAssemblyInPackage_ExplicitTfmScansAllLayouts()
+    {
+        WriteDll("tools/net472/MyTool.dll");
+        var libraryAssembly = WriteDll("lib/net8.0/MyLib.dll");
+
+        var (path, tfm) = TfmSelector.FindAssemblyInPackage(_tempDir, "MyLib", "net8.0");
+
+        Assert.Equal(libraryAssembly, path);
+        Assert.Equal("net8.0", tfm);
     }
 
     [Fact]

--- a/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
@@ -131,6 +131,31 @@ public class TfmSelectorTests : IDisposable
     }
 
     [Fact]
+    public void SelectHighestAssembliesFromPackage_AllTfmsScansAllLayouts()
+    {
+        var tool = WriteDll("tools/net6.0/Tool.dll");
+        var library = WriteDll("lib/net8.0/Lib.dll");
+        var runtime = WriteDll("runtimes/linux-x64/lib/net8.0/Runtime.dll");
+
+        var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir, "all");
+
+        Assert.Null(tfm);
+        Assert.Equal([library, runtime, tool], paths);
+    }
+
+    [Fact]
+    public void SelectHighestAssembliesFromPackage_FiltersSatelliteWithUppercaseCultureDirectory()
+    {
+        var primary = WriteDll("lib/net8.0/MyLib.dll");
+        WriteDll("lib/net8.0/ES-ES/MyLib.resources.dll");
+
+        var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir);
+
+        Assert.Equal("net8.0", tfm);
+        Assert.Equal([primary], paths);
+    }
+
+    [Fact]
     public void GetPackageTfms_ReturnsDistinctTfmsInPriorityOrder()
     {
         WriteDll("lib/netstandard2.0/MyLib.dll");

--- a/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
@@ -179,6 +179,17 @@ public class TfmSelectorTests : IDisposable
     }
 
     [Fact]
+    public void SelectHighestAssembliesFromPackage_RuntimeOnlyPackage_ReturnsRuntimeAssembly()
+    {
+        var runtimeAssembly = WriteDll("runtimes/linux-x64/lib/net8.0/MyRuntime.dll");
+
+        var (paths, tfm) = TfmSelector.SelectHighestAssembliesFromPackage(_tempDir);
+
+        Assert.Equal("net8.0", tfm);
+        Assert.Equal([runtimeAssembly], paths);
+    }
+
+    [Fact]
     public void FindAssemblyByTfm_UsesPackageNameMatch()
     {
         WriteDll("lib/net8.0/Companion.dll");

--- a/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
@@ -144,7 +144,7 @@ public class TfmSelectorTests : IDisposable
     public void FindAssemblyByTfm_FiltersResourceAssemblies()
     {
         var primary = WriteDll("tools/net8.0/any/MyTool.dll");
-        WriteDll("tools/net8.0/any/MyTool.resources.dll");
+        WriteDll("tools/net8.0/any/fr/MyTool.resources.dll");
 
         var result = TfmSelector.FindAssemblyByTfm(_tempDir, "net8.0");
 

--- a/src/DotnetInspector.Services/TfmSelector.cs
+++ b/src/DotnetInspector.Services/TfmSelector.cs
@@ -42,6 +42,21 @@ public static class TfmSelector
         return candidates.OrderBy(f => f).ToList();
     }
 
+    public static List<string> GetPackageAssemblies(string extractPath)
+        => FilterResourceAssemblies(GetPackageDlls(extractPath));
+
+    public static List<string> GetPackageTfms(string extractPath)
+        => GetPackageTfms(GetPackageDlls(extractPath), extractPath);
+
+    public static List<string> GetPackageTfms(IEnumerable<string> paths, string extractPath)
+        => paths
+            .Select(path => GetTfm(extractPath, path))
+            .Where(tfm => tfm != null)
+            .Select(tfm => tfm!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(TfmResolver.GetTfmPriority)
+            .ToList();
+
     public static (string? path, string? tfm) SelectHighestTfmAssembly(List<string> dlls, string extractPath, string? packageName = null)
     {
         dlls = FilterResourceAssemblies(dlls);
@@ -129,9 +144,33 @@ public static class TfmSelector
         return (byTfm[highestTfm], highestTfm);
     }
 
+    public static (List<string> paths, string? tfm) SelectHighestAssembliesFromPackage(string extractPath, string? tfm = null)
+        => SelectHighestAssemblies(GetPackageDlls(extractPath), extractPath, tfm);
+
+    public static (List<string> paths, string? tfm) SelectHighestAssemblies(List<string> dlls, string extractPath, string? tfm = null)
+    {
+        dlls = FilterResourceAssemblies(dlls);
+        if (string.Equals(tfm, "all", StringComparison.OrdinalIgnoreCase))
+            return (dlls, null);
+
+        if (dlls.Count == 0)
+            return ([], string.IsNullOrWhiteSpace(tfm) ? null : tfm);
+
+        if (!string.IsNullOrWhiteSpace(tfm))
+        {
+            var selected = dlls
+                .Where(path => string.Equals(GetTfm(extractPath, path), tfm, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            return (selected, tfm);
+        }
+
+        var (highestTfmDlls, highestTfm) = SelectHighestTfmAssemblies(dlls, extractPath);
+        return highestTfmDlls.Count > 0 ? (highestTfmDlls, highestTfm) : (dlls, null);
+    }
+
     public static (string? path, string? tfm) FindAssemblyInPackage(string extractPath, string assemblyName, string? tfm = null)
     {
-        var dlls = FilterResourceAssemblies(GetPackageDlls(extractPath));
+        var dlls = GetPackageAssemblies(extractPath);
         if (dlls.Count == 0)
             return (null, null);
 
@@ -177,7 +216,7 @@ public static class TfmSelector
 
     public static (string? path, string? tfm) FindAssemblyContainingType(string extractPath, string typeName, string? tfm = null)
     {
-        var dlls = FilterResourceAssemblies(GetPackageDlls(extractPath));
+        var dlls = GetPackageAssemblies(extractPath);
         if (dlls.Count == 0)
             return (null, null);
 
@@ -186,21 +225,11 @@ public static class TfmSelector
 
         if (!string.IsNullOrEmpty(tfm))
         {
-            candidateDlls = dlls
-                .Where(dll => string.Equals(
-                    TfmResolver.ExtractTfmFromPath(Path.GetRelativePath(extractPath, dll).Replace('\\', '/')),
-                    tfm,
-                    StringComparison.OrdinalIgnoreCase))
-                .ToList();
+            (candidateDlls, selectedTfm) = SelectHighestAssemblies(dlls, extractPath, tfm);
         }
         else
         {
-            var (highestTfmDlls, highestTfm) = SelectHighestTfmAssemblies(dlls, extractPath);
-            if (highestTfmDlls.Count > 0)
-            {
-                candidateDlls = highestTfmDlls;
-                selectedTfm = highestTfm;
-            }
+            (candidateDlls, selectedTfm) = SelectHighestAssemblies(dlls, extractPath);
         }
 
         foreach (var dll in candidateDlls)
@@ -225,6 +254,9 @@ public static class TfmSelector
 
         return (null, selectedTfm);
     }
+
+    private static string? GetTfm(string extractPath, string path)
+        => TfmResolver.ExtractTfmFromPath(Path.GetRelativePath(extractPath, path).Replace('\\', '/'));
 
     public static string? FindAssemblyByTfm(string extractPath, string tfm, string? packageName = null)
     {

--- a/src/DotnetInspector.Services/TfmSelector.cs
+++ b/src/DotnetInspector.Services/TfmSelector.cs
@@ -260,43 +260,11 @@ public static class TfmSelector
 
     public static string? FindAssemblyByTfm(string extractPath, string tfm, string? packageName = null)
     {
-        var refDir = Path.Combine(extractPath, "ref");
-        var libDir = Path.Combine(extractPath, "lib");
-        var toolsDir = Path.Combine(extractPath, "tools");
+        var (dlls, _) = SelectHighestAssembliesFromPackage(extractPath, tfm);
+        if (dlls.Count == 0)
+            return null;
 
-        // Check ref/ first (ref packages), then lib/
-        foreach (var dir in new[] { refDir, libDir })
-        {
-            if (Directory.Exists(dir))
-            {
-                var tfmDir = Path.Combine(dir, tfm);
-                if (Directory.Exists(tfmDir))
-                {
-                    var dlls = Directory.GetFiles(tfmDir, "*.dll");
-                    if (dlls.Length > 0)
-                    {
-                        if (packageName != null)
-                        {
-                            var match = dlls.FirstOrDefault(d =>
-                                Path.GetFileNameWithoutExtension(d).Equals(packageName, StringComparison.OrdinalIgnoreCase));
-                            if (match != null)
-                                return match;
-                        }
-                        return dlls[0];
-                    }
-                }
-            }
-        }
-
-        if (Directory.Exists(toolsDir))
-        {
-            var dlls = Directory.GetFiles(toolsDir, "*.dll", SearchOption.AllDirectories)
-                .Where(f => f.Replace('\\', '/').Contains($"/{tfm}/", StringComparison.OrdinalIgnoreCase))
-                .ToList();
-            if (dlls.Count > 0)
-                return dlls[0];
-        }
-
-        return null;
+        var (selectedPath, _) = SelectHighestTfmAssembly(dlls, extractPath, packageName);
+        return selectedPath ?? dlls[0];
     }
 }

--- a/src/DotnetInspector.Services/TfmSelector.cs
+++ b/src/DotnetInspector.Services/TfmSelector.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using DotnetInspector.Packages;
 using NuGetFetch;
 
@@ -9,7 +10,7 @@ namespace DotnetInspector.Services;
 public static class TfmSelector
 {
     private static List<string> FilterResourceAssemblies(IEnumerable<string> dlls)
-        => dlls.Where(d => !d.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase)).ToList();
+        => dlls.Where(d => !IsSatelliteResourceAssembly(d)).ToList();
 
     public static List<string> GetPackageDlls(string extractPath)
     {
@@ -260,11 +261,51 @@ public static class TfmSelector
 
     public static string? FindAssemblyByTfm(string extractPath, string tfm, string? packageName = null)
     {
-        var (dlls, _) = SelectHighestAssembliesFromPackage(extractPath, tfm);
+        var dlls = FilterResourceAssemblies(Directory.GetFiles(extractPath, "*.dll", SearchOption.AllDirectories))
+            .Where(path => string.Equals(GetTfm(extractPath, path), tfm, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(path => GetExplicitTfmLookupPriority(extractPath, path))
+            .ThenBy(path => Path.GetRelativePath(extractPath, path).Replace('\\', '/'), StringComparer.OrdinalIgnoreCase)
+            .ToList();
         if (dlls.Count == 0)
             return null;
 
         var (selectedPath, _) = SelectHighestTfmAssembly(dlls, extractPath, packageName);
         return selectedPath ?? dlls[0];
+    }
+
+    private static int GetExplicitTfmLookupPriority(string extractPath, string path)
+    {
+        var parts = Path.GetRelativePath(extractPath, path).Replace('\\', '/').Split('/');
+        if (parts.Length == 0)
+            return 4;
+
+        return parts[0] switch
+        {
+            "ref" => 0,
+            "lib" => 1,
+            "runtimes" => 2,
+            "tools" => 3,
+            _ => 4
+        };
+    }
+
+    private static bool IsSatelliteResourceAssembly(string path)
+    {
+        if (!Path.GetFileName(path).EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var parentDirectory = Directory.GetParent(path)?.Name;
+        if (string.IsNullOrWhiteSpace(parentDirectory))
+            return false;
+
+        try
+        {
+            _ = CultureInfo.GetCultureInfo(parentDirectory);
+            return true;
+        }
+        catch (CultureNotFoundException)
+        {
+            return false;
+        }
     }
 }

--- a/src/DotnetInspector.Services/TfmSelector.cs
+++ b/src/DotnetInspector.Services/TfmSelector.cs
@@ -210,16 +210,25 @@ public static class TfmSelector
     }
 
     public static (List<string> paths, string? tfm) SelectHighestAssembliesFromPackage(string extractPath, string? tfm = null)
-        => !string.IsNullOrWhiteSpace(tfm) && !string.Equals(tfm, "all", StringComparison.OrdinalIgnoreCase)
+    {
+        if (string.Equals(tfm, "all", StringComparison.OrdinalIgnoreCase))
+            return (GetAllPackageAssemblies(extractPath), null);
+
+        return !string.IsNullOrWhiteSpace(tfm)
             ? SelectAssembliesByTfmFromPackage(extractPath, tfm)
             : SelectHighestAssemblies(GetPackageDlls(extractPath), extractPath, tfm);
+    }
+
+    private static List<string> GetAllPackageAssemblies(string extractPath)
+        => FilterResourceAssemblies(Directory.GetFiles(extractPath, "*.dll", SearchOption.AllDirectories))
+            .OrderBy(path => GetExplicitTfmLookupPriority(extractPath, path))
+            .ThenBy(path => Path.GetRelativePath(extractPath, path).Replace('\\', '/'), StringComparer.OrdinalIgnoreCase)
+            .ToList();
 
     public static (List<string> paths, string? tfm) SelectAssembliesByTfmFromPackage(string extractPath, string tfm)
     {
-        var selected = FilterResourceAssemblies(Directory.GetFiles(extractPath, "*.dll", SearchOption.AllDirectories))
+        var selected = GetAllPackageAssemblies(extractPath)
             .Where(path => string.Equals(GetTfm(extractPath, path), tfm, StringComparison.OrdinalIgnoreCase))
-            .OrderBy(path => GetExplicitTfmLookupPriority(extractPath, path))
-            .ThenBy(path => Path.GetRelativePath(extractPath, path).Replace('\\', '/'), StringComparer.OrdinalIgnoreCase)
             .ToList();
         return (selected, tfm);
     }
@@ -386,15 +395,16 @@ public static class TfmSelector
     }
 
     private static bool IsLanguageSubtag(string value)
-        => value.Length is 2 or 3 && value.All(c => c is >= 'a' and <= 'z');
+        => value.Length is 2 or 3 && value.All(IsAsciiLetter);
 
     private static bool IsCultureSubtag(string value)
     {
         if (value.Length is < 2 or > 8)
             return false;
 
-        return value.All(c => c is >= 'a' and <= 'z'
-            || c is >= 'A' and <= 'Z'
-            || c is >= '0' and <= '9');
+        return value.All(c => IsAsciiLetter(c) || c is >= '0' and <= '9');
     }
+
+    private static bool IsAsciiLetter(char value)
+        => value is >= 'a' and <= 'z' or >= 'A' and <= 'Z';
 }

--- a/src/DotnetInspector.Services/TfmSelector.cs
+++ b/src/DotnetInspector.Services/TfmSelector.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using DotnetInspector.Packages;
 using NuGetFetch;
 
@@ -211,7 +210,19 @@ public static class TfmSelector
     }
 
     public static (List<string> paths, string? tfm) SelectHighestAssembliesFromPackage(string extractPath, string? tfm = null)
-        => SelectHighestAssemblies(GetPackageDlls(extractPath), extractPath, tfm);
+        => !string.IsNullOrWhiteSpace(tfm) && !string.Equals(tfm, "all", StringComparison.OrdinalIgnoreCase)
+            ? SelectAssembliesByTfmFromPackage(extractPath, tfm)
+            : SelectHighestAssemblies(GetPackageDlls(extractPath), extractPath, tfm);
+
+    public static (List<string> paths, string? tfm) SelectAssembliesByTfmFromPackage(string extractPath, string tfm)
+    {
+        var selected = FilterResourceAssemblies(Directory.GetFiles(extractPath, "*.dll", SearchOption.AllDirectories))
+            .Where(path => string.Equals(GetTfm(extractPath, path), tfm, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(path => GetExplicitTfmLookupPriority(extractPath, path))
+            .ThenBy(path => Path.GetRelativePath(extractPath, path).Replace('\\', '/'), StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        return (selected, tfm);
+    }
 
     public static (List<string> paths, string? tfm) SelectHighestAssemblies(List<string> dlls, string extractPath, string? tfm = null)
     {
@@ -236,7 +247,9 @@ public static class TfmSelector
 
     public static (string? path, string? tfm) FindAssemblyInPackage(string extractPath, string assemblyName, string? tfm = null)
     {
-        var dlls = GetPackageAssemblies(extractPath);
+        var dlls = !string.IsNullOrEmpty(tfm)
+            ? SelectAssembliesByTfmFromPackage(extractPath, tfm).paths
+            : GetPackageAssemblies(extractPath);
         if (dlls.Count == 0)
             return (null, null);
 
@@ -263,26 +276,15 @@ public static class TfmSelector
         if (matchingFiles.Count == 0)
             return (null, null);
 
-        if (!string.IsNullOrEmpty(tfm))
-        {
-            matchingFiles = matchingFiles
-                .Where(dll => string.Equals(
-                    TfmResolver.ExtractTfmFromPath(Path.GetRelativePath(extractPath, dll).Replace('\\', '/')),
-                    tfm,
-                    StringComparison.OrdinalIgnoreCase))
-                .ToList();
-
-            if (matchingFiles.Count == 0)
-                return (null, tfm);
-        }
-
         var (selectedPath, selectedTfm) = SelectHighestTfmAssembly(matchingFiles, extractPath);
         return (selectedPath ?? matchingFiles[0], selectedTfm ?? tfm);
     }
 
     public static (string? path, string? tfm) FindAssemblyContainingType(string extractPath, string typeName, string? tfm = null)
     {
-        var dlls = GetPackageAssemblies(extractPath);
+        var dlls = !string.IsNullOrEmpty(tfm)
+            ? SelectAssembliesByTfmFromPackage(extractPath, tfm).paths
+            : GetPackageAssemblies(extractPath);
         if (dlls.Count == 0)
             return (null, null);
 
@@ -291,7 +293,8 @@ public static class TfmSelector
 
         if (!string.IsNullOrEmpty(tfm))
         {
-            (candidateDlls, selectedTfm) = SelectHighestAssemblies(dlls, extractPath, tfm);
+            candidateDlls = dlls;
+            selectedTfm = tfm;
         }
         else
         {
@@ -326,11 +329,7 @@ public static class TfmSelector
 
     public static string? FindAssemblyByTfm(string extractPath, string tfm, string? packageName = null)
     {
-        var dlls = FilterResourceAssemblies(Directory.GetFiles(extractPath, "*.dll", SearchOption.AllDirectories))
-            .Where(path => string.Equals(GetTfm(extractPath, path), tfm, StringComparison.OrdinalIgnoreCase))
-            .OrderBy(path => GetExplicitTfmLookupPriority(extractPath, path))
-            .ThenBy(path => Path.GetRelativePath(extractPath, path).Replace('\\', '/'), StringComparer.OrdinalIgnoreCase)
-            .ToList();
+        var (dlls, _) = SelectAssembliesByTfmFromPackage(extractPath, tfm);
         if (dlls.Count == 0)
             return null;
 
@@ -359,18 +358,43 @@ public static class TfmSelector
         if (!Path.GetFileName(path).EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
             return false;
 
-        var parentDirectory = Directory.GetParent(path)?.Name;
-        if (string.IsNullOrWhiteSpace(parentDirectory))
+        var parentDirectory = Directory.GetParent(path);
+        if (!IsCultureDirectoryName(parentDirectory?.Name))
             return false;
 
-        try
-        {
-            _ = CultureInfo.GetCultureInfo(parentDirectory);
-            return true;
-        }
-        catch (CultureNotFoundException)
-        {
+        var primaryAssemblyName = Path.GetFileName(path)[..^".resources.dll".Length] + ".dll";
+        var primaryAssemblyPath = Path.Combine(
+            parentDirectory!.Parent?.FullName ?? "",
+            primaryAssemblyName);
+        return File.Exists(primaryAssemblyPath);
+    }
+
+    private static bool IsCultureDirectoryName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
             return false;
-        }
+
+        if (name.Equals("any", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var parts = name.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+            return false;
+
+        return IsLanguageSubtag(parts[0])
+            && parts.Skip(1).All(IsCultureSubtag);
+    }
+
+    private static bool IsLanguageSubtag(string value)
+        => value.Length is 2 or 3 && value.All(c => c is >= 'a' and <= 'z');
+
+    private static bool IsCultureSubtag(string value)
+    {
+        if (value.Length is < 2 or > 8)
+            return false;
+
+        return value.All(c => c is >= 'a' and <= 'z'
+            || c is >= 'A' and <= 'Z'
+            || c is >= '0' and <= '9');
     }
 }

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -281,29 +281,12 @@ public class DiffCommand
             return (null, null, null, outcome.ErrorMessage);
 
         var extracted = outcome.Result!;
-        var dlls = TfmSelector.GetPackageDlls(extracted.ExtractPath);
+        var dlls = TfmSelector.GetPackageAssemblies(extracted.ExtractPath);
         if (dlls.Count == 0)
             return (null, null, extracted.TempDir, "No DLLs found in package.");
 
-        List<string> paths;
-        string? selectedTfm;
-        if (!string.IsNullOrEmpty(options.Tfm))
-        {
-            paths = dlls
-                .Where(path =>
-                {
-                    var relativePath = Path.GetRelativePath(extracted.ExtractPath, path).Replace('\\', '/');
-                    return relativePath.Split('/').Any(part => string.Equals(part, options.Tfm, StringComparison.OrdinalIgnoreCase));
-                })
-                .Where(path => !path.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
-                .OrderBy(path => path, StringComparer.Ordinal)
-                .ToList();
-            selectedTfm = options.Tfm;
-        }
-        else
-        {
-            (paths, selectedTfm) = TfmSelector.SelectHighestTfmAssemblies(dlls, extracted.ExtractPath);
-        }
+        var (paths, selectedTfm) = TfmSelector.SelectHighestAssemblies(dlls, extracted.ExtractPath, options.Tfm);
+        paths = paths.OrderBy(path => path, StringComparer.Ordinal).ToList();
 
         if (paths.Count == 0)
             return (null, null, extracted.TempDir, "No DLLs found for selected TFM.");

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -281,11 +281,10 @@ public class DiffCommand
             return (null, null, null, outcome.ErrorMessage);
 
         var extracted = outcome.Result!;
-        var dlls = TfmSelector.GetPackageAssemblies(extracted.ExtractPath);
-        if (dlls.Count == 0)
+        var (paths, selectedTfm) = TfmSelector.SelectHighestAssembliesFromPackage(extracted.ExtractPath, options.Tfm);
+        if (paths.Count == 0 && string.IsNullOrEmpty(options.Tfm))
             return (null, null, extracted.TempDir, "No DLLs found in package.");
 
-        var (paths, selectedTfm) = TfmSelector.SelectHighestAssemblies(dlls, extracted.ExtractPath, options.Tfm);
         paths = paths.OrderBy(path => path, StringComparer.Ordinal).ToList();
 
         if (paths.Count == 0)

--- a/src/dotnet-inspect/Commands/LibraryCommand.cs
+++ b/src/dotnet-inspect/Commands/LibraryCommand.cs
@@ -1585,7 +1585,7 @@ public class LibraryCommand
         // --tfm all: return all assemblies from every TFM
         if (string.Equals(tfm, "all", StringComparison.OrdinalIgnoreCase))
         {
-            var candidates = TfmSelector.GetPackageDlls(extractPath);
+            var (candidates, _) = TfmSelector.SelectHighestAssembliesFromPackage(extractPath, tfm);
             if (candidates.Count == 0)
             {
                 Console.Error.WriteLine("Error: No DLLs found in package.");
@@ -1603,11 +1603,7 @@ public class LibraryCommand
             {
                 Console.Error.WriteLine($"Error: No library found for TFM '{tfm}'.");
                 Console.Error.WriteLine("Available TFMs:");
-                var tfms = allDlls
-                    .Select(d => TfmResolver.ExtractTfmFromPath(Path.GetRelativePath(extractPath, d).Replace('\\', '/')))
-                    .Where(t => t != null)
-                    .Distinct()
-                    .OrderByDescending(t => TfmResolver.GetTfmPriority(t!));
+                var tfms = TfmSelector.GetPackageTfms(allDlls, extractPath);
                 foreach (var t in tfms)
                 {
                     Console.Error.WriteLine($"  {t}");
@@ -1622,7 +1618,7 @@ public class LibraryCommand
         // No --tfm and no assembly name: select the highest-priority TFM (default)
         if (string.IsNullOrEmpty(assemblyName))
         {
-            var candidates = TfmSelector.GetPackageDlls(extractPath);
+            var candidates = TfmSelector.GetPackageAssemblies(extractPath);
             if (candidates.Count == 0)
             {
                 Console.Error.WriteLine("Error: No DLLs found in package.");

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -1350,28 +1350,7 @@ public class PackageCommand
 
     private static List<string> SelectPackageLibrariesForSourceFiles(string extractPath, InspectionOptions options)
     {
-        var candidates = TfmSelector.GetPackageDlls(extractPath)
-            .Where(path => !path.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
-            .ToList();
-        if (candidates.Count == 0)
-            return [];
-
-        if (string.Equals(options.Tfm, "all", StringComparison.OrdinalIgnoreCase))
-            return candidates
-                .OrderBy(path => Path.GetRelativePath(extractPath, path).Replace('\\', '/'), StringComparer.OrdinalIgnoreCase)
-                .ToList();
-
-        if (!string.IsNullOrWhiteSpace(options.Tfm))
-            return candidates
-                .Where(path => string.Equals(
-                    TfmResolver.ExtractTfmFromPath(Path.GetRelativePath(extractPath, path).Replace('\\', '/')),
-                    options.Tfm,
-                    StringComparison.OrdinalIgnoreCase))
-                .OrderBy(path => Path.GetRelativePath(extractPath, path).Replace('\\', '/'), StringComparer.OrdinalIgnoreCase)
-                .ToList();
-
-        var (highestTfmDlls, _) = TfmSelector.SelectHighestTfmAssemblies(candidates, extractPath);
-        var selected = highestTfmDlls.Count > 0 ? highestTfmDlls : candidates;
+        var (selected, _) = TfmSelector.SelectHighestAssembliesFromPackage(extractPath, options.Tfm);
         return selected
             .OrderBy(path => Path.GetRelativePath(extractPath, path).Replace('\\', '/'), StringComparer.OrdinalIgnoreCase)
             .ToList();
@@ -2004,37 +1983,19 @@ public class PackageCommand
             return null;
         }
 
-        var candidates = TfmSelector.GetPackageDlls(extractPath)
-            .Where(path => !path.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
-            .ToList();
-        if (candidates.Count == 0)
+        var allCandidates = TfmSelector.GetPackageAssemblies(extractPath);
+        if (allCandidates.Count == 0)
         {
             Console.Error.WriteLine($"Error: No DLLs found in package '{packageName}'.");
             return null;
         }
 
-        string? selectedTfm = options.Tfm;
-        List<string> pool;
-        if (!string.IsNullOrWhiteSpace(options.Tfm))
+        var (pool, selectedTfm) = TfmSelector.SelectHighestAssemblies(allCandidates, extractPath, options.Tfm);
+        if (pool.Count == 0)
         {
-            pool = candidates
-                .Where(path => string.Equals(
-                    TfmResolver.ExtractTfmFromPath(Path.GetRelativePath(extractPath, path).Replace('\\', '/')),
-                    options.Tfm,
-                    StringComparison.OrdinalIgnoreCase))
-                .ToList();
-            if (pool.Count == 0)
-            {
-                Console.Error.WriteLine($"Error: No library found for TFM '{options.Tfm}' in package '{packageName}'.");
-                WritePackageLibraryCandidates(extractPath, packageName, version, options.Tfm);
-                return null;
-            }
-        }
-        else
-        {
-            var (highestTfmDlls, highestTfm) = TfmSelector.SelectHighestTfmAssemblies(candidates, extractPath);
-            pool = highestTfmDlls.Count > 0 ? highestTfmDlls : candidates;
-            selectedTfm = highestTfm;
+            Console.Error.WriteLine($"Error: No library found for TFM '{options.Tfm}' in package '{packageName}'.");
+            WritePackageLibraryCandidates(extractPath, packageName, version, options.Tfm);
+            return null;
         }
 
         if (pool.Count == 1)
@@ -2059,42 +2020,23 @@ public class PackageCommand
         string version,
         InspectionOptions options)
     {
-        var candidates = TfmSelector.GetPackageDlls(extractPath)
-            .Where(path => !path.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        var candidates = TfmSelector.GetPackageAssemblies(extractPath);
         if (candidates.Count == 0)
         {
             Console.Error.WriteLine($"Error: No DLLs found in package '{packageName}'.");
             return null;
         }
 
-        List<string> selected;
-        if (string.Equals(options.Tfm, "all", StringComparison.OrdinalIgnoreCase))
+        var (selected, highestTfm) = TfmSelector.SelectHighestAssemblies(candidates, extractPath, options.Tfm);
+        if (selected.Count == 0)
         {
-            selected = candidates;
+            Console.Error.WriteLine($"Error: No libraries found for TFM '{options.Tfm}' in package '{packageName}'.");
+            WritePackageLibraryCandidates(extractPath, packageName, version, options.Tfm);
+            return null;
         }
-        else if (!string.IsNullOrWhiteSpace(options.Tfm))
-        {
-            selected = candidates
-                .Where(path => string.Equals(
-                    TfmResolver.ExtractTfmFromPath(Path.GetRelativePath(extractPath, path).Replace('\\', '/')),
-                    options.Tfm,
-                    StringComparison.OrdinalIgnoreCase))
-                .ToList();
-            if (selected.Count == 0)
-            {
-                Console.Error.WriteLine($"Error: No libraries found for TFM '{options.Tfm}' in package '{packageName}'.");
-                WritePackageLibraryCandidates(extractPath, packageName, version, options.Tfm);
-                return null;
-            }
-        }
-        else
-        {
-            var (highestTfmDlls, highestTfm) = TfmSelector.SelectHighestTfmAssemblies(candidates, extractPath);
-            selected = highestTfmDlls.Count > 0 ? highestTfmDlls : candidates;
-            if (highestTfm != null)
-                Console.Error.WriteLine($"Using TFM: {highestTfm}");
-        }
+
+        if (highestTfm != null && string.IsNullOrWhiteSpace(options.Tfm))
+            Console.Error.WriteLine($"Using TFM: {highestTfm}");
 
         return selected
             .OrderBy(path => Path.GetRelativePath(extractPath, path).Replace('\\', '/'), StringComparer.OrdinalIgnoreCase)
@@ -2582,14 +2524,9 @@ public class PackageCommand
         string? tfm,
         List<string>? candidates = null)
     {
-        candidates ??= TfmSelector.GetPackageDlls(extractPath)
-            .Where(path => !path.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
-            .Where(path => string.IsNullOrWhiteSpace(tfm)
-                || string.Equals(
-                    TfmResolver.ExtractTfmFromPath(Path.GetRelativePath(extractPath, path).Replace('\\', '/')),
-                    tfm,
-                    StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        candidates ??= string.IsNullOrWhiteSpace(tfm)
+            ? TfmSelector.GetPackageAssemblies(extractPath)
+            : TfmSelector.SelectHighestAssembliesFromPackage(extractPath, tfm).paths;
 
         if (candidates.Count > 0)
         {
@@ -2743,15 +2680,7 @@ public class PackageCommand
 
     private static void ListPackageTfms(string extractPath, bool tsv, bool jsonl)
     {
-        var dlls = TfmSelector.GetPackageDlls(extractPath);
-        var tfms = dlls
-            .Select(d => TfmResolver.ExtractTfmFromPath(
-                Path.GetRelativePath(extractPath, d).Replace('\\', '/')))
-            .Where(t => t != null)
-            .Select(t => t!)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderByDescending(t => TfmResolver.GetTfmPriority(t))
-            .ToList();
+        var tfms = TfmSelector.GetPackageTfms(extractPath);
 
         OutputFormatter.WriteStringList(tfms, "TFM", "Tfm", tsv, jsonl, Console.Out);
     }

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -1974,14 +1974,24 @@ public class PackageCommand
             return null;
         }
 
-        var allCandidates = TfmSelector.GetPackageAssemblies(extractPath);
-        if (allCandidates.Count == 0)
+        List<string> pool;
+        string? selectedTfm;
+        if (string.IsNullOrWhiteSpace(options.Tfm))
         {
-            Console.Error.WriteLine($"Error: No DLLs found in package '{packageName}'.");
-            return null;
+            var allCandidates = TfmSelector.GetPackageAssemblies(extractPath);
+            if (allCandidates.Count == 0)
+            {
+                Console.Error.WriteLine($"Error: No DLLs found in package '{packageName}'.");
+                return null;
+            }
+
+            (pool, selectedTfm) = TfmSelector.SelectHighestAssemblies(allCandidates, extractPath);
+        }
+        else
+        {
+            (pool, selectedTfm) = TfmSelector.SelectHighestAssembliesFromPackage(extractPath, options.Tfm);
         }
 
-        var (pool, selectedTfm) = TfmSelector.SelectHighestAssemblies(allCandidates, extractPath, options.Tfm);
         if (pool.Count == 0)
         {
             Console.Error.WriteLine($"Error: No library found for TFM '{options.Tfm}' in package '{packageName}'.");
@@ -2011,14 +2021,24 @@ public class PackageCommand
         string version,
         InspectionOptions options)
     {
-        var candidates = TfmSelector.GetPackageAssemblies(extractPath);
-        if (candidates.Count == 0)
+        List<string> selected;
+        string? highestTfm;
+        if (string.IsNullOrWhiteSpace(options.Tfm))
         {
-            Console.Error.WriteLine($"Error: No DLLs found in package '{packageName}'.");
-            return null;
+            var candidates = TfmSelector.GetPackageAssemblies(extractPath);
+            if (candidates.Count == 0)
+            {
+                Console.Error.WriteLine($"Error: No DLLs found in package '{packageName}'.");
+                return null;
+            }
+
+            (selected, highestTfm) = TfmSelector.SelectHighestAssemblies(candidates, extractPath);
+        }
+        else
+        {
+            (selected, highestTfm) = TfmSelector.SelectHighestAssembliesFromPackage(extractPath, options.Tfm);
         }
 
-        var (selected, highestTfm) = TfmSelector.SelectHighestAssemblies(candidates, extractPath, options.Tfm);
         if (selected.Count == 0)
         {
             Console.Error.WriteLine($"Error: No libraries found for TFM '{options.Tfm}' in package '{packageName}'.");

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -86,7 +86,7 @@ internal static class ApiServices
                 }
                 else
                 {
-                    var (highestPath, _) = TfmSelector.SelectHighestTfmAssembly(TfmSelector.GetPackageDlls(searchPath), searchPath, packageName);
+                    var (highestPath, _) = TfmSelector.SelectHighestTfmAssembly(TfmSelector.GetPackageAssemblies(searchPath), searchPath, packageName);
                     if (highestPath != null)
                         searchPath = highestPath;
                 }
@@ -199,7 +199,7 @@ internal static class ApiServices
             string? selectedTfm = null;
             if (Directory.Exists(searchPath))
             {
-                var dlls = TfmSelector.GetPackageDlls(searchPath);
+                var dlls = TfmSelector.GetPackageAssemblies(searchPath);
                 if (dlls.Count > 1)
                 {
                     var (selectedPath, tfm) = TfmSelector.SelectHighestTfmAssembly(dlls, searchPath);
@@ -258,7 +258,7 @@ internal static class ApiServices
             var (searchPath, packageName) = (extracted.ExtractPath, extracted.PackageName);
             tempDir = extracted.TempDir;
 
-            var dlls = TfmSelector.GetPackageDlls(searchPath);
+            var dlls = TfmSelector.GetPackageAssemblies(searchPath);
             if (dlls.Count == 0)
                 return (null, null);
 
@@ -266,7 +266,7 @@ internal static class ApiServices
             if (dlls.Count == 1)
                 return await ExtractApiSurfaceAsync(options, logger, httpClient);
 
-            var (tfmDlls, selectedTfm) = TfmSelector.SelectHighestTfmAssemblies(dlls, searchPath);
+            var (tfmDlls, selectedTfm) = TfmSelector.SelectHighestAssemblies(dlls, searchPath);
             if (tfmDlls.Count == 0)
                 return (null, null);
 

--- a/src/dotnet-inspect/Inspectors/ApiServices.cs
+++ b/src/dotnet-inspect/Inspectors/ApiServices.cs
@@ -200,7 +200,7 @@ internal static class ApiServices
             if (Directory.Exists(searchPath))
             {
                 var dlls = TfmSelector.GetPackageAssemblies(searchPath);
-                if (dlls.Count > 1)
+                if (dlls.Count > 0)
                 {
                     var (selectedPath, tfm) = TfmSelector.SelectHighestTfmAssembly(dlls, searchPath);
                     if (selectedPath != null)

--- a/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
+++ b/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
@@ -269,7 +269,7 @@ internal static class ApiSourceResolver
 
         if (Directory.Exists(searchPath))
         {
-            var dlls = TfmSelector.GetPackageDlls(searchPath);
+            var dlls = TfmSelector.GetPackageAssemblies(searchPath);
             if (dlls.Count > 1)
             {
                 var (selectedPath, tfm) = TfmSelector.SelectHighestTfmAssembly(dlls, searchPath, packageName);

--- a/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
+++ b/src/dotnet-inspect/Inspectors/ApiSourceResolver.cs
@@ -270,16 +270,17 @@ internal static class ApiSourceResolver
         if (Directory.Exists(searchPath))
         {
             var dlls = TfmSelector.GetPackageAssemblies(searchPath);
-            if (dlls.Count > 1)
+            if (dlls.Count > 0)
             {
                 var (selectedPath, tfm) = TfmSelector.SelectHighestTfmAssembly(dlls, searchPath, packageName);
                 if (selectedPath != null)
                 {
                     searchPath = selectedPath;
                     selectedTfm = tfm;
-                    logger.Log($"Auto-selected TFM: {tfm}");
+                    if (tfm != null)
+                        logger.Log($"Auto-selected TFM: {tfm}");
                 }
-                else
+                else if (dlls.Count > 1)
                 {
                     Console.Error.WriteLine("Error: Multiple libraries found. Please specify one with --library or --tfm.");
                     return (null!, 1);

--- a/src/dotnet-inspect/Inspectors/PackageInspector.cs
+++ b/src/dotnet-inspect/Inspectors/PackageInspector.cs
@@ -177,9 +177,7 @@ internal static class PackageInspector
         VerboseLogger logger,
         bool acquirePdb)
     {
-        var dlls = TfmSelector.GetPackageDlls(extractPath)
-            .Where(f => !f.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        var dlls = TfmSelector.GetPackageAssemblies(extractPath);
         if (dlls.Count == 0)
             return null;
 

--- a/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
+++ b/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
@@ -110,8 +110,7 @@ public static class ToolsAnalyzer
     /// </summary>
     public static int CountAssemblies(string extractPath)
     {
-        var dlls = TfmSelector.GetPackageDlls(extractPath)
-            .Where(f => !f.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase));
+        var dlls = TfmSelector.GetPackageAssemblies(extractPath);
 
         // Count unique assembly names (deduplicated across TFMs)
         return dlls

--- a/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
+++ b/src/dotnet-inspect/Inspectors/ToolsAnalyzer.cs
@@ -103,7 +103,8 @@ public static class ToolsAnalyzer
     /// </summary>
     public static int CountAssemblies(string extractPath)
     {
-        var dlls = TfmSelector.GetPackageAssemblies(extractPath);
+        var dlls = TfmSelector.GetPackageDlls(extractPath)
+            .Where(f => !f.EndsWith(".resources.dll", StringComparison.OrdinalIgnoreCase));
 
         // Count unique assembly names (deduplicated across TFMs)
         return dlls


### PR DESCRIPTION
## Summary

Part of #2122. Centralizes package assembly / TFM selection in `TfmSelector` and routes duplicated CLI callers through the shared service helper.

This keeps package layout discovery in one place, filters only true satellite resource assemblies, preserves explicit `--tfm` lookup semantics across `ref`, `lib`, `runtimes`, and `tools`, and keeps package-name preference for explicit TFM selection.

## Validation

- `dotnet run --project src/DotnetInspector.Services.Tests -c Release -- -class "*TfmSelectorTests*"`
- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config -p:NoWarn=NU1507 --nologo --verbosity minimal`

## Adversarial review

Three rounds were run against this slice:

- Gemini 3.1 Pro and Claude Opus 4.8 found/focused the explicit-TFM and layout edge cases.
- MAI-Code-1-Flash found that legacy explicit `--tfm` lookup still bypassed the new selector.
- Follow-up commits resolved the actionable findings:
  - `fa3bf713` preserves displayed TFM metadata after resource filtering.
  - `e85c779e` routes explicit TFM lookup through shared selector logic.
  - `5a2f10ca` preserves explicit lookup across mixed package layouts and narrows resource filtering to culture-directory satellites.

No unresolved blocking findings remain from the review rounds.
