### PR TITLE
Use ApiType parameters for RTS generic types

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -271,6 +271,55 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.generic-type",
+            "GeneratedFixtures.MinimalGenericType.Box`1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.generic-type",
+            "GeneratedFixtures.MinimalGenericType.Box`1",
+            "get_Value",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.generic-type",
+            "GeneratedFixtures.MinimalGenericType.Box`1",
+            "set_Value",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.generic-type",
+            "GeneratedFixtures.MinimalGenericType.Box`1",
+            "Echo",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.generic-type-constraints",
+            "GeneratedFixtures.MinimalGenericTypeConstraints.Factory`1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.generic-type-constraints",
+            "GeneratedFixtures.MinimalGenericTypeConstraints.Factory`1",
+            "Create",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.generic-type-constraints",
+            "GeneratedFixtures.MinimalGenericTypeConstraints.Factory`1",
+            "Echo",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.if-else",
             "GeneratedFixtures.MinimalIfElse.Class1",
             ".ctor",
@@ -526,6 +575,8 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.object-initializer", report);
         Assert.Contains("minimal.collection-initializer", report);
         Assert.Contains("minimal.generic-methods", report);
+        Assert.Contains("minimal.generic-type", report);
+        Assert.Contains("minimal.generic-type-constraints", report);
         Assert.Contains("minimal.if-else", report);
         Assert.Contains("minimal.integer-addition", report);
         Assert.Contains("minimal.struct-members", report);
@@ -582,6 +633,8 @@ public class GeneratedFixtureCatalogTests
                 "minimal.for-loop",
                 "minimal.foreach-array",
                 "minimal.generic-methods",
+                "minimal.generic-type",
+                "minimal.generic-type-constraints",
                 "minimal.if-else",
                 "minimal.indexer.getter",
                 "minimal.indexer.setter",
@@ -633,6 +686,8 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.object-initializer");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.collection-initializer");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.generic-methods");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.generic-type");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.generic-type-constraints");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.integer-addition");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.struct-members");

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -4,6 +4,8 @@ using ILInspector.Decompiler;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -1043,6 +1045,40 @@ public class ReturnToSenderPrototypeTests
                 result => Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status),
                 result => Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status));
             Assert.All(results, result => Assert.Contains("public class Box<T>", result.Source));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackSourceComposer_NestedGenericTypeParametersSkipDeclaringTypeParameters()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Outer<T>
+            {
+                public class Inner<U>
+                {
+                }
+            }
+            """);
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(assemblyPath));
+            var reader = pe.GetMetadataReader();
+            var nested = reader.TypeDefinitions
+                .Select(handle => reader.GetTypeDefinition(handle))
+                .Single(type => reader.GetString(type.Name).StartsWith("Inner", StringComparison.Ordinal));
+            var method = typeof(CompileBackSourceComposer).GetMethod(
+                "TypeParameters",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                [typeof(MetadataReader), typeof(TypeDefinition)]);
+
+            var typeParameters = Assert.IsAssignableFrom<IReadOnlyList<CompileBackTypeParameter>>(
+                method?.Invoke(null, [reader, nested]));
+            var typeParameter = Assert.Single(typeParameters);
+            Assert.Equal("U", typeParameter.Name);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1004,6 +1004,53 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RoundTripsGenericTypeTargets()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Box<T>
+            {
+                private T _value;
+
+                public Box(T value)
+                {
+                    _value = value;
+                }
+
+                public T Value
+                {
+                    get => _value;
+                    set => _value = value;
+                }
+
+                public T Echo(T value) => value;
+            }
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Box`1", ".ctor", 0),
+                    new ReturnToSender.RequestedTarget("Box`1", "get_Value", 0),
+                    new ReturnToSender.RequestedTarget("Box`1", "set_Value", 0),
+                    new ReturnToSender.RequestedTarget("Box`1", "Echo", 0),
+                ]);
+
+            Assert.Collection(
+                results,
+                result => Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status),
+                result => Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status),
+                result => Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status),
+                result => Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status));
+            Assert.All(results, result => Assert.Contains("public class Box<T>", result.Source));
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsStructPropertyTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -980,11 +980,19 @@ public static class CompileBackSourceComposer
     }
 
     static IReadOnlyList<CompileBackTypeParameter> TypeParameters(MetadataReader reader, TypeDefinition type)
-        => TypeParameters(reader, type.GetGenericParameters(), GenericContext.ForType(reader, type));
+    {
+        var handles = type.GetGenericParameters().ToArray();
+        int inheritedCount = 0;
+        var declaringType = type.GetDeclaringType();
+        if (!declaringType.IsNil)
+            inheritedCount = reader.GetTypeDefinition(declaringType).GetGenericParameters().Count;
+
+        return TypeParameters(reader, handles.Skip(inheritedCount), GenericContext.ForType(reader, type));
+    }
 
     static IReadOnlyList<CompileBackTypeParameter> TypeParameters(
         MetadataReader reader,
-        GenericParameterHandleCollection handles,
+        IEnumerable<GenericParameterHandle> handles,
         GenericContext context)
     {
         var parameters = new List<CompileBackTypeParameter>();

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -124,6 +124,7 @@ public sealed record CompileBackTypeDeclaration(
     CompileBackAccessibility Accessibility,
     CompileBackTypeSignature? BaseType,
     string? PrimaryConstructorParameters,
+    IReadOnlyList<CompileBackTypeParameter> TypeParameters,
     IReadOnlyList<CompileBackTypeSignature> Interfaces,
     IReadOnlyList<CompileBackMemberDeclaration> Members,
     IReadOnlyList<CompileBackFact> SourceFacts,
@@ -841,6 +842,13 @@ public static class CompileBackSourceComposer
                 CompileBackTypeKind.Enum => "enum",
                 _ => throw new NotSupportedException($"Unsupported type declaration kind '{type.Kind}'."),
             },
+            TypeParameters = type.TypeParameters
+                .Select(parameter => new TypeParameter
+                {
+                    Name = parameter.Name,
+                    Constraints = parameter.Constraints.ToList(),
+                })
+                .ToList(),
             Interfaces = type.Interfaces.Select(type => type.DisplayName).ToList(),
         };
 
@@ -968,8 +976,19 @@ public static class CompileBackSourceComposer
     {
         var declaringType = reader.GetTypeDefinition(method.GetDeclaringType());
         var context = GenericContext.ForMethod(reader, declaringType, method);
+        return TypeParameters(reader, method.GetGenericParameters(), context);
+    }
+
+    static IReadOnlyList<CompileBackTypeParameter> TypeParameters(MetadataReader reader, TypeDefinition type)
+        => TypeParameters(reader, type.GetGenericParameters(), GenericContext.ForType(reader, type));
+
+    static IReadOnlyList<CompileBackTypeParameter> TypeParameters(
+        MetadataReader reader,
+        GenericParameterHandleCollection handles,
+        GenericContext context)
+    {
         var parameters = new List<CompileBackTypeParameter>();
-        foreach (var handle in method.GetGenericParameters())
+        foreach (var handle in handles)
         {
             var parameter = reader.GetGenericParameter(handle);
             var constraints = new List<string>();
@@ -1420,6 +1439,7 @@ public static class CompileBackSourceComposer
                     CompileBackAccessibility.Public,
                     BaseType: null,
                     PrimaryConstructorParameters: requirement.PrimaryConstructor?.Parameters,
+                    TypeParameters: TypeParameters(reader, typeDef),
                     Interfaces: InterfaceSignatures(reader, typeDef),
                     members,
                     requirement.SourceFacts,
@@ -1468,6 +1488,7 @@ public static class CompileBackSourceComposer
                     CompileBackAccessibility.Public,
                     BaseType: null,
                     PrimaryConstructorParameters: null,
+                    TypeParameters: TypeParameters(reader, nestedDef),
                     Interfaces: InterfaceSignatures(reader, nestedDef),
                     members,
                     requirement.SourceFacts,

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -308,6 +308,63 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "generic", "method", "constraints"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalGenericType = new(
+        "minimal.generic-type",
+        """
+        namespace GeneratedFixtures.MinimalGenericType;
+
+        public class Box<T>
+        {
+            private T _value;
+
+            public Box(T value)
+            {
+                _value = value;
+            }
+
+            public T Value
+            {
+                get => _value;
+                set => _value = value;
+            }
+
+            public T Echo(T value) => value;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalGenericType.Box`1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalGenericType.Box`1", "get_Value",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalGenericType.Box`1", "set_Value",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalGenericType.Box`1", "Echo",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "generic", "type", "property", "setter"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalGenericTypeConstraints = new(
+        "minimal.generic-type-constraints",
+        """
+        namespace GeneratedFixtures.MinimalGenericTypeConstraints;
+
+        public class Factory<T> where T : class, new()
+        {
+            public T Create() => new T();
+
+            public T Echo(T value) => value;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalGenericTypeConstraints.Factory`1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalGenericTypeConstraints.Factory`1", "Create",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalGenericTypeConstraints.Factory`1", "Echo",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "generic", "type", "constraints"]);
+
     public static readonly GeneratedFixtureDefinition MinimalIfElse = new(
         "minimal.if-else",
         """
@@ -802,6 +859,8 @@ internal static class GeneratedFixtureCatalog
         MinimalObjectInitializer,
         MinimalCollectionInitializer,
         MinimalGenericMethods,
+        MinimalGenericType,
+        MinimalGenericTypeConstraints,
         MinimalIfElse,
         MinimalIntegerAddition,
         MinimalStructMembers,

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -418,7 +418,6 @@ static class ReturnToSender
             if (!typeDef.GetDeclaringType().IsNil
                 || typeName == "<Module>"
                 || typeName.Contains('<', StringComparison.Ordinal)
-                || typeName.Contains('`', StringComparison.Ordinal)
                 || !IsSupportedTargetType(reader, typeDef))
             {
                 continue;
@@ -1059,6 +1058,7 @@ static class ReturnToSender
                     CompileBackAccessibility.Public,
                     BaseType: null,
                     PrimaryConstructorParameters: null,
+                    TypeParameters: [],
                     Interfaces: [],
                     Members:
                     [
@@ -1160,7 +1160,6 @@ static class ReturnToSender
         string name = reader.GetString(typeDef.Name);
         return name is not "<Module>"
             && !name.Contains('<', StringComparison.Ordinal)
-            && !name.Contains('`', StringComparison.Ordinal)
             && !IsDelegate(reader, typeDef);
     }
 


### PR DESCRIPTION
- Advances #2057, #2049, and #2050
- Changes RTS compile-back source composition to use structured `ApiType` type parameters for generic type declarations.
- Evidence revision: `80a930a7`

## Change

> Should we accept this RTS generic-type slice?

**Conclusion:** **PASS** — RTS now checks generic type targets in the generated fixture catalog, with type parameters and constraints rendered through product-side `ApiType` / `CSharpDeclarationWriter`.

Before:

```text
minimal.generic-type
  Box`1::.ctor/get_Value/set_Value/Echo  skipped: unsupported-rts-target
```

After:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 31 fixture(s), 77 target(s)

Fixtures:
  Passed : 31
  Skipped: 0
  Failed : 0

Targets:
  Passed : 77
  Skipped: 0
  Failed : 0
```

## Scope and safety

- **Root cause:** RTS explicit target lookup rejected generic type roots, and compile-back type declarations did not carry type parameters into `ApiType`.
- **Fix shape:** Allow explicit generic type roots, add `CompileBackTypeDeclaration.TypeParameters`, map them to `ApiType.TypeParameters`, and keep broad A/B enumeration class-only.
- **Product impact:** Compile-back source composition only; no shipped decompiler output behavior is intended to change.
- **Scope boundary:** Generic methods were covered by #2149; this PR covers generic type declarations. Nested generic declaration support is guarded by a focused test but nested targets remain future work.
- **RTS boundary:** RTS remains orchestration only; product/shared code owns generated C# declarations/source.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Harness build | Pass |
| Focused generated fixture tests | `GeneratedFixtureCatalogTests` `8/8` passed |
| Focused RTS tests | `ReturnToSenderPrototypeTests` `37/37` passed |
| Decompiler fast suite | `1803/1803` passed with `-trait- "Speed=Slow"` |
| ReturnToSender A/B | `ILInspector.Decompiler.Tests.dll` `234 Same / 0 Worse / 0 CurrentMissing` |
| RTS catalog default | `31/31 fixtures`, `77/77 targets`, `0 skipped`, `0 failed` |
| RTS catalog with frontiers | `32 passed / 1 failed`, expected `minimal.switch-two-case-lowers-if` `opcode-diff` |
| Build-event validation | Not applicable |

### ReturnToSender catalog

Run: default generated fixture catalog.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 31 fixture(s), 77 target(s)

Fixtures:
  Passed : 31
  Skipped: 0
  Failed : 0

Targets:
  Passed : 77
  Skipped: 0
  Failed : 0
```

Run: `--return-to-sender-catalog minimal --max-examples 50`.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 33 fixture(s), 81 target(s)

Fixtures:
  Passed : 32
  Skipped: 0
  Failed : 1

Targets:
  Passed : 80
  Skipped: 0
  Failed : 1

Failed target buckets:
  opcode-diff: 1

Failed fixtures (first 1 of 1):
  minimal.switch-two-case-lowers-if
      GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1::Method1#0  rts=OpcodeDiff  bucket=opcode-diff
```

**RTS verdict:** **PASS** — generic type targets become checkable through the product structured type declaration path, and the default catalog remains fully green.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `minimal.switch-two-case-lowers-if` | Left as frontier | Known source/compiler-lowering opcode-diff frontier. |
| Nested generic targets | Not expanded | Type-parameter rendering skips inherited outer parameters, but target selection remains top-level in this slice. |
| Wider #2057 signature families | Future work | Defaults, parameter attributes, explicit interface members, operators, events, and keyword-named generic parameter edge cases remain out of scope. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Confirmed complete type-parameter construction, constraint rendering, A/B boundary, and catalog expectations. |
| Gemini 3.1 Pro | Finding resolved, follow-up clean | Found nested generic type-parameter duplication risk; fixed in `80a930a7`; follow-up reported no blocking findings. |

**Review conclusion:** **PASS** — all high-confidence review findings were resolved and follow-up review is clean.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet build tools/DecompilerHarness -c Release --nologo --verbosity quiet -p:NoWarn=NU1507
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog --max-examples 50
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll --return-to-sender-catalog minimal --max-examples 50
```
