### PR TITLE
Add RTS parameter signature coverage

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -320,6 +320,111 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.parameter-modifiers",
+            "GeneratedFixtures.MinimalParameterModifiers.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-modifiers",
+            "GeneratedFixtures.MinimalParameterModifiers.Class1",
+            "Increment",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-modifiers",
+            "GeneratedFixtures.MinimalParameterModifiers.Class1",
+            "Set",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-modifiers",
+            "GeneratedFixtures.MinimalParameterModifiers.Class1",
+            "Read",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-modifiers",
+            "GeneratedFixtures.MinimalParameterModifiers.Class1",
+            "Sum",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.default-parameters",
+            "GeneratedFixtures.MinimalDefaultParameters.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.default-parameters",
+            "GeneratedFixtures.MinimalDefaultParameters.Class1",
+            "Add",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.default-parameters",
+            "GeneratedFixtures.MinimalDefaultParameters.Class1",
+            "Format",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.default-parameters",
+            "GeneratedFixtures.MinimalDefaultParameters.Class1",
+            "DecimalDefault",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.default-parameters",
+            "GeneratedFixtures.MinimalDefaultParameters.Class1",
+            "EnumDefault",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.default-parameters",
+            "GeneratedFixtures.MinimalDefaultParameters.Class1",
+            "DateTimeDefault",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-attributes",
+            "GeneratedFixtures.MinimalParameterAttributes.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-attributes",
+            "GeneratedFixtures.MinimalParameterAttributes.Class1",
+            "Length",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-attributes",
+            "GeneratedFixtures.MinimalParameterAttributes.Class1",
+            "Copy",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-attributes",
+            "GeneratedFixtures.MinimalParameterAttributes.Class1",
+            "Update",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.if-else",
             "GeneratedFixtures.MinimalIfElse.Class1",
             ".ctor",
@@ -577,6 +682,9 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.generic-methods", report);
         Assert.Contains("minimal.generic-type", report);
         Assert.Contains("minimal.generic-type-constraints", report);
+        Assert.Contains("minimal.parameter-modifiers", report);
+        Assert.Contains("minimal.default-parameters", report);
+        Assert.Contains("minimal.parameter-attributes", report);
         Assert.Contains("minimal.if-else", report);
         Assert.Contains("minimal.integer-addition", report);
         Assert.Contains("minimal.struct-members", report);
@@ -629,6 +737,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.collection-initializer",
                 "minimal.conditional-expression-shape-frontier",
                 "minimal.ctor-field.getter",
+                "minimal.default-parameters",
                 "minimal.do-while",
                 "minimal.for-loop",
                 "minimal.foreach-array",
@@ -643,6 +752,8 @@ public class GeneratedFixtureCatalogTests
                 "minimal.method-call.same-type",
                 "minimal.null-coalesce",
                 "minimal.object-initializer",
+                "minimal.parameter-attributes",
+                "minimal.parameter-modifiers",
                 "minimal.primary-ctor.field-init",
                 "minimal.property.literal",
                 "minimal.static-class",
@@ -688,6 +799,9 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.generic-methods");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.generic-type");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.generic-type-constraints");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.parameter-modifiers");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.default-parameters");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.parameter-attributes");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.integer-addition");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.struct-members");

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1006,6 +1006,207 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RoundTripsParameterModifierSignatures()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public void Increment(ref int value)
+                {
+                    value++;
+                }
+
+                public void Set(out int value)
+                {
+                    value = 42;
+                }
+
+                public int Read(in int value) => value;
+
+                public int Sum(params int[] values)
+                {
+                    var sum = 0;
+                    foreach (var value in values)
+                        sum += value;
+                    return sum;
+                }
+            }
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Class1", "Increment", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "Set", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "Read", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "Sum", 0),
+                ]);
+
+            Assert.Collection(
+                results,
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("public void Increment(ref int value)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("public void Set(out int value)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("public int Read(in int value)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("public int Sum(params int[] values)", result.Source);
+                });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RoundTripsDefaultParameterSignatures()
+    {
+        var assemblyPath = CompileFixture("""
+            public enum Choice
+            {
+                None = 0,
+                One = 1,
+            }
+
+            public class Class1
+            {
+                public int Add(int value = 42, bool enabled = true)
+                    => enabled ? value + 1 : value;
+
+                public string Format(string text = "hello", object value = null)
+                    => value is null ? text : text + value.ToString();
+
+                public decimal DecimalDefault(decimal value = 1.25m)
+                    => value;
+
+                public int EnumDefault(Choice choice = Choice.One)
+                    => (int)choice;
+
+                public long DateTimeDefault(
+                    [System.Runtime.InteropServices.Optional, System.Runtime.CompilerServices.DateTimeConstant(637000000000000000L)] System.DateTime when)
+                    => when.Ticks;
+            }
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Class1", "Add", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "Format", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "DecimalDefault", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "EnumDefault", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "DateTimeDefault", 0),
+                ]);
+
+            Assert.Collection(
+                results,
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("public int Add(int value = 42, bool enabled = true)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("public string Format(string text = \"hello\", object value = null)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("public System.Decimal DecimalDefault(System.Decimal value = 1.25m)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("public int EnumDefault(Choice choice = (Choice)1)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("System.Runtime.CompilerServices.DateTimeConstant(637000000000000000L)", result.Source);
+                    Assert.Contains("System.DateTime when", result.Source);
+                    Assert.DoesNotContain("System.DateTime when =", result.Source);
+                });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RoundTripsParameterAttributes()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public int Length([System.Diagnostics.CodeAnalysis.NotNull] string value)
+                    => value.Length;
+
+                public int Copy([System.Runtime.InteropServices.Out] int value)
+                    => value;
+
+                public int Update([System.Runtime.InteropServices.In, System.Runtime.InteropServices.Out] ref int value)
+                {
+                    value++;
+                    return value;
+                }
+            }
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Class1", "Length", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "Copy", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "Update", 0),
+                ]);
+
+            Assert.Collection(
+                results,
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("System.Diagnostics.CodeAnalysis.NotNull", result.Source);
+                    Assert.Contains("int Length(", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("int Copy(", result.Source);
+                    Assert.DoesNotContain("out int value", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("ref int value", result.Source);
+                    Assert.DoesNotContain("out int value", result.Source);
+                    Assert.DoesNotContain("in int value", result.Source);
+                });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericTypeTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -213,7 +213,13 @@ public sealed record CompileBackTypeSignature(CompileBackTypeSignatureKind Kind,
         => new(CompileBackTypeSignatureKind.Definition, identity.FullName, identity);
 }
 
-public sealed record CompileBackParameter(string Name, CompileBackTypeSignature Type);
+public sealed record CompileBackParameter(
+    string Name,
+    CompileBackTypeSignature Type,
+    string? Modifier = null,
+    IReadOnlyList<string>? Attributes = null,
+    bool HasDefault = false,
+    string? DefaultValueText = null);
 
 public sealed record CompileBackTypeParameter(string Name, IReadOnlyList<string> Constraints);
 
@@ -900,10 +906,18 @@ public static class CompileBackSourceComposer
                     })
                     .ToList(),
                 Parameters = member.Parameters
-                    .Select(parameter => new ApiParameter
+                    .Select(parameter =>
                     {
-                        Name = parameter.Name,
-                        Type = parameter.Type.DisplayName,
+                        var (type, modifier) = NormalizeParameter(parameter);
+                        return new ApiParameter
+                        {
+                            Attributes = parameter.Attributes?.ToList() ?? [],
+                            Name = parameter.Name,
+                            Type = type,
+                            Modifier = modifier,
+                            HasDefault = parameter.HasDefault,
+                            DefaultValueText = parameter.DefaultValueText,
+                        };
                     })
                     .ToList(),
             };
@@ -958,19 +972,386 @@ public static class CompileBackSourceComposer
         MethodSignature<string> signature)
     {
         var names = new Dictionary<int, string>();
+        var modifiers = new Dictionary<int, string>();
+        var refKinds = new Dictionary<int, string>();
+        var attributes = new Dictionary<int, IReadOnlyList<string>>();
+        var defaultParameters = new Dictionary<int, System.Reflection.Metadata.Parameter>();
+        var attributedDefaultValues = new Dictionary<int, string>();
+        var attributedDefaultAttributes = new Dictionary<int, IReadOnlyList<string>>();
         foreach (var parameterHandle in method.GetParameters())
         {
             var parameter = reader.GetParameter(parameterHandle);
             if (parameter.SequenceNumber > 0)
+            {
                 names[parameter.SequenceNumber - 1] = reader.GetString(parameter.Name);
+                var customAttributes = parameter.GetCustomAttributes();
+                bool isParams = AttributeReader.HasAttribute(reader, customAttributes, "System.ParamArrayAttribute")
+                    || AttributeReader.HasAttribute(reader, customAttributes, KnownAttributeNames.ParamCollectionAttribute);
+                if (isParams)
+                    modifiers[parameter.SequenceNumber - 1] = "params";
+                var isOut = (parameter.Attributes & System.Reflection.ParameterAttributes.Out) != 0;
+                var isIn = (parameter.Attributes & System.Reflection.ParameterAttributes.In) != 0;
+                if (isOut && !isIn)
+                    refKinds[parameter.SequenceNumber - 1] = "out";
+                else if (isIn && !isOut)
+                    refKinds[parameter.SequenceNumber - 1] = "in";
+                var renderedAttributes = AttributeReader.RenderParameterAttributes(reader, parameterHandle);
+                if (renderedAttributes.Count != 0)
+                    attributes[parameter.SequenceNumber - 1] = renderedAttributes;
+                if (TryFormatAttributedParameterDefault(
+                    reader,
+                    customAttributes,
+                    out var attributedDefaultValue,
+                    out var attributedDefaultAttributeList))
+                {
+                    attributedDefaultValues[parameter.SequenceNumber - 1] = attributedDefaultValue;
+                    if (attributedDefaultAttributeList.Count != 0)
+                        attributedDefaultAttributes[parameter.SequenceNumber - 1] = attributedDefaultAttributeList;
+                }
+                if ((parameter.Attributes & System.Reflection.ParameterAttributes.HasDefault) != 0)
+                    defaultParameters[parameter.SequenceNumber - 1] = parameter;
+            }
         }
 
         return signature.ParameterTypes
-            .Select((type, index) => new CompileBackParameter(
-                Identifier(names.TryGetValue(index, out var name) && name.Length > 0 ? name : $"arg{index}"),
-                CompileBackTypeSignature.Display(type)))
+            .Select((type, index) =>
+            {
+                var typeSignature = CompileBackTypeSignature.Display(type);
+                var parameterAttributes = attributes.TryGetValue(index, out var attributeList)
+                    ? attributeList.ToList()
+                    : [];
+                if (attributedDefaultAttributes.TryGetValue(index, out var defaultAttributeList))
+                {
+                    foreach (var defaultAttribute in defaultAttributeList)
+                    {
+                        if (!parameterAttributes.Contains(defaultAttribute, StringComparer.Ordinal))
+                            parameterAttributes.Add(defaultAttribute);
+                    }
+                }
+                string? modifier = modifiers.TryGetValue(index, out var explicitModifier)
+                    ? explicitModifier
+                    : typeSignature.DisplayName.StartsWith("ref ", StringComparison.Ordinal)
+                        && refKinds.TryGetValue(index, out var refKind)
+                            ? refKind
+                            : null;
+                string? defaultValue = null;
+                bool hasDefault = false;
+                if (attributedDefaultValues.TryGetValue(index, out var attributedDefaultValue))
+                {
+                    hasDefault = true;
+                    if (attributedDefaultValue.Length == 0)
+                    {
+                        if (!parameterAttributes.Contains("System.Runtime.InteropServices.Optional", StringComparer.Ordinal))
+                            parameterAttributes.Add("System.Runtime.InteropServices.Optional");
+                    }
+                    else
+                    {
+                        defaultValue = attributedDefaultValue;
+                    }
+                }
+                else if (defaultParameters.TryGetValue(index, out var parameter))
+                {
+                    hasDefault = true;
+                    if (TryFormatParameterDefault(reader, parameter, typeSignature.DisplayName, out var formattedDefault))
+                    {
+                        defaultValue = formattedDefault;
+                    }
+                    else if (!parameterAttributes.Contains("System.Runtime.InteropServices.Optional", StringComparer.Ordinal))
+                    {
+                        parameterAttributes.Add("System.Runtime.InteropServices.Optional");
+                    }
+                }
+
+                return new CompileBackParameter(
+                    Identifier(names.TryGetValue(index, out var name) && name.Length > 0 ? name : $"arg{index}"),
+                    typeSignature,
+                    modifier,
+                    parameterAttributes,
+                    hasDefault,
+                    hasDefault ? defaultValue : null);
+            })
             .ToArray();
     }
+
+    static bool TryFormatAttributedParameterDefault(
+        MetadataReader reader,
+        CustomAttributeHandleCollection attributes,
+        out string defaultValueText,
+        out IReadOnlyList<string> defaultAttributes)
+    {
+        foreach (var attributeHandle in attributes)
+        {
+            var attribute = reader.GetCustomAttribute(attributeHandle);
+            var attributeTypeName = AttributeReader.GetAttributeTypeName(reader, attribute.Constructor);
+            if (attributeTypeName == KnownAttributeNames.DecimalConstantAttribute
+                && TryReadDecimalConstantAttribute(reader, attribute, out var decimalValue))
+            {
+                defaultValueText = FormatDecimalDefault(decimalValue);
+                defaultAttributes = [];
+                return true;
+            }
+
+            if (attributeTypeName == KnownAttributeNames.DateTimeConstantAttribute
+                && TryReadDateTimeConstantAttribute(reader, attribute, out var ticks))
+            {
+                defaultValueText = "";
+                defaultAttributes =
+                [
+                    "System.Runtime.InteropServices.Optional",
+                    $"System.Runtime.CompilerServices.DateTimeConstant({FormatInt64Default(ticks)})",
+                ];
+                return true;
+            }
+        }
+
+        defaultValueText = "";
+        defaultAttributes = [];
+        return false;
+    }
+
+    static bool TryReadDateTimeConstantAttribute(
+        MetadataReader reader,
+        CustomAttribute attribute,
+        out long ticks)
+    {
+        if (AttributeDecoder.TryDecode(reader, attribute) is { FixedArguments.Length: 1 } decoded
+            && decoded.FixedArguments[0].Value is long value)
+        {
+            ticks = value;
+            return true;
+        }
+
+        ticks = 0;
+        return false;
+    }
+
+    static bool TryReadDecimalConstantAttribute(
+        MetadataReader reader,
+        CustomAttribute attribute,
+        out decimal value)
+    {
+        if (AttributeDecoder.TryDecode(reader, attribute) is not { } decoded
+            || decoded.FixedArguments.Length != 5
+            || decoded.FixedArguments[0].Value is not byte scale
+            || decoded.FixedArguments[1].Value is not byte sign
+            || !TryGetUInt32(decoded.FixedArguments[2].Value, out var hi)
+            || !TryGetUInt32(decoded.FixedArguments[3].Value, out var mid)
+            || !TryGetUInt32(decoded.FixedArguments[4].Value, out var low)
+            || scale > 28
+            || sign > 1)
+        {
+            value = default;
+            return false;
+        }
+
+        value = new decimal(
+            unchecked((int)low),
+            unchecked((int)mid),
+            unchecked((int)hi),
+            sign != 0,
+            scale);
+        return true;
+    }
+
+    static bool TryGetUInt32(object? value, out uint result)
+    {
+        switch (value)
+        {
+            case uint unsigned:
+                result = unsigned;
+                return true;
+            case int signed:
+                result = unchecked((uint)signed);
+                return true;
+            default:
+                result = 0;
+                return false;
+        }
+    }
+
+    static string FormatDecimalDefault(decimal value)
+        => value.ToString("G29", CultureInfo.InvariantCulture) + "m";
+
+    static string FormatInt64Default(long value)
+    {
+        long minValue = long.MaxValue;
+        minValue = -minValue - 1;
+        return value == minValue
+            ? "long.MinValue"
+            : value.ToString(CultureInfo.InvariantCulture) + "L";
+    }
+
+    static bool TryFormatParameterDefault(
+        MetadataReader reader,
+        System.Reflection.Metadata.Parameter parameter,
+        string parameterType,
+        out string defaultValueText)
+    {
+        defaultValueText = "";
+        if ((parameter.Attributes & System.Reflection.ParameterAttributes.HasDefault) == 0)
+            return false;
+
+        var constantHandle = parameter.GetDefaultValue();
+        if (constantHandle.IsNil)
+            return false;
+
+        var constant = reader.GetConstant(constantHandle);
+        var blob = reader.GetBlobReader(constant.Value);
+        defaultValueText = constant.TypeCode switch
+        {
+            ConstantTypeCode.Boolean when IsDefaultType(parameterType, "bool") => blob.ReadBoolean() ? "true" : "false",
+            ConstantTypeCode.Char when IsDefaultType(parameterType, "char") => $"'{EscapeCharLiteral(blob.ReadChar())}'",
+            ConstantTypeCode.SByte when IsDefaultType(parameterType, "sbyte") => blob.ReadSByte().ToString(CultureInfo.InvariantCulture),
+            ConstantTypeCode.Byte when IsDefaultType(parameterType, "byte") => blob.ReadByte().ToString(CultureInfo.InvariantCulture),
+            ConstantTypeCode.Int16 when IsDefaultType(parameterType, "short") => blob.ReadInt16().ToString(CultureInfo.InvariantCulture),
+            ConstantTypeCode.UInt16 when IsDefaultType(parameterType, "ushort") => blob.ReadUInt16().ToString(CultureInfo.InvariantCulture),
+            ConstantTypeCode.Int32 when IsDefaultType(parameterType, "int") => blob.ReadInt32().ToString(CultureInfo.InvariantCulture),
+            ConstantTypeCode.Int32 when IsLikelyEnumDefaultType(parameterType) => FormatEnumParameterDefault(
+                reader,
+                blob.ReadInt32(),
+                parameterType),
+            ConstantTypeCode.UInt32 when IsDefaultType(parameterType, "uint") => blob.ReadUInt32().ToString(CultureInfo.InvariantCulture),
+            ConstantTypeCode.UInt32 when IsLikelyEnumDefaultType(parameterType) => FormatEnumParameterDefault(
+                reader,
+                blob.ReadUInt32(),
+                parameterType),
+            ConstantTypeCode.Int64 when IsDefaultType(parameterType, "long") => blob.ReadInt64().ToString(CultureInfo.InvariantCulture) + "L",
+            ConstantTypeCode.Int64 when IsLikelyEnumDefaultType(parameterType) => FormatEnumParameterDefault(
+                reader,
+                blob.ReadInt64(),
+                parameterType),
+            ConstantTypeCode.UInt64 when IsDefaultType(parameterType, "ulong") => blob.ReadUInt64().ToString(CultureInfo.InvariantCulture) + "UL",
+            ConstantTypeCode.UInt64 when IsLikelyEnumDefaultType(parameterType) => FormatEnumParameterDefault(
+                reader,
+                blob.ReadUInt64(),
+                parameterType),
+            ConstantTypeCode.Single when IsDefaultType(parameterType, "float") => FormatParameterSingleDefault(blob.ReadSingle()),
+            ConstantTypeCode.Double when IsDefaultType(parameterType, "double") => FormatParameterDoubleDefault(blob.ReadDouble()),
+            ConstantTypeCode.String when IsDefaultType(parameterType, "string") => StringLiteral(blob.ReadUTF16(blob.Length)),
+            ConstantTypeCode.NullReference when AcceptsNullParameterDefault(parameterType) => "null",
+            _ => "",
+        };
+        return defaultValueText.Length != 0;
+    }
+
+    static bool IsDefaultType(string parameterType, string expected)
+        => string.Equals(parameterType, expected, StringComparison.Ordinal);
+
+    static bool AcceptsNullParameterDefault(string parameterType)
+        => parameterType is not ("bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
+            or "float" or "int" or "uint" or "nint" or "nuint" or "long" or "ulong"
+            or "short" or "ushort" or "System.DateTime");
+
+    static bool IsLikelyEnumDefaultType(string parameterType)
+        => parameterType is not ("bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
+            or "float" or "int" or "uint" or "nint" or "nuint" or "long" or "ulong"
+            or "short" or "ushort" or "string" or "object" or "System.Boolean" or "System.Byte"
+            or "System.SByte" or "System.Char" or "System.Decimal" or "System.Double" or "System.Single"
+            or "System.Int32" or "System.UInt32" or "System.IntPtr" or "System.UIntPtr" or "System.Int64"
+            or "System.UInt64" or "System.Int16" or "System.UInt16" or "System.String" or "System.Object"
+            or "System.DateTime");
+
+    static string FormatEnumParameterDefault(MetadataReader reader, object value, string parameterType)
+    {
+        if (!TryConvertEnumConstant(value, out var defaultValue))
+            return "";
+
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            if (TypeResolver.GetTypeName(reader, typeDef.BaseType) != "System.Enum"
+                || !string.Equals(TypeResolver.GetFullName(reader, typeDef), parameterType, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            return $"({parameterType}){defaultValue.ToString(CultureInfo.InvariantCulture)}";
+        }
+
+        return "";
+    }
+
+    static bool TryConvertEnumConstant(object value, out decimal converted)
+    {
+        switch (value)
+        {
+            case sbyte v:
+                converted = v;
+                return true;
+            case byte v:
+                converted = v;
+                return true;
+            case short v:
+                converted = v;
+                return true;
+            case ushort v:
+                converted = v;
+                return true;
+            case int v:
+                converted = v;
+                return true;
+            case uint v:
+                converted = v;
+                return true;
+            case long v:
+                converted = v;
+                return true;
+            case ulong v:
+                converted = v;
+                return true;
+            default:
+                converted = 0;
+                return false;
+        }
+    }
+
+    static string FormatParameterSingleDefault(float value)
+    {
+        if (float.IsNaN(value))
+            return "float.NaN";
+        if (float.IsPositiveInfinity(value))
+            return "float.PositiveInfinity";
+        if (float.IsNegativeInfinity(value))
+            return "float.NegativeInfinity";
+        return value.ToString("R", CultureInfo.InvariantCulture) + "f";
+    }
+
+    static string FormatParameterDoubleDefault(double value)
+    {
+        if (double.IsNaN(value))
+            return "double.NaN";
+        if (double.IsPositiveInfinity(value))
+            return "double.PositiveInfinity";
+        if (double.IsNegativeInfinity(value))
+            return "double.NegativeInfinity";
+        return value.ToString("R", CultureInfo.InvariantCulture);
+    }
+
+    static string StringLiteral(string value)
+    {
+        var sb = new StringBuilder(value.Length + 2);
+        sb.Append('"');
+        foreach (char ch in value)
+            sb.Append(EscapeCharLiteral(ch));
+        sb.Append('"');
+        return sb.ToString();
+    }
+
+    static string EscapeCharLiteral(char ch) => ch switch
+    {
+        '\\' => "\\\\",
+        '\'' => "\\'",
+        '\0' => "\\0",
+        '\a' => "\\a",
+        '\b' => "\\b",
+        '\f' => "\\f",
+        '\n' => "\\n",
+        '\r' => "\\r",
+        '\t' => "\\t",
+        '\v' => "\\v",
+        _ when char.IsControl(ch) => $"\\u{(int)ch:x4}",
+        _ => ch.ToString(),
+    };
 
     static IReadOnlyList<CompileBackTypeParameter> MethodTypeParameters(MetadataReader reader, MethodDefinition method)
     {
@@ -1132,7 +1513,30 @@ public static class CompileBackSourceComposer
     }
 
     static string RenderParameter(CompileBackParameter parameter)
-        => $"{parameter.Type.DisplayName} {parameter.Name}";
+    {
+        var (type, modifier) = NormalizeParameter(parameter);
+        var declaration = string.IsNullOrWhiteSpace(modifier)
+            ? $"{type} {parameter.Name}"
+            : $"{modifier} {type} {parameter.Name}";
+        if (parameter.HasDefault && parameter.DefaultValueText is { Length: > 0 })
+            declaration = $"{declaration} = {parameter.DefaultValueText}";
+        return parameter.Attributes is { Count: > 0 }
+            ? $"[{string.Join(", ", parameter.Attributes)}] {declaration}"
+            : declaration;
+    }
+
+    static (string Type, string? Modifier) NormalizeParameter(CompileBackParameter parameter)
+    {
+        string type = parameter.Type.DisplayName;
+        string? modifier = parameter.Modifier;
+        if (type.StartsWith("ref ", StringComparison.Ordinal))
+        {
+            type = type["ref ".Length..];
+            modifier ??= "ref";
+        }
+
+        return (type, modifier);
+    }
 
     static Dictionary<int, string> ParameterNames(MetadataReader reader, MethodDefinition method)
     {

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -365,6 +365,126 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "generic", "type", "constraints"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalParameterModifiers = new(
+        "minimal.parameter-modifiers",
+        """
+        namespace GeneratedFixtures.MinimalParameterModifiers;
+
+        public class Class1
+        {
+            public void Increment(ref int value)
+            {
+                value++;
+            }
+
+            public void Set(out int value)
+            {
+                value = 42;
+            }
+
+            public int Read(in int value) => value;
+
+            public int Sum(params int[] values)
+            {
+                var sum = 0;
+                foreach (var value in values)
+                    sum += value;
+                return sum;
+            }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalParameterModifiers.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalParameterModifiers.Class1", "Increment",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalParameterModifiers.Class1", "Set",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalParameterModifiers.Class1", "Read",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalParameterModifiers.Class1", "Sum",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "parameters", "ref", "out", "in", "params"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalDefaultParameters = new(
+        "minimal.default-parameters",
+        """
+        namespace GeneratedFixtures.MinimalDefaultParameters;
+
+        public enum Choice
+        {
+            None = 0,
+            One = 1,
+        }
+
+        public class Class1
+        {
+            public int Add(int value = 42, bool enabled = true)
+                => enabled ? value + 1 : value;
+
+            public string Format(string text = "hello", object value = null)
+                => value is null ? text : text + value.ToString();
+
+            public decimal DecimalDefault(decimal value = 1.25m)
+                => value;
+
+            public int EnumDefault(Choice choice = Choice.One)
+                => (int)choice;
+
+            public long DateTimeDefault(
+                [System.Runtime.InteropServices.Optional, System.Runtime.CompilerServices.DateTimeConstant(637000000000000000L)] System.DateTime when)
+                => when.Ticks;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalDefaultParameters.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalDefaultParameters.Class1", "Add",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalDefaultParameters.Class1", "Format",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalDefaultParameters.Class1", "DecimalDefault",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalDefaultParameters.Class1", "EnumDefault",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalDefaultParameters.Class1", "DateTimeDefault",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "parameters", "defaults"]);
+
+    public static readonly GeneratedFixtureDefinition MinimalParameterAttributes = new(
+        "minimal.parameter-attributes",
+        """
+        namespace GeneratedFixtures.MinimalParameterAttributes;
+
+        public class Class1
+        {
+            public int Length([System.Diagnostics.CodeAnalysis.NotNull] string value)
+                => value.Length;
+
+            public int Copy([System.Runtime.InteropServices.Out] int value)
+                => value;
+
+            public int Update([System.Runtime.InteropServices.In, System.Runtime.InteropServices.Out] ref int value)
+            {
+                value++;
+                return value;
+            }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalParameterAttributes.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalParameterAttributes.Class1", "Length",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalParameterAttributes.Class1", "Copy",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalParameterAttributes.Class1", "Update",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["minimal", "parameters", "attributes"]);
+
     public static readonly GeneratedFixtureDefinition MinimalIfElse = new(
         "minimal.if-else",
         """
@@ -861,6 +981,9 @@ internal static class GeneratedFixtureCatalog
         MinimalGenericMethods,
         MinimalGenericType,
         MinimalGenericTypeConstraints,
+        MinimalParameterModifiers,
+        MinimalDefaultParameters,
+        MinimalParameterAttributes,
         MinimalIfElse,
         MinimalIntegerAddition,
         MinimalStructMembers,


### PR DESCRIPTION
- Advances #2057
- Changes product compile-back source composition for parameter signatures and expands RTS generated-fixture coverage.
- Evidence revision: `ed6456dc`

## Change

**Conclusion:** **PASS** — RTS now composes method parameters through structured `ApiParameter` facts for modifiers, source-spellable defaults, and custom attributes; the default generated-fixture catalog is clean at 34 fixtures / 92 targets.

Before:

```text
Parameter modifiers/defaults/attributes were not represented in CompileBackParameter, so structured declarations could not preserve ref/out/in/params, optional defaults, or parameter attributes.
```

After:

```text
minimal.parameter-modifiers, minimal.default-parameters, and minimal.parameter-attributes are Exact in the RTS catalog.
```

## Scope and safety

- **Root cause:** compile-back method parameter shells only carried name/type strings, losing declaration-level metadata that `ApiParameter` and `CSharpDeclarationWriter` already know how to render.
- **Fix shape:** product-side `CompileBackSourceComposer` now maps parameter modifiers, custom attributes, primitive/string/null/decimal/enum/DateTime defaults, and by-ref normalization into the structured declaration model.
- **Product impact:** compile-back source composition only; no RTS-local C# generation was added.
- **Scope boundary:** `[MarshalAs]` field-marshalling metadata is not claimed here; this slice covers custom attributes and source-level/default metadata already represented by product declaration APIs.
- **RTS boundary:** RTS remains orchestration-only; product/shared code owns C# source generation.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `GeneratedFixtureCatalogTests` 8/8; `ReturnToSenderPrototypeTests` 40/40 |
| Decompiler fast suite | Pass, 1803/1803 |
| Targeted compile-back | Default RTS catalog now `34/34` fixtures, `92/92` targets |
| ReturnToSender A/B | `234` Same, `0` Worse, `0` CurrentMissing |
| Broad compile-back | Not applicable; this is RTS catalog/product shell coverage |

## Compile-back quality

**Conclusion:** **PASS** — the changed population is a catalog slice; all new parameter fixtures are Exact and the broad RTS A/B remains unchanged.

### ReturnToSender catalog

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 34 fixture(s), 92 target(s)

Fixtures:
  Passed : 34
  Skipped: 0
  Failed : 0

Targets:
  Passed : 92
  Skipped: 0
  Failed : 0
```

Minimal selector, including known explicit frontiers:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 36 fixture(s), 96 target(s)

Fixtures:
  Passed : 35
  Skipped: 0
  Failed : 1

Targets:
  Passed : 95
  Skipped: 0
  Failed : 1

Failed target buckets:
  opcode-diff: 1

Failed fixtures (first 1 of 1):
  minimal.switch-two-case-lowers-if
      GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1::Method1#0  rts=OpcodeDiff  bucket=opcode-diff
```

### ReturnToSender A/B

Run: `artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll`, cap 500, max examples 20.

```text
RETURNTOSENDER A/B over 234 property getters

  Rescued       : 0
  Same          : 234
  Changed       : 0
  Worse         : 0
  CurrentMissing: 0
```

**RTS verdict:** **PASS** — the parameter-signature catalog expansion does not regress the existing property-getter A/B population.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `minimal.switch-two-case-lowers-if` | Left as frontier | Known compiler/source-lowering opcode-diff frontier, unrelated to parameter signatures. |
| `[MarshalAs]` field-marshalling metadata | Not changed | Separate product metadata surface; this PR covers custom attributes and defaults exposed through current declaration APIs. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | Findings resolved | Fixed by-value `[Out]`/`[In]` handling, `[In, Out] ref` preservation, and unsupported-default handling with canaries. |
| MAI-Code-1-Flash | Finding resolved | Preserved enum and DateTime default values instead of degrading to optional-only fallback. |
| Claude Opus 4.8 | No significant issues | Completed after PR creation; independently verified the by-ref, default, attribute, and catalog attack points. |

**Review conclusion:** **PASS** — all actionable Gemini and MAI findings were resolved in `ed6456dc`; Claude Opus completed later with no significant issues.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --return-to-sender-catalog --max-examples 50
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --return-to-sender-catalog minimal --max-examples 50
```

