### PR TITLE
Introduce AssemblyInspectionSession substrate (#2122)

### DIFF
--- a/src/ILInspector.Metadata/AssemblyImage.cs
+++ b/src/ILInspector.Metadata/AssemblyImage.cs
@@ -1,0 +1,59 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// Owns a single opened PE image (backing stream + <see cref="PEReader"/>) so that an inspection
+/// parses the file once and shares the reader across scanners, instead of every caller opening its
+/// own <see cref="PEReader"/>.
+///
+/// The reader is metadata-internal: it is not exposed to callers outside this assembly. Consumers
+/// go through <see cref="AssemblyInspectionSession"/>, which produces facets over the shared image.
+/// See <c>docs/design/assembly-inspection-query.md</c>.
+/// </summary>
+public sealed class AssemblyImage : IDisposable
+{
+    readonly Stream _stream;
+
+    internal PEReader PEReader { get; }
+
+    AssemblyImage(Stream stream, PEReader peReader)
+    {
+        _stream = stream;
+        PEReader = peReader;
+    }
+
+    /// <summary>Whether the image contains managed metadata (false for a native binary).</summary>
+    public bool HasMetadata => PEReader.HasMetadata;
+
+    /// <summary>Opens an image from a file path.</summary>
+    public static AssemblyImage Open(string path) => FromStream(File.OpenRead(path));
+
+    /// <summary>
+    /// Opens an image from a resolved assembly reference, using its stream opener. This is the
+    /// descriptor-based entry point that keeps callers off bare paths.
+    /// </summary>
+    public static AssemblyImage Open(ResolvedAssemblyReference reference) => FromStream(reference.OpenRead());
+
+    static AssemblyImage FromStream(Stream stream)
+    {
+        try
+        {
+            return new AssemblyImage(stream, new PEReader(stream));
+        }
+        catch
+        {
+            stream.Dispose();
+            throw;
+        }
+    }
+
+    internal MetadataReader GetMetadataReader() => PEReader.GetMetadataReader();
+
+    public void Dispose()
+    {
+        PEReader.Dispose();
+        _stream.Dispose();
+    }
+}

--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -1,0 +1,87 @@
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// The assembly-level inspection hub. Opens a PE image once (via <see cref="AssemblyImage"/>) and
+/// produces assembly <em>facets</em> by delegating to the metadata scanners over the single shared
+/// reader. Callers never touch a <c>PEReader</c>; each facet is produced on request.
+///
+/// This is the assembly seam of the inspection query model
+/// (<c>docs/design/assembly-inspection-query.md</c>): a facet registry that delegates to
+/// per-facet producers, not a god-object. The method-body seam is a sibling session opened over
+/// the same image.
+/// </summary>
+public sealed class AssemblyInspectionSession : IDisposable
+{
+    readonly AssemblyImage _image;
+
+    AssemblyInspectionSession(AssemblyImage image) => _image = image;
+
+    /// <summary>Opens a session from a file path.</summary>
+    public static AssemblyInspectionSession Open(string path) => new(AssemblyImage.Open(path));
+
+    /// <summary>Opens a session from a resolved assembly reference (path or stream opener).</summary>
+    public static AssemblyInspectionSession Open(ResolvedAssemblyReference reference) => new(AssemblyImage.Open(reference));
+
+    /// <summary>Whether the image contains managed metadata (false for a native binary).</summary>
+    public bool HasMetadata => _image.HasMetadata;
+
+    // --- assembly facets: each produced once over the single shared reader ---
+
+    /// <summary>Assembly identity and, optionally, its assembly references.</summary>
+    public AssemblyInfo AssemblyInfo(bool includeReferences = false)
+        => AssemblyInspector.ExtractAssemblyInfo(_image.PEReader, includeReferences);
+
+    /// <summary>The public (or, with <paramref name="includeAll"/>, full) API surface.</summary>
+    public ApiSurface ApiSurface(bool includeAll = false, bool typesOnly = false)
+        => ApiSurfaceExtractor.Extract(_image.PEReader, includeAll, typesOnly);
+
+    /// <summary>Manifest resources.</summary>
+    public List<ManifestResourceInfo> Resources()
+        => ResourceScanner.Scan(_image.PEReader);
+
+    /// <summary>Feature-switch metadata.</summary>
+    public List<SwitchInfo> Switches()
+        => SwitchScanner.Scan(_image.PEReader);
+
+    /// <summary>Classified methods (unsafe / P-Invoke / async).</summary>
+    public List<ClassifiedMethodInfo> ClassifiedMethods()
+        => MethodClassificationScanner.Scan(_image.PEReader);
+
+    /// <summary>OpenTelemetry integration signals.</summary>
+    public List<OpenTelemetrySignalInfo> OpenTelemetrySignals()
+        => OpenTelemetryScanner.Scan(_image.PEReader);
+
+    /// <summary>Ecosystem integration signals.</summary>
+    public List<EcosystemIntegrationSignalInfo> EcosystemIntegrations()
+        => EcosystemIntegrationScanner.Scan(_image.PEReader);
+
+    /// <summary>Integration opportunities, excluding already-present integrations.</summary>
+    public List<IntegrationOpportunityInfo> IntegrationOpportunities(IReadOnlySet<string> existingIntegrations)
+        => IntegrationOpportunityScanner.Scan(_image.PEReader, existingIntegrations);
+
+    /// <summary>Discriminated-union types.</summary>
+    public List<UnionTypeInfo> UnionTypes()
+        => UnionTypeScanner.Scan(_image.PEReader);
+
+    /// <summary>Extension methods.</summary>
+    public IEnumerable<ExtensionMethodInfo> ExtensionMethods(bool includeAll = false)
+        => ExtensionMethodScanner.FindAllExtensions(_image.PEReader, includeAll);
+
+    /// <summary>Assembly-level custom attributes.</summary>
+    public List<AssemblyAttributeInfo> CustomAttributes()
+        => AssemblyDetailScanner.ScanCustomAttributes(_image.PEReader);
+
+    /// <summary>Type forwarders.</summary>
+    public List<TypeForwarderInfo> TypeForwarders()
+        => AssemblyDetailScanner.ScanTypeForwarders(_image.PEReader);
+
+    /// <summary>Assembly audit metadata (P-Invoke counts, flags, …).</summary>
+    public AssemblyAuditMetadata AuditMetadata()
+        => AssemblyDetailScanner.ScanAuditMetadata(_image.PEReader);
+
+    /// <summary>Presence flags for assembly-level features.</summary>
+    public PresenceFlags PresenceFlags()
+        => AssemblyDetailScanner.ScanPresenceFlags(_image.PEReader);
+
+    public void Dispose() => _image.Dispose();
+}

--- a/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
+++ b/src/dotnet-inspect/Inspectors/AuditSignalBuilder.cs
@@ -37,14 +37,13 @@ internal static class AuditSignalBuilder
 
         try
         {
-            using var stream = File.OpenRead(assemblyPath);
-            using var peReader = new PEReader(stream);
-            metadata = AssemblyDetailScanner.ScanAuditMetadata(peReader);
+            using var session = AssemblyInspectionSession.Open(assemblyPath);
+            metadata = session.AuditMetadata();
             pInvokeMethodCount = metadata.PInvokeMethodCount;
 
-            // Reuse the same reader for the classified-methods scan rather than re-opening the file.
+            // Reuse the same session for the classified-methods scan rather than re-opening the file.
             if (inspection.UnsafeMethods == null || inspection.PInvokeMethods == null || inspection.AsyncMethods == null)
-                LibraryMetadataService.ScanClassifiedMethods(peReader, assemblyPath, inspection, logger);
+                LibraryMetadataService.ScanClassifiedMethods(session, assemblyPath, inspection, logger);
         }
         catch (Exception ex)
         {

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -501,61 +501,77 @@ internal static class LibraryMetadataService
     {
         try
         {
-            var classified = MethodClassificationScanner.Scan(peReader);
-            if (classified.Count == 0) return;
-
-            var unsafe_ = classified
-                .Where(m => m.Classification == MethodClassification.Unsafe)
-                .Select(m => new ClassifiedMethodSummary
-                {
-                    MethodName = m.MethodName,
-                    DeclaringType = m.DeclaringType,
-                    Signature = m.Signature
-                })
-                .OrderBy(m => m.DeclaringType)
-                .ThenBy(m => m.MethodName)
-                .ToList();
-
-            var pinvoke = classified
-                .Where(m => m.Classification == MethodClassification.PInvoke)
-                .Select(m => new ClassifiedMethodSummary
-                {
-                    MethodName = m.MethodName,
-                    DeclaringType = m.DeclaringType,
-                    Signature = m.Signature,
-                    ModuleName = m.ModuleName
-                })
-                .OrderBy(m => m.DeclaringType)
-                .ThenBy(m => m.MethodName)
-                .ToList();
-
-            inspection.UnsafeMethods = unsafe_.Count > 0 ? unsafe_ : null;
-            inspection.PInvokeMethods = pinvoke.Count > 0 ? pinvoke : null;
-
-            var async = classified
-                .Where(m => m.Classification is MethodClassification.RuntimeAsync
-                                             or MethodClassification.StateMachineAsync)
-                .Select(m => new AsyncMethodSummary
-                {
-                    MethodName = m.MethodName,
-                    DeclaringType = m.DeclaringType,
-                    Signature = m.Signature,
-                    Kind = m.Classification == MethodClassification.RuntimeAsync
-                        ? AsyncMethodSummary.RuntimeKind
-                        : AsyncMethodSummary.StateMachineKind
-                })
-                // Runtime async first (sorts before "State machine"), then by type/name.
-                .OrderBy(m => m.Kind, StringComparer.Ordinal)
-                .ThenBy(m => m.DeclaringType)
-                .ThenBy(m => m.MethodName)
-                .ToList();
-
-            inspection.AsyncMethods = async.Count > 0 ? async : null;
+            ApplyClassifiedMethods(MethodClassificationScanner.Scan(peReader), inspection);
         }
         catch (Exception ex)
         {
             logger.Log($"Warning: Error scanning classified methods in {path}: {ex.Message}");
         }
+    }
+
+    internal static void ScanClassifiedMethods(AssemblyInspectionSession session, string path, LibraryInspection inspection, VerboseLogger logger)
+    {
+        try
+        {
+            ApplyClassifiedMethods(session.ClassifiedMethods(), inspection);
+        }
+        catch (Exception ex)
+        {
+            logger.Log($"Warning: Error scanning classified methods in {path}: {ex.Message}");
+        }
+    }
+
+    static void ApplyClassifiedMethods(List<ClassifiedMethodInfo> classified, LibraryInspection inspection)
+    {
+        if (classified.Count == 0) return;
+
+        var unsafe_ = classified
+            .Where(m => m.Classification == MethodClassification.Unsafe)
+            .Select(m => new ClassifiedMethodSummary
+            {
+                MethodName = m.MethodName,
+                DeclaringType = m.DeclaringType,
+                Signature = m.Signature
+            })
+            .OrderBy(m => m.DeclaringType)
+            .ThenBy(m => m.MethodName)
+            .ToList();
+
+        var pinvoke = classified
+            .Where(m => m.Classification == MethodClassification.PInvoke)
+            .Select(m => new ClassifiedMethodSummary
+            {
+                MethodName = m.MethodName,
+                DeclaringType = m.DeclaringType,
+                Signature = m.Signature,
+                ModuleName = m.ModuleName
+            })
+            .OrderBy(m => m.DeclaringType)
+            .ThenBy(m => m.MethodName)
+            .ToList();
+
+        inspection.UnsafeMethods = unsafe_.Count > 0 ? unsafe_ : null;
+        inspection.PInvokeMethods = pinvoke.Count > 0 ? pinvoke : null;
+
+        var async = classified
+            .Where(m => m.Classification is MethodClassification.RuntimeAsync
+                                         or MethodClassification.StateMachineAsync)
+            .Select(m => new AsyncMethodSummary
+            {
+                MethodName = m.MethodName,
+                DeclaringType = m.DeclaringType,
+                Signature = m.Signature,
+                Kind = m.Classification == MethodClassification.RuntimeAsync
+                    ? AsyncMethodSummary.RuntimeKind
+                    : AsyncMethodSummary.StateMachineKind
+            })
+            // Runtime async first (sorts before "State machine"), then by type/name.
+            .OrderBy(m => m.Kind, StringComparer.Ordinal)
+            .ThenBy(m => m.DeclaringType)
+            .ThenBy(m => m.MethodName)
+            .ToList();
+
+        inspection.AsyncMethods = async.Count > 0 ? async : null;
     }
 
     internal static List<UnsafeMemberSummary>? ScanUnsafeMembers(string path, VerboseLogger logger)

--- a/tests/ILInspector.Metadata.Tests/AssemblyInspectionSessionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/AssemblyInspectionSessionTests.cs
@@ -1,0 +1,72 @@
+using System.Linq;
+
+namespace ILInspector.Metadata.Tests;
+
+/// <summary>
+/// Tests for the assembly inspection substrate (<see cref="AssemblyImage"/> /
+/// <see cref="AssemblyInspectionSession"/>): the shared-open hub that produces assembly facets
+/// over a single <c>PEReader</c>. See <c>docs/design/assembly-inspection-query.md</c>.
+/// </summary>
+public class AssemblyInspectionSessionTests
+{
+    static string SelfPath => typeof(AssemblyInspectionSessionTests).Assembly.Location;
+    const string SelfName = "ILInspector.Metadata.Tests";
+
+    [Fact]
+    public void Open_FromPath_HasMetadata()
+    {
+        using var session = AssemblyInspectionSession.Open(SelfPath);
+        Assert.True(session.HasMetadata);
+    }
+
+    [Fact]
+    public void AssemblyInfo_ReturnsAssemblyName()
+    {
+        using var session = AssemblyInspectionSession.Open(SelfPath);
+        Assert.Equal(SelfName, session.AssemblyInfo().AssemblyName);
+    }
+
+    [Fact]
+    public void Facets_ProduceOverSharedReader_WithoutReopening()
+    {
+        using var session = AssemblyInspectionSession.Open(SelfPath);
+
+        // Many facets, one open — none should throw, and the surface should be populated.
+        Assert.NotEmpty(session.ApiSurface(includeAll: true).Types);
+        Assert.NotNull(session.Resources());
+        Assert.NotNull(session.CustomAttributes());
+        Assert.NotNull(session.ClassifiedMethods());
+        Assert.NotNull(session.TypeForwarders());
+        Assert.NotNull(session.UnionTypes());
+        Assert.NotNull(session.Switches());
+        Assert.NotNull(session.OpenTelemetrySignals());
+        Assert.NotNull(session.EcosystemIntegrations());
+        Assert.NotNull(session.AuditMetadata());
+        Assert.NotNull(session.ExtensionMethods().ToList());
+    }
+
+    [Fact]
+    public void Open_FromResolvedReference_MatchesPathOpen()
+    {
+        var reference = new ResolvedAssemblyReference(
+            new AssemblyReferenceIdentity(SelfName, Version: null, Culture: null, PublicKeyToken: null),
+            SelfPath,
+            () => File.OpenRead(SelfPath));
+
+        using var fromRef = AssemblyInspectionSession.Open(reference);
+        using var fromPath = AssemblyInspectionSession.Open(SelfPath);
+
+        Assert.True(fromRef.HasMetadata);
+        Assert.Equal(fromPath.AssemblyInfo().AssemblyName, fromRef.AssemblyInfo().AssemblyName);
+        Assert.Equal(
+            fromPath.ApiSurface(includeAll: true).Types.Count,
+            fromRef.ApiSurface(includeAll: true).Types.Count);
+    }
+
+    [Fact]
+    public void AssemblyImage_Open_HasMetadata()
+    {
+        using var image = AssemblyImage.Open(SelfPath);
+        Assert.True(image.HasMetadata);
+    }
+}


### PR DESCRIPTION
## Summary

First implementation slice of the inspection query model
([`docs/design/assembly-inspection-query.md`](https://github.com/richlander/dotnet-inspect/blob/main/docs/design/assembly-inspection-query.md), from #2138):
the shared-open **assembly seam**. This introduces the substrate the rest of the CLI-thinning
migration builds on.

## Changes

- **`AssemblyImage`** (`ILInspector.Metadata`) — owns one opened PE image (backing stream +
  `PEReader`) so an inspection parses the file once. The `PEReader` is **metadata-internal** (not
  exposed outside the assembly). Opens from a path **or** a `ResolvedAssemblyReference` (the #2051
  descriptor), so callers can stay off bare paths.
- **`AssemblyInspectionSession`** — the assembly-level **facet hub**. Opens an image once and
  produces assembly facets by delegating to the existing metadata scanners over the single shared
  reader (`Resources`, `CustomAttributes`, `ClassifiedMethods`, `AuditMetadata`, `ApiSurface`,
  `ExtensionMethods`, `TypeForwarders`, `UnionTypes`, `Switches`, OpenTelemetry / ecosystem /
  opportunity signals, `PresenceFlags`, `AssemblyInfo`). It's a facet registry that *delegates* —
  not a god-object — matching the Research producer-registry precedent noted in the design.
- **First consumer:** `AuditSignalBuilder` now opens a session instead of its own
  `File.OpenRead + new PEReader` (one of the CLI's raw opens removed). Extracted a shared
  `ApplyClassifiedMethods` mapping so both the `PEReader` and new session `ScanClassifiedMethods`
  overloads reuse it — behavior preserved.

## Scope / not in this slice

Purely additive substrate + one consumer conversion. Follow-up slices (per the doc's migration)
convert the remaining `LibraryMetadataService` / `MemberCodeProvider` opens, compose
`PdbContext` / `MetadataSource` over a shared owner, and thread the
`InspectionQuery` / `ResolvedAssemblyReference` model end-to-end.

## Validation

- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507` — 0 warnings.
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507 -- -class ILInspector.Metadata.Tests.AssemblyInspectionSessionTests` — 5/5 (path + descriptor open, facet production over shared reader, path-vs-reference equivalence).
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -class DotnetInspector.Tests.MethodClassificationScannerTests -class DotnetInspector.Tests.AsyncKindDisplayTests` — 13/13.
- CLI smoke: `library <dll> -S Signals -v:d` renders audit signals (P/Invoke, memory-safety, async-kind) correctly through the converted path.

## Adversarial review

Non-trivial (new public metadata types + a behavior-touching conversion); requesting two-reviewer
adversarial review per `AGENTS.md`.

Part of #2122.
