### PR TITLE
Use ApiSignature helpers for constructor snippets

### DIFF
--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -187,7 +187,8 @@ public class ApiSignature
 
     public string ParameterDeclarationsSummary => Parameters.Count == 0
         ? "()"
-        : $"({string.Join(", ", Parameters.Select(parameter => parameter.Declaration))})";
+        : CSharpDeclarationWriter.EscapeQualifiedKeywordSegments(
+            $"({string.Join(", ", Parameters.Select(parameter => parameter.Declaration))})");
 
     public List<(string name, string type, bool hasDefault)> ParameterInfoSummary => Parameters
         .Select(parameter => (parameter.Name, parameter.TypeWithModifier, parameter.HasDefault))

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -185,6 +185,14 @@ public class ApiSignature
         ? ""
         : $"({string.Join(", ", Parameters.Select(parameter => parameter.TypeWithModifier))})";
 
+    public string ParameterDeclarationsSummary => Parameters.Count == 0
+        ? "()"
+        : $"({string.Join(", ", Parameters.Select(parameter => parameter.Declaration))})";
+
+    public List<(string name, string type, bool hasDefault)> ParameterInfoSummary => Parameters
+        .Select(parameter => (parameter.Name, parameter.TypeWithModifier, parameter.HasDefault))
+        .ToList();
+
     public string PublicAccessorsSummary => string.Join(", ",
         Accessors
             .Where(accessor => string.IsNullOrEmpty(accessor.Accessibility))
@@ -213,7 +221,7 @@ public class ApiParameter
                 : $"[{string.Join(", ", Attributes)}] ";
             var head = string.IsNullOrWhiteSpace(Name)
                 ? TypeWithModifier
-                : $"{TypeWithModifier} {Name}";
+                : $"{TypeWithModifier} {CSharpDeclarationWriter.EscapeIdentifier(Name)}";
             var declaration = HasDefault && DefaultValueText is { Length: > 0 }
                 ? $"{head} = {DefaultValueText}"
                 : head;

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -715,7 +715,7 @@ public static class CSharpDeclarationWriter
             : string.Concat(signature.AsSpan(0, nameIndex), escaped, signature.AsSpan(nameIndex + memberName.Length));
     }
 
-    static string EscapeQualifiedKeywordSegments(string signature)
+    internal static string EscapeQualifiedKeywordSegments(string signature)
     {
         var sb = new StringBuilder(signature.Length);
         bool inString = false;

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -853,7 +853,7 @@ public static class CSharpDeclarationWriter
     static string EscapeQualifiedName(string name)
         => string.Join(".", name.Split('.').Select(part => string.Join("+", part.Split('+').Select(EscapeIdentifier))));
 
-    static string EscapeIdentifier(string name)
+    internal static string EscapeIdentifier(string name)
         => s_csharpReservedKeywords.Contains(name) || name == "await" ? "@" + name : name;
 
     static bool IsIdentifierStart(char c) => char.IsLetter(c) || c == '_';

--- a/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/CSharpDeclarationFormatterTests.cs
@@ -357,6 +357,50 @@ public sealed class CSharpDeclarationFormatterTests
     }
 
     [Fact]
+    public void ConstructorOverloadSnippet_EscapesKeywordGenericParameterTypes()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Samples",
+            Name = "Widget",
+            Kind = "class",
+            TypeParameters = [new TypeParameter { Name = "event" }],
+            Members =
+            [
+                new ApiMember
+                {
+                    Name = ".ctor",
+                    Kind = "constructor",
+                    Signature = "BROKEN",
+                    SignatureModel = new ApiSignature
+                    {
+                        Parameters =
+                        [
+                            new ApiParameter
+                            {
+                                Type = "System.Action<event>",
+                                Name = "callback"
+                            }
+                        ]
+                    }
+                }
+            ]
+        };
+        var view = ApiOutputFormatter.BuildTypeView(
+            type,
+            foundIn: "Test.dll",
+            packageName: null,
+            packageVersion: null,
+            apiSource: "local",
+            selectedTfm: null,
+            new TypeOptions());
+
+        ApiOutputFormatter.PopulateConstructorOverloads(view, type, new TypeOptions());
+
+        Assert.Equal("new Widget(System.Action<@event> callback)", view.ConstructorOverloads![0].Signature.Content);
+    }
+
+    [Fact]
     public void ConstructorOverloadSnippet_IgnoresObsoleteAttributePrefix()
     {
         var type = new ApiType

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1028,7 +1028,7 @@ public static class ApiOutputFormatter
             var overloadView = new ConstructorOverloadView
             {
                 Title = $"Overload {i + 1}: {paramCount} parameter{(paramCount != 1 ? "s" : "")}",
-                Signature = new CodeSection("csharp", $"new {type.Name}{ConstructorCall(ctor)}")
+                Signature = new CodeSection("csharp", $"new {type.Name}{ConstructorCall(type, ctor)}")
             };
 
             if (paramInfo.Count > 0)
@@ -1051,17 +1051,41 @@ public static class ApiOutputFormatter
             ? signature.ParameterInfoSummary
             : SignatureParser.ExtractParameterInfo(constructor.Signature);
 
-    private static string ConstructorCall(ApiMember constructor)
+    private static string ConstructorCall(ApiType type, ApiMember constructor)
     {
         if (constructor.SignatureModel is { } signature
             && signature.Parameters.All(static parameter => !parameter.HasDefault || !string.IsNullOrWhiteSpace(parameter.DefaultValueText)))
         {
+            if (HasKeywordGenericIdentifier(type, signature))
+            {
+                var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
+                    type,
+                    constructor,
+                    new CSharpDeclarationOptions { IncludeObsoleteAttribute = false });
+                if (!string.IsNullOrWhiteSpace(declaration))
+                    return ConstructorCallFromDeclaration(declaration);
+            }
+
             return signature.ParameterDeclarationsSummary;
         }
 
         // Compatibility-only fallback for legacy signatures without complete
         // structured default-value facts.
         return SignatureParser.FormatConstructorCall(constructor.Signature);
+    }
+
+    private static bool HasKeywordGenericIdentifier(ApiType type, ApiSignature signature)
+    {
+        return type.TypeParameters
+            .Concat(signature.TypeParameters)
+            .Select(parameter => parameter.Name)
+            .Any(name => CSharpDeclarationWriter.EscapeIdentifier(name) != name);
+    }
+
+    private static string ConstructorCallFromDeclaration(string declaration)
+    {
+        var parenStart = declaration.IndexOf('(');
+        return parenStart < 0 ? "()" : declaration[parenStart..];
     }
 
     internal static void PopulateIndexSections(TypeView view, ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex, IReadOnlySet<string> requestedSections, string? pdbPath = null, IReadOnlySet<string>? explicitSections = null, IReadOnlyList<string>? callerScopeAssemblies = null, ApiOptions? options = null)

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1028,7 +1028,7 @@ public static class ApiOutputFormatter
             var overloadView = new ConstructorOverloadView
             {
                 Title = $"Overload {i + 1}: {paramCount} parameter{(paramCount != 1 ? "s" : "")}",
-                Signature = new CodeSection("csharp", $"new {type.Name}{ConstructorCall(type, ctor)}")
+                Signature = new CodeSection("csharp", $"new {type.Name}{ConstructorCall(ctor)}")
             };
 
             if (paramInfo.Count > 0)
@@ -1048,33 +1048,20 @@ public static class ApiOutputFormatter
 
     private static List<(string name, string type, bool hasDefault)> ConstructorParameterInfo(ApiMember constructor)
         => constructor.SignatureModel is { } signature
-            ? signature.Parameters
-                .Select(parameter => (parameter.Name, parameter.TypeWithModifier, parameter.HasDefault))
-                .ToList()
+            ? signature.ParameterInfoSummary
             : SignatureParser.ExtractParameterInfo(constructor.Signature);
 
-    private static string ConstructorCall(ApiType type, ApiMember constructor)
+    private static string ConstructorCall(ApiMember constructor)
     {
         if (constructor.SignatureModel is { } signature
             && signature.Parameters.All(static parameter => !parameter.HasDefault || !string.IsNullOrWhiteSpace(parameter.DefaultValueText)))
         {
-            var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
-                type,
-                constructor,
-                new CSharpDeclarationOptions { IncludeObsoleteAttribute = false });
-            if (!string.IsNullOrWhiteSpace(declaration))
-                return ConstructorCallFromDeclaration(declaration);
+            return signature.ParameterDeclarationsSummary;
         }
 
         // Compatibility-only fallback for legacy signatures without complete
         // structured default-value facts.
         return SignatureParser.FormatConstructorCall(constructor.Signature);
-    }
-
-    private static string ConstructorCallFromDeclaration(string declaration)
-    {
-        var parenStart = declaration.IndexOf('(');
-        return parenStart < 0 ? "()" : declaration[parenStart..];
     }
 
     internal static void PopulateIndexSections(TypeView view, ApiType type, List<ApiMember> methods, string dllPath, int? overloadIndex, IReadOnlySet<string> requestedSections, string? pdbPath = null, IReadOnlySet<string>? explicitSections = null, IReadOnlyList<string>? callerScopeAssemblies = null, ApiOptions? options = null)

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -78,6 +78,24 @@ public sealed class ApiSignatureModelTests
     }
 
     [Fact]
+    public void ParameterDeclarationsSummary_EscapesKeywordNamesAndQualifiedTypeSegments()
+    {
+        var signature = new ApiSignature
+        {
+            Parameters =
+            [
+                new ApiParameter
+                {
+                    Type = "System.event.MyClass",
+                    Name = "event"
+                }
+            ]
+        };
+
+        Assert.Equal("(System.@event.MyClass @event)", signature.ParameterDeclarationsSummary);
+    }
+
+    [Fact]
     public void CanonicalSignature_UsesStructuredSignatureModel()
     {
         var type = GetType(nameof(ApiSignatureFixtures));

--- a/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiSignatureModelTests.cs
@@ -71,6 +71,10 @@ public sealed class ApiSignatureModelTests
         Assert.Equal("int", ctor.SignatureModel.Parameters[1].Type);
         Assert.True(ctor.SignatureModel.Parameters[1].HasDefault);
         Assert.Equal("1", ctor.SignatureModel.Parameters[1].DefaultValueText);
+        Assert.Equal("(string name, int count = 1)", ctor.SignatureModel.ParameterDeclarationsSummary);
+        Assert.Equal(
+            [("name", "string", false), ("count", "int", true)],
+            ctor.SignatureModel.ParameterInfoSummary);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Adds structured `ApiSignature` helpers for parameter declarations and constructor parameter row data.
- Uses those helpers in `ApiOutputFormatter` constructor overload snippets instead of rendering a full C# declaration and reparsing the constructor call.
- Keeps `SignatureParser` only as compatibility fallback for model-less signatures and leaves XML-doc matching for a separate slice.

Refs #2122.

## Validation

- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:RestoreConfigFile=nuget.config -- -class "*ApiSignatureModelTests*"`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:RestoreConfigFile=nuget.config -- -class "*CSharpDeclarationFormatterTests*"`
- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config`

## Review

Adversarial review required because this changes constructor snippet rendering to use structured signature helpers directly. Results will be posted as a PR comment.