### PR TITLE
Add RTS parameter marshalling coverage

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -425,6 +425,48 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.parameter-marshalling",
+            "GeneratedFixtures.MinimalParameterMarshalling.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-marshalling",
+            "GeneratedFixtures.MinimalParameterMarshalling.Class1",
+            "I4",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-marshalling",
+            "GeneratedFixtures.MinimalParameterMarshalling.Class1",
+            "LpStr",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-marshalling",
+            "GeneratedFixtures.MinimalParameterMarshalling.Class1",
+            "Bool",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-marshalling",
+            "GeneratedFixtures.MinimalParameterMarshalling.Class1",
+            "Sum",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-marshalling",
+            "GeneratedFixtures.MinimalParameterMarshalling.Class1",
+            "FirstFour",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.if-else",
             "GeneratedFixtures.MinimalIfElse.Class1",
             ".ctor",
@@ -685,6 +727,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.parameter-modifiers", report);
         Assert.Contains("minimal.default-parameters", report);
         Assert.Contains("minimal.parameter-attributes", report);
+        Assert.Contains("minimal.parameter-marshalling", report);
         Assert.Contains("minimal.if-else", report);
         Assert.Contains("minimal.integer-addition", report);
         Assert.Contains("minimal.struct-members", report);
@@ -753,6 +796,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.null-coalesce",
                 "minimal.object-initializer",
                 "minimal.parameter-attributes",
+                "minimal.parameter-marshalling",
                 "minimal.parameter-modifiers",
                 "minimal.primary-ctor.field-init",
                 "minimal.property.literal",
@@ -802,6 +846,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.parameter-modifiers");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.default-parameters");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.parameter-attributes");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.parameter-marshalling");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.integer-addition");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.struct-members");

--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -467,6 +467,27 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.parameter-marshalling",
+            "GeneratedFixtures.MinimalParameterMarshalling.Class1",
+            "PlainArray",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-marshalling",
+            "GeneratedFixtures.MinimalParameterMarshalling.Class1",
+            "FixedArray",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.parameter-marshalling",
+            "GeneratedFixtures.MinimalParameterMarshalling.Class1",
+            "ZeroSizedArray",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.if-else",
             "GeneratedFixtures.MinimalIfElse.Class1",
             ".ctor",

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1207,6 +1207,82 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RoundTripsParameterMarshalling()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public int I4([System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)] int value)
+                    => value;
+
+                public int LpStr([System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPStr)] string value)
+                    => value.Length;
+
+                public int Bool([System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)] bool value)
+                    => value ? 1 : 0;
+
+                public int Sum(
+                    [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeParamIndex = 1)] int[] values,
+                    int count)
+                {
+                    var sum = 0;
+                    for (var i = 0; i < count; i++)
+                        sum += values[i];
+                    return sum;
+                }
+
+                public int FirstFour(
+                    [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)] int[] values)
+                    => values[0] + values[1] + values[2] + values[3];
+            }
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Class1", "I4", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "LpStr", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "Bool", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "Sum", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "FirstFour", 0),
+                ]);
+
+            Assert.Collection(
+                results,
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPStr)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeParamIndex = 1)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)", result.Source);
+                });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericTypeTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1234,6 +1234,18 @@ public class ReturnToSenderPrototypeTests
                 public int FirstFour(
                     [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)] int[] values)
                     => values[0] + values[1] + values[2] + values[3];
+
+                public int PlainArray(
+                    [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray)] int[] values)
+                    => values.Length;
+
+                public int FixedArray(
+                    [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 4)] int[] values)
+                    => values[0] + values[1] + values[2] + values[3];
+
+                public int ZeroSizedArray(
+                    [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 0)] int[] values)
+                    => values.Length;
             }
             """);
         try
@@ -1246,6 +1258,9 @@ public class ReturnToSenderPrototypeTests
                     new ReturnToSender.RequestedTarget("Class1", "Bool", 0),
                     new ReturnToSender.RequestedTarget("Class1", "Sum", 0),
                     new ReturnToSender.RequestedTarget("Class1", "FirstFour", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "PlainArray", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "FixedArray", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "ZeroSizedArray", 0),
                 ]);
 
             Assert.Collection(
@@ -1274,6 +1289,21 @@ public class ReturnToSenderPrototypeTests
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
                     Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 4)", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 0)", result.Source);
                 });
         }
         finally

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -336,12 +336,126 @@ public static class AttributeReader
         => RenderAttributes(reader, reader.GetParameter(parameter).GetCustomAttributes(), namespaces);
 
     public static List<string> RenderParameterAttributes(MetadataReader reader, ParameterHandle parameter, SortedSet<string>? namespaces = null)
-        => RenderAttributes(
+    {
+        var result = RenderAttributes(
             reader,
             reader.GetParameter(parameter).GetCustomAttributes(),
             namespaces,
             IsParameterSyntaxAttribute,
             qualifyNames: true);
+        try
+        {
+            if (TryRenderMarshalAsAttribute(reader, parameter) is { } marshalAs)
+                result.Add(marshalAs);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            // Match custom-attribute rendering: malformed or unsupported metadata is not emitted wrong.
+        }
+
+        return result;
+    }
+
+    static string? TryRenderMarshalAsAttribute(MetadataReader reader, ParameterHandle parameterHandle)
+    {
+        var parameter = reader.GetParameter(parameterHandle);
+        if ((parameter.Attributes & ParameterAttributes.HasFieldMarshal) == 0)
+            return null;
+
+        var descriptor = parameter.GetMarshallingDescriptor();
+        if (descriptor.IsNil)
+            return null;
+
+        var blob = reader.GetBlobReader(descriptor);
+        if (blob.RemainingBytes == 0)
+            return null;
+
+        var nativeType = blob.ReadByte();
+        if (nativeType == 0x2a)
+            return TryRenderArrayMarshalAs(ref blob);
+
+        if (blob.RemainingBytes != 0 || UnmanagedTypeName(nativeType) is not { } unmanagedType)
+            return null;
+
+        return $"System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.{unmanagedType})";
+    }
+
+    static string? TryRenderArrayMarshalAs(ref BlobReader blob)
+    {
+        var arguments = new List<string>
+        {
+            "System.Runtime.InteropServices.UnmanagedType.LPArray",
+        };
+        if (blob.RemainingBytes > 0)
+        {
+            var elementType = blob.ReadByte();
+            if (UnmanagedTypeName(elementType) is not { } elementUnmanagedType)
+                return null;
+            arguments.Add($"ArraySubType = System.Runtime.InteropServices.UnmanagedType.{elementUnmanagedType}");
+        }
+
+        if (blob.RemainingBytes > 0)
+        {
+            var sizeParamIndex = blob.ReadCompressedInteger();
+            if (blob.RemainingBytes == 0)
+            {
+                arguments.Add($"SizeParamIndex = {sizeParamIndex}");
+            }
+            else
+            {
+                var sizeConst = blob.ReadCompressedInteger();
+                var sizeParamSpecified = blob.ReadCompressedInteger() != 0;
+                if (blob.RemainingBytes != 0)
+                    return null;
+                if (sizeParamSpecified)
+                    arguments.Add($"SizeParamIndex = {sizeParamIndex}");
+                if (sizeConst != 0)
+                    arguments.Add($"SizeConst = {sizeConst}");
+            }
+        }
+
+        return $"System.Runtime.InteropServices.MarshalAs({string.Join(", ", arguments)})";
+    }
+
+    static string? UnmanagedTypeName(byte nativeType)
+        => nativeType switch
+        {
+            0x02 => "Bool",
+            0x03 => "I1",
+            0x04 => "U1",
+            0x05 => "I2",
+            0x06 => "U2",
+            0x07 => "I4",
+            0x08 => "U4",
+            0x09 => "I8",
+            0x0a => "U8",
+            0x0b => "R4",
+            0x0c => "R8",
+            0x0f => "Currency",
+            0x13 => "BStr",
+            0x14 => "LPStr",
+            0x15 => "LPWStr",
+            0x16 => "LPTStr",
+            0x19 => "IUnknown",
+            0x1a => "IDispatch",
+            0x1b => "Struct",
+            0x1c => "Interface",
+            0x1d => "SafeArray",
+            0x1f => "SysInt",
+            0x20 => "SysUInt",
+            0x23 => "AnsiBStr",
+            0x24 => "TBStr",
+            0x25 => "VariantBool",
+            0x26 => "FunctionPtr",
+            0x28 => "AsAny",
+            0x2a => "LPArray",
+            0x2b => "LPStruct",
+            0x2d => "Error",
+            0x2e => "IInspectable",
+            0x2f => "HString",
+            0x30 => "LPUTF8Str",
+            _ => null,
+        };
 
     /// <summary>
     /// Renders the attributes on a method, resolved by the same name + public-only

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -389,9 +389,12 @@ public static class AttributeReader
         if (blob.RemainingBytes > 0)
         {
             var elementType = blob.ReadByte();
-            if (UnmanagedTypeName(elementType) is not { } elementUnmanagedType)
-                return null;
-            arguments.Add($"ArraySubType = System.Runtime.InteropServices.UnmanagedType.{elementUnmanagedType}");
+            if (elementType != 0x50)
+            {
+                if (UnmanagedTypeName(elementType) is not { } elementUnmanagedType)
+                    return null;
+                arguments.Add($"ArraySubType = System.Runtime.InteropServices.UnmanagedType.{elementUnmanagedType}");
+            }
         }
 
         if (blob.RemainingBytes > 0)
@@ -409,8 +412,7 @@ public static class AttributeReader
                     return null;
                 if (sizeParamSpecified)
                     arguments.Add($"SizeParamIndex = {sizeParamIndex}");
-                if (sizeConst != 0)
-                    arguments.Add($"SizeConst = {sizeConst}");
+                arguments.Add($"SizeConst = {sizeConst}");
             }
         }
 
@@ -641,6 +643,7 @@ public static class AttributeReader
     static bool IsParameterSyntaxAttribute(string name) => name switch
     {
         "System.ParamArrayAttribute" => true,
+        "System.Runtime.InteropServices.MarshalAsAttribute" => true,
         KnownAttributeNames.ParamCollectionAttribute => true,
         KnownAttributeNames.DecimalConstantAttribute => true,
         KnownAttributeNames.DateTimeConstantAttribute => true,

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -255,6 +255,15 @@ public class ApiSurfaceExtractorTests
         Assert.Contains(
             "[System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)] int[] fixedValues",
             declaration);
+        Assert.Contains(
+            "[System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray)] int[] plainValues",
+            declaration);
+        Assert.Contains(
+            "[System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 4)] int[] fixedPlainValues",
+            declaration);
+        Assert.Contains(
+            "[System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 0)] int[] zeroSizedValues",
+            declaration);
     }
 
     [Fact]
@@ -754,6 +763,9 @@ public class SampleClassForTesting
         [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPStr)] string text,
         [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeParamIndex = 2)] int[] values,
         [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)] int[] fixedValues,
+        [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray)] int[] plainValues,
+        [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 4)] int[] fixedPlainValues,
+        [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 0)] int[] zeroSizedValues,
         int count) { }
 }
 

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -228,6 +228,36 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_RendersMarshalAsParameterAttributes()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleClassForTesting");
+        Assert.NotNull(testType);
+
+        var method = testType.Members.FirstOrDefault(m => m.Name == "MethodWithMarshalAs");
+        Assert.NotNull(method);
+        Assert.NotNull(method.SignatureModel);
+        var declaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, method);
+        Assert.Contains(
+            "[System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)] int value",
+            declaration);
+        Assert.Contains(
+            "[System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPStr)] string text",
+            declaration);
+        Assert.Contains(
+            "[System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeParamIndex = 2)] int[] values",
+            declaration);
+        Assert.Contains(
+            "[System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)] int[] fixedValues",
+            declaration);
+    }
+
+    [Fact]
     public void Extract_RendersEnumParameterDefaultsAsEnumLiterals()
     {
         var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
@@ -719,6 +749,12 @@ public class SampleClassForTesting
     public void MethodWithDateTimeConstantDefault(
         [System.Runtime.InteropServices.Optional, System.Runtime.CompilerServices.DateTimeConstant(637000000000000000L)] System.DateTime when) { }
     public void MethodWithStringDefault(string text = "a\"b\\c\n\u0001") { }
+    public void MethodWithMarshalAs(
+        [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)] int value,
+        [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPStr)] string text,
+        [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeParamIndex = 2)] int[] values,
+        [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)] int[] fixedValues,
+        int count) { }
 }
 
 public class SampleKeywordParameterHost

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -514,6 +514,18 @@ internal static class GeneratedFixtureCatalog
             public int FirstFour(
                 [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)] int[] values)
                 => values[0] + values[1] + values[2] + values[3];
+
+            public int PlainArray(
+                [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray)] int[] values)
+                => values.Length;
+
+            public int FixedArray(
+                [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 4)] int[] values)
+                => values[0] + values[1] + values[2] + values[3];
+
+            public int ZeroSizedArray(
+                [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 0)] int[] values)
+                => values.Length;
         }
         """,
         [
@@ -548,6 +560,24 @@ internal static class GeneratedFixtureCatalog
                 ExpectedSourceFragments:
                 [
                     "System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)",
+                ]),
+            new("GeneratedFixtures.MinimalParameterMarshalling.Class1", "PlainArray",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray)",
+                ]),
+            new("GeneratedFixtures.MinimalParameterMarshalling.Class1", "FixedArray",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 4)",
+                ]),
+            new("GeneratedFixtures.MinimalParameterMarshalling.Class1", "ZeroSizedArray",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, SizeConst = 0)",
                 ]),
         ],
         ["minimal", "parameters", "marshalling"]);

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -485,6 +485,73 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "parameters", "attributes"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalParameterMarshalling = new(
+        "minimal.parameter-marshalling",
+        """
+        namespace GeneratedFixtures.MinimalParameterMarshalling;
+
+        public class Class1
+        {
+            public int I4([System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)] int value)
+                => value;
+
+            public int LpStr([System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPStr)] string value)
+                => value.Length;
+
+            public int Bool([System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)] bool value)
+                => value ? 1 : 0;
+
+            public int Sum(
+                [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeParamIndex = 1)] int[] values,
+                int count)
+            {
+                var sum = 0;
+                for (var i = 0; i < count; i++)
+                    sum += values[i];
+                return sum;
+            }
+
+            public int FirstFour(
+                [System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)] int[] values)
+                => values[0] + values[1] + values[2] + values[3];
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalParameterMarshalling.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalParameterMarshalling.Class1", "I4",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)",
+                ]),
+            new("GeneratedFixtures.MinimalParameterMarshalling.Class1", "LpStr",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPStr)",
+                ]),
+            new("GeneratedFixtures.MinimalParameterMarshalling.Class1", "Bool",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)",
+                ]),
+            new("GeneratedFixtures.MinimalParameterMarshalling.Class1", "Sum",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeParamIndex = 1)",
+                ]),
+            new("GeneratedFixtures.MinimalParameterMarshalling.Class1", "FirstFour",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.LPArray, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I4, SizeConst = 4)",
+                ]),
+        ],
+        ["minimal", "parameters", "marshalling"]);
+
     public static readonly GeneratedFixtureDefinition MinimalIfElse = new(
         "minimal.if-else",
         """
@@ -984,6 +1051,7 @@ internal static class GeneratedFixtureCatalog
         MinimalParameterModifiers,
         MinimalDefaultParameters,
         MinimalParameterAttributes,
+        MinimalParameterMarshalling,
         MinimalIfElse,
         MinimalIntegerAddition,
         MinimalStructMembers,
@@ -1043,7 +1111,8 @@ internal sealed record GeneratedFixtureTarget(
     bool IsFrontier = false,
     string? Note = null,
     SyntaxKind? ExpectedShape = null,
-    SyntaxKind? FrontierShape = null)
+    SyntaxKind? FrontierShape = null,
+    IReadOnlyList<string>? ExpectedSourceFragments = null)
 {
     public string DisplayMember => $"{Type}::{Method}#{Overload}";
 }
@@ -1210,9 +1279,11 @@ internal static class GeneratedFixtureRunner
                         continue;
                     }
 
+                    var missingSourceFragment = MissingSourceFragment(actual.Source, target.ExpectedSourceFragments);
                     var status = actual.Status == FidelityCheck.CompileBackStatus.Exact
-                        ? GeneratedFixtureReturnToSenderStatus.Pass
-                        : GeneratedFixtureReturnToSenderStatus.Fail;
+                        && missingSourceFragment is null
+                            ? GeneratedFixtureReturnToSenderStatus.Pass
+                            : GeneratedFixtureReturnToSenderStatus.Fail;
                     results.Add(new GeneratedFixtureReturnToSenderResult(
                         fixture.Id,
                         target.Type,
@@ -1220,8 +1291,14 @@ internal static class GeneratedFixtureRunner
                         target.Overload,
                         status,
                         actual.Status,
-                        status == GeneratedFixtureReturnToSenderStatus.Pass ? "exact" : FailureReason(actual),
-                        actual.Detail,
+                        status == GeneratedFixtureReturnToSenderStatus.Pass
+                            ? "exact"
+                            : missingSourceFragment is not null
+                                ? "source-fragment-missing"
+                                : FailureReason(actual),
+                        missingSourceFragment is null
+                            ? actual.Detail
+                            : $"missing expected source fragment: {missingSourceFragment}",
                         target.IsFrontier,
                         target.Note));
                 }
@@ -1229,6 +1306,20 @@ internal static class GeneratedFixtureRunner
 
             return new GeneratedFixtureReturnToSenderRunResult(root, assemblyPath, results);
         });
+    }
+
+    static string? MissingSourceFragment(string source, IReadOnlyList<string>? expectedSourceFragments)
+    {
+        if (expectedSourceFragments is not { Count: > 0 })
+            return null;
+
+        foreach (var expected in expectedSourceFragments)
+        {
+            if (!source.Contains(expected, StringComparison.Ordinal))
+                return expected;
+        }
+
+        return null;
     }
 
     static GeneratedFixtureReturnToSenderResult Skipped(GeneratedFixtureDefinition fixture, GeneratedFixtureTarget target, string reason)


### PR DESCRIPTION
- Advances #2057
- Changes product parameter declaration rendering for faithfully spellable `MarshalAs` field-marshalling metadata and expands RTS generated-fixture coverage.
- Evidence revision: `e948f907`

## Change

**Conclusion:** **PASS** — `MarshalAs` field-marshalling metadata now flows through the product declaration path into source-aware RTS compile-back checks.

Before:

```text
minimal.parameter-marshalling source-aware RTS catalog failed 7 targets with source-fragment-missing on origin/main + tests-only.
API surface MarshalAs parameter declaration test failed: rendered declaration omitted MarshalAs attributes.
```

After:

```text
minimal.parameter-marshalling passes 1/1 fixture and 9/9 targets.
API surface MarshalAs parameter declaration test passes.
```

## Scope and safety

- **Root cause:** `RenderParameterAttributes` read custom attributes only; `[MarshalAs]` is stored in the FieldMarshal table, so the structured parameter declaration model could not preserve it.
- **Fix shape:** product-side SRM decoding of faithfully spellable parameter FieldMarshal descriptors into `MarshalAs(...)` source attributes.
- **Product impact:** parameter declaration rendering now preserves simple `MarshalAs` forms (`I4`, `LPStr`, `Bool`) and `LPArray` forms (`ArraySubType`, `SizeParamIndex`, `SizeConst`, omitted subtype, explicit `SizeConst = 0`). Unsupported/malformed descriptors are skipped rather than rendered wrong.
- **Scope boundary:** complex marshalling shapes such as SafeArray/custom marshaller payloads are intentionally not claimed in this slice.
- **RTS boundary:** RTS remains orchestration-only; product/shared code owns C# source generation. Harness changes are fixture source and optional source-fragment expectations.

## Before/after small corpus

Before run: `origin/main` plus the new tests/fixtures only.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 1 fixture(s), 8 target(s)

Fixtures:
  Passed : 0
  Skipped: 0
  Failed : 1

Targets:
  Passed : 1
  Skipped: 0
  Failed : 7

Failed target buckets:
  source-fragment-missing: 7
```

After run: branch head `e948f907`.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 1 fixture(s), 9 target(s)

Fixtures:
  Passed : 1
  Skipped: 0
  Failed : 0

Targets:
  Passed : 9
  Skipped: 0
  Failed : 0
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| API surface tests | `ApiSurfaceExtractorTests` 36/36 |
| Focused decompiler tests | `GeneratedFixtureCatalogTests` 8/8; `ReturnToSenderPrototypeTests` 41/41 |
| Decompiler fast suite | Pass, 1803/1803 |
| Default RTS catalog | `35/35` fixtures, `101/101` targets |
| ReturnToSender A/B | `235` Same, `0` Worse, `0` CurrentMissing |

## Compile-back quality

**Conclusion:** **PASS** — opcode-only fidelity was already Exact, so this PR adds source-aware fixture checks for metadata that does not affect method opcodes.

### ReturnToSender catalog

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 35 fixture(s), 101 target(s)

Fixtures:
  Passed : 35
  Skipped: 0
  Failed : 0

Targets:
  Passed : 101
  Skipped: 0
  Failed : 0
```

Minimal selector, including known explicit frontiers:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 37 fixture(s), 105 target(s)

Fixtures:
  Passed : 36
  Skipped: 0
  Failed : 1

Targets:
  Passed : 104
  Skipped: 0
  Failed : 1

Failed target buckets:
  opcode-diff: 1

Failed fixtures (first 1 of 1):
  minimal.switch-two-case-lowers-if
      GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1::Method1#0  rts=OpcodeDiff  bucket=opcode-diff
```

### ReturnToSender A/B

```text
RETURNTOSENDER A/B over 235 property getters

  Rescued       : 0
  Same          : 235
  Changed       : 0
  Worse         : 0
  CurrentMissing: 0
```

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `minimal.switch-two-case-lowers-if` | Left as frontier | Known compiler/source-lowering opcode-diff frontier, unrelated to parameter marshalling. |
| Complex marshalling descriptors | Not changed | This slice only renders source-spellable forms proven by the small corpus; unsupported shapes are skipped safely. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No significant issues | Final review on `e948f907` empirically decoded real Roslyn FieldMarshal blobs, including omitted subtype and `SizeConst = 0`. |
| Gemini 3.1 Pro | Findings resolved, final clean | Found omitted LPArray subtype `0x50` and explicit `SizeConst = 0`; fixed in `6fa0a86d` with canaries. Final review on `e948f907` found no significant issues. |

**Review conclusion:** **PASS** — actionable Gemini findings were resolved in `6fa0a86d`; final isolated Gemini and Claude follow-up reviews on `e948f907` found no significant issues.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -class "*ApiSurfaceExtractorTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --return-to-sender-catalog --max-examples 50
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --return-to-sender-catalog minimal --max-examples 50
```

