### PR TITLE
Consolidate package reference parsing

### DIFF
--- a/src/DotnetInspector.Packages/PackageExtractor.cs
+++ b/src/DotnetInspector.Packages/PackageExtractor.cs
@@ -40,6 +40,12 @@ public readonly record struct PackageExtractionOutcome(
     public static PackageExtractionOutcome Error(string message) => new(null, message);
 }
 
+public sealed record PackageReferenceTarget(
+    string OriginalArgument,
+    bool IsLocalFile,
+    string PackageName,
+    string Version);
+
 /// <summary>
 /// Shared utility for extracting NuGet packages from local files or NuGet feeds.
 /// </summary>
@@ -497,6 +503,35 @@ public static class PackageExtractor
         }
 
         return (packageSource, null);
+    }
+
+    public static PackageReferenceTarget ParsePackageTarget(string packageArg, string? explicitVersion = null)
+    {
+        bool isLocalFile = packageArg.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);
+        if (isLocalFile)
+        {
+            return new PackageReferenceTarget(
+                packageArg,
+                IsLocalFile: true,
+                Path.GetFileNameWithoutExtension(packageArg),
+                Version: "local");
+        }
+
+        var (name, parsedVersion) = ParsePackageReference(packageArg);
+        string version = explicitVersion ?? parsedVersion ?? "";
+        return new PackageReferenceTarget(
+            packageArg,
+            IsLocalFile: false,
+            name.ToLowerInvariant(),
+            version.ToLowerInvariant());
+    }
+
+    public static bool IsValidPackageReferenceVersion(string? version)
+    {
+        return string.IsNullOrEmpty(version)
+            || string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase)
+            || version.Contains('*', StringComparison.Ordinal)
+            || NuGet.Versioning.NuGetVersion.TryParse(version, out _);
     }
 
     private static readonly TimeSpan VersionCacheTtl = TimeSpan.FromHours(1);

--- a/src/DotnetInspector.Services.Tests/PackageResolverServiceTests.cs
+++ b/src/DotnetInspector.Services.Tests/PackageResolverServiceTests.cs
@@ -29,6 +29,58 @@ public class PackageExtractorTests
         Assert.Null(version);
     }
 
+    [Theory]
+    [InlineData("System.Text.Json", "system.text.json", "")]
+    [InlineData("System.Text.Json@8.0.5", "system.text.json", "8.0.5")]
+    [InlineData("Foo@11.0.0-PREVIEW*", "foo", "11.0.0-preview*")]
+    public void ParsePackageTarget_RemoteReference_NormalizesNameAndVersion(
+        string packageRef,
+        string expectedName,
+        string expectedVersion)
+    {
+        var target = PackageExtractor.ParsePackageTarget(packageRef);
+
+        Assert.False(target.IsLocalFile);
+        Assert.Equal(packageRef, target.OriginalArgument);
+        Assert.Equal(expectedName, target.PackageName);
+        Assert.Equal(expectedVersion, target.Version);
+    }
+
+    [Fact]
+    public void ParsePackageTarget_ExplicitVersion_OverridesEmbeddedVersion()
+    {
+        var target = PackageExtractor.ParsePackageTarget("System.Text.Json@8.0.0", explicitVersion: "9.0.0");
+
+        Assert.False(target.IsLocalFile);
+        Assert.Equal("system.text.json", target.PackageName);
+        Assert.Equal("9.0.0", target.Version);
+    }
+
+    [Fact]
+    public void ParsePackageTarget_LocalNupkg_UsesCliLocalTargetShape()
+    {
+        var target = PackageExtractor.ParsePackageTarget("/tmp/System.Text.Json.9.0.0.nupkg");
+
+        Assert.True(target.IsLocalFile);
+        Assert.Equal("/tmp/System.Text.Json.9.0.0.nupkg", target.OriginalArgument);
+        Assert.Equal("System.Text.Json.9.0.0", target.PackageName);
+        Assert.Equal("local", target.Version);
+    }
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData("latest", true)]
+    [InlineData("LATEST", true)]
+    [InlineData("1.0.0", true)]
+    [InlineData("13.0.3-beta1", true)]
+    [InlineData("11.0.0-preview*", true)]
+    [InlineData("not-a-version", false)]
+    public void IsValidPackageReferenceVersion_AllowsNuGetLatestAndWildcardVersions(string? version, bool expected)
+    {
+        Assert.Equal(expected, PackageExtractor.IsValidPackageReferenceVersion(version));
+    }
+
     [Fact]
     public async Task ExtractPackageAsync_LocalFile_DoesNotExist_ReturnsError()
     {

--- a/src/dotnet-inspect.Tests/PackageVersionTests.cs
+++ b/src/dotnet-inspect.Tests/PackageVersionTests.cs
@@ -97,6 +97,34 @@ public class PackageVersionTests
         Assert.Equal(routerOutput.Trim(), packageOutput.Trim());
     }
 
+    [Fact]
+    public async Task Package_InvalidPinnedVersion_ReturnsHelpfulError()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        var args = new[] { "package", "System.Text.Json@badversion" };
+
+        var (exit, _, error) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(root.Parse(args).InvokeAsync().Result));
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Error: 'badversion' is not a valid package version.", error);
+        Assert.Contains("To list available versions: dotnet-inspect package system.text.json --versions", error);
+    }
+
+    [Fact]
+    public async Task MultiPackage_InvalidPinnedVersion_ReturnsPerPackageHint()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        var args = new[] { "package", "System.Text.Json@badversion", "Newtonsoft.Json", "--table" };
+
+        var (exit, _, error) = await ConsoleCapture.RunAsync(
+            () => Task.FromResult(root.Parse(args).InvokeAsync().Result));
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Error: 'badversion' is not a valid package version.", error);
+        Assert.Contains("Use id@version for per-package version pins.", error);
+    }
+
     /// <summary>
     /// Downloads a package so it's in the NuGet cache for subsequent tests.
     /// </summary>

--- a/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using DotnetInspector.Commands;
 using DotnetInspector.Options;
+using DotnetInspector.Packages;
 using DotnetInspector.Services;
 
 namespace DotnetInspector.CommandLine;
@@ -122,8 +123,10 @@ public static class PackageCommandDefinitions
 
                     if (exitCode == 0 && success.Options.PackageArgs.Length > 0 && success.Options.PackageLibrary == null && !success.Options.AllLibraries && !success.Options.FormatExplicitlySet && !success.Options.IsRawOutput)
                     {
-                        var pkg = success.Options.PackageArgs[0];
-                        if (pkg.Contains('@')) pkg = pkg[..pkg.IndexOf('@')];
+                        var target = PackageExtractor.ParsePackageTarget(success.Options.PackageArgs[0]);
+                        var pkg = target.IsLocalFile
+                            ? target.OriginalArgument
+                            : PackageExtractor.ParsePackageReference(target.OriginalArgument).name;
                         TipWriter.WritePackageTips(pkg, success.Options.TipLevel, success.Verbosity);
                     }
 

--- a/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
+using DotnetInspector.Packages;
 using DotnetInspector.Services;
 using ILInspector.Metadata;
 
@@ -189,12 +190,9 @@ public static class SharedParsers
     /// <returns>Parsed package info with bare name, version, and flags.</returns>
     public static PackageVersionInfo ParsePackageVersion(string name)
     {
-        bool hasExplicitVersion = name.Contains('@');
-        if (!hasExplicitVersion)
-            return new(name, null, HasExplicitVersion: false, ForceLatest: false);
-
-        var bareName = name[..name.IndexOf('@')];
-        var explicitVersion = name[(name.IndexOf('@') + 1)..];
+        var (bareName, explicitVersion) = PackageExtractor.ParsePackageReference(name);
+        if (explicitVersion == null)
+            return new(bareName, null, HasExplicitVersion: false, ForceLatest: false);
 
         bool forceLatest = string.Equals(explicitVersion, "latest", StringComparison.OrdinalIgnoreCase);
         if (forceLatest)

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -232,34 +232,21 @@ public class PackageCommand
             return 0;
         }
 
-        // Check if first argument is a local file path
-        bool isLocalFile = packageArgs.Length >= 1 &&
-            packageArgs[0].EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);
-
         var client = context.HttpClient;
 
-        string packageName;
-        string version;
-
-        if (isLocalFile)
+        var target = PackageExtractor.ParsePackageTarget(packageArgs[0], explicitVersion);
+        string packageName = target.PackageName;
+        string version = target.Version;
+        if (target.IsLocalFile)
         {
-            string localPath = packageArgs[0];
-            if (!File.Exists(localPath))
+            if (!File.Exists(target.OriginalArgument))
             {
-                Console.Error.WriteLine($"Error: File not found: {localPath}");
+                Console.Error.WriteLine($"Error: File not found: {target.OriginalArgument}");
                 return 1;
             }
-
-            string fileName = Path.GetFileNameWithoutExtension(localPath);
-            packageName = fileName;
-            version = "local";
         }
         else
         {
-            var target = PackageExtractor.ParsePackageTarget(packageArgs[0], explicitVersion);
-            packageName = target.PackageName;
-            version = target.Version;
-
             if (explicitVersion != null)
                 logger.Log($"Using --version: {version}");
             else if (version.Length > 0)
@@ -286,10 +273,10 @@ public class PackageCommand
         {
             var outcome = await PackageExtractor.ExtractPackageAsync(
                 client,
-                isLocalFile ? packageArgs[0] : packageName,
+                target.IsLocalFile ? target.OriginalArgument : packageName,
                 logger.Log,
                 sourceOptions: options.SourceOptions,
-                version: isLocalFile ? null : (version.Length > 0 ? version : null),
+                version: target.IsLocalFile ? null : (version.Length > 0 ? version : null),
                 forceLatest: options.ForceLatest,
                 includePrerelease: options.IncludePrerelease);
 
@@ -354,8 +341,8 @@ public class PackageCommand
             {
                 return await ExecutePackageAllLibrariesAsync(
                     extractPath,
-                    isLocalFile,
-                    packageArgs[0],
+                    target.IsLocalFile,
+                    target.OriginalArgument,
                     packageName,
                     version,
                     options);
@@ -365,8 +352,8 @@ public class PackageCommand
             {
                 return await ExecutePackageLibraryAsync(
                     extractPath,
-                    isLocalFile,
-                    packageArgs[0],
+                    target.IsLocalFile,
+                    target.OriginalArgument,
                     packageName,
                     version,
                     options);
@@ -387,8 +374,8 @@ public class PackageCommand
                 : null;
 
             var result = await PackageInspector.InspectAsync(
-                extractPath, packageName, version, isLocalFile,
-                isLocalFile ? packageArgs[0] : null,
+                extractPath, packageName, version, target.IsLocalFile,
+                target.IsLocalFile ? target.OriginalArgument : null,
                 nuspec, client, logger, options.ForceLatest, options.Verbosity,
                 resolution.NupkgPath,
                 fetchMetadata: wantsSignals);
@@ -404,7 +391,7 @@ public class PackageCommand
                 result.SignatureResult = await SignatureVerifier.VerifyAsync(resolution.NupkgPath);
             }
 
-            result.Source = isLocalFile ? SourceKind.File : SourceKind.NuGet;
+            result.Source = target.IsLocalFile ? SourceKind.File : SourceKind.NuGet;
 
             PopulatePackageFileSections(result, extractPath, options);
             if (ShouldPopulatePackageSourceFiles(options))

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -256,36 +256,16 @@ public class PackageCommand
         }
         else
         {
-            // Support format: PackageName or PackageName@version
-            string packageArg = packageArgs[0];
-            int atIndex = packageArg.IndexOf('@');
+            var target = PackageExtractor.ParsePackageTarget(packageArgs[0], explicitVersion);
+            packageName = target.PackageName;
+            version = target.Version;
 
             if (explicitVersion != null)
-            {
-                packageName = atIndex > 0
-                    ? packageArg[..atIndex].ToLowerInvariant()
-                    : packageArg.ToLowerInvariant();
-                version = explicitVersion.ToLowerInvariant();
                 logger.Log($"Using --version: {version}");
-            }
-            else if (atIndex > 0)
-            {
-                packageName = packageArg[..atIndex].ToLowerInvariant();
-                version = packageArg[(atIndex + 1)..].ToLowerInvariant();
+            else if (version.Length > 0)
                 logger.Log($"Using specified version: {version}");
-            }
-            else
-            {
-                packageName = packageArg.ToLowerInvariant();
-                version = "";
-            }
 
-            // Validate version looks like a NuGet version (allow wildcard patterns like 11.0.0-preview*)
-            // "latest" is handled as a special tag by PackageExtractor
-            if (version.Length > 0
-                && !string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase)
-                && !version.Contains('*')
-                && !NuGet.Versioning.NuGetVersion.TryParse(version, out _))
+            if (!PackageExtractor.IsValidPackageReferenceVersion(version))
             {
                 string badVersion = packageArgs.Length >= 2 ? packageArgs[1] : version;
                 Console.Error.WriteLine($"Error: '{badVersion}' is not a valid package version.");
@@ -570,12 +550,6 @@ public class PackageCommand
         }
     }
 
-    private sealed record PackageTarget(
-        string OriginalArgument,
-        bool IsLocalFile,
-        string PackageName,
-        string Version);
-
     private static async Task<int> ExecuteMultiPackageAsync(
         string[] packageArgs,
         InspectionOptions options,
@@ -601,7 +575,7 @@ public class PackageCommand
             return 1;
         }
 
-        var targets = new List<PackageTarget>();
+        var targets = new List<PackageReferenceTarget>();
         foreach (var packageArg in packageArgs)
         {
             if (!TryCreatePackageTarget(packageArg, out var target))
@@ -1039,11 +1013,11 @@ public class PackageCommand
         return false;
     }
 
-    private static bool TryCreatePackageTarget(string packageArg, out PackageTarget target)
+    private static bool TryCreatePackageTarget(string packageArg, out PackageReferenceTarget target)
     {
         target = null!;
-        bool isLocalFile = packageArg.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);
-        if (isLocalFile)
+        var parsed = PackageExtractor.ParsePackageTarget(packageArg);
+        if (parsed.IsLocalFile)
         {
             if (!File.Exists(packageArg))
             {
@@ -1051,34 +1025,19 @@ public class PackageCommand
                 return false;
             }
 
-            target = new PackageTarget(
-                packageArg,
-                IsLocalFile: true,
-                Path.GetFileNameWithoutExtension(packageArg),
-                Version: "local");
+            target = parsed;
             return true;
         }
 
-        int atIndex = packageArg.IndexOf('@');
-        string packageName = atIndex > 0
-            ? packageArg[..atIndex].ToLowerInvariant()
-            : packageArg.ToLowerInvariant();
-        string version = atIndex > 0
-            ? packageArg[(atIndex + 1)..].ToLowerInvariant()
-            : "";
-
-        if (version.Length > 0
-            && !string.Equals(version, "latest", StringComparison.OrdinalIgnoreCase)
-            && !version.Contains('*')
-            && !NuGet.Versioning.NuGetVersion.TryParse(version, out _))
+        if (!PackageExtractor.IsValidPackageReferenceVersion(parsed.Version))
         {
-            Console.Error.WriteLine($"Error: '{version}' is not a valid package version.");
+            Console.Error.WriteLine($"Error: '{parsed.Version}' is not a valid package version.");
             Console.Error.WriteLine("Versions look like: 1.0.0, 8.0.5, 13.0.3-beta1, 11.0.0-preview*");
             Console.Error.WriteLine("Use id@version for per-package version pins.");
             return false;
         }
 
-        target = new PackageTarget(packageArg, IsLocalFile: false, packageName, version);
+        target = parsed;
         return true;
     }
 
@@ -1089,7 +1048,7 @@ public class PackageCommand
         InspectionOptions options,
         CommandContext context)
     {
-        var targets = new List<PackageTarget>();
+        var targets = new List<PackageReferenceTarget>();
         foreach (var packageArg in packageArgs)
         {
             if (!TryCreatePackageTarget(packageArg, out var target))
@@ -1110,7 +1069,7 @@ public class PackageCommand
     }
 
     private static async Task<PackageFileContentSet?> ReadPackageFileContentsAsync(
-        PackageTarget target,
+        PackageReferenceTarget target,
         InspectionOptions options,
         CommandContext context)
     {
@@ -1164,7 +1123,7 @@ public class PackageCommand
     }
 
     private static async Task<InspectionResult?> InspectPackageAsync(
-        PackageTarget target,
+        PackageReferenceTarget target,
         InspectionOptions options,
         CommandContext context,
         bool wantsFilesSection)

--- a/src/dotnet-inspect/Services/SourceResolver.cs
+++ b/src/dotnet-inspect/Services/SourceResolver.cs
@@ -318,8 +318,7 @@ public static class SourceResolver
             }
             else if (packagePath != null)
             {
-                var bareName = packagePath.Contains('@') ? packagePath[..packagePath.IndexOf('@')] : packagePath;
-                var explicitVersion = packagePath.Contains('@') ? packagePath[(packagePath.IndexOf('@') + 1)..] : null;
+                var (bareName, explicitVersion) = PackageExtractor.ParsePackageReference(packagePath);
 
                 // Try platform resolution for whole name (can go remote for platform candidates)
                 if (PlatformResolver.IsPlatformCandidate(bareName))


### PR DESCRIPTION
## Summary

- Adds shared `PackageExtractor.ParsePackageTarget(...)` and `IsValidPackageReferenceVersion(...)` helpers.
- Routes single-package, multi-package, and multi-content package target parsing through the shared package helper.
- Adds coverage for normal package refs, explicit-version override, local `.nupkg`, `@latest`, wildcard versions, invalid versions, and no-network CLI invalid-version diagnostics.

Refs #2122.

## Validation

- `dotnet run --project src/DotnetInspector.Services.Tests -c Release -p:RestoreConfigFile=nuget.config -- -class "*PackageExtractorTests*"`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:RestoreConfigFile=nuget.config -- -method "*InvalidPinnedVersion*"`
- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config`

## Review

Adversarial review required because this centralizes package target parsing and version validation across single and multi-package flows. Results will be posted as a PR comment.