### PR TITLE
Add MethodBodyInspectionSession; converge member + il-offset semantic facts (#2139)

### DIFF
--- a/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
+++ b/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using DotnetInspector.Inspectors;
+using Analysis = ILInspector.Analysis;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Tests for <see cref="MethodBodyInspectionSession"/>: the method-body composition layer that
+/// projects method/coordinate-scoped semantic facts over one shared analysis index. See
+/// <c>docs/design/method-body-inspection.md</c>.
+/// </summary>
+public class MethodBodyInspectionSessionTests
+{
+    static string SelfPath => typeof(MethodBodyInspectionSession).Assembly.Location;
+
+    static int AllocatingToken(Analysis.LibraryBodyIndex index)
+        => index.GetAllocationOccurrences().First(kv => kv.Value.Length > 0).Key;
+
+    [Fact]
+    public void AllocationFacts_MatchDirectProjection_ForAllocatingMethod()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var token = AllocatingToken(index);
+
+        var expected = Analysis.SemanticFactProjection.AllocationFacts(index.GetAllocationOccurrences(), token);
+        var actual = MethodBodyInspectionSession.Open(SelfPath).AllocationFacts(token);
+
+        Assert.NotEmpty(actual);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void AllocationFacts_UnknownToken_ReturnsEmpty()
+        => Assert.Empty(MethodBodyInspectionSession.Open(SelfPath).AllocationFacts(methodToken: 0));
+
+    [Fact]
+    public void AllocationFacts_CoordinateScoped_FiltersToOffset()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var pair = index.GetAllocationOccurrences().First(kv => kv.Value.Length > 0);
+        var offset = pair.Value[0].ILOffset;
+
+        var atOffset = MethodBodyInspectionSession.Open(SelfPath).AllocationFacts(pair.Key, offset);
+
+        Assert.NotEmpty(atOffset);
+        Assert.All(atOffset, fact => Assert.Equal(offset, fact.ILOffset));
+    }
+
+    [Fact]
+    public void OneSession_ProducesAllThreeFactKinds_OverSharedIndex()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var token = AllocatingToken(index);
+        var session = MethodBodyInspectionSession.Open(SelfPath);
+
+        Assert.NotEmpty(session.AllocationFacts(token)); // token chosen for allocations
+        _ = session.SafetyFacts(token).ToList();          // must not throw
+        _ = session.CostFacts(token).ToList();            // must not throw
+    }
+}

--- a/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
+++ b/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
@@ -268,9 +268,8 @@ internal static class ILOffsetSourceQuery
     {
         try
         {
-            var index = Analysis.LibraryBodyIndex.Open(assemblyPath);
-            var facts = Analysis.SemanticFactProjection
-                .AllocationFacts(index.GetAllocationOccurrences(), methodToken, ilOffset)
+            var facts = MethodBodyInspectionSession.Open(assemblyPath)
+                .AllocationFacts(methodToken, ilOffset)
                 .Select(ToILOffsetAllocationContext)
                 .ToList();
             if (facts.Count > 0)

--- a/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
+++ b/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
@@ -1,0 +1,44 @@
+using System.Collections.Immutable;
+using ILInspector.Metadata;
+using Analysis = ILInspector.Analysis;
+
+namespace DotnetInspector.Inspectors;
+
+/// <summary>
+/// Method-body inspection composition layer (see <c>docs/design/method-body-inspection.md</c>):
+/// opens a <see cref="Analysis.LibraryBodyIndex"/> once and produces method- or coordinate-scoped
+/// semantic facts, so the <c>member</c> and <c>library --il-offset</c> paths converge on one
+/// producer instead of each re-opening the index and re-projecting facts.
+///
+/// This sits above <c>ILInspector.Analysis</c> (and, in later slices, Metadata / Decompiler /
+/// Research); it is deliberately not part of the lower-level <c>DotnetInspector.Services</c>
+/// package layer. Early slices open from a <c>dllPath</c>; the target is to consume an
+/// <see cref="AssemblyInspectionSession"/> / <see cref="ResolvedAssemblyReference"/> once the
+/// shared-PE-owner composition lands.
+/// </summary>
+public sealed class MethodBodyInspectionSession
+{
+    readonly Analysis.LibraryBodyIndex _index;
+
+    MethodBodyInspectionSession(Analysis.LibraryBodyIndex index) => _index = index;
+
+    /// <summary>Opens a session over an assembly's analysis body index.</summary>
+    public static MethodBodyInspectionSession Open(string assemblyPath, IAssemblyReferenceResolver? resolver = null)
+        => new(Analysis.LibraryBodyIndex.Open(assemblyPath, resolver));
+
+    /// <summary>
+    /// Allocation facts for one method (<paramref name="methodToken"/>), optionally narrowed to a
+    /// single IL coordinate (<paramref name="ilOffset"/>).
+    /// </summary>
+    public ImmutableArray<Analysis.AllocationFact> AllocationFacts(int methodToken, int? ilOffset = null)
+        => Analysis.SemanticFactProjection.AllocationFacts(_index.GetAllocationOccurrences(), methodToken, ilOffset);
+
+    /// <summary>Safety facts for one method, optionally narrowed to a single IL coordinate.</summary>
+    public ImmutableArray<Analysis.SafetyFact> SafetyFacts(int methodToken, int? ilOffset = null)
+        => Analysis.SemanticFactProjection.SafetyFacts(
+            _index.GetUnsafeEvidenceByMember(), _index.GetUnsafetyOccurrences(), methodToken, ilOffset);
+
+    /// <summary>Cost facts for one method, optionally narrowed to a single IL coordinate.</summary>
+    public ImmutableArray<Analysis.CostFact> CostFacts(int methodToken, int? ilOffset = null)
+        => Analysis.SemanticFactProjection.CostFacts(_index.GetDirectCallsByCaller(), methodToken, ilOffset);
+}

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1339,11 +1339,11 @@ public static class ApiOutputFormatter
         if (requestedSections.Overlaps(SemanticFactSections) && singleMethodList is [{ MetadataToken: { } semanticToken } semanticMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.semantic-facts", semanticMethod.Name);
-            var index = Analysis.LibraryBodyIndex.Open(dllPath, assemblyResolver);
+            var bodySession = MethodBodyInspectionSession.Open(dllPath, assemblyResolver);
 
             if (requestedSections.Contains(SectionNames.AllocationFacts))
             {
-                var rows = Analysis.SemanticFactProjection.AllocationFacts(index.GetAllocationOccurrences(), semanticToken)
+                var rows = bodySession.AllocationFacts(semanticToken)
                     .Select(fact => ToAllocationFactRow(fact, includeMember: false))
                     .ToList();
                 if (rows.Count > 0 || ExplicitlySelected(SectionNames.AllocationFacts))
@@ -1355,7 +1355,7 @@ public static class ApiOutputFormatter
 
             if (requestedSections.Contains(SectionNames.SafetyFacts))
             {
-                var rows = Analysis.SemanticFactProjection.SafetyFacts(index.GetUnsafeEvidenceByMember(), index.GetUnsafetyOccurrences(), semanticToken)
+                var rows = bodySession.SafetyFacts(semanticToken)
                     .Select(fact => ToSafetyFactRow(fact, includeMember: false))
                     .ToList();
                 if (rows.Count > 0 || ExplicitlySelected(SectionNames.SafetyFacts))
@@ -1367,7 +1367,7 @@ public static class ApiOutputFormatter
 
             if (requestedSections.Contains(SectionNames.CostFacts))
             {
-                var rows = Analysis.SemanticFactProjection.CostFacts(index.GetDirectCallsByCaller(), semanticToken)
+                var rows = bodySession.CostFacts(semanticToken)
                     .Select(fact => ToCostFactRow(fact, includeMember: false))
                     .ToList();
                 if (rows.Count > 0 || ExplicitlySelected(SectionNames.CostFacts))


### PR DESCRIPTION
## Summary

First implementation slice of the method-body inspection design
([`docs/design/method-body-inspection.md`](https://github.com/richlander/dotnet-inspect/blob/main/docs/design/method-body-inspection.md), #2139).

Introduce **`MethodBodyInspectionSession`** — the composition layer that opens a
`LibraryBodyIndex` once and projects method/coordinate-scoped semantic facts
(`AllocationFacts` / `SafetyFacts` / `CostFacts`, with an optional `ilOffset`) via
`SemanticFactProjection`.

## Convergence

The two paths that previously each opened the index and projected facts inline now share one
producer:

- **`member`** — `ApiOutputFormatter`'s semantic-facts block (Allocation/Safety/Cost at a method
  token) uses one `MethodBodyInspectionSession` instead of `LibraryBodyIndex.Open` + inline
  `SemanticFactProjection`.
- **`library --il-offset`** — `ILOffsetSourceQuery.BuildAllocationContext` uses
  `session.AllocationFacts(token, offset)` (the instruction-heuristic fallback is unchanged).

This is the convergence the design calls for, on the semantic-fact facets. (`member` still has
other `LibraryBodyIndex` opens — scope/caller-graph — that convert in follow-up slices, along
with the metadata-coordinate facts.)

## Layering

Per the doc, this composition layer sits **above** `ILInspector.Analysis` and is **not** in
`DotnetInspector.Services`. It opens from a `dllPath` for now; consuming an
`AssemblyInspectionSession` / shared owner is a later slice (blocked on the pending shared-PE-owner
composition).

## Behavior preservation

The session is a thin projection over the same `SemanticFactProjection` calls. A
session-equivalence test asserts `session.AllocationFacts(...)` equals the direct projection;
existing member semantic-facts / section-pipeline / output-formatter tests stay green.

## Validation

- `dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507` — 0 warnings.
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -class DotnetInspector.Tests.MethodBodyInspectionSessionTests` — 4/4 (equivalence, coordinate-scoping, unknown-token, all-three-over-one-index).
- `... -class DotnetInspector.Tests.SemanticFactsSectionTests -class DotnetInspector.Tests.SectionPipelineTests -class DotnetInspector.Tests.ILOffsetParserTests` — green.

## Adversarial review

New composition-layer type + two converted producers; requesting two-reviewer adversarial review
per `AGENTS.md`.

Part of #2122 / #2139.
