### PR TITLE
Route call-graph/caller-graph through MethodBodyInspectionSession (#2139)

### DIFF
--- a/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
+++ b/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
@@ -57,4 +57,29 @@ public class MethodBodyInspectionSessionTests
         _ = session.SafetyFacts(token).ToList();          // must not throw
         _ = session.CostFacts(token).ToList();            // must not throw
     }
+
+    static int CallingToken(Analysis.LibraryBodyIndex index)
+        => index.GetDirectCallsByCaller().First(kv => kv.Value.Length > 0).Key;
+
+    [Fact]
+    public void CallTree_MatchesDirectBuild_ForCallingMethod()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var token = CallingToken(index);
+
+        var expected = index.BuildCallTree(token);
+        var actual = MethodBodyInspectionSession.Open(SelfPath).CallTree(token);
+
+        Assert.NotEmpty(actual.Children);
+        Assert.Equal(expected.Children.Count(), actual.Children.Count());
+    }
+
+    [Fact]
+    public void CallerTree_NoScope_ReturnsRoot()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var token = CallingToken(index);
+
+        Assert.NotNull(MethodBodyInspectionSession.Open(SelfPath).CallerTree(token));
+    }
 }

--- a/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
+++ b/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
@@ -41,4 +41,17 @@ public sealed class MethodBodyInspectionSession
     /// <summary>Cost facts for one method, optionally narrowed to a single IL coordinate.</summary>
     public ImmutableArray<Analysis.CostFact> CostFacts(int methodToken, int? ilOffset = null)
         => Analysis.SemanticFactProjection.CostFacts(_index.GetDirectCallsByCaller(), methodToken, ilOffset);
+
+    /// <summary>Outbound call graph rooted at one method.</summary>
+    public Analysis.CallTreeNode CallTree(int methodToken)
+        => _index.BuildCallTree(methodToken);
+
+    /// <summary>
+    /// Inbound caller graph rooted at one method. When <paramref name="scopeIndexes"/> is
+    /// non-empty the reverse graph is extended across those caller-scope assemblies.
+    /// </summary>
+    public Analysis.CallTreeNode CallerTree(int methodToken, IReadOnlyList<Analysis.LibraryBodyIndex>? scopeIndexes = null)
+        => scopeIndexes is { Count: > 0 }
+            ? _index.BuildCallerTree(methodToken, scopeIndexes)
+            : _index.BuildCallerTree(methodToken);
 }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1247,8 +1247,9 @@ public static class ApiOutputFormatter
         if (request.CallGraph && singleMethodList is [{ MetadataToken: { } graphToken } graphMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.call-graph", graphMethod.Name);
-            var index = Analysis.LibraryBodyIndex.Open(dllPath, assemblyResolver);
-            var root = ToCallGraphNode(index.BuildCallTree(graphToken), GetRequestedCallGraphFields(options));
+            var root = ToCallGraphNode(
+                MethodBodyInspectionSession.Open(dllPath, assemblyResolver).CallTree(graphToken),
+                GetRequestedCallGraphFields(options));
             if (root.Children is { Count: > 0 })
             {
                 memberCode.CallGraphNodes = [root];
@@ -1265,7 +1266,7 @@ public static class ApiOutputFormatter
         if (requestedSections.Contains(SectionNames.CallerGraph) && singleMethodList is [{ MetadataToken: { } callerGraphToken } callerGraphMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.caller-graph", callerGraphMethod.Name);
-            var index = Analysis.LibraryBodyIndex.Open(dllPath, assemblyResolver);
+            var callerSession = MethodBodyInspectionSession.Open(dllPath, assemblyResolver);
             // Extend the reverse graph across the caller scope (--bin/--project/--caller-package)
             // so a dependency member surfaces the product entry points and callers that reach it.
             var scopeIndexes = new List<Analysis.LibraryBodyIndex>();
@@ -1283,9 +1284,7 @@ public static class ApiOutputFormatter
                     }
                 }
             }
-            var callerTree = scopeIndexes.Count > 0
-                ? index.BuildCallerTree(callerGraphToken, scopeIndexes)
-                : index.BuildCallerTree(callerGraphToken);
+            var callerTree = callerSession.CallerTree(callerGraphToken, scopeIndexes);
             var root = ToCallGraphNode(callerTree, GetRequestedCallGraphFields(options));
             if (root.Children is { Count: > 0 } || ExplicitlySelected(SectionNames.CallerGraph))
             {


### PR DESCRIPTION
## Summary

Slice of the #2139 method-body seam: routes the call-graph and caller-graph
rendering through `MethodBodyInspectionSession` instead of opening a raw
`LibraryBodyIndex` in `ApiOutputFormatter`.

- Adds two facets to `MethodBodyInspectionSession`:
  - `CallTree(int methodToken)` → outbound call graph.
  - `CallerTree(int methodToken, IReadOnlyList<LibraryBodyIndex>? scopeIndexes)`
    → inbound caller graph, extended across caller-scope assemblies when scopes
    are supplied.
- Converts the two `ApiOutputFormatter` graph sites (call graph ~L1250, caller
  graph ~L1268) to consume the session.

Behavior-preserving: default `maxDepth=3`/`maxNodes=25` and the
`--bin`/`--project`/`--caller-package` caller-scope extension are unchanged.

## Validation

- `dotnet build src/dotnet-inspect -c Release` — clean (0 warnings).
- `MethodBodyInspectionSessionTests` — 6/6 pass (incl. new
  `CallTree_MatchesDirectBuild_ForCallingMethod`, `CallerTree_NoScope_ReturnsRoot`).
- `MemberCallGraphSectionTests` + `MemberCallersSectionTests` — 20/20 pass.
- CLI smoke: `member <dll> <member> -S "Call Graph"` renders the graph with
  fanout/fanin/depth annotations identical to before.

Part of #2139 / #2122 (thinning the CLI's raw PE/index opens).
