### PR TITLE
Route member Calls/Unsafe Operations through MethodBodyInspectionSession (#2139)

### DIFF
--- a/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
+++ b/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
@@ -82,4 +82,44 @@ public class MethodBodyInspectionSessionTests
 
         Assert.NotNull(MethodBodyInspectionSession.Open(SelfPath).CallerTree(token));
     }
+
+    [Fact]
+    public void DirectCalls_MatchesCallerFilter_ForCallingMethod()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var token = CallingToken(index);
+
+        var expected = index.DirectCalls.Where(call => call.Caller.MetadataToken == token).ToList();
+        var actual = MethodBodyInspectionSession.Open(SelfPath).DirectCalls(token);
+
+        Assert.NotEmpty(actual);
+        Assert.Equal(expected.Count, actual.Length);
+        Assert.Equal(
+            expected.Select(call => (call.Caller.MetadataToken, call.ILOffset)).OrderBy(x => x.ILOffset),
+            actual.Select(call => (call.Caller.MetadataToken, call.ILOffset)).OrderBy(x => x.ILOffset));
+    }
+
+    [Fact]
+    public void DirectCalls_UnknownToken_ReturnsEmpty()
+        => Assert.Empty(MethodBodyInspectionSession.Open(SelfPath).DirectCalls(methodToken: 0));
+
+    [Fact]
+    public void UnsafeEvidence_MatchesMemberFilter()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var grouped = index.GetUnsafeEvidenceByMember();
+        if (grouped.Count == 0)
+            return; // no unsafe evidence in this assembly; nothing to assert
+
+        var token = grouped.First(kv => kv.Value.Length > 0).Key;
+        var expected = index.UnsafeEvidence.Where(e => e.Member.MetadataToken == token).ToList();
+        var actual = MethodBodyInspectionSession.Open(SelfPath).UnsafeEvidence(token);
+
+        Assert.NotEmpty(actual);
+        Assert.Equal(expected.Count, actual.Length);
+    }
+
+    [Fact]
+    public void UnsafeEvidence_UnknownToken_ReturnsEmpty()
+        => Assert.Empty(MethodBodyInspectionSession.Open(SelfPath).UnsafeEvidence(methodToken: 0));
 }

--- a/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
+++ b/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
@@ -42,6 +42,26 @@ public sealed class MethodBodyInspectionSession
     public ImmutableArray<Analysis.CostFact> CostFacts(int methodToken, int? ilOffset = null)
         => Analysis.SemanticFactProjection.CostFacts(_index.GetDirectCallsByCaller(), methodToken, ilOffset);
 
+    /// <summary>
+    /// Direct call sites originating in one method (<paramref name="methodToken"/>). Empty when the
+    /// method has no recorded calls. Grouped by caller token, equivalent to filtering the flat
+    /// <c>DirectCalls</c> stream on <c>Caller.MetadataToken == methodToken</c>.
+    /// </summary>
+    public ImmutableArray<Analysis.DirectCall> DirectCalls(int methodToken)
+        => _index.GetDirectCallsByCaller().TryGetValue(methodToken, out var calls)
+            ? calls
+            : ImmutableArray<Analysis.DirectCall>.Empty;
+
+    /// <summary>
+    /// Unsafe-operation evidence recorded for one method (<paramref name="methodToken"/>). Empty when
+    /// the method has no evidence. Grouped by member token, equivalent to filtering the flat
+    /// <c>UnsafeEvidence</c> stream on <c>Member.MetadataToken == methodToken</c>.
+    /// </summary>
+    public ImmutableArray<Analysis.UnsafeEvidence> UnsafeEvidence(int methodToken)
+        => _index.GetUnsafeEvidenceByMember().TryGetValue(methodToken, out var evidence)
+            ? evidence
+            : ImmutableArray<Analysis.UnsafeEvidence>.Empty;
+
     /// <summary>Outbound call graph rooted at one method.</summary>
     public Analysis.CallTreeNode CallTree(int methodToken)
         => _index.BuildCallTree(methodToken);

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1129,9 +1129,8 @@ public static class ApiOutputFormatter
         if (request.Calls && singleMethodList is [{ MetadataToken: { } token } callsMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.calls", callsMethod.Name);
-            var index = Analysis.LibraryBodyIndex.Open(dllPath, assemblyResolver);
-            var rows = index.DirectCalls
-                .Where(call => call.Caller.MetadataToken == token)
+            var rows = MethodBodyInspectionSession.Open(dllPath, assemblyResolver)
+                .DirectCalls(token)
                 .OrderBy(call => call.ILOffset)
                 .Select(call => new CallSiteRow(
                     MarkoutInline.Code($"IL_{call.ILOffset:X4}"),
@@ -1296,9 +1295,8 @@ public static class ApiOutputFormatter
         if (request.UnsafeOperations && singleMethodList is [{ MetadataToken: { } unsafeToken } unsafeMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.unsafe", unsafeMethod.Name);
-            var index = Analysis.LibraryBodyIndex.Open(dllPath, assemblyResolver);
-            var evidence = index.UnsafeEvidence
-                .Where(evidence => evidence.Member.MetadataToken == unsafeToken)
+            var evidence = MethodBodyInspectionSession.Open(dllPath, assemblyResolver)
+                .UnsafeEvidence(unsafeToken)
                 .OrderBy(evidence => evidence.ILOffset ?? -1)
                 .ThenBy(evidence => evidence.Reason, StringComparer.Ordinal)
                 .ThenBy(evidence => evidence.Detail, StringComparer.Ordinal)


### PR DESCRIPTION
## Summary

Next slice of the #2139 method-body seam: routes the member-level **Calls** and
**Unsafe Operations** sections through `MethodBodyInspectionSession` instead of
opening a raw `LibraryBodyIndex` in `ApiOutputFormatter`.

- Adds two member-scoped facets to `MethodBodyInspectionSession`:
  - `DirectCalls(int methodToken)` → the method's outbound call sites.
  - `UnsafeEvidence(int methodToken)` → the method's unsafe-operation evidence.
  Both are backed by the index's existing grouped views
  (`GetDirectCallsByCaller` / `GetUnsafeEvidenceByMember`) and return an empty
  array for unknown tokens.
- Converts the two `ApiOutputFormatter` member sites (Calls ~L1132, Unsafe
  Operations ~L1299) to consume the facets.

Behavior-preserving: the grouped views key on the same `Caller.MetadataToken` /
`Member.MetadataToken` the sites previously filtered on, and all presentation
ordering stays in the formatter.

## Validation

- `dotnet build src/dotnet-inspect -c Release` — clean (0 warnings).
- `MethodBodyInspectionSessionTests` — 10/10 pass (incl. new
  `DirectCalls_MatchesCallerFilter_ForCallingMethod`,
  `UnsafeEvidence_MatchesMemberFilter`, and unknown-token empties).
- `MemberCallsSectionTests` + `UnsafeMembersSectionTests` — 15/15 pass.
- CLI smoke: `member <dll> ResourceScanner.Scan -S Calls` renders the call table
  identically. The member Unsafe Operations path shares the identical
  grouped-dictionary shape and is covered by the unit + section tests (the
  compiler-generated `<PrivateImplementationDetails>` type name blocks direct
  CLI member selection for a live smoke).

Part of #2139 / #2122 (thinning the CLI's raw PE/index opens). Remaining member
site: `Callers` (has caller-scope machinery) — dedicated follow-up slice.
