### PR TITLE
Add RTS property return metadata coverage

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -523,6 +523,34 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.property-return-metadata",
+            "GeneratedFixtures.MinimalPropertyReturnMetadata.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.property-return-metadata",
+            "GeneratedFixtures.MinimalPropertyReturnMetadata.Class1",
+            "get_Text",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.property-return-metadata",
+            "GeneratedFixtures.MinimalPropertyReturnMetadata.Class1",
+            "get_Number",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.property-return-metadata",
+            "GeneratedFixtures.MinimalPropertyReturnMetadata.Class1",
+            "get_Item",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.if-else",
             "GeneratedFixtures.MinimalIfElse.Class1",
             ".ctor",
@@ -785,6 +813,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.parameter-attributes", report);
         Assert.Contains("minimal.parameter-marshalling", report);
         Assert.Contains("minimal.return-parameter-metadata", report);
+        Assert.Contains("minimal.property-return-metadata", report);
         Assert.Contains("minimal.if-else", report);
         Assert.Contains("minimal.integer-addition", report);
         Assert.Contains("minimal.struct-members", report);
@@ -856,6 +885,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.parameter-marshalling",
                 "minimal.parameter-modifiers",
                 "minimal.primary-ctor.field-init",
+                "minimal.property-return-metadata",
                 "minimal.property.literal",
                 "minimal.return-parameter-metadata",
                 "minimal.static-class",
@@ -906,6 +936,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.parameter-attributes");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.parameter-marshalling");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.return-parameter-metadata");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.property-return-metadata");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.if-else");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.integer-addition");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.struct-members");

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1379,6 +1379,66 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RoundTripsPropertyReturnMetadata()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public string Text
+                {
+                    [return: System.Diagnostics.CodeAnalysis.NotNull]
+                    get => "hello";
+                }
+
+                public int Number
+                {
+                    [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)]
+                    get => 42;
+                }
+
+                public string this[int index]
+                {
+                    [return: System.Diagnostics.CodeAnalysis.NotNull]
+                    get => "hello";
+                }
+            }
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Class1", "get_Text", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "get_Number", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "get_Item", 0),
+                ]);
+
+            Assert.Collection(
+                results,
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("[return: System.Diagnostics.CodeAnalysis.NotNull] get", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("[return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)] get", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("this[int index]", result.Source);
+                    Assert.Contains("[return: System.Diagnostics.CodeAnalysis.NotNull] get", result.Source);
+                });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericTypeTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -325,7 +325,8 @@ public static class CompileBackSourceComposer
                                 new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name)),
                                 new CompileBackFact("metadata", "auto-property", propertyName)
                             ]
-                            : [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))])
+                            : [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))],
+                        MethodReturnAttributes(reader, getter))
                 ],
                 PrimaryConstructor: null,
                 targetFacts)
@@ -713,13 +714,13 @@ public static class CompileBackSourceComposer
                 }
                 if (member.StubBody == CompileBackStubBodyKind.AutoProperty)
                 {
-                    sb.AppendLine($"{pad}{declaration} {{ get; }}");
+                    sb.AppendLine($"{pad}{declaration} {{ {GetterDeclaration(member)}; }}");
                     break;
                 }
                 if (member.StubBody == CompileBackStubBodyKind.AutoPropertyGetSet)
                 {
                     declaration = StripPropertyAccessorBlock(declaration);
-                    sb.AppendLine($"{pad}{declaration} {{ get; set; }}");
+                    sb.AppendLine($"{pad}{declaration} {{ {GetterDeclaration(member)}; set; }}");
                     break;
                 }
                 if (member.StubBody == CompileBackStubBodyKind.ThrowGetSet)
@@ -727,7 +728,7 @@ public static class CompileBackSourceComposer
                     declaration = StripPropertyAccessorBlock(declaration);
                     sb.AppendLine($"{pad}{declaration}");
                     sb.AppendLine($"{pad}{{");
-                    sb.AppendLine($"{pad}    get");
+                    sb.AppendLine($"{pad}    {GetterDeclaration(member)}");
                     sb.AppendLine($"{pad}    {{");
                     sb.AppendLine($"{pad}        throw null;");
                     sb.AppendLine($"{pad}    }}");
@@ -742,7 +743,7 @@ public static class CompileBackSourceComposer
                 declaration = StripPropertyAccessorBlock(declaration);
                 sb.AppendLine($"{pad}{declaration}");
                 sb.AppendLine($"{pad}{{");
-                sb.AppendLine($"{pad}    get");
+                sb.AppendLine($"{pad}    {GetterDeclaration(member)}");
                 sb.AppendLine($"{pad}    {{");
                 if (member.StubBody == CompileBackStubBodyKind.Throw)
                 {
@@ -926,7 +927,6 @@ public static class CompileBackSourceComposer
                     .ToList(),
             };
         }
-
         return apiMember;
     }
 
@@ -969,6 +969,11 @@ public static class CompileBackSourceComposer
 
         return declaration;
     }
+
+    static string GetterDeclaration(CompileBackMemberDeclaration member)
+        => member.ReturnAttributes is { Count: > 0 }
+            ? $"[return: {string.Join(", ", member.ReturnAttributes)}] get"
+            : "get";
 
     static IReadOnlyList<CompileBackParameter> MethodParameters(
         MetadataReader reader,

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -236,6 +236,7 @@ public class ApiAccessor
 {
     public string Kind { get; set; } = "";
     public string? Accessibility { get; set; }
+    public List<string> ReturnAttributes { get; set; } = [];
 }
 
 public class ApiType

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -1290,7 +1290,12 @@ public static class ApiSurfaceExtractor
             var getStr = hasGetter ? FormatAccessor("get", getterAccess, Math.Max((int)getterAccess, (int)setterAccess)) : null;
             var setStr = hasSetter ? FormatAccessor("set", setterAccess, Math.Max((int)getterAccess, (int)setterAccess)) : null;
             if (hasGetter)
-                accessorModels.Add(new ApiAccessor { Kind = "get", Accessibility = AccessorAccessibility(getterAccess, Math.Max((int)getterAccess, (int)setterAccess)) });
+                accessorModels.Add(new ApiAccessor
+                {
+                    Kind = "get",
+                    Accessibility = AccessorAccessibility(getterAccess, Math.Max((int)getterAccess, (int)setterAccess)),
+                    ReturnAttributes = ReturnParameterAttributes(reader, reader.GetMethodDefinition(accessors.Getter).GetParameters())
+                });
             if (hasSetter)
                 accessorModels.Add(new ApiAccessor { Kind = "set", Accessibility = AccessorAccessibility(setterAccess, Math.Max((int)getterAccess, (int)setterAccess)) });
             accessorStr = (getStr, setStr) switch
@@ -1306,19 +1311,19 @@ public static class ApiSurfaceExtractor
             if (hasPublicGetter && hasPublicSetter)
             {
                 accessorStr = "{ get; set; }";
-                accessorModels.Add(new ApiAccessor { Kind = "get" });
+                accessorModels.Add(new ApiAccessor { Kind = "get", ReturnAttributes = ReturnParameterAttributes(reader, reader.GetMethodDefinition(accessors.Getter).GetParameters()) });
                 accessorModels.Add(new ApiAccessor { Kind = "set" });
             }
             else if (hasPublicGetter && hasSetter)
             {
                 accessorStr = "{ get; private set; }";
-                accessorModels.Add(new ApiAccessor { Kind = "get" });
+                accessorModels.Add(new ApiAccessor { Kind = "get", ReturnAttributes = ReturnParameterAttributes(reader, reader.GetMethodDefinition(accessors.Getter).GetParameters()) });
                 accessorModels.Add(new ApiAccessor { Kind = "set", Accessibility = "private" });
             }
             else if (hasPublicGetter)
             {
                 accessorStr = "{ get; }";
-                accessorModels.Add(new ApiAccessor { Kind = "get" });
+                accessorModels.Add(new ApiAccessor { Kind = "get", ReturnAttributes = ReturnParameterAttributes(reader, reader.GetMethodDefinition(accessors.Getter).GetParameters()) });
             }
             else if (hasPublicSetter)
             {

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -592,9 +592,14 @@ public static class CSharpDeclarationWriter
         return false;
 
         static string AccessorDeclaration(ApiAccessor accessor)
-            => string.IsNullOrWhiteSpace(accessor.Accessibility)
-                ? $"{accessor.Kind};"
-                : $"{accessor.Accessibility} {accessor.Kind};";
+        {
+            var attributePrefix = accessor.ReturnAttributes.Count == 0
+                ? ""
+                : $"[return: {string.Join(", ", accessor.ReturnAttributes)}] ";
+            return string.IsNullOrWhiteSpace(accessor.Accessibility)
+                ? $"{attributePrefix}{accessor.Kind};"
+                : $"{attributePrefix}{accessor.Accessibility} {accessor.Kind};";
+        }
 
         static bool IsOrdinaryPropertyName(string? name)
             => string.IsNullOrWhiteSpace(name)

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -311,6 +311,34 @@ public class ApiSurfaceExtractorTests
     }
 
     [Fact]
+    public void Extract_RendersPropertyAccessorReturnAttributes()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var testType = surface.Types.FirstOrDefault(t => t.Name == "SampleClassForTesting");
+        Assert.NotNull(testType);
+
+        var textProperty = testType.Members.FirstOrDefault(m => m.Name == "PropertyWithReturnNotNull");
+        Assert.NotNull(textProperty);
+        var textDeclaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, textProperty);
+        Assert.Contains("string PropertyWithReturnNotNull { [return: System.Diagnostics.CodeAnalysis.NotNull] get; }", textDeclaration);
+
+        var numberProperty = testType.Members.FirstOrDefault(m => m.Name == "PropertyWithReturnMarshalAs");
+        Assert.NotNull(numberProperty);
+        var numberDeclaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, numberProperty);
+        Assert.Contains("int PropertyWithReturnMarshalAs { [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)] get; }", numberDeclaration);
+
+        var indexer = testType.Members.FirstOrDefault(m => m.Name == "Item");
+        Assert.NotNull(indexer);
+        var indexerDeclaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, indexer);
+        Assert.Contains("this[int index] { [return: System.Diagnostics.CodeAnalysis.NotNull] get; }", indexerDeclaration);
+    }
+
+    [Fact]
     public void Extract_RendersEnumParameterDefaultsAsEnumLiterals()
     {
         var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
@@ -818,6 +846,23 @@ public class SampleClassForTesting
     [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)]
     public int MethodWithReturnAttributesAndFallbackSignature(
         [System.Runtime.InteropServices.Optional, System.Runtime.CompilerServices.DateTimeConstant(637000000000000000L)] System.DateTime when) => when.Year;
+    public string PropertyWithReturnNotNull
+    {
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        get => "hello";
+    }
+
+    public int PropertyWithReturnMarshalAs
+    {
+        [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)]
+        get => 42;
+    }
+
+    public string this[int index]
+    {
+        [return: System.Diagnostics.CodeAnalysis.NotNull]
+        get => "hello";
+    }
 }
 
 public class SampleKeywordParameterHost

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -638,6 +638,56 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "parameters", "return", "marshalling", "attributes"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalPropertyReturnMetadata = new(
+        "minimal.property-return-metadata",
+        """
+        namespace GeneratedFixtures.MinimalPropertyReturnMetadata;
+
+        public class Class1
+        {
+            public string Text
+            {
+                [return: System.Diagnostics.CodeAnalysis.NotNull]
+                get => "hello";
+            }
+
+            public int Number
+            {
+                [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)]
+                get => 42;
+            }
+
+            public string this[int index]
+            {
+                [return: System.Diagnostics.CodeAnalysis.NotNull]
+                get => "hello";
+            }
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalPropertyReturnMetadata.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new("GeneratedFixtures.MinimalPropertyReturnMetadata.Class1", "get_Text",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "[return: System.Diagnostics.CodeAnalysis.NotNull] get",
+                ]),
+            new("GeneratedFixtures.MinimalPropertyReturnMetadata.Class1", "get_Number",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "[return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.I4)] get",
+                ]),
+            new("GeneratedFixtures.MinimalPropertyReturnMetadata.Class1", "get_Item",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "[return: System.Diagnostics.CodeAnalysis.NotNull] get",
+                ]),
+        ],
+        ["minimal", "property", "return", "marshalling", "attributes"]);
+
     public static readonly GeneratedFixtureDefinition MinimalIfElse = new(
         "minimal.if-else",
         """
@@ -1139,6 +1189,7 @@ internal static class GeneratedFixtureCatalog
         MinimalParameterAttributes,
         MinimalParameterMarshalling,
         MinimalReturnParameterMetadata,
+        MinimalPropertyReturnMetadata,
         MinimalIfElse,
         MinimalIntegerAddition,
         MinimalStructMembers,


### PR DESCRIPTION
- Advances #2057
- Changes product property/indexer getter declaration rendering and expands source-aware RTS coverage.
- Evidence revision: `551aa1b3`

## Change

**Conclusion:** **PASS** — getter accessor return attributes now flow through property/indexer declarations and source-aware RTS checks.

Before:

```text
minimal.property-return-metadata failed 3 targets with source-fragment-missing on origin/main + tests-only.
API surface property-accessor return test failed.
```

After:

```text
minimal.property-return-metadata passes 1/1 fixture and 4/4 targets.
API surface property-accessor return test passes.
```

## Scope and safety

- **Root cause:** property/indexer getter return metadata lives on accessor method parameter sequence `0`, but `ApiAccessor` did not model return-target attributes.
- **Fix shape:** add `ApiAccessor.ReturnAttributes`, populate it from getter sequence `0`, and render `[return: ...]` inside the accessor block before `get`/accessibility.
- **Product impact:** API declarations and compile-back source now preserve getter `[return: MarshalAs(...)]` and custom return attributes for properties and indexers.
- **Scope boundary:** setters, methods, constructors, events, and new marshalling descriptor shapes are not changed.
- **RTS boundary:** RTS remains orchestration-only; product/shared code owns C# source generation. Harness changes are fixture source and source-fragment expectations.

## Before/after small corpus

Before run: `origin/main` plus the new tests/fixtures only.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 1 fixture(s), 4 target(s)

Fixtures:
  Passed : 0
  Skipped: 0
  Failed : 1

Targets:
  Passed : 1
  Skipped: 0
  Failed : 3

Failed target buckets:
  source-fragment-missing: 3
```

After run: branch head `551aa1b3`.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 1 fixture(s), 4 target(s)

Fixtures:
  Passed : 1
  Skipped: 0
  Failed : 0

Targets:
  Passed : 4
  Skipped: 0
  Failed : 0
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| API surface tests | `ApiSurfaceExtractorTests` 38/38 |
| Focused decompiler tests | `GeneratedFixtureCatalogTests` 8/8; `ReturnToSenderPrototypeTests` 43/43 |
| Decompiler fast suite | Pass, 1803/1803 |
| Default RTS catalog | `37/37` fixtures, `110/110` targets |
| ReturnToSender A/B | `235` Same, `0` Worse, `0` CurrentMissing |

## Compile-back quality

**Conclusion:** **PASS** — opcode-only fidelity was already Exact, so this PR extends source-aware checks to getter metadata that does not affect method opcodes.

### ReturnToSender catalog

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 37 fixture(s), 110 target(s)

Fixtures:
  Passed : 37
  Skipped: 0
  Failed : 0

Targets:
  Passed : 110
  Skipped: 0
  Failed : 0
```

Minimal selector, including known explicit frontiers:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 39 fixture(s), 114 target(s)

Fixtures:
  Passed : 38
  Skipped: 0
  Failed : 1

Targets:
  Passed : 113
  Skipped: 0
  Failed : 1

Failed target buckets:
  opcode-diff: 1

Failed fixtures (first 1 of 1):
  minimal.switch-two-case-lowers-if
      GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1::Method1#0  rts=OpcodeDiff  bucket=opcode-diff
```

### ReturnToSender A/B

```text
RETURNTOSENDER A/B over 235 property getters

  Rescued       : 0
  Same          : 235
  Changed       : 0
  Worse         : 0
  CurrentMissing: 0
```

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `minimal.switch-two-case-lowers-if` | Left as frontier | Known compiler/source-lowering opcode-diff frontier, unrelated to property return metadata. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | No significant issues | Verified accessor syntax/order, accessor-scoped placement, direct writer paths, SRM-only behavior, and fixture coverage. |
| Claude Opus 4.8 | No significant issues | Verified ApiSurface/RTS/catalog tests, auto-property/body-backed/indexer paths, sequence-0 sourcing, and setter isolation. |

**Review conclusion:** **PASS** — final isolated Gemini and Claude reviews on `551aa1b3` found no significant issues.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -class "*ApiSurfaceExtractorTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --return-to-sender-catalog --max-examples 50
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --return-to-sender-catalog minimal --max-examples 50
```
