### PR TITLE
Non-vacuous coercion audit + width-disciplined enum join typing (value-typed emission, #2145 + step 4 opener)

### DIFF
--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -289,17 +289,20 @@ output. Three structural properties fix what the assertion covers:
   cannot be *proven* an enum, so it stays render-time-handled and outside the
   checkable domain.
 
-The assertion's reach is bounded on purpose, and reading "0 violations" as
-"every sink renders faithfully" over-claims it. `CoercionInvariant.Check`
-shares the pass's `CoercionSinks.RequiresCoercion` decision, so the same
-enumerated residuals the pass skips — merge-node values (`Conditional`,
-`Coalesce`, switch expressions), slot loads, `Box` operands, `StoreIndirect`
-targets, `switch` labels, and lambda returns — are outside the checkable set by
-construction, not merely unviolated within it. What the checker guarantees is
-**routing agreement**: for an in-domain, non-residual sink, the pass and the
-checker cannot drift on whether a `Coerce` is required. Each residual stays
+The assertion's reach is bounded on purpose, and the bound is **measured, not
+silent** (#2145). `CoercionInvariant.Audit` returns two things: **violations**
+(in-domain, wrappable sinks without a `Coerce` — gates assert zero) and
+**counted residuals** — in-domain mismatches the scope deliberately leaves to
+later or targeted deciders, keyed by value kind. Merge-node arms at non-enum
+in-domain joins are enumerated as `PrinterOwned` sinks: the pass does not wrap
+them, but the checker sees and counts them, so "0 violations" can never be
+misread as covering them. The remaining residuals — slot loads (instance 2's
+lane), `Box` operands, `StoreIndirect` targets, `switch` labels, lambda
+returns — stay outside the enumeration with their reasons documented at
+`CoercionSinks`. What the checker guarantees is **routing agreement** for
+wrappable sinks plus a visible residual ledger for the rest; each residual is
 printer-owned — rendered by its own `CoerceText` branch — until it graduates
-into the enumeration.
+into the enumeration and its count goes to zero.
 
 This proves **routing, not rendering**: the invariant guarantees every sink *reaches*
 the one coercion function, collapsing the leak surface from ~12 sites to one — but it

--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -450,12 +450,27 @@ measurable, unlike the control-flow rewrite's all-or-nothing invariant relaxatio
    longer-term end state is Roslyn's: establish the invariant **at
    construction** (importer emits coerced trees) rather than by a
    pipeline-last mutating pass.
-4. **Complete join typing — the shared type-propagation spine** (worth its own
-   slice/issue). Where the importer drops to `Unknown` but a sound common type
-   exists, propagate types at joins (the RyuJIT typed-temp model), reducing
-   `Partial`-by-unknown-join. This is the prerequisite *both* instances lean on:
-   it feeds instance 1's constant/`Convert` typing and is what instance 2 needs to
-   materialize locals.
+4. **Complete join typing — the shared type-propagation spine.** Opened: the
+   importer's `MergeSlotTypes` types an enum-meets-integer join as the enum
+   **only when the integer side is exactly the enum's underlying type** —
+   nominal equality, so width and sign exact, same-assembly resolved enums
+   only, bool excluded. The merge is then a pure reinterpretation and every
+   downstream sink coercion is value-preserving. Two adversarial rounds set
+   that bar: a family-level match let a byte-backed enum absorb a full-int
+   path (`(BE)x` turned 300 into 44, marked Full — the
+   recompiles-to-a-different-program class), and the cross-assembly
+   pairing-proves-enum argument was dropped entirely because it proves the
+   family but never the width. The printer side gained `TryCoerceJoinArm` —
+   the one join-arm rule, both directions, serving conditional, switch-
+   expression, and coalesce arms alike, family-guarded so the underlying cast
+   can never truncate. Join-census over the 15-assembly corpus:
+   `Partial`-by-unknown-join methods 155 → 119; the enum/int bucket for
+   same-assembly int-backed enums is zero. Remaining, by census: cross-assembly
+   enum-likes (width unprovable — recoverable later only with sink-context
+   evidence), the reference-merge lane (cross-assembly base chains and
+   constructed-generic interfaces, SRM-boundary work), and the `void*`/`nuint`
+   native clique. The full RyuJIT typed-temp model (spill and re-import) stays
+   open here for instance 2.
 5. **Materialize stack-slot locals (instance 2).** On the step-4 propagation, emit
    each slot's live ranges as typed local IR nodes and **delete
    `TryChooseUnifiedStackSlotType`** — the writer stops inventing and unifying

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4076,6 +4076,7 @@ public enum CfgULong : ulong { None = 0, All = 18446744073709551615UL }
 // signed int -2147483648, the case the member-map key must agree on.
 [System.Flags]
 public enum CfgFlags : uint { None = 0, Top = 0x80000000u }
+public enum CfgTiny : byte { A = 1, B = 2 }
 
 // A flags enum with a named member at a non-low bit (Gamma = 16): a `ref CfgStyles`
 // bitwise test reads the enum via `ldind.i4`, so the importer must register the
@@ -4370,6 +4371,26 @@ public static class EnumCastSamples
     public static CfgFlags UnsignedEnumConstantBitwise(CfgFlags f) => f & (CfgFlags)uint.MaxValue;
 
     public static CfgFlags UnsignedEnumConstantCoalesce(CfgFlags? f) => f ?? (CfgFlags)uint.MaxValue;
+
+    // Slice-4 adversarial review (GPT-5.5): a byte-backed enum joined with a
+    // full int. The join's semantic type is int (the enum was widened into
+    // it); typing it as the enum re-narrows the int path — `(CfgTiny)x` turns
+    // 300 into 44 and flips the boxed type from int to CfgTiny.
+    public static object ByteEnumOrIntBox(bool c, CfgTiny e, int x)
+    {
+        int y = c ? (int)e : x;
+        return y;
+    }
+
+    // The sound half of the join rule: an int-backed enum meeting an int of
+    // exactly its underlying type is a pure reinterpretation, and the
+    // enum-typed slot must render legally at every int sink it reaches.
+    public static int IntEnumJoinThroughSlot(bool c, CfgPriority e)
+    {
+        int x = c ? (int)e : 1;
+        System.Console.WriteLine(x);
+        return x;
+    }
 
     // #2076 (review): long-backed enum constants in array-element and box
     // positions. The `stelem.i8` element type and `box` drop the enum type, so a

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4392,6 +4392,24 @@ public static class EnumCastSamples
         return x;
     }
 
+    // Slice-4 cross-check review (Opus 4.8, verified against real IL): a
+    // byte-backed enum arm in an int-typed switch dispatch. The raised switch
+    // expression must cast the enum arm (`0 => (int)e`) and the statement
+    // form's int store must cast at the sink — bare renders are
+    // CS0029/CS0266 while graded Full.
+    public static int SwitchEnumOrInt(int k, CfgTiny e, int x)
+    {
+        int r;
+        switch (k)
+        {
+            case 0: r = (int)e; break;
+            case 1: r = x; break;
+            case 2: r = 300; break;
+            default: r = 9; break;
+        }
+        return r;
+    }
+
     // #2076 (review): long-backed enum constants in array-element and box
     // positions. The `stelem.i8` element type and `box` drop the enum type, so a
     // long constant printed bare is CS0266/CS0029 unless cast.

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -370,6 +370,26 @@ public class EnumCastPrinterTests
     }
 
     [Fact]
+    public void ByteEnumSwitchDispatch_CastsEnumArmAtIntSinks()
+    {
+        // Slice-4 cross-check review (Opus 4.8): a byte-backed enum flowing
+        // into an int-typed switch dispatch — the raised switch-expression arm
+        // (or the statement form's int store) must cast, never render `e`
+        // bare (CS0029/CS0266 while graded Full). The widening enum→int cast
+        // is value-preserving; the sink rule now accepts same-family widening
+        // rather than demanding the exact underlying type.
+        string body = RenderRaisedFixture(nameof(EnumCastSamples.SwitchEnumOrInt));
+
+        Assert.Contains("(int)e", body);
+        Assert.DoesNotContain("=> e,", body);
+        Assert.DoesNotContain("= e;", body);
+        AssertCompiles(
+            "public static int M(int k, CfgTiny e, int x)",
+            body,
+            "public enum CfgTiny : byte { A = 1, B = 2 }");
+    }
+
+    [Fact]
     public void ByteEnumIntJoin_KeepsIntSemantics_NoNarrowing()
     {
         // Slice-4 adversarial review (GPT-5.5, blocking): the byte-enum/int

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -331,6 +331,45 @@ public class EnumCastPrinterTests
     }
 
     [Fact]
+    public void EnumArm_AtIntegerSwitchExpressionTarget_CastsToUnderlying()
+    {
+        // Slice-4 second-family review (GPT-5.5): the enum→integer mirror rule
+        // must cover switch-expression arms, not only conditional arms — an
+        // enum arm at an int-typed switch result is CS0266 bare. One join-arm
+        // rule (TryCoerceJoinArm) now serves all three arm renderers.
+        var enumType = TypeRef.Definition("test", "", "CfgPriority");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var switchExpression = new SwitchExpression(
+            new LoadArgument(0, "value", intType),
+            [
+                new SwitchExpressionArm(ImmutableArray.Create(0), isDefault: false, new LoadArgument(1, "e", enumType)),
+                new SwitchExpressionArm(ImmutableArray<int>.Empty, isDefault: true, new Constant(7, intType)),
+            ]);
+        var block = new Block(0);
+        block.Add(new Return(switchExpression));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(
+            intType,
+            [new Parameter("value", intType), new Parameter("e", enumType)],
+            HasThis: false,
+            GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("test", "", "Holder"), signature, [], container)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [enumType] = TypeShape.Enum },
+            EnumUnderlyingTypes = new Dictionary<TypeRef, TypeRef> { [enumType] = intType },
+        };
+        string body = CSharpPrinter.Print(function).Output!.Trim();
+
+        Assert.Contains("(int)e", body);
+        Assert.DoesNotContain("=> e,", body);
+        AssertCompiles(
+            "public static int M(int value, CfgPriority e)",
+            body,
+            "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
+    [Fact]
     public void ByteEnumIntJoin_KeepsIntSemantics_NoNarrowing()
     {
         // Slice-4 adversarial review (GPT-5.5, blocking): the byte-enum/int

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -330,6 +330,37 @@ public class EnumCastPrinterTests
             "public enum CfgLongPriority : long { Low = 0, High = 2 }");
     }
 
+    [Fact]
+    public void ByteEnumIntJoin_KeepsIntSemantics_NoNarrowing()
+    {
+        // Slice-4 adversarial review (GPT-5.5, blocking): the byte-enum/int
+        // join must NOT be typed as the enum — `(CfgTiny)x` would narrow 300
+        // to 44 and flip the boxed type. The join stays integer-typed and the
+        // int path renders uncast.
+        string body = RenderRaisedFixture(nameof(EnumCastSamples.ByteEnumOrIntBox));
+
+        Assert.DoesNotContain("(CfgTiny)x", body);
+        Assert.DoesNotContain("(CfgTiny)(x)", body);
+        AssertCompiles(
+            "public static object M(bool c, CfgTiny e, int x)",
+            body,
+            "public enum CfgTiny : byte { A = 1, B = 2 }");
+    }
+
+    [Fact]
+    public void IntEnumJoinThroughSlot_RendersLegalIntSinks()
+    {
+        // The sound half (exact underlying match): the enum-typed join is a
+        // pure reinterpretation, and the slot renders legally at int sinks —
+        // the Gemini finding's CS0266 shape, made valid by width discipline.
+        string body = RenderRaisedFixture(nameof(EnumCastSamples.IntEnumJoinThroughSlot));
+
+        AssertCompiles(
+            "public static int M(bool c, CfgPriority e)",
+            body,
+            "public enum CfgPriority { Low, Medium = 1, High = 2, Critical = 3 }");
+    }
+
     static string RenderFixture(string methodName)
     {
         using var source = MetadataSource.Open(typeof(EnumCastSamples).Assembly.Location);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1212,6 +1212,13 @@ public sealed partial class CSharpPrinter
             // and renders its member name via Operand.
             : TryCoerceEnumOperand(arm, target) is { } coercedArm
                 ? coercedArm
+            // The mirror direction (#2145): an enum arm flowing into an
+            // integer-typed join (`c ? E.One : e` merged as int) is CS0266 too —
+            // cast the enum arm to the integer target, the same enum→underlying
+            // rule CoerceText applies to whole values at integer sinks.
+            : target is { } integerTarget && TypeFamilies.IsIntegerLike(integerTarget)
+            && EnumUnderlyingType(EffectiveType(arm)) is not null
+                ? $"({TypeText(integerTarget)}){Operand(arm)}"
             : target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
             && EffectiveType(arm) is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary }
                 ? $"({Condition(arm)} ? 1 : 0)"

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1230,8 +1230,12 @@ public sealed partial class CSharpPrinter
     {
         if (TryCoerceEnumOperand(arm, target) is { } coerced)
             return coerced;
+        // Same stack family only: `(int)longBackedEnum` would truncate. The
+        // importer's family merge should never build such a join, but the cast
+        // must not be the place that finds out (slice-4 review's verify item).
         return target is { } integerTarget && TypeFamilies.IsIntegerLike(integerTarget)
-            && EnumUnderlyingType(EffectiveType(arm)) is not null
+            && EnumUnderlyingType(EffectiveType(arm)) is { } underlying
+            && TypeFamilies.Of(underlying) == TypeFamilies.Of(integerTarget)
             ? $"({TypeText(integerTarget)}){Operand(arm)}"
             : null;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1210,19 +1210,31 @@ public sealed partial class CSharpPrinter
             // structural test catches it), the composed `(E)(cond ? 1 : 0)` for a
             // bool arm. A same-assembly enum arm is enum-typed (not integer-like)
             // and renders its member name via Operand.
-            : TryCoerceEnumOperand(arm, target) is { } coercedArm
+            : TryCoerceJoinArm(arm, target) is { } coercedArm
                 ? coercedArm
-            // The mirror direction (#2145): an enum arm flowing into an
-            // integer-typed join (`c ? E.One : e` merged as int) is CS0266 too —
-            // cast the enum arm to the integer target, the same enum→underlying
-            // rule CoerceText applies to whole values at integer sinks.
-            : target is { } integerTarget && TypeFamilies.IsIntegerLike(integerTarget)
-            && EnumUnderlyingType(EffectiveType(arm)) is not null
-                ? $"({TypeText(integerTarget)}){Operand(arm)}"
             : target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
             && EffectiveType(arm) is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary }
                 ? $"({Condition(arm)} ? 1 : 0)"
                 : Operand(arm);
+
+    /// <summary>
+    /// The one join-arm coercion, both directions: an integer-family arm at an
+    /// enum-typed join takes the enum cast/name (<see cref="TryCoerceEnumOperand"/>),
+    /// and an enum arm at an integer-typed join takes the underlying cast —
+    /// `c ? E.One : e` merged as int is CS0266 bare, in a conditional arm, a
+    /// switch-expression arm, or a coalesce right side alike (#2145; slice-4
+    /// second-family review found the rule present in only one of the three).
+    /// Null when the arm needs no join coercion.
+    /// </summary>
+    string? TryCoerceJoinArm(IrExpression arm, TypeRef? target)
+    {
+        if (TryCoerceEnumOperand(arm, target) is { } coerced)
+            return coerced;
+        return target is { } integerTarget && TypeFamilies.IsIntegerLike(integerTarget)
+            && EnumUnderlyingType(EffectiveType(arm)) is not null
+            ? $"({TypeText(integerTarget)}){Operand(arm)}"
+            : null;
+    }
 
     string? TryConditionalTextForTarget(Conditional conditional, TypeRef target)
         => CanRenderConditionalForTarget(conditional, target)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1072,10 +1072,19 @@ public sealed partial class CSharpPrinter
         {
             return EnumArithmeticValueText(enumArithmetic) ?? Expression(value);
         }
+        // An enum value at an integer-typed sink: cast to the target whenever
+        // the cast is value-preserving — same stack family (a byte-backed enum
+        // at an int sink widens losslessly; exact equality here left it BARE,
+        // CS0266 — slice-4 cross-check review) or an I4 underlying at an I8
+        // target. Narrowing (I8 underlying, I4 target) never gets a silent
+        // cast; a real narrowing in the IL arrives as a Convert node instead.
         if (target is { } primitiveTarget
             && TypeFamilies.IsIntegerLike(primitiveTarget)
             && EnumUnderlyingType(EffectiveType(value)) is { } underlying
-            && underlying.Equals(primitiveTarget))
+            && TypeFamilies.Of(underlying) is { } underlyingFamily
+            && TypeFamilies.Of(primitiveTarget) is { } targetFamily
+            && (underlyingFamily == targetFamily
+                || (underlyingFamily == StackFamily.I4 && targetFamily == StackFamily.I8)))
         {
             return $"({TypeText(primitiveTarget)}){Operand(value)}";
         }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -161,7 +161,7 @@ public sealed partial class CSharpPrinter
                 labelEnum)));
 
     string SwitchArmValueText(IrExpression value, TypeRef? target)
-        => TryCoerceEnumOperand(value, target) is { } coerced ? coerced : Expression(value);
+        => TryCoerceJoinArm(value, target) is { } coerced ? coerced : Expression(value);
 
     /// <summary>The single-line form of a switch expression, used when it is nested inside another expression.</summary>
     string SwitchExpressionInline(SwitchExpression node, TypeRef? target = null)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2142,9 +2142,12 @@ public sealed partial class CSharpPrinter
         => element is CollectionSpreadElement spread ? $"..{Expression(spread.Source)}" : Expression(element);
 
     /// <summary>
-    /// True when rendered text is a bare identifier chain or numeric literal
-    /// (`LEnum.High`, `10`, `-1`) — safe unparenthesized in any operand
-    /// position, including as a member-access receiver.
+    /// True when rendered text is a bare identifier chain or non-negative
+    /// numeric literal (`LEnum.High`, `10`) — safe unparenthesized in any
+    /// operand position, including as a member-access receiver. A leading
+    /// minus is deliberately NOT an atom: `-1` as a receiver misbinds
+    /// (`-1.ToString()` negates the call), so negative literals keep
+    /// Operand's parens (#2145).
     /// </summary>
     static bool IsSimpleAtomText(string text)
     {
@@ -2152,7 +2155,7 @@ public sealed partial class CSharpPrinter
             return false;
         foreach (char c in text)
         {
-            if (!char.IsLetterOrDigit(c) && c is not ('.' or '_' or '@' or '-'))
+            if (!char.IsLetterOrDigit(c) && c is not ('.' or '_' or '@'))
                 return false;
         }
         return true;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1854,7 +1854,7 @@ public sealed partial class CSharpPrinter
     }
 
     string CoalesceRightText(IrExpression right, TypeRef? target)
-        => TryCoerceEnumOperand(right, target) is { } coerced ? coerced : Operand(right);
+        => TryCoerceJoinArm(right, target) is { } coerced ? coerced : Operand(right);
 
     static TypeRef? NullableValueType(TypeRef? type)
         => type is

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1443,11 +1443,51 @@ public static class IrImporter
             if (source.MergeReferenceTypes(a, b) is { } merged)
                 return merged;
         }
+        // An enum meeting an integer of its underlying family (a
+        // `cond ? RefKind.Ref : local` diamond, a flags accumulator): ECMA-335
+        // verification carries an enum on the evaluation stack as its
+        // underlying's verification type, so the integer path IS the enum's
+        // representation and the semantic type survives the join — the
+        // census's dominant Partial-by-unknown-join class (RefKind/int and
+        // kin, value-typed-emission step 4). Same-assembly resolved enums
+        // only (the underlying map is the proof); asserting enum for an
+        // unresolved definition would outrun the verifier's knowledge. Bool
+        // stays out: a bool path is BooleanFolding's lane, not an enum
+        // representation.
+        if (EnumOverUnderlyingFamily(source, a, b) is { } enumA)
+            return enumA;
+        if (EnumOverUnderlyingFamily(source, b, a) is { } enumB)
+            return enumB;
         var familyA = TypeFamilies.Of(a);
         var familyB = TypeFamilies.Of(b);
         if (familyA is not null && familyB is not null && familyA == familyB)
             return TypeFamilies.Canonical(familyA.Value);
         return null;
+    }
+
+    static TypeRef? EnumOverUnderlyingFamily(MetadataSource source, TypeRef enumSide, TypeRef integerSide)
+    {
+        if (TypeFamilies.Of(integerSide) is not { } integerFamily
+            || integerFamily is not (StackFamily.I4 or StackFamily.I8)
+            || TypeFamilies.IsBoolean(integerSide))
+        {
+            return null;
+        }
+        // Same-assembly: the underlying map is the proof, and the families
+        // must agree.
+        if (source.ResolveEnumUnderlyingType(enumSide) is { } underlying)
+            return TypeFamilies.Of(underlying) == integerFamily ? enumSide : null;
+        // Cross-assembly: the shape is unresolvable, but the pairing is the
+        // proof — verification only merges a named definition with an integer
+        // when the definition is an enum over that family (the same
+        // structural argument as the printer's IsEnumLikeInteger). A
+        // same-assembly definition the map classifies as a non-enum struct or
+        // reference is disproof, not unknown.
+        return enumSide is { Kind: TypeRefKind.Definition }
+            && TypeFamilies.Of(enumSide) is null
+            && source.ResolveShape(enumSide) == TypeShape.Unknown
+            ? enumSide
+            : null;
     }
 
     /// <summary>A reference type: object, string, an array, or a definition (or generic instantiation of one) the source resolves to a reference shape.</summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -1467,25 +1467,21 @@ public static class IrImporter
 
     static TypeRef? EnumOverUnderlyingFamily(MetadataSource source, TypeRef enumSide, TypeRef integerSide)
     {
-        if (TypeFamilies.Of(integerSide) is not { } integerFamily
-            || integerFamily is not (StackFamily.I4 or StackFamily.I8)
-            || TypeFamilies.IsBoolean(integerSide))
-        {
-            return null;
-        }
-        // Same-assembly: the underlying map is the proof, and the families
-        // must agree.
-        if (source.ResolveEnumUnderlyingType(enumSide) is { } underlying)
-            return TypeFamilies.Of(underlying) == integerFamily ? enumSide : null;
-        // Cross-assembly: the shape is unresolvable, but the pairing is the
-        // proof — verification only merges a named definition with an integer
-        // when the definition is an enum over that family (the same
-        // structural argument as the printer's IsEnumLikeInteger). A
-        // same-assembly definition the map classifies as a non-enum struct or
-        // reference is disproof, not unknown.
-        return enumSide is { Kind: TypeRefKind.Definition }
-            && TypeFamilies.Of(enumSide) is null
-            && source.ResolveShape(enumSide) == TypeShape.Unknown
+        // The integer side must be EXACTLY the enum's underlying type, not
+        // merely its stack family. A family-level match let a byte-backed enum
+        // absorb a full-int path, narrowing values the original program
+        // preserved — `int y = c ? (int)e : x` boxed 300 as int; the enum-typed
+        // join re-emitted `(BE)x` = 44, a recompiles-to-a-different-program
+        // corruption marked Full (slice-4 adversarial review, GPT-5.5 fixture).
+        // With an exact match the merge is a pure reinterpretation: same width,
+        // same sign, and every downstream sink coercion is value-preserving.
+        // Cross-assembly enum-like definitions are deliberately NOT merged:
+        // the pairing proves "an enum over this family" but never the width,
+        // which is exactly the unprovable fact the corruption rode in on.
+        // Bool stays out (BooleanFolding's lane).
+        return !TypeFamilies.IsBoolean(integerSide)
+            && source.ResolveEnumUnderlyingType(enumSide) is { } underlying
+            && underlying.Equals(integerSide)
             ? enumSide
             : null;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
@@ -12,7 +12,16 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 public static class CoercionSinks
 {
-    public readonly record struct TypedSink(IrExpression Value, TypeRef Target);
+    /// <summary>
+    /// Who decides the sink's coercion. <see cref="Wrappable"/> sinks are the
+    /// insertion pass's to wrap; <see cref="PrinterOwned"/> sinks are rendered
+    /// by CoerceText's own targeted branches (merge-node arms at non-enum
+    /// joins) — the checker counts their mismatches as residuals so the
+    /// invariant's scope limit is visible, never vacuous (#2145).
+    /// </summary>
+    public enum SinkScope { Wrappable, PrinterOwned }
+
+    public readonly record struct TypedSink(IrExpression Value, TypeRef Target, SinkScope Scope = SinkScope.Wrappable);
 
     /// <summary>
     /// One shared decision for pass and checker: an enumerated sink requires a
@@ -29,7 +38,19 @@ public static class CoercionSinks
         // own branches (TryConditionalTextForTarget and siblings), and wrapping
         // them re-routes statement-position spellings into the inline forms
         // (a multi-line switch expression collapsing to one line).
-        => sink.Value is not (Coerce or LoadStackSlot or Conditional or Coalesce or SwitchExpression or UnionSwitchExpression)
+        => sink.Scope == SinkScope.Wrappable
+            && sink.Value is not (Coerce or LoadStackSlot or Conditional or Coalesce or SwitchExpression or UnionSwitchExpression)
+            && CoercionDomain.InDomain(sink.Target, shapes)
+            && !CoercionDomain.IsAtTarget(sink.Value, sink.Target);
+
+    /// <summary>
+    /// A sink the invariant cannot assert but must not hide: in-domain,
+    /// mismatched, and owned by a later or targeted decider. Counted by
+    /// CoercionInvariant so "0 violations" is never read as covering them.
+    /// </summary>
+    public static bool IsResidual(TypedSink sink, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+        => !RequiresCoercion(sink, shapes)
+            && sink.Value is not Coerce
             && CoercionDomain.InDomain(sink.Target, shapes)
             && !CoercionDomain.IsAtTarget(sink.Value, sink.Target);
 
@@ -130,14 +151,17 @@ public static class CoercionSinks
                     for (int i = 0; i < ctor.Constructor.ParameterTypes.Length && i < ctor.Arguments.Count; i++)
                         yield return new(ctor.Arguments[i], ctor.Constructor.ParameterTypes[i]);
                     break;
-                // An enum-typed join types both arms. Enum merges only: bool
-                // joins belong to BooleanFoldingPass's 0/1 reconciliation, and
-                // int-merge arm rendering (bool arms as `(cond ? 1 : 0)`) is
-                // still a printer rule — residual for the burn-down.
-                case Conditional { MergedType: { } merged } conditional
-                    when function.TypeShapes.GetValueOrDefault(merged) == TypeShape.Enum:
-                    yield return new(conditional.WhenTrue, merged);
-                    yield return new(conditional.WhenFalse, merged);
+                // A typed join types both arms. Enum merges are wrappable; other
+                // in-domain merges (int joins with bool or enum arms) are
+                // printer-owned — ConditionalArm renders them, and the checker
+                // counts their mismatches as residuals rather than hiding them
+                // behind the exclusion (#2145).
+                case Conditional { MergedType: { } merged } conditional:
+                    var armScope = function.TypeShapes.GetValueOrDefault(merged) == TypeShape.Enum
+                        ? SinkScope.Wrappable
+                        : SinkScope.PrinterOwned;
+                    yield return new(conditional.WhenTrue, merged, armScope);
+                    yield return new(conditional.WhenFalse, merged, armScope);
                     break;
                 // Switch case labels are deliberately not enumerated:
                 // SwitchSection holds them outside the child tree (ReplaceWith
@@ -200,7 +224,7 @@ public sealed class CoercionInsertionPass : IIrPass
             .Where(s => CoercionSinks.RequiresCoercion(s, shapes))
             .OrderByDescending(s => Depth(s.Value))
             .ToList();
-        foreach (var (value, target) in sinks)
+        foreach (var (value, target, _) in sinks)
         {
             context.Stepper.StepOver($"coerce sink value to {target.Name}", value);
             // Clone so the wrapper owns a detached copy before the in-place
@@ -226,17 +250,39 @@ public sealed class CoercionInsertionPass : IIrPass
 /// </summary>
 public static class CoercionInvariant
 {
-    public static IReadOnlyList<string> Check(IrFunction function)
+    /// <summary>
+    /// <see cref="Violations"/> break the invariant (gates assert zero);
+    /// <see cref="Residuals"/> are in-domain mismatches the invariant's scope
+    /// deliberately leaves to later or targeted deciders, counted by value
+    /// kind so the scope limit is measurable burn-down, never silent (#2145).
+    /// </summary>
+    public readonly record struct CoercionAudit(
+        IReadOnlyList<string> Violations,
+        IReadOnlyDictionary<string, int> Residuals);
+
+    public static IReadOnlyList<string> Check(IrFunction function) => Audit(function).Violations;
+
+    public static CoercionAudit Audit(IrFunction function)
     {
         var shapes = function.TypeShapes;
         List<string>? violations = null;
+        Dictionary<string, int>? residuals = null;
         foreach (var sink in CoercionSinks.Enumerate(function))
         {
-            if (!CoercionSinks.RequiresCoercion(sink, shapes))
-                continue;
-            (violations ??= []).Add(
-                $"{function.Name}: {sink.Value.Describe()} occupies a {sink.Target.ToDisplayString()} sink without a Coerce");
+            if (CoercionSinks.RequiresCoercion(sink, shapes))
+            {
+                (violations ??= []).Add(
+                    $"{function.Name}: {sink.Value.Describe()} occupies a {sink.Target.ToDisplayString()} sink without a Coerce");
+            }
+            else if (CoercionSinks.IsResidual(sink, shapes))
+            {
+                var kind = sink.Scope == CoercionSinks.SinkScope.PrinterOwned
+                    ? $"printer-owned arm ({sink.Value.GetType().Name})"
+                    : sink.Value.GetType().Name;
+                residuals ??= [];
+                residuals[kind] = residuals.GetValueOrDefault(kind) + 1;
+            }
         }
-        return violations ?? [];
+        return new(violations ?? [], residuals ?? []);
     }
 }


### PR DESCRIPTION
## Change

Two arcs on one branch (per maintainer direction — no tiny PRs):

**#2145 hardening (closes #2145):**
- `CoercionInvariant.Audit`: violations (gates assert zero) **plus counted residuals** keyed by kind — non-enum in-domain merge arms enumerate as `PrinterOwned` sinks the checker sees but the pass never wraps. "0 violations" can no longer be misread.
- `TryCoerceJoinArm`: **one join-arm rule, both directions, all three arm renderers** (conditional / switch-expression / coalesce) — the enum-arm-at-integer-join direction existed in zero, then one, now all three.
- `IsSimpleAtomText` leading-minus hardening (receiver misbind); pre-existing bare-`Constant` variant filed as #2151.

**Step-4 opener — enum join typing at the importer:**
- `MergeSlotTypes` types an enum-meets-integer join as the enum **only when the integer side is exactly the enum's underlying type** (nominal equality: width + sign), same-assembly resolved enums only, bool excluded. The merge is a pure reinterpretation; every downstream sink coercion is value-preserving.
- The cross-assembly pairing-proves-enum argument is **dropped**: it proves the family, never the width.
- Sink-path counterpart: `CoerceText`'s enum→integer cast accepts **value-preserving widening** (same family, or I4-underlying at I8 target) instead of demanding the exact underlying — refusing widening produced bare CS0266/CS0029 renders graded Full. **Join typing must be exact; rendering must widen; narrowing never gets a silent cast** (a real narrowing arrives as a `Convert` node).

## Evidence

| Check | Result |
| --- | --- |
| Full suite | **1870/1870** at reviewed head |
| Join census (15 assemblies, 134,505 methods) | `Partial`-by-unknown-join **155 → 119**; same-assembly enum/int bucket zero; residuals named (cross-assembly enum-likes, reference-merge lane, native clique) |
| Render-text A/B vs merge base `c48af393` | **97 changed methods, 252 lines — all three classes intended**: enum-at-integer-sink widening casts (bare CS0266/CS0029 fixed), join upgrades (incl. a phantom-split repair: a read of a never-assigned split range now pairs with its store), argument-sink coercions. Zero noise, zero regressions |
| Real-world card (compile-back + fidelity oracles) | **Fully raised +6 (+0.01 pp)** — first positive corpus movement of the program; fidelity identical to baseline (5/36 pre-existing opcode-diffs, 31 exact, 0 recompile-failed); semantic defect rate unchanged. The card's "regressions" verdict is a **sampling-cap artifact** (PR-recipe caps vs the baseline's daily caps), stated here rather than hidden |
| PR quick card | Pinned gate 0 pp |

## Adversarial review — five rounds, reconciled

| Round | Finding | Resolution |
| --- | --- | --- |
| GPT-5.5 + Gemini (blocking) | family-level join match corrupts values (`(BE)x`: 300→44, marked Full); cross-assembly width unprovable | width-exact joins; cross-assembly rule dropped; both fixtures pinned |
| GPT-5.5 | mirror rule in 1 of 3 arm renderers | `TryCoerceJoinArm` consolidation, pinned |
| Opus 4.8 (first pass) | verify: join-arm cast could truncate | family guard, pinned |
| Opus 4.8 (cross-check) | sink-path exactness leaves byte-enum bare at int sinks (verified vs real IL) | family-safe widening; reviewer's `SwitchEnumOrInt` fixture pinned |
| Opus 4.8 (final, at head `dd3b7990`) | none — all fixes verified; gate = this fidelity card | delivered above |

Every finding was the same species — a width- or direction-partial rule present in one context and absent in a sibling — and every fix consolidated to one named rule. The design doc predicted the species; five rounds confirmed it.

## Decompiler quality

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity sampled 350 / 89,065 (0.39%); fidelity sampled 36 / 89,065 (0.04%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,405 (88.03%) | +6 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — sampled 25,179 / 89,065 (28.27%) | 1/350 — sampled 350 / 89,065 (0.39%) | -73 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | 0 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.03% (+0.01 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 5 (0).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25179, current 350)

Follow-ups tracked: #2151 (negative-constant receivers), #2155 (harness parallelization + `--render-ab` mode — the stale-base audit error this arc hit twice is designed out there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)