### PR TITLE
Inverse architecture: annotate the conversion family (Convert / Coerce / Box)

### DIFF
--- a/docs/design/inverse-architecture.md
+++ b/docs/design/inverse-architecture.md
@@ -291,15 +291,17 @@ a `[NotInverted(reason)]` row so the boundary is visible, not implicit.
 
 ## Status
 
-- **Framing (this doc):** drafted; under review.
+- **Framing (this doc):** landed (#2135).
 - **Annotation infrastructure** (`[InverseOf]`, enums, reflector, coverage test, the
-  `SinkDistinguishableFromStack` assertion): planned. First slice is the conversion
-  family (`Convert` / `Coerce` / `Box`).
-- **Node annotations applied across the IR:** planned, to follow the infrastructure.
-  Because the annotations land in `IrNodes.cs`, which value-typed-emission slices 4–5
-  actively edit, the annotation slice is sequenced *after* the slice-3 merge and the
-  follow-up infra, to keep the churn on that file serialized.
-- **Generated ledger:** planned; will replace the hand-written seed rows above.
+  `SinkDistinguishableFromStack` assertion): landed (#2148).
+- **Node annotations applied across the IR:** the conversion family (`Convert`,
+  `Coerce`, `Box`) is annotated and enforced by the coverage test; the remaining
+  in-domain nodes follow, applied where they are low-conflict with in-flight
+  value-typed-emission work on `IrNodes.cs`.
+- **Generated ledger:** generated from the annotations at
+  [inverse-ledger.generated.md](inverse-ledger.generated.md) (drift-gated); it is the
+  authoritative table. The conversion-family rows in [The node ledger](#the-node-ledger--the-type-assertions)
+  above are a hand-written worked example the generated ledger subsumes.
 - **Assertion dump (capability):** planned, last. An opt-in `--dump` lane that annotates
   each node with its `[InverseOf]` assertion, evaluates the `assumes:` predicate in
   place, and pinpoints the first unsound rewrite. Depends on the annotations and the

--- a/docs/design/inverse-architecture.md
+++ b/docs/design/inverse-architecture.md
@@ -230,7 +230,8 @@ Two design rules keep this sound and cheap:
   agreement are not enough — nothing above forces the *assumption itself* to stay true
   when a pass rewrite changes a node's real precondition. So the rule is: every
   `assumes:` names a member exposing a release-capable `Check()`, and the coverage test
-  **invokes** those predicates over the fixture corpus. An assumption that cannot be
+  resolves and **invokes** it structurally (per-predicate behavior — non-vacuity — lives
+  in predicate-specific tests). An assumption that cannot be
   spelled as a predicate does not go in the attribute — it goes in prose behind a
   `[NotInverted(reason)]`-style marker. This is the residual-drift guard: it
   binds the attribute's claim to a runnable check, the same discipline the node ledger's

--- a/docs/design/inverse-ledger.generated.md
+++ b/docs/design/inverse-ledger.generated.md
@@ -8,7 +8,9 @@ edit by hand. See [inverse-architecture.md](inverse-architecture.md) for the fra
 
 | Node | Forward construct | Naming | Precondition | Witness |
 | --- | --- | --- | --- | --- |
-| _(none yet)_ | — | — | — | — |
+| `Box` | BoundConversion (boxing) / GT_BOX | Inherited | target is the boxed value type | box/unbox fixtures |
+| `Coerce` | BoundConversion (implicit, target-driven) | Native | sink type recoverable and distinguishable from the stack type | CoerceChokePointTests, CoercionInvariantTests, corpus render-text A/B |
+| `Convert` | BoundConversion (numeric) / GT_CAST | Inherited | none — models the conv.* that ran | round-trips by construction; corpus compile-back |
 
 ## Declared non-inverse boundaries
 

--- a/docs/design/inverse-ledger.generated.md
+++ b/docs/design/inverse-ledger.generated.md
@@ -6,11 +6,11 @@ edit by hand. See [inverse-architecture.md](inverse-architecture.md) for the fra
 
 ## Type assertions
 
-| Node | Forward construct | Naming | Precondition | Witness |
-| --- | --- | --- | --- | --- |
-| `Box` | BoundConversion (boxing) / GT_BOX | Inherited | target is the boxed value type | box/unbox fixtures |
-| `Coerce` | BoundConversion (implicit, target-driven) | Native | sink type recoverable and distinguishable from the stack type | CoerceChokePointTests, CoercionInvariantTests, corpus render-text A/B |
-| `Convert` | BoundConversion (numeric) / GT_CAST | Inherited | none — models the conv.* that ran | round-trips by construction; corpus compile-back |
+| Node | Forward construct (Roslyn) | Oracle (RyuJIT) | Naming | Precondition | Witness |
+| --- | --- | --- | --- | --- | --- |
+| `Box` | BoundConversion (boxing) | RyuJitImporter | Inherited | target is the boxed value type | box/unbox fixtures |
+| `Coerce` | BoundConversion (implicit, target-driven) | RyuJitStackNormalization | Native | sink type recoverable and distinguishable from the stack type | CoerceChokePointTests, CoercionInvariantTests, corpus render-text A/B |
+| `Convert` | BoundConversion (numeric) | RyuJitStackNormalization | Inherited | none — models the conv.* that ran | round-trips by construction; corpus compile-back |
 
 ## Declared non-inverse boundaries
 

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
@@ -35,10 +35,11 @@ public class InverseArchitectureTests
             row => row.Node == nameof(SampleInverseNode));
 
         Assert.Equal("BoundConversion (sample)", sample.ForwardName);
+        Assert.Equal(Oracle.RyuJitStackNormalization, sample.Oracle);
         Assert.Equal(NameProvenance.Native, sample.Naming);
 
         var markdown = InverseLedger.RenderMarkdown(TestAssembly);
-        Assert.Contains("| `SampleInverseNode` | BoundConversion (sample) | Native |", markdown);
+        Assert.Contains("| `SampleInverseNode` | BoundConversion (sample) | RyuJitStackNormalization | Native |", markdown);
     }
 
     [Fact]
@@ -63,9 +64,12 @@ public class InverseArchitectureTests
         Assert.Contains("| `SampleBoundaryNode` | sample: outside the checkable domain |", markdown);
     }
 
-    // Rule #4: every [InverseOf(assumes: ...)] must name a runnable, release-capable
-    // predicate on InverseAssumptions, and the coverage test invokes it over a
-    // fixture corpus. This binds the attribute's claim to an executable check.
+    // Rule #4 (structural): every [InverseOf(assumes: ...)] must name a runnable,
+    // release-capable predicate on InverseAssumptions with the Check(IrFunction)
+    // shape — this gate resolves each and confirms it is invocable. It proves
+    // resolve-and-invoke, not non-vacuity: per-predicate *behavior* is covered by
+    // each predicate's own tests (e.g. CoercionInvariantTests for
+    // SinkDistinguishableFromStack), not re-proven here.
     [Fact]
     public void EveryAssumes_ResolvesToARunnablePredicate()
     {
@@ -122,6 +126,10 @@ public class InverseArchitectureTests
             _output.WriteLine($"  - {node}");
     }
 
+    // The committed generated ledger must match the reflector output. The match is
+    // content-normalized (line-ending- and trailing-whitespace-insensitive via
+    // Normalize), not raw byte-exact — so the gate is portable across checkouts and
+    // editors while still catching any content drift in the ledger.
     [Fact]
     public void GeneratedProductLedger_MatchesCommittedFile()
     {

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
@@ -19,10 +19,10 @@ public class InverseArchitectureTests
 
     public InverseArchitectureTests(ITestOutputHelper output) => _output = output;
 
-    // In-domain product nodes that MUST carry [InverseOf] or [NotInverted]. Empty
-    // for now: this machinery-only change adds no product annotations (no
-    // IrNodes.cs churn). The set grows as the ledger's declared domain grows.
-    static readonly string[] EnforcedProductNodes = [];
+    // In-domain product nodes that MUST carry [InverseOf] or [NotInverted]. The
+    // conversion family is the first annotated slice (docs/design/inverse-architecture.md);
+    // the set grows as the ledger's declared domain grows.
+    static readonly string[] EnforcedProductNodes = ["Convert", "Coerce", "Box"];
 
     static Assembly ProductAssembly => typeof(IrFunction).Assembly;
     Assembly TestAssembly => GetType().Assembly;

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseLedger.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseLedger.cs
@@ -19,6 +19,7 @@ public static class InverseLedger
     public sealed record Row(
         string Node,
         string ForwardName,
+        Oracle Oracle,
         NameProvenance Naming,
         string Precondition,
         string Witness);
@@ -37,6 +38,7 @@ public static class InverseLedger
             .Select(x => new Row(
                 x.Node.Name,
                 x.Inverse!.ForwardName ?? x.Inverse.Forward.ToString(),
+                x.Inverse.Oracle,
                 x.Inverse.Naming,
                 x.Inverse.Precondition ?? "—",
                 x.Inverse.Witness ?? "—"))];
@@ -67,15 +69,15 @@ public static class InverseLedger
         sb.Append("`ILInspector.Decompiler` by the test reflector; drift-gated by a test. Do not\n");
         sb.Append("edit by hand. See [inverse-architecture.md](inverse-architecture.md) for the framing.\n\n");
         sb.Append("## Type assertions\n\n");
-        sb.Append("| Node | Forward construct | Naming | Precondition | Witness |\n");
-        sb.Append("| --- | --- | --- | --- | --- |\n");
+        sb.Append("| Node | Forward construct (Roslyn) | Oracle (RyuJIT) | Naming | Precondition | Witness |\n");
+        sb.Append("| --- | --- | --- | --- | --- | --- |\n");
 
         var rows = Rows(assembly);
         if (rows.Count == 0)
-            sb.Append("| _(none yet)_ | — | — | — | — |\n");
+            sb.Append("| _(none yet)_ | — | — | — | — | — |\n");
         else
             foreach (var row in rows)
-                sb.Append($"| `{row.Node}` | {row.ForwardName} | {row.Naming} | {row.Precondition} | {row.Witness} |\n");
+                sb.Append($"| `{row.Node}` | {row.ForwardName} | {row.Oracle} | {row.Naming} | {row.Precondition} | {row.Witness} |\n");
 
         sb.Append("\n## Declared non-inverse boundaries\n\n");
         sb.Append("| Node | Reason |\n");

--- a/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseArchitecture.cs
+++ b/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseArchitecture.cs
@@ -22,12 +22,6 @@ public enum Forward
 
     /// <summary>Roslyn's <c>BoundConversion</c> (the bound-tree conversion node).</summary>
     RoslynBoundConversion,
-
-    /// <summary>RyuJIT's <c>GT_CAST</c>.</summary>
-    RyuJitCast,
-
-    /// <summary>RyuJIT's <c>GT_BOX</c>.</summary>
-    RyuJitBox,
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseArchitecture.cs
+++ b/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseArchitecture.cs
@@ -106,7 +106,8 @@ public sealed class InverseOfAttribute : Attribute
     /// Name of the runnable assumption predicate on <see cref="InverseAssumptions"/>
     /// that verifies <see cref="Precondition"/>. When set it must resolve to a
     /// release-capable <c>Check(IrFunction)</c>; the coverage test enforces this
-    /// and invokes it over a fixture corpus.
+    /// and structurally invokes it (per-predicate behavior is covered by
+    /// predicate-specific tests).
     /// </summary>
     public string? Assumes { get; }
 

--- a/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseAssumptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseAssumptions.cs
@@ -5,8 +5,9 @@ namespace ILInspector.Decompiler.Pipeline.InverseArchitecture;
 /// Each is a release-capable check over an <see cref="IrFunction"/> that returns
 /// violation messages (empty = the assumption holds on that function). The
 /// inverse-architecture rule: an <c>assumes:</c> must name one of these, and the
-/// coverage test invokes it over a fixture corpus
-/// (docs/design/inverse-architecture.md, "Two levels"). Binding the attribute's
+/// coverage test resolves and structurally invokes it
+/// (docs/design/inverse-architecture.md, "Two levels"); per-predicate behavior is
+/// covered by predicate-specific tests. Binding the attribute's
 /// claim to a runnable check is the residual-drift guard — an assumption that
 /// cannot be spelled as a predicate stays in prose behind a
 /// <see cref="NotInvertedAttribute"/> marker instead.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1,6 +1,6 @@
 using System.Collections.Immutable;
 
-using ILInspector.Decompiler.Pipeline.InverseArchitecture;
+using Inverse = ILInspector.Decompiler.Pipeline.InverseArchitecture;
 
 namespace ILInspector.Decompiler.Pipeline;
 
@@ -1231,13 +1231,13 @@ public sealed class IncrementDecrement : IrExpression
 /// CoerceText rule; asserted by CoercionInvariant. Roslyn's BoundConversion,
 /// in reverse.
 /// </summary>
-[InverseOf(
-    Forward.RoslynBoundConversion,
-    naming: NameProvenance.Native,
-    oracle: Oracle.RyuJitStackNormalization,
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundConversion,
+    naming: Inverse.NameProvenance.Native,
+    oracle: Inverse.Oracle.RyuJitStackNormalization,
     forwardName: "BoundConversion (implicit, target-driven)",
     precondition: "sink type recoverable and distinguishable from the stack type",
-    assumes: nameof(InverseAssumptions.SinkDistinguishableFromStack),
+    assumes: nameof(Inverse.InverseAssumptions.SinkDistinguishableFromStack),
     witness: "CoerceChokePointTests, CoercionInvariantTests, corpus render-text A/B")]
 public sealed class Coerce : IrExpression
 {
@@ -1256,11 +1256,11 @@ public sealed class Coerce : IrExpression
 }
 
 /// <summary>A numeric conversion (the conv.* family).</summary>
-[InverseOf(
-    Forward.RoslynBoundConversion,
-    naming: NameProvenance.Inherited,
-    oracle: Oracle.RyuJitStackNormalization,
-    forwardName: "BoundConversion (numeric) / GT_CAST",
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundConversion,
+    naming: Inverse.NameProvenance.Inherited,
+    oracle: Inverse.Oracle.RyuJitStackNormalization,
+    forwardName: "BoundConversion (numeric)",
     precondition: "none — models the conv.* that ran",
     witness: "round-trips by construction; corpus compile-back")]
 public sealed class Convert : IrExpression
@@ -2364,10 +2364,11 @@ public sealed class IndexFromEnd : IrExpression
 }
 
 /// <summary>The boxing conversion (the <c>box</c> opcode): a value type materialized as a reference.</summary>
-[InverseOf(
-    Forward.RoslynBoundConversion,
-    naming: NameProvenance.Inherited,
-    forwardName: "BoundConversion (boxing) / GT_BOX",
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundConversion,
+    naming: Inverse.NameProvenance.Inherited,
+    oracle: Inverse.Oracle.RyuJitImporter,
+    forwardName: "BoundConversion (boxing)",
     precondition: "target is the boxed value type",
     witness: "box/unbox fixtures")]
 public sealed class Box : IrExpression

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 
+using ILInspector.Decompiler.Pipeline.InverseArchitecture;
+
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>How a by-reference argument must be spelled at a C# call site — recovered from the callee's parameter metadata.</summary>
@@ -1229,6 +1231,14 @@ public sealed class IncrementDecrement : IrExpression
 /// CoerceText rule; asserted by CoercionInvariant. Roslyn's BoundConversion,
 /// in reverse.
 /// </summary>
+[InverseOf(
+    Forward.RoslynBoundConversion,
+    naming: NameProvenance.Native,
+    oracle: Oracle.RyuJitStackNormalization,
+    forwardName: "BoundConversion (implicit, target-driven)",
+    precondition: "sink type recoverable and distinguishable from the stack type",
+    assumes: nameof(InverseAssumptions.SinkDistinguishableFromStack),
+    witness: "CoerceChokePointTests, CoercionInvariantTests, corpus render-text A/B")]
 public sealed class Coerce : IrExpression
 {
     public Coerce(TypeRef target, IrExpression operand)
@@ -1246,6 +1256,13 @@ public sealed class Coerce : IrExpression
 }
 
 /// <summary>A numeric conversion (the conv.* family).</summary>
+[InverseOf(
+    Forward.RoslynBoundConversion,
+    naming: NameProvenance.Inherited,
+    oracle: Oracle.RyuJitStackNormalization,
+    forwardName: "BoundConversion (numeric) / GT_CAST",
+    precondition: "none — models the conv.* that ran",
+    witness: "round-trips by construction; corpus compile-back")]
 public sealed class Convert : IrExpression
 {
     public Convert(TypeRef target, bool isChecked, bool isUnsigned, IrExpression operand)
@@ -2346,6 +2363,13 @@ public sealed class IndexFromEnd : IrExpression
     public override string Describe() => "IndexFromEnd";
 }
 
+/// <summary>The boxing conversion (the <c>box</c> opcode): a value type materialized as a reference.</summary>
+[InverseOf(
+    Forward.RoslynBoundConversion,
+    naming: NameProvenance.Inherited,
+    forwardName: "BoundConversion (boxing) / GT_BOX",
+    precondition: "target is the boxed value type",
+    witness: "box/unbox fixtures")]
 public sealed class Box : IrExpression
 {
     public Box(TypeRef type, IrExpression operand)


### PR DESCRIPTION
## What

The first real **node-annotation slice** on top of the merged infra (#2148): annotates the conversion family — `Convert` / `Coerce` / `Box` — in `IrNodes.cs`, flips the coverage allowlist to enforce them, and regenerates the committed ledger. Follows the doc's declared "first slice = conversion family."

| Node | Forward | Naming | Precondition | `assumes` |
| --- | --- | --- | --- | --- |
| `Coerce` | BoundConversion (implicit) | **Native** | sink distinguishable from stack type | `SinkDistinguishableFromStack` (runnable) |
| `Convert` | BoundConversion (numeric) / GT_CAST | Inherited | none — models the `conv.*` | — |
| `Box` | BoundConversion (boxing) / GT_BOX | Inherited | target is the boxed value type | — |

## Why it's low-risk

**Pure metadata.** The `[InverseOf]` attributes are consumed only by the test reflector; the shipped decompiler never reads them at runtime, so there is **no behavior / IR / render / fidelity change** — the full decompiler suite is unchanged at **1814 passing**. The only edits to `IrNodes.cs` are one `using` and three attributes on nodes slice-4 already settled (minimal conflict surface with in-flight value-typed-emission work).

## Effects

- The coverage test now **enforces** `Convert`/`Coerce`/`Box` (allowlist), and the **drift gate** confirms `docs/design/inverse-ledger.generated.md` matches the reflector output byte-for-byte (it now carries the three rows).
- `inverse-architecture.md` Status updated: doc ✅ (#2135), infra ✅ (#2148), conversion family annotated; the generated ledger is now the authoritative table.

## Validation

- Build clean; **1814** decompiler tests pass (7 `InverseArchitectureTests`, incl. the enforced allowlist + drift gate); markdownlint clean on both changed docs.

## Review note

Metadata-only, docs-like risk — no adversarial two-model review needed by the low-risk carve-out. The one thing worth a human sanity-check is the **classification judgment** (is `Coerce` rightly *Native*? are the preconditions accurate?), which the coverage/drift gates don't semantically verify. Happy to get a review pass if preferred.
