### PR TITLE
Route member Callers through MethodBodyInspectionSession (#2139)

### DIFF
--- a/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
+++ b/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
@@ -122,4 +122,47 @@ public class MethodBodyInspectionSessionTests
     [Fact]
     public void UnsafeEvidence_UnknownToken_ReturnsEmpty()
         => Assert.Empty(MethodBodyInspectionSession.Open(SelfPath).UnsafeEvidence(methodToken: 0));
+
+    static int CalledToken(Analysis.LibraryBodyIndex index)
+    {
+        var methodTokens = index.Methods.Select(m => m.MetadataToken).ToHashSet();
+        return index.DirectCalls
+            .Select(call => call.CalleeDefinitionToken)
+            .First(token => methodTokens.Contains(token));
+    }
+
+    [Fact]
+    public void SourceName_MatchesAssemblyFileName()
+    {
+        var expected = System.IO.Path.GetFileNameWithoutExtension(SelfPath);
+        Assert.Equal(expected, MethodBodyInspectionSession.Open(SelfPath).SourceName);
+    }
+
+    [Fact]
+    public void CallerEdges_MatchSameAssemblyFilter_ForCalledMethod()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var targetToken = CalledToken(index);
+
+        // Reproduce the prior inline same-assembly matching to assert equivalence.
+        var identity = index.Methods.First(m => m.MetadataToken == targetToken);
+        var pattern = Analysis.MemberPattern.Method(identity.DeclaringType, identity.Name, identity.ParameterTypes);
+        var expected = index.DirectCalls
+            .Where(call => call.CalleeDefinitionToken == targetToken || pattern.Matches(call.Callee))
+            .ToList();
+
+        var session = MethodBodyInspectionSession.Open(SelfPath);
+        var actual = session.CallerEdges(targetToken);
+
+        Assert.NotEmpty(actual);
+        Assert.Equal(expected.Count, actual.Length);
+        Assert.All(actual, edge => Assert.Equal(session.SourceName, edge.Source));
+        Assert.Equal(
+            expected.Select(c => (c.Caller.MetadataToken, c.ILOffset)).OrderBy(x => x),
+            actual.Select(e => (e.Call.Caller.MetadataToken, e.Call.ILOffset)).OrderBy(x => x));
+    }
+
+    [Fact]
+    public void CallerEdges_UnknownToken_ReturnsEmpty()
+        => Assert.Empty(MethodBodyInspectionSession.Open(SelfPath).CallerEdges(targetToken: 0));
 }

--- a/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
+++ b/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
@@ -1,4 +1,6 @@
 using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
 using ILInspector.Metadata;
 using Analysis = ILInspector.Analysis;
 
@@ -20,11 +22,21 @@ public sealed class MethodBodyInspectionSession
 {
     readonly Analysis.LibraryBodyIndex _index;
 
-    MethodBodyInspectionSession(Analysis.LibraryBodyIndex index) => _index = index;
+    MethodBodyInspectionSession(Analysis.LibraryBodyIndex index, string sourceName)
+    {
+        _index = index;
+        SourceName = sourceName;
+    }
+
+    /// <summary>
+    /// Short assembly name (file name without extension) this session was opened from. Used to
+    /// attribute inbound caller edges to their originating assembly.
+    /// </summary>
+    public string SourceName { get; }
 
     /// <summary>Opens a session over an assembly's analysis body index.</summary>
     public static MethodBodyInspectionSession Open(string assemblyPath, IAssemblyReferenceResolver? resolver = null)
-        => new(Analysis.LibraryBodyIndex.Open(assemblyPath, resolver));
+        => new(Analysis.LibraryBodyIndex.Open(assemblyPath, resolver), Path.GetFileNameWithoutExtension(assemblyPath));
 
     /// <summary>
     /// Allocation facts for one method (<paramref name="methodToken"/>), optionally narrowed to a
@@ -74,4 +86,50 @@ public sealed class MethodBodyInspectionSession
         => scopeIndexes is { Count: > 0 }
             ? _index.BuildCallerTree(methodToken, scopeIndexes)
             : _index.BuildCallerTree(methodToken);
+
+    /// <summary>
+    /// Inbound call edges targeting one method (<paramref name="targetToken"/>), each tagged with the
+    /// <see cref="SourceName"/> of the assembly it originates in.
+    ///
+    /// Same-assembly edges match either the exact callee-definition token or a structural pattern
+    /// built from the target's identity (the pattern adds MemberRef-form references, including
+    /// abstract/interface members that have no body). When <paramref name="scopes"/> is non-empty and
+    /// a pattern is available, each scope session is scanned for cross-assembly callers using
+    /// generic-normalized matching (operand tokens are assembly-local, so only the pattern applies).
+    /// Results are unsorted and undeduplicated; the caller owns presentation ordering.
+    /// </summary>
+    public ImmutableArray<CallerEdge> CallerEdges(
+        int targetToken,
+        IReadOnlyList<MethodBodyInspectionSession>? scopes = null)
+    {
+        var selected = _index.Methods.FirstOrDefault(m => m.MetadataToken == targetToken);
+        var pattern = selected is { } identity
+            ? Analysis.MemberPattern.Method(identity.DeclaringType, identity.Name, identity.ParameterTypes)
+            : null;
+
+        var edges = ImmutableArray.CreateBuilder<CallerEdge>();
+
+        foreach (var call in _index.DirectCalls)
+        {
+            if (call.CalleeDefinitionToken == targetToken || (pattern is not null && pattern.Matches(call.Callee)))
+                edges.Add(new CallerEdge(SourceName, call));
+        }
+
+        if (pattern is not null && scopes is { Count: > 0 })
+        {
+            foreach (var scope in scopes)
+            {
+                foreach (var call in scope._index.DirectCalls)
+                {
+                    if (pattern.MatchesCrossAssembly(call.Callee))
+                        edges.Add(new CallerEdge(scope.SourceName, call));
+                }
+            }
+        }
+
+        return edges.ToImmutable();
+    }
 }
+
+/// <summary>An inbound call edge targeting a selected member, tagged with its originating assembly.</summary>
+public readonly record struct CallerEdge(string Source, Analysis.DirectCall Call);

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1174,57 +1174,33 @@ public static class ApiOutputFormatter
         if (request.Callers && methods.Count > 0)
         {
             RequestTelemetry.Breadcrumb("il-analysis.callers", $"{methods.Count} member(s)");
-            var index = Analysis.LibraryBodyIndex.Open(dllPath, assemblyResolver);
-            var ownSource = Path.GetFileNameWithoutExtension(dllPath);
+            var callerSession = MethodBodyInspectionSession.Open(dllPath, assemblyResolver);
             var rows = new List<CallerSiteRow>();
+
+            // Open each caller-scope assembly once as its own session (skipping any that fail to
+            // load); the edge facet attributes cross-assembly hits to each scope's SourceName.
+            var scopeSessions = new List<MethodBodyInspectionSession>();
+            if (callerScopeAssemblies is { Count: > 0 })
+            {
+                foreach (var scopePath in callerScopeAssemblies)
+                {
+                    try
+                    {
+                        scopeSessions.Add(MethodBodyInspectionSession.Open(scopePath, AnalysisReferenceResolver(scopePath, options)));
+                    }
+                    catch
+                    {
+                        // Unreadable scope assembly: skip, matching the prior per-method open behavior.
+                    }
+                }
+            }
 
             // Collect callers for each method (all overloads if multiple methods selected)
             foreach (var method in methods.Where(m => m.MetadataToken.HasValue))
             {
                 var targetToken = method.MetadataToken!.Value;
-
-                // Match call edges whose callee resolves to the selected member. The
-                // operand-token equality catches direct same-assembly references
-                // (including abstract/interface members that have no body and so are
-                // absent from index.Methods); the structural pattern (built from the
-                // selected member's own identity) adds MemberRef-form references.
-                var selected = index.Methods.FirstOrDefault(m => m.MetadataToken == targetToken);
-                var pattern = selected is { } identity
-                    ? Analysis.MemberPattern.Method(identity.DeclaringType, identity.Name, identity.ParameterTypes)
-                    : null;
-
-                // Same-assembly callers
-                rows.AddRange(index.DirectCalls
-                    .Where(call => call.CalleeDefinitionToken == targetToken || (pattern is not null && pattern.Matches(call.Callee)))
-                    .Select(call => CreateCallerRow(ownSource, call)));
-
-                // Cross-assembly scope: scan each additional assembly for inbound callers using the
-                // structural pattern only (operand tokens are assembly-local), attributing each hit
-                // to its source assembly. Results stay in a single Callers table with a Source column.
-                if (pattern is not null && callerScopeAssemblies is { Count: > 0 })
-                {
-                    foreach (var scopePath in callerScopeAssemblies)
-                    {
-                        Analysis.LibraryBodyIndex scopeIndex;
-                        try
-                        {
-                            scopeIndex = Analysis.LibraryBodyIndex.Open(scopePath, AnalysisReferenceResolver(scopePath, options));
-                        }
-                        catch
-                        {
-                            continue;
-                        }
-
-                        // Cross-assembly matching must normalize generic member identity: a
-                        // constructed call site (List<int>.Add / Id<int>) matches the open
-                        // target definition (List<T>.Add / Id<T>) it could never match exactly
-                        // (#1339). Same-assembly matching above stays exact, token-driven.
-                        var scopeSource = Path.GetFileNameWithoutExtension(scopePath);
-                        rows.AddRange(scopeIndex.DirectCalls
-                            .Where(call => pattern.MatchesCrossAssembly(call.Callee))
-                            .Select(call => CreateCallerRow(scopeSource, call)));
-                    }
-                }
+                rows.AddRange(callerSession.CallerEdges(targetToken, scopeSessions)
+                    .Select(edge => CreateCallerRow(edge.Source, edge.Call)));
             }
 
             // Deduplicate and sort


### PR DESCRIPTION
## Summary

Next slice of the #2139 method-body seam: routes the member **Callers** section
through `MethodBodyInspectionSession`, removing the last raw `LibraryBodyIndex`
opens on the `member` inbound-caller path (primary + caller-scope assemblies).

- Adds `CallerEdges(int targetToken, IReadOnlyList<MethodBodyInspectionSession>? scopes)`
  to the session. It encapsulates the inbound-caller edge logic that previously
  lived inline in `ApiOutputFormatter`:
  - builds the structural `MemberPattern` from the target's identity,
  - same-assembly match on exact callee-definition token **or** pattern,
  - generic-normalized cross-assembly match against each scope session,
  - tags every edge with its originating assembly.
- Adds a `SourceName` property (assembly file name without extension) so edges
  can be attributed to their source assembly.
- Caller-scope assemblies are now opened once as sibling sessions (skipping any
  that fail to load) instead of raw `LibraryBodyIndex` instances re-opened per
  selected method.
- Row creation (`CreateCallerRow`), dedup, and sort stay in the formatter.

## Validation

- `dotnet build src/dotnet-inspect -c Release` — clean (0 warnings).
- `MethodBodyInspectionSessionTests` — 13/13 pass (incl. new
  `CallerEdges_MatchSameAssemblyFilter_ForCalledMethod`,
  `SourceName_MatchesAssemblyFileName`, unknown-token empty).
- `MemberCallersSectionTests` — 11/11 pass.
- **Byte-for-byte parity vs `main`**: diffed the rendered `Callers` section for
  multiple members/overloads with `--bin` cross-assembly scope — all identical,
  including a 4-row cross-assembly case.

Part of #2139 / #2122. After this, the `member` path's raw index opens are
gone; remaining #2139 work is the type-level helpers
(`PopulateUnsafeMembers`/called-types/top-leverage) at ApiOutputFormatter
~L1716–1926.
