### PR TITLE
Make IrNode.Descendants iterative to cut allocation

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrNodeDescendantsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrNodeDescendantsTests.cs
@@ -1,0 +1,74 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+/// <summary>
+/// Permanent order-equivalence canary for <see cref="IrNode.Descendants"/>. The
+/// property is a hot-path primitive with 320 call sites; its contract is a
+/// depth-first pre-order walk of the subtree (excluding the node itself),
+/// children in source order. These tests pin that sequence so the iterative
+/// implementation cannot silently drift from the recursive pre-order it replaced.
+/// </summary>
+public class IrNodeDescendantsTests
+{
+    // Blocks nest via Block.Add(IrNode); StartOffset is the order marker.
+    static Block Node(int offset, params Block[] children)
+    {
+        var block = new Block(offset);
+        foreach (var child in children)
+            block.Add(child);
+        return block;
+    }
+
+    [Fact]
+    public void Descendants_MultiLevelTree_YieldsPreOrderChildrenInSourceOrder()
+    {
+        //        root(0x00)
+        //        ├── a(0x10)
+        //        │   ├── a1(0x11)
+        //        │   └── a2(0x12)
+        //        └── b(0x20)
+        //            └── b1(0x21)
+        var root = Node(0x00,
+            Node(0x10, Node(0x11), Node(0x12)),
+            Node(0x20, Node(0x21)));
+
+        var order = root.Descendants.Select(n => ((Block)n).StartOffset).ToArray();
+
+        // Pre-order, source order, excluding the root itself.
+        Assert.Equal(new[] { 0x10, 0x11, 0x12, 0x20, 0x21 }, order);
+    }
+
+    [Fact]
+    public void Descendants_Leaf_IsEmpty()
+    {
+        var leaf = Node(0x00);
+
+        Assert.Empty(leaf.Descendants);
+    }
+
+    [Fact]
+    public void Descendants_MatchesReferenceRecursivePreOrder()
+    {
+        // Independent recursive reference over the public Children view; the
+        // iterative Descendants must reproduce it exactly for an irregular tree.
+        var root = Node(0x00,
+            Node(0x10,
+                Node(0x11, Node(0x13)),
+                Node(0x12)),
+            Node(0x20),
+            Node(0x30, Node(0x31), Node(0x32, Node(0x33))));
+
+        static IEnumerable<IrNode> ReferencePreOrder(IrNode node)
+        {
+            foreach (var child in node.Children)
+            {
+                yield return child;
+                foreach (var d in ReferencePreOrder(child))
+                    yield return d;
+            }
+        }
+
+        Assert.Equal(ReferencePreOrder(root).ToList(), root.Descendants.ToList());
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNode.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNode.cs
@@ -118,11 +118,25 @@ public abstract class IrNode
     {
         get
         {
-            foreach (var child in _children)
+            // Iterative pre-order DFS. A recursive `yield return` over children
+            // allocates one nested enumerator per node (O(N) state machines per
+            // traversal) and re-yields every value up through its ancestors
+            // (O(N*depth) time); an explicit stack does the same walk with a
+            // single enumerator plus one stack, and cannot deep-recurse.
+            // Children are pushed in reverse so they pop in source order,
+            // reproducing the recursive pre-order exactly.
+            if (_children.Count == 0)
+                yield break;
+            var stack = new Stack<IrNode>();
+            for (int i = _children.Count - 1; i >= 0; i--)
+                stack.Push(_children[i]);
+            while (stack.Count > 0)
             {
-                yield return child;
-                foreach (var descendant in child.Descendants)
-                    yield return descendant;
+                var node = stack.Pop();
+                yield return node;
+                var children = node._children;
+                for (int i = children.Count - 1; i >= 0; i--)
+                    stack.Push(children[i]);
             }
         }
     }


### PR DESCRIPTION
- Changes `IrNode.Descendants` from a recursive `yield return` to an iterative pre-order DFS, cutting the decompiler's single largest allocator with no behavior change.
- Not a fidelity/validity/corpus change: raised output is byte-identical, so no corpus quality card applies (fidelity-equivalence evidence below stands in for it).

## Change

> Should we accept this change?

**Conclusion: PASS** — behavior-preserving (order-identical pre-order; empirically identical fidelity over 48,820 methods) and cuts total sweep allocation by 64%.

`IrNode.Descendants` was a recursive `yield return` over children: walking a subtree of N nodes allocated one nested enumerator per node (O(N) state machines per traversal) and re-yielded every value up through its ancestors (O(N·depth) time). With 320 call sites (mostly `.Descendants.OfType<T>()`), a full-tree allocation-tick join measured it as the #1 allocator in the decompiler.

Before:

```csharp
foreach (var child in _children)
{
    yield return child;
    foreach (var descendant in child.Descendants)
        yield return descendant;
}
```

After:

```csharp
if (_children.Count == 0)
    yield break;
var stack = new Stack<IrNode>();
for (int i = _children.Count - 1; i >= 0; i--)
    stack.Push(_children[i]);
while (stack.Count > 0)
{
    var node = stack.Pop();
    yield return node;
    var children = node._children;
    for (int i = children.Count - 1; i >= 0; i--)
        stack.Push(children[i]);
}
```

Children are pushed in reverse so they pop in source order, reproducing the recursive pre-order exactly. One enumerator plus one stack per call instead of O(N); it can also no longer deep-recurse on tall trees.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Full decompiler suite | 1871/1872 pass; the 1 failure (`TypeSourceComposerUnionTests.UnionDeclaration_WithNonPublicExplicitConstructors_KeepsConstructorsOutOfCases`) is pre-existing preview-SDK `union` drift (CS9374 on the fixture's input compile, before decompilation); it fails identically on `origin/main` |
| Targeted subset (post-rebase) | 57/57 pass (Structuring, PipelineImporter, FidelityRemarks, ReferenceOwnership, CSharpPrinter) |
| Fidelity equivalence | Identical before/after: 47168/48820 Full (96.62%), 0 importer bugs, identical stop-reason histogram over 5 major BCL assemblies |

### Allocation measurement

Method: `dotnet-trace collect` (GC verbose + JIT/IL-to-native-map keywords) of a full `System.Private.CoreLib` decompile sweep, joined to static allocation sites by IL offset (nearest static site at-or-before the tick's leaf IL).

| Metric | Before | After |
| --- | ---: | ---: |
| Total sampled allocation (sweep) | 12.4 GB | 4.4 GB (−64%) |
| Enumerator-kind allocation | 9.17 GB | 0.51 GB |
| `Descendants` site | 8.8 GB | 0.83 GB (one `Stack` per traversal) |

## Adversarial review

Two cross-model reviews (Gemini 3.1 Pro and MAI-Code-1-Flash), both attacking correctness:

- **Agreed clean:** order equivalence (both hand-traced the reverse-push → source-order pre-order), leaf guard, re-entrancy (fresh stack per enumeration), private-field access, NativeAOT/trim.
- **Single finding (both, non-blocking):** the old `List<T>` enumerator threw `InvalidOperationException` on mutation-during-enumeration; the new indexed walk does not throw. Both verified no caller relies on this — the codebase pattern is defensive `.ToList()` before structural mutation (e.g. `function.Descendants.OfType<BlockContainer>().ToList()`). The identical-fidelity result over 48,820 methods empirically confirms no caller mutates during `Descendants` enumeration.
- **Non-action rationale:** restoring the fail-fast guard would require a mutation-version counter on `IrNode` (more invasive than the fix); the guard was incidental and unused. Documented here instead.

## Note

Do not merge without @richlander approval.
