### PR TITLE
Route type-level analysis helpers through MethodBodyInspectionSession (#2139)

### DIFF
--- a/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
+++ b/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
@@ -165,4 +165,54 @@ public class MethodBodyInspectionSessionTests
     [Fact]
     public void CallerEdges_UnknownToken_ReturnsEmpty()
         => Assert.Empty(MethodBodyInspectionSession.Open(SelfPath).CallerEdges(targetToken: 0));
+
+    [Fact]
+    public void UnsafeEvidence_All_MatchesIndex()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var actual = MethodBodyInspectionSession.Open(SelfPath).UnsafeEvidence();
+        Assert.Equal(index.UnsafeEvidence.Length, actual.Length);
+    }
+
+    [Fact]
+    public void CalledTypes_MatchesIndex_ForDeclaringTypeScope()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var declaringType = index.Methods.First().DeclaringType;
+        bool Scope(Analysis.MethodIdentity m) => m.DeclaringType.Equals(declaringType);
+
+        var expected = index.CalledTypes(Scope);
+        var actual = MethodBodyInspectionSession.Open(SelfPath).CalledTypes(Scope);
+        Assert.Equal(expected.Length, actual.Length);
+    }
+
+    [Fact]
+    public void OptimizationOpportunities_MatchesIndex()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var actual = MethodBodyInspectionSession.Open(SelfPath).OptimizationOpportunities;
+        Assert.Equal(index.OptimizationOpportunities.Length, actual.Length);
+    }
+
+    [Fact]
+    public void GeneratedFrameworkTypeNames_MatchesIndex()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var actual = MethodBodyInspectionSession.Open(SelfPath).GeneratedFrameworkTypeNames;
+        Assert.Equal(index.GeneratedFrameworkTypeNames.Count, actual.Count);
+    }
+
+    [Fact]
+    public void TopLeverage_MatchesIndex_ForScope()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var declaringType = index.Methods.First().DeclaringType;
+        bool Scope(Analysis.MethodIdentity m) => m.DeclaringType.Equals(declaringType);
+
+        var expected = index.TopLeverage(count: int.MaxValue, scope: Scope);
+        var actual = MethodBodyInspectionSession.Open(SelfPath).TopLeverage(int.MaxValue, Scope);
+        Assert.Equal(
+            expected.Select(e => e.Method.MetadataToken),
+            actual.Select(e => e.Method.MetadataToken));
+    }
 }

--- a/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
+++ b/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
@@ -129,6 +129,31 @@ public sealed class MethodBodyInspectionSession
 
         return edges.ToImmutable();
     }
+
+    // --- Type/collection-scoped producer surface (the type/library analysis sections) ---
+
+    /// <summary>All unsafe-operation evidence in the assembly (unfiltered); the caller narrows by type.</summary>
+    public ImmutableArray<Analysis.UnsafeEvidence> UnsafeEvidence()
+        => _index.UnsafeEvidence;
+
+    /// <summary>
+    /// Called-type summaries aggregated over calls originating in methods matching
+    /// <paramref name="callerScope"/>.
+    /// </summary>
+    public ImmutableArray<Analysis.CalledTypeSummary> CalledTypes(Func<Analysis.MethodIdentity, bool> callerScope)
+        => _index.CalledTypes(callerScope);
+
+    /// <summary>All performance-triage optimization opportunities in the assembly (unfiltered).</summary>
+    public ImmutableArray<Analysis.OptimizationOpportunity> OptimizationOpportunities
+        => _index.OptimizationOpportunities;
+
+    /// <summary>Qualified names of types recognized as generated framework/protobuf/gRPC implementation detail.</summary>
+    public IReadOnlySet<string> GeneratedFrameworkTypeNames
+        => _index.GeneratedFrameworkTypeNames;
+
+    /// <summary>Leverage ranking (highest first) of up to <paramref name="count"/> methods matching <paramref name="scope"/>.</summary>
+    public ImmutableArray<Analysis.MethodLeverage> TopLeverage(int count, Func<Analysis.MethodIdentity, bool> scope)
+        => _index.TopLeverage(count, scope);
 }
 
 /// <summary>An inbound call edge targeting a selected member, tagged with its originating assembly.</summary>

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1687,8 +1687,8 @@ public static class ApiOutputFormatter
 
     internal static void PopulateUnsafeMembers(TypeView view, ApiType type, string dllPath)
     {
-        var index = Analysis.LibraryBodyIndex.Open(dllPath, AnalysisReferenceResolver(dllPath));
-        var rows = index.UnsafeEvidence
+        var rows = MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath))
+            .UnsafeEvidence()
             .Where(evidence => SameType(evidence.Member.DeclaringType, type))
             .OrderBy(evidence => evidence.Member.Name, StringComparer.Ordinal)
             .ThenBy(evidence => evidence.ILOffset ?? -1)
@@ -1735,8 +1735,8 @@ public static class ApiOutputFormatter
         string dllPath,
         IReadOnlySet<string>? explicitSections = null)
     {
-        var index = Analysis.LibraryBodyIndex.Open(dllPath, AnalysisReferenceResolver(dllPath));
-        var rows = index.CalledTypes(method => SameType(method.DeclaringType, type))
+        var rows = MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath))
+            .CalledTypes(method => SameType(method.DeclaringType, type))
             .Select(summary => new CalledTypeRow(
                 MarkoutInline.Code(summary.Type.ToQualifiedDisplayString()),
                 string.IsNullOrEmpty(summary.Assembly) ? null : summary.Assembly,
@@ -1756,7 +1756,7 @@ public static class ApiOutputFormatter
         IReadOnlySet<string>? requestedSections,
         IReadOnlySet<string>? explicitSections = null)
     {
-        var index = Analysis.LibraryBodyIndex.Open(dllPath, AnalysisReferenceResolver(dllPath));
+        var session = MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath));
         var methodTokens = type.Members
             .Where(member => member.MetadataToken is not null && ApiMemberSectionDescriptors.IsMethodLike(member))
             .Select(member => member.MetadataToken!.Value)
@@ -1764,9 +1764,8 @@ public static class ApiOutputFormatter
 
         if (requestedSections?.Contains(SectionNames.AllocationFacts) == true)
         {
-            var allocations = index.GetAllocationOccurrences();
             var rows = methodTokens
-                .SelectMany(token => Analysis.SemanticFactProjection.AllocationFacts(allocations, token))
+                .SelectMany(token => session.AllocationFacts(token))
                 .Select(fact => ToAllocationFactRow(fact, includeMember: true))
                 .ToList();
             if (rows.Count > 0 || explicitSections is not null && explicitSections.Contains(SectionNames.AllocationFacts))
@@ -1775,10 +1774,8 @@ public static class ApiOutputFormatter
 
         if (requestedSections?.Contains(SectionNames.SafetyFacts) == true)
         {
-            var unsafeEvidence = index.GetUnsafeEvidenceByMember();
-            var unsafety = index.GetUnsafetyOccurrences();
             var rows = methodTokens
-                .SelectMany(token => Analysis.SemanticFactProjection.SafetyFacts(unsafeEvidence, unsafety, token))
+                .SelectMany(token => session.SafetyFacts(token))
                 .Select(fact => ToSafetyFactRow(fact, includeMember: true))
                 .ToList();
             if (rows.Count > 0 || explicitSections is not null && explicitSections.Contains(SectionNames.SafetyFacts))
@@ -1787,9 +1784,8 @@ public static class ApiOutputFormatter
 
         if (requestedSections?.Contains(SectionNames.CostFacts) == true)
         {
-            var directCalls = index.GetDirectCallsByCaller();
             var rows = methodTokens
-                .SelectMany(token => Analysis.SemanticFactProjection.CostFacts(directCalls, token))
+                .SelectMany(token => session.CostFacts(token))
                 .Select(fact => ToCostFactRow(fact, includeMember: true))
                 .ToList();
             if (rows.Count > 0 || explicitSections is not null && explicitSections.Contains(SectionNames.CostFacts))
@@ -1805,14 +1801,14 @@ public static class ApiOutputFormatter
         PerformanceTriageOptions? options = null,
         bool restrictToModelMembers = false)
     {
-        var index = Analysis.LibraryBodyIndex.Open(dllPath, AnalysisReferenceResolver(dllPath));
+        var session = MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath));
         HashSet<int>? memberTokens = restrictToModelMembers
             ? type.Members.Where(m => m.MetadataToken is not null).Select(m => m.MetadataToken!.Value).ToHashSet()
             : null;
         var rows = LibraryMetadataService.FilterAndOrderTriageOpportunities(
-                index.OptimizationOpportunities
+                session.OptimizationOpportunities
                     .Where(opportunity => SameType(opportunity.Method.DeclaringType, type))
-                    .Where(opportunity => !LibraryMetadataService.IsGeneratedMethod(opportunity.Method, index.GeneratedFrameworkTypeNames))
+                    .Where(opportunity => !LibraryMetadataService.IsGeneratedMethod(opportunity.Method, session.GeneratedFrameworkTypeNames))
                     .Where(opportunity => memberTokens is null || memberTokens.Contains(opportunity.Method.MetadataToken)),
                 options)
             .Select(opportunity => new OptimizationOpportunityRow(
@@ -1898,7 +1894,7 @@ public static class ApiOutputFormatter
 
     internal static void PopulateTopLeverage(TypeView view, ApiType type, string dllPath, bool restrictToModelMembers = false)
     {
-        var index = Analysis.LibraryBodyIndex.Open(dllPath, AnalysisReferenceResolver(dllPath));
+        var session = MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath));
         var drillByToken = BuildMemberDrillMap(type);
 
         // Rank every method declared on this type; fanin is still measured across all
@@ -1906,12 +1902,12 @@ public static class ApiOutputFormatter
         // limiter (`-n`/`--rows`) trims the rendered table. In member-detail/overload
         // contexts `type.Members` is narrowed to the selected member(s), so restrict the
         // ranked rows to those tokens (mirrors PopulateOptimizationOpportunities).
-        var rows = index.TopLeverage(count: int.MaxValue, scope: method => SameType(method.DeclaringType, type))
+        var rows = session.TopLeverage(count: int.MaxValue, scope: method => SameType(method.DeclaringType, type))
             .Where(entry => !restrictToModelMembers || drillByToken.ContainsKey(entry.Method.MetadataToken))
             .Select(entry =>
             {
                 drillByToken.TryGetValue(entry.Method.MetadataToken, out var drill);
-                bool generated = LibraryMetadataService.IsGeneratedMethod(entry.Method, index.GeneratedFrameworkTypeNames);
+                bool generated = LibraryMetadataService.IsGeneratedMethod(entry.Method, session.GeneratedFrameworkTypeNames);
                 return new TopLeverageRow(
                     MarkoutInline.Code(FormatMember(null, entry.Method.Name, entry.Method.ParameterTypes, [])),
                     entry.DirectCallerCount.ToString(),


### PR DESCRIPTION
## Summary

Next slice of the #2139 method-body seam: routes the **type-level analysis
helpers** (the `type`/`library` command sections) through
`MethodBodyInspectionSession`, removing five raw `LibraryBodyIndex.Open` sites
from `ApiOutputFormatter`.

- Adds a type/collection-scoped producer surface to the session:
  - `UnsafeEvidence()` — all unsafe evidence (caller narrows by type),
  - `CalledTypes(Func<MethodIdentity,bool> scope)`,
  - `OptimizationOpportunities`,
  - `GeneratedFrameworkTypeNames`,
  - `TopLeverage(int count, Func<MethodIdentity,bool> scope)`.
- Converts the five helpers:
  - `PopulateUnsafeMembers`, `PopulateCalledTypes`,
    `PopulateOptimizationOpportunities`, `PopulateTopLeverage` → the new facets;
  - `PopulateTypeSemanticFacts` → now reuses the session's existing
    `AllocationFacts`/`SafetyFacts`/`CostFacts` token facets (drops the direct
    `SemanticFactProjection` + `GetAllocationOccurrences`/… calls from the CLI).

Selection predicates (`SameType`, scope funcs) and row rendering stay in the
formatter. After this, the only remaining raw index open in `ApiOutputFormatter`
is the caller-graph scope-index (a separate follow-up slice).

## Validation

- `dotnet build src/dotnet-inspect -c Release` — clean (0 warnings).
- `MethodBodyInspectionSessionTests` — 18/18 pass (5 new facet tests).
- Type-level section suites (`CalledTypesSectionTests`, `TopLeverageSectionTests`,
  `LibraryTopLeverageTests`, `NestedTypeLeverageTests`, `SemanticFactsSectionTests`,
  `UnsafeMembersSectionTests`) — 40/40 pass.
- **Byte-for-byte parity vs `main`**: diffed 70 renderings (2 libraries × 5 types
  × 7 sections: Unsafe Members, Called Types, Top Leverage, Allocation/Safety/Cost
  Facts, Performance Triage) — all identical, with substantial non-empty output
  (e.g. 61/60/56/19-row cases).

Part of #2139 / #2122.
