### PR TITLE
Add RTS type attribute metadata coverage

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -579,6 +579,20 @@ public class GeneratedFixtureCatalogTests
             frontier: false);
         AssertTarget(
             run,
+            "minimal.type-attributes",
+            "GeneratedFixtures.MinimalTypeAttributes.Class1",
+            ".ctor",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
+            "minimal.type-attributes",
+            "GeneratedFixtures.MinimalTypeAttributes.Class1",
+            "Method1",
+            FidelityCheck.CompileBackStatus.Exact,
+            frontier: false);
+        AssertTarget(
+            run,
             "minimal.if-else",
             "GeneratedFixtures.MinimalIfElse.Class1",
             ".ctor",
@@ -828,6 +842,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.auto-property.getter", report);
         Assert.Contains("minimal.method-call.same-type", report);
         Assert.Contains("minimal.member-attributes", report);
+        Assert.Contains("minimal.type-attributes", report);
         Assert.Contains("minimal.static-method-call", report);
         Assert.Contains("minimal.static-class", report);
         Assert.Contains("minimal.static-constructor", report);
@@ -927,6 +942,7 @@ public class GeneratedFixtureCatalogTests
                 "minimal.switch-int",
                 "minimal.switch-two-case-lowers-if",
                 "minimal.try-finally",
+                "minimal.type-attributes",
                 "minimal.using-dispose",
                 "minimal.while-loop",
             ],
@@ -953,6 +969,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.conditional-expression-shape-frontier");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.method-call.same-type");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.member-attributes");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.type-attributes");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.static-method-call");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.static-class");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.static-constructor");

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1518,6 +1518,45 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_RoundTripsTypeAttributes()
+    {
+        var assemblyPath = CompileFixture("""
+            [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+            public class Class1
+            {
+                public int Method1()
+                    => 42;
+            }
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Class1", ".ctor", 0),
+                    new ReturnToSender.RequestedTarget("Class1", "Method1", 0),
+                ]);
+
+            Assert.Collection(
+                results,
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public class Class1", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public class Class1", result.Source);
+                });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericTypeTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -128,7 +128,8 @@ public sealed record CompileBackTypeDeclaration(
     IReadOnlyList<CompileBackTypeSignature> Interfaces,
     IReadOnlyList<CompileBackMemberDeclaration> Members,
     IReadOnlyList<CompileBackFact> SourceFacts,
-    IReadOnlyList<CompileBackTypeDeclaration> NestedTypes)
+    IReadOnlyList<CompileBackTypeDeclaration> NestedTypes,
+    IReadOnlyList<string>? Attributes = null)
 {
     public string Namespace => Identity.Namespace;
     public string Name => Identity.DisplayName;
@@ -864,6 +865,7 @@ public static class CompileBackSourceComposer
                 })
                 .ToList(),
             Interfaces = type.Interfaces.Select(type => type.DisplayName).ToList(),
+            Attributes = type.Attributes?.ToList() ?? [],
         };
 
     static ApiMember ToApiMember(CompileBackTypeDeclaration type, CompileBackMemberDeclaration member)
@@ -1892,7 +1894,8 @@ public static class CompileBackSourceComposer
                         reader,
                         typeDef,
                         includeMemberSurface: requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member"),
-                        diagnostics)));
+                        diagnostics),
+                    TypeAttributeList(reader, typeDef)));
             }
 
             return shells;
@@ -1937,11 +1940,15 @@ public static class CompileBackSourceComposer
                     Interfaces: InterfaceSignatures(reader, nestedDef),
                     members,
                     requirement.SourceFacts,
-                    NestedTypes(reader, nestedDef, includeMemberSurface, diagnostics)));
+                    NestedTypes(reader, nestedDef, includeMemberSurface, diagnostics),
+                    TypeAttributeList(reader, nestedDef)));
             }
 
             return nestedTypes;
         }
+
+        static IReadOnlyList<string> TypeAttributeList(MetadataReader reader, TypeDefinition typeDef)
+            => AttributeReader.RenderAttributes(reader, typeDef.GetCustomAttributes(), qualifyNames: true);
 
         static IReadOnlyList<CompileBackTypeSignature> InterfaceSignatures(MetadataReader reader, TypeDefinition typeDef)
         {

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -244,6 +244,7 @@ public class ApiType
     public string? Namespace { get; set; }
     public string Name { get; set; } = "";
     public string Kind { get; set; } = "";  // class, struct, interface, enum, delegate
+    public List<string> Attributes { get; set; } = [];
 
     /// <summary>The C# enum underlying type, captured from the special <c>value__</c> field.</summary>
     public string? EnumUnderlyingType { get; set; }

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -50,6 +50,7 @@ public static class ApiSurfaceExtractor
                 Name = typeName,
                 IsSealed = (attributes & TypeAttributes.Sealed) != 0,
                 IsAbstract = (attributes & TypeAttributes.Abstract) != 0,
+                Attributes = AttributeReader.RenderAttributes(reader, typeDef.GetCustomAttributes(), qualifyNames: true),
             };
 
             // Determine kind

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -621,7 +621,9 @@ public static class AttributeReader
     static bool IsReEmittedAttribute(string name) => name switch
     {
         KnownAttributeNames.ExtensionAttribute => true,
+        KnownAttributeNames.CompilerFeatureRequiredAttribute => true,
         KnownAttributeNames.CompilerGeneratedAttribute => true,
+        "System.Runtime.CompilerServices.InlineArrayAttribute" => true,
         KnownAttributeNames.NullableAttribute => true,
         KnownAttributeNames.NullableContextAttribute => true,
         KnownAttributeNames.IsReadOnlyAttribute => true,

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -168,7 +168,10 @@ public static class CSharpDeclarationWriter
         if (bases.Count > 0)
             declaration += " : " + string.Join(", ", bases);
 
-        return AppendTypeParameterConstraints(declaration, type.TypeParameters);
+        declaration = AppendTypeParameterConstraints(declaration, type.TypeParameters);
+        return type.Attributes.Count == 0
+            ? declaration
+            : $"[{string.Join(", ", type.Attributes)}] {declaration}";
     }
 
     static bool NeedsTerminator(string declaration)

--- a/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
+++ b/src/dotnet-inspect.Tests/ApiSurfaceExtractorTests.cs
@@ -111,6 +111,9 @@ public class ApiSurfaceExtractorTests
         Assert.Equal("struct", refStruct.Kind);
         Assert.True(refStruct.IsByRefLike);
         Assert.False(refStruct.IsReadOnly);
+        var refStructDeclaration = CSharpDeclarationWriter.RenderTypeDeclaration(refStruct);
+        Assert.Contains("ref struct SampleRefStruct", refStructDeclaration);
+        Assert.DoesNotContain("CompilerFeatureRequired", refStructDeclaration);
 
         var readOnlyStruct = surface.Types.FirstOrDefault(t => t.Name == "SampleReadOnlyStruct");
         Assert.NotNull(readOnlyStruct);
@@ -121,6 +124,11 @@ public class ApiSurfaceExtractorTests
         Assert.NotNull(plainStruct);
         Assert.False(plainStruct.IsByRefLike);
         Assert.False(plainStruct.IsReadOnly);
+
+        var inlineArray = surface.Types.FirstOrDefault(t => t.Name == "SampleInlineBuffer");
+        Assert.NotNull(inlineArray);
+        var inlineArrayDeclaration = CSharpDeclarationWriter.RenderTypeDeclaration(inlineArray);
+        Assert.DoesNotContain("InlineArray", inlineArrayDeclaration);
     }
 
     [Fact]
@@ -371,6 +379,25 @@ public class ApiSurfaceExtractorTests
         var decimalFieldDeclaration = CSharpDeclarationWriter.RenderMemberDeclaration(testType, decimalField);
         Assert.DoesNotContain("DecimalConstant", decimalFieldDeclaration);
         Assert.Contains("DecimalField", decimalFieldDeclaration);
+    }
+
+    [Fact]
+    public void Extract_RendersTypeAttributes()
+    {
+        var assemblyPath = typeof(ApiSurfaceExtractorTests).Assembly.Location;
+        using var stream = File.OpenRead(assemblyPath);
+        using var peReader = new PEReader(stream);
+
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var testType = surface.Types.FirstOrDefault(t => t.Name == nameof(SampleTypeAttributeHost));
+        Assert.NotNull(testType);
+
+        var declaration = CSharpDeclarationWriter.RenderTypeDeclaration(testType);
+        Assert.StartsWith(
+            "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public class SampleTypeAttributeHost",
+            declaration,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -918,6 +945,12 @@ public class SampleKeywordParameterHost
     public static int Static(int @params, int @void) => @params + @void;
 }
 
+[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+public class SampleTypeAttributeHost
+{
+    public int Method1() => 42;
+}
+
 public class SampleRefReadonlyReturnHost
 {
     public static ref readonly int ChooseReadonly(in int left, in int right, bool chooseLeft)
@@ -993,6 +1026,12 @@ public readonly struct SampleReadOnlyStruct
 public struct SamplePlainStruct
 {
     public int Value;
+}
+
+[System.Runtime.CompilerServices.InlineArray(4)]
+public struct SampleInlineBuffer
+{
+    private int _element0;
 }
 
 /// <summary>

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -734,6 +734,34 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "member", "attributes"]);
 
+    public static readonly GeneratedFixtureDefinition MinimalTypeAttributes = new(
+        "minimal.type-attributes",
+        """
+        namespace GeneratedFixtures.MinimalTypeAttributes;
+
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        public class Class1
+        {
+            public int Method1()
+                => 42;
+        }
+        """,
+        [
+            new("GeneratedFixtures.MinimalTypeAttributes.Class1", ".ctor",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public class Class1",
+                ]),
+            new("GeneratedFixtures.MinimalTypeAttributes.Class1", "Method1",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage] public class Class1",
+                ]),
+        ],
+        ["minimal", "type", "attributes"]);
+
     public static readonly GeneratedFixtureDefinition MinimalIfElse = new(
         "minimal.if-else",
         """
@@ -1237,6 +1265,7 @@ internal static class GeneratedFixtureCatalog
         MinimalReturnParameterMetadata,
         MinimalPropertyReturnMetadata,
         MinimalMemberAttributes,
+        MinimalTypeAttributes,
         MinimalIfElse,
         MinimalIntegerAddition,
         MinimalStructMembers,


### PR DESCRIPTION
- Advances #2057
- Changes product type declaration rendering for source-spellable type attributes and expands source-aware RTS coverage.
- Evidence revision: `5e7bbebb`

## Change

**Conclusion:** **PASS** — source-spellable type attributes now flow through product declarations and source-aware RTS compile-back checks.

Before:

```text
minimal.type-attributes failed 2 targets with source-fragment-missing on origin/main + tests-only.
API surface type-attribute test failed.
```

After:

```text
minimal.type-attributes passes 1/1 fixture and 2/2 targets.
API surface type-attribute test passes.
```

## Scope and safety

- **Root cause:** `ApiType` had no general type-attribute bag, so source-spellable type custom attributes were lost in product declarations and RTS source.
- **Fix shape:** add `ApiType.Attributes`, render them before type declarations, and carry type attributes through `ApiSurfaceExtractor` and `CompileBackSourceComposer`.
- **Product impact:** source-spellable type attributes such as `ExcludeFromCodeCoverage` now appear in type declarations. Compiler-synthesized/reserved type attributes (`CompilerFeatureRequired`, `InlineArray`) remain filtered.
- **Scope boundary:** this does not add new member/parameter/return metadata shapes; it reuses the existing attribute renderer and source-aware catalog checks.
- **RTS boundary:** RTS remains orchestration-only; product/shared code owns C# source generation. Harness changes are fixture source and source-fragment expectations.

## Before/after small corpus

Before run: `origin/main` plus the new tests/fixtures only.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 1 fixture(s), 2 target(s)

Fixtures:
  Passed : 0
  Skipped: 0
  Failed : 1

Targets:
  Passed : 0
  Skipped: 0
  Failed : 2

Failed target buckets:
  source-fragment-missing: 2
```

After run: branch head `5e7bbebb`.

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 1 fixture(s), 2 target(s)

Fixtures:
  Passed : 1
  Skipped: 0
  Failed : 0

Targets:
  Passed : 2
  Skipped: 0
  Failed : 0
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| API surface tests | `ApiSurfaceExtractorTests` 40/40 |
| Focused decompiler tests | `GeneratedFixtureCatalogTests` 8/8; `ReturnToSenderPrototypeTests` 45/45 |
| Decompiler fast suite | Pass, 1814/1814 |
| Default RTS catalog | `39/39` fixtures, `116/116` targets |
| ReturnToSender A/B | `240` Same, `0` Worse, `0` CurrentMissing |

## Compile-back quality

**Conclusion:** **PASS** — source-aware checks cover type metadata that opcode-only fidelity cannot see, and A/B remains no-worse.

### ReturnToSender catalog

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 39 fixture(s), 116 target(s)

Fixtures:
  Passed : 39
  Skipped: 0
  Failed : 0

Targets:
  Passed : 116
  Skipped: 0
  Failed : 0
```

Minimal selector, including known explicit frontiers:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 41 fixture(s), 120 target(s)

Fixtures:
  Passed : 40
  Skipped: 0
  Failed : 1

Targets:
  Passed : 119
  Skipped: 0
  Failed : 1

Failed target buckets:
  opcode-diff: 1

Failed fixtures (first 1 of 1):
  minimal.switch-two-case-lowers-if
      GeneratedFixtures.MinimalSwitchTwoCaseLowersIf.Class1::Method1#0  rts=OpcodeDiff  bucket=opcode-diff
```

### ReturnToSender A/B

```text
RETURNTOSENDER A/B over 240 property getters

  Rescued       : 0
  Same          : 240
  Changed       : 0
  Worse         : 0
  CurrentMissing: 0
```

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `minimal.switch-two-case-lowers-if` | Left as frontier | Known compiler/source-lowering opcode-diff frontier, unrelated to type attributes. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | No significant issues | Reviewed type attribute rendering, synthesized filters, RTS boundary, and source-aware fixture behavior. |
| Claude Opus 4.8 | No significant issues | Verified type attribute ordering, compiler-synthesized filtering, no member/return leakage, closure-shell safety, and focused tests. |

**Review conclusion:** **PASS** — isolated Gemini and Claude reviews on `4c468a84` found no significant issues; post-merge validation on `5e7bbebb` is green.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -class "*ApiSurfaceExtractorTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --return-to-sender-catalog --max-examples 50
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --return-to-sender-catalog minimal --max-examples 50
```
