### PR TITLE
Inverse architecture: annotate the reference/unbox conversion nodes (batch 2)

### DIFF
--- a/docs/design/inverse-ledger.generated.md
+++ b/docs/design/inverse-ledger.generated.md
@@ -13,7 +13,7 @@ edit by hand. See [inverse-architecture.md](inverse-architecture.md) for the fra
 | `Coerce` | BoundConversion (implicit, target-driven) | RyuJitStackNormalization | Native | sink type recoverable and distinguishable from the stack type | CoerceChokePointTests, CoercionInvariantTests, corpus render-text A/B |
 | `Convert` | BoundConversion (numeric) | RyuJitStackNormalization | Inherited | none — models the conv.* that ran | round-trips by construction; corpus compile-back |
 | `Unbox` | BoundConversion (unboxing → managed pointer) | RyuJitImporter | Inherited | operand is a box of the value type; result is a managed pointer into it | box/unbox fixtures; corpus compile-back |
-| `UnboxAny` | BoundConversion (unboxing) | RyuJitImporter | Inherited | target is the unbox.any type token — an unboxed value type or a type parameter | box/unbox fixtures; corpus compile-back |
+| `UnboxAny` | BoundConversion (unboxing) | RyuJitImporter | Inherited | target is the unbox.any type token (value type, reference type, or type parameter) | box/unbox fixtures; corpus compile-back |
 
 ## Declared non-inverse boundaries
 

--- a/docs/design/inverse-ledger.generated.md
+++ b/docs/design/inverse-ledger.generated.md
@@ -9,8 +9,11 @@ edit by hand. See [inverse-architecture.md](inverse-architecture.md) for the fra
 | Node | Forward construct (Roslyn) | Oracle (RyuJIT) | Naming | Precondition | Witness |
 | --- | --- | --- | --- | --- | --- |
 | `Box` | BoundConversion (boxing) | RyuJitImporter | Inherited | target is the boxed value type | box/unbox fixtures |
+| `CastClass` | BoundConversion (reference cast) | RyuJitImporter | Inherited | target is the reference type the cast checks | cast fixtures; corpus compile-back |
 | `Coerce` | BoundConversion (implicit, target-driven) | RyuJitStackNormalization | Native | sink type recoverable and distinguishable from the stack type | CoerceChokePointTests, CoercionInvariantTests, corpus render-text A/B |
 | `Convert` | BoundConversion (numeric) | RyuJitStackNormalization | Inherited | none — models the conv.* that ran | round-trips by construction; corpus compile-back |
+| `Unbox` | BoundConversion (unboxing → managed pointer) | RyuJitImporter | Inherited | operand is a box of the value type; result is a managed pointer into it | box/unbox fixtures; corpus compile-back |
+| `UnboxAny` | BoundConversion (unboxing) | RyuJitImporter | Inherited | target is the unboxed value type | box/unbox fixtures; corpus compile-back |
 
 ## Declared non-inverse boundaries
 

--- a/docs/design/inverse-ledger.generated.md
+++ b/docs/design/inverse-ledger.generated.md
@@ -13,7 +13,7 @@ edit by hand. See [inverse-architecture.md](inverse-architecture.md) for the fra
 | `Coerce` | BoundConversion (implicit, target-driven) | RyuJitStackNormalization | Native | sink type recoverable and distinguishable from the stack type | CoerceChokePointTests, CoercionInvariantTests, corpus render-text A/B |
 | `Convert` | BoundConversion (numeric) | RyuJitStackNormalization | Inherited | none — models the conv.* that ran | round-trips by construction; corpus compile-back |
 | `Unbox` | BoundConversion (unboxing → managed pointer) | RyuJitImporter | Inherited | operand is a box of the value type; result is a managed pointer into it | box/unbox fixtures; corpus compile-back |
-| `UnboxAny` | BoundConversion (unboxing) | RyuJitImporter | Inherited | target is the unboxed value type | box/unbox fixtures; corpus compile-back |
+| `UnboxAny` | BoundConversion (unboxing) | RyuJitImporter | Inherited | target is the unbox.any type token — an unboxed value type or a type parameter | box/unbox fixtures; corpus compile-back |
 
 ## Declared non-inverse boundaries
 

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
@@ -22,7 +22,7 @@ public class InverseArchitectureTests
     // In-domain product nodes that MUST carry [InverseOf] or [NotInverted]. The
     // conversion family is the first annotated slice (docs/design/inverse-architecture.md);
     // the set grows as the ledger's declared domain grows.
-    static readonly string[] EnforcedProductNodes = ["Convert", "Coerce", "Box"];
+    static readonly string[] EnforcedProductNodes = ["Box", "CastClass", "Coerce", "Convert", "Unbox", "UnboxAny"];
 
     static Assembly ProductAssembly => typeof(IrFunction).Assembly;
     Assembly TestAssembly => GetType().Assembly;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -3178,7 +3178,7 @@ public sealed class Unbox : IrExpression
     naming: Inverse.NameProvenance.Inherited,
     oracle: Inverse.Oracle.RyuJitImporter,
     forwardName: "BoundConversion (unboxing)",
-    precondition: "target is the unbox.any type token — an unboxed value type or a type parameter",
+    precondition: "target is the unbox.any type token (value type, reference type, or type parameter)",
     witness: "box/unbox fixtures; corpus compile-back")]
 public sealed class UnboxAny : IrExpression
 {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -3178,7 +3178,7 @@ public sealed class Unbox : IrExpression
     naming: Inverse.NameProvenance.Inherited,
     oracle: Inverse.Oracle.RyuJitImporter,
     forwardName: "BoundConversion (unboxing)",
-    precondition: "target is the unboxed value type",
+    precondition: "target is the unbox.any type token — an unboxed value type or a type parameter",
     witness: "box/unbox fixtures; corpus compile-back")]
 public sealed class UnboxAny : IrExpression
 {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -2535,6 +2535,14 @@ public sealed class PositionalPattern : IrExpression
     public override string Describe() => $"PositionalPattern ({Subpatterns.Length} elements)";
 }
 
+/// <summary>The <c>castclass</c> reference type-check cast (<c>(T)x</c> for a reference type <c>T</c>).</summary>
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundConversion,
+    naming: Inverse.NameProvenance.Inherited,
+    oracle: Inverse.Oracle.RyuJitImporter,
+    forwardName: "BoundConversion (reference cast)",
+    precondition: "target is the reference type the cast checks",
+    witness: "cast fixtures; corpus compile-back")]
 public sealed class CastClass : IrExpression
 {
     public CastClass(TypeRef type, IrExpression operand)
@@ -3141,6 +3149,13 @@ public sealed class SwitchBranch : IrNode
 }
 
 /// <summary>unbox: a managed pointer into the box (distinct from unbox.any, which loads the value).</summary>
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundConversion,
+    naming: Inverse.NameProvenance.Inherited,
+    oracle: Inverse.Oracle.RyuJitImporter,
+    forwardName: "BoundConversion (unboxing → managed pointer)",
+    precondition: "operand is a box of the value type; result is a managed pointer into it",
+    witness: "box/unbox fixtures; corpus compile-back")]
 public sealed class Unbox : IrExpression
 {
     public Unbox(TypeRef type, IrExpression operand)
@@ -3157,6 +3172,14 @@ public sealed class Unbox : IrExpression
     public override string Describe() => $"Unbox {Type.ToDisplayString()}";
 }
 
+/// <summary>unbox.any: loads the unboxed value (<c>(T)boxed</c> for a value type <c>T</c>).</summary>
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundConversion,
+    naming: Inverse.NameProvenance.Inherited,
+    oracle: Inverse.Oracle.RyuJitImporter,
+    forwardName: "BoundConversion (unboxing)",
+    precondition: "target is the unboxed value type",
+    witness: "box/unbox fixtures; corpus compile-back")]
 public sealed class UnboxAny : IrExpression
 {
     public UnboxAny(TypeRef type, IrExpression operand)


### PR DESCRIPTION
## What

Batch 2 of node annotation (following #2171), **completing the conversion family**: `CastClass`, `Unbox`, `UnboxAny`.

| Node | Forward (Roslyn) | Oracle | Naming | Precondition |
| --- | --- | --- | --- | --- |
| `CastClass` | BoundConversion (reference cast) | RyuJitImporter | Inherited | target is the reference type the cast checks |
| `Unbox` | BoundConversion (unboxing → managed pointer) | RyuJitImporter | Inherited | operand is a box of the value type; result is a managed pointer into it |
| `UnboxAny` | BoundConversion (unboxing) | RyuJitImporter | Inherited | target is the unboxed value type |

**Rationale:** all three invert `BoundConversion` variants, their names follow the IL opcodes (`castclass`/`unbox`/`unbox.any`) directly → clean `Inherited`, they reuse the existing `Forward.RoslynBoundConversion` + `oracle: RyuJitImporter` (metadata-token type recovery, like `Box`), and none needs a runnable `assumes` (reference/unbox conversions are outside the numeric checkable domain — descriptive preconditions only).

## Effects

- Coverage allowlist now enforces all six conversion-family nodes (`Box`, `CastClass`, `Coerce`, `Convert`, `Unbox`, `UnboxAny`); the drift gate confirms the regenerated `inverse-ledger.generated.md` matches byte-for-byte.

## Why low-risk

Pure metadata — read only by the test reflector; the shipped decompiler never reflects it, so **no behavior/IR/render/fidelity change**. Uses the aliased `[Inverse.InverseOf(...)]` established in #2171. Reference/unbox nodes are well outside the in-flight value-typed-emission numeric/enum work — minimal conflict surface.

## Validation

Build clean; **7** `InverseArchitectureTests` pass (allowlist enforces 6, drift gate over the regenerated ledger); markdownlint clean.

## Classification calls worth a sanity-check

- `Unbox` yields a managed pointer (`ByRef(T)`), not a value — I still classified it `InverseOf(BoundConversion)` with an accurate "managed pointer into the box" forwardName/precondition. Reasonable, or should it be treated differently?
- `oracle: RyuJitImporter` for all three (the target type comes from the IL metadata token, recovered by the importer) — vs `None`.
