### PR TITLE
Fix multiplicity loop-exit soundness + weight reach/semantics (#2127 follow-up)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1345,7 +1345,7 @@ public class LibraryBodyIndexTests
     [Theory]
     [InlineData(nameof(OptimizationOpportunityFixtures.LocalArrayStaysLocal), AllocationKind.Array, "System.Int32[]", AllocationPathContext.StraightLine, AllocationPathConfidence.DominatesReturn, AllocationPostDominance.ReturnPostDominates, AllocationMultiplicity.Once)]
     [InlineData(nameof(OptimizationOpportunityFixtures.BoxesGuidValue), AllocationKind.Box, "boxed System.Guid", AllocationPathContext.StraightLine, AllocationPathConfidence.DominatesReturn, AllocationPostDominance.ReturnPostDominates, AllocationMultiplicity.Once)]
-    [InlineData(nameof(OptimizationOpportunityFixtures.ThrowsInLoop), AllocationKind.Object, "System.InvalidOperationException", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown, AllocationPostDominance.Unknown, AllocationMultiplicity.Conditional)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ThrowsInLoop), AllocationKind.Object, "System.InvalidOperationException", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown, AllocationPostDominance.Unknown, AllocationMultiplicity.Unknown)]
     [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesOnceInLoop), AllocationKind.Object, "System.Object", AllocationPathContext.LoopBody, AllocationPathConfidence.BehindBranch, AllocationPostDominance.Unknown, AllocationMultiplicity.Loop)]
     [InlineData(nameof(OptimizationOpportunityFixtures.FinallyAllocates), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.StraightLine, AllocationPathConfidence.Unknown, AllocationPostDominance.Unknown, AllocationMultiplicity.Unknown)]
     [InlineData(nameof(OptimizationOpportunityFixtures.CatchAllocatesInLoop), AllocationKind.Object, "ILInspector.Analysis.Tests.PlainObject", AllocationPathContext.ErrorPath, AllocationPathConfidence.Unknown, AllocationPostDominance.Unknown, AllocationMultiplicity.Loop)]
@@ -1366,6 +1366,25 @@ public class LibraryBodyIndexTests
         Assert.Equal(expectedConfidence, occurrence.PathConfidence);
         Assert.Equal(expectedPostDominance, occurrence.PostDominance);
         Assert.Equal(expectedMultiplicity, occurrence.Multiplicity);
+    }
+
+    [Fact]
+    public void AllocationOccurrences_EarlyReturnInsideLoop_IsNotLoopMultiplicity()
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var occurrence = index.GetAllocationOccurrences()
+            .Where(pair => index.Methods.Any(method => method.MetadataToken == pair.Key
+                && method.Name == nameof(OptimizationOpportunityFixtures.ReturnsObjectFromLoop)))
+            .SelectMany(pair => pair.Value)
+            .Single(occ => occ.CountsAsHeapAllocation
+                && occ.Kind == AllocationKind.Object
+                && occ.AllocatedType?.Name == "PlainObject");
+
+        // The allocation is returned from inside the loop; the return exits the frame,
+        // so it runs at most once -> Conditional (behind the i==5 branch), never Loop.
+        Assert.NotEqual(AllocationMultiplicity.Loop, occurrence.Multiplicity);
+        Assert.Equal(AllocationMultiplicity.Conditional, occurrence.Multiplicity);
     }
 
     [Theory]
@@ -4382,6 +4401,19 @@ public class OptimizationOpportunityFixtures
             if (i < 0)
                 throw new System.InvalidOperationException("never");
         }
+    }
+
+    // Early-return allocation inside a loop: the return exits the frame, so the
+    // allocation runs at most once even though its IL offset sits in the loop.
+    public static object? ReturnsObjectFromLoop(int n)
+    {
+        for (int i = 0; i < n; i++)
+        {
+            ConsumeBoolean(i > 0);
+            if (i == 5)
+                return new PlainObject(i);
+        }
+        return null;
     }
 
     public static void ThrowsInitializedExceptionInLoop(int n)

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -148,7 +148,10 @@ public sealed class LibraryBodyIndex
         var pathContext = opportunity.PathContext ?? FallbackPathContext(opportunity);
         var pathConfidence = opportunity.PathConfidence;
         var postDominance = opportunity.PostDominance;
-        var weight = opportunity.Weight ?? ComputeOpportunityWeight(opportunity, runtimeAllocation);
+        // Weight depends on the FINAL RootReach, which is applied after the per-method
+        // pass, so always recompute it here (this runs again post-reach) rather than
+        // caching a stale pre-reach value.
+        var weight = ComputeOpportunityWeight(opportunity, runtimeAllocation);
         return runtimeAllocation != opportunity.RuntimeAllocationType
             || pathContext != opportunity.PathContext
             || pathConfidence != opportunity.PathConfidence
@@ -3998,31 +4001,43 @@ public sealed class LibraryBodyIndex
         }
 
         // Per-invocation multiplicity, consolidated from the existing path axes.
-        // A thrown allocation exits the frame, so it runs at most once even inside a
-        // loop -> Conditional takes precedence over loop membership. Otherwise loop
-        // membership wins (a catch-block or normal allocation whose loop continues runs
-        // 0..N per call), then:
+        // Precedence favors soundness (never confidently wrong) over completeness:
+        //   post-dominates return -> the block reaches a return with NO loop backedge,
+        //     so it runs at most once (Once if it also dominates return, else Conditional).
+        //     This correctly demotes a `return new T()` early-exit inside a loop.
+        //   thrown value in a loop -> ambiguous (caught-in-loop iterates N times,
+        //     uncaught exits after one) so fail-honest Unknown; a non-loop throw is
+        //     Conditional (runs 0/1).
+        //   loop body        -> Loop (0..N per call; N is not statically resolved)
         //   error path       -> Conditional (runs only when the exception fires)
-        //   dominates-return -> Once (runs on every returning path, exactly once)
-        //   behind a branch  -> Conditional (0 or 1 per call)
-        //   otherwise        -> Unknown (straight-line but not proven to dominate return)
+        //   dominates-return -> Once
+        //   behind a branch  -> Conditional
+        //   otherwise        -> Unknown (fail-honest)
         static AllocationMultiplicity AllocationMultiplicityFor(
             DecodedBody decodedBody,
             int offset,
             IReadOnlyList<(int Start, int End)> loopRegions,
             AllocationEscape escape)
         {
+            int blockIndex = decodedBody.BlockGraph.BlockIndexAt(offset);
+            var confidence = decodedBody.PathConfidences.ConfidenceFor(blockIndex);
+
+            // Reaches a return without cycling back -> at most one execution per call,
+            // even when the block's IL offset happens to sit inside a loop region.
+            if (decodedBody.PostDominances.PostDominanceFor(blockIndex) == AllocationPostDominance.ReturnPostDominates)
+                return confidence == AllocationPathConfidence.DominatesReturn
+                    ? AllocationMultiplicity.Once
+                    : AllocationMultiplicity.Conditional;
+
+            bool inLoop = IsInLoopRegion(offset, loopRegions);
             if (escape == AllocationEscape.ThrowPath)
-                return AllocationMultiplicity.Conditional;
-            if (IsInLoopRegion(offset, loopRegions))
+                return inLoop ? AllocationMultiplicity.Unknown : AllocationMultiplicity.Conditional;
+            if (inLoop)
                 return AllocationMultiplicity.Loop;
 
-            int blockIndex = decodedBody.BlockGraph.BlockIndexAt(offset);
             var context = decodedBody.PathContexts.ContextFor(blockIndex);
             if (context == AllocationPathContext.ErrorPath)
                 return AllocationMultiplicity.Conditional;
-
-            var confidence = decodedBody.PathConfidences.ConfidenceFor(blockIndex);
             if (confidence == AllocationPathConfidence.DominatesReturn)
                 return AllocationMultiplicity.Once;
             if (confidence == AllocationPathConfidence.BehindBranch
@@ -4125,7 +4140,7 @@ public sealed class LibraryBodyIndex
                         PathConfidence = escape.Escape == AllocationEscape.ThrowPath ? AllocationPathConfidence.Unknown : occurrence.PathConfidence,
                         PostDominance = escape.Escape == AllocationEscape.ThrowPath ? AllocationPostDominance.Unknown : occurrence.PostDominance,
                         Multiplicity = escape.Escape == AllocationEscape.ThrowPath
-                            ? AllocationMultiplicity.Conditional
+                            ? (occurrence.Multiplicity == AllocationMultiplicity.Loop ? AllocationMultiplicity.Unknown : AllocationMultiplicity.Conditional)
                             : occurrence.Multiplicity,
                     });
             }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -171,7 +171,12 @@ public sealed class LibraryBodyIndex
         if (runtimeAllocation is null)
             return null;
 
-        bool loop = opportunity.Multiplicity == "loop" || opportunity.InLoop;
+        // Trust the semantic per-invocation multiplicity when it is known: a
+        // return/throw early-exit inside a loop is Conditional/Unknown, NOT a hot loop,
+        // even though its IL offset sits inside the loop bounds. Fall back to the
+        // structural InLoop flag only when multiplicity could not be determined.
+        bool loop = opportunity.Multiplicity == "loop"
+            || (opportunity.Multiplicity is null && opportunity.InLoop);
         bool hotReach = opportunity.RootReach >= DelegateHotRootReach;
         bool notableSize = opportunity.EstimatedSizeBytes is { } size && size >= WeightNotableSizeBytes;
 


### PR DESCRIPTION
## What

Follow-up to **#2166** (multiplicity + weight, already merged). A fresh
two-model adversarial round on #2166 surfaced four correctness issues, but the
PR was squash-merged before these fixes were pushed, so they landed on the
branch after the merge and are not on `main`. This PR carries them forward
(clean cherry-pick onto the merged base).

## Fixes (all found in the fresh GPT-5.5 + Gemini 3.1 Pro round on #2166)

- **Return-in-loop multiplicity (Gemini, High).** A `return new T()` early-exit
  inside a loop was labelled `Loop`, but the return exits the frame so it runs
  ≤ once. `AllocationMultiplicityFor` now checks
  `PostDominance == ReturnPostDominates` first (reaches a return with no loop
  backedge → runs ≤ once → `Once`/`Conditional`).
- **Throw-in-loop multiplicity (Gemini, High).** A throw caught inside a loop
  iterates N times while an uncaught one exits after one, and
  `NewObjectFeedsThrowSoon` can poison a nearby allocation with `ThrowPath`.
  Since caught-vs-uncaught isn't cheaply provable, a throw-path allocation inside
  a loop is now fail-honest `Unknown` (a non-loop throw stays `Conditional`).
- **Stale weight (GPT-5.5, High).** `Weight` was computed during the per-method
  pass when `RootReach` was still 0, and the `Weight ??` idempotence kept the
  stale value after the final reach, so hot-reach never contributed.
  `AddFallbackOpportunityMetadata` now always recomputes it post-reach.
  Evidence: Roslyn `high` weight `1 → 141`.
- **Weight vs semantic multiplicity (Gemini, High).** `ComputeOpportunityWeight`
  used `Multiplicity == "loop" || InLoop`; it now trusts the semantic
  multiplicity and only falls back to structural `InLoop` when multiplicity is
  unknown, so a loop early-exit no longer gets a loop-tier weight.

## Evidence

- Adds a `ReturnsObjectFromLoop` regression fixture/test; `ThrowsInLoop` now
  expects `Unknown`.
- Analysis suite **332 pass**; CLI suite green.
- Corpus (308 framework assemblies, 67,740 allocations, 0 failures): `Loop` is
  now **3.3%** — genuine iteration only (loop early-exits correctly excluded).

## Review

Both fresh-round reviewers (GPT-5.5, Gemini 3.1 Pro) confirmed these exact fixes
with **no remaining blocking findings** (on the pre-merge branch commits
`5d1beeb2`/`1c12106d`, identical to the cherry-picks here). The remaining
pre-existing structural-`InLoop` triage usages (Loop column, sort, confidence,
`--loop`) are tracked separately in **#2177**.

Related: #2166, #2127, #2177.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
