### PR TITLE
Eliminate remaining raw LibraryBodyIndex opens in the CLI (#2139)

### DIFF
--- a/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
+++ b/src/dotnet-inspect.Tests/MethodBodyInspectionSessionTests.cs
@@ -215,4 +215,52 @@ public class MethodBodyInspectionSessionTests
             expected.Select(e => e.Method.MetadataToken),
             actual.Select(e => e.Method.MetadataToken));
     }
+
+    [Fact]
+    public void TopLeverage_NoScope_MatchesIndex()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var expected = index.TopLeverage(int.MaxValue);
+        var actual = MethodBodyInspectionSession.Open(SelfPath).TopLeverage(int.MaxValue);
+        Assert.Equal(
+            expected.Select(e => e.Method.MetadataToken),
+            actual.Select(e => e.Method.MetadataToken));
+    }
+
+    [Fact]
+    public void Methods_MatchesIndex()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var actual = MethodBodyInspectionSession.Open(SelfPath).Methods;
+        Assert.Equal(index.Methods.Length, actual.Length);
+    }
+
+    [Fact]
+    public void MethodSignalsByToken_MatchesIndex()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var actual = MethodBodyInspectionSession.Open(SelfPath).MethodSignalsByToken;
+        Assert.Equal(index.GetMethodSignals().Count, actual.Count);
+    }
+
+    [Fact]
+    public void Diagnostics_MatchesIndex()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var actual = MethodBodyInspectionSession.Open(SelfPath).Diagnostics;
+        Assert.Equal(index.Diagnostics.Length, actual.Length);
+    }
+
+    [Fact]
+    public void CallerTree_SessionScopes_MatchesIndexScopes()
+    {
+        var index = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var token = CalledToken(index);
+
+        var expected = index.BuildCallerTree(token, new[] { Analysis.LibraryBodyIndex.Open(SelfPath) });
+        var actual = MethodBodyInspectionSession.Open(SelfPath)
+            .CallerTree(token, new[] { MethodBodyInspectionSession.Open(SelfPath) });
+
+        Assert.Equal(expected.Children.Count(), actual.Children.Count());
+    }
 }

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -428,9 +428,9 @@ public class DiffCommand
         var methods = new Dictionary<string, AnalysisMethod>(StringComparer.Ordinal);
         foreach (var path in paths)
         {
-            var index = LibraryBodyIndex.Open(path);
+            var index = MethodBodyInspectionSession.Open(path);
             var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
-            var signalsByToken = index.GetMethodSignals();
+            var signalsByToken = index.MethodSignalsByToken;
             foreach (var method in index.Methods)
             {
                 if (LibraryMetadataService.IsGeneratedMethod(method, generatedFrameworkTypes))

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -563,8 +563,8 @@ internal static class LibraryMetadataService
     {
         try
         {
-            var index = Analysis.LibraryBodyIndex.Open(path);
-            var rows = index.UnsafeEvidence
+            var session = MethodBodyInspectionSession.Open(path);
+            var rows = session.UnsafeEvidence()
                 .Select(evidence => new UnsafeMemberSummary
                 {
                     Member = FormatMethod(evidence.Member),
@@ -580,7 +580,7 @@ internal static class LibraryMetadataService
                 .ThenBy(row => row.Detail, StringComparer.Ordinal)
                 .ToList();
 
-            foreach (var diagnostic in index.Diagnostics)
+            foreach (var diagnostic in session.Diagnostics)
                 logger.Log($"Warning: unsafe analysis skipped {diagnostic.Method}: {diagnostic.Message}");
 
             return rows.Count > 0 ? rows : null;
@@ -635,13 +635,13 @@ internal static class LibraryMetadataService
     {
         try
         {
-            var index = Analysis.LibraryBodyIndex.Open(path);
-            var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
+            var session = MethodBodyInspectionSession.Open(path);
+            var generatedFrameworkTypes = session.GeneratedFrameworkTypeNames;
             // Reuse the exact Member Index canonical-signature/digest path (via the
             // extracted API surface) so library-scope rows carry the same round-tripping
             // Stable selector, Visibility, and Name:N Selector as the type-scoped view.
             var drillByToken = BuildLibraryDrillMap(path, logger);
-            var rows = index.TopLeverage(int.MaxValue)
+            var rows = session.TopLeverage(int.MaxValue)
                 .Select(entry =>
                 {
                     drillByToken.TryGetValue(entry.Method.MetadataToken, out var drill);
@@ -721,10 +721,10 @@ internal static class LibraryMetadataService
     {
         try
         {
-            var index = Analysis.LibraryBodyIndex.Open(path);
-            var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
+            var session = MethodBodyInspectionSession.Open(path);
+            var generatedFrameworkTypes = session.GeneratedFrameworkTypeNames;
             var rows = FilterAndOrderTriageOpportunities(
-                    index.OptimizationOpportunities
+                    session.OptimizationOpportunities
                         .Where(opportunity => !IsGeneratedMethod(opportunity.Method, generatedFrameworkTypes)),
                     options)
                 .Select(opportunity => new OptimizationOpportunitySummary

--- a/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
+++ b/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
@@ -88,6 +88,16 @@ public sealed class MethodBodyInspectionSession
             : _index.BuildCallerTree(methodToken);
 
     /// <summary>
+    /// Inbound caller graph rooted at one method, extended across sibling caller-scope
+    /// <paramref name="scopes"/> (opened as their own sessions). Empty scopes fall back to the
+    /// same-assembly-only reverse graph.
+    /// </summary>
+    public Analysis.CallTreeNode CallerTree(int methodToken, IReadOnlyList<MethodBodyInspectionSession> scopes)
+        => scopes is { Count: > 0 }
+            ? _index.BuildCallerTree(methodToken, scopes.Select(s => s._index).ToArray())
+            : _index.BuildCallerTree(methodToken);
+
+    /// <summary>
     /// Inbound call edges targeting one method (<paramref name="targetToken"/>), each tagged with the
     /// <see cref="SourceName"/> of the assembly it originates in.
     ///
@@ -154,6 +164,22 @@ public sealed class MethodBodyInspectionSession
     /// <summary>Leverage ranking (highest first) of up to <paramref name="count"/> methods matching <paramref name="scope"/>.</summary>
     public ImmutableArray<Analysis.MethodLeverage> TopLeverage(int count, Func<Analysis.MethodIdentity, bool> scope)
         => _index.TopLeverage(count, scope);
+
+    /// <summary>Leverage ranking (highest first) of up to <paramref name="count"/> methods across the whole assembly.</summary>
+    public ImmutableArray<Analysis.MethodLeverage> TopLeverage(int count)
+        => _index.TopLeverage(count);
+
+    /// <summary>All method identities defined in the assembly.</summary>
+    public ImmutableArray<Analysis.MethodIdentity> Methods
+        => _index.Methods;
+
+    /// <summary>Per-method body/call signals keyed by metadata token.</summary>
+    public IReadOnlyDictionary<int, Analysis.MethodSignals> MethodSignalsByToken
+        => _index.GetMethodSignals();
+
+    /// <summary>Diagnostics recorded while analyzing method bodies (e.g. bodies skipped by the analyzer).</summary>
+    public ImmutableArray<Analysis.AnalysisDiagnostic> Diagnostics
+        => _index.Diagnostics;
 }
 
 /// <summary>An inbound call edge targeting a selected member, tagged with its originating assembly.</summary>

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1244,14 +1244,14 @@ public static class ApiOutputFormatter
             var callerSession = MethodBodyInspectionSession.Open(dllPath, assemblyResolver);
             // Extend the reverse graph across the caller scope (--bin/--project/--caller-package)
             // so a dependency member surfaces the product entry points and callers that reach it.
-            var scopeIndexes = new List<Analysis.LibraryBodyIndex>();
+            var scopeSessions = new List<MethodBodyInspectionSession>();
             if (callerScopeAssemblies is { Count: > 0 })
             {
                 foreach (var scopePath in callerScopeAssemblies)
                 {
                     try
                     {
-                        scopeIndexes.Add(Analysis.LibraryBodyIndex.Open(scopePath, AnalysisReferenceResolver(scopePath, options)));
+                        scopeSessions.Add(MethodBodyInspectionSession.Open(scopePath, AnalysisReferenceResolver(scopePath, options)));
                     }
                     catch
                     {
@@ -1259,7 +1259,7 @@ public static class ApiOutputFormatter
                     }
                 }
             }
-            var callerTree = callerSession.CallerTree(callerGraphToken, scopeIndexes);
+            var callerTree = callerSession.CallerTree(callerGraphToken, scopeSessions);
             var root = ToCallGraphNode(callerTree, GetRequestedCallGraphFields(options));
             if (root.Children is { Count: > 0 } || ExplicitlySelected(SectionNames.CallerGraph))
             {


### PR DESCRIPTION
## Summary

Milestone slice of #2139: **the CLI no longer performs any raw
`LibraryBodyIndex.Open`.** The only remaining raw PE open in the CLI is
`MemberCodeProvider` (the decompiler/method-body seam), tackled separately.

Adds the last analysis-index facets to `MethodBodyInspectionSession`:

- `Methods`, `MethodSignalsByToken`, `Diagnostics`,
- a no-scope `TopLeverage(int count)` overload,
- a sibling-session `CallerTree(int, IReadOnlyList<MethodBodyInspectionSession>)`
  overload.

Routes the remaining raw opens through the session:

- `ApiOutputFormatter` caller-graph scope indexes → sibling sessions
  (**this file now has zero raw index opens**);
- `DiffCommand.BuildAnalysisSnapshot`;
- `LibraryMetadataService.ScanUnsafeMembers` / `ScanTopLeverage` /
  `ScanOptimizationOpportunities`.

Selection/rendering stays in the callers; the facets are thin, cached
delegations to the single held index.

## Validation

- `dotnet build src/dotnet-inspect -c Release` — clean (0 warnings).
- `MethodBodyInspectionSessionTests` — 23/23 pass (6 new facet tests incl. the
  session-scope `CallerTree` overload and no-scope `TopLeverage`).
- `DiffCommandTests`, `LibraryTopLeverageTests`, `MemberCallersSectionTests`,
  `UnsafeMembersSectionTests`, `MemberCallGraphSectionTests` — 55/55 pass.
- **Byte-for-byte parity vs `main`** (both CLIs pointed at the *same* assembly
  files, to exclude MVID/`[GeneratedRegex]`-hash build nondeterminism): identical
  output across Unsafe Members, Top Leverage (14407/2597/1370-row cases),
  Performance Triage (1108/47/67), the analysis `diff` (668 lines), and the
  caller graph with `--bin` scope.

### Note on self-analysis
Diffing the tool against its *own* freshly-built assembly shows expected
differences (new facet methods shift metadata tokens/IL offsets and raise
`MethodBodyInspectionSession.Open` fanin); those vanish when both CLIs analyze
the same input, confirming no behavior change.

Part of #2139 / #2122.
