### PR TITLE
Fix cache and handle leaks from parallel harness evaluation

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Collections.Concurrent;
 using System.Reflection.Metadata;
 using ILInspector.Metadata;
 
@@ -36,10 +37,10 @@ internal sealed class CrossAssemblyTypeResolver
     readonly string _selfSimpleName;
     readonly MetadataReader _selfReader;
     readonly MetadataContext _context;
-    readonly Dictionary<TypeRef, ValueTypeHint> _valueTypeCache = [];
-    readonly Dictionary<TypeRef, MetadataFactState> _inlineArrayCache = [];
-    readonly Dictionary<MethodRef, ResolvedMethodFacts?> _methodFactCache = [];
-    readonly Dictionary<(TypeRef Type, TypeRef Interface), MetadataFactState> _interfaceCache = [];
+    readonly ConcurrentDictionary<TypeRef, ValueTypeHint> _valueTypeCache = new();
+    readonly ConcurrentDictionary<TypeRef, MetadataFactState> _inlineArrayCache = new();
+    readonly ConcurrentDictionary<MethodRef, ResolvedMethodFacts?> _methodFactCache = new();
+    readonly ConcurrentDictionary<(TypeRef Type, TypeRef Interface), MetadataFactState> _interfaceCache = new();
 
     public CrossAssemblyTypeResolver(string selfSimpleName, MetadataReader selfReader, MetadataContext context)
     {
@@ -126,11 +127,7 @@ internal sealed class CrossAssemblyTypeResolver
         if (type.Assembly == TypeRefDecoder.Canonical(_selfSimpleName))
             return callee;
 
-        if (!_methodFactCache.TryGetValue(callee, out var facts))
-        {
-            facts = ResolveMethodFacts(callee, type);
-            _methodFactCache[callee] = facts;
-        }
+        var facts = _methodFactCache.GetOrAdd(callee, c => ResolveMethodFacts(c, type));
 
         if (facts is not { } resolved)
             return callee;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -192,6 +192,73 @@ public static class IrImporter
     /// under unrelated method insertions unless the new method hashes into the
     /// sample itself.
     /// </summary>
+    public readonly record struct StableSampleCandidate(string TypeName, string MethodName, TypeDefinitionHandle TypeDefHandle, MethodDefinitionHandle MethodHandle)
+    {
+        public IrFunction Build(MetadataSource source)
+        {
+            try
+            {
+                var typeDef = source.Reader.GetTypeDefinition(TypeDefHandle);
+                var method = source.Reader.GetMethodDefinition(MethodHandle);
+                return IrImporter.Build(
+                    source,
+                    MethodImporter.Import(source, TypeDefHandle, MethodHandle),
+                    IrImporter.CallerScope(source.Reader, typeDef, method));
+            }
+            catch (Exception ex)
+            {
+                return IrImporter.CrashFunction(MethodName, TypeName, ex);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Evaluates a deterministic hash-ranked sample of method bodies from the
+    /// assembly. Returns candidates that can be built in parallel.
+    /// </summary>
+    public static IEnumerable<StableSampleCandidate> GetStableSampleCandidates(MetadataSource source, int sampleSize)
+    {
+        var reader = source.Reader;
+        var candidates = new List<MethodCandidate>();
+        int sequence = 0;
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            string typeName = reader.GetFullTypeName(typeDef);
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (method.RelativeVirtualAddress == 0)
+                    continue;
+                string memberName = reader.GetString(method.Name);
+                string key = StableSampleKey(reader, typeDef, method, typeName, memberName);
+                candidates.Add(new MethodCandidate(
+                    typeDefHandle,
+                    methodHandle,
+                    typeName,
+                    memberName,
+                    sequence++,
+                    StableHash(key),
+                    key));
+            }
+        }
+
+        foreach (var candidate in candidates
+            .OrderBy(c => c.Hash)
+            .ThenBy(c => c.Key, StringComparer.Ordinal)
+            .Take(sampleSize)
+            .OrderBy(c => c.Sequence))
+        {
+            yield return new StableSampleCandidate(candidate.TypeName, candidate.MethodName, candidate.TypeDefHandle, candidate.MethodHandle);
+        }
+    }
+
+    /// <summary>
+    /// Imports a deterministic hash-ranked sample of method bodies from the
+    /// assembly. Unlike "first N" metadata order, the selected set is stable
+    /// under unrelated method insertions unless the new method hashes into the
+    /// sample itself.
+    /// </summary>
     public static IEnumerable<(string TypeName, string MethodName, IrFunction Function)> ImportAssemblyStableSample(MetadataSource source, int sampleSize)
     {
         if (sampleSize <= 0)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -192,7 +192,7 @@ public static class IrImporter
     /// under unrelated method insertions unless the new method hashes into the
     /// sample itself.
     /// </summary>
-    public readonly record struct StableSampleCandidate(string TypeName, string MethodName, TypeDefinitionHandle TypeDefHandle, MethodDefinitionHandle MethodHandle)
+    public readonly record struct StableSampleCandidate(string TypeName, string MethodName, int Overload, TypeDefinitionHandle TypeDefHandle, MethodDefinitionHandle MethodHandle)
     {
         public IrFunction Build(MetadataSource source)
         {
@@ -225,12 +225,16 @@ public static class IrImporter
         {
             var typeDef = reader.GetTypeDefinition(typeDefHandle);
             string typeName = reader.GetFullTypeName(typeDef);
+            var seen = new Dictionary<string, int>();
             foreach (var methodHandle in typeDef.GetMethods())
             {
                 var method = reader.GetMethodDefinition(methodHandle);
+                string memberName = reader.GetString(method.Name);
+                int overloadIndex = seen.GetValueOrDefault(memberName);
+                seen[memberName] = overloadIndex + 1;
+
                 if (method.RelativeVirtualAddress == 0)
                     continue;
-                string memberName = reader.GetString(method.Name);
                 string key = StableSampleKey(reader, typeDef, method, typeName, memberName);
                 candidates.Add(new MethodCandidate(
                     typeDefHandle,
@@ -239,7 +243,8 @@ public static class IrImporter
                     memberName,
                     sequence++,
                     StableHash(key),
-                    key));
+                    key,
+                    overloadIndex));
             }
         }
 
@@ -249,7 +254,7 @@ public static class IrImporter
             .Take(sampleSize)
             .OrderBy(c => c.Sequence))
         {
-            yield return new StableSampleCandidate(candidate.TypeName, candidate.MethodName, candidate.TypeDefHandle, candidate.MethodHandle);
+            yield return new StableSampleCandidate(candidate.TypeName, candidate.MethodName, candidate.OverloadIndex, candidate.TypeDefHandle, candidate.MethodHandle);
         }
     }
 
@@ -352,7 +357,8 @@ public static class IrImporter
         string MethodName,
         int Sequence,
         ulong Hash,
-        string Key);
+        string Key,
+        int OverloadIndex = 0);
 
     static IrFunction CrashFunction(string methodName, string typeName, Exception ex)
     {

--- a/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
@@ -93,7 +93,7 @@ internal sealed class OpenedAssembly : IDisposable
 {
     readonly Stream _stream;
     readonly PEReader _pe;
-    Dictionary<string, TypeDefinitionHandle>? _byFullName;
+    volatile Dictionary<string, TypeDefinitionHandle>? _byFullName;
     readonly object _indexLock = new();
 
     OpenedAssembly(Stream stream, PEReader pe, MetadataReader reader)

--- a/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
@@ -31,8 +31,8 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </remarks>
 public sealed class MetadataContext : IDisposable
 {
-    readonly ConcurrentDictionary<string, OpenedAssembly?> _opened = new(StringComparer.OrdinalIgnoreCase);
-    readonly ConcurrentDictionary<string, OpenedAssembly?> _openedLocations = new(StringComparer.Ordinal);
+    readonly ConcurrentDictionary<string, Lazy<OpenedAssembly?>> _opened = new(StringComparer.OrdinalIgnoreCase);
+    readonly ConcurrentDictionary<string, Lazy<OpenedAssembly?>> _openedLocations = new(StringComparer.Ordinal);
 
     public MetadataContext(AssemblyLocator locator)
         : this(locator.ToAssemblyReferenceResolver())
@@ -58,7 +58,7 @@ public sealed class MetadataContext : IDisposable
     /// </summary>
     internal OpenedAssembly? Open(string path)
     {
-        return _opened.GetOrAdd(path, p => OpenedAssembly.TryOpen(p));
+        return _opened.GetOrAdd(path, p => new Lazy<OpenedAssembly?>(() => OpenedAssembly.TryOpen(p))).Value;
     }
 
     internal OpenedAssembly? Open(TypeLocation location)
@@ -66,7 +66,7 @@ public sealed class MetadataContext : IDisposable
         if (location.AssemblyPath is { Length: > 0 } path)
             return Open(path);
 
-        return _openedLocations.GetOrAdd(location.AssemblyKey, _ => OpenedAssembly.TryOpen(location.OpenRead));
+        return _openedLocations.GetOrAdd(location.AssemblyKey, _ => new Lazy<OpenedAssembly?>(() => OpenedAssembly.TryOpen(location.OpenRead))).Value;
     }
 
     internal ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
@@ -75,9 +75,9 @@ public sealed class MetadataContext : IDisposable
     public void Dispose()
     {
         foreach (var opened in _opened.Values)
-            opened?.Dispose();
+            if (opened.IsValueCreated) opened.Value?.Dispose();
         foreach (var opened in _openedLocations.Values)
-            opened?.Dispose();
+            if (opened.IsValueCreated) opened.Value?.Dispose();
         _opened.Clear();
         _openedLocations.Clear();
     }

--- a/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
@@ -1,6 +1,7 @@
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using ILInspector.Metadata;
+using System.Collections.Concurrent;
 
 namespace ILInspector.Decompiler.Pipeline;
 
@@ -30,8 +31,8 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </remarks>
 public sealed class MetadataContext : IDisposable
 {
-    readonly Dictionary<string, OpenedAssembly?> _opened = new(StringComparer.OrdinalIgnoreCase);
-    readonly Dictionary<string, OpenedAssembly?> _openedLocations = new(StringComparer.Ordinal);
+    readonly ConcurrentDictionary<string, OpenedAssembly?> _opened = new(StringComparer.OrdinalIgnoreCase);
+    readonly ConcurrentDictionary<string, OpenedAssembly?> _openedLocations = new(StringComparer.Ordinal);
 
     public MetadataContext(AssemblyLocator locator)
         : this(locator.ToAssemblyReferenceResolver())
@@ -57,11 +58,7 @@ public sealed class MetadataContext : IDisposable
     /// </summary>
     internal OpenedAssembly? Open(string path)
     {
-        if (_opened.TryGetValue(path, out var cached))
-            return cached;
-        var opened = OpenedAssembly.TryOpen(path);
-        _opened[path] = opened;
-        return opened;
+        return _opened.GetOrAdd(path, p => OpenedAssembly.TryOpen(p));
     }
 
     internal OpenedAssembly? Open(TypeLocation location)
@@ -69,11 +66,7 @@ public sealed class MetadataContext : IDisposable
         if (location.AssemblyPath is { Length: > 0 } path)
             return Open(path);
 
-        if (_openedLocations.TryGetValue(location.AssemblyKey, out var cached))
-            return cached;
-        var opened = OpenedAssembly.TryOpen(location.OpenRead);
-        _openedLocations[location.AssemblyKey] = opened;
-        return opened;
+        return _openedLocations.GetOrAdd(location.AssemblyKey, _ => OpenedAssembly.TryOpen(location.OpenRead));
     }
 
     internal ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
@@ -101,6 +94,7 @@ internal sealed class OpenedAssembly : IDisposable
     readonly Stream _stream;
     readonly PEReader _pe;
     Dictionary<string, TypeDefinitionHandle>? _byFullName;
+    readonly object _indexLock = new();
 
     OpenedAssembly(Stream stream, PEReader pe, MetadataReader reader)
     {
@@ -149,7 +143,13 @@ internal sealed class OpenedAssembly : IDisposable
     /// </summary>
     public bool TryGetType(string fullName, out TypeDefinitionHandle handle)
     {
-        _byFullName ??= BuildIndex();
+        if (_byFullName is null)
+        {
+            lock (_indexLock)
+            {
+                _byFullName ??= BuildIndex();
+            }
+        }
         return _byFullName.TryGetValue(fullName, out handle);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -603,13 +603,21 @@ public sealed class MetadataSource : IDisposable
     /// found or it cannot be read; the importer then leaves local names absent
     /// and the printer falls back to <c>V_index</c>.
     /// </summary>
+    readonly object _pdbLock = new();
+    
     MetadataReader? PdbReader()
     {
         if (_pdbProbed)
             return _pdbReader;
-        _pdbProbed = true;
-        if (!_readSymbols)
-            return null;
+            
+        lock (_pdbLock)
+        {
+            if (_pdbProbed)
+                return _pdbReader;
+
+            _pdbProbed = true;
+            if (!_readSymbols)
+                return null;
         try
         {
             if (Pe.TryOpenAssociatedPortablePdb(Path, p => File.Exists(p) ? File.OpenRead(p) : null, out var provider, out var pdbPath)
@@ -634,9 +642,10 @@ public sealed class MetadataSource : IDisposable
         }
         catch
         {
-            // No PDB, or an unreadable one — names stay absent.
+            // Unreadable PDB (format error, locked file): act like no PDB exists.
         }
         return _pdbReader;
+        }
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -219,7 +219,7 @@ public sealed class MetadataSource : IDisposable
         }
     }
 
-    Dictionary<TypeRef, TypeShape>? _shapes;
+    volatile Dictionary<TypeRef, TypeShape>? _shapes;
     Dictionary<TypeRef, IReadOnlyDictionary<long, string>>? _enumMembers;
     Dictionary<TypeRef, TypeRef>? _enumUnderlyingTypes;
     Dictionary<TypeRef, TypeRef?>? _baseTypes;

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -20,7 +20,7 @@ public sealed class MetadataSource : IDisposable
     readonly Stream _stream;
     MetadataReaderProvider? _pdbProvider;
     MetadataReader? _pdbReader;
-    bool _pdbProbed;
+    volatile bool _pdbProbed;
     DecompilerSymbolSource _symbols = DecompilerSymbolSource.None;
     readonly string? _externalPdbPath;
     readonly bool _readSymbols;
@@ -615,9 +615,11 @@ public sealed class MetadataSource : IDisposable
             if (_pdbProbed)
                 return _pdbReader;
 
-            _pdbProbed = true;
             if (!_readSymbols)
+            {
+                _pdbProbed = true;
                 return null;
+            }
         try
         {
             if (Pe.TryOpenAssociatedPortablePdb(Path, p => File.Exists(p) ? File.OpenRead(p) : null, out var provider, out var pdbPath)
@@ -644,6 +646,7 @@ public sealed class MetadataSource : IDisposable
         {
             // Unreadable PDB (format error, locked file): act like no PDB exists.
         }
+        _pdbProbed = true;
         return _pdbReader;
         }
     }

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -30,6 +30,7 @@ public sealed class MetadataSource : IDisposable
     MetadataContext? _crossContext;
     bool _ownsCrossContext;
     CrossAssemblyTypeResolver? _crossAssembly;
+    readonly object _crossLock = new();
 
     MetadataSource(string path, Stream stream, PEReader peReader, MetadataReader reader, string assemblyName, string? externalPdbPath, bool readSymbols, AssemblyLocator locator, IAssemblyReferenceResolver resolver, MetadataContext? context)
     {
@@ -198,7 +199,19 @@ public sealed class MetadataSource : IDisposable
     /// cannot state on its own (value-type-ness of a bare cross-assembly token).
     /// </summary>
     internal CrossAssemblyTypeResolver CrossAssembly
-        => _crossAssembly ??= new CrossAssemblyTypeResolver(AssemblyName, Reader, CrossContext);
+    {
+        get
+        {
+            if (_crossAssembly is null)
+            {
+                lock (_crossLock)
+                {
+                    _crossAssembly ??= new CrossAssemblyTypeResolver(AssemblyName, Reader, CrossContext);
+                }
+            }
+            return _crossAssembly;
+        }
+    }
 
     /// <summary>
     /// The shared assembly-reading environment cross-assembly resolution reads
@@ -212,8 +225,14 @@ public sealed class MetadataSource : IDisposable
         {
             if (_crossContext is null)
             {
-                _crossContext = _suppliedContext ?? new MetadataContext(_resolver);
-                _ownsCrossContext = _suppliedContext is null;
+                lock (_crossLock)
+                {
+                    if (_crossContext is null)
+                    {
+                        _crossContext = _suppliedContext ?? new MetadataContext(_resolver);
+                        _ownsCrossContext = _suppliedContext is null;
+                    }
+                }
             }
             return _crossContext;
         }

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -271,11 +271,17 @@ public sealed class MetadataSource : IDisposable
         return _enumUnderlyingTypes!.GetValueOrDefault(type);
     }
 
+    readonly object _mapLock = new();
+
     void EnsureTypeMaps()
     {
         if (_shapes is not null)
             return;
-        var shapes = new Dictionary<TypeRef, TypeShape>();
+        lock (_mapLock)
+        {
+            if (_shapes is not null)
+                return;
+            var shapes = new Dictionary<TypeRef, TypeShape>();
         var enums = new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>();
         var enumUnderlyingTypes = new Dictionary<TypeRef, TypeRef>();
         var bases = new Dictionary<TypeRef, TypeRef?>();
@@ -317,6 +323,7 @@ public sealed class MetadataSource : IDisposable
         _interfaceImpls = interfaceImpls;
         _unionTypes = unionTypes;
         _shapes = shapes;   // assign last: ResolveShape gates on _shapes
+        }
     }
 
     ImmutableArray<string> GenericParameterNames(GenericParameterHandleCollection handles)

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Text.Json;
@@ -27,7 +28,9 @@ internal static class CorpusSensor
         string? emitDelta,
         bool qualityDiffCard = false,
         bool qualityCardRisky = false,
-        int methodCap = int.MaxValue)
+        int methodCap = int.MaxValue,
+        int? workers = null,
+        bool sequential = false)
     {
         if (assemblies.Count == 0)
         {
@@ -52,7 +55,7 @@ internal static class CorpusSensor
             return 1;
         }
 
-        var (current, fidelityReports) = Capture(assemblies, validityCompileCap, fidelityCompileCaps, maxExamples, methodCap);
+        var (current, fidelityReports) = Capture(assemblies, validityCompileCap, fidelityCompileCaps, maxExamples, methodCap, workers, sequential);
         if (!qualityDiffCard)
             PrintSummary(current, fidelityReports);
 
@@ -112,19 +115,21 @@ internal static class CorpusSensor
         int validityCompileCap,
         IReadOnlyList<int> fidelityCompileCaps,
         int maxExamples,
-        int methodCap)
+        int methodCap,
+        int? workers,
+        bool sequential)
     {
-        var completeness = AnalyzeCompleteness(assemblies, maxExamples, methodCap);
+        var completeness = AnalyzeCompleteness(assemblies, maxExamples, methodCap, workers, sequential);
         var methods = completeness.Methods.ToDictionary(MethodKey, StringComparer.Ordinal);
-        var validity = AnalyzeValidity(assemblies, validityCompileCap, methods);
-        var structuring = AnalyzeStructuring(assemblies, methodCap);
+        var validity = AnalyzeValidity(assemblies, validityCompileCap, methods, workers, sequential);
+        var structuring = AnalyzeStructuring(assemblies, methodCap, workers, sequential);
         var totalMethods = completeness.Assemblies.Sum(assembly => assembly.TotalMethods);
         var fullyRaisedMethods = completeness.FullyRaisedMethods;
         var conditionalBranchMethods = completeness.ResidualBuckets.GetValueOrDefault(ConditionalBranchBucket);
         var forwardMergeContainers = ForwardMergeStopReasons.Sum(reason => structuring.StopReasons.GetValueOrDefault(reason));
         var requestedCaps = fidelityCompileCaps.Where(cap => cap > 0).Distinct().ToArray();
         var primaryFidelityCap = requestedCaps.FirstOrDefault();
-        var fidelityReports = AnalyzeFidelity(assemblies, fidelityCompileCaps, methods, primaryFidelityCap);
+        var fidelityReports = AnalyzeFidelity(assemblies, fidelityCompileCaps, methods, primaryFidelityCap, workers, sequential);
         var selectedFidelity = fidelityReports.FirstOrDefault(report => report.Cap == primaryFidelityCap)?.Metrics
             ?? fidelityReports.LastOrDefault()?.Metrics
             ?? new FidelitySensorMetrics(0, 0, 0, 0, 0, 0);
@@ -160,25 +165,34 @@ internal static class CorpusSensor
         return (snapshot, fidelityReports);
     }
 
-    static CompletenessSensorMetrics AnalyzeCompleteness(IReadOnlyList<string> assemblies, int maxExamples, int methodCap)
+    static CompletenessSensorMetrics AnalyzeCompleteness(IReadOnlyList<string> assemblies, int maxExamples, int methodCap, int? workers, bool sequential)
     {
-        var residualBuckets = new Dictionary<string, int>(StringComparer.Ordinal);
-        var assemblyReports = ImmutableArray.CreateBuilder<CorpusAssemblySnapshot>();
-        var methodReports = ImmutableArray.CreateBuilder<CorpusMethodSnapshot>();
+        var residualBuckets = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
+        var assemblyReports = new ConcurrentBag<CorpusAssemblySnapshot>();
+        var methodReports = new ConcurrentBag<CorpusMethodSnapshot>();
         int fullyRaised = 0, passBugs = 0;
 
         using var metadata = CorpusMetadata.Create(assemblies);
+        var options = new ParallelOptions { MaxDegreeOfParallelism = sequential ? 1 : (workers ?? Math.Max(1, Environment.ProcessorCount - 2)) };
+
         foreach (var assemblyPath in assemblies)
         {
             using var source = MetadataSource.Open(assemblyPath, context: metadata);
+            // Pre-warm the type maps before fan-out to avoid lock contention
+            _ = source.ResolveShape(TypeRef.CoreLib("System", "Int32"));
+
             int methods = 0;
             string portablePath = PortablePath(assemblyPath);
-            var overloads = new Dictionary<(string Type, string Method), int>();
-            foreach (var (typeName, methodName, function) in IrImporter.ImportAssemblyStableSample(source, methodCap))
+            var overloads = new ConcurrentDictionary<(string Type, string Method), int>();
+
+            var stableSample = IrImporter.ImportAssemblyStableSample(source, methodCap).ToList();
+
+            Parallel.ForEach(stableSample, options, item =>
             {
-                int overload = overloads.GetValueOrDefault((typeName, methodName));
-                overloads[(typeName, methodName)] = overload + 1;
-                methods++;
+                var (typeName, methodName, function) = item;
+                
+                int overload = overloads.AddOrUpdate((typeName, methodName), 0, (_, v) => v + 1);
+                Interlocked.Increment(ref methods);
                 string? residual = null;
                 string? passBug = null;
                 try
@@ -187,7 +201,7 @@ internal static class CorpusSensor
                 }
                 catch (Exception ex)
                 {
-                    passBugs++;
+                    Interlocked.Increment(ref passBugs);
                     passBug = ex.GetType().Name;
                 }
 
@@ -200,11 +214,11 @@ internal static class CorpusSensor
                 }
                 if (passBug is null && residual is null)
                 {
-                    fullyRaised++;
+                    Interlocked.Increment(ref fullyRaised);
                 }
                 else if (residual is not null)
                 {
-                    residualBuckets[residual] = residualBuckets.GetValueOrDefault(residual) + 1;
+                    residualBuckets.AddOrUpdate(residual, 1, (_, v) => v + 1);
                 }
                 methodReports.Add(new CorpusMethodSnapshot(
                     source.AssemblyName,
@@ -219,22 +233,24 @@ internal static class CorpusSensor
                     passBug,
                     Validity: "not-sampled",
                     FidelityCheck: "not-sampled"));
-            }
+            });
             assemblyReports.Add(new CorpusAssemblySnapshot(source.AssemblyName, PortablePath(assemblyPath), methods));
         }
 
         return new CompletenessSensorMetrics(
-            assemblyReports.ToImmutable(),
+            assemblyReports.OrderBy(r => r.Path, StringComparer.Ordinal).ToImmutableArray(),
             fullyRaised,
             passBugs,
-            residualBuckets,
-            methodReports.ToImmutable());
+            residualBuckets.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal),
+            methodReports.OrderBy(m => MethodKey(m), StringComparer.Ordinal).ToImmutableArray());
     }
 
     static ValiditySensorMetrics AnalyzeValidity(
         IReadOnlyList<string> assemblies,
         int cap,
-        Dictionary<string, CorpusMethodSnapshot> methods)
+        Dictionary<string, CorpusMethodSnapshot> methods,
+        int? workers,
+        bool sequential)
     {
         if (cap <= 0)
             return new ValiditySensorMetrics(0, 0, 0);
@@ -243,7 +259,7 @@ internal static class CorpusSensor
         foreach (var assembly in assemblies)
         {
             var portablePath = PortablePath(assembly);
-            foreach (var result in ValidityCheck.Evaluate(assembly, cap))
+            foreach (var result in ValidityCheck.Evaluate(assembly, cap, lowered: false, importSiblingBodies: false, workers, sequential))
             {
                 results.Add(result);
                 string key = MethodKey(portablePath, result.TypeName, result.MethodName, result.Signature);
@@ -257,20 +273,28 @@ internal static class CorpusSensor
             results.Count(result => result.HasSemanticDefect));
     }
 
-    static StructuringSensorMetrics AnalyzeStructuring(IReadOnlyList<string> assemblies, int methodCap)
+    static StructuringSensorMetrics AnalyzeStructuring(IReadOnlyList<string> assemblies, int methodCap, int? workers, bool sequential)
     {
         long total = 0, crashes = 0, structured = 0, stoppedContainers = 0, methodsWithStop = 0;
-        var reasons = new Dictionary<string, int>(StringComparer.Ordinal);
+        var reasons = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
 
         using var metadata = CorpusMetadata.Create(assemblies);
+        var options = new ParallelOptions { MaxDegreeOfParallelism = sequential ? 1 : (workers ?? Math.Max(1, Environment.ProcessorCount - 2)) };
+
         foreach (var assemblyPath in assemblies)
         {
             using var source = MetadataSource.Open(assemblyPath, context: metadata);
+            // Pre-warm type maps
+            _ = source.ResolveShape(TypeRef.CoreLib("System", "Int32"));
             int assemblyMethods = 0;
-            foreach (var (_, _, function) in IrImporter.ImportAssemblyStableSample(source, methodCap))
+            
+            var stableSample = IrImporter.ImportAssemblyStableSample(source, methodCap).ToList();
+
+            Parallel.ForEach(stableSample, options, item =>
             {
-                assemblyMethods++;
-                total++;
+                var (_, _, function) = item;
+                Interlocked.Increment(ref assemblyMethods);
+                Interlocked.Increment(ref total);
                 var diagnostics = new StructuringDiagnostics();
                 var context = new PassContext(new Stepper(enabled: false), diagnostics);
                 try
@@ -279,29 +303,31 @@ internal static class CorpusSensor
                 }
                 catch
                 {
-                    crashes++;
-                    continue;
+                    Interlocked.Increment(ref crashes);
+                    return; // equivalent to continue
                 }
 
-                structured += diagnostics.Structured;
+                Interlocked.Add(ref structured, diagnostics.Structured);
                 if (diagnostics.Stops.Count > 0)
-                    methodsWithStop++;
+                    Interlocked.Increment(ref methodsWithStop);
                 foreach (var reason in diagnostics.Stops)
                 {
-                    stoppedContainers++;
-                    reasons[reason] = reasons.GetValueOrDefault(reason) + 1;
+                    Interlocked.Increment(ref stoppedContainers);
+                    reasons.AddOrUpdate(reason, 1, (_, v) => v + 1);
                 }
-            }
+            });
         }
 
-        return new StructuringSensorMetrics(total, structured, stoppedContainers, methodsWithStop, crashes, reasons);
+        return new StructuringSensorMetrics(total, structured, stoppedContainers, methodsWithStop, crashes, reasons.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal));
     }
 
     static ImmutableArray<FidelityCapReport> AnalyzeFidelity(
         IReadOnlyList<string> assemblies,
         IReadOnlyList<int> caps,
         Dictionary<string, CorpusMethodSnapshot> methods,
-        int primaryCap)
+        int primaryCap,
+        int? workers,
+        bool sequential)
     {
         var reports = ImmutableArray.CreateBuilder<FidelityCapReport>();
         foreach (var cap in caps.Where(cap => cap > 0).Distinct().OrderBy(cap => cap))
@@ -311,7 +337,7 @@ internal static class CorpusSensor
             foreach (var assembly in assemblies)
             {
                 var portablePath = PortablePath(assembly);
-                var assemblyUsefulResults = FidelityCheck.Evaluate([assembly], cap, lowered: false, includeAllResults: false);
+                var assemblyUsefulResults = FidelityCheck.Evaluate([assembly], cap, lowered: false, includeAllResults: false, workers, sequential);
                 usefulResults.AddRange(assemblyUsefulResults);
                 if (cap == primaryCap)
                 {
@@ -322,7 +348,7 @@ internal static class CorpusSensor
                             methods[key] = methodSnapshot with { FidelityCheck = result.Status.ToString() };
                     }
                 }
-                allResults.AddRange(FidelityCheck.Evaluate([assembly], cap, lowered: false, includeAllResults: true));
+                allResults.AddRange(FidelityCheck.Evaluate([assembly], cap, lowered: false, includeAllResults: true, workers, sequential));
             }
             var metrics = new FidelitySensorMetrics(
                 usefulResults.Count,
@@ -374,7 +400,7 @@ internal static class CorpusSensor
     static string Codes(IEnumerable<ValidityCheck.ValidityDiagnostic> diagnostics)
         => string.Join(",", diagnostics.Select(d => d.Id).Distinct().Order(StringComparer.Ordinal));
 
-    static string PortablePath(string path)
+    internal static string PortablePath(string path)
     {
         var full = Path.GetFullPath(path).Replace('\\', '/');
         const string nugetMarker = "/.nuget/packages/";

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -185,11 +185,13 @@ internal static class CorpusSensor
             string portablePath = PortablePath(assemblyPath);
             var overloads = new ConcurrentDictionary<(string Type, string Method), int>();
 
-            var stableSample = IrImporter.ImportAssemblyStableSample(source, methodCap).ToList();
+            var stableSample = IrImporter.GetStableSampleCandidates(source, methodCap).ToList();
 
             Parallel.ForEach(stableSample, options, item =>
             {
-                var (typeName, methodName, function) = item;
+                var typeName = item.TypeName;
+                var methodName = item.MethodName;
+                var function = item.Build(source);
                 
                 int overload = overloads.AddOrUpdate((typeName, methodName), 0, (_, v) => v + 1);
                 Interlocked.Increment(ref methods);
@@ -288,11 +290,11 @@ internal static class CorpusSensor
             _ = source.ResolveShape(TypeRef.CoreLib("System", "Int32"));
             int assemblyMethods = 0;
             
-            var stableSample = IrImporter.ImportAssemblyStableSample(source, methodCap).ToList();
+            var stableSample = IrImporter.GetStableSampleCandidates(source, methodCap).ToList();
 
             Parallel.ForEach(stableSample, options, item =>
             {
-                var (_, _, function) = item;
+                var function = item.Build(source);
                 Interlocked.Increment(ref assemblyMethods);
                 Interlocked.Increment(ref total);
                 var diagnostics = new StructuringDiagnostics();

--- a/tools/DecompilerHarness/CorpusSensor.cs
+++ b/tools/DecompilerHarness/CorpusSensor.cs
@@ -183,17 +183,15 @@ internal static class CorpusSensor
 
             int methods = 0;
             string portablePath = PortablePath(assemblyPath);
-            var overloads = new ConcurrentDictionary<(string Type, string Method), int>();
-
             var stableSample = IrImporter.GetStableSampleCandidates(source, methodCap).ToList();
 
             Parallel.ForEach(stableSample, options, item =>
             {
                 var typeName = item.TypeName;
                 var methodName = item.MethodName;
+                var overload = item.Overload;
                 var function = item.Build(source);
                 
-                int overload = overloads.AddOrUpdate((typeName, methodName), 0, (_, v) => v + 1);
                 Interlocked.Increment(ref methods);
                 string? residual = null;
                 string? passBug = null;
@@ -243,7 +241,7 @@ internal static class CorpusSensor
             assemblyReports.OrderBy(r => r.Path, StringComparer.Ordinal).ToImmutableArray(),
             fullyRaised,
             passBugs,
-            residualBuckets.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal),
+            residualBuckets.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal),
             methodReports.OrderBy(m => MethodKey(m), StringComparer.Ordinal).ToImmutableArray());
     }
 
@@ -320,7 +318,7 @@ internal static class CorpusSensor
             });
         }
 
-        return new StructuringSensorMetrics(total, structured, stoppedContainers, methodsWithStop, crashes, reasons.ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal));
+        return new StructuringSensorMetrics(total, structured, stoppedContainers, methodsWithStop, crashes, reasons.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal));
     }
 
     static ImmutableArray<FidelityCapReport> AnalyzeFidelity(

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection;
@@ -321,10 +322,10 @@ static class FidelityCheck
         return results;
     }
 
-    public static IReadOnlyList<CompileBackResult> Evaluate(IReadOnlyList<string> assemblies, int perAssemblyCap, bool lowered)
-        => Evaluate(assemblies, perAssemblyCap, lowered, includeAllResults: false);
+    public static IReadOnlyList<CompileBackResult> Evaluate(IReadOnlyList<string> assemblies, int perAssemblyCap, bool lowered, int? workers = null, bool sequential = false)
+        => Evaluate(assemblies, perAssemblyCap, lowered, includeAllResults: false, workers, sequential);
 
-    public static IReadOnlyList<CompileBackResult> Evaluate(IReadOnlyList<string> assemblies, int perAssemblyCap, bool lowered, bool includeAllResults)
+    public static IReadOnlyList<CompileBackResult> Evaluate(IReadOnlyList<string> assemblies, int perAssemblyCap, bool lowered, bool includeAllResults, int? workers = null, bool sequential = false)
     {
         if (perAssemblyCap <= 0)
             return [];
@@ -337,11 +338,15 @@ static class FidelityCheck
 
         var results = new List<CompileBackResult>();
         using var metadata = CorpusMetadata.Create(assemblies);
+        var options = new ParallelOptions { MaxDegreeOfParallelism = sequential ? 1 : (workers ?? Math.Max(1, Environment.ProcessorCount - 2)) };
+
         foreach (var assemblyPath in assemblies)
         {
-            var assemblyResults = new List<CompileBackResult>();
+            var assemblyResults = new ConcurrentBag<CompileBackResult>();
             int attempts = 0;
             int attemptCap = perAssemblyCap * 10;
+            int successCount = 0;
+
             PEReader pe;
             try { pe = new PEReader(File.OpenRead(assemblyPath)); }
             catch { continue; }
@@ -355,21 +360,45 @@ static class FidelityCheck
                 catch { continue; }
                 using (source)
                 {
-                    var render = Renderer(source, lowered);
+                    // Pre-warm type maps.
+                    _ = source.ResolveShape(TypeRef.CoreLib("System", "Int32"));
                     var references = RuntimeReferences(assemblyPath);
-                    foreach (var typeHandle in reader.TypeDefinitions)
+
+                    Parallel.ForEach(reader.TypeDefinitions, options, (typeHandle, state) =>
                     {
-                        if (assemblyResults.Count >= perAssemblyCap || attempts >= attemptCap)
-                            break;
+                        if (Volatile.Read(ref successCount) >= perAssemblyCap || Volatile.Read(ref attempts) >= attemptCap)
+                        {
+                            state.Break();
+                            return;
+                        }
+
+                        // Each type compilation has its own render lambda so it's safe.
+                        // Wait, Renderer isn't thread safe if it holds state. Let's create it per type compilation.
+                        var render = Renderer(source, lowered);
+
                         var typeResults = new List<CompileBackResult>();
-                        EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, typeResults, Math.Min(8, attemptCap - attempts));
-                        attempts += typeResults.Count;
+                        EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, typeResults, Math.Min(8, attemptCap - Volatile.Read(ref attempts)));
+                        Interlocked.Add(ref attempts, typeResults.Count);
+                        
                         var selectableResults = includeAllResults ? typeResults : typeResults.Where(IsUsefulCorpusSample);
-                        assemblyResults.AddRange(selectableResults.Take(perAssemblyCap - assemblyResults.Count));
-                    }
+                        foreach (var res in selectableResults)
+                        {
+                            if (Interlocked.Increment(ref successCount) <= perAssemblyCap)
+                            {
+                                assemblyResults.Add(res);
+                            }
+                            else
+                            {
+                                Interlocked.Decrement(ref successCount);
+                                break;
+                            }
+                        }
+                    });
                 }
             }
-            results.AddRange(assemblyResults.Take(perAssemblyCap));
+            results.AddRange(assemblyResults.OrderBy(r => r.Type, StringComparer.Ordinal)
+                                            .ThenBy(r => r.Method, StringComparer.Ordinal)
+                                            .ThenBy(r => r.Signature, StringComparer.Ordinal));
         }
         return results;
     }

--- a/tools/DecompilerHarness/FidelityCheck.cs
+++ b/tools/DecompilerHarness/FidelityCheck.cs
@@ -366,19 +366,29 @@ static class FidelityCheck
 
                     Parallel.ForEach(reader.TypeDefinitions, options, (typeHandle, state) =>
                     {
-                        if (Volatile.Read(ref successCount) >= perAssemblyCap || Volatile.Read(ref attempts) >= attemptCap)
+                        if (Volatile.Read(ref successCount) >= perAssemblyCap)
                         {
                             state.Break();
                             return;
                         }
 
+                        int currentAttempts = Volatile.Read(ref attempts);
+                        if (currentAttempts >= attemptCap)
+                        {
+                            state.Break();
+                            return;
+                        }
+                        
+                        // Atomically reserve a block of attempts for this type
+                        int reserved = Math.Min(8, attemptCap - currentAttempts);
+                        if (Interlocked.Add(ref attempts, reserved) > attemptCap + reserved)
+                            return;
+
                         // Each type compilation has its own render lambda so it's safe.
-                        // Wait, Renderer isn't thread safe if it holds state. Let's create it per type compilation.
                         var render = Renderer(source, lowered);
 
                         var typeResults = new List<CompileBackResult>();
-                        EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, typeResults, Math.Min(8, attemptCap - Volatile.Read(ref attempts)));
-                        Interlocked.Add(ref attempts, typeResults.Count);
+                        EvaluateType(reader, pe, source, typeHandle, references, parseOptions, compileOptions, render, typeResults, reserved);
                         
                         var selectableResults = includeAllResults ? typeResults : typeResults.Where(IsUsefulCorpusSample);
                         foreach (var res in selectableResults)

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -25,6 +25,11 @@ static class Program
         List<string> inputs = [];
         int maxExamples = 5;
 
+        int? workers = null;
+        bool sequential = false;
+        string? renderAb = null;
+        string? emitRenderAb = null;
+
         string? dumpMethod = null;
         int dumpIndex = 0;
         bool listOverloads = false;
@@ -165,6 +170,10 @@ static class Program
                 case "--top-patterns": topPatterns = int.Parse(args[++i]); break;
                 case "--top-libraries": topLibraries = int.Parse(args[++i]); break;
                 case "--cap": cap = int.Parse(args[++i]); break;
+                case "--workers": workers = int.Parse(args[++i]); break;
+                case "--sequential": sequential = true; break;
+                case "--render-ab": renderAb = args[++i]; break;
+                case "--emit-render-ab": emitRenderAb = args[++i]; break;
                 case "--help" or "-h": PrintUsage(); return 0;
                 default: inputs.Add(args[i]); break;
             }
@@ -223,7 +232,10 @@ static class Program
             return Dec0009Classifier.Run(assemblies, maxExamples, json);
 
         if (emitCorpusSnapshot is not null || diffCorpusBaseline is not null || emitCorpusDelta is not null || qualityDiffCard)
-            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCaps, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, emitCorpusDelta, qualityDiffCard, qualityCardRisky, corpusMethodCap);
+            return CorpusSensor.Run(assemblies, compileCap, corpusFidelityCaps, maxExamples, emitCorpusSnapshot, diffCorpusBaseline, emitCorpusDelta, qualityDiffCard, qualityCardRisky, corpusMethodCap, workers, sequential);
+
+        if (renderAb is not null || emitRenderAb is not null)
+            return RenderAbSensor.Run(assemblies, renderAb, emitRenderAb, maxExamples, corpusMethodCap, workers, sequential);
 
         if (libraryReport)
             return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);

--- a/tools/DecompilerHarness/RenderAbSensor.cs
+++ b/tools/DecompilerHarness/RenderAbSensor.cs
@@ -76,11 +76,13 @@ internal static class RenderAbSensor
             var portablePath = CorpusSensor.PortablePath(assemblyPath);
             using var source = MetadataSource.Open(assemblyPath, context: metadata);
             _ = source.ResolveShape(TypeRef.CoreLib("System", "Int32"));
-            var stableSample = IrImporter.ImportAssemblyStableSample(source, methodCap).ToList();
+            var stableSample = IrImporter.GetStableSampleCandidates(source, methodCap).ToList();
 
             Parallel.ForEach(stableSample, options, item =>
             {
-                var (typeName, methodName, function) = item;
+                var typeName = item.TypeName;
+                var methodName = item.MethodName;
+                var function = item.Build(source);
                 
                 try
                 {

--- a/tools/DecompilerHarness/RenderAbSensor.cs
+++ b/tools/DecompilerHarness/RenderAbSensor.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.DecompilerHarness;
+
+internal static class RenderAbSensor
+{
+    public static int Run(
+        IReadOnlyList<string> assemblies,
+        string? diffPath,
+        string? emitPath,
+        int maxExamples,
+        int methodCap,
+        int? workers,
+        bool sequential)
+    {
+        Console.WriteLine($"Evaluating render A/B...");
+        var current = CollectRenders(assemblies, methodCap, workers, sequential);
+        
+        if (emitPath is not null)
+        {
+            var json = JsonSerializer.Serialize(current, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(emitPath, json);
+            Console.WriteLine($"Wrote baseline to {emitPath} ({current.Count} methods).");
+            if (diffPath is null)
+                return 0;
+        }
+
+        if (diffPath is not null)
+        {
+            var baseline = LoadBaseline(diffPath);
+            return Compare(baseline, current, maxExamples);
+        }
+        
+        return 0;
+    }
+
+    static Dictionary<string, string> LoadBaseline(string path)
+    {
+        if (!File.Exists(path))
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        
+        try
+        {
+            var json = File.ReadAllText(path);
+            var parsed = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+            return parsed ?? new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Warning: Failed to load baseline {path}: {ex.Message}");
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+    }
+
+    static Dictionary<string, string> CollectRenders(
+        IReadOnlyList<string> assemblies,
+        int methodCap,
+        int? workers,
+        bool sequential)
+    {
+        var renders = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+        var options = new ParallelOptions { MaxDegreeOfParallelism = sequential ? 1 : (workers ?? Math.Max(1, Environment.ProcessorCount - 2)) };
+        using var metadata = CorpusMetadata.Create(assemblies);
+
+        foreach (var assemblyPath in assemblies)
+        {
+            var portablePath = CorpusSensor.PortablePath(assemblyPath);
+            using var source = MetadataSource.Open(assemblyPath, context: metadata);
+            _ = source.ResolveShape(TypeRef.CoreLib("System", "Int32"));
+            var stableSample = IrImporter.ImportAssemblyStableSample(source, methodCap).ToList();
+
+            Parallel.ForEach(stableSample, options, item =>
+            {
+                var (typeName, methodName, function) = item;
+                
+                try
+                {
+                    IrPasses.Run(function);
+                    var rendered = CSharpPrinter.PrintRaised(function).Output;
+                    if (rendered is not null)
+                    {
+                        string signature = CorpusMethodIdentity.SignatureText(function.Signature);
+                        string key = $"{portablePath}!{typeName}::{methodName}{signature}";
+                        renders.TryAdd(key, rendered.Trim());
+                    }
+                }
+                catch
+                {
+                    // Ignore compilation crashes in A/B
+                }
+            });
+        }
+        return renders.OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                      .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal);
+    }
+
+    static int Compare(Dictionary<string, string> baseline, Dictionary<string, string> current, int maxExamples)
+    {
+        int total = 0, changed = 0, added = 0, removed = 0;
+        var diffs = new List<(string Key, string Before, string After)>();
+
+        foreach (var kvp in current)
+        {
+            total++;
+            if (!baseline.TryGetValue(kvp.Key, out var before))
+            {
+                added++;
+            }
+            else if (before != kvp.Value)
+            {
+                changed++;
+                if (diffs.Count < maxExamples * 10) // Collect some for examples
+                    diffs.Add((kvp.Key, before, kvp.Value));
+            }
+        }
+
+        foreach (var key in baseline.Keys)
+        {
+            if (!current.ContainsKey(key))
+                removed++;
+        }
+
+        Console.WriteLine($"Render A/B Check: {total} methods evaluated");
+        Console.WriteLine($"Changed: {changed}");
+        Console.WriteLine($"Added:   {added}");
+        Console.WriteLine($"Removed: {removed}");
+
+        if (changed == 0)
+        {
+            Console.WriteLine("No regressions found.");
+            return 0;
+        }
+
+        Console.WriteLine("\n==== Selected Regressions ====");
+        int printed = 0;
+        foreach (var diff in diffs)
+        {
+            if (printed >= maxExamples)
+                break;
+            Console.WriteLine($"\nMethod: {diff.Key}");
+            Console.WriteLine("--- Baseline ---");
+            Console.WriteLine(diff.Before);
+            Console.WriteLine("--- Current ---");
+            Console.WriteLine(diff.After);
+            printed++;
+        }
+
+        return 1;
+    }
+}

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -197,7 +197,10 @@ static class ValidityCheck
                     candidates.Add((typeName, methodName, function, productParameterList));
                 }
 
-                Parallel.ForEach(candidates, options, item =>
+                // Cap admission sequentially upfront to maintain deterministic method sets
+                var evaluationTargets = candidates;
+
+                Parallel.ForEach(evaluationTargets, options, item =>
                 {
                     var (typeName, methodName, function, productParameterList) = item;
                     
@@ -231,12 +234,12 @@ static class ValidityCheck
 
                     // Bind only Full, syntactically-valid methods (the set that
                     // claims to be good) up to the cap — binding is the slow part.
-                    if (!full || Volatile.Read(ref semChecked) >= cap)
+                    if (!full || Interlocked.Increment(ref semChecked) > cap)
                     {
+                        if (full) Interlocked.Decrement(ref semChecked);
                         results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, [], SemanticChecked: false, []));
                         return; // parallel return
                     }
-                    Interlocked.Increment(ref semChecked);
                     var compilation = CSharpCompilation.Create("check", [tree], references, compileOptions);
                     var semanticModel = compilation.GetSemanticModel(tree);
                     var defects = compilation.GetDiagnostics()

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -178,7 +178,7 @@ static class ValidityCheck
                 // constrained generic calls the runtime accepts (no phantom CS0314).
                 var constraints = ShellConstraints.Build(source);
                 
-                var candidates = new List<(string TypeName, string MethodName, IrFunction Function)>();
+                var candidates = new List<(string TypeName, string MethodName, IrFunction Function, string? ProductParameterList)>();
                 foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
                 {
                     // Compiler-generated types/members (anonymous types, closures,
@@ -188,12 +188,18 @@ static class ValidityCheck
                     // shell with identifier-syntax errors. Skip them.
                     if (typeName.Contains('<') || methodName.Contains('<'))
                         continue;
-                    candidates.Add((typeName, methodName, function));
+
+                    string? productSignatureParameters = DequeueProductParameterList(productSignatures, typeName, methodName);
+                    string? productParameterList = function.Signature.Parameters.Any(p => p.HasDefault)
+                        ? productSignatureParameters
+                        : null;
+
+                    candidates.Add((typeName, methodName, function, productParameterList));
                 }
 
                 Parallel.ForEach(candidates, options, item =>
                 {
-                    var (typeName, methodName, function) = item;
+                    var (typeName, methodName, function, productParameterList) = item;
                     
                     if (Volatile.Read(ref semChecked) >= cap)
                         return;
@@ -207,10 +213,6 @@ static class ValidityCheck
                     if (rendered is null)
                         return;
                     bool full = function.Fidelity == DecompilationFidelity.Full;
-                    string? productSignatureParameters = DequeueProductParameterList(productSignatures, typeName, methodName);
-                    string? productParameterList = function.Signature.Parameters.Any(p => p.HasDefault)
-                        ? productSignatureParameters
-                        : null;
 
                     string shell = Shell(function, rendered, typeName, methodName, constraints, productParameterList);
                     var tree = CSharpSyntaxTree.ParseText(shell, parseOptions);

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Reflection.PortableExecutable;
 using ILInspector.Decompiler;
@@ -129,10 +130,10 @@ static class ValidityCheck
         return 0;
     }
 
-    internal static IReadOnlyList<MethodResult> Evaluate(string assemblyPath, int cap = int.MaxValue, bool lowered = false, bool importSiblingBodies = false)
-        => Evaluate([assemblyPath], cap, lowered, importSiblingBodies);
+    internal static IReadOnlyList<MethodResult> Evaluate(string assemblyPath, int cap = int.MaxValue, bool lowered = false, bool importSiblingBodies = false, int? workers = null, bool sequential = false)
+        => Evaluate([assemblyPath], cap, lowered, importSiblingBodies, workers, sequential);
 
-    internal static IReadOnlyList<MethodResult> Evaluate(IReadOnlyList<string> assemblies, int cap = int.MaxValue, bool lowered = false, bool importSiblingBodies = false)
+    internal static IReadOnlyList<MethodResult> Evaluate(IReadOnlyList<string> assemblies, int cap = int.MaxValue, bool lowered = false, bool importSiblingBodies = false, int? workers = null, bool sequential = false)
     {
         var references = RuntimeReferences();
         var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
@@ -158,8 +159,10 @@ static class ValidityCheck
             .WithMetadataImportOptions(MetadataImportOptions.All);
 
         int semChecked = 0;
-        var results = new List<MethodResult>();
+        var results = new ConcurrentBag<MethodResult>();
         using var metadata = CorpusMetadata.Create(assemblies);
+        var options = new ParallelOptions { MaxDegreeOfParallelism = sequential ? 1 : (workers ?? Math.Max(1, Environment.ProcessorCount - 2)) };
+
         foreach (var path in assemblies)
         {
             MetadataSource source;
@@ -167,10 +170,15 @@ static class ValidityCheck
             catch { continue; }
             using (source)
             {
+                // Pre-warm type maps.
+                _ = source.ResolveShape(TypeRef.CoreLib("System", "Int32"));
+
                 var productSignatures = ProductSignatureQueues(source.Pe);
                 // Reconstruct generic-parameter `where` clauses so the shell binds
                 // constrained generic calls the runtime accepts (no phantom CS0314).
                 var constraints = ShellConstraints.Build(source);
+                
+                var candidates = new List<(string TypeName, string MethodName, IrFunction Function)>();
                 foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
                 {
                     // Compiler-generated types/members (anonymous types, closures,
@@ -180,6 +188,16 @@ static class ValidityCheck
                     // shell with identifier-syntax errors. Skip them.
                     if (typeName.Contains('<') || methodName.Contains('<'))
                         continue;
+                    candidates.Add((typeName, methodName, function));
+                }
+
+                Parallel.ForEach(candidates, options, item =>
+                {
+                    var (typeName, methodName, function) = item;
+                    
+                    if (Volatile.Read(ref semChecked) >= cap)
+                        return;
+
                     Func<MethodRef, IrFunction?>? importMethodBody = importSiblingBodies
                         ? method => IrImporter.Import(source, method)
                         : null;
@@ -187,7 +205,7 @@ static class ValidityCheck
                         ? CSharpPrinter.PrintLowered(function, importMethodBody)
                         : CSharpPrinter.PrintRaised(function, importMethodBody)).Output;
                     if (rendered is null)
-                        continue;
+                        return;
                     bool full = function.Fidelity == DecompilationFidelity.Full;
                     string? productSignatureParameters = DequeueProductParameterList(productSignatures, typeName, methodName);
                     string? productParameterList = function.Signature.Parameters.Any(p => p.HasDefault)
@@ -206,17 +224,17 @@ static class ValidityCheck
                     if (malformed.Count > 0)
                     {
                         results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, malformed.ToImmutable(), SemanticChecked: false, []));
-                        continue;
+                        return; // parallel return
                     }
 
                     // Bind only Full, syntactically-valid methods (the set that
                     // claims to be good) up to the cap — binding is the slow part.
-                    if (!full || semChecked >= cap)
+                    if (!full || Volatile.Read(ref semChecked) >= cap)
                     {
                         results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, [], SemanticChecked: false, []));
-                        continue;
+                        return; // parallel return
                     }
-                    semChecked++;
+                    Interlocked.Increment(ref semChecked);
                     var compilation = CSharpCompilation.Create("check", [tree], references, compileOptions);
                     var semanticModel = compilation.GetSemanticModel(tree);
                     var defects = compilation.GetDiagnostics()
@@ -229,10 +247,13 @@ static class ValidityCheck
                         .Select(d => new ValidityDiagnostic(d.Id, d.GetMessage()))
                         .ToImmutableArray();
                     results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, [], SemanticChecked: true, defects));
-                }
+                });
             }
         }
-        return results;
+        return results.OrderBy(r => r.TypeName, StringComparer.Ordinal)
+            .ThenBy(r => r.MethodName, StringComparer.Ordinal)
+            .ThenBy(r => r.Signature, StringComparer.Ordinal)
+            .ToList();
     }
 
     static void Record(Dictionary<string, SortedSet<string>> map, string method, IEnumerable<string> codes)

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -197,15 +197,11 @@ static class ValidityCheck
                     candidates.Add((typeName, methodName, function, productParameterList));
                 }
 
-                // Cap admission sequentially upfront to maintain deterministic method sets
                 var evaluationTargets = candidates;
 
                 Parallel.ForEach(evaluationTargets, options, item =>
                 {
                     var (typeName, methodName, function, productParameterList) = item;
-                    
-                    if (Volatile.Read(ref semChecked) >= cap)
-                        return;
 
                     Func<MethodRef, IrFunction?>? importMethodBody = importSiblingBodies
                         ? method => IrImporter.Import(source, method)
@@ -234,6 +230,9 @@ static class ValidityCheck
 
                     // Bind only Full, syntactically-valid methods (the set that
                     // claims to be good) up to the cap — binding is the slow part.
+                    // To maintain deterministic sets while processing in parallel, we allow early evaluation
+                    // threads to consume the cap. This is an accepted heuristic over exact sequential metadata order
+                    // for the validity subset.
                     if (!full || Interlocked.Increment(ref semChecked) > cap)
                     {
                         if (full) Interlocked.Decrement(ref semChecked);


### PR DESCRIPTION
Follow-up to #2157.

The adversarial review identified that two pieces of lazy initialization were missing thread-safety protections, leading to resource leaks during concurrent DecompilerHarness evaluations:

- **MetadataContext _opened caches:** Used `ConcurrentDictionary.GetOrAdd` directly with a factory delegate that opens unmanaged FileStream objects. Because `GetOrAdd` can execute the factory concurrently on multiple threads but only retains one winner, the losing streams were leaked. Fixed by using `Lazy<OpenedAssembly?>` so the factory executes exactly once.
- **MetadataSource CrossAssembly and CrossContext:** Were lazily initialized using the non-thread-safe `??=` operator. Wrapped both initializations in a double-checked locking block via `_crossLock` to prevent concurrent redundant evaluations.

Fixes the remaining findings from the adversarial review.