### PR TITLE
Fix cache and handle leaks from parallel harness evaluation

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
@@ -31,8 +31,8 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </remarks>
 public sealed class MetadataContext : IDisposable
 {
-    readonly ConcurrentDictionary<string, OpenedAssembly?> _opened = new(StringComparer.OrdinalIgnoreCase);
-    readonly ConcurrentDictionary<string, OpenedAssembly?> _openedLocations = new(StringComparer.Ordinal);
+    readonly ConcurrentDictionary<string, Lazy<OpenedAssembly?>> _opened = new(StringComparer.OrdinalIgnoreCase);
+    readonly ConcurrentDictionary<string, Lazy<OpenedAssembly?>> _openedLocations = new(StringComparer.Ordinal);
 
     public MetadataContext(AssemblyLocator locator)
         : this(locator.ToAssemblyReferenceResolver())
@@ -58,7 +58,7 @@ public sealed class MetadataContext : IDisposable
     /// </summary>
     internal OpenedAssembly? Open(string path)
     {
-        return _opened.GetOrAdd(path, p => OpenedAssembly.TryOpen(p));
+        return _opened.GetOrAdd(path, p => new Lazy<OpenedAssembly?>(() => OpenedAssembly.TryOpen(p))).Value;
     }
 
     internal OpenedAssembly? Open(TypeLocation location)
@@ -66,7 +66,7 @@ public sealed class MetadataContext : IDisposable
         if (location.AssemblyPath is { Length: > 0 } path)
             return Open(path);
 
-        return _openedLocations.GetOrAdd(location.AssemblyKey, _ => OpenedAssembly.TryOpen(location.OpenRead));
+        return _openedLocations.GetOrAdd(location.AssemblyKey, _ => new Lazy<OpenedAssembly?>(() => OpenedAssembly.TryOpen(location.OpenRead))).Value;
     }
 
     internal ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
@@ -75,9 +75,9 @@ public sealed class MetadataContext : IDisposable
     public void Dispose()
     {
         foreach (var opened in _opened.Values)
-            opened?.Dispose();
+            if (opened.IsValueCreated) opened.Value?.Dispose();
         foreach (var opened in _openedLocations.Values)
-            opened?.Dispose();
+            if (opened.IsValueCreated) opened.Value?.Dispose();
         _opened.Clear();
         _openedLocations.Clear();
     }

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -30,6 +30,7 @@ public sealed class MetadataSource : IDisposable
     MetadataContext? _crossContext;
     bool _ownsCrossContext;
     CrossAssemblyTypeResolver? _crossAssembly;
+    readonly object _crossLock = new();
 
     MetadataSource(string path, Stream stream, PEReader peReader, MetadataReader reader, string assemblyName, string? externalPdbPath, bool readSymbols, AssemblyLocator locator, IAssemblyReferenceResolver resolver, MetadataContext? context)
     {
@@ -198,7 +199,19 @@ public sealed class MetadataSource : IDisposable
     /// cannot state on its own (value-type-ness of a bare cross-assembly token).
     /// </summary>
     internal CrossAssemblyTypeResolver CrossAssembly
-        => _crossAssembly ??= new CrossAssemblyTypeResolver(AssemblyName, Reader, CrossContext);
+    {
+        get
+        {
+            if (_crossAssembly is null)
+            {
+                lock (_crossLock)
+                {
+                    _crossAssembly ??= new CrossAssemblyTypeResolver(AssemblyName, Reader, CrossContext);
+                }
+            }
+            return _crossAssembly;
+        }
+    }
 
     /// <summary>
     /// The shared assembly-reading environment cross-assembly resolution reads
@@ -210,10 +223,19 @@ public sealed class MetadataSource : IDisposable
     {
         get
         {
+            if (_suppliedContext is not null)
+                return _suppliedContext;
+                
             if (_crossContext is null)
             {
-                _crossContext = _suppliedContext ?? new MetadataContext(_resolver);
-                _ownsCrossContext = _suppliedContext is null;
+                lock (_crossLock)
+                {
+                    if (_crossContext is null)
+                    {
+                        _crossContext = new MetadataContext(_resolver);
+                        _ownsCrossContext = true;
+                    }
+                }
             }
             return _crossContext;
         }


### PR DESCRIPTION
Follow-up to #2157.

The adversarial review identified that two pieces of lazy initialization were missing thread-safety protections, leading to resource leaks during concurrent DecompilerHarness evaluations:

- **MetadataContext _opened caches:** Used `ConcurrentDictionary.GetOrAdd` directly with a factory delegate that opens unmanaged FileStream objects. Because `GetOrAdd` can execute the factory concurrently on multiple threads but only retains one winner, the losing streams were leaked. Fixed by using `Lazy<OpenedAssembly?>` so the factory executes exactly once.
- **MetadataSource CrossAssembly and CrossContext:** Were lazily initialized using the non-thread-safe `??=` operator. Wrapped both initializations in a double-checked locking block via `_crossLock` to prevent concurrent redundant evaluations.

Fixes the remaining findings from the adversarial review.