### PR TITLE
Guard AssemblyImage stream ownership

### DIFF
--- a/tests/ILInspector.Metadata.Tests/AssemblyInspectionSessionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/AssemblyInspectionSessionTests.cs
@@ -73,7 +73,7 @@ public class AssemblyInspectionSessionTests
     [Fact]
     public void AssemblyImage_DisposesBackingStreamExactlyOnce()
     {
-        var stream = new DisposeCountingStream(File.OpenRead(SelfPath));
+        using var stream = new DisposeCountingStream(File.OpenRead(SelfPath));
         var reference = new ResolvedAssemblyReference(
             new AssemblyReferenceIdentity(SelfName, Version: null, Culture: null, PublicKeyToken: null),
             SelfPath,

--- a/tests/ILInspector.Metadata.Tests/AssemblyInspectionSessionTests.cs
+++ b/tests/ILInspector.Metadata.Tests/AssemblyInspectionSessionTests.cs
@@ -69,4 +69,70 @@ public class AssemblyInspectionSessionTests
         using var image = AssemblyImage.Open(SelfPath);
         Assert.True(image.HasMetadata);
     }
+
+    [Fact]
+    public void AssemblyImage_DisposesBackingStreamExactlyOnce()
+    {
+        var stream = new DisposeCountingStream(File.OpenRead(SelfPath));
+        var reference = new ResolvedAssemblyReference(
+            new AssemblyReferenceIdentity(SelfName, Version: null, Culture: null, PublicKeyToken: null),
+            SelfPath,
+            () => stream);
+
+        var image = AssemblyImage.Open(reference);
+        try
+        {
+            Assert.True(image.HasMetadata);
+            Assert.Equal(0, stream.DisposeCount);
+        }
+        finally
+        {
+            image.Dispose();
+        }
+
+        Assert.Equal(1, stream.DisposeCount);
+    }
+
+    sealed class DisposeCountingStream(Stream inner) : Stream
+    {
+        bool _innerDisposed;
+
+        public int DisposeCount { get; private set; }
+
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => inner.CanWrite;
+        public override long Length => inner.Length;
+
+        public override long Position
+        {
+            get => inner.Position;
+            set => inner.Position = value;
+        }
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => inner.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+
+        public override void SetLength(long value) => inner.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count) => inner.Write(buffer, offset, count);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                DisposeCount++;
+                if (!_innerDisposed)
+                {
+                    inner.Dispose();
+                    _innerDisposed = true;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a focused regression test for the AssemblyImage ownership invariant.
- Verifies `AssemblyImage` disposes the backing stream exactly once, locking in the existing `PEStreamOptions.LeaveOpen` behavior where `AssemblyImage` is the sole explicit stream owner.

Refs #2122.

## Validation

- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:RestoreConfigFile=nuget.config -- -class "*AssemblyInspectionSessionTests*"`
- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config`

## Review

Low-risk test-only guard for an ownership invariant already present on main; no adversarial review required.