### PR TITLE
Build the member analysis index once per command (#2139 perf)

### DIFF
--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1115,6 +1115,14 @@ public static class ApiOutputFormatter
         bool hasCode = false;
         var assemblyResolver = AnalysisReferenceResolver(dllPath, options);
 
+        // Build the analysis body index at most once per command, and only when an
+        // index-backed section is actually requested (sections like decompiled source / IL
+        // go through MemberCodeProvider and never touch it). Every index-backed block below
+        // shares this one session instead of re-opening and re-analyzing every method body.
+        MethodBodyInspectionSession? indexSession = null;
+        MethodBodyInspectionSession IndexSession() =>
+            indexSession ??= MethodBodyInspectionSession.Open(dllPath, assemblyResolver);
+
         // For sections that require a single selected method (Calls, CallGraph, decompiled source, etc.),
         // filter to that specific overload. Callers can aggregate across all overloads.
         var singleMethod = overloadIndex.HasValue
@@ -1129,7 +1137,7 @@ public static class ApiOutputFormatter
         if (request.Calls && singleMethodList is [{ MetadataToken: { } token } callsMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.calls", callsMethod.Name);
-            var rows = MethodBodyInspectionSession.Open(dllPath, assemblyResolver)
+            var rows = IndexSession()
                 .DirectCalls(token)
                 .OrderBy(call => call.ILOffset)
                 .Select(call => new CallSiteRow(
@@ -1174,7 +1182,7 @@ public static class ApiOutputFormatter
         if (request.Callers && methods.Count > 0)
         {
             RequestTelemetry.Breadcrumb("il-analysis.callers", $"{methods.Count} member(s)");
-            var callerSession = MethodBodyInspectionSession.Open(dllPath, assemblyResolver);
+            var callerSession = IndexSession();
             var rows = new List<CallerSiteRow>();
 
             // Open each caller-scope assembly once as its own session (skipping any that fail to
@@ -1223,7 +1231,7 @@ public static class ApiOutputFormatter
         {
             RequestTelemetry.Breadcrumb("il-analysis.call-graph", graphMethod.Name);
             var root = ToCallGraphNode(
-                MethodBodyInspectionSession.Open(dllPath, assemblyResolver).CallTree(graphToken),
+                IndexSession().CallTree(graphToken),
                 GetRequestedCallGraphFields(options));
             if (root.Children is { Count: > 0 })
             {
@@ -1241,7 +1249,7 @@ public static class ApiOutputFormatter
         if (requestedSections.Contains(SectionNames.CallerGraph) && singleMethodList is [{ MetadataToken: { } callerGraphToken } callerGraphMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.caller-graph", callerGraphMethod.Name);
-            var callerSession = MethodBodyInspectionSession.Open(dllPath, assemblyResolver);
+            var callerSession = IndexSession();
             // Extend the reverse graph across the caller scope (--bin/--project/--caller-package)
             // so a dependency member surfaces the product entry points and callers that reach it.
             var scopeSessions = new List<MethodBodyInspectionSession>();
@@ -1271,7 +1279,7 @@ public static class ApiOutputFormatter
         if (request.UnsafeOperations && singleMethodList is [{ MetadataToken: { } unsafeToken } unsafeMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.unsafe", unsafeMethod.Name);
-            var evidence = MethodBodyInspectionSession.Open(dllPath, assemblyResolver)
+            var evidence = IndexSession()
                 .UnsafeEvidence(unsafeToken)
                 .OrderBy(evidence => evidence.ILOffset ?? -1)
                 .ThenBy(evidence => evidence.Reason, StringComparer.Ordinal)
@@ -1312,7 +1320,7 @@ public static class ApiOutputFormatter
         if (requestedSections.Overlaps(SemanticFactSections) && singleMethodList is [{ MetadataToken: { } semanticToken } semanticMethod])
         {
             RequestTelemetry.Breadcrumb("il-analysis.semantic-facts", semanticMethod.Name);
-            var bodySession = MethodBodyInspectionSession.Open(dllPath, assemblyResolver);
+            var bodySession = IndexSession();
 
             if (requestedSections.Contains(SectionNames.AllocationFacts))
             {


### PR DESCRIPTION
## Summary

First perf slice enabled by the #2139 session seam: **build the member analysis
index once per command** instead of once per section.

Each member section handler (`Calls`, `Callers`, `Call Graph`, `Caller Graph`,
`Unsafe Operations`, semantic facts) previously opened its own
`MethodBodyInspectionSession`, and every `Open` rebuilds the full
`LibraryBodyIndex` (parse PE + analyze *every* method body). A `member` render
selecting N index-backed sections rebuilt the index N times.

This adds a lazily-memoized `IndexSession()` in `PopulateIndexSections` that all
index-backed blocks share. Laziness preserves the prior behavior of **not**
building the index when no index-backed section is requested (decompiled
source / IL go through `MemberCodeProvider` and never touch it).

## Results

- **Behavior-preserving**: byte-identical output across 24 member/section combos
  (Calls, Call Graph, Caller Graph, Unsafe Operations, Allocation/Safety/Cost
  Facts, and the combined 7-section render) plus the `--bin` caller graph.
- **~2× faster** on a large assembly (`ILInspector.Decompiler.dll`), collapsing
  6 per-section index builds into 1. Rigorous interleaved measurement (alternating
  old/new, same input dll):
  - NativeAOT, 5-section render (n=12): **3687 ms → 1797 ms median (~51%)**;
    NAOT startup floor ~24 ms, so the delta is essentially all index-build work.
  - CoreCLR, 7-section render (n=10): **4462 ms → 2037 ms median (2.19×)**.
  (An earlier 2.4× figure was measured sequentially and inflated by machine-load
  drift between batches; interleaved measurement gives the ~2× above.)
- Tests: `MemberCalls/Callers/CallGraph/UnsafeMembers/SemanticFactsSectionTests`
  + `MethodBodyInspectionSessionTests` — 66/66 pass.

## Follow-up

The `type`/`library` path (`ApiCommand` → `PopulateUnsafeMembers` /
`PopulateCalledTypes` / `PopulateTypeSemanticFacts` /
`PopulateOptimizationOpportunities` / `PopulateTopLeverage`) has the same
per-section rebuild (and per-type, for `library`). All five use the same
`options.DllPath`, so a follow-up will thread one session through the
type-section dispatch (hoisted above the `library` type loop) for the analogous
win.

Part of #2139 / #2122.

