### PR TITLE
Emit churned backing-store type for growable collections (#2127 Piece #3)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1388,6 +1388,23 @@ public class LibraryBodyIndexTests
     }
 
     [Theory]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesListOfInt), "System.Int32[]")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesQueueOfByte), "System.Byte[]")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesStackOfLong), "System.Int64[]")]
+    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesStringBuilder), "System.Char[]")]
+    // Fail-honest: no single known backing store.
+    [InlineData(nameof(OptimizationOpportunityFixtures.AllocatesDictionary), null)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.ReturnsPlainObject), null)]
+    public void AllocationOccurrences_ReportChurnedBackingType(string methodName, string? expectedChurnedType)
+    {
+        var index = LibraryBodyIndex.Open(typeof(OptimizationOpportunityFixtures).Assembly.Location);
+
+        var occurrence = SingleAllocationOccurrence(index, methodName, AllocationKind.Object);
+
+        Assert.Equal(expectedChurnedType, occurrence.ChurnedType);
+    }
+
+    [Theory]
     [InlineData(nameof(OptimizationOpportunityFixtures.ReturnsIntArray10), 64)]
     [InlineData(nameof(OptimizationOpportunityFixtures.ReturnsIntArray5), 48)]
     [InlineData(nameof(OptimizationOpportunityFixtures.ReturnsIntArray5AfterUnrelatedBranch), 48)]
@@ -3481,6 +3498,14 @@ public class OptimizationOpportunityFixtures
     }
 
     public static object ReturnsPlainObject() => new PlainObject(1);
+
+    // Growable collections whose churned backing store the analysis reports.
+    public static object AllocatesListOfInt() => new System.Collections.Generic.List<int>();
+    public static object AllocatesQueueOfByte() => new System.Collections.Generic.Queue<byte>();
+    public static object AllocatesStackOfLong() => new System.Collections.Generic.Stack<long>();
+    public static object AllocatesStringBuilder() => new System.Text.StringBuilder();
+    // Multi-array backing (buckets + entries) -> fail-honest, no single churned type.
+    public static object AllocatesDictionary() => new System.Collections.Generic.Dictionary<int, string>();
 
     public void StoresPlainObjectToField() => _objectField = new PlainObject(1);
 

--- a/src/ILInspector.Analysis/AllocationOccurrence.cs
+++ b/src/ILInspector.Analysis/AllocationOccurrence.cs
@@ -123,6 +123,14 @@ public sealed record AllocationOccurrence(
 
     public AllocationMultiplicity Multiplicity { get; init; }
 
+    /// <summary>
+    /// The backing array a growable collection actually churns as it resizes
+    /// (e.g. <c>List&lt;T&gt;</c> → <c>T[]</c>, <c>StringBuilder</c> → <c>char[]</c>),
+    /// distinct from the allocated object type. Null when there is no single known
+    /// backing store (fail-honest). Sharpens the static↔dynamic observed-type match.
+    /// </summary>
+    public string? ChurnedType { get; init; }
+
     public string AnnotationId => Kind switch
     {
         AllocationKind.Box => "alloc.box",

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -2612,6 +2612,7 @@ public sealed class LibraryBodyIndex
                 {
                     PostDominance = AllocationPostDominanceFor(decodedBody, offset, escape),
                     Multiplicity = AllocationMultiplicityFor(decodedBody, offset, loopRegions, escape),
+                    ChurnedType = ChurnedTypeFor(kind, allocatedType),
                 };
 
             bool ShouldEmitUnresolvedValueTypeAnnotation(int operandToken, TypeRef type)
@@ -3930,6 +3931,28 @@ public sealed class LibraryBodyIndex
                 AllocationKind.StateMachine => $"state machine ({RuntimeTypeName(allocatedType)})",
                 _ => RuntimeTypeName(allocatedType),
             };
+        }
+
+        // The backing array a growable collection churns as it resizes — the type that
+        // actually allocates at runtime, distinct from the collection object itself. Only
+        // the single-backing-array collections are reported; Dictionary/HashSet grow
+        // multiple internal arrays (buckets + entries) so they stay fail-honest null.
+        static string? ChurnedTypeFor(AllocationKind kind, TypeRef? allocatedType)
+        {
+            if (kind != AllocationKind.Object || allocatedType is null)
+                return null;
+
+            if (FrameworkIdentity.IsKnownFrameworkType(allocatedType, "System.Text", "System.Text", "StringBuilder"))
+                return "System.Char[]";
+
+            if (allocatedType.Kind == TypeRefKind.GenericInstance
+                && allocatedType.TypeArguments.Length == 1
+                && (FrameworkIdentity.IsKnownFrameworkType(allocatedType, "System.Collections", "System.Collections.Generic", "List`1")
+                    || FrameworkIdentity.IsKnownFrameworkType(allocatedType, "System.Collections", "System.Collections.Generic", "Queue`1")
+                    || FrameworkIdentity.IsKnownFrameworkType(allocatedType, "System.Collections", "System.Collections.Generic", "Stack`1")))
+                return $"{RuntimeTypeName(allocatedType.TypeArguments[0])}[]";
+
+            return null;
         }
 
         static string RuntimeTypeName(TypeRef type)

--- a/src/ILInspector.Analysis/SemanticFacts.cs
+++ b/src/ILInspector.Analysis/SemanticFacts.cs
@@ -18,7 +18,8 @@ public sealed record AllocationFact(
     string? PathConfidence,
     string? PostDominance,
     string Evidence,
-    string? Multiplicity);
+    string? Multiplicity,
+    string? ChurnedType);
 
 public sealed record SafetyFact(
     MethodIdentity Method,
@@ -79,7 +80,8 @@ public static class SemanticFactProjection
                 LibraryBodyIndex.FormatPathConfidence(occurrence.PathConfidence),
                 LibraryBodyIndex.FormatPostDominance(occurrence.PostDominance),
                 occurrence.Detail ?? FormatSource(occurrence.Source),
-                LibraryBodyIndex.FormatMultiplicity(occurrence.Multiplicity)))];
+                LibraryBodyIndex.FormatMultiplicity(occurrence.Multiplicity),
+                occurrence.ChurnedType))];
 
     public static ImmutableArray<SafetyFact> SafetyFacts(
         IReadOnlyDictionary<int, ImmutableArray<UnsafeEvidence>> unsafeEvidence,

--- a/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
+++ b/src/ILInspector.Research/AllocationOccurrenceFactProducer.cs
@@ -67,6 +67,8 @@ sealed class AllocationOccurrenceFactProducer : IResearchFactProducer
             parts.Add($"escape-kind={escapeKind}");
         if (FormatMultiplicity(occurrence.Multiplicity) is { } multiplicity)
             parts.Add($"multiplicity={multiplicity}");
+        if (occurrence.ChurnedType is { Length: > 0 } churned)
+            parts.Add($"churned={churned}");
         return parts.Count == 0 ? null : string.Join("; ", parts);
     }
 

--- a/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
+++ b/src/dotnet-inspect/Commands/ILOffsetSourceQuery.cs
@@ -399,7 +399,8 @@ internal static class ILOffsetSourceQuery
             PathConfidence = fact.PathConfidence,
             PostDominance = fact.PostDominance,
             Evidence = fact.Evidence,
-            Multiplicity = fact.Multiplicity
+            Multiplicity = fact.Multiplicity,
+            ChurnedType = fact.ChurnedType
         };
 
     private static ILOffsetSafetyContext ToILOffsetSafetyContext(Analysis.SafetyFact fact)

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -599,6 +599,9 @@ public class ILOffsetAllocationContext
     [JsonPropertyName("multiplicity")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Multiplicity { get; init; }
+    [JsonPropertyName("churned_type")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ChurnedType { get; init; }
 }
 
 public class ILOffsetSafetyContext

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -585,6 +585,7 @@ public class LibraryInspectionView
     [MarkoutSection(Name = SectionNames.AllocationContext, ShowWhenProperty = nameof(HasILOffsetAllocationContext))]
     [MarkoutIgnoreColumnWhen(nameof(AllocationContextEscapeKindIsEmpty), nameof(ILOffsetAllocationContextRow.EscapeKind))]
     [MarkoutIgnoreColumnWhen(nameof(AllocationContextMultiplicityIsEmpty), nameof(ILOffsetAllocationContextRow.Multiplicity))]
+    [MarkoutIgnoreColumnWhen(nameof(AllocationContextChurnedTypeIsEmpty), nameof(ILOffsetAllocationContextRow.ChurnedType))]
     public List<ILOffsetAllocationContextRow>? ILOffsetAllocationContextSection =>
         _data.ILOffset?.AllocationContext?
             .Select(context => new ILOffsetAllocationContextRow(
@@ -602,7 +603,8 @@ public class LibraryInspectionView
                 context.PathConfidence,
                 context.PostDominance,
                 context.Evidence,
-                context.Multiplicity))
+                context.Multiplicity,
+                context.ChurnedType))
             .ToList();
 
     [MarkoutIgnore]
@@ -857,6 +859,11 @@ public class LibraryInspectionView
     public static bool AllocationContextMultiplicityIsEmpty(List<ILOffsetAllocationContextRow>? rows)
         => rows is null || rows.All(row => string.IsNullOrEmpty(row.Multiplicity));
 
+    // The churned/backing type is only present on known growable-collection allocations,
+    // so drop the column when no row carries one.
+    public static bool AllocationContextChurnedTypeIsEmpty(List<ILOffsetAllocationContextRow>? rows)
+        => rows is null || rows.All(row => string.IsNullOrEmpty(row.ChurnedType));
+
     private static List<TreeNode> BuildNestedDependencyTree(List<AssemblyReferenceNode> nodes)
     {
         List<TreeNode> result = [];
@@ -1042,7 +1049,8 @@ public record ILOffsetAllocationContextRow(
     [property: MarkoutPropertyName("Path Confidence")] string? PathConfidence,
     [property: MarkoutPropertyName("Post Dominance")] string? PostDominance,
     string? Evidence,
-    [property: MarkoutSkipNull] string? Multiplicity);
+    [property: MarkoutSkipNull] string? Multiplicity,
+    [property: MarkoutPropertyName("Churned Type")][property: MarkoutSkipNull] string? ChurnedType);
 
 [MarkoutSerializable]
 public record ILOffsetSafetyContextRow(


### PR DESCRIPTION
## What

Implements **Piece #3 of #2127** — an explicit churned/backing-store type on
grown-collection allocations. An additive objective coordinate-layer fact,
mirroring the merged escape-kind (Piece #1) and multiplicity (Piece #2) priors.

`AllocationOccurrence.ChurnedType` = the backing array a growable collection
actually churns as it resizes, distinct from the allocated object itself:

- `List<T>` / `Queue<T>` / `Stack<T>` → `T[]`
- `StringBuilder` → `System.Char[]`
- `Dictionary` / `HashSet` grow multiple internal arrays (buckets + entries), so
  they stay **fail-honest null**; non-collection allocations are null too.

Computed at the single `MakeAllocation` choke point (`ChurnedTypeFor`). Surfaced
on `AllocationFact`, the allocation annotation detail (`churned=…`), and the
`AllocationContext` section + JSON (`churned_type`, hide-when-empty), appended
last so existing TSV column positions stay stable.

## Why

Sharpens the static↔dynamic observed-type match and **resolves the size-gap
case** from the runfaster finding: `StringBuilder`'s 9.2 GB observed churn is the
`char[]` backing growth, not the `StringBuilder` object — static now knows it's a
`char[]` growth (just not the count).

## Evidence

- Corpus (308 framework assemblies, 67,740 counted allocations, **0 failures**):
  **2,293 (3.4%)** now carry a churned type — 1,857 `T[]` (List/Queue/Stack),
  436 `char[]` (StringBuilder). Fail-honest null for Dictionary/HashSet/other.
- Additive: existing facts/verdicts unperturbed; analysis suite **338 pass**,
  CLI suite green.
- End-to-end verified: the `Churned Type` column (hide-when-empty), the
  `churned_type` JSON field (null-omitted), and the annotation detail.

## Tests

`AllocationOccurrences_ReportChurnedBackingType` theory covering List/Queue/Stack
→ `T[]`, StringBuilder → `char[]`, and fail-honest null for Dictionary and a
plain object.

## Adversarial review

Requested from two non-Opus models per policy; reconciled in a follow-up comment.

Completes #2127 (Pieces #1–#3). Related: #2166, #2110, #2008, #2177 (follow-up).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
