### PR TITLE
Inverse architecture: annotate the value-load and operator families (batch 3)

### DIFF
--- a/docs/design/inverse-ledger.generated.md
+++ b/docs/design/inverse-ledger.generated.md
@@ -12,7 +12,7 @@ edit by hand. See [inverse-architecture.md](inverse-architecture.md) for the fra
 | `Box` | BoundConversion (boxing) | RyuJitImporter | Inherited | target is the boxed value type | box/unbox fixtures |
 | `CastClass` | BoundConversion (reference cast) | RyuJitImporter | Inherited | target is the reference type the cast checks | cast fixtures; corpus compile-back |
 | `Coerce` | BoundConversion (implicit, target-driven) | RyuJitStackNormalization | Native | sink type recoverable and distinguishable from the stack type | CoerceChokePointTests, CoercionInvariantTests, corpus render-text A/B |
-| `Comparison` | BoundBinaryOperator (comparison) / ceq·clt·cgt | RyuJitImporter | Inherited | result is bool (the ceq/clt/cgt integer 0/1 result) | corpus compile-back |
+| `Comparison` | BoundBinaryOperator (comparison) / ceq·clt·cgt | RyuJitImporter | Native | result is bool (the ceq/clt/cgt integer 0/1 result) | corpus compile-back |
 | `Convert` | BoundConversion (numeric) | RyuJitStackNormalization | Inherited | none — models the conv.* that ran | round-trips by construction; corpus compile-back |
 | `LoadArgument` | BoundParameter / ldarg | None | Inherited | type is the argument's declared type (parameter signature; declaring type for `this`) | corpus compile-back |
 | `LoadField` | BoundFieldAccess / ldfld·ldsfld | None | Inherited | type is the field's declared type (field signature) | corpus compile-back |

--- a/docs/design/inverse-ledger.generated.md
+++ b/docs/design/inverse-ledger.generated.md
@@ -8,10 +8,16 @@ edit by hand. See [inverse-architecture.md](inverse-architecture.md) for the fra
 
 | Node | Forward construct (Roslyn) | Oracle (RyuJIT) | Naming | Precondition | Witness |
 | --- | --- | --- | --- | --- | --- |
+| `Binary` | BoundBinaryOperator (arithmetic/bitwise/shift) | RyuJitImporter | Inherited | result type is the ECMA binary-numeric result of the operand stack types | corpus compile-back |
 | `Box` | BoundConversion (boxing) | RyuJitImporter | Inherited | target is the boxed value type | box/unbox fixtures |
 | `CastClass` | BoundConversion (reference cast) | RyuJitImporter | Inherited | target is the reference type the cast checks | cast fixtures; corpus compile-back |
 | `Coerce` | BoundConversion (implicit, target-driven) | RyuJitStackNormalization | Native | sink type recoverable and distinguishable from the stack type | CoerceChokePointTests, CoercionInvariantTests, corpus render-text A/B |
+| `Comparison` | BoundBinaryOperator (comparison) / ceq·clt·cgt | RyuJitImporter | Inherited | result is bool (the ceq/clt/cgt integer 0/1 result) | corpus compile-back |
 | `Convert` | BoundConversion (numeric) | RyuJitStackNormalization | Inherited | none — models the conv.* that ran | round-trips by construction; corpus compile-back |
+| `LoadArgument` | BoundParameter / ldarg | None | Inherited | type is the argument's declared type (parameter signature; declaring type for `this`) | corpus compile-back |
+| `LoadField` | BoundFieldAccess / ldfld·ldsfld | None | Inherited | type is the field's declared type (field signature) | corpus compile-back |
+| `LoadLocal` | BoundLocal / ldloc | None | Inherited | type is the local's declared type (local variable signature) | corpus compile-back |
+| `Unary` | BoundUnaryOperator (neg/not) | RyuJitImporter | Inherited | result type is the operand's type (neg/not preserve the operand type) | corpus compile-back |
 | `Unbox` | BoundConversion (unboxing → managed pointer) | RyuJitImporter | Inherited | operand is a box of the value type; result is a managed pointer into it | box/unbox fixtures; corpus compile-back |
 | `UnboxAny` | BoundConversion (unboxing) | RyuJitImporter | Inherited | target is the unbox.any type token (value type, reference type, or type parameter) | box/unbox fixtures; corpus compile-back |
 

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
@@ -22,7 +22,7 @@ public class InverseArchitectureTests
     // In-domain product nodes that MUST carry [InverseOf] or [NotInverted]. The
     // conversion family is the first annotated slice (docs/design/inverse-architecture.md);
     // the set grows as the ledger's declared domain grows.
-    static readonly string[] EnforcedProductNodes = ["Box", "CastClass", "Coerce", "Convert", "Unbox", "UnboxAny"];
+    static readonly string[] EnforcedProductNodes = ["Binary", "Box", "CastClass", "Coerce", "Comparison", "Convert", "LoadArgument", "LoadField", "LoadLocal", "Unary", "Unbox", "UnboxAny"];
 
     static Assembly ProductAssembly => typeof(IrFunction).Assembly;
     Assembly TestAssembly => GetType().Assembly;

--- a/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseArchitecture.cs
+++ b/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseArchitecture.cs
@@ -22,6 +22,21 @@ public enum Forward
 
     /// <summary>Roslyn's <c>BoundConversion</c> (the bound-tree conversion node).</summary>
     RoslynBoundConversion,
+
+    /// <summary>Roslyn's <c>BoundParameter</c> (a method parameter / <c>this</c> reference).</summary>
+    RoslynBoundParameter,
+
+    /// <summary>Roslyn's <c>BoundLocal</c> (a local variable reference).</summary>
+    RoslynBoundLocal,
+
+    /// <summary>Roslyn's <c>BoundFieldAccess</c> (an instance or static field read).</summary>
+    RoslynBoundFieldAccess,
+
+    /// <summary>Roslyn's <c>BoundBinaryOperator</c> (arithmetic, bitwise, shift, and comparison).</summary>
+    RoslynBoundBinaryOperator,
+
+    /// <summary>Roslyn's <c>BoundUnaryOperator</c> (negation, bitwise complement).</summary>
+    RoslynBoundUnaryOperator,
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -929,6 +929,14 @@ public sealed class Continue : IrNode
 
 public enum ComparisonKind { Equal, NotEqual, LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual }
 
+/// <summary>An integer/float comparison (<c>ceq</c>/<c>clt</c>/<c>cgt</c> family), producing a boolean.</summary>
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundBinaryOperator,
+    naming: Inverse.NameProvenance.Inherited,
+    oracle: Inverse.Oracle.RyuJitImporter,
+    forwardName: "BoundBinaryOperator (comparison) / ceq·clt·cgt",
+    precondition: "result is bool (the ceq/clt/cgt integer 0/1 result)",
+    witness: "corpus compile-back")]
 public sealed class Comparison : IrExpression
 {
     public Comparison(ComparisonKind kind, bool isUnsigned, IrExpression left, IrExpression right)
@@ -1152,6 +1160,14 @@ public sealed class LogicalNot : IrExpression
 
 public enum UnaryKind { Negate, BitwiseNot }
 
+/// <summary>A unary arithmetic operator: negation (<c>neg</c>) or bitwise complement (<c>not</c>).</summary>
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundUnaryOperator,
+    naming: Inverse.NameProvenance.Inherited,
+    oracle: Inverse.Oracle.RyuJitImporter,
+    forwardName: "BoundUnaryOperator (neg/not)",
+    precondition: "result type is the operand's type (neg/not preserve the operand type)",
+    witness: "corpus compile-back")]
 public sealed class Unary : IrExpression
 {
     public Unary(UnaryKind kind, IrExpression operand)
@@ -1293,6 +1309,13 @@ public sealed class ExpressionStatement : IrNode
     public override string Describe() => "ExpressionStatement";
 }
 
+/// <summary>A method argument (or <c>this</c>) read — the <c>ldarg</c> family.</summary>
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundParameter,
+    naming: Inverse.NameProvenance.Inherited,
+    forwardName: "BoundParameter / ldarg",
+    precondition: "type is the argument's declared type (parameter signature; declaring type for `this`)",
+    witness: "corpus compile-back")]
 public sealed class LoadArgument : IrExpression
 {
     public LoadArgument(int index, string name, TypeRef type)
@@ -1329,6 +1352,13 @@ public sealed class StoreArgument : IrNode
     public override string Describe() => $"StoreArgument {Index} ({Type.ToDisplayString()} {Name})";
 }
 
+/// <summary>A local variable read — the <c>ldloc</c> family.</summary>
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundLocal,
+    naming: Inverse.NameProvenance.Inherited,
+    forwardName: "BoundLocal / ldloc",
+    precondition: "type is the local's declared type (local variable signature)",
+    witness: "corpus compile-back")]
 public sealed class LoadLocal : IrExpression
 {
     public LoadLocal(int index, TypeRef type)
@@ -1383,6 +1413,14 @@ public sealed class Constant : IrExpression
 
 public enum BinaryKind { Add, Subtract, Multiply, Divide, Remainder, And, Or, Xor, ShiftLeft, ShiftRight }
 
+/// <summary>An arithmetic, bitwise, or shift operator (<c>add</c>/<c>sub</c>/<c>and</c>/<c>shl</c> …).</summary>
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundBinaryOperator,
+    naming: Inverse.NameProvenance.Inherited,
+    oracle: Inverse.Oracle.RyuJitImporter,
+    forwardName: "BoundBinaryOperator (arithmetic/bitwise/shift)",
+    precondition: "result type is the ECMA binary-numeric result of the operand stack types",
+    witness: "corpus compile-back")]
 public sealed class Binary : IrExpression
 {
     public Binary(BinaryKind kind, bool isChecked, bool isUnsigned, IrExpression left, IrExpression right)
@@ -2181,6 +2219,13 @@ public sealed class Throw : IrNode
     public override string Describe() => "Throw";
 }
 
+/// <summary>A field read — instance (<c>ldfld</c>) or static (<c>ldsfld</c>).</summary>
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundFieldAccess,
+    naming: Inverse.NameProvenance.Inherited,
+    forwardName: "BoundFieldAccess / ldfld·ldsfld",
+    precondition: "type is the field's declared type (field signature)",
+    witness: "corpus compile-back")]
 public sealed class LoadField : IrExpression
 {
     public LoadField(FieldRef field, IrExpression? instance)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -929,10 +929,15 @@ public sealed class Continue : IrNode
 
 public enum ComparisonKind { Equal, NotEqual, LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual }
 
-/// <summary>An integer/float comparison (<c>ceq</c>/<c>clt</c>/<c>cgt</c> family), producing a boolean.</summary>
+/// <summary>
+/// An integer/float comparison (<c>ceq</c>/<c>clt</c>/<c>cgt</c> family), producing a boolean.
+/// Native name: Roslyn has no distinct comparison node (it is <c>BoundBinaryOperator</c> with a
+/// comparison kind) and IL uses <c>ceq</c>/<c>clt</c>/<c>cgt</c> — the decompiler groups them into
+/// one boolean-yielding node.
+/// </summary>
 [Inverse.InverseOf(
     Inverse.Forward.RoslynBoundBinaryOperator,
-    naming: Inverse.NameProvenance.Inherited,
+    naming: Inverse.NameProvenance.Native,
     oracle: Inverse.Oracle.RyuJitImporter,
     forwardName: "BoundBinaryOperator (comparison) / ceq·clt·cgt",
     precondition: "result is bool (the ceq/clt/cgt integer 0/1 result)",


### PR DESCRIPTION
## What

Broader batch 3 of node annotation (following #2171, #2180), the **first non-conversion** families: the value loads and the operators.

| Node | Forward (Roslyn) | Oracle | Naming | Precondition |
| --- | --- | --- | --- | --- |
| `LoadArgument` | BoundParameter / ldarg | None | Inherited | argument's declared type (parameter sig; declaring type for `this`) |
| `LoadLocal` | BoundLocal / ldloc | None | Inherited | local's declared type (local sig) |
| `LoadField` | BoundFieldAccess / ldfld·ldsfld | None | Inherited | field's declared type (field sig) |
| `Binary` | BoundBinaryOperator (arith/bitwise/shift) | RyuJitImporter | Inherited | ECMA binary-numeric result of the operand stack types |
| `Unary` | BoundUnaryOperator (neg/not) | RyuJitImporter | Inherited | operand's type (neg/not preserve type) |
| `Comparison` | BoundBinaryOperator (comparison) / ceq·clt·cgt | RyuJitImporter | Inherited | bool (the ceq/clt/cgt 0/1 result) |

Applies the conventions the #2171/#2180 reviews calibrated:
- **Naming = Inherited** — loads follow the `ld*` opcodes; `Binary`/`Unary` follow Roslyn's `BoundBinary/UnaryOperator`; `Comparison` follows the IL `ceq/clt/cgt` family.
- **Oracle: loads = `None`** (type is metadata-given — the parameter/local/field signature — *not* recovered from the erased stack, so no soundness oracle applies); **operators = `RyuJitImporter`** (result type computed by the importer per ECMA binary-numeric / comparison rules), never `RyuJitStackNormalization`.
- **Preconditions describe each node's actual contract** (per the #2180 memory), not just Roslyn's emission.

Adds five `Forward` enum values, flips the allowlist to enforce all **twelve** annotated nodes, and regenerates the ledger.

## Why low-risk

Pure metadata — read only by the test reflector; the shipped decompiler never reflects it → **no behavior/IR/render/fidelity change**. Build clean; **1817** decompiler tests pass (allowlist enforces 12, drift gate over the regenerated ledger); markdownlint clean.

## Classification calls worth scrutiny (reviewers)

- **`Comparison` provenance = `Inherited`.** Roslyn has no distinct comparison node (it's `BoundBinaryOperator` with a comparison kind); I marked it Inherited from the IL `ceq/clt/cgt` opcode family. Native is arguable — is the IL-family framing right, or should it be Native?
- **Loads `Oracle = None`.** The type is fully metadata-given, so I claim no recovery/oracle applies — vs `RyuJitImporter`. Right call?
- **Operators `Oracle = RyuJitImporter`** (ECMA binary-numeric result typing is an importer concern) — vs `RyuJitStackNormalization`. Right bucket?
