### PR TITLE
Centralize package library resolution

### DIFF
--- a/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
+++ b/src/DotnetInspector.Services.Tests/TfmSelectorTests.cs
@@ -190,6 +190,74 @@ public class TfmSelectorTests : IDisposable
     }
 
     [Fact]
+    public void SelectPackageLibrary_BareRequest_PrefersPackageNameMatch()
+    {
+        WriteDll("lib/net8.0/Companion.dll");
+        var primary = WriteDll("lib/net8.0/MyPackage.dll");
+
+        var result = TfmSelector.SelectPackageLibrary(_tempDir, "MyPackage", requestedLibrary: "");
+
+        Assert.True(result.IsSelected);
+        Assert.Equal(TfmSelector.PackageLibraryResolutionStatus.Selected, result.Status);
+        Assert.Equal([primary], result.Paths);
+        Assert.Equal("net8.0", result.Tfm);
+    }
+
+    [Fact]
+    public void SelectPackageLibrary_BareRequest_AmbiguousWhenNoPackageNameMatch()
+    {
+        var first = WriteDll("lib/net8.0/First.dll");
+        var second = WriteDll("lib/net8.0/Second.dll");
+
+        var result = TfmSelector.SelectPackageLibrary(_tempDir, "MyPackage", requestedLibrary: "");
+
+        Assert.False(result.IsSelected);
+        Assert.Equal(TfmSelector.PackageLibraryResolutionStatus.Ambiguous, result.Status);
+        Assert.Equal("net8.0", result.Tfm);
+        Assert.Equal([first, second], result.CandidatePaths);
+    }
+
+    [Fact]
+    public void SelectPackageLibrary_RequestedLibraryNotFound_ReturnsTfmCandidates()
+    {
+        var candidate = WriteDll("lib/net8.0/Actual.dll");
+
+        var result = TfmSelector.SelectPackageLibrary(_tempDir, "MyPackage", requestedLibrary: "Missing", tfm: "net8.0");
+
+        Assert.False(result.IsSelected);
+        Assert.Equal(TfmSelector.PackageLibraryResolutionStatus.RequestedLibraryNotFound, result.Status);
+        Assert.Equal("net8.0", result.Tfm);
+        Assert.Equal([candidate], result.CandidatePaths);
+    }
+
+    [Fact]
+    public void SelectPackageLibraries_NoTfm_SelectsHighestTfmInStableOrder()
+    {
+        WriteDll("lib/net8.0/Zeta.dll");
+        var alpha = WriteDll("lib/net10.0/Alpha.dll");
+        var beta = WriteDll("lib/net10.0/Beta.dll");
+
+        var result = TfmSelector.SelectPackageLibraries(_tempDir);
+
+        Assert.True(result.IsSelected);
+        Assert.Equal("net10.0", result.Tfm);
+        Assert.Equal([alpha, beta], result.Paths);
+    }
+
+    [Fact]
+    public void SelectPackageLibraries_ExplicitTfmWithoutMatches_ReturnsNoMatchingTfm()
+    {
+        WriteDll("lib/net8.0/Actual.dll");
+
+        var result = TfmSelector.SelectPackageLibraries(_tempDir, "net6.0");
+
+        Assert.False(result.IsSelected);
+        Assert.Equal(TfmSelector.PackageLibraryResolutionStatus.NoMatchingTargetFramework, result.Status);
+        Assert.Equal("net6.0", result.Tfm);
+        Assert.Empty(result.Paths);
+    }
+
+    [Fact]
     public void FindAssemblyByTfm_UsesPackageNameMatch()
     {
         WriteDll("lib/net8.0/Companion.dll");

--- a/src/DotnetInspector.Services/TfmSelector.cs
+++ b/src/DotnetInspector.Services/TfmSelector.cs
@@ -11,6 +11,24 @@ public static class TfmSelector
     private static List<string> FilterResourceAssemblies(IEnumerable<string> dlls)
         => dlls.Where(d => !IsSatelliteResourceAssembly(d)).ToList();
 
+    public enum PackageLibraryResolutionStatus
+    {
+        Selected,
+        NoAssemblies,
+        NoMatchingTargetFramework,
+        RequestedLibraryNotFound,
+        Ambiguous
+    }
+
+    public sealed record PackageLibraryResolution(
+        IReadOnlyList<string> Paths,
+        string? Tfm,
+        PackageLibraryResolutionStatus Status,
+        IReadOnlyList<string> CandidatePaths)
+    {
+        public bool IsSelected => Status == PackageLibraryResolutionStatus.Selected && Paths.Count > 0;
+    }
+
     public static IOrderedEnumerable<T> OrderByTfmPriorityDescending<T>(
         IEnumerable<T> items,
         Func<T, string?> tfmSelector)
@@ -253,6 +271,66 @@ public static class TfmSelector
         var (highestTfmDlls, highestTfm) = SelectHighestTfmAssemblies(dlls, extractPath);
         return highestTfmDlls.Count > 0 ? (highestTfmDlls, highestTfm) : (dlls, null);
     }
+
+    public static PackageLibraryResolution SelectPackageLibrary(
+        string extractPath,
+        string packageId,
+        string? requestedLibrary,
+        string? tfm = null)
+    {
+        if (!string.IsNullOrWhiteSpace(requestedLibrary))
+        {
+            var (matchedAssembly, matchedTfm) = FindAssemblyInPackage(extractPath, requestedLibrary, tfm);
+            return matchedAssembly != null
+                ? new PackageLibraryResolution([matchedAssembly], matchedTfm, PackageLibraryResolutionStatus.Selected, [matchedAssembly])
+                : new PackageLibraryResolution([], tfm, PackageLibraryResolutionStatus.RequestedLibraryNotFound, GetCandidateLibraries(extractPath, tfm));
+        }
+
+        var resolution = SelectPackageLibraries(extractPath, tfm);
+        if (!resolution.IsSelected)
+            return resolution;
+
+        if (resolution.Paths.Count == 1)
+            return new PackageLibraryResolution([resolution.Paths[0]], resolution.Tfm, PackageLibraryResolutionStatus.Selected, resolution.CandidatePaths);
+
+        var packageNameMatches = resolution.Paths
+            .Where(path => Path.GetFileNameWithoutExtension(path).Equals(packageId, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        return packageNameMatches.Count == 1
+            ? new PackageLibraryResolution([packageNameMatches[0]], resolution.Tfm, PackageLibraryResolutionStatus.Selected, resolution.CandidatePaths)
+            : new PackageLibraryResolution([], resolution.Tfm, PackageLibraryResolutionStatus.Ambiguous, resolution.Paths);
+    }
+
+    public static PackageLibraryResolution SelectPackageLibraries(string extractPath, string? tfm = null)
+    {
+        List<string> selected;
+        string? selectedTfm;
+        if (string.IsNullOrWhiteSpace(tfm))
+        {
+            var candidates = GetPackageAssemblies(extractPath);
+            if (candidates.Count == 0)
+                return new PackageLibraryResolution([], null, PackageLibraryResolutionStatus.NoAssemblies, []);
+
+            (selected, selectedTfm) = SelectHighestAssemblies(candidates, extractPath);
+        }
+        else
+        {
+            (selected, selectedTfm) = SelectHighestAssembliesFromPackage(extractPath, tfm);
+        }
+
+        if (selected.Count == 0)
+            return new PackageLibraryResolution([], tfm, PackageLibraryResolutionStatus.NoMatchingTargetFramework, GetCandidateLibraries(extractPath, tfm));
+
+        var ordered = selected
+            .OrderBy(path => Path.GetRelativePath(extractPath, path).Replace('\\', '/'), StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        return new PackageLibraryResolution(ordered, selectedTfm, PackageLibraryResolutionStatus.Selected, ordered);
+    }
+
+    private static List<string> GetCandidateLibraries(string extractPath, string? tfm)
+        => string.IsNullOrWhiteSpace(tfm)
+            ? GetPackageAssemblies(extractPath)
+            : SelectHighestAssembliesFromPackage(extractPath, tfm).paths;
 
     public static (string? path, string? tfm) FindAssemblyInPackage(string extractPath, string assemblyName, string? tfm = null)
     {

--- a/src/dotnet-inspect/Commands/PackageCommand.cs
+++ b/src/dotnet-inspect/Commands/PackageCommand.cs
@@ -1762,8 +1762,6 @@ public class PackageCommand
             options));
     }
 
-    private sealed record PackageLibrarySelection(string Path);
-
     private static async Task<int> ExecutePackageAllLibrariesAsync(
         string extractPath,
         bool isLocalFile,
@@ -1908,56 +1906,23 @@ public class PackageCommand
         if (requestedLibrary == null)
             return null;
         var packageId = PackageExtractor.ParsePackageReference(packageName).name;
+        var resolution = TfmSelector.SelectPackageLibrary(extractPath, packageId, requestedLibrary, options.Tfm);
+        if (resolution.IsSelected)
+            return new PackageLibrarySelection(resolution.Paths[0]);
 
-        if (!string.IsNullOrWhiteSpace(requestedLibrary))
-        {
-            var (matchedAssembly, matchedTfm) = TfmSelector.FindAssemblyInPackage(extractPath, requestedLibrary, options.Tfm);
-            if (matchedAssembly != null)
-                return new PackageLibrarySelection(matchedAssembly);
-
+        if (resolution.Status == TfmSelector.PackageLibraryResolutionStatus.RequestedLibraryNotFound)
             Console.Error.WriteLine($"Error: Library '{requestedLibrary}' not found in package '{packageName}'.");
-            WritePackageLibraryCandidates(extractPath, packageName, version, options.Tfm);
-            return null;
-        }
-
-        List<string> pool;
-        string? selectedTfm;
-        if (string.IsNullOrWhiteSpace(options.Tfm))
-        {
-            var allCandidates = TfmSelector.GetPackageAssemblies(extractPath);
-            if (allCandidates.Count == 0)
-            {
-                Console.Error.WriteLine($"Error: No DLLs found in package '{packageName}'.");
-                return null;
-            }
-
-            (pool, selectedTfm) = TfmSelector.SelectHighestAssemblies(allCandidates, extractPath);
-        }
-        else
-        {
-            (pool, selectedTfm) = TfmSelector.SelectHighestAssembliesFromPackage(extractPath, options.Tfm);
-        }
-
-        if (pool.Count == 0)
-        {
+        else if (resolution.Status == TfmSelector.PackageLibraryResolutionStatus.NoAssemblies)
+            Console.Error.WriteLine($"Error: No DLLs found in package '{packageName}'.");
+        else if (resolution.Status == TfmSelector.PackageLibraryResolutionStatus.NoMatchingTargetFramework)
             Console.Error.WriteLine($"Error: No library found for TFM '{options.Tfm}' in package '{packageName}'.");
-            WritePackageLibraryCandidates(extractPath, packageName, version, options.Tfm);
-            return null;
-        }
+        else
+            Console.Error.WriteLine(resolution.Tfm == null
+                ? $"Error: Package '{packageName}' contains multiple libraries."
+                : $"Error: Package '{packageName}' contains multiple libraries for {resolution.Tfm}.");
 
-        if (pool.Count == 1)
-            return new PackageLibrarySelection(pool[0]);
-
-        var packageNameMatch = pool
-            .Where(path => Path.GetFileNameWithoutExtension(path).Equals(packageId, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-        if (packageNameMatch.Count == 1)
-            return new PackageLibrarySelection(packageNameMatch[0]);
-
-        Console.Error.WriteLine(selectedTfm == null
-            ? $"Error: Package '{packageName}' contains multiple libraries."
-            : $"Error: Package '{packageName}' contains multiple libraries for {selectedTfm}.");
-        WritePackageLibraryCandidates(extractPath, packageName, version, selectedTfm, pool);
+        if (resolution.Status != TfmSelector.PackageLibraryResolutionStatus.NoAssemblies)
+            WritePackageLibraryCandidates(extractPath, packageName, version, resolution.Tfm ?? options.Tfm, resolution.CandidatePaths.ToList());
         return null;
     }
 
@@ -1967,39 +1932,28 @@ public class PackageCommand
         string version,
         InspectionOptions options)
     {
-        List<string> selected;
-        string? highestTfm;
-        if (string.IsNullOrWhiteSpace(options.Tfm))
+        var resolution = TfmSelector.SelectPackageLibraries(extractPath, options.Tfm);
+        if (resolution.Status == TfmSelector.PackageLibraryResolutionStatus.NoAssemblies)
         {
-            var candidates = TfmSelector.GetPackageAssemblies(extractPath);
-            if (candidates.Count == 0)
-            {
-                Console.Error.WriteLine($"Error: No DLLs found in package '{packageName}'.");
-                return null;
-            }
-
-            (selected, highestTfm) = TfmSelector.SelectHighestAssemblies(candidates, extractPath);
+            Console.Error.WriteLine($"Error: No DLLs found in package '{packageName}'.");
+            return null;
         }
-        else
-        {
-            (selected, highestTfm) = TfmSelector.SelectHighestAssembliesFromPackage(extractPath, options.Tfm);
-        }
-
-        if (selected.Count == 0)
+        if (resolution.Status == TfmSelector.PackageLibraryResolutionStatus.NoMatchingTargetFramework)
         {
             Console.Error.WriteLine($"Error: No libraries found for TFM '{options.Tfm}' in package '{packageName}'.");
-            WritePackageLibraryCandidates(extractPath, packageName, version, options.Tfm);
+            WritePackageLibraryCandidates(extractPath, packageName, version, options.Tfm, resolution.CandidatePaths.ToList());
             return null;
         }
 
-        if (highestTfm != null && string.IsNullOrWhiteSpace(options.Tfm))
-            Console.Error.WriteLine($"Using TFM: {highestTfm}");
+        if (resolution.Tfm != null && string.IsNullOrWhiteSpace(options.Tfm))
+            Console.Error.WriteLine($"Using TFM: {resolution.Tfm}");
 
-        return selected
-            .OrderBy(path => Path.GetRelativePath(extractPath, path).Replace('\\', '/'), StringComparer.OrdinalIgnoreCase)
+        return resolution.Paths
             .Select(path => new PackageLibrarySelection(path))
             .ToList();
     }
+
+    private sealed record PackageLibrarySelection(string Path);
 
     private static List<string> GetAllLibrariesSections(
         List<LibraryInspection> inspections,


### PR DESCRIPTION
## Summary

- Adds shared `TfmSelector.SelectPackageLibrary(...)` / `SelectPackageLibraries(...)` resolution results for package-library selection.
- Routes `PackageCommand.ResolvePackageLibrary` and `ResolveAllPackageLibraries` through the shared selector while keeping CLI diagnostics in the command layer.
- Covers package-name preference, ambiguous library pools, requested-library misses, highest-TFM all-library selection, and explicit-TFM no-match behavior.

Refs #2122.

## Validation

- `dotnet run --project src/DotnetInspector.Services.Tests -c Release -p:RestoreConfigFile=nuget.config -- -class "*TfmSelectorTests*"`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:RestoreConfigFile=nuget.config -- -method "*PackageCommand_AllLibraries*"`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:RestoreConfigFile=nuget.config -- -method "*PackageCommand_LibraryFlag*"`
- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config`

## Review

Adversarial review required because this centralizes package library selection behavior and diagnostics. Results will be posted as a PR comment.