### PR TITLE
Add NuGet-pinned RTS source probe

### DIFF
--- a/tools/DecompilerHarness/DecompilerHarness.csproj
+++ b/tools/DecompilerHarness/DecompilerHarness.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="../../src/ILInspector.Decompiler/ILInspector.Decompiler.csproj" />
     <ProjectReference Include="../../src/ILInspector.Research/ILInspector.Research.csproj" />
     <ProjectReference Include="../../src/DotnetInspector.Services/DotnetInspector.Services.csproj" />
+    <ProjectReference Include="../../src/DotnetInspector.Packages/DotnetInspector.Packages.csproj" />
     <!-- ILReader: the byte-match-validated IL reader the fidelity and annotation checks read the witness IL with. -->
     <ProjectReference Include="../../src/ILInspector.Metadata/ILInspector.Metadata.csproj" />
     <!-- Validity check: parse and bind the decompiled C# to measure validity. -->

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -6,6 +6,9 @@ using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
+using DotnetInspector.Core;
+using DotnetInspector.Packages;
+using DotnetInspector.Services;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 
@@ -42,6 +45,7 @@ static class Program
         bool returnToSender = false;
         bool returnToSenderAb = false;
         bool returnToSenderCatalog = false;
+        bool returnToSenderSourceProbe = false;
         bool fidelityTimings = false;
         int fidelityZeroSignalGuard = 0;
         bool gaps = false;
@@ -84,6 +88,10 @@ static class Program
         int topPatterns = 10;
         int? topLibraries = null;
         int cap = int.MaxValue;
+        var packages = new List<string>();
+        string? packageVersion = null;
+        string? packageTfm = null;
+        string? packageAssembly = null;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -112,6 +120,7 @@ static class Program
                 case "--fidelity-check": fidelityCheck = true; break;
                 case "--return-to-sender": returnToSender = true; break;
                 case "--return-to-sender-ab": returnToSenderAb = true; break;
+                case "--return-to-sender-source-probe": returnToSenderSourceProbe = true; break;
                 case "--return-to-sender-catalog":
                     returnToSenderCatalog = true;
                     if (i + 1 < args.Length && !args[i + 1].StartsWith('-')
@@ -170,6 +179,10 @@ static class Program
                 case "--top-patterns": topPatterns = int.Parse(args[++i]); break;
                 case "--top-libraries": topLibraries = int.Parse(args[++i]); break;
                 case "--cap": cap = int.Parse(args[++i]); break;
+                case "--package": packages.Add(args[++i]); break;
+                case "--package-version": packageVersion = args[++i]; break;
+                case "--package-tfm": packageTfm = args[++i]; break;
+                case "--package-assembly": packageAssembly = args[++i]; break;
                 case "--workers": workers = int.Parse(args[++i]); break;
                 case "--sequential": sequential = true; break;
                 case "--render-ab": renderAb = args[++i]; break;
@@ -193,7 +206,11 @@ static class Program
             return ReturnToSenderCatalog(returnToSenderCatalogSelector, keepGeneratedFixtures, json, maxExamples);
         }
 
-        var assemblies = ResolveAssemblies(inputs);
+        var assemblies = inputs.Count == 0 && packages.Count > 0
+            ? []
+            : ResolveAssemblies(inputs);
+        if (packages.Count > 0)
+            assemblies.AddRange(ResolvePackageAssemblies(packages, packageVersion, packageTfm, packageAssembly));
         if (assemblies.Count == 0)
             return Fail("No managed assemblies found in the given inputs.");
 
@@ -215,6 +232,9 @@ static class Program
 
         if (returnToSenderAb)
             return ReturnToSender.RunComparison(assemblies, cap, maxExamples);
+
+        if (returnToSenderSourceProbe)
+            return ReturnToSenderSourceProbe.Run(assemblies, cap, maxExamples);
 
         if (typeCheck)
             return TypeSourceCheck.Run(assemblies, cap, maxExamples);
@@ -1138,6 +1158,72 @@ static class Program
         return result;
     }
 
+    static List<string> ResolvePackageAssemblies(IReadOnlyList<string> packages, string? packageVersion, string? packageTfm, string? packageAssembly)
+    {
+        HttpClientFactory.Initialize();
+        NuGetCache.Initialize("dotnet-inspect");
+
+        var assemblies = new List<string>();
+        using var httpClient = HttpClientFactory.CreateNew();
+        foreach (var package in packages)
+        {
+            var outcome = PackageExtractor.ExtractPackageAsync(
+                    httpClient,
+                    package,
+                    log: message => Console.Error.WriteLine(message),
+                    tempDirPrefix: "decompiler-harness",
+                    version: packageVersion)
+                .GetAwaiter()
+                .GetResult();
+            if (!outcome.IsSuccess)
+            {
+                Console.Error.WriteLine($"Warning: {outcome.ErrorMessage}");
+                continue;
+            }
+
+            var extracted = outcome.Result!;
+            string? selectedPath;
+            string? selectedTfm;
+            if (!string.IsNullOrWhiteSpace(packageTfm))
+            {
+                selectedPath = TfmSelector.FindAssemblyByTfm(extracted.ExtractPath, packageTfm, extracted.PackageName);
+                selectedTfm = packageTfm;
+            }
+            else
+            {
+                (selectedPath, selectedTfm) = TfmSelector.SelectHighestTfmAssembly(
+                    TfmSelector.GetPackageAssemblies(extracted.ExtractPath),
+                    extracted.ExtractPath,
+                    extracted.PackageName);
+            }
+
+            if (!string.IsNullOrWhiteSpace(packageAssembly))
+            {
+                var assemblyName = packageAssembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                    ? packageAssembly
+                    : $"{packageAssembly}.dll";
+                selectedPath = Directory
+                    .EnumerateFiles(extracted.ExtractPath, assemblyName, SearchOption.AllDirectories)
+                    .Where(IsManaged)
+                    .OrderBy(path => path.Contains($"{Path.DirectorySeparatorChar}runtimes{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ? 1 : 0)
+                    .ThenBy(path => path, StringComparer.Ordinal)
+                    .FirstOrDefault();
+                selectedTfm = selectedPath is null ? null : Path.GetFileName(Path.GetDirectoryName(selectedPath));
+            }
+
+            if (selectedPath is null)
+            {
+                Console.Error.WriteLine($"Warning: no managed assembly found for package '{package}'.");
+                continue;
+            }
+
+            Console.Error.WriteLine($"Package input: {extracted.PackageName}@{extracted.Version} ({selectedTfm ?? "unknown TFM"}) -> {selectedPath}");
+            assemblies.Add(selectedPath);
+        }
+
+        return assemblies;
+    }
+
     static bool IsManaged(string path)
     {
         try
@@ -1239,12 +1325,26 @@ static class Program
                                 opcodes.
           --return-to-sender-ab   compare current compile-back and ReturnToSender
                                 over the same ReturnToSender property-getter targets.
+          --return-to-sender-source-probe
+                                derive source-aware metadata fragments from the
+                                input assemblies, run ReturnToSender over those
+                                targets, and report missing-fragment/source
+                                buckets alongside compile-back status.
           --return-to-sender-catalog [selector]
                                 compile the generated fixture catalog, run
                                 ReturnToSender over supported property getters,
                                 and report pass/skip/fail frontier buckets.
                                 Use selector prefix or "list"; supports --json
                                 and --keep-generated-fixtures.
+          --package <id[@version]>
+                                download/extract a NuGet package and add its
+                                selected managed assembly as input (use
+                                dotnet-inspect.any to pin to the deployed tool
+                                package payload instead of a local build).
+          --package-version <v>  explicit version for --package.
+          --package-tfm <tfm>    select a specific TFM from --package.
+          --package-assembly <dll>
+                                select a specific assembly inside --package.
           --fidelity-timings      with --fidelity-check: print phase timings for collect/render,
                                 skeleton emit, parse, compilation create, emit, and opcode compare
           --fidelity-zero-signal-guard <n>

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -206,11 +206,10 @@ static class Program
             return ReturnToSenderCatalog(returnToSenderCatalogSelector, keepGeneratedFixtures, json, maxExamples);
         }
 
+        using var packageInputs = ResolvePackageAssemblies(packages, packageVersion, packageTfm, packageAssembly);
         var assemblies = inputs.Count == 0 && packages.Count > 0
-            ? []
-            : ResolveAssemblies(inputs);
-        if (packages.Count > 0)
-            assemblies.AddRange(ResolvePackageAssemblies(packages, packageVersion, packageTfm, packageAssembly));
+            ? packageInputs.Assemblies.ToList()
+            : ResolveAssemblies(inputs).Concat(packageInputs.Assemblies).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         if (assemblies.Count == 0)
             return Fail("No managed assemblies found in the given inputs.");
 
@@ -1158,12 +1157,24 @@ static class Program
         return result;
     }
 
-    static List<string> ResolvePackageAssemblies(IReadOnlyList<string> packages, string? packageVersion, string? packageTfm, string? packageAssembly)
+    sealed class PackageAssemblyInputs(List<string> assemblies, List<string> tempDirs) : IDisposable
+    {
+        public IReadOnlyList<string> Assemblies => assemblies;
+
+        public void Dispose()
+        {
+            foreach (var tempDir in tempDirs)
+                PackageExtractor.Cleanup(tempDir);
+        }
+    }
+
+    static PackageAssemblyInputs ResolvePackageAssemblies(IReadOnlyList<string> packages, string? packageVersion, string? packageTfm, string? packageAssembly)
     {
         HttpClientFactory.Initialize();
         NuGetCache.Initialize("dotnet-inspect");
 
         var assemblies = new List<string>();
+        var tempDirs = new List<string>();
         using var httpClient = HttpClientFactory.CreateNew();
         foreach (var package in packages)
         {
@@ -1182,6 +1193,8 @@ static class Program
             }
 
             var extracted = outcome.Result!;
+            if (extracted.TempDir is not null)
+                tempDirs.Add(extracted.TempDir);
             string? selectedPath;
             string? selectedTfm;
             if (!string.IsNullOrWhiteSpace(packageTfm))
@@ -1199,16 +1212,7 @@ static class Program
 
             if (!string.IsNullOrWhiteSpace(packageAssembly))
             {
-                var assemblyName = packageAssembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
-                    ? packageAssembly
-                    : $"{packageAssembly}.dll";
-                selectedPath = Directory
-                    .EnumerateFiles(extracted.ExtractPath, assemblyName, SearchOption.AllDirectories)
-                    .Where(IsManaged)
-                    .OrderBy(path => path.Contains($"{Path.DirectorySeparatorChar}runtimes{Path.DirectorySeparatorChar}", StringComparison.Ordinal) ? 1 : 0)
-                    .ThenBy(path => path, StringComparer.Ordinal)
-                    .FirstOrDefault();
-                selectedTfm = selectedPath is null ? null : Path.GetFileName(Path.GetDirectoryName(selectedPath));
+                (selectedPath, selectedTfm) = TfmSelector.FindAssemblyInPackage(extracted.ExtractPath, packageAssembly, packageTfm);
             }
 
             if (selectedPath is null)
@@ -1221,7 +1225,7 @@ static class Program
             assemblies.Add(selectedPath);
         }
 
-        return assemblies;
+        return new PackageAssemblyInputs(assemblies, tempDirs);
     }
 
     static bool IsManaged(string path)

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -1,0 +1,242 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Metadata;
+
+namespace ILInspector.DecompilerHarness;
+
+static class ReturnToSenderSourceProbe
+{
+    sealed record ProbeTarget(ReturnToSender.RequestedTarget Target, IReadOnlyList<string> ExpectedFragments);
+
+    public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples)
+    {
+        int attempted = 0, passed = 0, failed = 0, skipped = 0;
+        var buckets = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        var examples = new List<string>();
+
+        foreach (var assemblyPath in assemblies)
+        {
+            if (attempted >= cap)
+                break;
+
+            var targets = DiscoverTargets(assemblyPath, cap - attempted);
+            if (targets.Count == 0)
+                continue;
+
+            var results = ReturnToSender.CompileBackTargets(
+                    assemblyPath,
+                    targets.Select(target => target.Target).Distinct().ToArray())
+                .ToDictionary(
+                    result => Key(
+                        result.Plan.TargetMethod.Type,
+                        result.Plan.TargetMethod.Method,
+                        result.Plan.TargetMethod.Overload),
+                    StringComparer.Ordinal);
+
+            foreach (var target in targets)
+            {
+                attempted++;
+                if (!results.TryGetValue(Key(target.Target.Type, target.Target.Method, target.Target.Overload), out var result))
+                {
+                    skipped++;
+                    AddBucket("unsupported-rts-target");
+                    AddExample(target, "Skipped", "unsupported-rts-target", null);
+                    continue;
+                }
+
+                if (result.Status != FidelityCheck.CompileBackStatus.Exact)
+                {
+                    failed++;
+                    var bucket = result.Status == FidelityCheck.CompileBackStatus.RecompileFail
+                        ? DiagnosticCode(result.Detail)
+                        : result.Status.ToString();
+                    AddBucket(bucket);
+                    AddExample(target, result.Status.ToString(), bucket, result.Detail);
+                    continue;
+                }
+
+                var missing = target.ExpectedFragments.FirstOrDefault(fragment => !result.Source.Contains(fragment, StringComparison.Ordinal));
+                if (missing is not null)
+                {
+                    failed++;
+                    AddBucket("source-fragment-missing");
+                    AddExample(target, "Exact", "source-fragment-missing", $"missing expected source fragment: {missing}");
+                    continue;
+                }
+
+                passed++;
+            }
+        }
+
+        Console.WriteLine($"RETURNTOSENDER SOURCE PROBE over {attempted} target(s)");
+        Console.WriteLine();
+        Console.WriteLine($"  Passed : {passed}");
+        Console.WriteLine($"  Failed : {failed}");
+        Console.WriteLine($"  Skipped: {skipped}");
+        if (buckets.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Buckets:");
+            foreach (var bucket in buckets.OrderByDescending(bucket => bucket.Value).ThenBy(bucket => bucket.Key, StringComparer.Ordinal))
+                Console.WriteLine($"  {bucket.Value}: {bucket.Key}");
+        }
+        if (examples.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine($"Examples (first {examples.Count}):");
+            foreach (var example in examples)
+                Console.WriteLine(example);
+        }
+
+        return failed == 0 ? 0 : 1;
+
+        void AddBucket(string bucket)
+            => buckets[bucket] = buckets.GetValueOrDefault(bucket) + 1;
+
+        void AddExample(ProbeTarget target, string status, string bucket, string? detail)
+        {
+            if (examples.Count >= maxExamples)
+                return;
+
+            examples.Add(detail is null
+                ? $"  {target.Target.Type}::{target.Target.Method}#{target.Target.Overload}  rts={status}  bucket={bucket}"
+                : $"  {target.Target.Type}::{target.Target.Method}#{target.Target.Overload}  rts={status}  bucket={bucket}\n      detail: {detail}");
+        }
+    }
+
+    static IReadOnlyList<ProbeTarget> DiscoverTargets(string assemblyPath, int cap)
+    {
+        var targets = new List<ProbeTarget>();
+        using var pe = new PEReader(File.OpenRead(assemblyPath));
+        if (!pe.HasMetadata)
+            return targets;
+
+        var reader = pe.GetMetadataReader();
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            if (targets.Count >= cap)
+                break;
+
+            var type = reader.GetTypeDefinition(typeHandle);
+            var typeNamespace = reader.GetString(type.Namespace);
+            if (!type.GetDeclaringType().IsNil
+                || !type.IsPublic
+                || typeNamespace == "System"
+                || typeNamespace.StartsWith("System.", StringComparison.Ordinal)
+                || AttributeReader.HasAttribute(reader, type.GetCustomAttributes(), "System.CodeDom.Compiler.GeneratedCodeAttribute")
+                || AttributeReader.HasAttribute(reader, type.GetCustomAttributes(), "System.Runtime.CompilerServices.CompilerGeneratedAttribute")
+                || reader.GetString(type.Name) == "<Module>"
+                || reader.GetString(type.Name).Contains('<', StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var fullType = reader.GetFullTypeName(type);
+            var typeFragments = AttributeReader.RenderAttributes(reader, type.GetCustomAttributes(), qualifyNames: true)
+                .Select(attribute => $"[{attribute}]")
+                .ToArray();
+
+            var methodOverloads = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (var methodHandle in type.GetMethods())
+            {
+                if (targets.Count >= cap)
+                    break;
+
+                var method = reader.GetMethodDefinition(methodHandle);
+                var methodName = reader.GetString(method.Name);
+                var overload = methodOverloads.GetValueOrDefault(methodName);
+                methodOverloads[methodName] = overload + 1;
+
+                if (method.RelativeVirtualAddress == 0
+                    || (method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public
+                    || methodName is ".ctor" or ".cctor"
+                    || methodName.StartsWith("get_", StringComparison.Ordinal)
+                    || methodName.StartsWith("set_", StringComparison.Ordinal)
+                    || methodName.StartsWith("add_", StringComparison.Ordinal)
+                    || methodName.StartsWith("remove_", StringComparison.Ordinal)
+                    || methodName.Contains('<', StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var fragments = new List<string>();
+                fragments.AddRange(typeFragments);
+                fragments.AddRange(AttributeReader.RenderAttributes(reader, method.GetCustomAttributes(), qualifyNames: true)
+                    .Select(attribute => $"[{attribute}]"));
+                AddReturnAndParameterFragments(reader, method.GetParameters(), fragments);
+                if (fragments.Count == 0)
+                    continue;
+
+                targets.Add(new ProbeTarget(new ReturnToSender.RequestedTarget(fullType, methodName, overload), fragments.Distinct(StringComparer.Ordinal).ToArray()));
+            }
+
+            foreach (var propertyHandle in type.GetProperties())
+            {
+                if (targets.Count >= cap)
+                    break;
+
+                var property = reader.GetPropertyDefinition(propertyHandle);
+                var accessors = property.GetAccessors();
+                if (accessors.Getter.IsNil)
+                    continue;
+
+                var getter = reader.GetMethodDefinition(accessors.Getter);
+                if (getter.RelativeVirtualAddress == 0
+                    || (getter.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public)
+                {
+                    continue;
+                }
+
+                var methodName = reader.GetString(getter.Name);
+                var overload = OverloadIndex(reader, type, accessors.Getter, methodName);
+                var fragments = new List<string>();
+                fragments.AddRange(typeFragments);
+                fragments.AddRange(AttributeReader.RenderAttributes(reader, property.GetCustomAttributes(), qualifyNames: true)
+                    .Select(attribute => $"[{attribute}]"));
+                AddReturnAndParameterFragments(reader, getter.GetParameters(), fragments);
+                if (fragments.Count == 0)
+                    continue;
+
+                targets.Add(new ProbeTarget(new ReturnToSender.RequestedTarget(fullType, methodName, overload), fragments.Distinct(StringComparer.Ordinal).ToArray()));
+            }
+        }
+
+        return targets;
+    }
+
+    static void AddReturnAndParameterFragments(MetadataReader reader, ParameterHandleCollection parameters, List<string> fragments)
+    {
+        foreach (var parameterHandle in parameters)
+        {
+            var parameter = reader.GetParameter(parameterHandle);
+            var attributes = AttributeReader.RenderParameterAttributes(reader, parameterHandle)
+                .Select(attribute => parameter.SequenceNumber == 0 ? $"[return: {attribute}]" : $"[{attribute}]");
+            fragments.AddRange(attributes);
+        }
+    }
+
+    static int OverloadIndex(MetadataReader reader, TypeDefinition typeDef, MethodDefinitionHandle target, string methodName)
+    {
+        int overload = 0;
+        foreach (var handle in typeDef.GetMethods())
+        {
+            if (handle == target)
+                return overload;
+            if (reader.GetString(reader.GetMethodDefinition(handle).Name) == methodName)
+                overload++;
+        }
+        return overload;
+    }
+
+    static string Key(string type, string method, int overload) => $"{type}::{method}#{overload}";
+
+    static string DiagnosticCode(string? detail)
+    {
+        if (string.IsNullOrWhiteSpace(detail))
+            return "recompile-fail";
+        var match = System.Text.RegularExpressions.Regex.Match(detail, @"CS\d{4}");
+        return match.Success ? match.Value : "recompile-fail";
+    }
+}


### PR DESCRIPTION
- Advances #2057
- Changes DecompilerHarness to support NuGet-pinned source-aware RTS probes.
- Evidence revision: `bae9862f`

## Change

**Conclusion:** **PASS** — source-aware RTS can now run against deployed NuGet package payloads, pinned to `dotnet-inspect.any`, instead of drifting local product assemblies.

Before:

```text
Real product-library source-aware RTS probes required local assembly paths, so evidence drifted with local builds.
```

After:

```text
DecompilerHarness accepts --package dotnet-inspect.any --package-version 0.16.0 and runs --return-to-sender-source-probe over the selected package assembly.
```

## Scope and safety

- **Root cause:** source-aware RTS evidence had only generated fixtures or local assemblies; there was no package-pinned product probe input.
- **Fix shape:** add DecompilerHarness package input resolution (`--package`, `--package-version`, `--package-tfm`, `--package-assembly`) and a source-aware RTS probe that derives expected fragments from metadata.
- **Product impact:** harness-only; no product output behavior changes.
- **Scope boundary:** this introduces a probe/reporting path, not a new product metadata shape.
- **RTS boundary:** RTS remains orchestration-only; source expectations are derived from product metadata readers and checked against RTS-generated source.

## Pinned package evidence

Run: `dotnet-inspect.any@0.16.0`, selected default tool assembly.

```text
RETURNTOSENDER SOURCE PROBE over 50 target(s)

  Passed : 50
  Failed : 0
  Skipped: 0
```

Contrast run: `dotnet-inspect.any@0.16.0 --package-assembly ILInspector.Decompiler.dll`.

```text
RETURNTOSENDER SOURCE PROBE over 1 target(s)

  Passed : 0
  Failed : 1
  Skipped: 0

Buckets:
  1: OpcodeDiff

Examples (first 1):
  ILInspector.Decompiler.Pipeline.IrNode::CheckInvariant#0  rts=OpcodeDiff  bucket=OpcodeDiff
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused decompiler tests | `GeneratedFixtureCatalogTests` 8/8; `ReturnToSenderPrototypeTests` 45/45 |
| Decompiler fast suite | Pass, 1817/1817 |
| Default RTS catalog | `39/39` fixtures, `116/116` targets |
| ReturnToSender A/B | `240` Same, `0` Worse, `0` CurrentMissing |
| Pinned package probe | `dotnet-inspect.any@0.16.0` default assembly `50/50` passed |

## Compile-back quality

**Conclusion:** **PASS** — the source-aware probe now has a drift-resistant product package input and already surfaces a real package OpcodeDiff in `ILInspector.Decompiler.dll`.

### ReturnToSender catalog

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 39 fixture(s), 116 target(s)

Fixtures:
  Passed : 39
  Skipped: 0
  Failed : 0

Targets:
  Passed : 116
  Skipped: 0
  Failed : 0
```

### ReturnToSender A/B

```text
RETURNTOSENDER A/B over 240 property getters

  Rescued       : 0
  Same          : 240
  Changed       : 0
  Worse         : 0
  CurrentMissing: 0
```

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `ILInspector.Decompiler.Pipeline.IrNode::CheckInvariant` | Reported as package probe OpcodeDiff | Real pinned-package signal; not fixed in this harness slice. |
| Generated/System types | Filtered from probe target discovery | Keeps the small probe product-shaped instead of source-generator/framework dominated. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | Findings resolved, final clean | Earlier review found temp-dir cleanup and `--package-assembly` TFM issues; fixed in `bae9862f`. Final review found no significant issues. |
| Claude Opus 4.8 | Findings resolved, final clean | Verified overload semantics, temp lifetime, package-only path, version pinning, TFM-aware selection, generated/System filtering, and classified failures. |

**Review conclusion:** **PASS** — actionable review findings were resolved in `bae9862f`; final isolated Gemini and Claude reviews found no significant issues.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --return-to-sender-catalog --max-examples 50
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --package dotnet-inspect.any --package-version 0.16.0 --return-to-sender-source-probe --cap 50 --max-examples 15
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --package dotnet-inspect.any --package-version 0.16.0 --package-assembly ILInspector.Decompiler.dll --return-to-sender-source-probe --cap 25 --max-examples 10
```
