### PR TITLE
Inverse architecture: build the assertion dump lane

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CoercionInvariantTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoercionInvariantTests.cs
@@ -48,7 +48,7 @@ public class CoercionInvariantTests
 
         var before = CoercionInvariant.Check(function);
         Assert.Single(before);
-        Assert.Contains("E32", before[0]);
+        Assert.Contains("E32", before[0].Message);
 
         new CoercionInsertionPass().Run(function, PassContext.None);
 
@@ -217,7 +217,7 @@ public class CoercionInvariantTests
             IrPasses.Run(function!);
             var violations = CoercionInvariant.Check(function!);
             Assert.True(violations.Count == 0,
-                $"{method}: " + string.Join("; ", violations));
+                $"{method}: " + string.Join("; ", violations.Select(v => v.Message)));
         }
     }
 }

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -48,6 +48,7 @@
     entry point).
   -->
   <ItemGroup>
+    <Compile Include="..\..\tools\DecompilerHarness\InverseLedger.cs" Link="InverseArchitecture\InverseLedger.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CorpusMetadata.cs"
              Link="CorpusMetadata.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\CorpusMethodIdentity.cs"

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
@@ -88,11 +88,11 @@ public class InverseArchitectureTests
 
                 Assert.True(predicate is not null,
                     $"{nodeType.Name}: assumes '{assumes}' has no InverseAssumptions.{assumes}(IrFunction).");
-                Assert.True(typeof(IReadOnlyList<string>).IsAssignableFrom(predicate!.ReturnType),
-                    $"{nodeType.Name}: assumes '{assumes}' must return IReadOnlyList<string>.");
+                Assert.True(typeof(IReadOnlyList<AssumptionViolation>).IsAssignableFrom(predicate!.ReturnType),
+                    $"{nodeType.Name}: assumes '{assumes}' must return IReadOnlyList<AssumptionViolation>.");
 
                 foreach (var probe in probes)
-                    Assert.IsAssignableFrom<IReadOnlyList<string>>(predicate.Invoke(null, [probe]));
+                    Assert.IsAssignableFrom<IReadOnlyList<AssumptionViolation>>(predicate.Invoke(null, [probe]));
 
                 validated++;
             }

--- a/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseAssumptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseAssumptions.cs
@@ -1,4 +1,8 @@
+using System.Collections.Generic;
+
 namespace ILInspector.Decompiler.Pipeline.InverseArchitecture;
+
+public readonly record struct AssumptionViolation(IrNode Node, string Message);
 
 /// <summary>
 /// The runnable assumption predicates named by <c>[InverseOf(assumes: ...)]</c>.
@@ -21,6 +25,18 @@ public static class InverseAssumptions
     /// slice-3 review turned on; reuses <see cref="CoercionInvariant.Check"/> so
     /// the ledger's assertion and the shipped invariant cannot diverge.
     /// </summary>
-    public static IReadOnlyList<string> SinkDistinguishableFromStack(IrFunction function)
-        => CoercionInvariant.Check(function);
+    public static IReadOnlyList<AssumptionViolation> SinkDistinguishableFromStack(IrFunction function)
+    {
+        var shapes = function.TypeShapes;
+        var violations = new List<AssumptionViolation>();
+        foreach (var sink in CoercionSinks.Enumerate(function))
+        {
+            if (CoercionSinks.RequiresCoercion(sink, shapes))
+            {
+                violations.Add(new(sink.Value, 
+                    $"{function.Name}: {sink.Value.Describe()} occupies a {sink.Target.ToDisplayString()} sink without a Coerce"));
+            }
+        }
+        return violations;
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseAssumptions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseAssumptions.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Linq;
+
 
 namespace ILInspector.Decompiler.Pipeline.InverseArchitecture;
 
@@ -27,16 +29,8 @@ public static class InverseAssumptions
     /// </summary>
     public static IReadOnlyList<AssumptionViolation> SinkDistinguishableFromStack(IrFunction function)
     {
-        var shapes = function.TypeShapes;
-        var violations = new List<AssumptionViolation>();
-        foreach (var sink in CoercionSinks.Enumerate(function))
-        {
-            if (CoercionSinks.RequiresCoercion(sink, shapes))
-            {
-                violations.Add(new(sink.Value, 
-                    $"{function.Name}: {sink.Value.Describe()} occupies a {sink.Target.ToDisplayString()} sink without a Coerce"));
-            }
-        }
-        return violations;
+        var violations = CoercionInvariant.Check(function);
+        if (violations.Count == 0) return System.Array.Empty<AssumptionViolation>();
+        return violations.Select(v => new AssumptionViolation(v.Node, v.Message)).ToList();
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
@@ -256,23 +256,25 @@ public static class CoercionInvariant
     /// deliberately leaves to later or targeted deciders, counted by value
     /// kind so the scope limit is measurable burn-down, never silent (#2145).
     /// </summary>
+    public readonly record struct CoercionViolation(IrNode Node, string Message);
+
     public readonly record struct CoercionAudit(
-        IReadOnlyList<string> Violations,
+        IReadOnlyList<CoercionViolation> Violations,
         IReadOnlyDictionary<string, int> Residuals);
 
-    public static IReadOnlyList<string> Check(IrFunction function) => Audit(function).Violations;
+    public static IReadOnlyList<CoercionViolation> Check(IrFunction function) => Audit(function).Violations;
 
     public static CoercionAudit Audit(IrFunction function)
     {
         var shapes = function.TypeShapes;
-        List<string>? violations = null;
+        List<CoercionViolation>? violations = null;
         Dictionary<string, int>? residuals = null;
         foreach (var sink in CoercionSinks.Enumerate(function))
         {
             if (CoercionSinks.RequiresCoercion(sink, shapes))
             {
-                (violations ??= []).Add(
-                    $"{function.Name}: {sink.Value.Describe()} occupies a {sink.Target.ToDisplayString()} sink without a Coerce");
+                (violations ??= []).Add(new(sink.Value,
+                    $"{function.Name}: {sink.Value.Describe()} occupies a {sink.Target.ToDisplayString()} sink without a Coerce"));
             }
             else if (CoercionSinks.IsResidual(sink, shapes))
             {

--- a/tools/DecompilerHarness/AssertionPrinter.cs
+++ b/tools/DecompilerHarness/AssertionPrinter.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Decompiler.Pipeline.InverseArchitecture;
+using ILInspector.Decompiler.Tests.InverseArchitecture;
+
+namespace ILInspector.DecompilerHarness;
+
+public static class AssertionPrinter
+{
+    public static string Dump(IrFunction function)
+    {
+        var sb = new StringBuilder();
+        bool firstViolationFlagged = false;
+        
+        var executedPredicates = new Dictionary<string, IReadOnlyList<string>>();
+        foreach (var t in InverseLedger.NodeTypes(typeof(IrFunction).Assembly))
+        {
+            var attr = t.GetCustomAttribute<InverseOfAttribute>();
+            if (attr?.Assumes != null && !executedPredicates.ContainsKey(attr.Assumes))
+            {
+                var method = typeof(InverseAssumptions).GetMethod(attr.Assumes, BindingFlags.Public | BindingFlags.Static);
+                if (method != null)
+                {
+                    var result = method.Invoke(null, new object[] { function }) as IReadOnlyList<string>;
+                    executedPredicates[attr.Assumes] = result ?? Array.Empty<string>();
+                }
+            }
+        }
+
+        var allViolations = executedPredicates.Values.SelectMany(v => v).ToList();
+
+        void Append(IrNode node, int indent)
+        {
+            var desc = node.Describe();
+            sb.Append(' ', indent * 2).AppendLine(desc);
+
+            var t = node.GetType();
+            var attr = t.GetCustomAttribute<InverseOfAttribute>();
+            if (attr != null)
+            {
+                var forwardName = attr.ForwardName ?? attr.Forward.ToString();
+                sb.Append(' ', indent * 2).Append($"// inverse: {forwardName} (oracle: {attr.Oracle}, naming: {attr.Naming})");
+                if (attr.Assumes != null)
+                {
+                    sb.Append($", assumes: {attr.Assumes}");
+                }
+                sb.AppendLine();
+            }
+
+            var related = allViolations.FirstOrDefault(v => v.Contains(desc));
+            if (related != null)
+            {
+                var highlight = !firstViolationFlagged ? "  <-- FIRST UNSOUND REWRITE" : "";
+                firstViolationFlagged = true;
+                sb.Append(' ', indent * 2).AppendLine($"// ❌ UNSOUND: {related}{highlight}");
+            }
+
+            foreach (var child in node.Children)
+                Append(child, indent + 1);
+        }
+
+        Append(function, 0);
+
+        foreach (var diagnostic in function.Diagnostics)
+            sb.AppendLine($"// {diagnostic}");
+        sb.AppendLine($"// fidelity: {function.Fidelity}");
+        return sb.ToString();
+    }
+}

--- a/tools/DecompilerHarness/AssertionPrinter.cs
+++ b/tools/DecompilerHarness/AssertionPrinter.cs
@@ -11,63 +11,77 @@ namespace ILInspector.DecompilerHarness;
 
 public static class AssertionPrinter
 {
-    public static string Dump(IrFunction function)
+    // Need a stateful object to track the first violation across pipeline stages
+    public sealed class StatefulPrinter
     {
-        var sb = new StringBuilder();
-        bool firstViolationFlagged = false;
-        
-        var executedPredicates = new Dictionary<string, IReadOnlyList<string>>();
-        foreach (var t in InverseLedger.NodeTypes(typeof(IrFunction).Assembly))
+        bool _firstViolationFlagged;
+
+        public string Dump(IrFunction function)
         {
-            var attr = t.GetCustomAttribute<InverseOfAttribute>();
-            if (attr?.Assumes != null && !executedPredicates.ContainsKey(attr.Assumes))
+            var sb = new StringBuilder();
+            
+            var executedPredicates = new Dictionary<string, IReadOnlyList<AssumptionViolation>>();
+            foreach (var t in InverseLedger.NodeTypes(typeof(IrFunction).Assembly))
             {
-                var method = typeof(InverseAssumptions).GetMethod(attr.Assumes, BindingFlags.Public | BindingFlags.Static);
-                if (method != null)
+                var attr = t.GetCustomAttribute<InverseOfAttribute>();
+                if (attr?.Assumes != null && !executedPredicates.ContainsKey(attr.Assumes))
                 {
-                    var result = method.Invoke(null, new object[] { function }) as IReadOnlyList<string>;
-                    executedPredicates[attr.Assumes] = result ?? Array.Empty<string>();
+                    var method = typeof(InverseAssumptions).GetMethod(attr.Assumes, BindingFlags.Public | BindingFlags.Static);
+                    if (method != null)
+                    {
+                        try
+                        {
+                            var result = method.Invoke(null, new object[] { function }) as IReadOnlyList<AssumptionViolation>;
+                            executedPredicates[attr.Assumes] = result ?? Array.Empty<AssumptionViolation>();
+                        }
+                        catch
+                        {
+                            // A throwing predicate shouldn't crash the dump
+                            executedPredicates[attr.Assumes] = new[] { new AssumptionViolation(function, $"Predicate {attr.Assumes} threw an exception") };
+                        }
+                    }
                 }
             }
-        }
 
-        var allViolations = executedPredicates.Values.SelectMany(v => v).ToList();
+            var allViolations = executedPredicates.Values.SelectMany(v => v).ToList();
 
-        void Append(IrNode node, int indent)
-        {
-            var desc = node.Describe();
-            sb.Append(' ', indent * 2).AppendLine(desc);
-
-            var t = node.GetType();
-            var attr = t.GetCustomAttribute<InverseOfAttribute>();
-            if (attr != null)
+            void Append(IrNode node, int indent)
             {
-                var forwardName = attr.ForwardName ?? attr.Forward.ToString();
-                sb.Append(' ', indent * 2).Append($"// inverse: {forwardName} (oracle: {attr.Oracle}, naming: {attr.Naming})");
-                if (attr.Assumes != null)
+                var desc = node.Describe();
+                sb.Append(' ', indent * 2).AppendLine(desc);
+
+                var t = node.GetType();
+                var attr = t.GetCustomAttribute<InverseOfAttribute>();
+                if (attr != null)
                 {
-                    sb.Append($", assumes: {attr.Assumes}");
+                    var forwardName = attr.ForwardName ?? attr.Forward.ToString();
+                    sb.Append(' ', indent * 2).Append($"// inverse: {forwardName} (oracle: {attr.Oracle}, naming: {attr.Naming})");
+                    if (attr.Assumes != null)
+                    {
+                        sb.Append($", assumes: {attr.Assumes}");
+                    }
+                    sb.AppendLine();
                 }
-                sb.AppendLine();
+
+                // Match violation by exact reference identity, not a lossy substring of Describe()
+                var related = allViolations.FirstOrDefault(v => ReferenceEquals(v.Node, node));
+                if (related.Node != null)
+                {
+                    var highlight = !_firstViolationFlagged ? "  <-- FIRST UNSOUND REWRITE" : "";
+                    _firstViolationFlagged = true;
+                    sb.Append(' ', indent * 2).AppendLine($"// ❌ UNSOUND: {related.Message}{highlight}");
+                }
+
+                foreach (var child in node.Children)
+                    Append(child, indent + 1);
             }
 
-            var related = allViolations.FirstOrDefault(v => v.Contains(desc));
-            if (related != null)
-            {
-                var highlight = !firstViolationFlagged ? "  <-- FIRST UNSOUND REWRITE" : "";
-                firstViolationFlagged = true;
-                sb.Append(' ', indent * 2).AppendLine($"// ❌ UNSOUND: {related}{highlight}");
-            }
+            Append(function, 0);
 
-            foreach (var child in node.Children)
-                Append(child, indent + 1);
+            foreach (var diagnostic in function.Diagnostics)
+                sb.AppendLine($"// {diagnostic}");
+            sb.AppendLine($"// fidelity: {function.Fidelity}");
+            return sb.ToString();
         }
-
-        Append(function, 0);
-
-        foreach (var diagnostic in function.Diagnostics)
-            sb.AppendLine($"// {diagnostic}");
-        sb.AppendLine($"// fidelity: {function.Fidelity}");
-        return sb.ToString();
     }
 }

--- a/tools/DecompilerHarness/AssertionPrinter.cs
+++ b/tools/DecompilerHarness/AssertionPrinter.cs
@@ -19,7 +19,7 @@ public static class AssertionPrinter
         public string Dump(IrFunction function)
         {
             var sb = new StringBuilder();
-            
+
             var executedPredicates = new Dictionary<string, IReadOnlyList<AssumptionViolation>>();
             foreach (var t in InverseLedger.NodeTypes(typeof(IrFunction).Assembly))
             {

--- a/tools/DecompilerHarness/InverseLedger.cs
+++ b/tools/DecompilerHarness/InverseLedger.cs
@@ -22,7 +22,8 @@ public static class InverseLedger
         Oracle Oracle,
         NameProvenance Naming,
         string Precondition,
-        string Witness);
+        string Witness,
+        string? Assumes = null);
 
     /// <summary>Concrete, non-abstract IR expression node types in the given assembly, name-ordered.</summary>
     public static IReadOnlyList<Type> NodeTypes(Assembly assembly)
@@ -41,7 +42,8 @@ public static class InverseLedger
                 x.Inverse.Oracle,
                 x.Inverse.Naming,
                 x.Inverse.Precondition ?? "—",
-                x.Inverse.Witness ?? "—"))];
+                x.Inverse.Witness ?? "—",
+                x.Inverse.Assumes))];
 
     /// <summary>One declared non-inverse boundary: a node deliberately outside the checkable domain.</summary>
     public sealed record Boundary(string Node, string Reason);

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -36,6 +36,7 @@ static class Program
         bool byShape = false;
         bool validityCheck = false;
         int compileCap = 4000;
+        bool assertions = false;
         string? emitValidityDefects = null;
         string? diffValidityDefects = null;
         bool fidelityCheck = false;
@@ -104,6 +105,7 @@ static class Program
                 case "--step-limit": steps = true; stepLimit = int.Parse(args[++i]); break;
                 case "--il": ilView = true; break;
                 case "--skip-pdb": skipPdb = true; break;
+                case "--assertions": assertions = true; break;
                 case "--max-examples": maxExamples = int.Parse(args[++i]); break;
                 case "--validity-check": validityCheck = true; break;
                 case "--compile-cap": compileCap = int.Parse(args[++i]); break;
@@ -264,6 +266,8 @@ static class Program
                 return DumpRemarks(assemblies, dumpMethod, dumpIndex, skipPdb);
             if (lowered)
                 return DumpLowered(assemblies, dumpMethod, dumpIndex, skipPdb, simulate);
+            if (assertions)
+                return DumpAssertions(assemblies, dumpMethod, dumpIndex, skipPdb);
             return steps
                 ? DumpSteps(assemblies, dumpMethod, dumpIndex, stepLimit, skipPdb)
                 : Dump(assemblies, dumpMethod, dumpIndex, ilView ? StageDumpView.Full : StageDumpView.IrTree, skipPdb, simulate);
@@ -873,6 +877,33 @@ static class Program
     }
 
     /// <summary>
+    /// Stage dump with the inverse-architecture assertions evaluated and annotated.
+    /// </summary>
+    static int DumpAssertions(List<string> assemblies, string dumpMethod, int overloadIndex, bool skipPdb = false)
+    {
+        int separator = dumpMethod.IndexOf("::", StringComparison.Ordinal);
+        if (separator <= 0)
+            return Fail("--dump expects Namespace.Type::Method (metadata type name)");
+        string typeName = dumpMethod[..separator];
+        string methodName = dumpMethod[(separator + 2)..];
+
+        using var metadata = CorpusMetadata.Create(assemblies);
+        foreach (var assemblyPath in assemblies)
+        {
+            using var source = OpenSource(assemblyPath, skipPdb, metadata);
+            var function = IrImporter.Import(source, typeName, methodName, overloadIndex);
+            if (function is null)
+                continue;
+
+            Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, assertions)");
+            var stages = IrPasses.RunWithStages(function, IrPasses.Default, AssertionPrinter.Dump);
+            Console.Write(StageDump.Format(stages));
+            return 0;
+        }
+        return Fail($"Method '{dumpMethod}' not found (or has no IL body) in the given assemblies.");
+    }
+
+    /// <summary>
     /// Surfaces the printer's definite-assignment dataflow facts — the per-block
     /// predecessors, gen, and the <c>in</c>/<c>out</c> sets of the CFG fixpoint
     /// that decides which locals keep <c>= default</c>. The same analysis that
@@ -1195,6 +1226,9 @@ static class Program
           --facts               with --dump: print the printer's definite-assignment
                                 dataflow facts — per-block preds/gen and the in/out
                                 sets that decide which locals keep `= default`.
+          --assertions          with --dump: annotates the staged IR with the
+                                inverse-architecture assumptions and flags the
+                                first unsound rewrite if a predicate fails.
           --cfg                 with --dump: print the control-flow graph (per-block
                                 predecessor/successor edges) of each block container
                                 in the raised IR.

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -896,7 +896,7 @@ static class Program
                 continue;
 
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, assertions)");
-            var stages = IrPasses.RunWithStages(function, IrPasses.Default, AssertionPrinter.Dump);
+            var stages = IrPasses.RunWithStages(function, IrPasses.Default, new AssertionPrinter.StatefulPrinter().Dump);
             Console.Write(StageDump.Format(stages));
             return 0;
         }


### PR DESCRIPTION
- Fixes #2179
- Changes: Adds `--assertions` dump lane to `tools/DecompilerHarness`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — Builds the assertion dump lane to execute `[InverseOf]` assumption predicates dynamically in the harness, providing an executable failure map without bleeding reflection into the product path.

Before:
```bash
# Static evaluation only, OpcodeDiffs rely on manual mapping to the ledger
```

After:
```bash
# Harness evaluates predicates and pinpoints the violation inline
dotnet run --project tools/DecompilerHarness -- ... --dump ... --assertions

// ❌ UNSOUND: LoadArgument 0 (char c) occupies a int sink without a Coerce  <-- FIRST UNSOUND REWRITE
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `ILInspector.Decompiler.Tests` passed |
| Decompiler fast suite | Pass |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Findings resolved | Caught a bug where lossy string matching on `node.Describe()` flagged wrong nodes; fixed in `07c90a1f` by matching exact `IrNode` references. Verified no product reflection. |
| GPT-5.5 | Findings resolved | Caught a bug where the "FIRST" violation marker repeated in every pipeline stage; fixed in `07c90a1f` with `StatefulPrinter`. |

**Review conclusion:** **PASS** — Both reviewers confirmed isolation is intact and correctly caught over-reporting bugs in the initial draft, which have been resolved.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:NoWarn=NU1507
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507
```
