### PR TITLE
Inverse architecture: annotate the raised/synthesized family (batch 4)

### DIFF
--- a/docs/design/inverse-ledger.generated.md
+++ b/docs/design/inverse-ledger.generated.md
@@ -17,6 +17,10 @@ edit by hand. See [inverse-architecture.md](inverse-architecture.md) for the fra
 | `LoadArgument` | BoundParameter / ldarg | None | Inherited | type is the argument's declared type (parameter signature; declaring type for `this`) | corpus compile-back |
 | `LoadField` | BoundFieldAccess / ldfld·ldsfld | None | Inherited | type is the field's declared type (field signature) | corpus compile-back |
 | `LoadLocal` | BoundLocal / ldloc | None | Inherited | type is the local's declared type (local variable signature) | corpus compile-back |
+| `LoadProperty` | BoundPropertyAccess / get_ accessor call | None | Native | type is the property/indexer's return type (accessor signature); raised from a get_ accessor call | corpus compile-back |
+| `LogicalBinary` | BoundBinaryOperator (logical AND / OR) | None | Native | result is bool; raised from short-circuit branch patterns (IL has no logical-and/or encoding) | corpus compile-back |
+| `LogicalNot` | BoundUnaryOperator (logical negation) | None | Native | result is bool; raised from ceq-zero / inverted-branch patterns (IL has no `!` opcode) | corpus compile-back |
+| `NullConditional` | BoundConditionalAccess / ?. | None | Native | result is the member's type (nullable-wrapped for value types); raised from the ?. null-check + receiver-spill pattern | corpus compile-back |
 | `Unary` | BoundUnaryOperator (neg/not) | RyuJitImporter | Inherited | result type is the operand's type (neg/not preserve the operand type) | corpus compile-back |
 | `Unbox` | BoundConversion (unboxing → managed pointer) | RyuJitImporter | Inherited | operand is a box of the value type; result is a managed pointer into it | box/unbox fixtures; corpus compile-back |
 | `UnboxAny` | BoundConversion (unboxing) | RyuJitImporter | Inherited | target is the unbox.any type token (value type, reference type, or type parameter) | box/unbox fixtures; corpus compile-back |

--- a/docs/design/inverse-ledger.generated.md
+++ b/docs/design/inverse-ledger.generated.md
@@ -17,10 +17,10 @@ edit by hand. See [inverse-architecture.md](inverse-architecture.md) for the fra
 | `LoadArgument` | BoundParameter / ldarg | None | Inherited | type is the argument's declared type (parameter signature; declaring type for `this`) | corpus compile-back |
 | `LoadField` | BoundFieldAccess / ldfld·ldsfld | None | Inherited | type is the field's declared type (field signature) | corpus compile-back |
 | `LoadLocal` | BoundLocal / ldloc | None | Inherited | type is the local's declared type (local variable signature) | corpus compile-back |
-| `LoadProperty` | BoundPropertyAccess / get_ accessor call | None | Native | type is the property/indexer's return type (accessor signature); raised from a get_ accessor call | corpus compile-back |
+| `LoadProperty` | BoundPropertyAccess / BoundIndexerAccess (get_ accessor call) | None | Native | type is the property or indexer's return type (accessor signature); raised from a get_ accessor call | corpus compile-back |
 | `LogicalBinary` | BoundBinaryOperator (logical AND / OR) | None | Native | result is bool; raised from short-circuit branch patterns (IL has no logical-and/or encoding) | corpus compile-back |
 | `LogicalNot` | BoundUnaryOperator (logical negation) | None | Native | result is bool; raised from ceq-zero / inverted-branch patterns (IL has no `!` opcode) | corpus compile-back |
-| `NullConditional` | BoundConditionalAccess / ?. | None | Native | result is the member's type (nullable-wrapped for value types); raised from the ?. null-check + receiver-spill pattern | corpus compile-back |
+| `NullConditional` | BoundConditionalAccess / ?. | None | Native | result is the member's unwrapped type (`Member.ResultType`); raised from the ?. null-check pattern (surrounding nodes carry any nullable wrapping / coalesce) | corpus compile-back |
 | `Unary` | BoundUnaryOperator (neg/not) | RyuJitImporter | Inherited | result type is the operand's type (neg/not preserve the operand type) | corpus compile-back |
 | `Unbox` | BoundConversion (unboxing → managed pointer) | RyuJitImporter | Inherited | operand is a box of the value type; result is a managed pointer into it | box/unbox fixtures; corpus compile-back |
 | `UnboxAny` | BoundConversion (unboxing) | RyuJitImporter | Inherited | target is the unbox.any type token (value type, reference type, or type parameter) | box/unbox fixtures; corpus compile-back |

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
@@ -22,7 +22,7 @@ public class InverseArchitectureTests
     // In-domain product nodes that MUST carry [InverseOf] or [NotInverted]. The
     // conversion family is the first annotated slice (docs/design/inverse-architecture.md);
     // the set grows as the ledger's declared domain grows.
-    static readonly string[] EnforcedProductNodes = ["Binary", "Box", "CastClass", "Coerce", "Comparison", "Convert", "LoadArgument", "LoadField", "LoadLocal", "Unary", "Unbox", "UnboxAny"];
+    static readonly string[] EnforcedProductNodes = ["Binary", "Box", "CastClass", "Coerce", "Comparison", "Convert", "LoadArgument", "LoadField", "LoadLocal", "LoadProperty", "LogicalBinary", "LogicalNot", "NullConditional", "Unary", "Unbox", "UnboxAny"];
 
     static Assembly ProductAssembly => typeof(IrFunction).Assembly;
     Assembly TestAssembly => GetType().Assembly;

--- a/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseArchitecture.cs
+++ b/src/ILInspector.Decompiler/Pipeline/InverseArchitecture/InverseArchitecture.cs
@@ -37,6 +37,12 @@ public enum Forward
 
     /// <summary>Roslyn's <c>BoundUnaryOperator</c> (negation, bitwise complement).</summary>
     RoslynBoundUnaryOperator,
+
+    /// <summary>Roslyn's <c>BoundPropertyAccess</c> / indexer access (a property or indexer read).</summary>
+    RoslynBoundPropertyAccess,
+
+    /// <summary>Roslyn's <c>BoundConditionalAccess</c> (the <c>?.</c> null-conditional access).</summary>
+    RoslynBoundConditionalAccess,
 }
 
 /// <summary>

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -1122,7 +1122,7 @@ public sealed class NullCoalescingPropertyAssignment : IrNode
     Inverse.Forward.RoslynBoundConditionalAccess,
     naming: Inverse.NameProvenance.Native,
     forwardName: "BoundConditionalAccess / ?.",
-    precondition: "result is the member's type (nullable-wrapped for value types); raised from the ?. null-check + receiver-spill pattern",
+    precondition: "result is the member's unwrapped type (`Member.ResultType`); raised from the ?. null-check pattern (surrounding nodes carry any nullable wrapping / coalesce)",
     witness: "corpus compile-back")]
 public sealed class NullConditional : IrExpression
 {
@@ -2876,8 +2876,8 @@ public sealed class LoadToken : IrExpression
 [Inverse.InverseOf(
     Inverse.Forward.RoslynBoundPropertyAccess,
     naming: Inverse.NameProvenance.Native,
-    forwardName: "BoundPropertyAccess / get_ accessor call",
-    precondition: "type is the property/indexer's return type (accessor signature); raised from a get_ accessor call",
+    forwardName: "BoundPropertyAccess / BoundIndexerAccess (get_ accessor call)",
+    precondition: "type is the property or indexer's return type (accessor signature); raised from a get_ accessor call",
     witness: "corpus compile-back")]
 public sealed class LoadProperty : IrExpression
 {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -969,6 +969,12 @@ public enum LogicalKind { And, Or }
 /// bitwise <see cref="Binary"/> forms. Raised by boolean folding from
 /// guard-return chains and nested guards; IL has no direct encoding.
 /// </summary>
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundBinaryOperator,
+    naming: Inverse.NameProvenance.Native,
+    forwardName: "BoundBinaryOperator (logical AND / OR)",
+    precondition: "result is bool; raised from short-circuit branch patterns (IL has no logical-and/or encoding)",
+    witness: "corpus compile-back")]
 public sealed class LogicalBinary : IrExpression
 {
     public LogicalBinary(LogicalKind kind, IrExpression left, IrExpression right)
@@ -1112,6 +1118,12 @@ public sealed class NullCoalescingPropertyAssignment : IrNode
 /// a reference type — so the access carries the member's own result type with no
 /// Nullable wrapping, and the lowered receiver spill collapses into the target.
 /// </summary>
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundConditionalAccess,
+    naming: Inverse.NameProvenance.Native,
+    forwardName: "BoundConditionalAccess / ?.",
+    precondition: "result is the member's type (nullable-wrapped for value types); raised from the ?. null-check + receiver-spill pattern",
+    witness: "corpus compile-back")]
 public sealed class NullConditional : IrExpression
 {
     public NullConditional(IrExpression member) => AddChild(member);
@@ -1153,6 +1165,13 @@ public sealed class Conditional : IrExpression
     public override string Describe() => "Conditional";
 }
 
+/// <summary>Boolean negation (<c>!</c>), raised from a <c>ceq</c>-zero or inverted-branch pattern.</summary>
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundUnaryOperator,
+    naming: Inverse.NameProvenance.Native,
+    forwardName: "BoundUnaryOperator (logical negation)",
+    precondition: "result is bool; raised from ceq-zero / inverted-branch patterns (IL has no `!` opcode)",
+    witness: "corpus compile-back")]
 public sealed class LogicalNot : IrExpression
 {
     public LogicalNot(IrExpression operand) => AddChild(operand);
@@ -2854,6 +2873,12 @@ public sealed class LoadToken : IrExpression
 }
 
 /// <summary>A raised property or indexer read (from a get_ accessor call).</summary>
+[Inverse.InverseOf(
+    Inverse.Forward.RoslynBoundPropertyAccess,
+    naming: Inverse.NameProvenance.Native,
+    forwardName: "BoundPropertyAccess / get_ accessor call",
+    precondition: "type is the property/indexer's return type (accessor signature); raised from a get_ accessor call",
+    witness: "corpus compile-back")]
 public sealed class LoadProperty : IrExpression
 {
     public LoadProperty(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments)


### PR DESCRIPTION
## What

Batch 4 — the **raised/synthesized family**: `LogicalNot`, `LogicalBinary`, `NullConditional`, `LoadProperty`. These are nodes the decompiler *raises* from IL patterns (inverted branches, short-circuit branches, null-check + receiver-spill, `get_` accessor calls) — none has a direct IL opcode.

| Node | Forward (Roslyn) | Oracle | Naming | Precondition |
| --- | --- | --- | --- | --- |
| `LogicalNot` | BoundUnaryOperator (logical negation) | None | Native | bool; raised from ceq-zero / inverted-branch patterns |
| `LogicalBinary` | BoundBinaryOperator (logical AND / OR) | None | Native | bool; raised from short-circuit branch patterns |
| `NullConditional` | BoundConditionalAccess / ?. | None | Native | member's type (nullable-wrapped); raised from the ?. pattern |
| `LoadProperty` | BoundPropertyAccess / get_ accessor call | None | Native | property/indexer return type; raised from a get_ call |

Applies the conventions banked from #2180/#2189:
- **All `Native`** — decompiler-born names (per the rule: `Inherited` requires following a *forward name*; a synthesized name is `Native` even with a Roslyn `Forward` mapping, like `Coerce`/`Comparison`).
- **All `Oracle = None`** — the result type is structural or metadata-given (a raised `bool`, a member type, an accessor signature), not recovered from the erased stack.

Reuses `RoslynBoundBinaryOperator`/`UnaryOperator`; adds two `Forward` values (`RoslynBoundPropertyAccess`, `RoslynBoundConditionalAccess`). Allowlist now enforces all **sixteen** annotated nodes; ledger regenerated.

## Why low-risk

Pure metadata — read only by the test reflector; the shipped decompiler never reflects it → **no behavior/IR/render/fidelity change**. Build clean; **1817** decompiler tests pass (allowlist enforces 16, drift gate); markdownlint clean.

## Notes for review

- **`LoadProperty` provenance = `Native`:** it follows the decompiler's own `Load*` family convention, not a forward name (no `ldprop` opcode; property access is a `get_` call). `Native` per the rule — reasonable, or is the `Load*`-family framing an argument for something else?
- **Reflector pipe-escaping (known follow-up):** `LogicalBinary`'s strings avoid a literal `|` because the reflector doesn't yet escape pipes in table cells (a `|` would corrupt the markdown table). I kept this a pure annotation batch and left reflector `|`-escaping as a small robustness follow-up. Flag if you'd rather it be fixed here.
