### PR TITLE
Route triage loop signals through semantic multiplicity (#2177)

### DIFF
--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -3136,18 +3136,19 @@ public sealed class LibraryBodyIndex
                                 && delegateAllocation.Frequency == AllocationFrequency.CachedOnce;
                             if (!cachedOnce && pendingDelegateCapturing)
                             {
-                                // Confidence tracks loop membership: an in-loop delegate is a
-                                // repeated allocation (high); a one-shot delegate in a cold
-                                // method is low-value, especially since .NET 10+ partially
-                                // stack-allocates non-escaping ones (low).
+                                // Confidence tracks semantic loop iteration: a delegate that
+                                // genuinely repeats each iteration is high; a one-shot delegate —
+                                // including a loop early-exit that runs once — is low, especially
+                                // since .NET 10+ partially stack-allocates non-escaping ones.
                                 var inLoop = IsInLoopRegion(offset, loopRegions);
+                                bool iteratesInLoop = AllocationMultiplicityFor(decodedBody, offset, loopRegions, AllocationEscape.Unknown) == AllocationMultiplicity.Loop;
                                 pendingDelegateOpportunityIndex = opportunities.Count;
                                 opportunities.Add(new OptimizationOpportunity(
                                     caller,
                                     "capturing-delegate",
                                     "delegate over a captured receiver or closure",
                                     "Each call allocates a closure delegate; a static local function with explicit state parameters avoids it.",
-                                    inLoop ? "high" : "low",
+                                    iteratesInLoop ? "high" : "low",
                                     inLoop,
                                     offset,
                                     "On .NET 10+ the JIT can partially stack-allocate a non-escaping closure (~88 to ~36 bytes/call measured), reducing but not eliminating it; it stays a full heap allocation when the closure escapes the method — stored, returned, or passed to a callee that lets it escape."));
@@ -3155,6 +3156,7 @@ public sealed class LibraryBodyIndex
                             else if (!cachedOnce && pendingDelegateInstanceGroup)
                             {
                                 var inLoop = IsInLoopRegion(offset, loopRegions);
+                                bool iteratesInLoop = AllocationMultiplicityFor(decodedBody, offset, loopRegions, AllocationEscape.Unknown) == AllocationMultiplicity.Loop;
                                 bool stackGuardFallback = IsStackGuardFallbackAllocation(decodedBody, offset, callerScope);
                                 pendingDelegateOpportunityIndex = opportunities.Count;
                                 opportunities.Add(new OptimizationOpportunity(
@@ -3164,7 +3166,7 @@ public sealed class LibraryBodyIndex
                                     stackGuardFallback
                                         ? "This delegate allocation is on a StackGuard fallback path, not the common path; if profiles show it matters, cache it in a field when the receiver is stable or use a static method with explicit state."
                                         : "Each call allocates a delegate that binds the receiver; cache it in a field when the receiver is stable, or use a static method with explicit state.",
-                                    stackGuardFallback ? "low" : inLoop ? "high" : "low",
+                                    stackGuardFallback ? "low" : iteratesInLoop ? "high" : "low",
                                     inLoop,
                                     offset,
                                     stackGuardFallback
@@ -3380,8 +3382,10 @@ public sealed class LibraryBodyIndex
                         var feedsThrow = allocating && boxAllocation!.Escape == AllocationEscape.ThrowPath;
                         pendingBoxOffset = allocating && !feedsThrow ? offset : null;
                         pendingBoxType = allocating && !feedsThrow ? boxAllocation!.AllocatedType ?? boxed : null;
+                        // Semantic loop iteration (a loop early-exit box runs once, so it is
+                        // not a hot loop) drives the box confidence and the Loop signal.
                         pendingBoxInLoop = pendingBoxOffset is not null
-                            && IsInLoopRegion(offset, loopRegions);
+                            && boxAllocation!.Multiplicity == AllocationMultiplicity.Loop;
                         break;
                     }
                     default:

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -296,7 +296,9 @@ public sealed class LibraryBodyIndex
                     && IsExceptionConstruction(type))
                     continue;
                 steadyAllocations[token] = steadyAllocations.GetValueOrDefault(token) + 1;
-                if (occurrence.InLoop)
+                // Only allocations that genuinely iterate (semantic multiplicity) make a
+                // method a loop hotspot — a return/throw early-exit inside a loop runs once.
+                if (occurrence.Multiplicity == AllocationMultiplicity.Loop)
                     steadyAllocationLoop.Add(token);
             }
         }
@@ -1665,10 +1667,12 @@ public sealed class LibraryBodyIndex
         sealed class AllocationPostDominanceIndex
         {
             readonly AllocationPostDominance[] _postDominanceByBlock;
+            readonly bool[] _reachesCycleByBlock;
 
-            AllocationPostDominanceIndex(AllocationPostDominance[] postDominanceByBlock)
+            AllocationPostDominanceIndex(AllocationPostDominance[] postDominanceByBlock, bool[] reachesCycleByBlock)
             {
                 _postDominanceByBlock = postDominanceByBlock;
+                _reachesCycleByBlock = reachesCycleByBlock;
             }
 
             public static AllocationPostDominanceIndex Create(DecodedBody decodedBody)
@@ -1676,13 +1680,14 @@ public sealed class LibraryBodyIndex
                 var blockGraph = decodedBody.BlockGraph;
                 var postDominanceByBlock = new AllocationPostDominance[blockGraph.Blocks.Length];
                 if (blockGraph.Blocks.Length == 0)
-                    return new AllocationPostDominanceIndex(postDominanceByBlock);
+                    return new AllocationPostDominanceIndex(postDominanceByBlock, []);
 
                 var edges = blockGraph.Blocks.Select(static block => block.Edges).ToArray();
+                var reachesCycleOnly = BackwardReachable(edges, CyclicBlocks(edges));
                 var postDominators = PostDominators.Of(edges);
                 var returnBlocks = ReturnBlocks(decodedBody);
                 if (returnBlocks.Length == 0)
-                    return new AllocationPostDominanceIndex(postDominanceByBlock);
+                    return new AllocationPostDominanceIndex(postDominanceByBlock, reachesCycleOnly);
 
                 var reachesReturn = BackwardReachable(edges, returnBlocks);
                 var returnSet = returnBlocks.ToHashSet();
@@ -1693,7 +1698,7 @@ public sealed class LibraryBodyIndex
                             || edges[block].LeavesRegion)));
                 var reachesNonExitingBlock = BackwardReachable(edges, Enumerable.Range(0, edges.Length)
                     .Where(block => postDominators.ImmediatePostDominator(block) == PostDominators.None));
-                var reachesCycle = BackwardReachable(edges, CyclicBlocks(edges));
+                var reachesCycle = reachesCycleOnly;
 
                 for (int blockIndex = 0; blockIndex < blockGraph.Blocks.Length; blockIndex++)
                 {
@@ -1708,13 +1713,19 @@ public sealed class LibraryBodyIndex
                     }
                 }
 
-                return new AllocationPostDominanceIndex(postDominanceByBlock);
+                return new AllocationPostDominanceIndex(postDominanceByBlock, reachesCycle);
             }
 
             public AllocationPostDominance PostDominanceFor(int blockIndex)
                 => (uint)blockIndex < (uint)_postDominanceByBlock.Length
                     ? _postDominanceByBlock[blockIndex]
                     : AllocationPostDominance.Unknown;
+
+            // Whether control can flow from this block back to a loop backedge. A block
+            // inside a loop region that CANNOT (it exits first via return/throw) runs at
+            // most once per call and is not a hot loop.
+            public bool ReachesCycleFor(int blockIndex)
+                => (uint)blockIndex < (uint)_reachesCycleByBlock.Length && _reachesCycleByBlock[blockIndex];
 
             static bool[] BackwardReachable(IReadOnlyList<BlockEdges> edges, IEnumerable<int> seeds)
             {
@@ -3480,8 +3491,11 @@ public sealed class LibraryBodyIndex
                         PathContext = opportunity.PathContext ?? FormatPathContext(AllocationPathContextFor(decodedBody, opportunityOffset, loopRegions, AllocationEscape.Unknown)),
                         PathConfidence = opportunity.PathConfidence ?? FormatPathConfidence(AllocationPathConfidenceFor(decodedBody, opportunityOffset, AllocationEscape.Unknown)),
                         PostDominance = opportunity.PostDominance ?? FormatPostDominance(AllocationPostDominanceFor(decodedBody, opportunityOffset, AllocationEscape.Unknown)),
-                        Multiplicity = opportunity.Multiplicity ?? FormatMultiplicity(allocation?.Multiplicity
-                            ?? AllocationMultiplicityFor(decodedBody, opportunityOffset, loopRegions, AllocationEscape.Unknown)),
+                        Multiplicity = opportunity.Multiplicity ?? FormatMultiplicity(
+                            allocation?.Multiplicity is { } allocationMultiplicity
+                                && allocationMultiplicity != AllocationMultiplicity.Unknown
+                                    ? allocationMultiplicity
+                                    : AllocationMultiplicityFor(decodedBody, opportunityOffset, loopRegions, AllocationEscape.Unknown)),
                         EstimatedSizeBytes = opportunity.EstimatedSizeBytes ?? allocation?.EstimatedSizeBytes,
                     };
                 }
@@ -4042,7 +4056,16 @@ public sealed class LibraryBodyIndex
             if (escape == AllocationEscape.ThrowPath)
                 return inLoop ? AllocationMultiplicity.Unknown : AllocationMultiplicity.Conditional;
             if (inLoop)
+            {
+                // A block inside a loop region only iterates if it can flow back to the
+                // loop backedge. One that exits first — an early return OR an uncaught
+                // throw after the allocation — runs at most once, so it is not a hot loop.
+                if (!decodedBody.PostDominances.ReachesCycleFor(blockIndex))
+                    return confidence == AllocationPathConfidence.DominatesReturn
+                        ? AllocationMultiplicity.Once
+                        : AllocationMultiplicity.Conditional;
                 return AllocationMultiplicity.Loop;
+            }
 
             var context = decodedBody.PathContexts.ContextFor(blockIndex);
             if (context == AllocationPathContext.ErrorPath)

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -436,7 +436,7 @@ public class OutputFormatterTests
         Assert.Equal(["OffsetSmall", "OffsetLarge"], filtered);
     }
 
-    static ILInspector.Analysis.OptimizationOpportunity Opp(string name, bool inLoop, string confidence, int rootReach, string shape)
+    static ILInspector.Analysis.OptimizationOpportunity Opp(string name, bool inLoop, string confidence, int rootReach, string shape, string? multiplicity = null)
     {
         var declaring = ILInspector.Analysis.TypeRef.Definition("Asm", "Ns", "Type");
         var method = new ILInspector.Analysis.MethodIdentity(
@@ -449,7 +449,38 @@ public class OutputFormatterTests
             MetadataToken: 0x06000001,
             IsStatic: true);
         return new ILInspector.Analysis.OptimizationOpportunity(
-            method, shape, "evidence", "fix", confidence, inLoop, ILOffset: null, Caveat: null, RootReach: rootReach);
+            method, shape, "evidence", "fix", confidence, inLoop, ILOffset: null, Caveat: null, RootReach: rootReach)
+        {
+            Multiplicity = multiplicity,
+        };
+    }
+
+    [Fact]
+    public void IteratesInLoop_TrustsSemanticMultiplicityOverStructuralInLoop()
+    {
+        // Structurally in a loop but a return/throw early-exit (Multiplicity conditional)
+        // is NOT a hot loop; a genuine loop is; a null multiplicity falls back to InLoop.
+        var loopEarlyExit = Opp("LoopEarlyExit", inLoop: true, confidence: "high", rootReach: 1, shape: "capturing-delegate", multiplicity: "conditional");
+        var genuineLoop = Opp("GenuineLoop", inLoop: true, confidence: "high", rootReach: 1, shape: "allocation-hotspot", multiplicity: "loop");
+        var unknownInLoop = Opp("UnknownInLoop", inLoop: true, confidence: "high", rootReach: 1, shape: "allocation-hotspot", multiplicity: null);
+        var unknownNotInLoop = Opp("UnknownNotInLoop", inLoop: false, confidence: "high", rootReach: 1, shape: "allocation-hotspot", multiplicity: null);
+
+        Assert.False(LibraryMetadataService.IteratesInLoop(loopEarlyExit));
+        Assert.True(LibraryMetadataService.IteratesInLoop(genuineLoop));
+        Assert.True(LibraryMetadataService.IteratesInLoop(unknownInLoop));
+        Assert.False(LibraryMetadataService.IteratesInLoop(unknownNotInLoop));
+
+        // The loop early-exit is deprioritized below a genuine loop despite equal confidence/reach.
+        var ordered = LibraryMetadataService.OrderByTriagePriority([loopEarlyExit, genuineLoop])
+            .Select(o => o.Method.Name).ToList();
+        Assert.Equal(["GenuineLoop", "LoopEarlyExit"], ordered);
+
+        // --loop keeps only genuine loops.
+        var loopOnly = LibraryMetadataService.FilterAndOrderTriageOpportunities(
+            [loopEarlyExit, genuineLoop],
+            new PerformanceTriageOptions { LoopOnly = true })
+            .Select(o => o.Method.Name).ToList();
+        Assert.Equal(["GenuineLoop"], loopOnly);
     }
 
     [Fact]

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -926,7 +926,7 @@ internal static class LibraryMetadataService
         if (field == "Weight")
             return WeightSortRank(left.Weight).CompareTo(WeightSortRank(right.Weight));
         if (field == "Loop")
-            return left.InLoop.CompareTo(right.InLoop);
+            return IteratesInLoop(left).CompareTo(IteratesInLoop(right));
         if (field == "IL")
             return (left.ILOffset ?? -1).CompareTo(right.ILOffset ?? -1);
         return string.Compare(

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -735,7 +735,7 @@ internal static class LibraryMetadataService
                     Evidence = opportunity.Evidence,
                     Fix = opportunity.SafeFixDirection,
                     Confidence = opportunity.Confidence,
-                    Loop = opportunity.InLoop ? "loop" : "",
+                    Loop = IteratesInLoop(opportunity) ? "loop" : "",
                     Allocation = opportunity.RuntimeAllocationType,
                     Path = opportunity.PathContext,
                     PathConfidence = opportunity.PathConfidence,
@@ -760,13 +760,23 @@ internal static class LibraryMetadataService
     // test (analysis quality ladder #1623 rung 5), not only by self-consistent monotonicity.
     internal static IEnumerable<Analysis.OptimizationOpportunity> OrderByTriagePriority(IEnumerable<Analysis.OptimizationOpportunity> opportunities)
         => opportunities
-            .OrderByDescending(opportunity => opportunity.InLoop)
+            .OrderByDescending(IteratesInLoop)
             .ThenByDescending(opportunity => ConfidenceRank(opportunity.Confidence))
             .ThenByDescending(opportunity => opportunity.RootReach)
             .ThenBy(opportunity => opportunity.Method.DeclaringType.ToQualifiedDisplayString(), StringComparer.Ordinal)
             .ThenBy(opportunity => opportunity.Method.Name, StringComparer.Ordinal)
             .ThenBy(opportunity => opportunity.ILOffset ?? -1)
             .ThenBy(opportunity => opportunity.Shape, StringComparer.Ordinal);
+
+    // Whether an allocation opportunity actually iterates as a hot loop, per the
+    // semantic per-invocation multiplicity (#2127). A structural in-loop offset that
+    // is really a return/throw early-exit (Multiplicity Conditional/Unknown) is NOT a
+    // hot loop; fall back to the structural InLoop flag only when multiplicity is
+    // unknown. This is the single source of truth for the Loop column, triage sort,
+    // and the --loop filter.
+    internal static bool IteratesInLoop(Analysis.OptimizationOpportunity opportunity)
+        => opportunity.Multiplicity == "loop"
+            || (opportunity.Multiplicity is null && opportunity.InLoop);
 
     // Triage ordering weight for a confidence label (high allocations are the surest pay-dirt).
     static int ConfidenceRank(string confidence)
@@ -788,7 +798,7 @@ internal static class LibraryMetadataService
         options ??= PerformanceTriageOptions.Default;
         var filtered = opportunities;
         if (options.LoopOnly)
-            filtered = filtered.Where(opportunity => opportunity.InLoop);
+            filtered = filtered.Where(IteratesInLoop);
         if (options.MinConfidence is { Length: > 0 } confidence)
         {
             var minimumRank = ConfidenceRank(confidence);
@@ -933,7 +943,7 @@ internal static class LibraryMetadataService
             "Evidence" => opportunity.Evidence,
             "Fix" => opportunity.SafeFixDirection,
             "Confidence" => opportunity.Confidence,
-            "Loop" => opportunity.InLoop ? "loop" : "",
+            "Loop" => IteratesInLoop(opportunity) ? "loop" : "",
             "Allocation" => opportunity.RuntimeAllocationType,
             "Path" => opportunity.PathContext,
             "PathConfidence" => opportunity.PathConfidence,

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1818,7 +1818,7 @@ public static class ApiOutputFormatter
                 opportunity.Evidence,
                 opportunity.SafeFixDirection,
                 opportunity.Confidence,
-                opportunity.InLoop ? "loop" : "",
+                LibraryMetadataService.IteratesInLoop(opportunity) ? "loop" : "",
                 opportunity.RuntimeAllocationType is { Length: > 0 } allocation ? MarkoutInline.Code(allocation) : null,
                 opportunity.PathContext,
                 opportunity.PathConfidence,


### PR DESCRIPTION
## What

Follow-up to #2127 (filed as #2177). Performance Triage derived several signals
from the **structural** `OptimizationOpportunity.InLoop` (IL offset inside a loop
region) rather than the **semantic** `AllocationMultiplicity` that #2127 Piece #2
introduced. So a `return`/`throw` early-exit *inside* a loop — which runs at most
once per call — was surfaced, ranked, and labelled as a hot loop, contradicting
the `multiplicity=conditional` fact in the coordinate layer.

- New `LibraryMetadataService.IteratesInLoop(opportunity)` = `Multiplicity == "loop"`,
  falling back to the structural `InLoop` only when multiplicity is unknown — the
  single source of truth for the **Loop column** (3 sites), the **default triage
  sort**, and the **`--loop` filter**.
- The **capturing-delegate / instance-method-group-delegate / box confidence**
  heuristics now key off semantic loop iteration instead of structural in-loop
  membership.

Additive to the objective coordinate facts — `Path`/`PathContext` (`loop body`)
are unchanged; only the curated triage judgment now reflects semantic reality.

## Evidence

End-to-end (compiled fixture, `-S "Performance Triage"`):

| Method | Confidence | Loop | Weight |
| --- | --- | --- | --- |
| `GenuineLoop` (delegate allocated every iteration) | `high` | `loop` | `medium` |
| `LoopEarlyReturn` (delegate on an early-return path in a loop, runs once) | `low` | *(empty)* | `low` |

- Analysis suite **332 pass**; full CLI suite green apart from one unrelated
  offline `SourceLink Integrity` discovery test.
- Adds `IteratesInLoop_TrustsSemanticMultiplicityOverStructuralInLoop`
  (semantic override vs structural `InLoop`; null falls back to `InLoop`;
  ordering + `--loop` filter).

## Review

Two non-Opus reviewers per policy; reconciled in a follow-up comment.

Closes #2177. Related: #2127, #2166.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
