### PR TITLE
Share one index build across type-scope analysis sections (#2139 perf)

### DIFF
--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -105,7 +105,7 @@ public class OutputFormatterTests
         ApiOutputFormatter.PopulateOptimizationOpportunities(
             view,
             type,
-            typeof(OutputFormatterTests).Assembly.Location,
+            ApiOutputFormatter.OpenTypeAnalysisSession(typeof(OutputFormatterTests).Assembly.Location),
             new HashSet<string>(StringComparer.OrdinalIgnoreCase) { SectionNames.PerformanceTriage });
 
         var rows = Assert.IsType<List<OptimizationOpportunityRow>>(view.OptimizationOpportunityRows);

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -660,10 +660,16 @@ public class ApiCommand
                         mo4.CallerScopeAssemblies, mo4);
             }
 
-            if (options.DllPath is { } unsafeDllPath
+            // Type-scope analysis sections share one index build per type (built lazily, only
+            // when such a section is requested) instead of opening one session per section.
+            MethodBodyInspectionSession? typeAnalysisSession = null;
+            MethodBodyInspectionSession TypeAnalysisSession() =>
+                typeAnalysisSession ??= ApiOutputFormatter.OpenTypeAnalysisSession(options.DllPath!);
+
+            if (options.DllPath is not null
                 && GetRequestedMemberSections(type, options).Contains(SectionNames.UnsafeMembers))
             {
-                ApiOutputFormatter.PopulateUnsafeMembers(view, type, unsafeDllPath);
+                ApiOutputFormatter.PopulateUnsafeMembers(view, type, TypeAnalysisSession());
             }
 
             if (options.DllPath is { } exceptionRegionsDllPath
@@ -673,34 +679,34 @@ public class ApiCommand
                 ApiOutputFormatter.PopulateTypeExceptionRegions(view, type, exceptionRegionsDllPath, options.IncludeSections);
             }
 
-            if (options.DllPath is { } calledTypesDllPath
+            if (options.DllPath is not null
                 && (GetRequestedMemberSections(type, options).Contains(SectionNames.CalledTypes)
                     || options.IncludeSections?.Contains(SectionNames.CalledTypes) == true))
             {
-                ApiOutputFormatter.PopulateCalledTypes(view, type, calledTypesDllPath, options.IncludeSections);
+                ApiOutputFormatter.PopulateCalledTypes(view, type, TypeAnalysisSession(), options.IncludeSections);
             }
 
             var semanticSections = GetRequestedMemberSections(type, options);
             if (options is not MemberOptions
-                && options.DllPath is { } semanticFactsDllPath
+                && options.DllPath is not null
                 && semanticSections.Overlaps(SemanticFactSections))
             {
-                ApiOutputFormatter.PopulateTypeSemanticFacts(view, type, semanticFactsDllPath, semanticSections, options.IncludeSections);
+                ApiOutputFormatter.PopulateTypeSemanticFacts(view, type, TypeAnalysisSession(), semanticSections, options.IncludeSections);
             }
 
-            if (options.DllPath is { } optimizationDllPath
+            if (options.DllPath is not null
                 && GetRequestedMemberSections(type, options).Contains(SectionNames.PerformanceTriage))
             {
-                ApiOutputFormatter.PopulateOptimizationOpportunities(view, type, optimizationDllPath, options.IncludeSections,
+                ApiOutputFormatter.PopulateOptimizationOpportunities(view, type, TypeAnalysisSession(), options.IncludeSections,
                     options.PerformanceTriage,
                     restrictToModelMembers: ApiMemberSectionPipelines.UsesDetailPipeline(options)
                         || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options));
             }
 
-            if (options.DllPath is { } leverageDllPath
+            if (options.DllPath is not null
                 && GetRequestedMemberSections(type, options).Contains(SectionNames.TopLeverage))
             {
-                ApiOutputFormatter.PopulateTopLeverage(view, type, leverageDllPath,
+                ApiOutputFormatter.PopulateTopLeverage(view, type, TypeAnalysisSession(),
                     restrictToModelMembers: ApiMemberSectionPipelines.UsesDetailPipeline(options)
                         || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(options));
             }
@@ -1286,10 +1292,14 @@ public class ApiCommand
                 }
             }
 
-            if (renderOptions.DllPath is { } unsafeDllPath
+            MethodBodyInspectionSession? typeAnalysisSession = null;
+            MethodBodyInspectionSession TypeAnalysisSession() =>
+                typeAnalysisSession ??= ApiOutputFormatter.OpenTypeAnalysisSession(renderOptions.DllPath!);
+
+            if (renderOptions.DllPath is not null
                 && GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.UnsafeMembers))
             {
-                ApiOutputFormatter.PopulateUnsafeMembers(view, type, unsafeDllPath);
+                ApiOutputFormatter.PopulateUnsafeMembers(view, type, TypeAnalysisSession());
             }
 
             if (renderOptions.DllPath is { } exceptionRegionsDllPath
@@ -1299,33 +1309,33 @@ public class ApiCommand
                 ApiOutputFormatter.PopulateTypeExceptionRegions(view, type, exceptionRegionsDllPath, renderOptions.IncludeSections);
             }
 
-            if (renderOptions.DllPath is { } calledTypesDllPath
+            if (renderOptions.DllPath is not null
                 && (GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.CalledTypes)
                     || renderOptions.IncludeSections?.Contains(SectionNames.CalledTypes) == true))
             {
-                ApiOutputFormatter.PopulateCalledTypes(view, type, calledTypesDllPath, renderOptions.IncludeSections);
+                ApiOutputFormatter.PopulateCalledTypes(view, type, TypeAnalysisSession(), renderOptions.IncludeSections);
             }
 
             var semanticSections = GetRequestedMemberSections(type, renderOptions);
             if (renderOptions is not MemberOptions
-                && renderOptions.DllPath is { } semanticFactsDllPath
+                && renderOptions.DllPath is not null
                 && semanticSections.Overlaps(SemanticFactSections))
             {
-                ApiOutputFormatter.PopulateTypeSemanticFacts(view, type, semanticFactsDllPath, semanticSections, renderOptions.IncludeSections);
+                ApiOutputFormatter.PopulateTypeSemanticFacts(view, type, TypeAnalysisSession(), semanticSections, renderOptions.IncludeSections);
             }
 
-            if (renderOptions.DllPath is { } optimizationDllPath
+            if (renderOptions.DllPath is not null
                 && GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.PerformanceTriage))
             {
-                ApiOutputFormatter.PopulateOptimizationOpportunities(view, type, optimizationDllPath, renderOptions.IncludeSections,
+                ApiOutputFormatter.PopulateOptimizationOpportunities(view, type, TypeAnalysisSession(), renderOptions.IncludeSections,
                     restrictToModelMembers: ApiMemberSectionPipelines.UsesDetailPipeline(renderOptions)
                         || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(renderOptions));
             }
 
-            if (renderOptions.DllPath is { } leverageDllPath
+            if (renderOptions.DllPath is not null
                 && GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.TopLeverage))
             {
-                ApiOutputFormatter.PopulateTopLeverage(view, type, leverageDllPath,
+                ApiOutputFormatter.PopulateTopLeverage(view, type, TypeAnalysisSession(),
                     restrictToModelMembers: ApiMemberSectionPipelines.UsesDetailPipeline(renderOptions)
                         || ApiMemberSectionPipelines.UsesOverloadInventoryPipeline(renderOptions));
             }

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -23,6 +23,13 @@ public static class ApiOutputFormatter
     static IAssemblyReferenceResolver AnalysisReferenceResolver(string dllPath, ApiOptions? options = null)
         => ApiCommand.PlatformAssemblyResolver(dllPath, options?.ProjectAssetsPath, options?.Tfm);
 
+    /// <summary>
+    /// Opens a type-scope analysis session for the type/library sections. Callers memoize this per
+    /// type so the five type-analysis populators share one index build instead of opening five.
+    /// </summary>
+    internal static MethodBodyInspectionSession OpenTypeAnalysisSession(string dllPath)
+        => MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath));
+
     // ===== Full API View Model Factory =====
 
     internal static (CliApiSurface view, int truncatedCount) BuildFullApiView(ApiSurface api, ApiOptions options)
@@ -1693,9 +1700,9 @@ public static class ApiOutputFormatter
         return builder.ToString();
     }
 
-    internal static void PopulateUnsafeMembers(TypeView view, ApiType type, string dllPath)
+    internal static void PopulateUnsafeMembers(TypeView view, ApiType type, MethodBodyInspectionSession session)
     {
-        var rows = MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath))
+        var rows = session
             .UnsafeEvidence()
             .Where(evidence => SameType(evidence.Member.DeclaringType, type))
             .OrderBy(evidence => evidence.Member.Name, StringComparer.Ordinal)
@@ -1740,10 +1747,10 @@ public static class ApiOutputFormatter
     internal static void PopulateCalledTypes(
         TypeView view,
         ApiType type,
-        string dllPath,
+        MethodBodyInspectionSession session,
         IReadOnlySet<string>? explicitSections = null)
     {
-        var rows = MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath))
+        var rows = session
             .CalledTypes(method => SameType(method.DeclaringType, type))
             .Select(summary => new CalledTypeRow(
                 MarkoutInline.Code(summary.Type.ToQualifiedDisplayString()),
@@ -1760,11 +1767,10 @@ public static class ApiOutputFormatter
     internal static void PopulateTypeSemanticFacts(
         TypeView view,
         ApiType type,
-        string dllPath,
+        MethodBodyInspectionSession session,
         IReadOnlySet<string>? requestedSections,
         IReadOnlySet<string>? explicitSections = null)
     {
-        var session = MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath));
         var methodTokens = type.Members
             .Where(member => member.MetadataToken is not null && ApiMemberSectionDescriptors.IsMethodLike(member))
             .Select(member => member.MetadataToken!.Value)
@@ -1804,12 +1810,11 @@ public static class ApiOutputFormatter
     internal static void PopulateOptimizationOpportunities(
         TypeView view,
         ApiType type,
-        string dllPath,
+        MethodBodyInspectionSession session,
         IReadOnlySet<string>? explicitSections = null,
         PerformanceTriageOptions? options = null,
         bool restrictToModelMembers = false)
     {
-        var session = MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath));
         HashSet<int>? memberTokens = restrictToModelMembers
             ? type.Members.Where(m => m.MetadataToken is not null).Select(m => m.MetadataToken!.Value).ToHashSet()
             : null;
@@ -1900,9 +1905,8 @@ public static class ApiOutputFormatter
         }
     }
 
-    internal static void PopulateTopLeverage(TypeView view, ApiType type, string dllPath, bool restrictToModelMembers = false)
+    internal static void PopulateTopLeverage(TypeView view, ApiType type, MethodBodyInspectionSession session, bool restrictToModelMembers = false)
     {
-        var session = MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath));
         var drillByToken = BuildMemberDrillMap(type);
 
         // Rank every method declared on this type; fanin is still measured across all


### PR DESCRIPTION
## Summary

Follow-up to #2187 (member path): **share one index build across the type-scope
analysis sections**. The five type populators — `PopulateUnsafeMembers`,
`PopulateCalledTypes`, `PopulateTypeSemanticFacts`,
`PopulateOptimizationOpportunities`, `PopulateTopLeverage` — each opened their own
`MethodBodyInspectionSession`, rebuilding the full `LibraryBodyIndex` per section
(per type). A `type` render selecting N of these rebuilt the index N times.

- The five helpers now accept a shared `MethodBodyInspectionSession` (replacing their
  `dllPath` parameter).
- New `ApiOutputFormatter.OpenTypeAnalysisSession(dllPath)` factory encapsulates the
  resolver.
- Both `ApiCommand` type-section dispatch sites memoize **one session per type**
  (built lazily, only when a type-analysis section is requested) and thread it to all
  five.

## Results

- **Behavior-preserving**: byte-identical output across all seven type sections on
  multiple types (`LibraryBodyIndex` 263 rows, `CSharpPrinter` 638 rows,
  `MemberPattern` 41, `ResourceScanner` 56) and the `library` Unsafe Members / Top
  Leverage / Performance Triage sections.
- **~3x faster** on a 7-section `type` render (CPU time, load-insensitive):
  **~1.18 -> ~0.39 CPU-sec** (5 index builds -> 1).
- Tests: `CalledTypes/TopLeverage/LibraryTopLeverage/NestedTypeLeverage/SemanticFacts/UnsafeMembers`
  section tests + `OutputFormatterTests` — 118/118 pass.

## Follow-up

The **`library` command's top-level** Unsafe Members / Top Leverage / Performance
Triage sections go through a different path — `LibraryMetadataService.Scan*`,
registered as independent section-pipeline steps that each open their own index.
Consolidating those needs a shared session carried on `SectionContext`, a separate
refactor (tracked in #2198).

Part of #2139 / #2122. See #2198 for the broader perf journey.
