### PR TITLE
Classify delegate-captured display classes

### DIFF
--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1240,6 +1240,7 @@ public class LibraryBodyIndexTests
     [InlineData(nameof(OptimizationOpportunityFixtures.ReturnsPlainObject), AllocationKind.Object, AllocationEscape.Escapes)]
     [InlineData(nameof(OptimizationOpportunityFixtures.StoresPlainObjectToField), AllocationKind.Object, AllocationEscape.Escapes)]
     [InlineData(nameof(OptimizationOpportunityFixtures.CapturingLambda), AllocationKind.Closure, AllocationEscape.Escapes)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.CapturingLambdaWithDependentLocal), AllocationKind.Closure, AllocationEscape.Escapes)]
     [InlineData(nameof(OptimizationOpportunityFixtures.ExceptionUnknownOrThrow), AllocationKind.Object, AllocationEscape.Unknown)]
     [InlineData(nameof(OptimizationOpportunityFixtures.BoxesThenUnboxesLocal), AllocationKind.Box, AllocationEscape.LocalOnly)]
     [InlineData(nameof(OptimizationOpportunityFixtures.BoxThenIsinstReturn), AllocationKind.Box, AllocationEscape.Unknown)]
@@ -1269,6 +1270,7 @@ public class LibraryBodyIndexTests
     [InlineData(nameof(OptimizationOpportunityFixtures.CapturesArrayInClosure), AllocationKind.Array, AllocationEscapeKind.Capture)]
     // The display-class allocation itself escapes as the target object captured by the delegate.
     [InlineData(nameof(OptimizationOpportunityFixtures.CapturingLambda), AllocationKind.Closure, AllocationEscapeKind.Capture)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.CapturingLambdaWithDependentLocal), AllocationKind.Closure, AllocationEscapeKind.Capture)]
     // Multiple distinct escape sinks -> fail-honest None (still an Escapes verdict).
     [InlineData(nameof(OptimizationOpportunityFixtures.StoresToStaticThenReturns), AllocationKind.Object, AllocationEscapeKind.None)]
     // Fail-honest: non-escaping / unknown verdicts carry no kind.
@@ -3961,6 +3963,12 @@ public class OptimizationOpportunityFixtures
     public static Func<int> CapturingLambda(int seed)
     {
         return () => seed + 1;
+    }
+
+    public static Func<int> CapturingLambdaWithDependentLocal(int seed, int addend)
+    {
+        int sum = seed + addend;
+        return () => seed + sum;
     }
 
     // A capturing lambda consumed by a lazy LINQ operator (Where). Rewriting the lambda as

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -1239,6 +1239,7 @@ public class LibraryBodyIndexTests
     [InlineData(nameof(OptimizationOpportunityFixtures.DropsPlainObject), AllocationKind.Object, AllocationEscape.LocalOnly)]
     [InlineData(nameof(OptimizationOpportunityFixtures.ReturnsPlainObject), AllocationKind.Object, AllocationEscape.Escapes)]
     [InlineData(nameof(OptimizationOpportunityFixtures.StoresPlainObjectToField), AllocationKind.Object, AllocationEscape.Escapes)]
+    [InlineData(nameof(OptimizationOpportunityFixtures.CapturingLambda), AllocationKind.Closure, AllocationEscape.Escapes)]
     [InlineData(nameof(OptimizationOpportunityFixtures.ExceptionUnknownOrThrow), AllocationKind.Object, AllocationEscape.Unknown)]
     [InlineData(nameof(OptimizationOpportunityFixtures.BoxesThenUnboxesLocal), AllocationKind.Box, AllocationEscape.LocalOnly)]
     [InlineData(nameof(OptimizationOpportunityFixtures.BoxThenIsinstReturn), AllocationKind.Box, AllocationEscape.Unknown)]
@@ -1266,6 +1267,8 @@ public class LibraryBodyIndexTests
     [InlineData(nameof(OptimizationOpportunityFixtures.StoresObjectToLookalikeDisplayClassField), AllocationKind.Object, AllocationEscapeKind.Field)]
     [InlineData(nameof(OptimizationOpportunityFixtures.StoresObjectIntoArrayElement), AllocationKind.Object, AllocationEscapeKind.Collection)]
     [InlineData(nameof(OptimizationOpportunityFixtures.CapturesArrayInClosure), AllocationKind.Array, AllocationEscapeKind.Capture)]
+    // The display-class allocation itself escapes as the target object captured by the delegate.
+    [InlineData(nameof(OptimizationOpportunityFixtures.CapturingLambda), AllocationKind.Closure, AllocationEscapeKind.Capture)]
     // Multiple distinct escape sinks -> fail-honest None (still an Escapes verdict).
     [InlineData(nameof(OptimizationOpportunityFixtures.StoresToStaticThenReturns), AllocationKind.Object, AllocationEscapeKind.None)]
     // Fail-honest: non-escaping / unknown verdicts carry no kind.

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -4355,6 +4355,12 @@ public sealed class LibraryBodyIndex
             if (stackValuesAbove != 0)
                 return EscapeClassification.Unknown;
 
+            if (IsCompilerGeneratedDisplayClass(allocatedType)
+                && TryClassifyDisplayClassDelegateTarget(decodedBody, instruction.Offset, callerScope, out var displayClassEscape))
+            {
+                return displayClassEscape;
+            }
+
             switch (instruction.OpCode)
             {
                 case ILOpCode.Pop:
@@ -4407,6 +4413,121 @@ public sealed class LibraryBodyIndex
                     return EscapeClassification.Unknown;
             }
         }
+
+        bool TryClassifyDisplayClassDelegateTarget(
+            DecodedBody decodedBody,
+            int position,
+            GenericScope callerScope,
+            out EscapeClassification classification)
+        {
+            classification = EscapeClassification.Unknown;
+            int index = decodedBody.NextNonNopIndexAtOrAfter(position);
+            if (index >= decodedBody.Instructions.Length)
+                return false;
+
+            // Track only copies of the display-class allocation (true) vs unrelated stack
+            // values (false); fail closed as soon as a shape needs fuller stack semantics.
+            var stack = new List<bool> { true };
+            const int MaxScanInstructions = 48;
+            int maxIndex = Math.Min(decodedBody.Instructions.Length, index + MaxScanInstructions);
+            for (; index < maxIndex; index++)
+            {
+                var instruction = decodedBody.Instructions[index];
+                if (instruction.Branches || instruction.Exits)
+                    return false;
+
+                switch (instruction.OpCode)
+                {
+                    case ILOpCode.Nop:
+                        continue;
+                    case ILOpCode.Dup:
+                        if (stack.Count == 0)
+                            return false;
+                        stack.Add(stack[^1]);
+                        continue;
+                    case ILOpCode.Stfld:
+                        if (!Pop(stack, 2))
+                            return false;
+                        if (!stack.Contains(true))
+                            return false;
+                        continue;
+                    case ILOpCode.Ldfld:
+                        if (stack.Count == 0 || stack[^1])
+                            return false;
+                        continue;
+                    case ILOpCode.Ldftn:
+                        stack.Add(false);
+                        if (StackTopIsDelegateTarget(stack)
+                            && NextNonNopIsDelegateConstructor(decodedBody, instruction.NextOffset, callerScope))
+                        {
+                            classification = EscapeClassification.Escapes(AllocationEscapeKind.Capture);
+                            return true;
+                        }
+                        return false;
+                    case ILOpCode.Ldvirtftn:
+                        if (!Pop(stack, 1))
+                            return false;
+                        stack.Add(false);
+                        if (StackTopIsDelegateTarget(stack)
+                            && NextNonNopIsDelegateConstructor(decodedBody, instruction.NextOffset, callerScope))
+                        {
+                            classification = EscapeClassification.Escapes(AllocationEscapeKind.Capture);
+                            return true;
+                        }
+                        return false;
+                    default:
+                        if (IsSimpleStackPush(instruction.OpCode))
+                        {
+                            stack.Add(false);
+                            continue;
+                        }
+                        return false;
+                }
+            }
+
+            return false;
+
+            static bool Pop(List<bool> stack, int count)
+            {
+                if (stack.Count < count)
+                    return false;
+                stack.RemoveRange(stack.Count - count, count);
+                return true;
+            }
+
+            static bool StackTopIsDelegateTarget(List<bool> stack)
+                => stack.Count >= 2 && !stack[^1] && stack[^2];
+        }
+
+        bool NextNonNopIsDelegateConstructor(DecodedBody decodedBody, int position, GenericScope callerScope)
+        {
+            int index = decodedBody.NextNonNopIndexAtOrAfter(position);
+            if (index >= decodedBody.Instructions.Length)
+                return false;
+
+            var instruction = decodedBody.Instructions[index];
+            if (instruction.OpCode != ILOpCode.Newobj)
+                return false;
+
+            int token = OperandInt32(instruction);
+            var constructor = MemberResolver.ResolveMethod(_reader, MetadataTokens.EntityHandle(token), callerScope);
+            return IsDelegateConstructorToken(token, constructor);
+        }
+
+        static bool IsCompilerGeneratedDisplayClass(TypeRef? type)
+            => type is not null
+               && DeclaringTypeLeafName(type).StartsWith("<>c__DisplayClass", StringComparison.Ordinal);
+
+        static bool IsSimpleStackPush(ILOpCode opcode)
+            => opcode is ILOpCode.Ldc_i4_m1 or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1 or ILOpCode.Ldc_i4_2
+                or ILOpCode.Ldc_i4_3 or ILOpCode.Ldc_i4_4 or ILOpCode.Ldc_i4_5 or ILOpCode.Ldc_i4_6
+                or ILOpCode.Ldc_i4_7 or ILOpCode.Ldc_i4_8 or ILOpCode.Ldnull
+                or ILOpCode.Ldc_i4_s or ILOpCode.Ldc_i4 or ILOpCode.Ldc_r4
+                or ILOpCode.Ldc_i8 or ILOpCode.Ldc_r8 or ILOpCode.Ldstr
+                or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
+                or ILOpCode.Ldloc_s or ILOpCode.Ldloc or ILOpCode.Ldloca_s or ILOpCode.Ldloca
+                or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3
+                or ILOpCode.Ldarg_s or ILOpCode.Ldarg or ILOpCode.Ldarga_s or ILOpCode.Ldarga;
 
         // stfld into a compiler-generated closure display class (<>c__DisplayClass) or
         // async/iterator state machine (<...>d__) hoists the value into that object's

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -4452,8 +4452,9 @@ public sealed class LibraryBodyIndex
                             return false;
                         continue;
                     case ILOpCode.Ldfld:
-                        if (stack.Count == 0 || stack[^1])
+                        if (!Pop(stack, 1))
                             return false;
+                        stack.Add(false);
                         continue;
                     case ILOpCode.Ldftn:
                         stack.Add(false);
@@ -4476,6 +4477,13 @@ public sealed class LibraryBodyIndex
                         }
                         return false;
                     default:
+                        if (IsSimpleBinaryStackReplacement(instruction.OpCode))
+                        {
+                            if (!PopUntracked(stack, 2))
+                                return false;
+                            stack.Add(false);
+                            continue;
+                        }
                         if (IsSimpleStackPush(instruction.OpCode))
                         {
                             stack.Add(false);
@@ -4491,6 +4499,19 @@ public sealed class LibraryBodyIndex
             {
                 if (stack.Count < count)
                     return false;
+                stack.RemoveRange(stack.Count - count, count);
+                return true;
+            }
+
+            static bool PopUntracked(List<bool> stack, int count)
+            {
+                if (stack.Count < count)
+                    return false;
+                for (int i = stack.Count - count; i < stack.Count; i++)
+                {
+                    if (stack[i])
+                        return false;
+                }
                 stack.RemoveRange(stack.Count - count, count);
                 return true;
             }
@@ -4528,6 +4549,15 @@ public sealed class LibraryBodyIndex
                 or ILOpCode.Ldloc_s or ILOpCode.Ldloc or ILOpCode.Ldloca_s or ILOpCode.Ldloca
                 or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3
                 or ILOpCode.Ldarg_s or ILOpCode.Ldarg or ILOpCode.Ldarga_s or ILOpCode.Ldarga;
+
+        static bool IsSimpleBinaryStackReplacement(ILOpCode opcode)
+            => opcode is ILOpCode.Add or ILOpCode.Add_ovf or ILOpCode.Add_ovf_un
+                or ILOpCode.Sub or ILOpCode.Sub_ovf or ILOpCode.Sub_ovf_un
+                or ILOpCode.Mul or ILOpCode.Mul_ovf or ILOpCode.Mul_ovf_un
+                or ILOpCode.Div or ILOpCode.Div_un or ILOpCode.Rem or ILOpCode.Rem_un
+                or ILOpCode.And or ILOpCode.Or or ILOpCode.Xor
+                or ILOpCode.Shl or ILOpCode.Shr or ILOpCode.Shr_un
+                or ILOpCode.Ceq or ILOpCode.Cgt or ILOpCode.Cgt_un or ILOpCode.Clt or ILOpCode.Clt_un;
 
         // stfld into a compiler-generated closure display class (<>c__DisplayClass) or
         // async/iterator state machine (<...>d__) hoists the value into that object's


### PR DESCRIPTION
## Summary

- classify compiler display-class allocations as `EscapeKind = Capture` when they flow as the target object of a delegate constructor
- keep the gate fail-honest: only compiler-generated `<>c__DisplayClass*` allocations and resolved delegate `.ctor(object, nint)` shapes qualify
- add regression coverage for the display-class allocation itself in capturing lambdas

Fixes #2190.

## Validation

- `dotnet run --no-restore --project src/ILInspector.Analysis.Tests -c Release`
- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config --no-restore`

## Adversarial review

Required analysis review is in progress; I will post a follow-up PR comment with the two-model review reconciliation.