### PR TITLE
Preserve abstract closure members in RTS

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1640,6 +1640,36 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_DoesNotMarkUserBaseOverrideWithoutBaseShell()
+    {
+        var assemblyPath = CompileFixture("""
+            public abstract class BaseNode
+            {
+                public abstract string Describe();
+            }
+
+            public class DerivedNode : BaseNode
+            {
+                public override string Describe() => "derived";
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("DerivedNode", "Describe", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public string Describe()", result.Source);
+            Assert.DoesNotContain("override string Describe", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericTypeTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1557,6 +1557,49 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_PreservesAbstractClosureTypeAndMethod()
+    {
+        var assemblyPath = CompileFixture("""
+            public abstract class Node
+            {
+                private readonly System.Collections.Generic.List<Node> _children = new();
+
+                public Node Parent { get; set; }
+
+                public int ChildIndex { get; set; }
+
+                public abstract string Describe();
+
+                public void CheckInvariant()
+                {
+                    for (int i = 0; i < _children.Count; i++)
+                    {
+                        var child = _children[i];
+                        if (child.Parent != this)
+                            throw new System.InvalidOperationException($"child {child.Describe()} of {Describe()}");
+                        if (child.ChildIndex != i)
+                            throw new System.InvalidOperationException($"child {child.Describe()} slot {child.ChildIndex} expected {i}");
+                    }
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Node", "CheckInvariant", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public abstract class Node", result.Source);
+            Assert.Contains("public abstract string Describe();", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericTypeTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1600,6 +1600,46 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_DoesNotMarkFinalNewSlotStructMethodVirtual()
+    {
+        var assemblyPath = CompileFixture("""
+            public interface IThing
+            {
+                int GetValue();
+            }
+
+            public struct Thing : IThing
+            {
+                public int GetValue() => 42;
+            }
+
+            public class Class1
+            {
+                public int UseThing()
+                {
+                    var thing = new Thing();
+                    return thing.GetValue();
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "UseThing", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public struct Thing", result.Source);
+            Assert.Contains("public int GetValue()", result.Source);
+            Assert.DoesNotContain("virtual int GetValue", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericTypeTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -1126,6 +1126,7 @@ public static class CompileBackSourceComposer
         => IsPublicMethod(method)
             && (method.Attributes & MethodAttributes.Virtual) != 0
             && (method.Attributes & MethodAttributes.Abstract) == 0
+            && (method.Attributes & MethodAttributes.Final) == 0
             && (method.Attributes & MethodAttributes.NewSlot) != 0;
 
     static bool IsOverrideMethod(MethodDefinition method)

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -129,7 +129,8 @@ public sealed record CompileBackTypeDeclaration(
     IReadOnlyList<CompileBackMemberDeclaration> Members,
     IReadOnlyList<CompileBackFact> SourceFacts,
     IReadOnlyList<CompileBackTypeDeclaration> NestedTypes,
-    IReadOnlyList<string>? Attributes = null)
+    IReadOnlyList<string>? Attributes = null,
+    bool IsAbstract = false)
 {
     public string Namespace => Identity.Namespace;
     public string Name => Identity.DisplayName;
@@ -155,7 +156,11 @@ public sealed record CompileBackMemberDeclaration(
     string? TargetBody,
     IReadOnlyList<CompileBackFact> SourceFacts,
     IReadOnlyList<string>? Attributes = null,
-    IReadOnlyList<string>? ReturnAttributes = null)
+    IReadOnlyList<string>? ReturnAttributes = null,
+    bool IsAbstract = false,
+    bool IsVirtual = false,
+    bool IsOverride = false,
+    bool IsSealed = false)
 {
     public string Name => Identity.Method;
     public string Type => ReturnType?.DisplayName ?? "";
@@ -263,7 +268,11 @@ public sealed record CompileBackMemberRequirement(
     string? TargetBody,
     IReadOnlyList<CompileBackFact> SourceFacts,
     IReadOnlyList<string>? Attributes = null,
-    IReadOnlyList<string>? ReturnAttributes = null);
+    IReadOnlyList<string>? ReturnAttributes = null,
+    bool IsAbstract = false,
+    bool IsVirtual = false,
+    bool IsOverride = false,
+    bool IsSealed = false);
 
 public sealed record CompileBackPlanningDiagnostic(string Layer, string Reason, string Detail);
 
@@ -534,7 +543,11 @@ public static class CompileBackSourceComposer
                         targetBody,
                         [new CompileBackFact("metadata", isConstructor ? "target-constructor" : "target-method", reader.GetString(method.Name))],
                         isConstructor ? null : MemberAttributes(reader, method.GetCustomAttributes()),
-                        isConstructor ? null : MethodReturnAttributes(reader, method))
+                        isConstructor ? null : MethodReturnAttributes(reader, method),
+                        IsAbstract: !isConstructor && IsAbstractMethod(method),
+                        IsVirtual: !isConstructor && IsVirtualMethod(method),
+                        IsOverride: !isConstructor && IsOverrideMethod(method),
+                        IsSealed: !isConstructor && IsSealedMethod(method))
                 ],
                 primaryConstructor,
                 targetFacts)
@@ -819,7 +832,7 @@ public static class CompileBackSourceComposer
                 sb.AppendLine($"{pad}{declaration} {{ throw null; }}");
                 break;
             case CompileBackMemberKind.Method:
-                if (type.Kind == CompileBackTypeKind.Interface)
+                if (type.Kind == CompileBackTypeKind.Interface || member.IsAbstract || member.StubBody == CompileBackStubBodyKind.None)
                 {
                     sb.AppendLine($"{pad}{(declaration.EndsWith(';') ? declaration : declaration + ";")}");
                     break;
@@ -866,6 +879,7 @@ public static class CompileBackSourceComposer
                 .ToList(),
             Interfaces = type.Interfaces.Select(type => type.DisplayName).ToList(),
             Attributes = type.Attributes?.ToList() ?? [],
+            IsAbstract = type.IsAbstract,
         };
 
     static ApiMember ToApiMember(CompileBackTypeDeclaration type, CompileBackMemberDeclaration member)
@@ -898,6 +912,10 @@ public static class CompileBackSourceComposer
                 _ => null,
             },
             IsStatic = member.IsStatic,
+            IsAbstract = member.IsAbstract,
+            IsVirtual = member.IsVirtual,
+            IsOverride = member.IsOverride,
+            IsSealed = member.IsSealed,
             Accessibility = null,
             Attributes = member.Attributes?.ToList() ?? [],
         };
@@ -1099,6 +1117,28 @@ public static class CompileBackSourceComposer
 
         return [];
     }
+
+    static bool IsAbstractMethod(MethodDefinition method)
+        => IsPublicMethod(method)
+            && (method.Attributes & MethodAttributes.Abstract) != 0;
+
+    static bool IsVirtualMethod(MethodDefinition method)
+        => IsPublicMethod(method)
+            && (method.Attributes & MethodAttributes.Virtual) != 0
+            && (method.Attributes & MethodAttributes.Abstract) == 0
+            && (method.Attributes & MethodAttributes.NewSlot) != 0;
+
+    static bool IsOverrideMethod(MethodDefinition method)
+        => IsPublicMethod(method)
+            && (method.Attributes & MethodAttributes.Virtual) != 0
+            && (method.Attributes & MethodAttributes.NewSlot) == 0;
+
+    static bool IsSealedMethod(MethodDefinition method)
+        => IsOverrideMethod(method)
+            && (method.Attributes & MethodAttributes.Final) != 0;
+
+    static bool IsPublicMethod(MethodDefinition method)
+        => (method.Attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Public;
 
     static IReadOnlyList<string> MemberAttributes(MetadataReader reader, CustomAttributeHandleCollection attributes)
         => AttributeReader.RenderAttributes(
@@ -1874,7 +1914,11 @@ public static class CompileBackSourceComposer
                         member.TargetBody,
                         member.SourceFacts,
                         member.Attributes,
-                        member.ReturnAttributes));
+                        member.ReturnAttributes,
+                        member.IsAbstract,
+                        member.IsVirtual,
+                        member.IsOverride,
+                        member.IsSealed));
                 }
 
                 if (requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member"))
@@ -1895,7 +1939,8 @@ public static class CompileBackSourceComposer
                         typeDef,
                         includeMemberSurface: requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member"),
                         diagnostics),
-                    TypeAttributeList(reader, typeDef)));
+                    TypeAttributeList(reader, typeDef),
+                    IsAbstract: (typeDef.Attributes & TypeAttributes.Abstract) != 0 && (typeDef.Attributes & TypeAttributes.Interface) == 0));
             }
 
             return shells;
@@ -1941,7 +1986,8 @@ public static class CompileBackSourceComposer
                     members,
                     requirement.SourceFacts,
                     NestedTypes(reader, nestedDef, includeMemberSurface, diagnostics),
-                    TypeAttributeList(reader, nestedDef)));
+                    TypeAttributeList(reader, nestedDef),
+                    IsAbstract: (nestedDef.Attributes & TypeAttributes.Abstract) != 0 && (nestedDef.Attributes & TypeAttributes.Interface) == 0));
             }
 
             return nestedTypes;
@@ -2153,9 +2199,15 @@ public static class CompileBackSourceComposer
                     isConstructor ? null : CompileBackTypeSignature.Display(signature.ReturnType),
                     parameters,
                     TypeParameters: [],
-                    requirement.RequiredKind == CompileBackTypeKind.Interface ? CompileBackStubBodyKind.None : CompileBackStubBodyKind.Throw,
+                    requirement.RequiredKind == CompileBackTypeKind.Interface || IsAbstractMethod(method)
+                        ? CompileBackStubBodyKind.None
+                        : CompileBackStubBodyKind.Throw,
                     TargetBody: null,
-                    [new CompileBackFact("metadata", isConstructor ? "closure-constructor" : "closure-method", name)]));
+                    [new CompileBackFact("metadata", isConstructor ? "closure-constructor" : "closure-method", name)],
+                    IsAbstract: !isConstructor && IsAbstractMethod(method),
+                    IsVirtual: !isConstructor && IsVirtualMethod(method),
+                    IsOverride: !isConstructor && IsOverrideMethod(method),
+                    IsSealed: !isConstructor && IsSealedMethod(method)));
             }
 
             if (requirement.RequiredKind == CompileBackTypeKind.Class

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -546,8 +546,8 @@ public static class CompileBackSourceComposer
                         isConstructor ? null : MethodReturnAttributes(reader, method),
                         IsAbstract: !isConstructor && IsAbstractMethod(method),
                         IsVirtual: !isConstructor && IsVirtualMethod(method),
-                        IsOverride: !isConstructor && IsOverrideMethod(method),
-                        IsSealed: !isConstructor && IsSealedMethod(method))
+                        IsOverride: false,
+                        IsSealed: false)
                 ],
                 primaryConstructor,
                 targetFacts)
@@ -1128,15 +1128,6 @@ public static class CompileBackSourceComposer
             && (method.Attributes & MethodAttributes.Abstract) == 0
             && (method.Attributes & MethodAttributes.Final) == 0
             && (method.Attributes & MethodAttributes.NewSlot) != 0;
-
-    static bool IsOverrideMethod(MethodDefinition method)
-        => IsPublicMethod(method)
-            && (method.Attributes & MethodAttributes.Virtual) != 0
-            && (method.Attributes & MethodAttributes.NewSlot) == 0;
-
-    static bool IsSealedMethod(MethodDefinition method)
-        => IsOverrideMethod(method)
-            && (method.Attributes & MethodAttributes.Final) != 0;
 
     static bool IsPublicMethod(MethodDefinition method)
         => (method.Attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Public;
@@ -2207,8 +2198,8 @@ public static class CompileBackSourceComposer
                     [new CompileBackFact("metadata", isConstructor ? "closure-constructor" : "closure-method", name)],
                     IsAbstract: !isConstructor && IsAbstractMethod(method),
                     IsVirtual: !isConstructor && IsVirtualMethod(method),
-                    IsOverride: !isConstructor && IsOverrideMethod(method),
-                    IsSealed: !isConstructor && IsSealedMethod(method)));
+                    IsOverride: false,
+                    IsSealed: false));
             }
 
             if (requirement.RequiredKind == CompileBackTypeKind.Class


### PR DESCRIPTION
- Advances #2057
- Changes RTS compile-back shell fidelity for abstract closure types/methods, driven by the pinned `dotnet-inspect.any` source-aware probe.
- Evidence revision: `4aab6eaf`

## Change

**Conclusion:** **PASS** — the pinned package probe's `IrNode::CheckInvariant` OpcodeDiff is fixed by preserving abstract type/method metadata in compile-back closure shells.

Before:

```text
dotnet-inspect.any@0.16.0 --package-assembly ILInspector.Decompiler.dll
ILInspector.Decompiler.Pipeline.IrNode::CheckInvariant#0  rts=OpcodeDiff
```

After:

```text
RETURNTOSENDER SOURCE PROBE over 1 target(s)

  Passed : 1
  Failed : 0
  Skipped: 0
```

## Scope and safety

- **Root cause:** closure shells rendered abstract `IrNode` and abstract `Describe()` as concrete/non-virtual, so Roslyn emitted `call` for `this.Describe()` where the original pinned package IL used `callvirt`.
- **Fix shape:** preserve abstract type metadata and public abstract/virtual method metadata in compile-back shells; emit abstract/no-body methods with semicolons.
- **Safety constraints:** do not preserve `Final|Virtual|NewSlot` implicit interface implementations as `virtual`; do not emit `override`/`sealed override` when compile-back does not emit the user-defined base type.
- **Product impact:** compile-back source composition only.
- **RTS boundary:** RTS remains orchestration-only; product compile-back source composition owns shell generation.

## Before/after small corpus

Before run: `origin/main` plus the new abstract-closure regression test only.

```text
CompileBackTargets_PreservesAbstractClosureTypeAndMethod [FAIL]
Expected: Exact
Actual:   OpcodeDiff
```

After run: branch head.

```text
CompileBackTargets_PreservesAbstractClosureTypeAndMethod: pass
CompileBackTargets_DoesNotMarkFinalNewSlotStructMethodVirtual: pass
CompileBackTargets_DoesNotMarkUserBaseOverrideWithoutBaseShell: pass
```

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `ReturnToSenderPrototypeTests` 48/48 |
| Generated catalog tests | `GeneratedFixtureCatalogTests` 8/8 |
| Decompiler fast suite | Pass, 1817/1817 |
| Default RTS catalog | `39/39` fixtures, `116/116` targets |
| ReturnToSender A/B | `240` Same, `0` Worse, `0` CurrentMissing |
| Pinned package probe | `dotnet-inspect.any@0.16.0 --package-assembly ILInspector.Decompiler.dll` `1/1` passed |

## Compile-back quality

**Conclusion:** **PASS** — this removes a real pinned-package OpcodeDiff without regressing the broader RTS property-getter A/B population.

### ReturnToSender source probe

```text
Using cached package: /home/rich/.cache/dotnet-inspect/packages/dotnet-inspect.any/0.16.0
Package input: dotnet-inspect.any@0.16.0 (net10.0) -> .../ILInspector.Decompiler.dll
RETURNTOSENDER SOURCE PROBE over 1 target(s)

  Passed : 1
  Failed : 0
  Skipped: 0
```

### ReturnToSender A/B

```text
RETURNTOSENDER A/B over 240 property getters

  Rescued       : 0
  Same          : 240
  Changed       : 0
  Worse         : 0
  CurrentMissing: 0
```

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| User-base `override` shell fidelity | Left as plain method | Compile-back currently does not emit user-defined base types; preserving `override` caused CS0115. Guarded by canary. |
| `Final|Virtual|NewSlot` methods | Left non-virtual | These represent implicit interface implementations; rendering `virtual` is invalid for structs and metadata-wrong for the source shape. |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini 3.1 Pro | Findings resolved | Found final-newslot implicit interface implementation issue; fixed in `37fd96e5`. True-final review on `96d1870c` found no significant issues. |
| Claude Opus 4.8 | Findings resolved | Found user-base override regression; fixed in `96d1870c`. True-final review found no significant issues. |

**Review conclusion:** **PASS** — actionable findings were resolved in `37fd96e5` and `96d1870c`; final isolated Gemini and Claude reviews found no significant issues.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --return-to-sender-catalog --max-examples 50
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --package dotnet-inspect.any --package-version 0.16.0 --package-assembly ILInspector.Decompiler.dll --return-to-sender-source-probe --cap 25 --max-examples 10
```
