### PR TITLE
Move library version display logic out of view

### DIFF
--- a/src/dotnet-inspect.Tests/VersionDisplayTests.cs
+++ b/src/dotnet-inspect.Tests/VersionDisplayTests.cs
@@ -54,6 +54,7 @@ public class VersionDisplayTests
             PlatformVersion = "10.0.1"
         };
 
+        Assert.Equal("10.0.1", LibraryInspectionDisplay.ResolveVersion(inspection));
         Assert.Equal("10.0.1", ExtractVersionField(SerializeCompact(inspection)));
     }
 
@@ -72,6 +73,7 @@ public class VersionDisplayTests
             }
         };
 
+        Assert.Equal("13.0.4", LibraryInspectionDisplay.ResolveVersion(inspection));
         Assert.Equal("13.0.4", ExtractVersionField(SerializeCompact(inspection)));
     }
 
@@ -89,6 +91,7 @@ public class VersionDisplayTests
             }
         };
 
+        Assert.Equal("9.0.0-preview.1", LibraryInspectionDisplay.ResolveVersion(inspection));
         Assert.Equal("9.0.0-preview.1", ExtractVersionField(SerializeCompact(inspection)));
     }
 
@@ -106,6 +109,7 @@ public class VersionDisplayTests
             }
         };
 
+        Assert.Equal("2.1.0.0", LibraryInspectionDisplay.ResolveVersion(inspection));
         Assert.Equal("2.1.0.0", ExtractVersionField(SerializeCompact(inspection)));
     }
 
@@ -122,7 +126,28 @@ public class VersionDisplayTests
             }
         };
 
+        Assert.Equal("1.2.3.0", LibraryInspectionDisplay.ResolveVersion(inspection));
         Assert.Equal("1.2.3.0", ExtractVersionField(SerializeCompact(inspection)));
+    }
+
+    [Fact]
+    public void ResolveVersion_NonVersionInformational_FallsBackToAssemblyVersion()
+    {
+        var inspection = new LibraryInspection
+        {
+            FileName = "Test.dll",
+            FileType = "dll",
+            FileSize = 1024,
+            AssemblyInfo = new AssemblyInfo
+            {
+                AssemblyVersion = "3.0.0.0",
+                InformationalVersion = "not-a-version+abc",
+                FileVersion = "3.1.0.0"
+            }
+        };
+
+        Assert.Equal("3.0.0.0", LibraryInspectionDisplay.ResolveVersion(inspection));
+        Assert.Equal("3.0.0.0", ExtractVersionField(SerializeCompact(inspection)));
     }
 
     // --- Platform integration tests ---

--- a/src/dotnet-inspect/Models/LibraryInspection.cs
+++ b/src/dotnet-inspect/Models/LibraryInspection.cs
@@ -4,6 +4,42 @@ using ILInspector.Metadata;
 
 namespace DotnetInspector.Models;
 
+internal static class LibraryInspectionDisplay
+{
+    /// <summary>
+    /// Resolves the compact display version using priority:
+    /// PlatformVersion, InformationalVersion prefix, AssemblyVersion, FileVersion.
+    /// </summary>
+    public static string ResolveVersion(LibraryInspection inspection)
+    {
+        if (!string.IsNullOrEmpty(inspection.PlatformVersion))
+            return inspection.PlatformVersion;
+
+        if (inspection.AssemblyInfo is { } info)
+        {
+            if (!string.IsNullOrEmpty(info.InformationalVersion))
+            {
+                var ver = info.InformationalVersion;
+                var plusIndex = ver.IndexOf('+');
+                if (plusIndex > 0)
+                    ver = ver[..plusIndex];
+                var dashIndex = ver.IndexOf('-');
+                var versionPart = dashIndex > 0 ? ver[..dashIndex] : ver;
+                if (versionPart.Split('.').All(p => int.TryParse(p, out _)))
+                    return dashIndex > 0 ? ver : versionPart;
+            }
+
+            if (!string.IsNullOrEmpty(info.AssemblyVersion))
+                return info.AssemblyVersion;
+
+            if (!string.IsNullOrEmpty(info.FileVersion))
+                return info.FileVersion;
+        }
+
+        return "";
+    }
+}
+
 public class LibraryInspection
 {
     [JsonIgnore]

--- a/src/dotnet-inspect/Views/LibraryInspectionView.cs
+++ b/src/dotnet-inspect/Views/LibraryInspectionView.cs
@@ -30,7 +30,7 @@ public class LibraryInspectionView
     public string? Name => _topFieldsOnly ? _data.AssemblyInfo?.AssemblyName : null;
 
     [MarkoutSkipNull]
-    public string? Version => _topFieldsOnly ? ResolveVersion() : null;
+    public string? Version => _topFieldsOnly ? LibraryInspectionDisplay.ResolveVersion(_data) : null;
 
     [MarkoutPropertyName("TFM")]
     [MarkoutSkipNull]
@@ -160,7 +160,7 @@ public class LibraryInspectionView
         TypeForwarders = CountOrZero(_data.TypeForwarders),
         Types = info.TypeDefinitionCount > 0 ? info.TypeDefinitionCount.ToString("N0") : null,
         UnionTypes = CountOrZero(_data.UnionTypes),
-        Version = ResolveVersion(),
+        Version = LibraryInspectionDisplay.ResolveVersion(_data),
     };
 
     [MarkoutSection(Name = "References")]
@@ -770,38 +770,6 @@ public class LibraryInspectionView
     public static bool TopLeverageGeneratedEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Generated));
     public static bool TopLeverageStableEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Stable));
     public static bool TopLeverageSelectorEmpty(List<TopLeverageRow>? rows) => rows is null || rows.All(r => string.IsNullOrEmpty(r.Selector));
-
-    /// <summary>
-    /// Resolves the display version using priority: PlatformVersion, InformationalVersion (prefix), AssemblyVersion, FileVersion.
-    /// </summary>
-    private string ResolveVersion()
-    {
-        if (!string.IsNullOrEmpty(_data.PlatformVersion))
-            return _data.PlatformVersion;
-
-        if (_data.AssemblyInfo is { } info)
-        {
-            if (!string.IsNullOrEmpty(info.InformationalVersion))
-            {
-                var ver = info.InformationalVersion;
-                var plusIndex = ver.IndexOf('+');
-                if (plusIndex > 0)
-                    ver = ver[..plusIndex];
-                var dashIndex = ver.IndexOf('-');
-                var versionPart = dashIndex > 0 ? ver[..dashIndex] : ver;
-                if (versionPart.Split('.').All(p => int.TryParse(p, out _)))
-                    return dashIndex > 0 ? ver : versionPart;
-            }
-
-            if (!string.IsNullOrEmpty(info.AssemblyVersion))
-                return info.AssemblyVersion;
-
-            if (!string.IsNullOrEmpty(info.FileVersion))
-                return info.FileVersion;
-        }
-
-        return "";
-    }
 
     private static int CountOrZero<T>(List<T>? values) => values?.Count ?? 0;
 


### PR DESCRIPTION
## Summary

- Adds `LibraryInspectionDisplay.ResolveVersion(...)` as a model-side helper for compact/detailed library display version selection.
- Routes `LibraryInspectionView` through the helper instead of owning version normalization/prefix stripping.
- Adds direct helper assertions while preserving compact and detailed view output coverage.

Refs #2122.

## Validation

- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:RestoreConfigFile=nuget.config -- -class "*VersionDisplayTests*"`
- `dotnet build src/dotnet-inspect -c Release --configfile nuget.config`

## Review

Adversarial review required because this moves display-version selection behavior out of the view. Results will be posted as a PR comment.