### PR TITLE
Slot-store reconciliation + surrogate-literal escaping (value-typed emission, slice 5a)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
@@ -377,6 +377,24 @@ public class TypedConstantsPassTests
     }
 
     [Fact]
+    public void LoneSurrogateCharConstant_RendersAsUnicodeEscape()
+    {
+        // A lone surrogate emitted raw cannot survive a UTF-8 encode (writers
+        // substitute U+FFFD, corrupting the literal — char.IsHighSurrogate's
+        // own bounds rendered as replacement characters). It must escape.
+        var charType = TypeRef.CoreLib("System", "Char");
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Return(new Constant('\ud800', charType)));
+        container.Add(block);
+        var function = EnumFunction(container, charType);
+
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.Contains("'\\ud800'", output);
+        Assert.DoesNotContain('\ud800'.ToString(), output);
+    }
+
+    [Fact]
     public void ConstantOnlyBoolSpill_RendersAsBool()
     {
         var boolType = TypeRef.CoreLib("System", "Boolean");

--- a/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
@@ -272,10 +272,95 @@ public class TypedConstantsPassTests
     }
 
     [Fact]
+    public void UntypedLoadWithConflictingSink_VetoesReconciliation()
+    {
+        // Slice-5a second round (GPT-5.5): an untyped load is not silence — it
+        // testifies through its consuming sink. Here the untyped load feeds an
+        // int local while the typed load says enum: reconciliation must veto,
+        // or slot reuse smuggles the enum type onto the int range's store.
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(3, new Constant(0, Int32Type)));
+        block.Add(new StoreLocal(0, Int32Type, new LoadStackSlot(3, null)));
+        block.Add(new Return(new LoadStackSlot(3, LongEnum)));
+        container.Add(block);
+        var function = EnumFunction(container, LongEnum);
+
+        new TypedConstantsPass().Run(function, PassContext.None);
+
+        var constant = Assert.IsType<Constant>(
+            Assert.Single(function.Descendants.OfType<StoreStackSlot>()).Value);
+        Assert.Equal(Int32Type, constant.Type);
+    }
+
+    [Fact]
+    public void NestedLambdaSlots_ReconcilePerScope()
+    {
+        // Slice-5a second round (GPT-5.5): slot ids are per-body. The outer
+        // scope's slot 3 (int) and the lambda's slot 3 (enum) are different
+        // variables; each reconciles in its own scope only.
+        var lambdaBody = new BlockContainer();
+        var lambdaBlock = new Block(0);
+        lambdaBlock.Add(new StoreStackSlot(3, new Constant(2, Int32Type)));
+        lambdaBlock.Add(new StoreLocal(0, LongEnum, new LoadStackSlot(3, LongEnum)));
+        lambdaBody.Add(lambdaBlock);
+        var lambda = new Lambda(
+            TypeRef.Definition("System.Private.CoreLib", "System", "Action"),
+            [], [], [], usesUpdatedMemorySafetyRules: false, skipLocalsInit: false,
+            lambdaBody);
+
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(3, new Constant(0, Int32Type)));
+        block.Add(new StoreLocal(1, Int32Type, new LoadStackSlot(3, Int32Type)));
+        block.Add(new StoreLocal(2, TypeRef.Definition("System.Private.CoreLib", "System", "Action"), lambda));
+        container.Add(block);
+        var function = EnumFunction(container, Int32Type);
+
+        new TypedConstantsPass().Run(function, PassContext.None);
+
+        var stores = function.Descendants.OfType<StoreStackSlot>().ToList();
+        var outer = Assert.IsType<Constant>(stores.Single(s => ((Constant)s.Value).Value is 0).Value);
+        Assert.Equal(Int32Type, outer.Type);
+        var nested = Assert.IsType<Constant>(stores.Single(s => ((Constant)s.Value).Value is not 0).Value);
+        Assert.Equal(LongEnum, nested.Type);
+    }
+
+    [Fact]
+    public void LambdaReturn_IsNotRetypedToOuterSignature()
+    {
+        // The pass's own latent CoercionSinks-class bug, fixed by the scope
+        // walk: a constant returned from a lambda body must not be retyped
+        // against the OUTER method's return type.
+        var lambdaBody = new BlockContainer();
+        var lambdaBlock = new Block(0);
+        lambdaBlock.Add(new Return(new Constant(1, Int32Type)));
+        lambdaBody.Add(lambdaBlock);
+        var lambda = new Lambda(
+            TypeRef.Definition("System.Private.CoreLib", "System", "Func`1"),
+            [], [], [], usesUpdatedMemorySafetyRules: false, skipLocalsInit: false,
+            lambdaBody);
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreLocal(0, TypeRef.Definition("System.Private.CoreLib", "System", "Func`1"), lambda));
+        block.Add(new Return(new Constant(2, Int32Type)));
+        container.Add(block);
+        var function = EnumFunction(container, LongEnum);
+
+        new TypedConstantsPass().Run(function, PassContext.None);
+
+        var lambdaReturn = Assert.IsType<Constant>(
+            function.Descendants.OfType<Lambda>().Single()
+                .Descendants.OfType<Return>().Single().Value);
+        Assert.Equal(Int32Type, lambdaReturn.Type);
+    }
+
+    [Fact]
     public void UntypedLoads_DoNotVetoReconciliation()
     {
-        // An untyped load is silence, not disagreement: the slot still
-        // reconciles to the one typed load's type (review verify item).
+        // An untyped load testifies through its consuming sink; when that sink
+        // AGREES with the typed evidence, the slot still reconciles (the
+        // sink-evidence rule from the slice-5a second round).
         var container = new BlockContainer();
         var block = new Block(0);
         block.Add(new StoreStackSlot(3, new Constant(2, Int32Type)));

--- a/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypedConstantsPassTests.cs
@@ -209,6 +209,88 @@ public class TypedConstantsPassTests
         Assert.Equal(LongEnum, constant.Type);
     }
 
+    // --- Slice 5a: slot-store reconciliation against the slot's unique load
+    // type (the phantom-split fix: `E S_3; int S_3_1;` where `S_3_1 = 0` was
+    // written but the load read `S_3`). ---
+
+    static BlockContainer SlotDiamond(IrExpression storeA, IrExpression storeB, TypeRef? loadType, TypeRef returnType)
+    {
+        // Two stores to slot 3 (the diamond arms) and one load (the join read),
+        // flattened — the pass only needs the access population, not the CFG.
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(3, storeA));
+        block.Add(new StoreStackSlot(3, storeB));
+        block.Add(new Return(new LoadStackSlot(3, loadType)));
+        container.Add(block);
+        return container;
+    }
+
+    [Fact]
+    public void SlotConstantStore_ReconcilesToUniqueLoadType_AndCollapsesNaming()
+    {
+        // The enum-diamond slot: one arm stores the enum, the other `0`; the
+        // load carries the joined enum type. The constant store retypes, and
+        // the printer's type-keyed naming collapses to ONE declaration whose
+        // constant arm renders by member name — no phantom `int S_3_1`.
+        var body = SlotDiamond(
+            new LoadArgument(0, "e", LongEnum),
+            new Constant(0, Int32Type),
+            LongEnum,
+            LongEnum);
+        var function = EnumFunction(body, LongEnum, new Parameter("e", LongEnum));
+
+        new TypedConstantsPass().Run(function, PassContext.None);
+
+        var constant = Assert.IsType<Constant>(
+            function.Descendants.OfType<StoreStackSlot>().Last().Value);
+        Assert.Equal(LongEnum, constant.Type);
+
+        string output = CSharpPrinter.Print(function).Output!;
+        Assert.DoesNotContain("S_3_1", output);
+        Assert.DoesNotContain("int S_3", output);
+    }
+
+    [Fact]
+    public void SlotWithDisagreeingLoadTypes_IsNotReconciled()
+    {
+        // Ambiguity is not an invitation to guess: two typed loads that
+        // disagree veto reconciliation and the constant keeps its type.
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(3, new Constant(0, Int32Type)));
+        block.Add(new StoreLocal(0, LongEnum, new LoadStackSlot(3, LongEnum)));
+        block.Add(new Return(new LoadStackSlot(3, Int32Type)));
+        container.Add(block);
+        var function = EnumFunction(container, Int32Type);
+
+        new TypedConstantsPass().Run(function, PassContext.None);
+
+        var constant = Assert.IsType<Constant>(
+            Assert.Single(function.Descendants.OfType<StoreStackSlot>()).Value);
+        Assert.Equal(Int32Type, constant.Type);
+    }
+
+    [Fact]
+    public void UntypedLoads_DoNotVetoReconciliation()
+    {
+        // An untyped load is silence, not disagreement: the slot still
+        // reconciles to the one typed load's type (review verify item).
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new StoreStackSlot(3, new Constant(2, Int32Type)));
+        block.Add(new StoreLocal(0, LongEnum, new LoadStackSlot(3, null)));
+        block.Add(new Return(new LoadStackSlot(3, LongEnum)));
+        container.Add(block);
+        var function = EnumFunction(container, LongEnum);
+
+        new TypedConstantsPass().Run(function, PassContext.None);
+
+        var constant = Assert.IsType<Constant>(
+            Assert.Single(function.Descendants.OfType<StoreStackSlot>()).Value);
+        Assert.Equal(LongEnum, constant.Type);
+    }
+
     [Fact]
     public void ConstantOnlyBoolSpill_RendersAsBool()
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3251,6 +3251,11 @@ public sealed partial class CSharpPrinter
         '\u2028' => "\\u2028",
         '\u2029' => "\\u2029",
         _ when char.IsControl(c) => $"\\u{(int)c:x4}",
+        // A lone surrogate code unit has no valid UTF-8/UTF-16 text form: emitted
+        // raw it cannot survive an encode (writers substitute U+FFFD, corrupting
+        // the literal \u2014 char.IsHighSurrogate's own bounds rendered as two
+        // replacement characters). Always the \u escape.
+        _ when char.IsSurrogate(c) => $"\\u{(int)c:x4}",
         _ => c.ToString(),
     };
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -11,16 +11,36 @@ public sealed class TypedConstantsPass : IIrPass
     public string Name => "typed-constants";
 
     public void Run(IrFunction function, PassContext context)
+        => RunScope(function.Body, function.Signature.ReturnType, function, context.Stepper);
+
+    /// <summary>
+    /// One body scope at a time: nested <see cref="Lambda"/> and
+    /// <see cref="LocalFunctionStatement"/> bodies carry their own return types
+    /// and their own slot numbering, so both the return target and the slot
+    /// reconciliation maps are per-scope — a parent's slot 3 and a lambda's
+    /// slot 3 are different variables (slice-5a review), and a lambda's return
+    /// is not the outer method's (the CoercionSinks lesson, which this pass had
+    /// latently too).
+    /// </summary>
+    void RunScope(IrNode scope, TypeRef? returnType, IrFunction function, Stepper stepper)
     {
         var shapes = function.TypeShapes;
-        var stepper = context.Stepper;
-        var slotTypes = UniqueSlotLoadTypes(function);
-        foreach (var node in function.Descendants.ToList())
+        var slotTypes = UniqueSlotLoadTypes(scope, returnType);
+        foreach (var node in ScopeNodes(scope).ToList())
         {
             switch (node)
             {
-                case Return { Value: { } value }:
-                    Retype(value, function.Signature.ReturnType, shapes, stepper);
+                case Lambda lambda:
+                    RunScope(lambda, returnType: null, function, stepper);
+                    continue;
+                case LocalFunctionStatement local:
+                    RunScope(local, local.ReturnType, function, stepper);
+                    continue;
+            }
+            switch (node)
+            {
+                case Return { Value: { } value } when returnType is { } scopeReturn:
+                    Retype(value, scopeReturn, shapes, stepper);
                     break;
                 // A synthetic slot whose loads all agree on one type — the join
                 // type the importer recovered (an enum diamond's entry state) —
@@ -114,22 +134,48 @@ public sealed class TypedConstantsPass : IIrPass
         }
     }
 
+    /// <summary>Scope-bounded descendants: yields every node in this body but does not cross into nested lambda / local-function bodies (their scopes recurse separately).</summary>
+    static IEnumerable<IrNode> ScopeNodes(IrNode scope)
+    {
+        foreach (var child in scope.Children)
+        {
+            yield return child;
+            if (child is not (Lambda or LocalFunctionStatement))
+            {
+                foreach (var nested in ScopeNodes(child))
+                    yield return nested;
+            }
+        }
+    }
+
     /// <summary>
-    /// Per slot, the single type every typed load of that slot agrees on — the
-    /// importer's recovered join type. Null (absent) when loads disagree or
-    /// none carries a type; ambiguity is not an invitation to guess.
+    /// Per slot, the single type every load of that slot agrees on — the
+    /// importer's recovered join type. Every load must testify: a typed load
+    /// contributes its type, an untyped load contributes its consuming sink's
+    /// target type, and an untyped load with no derivable sink vetoes the slot
+    /// (slice-5a review: an untyped load feeding an int sink must not be
+    /// silenced while the typed evidence says enum — slot reuse would smuggle
+    /// one range's type onto another's store). Disagreement vetoes; ambiguity
+    /// is not an invitation to guess.
     /// </summary>
-    static Dictionary<int, TypeRef> UniqueSlotLoadTypes(IrFunction function)
+    static Dictionary<int, TypeRef> UniqueSlotLoadTypes(IrNode scope, TypeRef? returnType)
     {
         var types = new Dictionary<int, TypeRef>();
         var ambiguous = new HashSet<int>();
-        foreach (var load in function.Descendants.OfType<LoadStackSlot>())
+        foreach (var load in ScopeNodes(scope).OfType<LoadStackSlot>())
         {
-            if (load.Type is not { } type || ambiguous.Contains(load.Slot))
+            if (ambiguous.Contains(load.Slot))
                 continue;
+            var evidence = load.Type ?? LoadSinkTargetType(load, returnType);
+            if (evidence is null)
+            {
+                types.Remove(load.Slot);
+                ambiguous.Add(load.Slot);
+                continue;
+            }
             if (types.TryGetValue(load.Slot, out var existing))
             {
-                if (!existing.Equals(type))
+                if (!existing.Equals(evidence))
                 {
                     types.Remove(load.Slot);
                     ambiguous.Add(load.Slot);
@@ -137,11 +183,23 @@ public sealed class TypedConstantsPass : IIrPass
             }
             else
             {
-                types[load.Slot] = type;
+                types[load.Slot] = evidence;
             }
         }
         return types;
     }
+
+    /// <summary>The target type of the sink directly consuming an untyped slot load, where one is derivable — the same sink-target vocabulary the printer's StackSlotLoadTargetType uses.</summary>
+    static TypeRef? LoadSinkTargetType(LoadStackSlot load, TypeRef? returnType)
+        => load.Parent switch
+        {
+            StoreLocal store when ReferenceEquals(store.Value, load) => store.Type,
+            StoreArgument store when ReferenceEquals(store.Value, load) => store.Type,
+            StoreField store when ReferenceEquals(store.Value, load) => store.Field.Type,
+            StoreIndirect store when ReferenceEquals(store.Value, load) => store.Type,
+            Return ret when ReferenceEquals(ret.Value, load) => returnType,
+            _ => null,
+        };
 
     static TypeRef? ElementTargetType(StoreElement store)
         => store.Array.ResultType is { Kind: TypeRefKind.SzArray or TypeRefKind.Array, ElementType: { } element }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/TypedConstantsPass.cs
@@ -14,12 +14,24 @@ public sealed class TypedConstantsPass : IIrPass
     {
         var shapes = function.TypeShapes;
         var stepper = context.Stepper;
+        var slotTypes = UniqueSlotLoadTypes(function);
         foreach (var node in function.Descendants.ToList())
         {
             switch (node)
             {
                 case Return { Value: { } value }:
                     Retype(value, function.Signature.ReturnType, shapes, stepper);
+                    break;
+                // A synthetic slot whose loads all agree on one type — the join
+                // type the importer recovered (an enum diamond's entry state) —
+                // types its stores too: the `0` arm of `c ? E.A : 0` stored to
+                // the slot is that enum's constant. Reconciling the store here
+                // collapses the printer's type-keyed naming to one variable per
+                // slot, instead of a phantom pair (`E S_3; int S_3_1;`) whose
+                // load reads the range the store never wrote (slice 5a).
+                case StoreStackSlot { Value: { } slotValue } slotStore
+                    when slotTypes.GetValueOrDefault(slotStore.Slot) is { } slotType:
+                    Retype(slotValue, slotType, shapes, stepper);
                     break;
                 case StoreLocal { Value: { } value } store:
                     Retype(value, store.Type, shapes, stepper);
@@ -100,6 +112,35 @@ public sealed class TypedConstantsPass : IIrPass
                 // them) and the printer spells labels through EnumConstantText.
             }
         }
+    }
+
+    /// <summary>
+    /// Per slot, the single type every typed load of that slot agrees on — the
+    /// importer's recovered join type. Null (absent) when loads disagree or
+    /// none carries a type; ambiguity is not an invitation to guess.
+    /// </summary>
+    static Dictionary<int, TypeRef> UniqueSlotLoadTypes(IrFunction function)
+    {
+        var types = new Dictionary<int, TypeRef>();
+        var ambiguous = new HashSet<int>();
+        foreach (var load in function.Descendants.OfType<LoadStackSlot>())
+        {
+            if (load.Type is not { } type || ambiguous.Contains(load.Slot))
+                continue;
+            if (types.TryGetValue(load.Slot, out var existing))
+            {
+                if (!existing.Equals(type))
+                {
+                    types.Remove(load.Slot);
+                    ambiguous.Add(load.Slot);
+                }
+            }
+            else
+            {
+                types[load.Slot] = type;
+            }
+        }
+        return types;
     }
 
     static TypeRef? ElementTargetType(StoreElement store)


### PR DESCRIPTION
## Change

**Slice 5a — the first instance-2 increment** ([value-typed-emission.md](docs/design/value-typed-emission.md)): a synthetic stack slot whose loads all agree on one type — the join type slice 4's importer work recovers — now types its **stores** too. `TypedConstantsPass` gains a `StoreStackSlot` case reusing the audited `Retype` machinery. Effect: the printer's type-keyed naming collapses to one variable per reconciled slot, killing the phantom-split shape (`TipLevel S_3; int S_3_1;` where `S_3_1 = 0` was written but the load read `S_3`) flagged in the slice-3 review.

Hardened across two adversarial rounds:
- **Per-body scopes** — slot ids and return types are per body; nested `Lambda`/`LocalFunctionStatement` bodies reconcile in their own scope. This also fixed the pass's own latent bug: lambda returns were retyped against the outer signature (the `CoercionSinks` lesson, present here all along).
- **All loads testify** — typed loads contribute their type, untyped loads contribute their consuming sink's target, an underivable load vetoes the slot. The slot-reuse smuggling hazard (an untyped load feeding an int sink silenced while typed evidence said enum) is structurally closed.

**Drive-by validity fix:** `EscapeChar` gains the lone-surrogate case — the printer emitted raw lone-surrogate char/string literals (`char.IsHighSurrogate`'s own bounds), output that cannot survive a UTF-8 encode (writers substitute U+FFFD). Found by byte-level audit of a #2157 render-A/B false positive.

## Evidence

| Check | Result |
| --- | --- |
| Full suite | **1897/1897** at head |
| Render A/B (134,890 methods, harness `--render-ab` vs explicit merge-base dump) | **33 changed methods, all in the two intended classes** (enum-slot reconciliations incl. the `UnixFileMode` phantom-split repair; surrogate escapes); diff-body fingerprint: `\ud800`-family escapes + `(uint)` casts only |
| Real-world card (compile-back + fidelity oracles) | Fully raised **+6**; opcode-diffs **5 → 2 (improved)**; 0 recompile failures; "regressions" verdict = sampling-cap artifact (PR caps vs daily baseline caps) |
| Split-name census | 271 → 257 methods (the remaining 257 are the true live-range population — 5b's opening census) |
| Tests | +8 (reconciliation collapse, ambiguity veto, conflicting-sink veto, per-scope isolation, lambda-return non-retype, agreeing-sink, surrogate escape) |

First slice measured on #2157's parallel harness: evidence stages ~100 min → ~4.5 min ([field report](https://github.com/richlander/dotnet-inspect/issues/2155#issuecomment-4873024737)).

## Decompiler quality

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity sampled 350 / 89,065 (0.39%); fidelity sampled 24 / 89,065 (0.03%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,405 (88.03%) | +6 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — sampled 25,179 / 89,065 (28.27%) | 0/350 — sampled 350 / 89,065 (0.39%) | -74 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 2/24, exact 22, recompile-failed 0, context-failed 0; sampled 24 / 89,065 (0.03%) | -3 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.03% (+0.01 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 2 (-3).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25179, current 350)
- fidelity checked methods lower than baseline (baseline 36, current 24)

## Adversarial review

Two rounds (Opus 4.8 + GPT-5.5, gists in thread); reconciliation comment follows. Round-1 gates (unit test, fidelity card) and round-2 findings (scope-blindness ×2) all resolved with resolution commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)