### PR TITLE
Emit equality operator pair shells for RTS

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1783,8 +1783,39 @@ public class ReturnToSenderPrototypeTests
                 assemblyPath,
                 [new ReturnToSender.RequestedTarget("Row`1", "op_Equality", 0)]));
 
-            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             Assert.Contains("return (object)left == (object)right;", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_PreservesInParameterEqualityOperatorReferenceComparison()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Row
+            {
+                public static bool operator ==(in Row left, in Row right) => (object)left == (object)right;
+                public static bool operator !=(in Row left, in Row right) => (object)left != (object)right;
+                public override bool Equals(object obj) => obj is Row;
+                public override int GetHashCode() => 0;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Row", "op_Equality", 0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("return (object)(left) == (object)(right);", result.Source);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1824,6 +1824,42 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_PreservesSpilledLocalEqualityOperatorReferenceComparison()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Row
+            {
+                public static bool operator ==(Row left, Row right)
+                {
+                    Row V_0 = right;
+                    Row S_256 = left;
+                    System.Console.WriteLine(S_256 is null);
+                    return (object)S_256 == (object)V_0;
+                }
+
+                public static bool operator !=(Row left, Row right) => (object)left != (object)right;
+                public override bool Equals(object obj) => obj is Row;
+                public override int GetHashCode() => 0;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Row", "op_Equality", 0)]));
+
+            Assert.True(
+                result.Status == FidelityCheck.CompileBackStatus.Exact,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains("return (object)S_256 == (object)V_0;", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericTypeTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1766,6 +1766,33 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_PreservesGenericEqualityOperatorReferenceComparison()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Row<T>
+            {
+                public static bool operator ==(Row<T> left, Row<T> right) => (object)left == (object)right;
+                public static bool operator !=(Row<T> left, Row<T> right) => (object)left != (object)right;
+                public override bool Equals(object obj) => obj is Row<T>;
+                public override int GetHashCode() => 0;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Row`1", "op_Equality", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("return (object)left == (object)right;", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericTypeTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1706,6 +1706,66 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_EmitsSignatureMatchedEqualityOperatorPairSibling()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Row
+            {
+                public static bool operator ==(Row left, Row right) => true;
+                public static bool operator !=(Row left, Row right) => false;
+                public static bool operator ==(Row left, string right) => right == "x";
+                public static bool operator !=(Row left, string right) => !(left == right);
+                public override bool Equals(object obj) => obj is Row;
+                public override int GetHashCode() => 0;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Row", "op_Equality", 1)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("operator ==(Row left, string right)", result.Source);
+            Assert.Contains("operator !=(Row left, string right)", result.Source);
+            Assert.DoesNotContain("operator !=(Row left, Row right)", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_EmitsNoBodyEqualityOperatorPairSibling()
+    {
+        var assemblyPath = CompileFixture("""
+            public sealed class Row
+            {
+                public static bool operator ==(Row left, Row right) => true;
+                [System.Runtime.InteropServices.DllImport("native")]
+                public static extern bool operator !=(Row left, Row right);
+                public override bool Equals(object obj) => obj is Row;
+                public override int GetHashCode() => 0;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Row", "op_Equality", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("operator ==(Row left, Row right)", result.Source);
+            Assert.Contains("operator !=(Row left, Row right)", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericTypeTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1670,6 +1670,42 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_EmitsEqualityOperatorPairSibling()
+    {
+        var assemblyPath = CompileFixture("""
+            public record Row(string Name);
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Row", "op_Equality", 0),
+                    new ReturnToSender.RequestedTarget("Row", "op_Inequality", 0),
+                ]);
+
+            Assert.Collection(
+                results,
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("operator ==(", result.Source);
+                    Assert.Contains("operator !=(", result.Source);
+                },
+                result =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+                    Assert.Contains("operator ==(", result.Source);
+                    Assert.Contains("operator !=(", result.Source);
+                });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsGenericTypeTargets()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -545,7 +545,7 @@ public static class CompileBackSourceComposer
                 IsSealed: false)
         ];
         if (!isConstructor
-            && EqualityOperatorSibling(reader, targetTypeDef, targetIdentity, methodName) is { } equalitySibling)
+            && EqualityOperatorSibling(reader, targetTypeDef, targetIdentity, methodName, signature) is { } equalitySibling)
         {
             targetMembers.Add(equalitySibling);
         }
@@ -1129,7 +1129,8 @@ public static class CompileBackSourceComposer
         MetadataReader reader,
         TypeDefinition typeDef,
         CompileBackTypeIdentity typeIdentity,
-        string methodName)
+        string methodName,
+        MethodSignature<string> targetSignature)
     {
         var siblingName = methodName switch
         {
@@ -1143,13 +1144,15 @@ public static class CompileBackSourceComposer
         foreach (var methodHandle in typeDef.GetMethods())
         {
             var method = reader.GetMethodDefinition(methodHandle);
-            if (reader.GetString(method.Name) != siblingName
-                || method.RelativeVirtualAddress == 0)
+            if (reader.GetString(method.Name) != siblingName)
             {
                 continue;
             }
 
             var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+            if (!OperatorSignaturesMatch(targetSignature, signature))
+                continue;
+
             return new CompileBackMemberRequirement(
                 new CompileBackMethodIdentity(typeIdentity.FullName, siblingName, 0, MethodSignatureText(siblingName, signature)),
                 CompileBackMemberKind.Method,
@@ -1170,6 +1173,10 @@ public static class CompileBackSourceComposer
 
         return null;
     }
+
+    static bool OperatorSignaturesMatch(MethodSignature<string> left, MethodSignature<string> right)
+        => left.ReturnType == right.ReturnType
+            && left.ParameterTypes.SequenceEqual(right.ParameterTypes, StringComparer.Ordinal);
 
     static string MethodSignatureText(string name, MethodSignature<string> signature)
         => $"{signature.ReturnType} {name}({string.Join(", ", signature.ParameterTypes)})";

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -525,30 +525,37 @@ public static class CompileBackSourceComposer
         if (closureFacts.TryGetValue(targetRoot, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
 
+        var targetMembers = primaryConstructor?.FieldInitializers.ToList() ??
+        [
+            new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(targetIdentity.FullName, targetMethodName, overload, signatureText),
+                isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method,
+                method.Attributes.HasFlag(MethodAttributes.Static),
+                MethodParameters(reader, method, signature),
+                isConstructor ? null : CompileBackTypeSignature.Display(signature.ReturnType),
+                MethodTypeParameters(reader, method),
+                CompileBackStubBodyKind.TargetBody,
+                targetBody,
+                [new CompileBackFact("metadata", isConstructor ? "target-constructor" : "target-method", reader.GetString(method.Name))],
+                isConstructor ? null : MemberAttributes(reader, method.GetCustomAttributes()),
+                isConstructor ? null : MethodReturnAttributes(reader, method),
+                IsAbstract: !isConstructor && IsAbstractMethod(method),
+                IsVirtual: !isConstructor && IsVirtualMethod(method),
+                IsOverride: false,
+                IsSealed: false)
+        ];
+        if (!isConstructor
+            && EqualityOperatorSibling(reader, targetTypeDef, targetIdentity, methodName) is { } equalitySibling)
+        {
+            targetMembers.Add(equalitySibling);
+        }
+
         var requirements = new List<CompileBackTypeRequirement>
         {
             new(
                 targetIdentity,
                 ShellKind(reader, targetTypeDef),
-                primaryConstructor?.FieldInitializers ??
-                [
-                    new CompileBackMemberRequirement(
-                        new CompileBackMethodIdentity(targetIdentity.FullName, targetMethodName, overload, signatureText),
-                        isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method,
-                        method.Attributes.HasFlag(MethodAttributes.Static),
-                        MethodParameters(reader, method, signature),
-                        isConstructor ? null : CompileBackTypeSignature.Display(signature.ReturnType),
-                        MethodTypeParameters(reader, method),
-                        CompileBackStubBodyKind.TargetBody,
-                        targetBody,
-                        [new CompileBackFact("metadata", isConstructor ? "target-constructor" : "target-method", reader.GetString(method.Name))],
-                        isConstructor ? null : MemberAttributes(reader, method.GetCustomAttributes()),
-                        isConstructor ? null : MethodReturnAttributes(reader, method),
-                        IsAbstract: !isConstructor && IsAbstractMethod(method),
-                        IsVirtual: !isConstructor && IsVirtualMethod(method),
-                        IsOverride: false,
-                        IsSealed: false)
-                ],
+                targetMembers,
                 primaryConstructor,
                 targetFacts)
         };
@@ -1117,6 +1124,55 @@ public static class CompileBackSourceComposer
 
         return [];
     }
+
+    static CompileBackMemberRequirement? EqualityOperatorSibling(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        CompileBackTypeIdentity typeIdentity,
+        string methodName)
+    {
+        var siblingName = methodName switch
+        {
+            "op_Equality" => "op_Inequality",
+            "op_Inequality" => "op_Equality",
+            _ => null,
+        };
+        if (siblingName is null)
+            return null;
+
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != siblingName
+                || method.RelativeVirtualAddress == 0)
+            {
+                continue;
+            }
+
+            var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+            return new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(typeIdentity.FullName, siblingName, 0, MethodSignatureText(siblingName, signature)),
+                CompileBackMemberKind.Method,
+                method.Attributes.HasFlag(MethodAttributes.Static),
+                MethodParameters(reader, method, signature),
+                CompileBackTypeSignature.Display(signature.ReturnType),
+                MethodTypeParameters(reader, method),
+                CompileBackStubBodyKind.Throw,
+                TargetBody: null,
+                [new CompileBackFact("metadata", "operator-pair-sibling", siblingName)],
+                MemberAttributes(reader, method.GetCustomAttributes()),
+                MethodReturnAttributes(reader, method),
+                IsAbstract: IsAbstractMethod(method),
+                IsVirtual: IsVirtualMethod(method),
+                IsOverride: false,
+                IsSealed: false);
+        }
+
+        return null;
+    }
+
+    static string MethodSignatureText(string name, MethodSignature<string> signature)
+        => $"{signature.ReturnType} {name}({string.Join(", ", signature.ParameterTypes)})";
 
     static bool IsAbstractMethod(MethodDefinition method)
         => IsPublicMethod(method)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -908,10 +908,19 @@ public sealed partial class CSharpPrinter
         => _function.Name is "op_Equality" or "op_Inequality";
 
     bool IsFirstTwoArgumentReferenceComparison(IrExpression left, IrExpression right)
-        => left is LoadArgument { Index: 0 } && right is LoadArgument { Index: 1 }
+        => ArgumentIndex(left) is 0 && ArgumentIndex(right) is 1
                 && IsKnownReferenceType(left.ResultType) && IsKnownReferenceType(right.ResultType)
-            || left is LoadArgument { Index: 1 } && right is LoadArgument { Index: 0 }
+            || ArgumentIndex(left) is 1 && ArgumentIndex(right) is 0
                 && IsKnownReferenceType(left.ResultType) && IsKnownReferenceType(right.ResultType);
+
+    static int? ArgumentIndex(IrExpression expression)
+        => expression switch
+        {
+            LoadArgument argument => argument.Index,
+            LoadIndirect { Address: LoadArgument argument } => argument.Index,
+            LoadIndirect { Address: LoadArgumentAddress argument } => argument.Index,
+            _ => null,
+        };
 
     bool IsKnownReferenceType(TypeRef? type)
         => TypeFamilies.Of(type) == StackFamily.O

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -916,7 +916,7 @@ public sealed partial class CSharpPrinter
     bool IsKnownReferenceType(TypeRef? type)
         => TypeFamilies.Of(type) == StackFamily.O
             || type is { Kind: TypeRefKind.SzArray or TypeRefKind.Array }
-            || type is { Kind: TypeRefKind.Definition } && _function.TypeShapes.GetValueOrDefault(type) == TypeShape.Reference;
+            || type is not null && _function.TypeShapes.GetValueOrDefault(NamedDefinition(type)) == TypeShape.Reference;
 
     string BoxedReferenceOperand(IrExpression operand)
         => operand is Box box ? $"(object){Operand(box.Operand)}" : Operand(operand);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -849,7 +849,7 @@ public sealed partial class CSharpPrinter
         if (kind is ComparisonKind.Equal or ComparisonKind.NotEqual)
         {
             if (IsCurrentEqualityOperator()
-                && IsFirstTwoArgumentReferenceComparison(left, right))
+                && IsKnownReferenceComparison(left, right))
             {
                 return $"(object){Operand(left)} {ComparisonOperator(kind)} (object){Operand(right)}";
             }
@@ -907,20 +907,8 @@ public sealed partial class CSharpPrinter
     bool IsCurrentEqualityOperator()
         => _function.Name is "op_Equality" or "op_Inequality";
 
-    bool IsFirstTwoArgumentReferenceComparison(IrExpression left, IrExpression right)
-        => ArgumentIndex(left) is 0 && ArgumentIndex(right) is 1
-                && IsKnownReferenceType(left.ResultType) && IsKnownReferenceType(right.ResultType)
-            || ArgumentIndex(left) is 1 && ArgumentIndex(right) is 0
-                && IsKnownReferenceType(left.ResultType) && IsKnownReferenceType(right.ResultType);
-
-    static int? ArgumentIndex(IrExpression expression)
-        => expression switch
-        {
-            LoadArgument argument => argument.Index,
-            LoadIndirect { Address: LoadArgument argument } => argument.Index,
-            LoadIndirect { Address: LoadArgumentAddress argument } => argument.Index,
-            _ => null,
-        };
+    bool IsKnownReferenceComparison(IrExpression left, IrExpression right)
+        => IsKnownReferenceType(left.ResultType) && IsKnownReferenceType(right.ResultType);
 
     bool IsKnownReferenceType(TypeRef? type)
         => TypeFamilies.Of(type) == StackFamily.O

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -848,6 +848,12 @@ public sealed partial class CSharpPrinter
         // pointer types (CS8521), so this uses the equality form, not is-null.
         if (kind is ComparisonKind.Equal or ComparisonKind.NotEqual)
         {
+            if (IsCurrentEqualityOperator()
+                && IsFirstTwoArgumentReferenceComparison(left, right))
+            {
+                return $"(object){Operand(left)} {ComparisonOperator(kind)} (object){Operand(right)}";
+            }
+
             var pointer = left.ResultType is { Kind: TypeRefKind.Pointer } ? left
                 : right.ResultType is { Kind: TypeRefKind.Pointer } ? right
                 : null;
@@ -897,6 +903,20 @@ public sealed partial class CSharpPrinter
             ? $"{UnsignedOperand(left)} {ComparisonOperator(kind)} {UnsignedOperand(right)}"
             : $"{Operand(left)} {ComparisonOperator(kind)} {Operand(right)}";
     }
+
+    bool IsCurrentEqualityOperator()
+        => _function.Name is "op_Equality" or "op_Inequality";
+
+    bool IsFirstTwoArgumentReferenceComparison(IrExpression left, IrExpression right)
+        => left is LoadArgument { Index: 0 } && right is LoadArgument { Index: 1 }
+                && IsKnownReferenceType(left.ResultType) && IsKnownReferenceType(right.ResultType)
+            || left is LoadArgument { Index: 1 } && right is LoadArgument { Index: 0 }
+                && IsKnownReferenceType(left.ResultType) && IsKnownReferenceType(right.ResultType);
+
+    bool IsKnownReferenceType(TypeRef? type)
+        => TypeFamilies.Of(type) == StackFamily.O
+            || type is { Kind: TypeRefKind.SzArray or TypeRefKind.Array }
+            || type is { Kind: TypeRefKind.Definition } && _function.TypeShapes.GetValueOrDefault(type) == TypeShape.Reference;
 
     string BoxedReferenceOperand(IrExpression operand)
         => operand is Box box ? $"(object){Operand(box.Operand)}" : Operand(operand);


### PR DESCRIPTION
- Advances RTS pinned-package source probe coverage
- Changes product compile-back source composition and a narrow equality-operator printer fallback
- Evidence revision: `f8b57c34`

## Change

**Conclusion:** **PASS** — record-style equality operators in the pinned `dotnet-inspect.any@0.16.0` probe no longer fail with `CS0216`; the remaining 69/300 failures are all pre-existing/known `OpcodeDiff` frontiers.

Before:

```text
CS0216 bucket: record-style op_Equality/op_Inequality targets failed because C# requires == and != to be declared as signature-matched pairs.
```

After:

```text
RETURNTOSENDER SOURCE PROBE over 300 target(s)

  Passed : 231
  Failed : 69
  Skipped: 0

Buckets:
  69: OpcodeDiff
```

## Scope and safety

- **Root cause:** RTS could reconstruct a targeted `op_Equality` or `op_Inequality` without its required sibling operator, making Roslyn reject otherwise-checkable record-style operator bodies with `CS0216`.
- **Fix shape:** `CompileBackSourceComposer` adds the signature-matched sibling operator shell for `==`/`!=` targets, including no-body siblings; `CSharpPrinter` preserves raw first-two-argument reference comparisons inside equality operators as `(object)left == (object)right` / `!=` so the added sibling does not recursively rebind the target body.
- **Product impact:** limited to compile-back/RTS source generation and the narrow operator-body comparison spelling above.
- **Scope boundary:** HasRows shared-return source shape remains tracked by #2203; record-generated `ToString` / `GetHashCode` / `Equals` OpcodeDiffs remain the next pinned-package frontier.
- **RTS boundary:** RTS still orchestrates target selection, closure compilation, and opcode/source-fragment comparison; product/shared code owns C# source generation.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `*EqualityOperatorPairSibling` passed, 3/3 |
| Generated fixture catalog | Pass, 39 fixtures / 116 targets |
| `ReturnToSenderPrototypeTests` | Pass, 51/51 |
| Decompiler fast suite | Pass, 1824/1824 |
| ReturnToSender catalog | Pass, 39 fixtures / 116 targets |
| ReturnToSender A/B | 240 Same / 0 Worse |
| Pinned package probe | `dotnet-inspect.any@0.16.0`, cap 300: 231 passed / 69 failed; only `OpcodeDiff` bucket |
| Real witness | `DotnetInspector.Views.TypeSummaryRow::op_Equality` / `op_Inequality` moved out of `CS0216`; remaining examples start at HasRows/record-generated OpcodeDiffs |

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| HasRows shared-return branch shape | Left as frontier, tracked by #2203 | Requires product source-shape modeling, not an operator shell fix |
| Record-generated `ToString` / `GetHashCode` / `Equals` OpcodeDiffs | Left as frontier | Next pinned-package slice after operator-pair validity is unblocked |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | No blocking findings | Verified sibling shell safety, value-type exclusion, no recursive binding, and no constructor/property impact |
| Gemini 3.1 Pro | Findings resolved | Found signature-insensitive sibling matching and skipped no-body siblings; fixed in `9bd13c03` with overload/no-body canaries |

**Review conclusion:** **PASS** — all adversarial findings are either clean or resolved in `9bd13c03`.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -method "*EqualityOperatorPairSibling"
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*GeneratedFixtureCatalogTests"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --return-to-sender-catalog --max-examples 50
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --package dotnet-inspect.any --package-version 0.16.0 --return-to-sender-source-probe --cap 300 --max-examples 15
```
