### PR TITLE
Share one index build across library-scope analysis scanners (#2139 perf)

### DIFF
--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -233,7 +233,7 @@ public class OutputFormatterTests
     public void ScanOptimizationOpportunities_OrdersByTriagePriority()
     {
         var rows = LibraryMetadataService.ScanOptimizationOpportunities(
-            MethodBodyInspectionSession.Open(typeof(OutputFormatterTests).Assembly.Location), typeof(OutputFormatterTests).Assembly.Location, new VerboseLogger(false));
+            () => MethodBodyInspectionSession.Open(typeof(OutputFormatterTests).Assembly.Location), typeof(OutputFormatterTests).Assembly.Location, new VerboseLogger(false));
 
         Assert.NotNull(rows);
         Assert.NotEmpty(rows);
@@ -487,7 +487,7 @@ public class OutputFormatterTests
     public void ScanOptimizationOpportunities_SuppressesGeneratedMethods()
     {
         var rows = LibraryMetadataService.ScanOptimizationOpportunities(
-            MethodBodyInspectionSession.Open(typeof(OutputFormatterTests).Assembly.Location), typeof(OutputFormatterTests).Assembly.Location, new VerboseLogger(false));
+            () => MethodBodyInspectionSession.Open(typeof(OutputFormatterTests).Assembly.Location), typeof(OutputFormatterTests).Assembly.Location, new VerboseLogger(false));
 
         Assert.NotNull(rows);
         Assert.NotEmpty(rows);

--- a/src/dotnet-inspect.Tests/OutputFormatterTests.cs
+++ b/src/dotnet-inspect.Tests/OutputFormatterTests.cs
@@ -233,7 +233,7 @@ public class OutputFormatterTests
     public void ScanOptimizationOpportunities_OrdersByTriagePriority()
     {
         var rows = LibraryMetadataService.ScanOptimizationOpportunities(
-            typeof(OutputFormatterTests).Assembly.Location, new VerboseLogger(false));
+            MethodBodyInspectionSession.Open(typeof(OutputFormatterTests).Assembly.Location), typeof(OutputFormatterTests).Assembly.Location, new VerboseLogger(false));
 
         Assert.NotNull(rows);
         Assert.NotEmpty(rows);
@@ -487,7 +487,7 @@ public class OutputFormatterTests
     public void ScanOptimizationOpportunities_SuppressesGeneratedMethods()
     {
         var rows = LibraryMetadataService.ScanOptimizationOpportunities(
-            typeof(OutputFormatterTests).Assembly.Location, new VerboseLogger(false));
+            MethodBodyInspectionSession.Open(typeof(OutputFormatterTests).Assembly.Location), typeof(OutputFormatterTests).Assembly.Location, new VerboseLogger(false));
 
         Assert.NotNull(rows);
         Assert.NotEmpty(rows);

--- a/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
+++ b/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
@@ -181,7 +181,7 @@ public class TopLeverageSectionTests
     public void LibraryTopLeverage_PopulatesVisibilityStableAndNameNSelector()
     {
         var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
-            DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
+            () => DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
 
         Assert.NotNull(rows);
         var helper = Assert.Single(rows!, r => r.Member.EndsWith("LeverageSampleType.SharedHelper()"));
@@ -199,7 +199,7 @@ public class TopLeverageSectionTests
     public void LibraryTopLeverage_PublicOverloadSharingNameWithNonPublic_GetsRoundTrippableSelector()
     {
         var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
-            DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
+            () => DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
 
         Assert.NotNull(rows);
         // The public Shadowed(int) is the only public overload, so its selector is the bare
@@ -218,7 +218,7 @@ public class TopLeverageSectionTests
     public void LibraryTopLeverage_AccessorRowUsesOwningPropertySelector()
     {
         var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
-            DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
+            () => DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
 
         Assert.NotNull(rows);
         // The ranked accessor (get_Tag) maps to the owning property's selector, so an agent
@@ -233,7 +233,7 @@ public class TopLeverageSectionTests
     public void LibraryTopLeverage_TopLevelInternalTypeRowGainsSelector()
     {
         var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
-            DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
+            () => DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
 
         Assert.NotNull(rows);
         // --all now surfaces top-level internal types, so a method on one gets a round-tripping
@@ -263,7 +263,7 @@ public class TopLeverageSectionTests
     public async Task LibraryTopLeverage_StableSelectorRoundTripsToMemberCommand()
     {
         var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
-            DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
+            () => DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
         var helper = rows!.First(r => r.Member.EndsWith("LeverageSampleType.SharedHelper()"));
         var match = System.Text.RegularExpressions.Regex.Match(helper.Stable!, @"([A-Za-z0-9_]+)~([0-9a-f]{10})");
         Assert.True(match.Success, "expected a Name~digest selector on the library-scope row");

--- a/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
+++ b/src/dotnet-inspect.Tests/TopLeverageSectionTests.cs
@@ -181,7 +181,7 @@ public class TopLeverageSectionTests
     public void LibraryTopLeverage_PopulatesVisibilityStableAndNameNSelector()
     {
         var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
-            typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
+            DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
 
         Assert.NotNull(rows);
         var helper = Assert.Single(rows!, r => r.Member.EndsWith("LeverageSampleType.SharedHelper()"));
@@ -199,7 +199,7 @@ public class TopLeverageSectionTests
     public void LibraryTopLeverage_PublicOverloadSharingNameWithNonPublic_GetsRoundTrippableSelector()
     {
         var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
-            typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
+            DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
 
         Assert.NotNull(rows);
         // The public Shadowed(int) is the only public overload, so its selector is the bare
@@ -218,7 +218,7 @@ public class TopLeverageSectionTests
     public void LibraryTopLeverage_AccessorRowUsesOwningPropertySelector()
     {
         var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
-            typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
+            DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
 
         Assert.NotNull(rows);
         // The ranked accessor (get_Tag) maps to the owning property's selector, so an agent
@@ -233,7 +233,7 @@ public class TopLeverageSectionTests
     public void LibraryTopLeverage_TopLevelInternalTypeRowGainsSelector()
     {
         var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
-            typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
+            DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
 
         Assert.NotNull(rows);
         // --all now surfaces top-level internal types, so a method on one gets a round-tripping
@@ -263,7 +263,7 @@ public class TopLeverageSectionTests
     public async Task LibraryTopLeverage_StableSelectorRoundTripsToMemberCommand()
     {
         var rows = DotnetInspector.Inspectors.LibraryMetadataService.ScanTopLeverage(
-            typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
+            DotnetInspector.Inspectors.MethodBodyInspectionSession.Open(typeof(LeverageSampleType).Assembly.Location), typeof(LeverageSampleType).Assembly.Location, new DotnetInspector.Output.VerboseLogger(false));
         var helper = rows!.First(r => r.Member.EndsWith("LeverageSampleType.SharedHelper()"));
         var match = System.Text.RegularExpressions.Regex.Match(helper.Stable!, @"([A-Za-z0-9_]+)~([0-9a-f]{10})");
         Assert.True(match.Success, "expected a Name~digest selector on the library-scope row");

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -559,11 +559,10 @@ internal static class LibraryMetadataService
         inspection.AsyncMethods = async.Count > 0 ? async : null;
     }
 
-    internal static List<UnsafeMemberSummary>? ScanUnsafeMembers(string path, VerboseLogger logger)
+    internal static List<UnsafeMemberSummary>? ScanUnsafeMembers(MethodBodyInspectionSession session, string path, VerboseLogger logger)
     {
         try
         {
-            var session = MethodBodyInspectionSession.Open(path);
             var rows = session.UnsafeEvidence()
                 .Select(evidence => new UnsafeMemberSummary
                 {
@@ -631,11 +630,10 @@ internal static class LibraryMetadataService
     /// then outbound shape). Emits the full ranked set so the row limiter (<c>-n</c>/
     /// <c>--rows</c>) controls how many rows are shown, matching the type-scoped view.
     /// </summary>
-    internal static List<MethodLeverageSummary>? ScanTopLeverage(string path, VerboseLogger logger)
+    internal static List<MethodLeverageSummary>? ScanTopLeverage(MethodBodyInspectionSession session, string path, VerboseLogger logger)
     {
         try
         {
-            var session = MethodBodyInspectionSession.Open(path);
             var generatedFrameworkTypes = session.GeneratedFrameworkTypeNames;
             // Reuse the exact Member Index canonical-signature/digest path (via the
             // extracted API surface) so library-scope rows carry the same round-tripping
@@ -715,13 +713,13 @@ internal static class LibraryMetadataService
     /// filtered set in triage priority order so the highest-value pay-dirt surfaces first.
     /// </summary>
     internal static List<OptimizationOpportunitySummary>? ScanOptimizationOpportunities(
+        MethodBodyInspectionSession session,
         string path,
         VerboseLogger logger,
         PerformanceTriageOptions? options = null)
     {
         try
         {
-            var session = MethodBodyInspectionSession.Open(path);
             var generatedFrameworkTypes = session.GeneratedFrameworkTypeNames;
             var rows = FilterAndOrderTriageOpportunities(
                     session.OptimizationOpportunities

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -559,10 +559,11 @@ internal static class LibraryMetadataService
         inspection.AsyncMethods = async.Count > 0 ? async : null;
     }
 
-    internal static List<UnsafeMemberSummary>? ScanUnsafeMembers(MethodBodyInspectionSession session, string path, VerboseLogger logger)
+    internal static List<UnsafeMemberSummary>? ScanUnsafeMembers(Func<MethodBodyInspectionSession> openSession, string path, VerboseLogger logger)
     {
         try
         {
+            var session = openSession();
             var rows = session.UnsafeEvidence()
                 .Select(evidence => new UnsafeMemberSummary
                 {
@@ -630,10 +631,11 @@ internal static class LibraryMetadataService
     /// then outbound shape). Emits the full ranked set so the row limiter (<c>-n</c>/
     /// <c>--rows</c>) controls how many rows are shown, matching the type-scoped view.
     /// </summary>
-    internal static List<MethodLeverageSummary>? ScanTopLeverage(MethodBodyInspectionSession session, string path, VerboseLogger logger)
+    internal static List<MethodLeverageSummary>? ScanTopLeverage(Func<MethodBodyInspectionSession> openSession, string path, VerboseLogger logger)
     {
         try
         {
+            var session = openSession();
             var generatedFrameworkTypes = session.GeneratedFrameworkTypeNames;
             // Reuse the exact Member Index canonical-signature/digest path (via the
             // extracted API surface) so library-scope rows carry the same round-tripping
@@ -713,13 +715,14 @@ internal static class LibraryMetadataService
     /// filtered set in triage priority order so the highest-value pay-dirt surfaces first.
     /// </summary>
     internal static List<OptimizationOpportunitySummary>? ScanOptimizationOpportunities(
-        MethodBodyInspectionSession session,
+        Func<MethodBodyInspectionSession> openSession,
         string path,
         VerboseLogger logger,
         PerformanceTriageOptions? options = null)
     {
         try
         {
+            var session = openSession();
             var generatedFrameworkTypes = session.GeneratedFrameworkTypeNames;
             var rows = FilterAndOrderTriageOpportunities(
                     session.OptimizationOpportunities

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -108,12 +108,12 @@ public static class LibrarySections
             .Add(ScannerSwitches, ctx =>
                 ctx.Model.Switches = LibraryMetadataService.ScanSwitches(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerUnsafeMembers, ctx =>
-                ctx.Model.UnsafeMembers = LibraryMetadataService.ScanUnsafeMembers(ctx.BodySession(), ctx.AssemblyPath, ctx.Logger))
+                ctx.Model.UnsafeMembers = LibraryMetadataService.ScanUnsafeMembers(ctx.BodySession, ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerTopLeverage, ctx =>
-                ctx.Model.TopLeverage = LibraryMetadataService.ScanTopLeverage(ctx.BodySession(), ctx.AssemblyPath, ctx.Logger))
+                ctx.Model.TopLeverage = LibraryMetadataService.ScanTopLeverage(ctx.BodySession, ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerOptimizationOpportunities, ctx =>
                 ctx.Model.OptimizationOpportunities = LibraryMetadataService.ScanOptimizationOpportunities(
-                    ctx.BodySession(), ctx.AssemblyPath, ctx.Logger, ctx.Model.PerformanceTriageOptions))
+                    ctx.BodySession, ctx.AssemblyPath, ctx.Logger, ctx.Model.PerformanceTriageOptions))
             .Add(ScannerIntegrations, ctx =>
                 LibraryMetadataService.ScanIntegrations(ctx.AssemblyPath, ctx.Model, ctx.Logger))
             .Add(ScannerIntegrationOpportunities, ctx =>

--- a/src/dotnet-inspect/Sections/LibrarySections.cs
+++ b/src/dotnet-inspect/Sections/LibrarySections.cs
@@ -108,12 +108,12 @@ public static class LibrarySections
             .Add(ScannerSwitches, ctx =>
                 ctx.Model.Switches = LibraryMetadataService.ScanSwitches(ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerUnsafeMembers, ctx =>
-                ctx.Model.UnsafeMembers = LibraryMetadataService.ScanUnsafeMembers(ctx.AssemblyPath, ctx.Logger))
+                ctx.Model.UnsafeMembers = LibraryMetadataService.ScanUnsafeMembers(ctx.BodySession(), ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerTopLeverage, ctx =>
-                ctx.Model.TopLeverage = LibraryMetadataService.ScanTopLeverage(ctx.AssemblyPath, ctx.Logger))
+                ctx.Model.TopLeverage = LibraryMetadataService.ScanTopLeverage(ctx.BodySession(), ctx.AssemblyPath, ctx.Logger))
             .Add(ScannerOptimizationOpportunities, ctx =>
                 ctx.Model.OptimizationOpportunities = LibraryMetadataService.ScanOptimizationOpportunities(
-                    ctx.AssemblyPath, ctx.Logger, ctx.Model.PerformanceTriageOptions))
+                    ctx.BodySession(), ctx.AssemblyPath, ctx.Logger, ctx.Model.PerformanceTriageOptions))
             .Add(ScannerIntegrations, ctx =>
                 LibraryMetadataService.ScanIntegrations(ctx.AssemblyPath, ctx.Model, ctx.Logger))
             .Add(ScannerIntegrationOpportunities, ctx =>

--- a/src/dotnet-inspect/Sections/ScannerRegistry.cs
+++ b/src/dotnet-inspect/Sections/ScannerRegistry.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Inspectors;
 using DotnetInspector.Models;
 using DotnetInspector.Output;
 
@@ -11,6 +12,17 @@ public sealed class ScannerContext
     public required string AssemblyPath { get; init; }
     public required LibraryInspection Model { get; init; }
     public required VerboseLogger Logger { get; init; }
+
+    private MethodBodyInspectionSession? _bodySession;
+
+    /// <summary>
+    /// Shared method-body analysis session for <see cref="AssemblyPath"/>, built once on first use.
+    /// The body-index scanners (unsafe members, top leverage, optimization opportunities) share it
+    /// instead of each rebuilding the full <c>LibraryBodyIndex</c>. Scanners run sequentially
+    /// (<see cref="ScannerRegistry.RunScanners"/>), so no synchronization is required.
+    /// </summary>
+    public MethodBodyInspectionSession BodySession() =>
+        _bodySession ??= MethodBodyInspectionSession.Open(AssemblyPath);
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Completes the "single index build per command" perf work (after #2187 member path,
#2199 type command) for the **`library` command**. Its Unsafe Members / Top Leverage
/ Performance Triage sections run as independent scanner steps
(`LibraryMetadataService.ScanUnsafeMembers` / `ScanTopLeverage` /
`ScanOptimizationOpportunities`), each rebuilding the full `LibraryBodyIndex`.

- Adds a lazily-memoized shared `MethodBodyInspectionSession` on `ScannerContext`
  (built once on first use). `ScannerRegistry.RunScanners` runs scanners
  **sequentially**, so no synchronization is required.
- Threads it through the three body-index scanners so they share one build.
- Laziness preserved: the session is only built if one of these three sections is
  requested (the metadata scanners and `BuildLibraryDrillMap`'s
  `AssemblyInspectionSession` are unchanged).

## Results

- **Behavior-preserving**: byte-identical output across Unsafe Members / Top Leverage
  / Performance Triage on four assemblies (`ILInspector.Metadata/Analysis/Decompiler`,
  `DotnetInspector.Services`), single and combined.
- **~33% faster** on a 3-section `library` render of `ILInspector.Decompiler.dll`
  (CPU time, load-insensitive): **~4.37 -> ~2.92 CPU-sec** (three index builds -> one).
- Tests: `LibraryTopLeverage/SectionPipeline/UnsafeMembers/TopLeverage/OutputFormatter`
  — 221/221 pass.

This closes the library-scope redundancy first measured in #2198
(`library` 3-section 2543 -> 3981 ms). Part of #2139 / #2122.
