### PR TITLE
Docs: update assertion dump status

### DIFF
--- a/docs/design/inverse-architecture.md
+++ b/docs/design/inverse-architecture.md
@@ -303,7 +303,6 @@ a `[NotInverted(reason)]` row so the boundary is visible, not implicit.
   [inverse-ledger.generated.md](inverse-ledger.generated.md) (drift-gated); it is the
   authoritative table. The conversion-family rows in [The node ledger](#the-node-ledger--the-type-assertions)
   above are a hand-written worked example the generated ledger subsumes.
-- **Assertion dump (capability):** planned, last. An opt-in `--dump` lane that annotates
-  each node with its `[InverseOf]` assertion, evaluates the `assumes:` predicate in
-  place, and pinpoints the first unsound rewrite. Depends on the annotations and the
-  `Check()` predicates.
+- **Assertion dump (capability):** landed (#2193). An opt-in `--dump --assertions` lane
+  that annotates each node with its `[InverseOf]` assertion, evaluates the `assumes:`
+  predicate in place, and pinpoints the first unsound rewrite.


### PR DESCRIPTION
- Advances #2179
- Changes: Updates `inverse-architecture.md` status to mark the assertion dump capability as landed now that #2193 has merged.

## Change

> Should we accept this change?

**Conclusion:** **PASS** — Simple documentation update to reflect the newly merged capability. This PR contains no product changes, so adversarial review and extensive corpus evidence are omitted.

## Validation

```bash
npx markdownlint-cli --fix docs/design/inverse-architecture.md
```
