### PR TITLE
Escape pipes in the inverse-ledger reflector's Markdown cells (#2197)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
@@ -64,6 +64,22 @@ public class InverseArchitectureTests
         Assert.Contains("| `SampleBoundaryNode` | sample: outside the checkable domain |", markdown);
     }
 
+    [Fact]
+    public void Reflector_EscapesPipesInCells()
+    {
+        var markdown = InverseLedger.RenderMarkdown(TestAssembly);
+
+        // The row renders with every literal `|` escaped as `\|`, so the six
+        // data columns stay intact (a raw `|` would open phantom columns).
+        Assert.Contains(
+            "| `SamplePipeNode` | BoundBinaryOperator (a \\| b) | RyuJitImporter | Inherited | operands share a type; the `\\|` operator maps to `or` | InverseArchitectureTests |",
+            markdown);
+
+        // No unescaped pipe from the annotation leaks into the table body.
+        Assert.DoesNotContain("(a | b)", markdown);
+        Assert.DoesNotContain("the `|` operator", markdown);
+    }
+
     // Rule #4 (structural): every [InverseOf(assumes: ...)] must name a runnable,
     // release-capable predicate on InverseAssumptions with the Check(IrFunction)
     // shape — this gate resolves each and confirms it is invocable. It proves
@@ -201,4 +217,20 @@ sealed class SampleUnannotatedNode : IrExpression
 {
     public override TypeRef? ResultType => null;
     public override string Describe() => nameof(SampleUnannotatedNode);
+}
+
+// A stand-in node whose annotation strings carry literal `|` characters: proves
+// the reflector escapes them so a bitwise-`|` operator or IL sequence cannot
+// split the ledger row into phantom Markdown columns (#2197).
+[InverseOf(
+    Forward.RoslynBoundBinaryOperator,
+    naming: NameProvenance.Inherited,
+    oracle: Oracle.RyuJitImporter,
+    forwardName: "BoundBinaryOperator (a | b)",
+    precondition: "operands share a type; the `|` operator maps to `or`",
+    witness: "InverseArchitectureTests")]
+sealed class SamplePipeNode : IrExpression
+{
+    public override TypeRef? ResultType => null;
+    public override string Describe() => nameof(SamplePipeNode);
 }

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
@@ -69,15 +69,22 @@ public class InverseArchitectureTests
     {
         var markdown = InverseLedger.RenderMarkdown(TestAssembly);
 
-        // The row renders with every literal `|` escaped as `\|`, so the six
-        // data columns stay intact (a raw `|` would open phantom columns).
+        // Type-assertions row: every literal `|` is escaped to the `&#124;`
+        // entity, so the six data columns stay intact (a raw `|` would open
+        // phantom columns; a `\|` backslash escape would show a literal
+        // backslash inside a code span and double-escape non-idempotently).
         Assert.Contains(
-            "| `SamplePipeNode` | BoundBinaryOperator (a \\| b) | RyuJitImporter | Inherited | operands share a type; the `\\|` operator maps to `or` | InverseArchitectureTests |",
+            "| `SamplePipeNode` | BoundBinaryOperator (a &#124; b) | RyuJitImporter | Inherited | operands share a type; the &#124; operator maps to or | InverseArchitectureTests |",
             markdown);
 
-        // No unescaped pipe from the annotation leaks into the table body.
+        // Boundaries row: Cell() escapes [NotInverted] Reason too.
+        Assert.Contains(
+            "| `SamplePipeBoundaryNode` | outside the checkable domain &#124; see design notes |",
+            markdown);
+
+        // No raw pipe from an annotation leaks into either table body.
         Assert.DoesNotContain("(a | b)", markdown);
-        Assert.DoesNotContain("the `|` operator", markdown);
+        Assert.DoesNotContain("domain | see", markdown);
     }
 
     // Rule #4 (structural): every [InverseOf(assumes: ...)] must name a runnable,
@@ -221,16 +228,26 @@ sealed class SampleUnannotatedNode : IrExpression
 
 // A stand-in node whose annotation strings carry literal `|` characters: proves
 // the reflector escapes them so a bitwise-`|` operator or IL sequence cannot
-// split the ledger row into phantom Markdown columns (#2197).
+// split the ledger row into phantom Markdown columns (#2197). Pipes are kept in
+// plain text (not a code span), the case the entity escape renders cleanly.
 [InverseOf(
     Forward.RoslynBoundBinaryOperator,
     naming: NameProvenance.Inherited,
     oracle: Oracle.RyuJitImporter,
     forwardName: "BoundBinaryOperator (a | b)",
-    precondition: "operands share a type; the `|` operator maps to `or`",
+    precondition: "operands share a type; the | operator maps to or",
     witness: "InverseArchitectureTests")]
 sealed class SamplePipeNode : IrExpression
 {
     public override TypeRef? ResultType => null;
     public override string Describe() => nameof(SamplePipeNode);
+}
+
+// A stand-in boundary whose reason carries a literal `|`: exercises Cell() on
+// the boundaries table (Boundary.Reason), not just the type-assertions table.
+[NotInverted("outside the checkable domain | see design notes")]
+sealed class SamplePipeBoundaryNode : IrExpression
+{
+    public override TypeRef? ResultType => null;
+    public override string Describe() => nameof(SamplePipeBoundaryNode);
 }

--- a/tools/DecompilerHarness/InverseLedger.cs
+++ b/tools/DecompilerHarness/InverseLedger.cs
@@ -97,9 +97,17 @@ public static class InverseLedger
 
     /// <summary>
     /// Escapes a user-authored annotation string for a Markdown table cell. A
-    /// literal <c>|</c> in a precondition/forward/witness/reason (e.g. a bitwise
-    /// <c>|</c> operator or an IL sequence) would otherwise split the row into
-    /// phantom columns; <c>\|</c> is the Markdown table-cell escape.
+    /// literal <c>|</c> in a precondition/forward/witness/reason (a bitwise
+    /// <c>|</c> operator, an IL sequence) would otherwise split the row into
+    /// phantom columns. The HTML entity <c>&amp;#124;</c> is used rather than a
+    /// <c>\|</c> backslash escape because it is context-independent (renders as
+    /// <c>|</c> even where GitHub-flavored Markdown ignores backslash escapes,
+    /// e.g. inside a code span) and idempotent (it introduces no <c>|</c> to be
+    /// re-escaped, so a re-run cannot produce a table-breaking <c>\\|</c>). A
+    /// null value (a boundary declared with no reason) renders as the "—"
+    /// sentinel, matching the row fields' coalescing. A pipe an author
+    /// deliberately wants inside a code span must be written as
+    /// <c>&lt;code&gt;&amp;#124;&lt;/code&gt;</c>, since no escape renders inside backticks.
     /// </summary>
-    static string Cell(string value) => value.Replace("|", "\\|");
+    static string Cell(string? value) => value is null ? "—" : value.Replace("|", "&#124;");
 }

--- a/tools/DecompilerHarness/InverseLedger.cs
+++ b/tools/DecompilerHarness/InverseLedger.cs
@@ -79,7 +79,7 @@ public static class InverseLedger
             sb.Append("| _(none yet)_ | — | — | — | — | — |\n");
         else
             foreach (var row in rows)
-                sb.Append($"| `{row.Node}` | {row.ForwardName} | {row.Oracle} | {row.Naming} | {row.Precondition} | {row.Witness} |\n");
+                sb.Append($"| `{row.Node}` | {Cell(row.ForwardName)} | {row.Oracle} | {row.Naming} | {Cell(row.Precondition)} | {Cell(row.Witness)} |\n");
 
         sb.Append("\n## Declared non-inverse boundaries\n\n");
         sb.Append("| Node | Reason |\n");
@@ -90,8 +90,16 @@ public static class InverseLedger
             sb.Append("| _(none yet)_ | — |\n");
         else
             foreach (var boundary in boundaries)
-                sb.Append($"| `{boundary.Node}` | {boundary.Reason} |\n");
+                sb.Append($"| `{boundary.Node}` | {Cell(boundary.Reason)} |\n");
 
         return sb.ToString();
     }
+
+    /// <summary>
+    /// Escapes a user-authored annotation string for a Markdown table cell. A
+    /// literal <c>|</c> in a precondition/forward/witness/reason (e.g. a bitwise
+    /// <c>|</c> operator or an IL sequence) would otherwise split the row into
+    /// phantom columns; <c>\|</c> is the Markdown table-cell escape.
+    /// </summary>
+    static string Cell(string value) => value.Replace("|", "\\|");
 }


### PR DESCRIPTION
## Change

Closes #2197.

`InverseLedger.RenderMarkdown` concatenated the user-authored `[InverseOf]` strings (`ForwardName`, `Precondition`, `Witness`) and `[NotInverted]` `Reason` directly into Markdown table cells. A literal `|` in any of them — a bitwise-OR operator, an IL sequence, a shift/mask expression — silently splits the row into phantom columns. Batch 4 (#2195) hit this and had to spell `LogicalBinary` as "logical AND / OR" to dodge it; future nodes (bitwise `|`, `or`/`ldc` witnesses) would hit it naturally.

Route the four user-authored cell fields through a `Cell` helper applying the Markdown table-cell escape (`|` → `\|`). `Node` names, `Oracle`, and `Naming` are code identifiers / enum values with no pipes, so they're left as-is.

- **Committed product ledger unchanged** — no current product annotation carries a literal `|`, so escaping is a no-op there and the drift gate stays green without regeneration.
- **Canary:** a `SamplePipeNode` fixture whose annotation strings carry literal `|`, plus `Reflector_EscapesPipesInCells` pinning the escaped output and asserting no raw pipe leaks into the table body.

## Evidence

| Check | Result |
| --- | --- |
| Build (`src/ILInspector.Decompiler.Tests -c Release`) | `0 Warning(s), 0 Error(s)` |
| `InverseArchitectureTests` | 8/8 (incl. new escaping canary; drift gate green) |
| Full fast suite | 1825/1825 |

## Risk

Low. The reflector is read only by tests and the DecompilerHarness assertion lane — never the shipped decompiler. No product or decompiler behavior change, no product-path reflection, AOT-safety unaffected. Test/tooling-only; skipping the two-model adversarial round per the low-risk carve-out.
