### PR TITLE
Add index-build-once-per-command invariant guard tests (#2198)

### DIFF
--- a/src/dotnet-inspect.Tests/IndexBuildInvariantTests.cs
+++ b/src/dotnet-inspect.Tests/IndexBuildInvariantTests.cs
@@ -1,0 +1,117 @@
+using DotnetInspector.Commands;
+using DotnetInspector.Inspectors;
+using DotnetInspector.Options;
+using DotnetInspector.Sections;
+
+namespace DotnetInspector.Tests;
+
+// Runs isolated from all other collections so the shared MethodBodyInspectionSession
+// open counter is reliable (no concurrent session opens from parallel tests).
+[CollectionDefinition("IndexBuildGuard", DisableParallelization = true)]
+public class IndexBuildGuardCollection;
+
+/// <summary>
+/// Guards the "build the analysis index once per command" invariant delivered by the #2139 perf
+/// work (PRs #2187 member, #2199 type, #2210 library): every index-backed section of one command
+/// shares a single <see cref="Analysis.LibraryBodyIndex"/> build. A new section that opens its own
+/// <see cref="MethodBodyInspectionSession"/> instead of the shared one would silently reintroduce a
+/// per-section rebuild — these tests fail immediately if that happens.
+/// </summary>
+[Collection("IndexBuildGuard")]
+public class IndexBuildInvariantTests
+{
+    static string FixtureAssembly => typeof(IndexBuildGuardFixture).Assembly.Location;
+
+    [Fact]
+    public async Task MemberCommand_MultipleIndexSections_BuildsIndexOnce()
+    {
+        MethodBodyInspectionSession.OpenCountForTests = 0;
+
+        var result = await ConsoleCapture.RunAsync(() => MemberCommand.ExecuteAsync(new MemberOptions
+        {
+            TypeName = typeof(IndexBuildGuardFixture).FullName,
+            AssemblyPath = FixtureAssembly,
+            MemberFilter = [nameof(IndexBuildGuardFixture.Work)],
+            IncludeSections =
+            [
+                SectionNames.Calls,
+                SectionNames.CallGraph,
+                SectionNames.CallerGraph,
+                SectionNames.UnsafeOperations,
+                SectionNames.AllocationFacts,
+                SectionNames.SafetyFacts,
+                SectionNames.CostFacts,
+            ],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Detailed,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(1, MethodBodyInspectionSession.OpenCountForTests);
+    }
+
+    [Fact]
+    public async Task TypeCommand_MultipleAnalysisSections_BuildsIndexOnce()
+    {
+        MethodBodyInspectionSession.OpenCountForTests = 0;
+
+        var result = await ConsoleCapture.RunAsync(() => TypeCommand.ExecuteAsync(new TypeOptions
+        {
+            TypeName = typeof(IndexBuildGuardFixture).FullName,
+            AssemblyPath = FixtureAssembly,
+            IncludeSections =
+            [
+                SectionNames.UnsafeMembers,
+                SectionNames.CalledTypes,
+                SectionNames.TopLeverage,
+                SectionNames.AllocationFacts,
+                SectionNames.SafetyFacts,
+                SectionNames.CostFacts,
+                SectionNames.PerformanceTriage,
+            ],
+            TipLevel = TipLevel.Quiet,
+            Verbosity = Verbosity.Minimal,
+            MarkdownExplicitlySet = true,
+            FormatExplicitlySet = true,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(1, MethodBodyInspectionSession.OpenCountForTests);
+    }
+
+    [Fact]
+    public async Task LibraryCommand_MultipleAnalysisSections_BuildsIndexOnce()
+    {
+        MethodBodyInspectionSession.OpenCountForTests = 0;
+
+        var result = await ConsoleCapture.RunAsync(() => LibraryCommand.ExecuteAsync(new LibraryOptions
+        {
+            AssemblyName = FixtureAssembly,
+            IncludeSections =
+            [
+                SectionNames.UnsafeMembers,
+                SectionNames.TopLeverage,
+                SectionNames.PerformanceTriage,
+            ],
+            Markdown = true,
+            Rows = 25,
+        }));
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(1, MethodBodyInspectionSession.OpenCountForTests);
+    }
+}
+
+public class IndexBuildGuardFixture
+{
+    // A body with a call and an allocation so the requested analysis sections have data to render.
+    public void Work()
+    {
+        var list = new List<int>();
+        Helper(list);
+        System.Console.WriteLine(list.Count);
+    }
+
+    public void Helper(List<int> items) => items.Add(1);
+}

--- a/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
+++ b/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
@@ -34,9 +34,20 @@ public sealed class MethodBodyInspectionSession
     /// </summary>
     public string SourceName { get; }
 
+    /// <summary>
+    /// Test-only counter of index builds (one per <see cref="Open"/>). The "build the index once
+    /// per command" invariant (#2139 perf: PRs #2187/#2199/#2210) is guarded by asserting this
+    /// stays at 1 across a multi-section render; a new section that opens its own session would
+    /// silently reintroduce a per-section rebuild.
+    /// </summary>
+    internal static int OpenCountForTests;
+
     /// <summary>Opens a session over an assembly's analysis body index.</summary>
     public static MethodBodyInspectionSession Open(string assemblyPath, IAssemblyReferenceResolver? resolver = null)
-        => new(Analysis.LibraryBodyIndex.Open(assemblyPath, resolver), Path.GetFileNameWithoutExtension(assemblyPath));
+    {
+        System.Threading.Interlocked.Increment(ref OpenCountForTests);
+        return new(Analysis.LibraryBodyIndex.Open(assemblyPath, resolver), Path.GetFileNameWithoutExtension(assemblyPath));
+    }
 
     /// <summary>
     /// Allocation facts for one method (<paramref name="methodToken"/>), optionally narrowed to a


### PR DESCRIPTION
## Summary

Locks in the "build the analysis index once per command" invariant delivered by the
#2139 perf trilogy (#2187 member ~2x, #2199 type ~3x, #2210 library ~33%). Nothing
enforced it, so a future section opening its own `MethodBodyInspectionSession` would
silently reintroduce the per-section rebuild and quietly give back the wins.

- Adds a test-only `Interlocked` counter (`OpenCountForTests`) on
  `MethodBodyInspectionSession.Open` (the single funnel for all CLI body-index builds).
- Adds three guard tests (member, type, library) that run a **multi-section** render and
  assert the index is built **exactly once**.
- The tests run in a `DisableParallelization = true` collection so the shared counter is
  reliable (no concurrent opens from parallel tests).

## Why this shape

- **Deterministic and load-insensitive** — a build-*count* invariant, not a flaky timing
  threshold, so it's safe in CI.
- **Proven to have teeth**: temporarily reverting one member section to open its own
  session makes `MemberCommand_MultipleIndexSections_BuildsIndexOnce` fail with
  `Expected: 1, Actual: 2`. Restored; green again.

Per-build *cost* drift (the separate ~30% gradual regression in #2198) is not what this
guards — that's handled by local profiling/benchmarking, tracked in #2198.

## Validation

- New guard tests: 3/3 pass (count == 1 for member/type/library multi-section renders).
- Broader run (guard + `MethodBodyInspectionSession` + Member Calls + Top Leverage +
  Library Top Leverage): 47/47 pass — the counter and isolated collection don't interfere.

Follow-up to #2198.
