### PR TITLE
Add decompiler assertion scan

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
@@ -155,6 +155,21 @@ public class AssertionScanTests
         Assert.Contains("#1", method.Violations[1].Identity);
     }
 
+    [Fact]
+    public void Snapshot_DiffIdentityIgnoresFirstFailingPass()
+    {
+        var importViolation = new AssertionScan.AssertionViolationRecord(
+            Pass: IrPasses.ImportStageName,
+            Predicate: "SinkDistinguishableFromStack",
+            Node: nameof(LoadArgument),
+            SinkType: "bool",
+            Message: "M: LoadArgument raw occupies a bool sink without a Coerce",
+            Ordinal: 0);
+        var laterViolation = importViolation with { Pass = "some-later-pass" };
+
+        Assert.Equal(importViolation.Identity, laterViolation.Identity);
+    }
+
     static IrFunction Function(BlockContainer body, TypeRef returnType, params Parameter[] parameters)
         => new(
             "M",

--- a/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 
+using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.DecompilerHarness;
 
@@ -94,6 +95,27 @@ public class AssertionScanTests
 
         var method = Assert.Single(snapshot.Methods);
         Assert.Equal("InvalidOperationException: boom", method.PassBug);
+    }
+
+    [Fact]
+    public void EvaluateFunction_TreatsImporterCrashDiagnosticAsPassBug()
+    {
+        var function = Function(Returning(new Constant(0, Int32)), Int32);
+        function.Diagnostics.Add(new DecompilerDiagnostic(
+            DiagnosticIds.InternalError,
+            "importer crash: InvalidOperationException: boom"));
+
+        var result = AssertionScan.EvaluateFunction(
+            "synthetic",
+            "synthetic.dll",
+            "Samples.Holder",
+            "ImportCrash",
+            overload: 0,
+            function);
+
+        Assert.Equal("DEC0001: importer crash: InvalidOperationException: boom", result.PassBug);
+        Assert.Empty(result.Violations);
+        Assert.Empty(result.CoveredNodes);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
@@ -71,6 +71,68 @@ public class AssertionScanTests
         Assert.Equal(snapshot.Methods.Count, roundTrip!.Methods.Count);
     }
 
+    [Fact]
+    public void Snapshot_PreservesPassBugsSoDiffDoesNotCountTruncationAsImprovement()
+    {
+        var crashed = new AssertionScan.MethodResult(
+            Assembly: "synthetic",
+            AssemblyPath: "synthetic.dll",
+            Type: "Samples.Holder",
+            Method: "Crashes",
+            Overload: 0,
+            Signature: "() -> corelib:System.Void",
+            Key: "synthetic.dll!Samples.Holder::Crashes() -> corelib:System.Void",
+            Violations: [],
+            CoveredNodes: [],
+            PassBug: "InvalidOperationException: boom");
+        var scan = new AssertionScan.Result(
+            [crashed],
+            new Dictionary<string, int>(StringComparer.Ordinal),
+            []);
+
+        var snapshot = AssertionScan.AssertionViolationSnapshot.FromResult(scan);
+
+        var method = Assert.Single(snapshot.Methods);
+        Assert.Equal("InvalidOperationException: boom", method.PassBug);
+    }
+
+    [Fact]
+    public void Snapshot_PreservesDuplicateViolationOrdinals()
+    {
+        var duplicateA = new AssertionScan.ViolationSite(
+            Method: "synthetic.dll!Samples.Holder::M() -> corelib:System.Void",
+            Pass: IrPasses.ImportStageName,
+            Predicate: "SinkDistinguishableFromStack",
+            Node: nameof(LoadArgument),
+            SinkType: "bool",
+            Message: "M: LoadArgument raw occupies a bool sink without a Coerce",
+            Ordinal: 0);
+        var duplicateB = duplicateA with { Ordinal = 1 };
+        var result = new AssertionScan.MethodResult(
+            Assembly: "synthetic",
+            AssemblyPath: "synthetic.dll",
+            Type: "Samples.Holder",
+            Method: "M",
+            Overload: 0,
+            Signature: "() -> corelib:System.Void",
+            Key: duplicateA.Method,
+            Violations: [duplicateA, duplicateB],
+            CoveredNodes: [],
+            PassBug: null);
+        var scan = new AssertionScan.Result(
+            [result],
+            new Dictionary<string, int>(StringComparer.Ordinal),
+            []);
+
+        var snapshot = AssertionScan.AssertionViolationSnapshot.FromResult(scan);
+        var method = Assert.Single(snapshot.Methods);
+
+        Assert.Equal(2, method.Violations.Count);
+        Assert.Equal(2, method.ViolationIdentities().Count);
+        Assert.Contains("#0", method.Violations[0].Identity);
+        Assert.Contains("#1", method.Violations[1].Identity);
+    }
+
     static IrFunction Function(BlockContainer body, TypeRef returnType, params Parameter[] parameters)
         => new(
             "M",

--- a/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class AssertionScanTests
+{
+    static readonly TypeRef Enum32 = TypeRef.Definition("synthetic", "", "E32");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+
+    [Fact]
+    public void EvaluateFunction_ReportsFirstAssertionViolationAndCoverage()
+    {
+        var function = Function(
+            Returning(new LoadArgument(0, "raw", Int32)),
+            Enum32,
+            new Parameter("raw", Int32));
+
+        var result = AssertionScan.EvaluateFunction(
+            "synthetic",
+            "synthetic.dll",
+            "Samples.Holder",
+            "EnumReturn",
+            overload: 0,
+            function);
+
+        Assert.Null(result.PassBug);
+        var violation = Assert.Single(result.Violations);
+        Assert.Equal(IrPasses.ImportStageName, violation.Pass);
+        Assert.Equal("SinkDistinguishableFromStack", violation.Predicate);
+        Assert.Equal(nameof(LoadArgument), violation.Node);
+        Assert.Equal("E32", violation.SinkType);
+        Assert.Contains("without a Coerce", violation.Message);
+
+        Assert.Contains(nameof(LoadArgument), result.CoveredNodes);
+        Assert.Contains(nameof(Coerce), result.CoveredNodes);
+    }
+
+    [Fact]
+    public void Snapshot_IncludesCleanMethodsSoDiffCanSeeImprovements()
+    {
+        var violating = AssertionScan.EvaluateFunction(
+            "synthetic",
+            "synthetic.dll",
+            "Samples.Holder",
+            "EnumReturn",
+            overload: 0,
+            Function(Returning(new LoadArgument(0, "raw", Int32)), Enum32, new Parameter("raw", Int32)));
+        var clean = AssertionScan.EvaluateFunction(
+            "synthetic",
+            "synthetic.dll",
+            "Samples.Holder",
+            "CleanEnumReturn",
+            overload: 0,
+            Function(Returning(new LoadArgument(0, "e", Enum32)), Enum32, new Parameter("e", Enum32)));
+        var scan = new AssertionScan.Result(
+            [violating, clean],
+            new Dictionary<string, int>(StringComparer.Ordinal),
+            []);
+
+        var snapshot = AssertionScan.AssertionViolationSnapshot.FromResult(scan);
+
+        Assert.Equal(2, snapshot.Methods.Count);
+        Assert.Contains(snapshot.Methods, m => m.Key == clean.Key && m.Violations.Count == 0);
+
+        var json = JsonSerializer.Serialize(snapshot);
+        var roundTrip = JsonSerializer.Deserialize<AssertionScan.AssertionViolationSnapshot>(json);
+        Assert.NotNull(roundTrip);
+        Assert.Equal(snapshot.Methods.Count, roundTrip!.Methods.Count);
+    }
+
+    static IrFunction Function(BlockContainer body, TypeRef returnType, params Parameter[] parameters)
+        => new(
+            "M",
+            TypeRef.Definition("synthetic", "", "Holder"),
+            new MethodSignature(returnType, [.. parameters], HasThis: false, GenericParameterCount: 0),
+            [],
+            body)
+        {
+            TypeShapes = new Dictionary<TypeRef, TypeShape> { [Enum32] = TypeShape.Enum },
+            EnumMembers = new Dictionary<TypeRef, IReadOnlyDictionary<long, string>>
+            {
+                [Enum32] = new Dictionary<long, string> { [1] = "One" },
+            },
+        };
+
+    static BlockContainer Returning(IrExpression value)
+    {
+        var container = new BlockContainer();
+        var block = new Block(0);
+        block.Add(new Return(value));
+        container.Add(block);
+        return container;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -67,6 +67,10 @@
              Link="GeneratedFixtures.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ValidityCheck.cs"
              Link="ValidityCheck.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\AssertionEvaluator.cs"
+             Link="AssertionEvaluator.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\AssertionScan.cs"
+             Link="AssertionScan.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AnnotationCheck.cs"
              Link="AnnotationCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\VolatileFieldDetector.cs"

--- a/tools/DecompilerHarness/AssertionEvaluator.cs
+++ b/tools/DecompilerHarness/AssertionEvaluator.cs
@@ -1,0 +1,49 @@
+using System.Reflection;
+
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Decompiler.Pipeline.InverseArchitecture;
+using ILInspector.Decompiler.Tests.InverseArchitecture;
+
+namespace ILInspector.DecompilerHarness;
+
+internal static class AssertionEvaluator
+{
+    public sealed record PredicateResult(string Name, IReadOnlyList<AssumptionViolation> Violations);
+
+    public static IReadOnlyList<PredicateResult> EvaluateAssumptions(IrFunction function)
+    {
+        var results = new List<PredicateResult>();
+        var executed = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var type in InverseLedger.NodeTypes(typeof(IrFunction).Assembly))
+        {
+            if (type.GetCustomAttribute<InverseOfAttribute>() is not { Assumes: { } assumes }
+                || !executed.Add(assumes))
+            {
+                continue;
+            }
+
+            var method = typeof(InverseAssumptions).GetMethod(
+                assumes,
+                BindingFlags.Public | BindingFlags.Static,
+                [typeof(IrFunction)]);
+            if (method is null)
+                continue;
+
+            try
+            {
+                var result = method.Invoke(null, [function]) as IReadOnlyList<AssumptionViolation>;
+                results.Add(new PredicateResult(assumes, result ?? Array.Empty<AssumptionViolation>()));
+            }
+            catch (Exception ex)
+            {
+                string message = ex.InnerException is { } inner
+                    ? $"{inner.GetType().Name}: {inner.Message}"
+                    : $"{ex.GetType().Name}: {ex.Message}";
+                results.Add(new PredicateResult(
+                    assumes,
+                    [new AssumptionViolation(function, $"Predicate {assumes} threw {message}")]));
+            }
+        }
+        return results;
+    }
+}

--- a/tools/DecompilerHarness/AssertionPrinter.cs
+++ b/tools/DecompilerHarness/AssertionPrinter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -20,30 +19,10 @@ public static class AssertionPrinter
         {
             var sb = new StringBuilder();
 
-            var executedPredicates = new Dictionary<string, IReadOnlyList<AssumptionViolation>>();
-            foreach (var t in InverseLedger.NodeTypes(typeof(IrFunction).Assembly))
-            {
-                var attr = t.GetCustomAttribute<InverseOfAttribute>();
-                if (attr?.Assumes != null && !executedPredicates.ContainsKey(attr.Assumes))
-                {
-                    var method = typeof(InverseAssumptions).GetMethod(attr.Assumes, BindingFlags.Public | BindingFlags.Static);
-                    if (method != null)
-                    {
-                        try
-                        {
-                            var result = method.Invoke(null, new object[] { function }) as IReadOnlyList<AssumptionViolation>;
-                            executedPredicates[attr.Assumes] = result ?? Array.Empty<AssumptionViolation>();
-                        }
-                        catch
-                        {
-                            // A throwing predicate shouldn't crash the dump
-                            executedPredicates[attr.Assumes] = new[] { new AssumptionViolation(function, $"Predicate {attr.Assumes} threw an exception") };
-                        }
-                    }
-                }
-            }
-
-            var allViolations = executedPredicates.Values.SelectMany(v => v).ToList();
+            var allViolations = AssertionEvaluator.EvaluateAssumptions(function)
+                .SelectMany(r => r.Violations)
+                .ToList();
+            var unannotated = InverseLedger.Unannotated(typeof(IrFunction).Assembly).ToHashSet(StringComparer.Ordinal);
 
             void Append(IrNode node, int indent)
             {
@@ -61,6 +40,10 @@ public static class AssertionPrinter
                         sb.Append($", assumes: {attr.Assumes}");
                     }
                     sb.AppendLine();
+                }
+                else if (node is IrExpression && unannotated.Contains(t.Name))
+                {
+                    sb.Append(' ', indent * 2).AppendLine("// inverse: (unannotated)");
                 }
 
                 // Match violation by exact reference identity, not a lossy substring of Describe()

--- a/tools/DecompilerHarness/AssertionScan.cs
+++ b/tools/DecompilerHarness/AssertionScan.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
+using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Decompiler.Pipeline.InverseArchitecture;
 using ILInspector.Decompiler.Tests.InverseArchitecture;
@@ -166,6 +167,23 @@ internal static class AssertionScan
         var violations = new List<ViolationSite>();
         var seenViolations = new HashSet<string>(StringComparer.Ordinal);
         var covered = new SortedSet<string>(StringComparer.Ordinal);
+        var importCrashes = function.Diagnostics
+            .Where(diagnostic => diagnostic.Id == DiagnosticIds.InternalError)
+            .ToArray();
+        if (importCrashes.Length > 0)
+        {
+            return new MethodResult(
+                assembly,
+                assemblyPath,
+                type,
+                method,
+                overload,
+                signature,
+                key,
+                violations,
+                covered,
+                importCrashes[0].ToString());
+        }
 
         void Capture(string passName)
         {

--- a/tools/DecompilerHarness/AssertionScan.cs
+++ b/tools/DecompilerHarness/AssertionScan.cs
@@ -24,9 +24,10 @@ internal static class AssertionScan
         string Predicate,
         string Node,
         string SinkType,
-        string Message)
+        string Message,
+        int Ordinal)
     {
-        public string Identity => $"{Pass}|{Predicate}|{Node}|{SinkType}|{Message}";
+        public string Identity => $"{Pass}|{Predicate}|{Node}|{SinkType}|{Message}#{Ordinal}";
     }
 
     public sealed record MethodResult(
@@ -183,7 +184,7 @@ internal static class AssertionScan
                     string stableIdentity = $"{identity}#{ordinal}";
                     stageViolations.Add((
                         stableIdentity,
-                        new ViolationSite(key, passName, predicate.Name, node, sinkType, violation.Message)));
+                        new ViolationSite(key, passName, predicate.Name, node, sinkType, violation.Message, ordinal)));
                 }
             }
 
@@ -326,9 +327,14 @@ internal static class AssertionScan
 
         var baselineByMethod = baseline.Methods.ToDictionary(m => m.Key, StringComparer.Ordinal);
         var currentByMethod = current.Methods.ToDictionary(m => m.Key, StringComparer.Ordinal);
-        var comparable = currentByMethod.Keys.Intersect(baselineByMethod.Keys, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
-        int onlyCurrent = currentByMethod.Count - comparable.Length;
-        int onlyBaseline = baselineByMethod.Count - comparable.Length;
+        var shared = currentByMethod.Keys.Intersect(baselineByMethod.Keys, StringComparer.Ordinal).ToArray();
+        var comparable = shared
+            .Where(method => currentByMethod[method].PassBug is null && baselineByMethod[method].PassBug is null)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        int onlyCurrent = currentByMethod.Count - shared.Length;
+        int onlyBaseline = baselineByMethod.Count - shared.Length;
+        int passBugExcluded = shared.Length - comparable.Length;
 
         var gained = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
         var lost = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
@@ -343,7 +349,7 @@ internal static class AssertionScan
         }
 
         Console.WriteLine();
-        Console.WriteLine($"ASSERTION VIOLATION DIFF vs {baselinePath} ({comparable.Length} methods checked in both; {onlyCurrent} only-current, {onlyBaseline} only-baseline excluded)");
+        Console.WriteLine($"ASSERTION VIOLATION DIFF vs {baselinePath} ({comparable.Length} methods checked in both; {onlyCurrent} only-current, {onlyBaseline} only-baseline, {passBugExcluded} pass-bug excluded)");
         PrintDiffSide("REGRESSED (method gained the violation)", gained);
         PrintDiffSide("IMPROVED (method lost the violation)", lost);
     }
@@ -389,8 +395,9 @@ internal static class AssertionScan
                         m.Overload,
                         m.Signature,
                         m.Key,
+                        m.PassBug,
                         m.Violations
-                            .Select(v => new AssertionViolationRecord(v.Pass, v.Predicate, v.Node, v.SinkType, v.Message))
+                            .Select(v => new AssertionViolationRecord(v.Pass, v.Predicate, v.Node, v.SinkType, v.Message, v.Ordinal))
                             .OrderBy(v => v.Identity, StringComparer.Ordinal)
                             .ToArray()))
                     .OrderBy(m => m.Key, StringComparer.Ordinal)
@@ -405,6 +412,7 @@ internal static class AssertionScan
         int Overload,
         string Signature,
         string Key,
+        string? PassBug,
         IReadOnlyList<AssertionViolationRecord> Violations)
     {
         public SortedSet<string> ViolationIdentities()
@@ -416,8 +424,9 @@ internal static class AssertionScan
         string Predicate,
         string Node,
         string SinkType,
-        string Message)
+        string Message,
+        int Ordinal)
     {
-        public string Identity => $"{Pass}|{Predicate}|{Node}|{SinkType}|{Message}";
+        public string Identity => $"{Pass}|{Predicate}|{Node}|{SinkType}|{Message}#{Ordinal}";
     }
 }

--- a/tools/DecompilerHarness/AssertionScan.cs
+++ b/tools/DecompilerHarness/AssertionScan.cs
@@ -1,0 +1,423 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Decompiler.Pipeline.InverseArchitecture;
+using ILInspector.Decompiler.Tests.InverseArchitecture;
+
+namespace ILInspector.DecompilerHarness;
+
+internal static class AssertionScan
+{
+    public sealed record Options(
+        int? SampleSize,
+        int MaxExamples,
+        string? EmitViolationsPath,
+        string? DiffViolationsPath,
+        int? Workers,
+        bool Sequential);
+
+    public sealed record ViolationSite(
+        string Method,
+        string Pass,
+        string Predicate,
+        string Node,
+        string SinkType,
+        string Message)
+    {
+        public string Identity => $"{Pass}|{Predicate}|{Node}|{SinkType}|{Message}";
+    }
+
+    public sealed record MethodResult(
+        string Assembly,
+        string AssemblyPath,
+        string Type,
+        string Method,
+        int Overload,
+        string Signature,
+        string Key,
+        IReadOnlyList<ViolationSite> Violations,
+        IReadOnlyCollection<string> CoveredNodes,
+        string? PassBug);
+
+    public sealed record Result(
+        IReadOnlyList<MethodResult> Methods,
+        IReadOnlyDictionary<string, int> CoverageByNode,
+        IReadOnlyList<string> AnnotatedNodes);
+
+    sealed record MethodInput(
+        string Assembly,
+        string AssemblyPath,
+        string Type,
+        string Method,
+        int Overload,
+        IrFunction Function);
+
+    public static int Run(IReadOnlyList<string> assemblies, Options options)
+    {
+        if (options.SampleSize is <= 0)
+        {
+            Console.Error.WriteLine("--sample must be greater than zero.");
+            return 1;
+        }
+
+        if (options.DiffViolationsPath is not null && !File.Exists(options.DiffViolationsPath))
+        {
+            Console.Error.WriteLine($"Assertion-violation baseline not found: {options.DiffViolationsPath}");
+            return 1;
+        }
+
+        var result = Evaluate(assemblies, options.SampleSize, options.Workers, options.Sequential);
+        Report(result, options.MaxExamples, options.SampleSize);
+
+        if (options.EmitViolationsPath is not null)
+            EmitViolations(options.EmitViolationsPath, result);
+        if (options.DiffViolationsPath is not null)
+            DiffViolations(options.DiffViolationsPath, result);
+
+        return result.Methods.Any(m => m.PassBug is not null) ? 1 : 0;
+    }
+
+    public static Result Evaluate(
+        IReadOnlyList<string> assemblies,
+        int? sampleSize = null,
+        int? workers = null,
+        bool sequential = false)
+    {
+        var methods = new ConcurrentBag<MethodResult>();
+        var coverage = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
+        var annotatedNodes = InverseLedger.Rows(typeof(IrFunction).Assembly)
+            .Select(row => row.Node)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        var parallel = new ParallelOptions
+        {
+            MaxDegreeOfParallelism = sequential ? 1 : (workers ?? Math.Max(1, Environment.ProcessorCount - 2)),
+        };
+
+        using var metadata = CorpusMetadata.Create(assemblies);
+        foreach (var assemblyPath in assemblies)
+        {
+            using var source = MetadataSource.Open(assemblyPath, context: metadata);
+            _ = source.ResolveShape(TypeRef.CoreLib("System", "Int32"));
+            string portablePath = CorpusSensor.PortablePath(assemblyPath);
+
+            if (sampleSize is { } sample)
+            {
+                var candidates = IrImporter.GetStableSampleCandidates(source, sample).ToList();
+                Parallel.ForEach(candidates, parallel, candidate =>
+                {
+                    var function = candidate.Build(source);
+                    var result = EvaluateFunction(
+                        source.AssemblyName,
+                        portablePath,
+                        candidate.TypeName,
+                        candidate.MethodName,
+                        candidate.Overload,
+                        function);
+                    methods.Add(result);
+                    AddCoverage(coverage, result.CoveredNodes);
+                });
+                continue;
+            }
+
+            var seen = new Dictionary<string, int>(StringComparer.Ordinal);
+            var inputs = new List<MethodInput>();
+            foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
+            {
+                string overloadKey = $"{typeName}::{methodName}";
+                int overload = seen.GetValueOrDefault(overloadKey);
+                seen[overloadKey] = overload + 1;
+                inputs.Add(new MethodInput(source.AssemblyName, portablePath, typeName, methodName, overload, function));
+            }
+
+            Parallel.ForEach(inputs, parallel, input =>
+            {
+                var result = EvaluateFunction(
+                    input.Assembly,
+                    input.AssemblyPath,
+                    input.Type,
+                    input.Method,
+                    input.Overload,
+                    input.Function);
+                methods.Add(result);
+                AddCoverage(coverage, result.CoveredNodes);
+            });
+        }
+
+        return new Result(
+            methods.OrderBy(m => m.Key, StringComparer.Ordinal).ToArray(),
+            coverage.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal),
+            annotatedNodes);
+    }
+
+    internal static MethodResult EvaluateFunction(
+        string assembly,
+        string assemblyPath,
+        string type,
+        string method,
+        int overload,
+        IrFunction function)
+    {
+        string signature = CorpusMethodIdentity.SignatureText(function.Signature);
+        string key = $"{assemblyPath}!{type}::{method}{signature}";
+        var violations = new List<ViolationSite>();
+        var seenViolations = new HashSet<string>(StringComparer.Ordinal);
+        var covered = new SortedSet<string>(StringComparer.Ordinal);
+
+        void Capture(string passName)
+        {
+            AddCoveredNodes(function, covered);
+            var stageViolations = new List<(string Identity, ViolationSite Site)>();
+            foreach (var predicate in AssertionEvaluator.EvaluateAssumptions(function))
+            {
+                var perIdentityOrdinal = new Dictionary<string, int>(StringComparer.Ordinal);
+                foreach (var violation in predicate.Violations)
+                {
+                    string node = violation.Node.GetType().Name;
+                    string sinkType = SinkType(violation.Message);
+                    string identity = $"{predicate.Name}|{node}|{sinkType}|{violation.Message}";
+                    int ordinal = perIdentityOrdinal.GetValueOrDefault(identity);
+                    perIdentityOrdinal[identity] = ordinal + 1;
+                    string stableIdentity = $"{identity}#{ordinal}";
+                    stageViolations.Add((
+                        stableIdentity,
+                        new ViolationSite(key, passName, predicate.Name, node, sinkType, violation.Message)));
+                }
+            }
+
+            foreach (var (identity, site) in stageViolations)
+            {
+                if (seenViolations.Add(identity))
+                    violations.Add(site);
+            }
+        }
+
+        try
+        {
+            Capture(IrPasses.ImportStageName);
+            foreach (var pass in IrPasses.Default)
+            {
+                pass.Run(function, PassContext.None);
+                function.CheckInvariant();
+                Capture(pass.Name);
+            }
+        }
+        catch (Exception ex)
+        {
+            return new MethodResult(
+                assembly,
+                assemblyPath,
+                type,
+                method,
+                overload,
+                signature,
+                key,
+                violations,
+                covered,
+                $"{ex.GetType().Name}: {ex.Message}");
+        }
+
+        return new MethodResult(assembly, assemblyPath, type, method, overload, signature, key, violations, covered, PassBug: null);
+    }
+
+    static void AddCoveredNodes(IrFunction function, ISet<string> covered)
+    {
+        foreach (var node in function.Descendants)
+        {
+            if (node.GetType().GetCustomAttributes(typeof(InverseOfAttribute), inherit: false).Length > 0)
+                covered.Add(node.GetType().Name);
+        }
+    }
+
+    static void AddCoverage(ConcurrentDictionary<string, int> coverage, IReadOnlyCollection<string> nodes)
+    {
+        foreach (var node in nodes)
+            coverage.AddOrUpdate(node, 1, (_, count) => count + 1);
+    }
+
+    static string SinkType(string message)
+    {
+        var match = Regex.Match(message, @" occupies a (?<sink>.+?) sink without a Coerce$", RegexOptions.CultureInvariant);
+        return match.Success ? match.Groups["sink"].Value : "(unknown)";
+    }
+
+    static void Report(Result result, int maxExamples, int? sampleSize)
+    {
+        int total = result.Methods.Count;
+        int passBugs = result.Methods.Count(m => m.PassBug is not null);
+        var methodsWithViolations = result.Methods.Where(m => m.Violations.Count > 0).ToArray();
+        int violationCount = methodsWithViolations.Sum(m => m.Violations.Count);
+
+        string scope = sampleSize is null ? $"{total} methods" : $"{total} methods (--sample {sampleSize} per assembly)";
+        Console.WriteLine($"ASSERTION SCAN over {scope} ({passBugs} pass bugs)");
+        Console.WriteLine($"  methods with >=1 violation: {methodsWithViolations.Length} ({Percent(methodsWithViolations.Length, total)})");
+        Console.WriteLine($"  first violation sites      : {violationCount}");
+        Console.WriteLine();
+
+        PrintHistogram("By sink type:", methodsWithViolations.SelectMany(m => m.Violations).GroupBy(v => v.SinkType));
+        PrintHistogram("By first failing pass:", methodsWithViolations.SelectMany(m => m.Violations).GroupBy(v => v.Pass));
+        PrintHistogram("By node:", methodsWithViolations.SelectMany(m => m.Violations).GroupBy(v => v.Node));
+        PrintHistogram("By predicate:", methodsWithViolations.SelectMany(m => m.Violations).GroupBy(v => v.Predicate));
+
+        Console.WriteLine();
+        Console.WriteLine("Annotation coverage:");
+        Console.WriteLine($"  distinct [InverseOf] nodes exercised: {result.CoverageByNode.Count}/{result.AnnotatedNodes.Count}");
+        if (result.CoverageByNode.Count > 0)
+            Console.WriteLine($"  covered: {string.Join(", ", result.CoverageByNode.Keys.Order(StringComparer.Ordinal))}");
+        var missing = result.AnnotatedNodes.Except(result.CoverageByNode.Keys, StringComparer.Ordinal).ToArray();
+        if (missing.Length > 0)
+            Console.WriteLine($"  not exercised: {string.Join(", ", missing)}");
+
+        if (methodsWithViolations.Length > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Examples:");
+            foreach (var method in methodsWithViolations.Take(maxExamples))
+            {
+                Console.WriteLine($"  {method.Key}");
+                foreach (var violation in method.Violations.Take(maxExamples))
+                    Console.WriteLine($"    {violation.Pass}: {violation.Predicate} {violation.Node} -> {violation.SinkType}: {violation.Message}");
+            }
+        }
+
+        var passBugExamples = result.Methods.Where(m => m.PassBug is not null).Take(maxExamples).ToArray();
+        if (passBugExamples.Length > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Pass-bug examples:");
+            foreach (var method in passBugExamples)
+                Console.WriteLine($"  {method.Key}: {method.PassBug}");
+        }
+    }
+
+    static void PrintHistogram(string title, IEnumerable<IGrouping<string, ViolationSite>> groups)
+    {
+        Console.WriteLine(title);
+        var ordered = groups
+            .Select(g => (Name: g.Key, Count: g.Count()))
+            .OrderByDescending(g => g.Count)
+            .ThenBy(g => g.Name, StringComparer.Ordinal)
+            .ToArray();
+        if (ordered.Length == 0)
+        {
+            Console.WriteLine("  (none)");
+            return;
+        }
+        foreach (var item in ordered)
+            Console.WriteLine($"  {item.Count,8}  {item.Name}");
+    }
+
+    static void EmitViolations(string path, Result result)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path)) ?? ".");
+        var snapshot = AssertionViolationSnapshot.FromResult(result);
+        File.WriteAllText(path, JsonSerializer.Serialize(snapshot, JsonOptions()));
+        Console.WriteLine();
+        Console.WriteLine($"Wrote assertion-violation map for {snapshot.Methods.Count} methods to {path}");
+    }
+
+    static void DiffViolations(string baselinePath, Result result)
+    {
+        var baseline = JsonSerializer.Deserialize<AssertionViolationSnapshot>(File.ReadAllText(baselinePath), JsonOptions())
+            ?? throw new InvalidOperationException($"Could not read assertion-violation baseline '{baselinePath}'.");
+        var current = AssertionViolationSnapshot.FromResult(result);
+
+        var baselineByMethod = baseline.Methods.ToDictionary(m => m.Key, StringComparer.Ordinal);
+        var currentByMethod = current.Methods.ToDictionary(m => m.Key, StringComparer.Ordinal);
+        var comparable = currentByMethod.Keys.Intersect(baselineByMethod.Keys, StringComparer.Ordinal).Order(StringComparer.Ordinal).ToArray();
+        int onlyCurrent = currentByMethod.Count - comparable.Length;
+        int onlyBaseline = baselineByMethod.Count - comparable.Length;
+
+        var gained = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
+        var lost = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var method in comparable)
+        {
+            var now = currentByMethod[method].ViolationIdentities();
+            var was = baselineByMethod[method].ViolationIdentities();
+            foreach (var violation in now.Except(was, StringComparer.Ordinal))
+                (gained.TryGetValue(violation, out var methods) ? methods : gained[violation] = []).Add(method);
+            foreach (var violation in was.Except(now, StringComparer.Ordinal))
+                (lost.TryGetValue(violation, out var methods) ? methods : lost[violation] = []).Add(method);
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"ASSERTION VIOLATION DIFF vs {baselinePath} ({comparable.Length} methods checked in both; {onlyCurrent} only-current, {onlyBaseline} only-baseline excluded)");
+        PrintDiffSide("REGRESSED (method gained the violation)", gained);
+        PrintDiffSide("IMPROVED (method lost the violation)", lost);
+    }
+
+    static void PrintDiffSide(string title, SortedDictionary<string, List<string>> byViolation)
+    {
+        Console.WriteLine();
+        Console.WriteLine(title + ":");
+        if (byViolation.Count == 0)
+        {
+            Console.WriteLine("  (none)");
+            return;
+        }
+
+        foreach (var (violation, methods) in byViolation.OrderByDescending(kv => kv.Value.Count).ThenBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            Console.WriteLine($"  {violation}: {methods.Count}");
+            foreach (var method in methods.OrderBy(m => m, StringComparer.Ordinal))
+                Console.WriteLine($"      {method}");
+        }
+    }
+
+    static JsonSerializerOptions JsonOptions()
+        => new() { WriteIndented = true };
+
+    static string Percent(long part, long whole) => whole == 0 ? "n/a" : $"{100.0 * part / whole:F2}%";
+
+    public sealed record AssertionViolationSnapshot(
+        int SchemaVersion,
+        DateTimeOffset GeneratedUtc,
+        IReadOnlyList<AssertionViolationMethod> Methods)
+    {
+        public static AssertionViolationSnapshot FromResult(Result result)
+            => new(
+                SchemaVersion: 1,
+                GeneratedUtc: DateTimeOffset.UtcNow,
+                Methods: result.Methods
+                    .Select(m => new AssertionViolationMethod(
+                        m.Assembly,
+                        m.AssemblyPath,
+                        m.Type,
+                        m.Method,
+                        m.Overload,
+                        m.Signature,
+                        m.Key,
+                        m.Violations
+                            .Select(v => new AssertionViolationRecord(v.Pass, v.Predicate, v.Node, v.SinkType, v.Message))
+                            .OrderBy(v => v.Identity, StringComparer.Ordinal)
+                            .ToArray()))
+                    .OrderBy(m => m.Key, StringComparer.Ordinal)
+                    .ToArray());
+    }
+
+    public sealed record AssertionViolationMethod(
+        string Assembly,
+        string AssemblyPath,
+        string Type,
+        string Method,
+        int Overload,
+        string Signature,
+        string Key,
+        IReadOnlyList<AssertionViolationRecord> Violations)
+    {
+        public SortedSet<string> ViolationIdentities()
+            => new(Violations.Select(v => v.Identity), StringComparer.Ordinal);
+    }
+
+    public sealed record AssertionViolationRecord(
+        string Pass,
+        string Predicate,
+        string Node,
+        string SinkType,
+        string Message)
+    {
+        public string Identity => $"{Pass}|{Predicate}|{Node}|{SinkType}|{Message}";
+    }
+}

--- a/tools/DecompilerHarness/AssertionScan.cs
+++ b/tools/DecompilerHarness/AssertionScan.cs
@@ -167,6 +167,7 @@ internal static class AssertionScan
         var violations = new List<ViolationSite>();
         var seenViolations = new HashSet<string>(StringComparer.Ordinal);
         var covered = new SortedSet<string>(StringComparer.Ordinal);
+        var occurrenceOrdinals = new Dictionary<string, Dictionary<IrNode, int>>(StringComparer.Ordinal);
         var importCrashes = function.Diagnostics
             .Where(diagnostic => diagnostic.Id == DiagnosticIds.InternalError)
             .ToArray();
@@ -191,14 +192,12 @@ internal static class AssertionScan
             var stageViolations = new List<(string Identity, ViolationSite Site)>();
             foreach (var predicate in AssertionEvaluator.EvaluateAssumptions(function))
             {
-                var perIdentityOrdinal = new Dictionary<string, int>(StringComparer.Ordinal);
                 foreach (var violation in predicate.Violations)
                 {
                     string node = violation.Node.GetType().Name;
                     string sinkType = SinkType(violation.Message);
                     string identity = $"{predicate.Name}|{node}|{sinkType}|{violation.Message}";
-                    int ordinal = perIdentityOrdinal.GetValueOrDefault(identity);
-                    perIdentityOrdinal[identity] = ordinal + 1;
+                    int ordinal = OccurrenceOrdinal(occurrenceOrdinals, identity, violation.Node);
                     string stableIdentity = $"{identity}#{ordinal}";
                     stageViolations.Add((
                         stableIdentity,
@@ -239,6 +238,17 @@ internal static class AssertionScan
         }
 
         return new MethodResult(assembly, assemblyPath, type, method, overload, signature, key, violations, covered, PassBug: null);
+    }
+
+    static int OccurrenceOrdinal(Dictionary<string, Dictionary<IrNode, int>> ordinals, string identity, IrNode node)
+    {
+        if (!ordinals.TryGetValue(identity, out var byNode))
+            ordinals[identity] = byNode = new Dictionary<IrNode, int>(ReferenceEqualityComparer.Instance);
+        if (byNode.TryGetValue(node, out int ordinal))
+            return ordinal;
+        ordinal = byNode.Count;
+        byNode.Add(node, ordinal);
+        return ordinal;
     }
 
     static void AddCoveredNodes(IrFunction function, ISet<string> covered)
@@ -445,6 +455,6 @@ internal static class AssertionScan
         string Message,
         int Ordinal)
     {
-        public string Identity => $"{Pass}|{Predicate}|{Node}|{SinkType}|{Message}#{Ordinal}";
+        public string Identity => $"{Predicate}|{Node}|{SinkType}|{Message}#{Ordinal}";
     }
 }

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -40,6 +40,10 @@ static class Program
         bool validityCheck = false;
         int compileCap = 4000;
         bool assertions = false;
+        bool assertionScan = false;
+        string? emitAssertionViolations = null;
+        string? diffAssertionViolations = null;
+        int? sampleSize = null;
         string? emitValidityDefects = null;
         string? diffValidityDefects = null;
         bool fidelityCheck = false;
@@ -114,9 +118,13 @@ static class Program
                 case "--il": ilView = true; break;
                 case "--skip-pdb": skipPdb = true; break;
                 case "--assertions": assertions = true; break;
+                case "--assertion-scan": assertionScan = true; break;
+                case "--sample": sampleSize = int.Parse(args[++i]); break;
                 case "--max-examples": maxExamples = int.Parse(args[++i]); break;
                 case "--validity-check": validityCheck = true; break;
                 case "--compile-cap": compileCap = int.Parse(args[++i]); break;
+                case "--emit-assertion-violations": emitAssertionViolations = args[++i]; break;
+                case "--diff-assertion-violations": diffAssertionViolations = args[++i]; break;
                 case "--emit-validity-defects": emitValidityDefects = args[++i]; break;
                 case "--diff-validity-defects": diffValidityDefects = args[++i]; break;
                 case "--fidelity-check": fidelityCheck = true; break;
@@ -214,6 +222,17 @@ static class Program
             : ResolveAssemblies(inputs).Concat(packageInputs.Assemblies).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         if (assemblies.Count == 0)
             return Fail("No managed assemblies found in the given inputs.");
+
+        if (assertionScan || emitAssertionViolations is not null || diffAssertionViolations is not null)
+            return AssertionScan.Run(
+                assemblies,
+                new AssertionScan.Options(
+                    sampleSize,
+                    maxExamples,
+                    emitAssertionViolations,
+                    diffAssertionViolations,
+                    workers,
+                    sequential));
 
         if (validityCheck || emitValidityDefects is not null || diffValidityDefects is not null)
             return ValidityCheck.Run(assemblies, compileCap, maxExamples, emitValidityDefects, diffValidityDefects, lowered);
@@ -1321,6 +1340,12 @@ static class Program
                                 first unsound rewrite if a predicate fails.
                                 Usage rules (dev aid vs PR signoff):
                                 docs/decompiler-raise-discipline.md.
+          --assertion-scan      run the inverse-architecture assumption predicates
+                                across input methods and report violation
+                                histograms plus annotation coverage. Measurement
+                                only; not a raw-count gate.
+          --sample <n>          with --assertion-scan: deterministic hash-ranked
+                                method sample per assembly.
           --cfg                 with --dump: print the control-flow graph (per-block
                                 predecessor/successor edges) of each block container
                                 in the raised IR.
@@ -1356,6 +1381,12 @@ static class Program
           --max-examples <n>    example methods per bucket (default 5)
           --validity-check       compile every decompiled body; report invalid C#
           --compile-cap <n>     cap semantically-bound methods (default 4000)
+          --emit-assertion-violations <f>
+                                with --assertion-scan, write per-method assertion
+                                violations to JSON file <f>.
+          --diff-assertion-violations <f>
+                                with --assertion-scan, diff per-method assertion
+                                violations against JSON baseline <f>.
           --emit-validity-defects <f>    with --validity-check, write per-method defect codes to <f>
           --diff-validity-defects <f>    with --validity-check, diff per-method defects against baseline <f>
           --fidelity-check        decompile, recompile in-context, and compare IL opcodes (semantic fidelity)

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -8,6 +8,40 @@ The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — t
 
 **Gaps** (`--gaps`): the completeness view — see below.
 
+**Assertion scan** (`--assertion-scan`): runs the executable
+inverse-architecture `assumes:` predicates across input methods and reports the
+measurement view that `--dump --assertions` cannot provide alone: methods with at
+least one violation, violation histograms by sink type, first failing pass, node,
+and predicate, plus the distinct `[InverseOf]` nodes exercised by the scanned
+population. Use `--sample N` to run a deterministic hash-ranked sample per
+assembly, and combine it with `--package` / `--package-version` /
+`--package-tfm` / `--package-assembly` the same way other harness scans do.
+
+The scan is a triage and localized-signoff aid, not a CI gate on a raw violation
+count. It automates the value-typed-emission leak-surface census, but the
+population-scale correctness gates remain compile-back, render A/B, and the
+quality-diff card; see
+[docs/decompiler-raise-discipline.md](../../docs/decompiler-raise-discipline.md)
+for the assertion-dump discipline.
+
+For before/after work, mirror the validity-defects loop with
+`--emit-assertion-violations <file>` and
+`--diff-assertion-violations <file>`. The emitted JSON includes every scanned
+method, including clean methods, so a method losing its last violation appears as
+an `IMPROVED` row rather than disappearing behind a cap-boundary artifact.
+
+```bash
+dotnet run --project tools/DecompilerHarness -c Release -- \
+  artifacts/bin/ILInspector.Decompiler/release/ILInspector.Decompiler.dll \
+  --assertion-scan --sample 125 --max-examples 5
+
+dotnet run --project tools/DecompilerHarness -c Release -- MyLib.dll \
+  --assertion-scan --sample 250 --emit-assertion-violations /tmp/assertions.base.json
+
+dotnet run --project tools/DecompilerHarness -c Release -- MyLib.dll \
+  --assertion-scan --sample 250 --diff-assertion-violations /tmp/assertions.base.json
+```
+
 **Generated fixtures** (`--generated-fixtures [id|prefix|list]`): builds selected
 generated-fixture catalogue entries into a temporary class library, runs the
 Roslyn shape oracle and compile-back oracle, and prints results by stable fixture


### PR DESCRIPTION
Fixes #2217

Changes: adds a DecompilerHarness `--assertion-scan` mode with deterministic `--sample`, violation/coverage histograms, and JSON `--emit-assertion-violations` / `--diff-assertion-violations` artifacts. `--dump --assertions` now reuses the same evaluator and marks unannotated in-domain nodes.

Card revision: `f2cf7e08`

## Change

**Conclusion:** **PASS** — harness-only measurement mode; the shipped decompiler pipeline and product rendering path are unchanged.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --configfile nuget.config` |
| Focused tests | Pass: `AssertionScanTests`, `InverseArchitectureTests` |
| Decompiler fast suite | Pass: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -noLogo -trait- 'Speed=Slow'` |
| Harness smoke | Pass: `--assertion-scan --sample 20 --emit-assertion-violations`, then `--diff-assertion-violations` reported 0 regressions / 0 improvements against the emitted baseline |
| Markdown | Pass: `npx markdownlint-cli tools/DecompilerHarness/README.md` |
| CI | Pass: `changes`, `markdownlint`, and `test (ubuntu-26.04, linux-x64)` |

## Decompiler quality

**Conclusion:** **PASS** — not a raise, structuring, typing, or printer semantics change; no corpus quality card is required. The new scan is documented as measurement/triage, not a raw-count gate.

## Reviews

### Review 1: Claude Opus 4.8 — clean

**Result:** No blocking or high-confidence correctness findings.

Opus independently reviewed scan behavior, `--sample`, emit/diff, package/raw routing, shared `--dump --assertions` evaluator, pass-bug handling, concurrency, and CLI routing. No code changes were required from this clean review.

### Review 2: Gemini Pro — clean on final head

**Result:** No blocking or high-confidence correctness findings on `f2cf7e08`.

The final Gemini pass verified the accumulated fixes: pass bugs and `DEC0001` importer crashes are excluded from diffs, node-reference duplicate ordinals avoid cross-stage over-deduping, first-failing pass remains report-only and is omitted from JSON diff identity, `--sample` remains deterministic, and CLI routing/evaluator behavior are sound.

### Prior review findings resolved

Earlier Gemini passes found artifact issues that were fixed before the final clean review:

- `62374827`: persisted `PassBug` in snapshots, excluded pass-bug methods from baseline comparisons, and preserved duplicate violation ordinals in JSON identities.
- `06a4efe8`: classified `DEC0001` importer-crash functions as pass-bug scan rows before assertion capture.
- `f2cf7e08`: assigned runtime duplicate ordinals by violating node reference across the pipeline and removed first-failing pass from JSON diff identity.

**Review conclusion:** **PASS** — two clean reviews are available on the final behavior: Claude Opus 4.8 and Gemini Pro on `f2cf7e08`.
