### PR TITLE
Skip escape-alloc and optimization index-build phases when unneeded (#2198)

### DIFF
--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -29,7 +29,8 @@ public sealed class LibraryBodyIndex
         IReadOnlyDictionary<(string Namespace, string Name), bool> inAssemblyTypeIsException,
         IReadOnlySet<int> suppressedOpportunityTokens,
         IReadOnlySet<string> exceptionTypeNames,
-        IReadOnlySet<int> nonHeapNewObjOperandTokens)
+        IReadOnlySet<int> nonHeapNewObjOperandTokens,
+        bool opportunitiesComputed)
     {
         Path = path;
         Methods = methods;
@@ -37,6 +38,7 @@ public sealed class LibraryBodyIndex
         UnsafeEvidence = unsafeEvidence;
         Diagnostics = diagnostics;
         _rawOpportunities = optimizationOpportunities;
+        _opportunitiesComputed = opportunitiesComputed;
         _unsafeLeverageMethods = unsafeLeverageMethods;
         MemorySafetyRulesEnabled = memorySafetyRulesEnabled;
         UnsafeModes = unsafeModes;
@@ -56,6 +58,7 @@ public sealed class LibraryBodyIndex
     public ImmutableArray<AnalysisDiagnostic> Diagnostics { get; }
 
     readonly ImmutableArray<OptimizationOpportunity> _rawOpportunities;
+    readonly bool _opportunitiesComputed;
     readonly ImmutableArray<MethodIdentity> _unsafeLeverageMethods;
     ImmutableArray<OptimizationOpportunity> _opportunities;
     IReadOnlyDictionary<int, ImmutableArray<DirectCall>>? _directCallsByCaller;
@@ -71,6 +74,8 @@ public sealed class LibraryBodyIndex
     {
         get
         {
+            if (!_opportunitiesComputed)
+                return ImmutableArray<OptimizationOpportunity>.Empty;
             if (_opportunities.IsDefault)
             {
                 var reachByToken = new Dictionary<int, int>();
@@ -748,7 +753,8 @@ public sealed class LibraryBodyIndex
             path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
             index.OptimizationOpportunities, index.UnsafeLeverageMethods, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
             index.BodySignals, index.AllocationOccurrences, index.UnsafetyOccurrences, index.InAssemblyTypeIsException, index.SuppressedOpportunityTokens, index.ExceptionTypeNames,
-            index.NonHeapNewObjOperandTokens);
+            index.NonHeapNewObjOperandTokens,
+            opportunitiesComputed: includeOpportunities);
     }
 
     public ImmutableArray<DirectCall> FindCalls(MemberPattern pattern)

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -732,7 +732,8 @@ public sealed class LibraryBodyIndex
     public static LibraryBodyIndex Open(string path)
         => Open(path, resolver: null);
 
-    public static LibraryBodyIndex Open(string path, IAssemblyReferenceResolver? resolver = null)
+    public static LibraryBodyIndex Open(string path, IAssemblyReferenceResolver? resolver = null,
+        bool includeAllocations = true, bool includeOpportunities = true)
     {
         using var stream = File.OpenRead(path);
         using var peReader = new PEReader(stream);
@@ -740,7 +741,9 @@ public sealed class LibraryBodyIndex
             throw new BadImageFormatException($"No managed metadata: {path}");
         var reader = peReader.GetMetadataReader();
         using var builder = new IndexBuilder(path, reader, peReader, resolver);
-        var index = builder.Build();
+        // Optimization opportunities are synthesized from allocation occurrences (allocation
+        // hotspots), so requesting opportunities implies computing allocations.
+        var index = builder.Build(includeAllocations || includeOpportunities, includeOpportunities);
         return new LibraryBodyIndex(
             path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
             index.OptimizationOpportunities, index.UnsafeLeverageMethods, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
@@ -1955,7 +1958,7 @@ public sealed class LibraryBodyIndex
                 && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
         }
 
-        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> AllocationOccurrences, IReadOnlyDictionary<int, ImmutableArray<UnsafetyOccurrence>> UnsafetyOccurrences, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames, IReadOnlySet<int> NonHeapNewObjOperandTokens) Build()
+        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> AllocationOccurrences, IReadOnlyDictionary<int, ImmutableArray<UnsafetyOccurrence>> UnsafetyOccurrences, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames, IReadOnlySet<int> NonHeapNewObjOperandTokens) Build(bool includeAllocations, bool includeOpportunities)
         {
             var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var unsafeLeverageMethods = ImmutableArray.CreateBuilder<MethodIdentity>();
@@ -2005,20 +2008,25 @@ public sealed class LibraryBodyIndex
                         var decodedBody = DecodeBody(il, body.ExceptionRegions);
                         bool hasUnsafeLocals = ScanLocals(body, caller, scope, unsafeEvidence);
                         var loopRegions = decodedBody.LoopRegions;
-                        var allocations = CollectAllocationOccurrences(il, decodedBody, body.ExceptionRegions, caller, scope, loopRegions, classifyEscapes: true);
+                        var allocations = includeAllocations
+                            ? CollectAllocationOccurrences(il, decodedBody, body.ExceptionRegions, caller, scope, loopRegions, classifyEscapes: true)
+                            : ImmutableArray<AllocationOccurrence>.Empty;
                         if (allocations.Length > 0)
                             allocationOccurrences[caller.MetadataToken] = allocations;
                         var unsafety = CollectUnsafetyOccurrences(decodedBody.Instructions, body, caller, scope);
                         if (unsafety.Length > 0)
                             unsafetyOccurrences[caller.MetadataToken] = unsafety;
                         var methodAttributes = methodDef.GetCustomAttributes();
-                        if (!typeSourceGenerated
-                            && !HasGeneratedCodeAttribute(methodAttributes)
-                            && !HasCompilerGeneratedAttribute(methodAttributes)
-                            && !IsBlazorRenderMethod(caller))
-                            optimizationOpportunities.AddRange(CollectOptimizationOpportunities(il, decodedBody, body.ExceptionRegions, caller, scope, loopRegions));
-                        else
-                            suppressedOpportunityTokens.Add(caller.MetadataToken);
+                        if (includeOpportunities)
+                        {
+                            if (!typeSourceGenerated
+                                && !HasGeneratedCodeAttribute(methodAttributes)
+                                && !HasCompilerGeneratedAttribute(methodAttributes)
+                                && !IsBlazorRenderMethod(caller))
+                                optimizationOpportunities.AddRange(CollectOptimizationOpportunities(il, decodedBody, body.ExceptionRegions, caller, scope, loopRegions));
+                            else
+                                suppressedOpportunityTokens.Add(caller.MetadataToken);
+                        }
                         var signals = CollectBodySignals(il, decodedBody, body, scope, loopRegions);
                         if (signals.Newarr > 0 || signals.Throws > 0 || signals.Catches > 0 || signals.Finallys > 0 || signals.Boxes > 0)
                             bodySignals[caller.MetadataToken] = signals;

--- a/src/dotnet-inspect.Tests/AnalysisScopeTests.cs
+++ b/src/dotnet-inspect.Tests/AnalysisScopeTests.cs
@@ -1,0 +1,63 @@
+using DotnetInspector.Output;
+using DotnetInspector.Sections;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Locks the section -> index-build-phase mapping (<see cref="ApiOutputFormatter.AnalysisScopeFor"/>):
+/// only Allocation Facts and Performance Triage consume the two expensive whole-assembly phases, so
+/// every other analysis section builds the index without escape-classified allocations or
+/// optimization opportunities.
+/// </summary>
+public class AnalysisScopeTests
+{
+    [Fact]
+    public void PerformanceTriage_NeedsOpportunitiesAndAllocations()
+    {
+        var (alloc, opp) = ApiOutputFormatter.AnalysisScopeFor([SectionNames.PerformanceTriage]);
+        Assert.True(opp);
+        Assert.True(alloc); // opportunities are synthesized from allocation hotspots
+    }
+
+    [Fact]
+    public void AllocationFacts_NeedsAllocationsButNotOpportunities()
+    {
+        var (alloc, opp) = ApiOutputFormatter.AnalysisScopeFor([SectionNames.AllocationFacts]);
+        Assert.True(alloc);
+        Assert.False(opp);
+    }
+
+    [Theory]
+    [InlineData(SectionNames.TopLeverage)]
+    [InlineData(SectionNames.Calls)]
+    [InlineData(SectionNames.Callers)]
+    [InlineData(SectionNames.CallGraph)]
+    [InlineData(SectionNames.CostFacts)]
+    [InlineData(SectionNames.SafetyFacts)]
+    [InlineData(SectionNames.UnsafeMembers)]
+    [InlineData(SectionNames.UnsafeOperations)]
+    [InlineData(SectionNames.CalledTypes)]
+    public void OtherAnalysisSections_NeedNeitherExpensivePhase(string section)
+    {
+        var (alloc, opp) = ApiOutputFormatter.AnalysisScopeFor([section]);
+        Assert.False(alloc);
+        Assert.False(opp);
+    }
+
+    [Fact]
+    public void UnionOfSections_TakesTheBroadestScope()
+    {
+        var (alloc, opp) = ApiOutputFormatter.AnalysisScopeFor(
+            [SectionNames.TopLeverage, SectionNames.AllocationFacts]);
+        Assert.True(alloc);
+        Assert.False(opp);
+    }
+
+    [Fact]
+    public void NullSections_DefaultsToFullBuild()
+    {
+        var (alloc, opp) = ApiOutputFormatter.AnalysisScopeFor(null);
+        Assert.True(alloc);
+        Assert.True(opp);
+    }
+}

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -664,7 +664,7 @@ public class ApiCommand
             // when such a section is requested) instead of opening one session per section.
             MethodBodyInspectionSession? typeAnalysisSession = null;
             MethodBodyInspectionSession TypeAnalysisSession() =>
-                typeAnalysisSession ??= ApiOutputFormatter.OpenTypeAnalysisSession(options.DllPath!);
+                typeAnalysisSession ??= ApiOutputFormatter.OpenTypeAnalysisSession(options.DllPath!, GetRequestedMemberSections(type, options));
 
             if (options.DllPath is not null
                 && GetRequestedMemberSections(type, options).Contains(SectionNames.UnsafeMembers))
@@ -1294,7 +1294,7 @@ public class ApiCommand
 
             MethodBodyInspectionSession? typeAnalysisSession = null;
             MethodBodyInspectionSession TypeAnalysisSession() =>
-                typeAnalysisSession ??= ApiOutputFormatter.OpenTypeAnalysisSession(renderOptions.DllPath!);
+                typeAnalysisSession ??= ApiOutputFormatter.OpenTypeAnalysisSession(renderOptions.DllPath!, GetRequestedMemberSections(type, renderOptions));
 
             if (renderOptions.DllPath is not null
                 && GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.UnsafeMembers))

--- a/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
+++ b/src/dotnet-inspect/Inspectors/LibraryMetadataService.cs
@@ -133,6 +133,7 @@ internal static class LibraryMetadataService
                     AssemblyPath = path,
                     Model = inspection,
                     Logger = logger,
+                    IncludeOpportunities = scanners.Contains(Sections.LibrarySections.ScannerOptimizationOpportunities),
                 });
             }
             else if (options.Verbosity == Options.Verbosity.Detailed)

--- a/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
+++ b/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
@@ -34,9 +34,16 @@ public sealed class MethodBodyInspectionSession
     /// </summary>
     public string SourceName { get; }
 
-    /// <summary>Opens a session over an assembly's analysis body index.</summary>
-    public static MethodBodyInspectionSession Open(string assemblyPath, IAssemblyReferenceResolver? resolver = null)
-        => new(Analysis.LibraryBodyIndex.Open(assemblyPath, resolver), Path.GetFileNameWithoutExtension(assemblyPath));
+    /// <summary>
+    /// Opens a session over an assembly's analysis body index. <paramref name="includeAllocations"/>
+    /// and <paramref name="includeOpportunities"/> gate the two expensive whole-assembly analysis
+    /// phases (escape-classified allocation occurrences and optimization opportunities); leave them
+    /// on unless the caller knows no requested section consumes them (see
+    /// <c>ApiOutputFormatter.AnalysisScopeFor</c>).
+    /// </summary>
+    public static MethodBodyInspectionSession Open(string assemblyPath, IAssemblyReferenceResolver? resolver = null,
+        bool includeAllocations = true, bool includeOpportunities = true)
+        => new(Analysis.LibraryBodyIndex.Open(assemblyPath, resolver, includeAllocations, includeOpportunities), Path.GetFileNameWithoutExtension(assemblyPath));
 
     /// <summary>
     /// Allocation facts for one method (<paramref name="methodToken"/>), optionally narrowed to a

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1295,7 +1295,11 @@ public static class ApiOutputFormatter
                 {
                     try
                     {
-                        scopeSessions.Add(MethodBodyInspectionSession.Open(scopePath, AnalysisReferenceResolver(scopePath, options), includeAllocations: false, includeOpportunities: false));
+                        // External caller nodes carry their scope assembly's method signals, so the
+                        // scope build needs allocations whenever this graph renders allocation/IL
+                        // fields (indexInclAllocations already captures that). Opportunities are never
+                        // read from the reverse graph.
+                        scopeSessions.Add(MethodBodyInspectionSession.Open(scopePath, AnalysisReferenceResolver(scopePath, options), includeAllocations: indexInclAllocations, includeOpportunities: false));
                     }
                     catch
                     {

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -24,11 +24,32 @@ public static class ApiOutputFormatter
         => ApiCommand.PlatformAssemblyResolver(dllPath, options?.ProjectAssetsPath, options?.Tfm);
 
     /// <summary>
-    /// Opens a type-scope analysis session for the type/library sections. Callers memoize this per
-    /// type so the five type-analysis populators share one index build instead of opening five.
+    /// Which expensive whole-assembly analysis phases the requested sections actually consume.
+    /// Escape-classified allocation occurrences feed Allocation Facts (and, transitively,
+    /// optimization opportunities); optimization opportunities feed Performance Triage. Every other
+    /// analysis section (Calls / Callers / Call Graph / Top Leverage / Cost / Safety / Unsafe /
+    /// Called Types) needs neither, so the index build can skip both. A null/unknown set is treated
+    /// as "needs everything" (safe default).
     /// </summary>
-    internal static MethodBodyInspectionSession OpenTypeAnalysisSession(string dllPath)
-        => MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath));
+    internal static (bool IncludeAllocations, bool IncludeOpportunities) AnalysisScopeFor(IReadOnlyCollection<string>? requestedSections)
+    {
+        if (requestedSections is null)
+            return (true, true);
+        bool opportunities = requestedSections.Contains(SectionNames.PerformanceTriage);
+        bool allocations = opportunities || requestedSections.Contains(SectionNames.AllocationFacts);
+        return (allocations, opportunities);
+    }
+
+    /// <summary>
+    /// Opens a type-scope analysis session for the type/library sections. Callers memoize this per
+    /// type so the five type-analysis populators share one index build instead of opening five. The
+    /// build is narrowed to the phases <paramref name="requestedSections"/> consumes.
+    /// </summary>
+    internal static MethodBodyInspectionSession OpenTypeAnalysisSession(string dllPath, IReadOnlyCollection<string>? requestedSections = null)
+    {
+        var (allocations, opportunities) = AnalysisScopeFor(requestedSections);
+        return MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath), allocations, opportunities);
+    }
 
     // ===== Full API View Model Factory =====
 
@@ -1126,9 +1147,11 @@ public static class ApiOutputFormatter
         // index-backed section is actually requested (sections like decompiled source / IL
         // go through MemberCodeProvider and never touch it). Every index-backed block below
         // shares this one session instead of re-opening and re-analyzing every method body.
+        // The build is narrowed to the phases the requested sections actually consume.
+        var (indexInclAllocations, indexInclOpportunities) = AnalysisScopeFor(requestedSections);
         MethodBodyInspectionSession? indexSession = null;
         MethodBodyInspectionSession IndexSession() =>
-            indexSession ??= MethodBodyInspectionSession.Open(dllPath, assemblyResolver);
+            indexSession ??= MethodBodyInspectionSession.Open(dllPath, assemblyResolver, indexInclAllocations, indexInclOpportunities);
 
         // For sections that require a single selected method (Calls, CallGraph, decompiled source, etc.),
         // filter to that specific overload. Callers can aggregate across all overloads.

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1149,6 +1149,12 @@ public static class ApiOutputFormatter
         // shares this one session instead of re-opening and re-analyzing every method body.
         // The build is narrowed to the phases the requested sections actually consume.
         var (indexInclAllocations, indexInclOpportunities) = AnalysisScopeFor(requestedSections);
+        // Call Graph / Caller Graph allocation and IL-evidence annotations (opt-in via
+        // --fields/--columns) read allocation-derived method signals, so the escape-classified
+        // allocation phase must run when those graphs are rendered with explicit fields.
+        if ((requestedSections.Contains(SectionNames.CallGraph) || requestedSections.Contains(SectionNames.CallerGraph))
+            && (options?.Fields is { Length: > 0 } || options?.Columns is { Length: > 0 }))
+            indexInclAllocations = true;
         MethodBodyInspectionSession? indexSession = null;
         MethodBodyInspectionSession IndexSession() =>
             indexSession ??= MethodBodyInspectionSession.Open(dllPath, assemblyResolver, indexInclAllocations, indexInclOpportunities);
@@ -1224,7 +1230,7 @@ public static class ApiOutputFormatter
                 {
                     try
                     {
-                        scopeSessions.Add(MethodBodyInspectionSession.Open(scopePath, AnalysisReferenceResolver(scopePath, options)));
+                        scopeSessions.Add(MethodBodyInspectionSession.Open(scopePath, AnalysisReferenceResolver(scopePath, options), includeAllocations: false, includeOpportunities: false));
                     }
                     catch
                     {
@@ -1289,7 +1295,7 @@ public static class ApiOutputFormatter
                 {
                     try
                     {
-                        scopeSessions.Add(MethodBodyInspectionSession.Open(scopePath, AnalysisReferenceResolver(scopePath, options)));
+                        scopeSessions.Add(MethodBodyInspectionSession.Open(scopePath, AnalysisReferenceResolver(scopePath, options), includeAllocations: false, includeOpportunities: false));
                     }
                     catch
                     {

--- a/src/dotnet-inspect/Sections/ScannerRegistry.cs
+++ b/src/dotnet-inspect/Sections/ScannerRegistry.cs
@@ -13,16 +13,27 @@ public sealed class ScannerContext
     public required LibraryInspection Model { get; init; }
     public required VerboseLogger Logger { get; init; }
 
+    /// <summary>
+    /// Whether the shared body session must compute optimization opportunities (and therefore the
+    /// allocation occurrences they build on). True only when the Performance Triage scanner is in
+    /// the requested set; the other body scanners (unsafe members, top leverage) need neither, so
+    /// the index build skips both expensive phases. Defaults to true (compute everything) so an
+    /// unset context never silently drops opportunity data.
+    /// </summary>
+    public bool IncludeOpportunities { get; init; } = true;
+
     private MethodBodyInspectionSession? _bodySession;
 
     /// <summary>
     /// Shared method-body analysis session for <see cref="AssemblyPath"/>, built once on first use.
     /// The body-index scanners (unsafe members, top leverage, optimization opportunities) share it
     /// instead of each rebuilding the full <c>LibraryBodyIndex</c>. Scanners run sequentially
-    /// (<see cref="ScannerRegistry.RunScanners"/>), so no synchronization is required.
+    /// (<see cref="ScannerRegistry.RunScanners"/>), so no synchronization is required. The build is
+    /// narrowed to the phases the requested scanners consume (see <see cref="IncludeOpportunities"/>).
     /// </summary>
     public MethodBodyInspectionSession BodySession() =>
-        _bodySession ??= MethodBodyInspectionSession.Open(AssemblyPath);
+        _bodySession ??= MethodBodyInspectionSession.Open(
+            AssemblyPath, includeAllocations: IncludeOpportunities, includeOpportunities: IncludeOpportunities);
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

The payoff of the #2198 profiling. The index build's two most expensive per-method
phases — `CollectAllocationOccurrences(classifyEscapes: true)` (~39% of the build) and
`CollectOptimizationOpportunities` (~24%) = **~63%** — feed **only** the Allocation Facts
and Performance Triage sections. Every other analysis section (Calls, Callers, Call Graph,
Top Leverage, Cost/Safety facts, Unsafe, Called Types) computed and discarded them.

This gates the two phases and computes them **on demand** from the requested sections:

- `LibraryBodyIndex.Open` gains `includeAllocations` / `includeOpportunities` (default
  **true** = full build, so every existing caller — DiffCommand, tests, the Detailed
  fallback — is unchanged). `IndexBuilder.Build` skips the gated phases.
- `ApiOutputFormatter.AnalysisScopeFor(requestedSections)` maps sections → the two flags
  (opportunities imply allocations, since opportunities are synthesized from allocation
  hotspots).
- The three render paths open their shared session with the narrowed scope: member
  (`PopulateIndexSections`), type (`OpenTypeAnalysisSession`, both `ApiCommand` dispatch
  sites), library (`ScannerContext.IncludeOpportunities`).

## Results

- **Behavior-preserving** — byte-identical output across **every** member/type/library
  analysis section, individually and combined, *including* Allocation Facts and
  Performance Triage when requested (verified against a same-commit baseline; a spike that
  skipped both phases confirmed the other sections are truly independent).
- **CPU (`ILInspector.Decompiler.dll`, load-insensitive):**
  - `library -S "Unsafe Members"`: **1.71 → 0.78s (~2.2×)**
  - `library -S "Top Leverage"`: **2.64 → 1.65s (~37%)**
  - `library -S "Top Leverage,Unsafe Members"`: 3.03 → 1.66s (~45%)
  - `library -S "Performance Triage"`: 2.49 → 2.53s — **unchanged** (correctly still builds
    the phases).
- Tests: 123 CLI section/formatter tests pass; 13 new `AnalysisScopeTests` lock the mapping.

## Notes

- `ILInspector.Analysis.Tests` can't build in this environment due to a **pre-existing**,
  unrelated `CS0436` in `ILInspector.Analysis.LookalikeFixtures` (baseline fails identically).
  The `LibraryBodyIndex.Open` callers there use the default (full) params, so they're
  unaffected.
- Complements #2216 (build-once guard): this narrows *what* the single build computes.

Closes the on-demand-phases item in #2198.
