### PR TITLE
Preserve record helper shells in RTS

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1706,6 +1706,41 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_PreservesRecordGeneratedVirtualHelperShells()
+    {
+        var assemblyPath = CompileFixture("""
+            public record Row(string Name, string Value);
+            """);
+        try
+        {
+            var results = ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [
+                    new ReturnToSender.RequestedTarget("Row", "ToString", 0),
+                    new ReturnToSender.RequestedTarget("Row", "Equals", 0),
+                ]);
+
+            Assert.Collection(
+                results,
+                toString =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, toString.Status);
+                    Assert.Contains("protected virtual bool PrintMembers", toString.Source);
+                    Assert.Contains("protected virtual System.Type EqualityContract", toString.Source);
+                },
+                equalsObject =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, equalsObject.Status);
+                    Assert.Contains("public virtual bool Equals(Row other)", equalsObject.Source);
+                });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_EmitsSignatureMatchedEqualityOperatorPairSibling()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1741,6 +1741,52 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_PreservesGenericRecordTypedEqualsShell()
+    {
+        var assemblyPath = CompileFixture("""
+            public record Row<T>(T Value);
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Row`1", "Equals", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public virtual bool Equals(Row<T> other)", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_RendersAbstractClosurePropertiesWithoutBodies()
+    {
+        var assemblyPath = CompileFixture("""
+            public abstract class Row
+            {
+                public abstract string Name { get; }
+                public string Describe() => Name;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Row", "Describe", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains("public abstract string Name { get; }", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_EmitsSignatureMatchedEqualityOperatorPairSibling()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1,5 +1,6 @@
 using ILInspector.DecompilerHarness;
 using ILInspector.Decompiler;
+using ILInspector.Metadata;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -1767,18 +1768,49 @@ public class ReturnToSenderPrototypeTests
         var assemblyPath = CompileFixture("""
             public abstract class Row
             {
-                public abstract string Name { get; }
-                public string Describe() => Name;
+                public abstract string Name { get; set; }
+                public void SetName(string value) => Name = value;
             }
             """);
         try
         {
             var result = Assert.Single(ReturnToSender.CompileBackTargets(
                 assemblyPath,
-                [new ReturnToSender.RequestedTarget("Row", "Describe", 0)]));
+                [new ReturnToSender.RequestedTarget("Row", "SetName", 0)]));
 
             Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
-            Assert.Contains("public abstract string Name { get; }", result.Source);
+            Assert.Contains("public abstract string Name { get; set; }", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackSelfTypeSignature_IncludesDeclaringGenericParameters()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Container<T>
+            {
+                public record Row<U>(T Outer, U Value);
+            }
+            """);
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(assemblyPath));
+            var reader = pe.GetMetadataReader();
+            var typeHandle = reader.TypeDefinitions
+                .Single(handle => TypeResolver.GetFullName(reader, reader.GetTypeDefinition(handle)) == "Container`1.Row`1");
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            var identity = CompileBackTypeIdentity.FromDefinition(reader, typeDef);
+            var helper = typeof(CompileBackSourceComposer).GetMethod(
+                "SelfTypeSignature",
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+            var selfType = Assert.IsType<string>(helper!.Invoke(null, [reader, typeDef, identity]));
+
+            Assert.Equal("Container<T>.Row<U>", selfType);
         }
         finally
         {

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -743,6 +743,11 @@ public static class CompileBackSourceComposer
                     sb.AppendLine($"{pad}{declaration}");
                     return;
                 }
+                if (member.IsAbstract || member.StubBody == CompileBackStubBodyKind.None)
+                {
+                    sb.AppendLine($"{pad}{declaration} {{ {GetterDeclaration(member)}; }}");
+                    break;
+                }
                 if (member.StubBody == CompileBackStubBodyKind.AutoProperty)
                 {
                     sb.AppendLine($"{pad}{declaration} {{ {GetterDeclaration(member)}; }}");
@@ -1213,9 +1218,10 @@ public static class CompileBackSourceComposer
                 continue;
 
             var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+            string selfType = SelfTypeSignature(reader, typeDef, typeIdentity);
             if (signature.ReturnType != "bool"
                 || signature.ParameterTypes is not [var parameterType]
-                || parameterType != typeIdentity.MetadataFullName)
+                || parameterType != selfType)
             {
                 continue;
             }
@@ -1239,6 +1245,14 @@ public static class CompileBackSourceComposer
         }
 
         return null;
+    }
+
+    static string SelfTypeSignature(MetadataReader reader, TypeDefinition typeDef, CompileBackTypeIdentity typeIdentity)
+    {
+        var typeParameters = typeDef.GetGenericParameters()
+            .Select(handle => reader.GetString(reader.GetGenericParameter(handle).Name))
+            .ToArray();
+        return TypeResolver.ApplyGenericArguments(typeIdentity.MetadataFullName, typeParameters);
     }
 
     static string MethodSignatureText(string name, MethodSignature<string> signature)
@@ -2249,6 +2263,7 @@ public static class CompileBackSourceComposer
                 bool isAutoProperty = !accessors.Getter.IsNil
                     && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnType.DisplayName);
                 bool hasSetter = !accessors.Setter.IsNil;
+                bool isAbstractAccessor = !accessor.IsNil && IsAbstractMethod(accessorMethod);
                 members.Add(new CompileBackMemberDeclaration(
                     new CompileBackMethodIdentity(requirement.Type.FullName, Identifier(propertyName), 0, $"property {signature.ReturnType}"),
                     CompileBackMemberKind.PropertyGet,
@@ -2257,7 +2272,7 @@ public static class CompileBackSourceComposer
                     returnType,
                     Parameters: [],
                     TypeParameters: [],
-                    requirement.RequiredKind == CompileBackTypeKind.Interface
+                    requirement.RequiredKind == CompileBackTypeKind.Interface || isAbstractAccessor
                         ? CompileBackStubBodyKind.None
                         : hasSetter && isAutoProperty
                             ? CompileBackStubBodyKind.AutoPropertyGetSet
@@ -2268,7 +2283,7 @@ public static class CompileBackSourceComposer
                                 : CompileBackStubBodyKind.Throw,
                     TargetBody: null,
                     [new CompileBackFact("metadata", "closure-property", propertyName)],
-                    IsAbstract: !accessor.IsNil && IsAbstractMethod(accessorMethod),
+                    IsAbstract: isAbstractAccessor,
                     IsVirtual: !accessor.IsNil && IsVirtualMethod(accessorMethod)));
             }
 

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -179,6 +179,7 @@ public enum CompileBackMemberKind
 public enum CompileBackAccessibility
 {
     Public,
+    Protected,
 }
 
 public enum CompileBackTypeSignatureKind
@@ -548,6 +549,11 @@ public static class CompileBackSourceComposer
             && EqualityOperatorSibling(reader, targetTypeDef, targetIdentity, methodName, signature) is { } equalitySibling)
         {
             targetMembers.Add(equalitySibling);
+        }
+        if (!isConstructor
+            && TypedEqualsSibling(reader, targetTypeDef, targetIdentity, methodName, signature) is { } typedEqualsSibling)
+        {
+            targetMembers.Add(typedEqualsSibling);
         }
 
         var requirements = new List<CompileBackTypeRequirement>
@@ -923,7 +929,7 @@ public static class CompileBackSourceComposer
             IsVirtual = member.IsVirtual,
             IsOverride = member.IsOverride,
             IsSealed = member.IsSealed,
-            Accessibility = null,
+            Accessibility = AccessibilityText(member.Accessibility),
             Attributes = member.Attributes?.ToList() ?? [],
         };
         if (member.Kind == CompileBackMemberKind.Method)
@@ -961,6 +967,14 @@ public static class CompileBackSourceComposer
         }
         return apiMember;
     }
+
+    static string AccessibilityText(CompileBackAccessibility accessibility)
+        => accessibility switch
+        {
+            CompileBackAccessibility.Public => "public",
+            CompileBackAccessibility.Protected => "protected",
+            _ => "public",
+        };
 
     static bool RequiresUnsafe(CompileBackMemberDeclaration member)
         => member.ReturnType?.DisplayName.Contains('*', StringComparison.Ordinal) == true
@@ -1178,22 +1192,80 @@ public static class CompileBackSourceComposer
         => left.ReturnType == right.ReturnType
             && left.ParameterTypes.SequenceEqual(right.ParameterTypes, StringComparer.Ordinal);
 
+    static CompileBackMemberRequirement? TypedEqualsSibling(
+        MetadataReader reader,
+        TypeDefinition typeDef,
+        CompileBackTypeIdentity typeIdentity,
+        string methodName,
+        MethodSignature<string> targetSignature)
+    {
+        if (methodName != "Equals"
+            || targetSignature.ReturnType != "bool"
+            || targetSignature.ParameterTypes is not ["object"])
+        {
+            return null;
+        }
+
+        foreach (var methodHandle in typeDef.GetMethods())
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if (reader.GetString(method.Name) != "Equals")
+                continue;
+
+            var signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+            if (signature.ReturnType != "bool"
+                || signature.ParameterTypes is not [var parameterType]
+                || parameterType != typeIdentity.MetadataFullName)
+            {
+                continue;
+            }
+
+            return new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(typeIdentity.FullName, "Equals", 0, MethodSignatureText("Equals", signature)),
+                CompileBackMemberKind.Method,
+                method.Attributes.HasFlag(MethodAttributes.Static),
+                MethodParameters(reader, method, signature),
+                CompileBackTypeSignature.Display(signature.ReturnType),
+                MethodTypeParameters(reader, method),
+                CompileBackStubBodyKind.Throw,
+                TargetBody: null,
+                [new CompileBackFact("metadata", "record-equals-sibling", "Equals")],
+                MemberAttributes(reader, method.GetCustomAttributes()),
+                MethodReturnAttributes(reader, method),
+                IsAbstract: IsAbstractMethod(method),
+                IsVirtual: IsVirtualMethod(method),
+                IsOverride: false,
+                IsSealed: false);
+        }
+
+        return null;
+    }
+
     static string MethodSignatureText(string name, MethodSignature<string> signature)
         => $"{signature.ReturnType} {name}({string.Join(", ", signature.ParameterTypes)})";
 
     static bool IsAbstractMethod(MethodDefinition method)
-        => IsPublicMethod(method)
+        => IsPublicOrProtectedMethod(method)
             && (method.Attributes & MethodAttributes.Abstract) != 0;
 
     static bool IsVirtualMethod(MethodDefinition method)
-        => IsPublicMethod(method)
+        => IsPublicOrProtectedMethod(method)
             && (method.Attributes & MethodAttributes.Virtual) != 0
             && (method.Attributes & MethodAttributes.Abstract) == 0
             && (method.Attributes & MethodAttributes.Final) == 0
             && (method.Attributes & MethodAttributes.NewSlot) != 0;
 
+    static bool IsPublicOrProtectedMethod(MethodDefinition method)
+        => IsPublicMethod(method) || IsProtectedMethod(method);
+
     static bool IsPublicMethod(MethodDefinition method)
         => (method.Attributes & MethodAttributes.MemberAccessMask) == MethodAttributes.Public;
+
+    static bool IsProtectedMethod(MethodDefinition method)
+        => (method.Attributes & MethodAttributes.MemberAccessMask) is MethodAttributes.Family or MethodAttributes.FamORAssem;
+
+    static CompileBackAccessibility MethodAccessibility(MethodDefinition method)
+        => IsProtectedMethod(method) ? CompileBackAccessibility.Protected : CompileBackAccessibility.Public;
 
     static IReadOnlyList<string> MemberAttributes(MetadataReader reader, CustomAttributeHandleCollection attributes)
         => AttributeReader.RenderAttributes(
@@ -2169,7 +2241,8 @@ public static class CompileBackSourceComposer
                     continue;
 
                 var accessor = accessors.Getter.IsNil ? accessors.Setter : accessors.Getter;
-                bool isStatic = !accessor.IsNil && reader.GetMethodDefinition(accessor).Attributes.HasFlag(MethodAttributes.Static);
+                var accessorMethod = accessor.IsNil ? default : reader.GetMethodDefinition(accessor);
+                bool isStatic = !accessor.IsNil && accessorMethod.Attributes.HasFlag(MethodAttributes.Static);
                 if (requirement.RequiredKind == CompileBackTypeKind.Interface && isStatic)
                     continue;
                 var returnType = CompileBackTypeSignature.Display(signature.ReturnType);
@@ -2179,7 +2252,7 @@ public static class CompileBackSourceComposer
                 members.Add(new CompileBackMemberDeclaration(
                     new CompileBackMethodIdentity(requirement.Type.FullName, Identifier(propertyName), 0, $"property {signature.ReturnType}"),
                     CompileBackMemberKind.PropertyGet,
-                    CompileBackAccessibility.Public,
+                    accessor.IsNil ? CompileBackAccessibility.Public : MethodAccessibility(accessorMethod),
                     isStatic,
                     returnType,
                     Parameters: [],
@@ -2194,7 +2267,9 @@ public static class CompileBackSourceComposer
                                     ? CompileBackStubBodyKind.ThrowGetSet
                                 : CompileBackStubBodyKind.Throw,
                     TargetBody: null,
-                    [new CompileBackFact("metadata", "closure-property", propertyName)]));
+                    [new CompileBackFact("metadata", "closure-property", propertyName)],
+                    IsAbstract: !accessor.IsNil && IsAbstractMethod(accessorMethod),
+                    IsVirtual: !accessor.IsNil && IsVirtualMethod(accessorMethod)));
             }
 
             int overload = 0;
@@ -2249,7 +2324,7 @@ public static class CompileBackSourceComposer
                 members.Add(new CompileBackMemberDeclaration(
                     new CompileBackMethodIdentity(requirement.Type.FullName, identifierName, overload++, MethodSignatureText(name, signature)),
                     isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method,
-                    CompileBackAccessibility.Public,
+                    MethodAccessibility(method),
                     method.Attributes.HasFlag(MethodAttributes.Static),
                     isConstructor ? null : CompileBackTypeSignature.Display(signature.ReturnType),
                     parameters,

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -745,7 +745,7 @@ public static class CompileBackSourceComposer
                 }
                 if (member.IsAbstract || member.StubBody == CompileBackStubBodyKind.None)
                 {
-                    sb.AppendLine($"{pad}{declaration} {{ {GetterDeclaration(member)}; }}");
+                    sb.AppendLine($"{pad}{declaration} {{ {GetterDeclaration(member)};{(HasSetterShape(member) ? " set;" : "")} }}");
                     break;
                 }
                 if (member.StubBody == CompileBackStubBodyKind.AutoProperty)
@@ -920,7 +920,7 @@ public static class CompileBackSourceComposer
             Signature = member.Kind switch
             {
                 CompileBackMemberKind.PropertyGet when member.Parameters.Count > 0 => $"{returnType ?? "void"} this[{parameterList}] {{ get; }}",
-                CompileBackMemberKind.PropertyGet when type.Kind == CompileBackTypeKind.Interface => $"{returnType ?? "void"} {member.Name} {{ get; }}",
+                CompileBackMemberKind.PropertyGet when type.Kind == CompileBackTypeKind.Interface => $"{returnType ?? "void"} {member.Name} {{ get;{(HasSetterShape(member) ? " set;" : "")} }}",
                 CompileBackMemberKind.PropertyGet => $"{returnType ?? "void"} {member.Name}",
                 CompileBackMemberKind.PropertySet when member.Parameters.Count > 0 => $"{returnType ?? "void"} this[{parameterList}] {{ set; }}",
                 CompileBackMemberKind.PropertySet => $"{returnType ?? "void"} {member.Name} {{ set; }}",
@@ -1025,6 +1025,11 @@ public static class CompileBackSourceComposer
         => member.ReturnAttributes is { Count: > 0 }
             ? $"[return: {string.Join(", ", member.ReturnAttributes)}] get"
             : "get";
+
+    static bool HasSetterShape(CompileBackMemberDeclaration member)
+        => member.StubBody is CompileBackStubBodyKind.AutoPropertyGetSet
+            or CompileBackStubBodyKind.ThrowGetSet
+            or CompileBackStubBodyKind.TargetGetterWithSetter;
 
     static IReadOnlyList<CompileBackParameter> MethodParameters(
         MetadataReader reader,
@@ -1249,10 +1254,47 @@ public static class CompileBackSourceComposer
 
     static string SelfTypeSignature(MetadataReader reader, TypeDefinition typeDef, CompileBackTypeIdentity typeIdentity)
     {
-        var typeParameters = typeDef.GetGenericParameters()
+        var directTypeParameters = TypeParameterNames(reader, typeDef);
+        var typeParameters = directTypeParameters.Count >= GenericArity(typeIdentity.MetadataFullName)
+            ? directTypeParameters
+            : TypeAndDeclaringTypeParameters(reader, typeDef);
+        return TypeResolver.ApplyGenericArguments(typeIdentity.MetadataFullName, typeParameters);
+    }
+
+    static IReadOnlyList<string> TypeAndDeclaringTypeParameters(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var parameters = new List<string>();
+        var declaringType = typeDef.GetDeclaringType();
+        if (!declaringType.IsNil)
+            parameters.AddRange(TypeAndDeclaringTypeParameters(reader, reader.GetTypeDefinition(declaringType)));
+        parameters.AddRange(TypeParameterNames(reader, typeDef));
+        return parameters;
+    }
+
+    static IReadOnlyList<string> TypeParameterNames(MetadataReader reader, TypeDefinition typeDef)
+        => typeDef.GetGenericParameters()
             .Select(handle => reader.GetString(reader.GetGenericParameter(handle).Name))
             .ToArray();
-        return TypeResolver.ApplyGenericArguments(typeIdentity.MetadataFullName, typeParameters);
+
+    static int GenericArity(string metadataFullName)
+    {
+        int arity = 0;
+        for (int i = 0; i < metadataFullName.Length; i++)
+        {
+            if (metadataFullName[i] != '`')
+                continue;
+            int start = i + 1;
+            int end = start;
+            while (end < metadataFullName.Length && char.IsDigit(metadataFullName[end]))
+                end++;
+            if (end > start && int.TryParse(metadataFullName.AsSpan(start, end - start), out var value))
+            {
+                arity += value;
+                i = end - 1;
+            }
+        }
+
+        return arity;
     }
 
     static string MethodSignatureText(string name, MethodSignature<string> signature)
@@ -2264,6 +2306,18 @@ public static class CompileBackSourceComposer
                     && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnType.DisplayName);
                 bool hasSetter = !accessors.Setter.IsNil;
                 bool isAbstractAccessor = !accessor.IsNil && IsAbstractMethod(accessorMethod);
+                var noBodyProperty = requirement.RequiredKind == CompileBackTypeKind.Interface || isAbstractAccessor;
+                var stubBody = noBodyProperty
+                    ? hasSetter
+                        ? CompileBackStubBodyKind.AutoPropertyGetSet
+                        : CompileBackStubBodyKind.None
+                    : hasSetter && isAutoProperty
+                        ? CompileBackStubBodyKind.AutoPropertyGetSet
+                        : isAutoProperty
+                            ? CompileBackStubBodyKind.AutoProperty
+                            : hasSetter
+                                ? CompileBackStubBodyKind.ThrowGetSet
+                                : CompileBackStubBodyKind.Throw;
                 members.Add(new CompileBackMemberDeclaration(
                     new CompileBackMethodIdentity(requirement.Type.FullName, Identifier(propertyName), 0, $"property {signature.ReturnType}"),
                     CompileBackMemberKind.PropertyGet,
@@ -2272,15 +2326,7 @@ public static class CompileBackSourceComposer
                     returnType,
                     Parameters: [],
                     TypeParameters: [],
-                    requirement.RequiredKind == CompileBackTypeKind.Interface || isAbstractAccessor
-                        ? CompileBackStubBodyKind.None
-                        : hasSetter && isAutoProperty
-                            ? CompileBackStubBodyKind.AutoPropertyGetSet
-                            : isAutoProperty
-                                ? CompileBackStubBodyKind.AutoProperty
-                                : hasSetter
-                                    ? CompileBackStubBodyKind.ThrowGetSet
-                                : CompileBackStubBodyKind.Throw,
+                    stubBody,
                     TargetBody: null,
                     [new CompileBackFact("metadata", "closure-property", propertyName)],
                     IsAbstract: isAbstractAccessor,


### PR DESCRIPTION
- Advances RTS pinned-package source probe coverage
- Changes compile-back source composition for record-generated helper shells
- Evidence revision: `70cfe34f`

## Change

**Conclusion:** **PASS** — record-generated `ToString` and `Equals(object)` targets move from `OpcodeDiff` to `Exact`; pinned `dotnet-inspect.any@0.16.0` cap-300 probe improves from 231/69 to 263/37.

Before:

```text
TypeSummaryRow::ToString#0       OpcodeDiff  (PrintMembers compiled as call instead of callvirt)
TypeSummaryRow::Equals#0         OpcodeDiff  (typed Equals sibling absent; call instead of callvirt)
RETURNTOSENDER SOURCE PROBE: 231 passed / 69 failed
```

After:

```text
TypeSummaryRow::ToString#0       Exact
TypeSummaryRow::Equals#0         Exact
RETURNTOSENDER SOURCE PROBE over 300 target(s)

  Passed : 263
  Failed : 37
  Skipped: 0

Buckets:
  37: OpcodeDiff
```

## Scope and safety

- **Root cause:** compile-back shells erased protected/virtual record helper shape (`PrintMembers`, `EqualityContract`) and did not include the typed `Equals(T)` overload needed by `Equals(object)` target bodies.
- **Fix shape:** preserve protected accessibility and virtual/abstract flags for closure member surfaces, and add a typed `Equals(T)` sibling shell for `Equals(object)` targets when metadata contains that overload.
- **Product impact:** compile-back/RTS source composition only; the shipped decompiler method-body output is unchanged.
- **Scope boundary:** record-generated `GetHashCode` and typed `Equals(T)` remain OpcodeDiff because their bodies use backing-field loads while shell source still exposes auto-properties; #2203 HasRows remains separate.
- **RTS boundary:** RTS still orchestrates target selection, closure compilation, and opcode/source-fragment comparison; product/shared code owns C# source generation.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `CompileBackTargets_PreservesRecordGeneratedVirtualHelperShells` passed |
| `ReturnToSenderPrototypeTests` | Pass, 55/55 |
| ReturnToSender catalog | Pass, 39 fixtures / 116 targets |
| Decompiler fast suite | Pass, 1825/1825 |
| ReturnToSender A/B | 242 Same / 0 Worse |
| Pinned package probe | `dotnet-inspect.any@0.16.0`, cap 300: 263 passed / 37 failed; only `OpcodeDiff` bucket |
| Real witness | `DotnetInspector.Views.TypeSummaryRow::ToString` and `Equals(object)` moved `OpcodeDiff` -> `Exact` |

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| HasRows shared-return branch shape | Left as frontier, tracked by #2203 | Requires product source-shape modeling, not record helper shell metadata |
| Record-generated `GetHashCode` / typed `Equals(T)` | Left as frontier | Requires backing-field-vs-property getter modeling in compile-back shells |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Pending | Adversarial review requested |
| Gemini 3.1 Pro | Pending | Adversarial review requested |

**Review conclusion:** **REVIEW** — awaiting two model-family adversarial reviews.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -method "*RecordGeneratedVirtualHelperShells"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --return-to-sender-catalog --max-examples 50
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --package dotnet-inspect.any --package-version 0.16.0 --return-to-sender-source-probe --cap 300 --max-examples 20
```
