### PR TITLE
Route MemberCodeProvider through the assembly session — no raw PE opens in the CLI (#2122)

### DIFF
--- a/src/ILInspector.Metadata/AssemblyInspectionSession.cs
+++ b/src/ILInspector.Metadata/AssemblyInspectionSession.cs
@@ -25,6 +25,14 @@ public sealed class AssemblyInspectionSession : IDisposable
     /// <summary>Whether the image contains managed metadata (false for a native binary).</summary>
     public bool HasMetadata => _image.HasMetadata;
 
+    // The method-body / IL seam (the CLI's MemberCodeProvider + ILDisassembler) needs low-level
+    // reader access that the public facet API deliberately does not expose. These internal
+    // accessors let that composition read through this owned image instead of opening its own raw
+    // PEReader, so the single PE open stays owned here. The public contract ("callers never touch a
+    // PEReader") is unchanged for external consumers.
+    internal System.Reflection.PortableExecutable.PEReader PeReader => _image.PEReader;
+    internal System.Reflection.Metadata.MetadataReader MetadataReader => _image.GetMetadataReader();
+
     // --- assembly facets: each produced once over the single shared reader ---
 
     /// <summary>Assembly identity and, optionally, its assembly references.</summary>

--- a/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
+++ b/src/dotnet-inspect/Inspectors/MemberCodeProvider.cs
@@ -54,12 +54,15 @@ internal static class MemberCodeProvider
         if (!overloadIndex.HasValue)
             return results;
             
-        using var stream = File.OpenRead(dllPath);
-        using var peReader = new PEReader(stream);
-        if (!peReader.HasMetadata)
+        // Read metadata/IL through the assembly seam (which owns the single PE open) rather than
+        // opening a raw PEReader here — the decompiler-backed sections still open their own
+        // MetadataSource below (with symbols) via OpenPipelineSource.
+        using var image = ILInspector.Metadata.AssemblyInspectionSession.Open(dllPath);
+        if (!image.HasMetadata)
             return results;
 
-        var reader = peReader.GetMetadataReader();
+        var peReader = image.PeReader;
+        var reader = image.MetadataReader;
 
         // All decompiler-backed sections (decompiled source, annotated source, IR
         // stages) read through one MetadataSource that owns its own readers.


### PR DESCRIPTION
## Summary

Closes the original #2122 goal — **the CLI now performs no raw `new PEReader` / `LibraryBodyIndex.Open`**. Every PE/metadata open flows through a session that owns it.

`MemberCodeProvider` (the member IL / decompiled-source path) opened a raw
`new PEReader(stream)` for the `MetadataReader` it uses to build its type index, resolve
generic parameters, render custom attributes, and disassemble IL. That was the last raw PE
open in the CLI.

- Routes it through `AssemblyInspectionSession` (the assembly seam, which already owns the
  single PE open), via two new **internal** accessors (`PeReader`, `MetadataReader`) that let
  the CLI's method-body composition read through the owned image.
- The public facet contract ("callers never touch a `PEReader`") is unchanged for external
  consumers — the accessors are `internal` (dotnet-inspect composition only).
- The decompiler-backed sections still open their own `MetadataSource` (with symbols) — that's
  a session too, the decompiler seam.

## Validation

- `dotnet build src/dotnet-inspect -c Release` — clean.
- Grep confirms **zero** raw `new PEReader` / `LibraryBodyIndex.Open` in `src/dotnet-inspect`
  (outside `MethodBodyInspectionSession`, itself a session).
- **Byte-identical** output for IL, Decompiled Source, Annotated Source, Custom Attributes,
  Facts, and combined member renders on multiple members.
- `ILDisassemblerTests` (51), `SectionPipelineTests` + `ProjectionDiagnosticsTests` (119) pass.

Part of #2122.
