### PR TITLE
docs: document the assertion-scan aggregate tier in raise discipline

### DIFF
--- a/docs/decompiler-raise-discipline.md
+++ b/docs/decompiler-raise-discipline.md
@@ -113,6 +113,33 @@ Rule of thumb: **its signoff weight equals how many of the changed nodes
 carry runnable predicates.** No predicate → dev aid only; predicate present →
 localized proof, on top of the card.
 
+### The aggregate view: `--assertion-scan`
+
+The single-method dump can't answer population questions; `DecompilerHarness
+--assertion-scan [--sample N] [--package …]` runs the same `assumes:`
+predicates across an assembly and reports a violation histogram (by sink type /
+pass / node / predicate), the methods-with-violation rate, and **annotation
+coverage** — which `[InverseOf]` nodes the scanned population actually
+exercised. `--emit-assertion-violations` / `--diff-assertion-violations` give a
+REGRESSED / IMPROVED differential (the "N→M violations, 0 regressions" proof for
+a coercion PR, mirroring the validity-defects loop).
+
+Reach for it to:
+
+- **Audit a new annotation batch** across a corpus — confirm the nodes you
+  annotated actually appear over real IR (e.g. a full scan of the decompiler
+  assembly, 6756 methods, exercised 22/25 annotated nodes with 0 pass bugs).
+- **Measure the leak surface** — the methods-with-violation rate is the
+  automatable form of the value-typed-emission leak number.
+- **Localize a coercion regression** — the emit/diff pair names the methods
+  that gained a violation.
+
+It stays **measurement and triage, not a correctness gate.** Its counts and
+histograms do not gate fidelity or validity — that remains the quality-diff
+card and render A/B. Its exit code flags *pass bugs* (importer / pipeline
+crashes), never a violation count. Same rule as the single-method dump: an
+assertion-scan number is population *measurement*, not a pass/fail bar.
+
 ## Annotations (the inverse ledger)
 
 - **`assumes` names an executable, or it moves to prose.** An attribute


### PR DESCRIPTION
## Change

Docs-only. #2218 landed `DecompilerHarness --assertion-scan` (corpus violation histograms, annotation coverage, and the `--emit`/`--diff-assertion-violations` regression loop), but the **"assertion dump: development aid vs signoff"** section in `docs/decompiler-raise-discipline.md` only described the single-method `--dump --assertions` and framed *all* population claims as the quality-diff card / render-A/B's job — leaving no documented home for the new population-*measurement* tier.

Adds a **"The aggregate view: `--assertion-scan`"** subsection covering:

- what it reports (histograms by sink/pass/node/predicate, methods-with-violation rate, annotation coverage, emit/diff differential);
- when to reach for it — auditing a new annotation batch across a corpus, measuring the value-typed-emission leak surface, localizing a coercion regression;
- and, restating the section's guardrail, that it stays **measurement and triage, never a correctness gate** (counts don't gate fidelity/validity — that remains the card and render A/B; the exit code flags *pass bugs*, not violation counts).

The `tools/DecompilerHarness/README.md` invocation reference was already added in #2218; this fills the *strategy/discipline* side, matching the README-invocation / discipline-strategy split.

## Evidence

Docs-only, no behavior claims. Dogfooded the tool on my batch-5 (#2219) address/indirection annotations first: a full `--assertion-scan` of the decompiler assembly exercised **22/25 annotated nodes over 6756 methods with 0 pass bugs** (7 of the 9 batch-5 nodes surfaced; only the rare `AddressOfMethod`/`CallIndirect` did not). `markdownlint docs/decompiler-raise-discipline.md` clean.

## Risk

Low — documentation only, single file, no measured-behavior claims. Per the docs-only carve-out, stopping at markdownlint; no adversarial round needed.
