### PR TITLE
Add assertion scan audit corpus report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
               src/*) CODE=true ;;
               tools/DecompilerHarness/*.md|tools/DecompilerHarness/*.txt) ;;
               tools/DecompilerHarness/*) CODE=true ;;
+              eng/prepare-decompiler-assertion-corpus.sh) CODE=true ;;
               eng/prepare-decompiler-corpus.sh) CODE=true ;;
               eng/prepare-decompiler-pr-corpus.sh) CODE=true ;;
               *.props|*.sln) CODE=true ;;

--- a/.github/workflows/decompiler-daily.yml
+++ b/.github/workflows/decompiler-daily.yml
@@ -77,6 +77,22 @@ jobs:
             --corpus-fidelity-cap 3 \
             --max-examples 3
 
+      - name: Run assertion scan coverage report
+        continue-on-error: true
+        shell: bash
+        run: |
+          mkdir -p artifacts/assertion-scan
+          bash eng/prepare-decompiler-assertion-corpus.sh artifacts/assertion-scan/assemblies.txt
+          mapfile -t assertion_assemblies < artifacts/assertion-scan/assemblies.txt
+          set +e
+          dotnet run --project tools/DecompilerHarness -c Release -- "${assertion_assemblies[@]}" \
+            --assertion-scan \
+            --max-examples 10 \
+            | tee artifacts/assertion-scan/assertion-scan.txt
+          status=${PIPESTATUS[0]}
+          echo "$status" > artifacts/assertion-scan/exit-code.txt
+          exit 0
+
       # Analysis corpus stability sensor (#1818, Layer 2): same pinned corpus, but it checks
       # analyzer robustness (every assembly opens, no analyzer-diagnostic jump) against a
       # committed baseline. Signal-count drift is reported, not failed; only a regression
@@ -104,4 +120,12 @@ jobs:
         with:
           name: decompiler-corpus-snapshot
           path: artifacts/decompiler-daily/corpus-snapshot.json
+          if-no-files-found: warn
+
+      - name: Upload assertion scan report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: assertion-scan-report
+          path: artifacts/assertion-scan/
           if-no-files-found: warn

--- a/docs/decompiler-raise-discipline.md
+++ b/docs/decompiler-raise-discipline.md
@@ -129,6 +129,9 @@ Reach for it to:
 - **Audit a new annotation batch** across a corpus — confirm the nodes you
   annotated actually appear over real IR (e.g. a full scan of the decompiler
   assembly, 6756 methods, exercised 22/25 annotated nodes with 0 pass bugs).
+  For batch signoff, prefer the audit corpus from
+  `eng/prepare-decompiler-assertion-corpus.sh`: fixed real-world corpus plus
+  current local product assemblies.
 - **Measure the leak surface** — the methods-with-violation rate is the
   automatable form of the value-typed-emission leak number.
 - **Localize a coercion regression** — the emit/diff pair names the methods

--- a/eng/prepare-decompiler-assertion-corpus.sh
+++ b/eng/prepare-decompiler-assertion-corpus.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Restores the fixed decompiler corpus and appends the current local product
+# assemblies. This is the recommended assertion-scan audit corpus: pinned
+# published packages provide stable breadth, while the local product assemblies
+# exercise the current decompiler/analysis code under review.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+out="${1:-}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+bash "$root/eng/prepare-decompiler-corpus.sh" "$tmp/pinned.txt"
+
+declare -a local_assemblies=(
+  "$root/artifacts/bin/DotnetInspector.Core/release/DotnetInspector.Core.dll"
+  "$root/artifacts/bin/DotnetInspector.Packages/release/DotnetInspector.Packages.dll"
+  "$root/artifacts/bin/DotnetInspector.Services/release/DotnetInspector.Services.dll"
+  "$root/artifacts/bin/DotnetInspector.Services/release/ILInspector.Metadata.dll"
+  "$root/artifacts/bin/DotnetInspector.Services/release/ILInspector.MetadataPrimitives.dll"
+  "$root/artifacts/bin/dotnet-inspect/release/dotnet-inspect.dll"
+  "$root/artifacts/bin/dotnet-inspect/release/ILInspector.Analysis.dll"
+  "$root/artifacts/bin/dotnet-inspect/release/ILInspector.Decompiler.dll"
+)
+
+for assembly in "${local_assemblies[@]}"; do
+  if [ ! -f "$assembly" ]; then
+    echo "Missing local product assembly: $assembly" >&2
+    echo "Build first: dotnet build src/dotnet-inspect -c Release -p:PublishAot=false" >&2
+    exit 1
+  fi
+done
+
+{
+  cat "$tmp/pinned.txt"
+  printf '%s\n' "${local_assemblies[@]}"
+} | awk '!seen[$0]++' > "$tmp/assertion-corpus.txt"
+
+if [ -n "$out" ]; then
+  cp "$tmp/assertion-corpus.txt" "$out"
+else
+  cat "$tmp/assertion-corpus.txt"
+fi

--- a/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
@@ -170,6 +170,19 @@ public class AssertionScanTests
         Assert.Equal(importViolation.Identity, laterViolation.Identity);
     }
 
+    [Fact]
+    public void SinkType_ParsesRealCoercionInvariantMessage()
+    {
+        var function = Function(
+            Returning(new LoadArgument(0, "raw", Int32)),
+            Enum32,
+            new Parameter("raw", Int32));
+
+        var violation = Assert.Single(CoercionInvariant.Check(function));
+
+        Assert.Equal("E32", AssertionScan.SinkType(violation.Message));
+    }
+
     static IrFunction Function(BlockContainer body, TypeRef returnType, params Parameter[] parameters)
         => new(
             "M",

--- a/tools/DecompilerHarness/AssertionScan.cs
+++ b/tools/DecompilerHarness/AssertionScan.cs
@@ -266,7 +266,7 @@ internal static class AssertionScan
             coverage.AddOrUpdate(node, 1, (_, count) => count + 1);
     }
 
-    static string SinkType(string message)
+    internal static string SinkType(string message)
     {
         var match = Regex.Match(message, @" occupies a (?<sink>.+?) sink without a Coerce$", RegexOptions.CultureInvariant);
         return match.Success ? match.Groups["sink"].Value : "(unknown)";

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -42,6 +42,25 @@ dotnet run --project tools/DecompilerHarness -c Release -- MyLib.dll \
   --assertion-scan --sample 250 --diff-assertion-violations /tmp/assertions.base.json
 ```
 
+For annotation-batch audits, use the assertion audit corpus instead of one local
+assembly. It combines the fixed real-world decompiler corpus with the current
+managed product assemblies, so rare annotated nodes are more likely to be
+exercised over real IR while the input set stays reproducible:
+
+```bash
+dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+bash eng/prepare-decompiler-assertion-corpus.sh /tmp/assertion-corpus.txt
+mapfile -t assemblies < /tmp/assertion-corpus.txt
+dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
+  --assertion-scan \
+  --max-examples 10
+```
+
+`decompiler-daily.yml` runs the same corpus as a report-only artifact named
+`assertion-scan-report`. The artifact's `assertion-scan.txt` lists exercised and
+unexercised `[InverseOf]` nodes; a non-empty unexercised list is follow-up work
+for corpus/fixture breadth, not a failed daily gate.
+
 **Generated fixtures** (`--generated-fixtures [id|prefix|list]`): builds selected
 generated-fixture catalogue entries into a temporary class library, runs the
 Roslyn shape oracle and compile-back oracle, and prints results by stable fixture


### PR DESCRIPTION
Fixes #2224

Changes: adds a reusable assertion-scan audit corpus recipe/script, a report-only daily assertion coverage artifact, and a sink-type parser canary against the real coercion invariant message.

Card revision: `046aa043`

## Change

**Conclusion:** **PASS** — this is harness/workflow measurement plumbing only; it does not change decompiler raising, structuring, typing, or product rendering behavior.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --configfile nuget.config -p:PublishAot=false` |
| Harness build | Pass: `dotnet build tools/DecompilerHarness -c Release --configfile nuget.config -p:PublishAot=false` |
| Focused tests | Pass: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -noLogo -class ILInspector.Decompiler.Tests.AssertionScanTests` |
| Decompiler fast suite | Pass: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -noLogo -trait- 'Speed=Slow'` |
| Script smoke | Pass: `bash -n eng/prepare-decompiler-assertion-corpus.sh`; generated 22 assembly paths after product build |
| Harness smoke | Pass: assertion audit corpus with `--assertion-scan --sample 2 --max-examples 1` (44 sampled methods, 0 pass bugs) |
| Markdown | Pass: `npx markdownlint-cli tools/DecompilerHarness/README.md docs/decompiler-raise-discipline.md` |
| CI | Pass: `changes`, `markdownlint`, `test (ubuntu-26.04, linux-x64)`, `pack`, and `pack-rid (linux-arm64, ubuntu-26.04-arm)` |

## Decompiler quality

**Conclusion:** **PASS** — report-only coverage measurement. The daily assertion-scan step is `continue-on-error: true`, uploads `assertion-scan-report`, and does not gate on coverage or violation counts.

## Reviews

### Review 1: Claude Opus 4.8

**Result:** Clean — no blocking or high-confidence correctness findings.

Opus verified the audit corpus script end-to-end, report-only daily behavior, unexercised-node reporting without failure, CI change detection, the `SinkType` canary/linking model, and GitHub Actions command viability.

### Review 2: Gemini Pro

**Result:** Clean — no blocking or high-confidence correctness findings.

Gemini verified the audit corpus script, report-only workflow isolation, CI change detection, and the sink-type canary. The only note was non-blocking: the local assembly list omits newer leaf projects such as `ILInspector.ControlFlow` and `ILInspector.Instructions`, which do not contain `[InverseOf]` annotations and therefore do not affect annotation-node coverage.

**Review conclusion:** **PASS** — two clean reviews are complete and surfaced on the PR.
