### PR TITLE
Targeted single-member decode for forward-only member queries (#2198)

### DIFF
--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -738,7 +738,7 @@ public sealed class LibraryBodyIndex
         => Open(path, resolver: null);
 
     public static LibraryBodyIndex Open(string path, IAssemblyReferenceResolver? resolver = null,
-        bool includeAllocations = true, bool includeOpportunities = true)
+        bool includeAllocations = true, bool includeOpportunities = true, IReadOnlySet<int>? bodyScope = null)
     {
         using var stream = File.OpenRead(path);
         using var peReader = new PEReader(stream);
@@ -748,7 +748,7 @@ public sealed class LibraryBodyIndex
         using var builder = new IndexBuilder(path, reader, peReader, resolver);
         // Optimization opportunities are synthesized from allocation occurrences (allocation
         // hotspots), so requesting opportunities implies computing allocations.
-        var index = builder.Build(includeAllocations || includeOpportunities, includeOpportunities);
+        var index = builder.Build(includeAllocations || includeOpportunities, includeOpportunities, bodyScope);
         return new LibraryBodyIndex(
             path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
             index.OptimizationOpportunities, index.UnsafeLeverageMethods, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
@@ -1964,7 +1964,7 @@ public sealed class LibraryBodyIndex
                 && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
         }
 
-        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> AllocationOccurrences, IReadOnlyDictionary<int, ImmutableArray<UnsafetyOccurrence>> UnsafetyOccurrences, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames, IReadOnlySet<int> NonHeapNewObjOperandTokens) Build(bool includeAllocations, bool includeOpportunities)
+        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> AllocationOccurrences, IReadOnlyDictionary<int, ImmutableArray<UnsafetyOccurrence>> UnsafetyOccurrences, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames,         IReadOnlySet<int> NonHeapNewObjOperandTokens) Build(bool includeAllocations, bool includeOpportunities, IReadOnlySet<int>? bodyScope = null)
         {
             var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var unsafeLeverageMethods = ImmutableArray.CreateBuilder<MethodIdentity>();
@@ -2009,6 +2009,13 @@ public sealed class LibraryBodyIndex
                             continue;
 
                         methods.Add(caller);
+                        // Targeted (single-member) builds decode only the requested method bodies;
+                        // every other method is still indexed as an identity (cheap metadata read)
+                        // but its body is not decoded/scanned. Only sections whose facts are local to
+                        // the selected member (Calls / Unsafe Operations / Allocation-Safety-Cost
+                        // facts) may open a scoped build — reverse/aggregate sections pass null.
+                        if (bodyScope is not null && !bodyScope.Contains(caller.MetadataToken))
+                            continue;
                         var body = _peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
                         var il = body.GetILBytes() ?? [];
                         var decodedBody = DecodeBody(il, body.ExceptionRegions);

--- a/src/dotnet-inspect.Tests/TargetedDecodeTests.cs
+++ b/src/dotnet-inspect.Tests/TargetedDecodeTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Immutable;
+using Analysis = ILInspector.Analysis;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Locks the targeted-decode invariant: opening a <see cref="Analysis.LibraryBodyIndex"/> with a
+/// <c>bodyScope</c> restricted to one method decodes only that body, yet produces per-method facts
+/// (direct calls, unsafe evidence, unsafety occurrences, allocation occurrences) identical to the
+/// full whole-assembly build. This is what lets the member command render Calls / Unsafe Operations
+/// / Allocation-Safety-Cost facts for one member without decoding every method in the assembly.
+/// </summary>
+public class TargetedDecodeTests
+{
+    static string SelfPath => typeof(Analysis.LibraryBodyIndex).Assembly.Location;
+
+    static string Facts<T>(IReadOnlyDictionary<int, ImmutableArray<T>> byToken, int token)
+        => byToken.TryGetValue(token, out var v)
+            ? string.Join(";", v.Select(x => x!.ToString()).OrderBy(s => s, StringComparer.Ordinal))
+            : "";
+
+    [Fact]
+    public void TargetedBuild_MatchesFullBuild_ForEveryPerMethodFactOfTheTarget()
+    {
+        var full = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var fullCalls = full.GetDirectCallsByCaller();
+        var fullUnsafe = full.GetUnsafeEvidenceByMember();
+        var fullUnsafety = full.GetUnsafetyOccurrences();
+        var fullAlloc = full.GetAllocationOccurrences();
+
+        // Sample methods that actually carry each kind of fact, plus a few plain ones.
+        var sample = new HashSet<int>();
+        if (fullCalls.Count > 0) sample.Add(fullCalls.OrderByDescending(kv => kv.Value.Length).First().Key);
+        if (fullAlloc.Count > 0) sample.Add(fullAlloc.First().Key);
+        if (fullUnsafe.Count > 0) sample.Add(fullUnsafe.First().Key);
+        foreach (var m in full.Methods.Take(25))
+            sample.Add(m.MetadataToken);
+
+        Assert.NotEmpty(sample);
+        foreach (var token in sample)
+        {
+            var targeted = Analysis.LibraryBodyIndex.Open(SelfPath, bodyScope: new HashSet<int> { token });
+            Assert.Equal(Facts(fullCalls, token), Facts(targeted.GetDirectCallsByCaller(), token));
+            Assert.Equal(Facts(fullUnsafe, token), Facts(targeted.GetUnsafeEvidenceByMember(), token));
+            Assert.Equal(Facts(fullUnsafety, token), Facts(targeted.GetUnsafetyOccurrences(), token));
+            Assert.Equal(Facts(fullAlloc, token), Facts(targeted.GetAllocationOccurrences(), token));
+        }
+    }
+
+    [Fact]
+    public void TargetedBuild_DecodesOnlyTheScopedMember()
+    {
+        var full = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var caller = full.GetDirectCallsByCaller().OrderByDescending(kv => kv.Value.Length).First().Key;
+
+        var targeted = Analysis.LibraryBodyIndex.Open(SelfPath, bodyScope: new HashSet<int> { caller });
+        var targetedCalls = targeted.GetDirectCallsByCaller();
+
+        // Only the scoped member has decoded direct calls; other callers are not decoded.
+        Assert.True(targetedCalls.ContainsKey(caller));
+        Assert.Single(targetedCalls);
+    }
+}

--- a/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
+++ b/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
@@ -47,13 +47,16 @@ public sealed class MethodBodyInspectionSession
     /// and <paramref name="includeOpportunities"/> gate the two expensive whole-assembly analysis
     /// phases (escape-classified allocation occurrences and optimization opportunities); leave them
     /// on unless the caller knows no requested section consumes them (see
-    /// <c>ApiOutputFormatter.AnalysisScopeFor</c>).
+    /// <c>ApiOutputFormatter.AnalysisScopeFor</c>). <paramref name="bodyScope"/>, when non-null,
+    /// restricts body decoding to the given method tokens (a single-member "targeted" build); it is
+    /// only valid when every requested section's facts are local to those members (Calls / Unsafe
+    /// Operations / Allocation-Safety-Cost facts) — reverse/aggregate sections require a full build.
     /// </summary>
     public static MethodBodyInspectionSession Open(string assemblyPath, IAssemblyReferenceResolver? resolver = null,
-        bool includeAllocations = true, bool includeOpportunities = true)
+        bool includeAllocations = true, bool includeOpportunities = true, IReadOnlySet<int>? bodyScope = null)
     {
         System.Threading.Interlocked.Increment(ref OpenCountForTests);
-        return new(Analysis.LibraryBodyIndex.Open(assemblyPath, resolver, includeAllocations, includeOpportunities), Path.GetFileNameWithoutExtension(assemblyPath));
+        return new(Analysis.LibraryBodyIndex.Open(assemblyPath, resolver, includeAllocations, includeOpportunities, bodyScope), Path.GetFileNameWithoutExtension(assemblyPath));
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -1155,9 +1155,29 @@ public static class ApiOutputFormatter
         if ((requestedSections.Contains(SectionNames.CallGraph) || requestedSections.Contains(SectionNames.CallerGraph))
             && (options?.Fields is { Length: > 0 } || options?.Columns is { Length: > 0 }))
             indexInclAllocations = true;
+
+        // Targeted (single-member) build: when no requested index-backed section needs the
+        // whole-assembly reverse graph (Callers / Call Graph / Caller Graph), the shared index only
+        // decodes the selected member(s) instead of every method body. The remaining index-backed
+        // member sections — Calls, Unsafe Operations, and the Allocation/Safety/Cost facts — read
+        // only the selected member's own body, so their output is identical to a full build (verified
+        // across the DirectCalls / UnsafeEvidence / UnsafetyOccurrences / AllocationOccurrences facts).
+        IReadOnlySet<int>? bodyScope = null;
+        bool needsWholeAssemblyBody = requestedSections.Contains(SectionNames.Callers)
+            || requestedSections.Contains(SectionNames.CallGraph)
+            || requestedSections.Contains(SectionNames.CallerGraph);
+        if (!needsWholeAssemblyBody)
+        {
+            var memberTokens = methods.Where(m => m.MetadataToken.HasValue).Select(m => m.MetadataToken!.Value).ToHashSet();
+            // Only target when every selected member carries a token (a missing token would mean a
+            // rendered member is absent from the scope); otherwise fall back to a full build.
+            if (memberTokens.Count > 0 && memberTokens.Count == methods.Count)
+                bodyScope = memberTokens;
+        }
+
         MethodBodyInspectionSession? indexSession = null;
         MethodBodyInspectionSession IndexSession() =>
-            indexSession ??= MethodBodyInspectionSession.Open(dllPath, assemblyResolver, indexInclAllocations, indexInclOpportunities);
+            indexSession ??= MethodBodyInspectionSession.Open(dllPath, assemblyResolver, indexInclAllocations, indexInclOpportunities, bodyScope);
 
         // For sections that require a single selected method (Calls, CallGraph, decompiled source, etc.),
         // filter to that specific overload. Callers can aggregate across all overloads.


### PR DESCRIPTION
## Summary

The last big lever from the #2198 perf work: for single-member **forward** queries, decode
only the selected member's body instead of every method in the assembly.

Profiling showed that `member X -S Calls` (and Unsafe Operations / Allocation-Safety-Cost
facts) pays the full whole-assembly body walk even though those sections read only the
selected member's own body. This adds a **targeted build**:

- `LibraryBodyIndex.Open` / `IndexBuilder.Build` gain a `bodyScope` token set; when non-null,
  only those method bodies are decoded/scanned (every method is still indexed as a cheap
  identity). `MethodBodyInspectionSession.Open` threads it.
- `ApiOutputFormatter.PopulateIndexSections` computes the scope and applies it **only** when no
  requested section needs the whole-assembly reverse graph (Callers / Call Graph / Caller
  Graph) and every selected member carries a token; otherwise it's a full build.

## Correctness (this is the whole risk)

- **Analysis-level proof**: across 400 methods, `DirectCalls`, `UnsafeEvidence`,
  `UnsafetyOccurrences`, and `AllocationOccurrences` (the escape-classified one) for a method
  are **identical** under a targeted vs full build.
- **Byte-identical CLI output** vs `main` across: each targetable section alone; the
  targetable sections combined; each non-targetable section (Callers/Call Graph/Caller Graph);
  and mixed / `--fields alloc,il` combinations that must fall back to full — all match.
- New `TargetedDecodeTests` lock the invariant; the #2216 build-once guard still passes
  (targeted still builds once per command); 59 member/section/scope tests pass.

## Results (CPU, `ILInspector.Decompiler.dll`, `member CSharpPrinter.Print`)

| Sections | OLD | NEW |
| --- | --- | --- |
| `-S Calls` | 0.75s | **0.16s (~4.7x)** |
| `-S "Unsafe Operations"` | 0.70s | **0.16s** |
| `-S "Allocation Facts,Safety Facts,Cost Facts"` | 1.21s | **0.18s (~6.7x)** |
| `-S Callers` (non-targetable) | 0.76s | 0.70s (unchanged, correct) |

Closes the targeted-decode item in #2198.
