### PR TITLE
Extend targeted decode to the type command

### DIFF
--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -738,7 +738,7 @@ public sealed class LibraryBodyIndex
         => Open(path, resolver: null);
 
     public static LibraryBodyIndex Open(string path, IAssemblyReferenceResolver? resolver = null,
-        bool includeAllocations = true, bool includeOpportunities = true, IReadOnlySet<int>? bodyScope = null)
+        bool includeAllocations = true, bool includeOpportunities = true, IReadOnlySet<int>? bodyScope = null, Func<TypeRef, bool>? bodyTypeScope = null)
     {
         using var stream = File.OpenRead(path);
         using var peReader = new PEReader(stream);
@@ -748,7 +748,7 @@ public sealed class LibraryBodyIndex
         using var builder = new IndexBuilder(path, reader, peReader, resolver);
         // Optimization opportunities are synthesized from allocation occurrences (allocation
         // hotspots), so requesting opportunities implies computing allocations.
-        var index = builder.Build(includeAllocations || includeOpportunities, includeOpportunities, bodyScope);
+        var index = builder.Build(includeAllocations || includeOpportunities, includeOpportunities, bodyScope, bodyTypeScope);
         return new LibraryBodyIndex(
             path, index.Methods, index.DirectCalls, index.UnsafeEvidence, index.Diagnostics,
             index.OptimizationOpportunities, index.UnsafeLeverageMethods, builder.MemorySafetyRulesEnabled, index.UnsafeModes,
@@ -1964,7 +1964,7 @@ public sealed class LibraryBodyIndex
                 && HasAttributeNamed(_reader.GetAssemblyDefinition().GetCustomAttributes(), "MemorySafetyRulesAttribute", ns);
         }
 
-        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> AllocationOccurrences, IReadOnlyDictionary<int, ImmutableArray<UnsafetyOccurrence>> UnsafetyOccurrences, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames,         IReadOnlySet<int> NonHeapNewObjOperandTokens) Build(bool includeAllocations, bool includeOpportunities, IReadOnlySet<int>? bodyScope = null)
+        public (ImmutableArray<MethodIdentity> Methods, ImmutableArray<DirectCall> DirectCalls, ImmutableArray<UnsafeEvidence> UnsafeEvidence, ImmutableArray<AnalysisDiagnostic> Diagnostics, ImmutableArray<OptimizationOpportunity> OptimizationOpportunities, ImmutableArray<MethodIdentity> UnsafeLeverageMethods, UnsafeModeBreakdown UnsafeModes, IReadOnlyDictionary<int, BodySignals> BodySignals, IReadOnlyDictionary<int, ImmutableArray<AllocationOccurrence>> AllocationOccurrences, IReadOnlyDictionary<int, ImmutableArray<UnsafetyOccurrence>> UnsafetyOccurrences, IReadOnlyDictionary<(string Namespace, string Name), bool> InAssemblyTypeIsException, IReadOnlySet<int> SuppressedOpportunityTokens, IReadOnlySet<string> ExceptionTypeNames,         IReadOnlySet<int> NonHeapNewObjOperandTokens) Build(bool includeAllocations, bool includeOpportunities, IReadOnlySet<int>? bodyScope = null, Func<TypeRef, bool>? bodyTypeScope = null)
         {
             var methods = ImmutableArray.CreateBuilder<MethodIdentity>();
             var unsafeLeverageMethods = ImmutableArray.CreateBuilder<MethodIdentity>();
@@ -2009,12 +2009,15 @@ public sealed class LibraryBodyIndex
                             continue;
 
                         methods.Add(caller);
-                        // Targeted (single-member) builds decode only the requested method bodies;
-                        // every other method is still indexed as an identity (cheap metadata read)
-                        // but its body is not decoded/scanned. Only sections whose facts are local to
-                        // the selected member (Calls / Unsafe Operations / Allocation-Safety-Cost
-                        // facts) may open a scoped build — reverse/aggregate sections pass null.
+                        // Scoped builds decode only selected method bodies; every other method is
+                        // still indexed as an identity (cheap metadata read) but its body is not
+                        // decoded/scanned. bodyScope selects by method token (single-member queries);
+                        // bodyTypeScope selects by declaring type (single-type queries). Only sections
+                        // whose facts are local to the selected member(s)/type may open a scoped build;
+                        // reverse/aggregate sections (callers, leverage, opportunities) pass null.
                         if (bodyScope is not null && !bodyScope.Contains(caller.MetadataToken))
+                            continue;
+                        if (bodyTypeScope is not null && !bodyTypeScope(caller.DeclaringType))
                             continue;
                         var body = _peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
                         var il = body.GetILBytes() ?? [];

--- a/src/dotnet-inspect.Tests/TypeTargetedDecodeTests.cs
+++ b/src/dotnet-inspect.Tests/TypeTargetedDecodeTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Immutable;
+using Analysis = ILInspector.Analysis;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Locks the type-targeted-decode invariant: opening a <see cref="Analysis.LibraryBodyIndex"/> with a
+/// <c>bodyTypeScope</c> predicate restricted to one declaring type decodes only that type's method
+/// bodies, yet produces per-method facts (direct calls, unsafe evidence, unsafety occurrences,
+/// allocation occurrences) identical to the full whole-assembly build for every method of that type.
+/// This is what lets the type command render Unsafe Members / Called Types / Allocation-Safety-Cost
+/// facts for one type — including its private/compiler-generated methods — without decoding every
+/// method in the assembly. Unlike a token <c>bodyScope</c> (member command), a declaring-type
+/// predicate is required because type sections scan ALL of a type's methods, not just its public API.
+/// </summary>
+public class TypeTargetedDecodeTests
+{
+    static string SelfPath => typeof(Analysis.LibraryBodyIndex).Assembly.Location;
+
+    static string Facts<T>(IReadOnlyDictionary<int, ImmutableArray<T>> byToken, int token)
+        => byToken.TryGetValue(token, out var v)
+            ? string.Join(";", v.Select(x => x!.ToString()).OrderBy(s => s, StringComparer.Ordinal))
+            : "";
+
+    static Analysis.TypeRef LargestType(Analysis.LibraryBodyIndex full)
+        => full.Methods
+            .GroupBy(m => m.DeclaringType)
+            .OrderByDescending(g => g.Count())
+            .First().Key;
+
+    [Fact]
+    public void TypeTargetedBuild_MatchesFullBuild_ForEveryMethodOfTheType()
+    {
+        var full = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var fullCalls = full.GetDirectCallsByCaller();
+        var fullUnsafe = full.GetUnsafeEvidenceByMember();
+        var fullUnsafety = full.GetUnsafetyOccurrences();
+        var fullAlloc = full.GetAllocationOccurrences();
+
+        var target = LargestType(full);
+        var tokens = full.Methods.Where(m => m.DeclaringType.Equals(target)).Select(m => m.MetadataToken).ToArray();
+        Assert.NotEmpty(tokens);
+
+        var targeted = Analysis.LibraryBodyIndex.Open(SelfPath, bodyTypeScope: tr => tr.Equals(target));
+        var tCalls = targeted.GetDirectCallsByCaller();
+        var tUnsafe = targeted.GetUnsafeEvidenceByMember();
+        var tUnsafety = targeted.GetUnsafetyOccurrences();
+        var tAlloc = targeted.GetAllocationOccurrences();
+
+        foreach (var token in tokens)
+        {
+            Assert.Equal(Facts(fullCalls, token), Facts(tCalls, token));
+            Assert.Equal(Facts(fullUnsafe, token), Facts(tUnsafe, token));
+            Assert.Equal(Facts(fullUnsafety, token), Facts(tUnsafety, token));
+            Assert.Equal(Facts(fullAlloc, token), Facts(tAlloc, token));
+        }
+    }
+
+    [Fact]
+    public void TypeTargetedBuild_DecodesOnlyTheScopedType()
+    {
+        var full = Analysis.LibraryBodyIndex.Open(SelfPath);
+        var target = LargestType(full);
+        var inScope = full.Methods.Where(m => m.DeclaringType.Equals(target)).Select(m => m.MetadataToken).ToHashSet();
+
+        var targeted = Analysis.LibraryBodyIndex.Open(SelfPath, bodyTypeScope: tr => tr.Equals(target));
+
+        // Every decoded direct-call caller belongs to the scoped type; no other type is decoded.
+        foreach (var caller in targeted.GetDirectCallsByCaller().Keys)
+            Assert.Contains(caller, inScope);
+
+        // At least one method of the target type actually decoded (the type has bodies with calls).
+        Assert.NotEmpty(targeted.GetDirectCallsByCaller());
+    }
+}

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -664,7 +664,7 @@ public class ApiCommand
             // when such a section is requested) instead of opening one session per section.
             MethodBodyInspectionSession? typeAnalysisSession = null;
             MethodBodyInspectionSession TypeAnalysisSession() =>
-                typeAnalysisSession ??= ApiOutputFormatter.OpenTypeAnalysisSession(options.DllPath!, GetRequestedMemberSections(type, options));
+                typeAnalysisSession ??= ApiOutputFormatter.OpenTypeAnalysisSession(options.DllPath!, GetRequestedMemberSections(type, options), type);
 
             if (options.DllPath is not null
                 && GetRequestedMemberSections(type, options).Contains(SectionNames.UnsafeMembers))
@@ -1294,7 +1294,7 @@ public class ApiCommand
 
             MethodBodyInspectionSession? typeAnalysisSession = null;
             MethodBodyInspectionSession TypeAnalysisSession() =>
-                typeAnalysisSession ??= ApiOutputFormatter.OpenTypeAnalysisSession(renderOptions.DllPath!, GetRequestedMemberSections(type, renderOptions));
+                typeAnalysisSession ??= ApiOutputFormatter.OpenTypeAnalysisSession(renderOptions.DllPath!, GetRequestedMemberSections(type, renderOptions), type);
 
             if (renderOptions.DllPath is not null
                 && GetRequestedMemberSections(type, renderOptions).Contains(SectionNames.UnsafeMembers))

--- a/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
+++ b/src/dotnet-inspect/Inspectors/MethodBodyInspectionSession.cs
@@ -53,10 +53,11 @@ public sealed class MethodBodyInspectionSession
     /// Operations / Allocation-Safety-Cost facts) — reverse/aggregate sections require a full build.
     /// </summary>
     public static MethodBodyInspectionSession Open(string assemblyPath, IAssemblyReferenceResolver? resolver = null,
-        bool includeAllocations = true, bool includeOpportunities = true, IReadOnlySet<int>? bodyScope = null)
+        bool includeAllocations = true, bool includeOpportunities = true, IReadOnlySet<int>? bodyScope = null,
+        Func<Analysis.TypeRef, bool>? bodyTypeScope = null)
     {
         System.Threading.Interlocked.Increment(ref OpenCountForTests);
-        return new(Analysis.LibraryBodyIndex.Open(assemblyPath, resolver, includeAllocations, includeOpportunities, bodyScope), Path.GetFileNameWithoutExtension(assemblyPath));
+        return new(Analysis.LibraryBodyIndex.Open(assemblyPath, resolver, includeAllocations, includeOpportunities, bodyScope, bodyTypeScope), Path.GetFileNameWithoutExtension(assemblyPath));
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -43,12 +43,22 @@ public static class ApiOutputFormatter
     /// <summary>
     /// Opens a type-scope analysis session for the type/library sections. Callers memoize this per
     /// type so the five type-analysis populators share one index build instead of opening five. The
-    /// build is narrowed to the phases <paramref name="requestedSections"/> consumes.
+    /// build is narrowed to the phases <paramref name="requestedSections"/> consumes, and — when
+    /// <paramref name="type"/> is supplied and no requested section needs the whole-assembly reverse
+    /// graph (Top Leverage / Performance Triage) — to only that type's method bodies.
     /// </summary>
-    internal static MethodBodyInspectionSession OpenTypeAnalysisSession(string dllPath, IReadOnlyCollection<string>? requestedSections = null)
+    internal static MethodBodyInspectionSession OpenTypeAnalysisSession(string dllPath, IReadOnlyCollection<string>? requestedSections = null, ApiType? type = null)
     {
         var (allocations, opportunities) = AnalysisScopeFor(requestedSections);
-        return MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath), allocations, opportunities);
+        // Unsafe Members, Called Types, and the Allocation/Safety/Cost facts read only the type's
+        // own method bodies; Top Leverage (whole-assembly fanin) and Performance Triage (leverage
+        // join) need every method, so their presence forces a full build.
+        Func<Analysis.TypeRef, bool>? bodyTypeScope = null;
+        if (type is not null && requestedSections is not null
+            && !requestedSections.Contains(SectionNames.TopLeverage)
+            && !requestedSections.Contains(SectionNames.PerformanceTriage))
+            bodyTypeScope = typeRef => SameType(typeRef, type);
+        return MethodBodyInspectionSession.Open(dllPath, AnalysisReferenceResolver(dllPath), allocations, opportunities, bodyScope: null, bodyTypeScope: bodyTypeScope);
     }
 
     // ===== Full API View Model Factory =====


### PR DESCRIPTION
## Result: 3.4–5.2× faster type inspection

Type-targetable sections now decode only the target type's method bodies instead of every method in the assembly. CPU time (user+sys), pointing `type <T>` at `ILInspector.Decompiler.dll`:

| Section(s) | Before | After | Speedup |
| --- | --- | --- | --- |
| `Allocation Facts,Safety Facts,Cost Facts` | 1.36s | 0.26s | **5.2×** |
| `Unsafe Members` | 0.79s | 0.23s | **3.4×** |
| `Called Types` | 0.69s | 0.22s | **3.1×** |
| `Unsafe Members,Called Types` (small type) | 0.70s | 0.15s | **4.7×** |
| `Top Leverage` (non-targetable → full build) | 1.42s | 1.32s | unchanged ✓ |

Non-targetable sections correctly fall back to a full build (last row), so the win is scoped precisely to type-local queries.

## Summary

Extends the targeted-decode optimization (member command, #2228) to the **type command**. `LibraryBodyIndex.Open`/`Build` gain a `bodyTypeScope` predicate that gates body decode on `caller.DeclaringType`, mirroring the token-set `bodyScope` from #2228. `OpenTypeAnalysisSession` builds the predicate from the type via the existing `SameType` matcher — but **only when no requested section needs the whole-assembly reverse graph**.

## Gate completeness (by construction)

The two type sections that consume cross-type data are:

- **Top Leverage** — whole-assembly fanin
- **Performance Triage** — leverage join over opportunities

These are exactly the two section names that force a full build. Every other `TypeAnalysisSession()` consumer (`PopulateUnsafeMembers`, `PopulateCalledTypes`, `PopulateTypeSemanticFacts` = Allocation/Safety/Cost facts) reads only the type's own bodies.

A declaring-type predicate (not a token set) is required because type sections scan **all** of a type's methods, including private/compiler-generated ones that aren't in the public member list.

## Validation

- **Byte-identical CLI** across 4 types × 12 section combos (targetable alone, non-targetable, and mixed combos that fall back to full), the default view, all `-v:q|m|n|d` levels, plus the `library` command (renders per-type via the same dispatch).
- **New `TypeTargetedDecodeTests`**: type-scoped facts (direct calls, unsafe evidence, unsafety/allocation occurrences) identical to the full build for **every** method of the target type; only that type's bodies decoded.
- **Existing tests pass**: IndexBuildInvariant (build-once guard still holds — one open per command), CalledTypes, TopLeverage, UnsafeMembers, SemanticFacts, LibraryTopLeverage, OutputFormatter, TargetedDecode (123 total).

## Risk

Behavior-preserving. The only risk is gate incompleteness (a type section secretly needing whole-assembly data). Adversarial review confirmed the gate is aligned 1:1 with the whole-assembly consumers, and byte-diff confirms mixed combos fall back correctly.
