### PR TITLE
Prefer assembly reference resolver boundary

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AllocationOccurrenceFactTests.cs
@@ -8,11 +8,13 @@ namespace ILInspector.Decompiler.Tests;
 public class AllocationOccurrenceFactTests
 {
     static IReadOnlyList<Annotation> Classify(string methodName)
-        => Classify(methodName, locator: null);
+        => Classify(methodName, resolver: null);
 
-    static IReadOnlyList<Annotation> Classify(string methodName, ILInspector.Metadata.AssemblyLocator? locator)
+    static IReadOnlyList<Annotation> Classify(string methodName, ILInspector.Metadata.IAssemblyReferenceResolver? resolver)
     {
-        var source = MetadataSource.Open(typeof(AllocSampleClass).Assembly.Location, null, locator);
+        var source = resolver is null
+            ? MetadataSource.Open(typeof(AllocSampleClass).Assembly.Location)
+            : MetadataSource.Open(typeof(AllocSampleClass).Assembly.Location, null, resolver);
         return ResearchViews.CollectFacts(source, typeof(AllocSampleClass).FullName!, methodName)
             .Where(annotation => annotation.Descriptor.Category == AnnotationCategory.Allocation)
             .ToList();
@@ -20,13 +22,8 @@ public class AllocationOccurrenceFactTests
 
     // Resolves referenced assemblies from the running runtime directory, where
     // System.Private.CoreLib (and the rest of the shared framework) lives. The
-    // default sibling locator cannot find corelib beside the test assembly.
-    static readonly ILInspector.Metadata.AssemblyLocator RuntimeLocator = (name, trust) =>
-    {
-        string dir = System.IO.Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-        string path = System.IO.Path.Combine(dir, name + ".dll");
-        return System.IO.File.Exists(path) ? path : null;
-    };
+    // default sibling resolver cannot find corelib beside the test assembly.
+    static readonly ILInspector.Metadata.IAssemblyReferenceResolver RuntimeResolver = TestAssemblyReferenceResolvers.RuntimeAssemblies();
 
     static IReadOnlyList<string> Ids(IReadOnlyList<Annotation> annotations)
         => annotations.Select(a => a.Descriptor.Id).ToList();
@@ -76,19 +73,19 @@ public class AllocationOccurrenceFactTests
     }
 
     [Fact]
-    public void CrossAssemblyValueTypeNewObject_PreservesLegacyAnnotationParity_WithLocator()
+    public void CrossAssemblyValueTypeNewObject_PreservesLegacyAnnotationParity_WithResolver()
     {
         // Track A preserves the legacy visible allocation annotation shape for
         // bare cross-assembly framework value-type constructors. The occurrence
         // is non-counting for Analysis performance signals, but still projects
         // to alloc.new for annotation parity.
-        Assert.Contains("alloc.new", Ids(Classify(nameof(AllocSampleClass.MakeDateTime), RuntimeLocator)));
+        Assert.Contains("alloc.new", Ids(Classify(nameof(AllocSampleClass.MakeDateTime), RuntimeResolver)));
     }
 
     [Fact]
-    public void CrossAssemblyValueTypeNewObject_PreservesLegacyAnnotationParity_WithoutLocator()
+    public void CrossAssemblyValueTypeNewObject_PreservesLegacyAnnotationParity_WithoutResolver()
     {
-        Assert.Contains("alloc.new", Ids(Classify(nameof(AllocSampleClass.MakeDateTime), locator: (name, trust) => null)));
+        Assert.Contains("alloc.new", Ids(Classify(nameof(AllocSampleClass.MakeDateTime), TestAssemblyReferenceResolvers.None)));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/CollectionExpressionFrontierTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CollectionExpressionFrontierTests.cs
@@ -7,7 +7,7 @@ public class CollectionExpressionFrontierTests
 {
     static IrFunction Raised(string methodName)
     {
-        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, locator: RuntimeLocator);
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, null, RuntimeResolver);
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
         Assert.NotNull(function);
         IrPasses.Run(function!);
@@ -17,7 +17,7 @@ public class CollectionExpressionFrontierTests
 
     static IrFunction RaisedWithoutSymbols(string methodName)
     {
-        using var source = MetadataSource.OpenWithoutSymbols(typeof(CfgSampleClass).Assembly.Location, locator: RuntimeLocator);
+        using var source = MetadataSource.OpenWithoutSymbols(typeof(CfgSampleClass).Assembly.Location, RuntimeResolver);
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
         Assert.NotNull(function);
         IrPasses.Run(function!);
@@ -27,17 +27,7 @@ public class CollectionExpressionFrontierTests
 
     static string Print(string methodName) => CSharpPrinter.Print(Raised(methodName)).Output!;
 
-    static readonly Lazy<IReadOnlyDictionary<string, string>> s_runtimeAssemblies = new(() =>
-        (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-        .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-        .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-        .GroupBy(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase)
-        .ToDictionary(group => group.Key!, group => group.First(), StringComparer.OrdinalIgnoreCase));
-
-    static readonly AssemblyLocator RuntimeLocator = (name, trust) =>
-        trust == AssemblyResolutionScope.Platform && s_runtimeAssemblies.Value.TryGetValue(name, out var path)
-            ? path
-            : null;
+    static readonly IAssemblyReferenceResolver RuntimeResolver = TestAssemblyReferenceResolvers.TrustedPlatformAssemblies();
 
     [Fact]
     public void GeneralListCollectionExpression_RaisesWithPdbHiddenLocals()

--- a/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
@@ -26,7 +26,7 @@ public class CrossAssemblyMethodFactsTests
     public void PlatformForwardedByRefMemberRef_RecoversParameterRefKinds()
     {
         using var fixture = CrossAssemblyFixture.Create();
-        using var source = MetadataSource.Open(fixture.ConsumerPath, locator: TrustedPlatformLocator());
+        using var source = MetadataSource.Open(fixture.ConsumerPath, null, TestAssemblyReferenceResolvers.TrustedPlatformAssemblies());
 
         var call = SingleCall(source, nameof(CrossAssemblyFixtureMethods.UseUri), "TryCreate");
         Assert.Equal(ParameterRefKindFacts.Known, call.Callee.ParameterRefKindsFacts);
@@ -151,7 +151,7 @@ public class CrossAssemblyMethodFactsTests
     public void MissingCrossAssemblyMetadata_KeepsFactsUnknown()
     {
         using var fixture = CrossAssemblyFixture.Create();
-        using var source = MetadataSource.Open(fixture.ConsumerPath, locator: (_, _) => null);
+        using var source = MetadataSource.Open(fixture.ConsumerPath, null, TestAssemblyReferenceResolvers.None);
 
         var byRef = SingleCall(source, nameof(CrossAssemblyFixtureMethods.UseOut), "WriteOut");
         Assert.Equal(ParameterRefKindFacts.Unknown, byRef.Callee.ParameterRefKindsFacts);
@@ -172,7 +172,7 @@ public class CrossAssemblyMethodFactsTests
     public void MissingCrossAssemblyAccessorMetadata_KeepsAccessorFactUnknown()
     {
         using var fixture = CrossAssemblyFixture.Create();
-        using var source = MetadataSource.Open(fixture.ConsumerPath, locator: (_, _) => null);
+        using var source = MetadataSource.Open(fixture.ConsumerPath, null, TestAssemblyReferenceResolvers.None);
 
         var function = ImportFunction(source, nameof(CrossAssemblyFixtureMethods.UseProperty));
         var call = Assert.Single(function.Descendants.OfType<Call>(), c => c.Callee.Name == "get_Count");
@@ -390,20 +390,6 @@ public class CrossAssemblyMethodFactsTests
         }
 
         public void Dispose() => Directory.Delete(_directory, recursive: true);
-    }
-
-    static AssemblyLocator TrustedPlatformLocator()
-    {
-        var assemblies = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-            .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-            .GroupBy(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(group => group.Key!, group => group.First(), StringComparer.OrdinalIgnoreCase);
-
-        return (name, trust) =>
-            trust == AssemblyResolutionScope.Platform && assemblies.TryGetValue(name, out var path)
-                ? path
-                : null;
     }
 
     static class CrossAssemblyFixtureMethods

--- a/src/ILInspector.Decompiler.Tests/ExtensionMethodCallTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExtensionMethodCallTests.cs
@@ -5,20 +5,15 @@ namespace ILInspector.Decompiler.Tests;
 public class ExtensionMethodCallTests
 {
     // Extension-ness is a cross-assembly fact (System.Linq lives in the shared
-    // framework, not beside the test assembly), so the default sibling locator
+    // framework, not beside the test assembly), so the default sibling resolver
     // cannot resolve it. Reach the running runtime directory, the same pattern
     // AllocationOccurrenceFactTests uses for its corelib base-chain checks.
-    static readonly ILInspector.Metadata.AssemblyLocator RuntimeLocator = (name, trust) =>
-    {
-        string dir = System.IO.Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-        string path = System.IO.Path.Combine(dir, name + ".dll");
-        return System.IO.File.Exists(path) ? path : null;
-    };
+    static readonly ILInspector.Metadata.IAssemblyReferenceResolver RuntimeResolver = TestAssemblyReferenceResolvers.RuntimeAssemblies();
 
     static string PrintRaised(string methodName)
     {
-        using var context = new MetadataContext(RuntimeLocator);
-        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, null, RuntimeLocator, context);
+        using var context = new MetadataContext(RuntimeResolver);
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, null, RuntimeResolver, context);
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
         Assert.NotNull(function);
 

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -18,7 +18,7 @@ public class IrImporterTests
 
     static IrFunction ImportFixtureWithTrustedPlatformContext(string methodName)
     {
-        using var context = new MetadataContext(TrustedPlatformLocator());
+        using var context = new MetadataContext(TestAssemblyReferenceResolvers.TrustedPlatformAssemblies());
         using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, context: context);
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
         Assert.NotNull(function);
@@ -923,20 +923,6 @@ public class IrImporterTests
         => type.Kind is TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter
             || (type.ElementType is { } element && ContainsGenericParameter(element))
             || type.TypeArguments.Any(ContainsGenericParameter);
-
-    static AssemblyLocator TrustedPlatformLocator()
-    {
-        var assemblies = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-            .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-            .GroupBy(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(group => group.Key!, group => group.First(), StringComparer.OrdinalIgnoreCase);
-
-        return (name, trust) =>
-            trust == AssemblyResolutionScope.Platform && assemblies.TryGetValue(name, out var path)
-                ? path
-                : null;
-    }
 
     [Fact]
     public void AddressOf_OutArgument_ImportsAsLocalAddress()

--- a/src/ILInspector.Decompiler.Tests/LadderRung1ProductPathGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung1ProductPathGateTests.cs
@@ -10,18 +10,18 @@ namespace ILInspector.Decompiler.Tests;
 /// <summary>
 /// The rung 1 <em>product-path</em> guard for the decompiler product quality
 /// ladder (#1599 / #1695). The other rung gates ride the bare per-method seam
-/// (no cross-method import callback, no platform assembly locator), which is fine
+/// (no cross-method import callback, no platform assembly resolver), which is fine
 /// for self-contained syntax but <em>under-resolves</em> the constructs that only
 /// recover through the path users actually hit (<c>dotnet-inspect type … -S
 /// "Decompiled Source"</c>): lambdas and LINQ need the cross-method import seam,
 /// and cross-assembly <c>out</c>/<c>ref</c>/<c>in</c> arguments need a platform
-/// locator. On the seam alone those degrade (lambdas leak <c>&lt;&gt;c</c> names,
+/// resolver. On the seam alone those degrade (lambdas leak <c>&lt;&gt;c</c> names,
 /// a cross-assembly <c>out</c> arg renders <c>ref</c>) even though the product
 /// renders them correctly — exactly the seam-vs-product gap that made the
 /// cross-assembly out-variable look like a bug (#1692).
 ///
 /// <para>This gate composes the <see cref="LadderRung1.ProductSurface"/> fixture
-/// through the same wiring the product uses — a TPA-backed platform locator on
+/// through the same wiring the product uses — a TPA-backed platform resolver on
 /// the <see cref="MetadataSource"/> plus the cross-method import seam on
 /// <see cref="CSharpPrinter"/> — and pins the real product rendering: lambdas
 /// raise to <c>x =&gt; …</c>, LINQ to a raised operator chain, and the
@@ -33,23 +33,13 @@ public class LadderRung1ProductPathGateTests
     static string FixturePath => typeof(LadderRung1.ProductSurface).Assembly.Location;
     static readonly string FixtureType = typeof(LadderRung1.ProductSurface).FullName!;
 
-    // Platform locator backed by the running runtime's trusted-platform-assembly
+    // Platform resolver backed by the running runtime's trusted-platform-assembly
     // list — always populated for the host runtime, so it resolves the fixture's
     // framework references (System.Private.CoreLib for int.TryParse) without
     // depending on SDK/shared-framework discovery. Only Platform-trust references
     // resolve, so a planted local copy can never satisfy a platform name. This is
     // the same convention LadderRung2GateTests uses.
-    static readonly Lazy<IReadOnlyDictionary<string, string>> s_runtimeAssemblies = new(() =>
-        (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-        .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-        .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-        .GroupBy(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase)
-        .ToDictionary(group => group.Key!, group => group.First(), StringComparer.OrdinalIgnoreCase));
-
-    static readonly AssemblyLocator RuntimeLocator = (name, trust) =>
-        trust == AssemblyResolutionScope.Platform && s_runtimeAssemblies.Value.TryGetValue(name, out var path)
-            ? path
-            : null;
+    static readonly IAssemblyReferenceResolver RuntimeResolver = TestAssemblyReferenceResolvers.TrustedPlatformAssemblies();
 
     static readonly string[] ExpectedMembers =
     [
@@ -100,7 +90,7 @@ public class LadderRung1ProductPathGateTests
         Assert.Contains("value => value * 2", linq);
 
         // The cross-assembly out-variable resolves to `out`, not `ref` — the
-        // platform locator reads int.TryParse's real parameter rows (#1692).
+        // platform resolver reads int.TryParse's real parameter rows (#1692).
         var outVar = Body("OutVariable");
         Assert.Contains("int.TryParse(text, out result)", outVar);
         Assert.DoesNotContain("ref result", outVar);
@@ -121,7 +111,7 @@ public class LadderRung1ProductPathGateTests
 
         // Parsing each body as a method body catches the degraded forms this gate
         // exists to prevent: a leaked `<>c` name is not a legal C# identifier, so
-        // seam/locator regressions surface as parse errors here, not just as a
+        // seam/resolver regressions surface as parse errors here, not just as a
         // failed substring assertion.
         foreach (var (name, _, body) in members)
         {
@@ -139,13 +129,13 @@ public class LadderRung1ProductPathGateTests
     static List<(string Name, IrFunction Function, string Body)> LoadProductPathMembers()
     {
         var members = new List<(string Name, IrFunction Function, string Body)>();
-        using var source = MetadataSource.Open(FixturePath, locator: RuntimeLocator);
+        using var source = MetadataSource.Open(FixturePath, null, RuntimeResolver);
         foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
         {
             if (typeName != FixtureType)
                 continue;
             // Product wiring: the import seam raises cross-method lambda bodies,
-            // and the locator on `source` resolves cross-assembly ref-kinds.
+            // and the resolver on `source` resolves cross-assembly ref-kinds.
             var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
             members.Add((methodName, function, (result.Output ?? "").Trim()));
         }

--- a/src/ILInspector.Decompiler.Tests/LadderRung2GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung2GateTests.cs
@@ -38,17 +38,7 @@ public class LadderRung2GateTests
     static readonly string ExtensionsType = typeof(LadderRung2.LadderRung2Extensions).FullName!;
     static readonly HashSet<string> FixtureTypes = [ProgramType, BoxType, ExtensionsType];
 
-    static readonly Lazy<IReadOnlyDictionary<string, string>> s_runtimeAssemblies = new(() =>
-        (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-        .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-        .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-        .GroupBy(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase)
-        .ToDictionary(group => group.Key!, group => group.First(), StringComparer.OrdinalIgnoreCase));
-
-    static readonly AssemblyLocator RuntimeLocator = (name, trust) =>
-        trust == AssemblyResolutionScope.Platform && s_runtimeAssemblies.Value.TryGetValue(name, out var path)
-            ? path
-            : null;
+    static readonly IAssemblyReferenceResolver RuntimeResolver = TestAssemblyReferenceResolvers.TrustedPlatformAssemblies();
 
     // The exact rung 2 construct set across every user-authored fixture type. Locked
     // (type-qualified, duplicates included) so a future fixture edit that drops a
@@ -218,7 +208,7 @@ public class LadderRung2GateTests
     static List<(string Key, IrFunction Function)> LoadRaisedMembers()
     {
         var members = new List<(string Key, IrFunction Function)>();
-        using var source = MetadataSource.Open(FixturePath, locator: RuntimeLocator);
+        using var source = MetadataSource.Open(FixturePath, null, RuntimeResolver);
         foreach (var (typeName, methodName, function) in IrImporter.ImportAssembly(source))
         {
             if (!FixtureTypes.Contains(typeName))

--- a/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ObjectInitializerPassTests.cs
@@ -7,7 +7,7 @@ public class ObjectInitializerPassTests
 {
     static IrFunction Raised(string methodName)
     {
-        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, locator: RuntimeLocator);
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location, null, RuntimeResolver);
         var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
         Assert.NotNull(function);
         IrPasses.Run(function!);
@@ -17,17 +17,7 @@ public class ObjectInitializerPassTests
 
     static string Print(string methodName) => CSharpPrinter.Print(Raised(methodName)).Output!;
 
-    static readonly Lazy<IReadOnlyDictionary<string, string>> s_runtimeAssemblies = new(() =>
-        (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-        .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-        .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-        .GroupBy(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase)
-        .ToDictionary(group => group.Key!, group => group.First(), StringComparer.OrdinalIgnoreCase));
-
-    static readonly AssemblyLocator RuntimeLocator = (name, trust) =>
-        trust == AssemblyResolutionScope.Platform && s_runtimeAssemblies.Value.TryGetValue(name, out var path)
-            ? path
-            : null;
+    static readonly IAssemblyReferenceResolver RuntimeResolver = TestAssemblyReferenceResolvers.TrustedPlatformAssemblies();
 
     [Fact]
     public void ObjectInitializer_RaisesPropertyMembers()

--- a/src/ILInspector.Decompiler.Tests/TestAssemblyReferenceResolvers.cs
+++ b/src/ILInspector.Decompiler.Tests/TestAssemblyReferenceResolvers.cs
@@ -1,0 +1,45 @@
+using ILInspector.Metadata;
+
+namespace ILInspector.Decompiler.Tests;
+
+static class TestAssemblyReferenceResolvers
+{
+    static readonly Lazy<IReadOnlyDictionary<string, string>> s_runtimeAssemblies = new(() =>
+        (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+        .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+        .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+        .GroupBy(Path.GetFileNameWithoutExtension, StringComparer.OrdinalIgnoreCase)
+        .ToDictionary(group => group.Key!, group => group.First(), StringComparer.OrdinalIgnoreCase));
+
+    public static IAssemblyReferenceResolver None { get; } = new DelegateResolver((_, _) => null);
+
+    public static IAssemblyReferenceResolver TrustedPlatformAssemblies()
+        => new DelegateResolver((identity, scope) =>
+            scope == AssemblyResolutionScope.Platform && s_runtimeAssemblies.Value.TryGetValue(identity.Name, out var path)
+                ? FromPath(identity, path, "TrustedPlatformAssemblies")
+                : null);
+
+    public static IAssemblyReferenceResolver RuntimeAssemblies()
+        => new DelegateResolver((identity, _) =>
+            s_runtimeAssemblies.Value.TryGetValue(identity.Name, out var path)
+                ? FromPath(identity, path, "TrustedPlatformAssemblies")
+                : null);
+
+    public static IAssemblyReferenceResolver SingleAssembly(string assemblyPath)
+    {
+        string assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
+        return new DelegateResolver((identity, _) =>
+            string.Equals(identity.Name, assemblyName, StringComparison.OrdinalIgnoreCase)
+                ? FromPath(identity, assemblyPath, "TestAssembly")
+                : null);
+    }
+
+    static ResolvedAssemblyReference FromPath(AssemblyReferenceIdentity identity, string path, string provenance)
+        => new(identity, path, () => File.OpenRead(path), provenance);
+
+    sealed class DelegateResolver(Func<AssemblyReferenceIdentity, AssemblyResolutionScope, ResolvedAssemblyReference?> resolve) : IAssemblyReferenceResolver
+    {
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+            => resolve(identity, scope);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnspeakableNameFidelityTests.cs
@@ -100,7 +100,10 @@ public class UnspeakableNameFidelityTests
     [Fact]
     public void CrossAssemblyBackingFieldEvidence_RecoversMatchingProperty()
     {
-        using var source = MetadataSource.Open(typeof(object).Assembly.Location, locator: LocateTestAssembly);
+        using var source = MetadataSource.Open(
+            typeof(object).Assembly.Location,
+            null,
+            TestAssemblyReferenceResolvers.SingleAssembly(typeof(CfgSampleClass).Assembly.Location));
         var declaringType = TypeRef.Definition(
             typeof(CfgSampleClass).Assembly.GetName().Name!,
             typeof(CfgSampleClass).Namespace!,
@@ -115,7 +118,10 @@ public class UnspeakableNameFidelityTests
     [Fact]
     public void CrossAssemblyBackingFieldEvidence_DeclinesMissingProperty()
     {
-        using var source = MetadataSource.Open(typeof(object).Assembly.Location, locator: LocateTestAssembly);
+        using var source = MetadataSource.Open(
+            typeof(object).Assembly.Location,
+            null,
+            TestAssemblyReferenceResolvers.SingleAssembly(typeof(CfgSampleClass).Assembly.Location));
         var declaringType = TypeRef.Definition(
             typeof(CfgSampleClass).Assembly.GetName().Name!,
             typeof(CfgSampleClass).Namespace!,
@@ -126,11 +132,6 @@ public class UnspeakableNameFidelityTests
 
         Assert.Null(upgraded.BackingPropertyName);
     }
-
-    static string? LocateTestAssembly(string assemblyName, AssemblyResolutionScope _)
-        => assemblyName == typeof(CfgSampleClass).Assembly.GetName().Name
-            ? typeof(CfgSampleClass).Assembly.Location
-            : null;
 
     [Fact]
     public void LocalFunctionMetadataName_StaysFull()

--- a/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CrossAssemblyTypeResolver.cs
@@ -18,11 +18,11 @@ namespace ILInspector.Decompiler.Pipeline;
 /// </summary>
 /// <remarks>
 /// Precision-preserving: a fact is returned only when the defining assembly is
-/// located and its metadata confirms it. Anything unreachable (no locator hit,
+/// located and its metadata confirms it. Anything unreachable (no resolver hit,
 /// a forwarder dead-end, an I/O or format error) yields
 /// <see cref="ValueTypeHint.Unknown"/> — never a guess. Security: a reference
 /// whose public-key token is a trusted platform key is asserted
-/// <see cref="AssemblyResolutionScope.Platform"/> so the locator resolves it only from
+/// <see cref="AssemblyResolutionScope.Platform"/> so resolution is constrained to
 /// platform/framework sources, never a confusable local copy.
 ///
 /// Reading is delegated to a shared <see cref="MetadataContext"/>: each defining

--- a/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataContext.cs
@@ -34,6 +34,10 @@ public sealed class MetadataContext : IDisposable
     readonly ConcurrentDictionary<string, Lazy<OpenedAssembly?>> _opened = new(StringComparer.OrdinalIgnoreCase);
     readonly ConcurrentDictionary<string, Lazy<OpenedAssembly?>> _openedLocations = new(StringComparer.Ordinal);
 
+    /// <summary>
+    /// Creates a context from a legacy path-only locator. Prefer the
+    /// <see cref="IAssemblyReferenceResolver"/> constructor for new code.
+    /// </summary>
     public MetadataContext(AssemblyLocator locator)
         : this(locator.ToAssemblyReferenceResolver())
     {
@@ -42,11 +46,7 @@ public sealed class MetadataContext : IDisposable
     public MetadataContext(IAssemblyReferenceResolver resolver)
     {
         Resolver = resolver;
-        Locator = resolver.ToAssemblyLocator();
     }
-
-    /// <summary>Resolves a referenced assembly name to an on-disk path.</summary>
-    internal AssemblyLocator Locator { get; }
 
     internal IAssemblyReferenceResolver Resolver { get; }
 

--- a/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
+++ b/src/ILInspector.Decompiler/Pipeline/MetadataSource.cs
@@ -24,7 +24,6 @@ public sealed class MetadataSource : IDisposable
     DecompilerSymbolSource _symbols = DecompilerSymbolSource.None;
     readonly string? _externalPdbPath;
     readonly bool _readSymbols;
-    readonly AssemblyLocator _locator;
     readonly IAssemblyReferenceResolver _resolver;
     readonly MetadataContext? _suppliedContext;
     MetadataContext? _crossContext;
@@ -32,7 +31,7 @@ public sealed class MetadataSource : IDisposable
     CrossAssemblyTypeResolver? _crossAssembly;
     readonly object _crossLock = new();
 
-    MetadataSource(string path, Stream stream, PEReader peReader, MetadataReader reader, string assemblyName, string? externalPdbPath, bool readSymbols, AssemblyLocator locator, IAssemblyReferenceResolver resolver, MetadataContext? context)
+    MetadataSource(string path, Stream stream, PEReader peReader, MetadataReader reader, string assemblyName, string? externalPdbPath, bool readSymbols, IAssemblyReferenceResolver resolver, MetadataContext? context)
     {
         Path = path;
         _stream = stream;
@@ -41,7 +40,6 @@ public sealed class MetadataSource : IDisposable
         AssemblyName = assemblyName;
         _externalPdbPath = externalPdbPath;
         _readSymbols = readSymbols;
-        _locator = locator;
         _resolver = resolver;
         _suppliedContext = context;
     }
@@ -79,14 +77,15 @@ public sealed class MetadataSource : IDisposable
     /// without managed metadata. <paramref name="externalPdbPath"/> is a portable
     /// PDB to use for source local names when the assembly carries no embedded
     /// or sidecar PDB — e.g. one the CLI downloaded from a symbol server.
-    /// <paramref name="locator"/> resolves referenced assemblies for
-    /// cross-assembly type facts (value-type-ness of a bare token); when null,
-    /// the default policy looks only beside the opened assembly. A richer caller
-    /// (the CLI) supplies a platform/package-aware locator.
+    /// <paramref name="locator"/> is the legacy path-only adapter for resolving
+    /// referenced assemblies for cross-assembly type facts (value-type-ness of a
+    /// bare token); when null, the default policy looks only beside the opened
+    /// assembly. New callers should prefer the <see cref="IAssemblyReferenceResolver"/>
+    /// overload so identity and stream-backed assemblies flow through.
     /// <paramref name="context"/> is a shared <see cref="MetadataContext"/> a
     /// batch caller may pass so a dependency such as CoreLib is opened once
-    /// across many sources; when null, this source creates and owns one (and the
-    /// supplied <paramref name="locator"/> seeds it). A supplied context is
+    /// across many sources; when null, this source creates and owns one seeded
+    /// by the effective resolver. A supplied context is
     /// borrowed — the caller owns its disposal.
     /// </summary>
     public static MetadataSource Open(string path, string? externalPdbPath = null, AssemblyLocator? locator = null, MetadataContext? context = null)
@@ -114,11 +113,18 @@ public sealed class MetadataSource : IDisposable
         => OpenCore(assembly, externalPdbPath: null, readSymbols: false, resolver, context);
 
     /// <summary>
-    /// Default referenced-assembly probing policy for callers that need to share a
-    /// <see cref="MetadataContext"/> across several <see cref="MetadataSource"/>
-    /// instances.
+    /// Default referenced-assembly probing policy for callers that need to share
+    /// a <see cref="MetadataContext"/> across several <see cref="MetadataSource"/>
+    /// instances. It resolves only non-platform assemblies copied beside
+    /// <paramref name="path"/>.
     /// </summary>
-    public static AssemblyLocator DefaultAssemblyLocator(string path) => SiblingLocator(path);
+    public static IAssemblyReferenceResolver DefaultAssemblyReferenceResolver(string path) => new SiblingAssemblyReferenceResolver(path);
+
+    /// <summary>
+    /// Legacy path-only view over <see cref="DefaultAssemblyReferenceResolver"/>.
+    /// Prefer the resolver-returning API for new code.
+    /// </summary>
+    public static AssemblyLocator DefaultAssemblyLocator(string path) => DefaultAssemblyReferenceResolver(path).ToAssemblyLocator();
 
     static MetadataSource OpenCore(string path, string? externalPdbPath, bool readSymbols, AssemblyLocator? locator, IAssemblyReferenceResolver? resolver, MetadataContext? context)
     {
@@ -133,9 +139,8 @@ public sealed class MetadataSource : IDisposable
             string assemblyName = reader.IsAssembly
                 ? reader.GetString(reader.GetAssemblyDefinition().Name)
                 : System.IO.Path.GetFileNameWithoutExtension(path);
-            var effectiveLocator = locator ?? DefaultAssemblyLocator(path);
-            var effectiveResolver = resolver ?? effectiveLocator.ToAssemblyReferenceResolver();
-            return new MetadataSource(path, stream, peReader, reader, assemblyName, externalPdbPath, readSymbols, effectiveLocator, effectiveResolver, context);
+            var effectiveResolver = resolver ?? locator?.ToAssemblyReferenceResolver() ?? DefaultAssemblyReferenceResolver(path);
+            return new MetadataSource(path, stream, peReader, reader, assemblyName, externalPdbPath, readSymbols, effectiveResolver, context);
         }
         catch
         {
@@ -159,7 +164,7 @@ public sealed class MetadataSource : IDisposable
                 ? reader.GetString(reader.GetAssemblyDefinition().Name)
                 : assembly.Identity.Name;
             string path = assembly.Path ?? assembly.Identity.Name;
-            return new MetadataSource(path, stream, peReader, reader, assemblyName, externalPdbPath, readSymbols, resolver.ToAssemblyLocator(), resolver, context);
+            return new MetadataSource(path, stream, peReader, reader, assemblyName, externalPdbPath, readSymbols, resolver, context);
         }
         catch
         {
@@ -175,23 +180,30 @@ public sealed class MetadataSource : IDisposable
     /// resolution (packages, deps.json, projects, shared frameworks) belongs to
     /// callers that inject a resolver.
     /// </summary>
-    static AssemblyLocator SiblingLocator(string path)
+    sealed class SiblingAssemblyReferenceResolver(string path) : IAssemblyReferenceResolver
     {
-        string? dir = System.IO.Path.GetDirectoryName(path);
-        return (name, scope) =>
+        readonly string? _directory = System.IO.Path.GetDirectoryName(path);
+
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
         {
             if (scope == AssemblyResolutionScope.Platform)
                 return null;
 
-            if (dir is not null)
+            if (_directory is not null)
             {
-                string sibling = System.IO.Path.Combine(dir, name + ".dll");
+                string sibling = System.IO.Path.Combine(_directory, identity.Name + ".dll");
                 if (File.Exists(sibling))
-                    return sibling;
+                {
+                    return new ResolvedAssemblyReference(
+                        identity,
+                        sibling,
+                        () => File.OpenRead(sibling),
+                        Provenance: "SiblingAssembly");
+                }
             }
 
             return null;
-        };
+        }
     }
 
     /// <summary>
@@ -215,9 +227,9 @@ public sealed class MetadataSource : IDisposable
 
     /// <summary>
     /// The shared assembly-reading environment cross-assembly resolution reads
-    /// through. A borrowed context (passed to <see cref="Open(string, string?, AssemblyLocator?, MetadataContext?)"/>)
+    /// through. A borrowed context (passed to <see cref="Open(string, string?, IAssemblyReferenceResolver, MetadataContext?)"/>)
     /// is reused and left for its owner to dispose; otherwise this source creates
-    /// and owns one seeded with its own locator.
+    /// and owns one seeded with its resolver.
     /// </summary>
     MetadataContext CrossContext
     {

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -17,18 +17,15 @@ namespace ILInspector.Decompiler;
 /// </summary>
 public static class TypeSourceComposer
 {
+    /// <summary>
+    /// Legacy path-only entry point. Prefer the <see cref="IAssemblyReferenceResolver"/>
+    /// overload for new product and harness code.
+    /// </summary>
     public static string? Compose(ApiType type, string dllPath, string? pdbPath, AssemblyLocator? locateAssembly = null, Pipeline.MetadataContext? context = null)
     {
-        locateAssembly ??= SiblingLocator(dllPath);
-        return ComposeCore(
-            type,
-            dllPath,
-            pdbPath,
-            () => TypeForwardResolver.LocateType(dllPath, type.FullName, locateAssembly),
-            (location, ctx) => location.AssemblyPath is { } path
-                ? Pipeline.MetadataSource.Open(path, pdbPath, locateAssembly, ctx)
-                : Pipeline.MetadataSource.Open(location.ToResolvedAssemblyReference(), pdbPath, locateAssembly.ToAssemblyReferenceResolver(), ctx),
-            context);
+        var resolver = locateAssembly?.ToAssemblyReferenceResolver()
+            ?? Pipeline.MetadataSource.DefaultAssemblyReferenceResolver(dllPath);
+        return Compose(type, dllPath, pdbPath, resolver, context);
     }
 
     public static string? Compose(ApiType type, string dllPath, string? pdbPath, IAssemblyReferenceResolver resolver, Pipeline.MetadataContext? context = null)
@@ -149,15 +146,6 @@ public static class TypeSourceComposer
             return $"// {DiagnosticIds.InternalError}: type source unavailable: {ex.GetType().Name}: {ex.Message}";
         }
     }
-
-    static AssemblyLocator SiblingLocator(string dllPath) => (name, scope) =>
-    {
-        if (scope == AssemblyResolutionScope.Platform)
-            return null;
-
-        string sibling = Path.Combine(Path.GetDirectoryName(dllPath)!, name + ".dll");
-        return File.Exists(sibling) ? sibling : null;
-    };
 
     sealed record UnionDeclarationInfo(
         IReadOnlyList<string> CaseTypes,

--- a/src/ILInspector.Metadata/AssemblyReferenceIdentity.cs
+++ b/src/ILInspector.Metadata/AssemblyReferenceIdentity.cs
@@ -68,6 +68,10 @@ public interface IAssemblyReferenceResolver
 
 public static class AssemblyReferenceResolverExtensions
 {
+    /// <summary>
+    /// Adapts the canonical identity resolver to the legacy path-only locator
+    /// shape. This adapter can only represent file-backed resolutions.
+    /// </summary>
     public static AssemblyLocator ToAssemblyLocator(this IAssemblyReferenceResolver resolver)
         => (assemblyName, scope) =>
         {
@@ -77,6 +81,10 @@ public static class AssemblyReferenceResolverExtensions
                 : throw new NotSupportedException("AssemblyLocator requires a file-backed resolver result."));
         };
 
+    /// <summary>
+    /// Adapts a legacy path-only locator to the canonical identity resolver
+    /// boundary.
+    /// </summary>
     public static IAssemblyReferenceResolver ToAssemblyReferenceResolver(this AssemblyLocator locator)
         => new AssemblyLocatorReferenceResolver(locator);
 

--- a/src/ILInspector.Metadata/TypeForwardResolver.cs
+++ b/src/ILInspector.Metadata/TypeForwardResolver.cs
@@ -17,12 +17,10 @@ public enum AssemblyResolutionScope
 }
 
 /// <summary>
-/// Locates the file for an assembly by simple name. Policy lives with the
-/// caller (sibling directory, ref pack, shared framework, package graph);
-/// the resolver below supplies only the metadata mechanism. Returns null
-/// when the assembly cannot be located. <paramref name="scope"/> lets the
-/// caller constrain platform identities so the locator refuses confusable
-/// impostors and fast-paths to framework sources.
+/// Legacy path-only adapter for callers that can only locate assemblies by
+/// simple name. New product and harness code should prefer
+/// <see cref="IAssemblyReferenceResolver"/> so full metadata identity and
+/// stream-backed assemblies flow through the resolver boundary.
 /// </summary>
 public delegate string? AssemblyLocator(string assemblyName, AssemblyResolutionScope scope);
 
@@ -68,49 +66,43 @@ public sealed record TypeLocation(
 
 /// <summary>
 /// Type-forwarder resolution: the mechanism (ExportedTypes traversal, hop
-/// limit, cycle detection) lives here; locating assembly files is the
-/// caller's policy via <see cref="AssemblyLocator"/> — the same split as
-/// MetadataLoadContext's MetadataAssemblyResolver and ILSpy's
-/// IAssemblyResolver.
+/// limit, cycle detection) lives here; resolving assembly identities is the
+/// caller's policy via <see cref="IAssemblyReferenceResolver"/> — the same
+/// split as MetadataLoadContext's MetadataAssemblyResolver and ILSpy's
+/// IAssemblyResolver. <see cref="AssemblyLocator"/> overloads are retained as
+/// compatibility adapters for path-only callers.
 /// </summary>
 public static class TypeForwardResolver
 {
     /// <summary>
     /// Resolves the assembly that defines <paramref name="fullTypeName"/>,
     /// starting at <paramref name="assemblyPath"/> and following type
-    /// forwarders through assemblies supplied by <paramref name="locateAssembly"/>.
+    /// forwarders through assemblies supplied by <paramref name="resolver"/>.
     /// Returns null if the chain dead-ends, exceeds <paramref name="maxHops"/>,
     /// or revisits an assembly.
     /// </summary>
     public static TypeLocation? LocateType(
-        string assemblyPath, string fullTypeName, AssemblyLocator locateAssembly,
+        string assemblyPath, string fullTypeName, IAssemblyReferenceResolver resolver,
         int maxHops = 8, AssemblyResolutionScope scope = AssemblyResolutionScope.Any)
     {
-        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        string current = assemblyPath;
-
-        for (int hop = 0; hop <= maxHops; hop++)
-        {
-            if (!visited.Add(Path.GetFullPath(current)))
-                return null;
-
-            using var stream = File.OpenRead(current);
-            using var peReader = new PEReader(stream);
-            if (!peReader.HasMetadata)
-                return null;
-            var reader = peReader.GetMetadataReader();
-
-            if (FindTypeDefinition(reader, fullTypeName) is { IsNil: false })
-                return new TypeLocation(current, fullTypeName);
-
-            if (ForwardTargetAssembly(reader, fullTypeName) is not { } targetAssembly)
-                return null;
-            if (locateAssembly(targetAssembly, scope) is not { } next || !File.Exists(next))
-                return null;
-            current = next;
-        }
-        return null;
+        var start = new ResolvedAssemblyReference(
+            new AssemblyReferenceIdentity(Path.GetFileNameWithoutExtension(assemblyPath), Version: null, Culture: null, PublicKeyToken: null),
+            assemblyPath,
+            () => File.OpenRead(assemblyPath),
+            Provenance: "StartAssembly");
+        return LocateType(start, fullTypeName, resolver, maxHops, scope);
     }
+
+    /// <summary>
+    /// Resolves the assembly that defines <paramref name="fullTypeName"/>,
+    /// starting at <paramref name="assemblyPath"/> and following type
+    /// forwarders through assemblies supplied by legacy
+    /// <paramref name="locateAssembly"/>.
+    /// </summary>
+    public static TypeLocation? LocateType(
+        string assemblyPath, string fullTypeName, AssemblyLocator locateAssembly,
+        int maxHops = 8, AssemblyResolutionScope scope = AssemblyResolutionScope.Any)
+        => LocateType(assemblyPath, fullTypeName, locateAssembly.ToAssemblyReferenceResolver(), maxHops, scope);
 
     /// <summary>
     /// Resolves the assembly that defines <paramref name="fullTypeName"/>,

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -485,15 +485,6 @@ public class ApiCommand
 
     // ===== Method Source Resolution =====
 
-    /// <summary>
-    /// Forwarder-following policy for whole-type listings: implementations
-    /// beside the starting assembly first, then the installed shared
-    /// framework (so package facades resolve to the platform assemblies
-    /// they forward to at runtime).
-    /// </summary>
-    internal static ILInspector.Metadata.AssemblyLocator PlatformAssemblyLocator(string startingDll)
-        => PlatformAssemblyResolver(startingDll).ToAssemblyLocator();
-
     internal static AssemblyDependencyResolver PlatformAssemblyResolver(string startingDll, string? projectAssetsPath = null, string? targetFramework = null)
     {
         return new AssemblyDependencyResolver(new AssemblyDependencyResolutionOptions(startingDll)

--- a/tests/ILInspector.Metadata.Tests/TypeForwardResolverTests.cs
+++ b/tests/ILInspector.Metadata.Tests/TypeForwardResolverTests.cs
@@ -6,17 +6,12 @@ public class TypeForwardResolverTests
     static string FrameworkDir => Path.GetDirectoryName(CoreLibPath)!;
     static string NetstandardFacade => Path.Combine(FrameworkDir, "netstandard.dll");
 
-    /// <summary>Sibling-directory policy over the shared framework.</summary>
-    static string? SiblingLocator(string assemblyName, AssemblyResolutionScope scope)
-    {
-        string candidate = Path.Combine(FrameworkDir, assemblyName + ".dll");
-        return File.Exists(candidate) ? candidate : null;
-    }
+    static readonly IAssemblyReferenceResolver FrameworkResolver = new FrameworkStreamResolver(pathBacked: true);
 
     [Fact]
     public void LocateType_DefinedInStartingAssembly_ReturnsIt()
     {
-        var location = TypeForwardResolver.LocateType(CoreLibPath, "System.String", SiblingLocator);
+        var location = TypeForwardResolver.LocateType(CoreLibPath, "System.String", FrameworkResolver);
 
         Assert.NotNull(location);
         Assert.Equal(CoreLibPath, location.AssemblyPath);
@@ -27,7 +22,7 @@ public class TypeForwardResolverTests
     {
         // netstandard.dll defines nothing; every type is a forwarder.
         var location = TypeForwardResolver.LocateType(
-            NetstandardFacade, "System.Collections.Generic.List`1", SiblingLocator);
+            NetstandardFacade, "System.Collections.Generic.List`1", FrameworkResolver);
 
         Assert.NotNull(location);
         Assert.NotEqual(NetstandardFacade, location.AssemblyPath);
@@ -42,7 +37,7 @@ public class TypeForwardResolverTests
             Path: null,
             OpenRead: () => File.OpenRead(NetstandardFacade),
             Provenance: "test");
-        var resolver = new FrameworkStreamResolver();
+        var resolver = new FrameworkStreamResolver(pathBacked: false);
 
         var location = TypeForwardResolver.LocateType(
             start, "System.Collections.Generic.List`1", resolver);
@@ -57,7 +52,7 @@ public class TypeForwardResolverTests
     public void LocateType_LocatorCannotResolve_ReturnsNull()
     {
         var location = TypeForwardResolver.LocateType(
-            NetstandardFacade, "System.Collections.Generic.List`1", (_, _) => null);
+            NetstandardFacade, "System.Collections.Generic.List`1", new NullResolver());
 
         Assert.Null(location);
     }
@@ -66,7 +61,7 @@ public class TypeForwardResolverTests
     public void LocateType_UnknownType_ReturnsNull()
     {
         var location = TypeForwardResolver.LocateType(
-            CoreLibPath, "Definitely.Not.A.Type", SiblingLocator);
+            CoreLibPath, "Definitely.Not.A.Type", FrameworkResolver);
 
         Assert.Null(location);
     }
@@ -77,7 +72,7 @@ public class TypeForwardResolverTests
         // A locator that always points back at the facade would loop forever
         // without cycle detection.
         var location = TypeForwardResolver.LocateType(
-            NetstandardFacade, "System.Collections.Generic.List`1", (_, _) => NetstandardFacade);
+            NetstandardFacade, "System.Collections.Generic.List`1", new SelfLoopResolver());
 
         Assert.Null(location);
     }
@@ -92,14 +87,25 @@ public class TypeForwardResolverTests
         Assert.True(TypeForwardResolver.ForwardsType(NetstandardFacade, "System.String"));
     }
 
-    sealed class FrameworkStreamResolver : IAssemblyReferenceResolver
+    sealed class FrameworkStreamResolver(bool pathBacked) : IAssemblyReferenceResolver
     {
         public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
         {
             string candidate = Path.Combine(FrameworkDir, identity.Name + ".dll");
             return File.Exists(candidate)
-                ? new ResolvedAssemblyReference(identity, Path: null, OpenRead: () => File.OpenRead(candidate), Provenance: "test")
+                ? new ResolvedAssemblyReference(identity, Path: pathBacked ? candidate : null, OpenRead: () => File.OpenRead(candidate), Provenance: "test")
                 : null;
         }
+    }
+
+    sealed class NullResolver : IAssemblyReferenceResolver
+    {
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope) => null;
+    }
+
+    sealed class SelfLoopResolver : IAssemblyReferenceResolver
+    {
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
+            => new(identity, NetstandardFacade, () => File.OpenRead(NetstandardFacade), Provenance: "test");
     }
 }

--- a/tools/DecompilerHarness/CorpusMetadata.cs
+++ b/tools/DecompilerHarness/CorpusMetadata.cs
@@ -36,33 +36,48 @@ static class CorpusMetadata
             .ToList();
         var platformAssemblies = TrustedPlatformAssemblies();
 
-        AssemblyLocator locator = (name, trust) =>
+        return new MetadataContext(new CorpusAssemblyReferenceResolver(
+            directories,
+            dependencyResolvers,
+            platformAssemblies));
+    }
+
+    sealed class CorpusAssemblyReferenceResolver(
+        IReadOnlyList<string?> directories,
+        IReadOnlyList<AssemblyDependencyResolver> dependencyResolvers,
+        IReadOnlyDictionary<string, string> platformAssemblies) : IAssemblyReferenceResolver
+    {
+        public ResolvedAssemblyReference? Resolve(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
         {
-            if (trust == AssemblyResolutionScope.Platform)
+            if (scope == AssemblyResolutionScope.Platform)
             {
                 foreach (var directory in directories)
                 {
-                    string candidate = Path.Combine(directory!, name + ".dll");
+                    string candidate = Path.Combine(directory!, identity.Name + ".dll");
                     if (File.Exists(candidate) && IsTrustedPlatformAssembly(candidate))
-                        return candidate;
+                        return FromPath(identity, candidate, "CorpusPlatformSibling");
                 }
 
-                return platformAssemblies.GetValueOrDefault(name);
+                return platformAssemblies.TryGetValue(identity.Name, out var platformPath)
+                    ? FromPath(identity, platformPath, "TrustedPlatformAssembly")
+                    : null;
             }
 
             foreach (var directory in directories)
             {
-                string candidate = Path.Combine(directory!, name + ".dll");
+                string candidate = Path.Combine(directory!, identity.Name + ".dll");
                 if (File.Exists(candidate))
-                    return candidate;
+                    return FromPath(identity, candidate, "CorpusSibling");
             }
+
             foreach (var resolver in dependencyResolvers)
-                if (resolver.Resolve(new AssemblyReferenceIdentity(name, Version: null, Culture: null, PublicKeyToken: null), trust)?.Path is { } resolved)
+                if (resolver.Resolve(identity, scope) is { } resolved)
                     return resolved;
             return null;
-        };
+        }
 
-        return new MetadataContext(locator);
+        static ResolvedAssemblyReference FromPath(AssemblyReferenceIdentity identity, string path, string provenance)
+            => new(identity, path, () => File.OpenRead(path), provenance);
     }
 
     static IReadOnlyDictionary<string, string> TrustedPlatformAssemblies()


### PR DESCRIPTION
## Summary

- make `IAssemblyReferenceResolver` the primary type-forwarding, metadata context, metadata source, and corpus metadata boundary
- keep `AssemblyLocator` as a documented legacy path-only adapter/convenience overload
- migrate resolver-sensitive tests to identity/stream resolver fakes so coverage exercises `ResolvedAssemblyReference` semantics directly

Fixes #2205.

## Validation

- `dotnet restore src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj --configfile nuget.config --verbosity quiet`
- `dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-restore --verbosity minimal`
- `dotnet restore tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj --configfile nuget.config --verbosity quiet`
- `dotnet run --project tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj -c Release --no-restore --verbosity quiet`
- `dotnet restore src/dotnet-inspect/dotnet-inspect.csproj --configfile nuget.config --verbosity quiet`
- `dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --no-restore --verbosity minimal`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -class ILInspector.Decompiler.Tests.ExtensionMethodCallTests -class ILInspector.Decompiler.Tests.ObjectInitializerPassTests -class ILInspector.Decompiler.Tests.CollectionExpressionFrontierTests -class ILInspector.Decompiler.Tests.AllocationOccurrenceFactTests -class ILInspector.Decompiler.Tests.CrossAssemblyMethodFactsTests -class ILInspector.Decompiler.Tests.LadderRung1ProductPathGateTests -class ILInspector.Decompiler.Tests.LadderRung2GateTests -class ILInspector.Decompiler.Tests.UnspeakableNameFidelityTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -method ILInspector.Decompiler.Tests.IrImporterTests.AddressOf_OutArgument_ImportsAsLocalAddress`

A full `ILInspector.Decompiler.Tests` executable run was stopped after 20+ minutes while CPU-active and replaced with the focused resolver/decompiler coverage above.

## Adversarial review

Required decompiler-boundary adversarial reviews are running in isolated worktrees:

- Claude Opus 4.8: `/home/rich/git/dotnet-inspect/.worktrees/review-2205-opus`
- Gemini 3.1 Pro: `/home/rich/git/dotnet-inspect/.worktrees/review-2205-gemini`

I will post the attributed review reconciliation as a PR comment when both complete.
