### PR TITLE
Preserve record backing-field shells in RTS

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1719,6 +1719,8 @@ public class ReturnToSenderPrototypeTests
                 [
                     new ReturnToSender.RequestedTarget("Row", "ToString", 0),
                     new ReturnToSender.RequestedTarget("Row", "Equals", 0),
+                    new ReturnToSender.RequestedTarget("Row", "GetHashCode", 0),
+                    new ReturnToSender.RequestedTarget("Row", "Equals", 1),
                 ]);
 
             Assert.Collection(
@@ -1733,6 +1735,20 @@ public class ReturnToSenderPrototypeTests
                 {
                     Assert.Equal(FidelityCheck.CompileBackStatus.Exact, equalsObject.Status);
                     Assert.Contains("public virtual bool Equals(Row other)", equalsObject.Source);
+                },
+                getHashCode =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, getHashCode.Status);
+                    Assert.Contains("public string Name;", getHashCode.Source);
+                    Assert.Contains("public string Value;", getHashCode.Source);
+                    Assert.DoesNotContain("public string Name { get;", getHashCode.Source);
+                },
+                equalsTyped =>
+                {
+                    Assert.Equal(FidelityCheck.CompileBackStatus.Exact, equalsTyped.Status);
+                    Assert.Contains("public string Name;", equalsTyped.Source);
+                    Assert.Contains("public string Value;", equalsTyped.Source);
+                    Assert.DoesNotContain("public string Name { get;", equalsTyped.Source);
                 });
         }
         finally

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1,5 +1,6 @@
 using ILInspector.DecompilerHarness;
 using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
 
 using Microsoft.CodeAnalysis;
@@ -1750,6 +1751,40 @@ public class ReturnToSenderPrototypeTests
                     Assert.Contains("public string Value;", equalsTyped.Source);
                     Assert.DoesNotContain("public string Name { get;", equalsTyped.Source);
                 });
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackFieldOnType_MatchesNestedRecordBackingFields()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Container
+            {
+                public record Row(string Name, string Value);
+            }
+            """);
+        try
+        {
+            using var pe = new PEReader(File.OpenRead(assemblyPath));
+            using var source = MetadataSource.Open(assemblyPath);
+            var reader = pe.GetMetadataReader();
+            var typeHandle = reader.TypeDefinitions
+                .Single(handle => TypeResolver.GetFullName(reader, reader.GetTypeDefinition(handle)) == "Container.Row");
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            var identity = CompileBackTypeIdentity.FromDefinition(reader, typeDef);
+            var function = IrImporter.Import(source, "Container.Row", "GetHashCode", publicOnly: false);
+            Assert.NotNull(function);
+            IrPasses.Run(function, IrPasses.Default, new PassContext(new Stepper(enabled: false)));
+            var load = Assert.Single(function.Descendants.OfType<LoadField>(), field => field.Field.BackingPropertyName == "Name");
+            var helper = typeof(CompileBackSourceComposer).GetMethod(
+                "IsFieldOnType",
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+            Assert.True((bool)helper!.Invoke(null, [load.Field.DeclaringType, identity])!);
         }
         finally
         {

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -555,6 +555,11 @@ public static class CompileBackSourceComposer
         {
             targetMembers.Add(typedEqualsSibling);
         }
+        foreach (var backingFieldMember in BackingFieldMembers(targetIdentity, function))
+        {
+            if (!targetMembers.Any(member => member.Kind == CompileBackMemberKind.Field && member.Identity.Method == backingFieldMember.Identity.Method))
+                targetMembers.Add(backingFieldMember);
+        }
 
         var requirements = new List<CompileBackTypeRequirement>
         {
@@ -1250,6 +1255,43 @@ public static class CompileBackSourceComposer
         }
 
         return null;
+    }
+
+    static IReadOnlyList<CompileBackMemberRequirement> BackingFieldMembers(
+        CompileBackTypeIdentity typeIdentity,
+        IrFunction function)
+    {
+        var members = new Dictionary<string, CompileBackMemberRequirement>(StringComparer.Ordinal);
+        foreach (var load in function.Descendants.OfType<LoadField>())
+        {
+            if (load.Field.BackingPropertyName is not { Length: > 0 } propertyName
+                || !IsFieldOnType(load.Field.DeclaringType, typeIdentity))
+            {
+                continue;
+            }
+
+            string memberName = Identifier(propertyName);
+            members.TryAdd(memberName, new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(typeIdentity.FullName, memberName, 0, $"field {load.Field.Type.ToDisplayString()}"),
+                CompileBackMemberKind.Field,
+                IsStatic: load.Instance is null,
+                Parameters: [],
+                ReturnType: CompileBackTypeSignature.Display(load.Field.Type.ToDisplayString()),
+                TypeParameters: [],
+                StubBody: CompileBackStubBodyKind.None,
+                TargetBody: null,
+                SourceFacts: [new CompileBackFact("metadata", "target-backing-field", load.Field.Name)]));
+        }
+
+        return members.Values.ToArray();
+    }
+
+    static bool IsFieldOnType(TypeRef type, CompileBackTypeIdentity identity)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+        return definition.Kind == TypeRefKind.Definition
+            && definition.Namespace == identity.Namespace
+            && definition.Name == identity.MetadataName;
     }
 
     static string SelfTypeSignature(MetadataReader reader, TypeDefinition typeDef, CompileBackTypeIdentity typeIdentity)
@@ -2277,6 +2319,8 @@ public static class CompileBackSourceComposer
                 if (members.Any(member =>
                         member.Kind is CompileBackMemberKind.PropertyGet or CompileBackMemberKind.PropertySet
                         && member.Name == Identifier(propertyName)))
+                    continue;
+                if (members.Any(member => member.Kind == CompileBackMemberKind.Field && member.Name == Identifier(propertyName)))
                     continue;
 
                 MethodSignature<string> signature;

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -1289,9 +1289,14 @@ public static class CompileBackSourceComposer
     static bool IsFieldOnType(TypeRef type, CompileBackTypeIdentity identity)
     {
         var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
-        return definition.Kind == TypeRefKind.Definition
-            && definition.Namespace == identity.Namespace
-            && definition.Name == identity.MetadataName;
+        if (definition.Kind != TypeRefKind.Definition)
+            return false;
+
+        string typeRefMetadataFullName = definition.Namespace.Length == 0
+            ? definition.Name.Replace('+', '.')
+            : $"{definition.Namespace}.{definition.Name.Replace('+', '.')}";
+
+        return typeRefMetadataFullName == identity.MetadataFullName;
     }
 
     static string SelfTypeSignature(MetadataReader reader, TypeDefinition typeDef, CompileBackTypeIdentity typeIdentity)

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -1291,6 +1291,8 @@ public static class CompileBackSourceComposer
         var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
         if (definition.Kind != TypeRefKind.Definition)
             return false;
+        if (definition.Namespace != identity.Namespace)
+            return false;
 
         string typeRefMetadataFullName = definition.Namespace.Length == 0
             ? definition.Name.Replace('+', '.')


### PR DESCRIPTION
- Fixes #2227
- Changes compile-back source composition for target-body backing-field shells
- Evidence revision: `9c8d8605`

## Change

**Conclusion:** **PASS** — record-generated `GetHashCode` and typed `Equals(T)` targets move from `OpcodeDiff` to `Exact`; pinned `dotnet-inspect.any@0.16.0` cap-300 probe improves from 263/37 to 295/5.

Before:

```text
TypeSummaryRow::GetHashCode#0    OpcodeDiff  (property getter calls instead of ldfld)
TypeSummaryRow::Equals#1         OpcodeDiff  (property getter calls instead of ldfld)
RETURNTOSENDER SOURCE PROBE: 263 passed / 37 failed
```

After:

```text
RETURNTOSENDER SOURCE PROBE over 300 target(s)

  Passed : 295
  Failed : 5
  Skipped: 0

Buckets:
  5: OpcodeDiff
```

Remaining examples are only the HasRows rows tracked by #2203.

## Scope and safety

- **Root cause:** record-generated `GetHashCode` and typed `Equals(T)` read compiler-generated backing fields directly, but compile-back shells exposed auto-properties, so Roslyn recompiled those reads as getter calls.
- **Fix shape:** when the target body has positive `BackingPropertyName` evidence on a same-target-type `LoadField`, emit a field-shaped shell member using the property name and suppress the matching auto-property shell.
- **Product impact:** compile-back/RTS source composition only; shipped decompiler method-body output is unchanged.
- **Scope boundary:** HasRows shared-return source shape remains tracked by #2203.
- **RTS boundary:** RTS still orchestrates target selection, closure compilation, and opcode/source-fragment comparison; product/shared code owns C# source generation.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `CompileBackTargets_PreservesRecordGeneratedVirtualHelperShells` passed |
| `ReturnToSenderPrototypeTests` | Pass, 58/58 |
| ReturnToSender catalog | Pass, 39 fixtures / 116 targets |
| Decompiler fast suite | Pass, 1831/1831 |
| ReturnToSender A/B | 242 Same / 0 Worse |
| Pinned package probe | `dotnet-inspect.any@0.16.0`, cap 300: 295 passed / 5 failed; only #2203 HasRows OpcodeDiff rows remain |

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| HasRows shared-return branch shape | Left as frontier, tracked by #2203 | Requires product source-shape modeling, not record shell backing fields |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Pending | Adversarial review requested |
| Gemini 3.1 Pro | Pending | Adversarial review requested |

**Review conclusion:** **REVIEW** — awaiting two model-family adversarial reviews.

## Validation

```bash
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false -p:NoWarn=NU1507 --nologo --verbosity quiet
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -method "*RecordGeneratedVirtualHelperShells"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -class "*ReturnToSenderPrototypeTests"
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --return-to-sender-catalog --max-examples 50
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -p:NoWarn=NU1507 -- -trait- "Speed=Slow"
dotnet tools/DecompilerHarness/bin/Release/net11.0/decompiler-harness.dll artifacts/bin/ILInspector.Decompiler.Tests/release/ILInspector.Decompiler.Tests.dll --return-to-sender-ab --cap 500 --max-examples 20
dotnet run --project tools/DecompilerHarness -c Release -p:NoWarn=NU1507 -- --package dotnet-inspect.any --package-version 0.16.0 --return-to-sender-source-probe --cap 300 --max-examples 20
```
