### PR TITLE
Preserve mixed shared return dispatches

### DIFF
--- a/docs/design/control-flow-structuring.md
+++ b/docs/design/control-flow-structuring.md
@@ -90,9 +90,13 @@ after every step of this plan.
   is-pattern / type-test dispatch). Unlike `--structuring-stops` this counts
   **per method in the bucket**, so it scopes which slice clears the most methods.
 
-Two shapes that are **already handled** and are out of scope: short-circuit
-`&&`/`||` guard chains (they nest cleanly today — the `TripleAnd`/`IfAnd`/
-`OrChainGuardPass` fixtures round-trip), and the comparison tree (#640).
+Two shapes that are **already handled** and are out of scope: ordinary
+short-circuit `&&`/`||` guard chains (they nest cleanly today — the
+`TripleAnd`/`IfAnd`/`OrChainGuardPass` fixtures round-trip), and the comparison
+tree (#640). Temp-backed shared-return chains are the caveat: when multiple
+guards branch to one shared return while another guard/default return remains
+distinct, duplicating the shared arm can break compile-back opcode fidelity, so
+return-dispatch must decline that mixed shared-target shape.
 
 ## The blocker is the region model, not a missing case
 

--- a/src/ILInspector.Decompiler.Tests/ReturnDispatchPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnDispatchPassTests.cs
@@ -107,6 +107,38 @@ public class ReturnDispatchPassTests
     }
 
     [Fact]
+    public void MixedSharedReturnTargets_DeclinesOrderedGuardReturns()
+    {
+        var body = new BlockContainer();
+        AddGuard(body, 0, new LoadArgument(0, "x", Int32), targetOffset: 5);
+        AddGuard(body, 1, new LoadArgument(1, "y", Int32), targetOffset: 5);
+        AddGuard(body, 2, new LoadArgument(2, "z", Int32), targetOffset: 6);
+        AddGuard(body, 3, new LoadArgument(3, "w", Int32), targetOffset: 7);
+        AddReturn(body, 4, 0);
+        AddReturn(body, 5, 1);
+        AddReturn(body, 6, 2);
+        AddReturn(body, 7, 3);
+        var function = new IrFunction(
+            "M",
+            Holder,
+            new MethodSignature(Int32, [
+                new Parameter("x", Int32),
+                new Parameter("y", Int32),
+                new Parameter("z", Int32),
+                new Parameter("w", Int32),
+            ], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        new ReturnDispatchPass().Run(function, PassContext.None);
+        function.CheckInvariant();
+
+        Assert.Equal(8, function.Body.Blocks.Count);
+        Assert.Equal(4, function.Descendants.OfType<ConditionalBranch>().Count());
+        Assert.Empty(function.Descendants.OfType<IfStatement>());
+    }
+
+    [Fact]
     public void ComparisonTree_StillFoldsToNestedGuardReturns()
     {
         var function = BuildComparisonTreeCandidate();

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ReturnDispatchPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ReturnDispatchPass.cs
@@ -54,6 +54,9 @@ public sealed class ReturnDispatchPass : IIrPass
                 return true;
             }
 
+            if (HasMixedSharedReturnTarget(plan))
+                return false;
+
             var block = new Block(blocks[0].StartOffset);
             foreach (var arm in plan.Arms)
             {
@@ -82,6 +85,20 @@ public sealed class ReturnDispatchPass : IIrPass
         }
 
         return false;
+    }
+
+    static bool HasMixedSharedReturnTarget(Plan plan)
+    {
+        // Rewriting a repeated target into ordered guard returns duplicates that
+        // shared arm. That is fine when every guard shares one target and the
+        // positive-fallthrough fold above succeeds; mixed targets are the
+        // temp-backed short-circuit shape where duplication changes Roslyn's
+        // branch layout and breaks compile-back opcode fidelity.
+        var targets = plan.Arms
+            .GroupBy(arm => arm.TargetIndex)
+            .Select(group => group.Count())
+            .ToArray();
+        return targets.Length > 1 && targets.Any(count => count > 1);
     }
 
     static void ReplaceContainer(BlockContainer container, Block block)

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -20,6 +20,35 @@ namespace ILInspector.DecompilerHarness;
 /// </summary>
 internal static class GeneratedFixtureCatalog
 {
+    public static readonly GeneratedFixtureDefinition SharedReturnHasRows = new(
+        "shared.return.hasrows",
+        """
+        using System.Collections.Generic;
+
+        namespace GeneratedFixtures.SharedReturnHasRows;
+
+        public class Class1
+        {
+            public List<string>? Rows { get; }
+            public List<string>? RowsWithDocs { get; }
+            public List<string>? SelectRows { get; }
+            public List<string>? SelectRowsWithDocs { get; }
+            public List<string>? SummaryRows { get; }
+
+            public bool HasRows =>
+                Rows is { Count: > 0 }
+                || RowsWithDocs is { Count: > 0 }
+                || SelectRows is { Count: > 0 }
+                || SelectRowsWithDocs is { Count: > 0 }
+                || SummaryRows is { Count: > 0 };
+        }
+        """,
+        [
+            new("GeneratedFixtures.SharedReturnHasRows.Class1", "get_HasRows",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["shared-return", "hasrows", "or-chain", "property-pattern"]);
+
     public static readonly GeneratedFixtureDefinition MinimalPropertyLiteral = new(
         "minimal.property.literal",
         """
@@ -1244,6 +1273,7 @@ internal static class GeneratedFixtureCatalog
 
     public static IReadOnlyList<GeneratedFixtureDefinition> All { get; } =
     [
+        SharedReturnHasRows,
         MinimalPropertyLiteral,
         MinimalPrimaryCtorFieldInit,
         MinimalCtorFieldGetter,


### PR DESCRIPTION
## Summary

Fixes #2203 by making `ReturnDispatchPass` decline the mixed shared-return target shape: repeated guard arms sharing one return target while other arms/defaults return distinct values.

That shape is the temp-backed `HasRows` short-circuit lowering. Folding it into ordered guard returns duplicates the shared `return true` arm, which recompiles to a different branch layout. The existing positive-fallthrough fold still handles the all-arms-share-one-target case.

## Evidence

- `dotnet build src/dotnet-inspect -c Release --no-restore`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -trait- "Speed=Slow"` — 1833 passed
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnDispatchPassTests/*"` — 8 passed
- `dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --generated-fixtures shared.return.hasrows --json` — `Exact`
- `dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --package dotnet-inspect.any --package-version 0.16.0 --return-to-sender-source-probe --cap 100 --max-examples 8` — 100 passed, 0 failed
- `dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --generated-fixtures --json` — 117 passed, 0 failed
- `npx markdownlint-cli docs/design/control-flow-structuring.md`
- `git diff --check`

## Render A/B

Targeted render A/B against `$(git merge-base origin/main HEAD)` over the generated HasRows assembly evaluated 7 methods and changed 1 method: `GeneratedFixtures.SharedReturnHasRows.Class1::get_HasRows`.

The changed render is intentional: baseline emitted repeated early `return true` blocks; current output preserves one shared final `return true`. The generated fixture compile-back result is `Exact` for that method.

## Notes

A full unfiltered `src/ILInspector.Decompiler.Tests` run was stopped after an extended no-output wait; the PR-gate fast subset completed green.

Adversarial review is being requested per the decompiler PR policy.
