### PR TITLE
Assertion scan: classify coverage gaps and guarantee inverse-node fixtures

### DIFF
--- a/.github/workflows/decompiler-daily.yml
+++ b/.github/workflows/decompiler-daily.yml
@@ -87,6 +87,7 @@ jobs:
           set +e
           dotnet run --project tools/DecompilerHarness -c Release -- "${assertion_assemblies[@]}" \
             --assertion-scan \
+            --assertion-fixture-guarantee \
             --max-examples 10 \
             | tee artifacts/assertion-scan/assertion-scan.txt
           status=${PIPESTATUS[0]}

--- a/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Decompiler.Tests.InverseArchitecture;
 using ILInspector.DecompilerHarness;
 
 namespace ILInspector.Decompiler.Tests;
@@ -181,6 +182,26 @@ public class AssertionScanTests
         var violation = Assert.Single(CoercionInvariant.Check(function));
 
         Assert.Equal("E32", AssertionScan.SinkType(violation.Message));
+    }
+
+    [Fact]
+    public void InverseLedger_ClassifiesPassRaisedNodesSeparatelyFromImporterNodes()
+    {
+        Assert.Equal(InverseLedger.NodeCause.PassRaised, InverseLedger.CauseFor(nameof(Lambda)));
+        Assert.Equal(InverseLedger.NodeCause.PassRaised, InverseLedger.CauseFor(nameof(LocalFunctionInvocation)));
+        Assert.Equal(InverseLedger.NodeCause.ImporterEmitted, InverseLedger.CauseFor(nameof(CallIndirect)));
+        Assert.Equal(InverseLedger.NodeCause.ImporterEmitted, InverseLedger.CauseFor(nameof(Unbox)));
+    }
+
+    [Fact]
+    public void FixtureGuarantee_HasMappingForEveryAnnotatedNode()
+    {
+        var annotatedNodes = InverseLedger.Rows(typeof(IrFunction).Assembly)
+            .Select(row => row.Node)
+            .ToArray();
+
+        Assert.Empty(AssertionScan.NodesWithoutFixtureGuarantee(annotatedNodes));
+        Assert.Empty(AssertionScan.InvalidFixtureGuaranteeIds());
     }
 
     static IrFunction Function(BlockContainer body, TypeRef returnType, params Parameter[] parameters)

--- a/tools/DecompilerHarness/AssertionScan.cs
+++ b/tools/DecompilerHarness/AssertionScan.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using System.Reflection;
+using System.Reflection.Emit;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 
@@ -17,7 +19,8 @@ internal static class AssertionScan
         string? EmitViolationsPath,
         string? DiffViolationsPath,
         int? Workers,
-        bool Sequential);
+        bool Sequential,
+        bool IncludeFixtureGuarantee);
 
     public sealed record ViolationSite(
         string Method,
@@ -46,7 +49,42 @@ internal static class AssertionScan
     public sealed record Result(
         IReadOnlyList<MethodResult> Methods,
         IReadOnlyDictionary<string, int> CoverageByNode,
-        IReadOnlyList<string> AnnotatedNodes);
+        IReadOnlyList<string> AnnotatedNodes,
+        IReadOnlyDictionary<string, InverseLedger.NodeCause>? CauseByNode = null,
+        AssertionFixtureGuaranteeResult? FixtureGuarantee = null);
+
+    public sealed record AssertionFixtureGuaranteeResult(
+        string FixtureIds,
+        IReadOnlyDictionary<string, int> CoverageByNode,
+        IReadOnlyList<AssertionFixtureNodeResult> Nodes)
+    {
+        public IReadOnlyList<AssertionFixtureNodeResult> MissingFixtures
+            => Nodes.Where(n => n.Status == AssertionFixtureNodeStatus.MissingFixture).ToArray();
+
+        public IReadOnlyList<AssertionFixtureNodeResult> Regressions
+            => Nodes.Where(n => n.Status == AssertionFixtureNodeStatus.Regression).ToArray();
+    }
+
+    public sealed record AssertionFixtureNodeResult(
+        string Node,
+        InverseLedger.NodeCause Cause,
+        IReadOnlyList<string> FixtureIds,
+        int ObservedCount)
+    {
+        public AssertionFixtureNodeStatus Status
+            => FixtureIds.Count == 0
+                ? AssertionFixtureNodeStatus.MissingFixture
+                : ObservedCount == 0
+                    ? AssertionFixtureNodeStatus.Regression
+                    : AssertionFixtureNodeStatus.Pass;
+    }
+
+    public enum AssertionFixtureNodeStatus
+    {
+        Pass,
+        MissingFixture,
+        Regression,
+    }
 
     sealed record MethodInput(
         string Assembly,
@@ -55,6 +93,52 @@ internal static class AssertionScan
         string Method,
         int Overload,
         IrFunction Function);
+
+    sealed record AssertionFixtureGuarantee(string Node, IReadOnlyList<string> FixtureIds);
+
+    const string AssertionCoverageFixture = "assertion.inverse-node-coverage";
+    const string AssertionIlUnboxFixture = "assertion.il-unbox";
+
+    static readonly IReadOnlyList<AssertionFixtureGuarantee> AssertionFixtureGuarantees =
+    [
+        new("AddressOfMethod", [AssertionCoverageFixture]),
+        new("ArrayLength", [AssertionCoverageFixture]),
+        new("Binary", [AssertionCoverageFixture]),
+        new("Box", [AssertionCoverageFixture]),
+        new("Call", [AssertionCoverageFixture]),
+        new("CallIndirect", [AssertionCoverageFixture]),
+        new("CastClass", [AssertionCoverageFixture]),
+        new("Coerce", [AssertionCoverageFixture]),
+        new("Comparison", [AssertionCoverageFixture]),
+        new("Convert", [AssertionCoverageFixture]),
+        new("DelegateCreation", [AssertionCoverageFixture]),
+        new("IsInstance", [AssertionCoverageFixture]),
+        new("Lambda", [AssertionCoverageFixture]),
+        new("LoadArgument", [AssertionCoverageFixture]),
+        new("LoadArgumentAddress", [AssertionCoverageFixture]),
+        new("LoadElement", [AssertionCoverageFixture]),
+        new("LoadElementAddress", [AssertionCoverageFixture]),
+        new("LoadField", [AssertionCoverageFixture]),
+        new("LoadFieldAddress", [AssertionCoverageFixture]),
+        new("LoadFunctionPointer", [AssertionCoverageFixture]),
+        new("LoadIndirect", [AssertionCoverageFixture]),
+        new("LoadLocal", [AssertionCoverageFixture]),
+        new("LoadLocalAddress", [AssertionCoverageFixture]),
+        new("LoadProperty", [AssertionCoverageFixture]),
+        new("LoadStackSlot", [AssertionCoverageFixture]),
+        new("LoadToken", [AssertionCoverageFixture]),
+        new("LocalFunctionInvocation", [AssertionCoverageFixture]),
+        new("LogicalBinary", [AssertionCoverageFixture]),
+        new("LogicalNot", [AssertionCoverageFixture]),
+        new("NewArray", [AssertionCoverageFixture]),
+        new("NewObject", [AssertionCoverageFixture]),
+        new("NullConditional", [AssertionCoverageFixture]),
+        new("SizeOf", [AssertionCoverageFixture]),
+        new("TypeOf", [AssertionCoverageFixture]),
+        new("Unary", [AssertionCoverageFixture]),
+        new("Unbox", [AssertionIlUnboxFixture]),
+        new("UnboxAny", [AssertionCoverageFixture]),
+    ];
 
     public static int Run(IReadOnlyList<string> assemblies, Options options)
     {
@@ -70,7 +154,12 @@ internal static class AssertionScan
             return 1;
         }
 
-        var result = Evaluate(assemblies, options.SampleSize, options.Workers, options.Sequential);
+        var result = Evaluate(
+            assemblies,
+            options.SampleSize,
+            options.Workers,
+            options.Sequential,
+            options.IncludeFixtureGuarantee);
         Report(result, options.MaxExamples, options.SampleSize);
 
         if (options.EmitViolationsPath is not null)
@@ -85,14 +174,32 @@ internal static class AssertionScan
         IReadOnlyList<string> assemblies,
         int? sampleSize = null,
         int? workers = null,
-        bool sequential = false)
+        bool sequential = false,
+        bool includeFixtureGuarantee = false)
+    {
+        var annotatedRows = InverseLedger.Rows(typeof(IrFunction).Assembly)
+            .OrderBy(row => row.Node, StringComparer.Ordinal)
+            .ToArray();
+        var annotatedNodes = annotatedRows.Select(row => row.Node).ToArray();
+        var causeByNode = annotatedRows.ToDictionary(row => row.Node, row => row.Cause, StringComparer.Ordinal);
+        var result = EvaluateAssemblies(assemblies, sampleSize, workers, sequential, annotatedNodes, causeByNode);
+        if (!includeFixtureGuarantee)
+            return result;
+
+        var fixtureResult = EvaluateFixtureGuarantee(annotatedNodes, causeByNode, workers, sequential);
+        return Merge(result, fixtureResult);
+    }
+
+    static Result EvaluateAssemblies(
+        IReadOnlyList<string> assemblies,
+        int? sampleSize,
+        int? workers,
+        bool sequential,
+        IReadOnlyList<string> annotatedNodes,
+        IReadOnlyDictionary<string, InverseLedger.NodeCause> causeByNode)
     {
         var methods = new ConcurrentBag<MethodResult>();
         var coverage = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
-        var annotatedNodes = InverseLedger.Rows(typeof(IrFunction).Assembly)
-            .Select(row => row.Node)
-            .Order(StringComparer.Ordinal)
-            .ToArray();
         var parallel = new ParallelOptions
         {
             MaxDegreeOfParallelism = sequential ? 1 : (workers ?? Math.Max(1, Environment.ProcessorCount - 2)),
@@ -117,7 +224,8 @@ internal static class AssertionScan
                         candidate.TypeName,
                         candidate.MethodName,
                         candidate.Overload,
-                        function);
+                        function,
+                        method => IrImporter.Import(source, method));
                     methods.Add(result);
                     AddCoverage(coverage, result.CoveredNodes);
                 });
@@ -142,7 +250,8 @@ internal static class AssertionScan
                     input.Type,
                     input.Method,
                     input.Overload,
-                    input.Function);
+                    input.Function,
+                    method => IrImporter.Import(source, method));
                 methods.Add(result);
                 AddCoverage(coverage, result.CoveredNodes);
             });
@@ -151,7 +260,152 @@ internal static class AssertionScan
         return new Result(
             methods.OrderBy(m => m.Key, StringComparer.Ordinal).ToArray(),
             coverage.OrderBy(kvp => kvp.Key, StringComparer.Ordinal).ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.Ordinal),
-            annotatedNodes);
+            annotatedNodes,
+            causeByNode);
+    }
+
+    static Result Merge(Result corpus, Result fixtures)
+    {
+        var coverage = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        foreach (var (node, count) in corpus.CoverageByNode)
+            coverage[node] = count;
+        foreach (var (node, count) in fixtures.CoverageByNode)
+            coverage[node] = coverage.GetValueOrDefault(node) + count;
+
+        return corpus with
+        {
+            Methods = corpus.Methods.Concat(fixtures.Methods).OrderBy(m => m.Key, StringComparer.Ordinal).ToArray(),
+            CoverageByNode = coverage,
+            FixtureGuarantee = fixtures.FixtureGuarantee,
+        };
+    }
+
+    static Result EvaluateFixtureGuarantee(
+        IReadOnlyList<string> annotatedNodes,
+        IReadOnlyDictionary<string, InverseLedger.NodeCause> causeByNode,
+        int? workers,
+        bool sequential)
+    {
+        var fixtureIds = AssertionFixtureGuarantees
+            .SelectMany(pair => pair.FixtureIds)
+            .Where(id => id != AssertionIlUnboxFixture)
+            .Distinct(StringComparer.Ordinal)
+            .ToHashSet(StringComparer.Ordinal);
+        var fixtures = GeneratedFixtureCatalog.Catalog
+            .Where(fixture => fixtureIds.Contains(fixture.Id))
+            .ToArray();
+        var csharpResult = GeneratedFixtureRunner.RunWithMaterializedFixtures(
+            fixtures,
+            GeneratedFixtureRunOptions.Default,
+            (_, assemblyPath) =>
+            {
+                return EvaluateAssemblies([assemblyPath], null, workers, sequential, annotatedNodes, causeByNode);
+            });
+
+        var unboxFixture = BuildUnboxFixtureAssembly();
+        try
+        {
+            var unboxResult = EvaluateAssemblies([unboxFixture.Path], null, workers, sequential, annotatedNodes, causeByNode);
+            var scan = Merge(csharpResult, unboxResult);
+            var guarantee = BuildFixtureGuarantee(
+                string.Join(", ", AssertionFixtureGuarantees
+                    .SelectMany(g => g.FixtureIds)
+                    .Distinct(StringComparer.Ordinal)
+                    .Order(StringComparer.Ordinal)),
+                annotatedNodes,
+                causeByNode,
+                scan.CoverageByNode);
+            return scan with { FixtureGuarantee = guarantee };
+        }
+        finally
+        {
+            TryDeleteDirectory(unboxFixture.Directory);
+        }
+    }
+
+    static AssertionFixtureGuaranteeResult BuildFixtureGuarantee(
+        string assemblyPath,
+        IReadOnlyList<string> annotatedNodes,
+        IReadOnlyDictionary<string, InverseLedger.NodeCause> causeByNode,
+        IReadOnlyDictionary<string, int> coverageByNode)
+    {
+        var fixturesByNode = AssertionFixtureGuarantees
+            .ToDictionary(g => g.Node, g => g.FixtureIds, StringComparer.Ordinal);
+        var rows = annotatedNodes
+            .Select(node => new AssertionFixtureNodeResult(
+                node,
+                causeByNode.TryGetValue(node, out var cause) ? cause : InverseLedger.CauseFor(node),
+                fixturesByNode.TryGetValue(node, out var fixtures) ? fixtures : [],
+                coverageByNode.GetValueOrDefault(node)))
+            .OrderBy(row => row.Node, StringComparer.Ordinal)
+            .ToArray();
+        return new AssertionFixtureGuaranteeResult(assemblyPath, coverageByNode, rows);
+    }
+
+    internal static IReadOnlyList<string> NodesWithoutFixtureGuarantee(IReadOnlyList<string> annotatedNodes)
+    {
+        var guaranteed = AssertionFixtureGuarantees
+            .Select(g => g.Node)
+            .ToHashSet(StringComparer.Ordinal);
+        return annotatedNodes
+            .Where(node => !guaranteed.Contains(node))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    internal static IReadOnlyList<string> InvalidFixtureGuaranteeIds()
+    {
+        var fixtureIds = GeneratedFixtureCatalog.Catalog
+            .Select(fixture => fixture.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        fixtureIds.Add(AssertionIlUnboxFixture);
+        return AssertionFixtureGuarantees
+            .SelectMany(g => g.FixtureIds)
+            .Where(id => !fixtureIds.Contains(id))
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    static (string Path, string Directory) BuildUnboxFixtureAssembly()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "dotnet-inspect-assertion-il-unbox-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "GeneratedAssertionIlUnbox.dll");
+
+        var assemblyName = new AssemblyName("GeneratedAssertionIlUnbox");
+        var assembly = new PersistedAssemblyBuilder(assemblyName, typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule(assemblyName.Name!);
+        var mutableBuilder = module.DefineType(
+            "GeneratedFixtures.AssertionIlUnbox.Mutable",
+            TypeAttributes.Public | TypeAttributes.SequentialLayout | TypeAttributes.Sealed,
+            typeof(ValueType));
+        mutableBuilder.DefineField("Value", typeof(int), FieldAttributes.Public);
+        var mutable = mutableBuilder.CreateType();
+
+        var holder = module.DefineType(
+            "GeneratedFixtures.AssertionIlUnbox.Class1",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Abstract | TypeAttributes.Sealed);
+        var method = holder.DefineMethod(
+            "Unbox",
+            MethodAttributes.Public | MethodAttributes.Static,
+            mutable.MakeByRefType(),
+            [typeof(object)]);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Unbox, mutable);
+        il.Emit(OpCodes.Ret);
+
+        holder.CreateType();
+        assembly.Save(path);
+        return (path, directory);
+    }
+
+    static void TryDeleteDirectory(string path)
+    {
+        try { Directory.Delete(path, recursive: true); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
     }
 
     internal static MethodResult EvaluateFunction(
@@ -160,7 +414,8 @@ internal static class AssertionScan
         string type,
         string method,
         int overload,
-        IrFunction function)
+        IrFunction function,
+        Func<MethodRef, IrFunction?>? importMethodBody = null)
     {
         string signature = CorpusMethodIdentity.SignatureText(function.Signature);
         string key = $"{assemblyPath}!{type}::{method}{signature}";
@@ -214,10 +469,13 @@ internal static class AssertionScan
 
         try
         {
+            var context = importMethodBody is null
+                ? PassContext.None
+                : new PassContext(new Stepper(enabled: false), importMethodBody: importMethodBody);
             Capture(IrPasses.ImportStageName);
             foreach (var pass in IrPasses.Default)
             {
-                pass.Run(function, PassContext.None);
+                pass.Run(function, context);
                 function.CheckInvariant();
                 Capture(pass.Name);
             }
@@ -297,7 +555,30 @@ internal static class AssertionScan
             Console.WriteLine($"  covered: {string.Join(", ", result.CoverageByNode.Keys.Order(StringComparer.Ordinal))}");
         var missing = result.AnnotatedNodes.Except(result.CoverageByNode.Keys, StringComparer.Ordinal).ToArray();
         if (missing.Length > 0)
-            Console.WriteLine($"  not exercised: {string.Join(", ", missing)}");
+        {
+            PrintMissingByCause("  importer-emitted not exercised", missing, result.CauseByNode, InverseLedger.NodeCause.ImporterEmitted);
+            PrintMissingByCause("  pass-raised not exercised (raise-pass or fixture gap; investigate)", missing, result.CauseByNode, InverseLedger.NodeCause.PassRaised);
+        }
+
+        if (result.FixtureGuarantee is { } fixtureGuarantee)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Generated fixture guarantee:");
+            Console.WriteLine($"  fixtures: {fixtureGuarantee.FixtureIds}");
+            Console.WriteLine($"  guaranteed nodes: {fixtureGuarantee.Nodes.Count(n => n.Status == AssertionFixtureNodeStatus.Pass)}/{fixtureGuarantee.Nodes.Count}");
+            if (fixtureGuarantee.MissingFixtures.Count > 0)
+                Console.WriteLine($"  nodes without fixture mapping: {string.Join(", ", fixtureGuarantee.MissingFixtures.Select(n => n.Node))}");
+            if (fixtureGuarantee.Regressions.Count > 0)
+            {
+                Console.WriteLine("  fixture regression alarms (report-only):");
+                foreach (var row in fixtureGuarantee.Regressions.OrderBy(r => r.Cause).ThenBy(r => r.Node, StringComparer.Ordinal))
+                    Console.WriteLine($"    {row.Cause}: {row.Node} expected from {string.Join(", ", row.FixtureIds)}");
+            }
+            else if (fixtureGuarantee.MissingFixtures.Count == 0)
+            {
+                Console.WriteLine("  fixture regression alarms (report-only): (none)");
+            }
+        }
 
         if (methodsWithViolations.Length > 0)
         {
@@ -319,6 +600,22 @@ internal static class AssertionScan
             foreach (var method in passBugExamples)
                 Console.WriteLine($"  {method.Key}: {method.PassBug}");
         }
+    }
+
+    static void PrintMissingByCause(
+        string label,
+        IReadOnlyList<string> missing,
+        IReadOnlyDictionary<string, InverseLedger.NodeCause>? causeByNode,
+        InverseLedger.NodeCause cause)
+    {
+        var nodes = missing
+            .Where(node => (causeByNode is not null && causeByNode.TryGetValue(node, out var classified)
+                ? classified
+                : InverseLedger.CauseFor(node)) == cause)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        if (nodes.Length > 0)
+            Console.WriteLine($"{label}: {string.Join(", ", nodes)}");
     }
 
     static void PrintHistogram(string title, IEnumerable<IGrouping<string, ViolationSite>> groups)

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -1242,6 +1242,173 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "conditional-expression", "branch", "frontier", "shape"]);
 
+    public static readonly GeneratedFixtureDefinition AssertionNodeCoverage = new(
+        "assertion.inverse-node-coverage",
+        """
+        namespace GeneratedFixtures.AssertionNodeCoverage;
+
+        public enum Choice
+        {
+            None = 0,
+            One = 1,
+        }
+
+        public struct Mutable
+        {
+            public int Value;
+
+            public Mutable(int value)
+            {
+                Value = value;
+            }
+
+            public int Increment()
+            {
+                Value++;
+                return Value;
+            }
+        }
+
+        public sealed class Holder
+        {
+            public int Number { get; set; }
+            public string Text { get; set; }
+        }
+
+        public unsafe class Class1
+        {
+            private int _field;
+
+            public static int StaticAdd(int left, int right) => left + right;
+
+            public static int Invoke(delegate*<int, int, int> callback, int left, int right)
+                => callback(left, right);
+
+            public static delegate*<int, int, int> Pointer() => &StaticAdd;
+
+            public static System.Func<int, int> Lambda() => x => x + 1;
+
+            public int UseLambda(int value)
+            {
+                System.Func<int, int> add = x => x + _field;
+                return add(value);
+            }
+
+            public static int LocalFunction(int value)
+            {
+                int Twice(int input) => input * 2;
+                return Twice(value);
+            }
+
+            public int InstanceLocalFunction(int value)
+            {
+                int AddField(int input) => input + _field;
+                return AddField(value);
+            }
+
+            public static int Logical(bool left, bool right)
+                => left && !right ? 1 : 0;
+
+            public static int Compare(int left, int right)
+                => left < right ? left : right;
+
+            public static int NullConditional(Holder holder)
+                => holder?.Number ?? -1;
+
+            public static string NullConditionalReference(Holder holder)
+                => holder?.Text ?? "none";
+
+            public static System.Type TypeToken()
+                => typeof(Holder);
+
+            public static int Size()
+                => sizeof(Mutable);
+
+            public static int BoxValue(int value)
+            {
+                object boxed = value;
+                return boxed.GetHashCode();
+            }
+
+            public static int UnboxAny(object boxed)
+                => (int)boxed;
+
+            public static int Unbox(object boxed)
+            {
+                var mutable = (Mutable)boxed;
+                return mutable.Increment();
+            }
+
+            public static string Cast(object value)
+                => ((string)value).ToString();
+
+            public static string As(object value)
+                => value as string;
+
+            public static int[] NewArray(int count)
+                => new int[count];
+
+            public static int ArrayAccess(int[] values, int index)
+                => values[index];
+
+            public static int ArrayLength(int[] values)
+                => values.Length;
+
+            public static ref int ArrayElementAddress(int[] values, int index)
+                => ref values[index];
+
+            public static int Indirect(ref int value)
+                => value;
+
+            public static int ArgumentAddress(Mutable value)
+                => value.Increment();
+
+            public static int LocalAddress()
+            {
+                var value = 41;
+                Increment(ref value);
+                return value;
+            }
+
+            public static void Increment(ref int value)
+                => value++;
+
+            public static void ForwardArgumentAddress(ref int value)
+                => Increment(ref value);
+
+            public Choice CoercedEnum(int value)
+                => (Choice)value;
+
+            public int Field()
+            {
+                _field = 1;
+                return _field;
+            }
+
+            public int FieldAddress()
+            {
+                Increment(ref _field);
+                return _field;
+            }
+
+            public int Property()
+            {
+                Number = 2;
+                return Number;
+            }
+
+            public int Number { get; set; }
+
+            public static int Unary(int value)
+                => -value;
+
+            public static long ConvertNumeric(int value)
+                => (long)value;
+        }
+        """,
+        [],
+        ["assertion", "inverse-ledger", "coverage", "unsafe"]);
+
     public static IReadOnlyList<GeneratedFixtureDefinition> All { get; } =
     [
         MinimalPropertyLiteral,
@@ -1291,10 +1458,16 @@ internal static class GeneratedFixtureCatalog
         MinimalConditionalExpressionShapeFrontier,
     ];
 
+    public static IReadOnlyList<GeneratedFixtureDefinition> AssertionCoverage { get; } =
+    [
+        AssertionNodeCoverage,
+    ];
+
     public static IReadOnlyList<GeneratedFixtureDefinition> Catalog { get; } =
     [
         .. All,
         .. Frontiers,
+        .. AssertionCoverage,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> MinimalCompileBackRungs => All;
@@ -1558,7 +1731,7 @@ internal static class GeneratedFixtureRunner
             _ => result.Status.ToString(),
         };
 
-    static T RunWithMaterializedFixtures<T>(
+    internal static T RunWithMaterializedFixtures<T>(
         IReadOnlyList<GeneratedFixtureDefinition> fixtures,
         GeneratedFixtureRunOptions? options,
         Func<string, string, T> run)
@@ -1824,6 +1997,7 @@ internal static class GeneratedFixtureRunner
             <ImplicitUsings>disable</ImplicitUsings>
             <Nullable>disable</Nullable>
             <LangVersion>preview</LangVersion>
+            <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
             <IsPackable>false</IsPackable>
             <IsAotCompatible>false</IsAotCompatible>
             <AssemblyName>GeneratedDecompilerFixtures</AssemblyName>

--- a/tools/DecompilerHarness/InverseLedger.cs
+++ b/tools/DecompilerHarness/InverseLedger.cs
@@ -15,6 +15,25 @@ namespace ILInspector.Decompiler.Tests.InverseArchitecture;
 /// </summary>
 public static class InverseLedger
 {
+    public enum NodeCause
+    {
+        ImporterEmitted,
+        PassRaised,
+    }
+
+    static readonly HashSet<string> s_passRaisedNodes = new(StringComparer.Ordinal)
+    {
+        "AddressOfMethod",
+        "Coerce",
+        "DelegateCreation",
+        "Lambda",
+        "LoadProperty",
+        "LocalFunctionInvocation",
+        "LogicalBinary",
+        "NullConditional",
+        "TypeOf",
+    };
+
     /// <summary>One generated ledger row: the type assertion an inverse node makes.</summary>
     public sealed record Row(
         string Node,
@@ -23,7 +42,8 @@ public static class InverseLedger
         NameProvenance Naming,
         string Precondition,
         string Witness,
-        string? Assumes = null);
+        string? Assumes,
+        NodeCause Cause);
 
     /// <summary>Concrete, non-abstract IR expression node types in the given assembly, name-ordered.</summary>
     public static IReadOnlyList<Type> NodeTypes(Assembly assembly)
@@ -43,7 +63,13 @@ public static class InverseLedger
                 x.Inverse.Naming,
                 x.Inverse.Precondition ?? "—",
                 x.Inverse.Witness ?? "—",
-                x.Inverse.Assumes))];
+                x.Inverse.Assumes,
+                CauseFor(x.Node.Name)))];
+
+    public static NodeCause CauseFor(string node)
+        => s_passRaisedNodes.Contains(node)
+            ? NodeCause.PassRaised
+            : NodeCause.ImporterEmitted;
 
     /// <summary>One declared non-inverse boundary: a node deliberately outside the checkable domain.</summary>
     public sealed record Boundary(string Node, string Reason);

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -41,6 +41,7 @@ static class Program
         int compileCap = 4000;
         bool assertions = false;
         bool assertionScan = false;
+        bool assertionFixtureGuarantee = false;
         string? emitAssertionViolations = null;
         string? diffAssertionViolations = null;
         int? sampleSize = null;
@@ -119,6 +120,7 @@ static class Program
                 case "--skip-pdb": skipPdb = true; break;
                 case "--assertions": assertions = true; break;
                 case "--assertion-scan": assertionScan = true; break;
+                case "--assertion-fixture-guarantee": assertionFixtureGuarantee = true; break;
                 case "--sample": sampleSize = int.Parse(args[++i]); break;
                 case "--max-examples": maxExamples = int.Parse(args[++i]); break;
                 case "--validity-check": validityCheck = true; break;
@@ -232,7 +234,8 @@ static class Program
                     emitAssertionViolations,
                     diffAssertionViolations,
                     workers,
-                    sequential));
+                    sequential,
+                    assertionFixtureGuarantee));
 
         if (validityCheck || emitValidityDefects is not null || diffValidityDefects is not null)
             return ValidityCheck.Run(assemblies, compileCap, maxExamples, emitValidityDefects, diffValidityDefects, lowered);
@@ -1344,6 +1347,12 @@ static class Program
                                 across input methods and report violation
                                 histograms plus annotation coverage. Measurement
                                 only; not a raw-count gate.
+          --assertion-fixture-guarantee
+                                with --assertion-scan: add the generated
+                                inverse-node fixture assembly to annotation
+                                coverage and report any guaranteed node that the
+                                fixture no longer produces. Report-only; not a
+                                raw-count gate.
           --sample <n>          with --assertion-scan: deterministic hash-ranked
                                 method sample per assembly.
           --cfg                 with --dump: print the control-flow graph (per-block

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -13,7 +13,9 @@ inverse-architecture `assumes:` predicates across input methods and reports the
 measurement view that `--dump --assertions` cannot provide alone: methods with at
 least one violation, violation histograms by sink type, first failing pass, node,
 and predicate, plus the distinct `[InverseOf]` nodes exercised by the scanned
-population. Use `--sample N` to run a deterministic hash-ranked sample per
+population. Unexercised nodes are split into importer-emitted nodes (rare opcode
+or corpus breadth gap) and pass-raised nodes (raise-pass or fixture gap;
+investigate). Use `--sample N` to run a deterministic hash-ranked sample per
 assembly, and combine it with `--package` / `--package-version` /
 `--package-tfm` / `--package-assembly` the same way other harness scans do.
 
@@ -23,6 +25,15 @@ population-scale correctness gates remain compile-back, render A/B, and the
 quality-diff card; see
 [docs/decompiler-raise-discipline.md](../../docs/decompiler-raise-discipline.md)
 for the assertion-dump discipline.
+
+Add `--assertion-fixture-guarantee` to materialize the generated inverse-node
+fixture assembly and include it in annotation coverage. The report prints a
+per-node guarantee summary and any node the fixture no longer produces as a
+**fixture regression alarm**. That alarm is report-only: it identifies a
+raise-pass or fixture regression to investigate, but it does not turn coverage
+counts into a CI gate. The daily assertion scan uses this mode so the
+unexercised list can reach a true zero when the audit corpus plus deterministic
+fixtures cover every `[InverseOf]` node.
 
 For before/after work, mirror the validity-defects loop with
 `--emit-assertion-violations <file>` and
@@ -40,6 +51,9 @@ dotnet run --project tools/DecompilerHarness -c Release -- MyLib.dll \
 
 dotnet run --project tools/DecompilerHarness -c Release -- MyLib.dll \
   --assertion-scan --sample 250 --diff-assertion-violations /tmp/assertions.base.json
+
+dotnet run --project tools/DecompilerHarness -c Release -- MyLib.dll \
+  --assertion-scan --assertion-fixture-guarantee --max-examples 10
 ```
 
 For annotation-batch audits, use the assertion audit corpus instead of one local
@@ -53,13 +67,16 @@ bash eng/prepare-decompiler-assertion-corpus.sh /tmp/assertion-corpus.txt
 mapfile -t assemblies < /tmp/assertion-corpus.txt
 dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --assertion-scan \
+  --assertion-fixture-guarantee \
   --max-examples 10
 ```
 
-`decompiler-daily.yml` runs the same corpus as a report-only artifact named
-`assertion-scan-report`. The artifact's `assertion-scan.txt` lists exercised and
-unexercised `[InverseOf]` nodes; a non-empty unexercised list is follow-up work
-for corpus/fixture breadth, not a failed daily gate.
+`decompiler-daily.yml` runs the same corpus plus the generated fixture guarantee
+as a report-only artifact named `assertion-scan-report`. The artifact's
+`assertion-scan.txt` lists exercised and unexercised `[InverseOf]` nodes by
+cause; a non-empty importer-emitted list is follow-up work for corpus/fixture
+breadth, while a non-empty pass-raised list or fixture regression alarm is a
+raise-pass or fixture-gap investigation signal, not a failed daily gate.
 
 **Generated fixtures** (`--generated-fixtures [id|prefix|list]`): builds selected
 generated-fixture catalogue entries into a temporary class library, runs the
@@ -78,10 +95,13 @@ source-switch lowering observation (lowered as if/else, not the dense switch
 shape) and is opt-in by ID. `minimal.conditional-expression-shape-frontier`
 records a source-shape frontier: the conditional-expression source is
 compile-back exact, but the accepted current output is return-statement shaped
-rather than `ConditionalExpression` shaped. With no selector, stable generated
-fixtures run; use `list` to list fixture IDs, `--json` for machine-readable
-list/results, and `--keep-generated-fixtures` to preserve the generated project
-for drill-down.
+rather than `ConditionalExpression` shaped.
+`assertion.inverse-node-coverage` is the deterministic inverse-ledger coverage
+fixture used by `--assertion-fixture-guarantee`; it is addressable by ID but is
+not part of the default stable generated-fixture ladder. With no selector,
+stable generated fixtures run; use `list` to list fixture IDs, `--json` for
+machine-readable list/results, and `--keep-generated-fixtures` to preserve the
+generated project for drill-down.
 Rows may carry two independent expectations: a Roslyn `SyntaxKind` shape verdict
 for the intended C# idiom, and a compile-back opcode verdict for semantic
 fidelity. A row can therefore be opcode-exact while still exposing a shape


### PR DESCRIPTION
- Fixes/advances #2237
- Changes assertion-scan measurement output only; no decompiler raise/printer behavior change.
- Card revision: `13b81527`

## Change

**Conclusion:** **PASS** — assertion scan now separates unexercised `[InverseOf]` nodes by cause and adds a report-only per-node fixture guarantee.

- Adds importer-emitted vs pass-raised node classification to the inverse ledger and assertion coverage output.
- Adds `--assertion-fixture-guarantee`, which materializes deterministic generated fixtures plus an IL-only `unbox` fixture, merges their coverage into the report, and prints report-only fixture regression alarms.
- Wires the daily assertion scan to include the fixture guarantee artifact signal.
- Documents the measurement-not-gate semantics in `tools/DecompilerHarness/README.md`.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build src/dotnet-inspect -c Release --configfile nuget.config --nologo` |
| Focused tests | Pass: `AssertionScanTests` and `InverseArchitectureTests` |
| Decompiler fast suite | Pass: 1834 tests, `-trait- "Speed=Slow"` |
| Markdown lint | Pass: `npx markdownlint-cli tools/DecompilerHarness/README.md` |
| Assertion fixture smoke | Pass: 37/37 `[InverseOf]` nodes covered; no fixture regression alarms |

The full slow `ILInspector.Decompiler.Tests` executable was attempted and stopped after ~20 minutes with no new output; the PR-fast decompiler subset and focused harness tests completed successfully.

## Review

Adversarial reviews requested in isolated worktrees:

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Pending | `/home/rich/git/dotnet-inspect/.worktrees/review-2237-opus` |
| Gemini 3.1 Pro | Pending | `/home/rich/git/dotnet-inspect/.worktrees/review-2237-gemini` |

Review results will be posted as a PR comment when both complete.
