### PR TITLE
Parallelize whole-assembly body decode

### DIFF
--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -740,8 +740,15 @@ public sealed class LibraryBodyIndex
     public static LibraryBodyIndex Open(string path, IAssemblyReferenceResolver? resolver = null,
         bool includeAllocations = true, bool includeOpportunities = true, IReadOnlySet<int>? bodyScope = null, Func<TypeRef, bool>? bodyTypeScope = null)
     {
+        // Full (unscoped) builds decode every method body in parallel; prefetch the entire image
+        // so concurrent GetMethodBody reads are served from an immutable in-memory block rather
+        // than seeking a shared FileStream (which is not safe for concurrent reads). Scoped builds
+        // decode only a handful of bodies sequentially, so they keep the lazy default.
+        var streamOptions = bodyScope is null && bodyTypeScope is null
+            ? PEStreamOptions.PrefetchEntireImage
+            : PEStreamOptions.Default;
         using var stream = File.OpenRead(path);
-        using var peReader = new PEReader(stream);
+        using var peReader = new PEReader(stream, streamOptions);
         if (!peReader.HasMetadata)
             throw new BadImageFormatException($"No managed metadata: {path}");
         var reader = peReader.GetMetadataReader();
@@ -1330,12 +1337,20 @@ public sealed class LibraryBodyIndex
         ReferencedAssemblyMetadata? ResolveReferencedAssembly(AssemblyReferenceHandle handle)
         {
             var identity = AssemblyReferenceIdentity.From(_reader, handle);
-            if (_referencedAssemblyCache.TryGetValue(identity, out var cached))
-                return cached;
+            // Guarded because parallel full builds resolve referenced assemblies concurrently
+            // from many method-analysis threads. Resolution is per unique referenced assembly
+            // (bounded and cached), so lock contention is negligible; the lock is reentrant on
+            // the same thread for any transitive resolution. Holding it across the open keeps
+            // single-resolve semantics (no duplicate opens leaking undisposed metadata).
+            lock (_referencedAssemblyCache)
+            {
+                if (_referencedAssemblyCache.TryGetValue(identity, out var cached))
+                    return cached;
 
-            var resolved = OpenReferencedAssembly(identity, ScopeForReference(handle));
-            _referencedAssemblyCache[identity] = resolved;
-            return resolved;
+                var resolved = OpenReferencedAssembly(identity, ScopeForReference(handle));
+                _referencedAssemblyCache[identity] = resolved;
+                return resolved;
+            }
         }
 
         ReferencedAssemblyMetadata? OpenReferencedAssembly(AssemblyReferenceIdentity identity, AssemblyResolutionScope scope)
@@ -1979,6 +1994,14 @@ public sealed class LibraryBodyIndex
             var exceptionTypeNames = ComputeExceptionTypeNames();
             int none = 0, impl = 0, expl = 0;
 
+            // Flatten types->methods into a work list (cheap, reader-bound), then analyze each
+            // method body. For a full (unscoped) build the analysis runs in parallel across cores;
+            // each method writes only to method-local builders, and results are merged back in
+            // metadata order below, so output is byte-identical to a sequential build. Metadata/PE
+            // reads are thread-safe on the immutable prefetched image (see Open); the two lazily
+            // populated caches touched during analysis are made concurrency-safe (AsyncStateMachineTypes
+            // is prewarmed here, _referencedAssemblyCache is lock-guarded).
+            var workItems = new List<(TypeDefinitionHandle TypeHandle, TypeDefinition TypeDef, bool TypeSourceGenerated, MethodDefinitionHandle MethodHandle)>();
             foreach (var typeHandle in _reader.TypeDefinitions)
             {
                 var typeDef = _reader.GetTypeDefinition(typeHandle);
@@ -1987,77 +2010,74 @@ public sealed class LibraryBodyIndex
                 // collection for them (they are still indexed for calls/leverage/signals).
                 bool typeSourceGenerated = HasGeneratedCodeAttribute(typeDef.GetCustomAttributes());
                 foreach (var methodHandle in typeDef.GetMethods())
-                {
-                    try
-                    {
-                        var methodDef = _reader.GetMethodDefinition(methodHandle);
-                        var scope = CreateScope(typeDef, methodDef);
-                        var caller = CreateMethodIdentity(typeHandle, methodHandle, methodDef, scope);
-                        // Tally the unsafe mode for every method, including bodiless
-                        // extern/abstract members (P/Invokes are a major source).
-                        switch (caller.CallerUnsafeMode)
-                        {
-                            case CallerUnsafeMode.Explicit: expl++; break;
-                            case CallerUnsafeMode.Implicit: impl++; break;
-                            default: none++; break;
-                        }
-                        bool hasUnsafeApiMember = AddUnsafeApiMemberEvidence(caller, unsafeEvidence);
-                        bool hasUnsafeSignature = AddUnsafeSignatureEvidence(caller, unsafeEvidence);
-                        if (caller.CallerUnsafeMode != CallerUnsafeMode.None || hasUnsafeApiMember)
-                            unsafeLeverageMethods.Add(caller);
-                        if (methodDef.RelativeVirtualAddress == 0)
-                            continue;
+                    workItems.Add((typeHandle, typeDef, typeSourceGenerated, methodHandle));
+            }
 
-                        methods.Add(caller);
-                        // Scoped builds decode only selected method bodies; every other method is
-                        // still indexed as an identity (cheap metadata read) but its body is not
-                        // decoded/scanned. bodyScope selects by method token (single-member queries);
-                        // bodyTypeScope selects by declaring type (single-type queries). Only sections
-                        // whose facts are local to the selected member(s)/type may open a scoped build;
-                        // reverse/aggregate sections (callers, leverage, opportunities) pass null.
-                        if (bodyScope is not null && !bodyScope.Contains(caller.MetadataToken))
-                            continue;
-                        if (bodyTypeScope is not null && !bodyTypeScope(caller.DeclaringType))
-                            continue;
-                        var body = _peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
-                        var il = body.GetILBytes() ?? [];
-                        var decodedBody = DecodeBody(il, body.ExceptionRegions);
-                        bool hasUnsafeLocals = ScanLocals(body, caller, scope, unsafeEvidence);
-                        var loopRegions = decodedBody.LoopRegions;
-                        var allocations = includeAllocations
-                            ? CollectAllocationOccurrences(il, decodedBody, body.ExceptionRegions, caller, scope, loopRegions, classifyEscapes: true)
-                            : ImmutableArray<AllocationOccurrence>.Empty;
-                        if (allocations.Length > 0)
-                            allocationOccurrences[caller.MetadataToken] = allocations;
-                        var unsafety = CollectUnsafetyOccurrences(decodedBody.Instructions, body, caller, scope);
-                        if (unsafety.Length > 0)
-                            unsafetyOccurrences[caller.MetadataToken] = unsafety;
-                        var methodAttributes = methodDef.GetCustomAttributes();
-                        if (includeOpportunities)
-                        {
-                            if (!typeSourceGenerated
-                                && !HasGeneratedCodeAttribute(methodAttributes)
-                                && !HasCompilerGeneratedAttribute(methodAttributes)
-                                && !IsBlazorRenderMethod(caller))
-                                optimizationOpportunities.AddRange(CollectOptimizationOpportunities(il, decodedBody, body.ExceptionRegions, caller, scope, loopRegions));
-                            else
-                                suppressedOpportunityTokens.Add(caller.MetadataToken);
-                        }
-                        var signals = CollectBodySignals(il, decodedBody, body, scope, loopRegions);
-                        if (signals.Newarr > 0 || signals.Throws > 0 || signals.Catches > 0 || signals.Finallys > 0 || signals.Boxes > 0)
-                            bodySignals[caller.MetadataToken] = signals;
-                        ScanBody(decodedBody.Instructions, caller, scope, calls, unsafeEvidence,
-                            includeIndirectOpcodes: hasUnsafeApiMember || hasUnsafeSignature || hasUnsafeLocals,
-                            loopRegions);
-                    }
-                    catch (Exception ex) when (IsRecoverableMethodFailure(ex))
-                    {
-                        diagnostics.Add(new AnalysisDiagnostic(
-                            MetadataTokens.GetToken(methodHandle),
-                            MethodLabel(typeHandle, methodHandle),
-                            $"{ex.GetType().Name}: {ex.Message}"));
-                    }
+            var results = new MethodBuildResult[workItems.Count];
+            // Only full builds are worth parallelizing: scoped (member/type) builds decode a handful
+            // of bodies, where thread overhead would dominate. The threshold also keeps trivial
+            // assemblies sequential.
+            bool parallel = bodyScope is null && bodyTypeScope is null && workItems.Count >= ParallelBuildMethodThreshold;
+            if (parallel)
+            {
+                // Prewarm the async-state-machine set so it is fully computed before the parallel
+                // pass reads it read-only.
+                _ = AsyncStateMachineTypes();
+                Parallel.For(0, workItems.Count, i =>
+                {
+                    var w = workItems[i];
+                    results[i] = ProcessMethod(w.TypeHandle, w.TypeDef, w.TypeSourceGenerated, w.MethodHandle,
+                        includeAllocations, includeOpportunities, bodyScope, bodyTypeScope);
+                });
+            }
+            else
+            {
+                for (int i = 0; i < workItems.Count; i++)
+                {
+                    var w = workItems[i];
+                    results[i] = ProcessMethod(w.TypeHandle, w.TypeDef, w.TypeSourceGenerated, w.MethodHandle,
+                        includeAllocations, includeOpportunities, bodyScope, bodyTypeScope);
                 }
+            }
+
+            // Merge per-method results in metadata order, reproducing the exact sequence of appends
+            // the original sequential loop performed. A method that hit a recoverable failure carries
+            // its partial contributions (accumulated before the throw) alongside its diagnostic, so
+            // even the failure path is byte-identical to the sequential build.
+            foreach (var r in results)
+            {
+                if (!r.HasCaller)
+                {
+                    if (r.Diagnostic is not null)
+                        diagnostics.Add(r.Diagnostic);
+                    continue;
+                }
+                switch (r.Mode)
+                {
+                    case CallerUnsafeMode.Explicit: expl++; break;
+                    case CallerUnsafeMode.Implicit: impl++; break;
+                    default: none++; break;
+                }
+                if (!r.UnsafeEvidence.IsDefaultOrEmpty)
+                    unsafeEvidence.AddRange(r.UnsafeEvidence);
+                if (r.IsLeverage)
+                    unsafeLeverageMethods.Add(r.Caller!);
+                if (r.HasBody)
+                    methods.Add(r.Caller!);
+                if (!r.Calls.IsDefaultOrEmpty)
+                    calls.AddRange(r.Calls);
+                if (!r.Allocations.IsDefaultOrEmpty)
+                    allocationOccurrences[r.Token] = r.Allocations;
+                if (!r.Unsafety.IsDefaultOrEmpty)
+                    unsafetyOccurrences[r.Token] = r.Unsafety;
+                if (!r.Opportunities.IsDefaultOrEmpty)
+                    optimizationOpportunities.AddRange(r.Opportunities);
+                if (r.Suppressed)
+                    suppressedOpportunityTokens.Add(r.Token);
+                if (r.HasSignals)
+                    bodySignals[r.Token] = r.Signals;
+                if (r.Diagnostic is not null)
+                    diagnostics.Add(r.Diagnostic);
             }
 
             var directCalls = calls.ToImmutable();
@@ -2067,7 +2087,124 @@ public sealed class LibraryBodyIndex
                 BuildInAssemblyExceptionMap(), suppressedOpportunityTokens, exceptionTypeNames, nonHeapNewObjOperandTokens);
         }
 
-        // The metadata operand tokens of `newobj` instructions that construct a VALUE TYPE
+        // Assemblies with at least this many methods use the parallel per-method analysis path.
+        // Below it (and for all scoped member/type builds) the sequential path avoids thread overhead.
+        const int ParallelBuildMethodThreshold = 200;
+
+        // Per-method analysis output, accumulated into method-local builders so the parallel build
+        // never mutates shared Build() state. Merged back in metadata order by Build(). Field-set
+        // points mirror the exact shared-state mutations of the original sequential loop (including
+        // the ordering across the RVA/scope early-returns), so the merged result is byte-identical —
+        // and a recoverable per-method failure carries whatever partial contributions preceded the
+        // throw (UnsafeEvidence/Calls captured after the catch) plus the Diagnostic.
+        sealed class MethodBuildResult
+        {
+            public bool HasCaller;
+            public MethodIdentity? Caller;
+            public int Token;
+            public CallerUnsafeMode Mode;
+            public bool IsLeverage;
+            public bool HasBody;
+            public ImmutableArray<UnsafeEvidence> UnsafeEvidence;
+            public ImmutableArray<DirectCall> Calls;
+            public ImmutableArray<AllocationOccurrence> Allocations;
+            public ImmutableArray<UnsafetyOccurrence> Unsafety;
+            public ImmutableArray<OptimizationOpportunity> Opportunities;
+            public bool Suppressed;
+            public bool HasSignals;
+            public BodySignals Signals;
+            public AnalysisDiagnostic? Diagnostic;
+        }
+
+        // Analyze a single method into a MethodBuildResult. Mirrors the original per-method loop body
+        // statement-for-statement, writing to method-local builders instead of the shared Build()
+        // builders. Safe to run concurrently: metadata/PE reads are thread-safe on the prefetched
+        // image, and the only lazily-populated shared caches it can touch are AsyncStateMachineTypes
+        // (prewarmed) and _referencedAssemblyCache (lock-guarded).
+        MethodBuildResult ProcessMethod(TypeDefinitionHandle typeHandle, TypeDefinition typeDef, bool typeSourceGenerated,
+            MethodDefinitionHandle methodHandle, bool includeAllocations, bool includeOpportunities,
+            IReadOnlySet<int>? bodyScope, Func<TypeRef, bool>? bodyTypeScope)
+        {
+            var result = new MethodBuildResult();
+            var evidence = ImmutableArray.CreateBuilder<UnsafeEvidence>();
+            var calls = ImmutableArray.CreateBuilder<DirectCall>();
+            try
+            {
+                var methodDef = _reader.GetMethodDefinition(methodHandle);
+                var scope = CreateScope(typeDef, methodDef);
+                var caller = CreateMethodIdentity(typeHandle, methodHandle, methodDef, scope);
+                result.HasCaller = true;
+                result.Caller = caller;
+                result.Token = caller.MetadataToken;
+                // Tally the unsafe mode for every method, including bodiless
+                // extern/abstract members (P/Invokes are a major source).
+                result.Mode = caller.CallerUnsafeMode;
+                bool hasUnsafeApiMember = AddUnsafeApiMemberEvidence(caller, evidence);
+                bool hasUnsafeSignature = AddUnsafeSignatureEvidence(caller, evidence);
+                if (caller.CallerUnsafeMode != CallerUnsafeMode.None || hasUnsafeApiMember)
+                    result.IsLeverage = true;
+                if (methodDef.RelativeVirtualAddress == 0)
+                    return result;
+
+                result.HasBody = true;
+                // Scoped builds decode only selected method bodies; every other method is still
+                // indexed as an identity (above) but its body is not decoded/scanned. bodyScope
+                // selects by method token (single-member queries); bodyTypeScope selects by declaring
+                // type (single-type queries). Reverse/aggregate sections pass null (full build).
+                if (bodyScope is not null && !bodyScope.Contains(caller.MetadataToken))
+                    return result;
+                if (bodyTypeScope is not null && !bodyTypeScope(caller.DeclaringType))
+                    return result;
+                var body = _peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
+                var il = body.GetILBytes() ?? [];
+                var decodedBody = DecodeBody(il, body.ExceptionRegions);
+                bool hasUnsafeLocals = ScanLocals(body, caller, scope, evidence);
+                var loopRegions = decodedBody.LoopRegions;
+                result.Allocations = includeAllocations
+                    ? CollectAllocationOccurrences(il, decodedBody, body.ExceptionRegions, caller, scope, loopRegions, classifyEscapes: true)
+                    : ImmutableArray<AllocationOccurrence>.Empty;
+                result.Unsafety = CollectUnsafetyOccurrences(decodedBody.Instructions, body, caller, scope);
+                var methodAttributes = methodDef.GetCustomAttributes();
+                if (includeOpportunities)
+                {
+                    if (!typeSourceGenerated
+                        && !HasGeneratedCodeAttribute(methodAttributes)
+                        && !HasCompilerGeneratedAttribute(methodAttributes)
+                        && !IsBlazorRenderMethod(caller))
+                        result.Opportunities = CollectOptimizationOpportunities(il, decodedBody, body.ExceptionRegions, caller, scope, loopRegions);
+                    else
+                        result.Suppressed = true;
+                }
+                var signals = CollectBodySignals(il, decodedBody, body, scope, loopRegions);
+                if (signals.Newarr > 0 || signals.Throws > 0 || signals.Catches > 0 || signals.Finallys > 0 || signals.Boxes > 0)
+                {
+                    result.Signals = signals;
+                    result.HasSignals = true;
+                }
+                ScanBody(decodedBody.Instructions, caller, scope, calls, evidence,
+                    includeIndirectOpcodes: hasUnsafeApiMember || hasUnsafeSignature || hasUnsafeLocals,
+                    loopRegions);
+            }
+            catch (Exception ex) when (IsRecoverableMethodFailure(ex))
+            {
+                result.Diagnostic = new AnalysisDiagnostic(
+                    MetadataTokens.GetToken(methodHandle),
+                    MethodLabel(typeHandle, methodHandle),
+                    $"{ex.GetType().Name}: {ex.Message}");
+            }
+            finally
+            {
+                // Runs on every exit path (early returns at the RVA/scope gates, a recoverable
+                // failure, or normal completion) so the method-local evidence/calls accumulated so
+                // far always reach the result — including bodiless members whose only contribution
+                // is unsafe-API/signature evidence recorded before the RVA==0 early return.
+                result.UnsafeEvidence = evidence.ToImmutable();
+                result.Calls = calls.ToImmutable();
+            }
+            return result;
+        }
+
+
         // (struct/enum) and therefore do not allocate on the heap (#1804). Classified here,
         // during Build, where the metadata reader is available — the lazy signal and
         // allocation-density paths run after the reader is released, so they consult this set

--- a/src/dotnet-inspect.Tests/ParallelBuildDeterminismTests.cs
+++ b/src/dotnet-inspect.Tests/ParallelBuildDeterminismTests.cs
@@ -1,0 +1,41 @@
+using Analysis = ILInspector.Analysis;
+
+namespace DotnetInspector.Tests;
+
+/// <summary>
+/// Locks the parallel full-build invariant: <see cref="Analysis.LibraryBodyIndex.Open(string)"/> analyzes
+/// method bodies concurrently for assemblies above the parallel threshold, then merges per-method results
+/// back in metadata order. The merge must be order-stable and race-free, so repeated opens of the same
+/// assembly must produce byte-identical ordered output for every order-sensitive collection (methods,
+/// direct calls, unsafe evidence, optimization opportunities, diagnostics). A residual data race would
+/// surface here as nondeterministic ordering or counts across repeats.
+///
+/// Equivalence to the previous sequential build is proven separately by whole-CLI byte-diff in the PR;
+/// this test is the ongoing regression guard against concurrency-induced nondeterminism.
+/// </summary>
+public class ParallelBuildDeterminismTests
+{
+    // The Analysis assembly itself has thousands of methods, so Open takes the parallel path.
+    static string LargeAssemblyPath => typeof(Analysis.LibraryBodyIndex).Assembly.Location;
+
+    static string Signature(Analysis.LibraryBodyIndex idx) => string.Join("\n", new[]
+    {
+        "M:" + string.Join(";", idx.Methods.Select(m => m.MetadataToken)),
+        "C:" + string.Join(";", idx.DirectCalls.Select(c => c.ToString())),
+        "U:" + string.Join(";", idx.UnsafeEvidence.Select(e => e.ToString())),
+        "O:" + string.Join(";", idx.OptimizationOpportunities.Select(o => o.ToString())),
+        "D:" + string.Join(";", idx.Diagnostics.Select(d => d.ToString())),
+    });
+
+    [Fact]
+    public void ParallelBuild_IsOrderStable_AcrossRepeatedOpens()
+    {
+        var reference = Signature(Analysis.LibraryBodyIndex.Open(LargeAssemblyPath));
+        Assert.Contains("M:", reference);
+
+        // Repeat several times; any race in the concurrent per-method analysis or the ordered merge
+        // would produce a differing signature on at least one iteration.
+        for (int i = 0; i < 6; i++)
+            Assert.Equal(reference, Signature(Analysis.LibraryBodyIndex.Open(LargeAssemblyPath)));
+    }
+}


### PR DESCRIPTION
## Result: 20–43% faster whole-assembly analysis

Top Leverage and Performance Triage must decode every method body (whole-assembly fanin / leverage join), so they were the dominant remaining cost after targeted decode covered single-member (#2228) and single-type (#2233) queries. This parallelizes the per-method body analysis across cores.

Wall-clock, best-of-5:

| Command | Assembly | Before | After | Faster |
| --- | --- | --- | --- | --- |
| `-S "Performance Triage"` | ILInspector.Decompiler | 2.18s | 1.24s | **43%** |
| `-S "Top Leverage"` | ILInspector.Decompiler | 1.50s | 1.13s | **25%** |
| `-S "Performance Triage"` | dotnet-inspect | 2.58s | 2.07s | 20% |
| `-S "Top Leverage"` | dotnet-inspect | 1.80s | 1.29s | 28% |

## Design

`LibraryBodyIndex.IndexBuilder.Build` becomes three phases:

1. **Flatten** types→methods into a work list (cheap, reader-bound).
2. **Analyze** each method into a method-local `MethodBuildResult` — `Parallel.For` for full builds at/above a method-count threshold, sequential otherwise.
3. **Merge** results back in metadata order.

The merge reproduces the original sequential loop's shared-state mutations **exactly** — the field-set points in `ProcessMethod` mirror each append across the RVA/scope early-returns, and a recoverable per-method failure carries its partial contributions (captured in a `finally`) alongside its diagnostic. So output is byte-identical to a sequential build, including the failure path.

## Concurrency safety

- **Reads:** full builds open the PE with `PrefetchEntireImage`, so concurrent `GetMethodBody` reads hit an immutable in-memory block rather than seeking a shared `FileStream`. `MetadataReader`/`PEReader` reads are thread-safe on an immutable image.
- **Shared caches:** the only two lazily-populated caches touched during analysis are made safe — `AsyncStateMachineTypes` is prewarmed before the parallel pass (then read-only); `_referencedAssemblyCache` is lock-guarded (bounded, per-referenced-assembly, negligible contention, reentrant for transitive resolution).
- **Scoped builds** (member/type targeted) keep the sequential path — zero behavior/perf change to the already-fast targeted queries.

## Validation

- **Byte-identical CLI**: 6 assemblies × {all `-v` levels + the three body-index sections + their combination} = 48 library diffs (36 re-confirmed post-rebase), plus member/type scoped diffs.
- **Determinism**: 10 repeated parallel runs identical; new `ParallelBuildDeterminismTests` locks order-stability across 6 opens (a residual race would surface as reordered/mismatched output).
- **Full `dotnet-inspect.Tests`**: 1607 passed, 9 skipped.

## Risk / review focus

Concurrency correctness. Attack points: (1) a shared-state read/write in a per-method helper I missed (beyond the two guarded caches); (2) an order-sensitive merge that diverges from the sequential append order; (3) `PrefetchEntireImage` semantics vs the lazy stream; (4) a per-method failure path whose partial state differs from sequential.
