### PR TITLE
Harden runfaster nettrace fixture

### DIFF
--- a/src/runfaster.Tests/E2EFixtureTests.cs
+++ b/src/runfaster.Tests/E2EFixtureTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Diagnostics;
+using System.Reflection;
 using Xunit;
 
 namespace runfaster.Tests;
@@ -14,6 +15,12 @@ public class E2EFixtureTests
         string tracePath = Path.Combine(fixtureDir, "fixture.nettrace");
         string assemblyPath = Path.Combine(AppContext.BaseDirectory, "RunFaster.AllocationFixture.dll");
         string runfasterDll = Path.Combine(AppContext.BaseDirectory, "runfaster.dll");
+        var allocateOne = typeof(RunFaster.AllocationFixture.Program).GetMethod(
+            "AllocateOne",
+            BindingFlags.Public | BindingFlags.Static);
+
+        Assert.NotNull(allocateOne);
+        Assert.Equal(0x06000002, allocateOne.MetadataToken);
 
         var correlate = Process.Start(new ProcessStartInfo
         {
@@ -30,20 +37,35 @@ public class E2EFixtureTests
         correlate.WaitForExit();
 
         Assert.True(0 == correlate.ExitCode, $"runfaster failed with exit code {correlate.ExitCode}.\nError: {error}\nOutput: {output}");
-        
-        // Assert the report marks the expected row as il-offset-hot
-        Assert.Contains("il-offset-hot", output);
-        Assert.Contains("RunFaster.AllocationFixture.Program.AllocateOne()", output);
-        
-        // Assert it surfaces AllocationKind + EscapeKind
-        Assert.Contains("Object", output); // AllocationKind
-        Assert.Contains("Return", output); // EscapeKind
-        
+
+        string observedAllocateOneRow = RowContaining(
+            output,
+            "il-offset-hot",
+            "RunFaster.AllocationFixture.Program.AllocateOne()");
+        Assert.Contains("Object", observedAllocateOneRow); // AllocationKind
+        Assert.Contains("Return", observedAllocateOneRow); // EscapeKind
+
         // Assert it preserves bytes without ambiguity inflation (the fixture trace has 11 ticks and 1.11 MB for AllocateOne)
-        Assert.Contains("11 alloc ticks / 1.11 MB", output);
-        Assert.Contains("System.Object 1.11 MB", output);
-        
+        string confirmedAllocateOneRow = RowContaining(
+            output,
+            "RunFaster.AllocationFixture.Program.AllocateOne()",
+            "11 alloc ticks / 1.11 MB");
+        Assert.Contains("Object", confirmedAllocateOneRow); // AllocationKind
+        Assert.Contains("Return", confirmedAllocateOneRow); // EscapeKind
+        Assert.Contains("System.Object 1.11 MB", confirmedAllocateOneRow);
+
         // Assert it shows negative evidence for the unexercised row
-        Assert.Contains("1 static candidate row(s) were not observed", output); 
+        Assert.Contains("1 static candidate row(s) were not observed", output);
+    }
+
+    static string RowContaining(string output, params string[] fragments)
+    {
+        foreach (var line in output.Split('\n'))
+        {
+            if (fragments.All(fragment => line.Contains(fragment, StringComparison.Ordinal)))
+                return line;
+        }
+
+        throw new Xunit.Sdk.XunitException($"Expected a report row containing '{string.Join("', '", fragments)}'.\nOutput:\n{output}");
     }
 }

--- a/src/runfaster.Tests/Fixtures/RunFaster.AllocationFixture/Program.cs
+++ b/src/runfaster.Tests/Fixtures/RunFaster.AllocationFixture/Program.cs
@@ -13,6 +13,9 @@ public class Program
         }
     }
 
+    // The checked-in fixture.nettrace was captured with AllocateOne at metadata
+    // token 0x06000002. Keep this method first among user-declared methods, or
+    // update the trace and E2EFixtureTests token guard together.
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static object AllocateOne() => new object();
 

--- a/src/runfaster.Tests/runfaster.Tests.csproj
+++ b/src/runfaster.Tests/runfaster.Tests.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <Compile Remove="Fixtures\**" />
-    <Content Include="Fixtures\**" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Fixtures\**\*.nettrace" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Closes #2248
- Changes test fixture/project only; product behavior is unchanged
- Evidence revision: `0ac5b005`

## Change

**Conclusion:** **PASS** — this fixes the #2246 review follow-ups by making the checked-in nettrace fixture contract explicit, tightening copied fixture assets, and anchoring assertions to the `AllocateOne` report rows.

## Scope and safety

- Adds a metadata-token guard for `AllocateOne` (`0x06000002`) so fixture method reordering fails locally instead of silently invalidating the trace join.
- Documents the token/order contract next to the fixture method.
- Narrows `runfaster.Tests` content copying from all fixture files to `*.nettrace` only.
- Replaces broad `Object` / `Return` output assertions with row-anchored checks against the observed candidate and confirmed paydirt rows.
- Low-risk test-only change; no adversarial review needed.

## Validation

```bash
dotnet clean src/runfaster.Tests/runfaster.Tests.csproj -c Release --nologo --verbosity quiet
dotnet run --no-restore --project src/runfaster.Tests -c Release
find artifacts/bin/runfaster.Tests/release/Fixtures/RunFaster.AllocationFixture -maxdepth 1 -type f -printf '%f\\n' | sort
```

Result:

```text
runfaster.Tests  Total: 7, Errors: 0, Failed: 0, Skipped: 0
fixture.nettrace
```
