### PR TITLE
Share coercion rendering predicates

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/CoercionRendering.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CoercionRendering.cs
@@ -1,0 +1,99 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// Shared preconditions for the coercion spellings owned by <see cref="CSharpPrinter"/>.
+/// The insertion pass asks the same questions before it inserts a <see cref="Coerce"/>,
+/// so slot-store wrappability cannot drift from what the renderer can spell.
+/// </summary>
+public static class CoercionRendering
+{
+    /// <summary>
+    /// The slot-store wrappability contract: every accepted pair is a coercion
+    /// spelling that <c>CoerceText</c> renders. The asymmetries are intentional:
+    /// integer to bool has no spelling, missing enum underlying data assumes I4
+    /// for same-family enum casts, and I4 to I8 enum widening requires a resolved
+    /// enum source.
+    /// </summary>
+    public static bool CanSpellSlotCoercion(
+        TypeRef? valueType,
+        TypeRef target,
+        IReadOnlyDictionary<TypeRef, TypeShape> shapes,
+        IReadOnlyDictionary<TypeRef, TypeRef> enumUnderlyingTypes)
+    {
+        if (valueType is null)
+            return false;
+        if (CanSpellBoolToInteger(valueType, target)
+            || CanSpellIntegerToEnum(valueType, target, shapes)
+            || CanSpellEnumToInteger(valueType, target, shapes, enumUnderlyingTypes)
+            || CanSpellEnumToEnum(valueType, target, shapes, enumUnderlyingTypes))
+            return true;
+        if (TypeFamilies.IsBoolean(valueType) || TypeFamilies.IsBoolean(target))
+            return valueType.Equals(target);
+        if (!TypeFamilies.IsNumericPrimitive(valueType) || !TypeFamilies.IsNumericPrimitive(target))
+            return false;
+        var valueFamily = TypeFamilies.Of(valueType);
+        return valueFamily is not null && valueFamily == TypeFamilies.Of(target);
+    }
+
+    public static bool CanSpellIntegerToEnum(
+        TypeRef? valueType,
+        TypeRef target,
+        IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+        => shapes.GetValueOrDefault(target) == TypeShape.Enum
+            && valueType is not null
+            && !target.Equals(valueType)
+            && TypeFamilies.IsIntegerLike(valueType);
+
+    public static bool CanSpellEnumToInteger(
+        TypeRef? valueType,
+        TypeRef target,
+        IReadOnlyDictionary<TypeRef, TypeShape> shapes,
+        IReadOnlyDictionary<TypeRef, TypeRef> enumUnderlyingTypes)
+        => TypeFamilies.IsIntegerLike(target)
+            && EnumSemanticFamily(valueType, shapes, enumUnderlyingTypes) is { } underlyingFamily
+            && TypeFamilies.Of(target) is { } targetFamily
+            && (underlyingFamily == targetFamily
+                || (underlyingFamily == StackFamily.I4 && targetFamily == StackFamily.I8
+                    && valueType is not null
+                    && enumUnderlyingTypes.ContainsKey(valueType)));
+
+    public static bool CanSpellEnumToEnum(
+        TypeRef? valueType,
+        TypeRef target,
+        IReadOnlyDictionary<TypeRef, TypeShape> shapes,
+        IReadOnlyDictionary<TypeRef, TypeRef> enumUnderlyingTypes)
+        => EnumSemanticFamily(target, shapes, enumUnderlyingTypes) is not null
+            && EnumSemanticFamily(valueType, shapes, enumUnderlyingTypes) is { } valueFamily
+            && EnumSemanticFamily(target, shapes, enumUnderlyingTypes) == valueFamily
+            && valueType?.Equals(target) != true;
+
+    public static bool CanSpellUnknownEnumConstant(
+        TypeRef? valueType,
+        TypeRef target,
+        IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+        => target is { Kind: TypeRefKind.Definition, Name: not "Boolean" }
+            && shapes.GetValueOrDefault(target) == TypeShape.Unknown
+            && !TypeFamilies.IsNumericPrimitive(target)
+            && valueType is not null
+            && TypeFamilies.IsIntegerLike(valueType);
+
+    public static bool CanSpellBoolToInteger(TypeRef? valueType, TypeRef target)
+        => TypeFamilies.IsIntegerLike(target) && TypeFamilies.IsBoolean(valueType);
+
+    /// <summary>
+    /// The stack family of an enum-typed value's underlying: the resolved
+    /// underlying family, or I4 for a missing-<c>value__</c> enum shape. Null for
+    /// non-enums.
+    /// </summary>
+    public static StackFamily? EnumSemanticFamily(
+        TypeRef? type,
+        IReadOnlyDictionary<TypeRef, TypeShape> shapes,
+        IReadOnlyDictionary<TypeRef, TypeRef> enumUnderlyingTypes)
+    {
+        if (type is null || TypeFamilies.Of(type) is not null)
+            return null;
+        if (enumUnderlyingTypes.GetValueOrDefault(type) is { } underlying)
+            return TypeFamilies.Of(underlying);
+        return shapes.GetValueOrDefault(type) == TypeShape.Enum ? StackFamily.I4 : null;
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/CoercionRendering.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CoercionRendering.cs
@@ -8,11 +8,12 @@ namespace ILInspector.Decompiler.Pipeline;
 public static class CoercionRendering
 {
     /// <summary>
-    /// The slot-store wrappability contract: every accepted pair is a coercion
-    /// spelling that <c>CoerceText</c> renders. The asymmetries are intentional:
-    /// integer to bool has no spelling, missing enum underlying data assumes I4
-    /// for same-family enum casts, and I4 to I8 enum widening requires a resolved
-    /// enum source.
+    /// The slot-store wrappability contract: every accepted pair is both a
+    /// coercion spelling that <c>CoerceText</c> renders and a stack-family
+    /// relation the verifier can carry in one live range. The asymmetries are
+    /// intentional: integer to bool has no spelling, missing enum underlying
+    /// data assumes I4 for same-family enum casts, and slot I4 to I8 enum
+    /// widening requires a resolved enum source.
     /// </summary>
     public static bool CanSpellSlotCoercion(
         TypeRef? valueType,
@@ -22,17 +23,15 @@ public static class CoercionRendering
     {
         if (valueType is null)
             return false;
-        if (CanSpellBoolToInteger(valueType, target)
-            || CanSpellIntegerToEnum(valueType, target, shapes)
-            || CanSpellEnumToInteger(valueType, target, shapes, enumUnderlyingTypes)
-            || CanSpellEnumToEnum(valueType, target, shapes, enumUnderlyingTypes))
-            return true;
-        if (TypeFamilies.IsBoolean(valueType) || TypeFamilies.IsBoolean(target))
-            return valueType.Equals(target);
-        if (!TypeFamilies.IsNumericPrimitive(valueType) || !TypeFamilies.IsNumericPrimitive(target))
+        if (!CanSpellSlotValue(valueType, target, shapes, enumUnderlyingTypes))
             return false;
-        var valueFamily = TypeFamilies.Of(valueType);
-        return valueFamily is not null && valueFamily == TypeFamilies.Of(target);
+
+        var valueFamily = SlotSemanticFamily(valueType, shapes, enumUnderlyingTypes);
+        var targetFamily = SlotSemanticFamily(target, shapes, enumUnderlyingTypes);
+        return valueFamily is not null && targetFamily is not null
+            && (valueFamily == targetFamily
+                || (valueFamily == StackFamily.I4 && targetFamily == StackFamily.I8
+                    && enumUnderlyingTypes.ContainsKey(valueType)));
     }
 
     public static bool CanSpellIntegerToEnum(
@@ -53,9 +52,7 @@ public static class CoercionRendering
             && EnumSemanticFamily(valueType, shapes, enumUnderlyingTypes) is { } underlyingFamily
             && TypeFamilies.Of(target) is { } targetFamily
             && (underlyingFamily == targetFamily
-                || (underlyingFamily == StackFamily.I4 && targetFamily == StackFamily.I8
-                    && valueType is not null
-                    && enumUnderlyingTypes.ContainsKey(valueType)));
+                || underlyingFamily == StackFamily.I4 && targetFamily == StackFamily.I8);
 
     public static bool CanSpellEnumToEnum(
         TypeRef? valueType,
@@ -63,8 +60,7 @@ public static class CoercionRendering
         IReadOnlyDictionary<TypeRef, TypeShape> shapes,
         IReadOnlyDictionary<TypeRef, TypeRef> enumUnderlyingTypes)
         => EnumSemanticFamily(target, shapes, enumUnderlyingTypes) is not null
-            && EnumSemanticFamily(valueType, shapes, enumUnderlyingTypes) is { } valueFamily
-            && EnumSemanticFamily(target, shapes, enumUnderlyingTypes) == valueFamily
+            && EnumSemanticFamily(valueType, shapes, enumUnderlyingTypes) is not null
             && valueType?.Equals(target) != true;
 
     public static bool CanSpellUnknownEnumConstant(
@@ -79,6 +75,31 @@ public static class CoercionRendering
 
     public static bool CanSpellBoolToInteger(TypeRef? valueType, TypeRef target)
         => TypeFamilies.IsIntegerLike(target) && TypeFamilies.IsBoolean(valueType);
+
+    static bool CanSpellSlotValue(
+        TypeRef valueType,
+        TypeRef target,
+        IReadOnlyDictionary<TypeRef, TypeShape> shapes,
+        IReadOnlyDictionary<TypeRef, TypeRef> enumUnderlyingTypes)
+        => valueType.Equals(target)
+            || CanSpellBoolToInteger(valueType, target)
+            || CanSpellIntegerToEnum(valueType, target, shapes)
+            || CanSpellEnumToInteger(valueType, target, shapes, enumUnderlyingTypes)
+            || CanSpellEnumToEnum(valueType, target, shapes, enumUnderlyingTypes)
+            || CanSpellPrimitiveNumeric(valueType, target);
+
+    static bool CanSpellPrimitiveNumeric(TypeRef valueType, TypeRef target)
+        => !TypeFamilies.IsBoolean(valueType)
+            && !TypeFamilies.IsBoolean(target)
+            && TypeFamilies.IsNumericPrimitive(valueType)
+            && TypeFamilies.IsNumericPrimitive(target)
+            && TypeFamilies.Of(valueType) == TypeFamilies.Of(target);
+
+    static StackFamily? SlotSemanticFamily(
+        TypeRef? type,
+        IReadOnlyDictionary<TypeRef, TypeShape> shapes,
+        IReadOnlyDictionary<TypeRef, TypeRef> enumUnderlyingTypes)
+        => TypeFamilies.Of(type) ?? EnumSemanticFamily(type, shapes, enumUnderlyingTypes);
 
     /// <summary>
     /// The stack family of an enum-typed value's underlying: the resolved

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -175,20 +175,6 @@ public sealed partial class CSharpPrinter
     /// the IL already carries as the enum, so it is faithful. A negative literal
     /// is parenthesized (CS0075), mirroring <see cref="CoerceText"/>'s enum path.
     /// </summary>
-    /// <summary>
-    /// The stack family of an enum-typed value's underlying: the resolved
-    /// underlying's family, or I4 for a missing-<c>value__</c> shape (the
-    /// MayOverflowEnumBackingType assumption). Null for non-enums.
-    /// </summary>
-    StackFamily? EnumSemanticFamily(TypeRef? type)
-    {
-        if (type is null || TypeFamilies.Of(type) is not null)
-            return null;
-        if (EnumUnderlyingType(type) is { } underlying)
-            return TypeFamilies.Of(underlying);
-        return _function.TypeShapes.GetValueOrDefault(type) == TypeShape.Enum ? StackFamily.I4 : null;
-    }
-
     string EnumIntegerCast(IrExpression value, TypeRef enumType)
     {
         // A negative literal needs parentheses after the cast (CS0075); whether it
@@ -1072,9 +1058,7 @@ public sealed partial class CSharpPrinter
         // whole merge — `(StringComparison)(flag ? 1 : 0)` — which is legal off a
         // concrete enum target (the bail's CS0030 risk is type-parameter-only).
         if (target is { } enumTarget
-            && _function.TypeShapes.GetValueOrDefault(enumTarget) == TypeShape.Enum
-            && EffectiveType(value) is { } enumSource && !enumTarget.Equals(enumSource)
-            && TypeFamilies.IsIntegerLike(enumSource))
+            && CoercionRendering.CanSpellIntegerToEnum(EffectiveType(value), enumTarget, _function.TypeShapes))
         {
             return value is Constant { Value: int or long } enumKonst
                 ? EnumConstantText(enumKonst, enumTarget)
@@ -1093,11 +1077,11 @@ public sealed partial class CSharpPrinter
         // target. Narrowing (I8 underlying, I4 target) never gets a silent
         // cast; a real narrowing in the IL arrives as a Convert node instead.
         if (target is { } primitiveTarget
-            && TypeFamilies.IsIntegerLike(primitiveTarget)
-            && EnumSemanticFamily(EffectiveType(value)) is { } underlyingFamily
-            && TypeFamilies.Of(primitiveTarget) is { } targetFamily
-            && (underlyingFamily == targetFamily
-                || (underlyingFamily == StackFamily.I4 && targetFamily == StackFamily.I8)))
+            && CoercionRendering.CanSpellEnumToInteger(
+                EffectiveType(value),
+                primitiveTarget,
+                _function.TypeShapes,
+                _function.EnumUnderlyingTypes))
         {
             return $"({TypeText(primitiveTarget)}){Operand(value)}";
         }
@@ -1107,9 +1091,11 @@ public sealed partial class CSharpPrinter
         // (slice-5b round 4: without the spelling, the range severed into an
         // unassigned read).
         if (target is { } enumToEnumTarget
-            && EnumSemanticFamily(enumToEnumTarget) is not null
-            && EnumSemanticFamily(EffectiveType(value)) is not null
-            && EffectiveType(value)?.Equals(enumToEnumTarget) != true)
+            && CoercionRendering.CanSpellEnumToEnum(
+                EffectiveType(value),
+                enumToEnumTarget,
+                _function.TypeShapes,
+                _function.EnumUnderlyingTypes))
         {
             return CheckedSafeCast($"({TypeText(enumToEnumTarget)}){Operand(value)}");
         }
@@ -1127,10 +1113,8 @@ public sealed partial class CSharpPrinter
         // spelling. Constants only: a non-constant integer into such a position is
         // rarer and not needed for the validity defects this targets.
         if (value is Constant { Value: int or long } unknownKonst
-            && target is { Kind: TypeRefKind.Definition, Name: not "Boolean" } unknownEnum
-            && _function.TypeShapes.GetValueOrDefault(unknownEnum) == TypeShape.Unknown
-            && !TypeFamilies.IsNumericPrimitive(unknownEnum)
-            && EffectiveType(value) is { } unknownEnumSource && TypeFamilies.IsIntegerLike(unknownEnumSource))
+            && target is { } unknownEnum
+            && CoercionRendering.CanSpellUnknownEnumConstant(EffectiveType(value), unknownEnum, _function.TypeShapes))
         {
             return EnumConstantText(unknownKonst, unknownEnum);
         }
@@ -1141,8 +1125,7 @@ public sealed partial class CSharpPrinter
         // back to the bare comparison opcode, so it recompiles exactly. Runs
         // before the merge-node bail so a bool ternary/coalesce into int is wrapped
         // too (its arms are bool, the wrap is legal).
-        if (target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
-            && EffectiveType(value) is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary })
+        if (target is { } intTarget && CoercionRendering.CanSpellBoolToInteger(EffectiveType(value), intTarget))
         {
             // The composition's natural int converts implicitly only to int
             // and wider signed targets; narrow and unsigned targets need the

--- a/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/CoercionInsertionPass.cs
@@ -130,47 +130,6 @@ public static class CoercionSinks
         return types;
     }
 
-    /// <summary>
-    /// The slot-store wrappability gate: a POSITIVE whitelist where every
-    /// allowed pair names the CoerceText branch that spells it. Three review
-    /// rounds proved the subtractive form ("same family, minus exceptions")
-    /// cannot be kept honest against the renderer — cross-enum, bool→narrow,
-    /// and assumed-underlying each slipped through a family-level
-    /// approximation. Anything not listed is PrinterOwned: counted residual,
-    /// split naming, no wrap.
-    /// </summary>
-    static bool RenderableSlotCoercion(TypeRef? valueType, TypeRef target, IrFunction function)
-    {
-        // Round 4 inverted the strategy: for a single testified live range,
-        // DENYING the wrap severs the range into an unassigned read (CS0165),
-        // which is strictly worse than any cast. CoerceText is now total over
-        // same-semantic-family pairs — bool composes with a target cast where
-        // int doesn't convert implicitly, enum→enum casts directly, and
-        // missing-`value__` uses the assumed-int rule on both directions — so
-        // the gate is semantic-family equality with one directional exception:
-        // nothing spells integer→bool. Cross-family denials remain, and they
-        // are exactly the true disjoint ranges (cross-family single ranges
-        // cannot verify), where split naming is CORRECT. #2242 tracks
-        // extracting this contract so gate and renderer share one predicate.
-        if (valueType is null)
-            return false;
-        if (TypeFamilies.IsBoolean(target) && !TypeFamilies.IsBoolean(valueType))
-            return false;
-        var valueFamily = SemanticFamily(valueType, function);
-        var targetFamily = SemanticFamily(target, function);
-        return valueFamily is not null && targetFamily is not null
-            && (valueFamily == targetFamily
-                || (valueFamily == StackFamily.I4 && targetFamily == StackFamily.I8
-                    && function.EnumUnderlyingTypes.ContainsKey(valueType)));
-    }
-
-    /// <summary>A type's semantic stack family: its own, or its resolved enum underlying's, or I4 for a missing-<c>value__</c> enum shape (the MayOverflowEnumBackingType assumption, now shared by the renderer's branches).</summary>
-    static StackFamily? SemanticFamily(TypeRef? type, IrFunction function)
-        => TypeFamilies.Of(type)
-            ?? (type is not null && function.TypeShapes.GetValueOrDefault(type) == TypeShape.Enum
-                ? TypeFamilies.Of(function.EnumUnderlyingTypes.GetValueOrDefault(type)) ?? StackFamily.I4
-                : null);
-
     /// <summary>The target type of the sink directly consuming an untyped slot load, where one is derivable — the printer's StackSlotLoadTargetType vocabulary.</summary>
     static TypeRef? LoadSinkTargetType(LoadStackSlot load, TypeRef? returnType)
         => load.Parent switch
@@ -217,18 +176,20 @@ public static class CoercionSinks
                 // reads at one type — 5a reconciled the constant arms; the
                 // Coerce wrap covers the rest, and the printer's type-keyed
                 // naming collapses to one declaration by construction.
-                // Wrappable only within the testified type's stack family: a
-                // cross-family store (a dead `long` store on an int-testified
-                // slot) is not a coercion candidate but PROOF of a disjoint
-                // live range — the verifier never merges across families, so
-                // the testimony belongs to a different range. Those yield as
-                // PrinterOwned: counted residuals (the #2209 burn-down), left
-                // to the unifier's split naming until materialization
-                // (slice-5b adversarial review, Gemini blocking finding).
+                // Wrappable exactly when CoerceText has a spelling for this
+                // value/target pair. Cross-family stores (a dead `long` store
+                // on an int-testified slot) are proof of disjoint live ranges,
+                // where split naming is correct; same-family oddities stay
+                // unified because CoercionRendering and CoerceText share one
+                // contract.
                 case StoreStackSlot { Value: { } slotValue } slotStore
                     when slotTypes.GetValueOrDefault(slotStore.Slot) is { } slotType:
                     yield return new(slotValue, slotType,
-                        RenderableSlotCoercion(slotValue.ResultType, slotType, function)
+                        CoercionRendering.CanSpellSlotCoercion(
+                            slotValue.ResultType,
+                            slotType,
+                            function.TypeShapes,
+                            function.EnumUnderlyingTypes)
                             ? SinkScope.Wrappable
                             : SinkScope.PrinterOwned);
                     break;


### PR DESCRIPTION
## Summary

Extracts the coercion renderability contract into `CoercionRendering` so the slot-store gate and `CSharpPrinter.CoerceText` consume the same predicate arms instead of maintaining parallel approximations.

This is intended as a pure extraction for #2242: the slice-5b asymmetries remain explicit, including bool directionality, enum semantic-family handling, missing-`value__` assumptions, and resolved-underlying I4→I8 enum widening.

## Validation

- `dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.CoercionInvariantTests -class ILInspector.Decompiler.Tests.SubstratePredicateCensusTests`
- `dotnet build --no-restore src/dotnet-inspect/dotnet-inspect.csproj -c Release -p:PublishAot=false --nologo --verbosity:minimal`
- Render A/B against `32900e4d`: 89,065 methods evaluated; Changed/Added/Removed all 0.

Fixes #2242.
