### PR TITLE
Add a first-class --emit-inverse-ledger regeneration command

### DIFF
--- a/eng/regen-inverse-ledger.sh
+++ b/eng/regen-inverse-ledger.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Find the repository root
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Run DecompilerHarness to regenerate the ledger
+dotnet run --project "$REPO_ROOT/tools/DecompilerHarness" -c Release -- \
+    --emit-inverse-ledger "$REPO_ROOT/docs/design/inverse-ledger.generated.md"
+
+echo "Ledger regenerated at docs/design/inverse-ledger.generated.md"

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
@@ -162,7 +162,7 @@ public class InverseArchitectureTests
 
         var path = Path.Combine(root!, "docs", "design", "inverse-ledger.generated.md");
         Assert.True(File.Exists(path),
-            $"Missing {path}. Regenerate it from InverseLedger.RenderMarkdown(ProductAssembly).");
+            $"Missing {path}. Regenerate it via `dotnet run --project tools/DecompilerHarness -c Release -- --emit-inverse-ledger <path>`. ");
         Assert.Equal(
             Normalize(InverseLedger.RenderMarkdown(ProductAssembly)),
             Normalize(File.ReadAllText(path)));

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
@@ -161,11 +161,15 @@ public class InverseArchitectureTests
             "Repo source tree is not co-located with the test binary; the drift gate is a source-tree check.");
 
         var path = Path.Combine(root!, "docs", "design", "inverse-ledger.generated.md");
+        string regenHint = $"Regenerate it from the repository root via `./eng/regen-inverse-ledger.sh`.";
         Assert.True(File.Exists(path),
-            $"Missing {path}. Regenerate it via `dotnet run --project tools/DecompilerHarness -c Release -- --emit-inverse-ledger <path>`.");
-        Assert.Equal(
-            Normalize(InverseLedger.RenderMarkdown(ProductAssembly)),
-            Normalize(File.ReadAllText(path)));
+            $"Missing {path}. {regenHint}");
+
+        string expected = Normalize(InverseLedger.RenderMarkdown(ProductAssembly));
+        string actual = Normalize(File.ReadAllText(path));
+        Assert.True(
+            string.Equals(expected, actual, StringComparison.Ordinal),
+            $"Generated inverse ledger drifted: {path}. {regenHint}");
     }
 
     static IrFunction EmptyProbeFunction()

--- a/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
+++ b/src/ILInspector.Decompiler.Tests/InverseArchitecture/InverseArchitectureTests.cs
@@ -162,7 +162,7 @@ public class InverseArchitectureTests
 
         var path = Path.Combine(root!, "docs", "design", "inverse-ledger.generated.md");
         Assert.True(File.Exists(path),
-            $"Missing {path}. Regenerate it via `dotnet run --project tools/DecompilerHarness -c Release -- --emit-inverse-ledger <path>`. ");
+            $"Missing {path}. Regenerate it via `dotnet run --project tools/DecompilerHarness -c Release -- --emit-inverse-ledger <path>`.");
         Assert.Equal(
             Normalize(InverseLedger.RenderMarkdown(ProductAssembly)),
             Normalize(File.ReadAllText(path)));

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -73,6 +73,7 @@ static class Program
         bool structuringStops = false;
         bool postdomProbe = false;
         int postdomSample = 0;
+        string? emitInverseLedger = null;
         bool libraryReport = false;
         bool unsupportedNodes = false;
         bool typeCheck = false;
@@ -118,6 +119,7 @@ static class Program
                 case "--step-limit": steps = true; stepLimit = int.Parse(args[++i]); break;
                 case "--il": ilView = true; break;
                 case "--skip-pdb": skipPdb = true; break;
+                case "--emit-inverse-ledger": emitInverseLedger = args[++i]; break;
                 case "--assertions": assertions = true; break;
                 case "--assertion-scan": assertionScan = true; break;
                 case "--assertion-fixture-guarantee": assertionFixtureGuarantee = true; break;
@@ -219,6 +221,14 @@ static class Program
         }
 
         using var packageInputs = ResolvePackageAssemblies(packages, packageVersion, packageTfm, packageAssembly);
+
+        if (emitInverseLedger is not null)
+        {
+            File.WriteAllText(emitInverseLedger, ILInspector.Decompiler.Tests.InverseArchitecture.InverseLedger.RenderMarkdown(typeof(IrFunction).Assembly));
+            Console.WriteLine($"Wrote inverse ledger to {emitInverseLedger}");
+            return 0;
+        }
+
         var assemblies = inputs.Count == 0 && packages.Count > 0
             ? packageInputs.Assemblies.ToList()
             : ResolveAssemblies(inputs).Concat(packageInputs.Assemblies).Distinct(StringComparer.OrdinalIgnoreCase).ToList();

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -6,7 +6,6 @@ The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — t
 
 **Inverse ledger regeneration** (`--emit-inverse-ledger <path>`): evaluates `[InverseOf]` and `[NotInverted]` attributes on the decompiler's node schema and renders the Markdown representation to the specified path. Use this command to update the single-source-of-truth document at `docs/design/inverse-ledger.generated.md` after adding or changing inverse annotations in the IR types. A drift-gate test enforces that the committed file matches this command's output.
 
-
 **Inventory** (default): sweeps every method body in the given assemblies through the pipeline and reports the fidelity histogram plus stop-reason buckets — the prioritized slice roadmap. Exits nonzero if any importer bug (DEC0001) appears. `--max-examples N` sets how many example methods each bucket lists (default 5) — raise it to widen the candidate pool when picking the next target.
 
 **Gaps** (`--gaps`): the completeness view — see below.

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -4,6 +4,9 @@ The diagnostic harness from [docs/decompiler.md](../../docs/decompiler.md) — t
 
 ## Modes
 
+**Inverse ledger regeneration** (`--emit-inverse-ledger <path>`): evaluates `[InverseOf]` and `[NotInverted]` attributes on the decompiler's node schema and renders the Markdown representation to the specified path. Use this command to update the single-source-of-truth document at `docs/design/inverse-ledger.generated.md` after adding or changing inverse annotations in the IR types. A drift-gate test enforces that the committed file matches this command's output.
+
+
 **Inventory** (default): sweeps every method body in the given assemblies through the pipeline and reports the fidelity histogram plus stop-reason buckets — the prioritized slice roadmap. Exits nonzero if any importer bug (DEC0001) appears. `--max-examples N` sets how many example methods each bucket lists (default 5) — raise it to widen the candidate pool when picking the next target.
 
 **Gaps** (`--gaps`): the completeness view — see below.


### PR DESCRIPTION
## Problem

`docs/design/inverse-ledger.generated.md` is guarded by a strict drift gate, but there was no committed, documented way to regenerate the file. Generating it required ad-hoc file-based apps with multiple dependencies and preview features enabled.

## Fix

Added a first-class regeneration path: `--emit-inverse-ledger <path>` to `DecompilerHarness`.

- Updated the `GeneratedProductLedger_MatchesCommittedFile` drift-gate failure message to instruct users to run the new command.
- Documented `--emit-inverse-ledger` in `tools/DecompilerHarness/README.md`.
- Added an `eng/regen-inverse-ledger.sh` wrapper script for one-command regeneration.

Fixes #2254.
