### PR TITLE
Harden assertion coverage fixtures against SDK-lowering drift (#2255)

### DIFF
--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -1460,7 +1460,7 @@ internal static class GeneratedFixtureCatalog
 
             public static int SpanLiteral()
             {
-                System.ReadOnlySpan<int> values = [1, 2, 3];
+                System.ReadOnlySpan<int> values = new int[] { 1, 2, 3 };
                 return values[0];
             }
 
@@ -1482,6 +1482,22 @@ internal static class GeneratedFixtureCatalog
             {
                 InlineBuffer buffer = default;
                 System.Span<int> values = buffer;
+                values[0] = 7;
+                return values[0];
+            }
+        }
+
+        // Field-backed inline-array place — the canonical InlineArrayAsSpan
+        // (ldflda) shape. Exercises the LoadFieldAddress branch of the
+        // place-conversion raise and keeps InlineArraySpanConversion covered
+        // even if the local-buffer lowering above shifts.
+        public sealed class InlineArrayFieldHolder
+        {
+            private InlineBuffer _values;
+
+            public int InlineArraySpanConversion()
+            {
+                System.Span<int> values = _values;
                 values[0] = 7;
                 return values[0];
             }


### PR DESCRIPTION
## Summary

Fixes #2255. The `assertion.inverse-node-coverage` fixture compiles with `LangVersion=preview`, so two batch-8 node shapes depended on a drift-prone lowering. When a lowering shifts, the affected node flips uncovered and the harness raises a "fixture regression alarm" that *looks like* a product regression but is really a fixture-lowering shift — a confusing, mis-attributed false-alarm class on SDK bumps.

- **`SpanLiteral`** — use `new int[] { 1, 2, 3 }` (the canonical `CreateSpan` trigger the node doc names) instead of the collection expression `[1, 2, 3]`, which a future Roslyn could lower through an inline-array buffer into a `CollectionExpression` instead.
- **`InlineArraySpanConversion`** — add a field-backed producer (`InlineArrayFieldHolder`, the `ldflda`/`LoadFieldAddress` branch — the canonical `BitVector256._values` shape) alongside the existing default-init local-buffer producer (`LoadLocalAddress` branch). The node is now covered by **two independent importer branches**, so a single lowering shift can't flip it uncovered.

## Evidence

- `dotnet build src/ILInspector.Decompiler -c Release` + `dotnet build tools/DecompilerHarness -c Release` — clean.
- Fixture guarantee: **46/46 covered and guaranteed, no regression alarms**.
- Final-IR dumps confirm intended nodes:
  - `Class1::SpanLiteral` → `SpanLiteral int[3]` (renders `new int[] { 1, 2, 3 }`).
  - `Class1::InlineArraySpan` → `InlineArraySpanConversion` via `LoadLocalAddress` (local buffer).
  - `InlineArrayFieldHolder::InlineArraySpanConversion` → `InlineArraySpanConversion` via `LoadFieldAddress InlineArrayFieldHolder._values` (field place).
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ...AssertionScanTests -class ...InverseArchitectureTests -class ...GeneratedFixtureCatalogTests` — 25/25 pass.

## Risk

Harness/test only (generated-fixture source); **no product decompiler behavior change**, SRM-only, NativeAOT-friendly. Low-risk. Does not fully close #2255 (the alarm-disambiguation option is deferred); this addresses the fragility directly by moving guaranteed nodes onto stable/redundant shapes.
