### PR TITLE
Reuse the per-method allocation scan for optimization opportunities

### DIFF
--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -2160,9 +2160,17 @@ public sealed class LibraryBodyIndex
                 var decodedBody = DecodeBody(il, body.ExceptionRegions);
                 bool hasUnsafeLocals = ScanLocals(body, caller, scope, evidence);
                 var loopRegions = decodedBody.LoopRegions;
-                result.Allocations = includeAllocations
-                    ? CollectAllocationOccurrences(il, decodedBody, body.ExceptionRegions, caller, scope, loopRegions, classifyEscapes: true)
+                // Scan allocation occurrences once (raw, escape = Unknown). The main allocation output
+                // needs escape classification, while Performance Triage's optimization-opportunity pass
+                // reuses the same raw occurrences (it keys them by IL offset and does not read escape
+                // state). Classifying once and sharing the raw scan avoids a second full instruction/
+                // token scan per method whenever opportunities are computed.
+                var rawAllocations = includeAllocations
+                    ? CollectAllocationOccurrences(il, decodedBody, body.ExceptionRegions, caller, scope, loopRegions, classifyEscapes: false)
                     : ImmutableArray<AllocationOccurrence>.Empty;
+                result.Allocations = includeAllocations && !rawAllocations.IsDefaultOrEmpty
+                    ? ClassifyAllocationEscapes(rawAllocations, il, decodedBody, body.ExceptionRegions, caller, scope)
+                    : rawAllocations;
                 result.Unsafety = CollectUnsafetyOccurrences(decodedBody.Instructions, body, caller, scope);
                 var methodAttributes = methodDef.GetCustomAttributes();
                 if (includeOpportunities)
@@ -2171,7 +2179,7 @@ public sealed class LibraryBodyIndex
                         && !HasGeneratedCodeAttribute(methodAttributes)
                         && !HasCompilerGeneratedAttribute(methodAttributes)
                         && !IsBlazorRenderMethod(caller))
-                        result.Opportunities = CollectOptimizationOpportunities(il, decodedBody, body.ExceptionRegions, caller, scope, loopRegions);
+                        result.Opportunities = CollectOptimizationOpportunities(rawAllocations, il, decodedBody, body.ExceptionRegions, caller, scope, loopRegions);
                     else
                         result.Suppressed = true;
                 }
@@ -3183,11 +3191,12 @@ public sealed class LibraryBodyIndex
             }
         }
 
-        ImmutableArray<OptimizationOpportunity> CollectOptimizationOpportunities(byte[] il, DecodedBody decodedBody, IReadOnlyCollection<ExceptionRegion> exceptionRegions, MethodIdentity caller, GenericScope callerScope, IReadOnlyList<(int Start, int End)> loopRegions)
+        ImmutableArray<OptimizationOpportunity> CollectOptimizationOpportunities(ImmutableArray<AllocationOccurrence> rawAllocations, byte[] il, DecodedBody decodedBody, IReadOnlyCollection<ExceptionRegion> exceptionRegions, MethodIdentity caller, GenericScope callerScope, IReadOnlyList<(int Start, int End)> loopRegions)
         {
             var opportunities = ImmutableArray.CreateBuilder<OptimizationOpportunity>();
-            var allocationByOffset = CollectAllocationOccurrences(il, decodedBody, exceptionRegions, caller, callerScope, loopRegions, classifyEscapes: false)
-                .ToDictionary(occurrence => occurrence.ILOffset);
+            // Raw (unclassified) allocation occurrences for this method, scanned once by the caller
+            // and shared here to avoid a redundant second allocation scan. Escape state is not read.
+            var allocationByOffset = rawAllocations.ToDictionary(occurrence => occurrence.ILOffset);
             ReachingDefinitionsResult? reachingDefinitions = null;
             ReachingDefinitionsResult GetReachingDefinitions()
                 => reachingDefinitions ??= ReachingDefinitions.Analyze(il, ArgumentSlotCount(caller), exceptionRegions);


### PR DESCRIPTION
## Result: ~20% less CPU work on Performance Triage

Performance Triage computed each method's allocation occurrences **twice**: once in the main path with escape classification (`classifyEscapes: true`), and again inside `CollectOptimizationOpportunities` without it (`classifyEscapes: false`). Both run the identical instruction/token scan — `classifyEscapes` only controls whether a final `ClassifyAllocationEscapes` pass runs on top of the same raw occurrences.

This scans once (raw), classifies that result for the main allocation output, and hands the raw occurrences to the opportunity pass (which keys them by IL offset and never reads escape state) — removing one full allocation scan per method whenever opportunities are computed.

| Command | Assembly | CPU before | CPU after | Less work |
| --- | --- | --- | --- | --- |
| `-S "Performance Triage"` | System.Private.CoreLib (16 MB) | 7.45s | 6.01s | **19%** |
| `-S "Performance Triage"` | ILInspector.Decompiler | 3.45s | 2.65s | **23%** |

Savings scale with allocation density. **Note on wall-clock:** on an idle box, large-assembly wall-clock is unchanged because that path is already parallel across cores (#2247) and the sequential render/merge dominates its wall time — but the ~20% CPU reduction translates directly to wall-clock under core contention (this environment runs many concurrent analyses).

## Why it's byte-identical

`classifyEscapes: false` returns the raw `collected` occurrences directly; `true` returns `ClassifyAllocationEscapes(collected, …)` on top. So the base occurrences (offsets, kinds, sizes, types) are identical between the two — only the escape field differs. The opportunity pass consumed the `false` (raw, `Unknown`-escape) occurrences and keys them by IL offset without reading escape state, so handing it the shared raw scan gives it exactly what it computed before.

## Validation

- **Byte-identical CLI**: 21 diffs across 7 real framework assemblies (including System.Private.CoreLib) for Performance Triage / Allocation Facts / combined, plus type-level Allocation-Safety-Cost and Performance Triage.
- SemanticFacts / ParallelBuildDeterminism / IndexBuildInvariant / Targeted / TypeTargeted tests pass.

## Risk / review focus

Behavior-preserving. Attack point: does `CollectOptimizationOpportunities` ever read allocation **escape** state (which would differ between the raw scan it did before and… still the raw scan now — so this is actually a no-op risk), or does the main allocation output still get classification applied exactly as before? Confirm the raw-vs-classified split is faithful.
