### PR TITLE
Wire cross-method import seam into --dump/--steps for classic-async (#2253)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/StepperTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StepperTests.cs
@@ -109,6 +109,26 @@ public class StepperTests
     }
 
     [Fact]
+    public void CrossMethodImports_DoNotRecordNestedStepsInParentStepper()
+    {
+        var parent = ImportFixture(nameof(CfgSampleClass.Add));
+        var imported = ImportFixture(nameof(CfgSampleClass.Twice));
+        var stepper = new Stepper(enabled: true);
+        var target = new MethodRef(
+            TypeRef.Definition("Asm", "Ns", "Type"),
+            "Imported",
+            TypeRef.CoreLib("System", "Void"),
+            [],
+            HasThis: false);
+        var context = new PassContext(stepper, importMethodBody: method => method == target ? imported : null);
+
+        new ImportingStepPass(target).Run(parent, context);
+
+        var descriptions = Flatten(stepper.Steps).Select(s => s.Description).ToList();
+        Assert.Equal(["parent before import", "parent after import"], descriptions);
+    }
+
+    [Fact]
     public void PinnedLocalAudit_RecordsFixedStatementRewrite()
     {
         var function = ImportFixture(nameof(CfgSampleClass.SumPinnedArray));
@@ -180,5 +200,26 @@ public class StepperTests
             foreach (var child in Flatten(step.Children))
                 yield return child;
         }
+    }
+
+    sealed class ImportingStepPass(MethodRef target) : IIrPass
+    {
+        public string Name => "importing-step-pass";
+
+        public void Run(IrFunction function, PassContext context)
+        {
+            context.Stepper.StepOver("parent before import");
+            Assert.True(context.TryImportAndRunMethodBody(target, [new NestedStepPass()], out var imported));
+            Assert.NotNull(imported);
+            context.Stepper.StepOver("parent after import");
+        }
+    }
+
+    sealed class NestedStepPass : IIrPass
+    {
+        public string Name => "nested-step-pass";
+
+        public void Run(IrFunction function, PassContext context)
+            => context.Stepper.StepOver("nested imported rewrite");
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/PassContext.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PassContext.cs
@@ -13,16 +13,26 @@ namespace ILInspector.Decompiler.Pipeline;
 public sealed class PassContext
 {
     const int MaxCrossMethodPipelineDepth = 64;
-    readonly List<string> _activeCrossMethodPipelines = [];
+    readonly List<string> _activeCrossMethodPipelines;
 
     public PassContext(
         Stepper stepper,
         StructuringDiagnostics? structuringDiagnostics = null,
         Func<MethodRef, IrFunction?>? importMethodBody = null)
+        : this(stepper, structuringDiagnostics, importMethodBody, [])
+    {
+    }
+
+    PassContext(
+        Stepper stepper,
+        StructuringDiagnostics? structuringDiagnostics,
+        Func<MethodRef, IrFunction?>? importMethodBody,
+        List<string> activeCrossMethodPipelines)
     {
         Stepper = stepper;
         StructuringDiagnostics = structuringDiagnostics;
         ImportMethodBody = importMethodBody;
+        _activeCrossMethodPipelines = activeCrossMethodPipelines;
     }
 
     public Stepper Stepper { get; }
@@ -63,10 +73,15 @@ public sealed class PassContext
         {
             body = scope.Import();
             if (body is not null)
-                IrPasses.Run(body, passes, this);
+                IrPasses.Run(body, passes, NestedPipelineContext());
             return true;
         }
     }
+
+    PassContext NestedPipelineContext()
+        => Stepper.IsEnabled
+            ? new PassContext(new Stepper(enabled: false), StructuringDiagnostics, ImportMethodBody, _activeCrossMethodPipelines)
+            : this;
 
     /// <summary>
     /// Marks a sibling method active across any raw inspection and nested pass run

--- a/src/ILInspector.Decompiler/Pipeline/PassContext.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PassContext.cs
@@ -135,4 +135,14 @@ public sealed class PassContext
 
     /// <summary>A context with stepping disabled — the default for normal runs and for tests that drive a pass directly.</summary>
     public static PassContext None { get; } = new(new Stepper(enabled: false));
+
+    /// <summary>
+    /// A non-stepping context that carries the cross-method import
+    /// <paramref name="importMethodBody"/> seam for the diagnostic dump paths, or
+    /// <see cref="None"/> when no seam is wired. Lets cross-method passes
+    /// (classic-async / iterator / lambda / local-function reconstruction) run in
+    /// the single-method dumps as they do in the shipped product path.
+    /// </summary>
+    public static PassContext ForImport(Func<MethodRef, IrFunction?>? importMethodBody)
+        => importMethodBody is null ? None : new PassContext(new Stepper(enabled: false), importMethodBody: importMethodBody);
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -373,22 +373,39 @@ public static class IrPasses
         => RunWithStages(function, Default, IrPrinter.Dump);
 
     /// <summary>
+    /// As <see cref="RunWithStages(IrFunction)"/>, but wires the cross-method
+    /// import seam so cross-method passes (e.g. <see cref="ClassicAsyncReconstructionPass"/>,
+    /// which pulls in the sibling <c>MoveNext</c>) run in the staged/diagnostic
+    /// view exactly as they do in the product path. Pass <c>null</c> to leave
+    /// them no-ops (the historical behaviour).
+    /// </summary>
+    public static IReadOnlyList<PipelineStage> RunWithStages(
+        IrFunction function, Func<MethodRef, IrFunction?>? importMethodBody)
+        => RunWithStages(function, Default, IrPrinter.Dump, importMethodBody);
+
+    /// <summary>
     /// Runs <paramref name="passes"/>, capturing <paramref name="project"/>'s
     /// output at the importer boundary and after each pass. The projection runs
     /// between mutations, so each captured string is the tree as that stage left
     /// it. Debug builds validate invariants after every pass, exactly as
     /// <see cref="Run(IrFunction, ImmutableArray{IIrPass})"/> does.
+    /// <paramref name="importMethodBody"/> wires the cross-method import seam;
+    /// <c>null</c> uses the shared no-import context (cross-method passes no-op).
     /// </summary>
     public static IReadOnlyList<PipelineStage> RunWithStages(
-        IrFunction function, ImmutableArray<IIrPass> passes, Func<IrFunction, string> project)
+        IrFunction function, ImmutableArray<IIrPass> passes, Func<IrFunction, string> project,
+        Func<MethodRef, IrFunction?>? importMethodBody = null)
     {
+        var context = importMethodBody is null
+            ? PassContext.None
+            : new PassContext(new Stepper(enabled: false), importMethodBody: importMethodBody);
         var stages = new List<PipelineStage>(passes.Length + 1)
         {
             new(ImportStageName, project(function), function.Fidelity),
         };
         foreach (var pass in passes)
         {
-            pass.Run(function, PassContext.None);
+            pass.Run(function, context);
             function.CheckInvariant();
             stages.Add(new(pass.Name, project(function), function.Fidelity));
         }
@@ -403,11 +420,16 @@ public static class IrPasses
     /// <see cref="int.MaxValue"/> to record every step without stopping. The
     /// <see cref="StepLimitReachedException"/> is caught here — callers see a
     /// normal return with the partially-transformed <paramref name="function"/>.
+    /// <paramref name="importMethodBody"/> wires the cross-method import seam so
+    /// cross-method passes step through their rewrites in the stepper view as
+    /// they do in the product path; <c>null</c> leaves them no-ops.
     /// </summary>
-    public static Stepper RunWithSteps(IrFunction function, int stepLimit = int.MaxValue)
+    public static Stepper RunWithSteps(
+        IrFunction function, int stepLimit = int.MaxValue,
+        Func<MethodRef, IrFunction?>? importMethodBody = null)
     {
         var stepper = new Stepper(enabled: true) { StepLimit = stepLimit };
-        var context = new PassContext(stepper);
+        var context = new PassContext(stepper, importMethodBody: importMethodBody);
         try
         {
             foreach (var pass in Default)

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -350,6 +350,17 @@ public static class IrPasses
     public static void Run(IrFunction function, ImmutableArray<IIrPass> passes)
         => Run(function, passes, PassContext.None);
 
+    /// <summary>
+    /// As <see cref="Run(IrFunction, ImmutableArray{IIrPass})"/>, but wires the
+    /// cross-method import seam so cross-method passes (classic-async / iterator /
+    /// lambda / local-function reconstruction) run as they do in the product path.
+    /// <c>null</c> leaves them no-ops (the shared no-import context). Used by the
+    /// single-method diagnostic dump paths so they match the shipped output.
+    /// </summary>
+    public static void Run(
+        IrFunction function, ImmutableArray<IIrPass> passes, Func<MethodRef, IrFunction?>? importMethodBody)
+        => Run(function, passes, DiagnosticContext(importMethodBody));
+
     public static void Run(IrFunction function, ImmutableArray<IIrPass> passes, PassContext context)
     {
         foreach (var pass in passes)
@@ -358,6 +369,17 @@ public static class IrPasses
             function.CheckInvariant();
         }
     }
+
+    /// <summary>
+    /// A non-stepping context that carries the cross-method import seam for the
+    /// diagnostic dump paths, or <see cref="PassContext.None"/> when no seam is
+    /// wired. The stepper stays disabled — this is for the staged/tree dumps, not
+    /// <see cref="RunWithSteps(IrFunction, int)"/> which needs an enabled stepper.
+    /// </summary>
+    static PassContext DiagnosticContext(Func<MethodRef, IrFunction?>? importMethodBody)
+        => importMethodBody is null
+            ? PassContext.None
+            : new PassContext(new Stepper(enabled: false), importMethodBody: importMethodBody);
 
     /// <summary>The synthetic stage name for the importer output — the pre-transform tree, before any pass runs.</summary>
     public const string ImportStageName = "(import)";
@@ -389,16 +411,21 @@ public static class IrPasses
     /// between mutations, so each captured string is the tree as that stage left
     /// it. Debug builds validate invariants after every pass, exactly as
     /// <see cref="Run(IrFunction, ImmutableArray{IIrPass})"/> does.
-    /// <paramref name="importMethodBody"/> wires the cross-method import seam;
+    /// </summary>
+    public static IReadOnlyList<PipelineStage> RunWithStages(
+        IrFunction function, ImmutableArray<IIrPass> passes, Func<IrFunction, string> project)
+        => RunWithStages(function, passes, project, importMethodBody: null);
+
+    /// <summary>
+    /// As <see cref="RunWithStages(IrFunction, ImmutableArray{IIrPass}, Func{IrFunction, string})"/>,
+    /// but <paramref name="importMethodBody"/> wires the cross-method import seam;
     /// <c>null</c> uses the shared no-import context (cross-method passes no-op).
     /// </summary>
     public static IReadOnlyList<PipelineStage> RunWithStages(
         IrFunction function, ImmutableArray<IIrPass> passes, Func<IrFunction, string> project,
-        Func<MethodRef, IrFunction?>? importMethodBody = null)
+        Func<MethodRef, IrFunction?>? importMethodBody)
     {
-        var context = importMethodBody is null
-            ? PassContext.None
-            : new PassContext(new Stepper(enabled: false), importMethodBody: importMethodBody);
+        var context = DiagnosticContext(importMethodBody);
         var stages = new List<PipelineStage>(passes.Length + 1)
         {
             new(ImportStageName, project(function), function.Fidelity),
@@ -420,13 +447,18 @@ public static class IrPasses
     /// <see cref="int.MaxValue"/> to record every step without stopping. The
     /// <see cref="StepLimitReachedException"/> is caught here — callers see a
     /// normal return with the partially-transformed <paramref name="function"/>.
+    /// </summary>
+    public static Stepper RunWithSteps(IrFunction function, int stepLimit = int.MaxValue)
+        => RunWithSteps(function, stepLimit, importMethodBody: null);
+
+    /// <summary>
+    /// As <see cref="RunWithSteps(IrFunction, int)"/>, but
     /// <paramref name="importMethodBody"/> wires the cross-method import seam so
     /// cross-method passes step through their rewrites in the stepper view as
     /// they do in the product path; <c>null</c> leaves them no-ops.
     /// </summary>
     public static Stepper RunWithSteps(
-        IrFunction function, int stepLimit = int.MaxValue,
-        Func<MethodRef, IrFunction?>? importMethodBody = null)
+        IrFunction function, int stepLimit, Func<MethodRef, IrFunction?>? importMethodBody)
     {
         var stepper = new Stepper(enabled: true) { StepLimit = stepLimit };
         var context = new PassContext(stepper, importMethodBody: importMethodBody);

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -350,17 +350,6 @@ public static class IrPasses
     public static void Run(IrFunction function, ImmutableArray<IIrPass> passes)
         => Run(function, passes, PassContext.None);
 
-    /// <summary>
-    /// As <see cref="Run(IrFunction, ImmutableArray{IIrPass})"/>, but wires the
-    /// cross-method import seam so cross-method passes (classic-async / iterator /
-    /// lambda / local-function reconstruction) run as they do in the product path.
-    /// <c>null</c> leaves them no-ops (the shared no-import context). Used by the
-    /// single-method diagnostic dump paths so they match the shipped output.
-    /// </summary>
-    public static void Run(
-        IrFunction function, ImmutableArray<IIrPass> passes, Func<MethodRef, IrFunction?>? importMethodBody)
-        => Run(function, passes, DiagnosticContext(importMethodBody));
-
     public static void Run(IrFunction function, ImmutableArray<IIrPass> passes, PassContext context)
     {
         foreach (var pass in passes)
@@ -369,17 +358,6 @@ public static class IrPasses
             function.CheckInvariant();
         }
     }
-
-    /// <summary>
-    /// A non-stepping context that carries the cross-method import seam for the
-    /// diagnostic dump paths, or <see cref="PassContext.None"/> when no seam is
-    /// wired. The stepper stays disabled — this is for the staged/tree dumps, not
-    /// <see cref="RunWithSteps(IrFunction, int)"/> which needs an enabled stepper.
-    /// </summary>
-    static PassContext DiagnosticContext(Func<MethodRef, IrFunction?>? importMethodBody)
-        => importMethodBody is null
-            ? PassContext.None
-            : new PassContext(new Stepper(enabled: false), importMethodBody: importMethodBody);
 
     /// <summary>The synthetic stage name for the importer output — the pre-transform tree, before any pass runs.</summary>
     public const string ImportStageName = "(import)";
@@ -425,7 +403,7 @@ public static class IrPasses
         IrFunction function, ImmutableArray<IIrPass> passes, Func<IrFunction, string> project,
         Func<MethodRef, IrFunction?>? importMethodBody)
     {
-        var context = DiagnosticContext(importMethodBody);
+        var context = PassContext.ForImport(importMethodBody);
         var stages = new List<PipelineStage>(passes.Length + 1)
         {
             new(ImportStageName, project(function), function.Fidelity),

--- a/src/ILInspector.Decompiler/Pipeline/PipelineStages.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PipelineStages.cs
@@ -227,11 +227,13 @@ public static class StageDump
                 }
             }
 
-            sb.Append(Format(IrPasses.RunWithStages(function)));
+            sb.Append(Format(IrPasses.RunWithStages(function, method => IrImporter.Import(source, method))));
 
             sb.AppendLine();
             // RunWithStages above ran the canonical Default pass list on
-            // `function`, so it is now fully raised. Printing it here is
+            // `function` with the cross-method import seam wired (so cross-method
+            // passes such as classic-async reconstruction run exactly as in the
+            // product path), so it is now fully raised. Printing it here is
             // byte-identical to CSharpPrinter.PrintRaised(import) — i.e. this is
             // the exact C# the shipped product emits, not an intermediate view.
             sb.AppendLine("==== C# (raised — the shipped product output) ====");

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -817,6 +817,16 @@ static class Program
         }
     }
 
+    /// <summary>
+    /// The cross-method import seam for the single-method diagnostic dumps: lets
+    /// cross-method passes (classic-async / iterator / lambda / local-function
+    /// reconstruction) pull in sibling bodies so the dump matches the shipped
+    /// product output. Mirrors the delegate the product path wires in
+    /// <c>TypeSourceComposer</c>.
+    /// </summary>
+    static Func<MethodRef, IrFunction?> ImportSeam(MetadataSource source)
+        => method => IrImporter.Import(source, method);
+
     /// <summary>Stage dump through the pipeline: the IR tree with diagnostics and fidelity (with <paramref name="view"/> = Full, the annotated-IL import views too).</summary>
     static int Dump(List<string> assemblies, string dumpMethod, int overloadIndex, StageDumpView view, bool skipPdb = false, bool simulate = false)
     {
@@ -866,7 +876,7 @@ static class Program
                 continue;
 
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, per-pass diff)");
-            Console.Write(StageDump.FormatDiff(IrPasses.RunWithStages(function)));
+            Console.Write(StageDump.FormatDiff(IrPasses.RunWithStages(function, ImportSeam(source))));
             return 0;
         }
         return Fail($"Method '{dumpMethod}' not found (or has no IL body) in the given assemblies.");
@@ -892,7 +902,7 @@ static class Program
 
             string where = stepLimit == int.MaxValue ? "all steps" : $"replay to step {stepLimit}";
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, {where})");
-            var stepper = IrPasses.RunWithSteps(function, stepLimit, method => IrImporter.Import(source, method));
+            var stepper = IrPasses.RunWithSteps(function, stepLimit, ImportSeam(source));
 
             Console.WriteLine();
             Console.WriteLine($"==== steps ({stepper.Count} recorded) ====");
@@ -937,7 +947,7 @@ static class Program
                 continue;
 
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, assertions)");
-            var stages = IrPasses.RunWithStages(function, IrPasses.Default, new AssertionPrinter.StatefulPrinter().Dump);
+            var stages = IrPasses.RunWithStages(function, IrPasses.Default, new AssertionPrinter.StatefulPrinter().Dump, ImportSeam(source));
             Console.Write(StageDump.Format(stages));
             return 0;
         }
@@ -968,7 +978,7 @@ static class Program
             if (function is null)
                 continue;
 
-            IrPasses.Run(function);  // raise through the canonical pipeline, as the product does
+            IrPasses.Run(function, IrPasses.Default, ImportSeam(source));  // raise through the canonical pipeline, as the product does
             var facts = CSharpPrinter.CollectDataflowFacts(function);
 
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, definite-assignment facts)");
@@ -1030,7 +1040,7 @@ static class Program
             if (function is null)
                 continue;
 
-            IrPasses.Run(function);  // raise through the canonical pipeline, as the product does
+            IrPasses.Run(function, IrPasses.Default, ImportSeam(source));  // raise through the canonical pipeline, as the product does
             var remarks = FidelityRemarks.Collect(function);
 
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, fidelity remarks)");
@@ -1085,7 +1095,7 @@ static class Program
             if (function is null)
                 continue;
 
-            IrPasses.Run(function, IrPasses.Lowered);  // lower, but stop short of the cosmetic sugar
+            IrPasses.Run(function, IrPasses.Lowered, ImportSeam(source));  // lower, but stop short of the cosmetic sugar
             var facts = CSharpPrinter.CollectDataflowFacts(function);
             var body = CSharpPrinter.Print(function).Output;
 
@@ -1128,7 +1138,7 @@ static class Program
             if (function is null)
                 continue;
 
-            IrPasses.Run(function);  // raise through the canonical pipeline, as the product does
+            IrPasses.Run(function, IrPasses.Default, ImportSeam(source));  // raise through the canonical pipeline, as the product does
 
             string form = mermaid ? "mermaid flowchart" : "control-flow graph";
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, {form})");

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -978,7 +978,7 @@ static class Program
             if (function is null)
                 continue;
 
-            IrPasses.Run(function, IrPasses.Default, ImportSeam(source));  // raise through the canonical pipeline, as the product does
+            IrPasses.Run(function, IrPasses.Default, PassContext.ForImport(ImportSeam(source)));  // raise through the canonical pipeline, as the product does
             var facts = CSharpPrinter.CollectDataflowFacts(function);
 
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, definite-assignment facts)");
@@ -1040,7 +1040,7 @@ static class Program
             if (function is null)
                 continue;
 
-            IrPasses.Run(function, IrPasses.Default, ImportSeam(source));  // raise through the canonical pipeline, as the product does
+            IrPasses.Run(function, IrPasses.Default, PassContext.ForImport(ImportSeam(source)));  // raise through the canonical pipeline, as the product does
             var remarks = FidelityRemarks.Collect(function);
 
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, fidelity remarks)");
@@ -1095,7 +1095,7 @@ static class Program
             if (function is null)
                 continue;
 
-            IrPasses.Run(function, IrPasses.Lowered, ImportSeam(source));  // lower, but stop short of the cosmetic sugar
+            IrPasses.Run(function, IrPasses.Lowered, PassContext.ForImport(ImportSeam(source)));  // lower, but stop short of the cosmetic sugar
             var facts = CSharpPrinter.CollectDataflowFacts(function);
             var body = CSharpPrinter.Print(function).Output;
 
@@ -1138,7 +1138,7 @@ static class Program
             if (function is null)
                 continue;
 
-            IrPasses.Run(function, IrPasses.Default, ImportSeam(source));  // raise through the canonical pipeline, as the product does
+            IrPasses.Run(function, IrPasses.Default, PassContext.ForImport(ImportSeam(source)));  // raise through the canonical pipeline, as the product does
 
             string form = mermaid ? "mermaid flowchart" : "control-flow graph";
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, {form})");

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -892,7 +892,7 @@ static class Program
 
             string where = stepLimit == int.MaxValue ? "all steps" : $"replay to step {stepLimit}";
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, {where})");
-            var stepper = IrPasses.RunWithSteps(function, stepLimit);
+            var stepper = IrPasses.RunWithSteps(function, stepLimit, method => IrImporter.Import(source, method));
 
             Console.WriteLine();
             Console.WriteLine($"==== steps ({stepper.Count} recorded) ====");


### PR DESCRIPTION
## Summary

Fixes #2253. The stage-dump (`--dump`) and stepper (`--steps`) diagnostics ran the pipeline with **no `ImportMethodBody` delegate**, so `ClassicAsyncReconstructionPass` short-circuited (it no-ops when `context.ImportMethodBody` is null). Classic (runtime-async=off) async methods were shown **un-raised** — the lowered `MoveNext` state machine, not the recovered `await` — diverging from shipped product output, which already wires the seam via `CSharpPrinter.PrintRaised` / `TypeSourceComposer`.

Thread an optional `importMethodBody` delegate through `IrPasses.RunWithStages` and `IrPasses.RunWithSteps`, and pass `method => IrImporter.Import(source, method)` (the exact delegate the product path uses) from `StageDump.DumpMethod` (`--dump`) and `DumpSteps` (`--steps`).

## Product output is unchanged

The delegate defaults to `null`, preserving exact prior behavior for every other caller (tests, direct pass runs). Only the two diagnostic entry points now pass a delegate; `CSharpPrinter`/`TypeSourceComposer` (the shipped decompile path) are untouched — so **no raise/structuring/printer semantics change and no render-text A/B is needed**. `RunWithStages`/`RunWithSteps` have no other production callers.

## Evidence

- Before: dumping a classic-async method showed the state-machine kickoff (`AsyncTaskMethodBuilder`, `return V_0.<>t__builder.Task;`) at `Partial` fidelity.
- After (same method): final IR is `AwaitExpression` over `Call Task.FromResult`, raised C# `return await Task.FromResult<int>(42);`, fidelity `Full`. `--steps` now records `[4] reconstruct classic async 'AwaitExpression' from ...MoveNext`.
- `PipelineStageTests` + `StageDiffTests` + `StepperTests` + `ClassicAsyncReconstructionPassTests`: 45/45 pass.
- Full fast decompiler suite (`-trait- "Speed=Slow"`): **1835/0**.

Also corrects the `DumpMethod` "byte-identical to shipped product output" comment, which is now accurate for classic-async too.

## Review

Decompiler product change (diagnostic wiring). Requesting two-model adversarial review per policy; will reconcile on the PR.
