### PR TITLE
Fix classic async reconstruction in diagnostic paths

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ClassicAsyncTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ClassicAsyncTests.cs
@@ -15,8 +15,7 @@ public class ClassicAsyncTests
         if (!File.Exists(fixturePath))
             fixturePath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "artifacts", "bin", "ILInspector.Decompiler.Fixtures.ClassicAsync", "release", "ILInspector.Decompiler.Fixtures.ClassicAsync.dll");
             
-        if (!File.Exists(fixturePath))
-            return;
+        Assert.True(File.Exists(fixturePath), "ClassicAsync fixture DLL not found");
 
         var source = MetadataSource.OpenWithoutSymbols(fixturePath);
         var dump = StageDump.DumpMethod(source, "ILInspector.Decompiler.Fixtures.ClassicAsync.AsyncFixtures", "AwaitValue");

--- a/src/ILInspector.Decompiler.Tests/ClassicAsyncTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ClassicAsyncTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ClassicAsyncTests
+{
+    [Fact]
+    public void DumpMethod_WithClassicAsync_ResolvesImportAndReconstructsAwait()
+    {
+        string fixturePath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "artifacts", "bin", "ILInspector.Decompiler.Fixtures.ClassicAsync", "release", "ILInspector.Decompiler.Fixtures.ClassicAsync.dll");
+        if (!File.Exists(fixturePath))
+            fixturePath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "artifacts", "bin", "ILInspector.Decompiler.Fixtures.ClassicAsync", "release", "ILInspector.Decompiler.Fixtures.ClassicAsync.dll");
+            
+        if (!File.Exists(fixturePath))
+            return;
+
+        var source = MetadataSource.OpenWithoutSymbols(fixturePath);
+        var dump = StageDump.DumpMethod(source, "ILInspector.Decompiler.Fixtures.ClassicAsync.AsyncFixtures", "AwaitValue");
+        
+        Assert.NotNull(dump.Output);
+        Assert.Contains("AwaitExpression", dump.Output);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\ILInspector.Research\ILInspector.Research.csproj" />
     <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LegacyUnsafe\ILInspector.Decompiler.Fixtures.LegacyUnsafe.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.ClassicAsync\ILInspector.Decompiler.Fixtures.ClassicAsync.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.NewUnsafe\ILInspector.Decompiler.Fixtures.NewUnsafe.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainA\ILInspector.Decompiler.Fixtures.UnsafeChainA.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainB\ILInspector.Decompiler.Fixtures.UnsafeChainB.csproj" />

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -369,8 +369,8 @@ public static class IrPasses
     /// per stage, so the harness and the CLI share identical boundaries rather
     /// than each re-deriving them (docs/decompiler.md).
     /// </summary>
-    public static IReadOnlyList<PipelineStage> RunWithStages(IrFunction function)
-        => RunWithStages(function, Default, IrPrinter.Dump);
+    public static IReadOnlyList<PipelineStage> RunWithStages(IrFunction function, PassContext? context = null)
+        => RunWithStages(function, Default, IrPrinter.Dump, context);
 
     /// <summary>
     /// Runs <paramref name="passes"/>, capturing <paramref name="project"/>'s
@@ -380,7 +380,7 @@ public static class IrPasses
     /// <see cref="Run(IrFunction, ImmutableArray{IIrPass})"/> does.
     /// </summary>
     public static IReadOnlyList<PipelineStage> RunWithStages(
-        IrFunction function, ImmutableArray<IIrPass> passes, Func<IrFunction, string> project)
+        IrFunction function, ImmutableArray<IIrPass> passes, Func<IrFunction, string> project, PassContext? context = null)
     {
         var stages = new List<PipelineStage>(passes.Length + 1)
         {
@@ -388,7 +388,7 @@ public static class IrPasses
         };
         foreach (var pass in passes)
         {
-            pass.Run(function, PassContext.None);
+            pass.Run(function, context ?? PassContext.None);
             function.CheckInvariant();
             stages.Add(new(pass.Name, project(function), function.Fidelity));
         }
@@ -404,10 +404,10 @@ public static class IrPasses
     /// <see cref="StepLimitReachedException"/> is caught here — callers see a
     /// normal return with the partially-transformed <paramref name="function"/>.
     /// </summary>
-    public static Stepper RunWithSteps(IrFunction function, int stepLimit = int.MaxValue)
+    public static Stepper RunWithSteps(IrFunction function, int stepLimit = int.MaxValue, Func<MethodRef, IrFunction?>? importMethodBody = null)
     {
         var stepper = new Stepper(enabled: true) { StepLimit = stepLimit };
-        var context = new PassContext(stepper);
+        var context = new PassContext(stepper, importMethodBody: importMethodBody);
         try
         {
             foreach (var pass in Default)

--- a/src/ILInspector.Decompiler/Pipeline/PipelineStages.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PipelineStages.cs
@@ -227,7 +227,7 @@ public static class StageDump
                 }
             }
 
-            sb.Append(Format(IrPasses.RunWithStages(function)));
+            sb.Append(Format(IrPasses.RunWithStages(function, new PassContext(new Stepper(enabled: false), importMethodBody: refMethod => IrImporter.Import(source, refMethod)))));
 
             sb.AppendLine();
             // RunWithStages above ran the canonical Default pass list on

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -649,7 +649,7 @@ static class Program
                 IReadOnlyList<PipelineStage> stages;
                 try
                 {
-                    stages = IrPasses.RunWithStages(function);
+                    stages = IrPasses.RunWithStages(function, new PassContext(new Stepper(enabled: false), importMethodBody: refMethod => IrImporter.Import(source, refMethod)));
                 }
                 catch (Exception ex)
                 {
@@ -876,7 +876,7 @@ static class Program
                 continue;
 
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, per-pass diff)");
-            Console.Write(StageDump.FormatDiff(IrPasses.RunWithStages(function)));
+            Console.Write(StageDump.FormatDiff(IrPasses.RunWithStages(function, new PassContext(new Stepper(enabled: false), importMethodBody: refMethod => IrImporter.Import(source, refMethod)))));
             return 0;
         }
         return Fail($"Method '{dumpMethod}' not found (or has no IL body) in the given assemblies.");
@@ -947,7 +947,7 @@ static class Program
                 continue;
 
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, assertions)");
-            var stages = IrPasses.RunWithStages(function, IrPasses.Default, new AssertionPrinter.StatefulPrinter().Dump);
+            var stages = IrPasses.RunWithStages(function, IrPasses.Default, new AssertionPrinter.StatefulPrinter().Dump, new PassContext(new Stepper(enabled: false), importMethodBody: refMethod => IrImporter.Import(source, refMethod)));
             Console.Write(StageDump.Format(stages));
             return 0;
         }

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -902,7 +902,7 @@ static class Program
 
             string where = stepLimit == int.MaxValue ? "all steps" : $"replay to step {stepLimit}";
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, {where})");
-            var stepper = IrPasses.RunWithSteps(function, stepLimit);
+            var stepper = IrPasses.RunWithSteps(function, stepLimit, refMethod => IrImporter.Import(source, refMethod));
 
             Console.WriteLine();
             Console.WriteLine($"==== steps ({stepper.Count} recorded) ====");


### PR DESCRIPTION
## Problem

The stage-dump and stepper diagnostic paths run the pass pipeline without an `ImportMethodBody` delegate. As a result, `ClassicAsyncReconstructionPass` silently short-circuited and classic (runtime-async=off) async methods were shown un-raised (lowered `MoveNext` state machine) rather than recovered `await`s. This made the diagnostics diverge from the shipped product output and left a blind spot when verifying classic-async behaviors using `--dump` and `--steps`.

## Fix

- Updated `IrPasses.RunWithStages` and `IrPasses.RunWithSteps` to accept an optional `ImportMethodBody` delegate, threading it into the `PassContext`.
- Updated `StageDump.DumpMethod` and `DecompilerHarness` (across `--dump`, `--steps`, `--diff`, `--assertions`, and `--pass-impact`) to wire up `IrImporter.Import` back to the same `MetadataSource` when passing the context, matching what the full product pipeline does.
- Added `ClassicAsyncTests.DumpMethod_WithClassicAsync_ResolvesImportAndReconstructsAwait` to verify that `StageDump.DumpMethod` correctly reconstructs `AwaitExpression` nodes for a known classic async fixture method.

Fixes #2253.