### PR TITLE
Bump Markout to 0.15.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Markout" Version="0.14.0" />
+    <PackageVersion Include="Markout" Version="0.15.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />


### PR DESCRIPTION
Updates the `Markout` package `0.14.0` → `0.15.0`.

## What's in 0.15.0

Markout reshaped the `TreeNode` constructor (richlander/markout#118, richlander/markout#119): `Badge` became a property and children moved to a single `TreeNode(string text, IEnumerable<TreeNode>? children = null)` constructor. Breaking-change notice: richlander/markout#120.

## Impact here: none (non-breaking)

Every `TreeNode` site in dotnet-inspect already builds nodes as `new TreeNode(label)` plus a `{ Children = list }` object initializer, and never called the removed `(text, badge, …)` overloads. The solution builds with **no code changes**, and the `OutputFormatterTests` suite passes (90 tests).

## TreeNode pattern evaluation (requested)

The `{ Children = list }` initializer originated as a workaround for the old `(text, badge, params ReadOnlySpan<TreeNode>)` constructor, which couldn't take a `List<TreeNode>` without `new TreeNode(label, null, [..list])`. Under 0.15.0 it is **still the right pattern for this codebase**, so it is intentionally kept:

- **Zero-copy.** The new constructor does `children?.ToList()`. dotnet-inspect's recursive builders (`ToTreeNodes`, `BuildTreeNodes`, `BuildNestedNodes`, …) already produce a fresh child list per node; assigning it by reference avoids a redundant per-node copy.
- **Semantically exact.** The `count > 0 ? … { Children = list } : new TreeNode(label)` shape keeps `Children == null` for leaves. Switching to `new TreeNode(label, children)` and collapsing the ternary would make empty children a non-null `[]` — identical for tree rendering, but different in JSON output.

So the ergonomic win of the Markout change lands for new code (`new TreeNode(text, [children])`) without churning ~20 call sites here into a form that allocates more.

## Verification

- `dotnet restore`/`build src/dotnet-inspect` against 0.15.0 — succeeds, 0 warnings, 0 code changes.
- `dotnet-inspect.Tests` `-class "*OutputFormatterTests"` — 90 passed, 0 failed.
