### PR TITLE
Assertion lane: OBLIGATION (informational) vs UNSOUND (error) by stage (#2269)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
@@ -204,6 +204,47 @@ public class AssertionScanTests
         Assert.Empty(AssertionScan.InvalidFixtureGuaranteeIds());
     }
 
+    [Fact]
+    public void AssertionPrinter_MarksNonFinalStagesObligation_FinalStageUnsound()
+    {
+        // A LoadArgument occupying an enum sink with no Coerce is an undischarged
+        // typing assertion. Across stages it should read as an informational
+        // OBLIGATION until the final stage, where an undischarged survivor is the
+        // real UNSOUND soundness failure. (#2269)
+        var function = Function(
+            Returning(new LoadArgument(0, "raw", Int32)),
+            Enum32,
+            new Parameter("raw", Int32));
+
+        var printer = new AssertionPrinter.StatefulPrinter(totalStages: 3);
+        var stage1 = printer.Dump(function);
+        var stage2 = printer.Dump(function);
+        var stageFinal = printer.Dump(function);
+
+        Assert.Contains("OBLIGATION (informational)", stage1);
+        Assert.DoesNotContain("UNSOUND", stage1);
+        Assert.Contains("OBLIGATION (informational)", stage2);
+        Assert.DoesNotContain("UNSOUND", stage2);
+
+        Assert.Contains("UNSOUND (error)", stageFinal);
+        Assert.Contains("FIRST UNSOUND SURVIVOR", stageFinal);
+        Assert.DoesNotContain("OBLIGATION", stageFinal);
+    }
+
+    [Fact]
+    public void AssertionPrinter_DefaultSingleStage_TreatsViolationAsUnsound()
+    {
+        var function = Function(
+            Returning(new LoadArgument(0, "raw", Int32)),
+            Enum32,
+            new Parameter("raw", Int32));
+
+        var dump = new AssertionPrinter.StatefulPrinter().Dump(function);
+
+        Assert.Contains("UNSOUND (error)", dump);
+        Assert.DoesNotContain("OBLIGATION", dump);
+    }
+
     static IrFunction Function(BlockContainer body, TypeRef returnType, params Parameter[] parameters)
         => new(
             "M",

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -69,6 +69,8 @@
              Link="ValidityCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AssertionEvaluator.cs"
              Link="AssertionEvaluator.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\AssertionPrinter.cs"
+             Link="AssertionPrinter.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AssertionScan.cs"
              Link="AssertionScan.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AnnotationCheck.cs"

--- a/tools/DecompilerHarness/AssertionPrinter.cs
+++ b/tools/DecompilerHarness/AssertionPrinter.cs
@@ -10,13 +10,33 @@ namespace ILInspector.DecompilerHarness;
 
 public static class AssertionPrinter
 {
-    // Need a stateful object to track the first violation across pipeline stages
+    // Need a stateful object to track stage position + the first unsound survivor
+    // across pipeline stages. An undischarged typing assertion at a non-final
+    // stage is an OBLIGATION (informational): the rewrite accrued a typing claim
+    // that a downstream pass is contracted to discharge (e.g. coercion insertion
+    // wrapping the sink). Only an assertion that survives to the FINAL stage is
+    // UNSOUND (error) — nothing downstream remains to discharge it, so the
+    // rendered output leans on an unproven claim. See issue #2269.
     public sealed class StatefulPrinter
     {
-        bool _firstViolationFlagged;
+        readonly int _finalStage;
+        int _stage;
+        bool _firstUnsoundFlagged;
+
+        /// <param name="totalStages">
+        /// The number of projection calls the pipeline will make — the importer
+        /// boundary plus one per pass (<c>IrPasses.Default.Length + 1</c>). The
+        /// last call is the final stage, where an undischarged assertion is
+        /// <c>UNSOUND</c> rather than an <c>OBLIGATION</c>. Defaults to 1 (every
+        /// stage treated as final) for single-stage callers.
+        /// </param>
+        public StatefulPrinter(int totalStages = 1)
+            => _finalStage = totalStages;
 
         public string Dump(IrFunction function)
         {
+            _stage++;
+            bool isFinalStage = _stage >= _finalStage;
             var sb = new StringBuilder();
 
             var allViolations = AssertionEvaluator.EvaluateAssumptions(function)
@@ -50,9 +70,20 @@ public static class AssertionPrinter
                 var related = allViolations.FirstOrDefault(v => ReferenceEquals(v.Node, node));
                 if (related.Node != null)
                 {
-                    var highlight = !_firstViolationFlagged ? "  <-- FIRST UNSOUND REWRITE" : "";
-                    _firstViolationFlagged = true;
-                    sb.Append(' ', indent * 2).AppendLine($"// ❌ UNSOUND: {related.Message}{highlight}");
+                    if (isFinalStage)
+                    {
+                        // Survived to the final stage: nothing downstream remains
+                        // to discharge it — a real soundness failure.
+                        var highlight = !_firstUnsoundFlagged ? "  <-- FIRST UNSOUND SURVIVOR" : "";
+                        _firstUnsoundFlagged = true;
+                        sb.Append(' ', indent * 2).AppendLine($"// ❌ UNSOUND (error): {related.Message}{highlight}");
+                    }
+                    else
+                    {
+                        // Stage-relative: a downstream pass is contracted to
+                        // discharge this typing obligation before the final stage.
+                        sb.Append(' ', indent * 2).AppendLine($"// OBLIGATION (informational): {related.Message}");
+                    }
                 }
 
                 foreach (var child in node.Children)

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -957,7 +957,8 @@ static class Program
                 continue;
 
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, assertions)");
-            var stages = IrPasses.RunWithStages(function, IrPasses.Default, new AssertionPrinter.StatefulPrinter().Dump, ImportSeam(source));
+            var printer = new AssertionPrinter.StatefulPrinter(IrPasses.Default.Length + 1);
+            var stages = IrPasses.RunWithStages(function, IrPasses.Default, printer.Dump, ImportSeam(source));
             Console.Write(StageDump.Format(stages));
             return 0;
         }

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -28,6 +28,16 @@ quality-diff card; see
 [docs/decompiler-raise-discipline.md](../../docs/decompiler-raise-discipline.md)
 for the assertion-dump discipline.
 
+`--dump --assertions` marks undischarged typing assertions by *where* they are
+observed. At a non-final stage it prints `OBLIGATION (informational)` — the
+rewrite accrued a typing claim a downstream pass is contracted to discharge (e.g.
+coercion insertion wrapping the sink), so a mid-pipeline marker is bookkeeping,
+not a defect. Only an assertion that survives to the **final** stage prints
+`❌ UNSOUND (error)` (the first one flagged `FIRST UNSOUND SURVIVOR`): nothing
+downstream remains to discharge it, so the rendered output leans on an unproven
+claim. "Final stage is zero UNSOUND" is the real soundness statement; the
+intermediate obligations are the pipeline working as designed.
+
 Add `--assertion-fixture-guarantee` to materialize the generated inverse-node
 fixture assembly and include it in annotation coverage. The report prints a
 per-node guarantee summary and any node the fixture no longer produces as a


### PR DESCRIPTION
## Summary

Fixes the core of #2269. The `--dump --assertions` view printed the same `UNSOUND` marker for two very different facts:

1. A typing assertion undischarged at an **intermediate** stage but wrapped by a later pass (e.g. `CoercionInsertionPass` runs after `SlotMaterializationPass`) — the pipeline working as designed.
2. An assertion **surviving to the final stage** — the real soundness failure.

Because both printed identically, every reader (including two adversarial reviewers this session) had to re-derive the distinction from pipeline order. This splits the marker by *where* it is observed:

- **`OBLIGATION (informational)`** — any non-final stage. The rewrite accrued a typing claim a downstream pass is contracted to discharge.
- **`❌ UNSOUND (error)`** — survives to the final stage; first flagged `FIRST UNSOUND SURVIVOR`.

`AssertionPrinter.StatefulPrinter` now takes the total stage count (`IrPasses.Default.Length + 1`) and treats only the last projection call as the final stage.

## Evidence

- `--dump --assertions` on the `CoercedEnum` fixture (`(Choice)value`): the enum-sink `LoadArgument` reads `OBLIGATION (informational)` across 75 intermediate stage-lines and **0 `UNSOUND`** — the final stage shows `Coerce Choice` wrapping it (obligation discharged).
- New tests: `AssertionPrinter_MarksNonFinalStagesObligation_FinalStageUnsound` (intermediate → OBLIGATION, final → UNSOUND + `FIRST UNSOUND SURVIVOR`) and `AssertionPrinter_DefaultSingleStage_TreatsViolationAsUnsound`.
- `AssertionScanTests` 11/11; fast decompiler suite **1845/0**; `markdownlint` clean.

## Scope

Harness/test only (`AssertionPrinter`, `DumpAssertions` wiring, test-project link, README); **no product code**. Follow-ups from #2269 (not here): gate `--assertion-scan` on final-stage survivors corpus-wide; obligation-lifetime metric; name the discharging pass (`OBLIGATION (discharged by coercion-insertion)`).

## The memory-safety parallel

Per the issue: this is an effect system over pipeline stages, the way `RequiresUnsafe` is an effect system over the call graph — an intermediate `OBLIGATION` *propagates* the typing claim downstream, a discharging pass *encapsulates* it, and only an obligation that escapes to the final stage is `UNSOUND`. "Final stage is zero" ≙ "the public surface is safe."

## Review

Two-model adversarial review complete (both a different model family than the author): **GPT-5.5** and **Gemini 3.1 Pro**, each in its own isolated worktree — **both clean, no blocking findings**. They verified the crux (final-stage detection is exact: `IrPasses.RunWithStages` calls the projector `passes.Length + 1` times, so 75 passes → 76 stages, final = `after coercion-insertion`), the discharge case (`CoercedEnum`: 75 `OBLIGATION` / **0** `UNSOUND`, final stage shows `Coerce Choice`), both new tests, and no cross-method state leakage. One dismissed nit (the `IrPasses.Default.Length + 1` coupling — acceptable for a harness). Full reconciliation in the PR comment. Harness/test-only, no product code. **Ready to merge.**

