### PR TITLE
Wire cross-method import seam into --pass-impact

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ClassicAsyncTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ClassicAsyncTests.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ClassicAsyncTests
+{
+    [Fact]
+    public void DumpMethod_WithClassicAsync_ResolvesImportAndReconstructsAwait()
+    {
+        string fixturePath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "artifacts", "bin", "ILInspector.Decompiler.Fixtures.ClassicAsync", "release", "ILInspector.Decompiler.Fixtures.ClassicAsync.dll");
+        if (!File.Exists(fixturePath))
+            fixturePath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "artifacts", "bin", "ILInspector.Decompiler.Fixtures.ClassicAsync", "release", "ILInspector.Decompiler.Fixtures.ClassicAsync.dll");
+            
+        Assert.True(File.Exists(fixturePath), "ClassicAsync fixture DLL not found");
+
+        var source = MetadataSource.OpenWithoutSymbols(fixturePath);
+        var dump = StageDump.DumpMethod(source, "ILInspector.Decompiler.Fixtures.ClassicAsync.AsyncFixtures", "AwaitValue");
+        
+        Assert.NotNull(dump.Output);
+        Assert.Contains("AwaitExpression", dump.Output);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\ILInspector.Research\ILInspector.Research.csproj" />
     <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LegacyUnsafe\ILInspector.Decompiler.Fixtures.LegacyUnsafe.csproj" />
+    <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.ClassicAsync\ILInspector.Decompiler.Fixtures.ClassicAsync.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.NewUnsafe\ILInspector.Decompiler.Fixtures.NewUnsafe.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainA\ILInspector.Decompiler.Fixtures.UnsafeChainA.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.UnsafeChainB\ILInspector.Decompiler.Fixtures.UnsafeChainB.csproj" />

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -649,7 +649,7 @@ static class Program
                 IReadOnlyList<PipelineStage> stages;
                 try
                 {
-                    stages = IrPasses.RunWithStages(function);
+                    stages = IrPasses.RunWithStages(function, ImportSeam(source));
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Problem

Issue #2253 reported that `--dump` and `--steps` diagnostic paths skip `ClassicAsyncReconstructionPass`. This was fixed in #2263, which correctly updated `--dump`, `--steps`, `--diff`, and `--assertions` to use the `ImportMethodBody` delegate. However, the `--pass-impact` mode was missed and continued to run `IrPasses.RunWithStages` without the delegate.

## Fix

- Updated `PassImpact` in `DecompilerHarness/Program.cs` to pass `ImportSeam(source)` into `RunWithStages`.
- Added `ClassicAsyncTests.DumpMethod_WithClassicAsync_ResolvesImportAndReconstructsAwait` to guarantee diagnostic dumps correctly reconstruct `AwaitExpression` nodes for a known classic async fixture method, guarding against future regressions.

Fixes the remainder of #2253.
