### PR TITLE
Promote exact RTS shape frontier

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -875,8 +875,8 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("minimal.while-loop", report);
         Assert.Contains("minimal.do-while", report);
         Assert.Contains("minimal.switch-int", report);
+        Assert.Contains("minimal.conditional-expression-shape-frontier", report);
         Assert.DoesNotContain("minimal.switch-two-case-lowers-if", report);
-        Assert.DoesNotContain("minimal.conditional-expression-shape-frontier", report);
         Assert.Contains("decompiler=Full", report);
         Assert.Contains("compile-back=Exact", report);
         Assert.Contains("shape=ForStatement", report);
@@ -893,6 +893,7 @@ public class GeneratedFixtureCatalogTests
         AssertShape(run, "minimal.while-loop", "Method1", SyntaxKind.WhileStatement);
         AssertShape(run, "minimal.do-while", "Method1", SyntaxKind.DoStatement);
         AssertShape(run, "minimal.switch-int", "Method1", SyntaxKind.SwitchStatement);
+        AssertShape(run, "minimal.conditional-expression-shape-frontier", "Method1", SyntaxKind.ReturnStatement);
     }
 
     [Fact]
@@ -1068,7 +1069,7 @@ public class GeneratedFixtureCatalogTests
     }
 
     [Fact]
-    public void CompilerLoweringFrontiers_AreSelectableButNotInDefaultRun()
+    public void CompilerLoweringFrontier_IsSelectableButNotInDefaultRun()
     {
         var switchRun = GeneratedFixtureRunner.Run(GeneratedFixtureCatalog.Select("minimal.switch-two-case-lowers-if"));
         string switchReport = GeneratedFixtureRunner.FormatReport(switchRun);
@@ -1089,7 +1090,7 @@ public class GeneratedFixtureCatalogTests
             FidelityCheck.CompileBackStatus.OpcodeDiff,
             frontier: true);
 
-        var shapeRun = GeneratedFixtureRunner.Run(GeneratedFixtureCatalog.Select("minimal.conditional-expression-shape-frontier"));
+        var shapeRun = GeneratedFixtureRunner.Run(GeneratedFixtureCatalog.MinimalCompileBackRungs);
         string shapeReport = GeneratedFixtureRunner.FormatReport(shapeRun);
 
         Assert.True(shapeRun.Passed, shapeReport);
@@ -1118,7 +1119,9 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(GeneratedFixtureCatalog.Frontiers, fixture =>
             fixture.Id == "minimal.switch-two-case-lowers-if" &&
             fixture.Tags.Contains("compiler-lowering"));
-        Assert.Contains(GeneratedFixtureCatalog.Frontiers, fixture =>
+        Assert.DoesNotContain(GeneratedFixtureCatalog.Frontiers, fixture =>
+            fixture.Id == "minimal.conditional-expression-shape-frontier");
+        Assert.Contains(GeneratedFixtureCatalog.MinimalCompileBackRungs, fixture =>
             fixture.Id == "minimal.conditional-expression-shape-frontier" &&
             fixture.Tags.Contains("shape"));
     }

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -1554,12 +1554,12 @@ internal static class GeneratedFixtureCatalog
         MinimalWhileLoop,
         MinimalDoWhileLoop,
         MinimalSwitchInt,
+        MinimalConditionalExpressionShapeFrontier,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> Frontiers { get; } =
     [
         MinimalSwitchTwoCaseLowersIf,
-        MinimalConditionalExpressionShapeFrontier,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> AssertionCoverage { get; } =

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -92,12 +92,12 @@ integer-addition, array-index, array-length, string-length, null-coalescing,
 try/finally, using/dispose, foreach-array, for-loop, while-loop, and do-while
 rungs extend that minimal exact set;
 `minimal.switch-int` adds the first switch statement rung.
+`minimal.conditional-expression-shape-frontier` records a source-shape frontier:
+the conditional-expression source is compile-back exact, but the accepted current
+output is return-statement shaped rather than `ConditionalExpression` shaped.
 `minimal.switch-two-case-lowers-if` records the current SDK's two-case
 source-switch lowering observation (lowered as if/else, not the dense switch
-shape) and is opt-in by ID. `minimal.conditional-expression-shape-frontier`
-records a source-shape frontier: the conditional-expression source is
-compile-back exact, but the accepted current output is return-statement shaped
-rather than `ConditionalExpression` shaped.
+shape) and is opt-in by ID because it is a non-exact compiler-lowering frontier.
 `assertion.inverse-node-coverage` is the deterministic inverse-ledger coverage
 fixture used by `--assertion-fixture-guarantee`; it is addressable by ID but is
 not part of the default stable generated-fixture ladder. With no selector,
@@ -119,7 +119,7 @@ The generated fixture ladder is intentionally staged:
 | Projection | Decompile each target through the shipped raised product path and record the decompiler fidelity grade. |
 | Shape verdict | Parse the rendered body with Roslyn and compare the optional expected `SyntaxKind`. |
 | Compile-back verdict | Recompile the rendered body and compare canonical opcode streams with `FidelityCheck`. |
-| Frontier ledger | Keep expected non-exact or compiler-lowering observations explicit and opt-in. |
+| Frontier ledger | Keep non-exact compiler-lowering observations opt-in; keep source-shape frontiers explicit even when they are compile-back exact. |
 
 **Library report** (`--library-report`): a portfolio view. It combines the IR
 residual buckets from `--gaps` with the Roslyn-backed validity oracle from


### PR DESCRIPTION
- Follow-up to #2230 / #2243
- Changes harness-only generated fixture coverage; product decompiler output is unchanged
- Evidence revision: `dbe7b693`

## Change

**Conclusion:** **PASS** — `minimal.conditional-expression-shape-frontier` is now compile-back exact through ReturnToSender, so the default generated-fixture / RTS ladder now includes it while the non-exact two-case switch compiler-lowering frontier remains opt-in.

Before:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 40 fixture(s), 117 target(s)
```

After:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 41 fixture(s), 119 target(s)
Fixtures: Passed 41, Skipped 0, Failed 0
Targets : Passed 119, Skipped 0, Failed 0
```

## Scope and safety

- **Root cause:** the conditional-expression source-shape frontier was grouped with non-exact opt-in frontiers even though RTS now compiles it back exactly.
- **Fix shape:** move that fixture into `MinimalCompileBackRungs` / default catalog selection, keep `minimal.switch-two-case-lowers-if` in `Frontiers`, and update tests/docs.
- **Product impact:** none; this only changes harness catalog membership, tests, and README wording.
- **Scope boundary:** the conditional-expression body remains a source-shape frontier (`ReturnStatement` accepted, `ConditionalExpression` desired); only the semantic compile-back coverage is promoted.
- **RTS boundary:** RTS remains the closure + Roslyn + opcode-compare harness; no product source-generation path changed.

## Evidence

| Check | Result |
| --- | --- |
| Product build | `dotnet build src/dotnet-inspect -c Release --no-restore --verbosity minimal` passed after repo-config restore |
| Focused tests | `GeneratedFixtureCatalogTests` passed, 8/8 |
| Targeted RTS catalog | `--return-to-sender-catalog --max-examples 5` passed, 41 fixtures / 119 targets |
| Markdown | `npx markdownlint-cli tools/DecompilerHarness/README.md` passed |
| Frontiers | `minimal.switch-two-case-lowers-if` remains opt-in and non-exact |

## Review

No adversarial review requested: this is a low-risk harness-only catalog promotion with no product decompiler behavior change.
