### PR TITLE
docs: assertion lane as a staged effect system

### DIFF
--- a/docs/design/assertion-lane-effects.md
+++ b/docs/design/assertion-lane-effects.md
@@ -1,0 +1,99 @@
+# The assertion lane as a staged effect system
+
+The inverse-architecture assertion lane (see
+[inverse-architecture.md](inverse-architecture.md)) is, structurally, an **effect
+system over pipeline stages**. Naming it that way explains the `OBLIGATION` /
+`UNSOUND` vocabulary introduced in [#2269](https://github.com/richlander/dotnet-inspect/issues/2269),
+gives the markers a theory instead of a convention, and points at a concrete next
+step. This note is the framing; the mechanics live in the harness assertion lane.
+
+## The algebra: accrue, discharge, escape
+
+Every `[InverseOf]` node carries an `assumes:` predicate — a type claim the raw
+type system does not encode. As a value is rewritten across the pipeline, three
+things can happen to that claim:
+
+- **Accrue.** A rewrite mints a node whose `assumes:` predicate does not yet hold
+  — for example, `SlotMaterializationPass` runs before `CoercionInsertionPass`, so
+  for a few stages a minted `LoadLocal` sits at a sink whose target type it does
+  not match. The rewrite has *accrued a typing obligation*.
+- **Discharge.** A downstream pass is contracted to make the claim hold —
+  coercion insertion wraps the sink in a `Coerce`, and the obligation is gone.
+- **Escape.** An obligation that no pass discharged reaches the final stage. The
+  rendered output now leans on a claim nothing justified.
+
+Only *escape* is an error. Accrual and mid-pipeline persistence are the pipeline
+working as designed. That is exactly the `OBLIGATION` (informational, at any
+non-final stage) vs `UNSOUND` (error, a final-stage survivor) split: the marker
+is bookkeeping until it crosses the boundary. **"Final stage is zero `UNSOUND`"**
+is the soundness statement.
+
+## Two lenses
+
+The same algebra reads two ways, and both are worth keeping.
+
+**Memory safety (the evocative lens).** This is the mapping
+[#2269](https://github.com/richlander/dotnet-inspect/issues/2269) draws:
+
+| Memory safety | Assertion lane |
+| --- | --- |
+| `unsafe` propagates the obligation to callers (`RequiresUnsafe`) | an `OBLIGATION` propagates the typing claim down the pipeline |
+| an `unsafe { }` block *encapsulates* — the author discharges it locally | a downstream pass *discharges* the obligation (the claim is now proven) |
+| an unencapsulated unsafe operation escaping a safe boundary | an `UNSOUND` obligation escaping to the final stage |
+
+In both, the mid-flight marker is bookkeeping, not a diagnosis; only crossing the
+boundary undischarged is an error. "Final stage is zero" ≙ "the public surface is
+safe." It also inherits the static half already documented in inverse-architecture.md:
+Rust's [Safety Tags RFC (rust-lang/rfcs#3842)](https://github.com/rust-lang/rfcs/pull/3842)
+and the [Contracts experiment (rust-lang/rust#128044)](https://github.com/rust-lang/rust/issues/128044)
+are the same move from a `//` safety comment to a named, tool-checkable
+obligation that a matching site must discharge.
+
+**Compiler legalization (the mechanically exact lens).** Memory safety's effect
+propagates over the *call graph*; the assertion lane's obligation propagates over
+a *linear sequence of passes*. The "caller" is just "the next pass," and discharge
+is by *contract* — a specific pass is designed to discharge a specific obligation
+class — not by author choice. That makes the closest technical cousin not Rust but
+**dialect legalization / typestate across lowering phases**: MLIR's partial→full
+legalization ("illegal ops must be legalized before this boundary") and the LLVM
+verifier invariants that hold only after certain passes. An intermediate
+`OBLIGATION` is an "illegal-but-scheduled-for-legalization" op; `UNSOUND` is an
+illegal op that reached the legal boundary.
+
+Where the analogy breaks: this is an effect system over a *fixed, ordered* pipeline,
+so it is simpler than a whole-program one — there is exactly one boundary (the final
+stage) and the discharge schedule is static.
+
+## The concrete next step: per-pass effect signatures
+
+Today discharge is **observed**, not **declared**: the lane notices the marker
+disappear between stages. Memory safety's power comes from the obligation being
+*named and matched* — an unsafe operation names the invariant, and a matching
+`unsafe`/tag discharges *that* invariant.
+
+The analogous step here is a **per-pass effect signature**: each pass declares
+which obligation classes it is contracted to discharge (and, optionally, which it
+may accrue). The lane then checks a property strictly stronger than "final stage
+is zero":
+
+> every accrued obligation has a *named* discharger that provably runs before the
+> boundary.
+
+That turns [#2269](https://github.com/richlander/dotnet-inspect/issues/2269)'s
+"name the discharging pass" hint (`OBLIGATION (discharged by coercion-insertion)`)
+from a printed convenience into a checkable contract, and it catches a class the
+observational check cannot: an obligation that happens to be zero on today's
+corpus but has no pass contracted to discharge it — a latent escape.
+
+## Follow-ups
+
+Tracked on [#2269](https://github.com/richlander/dotnet-inspect/issues/2269),
+in rough dependency order:
+
+1. Gate `--assertion-scan` on **final-stage survivors** corpus-wide (today "final
+   stage is zero" is eyeballed from `--dump --assertions` exemplars).
+2. Track **obligation lifetime** — stages between accrual and discharge — as a
+   construction-quality metric. Lifetime trending down means passes decide early
+   rather than retrofitting a claim late.
+3. Attribute discharge to a named pass, then graduate to the per-pass effect
+   signatures above.

--- a/docs/design/assertion-lane-effects.md
+++ b/docs/design/assertion-lane-effects.md
@@ -90,8 +90,13 @@ corpus but has no pass contracted to discharge it — a latent escape.
 Tracked on [#2269](https://github.com/richlander/dotnet-inspect/issues/2269),
 in rough dependency order:
 
-1. Gate `--assertion-scan` on **final-stage survivors** corpus-wide (today "final
-   stage is zero" is eyeballed from `--dump --assertions` exemplars).
+1. **Landed ([#2281](https://github.com/richlander/dotnet-inspect/pull/2281)):**
+   `--assertion-scan` counts **final-stage survivors** corpus-wide — the survivor
+   number, distinct from discharged obligations, is reported and diffable
+   (snapshot schema v2 + survivor delta) instead of eyeballed from
+   `--dump --assertions`. Still open: promote it from a report/diff signal to a
+   hard zero-gate, which needs an allowlist of the known `PrinterOwned` residuals
+   so only *new* survivors fail.
 2. Track **obligation lifetime** — stages between accrual and discharge — as a
    construction-quality metric. Lifetime trending down means passes decide early
    rather than retrofitting a claim late.

--- a/docs/design/inverse-architecture.md
+++ b/docs/design/inverse-architecture.md
@@ -281,9 +281,11 @@ typed → structured → IR after each pass → C#).
 
 An opt-in assertion lane annotates each IR node in that staged view with its
 `[InverseOf]` forward construct and `assumes:` predicate, evaluates the predicate in
-place (the release-capable `Check()` the load-bearing rule requires), and flags the
-first node whose assertion is unsound. Three properties make this more than a pretty
-print:
+place (the release-capable `Check()` the load-bearing rule requires), and marks each
+undischarged assertion by *where* it is observed — an informational `OBLIGATION` at
+any non-final stage (a downstream pass is contracted to discharge it), and an error
+`UNSOUND` only for a survivor at the final stage. Three properties make this more than
+a pretty print:
 
 - **It is the executable failure map.** A method that `OpcodeDiff`s shows a red
   assertion at the first unsound rewrite — the "violated assumption" of the failure
@@ -295,7 +297,8 @@ print:
   insertion; before that there is nothing to check. So the lane reads as claims coming
   into being and being checked at the moment they are made — the dynamic instantiation
   of the node ledger on one method: the stack of type claims a value accumulates as it
-  is rewritten.
+  is rewritten. This staged structure is an effect system — accrue, discharge, escape —
+  described in [assertion-lane-effects.md](assertion-lane-effects.md).
 
 Guardrails: the lane is opt-in, and it lives in the harness, where attribute reflection
 is fine. The shipped decompiler stays SRM-only and NativeAOT-clean — the product


### PR DESCRIPTION
## Summary

Adds `docs/design/assertion-lane-effects.md` — a focused design note framing the inverse-architecture assertion lane as an **effect system over pipeline stages**:

- **The algebra**: a rewrite *accrues* a typing obligation, a downstream pass *discharges* it, and only an obligation that *escapes* to the final stage is `UNSOUND`. This is the theory behind the `OBLIGATION` / `UNSOUND` vocabulary from #2269 (implemented in #2271).
- **Two lenses**: memory safety (the evocative one #2269 draws — `unsafe` propagate / `unsafe {}` encapsulate / unencapsulated escape) and **compiler dialect legalization / typestate across lowering phases** (the mechanically exact one — the effect propagates over a linear pass sequence, not the call graph, and discharge is by contract). Notes where the analogy breaks.
- **The concrete next step**: per-pass **effect signatures** — each pass declares which obligation classes it discharges — turning "final stage is zero" (observational) into "every accrued obligation has a named, provably-scheduled discharger" (structural), which catches latent escapes the observational check cannot.
- **Follow-ups** already tracked on #2269 (scan gating on final-stage survivors, obligation-lifetime metric, named discharge).

Also aligns `inverse-architecture.md`'s assertion-dump section to the `OBLIGATION`/`UNSOUND` vocabulary and links the new note from its stage-relative bullet.

## Risk

**Docs-only** — no code, no measured-behavior claims. Validated with `markdownlint` (clean). Low-risk; no adversarial review required per policy.
