### PR TITLE
Add RTS record generated fixtures

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -905,6 +905,17 @@ public class GeneratedFixtureCatalogTests
 
         Assert.Equal(
             [
+                "record.equality-operators",
+                "record.field-read-helpers",
+                "record.generic-typed-equals",
+                "record.property-getter",
+                "record.struct-field-read-helpers",
+                "record.virtual-helpers",
+            ],
+            GeneratedFixtureCatalog.Select("record").Select(fixture => fixture.Id).Order(StringComparer.Ordinal).ToArray());
+
+        Assert.Equal(
+            [
                 "minimal.array-index",
                 "minimal.array-length",
                 "minimal.auto-property.getter",
@@ -1004,6 +1015,12 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.do-while");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.switch-int");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "minimal.switch-two-case-lowers-if");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "record.property-getter");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "record.equality-operators");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "record.virtual-helpers");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "record.field-read-helpers");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "record.struct-field-read-helpers");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "record.generic-typed-equals");
 
         var primaryCtor = Assert.Single(fixtures,
             fixture => fixture.GetProperty("Id").GetString() == "minimal.primary-ctor.field-init");
@@ -1066,6 +1083,39 @@ public class GeneratedFixtureCatalogTests
             result => result.GetProperty("Status").GetString() == "Pass");
         Assert.DoesNotContain(document.RootElement.GetProperty("Results").EnumerateArray(),
             result => result.GetProperty("Reason").GetString() == "constructor-target");
+    }
+
+    [Fact]
+    public void ReturnToSenderRecordCatalog_CoversGeneratedRecordHelpers()
+    {
+        var run = GeneratedFixtureRunner.RunReturnToSenderCatalog(
+            GeneratedFixtureCatalog.Select("record"));
+        string report = GeneratedFixtureRunner.FormatReturnToSenderCatalogReport(run, maxExamples: 10);
+
+        Assert.True(run.Passed, report);
+        Assert.Equal(11, run.Results.Count);
+        Assert.All(run.Results, result =>
+        {
+            Assert.Equal(GeneratedFixtureReturnToSenderStatus.Pass, result.Status);
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.ActualStatus);
+        });
+        Assert.Contains(run.Results, result =>
+            result.FixtureId == "record.equality-operators" &&
+            result.Method == "op_Equality");
+        Assert.Contains(run.Results, result =>
+            result.FixtureId == "record.field-read-helpers" &&
+            result.Method == "Equals" &&
+            result.Overload == 1);
+        Assert.Contains(run.Results, result =>
+            result.FixtureId == "record.struct-field-read-helpers" &&
+            result.Method == "Equals" &&
+            result.Overload == 1);
+        Assert.Contains(run.Results, result =>
+            result.FixtureId == "record.generic-typed-equals" &&
+            result.Type == "RecordGenericTypedEqualsRow`1");
+        Assert.Contains("record.generic-typed-equals", report);
+        Assert.DoesNotContain("Skipped target reasons", report);
+        Assert.DoesNotContain("Failed target buckets", report);
     }
 
     [Fact]

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -1271,6 +1271,159 @@ internal static class GeneratedFixtureCatalog
         ],
         ["minimal", "conditional-expression", "branch", "frontier", "shape"]);
 
+    public static readonly GeneratedFixtureDefinition RecordPropertyGetter = new(
+        "record.property-getter",
+        """
+        public sealed record RecordPropertyGetterSnapshot(string Assembly, int Count);
+        """,
+        [
+            new(
+                "RecordPropertyGetterSnapshot",
+                "get_Assembly",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "public string Assembly { get; }",
+                ]),
+        ],
+        ["record", "property", "getter", "return-to-sender"]);
+
+    public static readonly GeneratedFixtureDefinition RecordEqualityOperators = new(
+        "record.equality-operators",
+        """
+        public record RecordEqualityOperatorsRow(string Name);
+        """,
+        [
+            new(
+                "RecordEqualityOperatorsRow",
+                "op_Equality",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "operator ==(",
+                    "operator !=(",
+                ]),
+            new(
+                "RecordEqualityOperatorsRow",
+                "op_Inequality",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "operator ==(",
+                    "operator !=(",
+                ]),
+        ],
+        ["record", "operator", "equality", "return-to-sender"]);
+
+    public static readonly GeneratedFixtureDefinition RecordVirtualHelpers = new(
+        "record.virtual-helpers",
+        """
+        public record RecordVirtualHelpersRow(string Name, string Value);
+        """,
+        [
+            new(
+                "RecordVirtualHelpersRow",
+                "ToString",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "protected virtual bool PrintMembers",
+                    "protected virtual System.Type EqualityContract",
+                ]),
+            new(
+                "RecordVirtualHelpersRow",
+                "Equals",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "public virtual bool Equals(RecordVirtualHelpersRow other)",
+                ]),
+        ],
+        ["record", "virtual", "helper", "return-to-sender"]);
+
+    public static readonly GeneratedFixtureDefinition RecordFieldReadHelpers = new(
+        "record.field-read-helpers",
+        """
+        public record RecordFieldReadHelpersRow(string Name, string Value);
+        """,
+        [
+            new(
+                "RecordFieldReadHelpersRow",
+                "GetHashCode",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "public string Name;",
+                    "public string Value;",
+                ]),
+            new(
+                "RecordFieldReadHelpersRow",
+                "ToString",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "public string Name { get; set; }",
+                ]),
+            new(
+                "RecordFieldReadHelpersRow",
+                "Equals",
+                FidelityCheck.CompileBackStatus.Exact,
+                Overload: 1,
+                ExpectedSourceFragments:
+                [
+                    "public virtual bool Equals(RecordFieldReadHelpersRow other)",
+                    "public string Name;",
+                    "public string Value;",
+                ]),
+        ],
+        ["record", "field", "helper", "return-to-sender"]);
+
+    public static readonly GeneratedFixtureDefinition RecordStructFieldReadHelpers = new(
+        "record.struct-field-read-helpers",
+        """
+        public record struct RecordStructFieldReadHelpersRow(string Name, string Value);
+        """,
+        [
+            new(
+                "RecordStructFieldReadHelpersRow",
+                "GetHashCode",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "public string Name;",
+                    "public string Value;",
+                ]),
+            new(
+                "RecordStructFieldReadHelpersRow",
+                "Equals",
+                FidelityCheck.CompileBackStatus.Exact,
+                Overload: 1,
+                ExpectedSourceFragments:
+                [
+                    "public bool Equals(RecordStructFieldReadHelpersRow other)",
+                    "public string Name;",
+                    "public string Value;",
+                ]),
+        ],
+        ["record", "struct", "field", "helper", "return-to-sender"]);
+
+    public static readonly GeneratedFixtureDefinition RecordGenericTypedEquals = new(
+        "record.generic-typed-equals",
+        """
+        public record RecordGenericTypedEqualsRow<T>(T Value);
+        """,
+        [
+            new(
+                "RecordGenericTypedEqualsRow`1",
+                "Equals",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedSourceFragments:
+                [
+                    "public virtual bool Equals(RecordGenericTypedEqualsRow<T> other)",
+                ]),
+        ],
+        ["record", "generic", "equals", "return-to-sender"]);
+
     public static readonly GeneratedFixtureDefinition AssertionNodeCoverage = new(
         "assertion.inverse-node-coverage",
         """
@@ -1562,6 +1715,16 @@ internal static class GeneratedFixtureCatalog
         MinimalSwitchTwoCaseLowersIf,
     ];
 
+    public static IReadOnlyList<GeneratedFixtureDefinition> ReturnToSenderRecords { get; } =
+    [
+        RecordPropertyGetter,
+        RecordEqualityOperators,
+        RecordVirtualHelpers,
+        RecordFieldReadHelpers,
+        RecordStructFieldReadHelpers,
+        RecordGenericTypedEquals,
+    ];
+
     public static IReadOnlyList<GeneratedFixtureDefinition> AssertionCoverage { get; } =
     [
         AssertionNodeCoverage,
@@ -1571,6 +1734,7 @@ internal static class GeneratedFixtureCatalog
     [
         .. All,
         .. Frontiers,
+        .. ReturnToSenderRecords,
         .. AssertionCoverage,
     ];
 

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -1280,11 +1280,7 @@ internal static class GeneratedFixtureCatalog
             new(
                 "RecordPropertyGetterSnapshot",
                 "get_Assembly",
-                FidelityCheck.CompileBackStatus.Exact,
-                ExpectedSourceFragments:
-                [
-                    "public string Assembly { get; }",
-                ]),
+                FidelityCheck.CompileBackStatus.Exact),
         ],
         ["record", "property", "getter", "return-to-sender"]);
 
@@ -1297,21 +1293,11 @@ internal static class GeneratedFixtureCatalog
             new(
                 "RecordEqualityOperatorsRow",
                 "op_Equality",
-                FidelityCheck.CompileBackStatus.Exact,
-                ExpectedSourceFragments:
-                [
-                    "operator ==(",
-                    "operator !=(",
-                ]),
+                FidelityCheck.CompileBackStatus.Exact),
             new(
                 "RecordEqualityOperatorsRow",
                 "op_Inequality",
-                FidelityCheck.CompileBackStatus.Exact,
-                ExpectedSourceFragments:
-                [
-                    "operator ==(",
-                    "operator !=(",
-                ]),
+                FidelityCheck.CompileBackStatus.Exact),
         ],
         ["record", "operator", "equality", "return-to-sender"]);
 
@@ -1324,20 +1310,11 @@ internal static class GeneratedFixtureCatalog
             new(
                 "RecordVirtualHelpersRow",
                 "ToString",
-                FidelityCheck.CompileBackStatus.Exact,
-                ExpectedSourceFragments:
-                [
-                    "protected virtual bool PrintMembers",
-                    "protected virtual System.Type EqualityContract",
-                ]),
+                FidelityCheck.CompileBackStatus.Exact),
             new(
                 "RecordVirtualHelpersRow",
                 "Equals",
-                FidelityCheck.CompileBackStatus.Exact,
-                ExpectedSourceFragments:
-                [
-                    "public virtual bool Equals(RecordVirtualHelpersRow other)",
-                ]),
+                FidelityCheck.CompileBackStatus.Exact),
         ],
         ["record", "virtual", "helper", "return-to-sender"]);
 
@@ -1350,31 +1327,16 @@ internal static class GeneratedFixtureCatalog
             new(
                 "RecordFieldReadHelpersRow",
                 "GetHashCode",
-                FidelityCheck.CompileBackStatus.Exact,
-                ExpectedSourceFragments:
-                [
-                    "public string Name;",
-                    "public string Value;",
-                ]),
+                FidelityCheck.CompileBackStatus.Exact),
             new(
                 "RecordFieldReadHelpersRow",
                 "ToString",
-                FidelityCheck.CompileBackStatus.Exact,
-                ExpectedSourceFragments:
-                [
-                    "public string Name { get; set; }",
-                ]),
+                FidelityCheck.CompileBackStatus.Exact),
             new(
                 "RecordFieldReadHelpersRow",
                 "Equals",
                 FidelityCheck.CompileBackStatus.Exact,
-                Overload: 1,
-                ExpectedSourceFragments:
-                [
-                    "public virtual bool Equals(RecordFieldReadHelpersRow other)",
-                    "public string Name;",
-                    "public string Value;",
-                ]),
+                Overload: 1),
         ],
         ["record", "field", "helper", "return-to-sender"]);
 
@@ -1387,23 +1349,12 @@ internal static class GeneratedFixtureCatalog
             new(
                 "RecordStructFieldReadHelpersRow",
                 "GetHashCode",
-                FidelityCheck.CompileBackStatus.Exact,
-                ExpectedSourceFragments:
-                [
-                    "public string Name;",
-                    "public string Value;",
-                ]),
+                FidelityCheck.CompileBackStatus.Exact),
             new(
                 "RecordStructFieldReadHelpersRow",
                 "Equals",
                 FidelityCheck.CompileBackStatus.Exact,
-                Overload: 1,
-                ExpectedSourceFragments:
-                [
-                    "public bool Equals(RecordStructFieldReadHelpersRow other)",
-                    "public string Name;",
-                    "public string Value;",
-                ]),
+                Overload: 1),
         ],
         ["record", "struct", "field", "helper", "return-to-sender"]);
 
@@ -1416,11 +1367,7 @@ internal static class GeneratedFixtureCatalog
             new(
                 "RecordGenericTypedEqualsRow`1",
                 "Equals",
-                FidelityCheck.CompileBackStatus.Exact,
-                ExpectedSourceFragments:
-                [
-                    "public virtual bool Equals(RecordGenericTypedEqualsRow<T> other)",
-                ]),
+                FidelityCheck.CompileBackStatus.Exact),
         ],
         ["record", "generic", "equals", "return-to-sender"]);
 

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -110,10 +110,13 @@ source-switch lowering observation (lowered as if/else, not the dense switch
 shape) and is opt-in by ID because it is a non-exact compiler-lowering frontier.
 `assertion.inverse-node-coverage` is the deterministic inverse-ledger coverage
 fixture used by `--assertion-fixture-guarantee`; it is addressable by ID but is
-not part of the default stable generated-fixture ladder. With no selector,
-stable generated fixtures run; use `list` to list fixture IDs, `--json` for
-machine-readable list/results, and `--keep-generated-fixtures` to preserve the
-generated project for drill-down.
+not part of the default stable generated-fixture ladder. The `record.*` fixtures
+are addressable ReturnToSender catalog coverage for record property accessors,
+equality operators, virtual helpers, field-read helpers, record structs, and
+generic typed `Equals(T)`; run `--return-to-sender-catalog record` for that
+slice. With no selector, stable generated fixtures run; use `list` to list
+fixture IDs, `--json` for machine-readable list/results, and
+`--keep-generated-fixtures` to preserve the generated project for drill-down.
 Rows may carry two independent expectations: a Roslyn `SyntaxKind` shape verdict
 for the intended C# idiom, and a compile-back opcode verdict for semantic
 fidelity. A row can therefore be opcode-exact while still exposing a shape


### PR DESCRIPTION
- Follow-up to #2230 / #2243 / #2273
- Changes harness-only generated fixture coverage; product output is unchanged
- Evidence revision: `6872555b`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — record-specific RTS prototype coverage is now addressable as generated fixture catalog rows, and the `record` ReturnToSender slice passes without skips or failures.

Before:

```text
Record RTS scenarios existed only as bespoke ReturnToSenderPrototypeTests.
```

After:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 6 fixture(s), 11 target(s)
Fixtures: Passed 6, Skipped 0, Failed 0
Targets : Passed 11, Skipped 0, Failed 0
```

## Scope and safety

- **Root cause:** record RTS coverage was passing in prototype tests but was not addressable through the generated fixture catalog.
- **Fix shape:** add `record.*` generated fixture definitions and a `ReturnToSenderRecords` catalog slice for property accessors, equality operators, virtual helpers, record field-read helpers, record structs, and generic typed `Equals`.
- **Product impact:** none; this is harness/catalog/test/docs only.
- **Scope boundary:** nested generic record self-type remains covered by the existing prototype helper test, but is not promoted here because the generated RTS catalog target is currently unsupported.
- **RTS boundary:** RTS remains closure + Roslyn + opcode compare; no product source generation changed.

## Evidence

| Check | Result |
| --- | --- |
| Product build | `dotnet build src/dotnet-inspect -c Release --no-restore --verbosity minimal` passed after repo-config restore |
| Focused tests | `GeneratedFixtureCatalogTests` passed, 9/9 |
| Targeted compile-back | `--return-to-sender-catalog record --max-examples 20` passed, 6 fixtures / 11 targets |
| Markdown | `npx markdownlint-cli tools/DecompilerHarness/README.md` passed |
| Build-event validation | Not applicable; harness catalog/docs only |

## Compile-back quality

> Did this increase the checkable population without hiding a product defect?

**Conclusion:** **PASS** — the addressable RTS record population is now 6 fixtures / 11 targets, all exact; no product behavior is hidden because this only adds targeted fixture rows around already-supported record helper shapes.

### Targeted changed-method boss

Run: generated `record.*` fixture catalog, 11 RTS targets.

| Metric (goal) | Baseline | PR |
| --- | ---: | ---: |
| Attempted (+) | 0 catalog rows | 11 |
| Exact (+) | 0 catalog rows | 11 |
| OpcodeDiff Full (-) | 0 | 0 |
| RecompileFail (-) | 0 | 0 |
| ContextFail (-) | 0 | 0 |
| Skipped (-) | 0 | 0 |

### Broad assembly context

Not applicable; this PR adds generated fixture catalog coverage only.

### ReturnToSender A/B

Not applicable; this PR does not change RTS behavior. It makes existing passing record RTS scenarios addressable through `--return-to-sender-catalog record`.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Nested generic record self-type catalog target | Left as frontier | Existing prototype helper coverage remains; generated RTS catalog targeting is unsupported for that nested generic method shape. |
| Product record source shape | Not changed | Harness-only catalog promotion. |

## Build-event validation

**Conclusion:** not applicable — no build-event instrumentation or product build behavior changed.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Pending | Pending | Adversarial review requested after PR creation. |
| Pending | Pending | Adversarial review requested after PR creation. |

**Review conclusion:** **REVIEW** — pending adversarial review reconciliation.

## Validation

```bash
dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --return-to-sender-catalog record --max-examples 20
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
npx markdownlint-cli tools/DecompilerHarness/README.md
dotnet restore src/dotnet-inspect/dotnet-inspect.csproj --configfile nuget.config --verbosity minimal
dotnet build src/dotnet-inspect -c Release --no-restore --verbosity minimal
git diff --check
```
