### PR TITLE
Support nested generic record RTS fixtures

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -908,6 +908,7 @@ public class GeneratedFixtureCatalogTests
                 "record.equality-operators",
                 "record.field-read-helpers",
                 "record.generic-typed-equals",
+                "record.nested-generic-typed-equals",
                 "record.property-getter",
                 "record.struct-field-read-helpers",
                 "record.virtual-helpers",
@@ -1021,6 +1022,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "record.field-read-helpers");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "record.struct-field-read-helpers");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "record.generic-typed-equals");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "record.nested-generic-typed-equals");
 
         var primaryCtor = Assert.Single(fixtures,
             fixture => fixture.GetProperty("Id").GetString() == "minimal.primary-ctor.field-init");
@@ -1093,7 +1095,7 @@ public class GeneratedFixtureCatalogTests
         string report = GeneratedFixtureRunner.FormatReturnToSenderCatalogReport(run, maxExamples: 10);
 
         Assert.True(run.Passed, report);
-        Assert.Equal(11, run.Results.Count);
+        Assert.Equal(12, run.Results.Count);
         Assert.All(run.Results, result =>
         {
             Assert.Equal(GeneratedFixtureReturnToSenderStatus.Pass, result.Status);
@@ -1113,7 +1115,11 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(run.Results, result =>
             result.FixtureId == "record.generic-typed-equals" &&
             result.Type == "RecordGenericTypedEqualsRow`1");
+        Assert.Contains(run.Results, result =>
+            result.FixtureId == "record.nested-generic-typed-equals" &&
+            result.Type == "RecordNestedGenericTypedEqualsContainer`1.Row`1");
         Assert.Contains("record.generic-typed-equals", report);
+        Assert.Contains("record.nested-generic-typed-equals", report);
         Assert.DoesNotContain("Skipped target reasons", report);
         Assert.DoesNotContain("Failed target buckets", report);
     }

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -1055,11 +1055,49 @@ public static class CompileBackSourceComposer
         MetadataReader reader,
         MethodDefinition method,
         MethodSignature<string> signature)
-        => ToCompileBackParameters(MetadataDeclarationQuery.GetMethod(
+    {
+        var declaringType = reader.GetTypeDefinition(method.GetDeclaringType());
+        var parameters = ToCompileBackParameters(MetadataDeclarationQuery.GetMethod(
             reader,
-            reader.GetTypeDefinition(method.GetDeclaringType()),
+            declaringType,
             method,
             signature).Signature.Parameters);
+        return NormalizeSelfTypeParameters(reader, declaringType, parameters);
+    }
+
+    static IReadOnlyList<CompileBackParameter> NormalizeSelfTypeParameters(
+        MetadataReader reader,
+        TypeDefinition declaringType,
+        IReadOnlyList<CompileBackParameter> parameters)
+    {
+        if (parameters.Count == 0 || declaringType.GetDeclaringType().IsNil)
+            return parameters;
+
+        string selfType = MetadataDeclarationQuery.SelfTypeSignature(reader, declaringType);
+        string directSelfType = DirectSelfTypeSignature(reader, declaringType);
+        if (directSelfType == selfType || parameters.All(parameter => parameter.Type.DisplayName != directSelfType))
+            return parameters;
+
+        return parameters
+            .Select(parameter => parameter.Type.DisplayName == directSelfType
+                ? parameter with { Type = CompileBackTypeSignature.Display(selfType) }
+                : parameter)
+            .ToArray();
+    }
+
+    static string DirectSelfTypeSignature(MetadataReader reader, TypeDefinition type)
+    {
+        var handles = type.GetGenericParameters();
+        int inheritedCount = 0;
+        var declaringType = type.GetDeclaringType();
+        if (!declaringType.IsNil)
+            inheritedCount = reader.GetTypeDefinition(declaringType).GetGenericParameters().Count;
+        var directNames = handles
+            .Skip(inheritedCount)
+            .Select(handle => reader.GetString(reader.GetGenericParameter(handle).Name))
+            .ToArray();
+        return TypeResolver.ApplyGenericArguments(TypeResolver.GetFullName(reader, type), directNames);
+    }
 
     static IReadOnlyList<string> MethodReturnAttributes(MetadataReader reader, MethodDefinition method)
         => MetadataDeclarationQuery.GetMethod(
@@ -1838,6 +1876,11 @@ public static class CompileBackSourceComposer
             List<CompileBackPlanningDiagnostic> diagnostics)
         {
             var shells = new List<CompileBackTypeDeclaration>();
+            var requirementsByMetadataName = requirements.ToDictionary(
+                requirement => requirement.Type.MetadataFullName,
+                requirement => requirement,
+                StringComparer.Ordinal);
+            var emittedRoots = new HashSet<TypeDefinitionHandle>();
             foreach (var requirement in requirements)
             {
                 if (FindType(reader, requirement.Type.MetadataFullName) is not { } handle)
@@ -1846,57 +1889,92 @@ public static class CompileBackSourceComposer
                     continue;
                 }
 
-                var typeDef = reader.GetTypeDefinition(handle);
-                var members = new List<CompileBackMemberDeclaration>();
-                foreach (var member in requirement.RequiredMembers)
+                var rootHandle = TopLevelRootOf(reader, handle);
+                if (!emittedRoots.Add(rootHandle))
+                    continue;
+
+                var rootDef = reader.GetTypeDefinition(rootHandle);
+                var rootIdentity = CompileBackTypeIdentity.FromDefinition(reader, rootDef);
+                if (!requirementsByMetadataName.TryGetValue(rootIdentity.MetadataFullName, out var rootRequirement))
                 {
-                    members.Add(new CompileBackMemberDeclaration(
-                        member.Identity,
-                        member.Kind,
-                        CompileBackAccessibility.Public,
-                        member.IsStatic,
-                        member.ReturnType,
-                        member.Parameters,
-                        member.TypeParameters,
-                        member.StubBody,
-                        member.TargetBody,
-                        member.SourceFacts,
-                        member.Attributes,
-                        member.ReturnAttributes,
-                        member.IsAbstract,
-                        member.IsVirtual,
-                        member.IsOverride,
-                        member.IsSealed));
+                    rootRequirement = new CompileBackTypeRequirement(
+                        rootIdentity,
+                        ShellKind(reader, rootDef),
+                        RequiredMembers: [],
+                        PrimaryConstructor: null,
+                        SourceFacts: [new CompileBackFact("metadata", "declaring-closure-type", rootIdentity.FullName)]);
                 }
 
-                if (requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member"))
-                    AddClosureMemberSurface(reader, typeDef, requirement, members, diagnostics);
-
-                shells.Add(new CompileBackTypeDeclaration(
-                    requirement.Type,
-                    requirement.RequiredKind,
-                    CompileBackAccessibility.Public,
-                    BaseType: null,
-                    PrimaryConstructorParameters: requirement.PrimaryConstructor?.Parameters,
-                    TypeParameters: TypeParameters(reader, typeDef),
-                    Interfaces: InterfaceSignatures(reader, typeDef),
-                    members,
-                    requirement.SourceFacts,
-                    NestedTypes(
-                        reader,
-                        typeDef,
-                        includeMemberSurface: requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member"),
-                        diagnostics),
-                    TypeAttributeList(reader, typeDef),
-                    IsAbstract: (typeDef.Attributes & TypeAttributes.Abstract) != 0 && (typeDef.Attributes & TypeAttributes.Interface) == 0));
+                shells.Add(TypeDeclaration(reader, rootHandle, rootRequirement, requirementsByMetadataName, diagnostics));
             }
 
             return shells;
         }
 
+        static CompileBackTypeDeclaration TypeDeclaration(
+            MetadataReader reader,
+            TypeDefinitionHandle handle,
+            CompileBackTypeRequirement requirement,
+            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
+            List<CompileBackPlanningDiagnostic> diagnostics)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            var members = RequiredMemberDeclarations(requirement);
+            bool includeMemberSurface = requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+            if (includeMemberSurface)
+                AddClosureMemberSurface(reader, typeDef, requirement, members, diagnostics);
+
+            return new CompileBackTypeDeclaration(
+                requirement.Type,
+                requirement.RequiredKind,
+                CompileBackAccessibility.Public,
+                BaseType: null,
+                PrimaryConstructorParameters: requirement.PrimaryConstructor?.Parameters,
+                TypeParameters: TypeParameters(reader, typeDef),
+                Interfaces: InterfaceSignatures(reader, typeDef),
+                members,
+                requirement.SourceFacts,
+                NestedTypes(
+                    reader,
+                    typeDef,
+                    requirementsByMetadataName,
+                    includeMemberSurface,
+                    diagnostics),
+                TypeAttributeList(reader, typeDef),
+                IsAbstract: (typeDef.Attributes & TypeAttributes.Abstract) != 0 && (typeDef.Attributes & TypeAttributes.Interface) == 0);
+        }
+
+        static List<CompileBackMemberDeclaration> RequiredMemberDeclarations(CompileBackTypeRequirement requirement)
+        {
+            var members = new List<CompileBackMemberDeclaration>();
+            foreach (var member in requirement.RequiredMembers)
+            {
+                members.Add(new CompileBackMemberDeclaration(
+                    member.Identity,
+                    member.Kind,
+                    CompileBackAccessibility.Public,
+                    member.IsStatic,
+                    member.ReturnType,
+                    member.Parameters,
+                    member.TypeParameters,
+                    member.StubBody,
+                    member.TargetBody,
+                    member.SourceFacts,
+                    member.Attributes,
+                    member.ReturnAttributes,
+                    member.IsAbstract,
+                    member.IsVirtual,
+                    member.IsOverride,
+                    member.IsSealed));
+            }
+
+            return members;
+        }
+
         static IReadOnlyList<CompileBackTypeDeclaration> NestedTypes(
             MetadataReader reader,
             TypeDefinition typeDef,
+            IReadOnlyDictionary<string, CompileBackTypeRequirement> requirementsByMetadataName,
             bool includeMemberSurface,
             List<CompileBackPlanningDiagnostic> diagnostics)
         {
@@ -1906,7 +1984,6 @@ public static class CompileBackSourceComposer
                 var nestedDef = reader.GetTypeDefinition(nestedHandle);
                 string name = reader.GetString(nestedDef.Name);
                 if (name.Contains('<', StringComparison.Ordinal)
-                    || name.Contains('`', StringComparison.Ordinal)
                     || IsDelegate(reader, nestedDef))
                 {
                     continue;
@@ -1914,26 +1991,29 @@ public static class CompileBackSourceComposer
 
                 var identity = CompileBackTypeIdentity.FromDefinition(reader, nestedDef);
                 var kind = ShellKind(reader, nestedDef);
-                var requirement = new CompileBackTypeRequirement(
+                requirementsByMetadataName.TryGetValue(identity.MetadataFullName, out var requirement);
+                requirement ??= new CompileBackTypeRequirement(
                     identity,
                     kind,
                     RequiredMembers: [],
                     PrimaryConstructor: null,
                     SourceFacts: [new CompileBackFact("metadata", "nested-closure-type", identity.FullName)]);
-                var members = new List<CompileBackMemberDeclaration>();
-                if (includeMemberSurface)
+                var members = RequiredMemberDeclarations(requirement);
+                bool includeNestedMemberSurface = includeMemberSurface
+                    || requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+                if (includeNestedMemberSurface)
                     AddClosureMemberSurface(reader, nestedDef, requirement, members, diagnostics, allowUnsafeSurface: true);
                 nestedTypes.Add(new CompileBackTypeDeclaration(
                     identity,
                     kind,
                     CompileBackAccessibility.Public,
                     BaseType: null,
-                    PrimaryConstructorParameters: null,
+                    PrimaryConstructorParameters: requirement.PrimaryConstructor?.Parameters,
                     TypeParameters: TypeParameters(reader, nestedDef),
                     Interfaces: InterfaceSignatures(reader, nestedDef),
                     members,
                     requirement.SourceFacts,
-                    NestedTypes(reader, nestedDef, includeMemberSurface, diagnostics),
+                    NestedTypes(reader, nestedDef, requirementsByMetadataName, includeNestedMemberSurface, diagnostics),
                     TypeAttributeList(reader, nestedDef),
                     IsAbstract: (nestedDef.Attributes & TypeAttributes.Abstract) != 0 && (nestedDef.Attributes & TypeAttributes.Interface) == 0));
             }

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -1371,6 +1371,22 @@ internal static class GeneratedFixtureCatalog
         ],
         ["record", "generic", "equals", "return-to-sender"]);
 
+    public static readonly GeneratedFixtureDefinition RecordNestedGenericTypedEquals = new(
+        "record.nested-generic-typed-equals",
+        """
+        public class RecordNestedGenericTypedEqualsContainer<T>
+        {
+            public record Row<U>(T Outer, U Value);
+        }
+        """,
+        [
+            new(
+                "RecordNestedGenericTypedEqualsContainer`1.Row`1",
+                "Equals",
+                FidelityCheck.CompileBackStatus.Exact),
+        ],
+        ["record", "nested", "generic", "equals", "return-to-sender"]);
+
     public static readonly GeneratedFixtureDefinition AssertionNodeCoverage = new(
         "assertion.inverse-node-coverage",
         """
@@ -1670,6 +1686,7 @@ internal static class GeneratedFixtureCatalog
         RecordFieldReadHelpers,
         RecordStructFieldReadHelpers,
         RecordGenericTypedEquals,
+        RecordNestedGenericTypedEquals,
     ];
 
     public static IReadOnlyList<GeneratedFixtureDefinition> AssertionCoverage { get; } =

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -113,9 +113,10 @@ fixture used by `--assertion-fixture-guarantee`; it is addressable by ID but is
 not part of the default stable generated-fixture ladder. The `record.*` fixtures
 are addressable ReturnToSender catalog coverage for record property accessors,
 equality operators, virtual helpers, field-read helpers, record structs, and
-generic typed `Equals(T)`; run `--return-to-sender-catalog record` for that
-slice. With no selector, stable generated fixtures run; use `list` to list
-fixture IDs, `--json` for machine-readable list/results, and
+generic and nested-generic typed `Equals(T)`; run
+`--return-to-sender-catalog record` for that slice. With no selector, stable
+generated fixtures run; use `list` to list fixture IDs, `--json` for
+machine-readable list/results, and
 `--keep-generated-fixtures` to preserve the generated project for drill-down.
 Rows may carry two independent expectations: a Roslyn `SyntaxKind` shape verdict
 for the intended C# idiom, and a compile-back opcode verdict for semantic

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -404,8 +404,7 @@ static class ReturnToSender
         var typeHandles = reader.TypeDefinitions
             .Select(handle => (Handle: handle, Definition: reader.GetTypeDefinition(handle)))
             .Where(item => reader.GetFullTypeName(item.Definition) is { } fullName
-                && fullName.Length != 0
-                && item.Definition.GetDeclaringType().IsNil)
+                && fullName.Length != 0)
             .ToDictionary(item => reader.GetFullTypeName(item.Definition), item => item.Handle, StringComparer.Ordinal);
 
         foreach (var target in targets)
@@ -415,8 +414,7 @@ static class ReturnToSender
 
             var typeDef = reader.GetTypeDefinition(typeHandle);
             string typeName = reader.GetString(typeDef.Name);
-            if (!typeDef.GetDeclaringType().IsNil
-                || typeName == "<Module>"
+            if (typeName == "<Module>"
                 || typeName.Contains('<', StringComparison.Ordinal)
                 || !IsSupportedTargetType(reader, typeDef))
             {


### PR DESCRIPTION
- Follow-up to #2276
- Changes product compile-back source composition plus RTS target lookup for nested metadata targets
- Evidence revision: `d414f390`

## Change

> Should we accept this harness/product compile-back change?

**Conclusion:** **PASS** — the `record.nested-generic-typed-equals` frontier moved from unsupported/failing to exact RTS compile-back by fixing nested target lookup and product-side nested generic source composition.

Before:

```text
record.nested-generic-typed-equals
  unsupported-rts-target

After nested lookup exposed product composition:
  RecompileFail CS0246: RecordNestedGenericTypedEqualsContainer<> could not be found
```

After:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 7 fixture(s), 12 target(s)
Fixtures: Passed 7, Skipped 0, Failed 0
Targets : Passed 12, Skipped 0, Failed 0
```

## Scope and safety

- **Root cause:** RTS target lookup only indexed top-level metadata types, and product compile-back source composition emitted a nested target requirement as a top-level shell with a self-type parameter missing declaring generic arguments (`Container<>.Row<U>` instead of `Container<T>.Row<U>`).
- **Fix shape:** RTS now locates nested metadata targets by full metadata name; product `CompileBackSourceComposer` groups requirements by top-level root, emits nested requirements under their declaring shell, allows generic nested declarations, and normalizes self-type parameters through `MetadataDeclarationQuery.SelfTypeSignature`.
- **Product impact:** compile-back source composition only; no decompiler raise/printer output path change.
- **Scope boundary:** no RTS C# generation added. RTS remains orchestration/measurement; the source-shape gap is fixed in product source composition.
- **RTS boundary:** target discovery only, not source generation.

## Evidence

| Check | Result |
| --- | --- |
| Product build | `dotnet build src/dotnet-inspect -c Release --no-restore --verbosity minimal` passed |
| Focused tests | `GeneratedFixtureCatalogTests` passed, 9/9 |
| Targeted compile-back | `--return-to-sender-catalog record --max-examples 20` passed, 7 fixtures / 12 targets |
| Markdown | `npx markdownlint-cli tools/DecompilerHarness/README.md` passed |
| Diff hygiene | `git diff --check` passed |

## Compile-back quality

> Did this increase the checkable population without hiding a product defect?

**Conclusion:** **PASS** — the explicit nested generic record frontier is now exact; the record catalog grows from 6 fixtures / 11 targets to 7 fixtures / 12 targets with no skips or failures.

### Targeted changed-method boss

Run: generated `record.*` fixture catalog, 12 RTS targets.

| Metric (goal) | Baseline | PR |
| --- | ---: | ---: |
| Attempted (+) | 11 | 12 |
| Exact (+) | 11 | 12 |
| OpcodeDiff Full (-) | 0 | 0 |
| RecompileFail (-) | 1 for nested probe after target lookup | 0 |
| ContextFail (-) | 0 | 0 |
| Skipped (-) | 1 nested target before lookup | 0 |

### Broad assembly context

Not run; this is a targeted compile-back source composition fix with generated fixture proof.

### ReturnToSender A/B

Not applicable; current compile-back path does not address this generated RTS catalog selector. The targeted RTS catalog run is the proof surface.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Nested generic record typed Equals | Fixed | Product source composition now emits nested generic target shells under the declaring type and renders self-type parameters with declaring generic arguments. |
| RTS source generation | Not changed | Per project rule, RTS does not generate C#; product source composition owns the fix. |

## Build-event validation

**Conclusion:** not applicable — no build-event instrumentation changed.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Pending | Pending | Adversarial review requested after PR creation. |
| Pending | Pending | Adversarial review requested after PR creation. |

**Review conclusion:** **REVIEW** — pending adversarial review reconciliation.

## Validation

```bash
dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --return-to-sender-catalog record --max-examples 20
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
npx markdownlint-cli tools/DecompilerHarness/README.md
dotnet restore src/dotnet-inspect/dotnet-inspect.csproj --configfile nuget.config --verbosity minimal
dotnet build src/dotnet-inspect -c Release --no-restore --verbosity minimal
git diff --check
```
