### PR TITLE
Add RTS target body fragment checks

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1125,6 +1125,37 @@ public class GeneratedFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderRecordCatalog_TargetBodyFragmentsDoNotMatchShellSource()
+    {
+        var shellOnlyFragment = new GeneratedFixtureDefinition(
+            "test.record-shell-only-fragment",
+            """
+            public record ShellOnlyFragmentRecord(string Name, string Value);
+            """,
+            [
+                new(
+                    "ShellOnlyFragmentRecord",
+                    "GetHashCode",
+                    FidelityCheck.CompileBackStatus.Exact,
+                    ExpectedTargetBodyFragments:
+                    [
+                        "public string Name;",
+                    ]),
+            ],
+            ["test", "record"]);
+
+        var run = GeneratedFixtureRunner.RunReturnToSenderCatalog([shellOnlyFragment]);
+        string report = GeneratedFixtureRunner.FormatReturnToSenderCatalogReport(run, maxExamples: 10);
+        var result = Assert.Single(run.Results);
+
+        Assert.False(run.Passed, report);
+        Assert.Equal(GeneratedFixtureReturnToSenderStatus.Fail, result.Status);
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.ActualStatus);
+        Assert.Equal("target-body-fragment-missing", result.Reason);
+        Assert.Contains("missing expected target body fragment: public string Name;", result.Detail);
+    }
+
+    [Fact]
     public void CompilerLoweringFrontier_IsSelectableButNotInDefaultRun()
     {
         var switchRun = GeneratedFixtureRunner.Run(GeneratedFixtureCatalog.Select("minimal.switch-two-case-lowers-if"));

--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1156,6 +1156,52 @@ public class GeneratedFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderCatalog_NonExactRowsKeepFailureReasonBeforeBodyFragments()
+    {
+        var opcodeDiffWithBodyFragment = new GeneratedFixtureDefinition(
+            "test.non-exact-body-fragment",
+            """
+            public class NonExactBodyFragment
+            {
+                public string Method1(int value)
+                {
+                    switch (value)
+                    {
+                        case 0:
+                            return "zero";
+                        case 1:
+                            return "one";
+                        default:
+                            return "many";
+                    }
+                }
+            }
+            """,
+            [
+                new(
+                    "NonExactBodyFragment",
+                    "Method1",
+                    FidelityCheck.CompileBackStatus.OpcodeDiff,
+                    IsFrontier: true,
+                    ExpectedTargetBodyFragments:
+                    [
+                        "fragment that is absent from the target body",
+                    ]),
+            ],
+            ["test"]);
+
+        var run = GeneratedFixtureRunner.RunReturnToSenderCatalog([opcodeDiffWithBodyFragment]);
+        string report = GeneratedFixtureRunner.FormatReturnToSenderCatalogReport(run, maxExamples: 10);
+        var result = Assert.Single(run.Results);
+
+        Assert.False(run.Passed, report);
+        Assert.Equal(GeneratedFixtureReturnToSenderStatus.Fail, result.Status);
+        Assert.Equal(FidelityCheck.CompileBackStatus.OpcodeDiff, result.ActualStatus);
+        Assert.Equal("opcode-diff", result.Reason);
+        Assert.DoesNotContain("target-body-fragment-missing", report);
+    }
+
+    [Fact]
     public void CompilerLoweringFrontier_IsSelectableButNotInDefaultRun()
     {
         var switchRun = GeneratedFixtureRunner.Run(GeneratedFixtureCatalog.Select("minimal.switch-two-case-lowers-if"));

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -1958,9 +1958,14 @@ internal static class GeneratedFixtureRunner
                         continue;
                     }
 
-                    var missingSourceFragment = MissingSourceFragment(actual.Source, target.ExpectedSourceFragments);
-                    var missingTargetBodyFragment = MissingSourceFragment(actual.TargetBody, target.ExpectedTargetBodyFragments);
-                    var status = actual.Status == FidelityCheck.CompileBackStatus.Exact
+                    bool exact = actual.Status == FidelityCheck.CompileBackStatus.Exact;
+                    var missingSourceFragment = exact
+                        ? MissingSourceFragment(actual.Source, target.ExpectedSourceFragments)
+                        : null;
+                    var missingTargetBodyFragment = exact
+                        ? MissingSourceFragment(actual.TargetBody, target.ExpectedTargetBodyFragments)
+                        : null;
+                    var status = exact
                         && missingSourceFragment is null
                         && missingTargetBodyFragment is null
                             ? GeneratedFixtureReturnToSenderStatus.Pass

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -1280,7 +1280,11 @@ internal static class GeneratedFixtureCatalog
             new(
                 "RecordPropertyGetterSnapshot",
                 "get_Assembly",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedTargetBodyFragments:
+                [
+                    "return this.Assembly;",
+                ]),
         ],
         ["record", "property", "getter", "return-to-sender"]);
 
@@ -1293,11 +1297,20 @@ internal static class GeneratedFixtureCatalog
             new(
                 "RecordEqualityOperatorsRow",
                 "op_Equality",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedTargetBodyFragments:
+                [
+                    "(object)left == (object)right",
+                    "left.Equals(right)",
+                ]),
             new(
                 "RecordEqualityOperatorsRow",
                 "op_Inequality",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedTargetBodyFragments:
+                [
+                    "return !(left == right);",
+                ]),
         ],
         ["record", "operator", "equality", "return-to-sender"]);
 
@@ -1310,11 +1323,21 @@ internal static class GeneratedFixtureCatalog
             new(
                 "RecordVirtualHelpersRow",
                 "ToString",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedTargetBodyFragments:
+                [
+                    "new StringBuilder()",
+                    "PrintMembers(V_0)",
+                    "return V_0.ToString();",
+                ]),
             new(
                 "RecordVirtualHelpersRow",
                 "Equals",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedTargetBodyFragments:
+                [
+                    "return Equals(obj as RecordVirtualHelpersRow);",
+                ]),
         ],
         ["record", "virtual", "helper", "return-to-sender"]);
 
@@ -1327,16 +1350,34 @@ internal static class GeneratedFixtureCatalog
             new(
                 "RecordFieldReadHelpersRow",
                 "GetHashCode",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedTargetBodyFragments:
+                [
+                    "EqualityContract",
+                    "this.Name",
+                    "this.Value",
+                ]),
             new(
                 "RecordFieldReadHelpersRow",
                 "ToString",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedTargetBodyFragments:
+                [
+                    "RecordFieldReadHelpersRow",
+                    "PrintMembers(V_0)",
+                    "return V_0.ToString();",
+                ]),
             new(
                 "RecordFieldReadHelpersRow",
                 "Equals",
                 FidelityCheck.CompileBackStatus.Exact,
-                Overload: 1),
+                Overload: 1,
+                ExpectedTargetBodyFragments:
+                [
+                    "other.EqualityContract",
+                    "this.Name, other.Name",
+                    "this.Value, other.Value",
+                ]),
         ],
         ["record", "field", "helper", "return-to-sender"]);
 
@@ -1349,12 +1390,22 @@ internal static class GeneratedFixtureCatalog
             new(
                 "RecordStructFieldReadHelpersRow",
                 "GetHashCode",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedTargetBodyFragments:
+                [
+                    "this.Name",
+                    "this.Value",
+                ]),
             new(
                 "RecordStructFieldReadHelpersRow",
                 "Equals",
                 FidelityCheck.CompileBackStatus.Exact,
-                Overload: 1),
+                Overload: 1,
+                ExpectedTargetBodyFragments:
+                [
+                    "this.Name, other.Name",
+                    "this.Value, other.Value",
+                ]),
         ],
         ["record", "struct", "field", "helper", "return-to-sender"]);
 
@@ -1367,7 +1418,11 @@ internal static class GeneratedFixtureCatalog
             new(
                 "RecordGenericTypedEqualsRow`1",
                 "Equals",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedTargetBodyFragments:
+                [
+                    "return Equals(obj as RecordGenericTypedEqualsRow<T>);",
+                ]),
         ],
         ["record", "generic", "equals", "return-to-sender"]);
 
@@ -1383,7 +1438,11 @@ internal static class GeneratedFixtureCatalog
             new(
                 "RecordNestedGenericTypedEqualsContainer`1.Row`1",
                 "Equals",
-                FidelityCheck.CompileBackStatus.Exact),
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedTargetBodyFragments:
+                [
+                    "return Equals(obj as Row<U>);",
+                ]),
         ],
         ["record", "nested", "generic", "equals", "return-to-sender"]);
 
@@ -1731,7 +1790,8 @@ internal sealed record GeneratedFixtureTarget(
     string? Note = null,
     SyntaxKind? ExpectedShape = null,
     SyntaxKind? FrontierShape = null,
-    IReadOnlyList<string>? ExpectedSourceFragments = null)
+    IReadOnlyList<string>? ExpectedSourceFragments = null,
+    IReadOnlyList<string>? ExpectedTargetBodyFragments = null)
 {
     public string DisplayMember => $"{Type}::{Method}#{Overload}";
 }
@@ -1899,8 +1959,10 @@ internal static class GeneratedFixtureRunner
                     }
 
                     var missingSourceFragment = MissingSourceFragment(actual.Source, target.ExpectedSourceFragments);
+                    var missingTargetBodyFragment = MissingSourceFragment(actual.TargetBody, target.ExpectedTargetBodyFragments);
                     var status = actual.Status == FidelityCheck.CompileBackStatus.Exact
                         && missingSourceFragment is null
+                        && missingTargetBodyFragment is null
                             ? GeneratedFixtureReturnToSenderStatus.Pass
                             : GeneratedFixtureReturnToSenderStatus.Fail;
                     results.Add(new GeneratedFixtureReturnToSenderResult(
@@ -1914,10 +1976,14 @@ internal static class GeneratedFixtureRunner
                             ? "exact"
                             : missingSourceFragment is not null
                                 ? "source-fragment-missing"
+                                : missingTargetBodyFragment is not null
+                                    ? "target-body-fragment-missing"
                                 : FailureReason(actual),
-                        missingSourceFragment is null
-                            ? actual.Detail
-                            : $"missing expected source fragment: {missingSourceFragment}",
+                        missingSourceFragment is not null
+                            ? $"missing expected source fragment: {missingSourceFragment}"
+                            : missingTargetBodyFragment is not null
+                                ? $"missing expected target body fragment: {missingTargetBodyFragment}"
+                                : actual.Detail,
                         target.IsFrontier,
                         target.Note));
                 }

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -122,7 +122,9 @@ Rows may carry two independent expectations: a Roslyn `SyntaxKind` shape verdict
 for the intended C# idiom, and a compile-back opcode verdict for semantic
 fidelity. A row can therefore be opcode-exact while still exposing a shape
 frontier. Shape frontiers record both the accepted current shape and the desired
-frontier shape.
+frontier shape. ReturnToSender catalog rows can also carry body-scoped fragment
+expectations; those match only the decompiled target body, not the reconstructed
+type shell, so metadata scaffolding cannot satisfy a target-body assertion.
 
 The generated fixture ladder is intentionally staged:
 

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -26,7 +26,8 @@ static class ReturnToSender
         FidelityCheck.CompileBackStatus Status,
         string OriginalOpcodes,
         string RecompiledOpcodes,
-        string? Detail);
+        string? Detail,
+        string TargetBody = "");
 
     public sealed record RequestedTarget(string Type, string Method, int Overload);
 
@@ -687,7 +688,8 @@ static class ReturnToSender
                         : FidelityCheck.CompileBackStatus.OpcodeDiff,
                     string.Join(" ", originalOps),
                     string.Join(" ", recompiledOps),
-                    null);
+                    null,
+                    TargetBody: printed.Output);
             }
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
@@ -834,7 +836,8 @@ static class ReturnToSender
                         : FidelityCheck.CompileBackStatus.OpcodeDiff,
                     string.Join(" ", originalOps),
                     string.Join(" ", recompiledOps),
-                    null);
+                    null,
+                    TargetBody: printed.Output);
             }
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
@@ -982,7 +985,8 @@ static class ReturnToSender
                         : FidelityCheck.CompileBackStatus.OpcodeDiff,
                     string.Join(" ", originalOps),
                     string.Join(" ", recompiledOps),
-                    null);
+                    null,
+                    TargetBody: printed.Output);
             }
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();


### PR DESCRIPTION
- Follow-up to #2276 / #2278
- Changes harness-only ReturnToSender catalog measurement; product output is unchanged
- Evidence revision: `3c8670fd`

## Change

> Should we accept this harness change?

**Conclusion:** **PASS** — record RTS catalog rows now assert meaningful body-scoped fragments against the decompiled target body, not the reconstructed type shell.

Before:

```text
Record ExpectedSourceFragments were removed because full-shell matching could be satisfied by metadata scaffolding.
```

After:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 7 fixture(s), 12 target(s)
Fixtures: Passed 7, Skipped 0, Failed 0
Targets : Passed 12, Skipped 0, Failed 0
```

## Scope and safety

- **Root cause:** existing source-fragment checks matched `actual.Source`, the full reconstructed compile-back shell, so shell declarations could satisfy assertions intended for decompiled target bodies.
- **Fix shape:** expose `ReturnToSender.Result.TargetBody`, add `ExpectedTargetBodyFragments` to generated fixture targets, and evaluate those fragments against only the decompiled target body.
- **Product impact:** none; this is harness measurement only. RTS still does not generate C#.
- **Scope boundary:** existing `ExpectedSourceFragments` remain available for full-shell metadata assertions; record rows use target-body fragments for body-shape evidence.
- **RTS boundary:** orchestration/measurement only; no source generation behavior added.

## Evidence

| Check | Result |
| --- | --- |
| Product build | `dotnet build src/dotnet-inspect -c Release --no-restore --verbosity minimal` passed |
| Focused tests | `GeneratedFixtureCatalogTests` passed, 10/10 |
| Targeted compile-back | `--return-to-sender-catalog record --max-examples 20` passed, 7 fixtures / 12 targets |
| Markdown | `npx markdownlint-cli tools/DecompilerHarness/README.md` passed |
| Diff hygiene | `git diff --check` passed |

## Compile-back quality

> Did this increase the checkable population without hiding a product defect?

**Conclusion:** **PASS** — target count stays 7 fixtures / 12 exact targets, and the check quality improves by making record fragments body-scoped. A negative test proves a shell-only fragment (`public string Name;`) fails when asserted as a target-body fragment.

### Targeted changed-method boss

Run: generated `record.*` fixture catalog, 12 RTS targets.

| Metric (goal) | Baseline | PR |
| --- | ---: | ---: |
| Attempted (+) | 12 | 12 |
| Exact (+) | 12 | 12 |
| Body fragments checked (+) | 0 | 12 targets carry body fragments |
| OpcodeDiff Full (-) | 0 | 0 |
| RecompileFail (-) | 0 | 0 |
| ContextFail (-) | 0 | 0 |
| Skipped (-) | 0 | 0 |

### Broad assembly context

Not applicable; this PR changes generated RTS catalog assertion quality only.

### ReturnToSender A/B

Not applicable; this PR does not change RTS compile-back behavior or product decompiler output.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Full-shell source fragments | Left supported | Existing metadata-shell checks still use `ExpectedSourceFragments`. |
| Body-scoped source extraction from full source | Not needed | `ReturnToSender.Result.TargetBody` already has the decompiled target body from the product printer. |

## Build-event validation

**Conclusion:** not applicable — no build-event instrumentation changed.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Pending | Pending | Adversarial review requested after PR creation. |
| Pending | Pending | Adversarial review requested after PR creation. |

**Review conclusion:** **REVIEW** — pending adversarial review reconciliation.

## Validation

```bash
dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --return-to-sender-catalog record --max-examples 20
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
npx markdownlint-cli tools/DecompilerHarness/README.md
dotnet restore src/dotnet-inspect/dotnet-inspect.csproj --configfile nuget.config --verbosity minimal
dotnet build src/dotnet-inspect -c Release --no-restore --verbosity minimal
git diff --check
```
