### PR TITLE
Count final-stage survivors in --assertion-scan (#2269)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
@@ -245,6 +245,56 @@ public class AssertionScanTests
         Assert.DoesNotContain("OBLIGATION", dump);
     }
 
+    [Fact]
+    public void EvaluateFunction_DischargedViolationIsNotFinalStageSurvivor()
+    {
+        // A LoadArgument(int) at an enum sink is flagged at import, but coercion
+        // insertion wraps it in a Coerce before the final stage — a discharged
+        // OBLIGATION, not a survivor. (#2269)
+        var function = Function(
+            Returning(new LoadArgument(0, "raw", Int32)),
+            Enum32,
+            new Parameter("raw", Int32));
+
+        var result = AssertionScan.EvaluateFunction(
+            "synthetic", "synthetic.dll", "Samples.Holder", "EnumReturn", overload: 0, function);
+
+        var violation = Assert.Single(result.Violations);
+        Assert.False(violation.FinalStageSurvivor);
+        Assert.Contains(nameof(Coerce), result.CoveredNodes);
+    }
+
+    [Fact]
+    public void MarkSurvivors_FlagsOnlyViolationsPresentAtFinalStage()
+    {
+        var discharged = new AssertionScan.ViolationSite(
+            Method: "m", Pass: IrPasses.ImportStageName, Predicate: "SinkDistinguishableFromStack",
+            Node: nameof(LoadArgument), SinkType: "E32", Message: "raw occupies a E32 sink without a Coerce", Ordinal: 0);
+        var survivor = new AssertionScan.ViolationSite(
+            Method: "m", Pass: IrPasses.ImportStageName, Predicate: "SinkDistinguishableFromStack",
+            Node: nameof(Constant), SinkType: "bool", Message: "0 occupies a bool sink without a Coerce", Ordinal: 0);
+
+        // Only the survivor's stage identity is present at the final stage.
+        var finalStage = new HashSet<string>(StringComparer.Ordinal) { survivor.StageIdentity };
+
+        var marked = AssertionScan.MarkSurvivors([discharged, survivor], finalStage);
+
+        Assert.False(marked.Single(v => v.Node == nameof(LoadArgument)).FinalStageSurvivor);
+        Assert.True(marked.Single(v => v.Node == nameof(Constant)).FinalStageSurvivor);
+    }
+
+    [Fact]
+    public void ViolationSite_StageIdentityIsPassIndependent()
+    {
+        var atImport = new AssertionScan.ViolationSite(
+            Method: "m", Pass: IrPasses.ImportStageName, Predicate: "P",
+            Node: nameof(LoadArgument), SinkType: "bool", Message: "msg", Ordinal: 2);
+        var atLaterPass = atImport with { Pass = "some-later-pass" };
+
+        Assert.Equal(atImport.StageIdentity, atLaterPass.StageIdentity);
+        Assert.NotEqual(atImport.Identity, atLaterPass.Identity);
+    }
+
     static IrFunction Function(BlockContainer body, TypeRef returnType, params Parameter[] parameters)
         => new(
             "M",

--- a/tools/DecompilerHarness/AssertionScan.cs
+++ b/tools/DecompilerHarness/AssertionScan.cs
@@ -29,9 +29,17 @@ internal static class AssertionScan
         string Node,
         string SinkType,
         string Message,
-        int Ordinal)
+        int Ordinal,
+        bool FinalStageSurvivor = false)
     {
         public string Identity => $"{Pass}|{Predicate}|{Node}|{SinkType}|{Message}#{Ordinal}";
+
+        /// <summary>
+        /// Pass-independent identity — the assertion is the same claim wherever it
+        /// is observed. Used to match a first-appearance site against the set of
+        /// violations still present at the final stage (the survivor set).
+        /// </summary>
+        public string StageIdentity => $"{Predicate}|{Node}|{SinkType}|{Message}#{Ordinal}";
     }
 
     public sealed record MethodResult(
@@ -450,9 +458,12 @@ internal static class AssertionScan
                 importCrashes[0].ToString());
         }
 
+        var finalStageIdentities = new HashSet<string>(StringComparer.Ordinal);
+
         void Capture(string passName)
         {
             AddCoveredNodes(function, covered);
+            var stageIdentities = new HashSet<string>(StringComparer.Ordinal);
             var stageViolations = new List<(string Identity, ViolationSite Site)>();
             foreach (var predicate in AssertionEvaluator.EvaluateAssumptions(function))
             {
@@ -463,6 +474,7 @@ internal static class AssertionScan
                     string identity = $"{predicate.Name}|{node}|{sinkType}|{violation.Message}";
                     int ordinal = OccurrenceOrdinal(occurrenceOrdinals, identity, violation.Node);
                     string stableIdentity = $"{identity}#{ordinal}";
+                    stageIdentities.Add(stableIdentity);
                     stageViolations.Add((
                         stableIdentity,
                         new ViolationSite(key, passName, predicate.Name, node, sinkType, violation.Message, ordinal)));
@@ -474,6 +486,12 @@ internal static class AssertionScan
                 if (seenViolations.Add(identity))
                     violations.Add(site);
             }
+
+            // The most recent Capture is the final stage once the loop ends: keep
+            // this stage's identities so survivors (still present at the final
+            // stage — the corpus analog of #2271's UNSOUND) can be marked after.
+            finalStageIdentities.Clear();
+            finalStageIdentities.UnionWith(stageIdentities);
         }
 
         try
@@ -499,13 +517,25 @@ internal static class AssertionScan
                 overload,
                 signature,
                 key,
-                violations,
+                MarkSurvivors(violations, finalStageIdentities),
                 covered,
                 $"{ex.GetType().Name}: {ex.Message}");
         }
 
-        return new MethodResult(assembly, assemblyPath, type, method, overload, signature, key, violations, covered, PassBug: null);
+        return new MethodResult(assembly, assemblyPath, type, method, overload, signature, key,
+            MarkSurvivors(violations, finalStageIdentities), covered, PassBug: null);
     }
+
+    /// <summary>
+    /// Flags each first-appearance violation whose claim is still present at the
+    /// final stage — a discharged obligation (wrapped by a later pass, e.g.
+    /// coercion insertion) is cleared, a survivor is the real soundness signal.
+    /// </summary>
+    internal static IReadOnlyList<ViolationSite> MarkSurvivors(
+        IReadOnlyList<ViolationSite> violations, IReadOnlySet<string> finalStageIdentities)
+        => violations
+            .Select(v => v with { FinalStageSurvivor = finalStageIdentities.Contains(v.StageIdentity) })
+            .ToArray();
 
     static int OccurrenceOrdinal(Dictionary<string, Dictionary<IrNode, int>> ordinals, string identity, IrNode node)
     {
@@ -550,12 +580,32 @@ internal static class AssertionScan
         Console.WriteLine($"ASSERTION SCAN over {scope} ({passBugs} pass bugs)");
         Console.WriteLine($"  methods with >=1 violation: {methodsWithViolations.Length} ({Percent(methodsWithViolations.Length, total)})");
         Console.WriteLine($"  first violation sites      : {violationCount}");
+
+        // Final-stage survivors are the corpus analog of #2271's UNSOUND marker:
+        // an assertion still failing after the last pass, where nothing downstream
+        // remains to discharge it. Every other violation site is a discharged
+        // OBLIGATION (a later pass, e.g. coercion insertion, wrapped the sink) —
+        // the pipeline working as designed. The survivor count is the real
+        // soundness number; "final stage is zero" for the wrappable population is
+        // the target (known PrinterOwned residuals excluded). See #2269.
+        var survivors = methodsWithViolations.SelectMany(m => m.Violations).Where(v => v.FinalStageSurvivor).ToArray();
+        int survivorMethods = methodsWithViolations.Count(m => m.Violations.Any(v => v.FinalStageSurvivor));
+        Console.WriteLine($"  final-stage survivors (UNSOUND): {survivors.Length} across {survivorMethods} method(s)");
+        Console.WriteLine($"  discharged obligations         : {violationCount - survivors.Length}");
         Console.WriteLine();
 
         PrintHistogram("By sink type:", methodsWithViolations.SelectMany(m => m.Violations).GroupBy(v => v.SinkType));
         PrintHistogram("By first failing pass:", methodsWithViolations.SelectMany(m => m.Violations).GroupBy(v => v.Pass));
         PrintHistogram("By node:", methodsWithViolations.SelectMany(m => m.Violations).GroupBy(v => v.Node));
         PrintHistogram("By predicate:", methodsWithViolations.SelectMany(m => m.Violations).GroupBy(v => v.Predicate));
+
+        if (survivors.Length > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Final-stage survivors (UNSOUND — the soundness signal):");
+            PrintHistogram("  by node:", survivors.GroupBy(v => v.Node));
+            PrintHistogram("  by sink type:", survivors.GroupBy(v => v.SinkType));
+        }
 
         Console.WriteLine();
         Console.WriteLine("Annotation coverage:");
@@ -672,6 +722,8 @@ internal static class AssertionScan
 
         var gained = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
         var lost = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
+        var survivorGained = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
+        var survivorLost = new SortedDictionary<string, List<string>>(StringComparer.Ordinal);
         foreach (var method in comparable)
         {
             var now = currentByMethod[method].ViolationIdentities();
@@ -680,12 +732,27 @@ internal static class AssertionScan
                 (gained.TryGetValue(violation, out var methods) ? methods : gained[violation] = []).Add(method);
             foreach (var violation in was.Except(now, StringComparer.Ordinal))
                 (lost.TryGetValue(violation, out var methods) ? methods : lost[violation] = []).Add(method);
+
+            var nowSurvivors = currentByMethod[method].SurvivorIdentities();
+            var wasSurvivors = baselineByMethod[method].SurvivorIdentities();
+            foreach (var violation in nowSurvivors.Except(wasSurvivors, StringComparer.Ordinal))
+                (survivorGained.TryGetValue(violation, out var methods) ? methods : survivorGained[violation] = []).Add(method);
+            foreach (var violation in wasSurvivors.Except(nowSurvivors, StringComparer.Ordinal))
+                (survivorLost.TryGetValue(violation, out var methods) ? methods : survivorLost[violation] = []).Add(method);
         }
 
         Console.WriteLine();
         Console.WriteLine($"ASSERTION VIOLATION DIFF vs {baselinePath} ({comparable.Length} methods checked in both; {onlyCurrent} only-current, {onlyBaseline} only-baseline, {passBugExcluded} pass-bug excluded)");
         PrintDiffSide("REGRESSED (method gained the violation)", gained);
         PrintDiffSide("IMPROVED (method lost the violation)", lost);
+
+        // The survivor deltas are the load-bearing soundness signal: a newly
+        // surviving assertion (UNSOUND) is a real regression, distinct from a
+        // gained-but-discharged obligation. See #2269.
+        Console.WriteLine();
+        Console.WriteLine("Final-stage survivors (UNSOUND) delta:");
+        PrintDiffSide("  SURVIVOR REGRESSED (method gained a final-stage survivor)", survivorGained);
+        PrintDiffSide("  SURVIVOR IMPROVED (method discharged a former survivor)", survivorLost);
     }
 
     static void PrintDiffSide(string title, SortedDictionary<string, List<string>> byViolation)
@@ -718,7 +785,7 @@ internal static class AssertionScan
     {
         public static AssertionViolationSnapshot FromResult(Result result)
             => new(
-                SchemaVersion: 1,
+                SchemaVersion: 2,
                 GeneratedUtc: DateTimeOffset.UtcNow,
                 Methods: result.Methods
                     .Select(m => new AssertionViolationMethod(
@@ -731,7 +798,7 @@ internal static class AssertionScan
                         m.Key,
                         m.PassBug,
                         m.Violations
-                            .Select(v => new AssertionViolationRecord(v.Pass, v.Predicate, v.Node, v.SinkType, v.Message, v.Ordinal))
+                            .Select(v => new AssertionViolationRecord(v.Pass, v.Predicate, v.Node, v.SinkType, v.Message, v.Ordinal, v.FinalStageSurvivor))
                             .OrderBy(v => v.Identity, StringComparer.Ordinal)
                             .ToArray()))
                     .OrderBy(m => m.Key, StringComparer.Ordinal)
@@ -751,6 +818,10 @@ internal static class AssertionScan
     {
         public SortedSet<string> ViolationIdentities()
             => new(Violations.Select(v => v.Identity), StringComparer.Ordinal);
+
+        /// <summary>Identities of violations still failing at the final stage — the survivor (UNSOUND) set.</summary>
+        public SortedSet<string> SurvivorIdentities()
+            => new(Violations.Where(v => v.FinalStageSurvivor).Select(v => v.Identity), StringComparer.Ordinal);
     }
 
     public sealed record AssertionViolationRecord(
@@ -759,7 +830,8 @@ internal static class AssertionScan
         string Node,
         string SinkType,
         string Message,
-        int Ordinal)
+        int Ordinal,
+        bool FinalStageSurvivor = false)
     {
         public string Identity => $"{Predicate}|{Node}|{SinkType}|{Message}#{Ordinal}";
     }

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -21,6 +21,21 @@ investigate). Use `--sample N` to run a deterministic hash-ranked sample per
 assembly, and combine it with `--package` / `--package-version` /
 `--package-tfm` / `--package-assembly` the same way other harness scans do.
 
+The scan splits every violation into a **discharged obligation** (flagged at an
+intermediate stage, then wrapped by a later pass — e.g. coercion insertion) and a
+**final-stage survivor** — an assertion still failing after the last pass, the
+corpus-scale analog of `--dump --assertions`' `UNSOUND` marker (see below and
+[docs/design/assertion-lane-effects.md](../../docs/design/assertion-lane-effects.md)).
+The `final-stage survivors (UNSOUND)` line is the real soundness number:
+`first violation sites` counts everything (mostly discharged obligations, which
+are the pipeline working as designed), while a non-zero survivor count is the
+load-bearing signal. "Final stage is zero survivors" for the wrappable population
+is now measured corpus-wide rather than eyeballed from `--dump --assertions`
+exemplars (known `PrinterOwned` residuals excluded). `--emit-assertion-violations`
+persists the survivor flag (snapshot schema v2), and `--diff-assertion-violations`
+reports a dedicated **survivor delta** so a newly surviving assertion is
+distinguished from a gained-but-discharged obligation.
+
 The scan is a triage and localized-signoff aid, not a CI gate on a raw violation
 count. It automates the value-typed-emission leak-surface census, but the
 population-scale correctness gates remain compile-back, render A/B, and the


### PR DESCRIPTION
## Summary

Implements the first #2269 follow-up: make **final-stage survivors** a measured, corpus-wide number instead of eyeballing "final stage is zero" from `--dump --assertions` exemplars.

The scan reported `first violation sites` — every assertion that failed at *any* stage. Most are **discharged obligations** (flagged at an intermediate stage, then wrapped by a later pass — the corpus analog of #2271's `OBLIGATION`, the pipeline working as designed). The real soundness signal is a **final-stage survivor**: an assertion still failing after the last pass (the corpus analog of `UNSOUND`).

- Track the violation identities present at the final stage; mark each first-appearance site as survivor or discharged obligation (`ViolationSite.FinalStageSurvivor`).
- Report `final-stage survivors (UNSOUND)` as the load-bearing number, with by-node/by-sink histograms, distinct from the raw `first violation sites`.
- Persist the flag in `--emit-assertion-violations` (snapshot **schema v2**); add a dedicated **survivor delta** to `--diff-assertion-violations` so a newly surviving assertion is distinguished from a gained-but-discharged obligation.

## Evidence

- **Decompiler corpus (89,065 methods): 52,837 first violation sites → 0 final-stage survivors** (all discharged) — "final stage is zero" now measured, not eyeballed.
- `--sample 200` on the decompiler DLL: 129 sites → 0 survivors → 129 discharged.
- Emit → diff round-trip: snapshot is `SchemaVersion: 2` with `FinalStageSurvivor`; self-diff shows no survivor regressions; the survivor-delta section renders.
- Tests (14/14 `AssertionScanTests`): discharged-through-pipeline is *not* a survivor; `MarkSurvivors` flags only final-stage identities; `StageIdentity` is pass-independent. Fast decompiler suite **1849/0**; `markdownlint` clean.

## Scope / relationship

Harness/test only; **no product code**. This is follow-up #1 from #2269 and realizes the first roadmap item in `docs/design/assertion-lane-effects.md` (PR #2274). Remaining #2269 follow-ups (obligation-lifetime metric; named discharge → per-pass effect signatures) stay tracked on the issue. The survivor number is **report/diff-only** — it does not flip the default exit code (the corpus has known `PrinterOwned` residuals; a hard zero-gate would need a residual allowlist, a later step).

## Review

Requesting two-model adversarial review per policy (decompiler-adjacent measurement semantics), though it is harness/test-only.
