### PR TITLE
Preserve attribute base in RTS shells

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -904,6 +904,10 @@ public class GeneratedFixtureCatalogTests
             GeneratedFixtureCatalog.Select("minimal.property.literal").Select(fixture => fixture.Id).ToArray());
 
         Assert.Equal(
+            ["rts.attribute-shell"],
+            GeneratedFixtureCatalog.Select("rts").Select(fixture => fixture.Id).Order(StringComparer.Ordinal).ToArray());
+
+        Assert.Equal(
             [
                 "record.equality-operators",
                 "record.field-read-helpers",
@@ -1023,6 +1027,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "record.struct-field-read-helpers");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "record.generic-typed-equals");
         Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "record.nested-generic-typed-equals");
+        Assert.Contains(fixtures, fixture => fixture.GetProperty("Id").GetString() == "rts.attribute-shell");
 
         var primaryCtor = Assert.Single(fixtures,
             fixture => fixture.GetProperty("Id").GetString() == "minimal.primary-ctor.field-init");
@@ -1122,6 +1127,29 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("record.nested-generic-typed-equals", report);
         Assert.DoesNotContain("Skipped target reasons", report);
         Assert.DoesNotContain("Failed target buckets", report);
+    }
+
+    [Fact]
+    public void ReturnToSenderRtsCatalog_CoversAttributeShellBaseType()
+    {
+        var run = GeneratedFixtureRunner.RunReturnToSenderCatalog(
+            GeneratedFixtureCatalog.Select("rts.attribute-shell"));
+        string report = GeneratedFixtureRunner.FormatReturnToSenderCatalogReport(run, maxExamples: 10);
+
+        Assert.True(run.Passed, report);
+        Assert.Equal(2, run.Results.Count);
+        Assert.All(run.Results, result =>
+        {
+            Assert.Equal(GeneratedFixtureReturnToSenderStatus.Pass, result.Status);
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.ActualStatus);
+        });
+        Assert.Contains(run.Results, result =>
+            result.FixtureId == "rts.attribute-shell" &&
+            result.Method == ".ctor");
+        Assert.Contains(run.Results, result =>
+            result.FixtureId == "rts.attribute-shell" &&
+            result.Method == "get_FeatureType");
+        Assert.DoesNotContain("CS0641", report);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -899,6 +899,7 @@ public static class CompileBackSourceComposer
                 })
                 .ToList(),
             Interfaces = type.Interfaces.Select(type => type.DisplayName).ToList(),
+            BaseType = type.BaseType?.DisplayName,
             Attributes = type.Attributes?.ToList() ?? [],
             IsAbstract = type.IsAbstract,
         };
@@ -1928,7 +1929,7 @@ public static class CompileBackSourceComposer
                 requirement.Type,
                 requirement.RequiredKind,
                 CompileBackAccessibility.Public,
-                BaseType: null,
+                BaseType: BaseTypeSignature(reader, typeDef),
                 PrimaryConstructorParameters: requirement.PrimaryConstructor?.Parameters,
                 TypeParameters: TypeParameters(reader, typeDef),
                 Interfaces: InterfaceSignatures(reader, typeDef),
@@ -2007,7 +2008,7 @@ public static class CompileBackSourceComposer
                     identity,
                     kind,
                     CompileBackAccessibility.Public,
-                    BaseType: null,
+                    BaseType: BaseTypeSignature(reader, nestedDef),
                     PrimaryConstructorParameters: requirement.PrimaryConstructor?.Parameters,
                     TypeParameters: TypeParameters(reader, nestedDef),
                     Interfaces: InterfaceSignatures(reader, nestedDef),
@@ -2023,6 +2024,19 @@ public static class CompileBackSourceComposer
 
         static IReadOnlyList<string> TypeAttributeList(MetadataReader reader, TypeDefinition typeDef)
             => AttributeReader.RenderAttributes(reader, typeDef.GetCustomAttributes(), qualifyNames: true);
+
+        static CompileBackTypeSignature? BaseTypeSignature(MetadataReader reader, TypeDefinition typeDef)
+        {
+            if ((typeDef.Attributes & TypeAttributes.Interface) != 0)
+                return null;
+            if (typeDef.BaseType.IsNil)
+                return null;
+
+            string? baseType = TypeResolver.GetTypeName(reader, typeDef.BaseType, GenericContext.ForType(reader, typeDef));
+            return baseType is "System.Attribute"
+                ? CompileBackTypeSignature.Display(baseType)
+                : null;
+        }
 
         static IReadOnlyList<CompileBackTypeSignature> InterfaceSignatures(MetadataReader reader, TypeDefinition typeDef)
         {

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -1446,6 +1446,38 @@ internal static class GeneratedFixtureCatalog
         ],
         ["record", "nested", "generic", "equals", "return-to-sender"]);
 
+    public static readonly GeneratedFixtureDefinition RtsAttributeShell = new(
+        "rts.attribute-shell",
+        """
+        namespace System.Diagnostics.CodeAnalysis;
+
+        [System.AttributeUsage(System.AttributeTargets.Property | System.AttributeTargets.Parameter | System.AttributeTargets.ReturnValue)]
+        public sealed class FeatureGuardAttribute : System.Attribute
+        {
+            public FeatureGuardAttribute(System.Type featureType)
+            {
+                FeatureType = featureType;
+            }
+
+            public System.Type FeatureType { get; }
+        }
+        """,
+        [
+            new(
+                "System.Diagnostics.CodeAnalysis.FeatureGuardAttribute",
+                ".ctor",
+                FidelityCheck.CompileBackStatus.Exact),
+            new(
+                "System.Diagnostics.CodeAnalysis.FeatureGuardAttribute",
+                "get_FeatureType",
+                FidelityCheck.CompileBackStatus.Exact,
+                ExpectedTargetBodyFragments:
+                [
+                    "return this.FeatureType;",
+                ]),
+        ],
+        ["rts", "attribute", "shell", "return-to-sender"]);
+
     public static readonly GeneratedFixtureDefinition AssertionNodeCoverage = new(
         "assertion.inverse-node-coverage",
         """
@@ -1817,6 +1849,11 @@ internal static class GeneratedFixtureCatalog
         RecordNestedGenericTypedEquals,
     ];
 
+    public static IReadOnlyList<GeneratedFixtureDefinition> ReturnToSenderParity { get; } =
+    [
+        RtsAttributeShell,
+    ];
+
     public static IReadOnlyList<GeneratedFixtureDefinition> AssertionCoverage { get; } =
     [
         AssertionNodeCoverage,
@@ -1828,6 +1865,7 @@ internal static class GeneratedFixtureCatalog
         .. All,
         .. Frontiers,
         .. ReturnToSenderRecords,
+        .. ReturnToSenderParity,
         .. AssertionCoverage,
     ];
 

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -133,6 +133,9 @@ generic and nested-generic typed `Equals(T)`; run
 generated fixtures run; use `list` to list fixture IDs, `--json` for
 machine-readable list/results, and
 `--keep-generated-fixtures` to preserve the generated project for drill-down.
+The `rts.*` fixtures are focused ReturnToSender parity-burndown probes; for
+example `rts.attribute-shell` protects attribute type shells that must preserve a
+spellable `System.Attribute` base before attribute usages can compile.
 Rows may carry two independent expectations: a Roslyn `SyntaxKind` shape verdict
 for the intended C# idiom, and a compile-back opcode verdict for semantic
 fidelity. A row can therefore be opcode-exact while still exposing a shape


### PR DESCRIPTION
- Advances #2280
- Changes product compile-back source composition plus RTS parity fixture coverage
- Evidence revision: `344aa575`

## Change

> Should we accept this harness/product compile-back change?

**Conclusion:** **PASS** — the issue #2280 attribute-shell blocker now has a product-side fix and an addressable RTS parity fixture.

Before:

```text
rts.attribute-shell
  FeatureGuardAttribute::.ctor          RecompileFail CS0641
  FeatureGuardAttribute::get_FeatureType RecompileFail CS0641
```

After:

```text
RETURNTOSENDER GENERATED FIXTURE FRONTIER over 1 fixture(s), 2 target(s)
Fixtures: Passed 1, Skipped 0, Failed 0
Targets : Passed 2, Skipped 0, Failed 0
```

## Scope and safety

- **Root cause:** product compile-back source composition dropped the `System.Attribute` base from reconstructed attribute class shells, so emitted `[AttributeUsage]` metadata failed to compile with CS0641.
- **Fix shape:** carry `CompileBackTypeDeclaration.BaseType` into `ApiType.BaseType` and set that base to `System.Attribute` for reconstructed attribute shells.
- **Product impact:** compile-back source composition only; no decompiler raise/printer output path change.
- **Scope boundary:** direct `System.Attribute` base preservation for the observed issue #2280 blocker. Broader custom attribute base-chain closure remains future RTS parity work if corpus evidence demands it.
- **RTS boundary:** no RTS C# generation. RTS remains orchestration/measurement; the source gap is fixed in product source composition.

## Evidence

| Check | Result |
| --- | --- |
| Product build | `dotnet build src/dotnet-inspect -c Release --no-restore --verbosity minimal` passed |
| Focused tests | `GeneratedFixtureCatalogTests` passed, 12/12 |
| Targeted compile-back | `--return-to-sender-catalog rts.attribute-shell --max-examples 10` passed, 1 fixture / 2 targets |
| Markdown | `npx markdownlint-cli tools/DecompilerHarness/README.md` passed |
| Diff hygiene | `git diff --check` passed |

## Compile-back quality

> Did this increase the checkable population without hiding a product defect?

**Conclusion:** **PASS** — the focused RTS parity fixture converts the CS0641 attribute-shell bucket into 2 exact targets.

### Targeted changed-method boss

Run: generated `rts.attribute-shell` fixture, 2 RTS targets.

| Metric (goal) | Baseline | PR |
| --- | ---: | ---: |
| Attempted (+) | 2 | 2 |
| Exact (+) | 0 | 2 |
| OpcodeDiff Full (-) | 0 | 0 |
| RecompileFail (-) | 2 | 0 |
| ContextFail (-) | 0 | 0 |
| Skipped (-) | 0 | 0 |

| Bucket / code (goal) | Baseline | PR | Delta | Example |
| --- | ---: | ---: | ---: | --- |
| RecompileFail `CS0641` (-) | 2 | 0 | -2 | `FeatureGuardAttribute::get_FeatureType` |
| Exact (+) | 0 | 2 | +2 | `FeatureGuardAttribute::.ctor` |

### Broad assembly context

Not run; this PR targets the issue #2280 attribute-shell blocker with a generated parity fixture.

### ReturnToSender A/B

Not applicable; the targeted `rts.attribute-shell` generated fixture is the proof surface.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Direct `System.Attribute` shell base | Fixed | Required for `[AttributeUsage]` metadata on reconstructed attribute shells to compile. |
| Custom attribute base-chain closure | Left as future work | Not required by the current issue #2280 evidence; keep scope to the measured blocker. |
| RTS source generation | Not changed | Per project rule, RTS does not generate C#; product source composition owns the fix. |

## Build-event validation

**Conclusion:** not applicable — no build-event instrumentation changed.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Pending | Pending | Adversarial review requested after PR creation. |
| Pending | Pending | Adversarial review requested after PR creation. |

**Review conclusion:** **REVIEW** — pending adversarial review reconciliation.

## Validation

```bash
dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --return-to-sender-catalog rts.attribute-shell --max-examples 10
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
npx markdownlint-cli tools/DecompilerHarness/README.md
dotnet restore src/dotnet-inspect/dotnet-inspect.csproj --configfile nuget.config --verbosity minimal
dotnet build src/dotnet-inspect -c Release --no-restore --verbosity minimal
git diff --check
```
