### PR TITLE
Avoid HashSet copies in the forward-dataflow fixpoint (#2198)

### DIFF
--- a/src/ILInspector.ControlFlow/ForwardDataflow.cs
+++ b/src/ILInspector.ControlFlow/ForwardDataflow.cs
@@ -173,6 +173,13 @@ public static class ForwardDataflow
     {
         if (merge == DataflowMerge.Union)
         {
+            // Fast path: with no seed and exactly one reachable predecessor, the merged in-set is
+            // that predecessor's out-set. Dataflow sets are immutable once assigned (they are always
+            // replaced by a fresh set, never mutated in place, and MergePredecessors only reads
+            // out-sets), so aliasing it avoids a full HashSet copy on the common straight-line block.
+            if (seed is null && TrySingleReachablePredecessor(predecessors, reachable, out int only))
+                return outSets[only];
+
             var result = seed is null ? new HashSet<int>() : new HashSet<int>(seed);
             foreach (int predecessor in predecessors)
                 if (reachable[predecessor])
@@ -193,8 +200,32 @@ public static class ForwardDataflow
         return intersection ?? [];
     }
 
-    static HashSet<int> Apply(IReadOnlySet<int> input, GenKillSet transfer)
+    static bool TrySingleReachablePredecessor(IReadOnlyList<int> predecessors, IReadOnlyList<bool> reachable, out int only)
     {
+        only = -1;
+        foreach (int predecessor in predecessors)
+        {
+            if (!reachable[predecessor])
+                continue;
+            if (only >= 0)
+            {
+                only = -1;
+                return false;
+            }
+            only = predecessor;
+        }
+        return only >= 0;
+    }
+
+    static HashSet<int> Apply(HashSet<int> input, GenKillSet transfer)
+    {
+        // Fast path: a block with no gen and no kill passes its in-set straight through as its
+        // out-set. Dataflow sets are immutable once assigned (see MergePredecessors), so aliasing the
+        // in-set as the out-set avoids a full HashSet copy for every control-flow-only block on every
+        // fixpoint iteration — the dominant allocation in the solver.
+        if (transfer.Gen.Count == 0 && transfer.Kill.Count == 0)
+            return input;
+
         var output = new HashSet<int>(input);
         output.ExceptWith(transfer.Kill);
         output.UnionWith(transfer.Gen);


### PR DESCRIPTION
- Advances #2198 (analysis index-build cost).
- Cuts HashSet copies in the forward-dataflow fixpoint; behavior-preserving; ~18-20% faster full index build.

## Change

> Should we accept this change?

**Conclusion: PASS** — behavior-preserving (identical dataflow results and byte-identical product output), removes the largest real-work leaf in the index build, ~18-20% faster.

CPU sampling of a full `LibraryBodyIndex` build (the cost #2198 tracks) showed **`HashSet<int>` copy-construction as the single largest real-work leaf (~13% of samples)** — dominating the reaching-definitions / definite-assignment dataflow. The solver allocates a fresh `HashSet` per block per fixpoint iteration in two spots that are usually pass-throughs.

**Key invariant:** dataflow sets are immutable once assigned — `inSets[i]`/`outSets[i]` are always *replaced* by a fresh set, never mutated in place, and `MergePredecessors` only *reads* predecessor out-sets. So the two common pass-through cases can alias an existing set instead of copying:

- **`Apply`** — a block with empty gen and kill returns its in-set unchanged; return it directly instead of `new HashSet<int>(input)`. (Every control-flow-only block, every iteration.)
- **`MergePredecessors`** — a union merge with no seed and exactly one reachable predecessor equals that predecessor's out-set; return it directly. (Every straight-line block.)

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| ForwardDataflow tests | 8/8 |
| Analysis tests | 342/342 |
| Decompiler fast suite (Speed!=Slow) | 1846/1846 |
| Output equivalence | `library -S "Performance Triage"` over `ILInspector.Decompiler.dll` byte-identical before/after (673 rows) |

### Perf (interleaved A/B, full index build, `ILInspector.Decompiler.dll`, 6781 methods)

| Build | Median ms/build |
| --- | ---: |
| base | ~410 |
| this PR | ~336 |

~18-20% faster — recovering most of the ~30% index-build regression #2198 tracks. Both `ForwardDataflow` consumers exercised: `ReachingDefinitions` (Analysis) and `DefiniteAssignment` (decompiler printer).

## Adversarial review

Requested from two models (isolated worktrees) — this touches a shared analysis/decompiler correctness primitive. Reconciliation to follow on this PR.
