### PR TITLE
Report obligation lifetime in --assertion-scan (#2269)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
@@ -262,10 +262,13 @@ public class AssertionScanTests
         var violation = Assert.Single(result.Violations);
         Assert.False(violation.FinalStageSurvivor);
         Assert.Contains(nameof(Coerce), result.CoveredNodes);
+        // Discharged, so it has a real lifetime and a named discharging pass.
+        Assert.True(violation.LifetimeStages > 0);
+        Assert.NotEqual("", violation.DischargePass);
     }
 
     [Fact]
-    public void MarkSurvivors_FlagsOnlyViolationsPresentAtFinalStage()
+    public void Finalize_FlagsSurvivorsAndComputesDischargedLifetime()
     {
         var discharged = new AssertionScan.ViolationSite(
             Method: "m", Pass: IrPasses.ImportStageName, Predicate: "SinkDistinguishableFromStack",
@@ -274,13 +277,32 @@ public class AssertionScanTests
             Method: "m", Pass: IrPasses.ImportStageName, Predicate: "SinkDistinguishableFromStack",
             Node: nameof(Constant), SinkType: "bool", Message: "0 occupies a bool sink without a Coerce", Ordinal: 0);
 
-        // Only the survivor's stage identity is present at the final stage.
+        // Stage order: import(0), pass-a(1), coercion-insertion(2), tail(3).
+        var stageNames = new[] { IrPasses.ImportStageName, "pass-a", "coercion-insertion", "tail" };
+        // Discharged accrued at import(0), last present at pass-a(1) -> discharged at index 2.
+        var firstStage = new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            [discharged.StageIdentity] = 0,
+            [survivor.StageIdentity] = 0,
+        };
+        var lastStage = new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            [discharged.StageIdentity] = 1,
+            [survivor.StageIdentity] = 3,
+        };
         var finalStage = new HashSet<string>(StringComparer.Ordinal) { survivor.StageIdentity };
 
-        var marked = AssertionScan.MarkSurvivors([discharged, survivor], finalStage);
+        var marked = AssertionScan.Finalize([discharged, survivor], finalStage, stageNames, firstStage, lastStage);
 
-        Assert.False(marked.Single(v => v.Node == nameof(LoadArgument)).FinalStageSurvivor);
-        Assert.True(marked.Single(v => v.Node == nameof(Constant)).FinalStageSurvivor);
+        var d = marked.Single(v => v.Node == nameof(LoadArgument));
+        Assert.False(d.FinalStageSurvivor);
+        Assert.Equal(2, d.LifetimeStages);            // dischargeIndex(2) - accrual(0)
+        Assert.Equal("coercion-insertion", d.DischargePass);
+
+        var s = marked.Single(v => v.Node == nameof(Constant));
+        Assert.True(s.FinalStageSurvivor);
+        Assert.Equal(0, s.LifetimeStages);            // survivors never discharge
+        Assert.Equal("", s.DischargePass);
     }
 
     [Fact]

--- a/tools/DecompilerHarness/AssertionScan.cs
+++ b/tools/DecompilerHarness/AssertionScan.cs
@@ -30,7 +30,9 @@ internal static class AssertionScan
         string SinkType,
         string Message,
         int Ordinal,
-        bool FinalStageSurvivor = false)
+        bool FinalStageSurvivor = false,
+        int LifetimeStages = 0,
+        string DischargePass = "")
     {
         public string Identity => $"{Pass}|{Predicate}|{Node}|{SinkType}|{Message}#{Ordinal}";
 
@@ -466,9 +468,14 @@ internal static class AssertionScan
         }
 
         var finalStageIdentities = new HashSet<string>(StringComparer.Ordinal);
+        var stageNames = new List<string>();
+        var firstStageByIdentity = new Dictionary<string, int>(StringComparer.Ordinal);
+        var lastStageByIdentity = new Dictionary<string, int>(StringComparer.Ordinal);
 
         void Capture(string passName)
         {
+            int stageIndex = stageNames.Count;
+            stageNames.Add(passName);
             AddCoveredNodes(function, covered);
             var stageIdentities = new HashSet<string>(StringComparer.Ordinal);
             var stageViolations = new List<(string Identity, ViolationSite Site)>();
@@ -482,6 +489,13 @@ internal static class AssertionScan
                     int ordinal = OccurrenceOrdinal(occurrenceOrdinals, identity, violation.Node);
                     string stableIdentity = $"{identity}#{ordinal}";
                     stageIdentities.Add(stableIdentity);
+                    // Track the accrual (first) and last-present stage index per
+                    // identity — pass names in IrPasses.Default are not unique
+                    // (e.g. typed-constants runs twice), so lifetime must key on
+                    // capture-order index, not the pass name.
+                    if (!firstStageByIdentity.ContainsKey(stableIdentity))
+                        firstStageByIdentity[stableIdentity] = stageIndex;
+                    lastStageByIdentity[stableIdentity] = stageIndex;
                     stageViolations.Add((
                         stableIdentity,
                         new ViolationSite(key, passName, predicate.Name, node, sinkType, violation.Message, ordinal)));
@@ -524,24 +538,47 @@ internal static class AssertionScan
                 overload,
                 signature,
                 key,
-                MarkSurvivors(violations, finalStageIdentities),
+                Finalize(violations, finalStageIdentities, stageNames, firstStageByIdentity, lastStageByIdentity),
                 covered,
                 $"{ex.GetType().Name}: {ex.Message}");
         }
 
         return new MethodResult(assembly, assemblyPath, type, method, overload, signature, key,
-            MarkSurvivors(violations, finalStageIdentities), covered, PassBug: null);
+            Finalize(violations, finalStageIdentities, stageNames, firstStageByIdentity, lastStageByIdentity),
+            covered, PassBug: null);
     }
 
     /// <summary>
-    /// Flags each first-appearance violation whose claim is still present at the
-    /// final stage — a discharged obligation (wrapped by a later pass, e.g.
-    /// coercion insertion) is cleared, a survivor is the real soundness signal.
+    /// Marks each first-appearance violation with its final-stage-survivor status
+    /// and, for a discharged obligation, its lifetime — the number of pipeline
+    /// stages it persisted from accrual to discharge (the corpus analog of the
+    /// obligation-lifetime the effects model describes). A survivor has no
+    /// discharge, so its lifetime is 0 and <c>DischargePass</c> is empty; a
+    /// discharged obligation records the pass that cleared it. A short lifetime
+    /// means a pass decided the type early; a long one means it retrofitted the
+    /// claim late.
     /// </summary>
-    internal static IReadOnlyList<ViolationSite> MarkSurvivors(
-        IReadOnlyList<ViolationSite> violations, IReadOnlySet<string> finalStageIdentities)
+    internal static IReadOnlyList<ViolationSite> Finalize(
+        IReadOnlyList<ViolationSite> violations,
+        IReadOnlySet<string> finalStageIdentities,
+        IReadOnlyList<string> stageNames,
+        IReadOnlyDictionary<string, int> firstStageByIdentity,
+        IReadOnlyDictionary<string, int> lastStageByIdentity)
         => violations
-            .Select(v => v with { FinalStageSurvivor = finalStageIdentities.Contains(v.StageIdentity) })
+            .Select(v =>
+            {
+                bool survivor = finalStageIdentities.Contains(v.StageIdentity);
+                if (survivor)
+                    return v with { FinalStageSurvivor = true, LifetimeStages = 0, DischargePass = "" };
+
+                int first = firstStageByIdentity[v.StageIdentity];
+                int last = lastStageByIdentity[v.StageIdentity];
+                // Discharged after `last`: the first absent stage is last+1.
+                int dischargeIndex = last + 1;
+                int lifetime = dischargeIndex - first;
+                string dischargePass = dischargeIndex < stageNames.Count ? stageNames[dischargeIndex] : "";
+                return v with { FinalStageSurvivor = false, LifetimeStages = lifetime, DischargePass = dischargePass };
+            })
             .ToArray();
 
     static int OccurrenceOrdinal(Dictionary<string, Dictionary<IrNode, int>> ordinals, string identity, IrNode node)
@@ -612,6 +649,24 @@ internal static class AssertionScan
             Console.WriteLine("Final-stage survivors (UNSOUND — the soundness signal):");
             PrintHistogram("  by node:", survivors.GroupBy(v => v.Node));
             PrintHistogram("  by sink type:", survivors.GroupBy(v => v.SinkType));
+        }
+
+        // Obligation lifetime — stages from accrual to discharge — is a
+        // construction-quality signal: a short lifetime means a pass decided the
+        // type early, a long one means it retrofitted the claim late. Only
+        // discharged obligations have a lifetime (survivors never discharge). See
+        // docs/design/assertion-lane-effects.md.
+        var discharged = methodsWithViolations.SelectMany(m => m.Violations).Where(v => !v.FinalStageSurvivor).ToArray();
+        if (discharged.Length > 0)
+        {
+            var lifetimes = discharged.Select(v => v.LifetimeStages).ToArray();
+            Console.WriteLine();
+            Console.WriteLine("Obligation lifetime (discharged; stages from accrual to discharge):");
+            Console.WriteLine($"  mean: {lifetimes.Average():F1}  max: {lifetimes.Max()}  min: {lifetimes.Min()}");
+            PrintHistogram("  by discharging pass:", discharged.Where(v => v.DischargePass.Length > 0).GroupBy(v => v.DischargePass));
+            Console.WriteLine("  longest-lived (retrofit hotspots):");
+            foreach (var v in discharged.OrderByDescending(v => v.LifetimeStages).Take(maxExamples))
+                Console.WriteLine($"    {v.LifetimeStages} stages  {v.Node} -> {v.SinkType}  ({v.Pass} -> {v.DischargePass})");
         }
 
         Console.WriteLine();

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -36,6 +36,14 @@ persists the survivor flag (snapshot schema v2), and `--diff-assertion-violation
 reports a dedicated **survivor delta** so a newly surviving assertion is
 distinguished from a gained-but-discharged obligation.
 
+For discharged obligations the scan also reports **obligation lifetime** — the
+number of pipeline stages from accrual (first appearance) to discharge (the stage
+a later pass cleared it). A short lifetime means a pass decided the type early; a
+long one means it retrofitted the claim late, so the `longest-lived (retrofit
+hotspots)` list surfaces the obligations a pass could discharge sooner. Lifetime
+is a construction-quality trend, not a gate; see
+[docs/design/assertion-lane-effects.md](../../docs/design/assertion-lane-effects.md).
+
 The scan is a triage and localized-signoff aid, not a CI gate on a raw violation
 count. It automates the value-typed-emission leak-surface census, but the
 population-scale correctness gates remain compile-back, render A/B, and the


### PR DESCRIPTION
## Summary

Second #2269 follow-up (roadmap item 2 in `assertion-lane-effects.md`), building on the survivor split (#2281). For each **discharged obligation** the scan now records its **lifetime** — the number of pipeline stages from accrual (first appearance) to discharge (the stage a later pass cleared it) — plus the discharging pass.

A short lifetime means a pass decided the type early; a long one means it retrofitted the claim late. The report adds:

- `Obligation lifetime (discharged; stages from accrual to discharge): mean/max/min`
- a histogram **by discharging pass**
- a `longest-lived (retrofit hotspots)` list — the obligations a pass could discharge sooner.

Lifetime keys on **capture-order stage index**, not pass name, because `IrPasses.Default` names are not unique (e.g. `typed-constants` runs twice). Survivors have no discharge → lifetime 0 / empty discharge pass.

## Evidence

- Decompiler corpus (89,065 methods): 52,883 discharged obligations, **mean 5.2 stages, max 76**. Most `Constant->bool` obligations discharge at `typed-constants` (lifetime ~1); a `Comparison->int` tail lingers **50+ stages** before `bool-to-int-normalization` — the actionable "decided late" signal.
- `--sample 300` on the decompiler DLL: mean 2.3, max 52, discharging passes `typed-constants` (171) / `slot-store-diamond` (4) / `bool-to-int-normalization` (2).
- Tests (14/14 `AssertionScanTests`): `Finalize_FlagsSurvivorsAndComputesDischargedLifetime` (discharged lifetime = dischargeIndex − accrual, named discharge pass; survivor = 0/empty); the real-pipeline discharge test now also asserts `LifetimeStages > 0` and a non-empty `DischargePass`. Fast decompiler suite **1854/0**; `markdownlint` clean.

## Scope

Harness/test only; **no product code**. The `MarkSurvivors` finalize step is renamed `Finalize` (now computes survivor status + lifetime in one pass). Lifetime is a construction-quality trend, **report-only** — not added to the snapshot/diff and does not affect the exit code. Remaining #2269 item (named-discharge → per-pass effect *signatures*, the structural gate) stays tracked on the issue.

## Review

Requesting two-model adversarial review per policy (decompiler-adjacent measurement semantics), though it is harness/test-only.
