### PR TITLE
runfaster: consume the static multiplicity prior as predict-vs-observe (#2286)

### DIFF
--- a/src/runfaster.Tests/MultiplicityCheckTests.cs
+++ b/src/runfaster.Tests/MultiplicityCheckTests.cs
@@ -6,13 +6,13 @@ using System.Collections.Generic;
 public class MultiplicityCheckTests
 {
     [Fact]
-    public void LoopMultiplicity_Observed_IsLoopConfirmed()
+    public void LoopMultiplicity_Observed_IsLoopHot()
     {
         var c = Candidate(multiplicity: "Loop");
         c.AllocationHits = 3;
         c.AllocationBytes = 5_000_000;
 
-        Assert.Equal("loop-confirmed", c.MultiplicityCheck);
+        Assert.Equal("loop-hot", c.MultiplicityCheck);
     }
 
     [Fact]
@@ -36,11 +36,25 @@ public class MultiplicityCheckTests
     }
 
     [Fact]
-    public void LoopMultiplicity_NotObserved_IsLoopCold()
+    public void LoopMultiplicity_NotObserved_IsLoopUnexercised()
     {
         var c = Candidate(multiplicity: "Loop"); // no runtime hits
 
-        Assert.Equal("loop-cold", c.MultiplicityCheck);
+        Assert.Equal("loop-unexercised", c.MultiplicityCheck);
+    }
+
+    [Fact]
+    public void LoopMultiplicity_TypeConfirmed_IsLoopHotNotUnexercised()
+    {
+        // A type-confirmed loop site (its type realized-hot, exact site inlined) is HOT, not cold —
+        // labeling it "loop-unexercised" would contradict the type-confirmation. It must read loop-hot.
+        var c = Candidate(multiplicity: "Loop");
+        c.TypeConfirmedBytes = 700_000_000;
+        c.TypeConfirmedSiteCount = 1;
+
+        Assert.True(c.TypeConfirmed);
+        Assert.False(c.IsObserved);
+        Assert.Equal("loop-hot", c.MultiplicityCheck);
     }
 
     [Fact]

--- a/src/runfaster.Tests/MultiplicityCheckTests.cs
+++ b/src/runfaster.Tests/MultiplicityCheckTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+
+// Tests for the multiplicity predict-vs-observe signal (issue #2286): the static multiplicity prior
+// disambiguates a hot site's cause (intrinsic per-iteration churn vs call-frequency-driven volume)
+// and flags loop sites predicted per-iteration but not exercised.
+public class MultiplicityCheckTests
+{
+    [Fact]
+    public void LoopMultiplicity_Observed_IsLoopConfirmed()
+    {
+        var c = Candidate(multiplicity: "Loop");
+        c.AllocationHits = 3;
+        c.AllocationBytes = 5_000_000;
+
+        Assert.Equal("loop-confirmed", c.MultiplicityCheck);
+    }
+
+    [Fact]
+    public void OnceMultiplicity_Observed_IsCallFrequency()
+    {
+        var c = Candidate(multiplicity: "Once");
+        c.AllocationHits = 3;
+        c.AllocationBytes = 5_000_000;
+
+        Assert.Equal("call-frequency", c.MultiplicityCheck);
+    }
+
+    [Fact]
+    public void ConditionalMultiplicity_Observed_IsCallFrequency()
+    {
+        var c = Candidate(multiplicity: "Conditional");
+        c.AllocationHits = 1;
+        c.AllocationBytes = 1_000_000;
+
+        Assert.Equal("call-frequency", c.MultiplicityCheck);
+    }
+
+    [Fact]
+    public void LoopMultiplicity_NotObserved_IsLoopCold()
+    {
+        var c = Candidate(multiplicity: "Loop"); // no runtime hits
+
+        Assert.Equal("loop-cold", c.MultiplicityCheck);
+    }
+
+    [Fact]
+    public void OnceMultiplicity_NotObserved_IsNull()
+    {
+        var c = Candidate(multiplicity: "Once"); // cold, not loop -> no signal
+
+        Assert.Null(c.MultiplicityCheck);
+    }
+
+    [Fact]
+    public void UnknownMultiplicity_IsNullRegardlessOfObservation()
+    {
+        var cold = Candidate(multiplicity: "Unknown");
+        var hot = Candidate(multiplicity: "Unknown");
+        hot.AllocationHits = 5;
+        hot.AllocationBytes = 9_000_000;
+
+        Assert.Null(cold.Multiplicity);
+        Assert.Null(cold.MultiplicityCheck);
+        Assert.Null(hot.MultiplicityCheck);
+    }
+
+    static AllocationCandidate Candidate(string multiplicity)
+        => new(
+            id: 1,
+            source: "library",
+            libraryPath: "/tmp/Fixture.dll",
+            assemblyName: "Fixture",
+            moduleVersionId: null,
+            methodToken: 0x06000001,
+            ilOffset: 0x0010,
+            method: "Fixture.Type.M()",
+            methodKey: "Fixture.Type.M",
+            methodStackKey: "Fixture.Type::M",
+            allocationKind: "Object",
+            allocatedType: "Fixture.Allocated",
+            detail: null,
+            inLoop: multiplicity == "Loop",
+            frequency: "Always",
+            escape: "Escapes",
+            confidence: null,
+            fix: null,
+            rootReach: null,
+            pathKind: null,
+            pathConfidence: null,
+            postDominance: null,
+            estimatedSizeBytes: null,
+            sizeTier: null,
+            escapeKind: null,
+            churnedType: null,
+            runtimeAllocationType: null,
+            multiplicity: multiplicity);
+}

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -1189,35 +1189,36 @@ static void RenderMarkdown(CorrelationResult result, IReadOnlyList<AllocationCan
     }
 
     // Multiplicity predict-vs-observe (#2286): disambiguate a hot site's cause using the static
-    // multiplicity prior, and surface loop sites that were predicted per-iteration but not exercised.
-    var loopConfirmed = observed.Where(c => c.MultiplicityCheck == "loop-confirmed").OrderByDescending(c => c.EffectiveObservedBytes).ToArray();
+    // multiplicity prior. The trace confirms the site/type is HOT; the Loop/Once split is a static
+    // prior it does not verify — so this describes the likely cause, it does not prescribe a fix.
+    var loopHot = observed.Where(c => c.MultiplicityCheck == "loop-hot").OrderByDescending(c => c.EffectiveObservedBytes).ToArray();
     var callFrequency = observed.Where(c => c.MultiplicityCheck == "call-frequency").OrderByDescending(c => c.EffectiveObservedBytes).ToArray();
-    var loopCold = result.Candidates.Where(c => c.MultiplicityCheck == "loop-cold").ToArray();
-    if (loopConfirmed.Length > 0 || callFrequency.Length > 0 || loopCold.Length > 0)
+    int loopUnexercised = result.Candidates.Count(c => c.MultiplicityCheck == "loop-unexercised");
+    if (loopHot.Length > 0 || callFrequency.Length > 0 || loopUnexercised > 0)
     {
         Console.WriteLine("## Multiplicity read (predict-vs-observe)");
         Console.WriteLine();
-        Console.WriteLine("Observed volume alone conflates intrinsic per-iteration churn with call-frequency-driven volume. The static multiplicity prior disambiguates them, and the fix differs: hoist/pool out of the loop vs reduce call frequency / cache.");
+        Console.WriteLine("Realized volume alone conflates intrinsic per-iteration churn with call-frequency-driven volume. The static multiplicity prior distinguishes the likely cause. Note: the trace confirms each site is hot — it does not verify the iteration count, so the loop/once split is a static prior, not a runtime measurement, and the appropriate fix is workload- and code-specific (a per-iteration allocation may be intrinsic and un-hoistable; an identity-bearing object may not be cacheable).");
         Console.WriteLine();
-        if (loopConfirmed.Length > 0)
+        if (loopHot.Length > 0)
         {
-            Console.WriteLine("**Loop-confirmed** (predicted per-iteration, realized hot -> hoist/pool out of the loop):");
+            Console.WriteLine("**Loop prior + hot** — static multiplicity is `Loop`; realized hot. The volume is likely intrinsic (per-iteration):");
             Console.WriteLine();
-            foreach (var c in loopConfirmed.Take(10))
+            foreach (var c in loopHot.Take(10))
                 Console.WriteLine($"- `{Escape(c.Method)}` ({Escape(c.AllocationKind)}, {FormatBytes(c.EffectiveObservedBytes)})");
             Console.WriteLine();
         }
         if (callFrequency.Length > 0)
         {
-            Console.WriteLine("**Call-frequency** (allocates once per call, but the method is hot -> reduce call frequency / cache):");
+            Console.WriteLine("**Call-frequency** — static multiplicity is `Once`/`Conditional`; realized hot. The volume is likely call-frequency-driven (the method is hot, not a loop at this site):");
             Console.WriteLine();
             foreach (var c in callFrequency.Take(10))
                 Console.WriteLine($"- `{Escape(c.Method)}` ({Escape(c.AllocationKind)}, {Escape(c.Multiplicity ?? "")}, {FormatBytes(c.EffectiveObservedBytes)})");
             Console.WriteLine();
         }
-        if (loopCold.Length > 0)
+        if (loopUnexercised > 0)
         {
-            Console.WriteLine($"**Predicted per-iteration, not exercised**: {loopCold.Length.ToString(CultureInfo.InvariantCulture)} loop-multiplicity site(s) allocated nothing in this workload. These are the highest-value cold rows — they would be hot under a workload that drives their loop; not a global dismissal.");
+            Console.WriteLine($"**Loop prior, not exercised**: {loopUnexercised.ToString(CultureInfo.InvariantCulture)} `Loop`-multiplicity site(s) were not observed in this workload. Some would allocate under a workload that drives their loop; others are cold by design (error-handling or one-shot init loops). This is workload-scoped negative evidence, not a ranking.");
             Console.WriteLine();
         }
     }
@@ -1759,18 +1760,21 @@ sealed class AllocationCandidate(
         => EstimatedSizeBytes is null && ShapeMatched && ShapeAllocationBytes > 0 ? "gap" : null;
     // Multiplicity predict-vs-observe (#2286): the static multiplicity prior disambiguates a hot
     // site's cause. Observed volume alone conflates intrinsic per-iteration churn (Loop) with
-    // call-frequency-driven volume (Once/Conditional, hot because the method is called a lot). The
-    // fix differs: hoist/pool out of the loop vs reduce call frequency / cache. A Loop site that is
-    // NOT observed is the highest-value cold row — predicted per-iteration, just not exercised here.
+    // call-frequency-driven volume (Once/Conditional, hot because the method is called a lot).
+    // IMPORTANT: the trace confirms the site/type was HOT, not that the loop iterated many times —
+    // the Loop/Once split is a static prior the trace does not verify. "Seen" here means the site was
+    // observed directly OR its type was realized-hot via type-confirmation (#2264); a type-confirmed
+    // loop site is therefore hot, not cold (it would otherwise be mislabeled "not exercised").
+    bool SeenHot => IsObserved || TypeConfirmed;
     public string? MultiplicityCheck
     {
         get
         {
             if (Multiplicity is null)
                 return null;
-            if (IsObserved)
-                return IsLoopMultiplicity ? "loop-confirmed" : "call-frequency";
-            return IsLoopMultiplicity ? "loop-cold" : null;
+            if (SeenHot)
+                return IsLoopMultiplicity ? "loop-hot" : "call-frequency";
+            return IsLoopMultiplicity ? "loop-unexercised" : null;
         }
     }
     // Gen-aware expensive judgment: weight observed cost by promotion likelihood, using the static escape

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -1188,6 +1188,40 @@ static void RenderMarkdown(CorrelationResult result, IReadOnlyList<AllocationCan
         Console.WriteLine();
     }
 
+    // Multiplicity predict-vs-observe (#2286): disambiguate a hot site's cause using the static
+    // multiplicity prior, and surface loop sites that were predicted per-iteration but not exercised.
+    var loopConfirmed = observed.Where(c => c.MultiplicityCheck == "loop-confirmed").OrderByDescending(c => c.EffectiveObservedBytes).ToArray();
+    var callFrequency = observed.Where(c => c.MultiplicityCheck == "call-frequency").OrderByDescending(c => c.EffectiveObservedBytes).ToArray();
+    var loopCold = result.Candidates.Where(c => c.MultiplicityCheck == "loop-cold").ToArray();
+    if (loopConfirmed.Length > 0 || callFrequency.Length > 0 || loopCold.Length > 0)
+    {
+        Console.WriteLine("## Multiplicity read (predict-vs-observe)");
+        Console.WriteLine();
+        Console.WriteLine("Observed volume alone conflates intrinsic per-iteration churn with call-frequency-driven volume. The static multiplicity prior disambiguates them, and the fix differs: hoist/pool out of the loop vs reduce call frequency / cache.");
+        Console.WriteLine();
+        if (loopConfirmed.Length > 0)
+        {
+            Console.WriteLine("**Loop-confirmed** (predicted per-iteration, realized hot -> hoist/pool out of the loop):");
+            Console.WriteLine();
+            foreach (var c in loopConfirmed.Take(10))
+                Console.WriteLine($"- `{Escape(c.Method)}` ({Escape(c.AllocationKind)}, {FormatBytes(c.EffectiveObservedBytes)})");
+            Console.WriteLine();
+        }
+        if (callFrequency.Length > 0)
+        {
+            Console.WriteLine("**Call-frequency** (allocates once per call, but the method is hot -> reduce call frequency / cache):");
+            Console.WriteLine();
+            foreach (var c in callFrequency.Take(10))
+                Console.WriteLine($"- `{Escape(c.Method)}` ({Escape(c.AllocationKind)}, {Escape(c.Multiplicity ?? "")}, {FormatBytes(c.EffectiveObservedBytes)})");
+            Console.WriteLine();
+        }
+        if (loopCold.Length > 0)
+        {
+            Console.WriteLine($"**Predicted per-iteration, not exercised**: {loopCold.Length.ToString(CultureInfo.InvariantCulture)} loop-multiplicity site(s) allocated nothing in this workload. These are the highest-value cold rows — they would be hot under a workload that drives their loop; not a global dismissal.");
+            Console.WriteLine();
+        }
+    }
+
     Console.WriteLine("## Inputs");
     Console.WriteLine();
     Console.WriteLine("| Kind | Path | Format | Lines | Matches | Observations |");
@@ -1397,6 +1431,10 @@ static void WriteCandidateJsonObject(Utf8JsonWriter writer, AllocationCandidate 
     writer.WriteNumber("shapeAllocationBytes", candidate.ShapeAllocationBytes);
     if (candidate.SizeCheck is not null)
         writer.WriteString("sizeCheck", candidate.SizeCheck);
+    if (candidate.Multiplicity is not null)
+        writer.WriteString("multiplicity", candidate.Multiplicity);
+    if (candidate.MultiplicityCheck is not null)
+        writer.WriteString("multiplicityCheck", candidate.MultiplicityCheck);
     if (candidate.IsObserved)
     {
         writer.WriteNumber("promotionFactor", candidate.PromotionFactor);
@@ -1644,7 +1682,8 @@ sealed class AllocationCandidate(
     string? sizeTier = null,
     string? escapeKind = null,
     string? churnedType = null,
-    string? runtimeAllocationType = null)
+    string? runtimeAllocationType = null,
+    string? multiplicity = null)
 {
     public int Id { get; } = id;
     public string Source { get; } = source;
@@ -1677,6 +1716,12 @@ sealed class AllocationCandidate(
     public string? SizeTier { get; } = string.IsNullOrWhiteSpace(sizeTier) ? null : sizeTier;
     public string? EscapeKind { get; } = string.IsNullOrWhiteSpace(escapeKind) ? null : escapeKind;
     public string? ChurnedType { get; } = string.IsNullOrWhiteSpace(churnedType) ? null : churnedType;
+    // Static per-invocation multiplicity prior (#2166): Once / Conditional / Loop / Unknown — how many
+    // times a call to the declaring method executes this allocation. Consumed as a predict-vs-observe
+    // signal (#2286): it disambiguates realized volume that is intrinsic (loop body) from volume that
+    // is call-frequency-driven (once per call, but the method is hot).
+    public string? Multiplicity { get; } = string.IsNullOrWhiteSpace(multiplicity) || string.Equals(multiplicity, "Unknown", StringComparison.OrdinalIgnoreCase) ? null : multiplicity;
+    public bool IsLoopMultiplicity => string.Equals(Multiplicity, "Loop", StringComparison.OrdinalIgnoreCase);
     public int RuntimeHits { get; set; }
     public double RuntimeWeight { get; set; }
     public long RuntimeBytes { get; set; }
@@ -1712,6 +1757,22 @@ sealed class AllocationCandidate(
     // cost-shape worth filling. This validates/annotates the objective layer; it is not the expensive judgment.
     public string? SizeCheck
         => EstimatedSizeBytes is null && ShapeMatched && ShapeAllocationBytes > 0 ? "gap" : null;
+    // Multiplicity predict-vs-observe (#2286): the static multiplicity prior disambiguates a hot
+    // site's cause. Observed volume alone conflates intrinsic per-iteration churn (Loop) with
+    // call-frequency-driven volume (Once/Conditional, hot because the method is called a lot). The
+    // fix differs: hoist/pool out of the loop vs reduce call frequency / cache. A Loop site that is
+    // NOT observed is the highest-value cold row — predicted per-iteration, just not exercised here.
+    public string? MultiplicityCheck
+    {
+        get
+        {
+            if (Multiplicity is null)
+                return null;
+            if (IsObserved)
+                return IsLoopMultiplicity ? "loop-confirmed" : "call-frequency";
+            return IsLoopMultiplicity ? "loop-cold" : null;
+        }
+    }
     // Gen-aware expensive judgment: weight observed cost by promotion likelihood, using the static escape
     // verdict as the prior. Raw allocation volume over-weights gen0-cheap churn; a promoting allocation
     // (escapes) is genuinely expensive, a cold/throw-path or provably-local one is cheap. This is the
@@ -1833,7 +1894,8 @@ sealed class AllocationCandidate(
         occurrence.SizeTier == AllocationSizeTier.Unknown ? null : FormatSizeTier(occurrence.SizeTier),
         occurrence.EscapeKind == AllocationEscapeKind.None ? null : occurrence.EscapeKind.ToString(),
         occurrence.ChurnedType,
-        occurrence.RuntimeAllocationType);
+        occurrence.RuntimeAllocationType,
+        occurrence.Multiplicity == AllocationMultiplicity.Unknown ? null : occurrence.Multiplicity.ToString());
 
     static string FormatPathContext(AllocationPathContext context) => context switch
     {


### PR DESCRIPTION
- Fixes #2286 (consumes the static multiplicity prior from #2166 / #2127).
- Adds a multiplicity predict-vs-observe signal to runfaster; disambiguates a hot site's cause; no site-join change.

## Change

> Should we accept this change?

**Conclusion: PASS** — turns the previously-unconsumed static multiplicity prior into an actionable predict-vs-observe signal that separates two fix shapes a pure volume ranking cannot; additive, fail-honest, tested.

runfaster ignored `AllocationOccurrence.Multiplicity` entirely. Observed volume conflates **intrinsic** per-iteration churn (a `Loop` site) with **call-frequency-driven** volume (a `Once`/`Conditional` site that is hot only because the method is called a lot). The fix differs — hoist/pool out of the loop vs reduce call frequency / cache — so disambiguating them matters.

- Flow `Multiplicity` into `AllocationCandidate`; derived `MultiplicityCheck` (mirrors `SizeCheck`):
  - observed + `Loop` -> `loop-confirmed`
  - observed + `Once`/`Conditional` -> `call-frequency`
  - `Loop` + not observed -> `loop-cold` (highest-value cold rows)
  - `Unknown` -> null (fail-honest)
- New "Multiplicity read" report section + JSONL (`multiplicity`, `multiplicityCheck`).

## Witness (Aspire dashboard OTLP trace)

The two top allocators — identical in a volume ranking — separate correctly, verified against source:

| Site | Volume | MultiplicityCheck | Source shape | Fix |
| --- | ---: | --- | --- | --- |
| `TelemetryExportService.ConvertAttributes` | 16.4 GB | `loop-confirmed` | `for (…) result[i] = new OtlpKeyValueJson { Value = new OtlpAnyValueJson }` | hoist/pool |
| `TelemetryExportService.ConvertSpan` | 14.0 GB | `call-frequency` | `return new OtlpSpanJson { … }` (once/call, hot via per-span invocation) | reduce call frequency / cache |

Plus **416 loop-cold** sites flagged as predicted-per-iteration-but-not-exercised.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| runfaster.Tests | 23/23 (6 new MultiplicityCheck cases: loop-confirmed / call-frequency / loop-cold / once-cold-null / unknown-null) |
| Site-join regression | None (multiplicity is additive metadata) |
| Classification accuracy | Verified against Aspire source (ConvertAttributes loop vs ConvertSpan once) |

## Honest scope

- `GCAllocationTick` is a ~100 KB aggregate sampler, so this uses the coarse hot/cold observation — the *category* (intrinsic vs extrinsic vs cold-loop), not a per-call instance count.
- Workload-scoped, like all runfaster verdicts.
- runfaster is a CoreCLR-only prototype.

## Adversarial review

Requested from two models (isolated worktrees). Reconciliation to follow on this PR.
