### PR TITLE
Extract shared CSharp name formatter

### DIFF
--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -8,93 +8,6 @@ using ILInspector.Metadata;
 
 namespace ILInspector.Decompiler;
 
-static class CompileBackCSharpNames
-{
-    public static string Clean(string type)
-    {
-        if (type.Contains('!'))
-            return "object";
-
-        type = type.Replace("modreq(", "", StringComparison.Ordinal)
-            .Replace("modopt(", "", StringComparison.Ordinal)
-            .Replace(")", "", StringComparison.Ordinal)
-            .Trim();
-
-        type = type switch
-        {
-            "System.String" => "string",
-            "System.Int32" => "int",
-            "System.Void" => "void",
-            _ => type,
-        };
-
-        return EscapeTypeKeywords(type);
-    }
-
-    public static string StripArity(string name)
-    {
-        int tick = name.IndexOf('`');
-        return tick >= 0 ? name[..tick] : name;
-    }
-
-    public static string Identifier(string name) => IsCSharpKeyword(name) ? "@" + name : name;
-
-    public static string EscapeNamespace(string ns)
-        => string.Join(".", ns.Split('.').Select(Identifier));
-
-    static string EscapeTypeKeywords(string type)
-    {
-        var sb = new StringBuilder(type.Length);
-        int i = 0;
-        while (i < type.Length)
-        {
-            char c = type[i];
-            if (char.IsLetter(c) || c == '_')
-            {
-                int start = i;
-                while (i < type.Length && (char.IsLetterOrDigit(type[i]) || type[i] == '_'))
-                    i++;
-
-                string word = type[start..i];
-                bool alreadyEscaped = start > 0 && type[start - 1] == '@';
-                bool qualifiedSegment = start > 0 && type[start - 1] == '.';
-                bool bareSpelling = (word is "void" or "ref" || IsPrimitiveTypeName(word)) && !qualifiedSegment;
-                if (!alreadyEscaped && !bareSpelling && IsCSharpKeyword(word))
-                    sb.Append('@');
-                sb.Append(word);
-            }
-            else
-            {
-                sb.Append(c);
-                i++;
-            }
-        }
-
-        return sb.ToString();
-    }
-
-    static bool IsPrimitiveTypeName(string name)
-        => name is "bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
-            or "float" or "int" or "uint" or "nint" or "nuint" or "long" or "ulong"
-            or "object" or "short" or "ushort" or "string";
-
-    static bool IsCSharpKeyword(string word)
-        => word is "abstract" or "as" or "base" or "bool" or "break" or "byte"
-            or "case" or "catch" or "char" or "checked" or "class" or "const"
-            or "continue" or "decimal" or "default" or "delegate" or "do"
-            or "double" or "else" or "enum" or "event" or "explicit" or "extern"
-            or "false" or "finally" or "fixed" or "float" or "for" or "foreach"
-            or "goto" or "if" or "implicit" or "in" or "int" or "interface"
-            or "internal" or "is" or "lock" or "long" or "namespace" or "new"
-            or "null" or "object" or "operator" or "out" or "override" or "params"
-            or "private" or "protected" or "public" or "readonly" or "ref"
-            or "return" or "sbyte" or "sealed" or "short" or "sizeof" or "stackalloc"
-            or "static" or "string" or "struct" or "switch" or "this" or "throw"
-            or "true" or "try" or "typeof" or "uint" or "ulong" or "unchecked"
-            or "unsafe" or "ushort" or "using" or "virtual" or "void" or "volatile"
-            or "while" or "record" or "required" or "init" or "file" or "scoped";
-}
-
 public sealed record CompileBackSourceResult(CompileBackReconstructionPlan Plan, string Source);
 
 public sealed record CompileBackReconstructionPlan(
@@ -193,7 +106,7 @@ public sealed record CompileBackTypeIdentity(string Namespace, string MetadataNa
     public static CompileBackTypeIdentity FromDefinition(MetadataReader reader, TypeDefinition typeDef)
     {
         string metadataName = reader.GetString(typeDef.Name);
-        string displayName = CompileBackCSharpNames.Identifier(CompileBackCSharpNames.StripArity(metadataName));
+        string displayName = CSharpNameFormatter.EscapeIdentifier(CSharpNameFormatter.StripArity(metadataName));
         if (!typeDef.GetDeclaringType().IsNil)
         {
             var declaring = FromDefinition(reader, reader.GetTypeDefinition(typeDef.GetDeclaringType()));
@@ -206,7 +119,7 @@ public sealed record CompileBackTypeIdentity(string Namespace, string MetadataNa
         }
 
         string ns = reader.GetString(typeDef.Namespace);
-        string displayNamespace = CompileBackCSharpNames.EscapeNamespace(ns);
+        string displayNamespace = CSharpNameFormatter.EscapeNamespace(ns);
         string fullName = displayNamespace.Length == 0 ? displayName : $"{displayNamespace}.{displayName}";
         string metadataFullName = ns.Length == 0 ? metadataName : $"{ns}.{metadataName}";
         return new CompileBackTypeIdentity(ns, metadataName, displayName, fullName, metadataFullName);
@@ -216,7 +129,7 @@ public sealed record CompileBackTypeIdentity(string Namespace, string MetadataNa
 public sealed record CompileBackTypeSignature(CompileBackTypeSignatureKind Kind, string DisplayName, CompileBackTypeIdentity? Identity)
 {
     public static CompileBackTypeSignature Display(string text)
-        => new(CompileBackTypeSignatureKind.Display, CompileBackCSharpNames.Clean(text), null);
+        => new(CompileBackTypeSignatureKind.Display, CSharpNameFormatter.CleanTypeName(text), null);
 
     public static CompileBackTypeSignature Definition(CompileBackTypeIdentity identity)
         => new(CompileBackTypeSignatureKind.Definition, identity.FullName, identity);
@@ -372,7 +285,7 @@ public static class CompileBackSourceComposer
             Usings: RequiredNamespaces(function)
                 .Concat(DeclarationNamespaces(declarations))
                 .Prepend("System")
-                .Select(CompileBackCSharpNames.EscapeNamespace)
+                .Select(CSharpNameFormatter.EscapeNamespace)
                 .Distinct(StringComparer.Ordinal)
                 .Order(StringComparer.Ordinal)
                 .ToArray(),
@@ -478,7 +391,7 @@ public static class CompileBackSourceComposer
             Usings: RequiredNamespaces(function)
                 .Concat(DeclarationNamespaces(declarations))
                 .Prepend("System")
-                .Select(CompileBackCSharpNames.EscapeNamespace)
+                .Select(CSharpNameFormatter.EscapeNamespace)
                 .Distinct(StringComparer.Ordinal)
                 .Order(StringComparer.Ordinal)
                 .ToArray(),
@@ -594,7 +507,7 @@ public static class CompileBackSourceComposer
             Usings: RequiredNamespaces(function)
                 .Concat(DeclarationNamespaces(declarations))
                 .Prepend("System")
-                .Select(CompileBackCSharpNames.EscapeNamespace)
+                .Select(CSharpNameFormatter.EscapeNamespace)
                 .Distinct(StringComparer.Ordinal)
                 .Order(StringComparer.Ordinal)
                 .ToArray(),
@@ -618,14 +531,14 @@ public static class CompileBackSourceComposer
             sb.AppendLine($"[assembly: {attribute.Text}]");
         foreach (var attribute in plan.Module.ModuleAttributes)
             sb.AppendLine($"[module: {attribute.Text}]");
-        foreach (var ns in plan.Module.Usings.Select(CompileBackCSharpNames.EscapeNamespace).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal))
+        foreach (var ns in plan.Module.Usings.Select(CSharpNameFormatter.EscapeNamespace).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal))
             sb.AppendLine($"using {ns};");
 
         foreach (var group in plan.Types.GroupBy(type => type.Namespace, StringComparer.Ordinal))
         {
             if (group.Key.Length > 0)
             {
-                sb.AppendLine($"namespace {CompileBackCSharpNames.EscapeNamespace(group.Key)}");
+                sb.AppendLine($"namespace {CSharpNameFormatter.EscapeNamespace(group.Key)}");
                 sb.AppendLine("{");
                 foreach (var type in group)
                     WriteType(sb, type, indent: 1);
@@ -1862,11 +1775,7 @@ public static class CompileBackSourceComposer
         return namespaces;
     }
 
-    static string Clean(string type) => CompileBackCSharpNames.Clean(type);
-
-    static string StripArity(string name) => CompileBackCSharpNames.StripArity(name);
-
-    static string Identifier(string name) => CompileBackCSharpNames.Identifier(name);
+    static string Identifier(string name) => CSharpNameFormatter.EscapeIdentifier(name);
 
     sealed class TypeProducer
     {

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -874,7 +874,7 @@ public static class CSharpDeclarationWriter
         => string.Join(".", name.Split('.').Select(part => string.Join("+", part.Split('+').Select(EscapeIdentifier))));
 
     internal static string EscapeIdentifier(string name)
-        => s_csharpReservedKeywords.Contains(name) || name == "await" ? "@" + name : name;
+        => CSharpNameFormatter.EscapeIdentifier(name);
 
     static bool IsIdentifierStart(char c) => char.IsLetter(c) || c == '_';
 
@@ -1192,31 +1192,12 @@ public static class CSharpDeclarationWriter
             if (lastDot <= 0 || lastDot == value.Length - 1)
                 return null;
             var ns = value[..lastDot];
-            var simple = StripArity(value[(lastDot + 1)..]);
-            if (s_csharpReservedKeywords.Contains(simple))
+            var simple = CSharpNameFormatter.StripArity(value[(lastDot + 1)..]);
+            if (CSharpNameFormatter.IsReservedKeyword(simple))
                 return null;
             return new TypeRef(value, ns, simple);
-        }
-
-        static string StripArity(string name)
-        {
-            var tick = name.IndexOf('`');
-            return tick < 0 ? name : name[..tick];
         }
     }
 
     static readonly string[] s_parameterModifiers = ["this", "params", "ref", "out", "in", "scoped"];
-
-    static readonly HashSet<string> s_csharpReservedKeywords = new(StringComparer.Ordinal)
-    {
-        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
-        "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else",
-        "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
-        "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
-        "long", "namespace", "new", "null", "object", "operator", "out", "override", "params",
-        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
-        "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
-        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
-        "void", "volatile", "while",
-    };
 }

--- a/src/ILInspector.Metadata/CSharpNameFormatter.cs
+++ b/src/ILInspector.Metadata/CSharpNameFormatter.cs
@@ -1,0 +1,94 @@
+using System.Text;
+
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// C# identifier and metadata-name formatting shared by declaration emitters.
+/// </summary>
+public static class CSharpNameFormatter
+{
+    static readonly HashSet<string> s_reservedKeywords = new(StringComparer.Ordinal)
+    {
+        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char", "checked",
+        "class", "const", "continue", "decimal", "default", "delegate", "do", "double", "else",
+        "enum", "event", "explicit", "extern", "false", "finally", "fixed", "float", "for",
+        "foreach", "goto", "if", "implicit", "in", "int", "interface", "internal", "is", "lock",
+        "long", "namespace", "new", "null", "object", "operator", "out", "override", "params",
+        "private", "protected", "public", "readonly", "ref", "return", "sbyte", "sealed", "short",
+        "sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
+        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
+        "void", "volatile", "while", "record", "required", "init", "file", "scoped",
+    };
+
+    public static bool IsReservedKeyword(string name)
+        => s_reservedKeywords.Contains(name) || name == "await";
+
+    public static string EscapeIdentifier(string name)
+        => IsReservedKeyword(name) ? "@" + name : name;
+
+    public static string EscapeNamespace(string ns)
+        => string.Join(".", ns.Split('.').Select(EscapeIdentifier));
+
+    public static string StripArity(string name)
+    {
+        int tick = name.IndexOf('`');
+        return tick >= 0 ? name[..tick] : name;
+    }
+
+    public static string CleanTypeName(string type)
+    {
+        if (type.Contains('!'))
+            return "object";
+
+        type = type.Replace("modreq(", "", StringComparison.Ordinal)
+            .Replace("modopt(", "", StringComparison.Ordinal)
+            .Replace(")", "", StringComparison.Ordinal)
+            .Trim();
+
+        type = type switch
+        {
+            "System.String" => "string",
+            "System.Int32" => "int",
+            "System.Void" => "void",
+            _ => type,
+        };
+
+        return EscapeTypeKeywords(type);
+    }
+
+    static string EscapeTypeKeywords(string type)
+    {
+        var sb = new StringBuilder(type.Length);
+        int i = 0;
+        while (i < type.Length)
+        {
+            char c = type[i];
+            if (char.IsLetter(c) || c == '_')
+            {
+                int start = i;
+                while (i < type.Length && (char.IsLetterOrDigit(type[i]) || type[i] == '_'))
+                    i++;
+
+                string word = type[start..i];
+                bool alreadyEscaped = start > 0 && type[start - 1] == '@';
+                bool qualifiedSegment = start > 0 && type[start - 1] == '.';
+                bool bareSpelling = (word is "void" or "ref" || IsPrimitiveTypeName(word)) && !qualifiedSegment;
+                if (!alreadyEscaped && !bareSpelling && IsReservedKeyword(word))
+                    sb.Append('@');
+                sb.Append(word);
+            }
+            else
+            {
+                sb.Append(c);
+                i++;
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    static bool IsPrimitiveTypeName(string name)
+        => name is "bool" or "byte" or "sbyte" or "char" or "decimal" or "double"
+            or "float" or "int" or "uint" or "nint" or "nuint" or "long" or "ulong"
+            or "object" or "short" or "ushort" or "string";
+}


### PR DESCRIPTION
- Follows the ReturnToSender / compile-back source-composition architecture discussion
- Changes product-side declaration/name formatting plumbing; RTS behavior is unchanged
- Evidence revision: `b58ee07d`

## Change

> Should we accept this source-composer contraction?

**Conclusion:** **PASS** — `CompileBackSourceComposer` no longer owns its own C# keyword/arity/type-name cleanup helper; that logic now lives in a shared metadata-side `CSharpNameFormatter` also used by `CSharpDeclarationWriter`.

Before:

```text
CompileBackSourceComposer carried local C# name logic:
- Clean
- StripArity
- Identifier
- EscapeNamespace
- C# keyword tables
```

After:

```text
ILInspector.Metadata.CSharpNameFormatter owns the shared name/keyword/arity cleanup.
CompileBackSourceComposer delegates to it and keeps only a small local Identifier wrapper for readability at call sites.
```

## Scope and safety

- **Root cause:** compile-back source composition had grown a parallel C# name formatter, reinforcing the same bespoke generator design problems that RTS is meant to retire.
- **Fix shape:** extract C# identifier escaping, namespace escaping, metadata arity stripping, and simple type-name cleanup into `CSharpNameFormatter`; switch `CSharpDeclarationWriter` and `CompileBackSourceComposer` to use it.
- **Product impact:** shared declaration/name formatting only; no RTS source generation and no decompiler raise/pass behavior change.
- **Scope boundary:** this is a first contraction seam, not a full source-composer rewrite. Member/body shell composition remains future work.
- **RTS boundary:** unchanged; RTS remains orchestration/measurement only.

## Evidence

| Check | Result |
| --- | --- |
| Product build | `dotnet build src/dotnet-inspect -c Release --no-restore --verbosity minimal` passed |
| Focused tests | `GeneratedFixtureCatalogTests` passed |
| Targeted RTS catalog | `--return-to-sender-catalog record --max-examples 20` passed, 7 fixtures / 12 targets |
| Attribute RTS catalog | `--return-to-sender-catalog rts.attribute-shell --max-examples 10` passed, 1 fixture / 2 targets |
| Diff hygiene | `git diff --check` passed |

## Compile-back quality

> Did this reduce bespoke generation without hiding a product defect?

**Conclusion:** **PASS** — exact RTS catalog coverage remains unchanged for record and attribute slices while one duplicated C# naming surface moves to a shared product primitive.

### Targeted changed-method boss

Not applicable; this is a behavior-preserving contraction. Targeted generated RTS fixtures stayed exact.

### Broad assembly context

Not run; this PR intentionally avoids corpus behavior claims.

### ReturnToSender A/B

Not applicable; RTS behavior is unchanged.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| Member/source shell composition | Left as future contraction | Larger design surface; should move one measured seam at a time. |
| `CompileBackSourceComposer` local `Identifier` wrapper | Left intentionally | Keeps call sites readable while delegating implementation to `CSharpNameFormatter`. |
| Other C# name helpers elsewhere | Not changed | This PR targets the compile-back composer duplicate surfaced by the architecture concern. |

## Build-event validation

**Conclusion:** not applicable — no build-event instrumentation changed.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Pending | Pending | Adversarial review requested after PR creation. |
| Pending | Pending | Adversarial review requested after PR creation. |

**Review conclusion:** **REVIEW** — pending adversarial review reconciliation.

## Validation

```bash
dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --return-to-sender-catalog record --max-examples 20
dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --return-to-sender-catalog rts.attribute-shell --max-examples 10
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet build src/dotnet-inspect -c Release --no-restore --verbosity minimal
git diff --check
```
