### PR TITLE
Add product IL body diff pilot

### DIFF
--- a/src/DiffFixtures.V1/DiffFixtures.V1.csproj
+++ b/src/DiffFixtures.V1/DiffFixtures.V1.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>DiffFixtureSample</AssemblyName>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>

--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -38,6 +38,12 @@ namespace DiffFixtureSample
             return value + 3;
         }
 
+        // V1/V2 differ only in a user-string token operand.
+        public static string StringToken() => "alpha";
+
+        // V1/V2 differ only in a member-reference token operand.
+        public static int CallToken(int value) => System.Math.Abs(value);
+
         // V2 inserts an operation before the label target. The branch target's
         // raw IL offset shifts, but it still targets the same logical return.
         public static int BranchTargetOffsetShift(bool skip)

--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -27,7 +27,44 @@ namespace DiffFixtureSample
         // Identical in both versions -> no diff row.
         public static int Stable() => 42;
 
+        // V1/V2 differ only in the loaded constant value.
+        public static int ConstantValue() => 1;
+
+        // V2 inserts an operation before the label target. The branch target's
+        // raw IL offset shifts, but it still targets the same logical return.
+        public static int BranchTargetOffsetShift(bool skip)
+        {
+            if (skip)
+                goto Target;
+
+            Sink(1);
+
+        Target:
+            return 3;
+        }
+
+        // V2 retargets the branch to a different return.
+        public static int BranchRetarget(bool skip)
+        {
+            if (skip)
+                goto First;
+
+            goto Second;
+
+        First:
+            return 1;
+
+        Second:
+            return 2;
+        }
+
         // V1: safe body. V2 adds a visible unsafe operation.
         public static int AddsUnsafe(int value) => value;
+
+        static void Sink(int value)
+        {
+            if (value == int.MinValue)
+                throw new System.InvalidOperationException();
+        }
     }
 }

--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -26,5 +26,8 @@ namespace DiffFixtureSample
 
         // Identical in both versions -> no diff row.
         public static int Stable() => 42;
+
+        // V1: safe body. V2 adds a visible unsafe operation.
+        public static int AddsUnsafe(int value) => value;
     }
 }

--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -30,6 +30,14 @@ namespace DiffFixtureSample
         // V1/V2 differ only in the loaded constant value.
         public static int ConstantValue() => 1;
 
+        // V1/V2 have two separated value changes with stable work between them.
+        public static int MultipleHunks(int value)
+        {
+            int first = value + 1;
+            Sink(first);
+            return value + 3;
+        }
+
         // V2 inserts an operation before the label target. The branch target's
         // raw IL offset shifts, but it still targets the same logical return.
         public static int BranchTargetOffsetShift(bool skip)

--- a/src/DiffFixtures.V2/DiffFixtures.V2.csproj
+++ b/src/DiffFixtures.V2/DiffFixtures.V2.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>DiffFixtureSample</AssemblyName>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -29,5 +29,13 @@ namespace DiffFixtureSample
 
         // Identical in both versions -> no diff row.
         public static int Stable() => 42;
+
+        // V2: visible unsafe operation added relative to V1.
+        public static unsafe int AddsUnsafe(int value)
+        {
+            int* values = stackalloc int[1];
+            values[0] = value;
+            return values[0];
+        }
     }
 }

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -30,12 +30,50 @@ namespace DiffFixtureSample
         // Identical in both versions -> no diff row.
         public static int Stable() => 42;
 
+        // V1/V2 differ only in the loaded constant value.
+        public static int ConstantValue() => 2;
+
+        // V2 inserts an operation before the label target. The branch target's
+        // raw IL offset shifts, but it still targets the same logical return.
+        public static int BranchTargetOffsetShift(bool skip)
+        {
+            if (skip)
+                goto Target;
+
+            Sink(1);
+            Sink(2);
+
+        Target:
+            return 3;
+        }
+
+        // V2 retargets the branch to a different return.
+        public static int BranchRetarget(bool skip)
+        {
+            if (skip)
+                goto Second;
+
+            goto First;
+
+        First:
+            return 1;
+
+        Second:
+            return 2;
+        }
+
         // V2: visible unsafe operation added relative to V1.
         public static unsafe int AddsUnsafe(int value)
         {
             int* values = stackalloc int[1];
             values[0] = value;
             return values[0];
+        }
+
+        static void Sink(int value)
+        {
+            if (value == int.MinValue)
+                throw new System.InvalidOperationException();
         }
     }
 }

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -41,6 +41,12 @@ namespace DiffFixtureSample
             return value + 4;
         }
 
+        // V1/V2 differ only in a user-string token operand.
+        public static string StringToken() => "beta";
+
+        // V1/V2 differ only in a member-reference token operand.
+        public static int CallToken(int value) => System.Math.Sign(value);
+
         // V2 inserts an operation before the label target. The branch target's
         // raw IL offset shifts, but it still targets the same logical return.
         public static int BranchTargetOffsetShift(bool skip)

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -33,6 +33,14 @@ namespace DiffFixtureSample
         // V1/V2 differ only in the loaded constant value.
         public static int ConstantValue() => 2;
 
+        // V1/V2 have two separated value changes with stable work between them.
+        public static int MultipleHunks(int value)
+        {
+            int first = value + 2;
+            Sink(first);
+            return value + 4;
+        }
+
         // V2 inserts an operation before the label target. The branch target's
         // raw IL offset shifts, but it still targets the same logical return.
         public static int BranchTargetOffsetShift(bool skip)

--- a/src/ILInspector.Analysis.Tests/BodySignalDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/BodySignalDiffTests.cs
@@ -1,0 +1,40 @@
+using ILInspector.Analysis;
+
+namespace ILInspector.Analysis.Tests;
+
+public class BodySignalDiffTests
+{
+    [Fact]
+    public void CompareUnsafe_SurfacesAddedUnsafeOperation()
+    {
+        var oldIndex = LibraryBodyIndex.Open(DiffFixturePath("DiffFixtures.V1"));
+        var newIndex = LibraryBodyIndex.Open(DiffFixturePath("DiffFixtures.V2"));
+
+        var diff = BodySignalDiff.CompareUnsafe(oldIndex, newIndex);
+
+        Assert.Contains(diff.Rows, row =>
+            row.Kind == BodySignalDiffKind.Added
+            && row.Signal == "stackalloc"
+            && row.Member.Contains("AddsUnsafe", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareUnsafe_SelfDiffHasNoRows()
+    {
+        var index = LibraryBodyIndex.Open(DiffFixturePath("DiffFixtures.V2"));
+
+        var diff = BodySignalDiff.CompareUnsafe(index, index);
+
+        Assert.Empty(diff.Rows);
+    }
+
+    static string DiffFixturePath(string project)
+    {
+        var outputDirectory = new DirectoryInfo(
+            AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string path = Path.GetFullPath(Path.Combine(
+            outputDirectory.FullName, "..", "..", project, outputDirectory.Name, "DiffFixtureSample.dll"));
+        Assert.True(File.Exists(path), $"Expected diff fixture assembly at {path}");
+        return path;
+    }
+}

--- a/src/ILInspector.Analysis.Tests/BodySignalDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/BodySignalDiffTests.cs
@@ -28,6 +28,45 @@ public class BodySignalDiffTests
         Assert.Empty(diff.Rows);
     }
 
+    [Fact]
+    public void CompareUnsafe_MethodKeyDistinguishesSameNameDifferentArityDeclaringTypes()
+    {
+        var method1 = DiffMethod(TypeRef.Definition("Asm", "Ns", "Box`1"), "Use");
+        var method2 = DiffMethod(TypeRef.Definition("Asm", "Ns", "Box`2"), "Use");
+        var oldIndex = LibraryBodyIndex.FromEvidence(
+            [method1],
+            [new UnsafeEvidence(method1, "Unsafe operation", "stackalloc", "opcode", 0, null)]);
+        var newIndex = LibraryBodyIndex.FromEvidence(
+            [method2],
+            [new UnsafeEvidence(method2, "Unsafe operation", "stackalloc", "opcode", 0, null)]);
+
+        var diff = BodySignalDiff.CompareUnsafe(oldIndex, newIndex);
+
+        Assert.Contains(diff.Rows, row => row.Kind == BodySignalDiffKind.Removed);
+        Assert.Contains(diff.Rows, row => row.Kind == BodySignalDiffKind.Added);
+    }
+
+    [Fact]
+    public void CompareUnsafe_PreservesCountOfRepeatedUnsafeOperations()
+    {
+        var method = DiffMethod(TypeRef.Definition("Asm", "Ns", "UnsafeApi"), "Use");
+        var oldIndex = LibraryBodyIndex.FromEvidence(
+            [method],
+            [new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 0, null)]);
+        var newIndex = LibraryBodyIndex.FromEvidence(
+            [method],
+            [
+                new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 0, null),
+                new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 4, null),
+            ]);
+
+        var diff = BodySignalDiff.CompareUnsafe(oldIndex, newIndex);
+
+        var added = Assert.Single(diff.Rows);
+        Assert.Equal(BodySignalDiffKind.Added, added.Kind);
+        Assert.Equal("stackalloc", added.Operation);
+    }
+
     static string DiffFixturePath(string project)
     {
         var outputDirectory = new DirectoryInfo(
@@ -37,4 +76,15 @@ public class BodySignalDiffTests
         Assert.True(File.Exists(path), $"Expected diff fixture assembly at {path}");
         return path;
     }
+
+    static MethodIdentity DiffMethod(TypeRef declaring, string name)
+        => new(
+            "Asm",
+            Guid.Empty,
+            declaring,
+            name,
+            [],
+            TypeRef.CoreLib("System", "Void"),
+            MetadataToken: 0x06000001,
+            IsStatic: true);
 }

--- a/src/ILInspector.Analysis.Tests/BodySignalDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/BodySignalDiffTests.cs
@@ -92,6 +92,31 @@ public class BodySignalDiffTests
         Assert.Equal(5, added.ILOffset);
     }
 
+    [Fact]
+    public void CompareUnsafe_OffsetShiftWithAddedOperation_DoesNotEmitRemoveAddFlood()
+    {
+        var method = DiffMethod(TypeRef.Definition("Asm", "Ns", "UnsafeApi"), "Use");
+        var oldIndex = LibraryBodyIndex.FromEvidence(
+            [method],
+            [
+                new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 10, null),
+                new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 20, null),
+            ]);
+        var newIndex = LibraryBodyIndex.FromEvidence(
+            [method],
+            [
+                new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 5, null),
+                new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 15, null),
+                new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 25, null),
+            ]);
+
+        var diff = BodySignalDiff.CompareUnsafe(oldIndex, newIndex);
+
+        var added = Assert.Single(diff.Rows);
+        Assert.Equal(BodySignalDiffKind.Added, added.Kind);
+        Assert.Null(added.ILOffset);
+    }
+
     static string DiffFixturePath(string project)
     {
         var outputDirectory = new DirectoryInfo(

--- a/src/ILInspector.Analysis.Tests/BodySignalDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/BodySignalDiffTests.cs
@@ -67,6 +67,31 @@ public class BodySignalDiffTests
         Assert.Equal("stackalloc", added.Operation);
     }
 
+    [Fact]
+    public void CompareUnsafe_AttributesPrependedOffsetAdditionToNewOffset()
+    {
+        var method = DiffMethod(TypeRef.Definition("Asm", "Ns", "UnsafeApi"), "Use");
+        var oldIndex = LibraryBodyIndex.FromEvidence(
+            [method],
+            [
+                new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 10, null),
+                new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 20, null),
+            ]);
+        var newIndex = LibraryBodyIndex.FromEvidence(
+            [method],
+            [
+                new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 5, null),
+                new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 10, null),
+                new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 20, null),
+            ]);
+
+        var diff = BodySignalDiff.CompareUnsafe(oldIndex, newIndex);
+
+        var added = Assert.Single(diff.Rows);
+        Assert.Equal(BodySignalDiffKind.Added, added.Kind);
+        Assert.Equal(5, added.ILOffset);
+    }
+
     static string DiffFixturePath(string project)
     {
         var outputDirectory = new DirectoryInfo(

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -37,6 +37,8 @@
     <ProjectReference Include="..\ILInspector.Analysis.CallerGraphLookalikeCaller\ILInspector.Analysis.CallerGraphLookalikeCaller.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffAsmFixtures.Target\DiffAsmFixtures.Target.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffAsmFixtures.Caller\DiffAsmFixtures.Caller.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\DiffFixtures.V1\DiffFixtures.V1.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\DiffFixtures.V2\DiffFixtures.V2.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
     <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
     <ProjectReference Include="..\..\tools\AnalysisHarness\AnalysisHarness.csproj" />

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -68,6 +68,29 @@ public class IlBodyDiffTests
     }
 
     [Fact]
+    public void Compare_RetargetedBranchAndRemovedInstruction_ReportsInProgramOrder()
+    {
+        var left = MethodInstructions.Decode([0x2b, 0x03, 0x00, 0x16, 0x2a, 0x17, 0x2a], 7, []);
+        var right = MethodInstructions.Decode([0x2b, 0x00, 0x16, 0x2a, 0x17, 0x2a], 6, []);
+
+        var diff = IlBodyDiff.Compare(left, right);
+
+        Assert.Collection(
+            diff.Differences,
+            changed =>
+            {
+                Assert.Equal(IlBodyDiffChangeKind.Changed, changed.Kind);
+                Assert.Equal(0, changed.OldOffset);
+                Assert.Equal(0, changed.NewOffset);
+            },
+            removed =>
+            {
+                Assert.Equal(IlBodyDiffChangeKind.Removed, removed.Kind);
+                Assert.Equal(2, removed.OldOffset);
+            });
+    }
+
+    [Fact]
     public void Compare_MalformedBody_ReportsFailure()
     {
         var malformed = MethodInstructions.Decode([0xfe], 1, []);

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -83,10 +83,7 @@ public class IlBodyDiffTests
     [Fact]
     public void Compare_CompiledFixtureConstantValueChange_ReportsImmediateChange()
     {
-        var left = DiffFixtureMethod("DiffFixtures.V1", "ConstantValue");
-        var right = DiffFixtureMethod("DiffFixtures.V2", "ConstantValue");
-
-        var diff = IlBodyDiff.Compare(left, right);
+        var diff = DiffFixtureDiff("ConstantValue");
 
         Assert.Collection(
             diff.Rows,
@@ -105,12 +102,65 @@ public class IlBodyDiffTests
     }
 
     [Fact]
-    public void Compare_CompiledFixtureMultipleHunks_AssignsSeparateHunkIds()
+    public void Compare_CompiledFixtureStringTokenChange_ReportsStringOperandChange()
     {
-        var left = DiffFixtureMethod("DiffFixtures.V1", "MultipleHunks");
-        var right = DiffFixtureMethod("DiffFixtures.V2", "MultipleHunks");
+        var diff = DiffFixtureDiff("StringToken");
+
+        Assert.Collection(
+            diff.Rows,
+            removed =>
+            {
+                Assert.Equal(IlDiffKind.Remove, removed.Kind);
+                Assert.Equal("ldstr", removed.Operation.OpcodeFamily);
+                Assert.Equal("string \"alpha\"", removed.Operation.Operand?.Value);
+            },
+            added =>
+            {
+                Assert.Equal(IlDiffKind.Add, added.Kind);
+                Assert.Equal("ldstr", added.Operation.OpcodeFamily);
+                Assert.Equal("string \"beta\"", added.Operation.Operand?.Value);
+            });
+    }
+
+    [Fact]
+    public void Compare_CompiledFixtureCallTokenChange_ReportsMemberOperandChange()
+    {
+        var diff = DiffFixtureDiff("CallToken");
+
+        Assert.Collection(
+            diff.Rows,
+            removed =>
+            {
+                Assert.Equal(IlDiffKind.Remove, removed.Kind);
+                Assert.Equal("call", removed.Operation.OpcodeFamily);
+                Assert.Contains("::Abs(", removed.Operation.Operand?.Value, StringComparison.Ordinal);
+            },
+            added =>
+            {
+                Assert.Equal(IlDiffKind.Add, added.Kind);
+                Assert.Equal("call", added.Operation.OpcodeFamily);
+                Assert.Contains("::Sign(", added.Operation.Operand?.Value, StringComparison.Ordinal);
+            });
+    }
+
+    [Fact]
+    public void Compare_TokenOperandWithoutMetadata_FailsClosed()
+    {
+        var left = DiffFixtureMethod("DiffFixtures.V1", "StringToken");
+        var right = DiffFixtureMethod("DiffFixtures.V2", "StringToken");
 
         var diff = IlBodyDiff.Compare(left, right);
+
+        Assert.False(diff.IsExact);
+        Assert.NotNull(diff.Failure);
+        Assert.Contains("requires a MetadataReader-backed comparison", diff.Failure, StringComparison.Ordinal);
+        Assert.Empty(diff.Rows);
+    }
+
+    [Fact]
+    public void Compare_CompiledFixtureMultipleHunks_AssignsSeparateHunkIds()
+    {
+        var diff = DiffFixtureDiff("MultipleHunks");
 
         Assert.Collection(
             diff.Rows,
@@ -147,10 +197,7 @@ public class IlBodyDiffTests
     [Fact]
     public void Compare_CompiledFixtureBranchTargetOffsetShift_DoesNotMarkBranchChanged()
     {
-        var left = DiffFixtureMethod("DiffFixtures.V1", "BranchTargetOffsetShift");
-        var right = DiffFixtureMethod("DiffFixtures.V2", "BranchTargetOffsetShift");
-
-        var diff = IlBodyDiff.Compare(left, right);
+        var diff = DiffFixtureDiff("BranchTargetOffsetShift");
 
         Assert.NotEmpty(diff.Rows);
         Assert.Contains(diff.Rows, row => row.Kind == IlDiffKind.Add && row.Operation.OpcodeFamily == "call");
@@ -160,10 +207,7 @@ public class IlBodyDiffTests
     [Fact]
     public void Compare_CompiledFixtureBranchRetarget_ReportsChangedBranch()
     {
-        var left = DiffFixtureMethod("DiffFixtures.V1", "BranchRetarget");
-        var right = DiffFixtureMethod("DiffFixtures.V2", "BranchRetarget");
-
-        var diff = IlBodyDiff.Compare(left, right);
+        var diff = DiffFixtureDiff("BranchRetarget");
 
         Assert.Contains(diff.Rows, row => row.Kind == IlDiffKind.Remove && IsBranchRow(row));
         Assert.Contains(diff.Rows, row => row.Kind == IlDiffKind.Add && IsBranchRow(row));
@@ -216,19 +260,39 @@ public class IlBodyDiffTests
     static bool IsBranchRow(IlDiffRow row)
         => row.Operation.OpcodeFamily.StartsWith("br", StringComparison.Ordinal);
 
+    static IlBodyDiffResult DiffFixtureDiff(string name)
+    {
+        using var oldStream = File.OpenRead(DiffFixturePath("DiffFixtures.V1"));
+        using var newStream = File.OpenRead(DiffFixturePath("DiffFixtures.V2"));
+        using var oldPe = new PEReader(oldStream);
+        using var newPe = new PEReader(newStream);
+        var oldReader = oldPe.GetMetadataReader();
+        var newReader = newPe.GetMetadataReader();
+        return IlBodyDiff.Compare(
+            oldReader,
+            DiffFixtureMethodBody(oldPe, oldReader, name),
+            newReader,
+            DiffFixtureMethodBody(newPe, newReader, name));
+    }
+
     static MethodInstructions DiffFixtureMethod(string project, string name)
     {
         using var stream = File.OpenRead(DiffFixturePath(project));
         using var peReader = new PEReader(stream);
         var metadataReader = peReader.GetMetadataReader();
+        return MethodInstructions.Decode(DiffFixtureMethodBody(peReader, metadataReader, name));
+    }
+
+    static MethodBodyBlock DiffFixtureMethodBody(PEReader peReader, MetadataReader metadataReader, string name)
+    {
         foreach (var handle in metadataReader.MethodDefinitions)
         {
             var method = metadataReader.GetMethodDefinition(handle);
             if (metadataReader.GetString(method.Name) == name)
-                return MethodInstructions.Decode(peReader.GetMethodBody(method.RelativeVirtualAddress));
+                return peReader.GetMethodBody(method.RelativeVirtualAddress);
         }
 
-        throw new InvalidOperationException($"Could not find method '{name}' in {project}.");
+        throw new InvalidOperationException($"Could not find method '{name}'.");
     }
 
     static string DiffFixturePath(string project)

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -105,6 +105,46 @@ public class IlBodyDiffTests
     }
 
     [Fact]
+    public void Compare_CompiledFixtureMultipleHunks_AssignsSeparateHunkIds()
+    {
+        var left = DiffFixtureMethod("DiffFixtures.V1", "MultipleHunks");
+        var right = DiffFixtureMethod("DiffFixtures.V2", "MultipleHunks");
+
+        var diff = IlBodyDiff.Compare(left, right);
+
+        Assert.Collection(
+            diff.Rows,
+            firstRemoved =>
+            {
+                Assert.Equal(0, firstRemoved.HunkId);
+                Assert.Equal(IlDiffKind.Remove, firstRemoved.Kind);
+                Assert.Equal("ldc.i4", firstRemoved.Operation.OpcodeFamily);
+                Assert.Equal("1", firstRemoved.Operation.Operand?.Value);
+            },
+            firstAdded =>
+            {
+                Assert.Equal(0, firstAdded.HunkId);
+                Assert.Equal(IlDiffKind.Add, firstAdded.Kind);
+                Assert.Equal("ldc.i4", firstAdded.Operation.OpcodeFamily);
+                Assert.Equal("2", firstAdded.Operation.Operand?.Value);
+            },
+            secondRemoved =>
+            {
+                Assert.Equal(1, secondRemoved.HunkId);
+                Assert.Equal(IlDiffKind.Remove, secondRemoved.Kind);
+                Assert.Equal("ldc.i4", secondRemoved.Operation.OpcodeFamily);
+                Assert.Equal("3", secondRemoved.Operation.Operand?.Value);
+            },
+            secondAdded =>
+            {
+                Assert.Equal(1, secondAdded.HunkId);
+                Assert.Equal(IlDiffKind.Add, secondAdded.Kind);
+                Assert.Equal("ldc.i4", secondAdded.Operation.OpcodeFamily);
+                Assert.Equal("4", secondAdded.Operation.Operand?.Value);
+            });
+    }
+
+    [Fact]
     public void Compare_CompiledFixtureBranchTargetOffsetShift_DoesNotMarkBranchChanged()
     {
         var left = DiffFixtureMethod("DiffFixtures.V1", "BranchTargetOffsetShift");

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -19,7 +19,7 @@ public class IlBodyDiffTests
     }
 
     [Fact]
-    public void Compare_AddedInstruction_ReportsAddedRow()
+    public void Compare_InsertedInstruction_AlignsUnchangedSuffix()
     {
         var left = MethodInstructions.Decode([0x00, 0x2a], 2, []);
         var right = MethodInstructions.Decode([0x00, 0x00, 0x2a], 3, []);
@@ -27,12 +27,27 @@ public class IlBodyDiffTests
         var diff = IlBodyDiff.Compare(left, right);
 
         Assert.False(diff.IsExact);
-        var changed = Assert.Single(diff.Differences, row => row.Kind == IlBodyDiffChangeKind.Changed);
-        Assert.Equal(ILOpCode.Ret, changed.OldOpCode);
-        Assert.Equal(ILOpCode.Nop, changed.NewOpCode);
         var added = Assert.Single(diff.Differences, row => row.Kind == IlBodyDiffChangeKind.Added);
         Assert.Null(added.OldOpCode);
-        Assert.Equal(ILOpCode.Ret, added.NewOpCode);
+        Assert.Equal(ILOpCode.Nop, added.NewOpCode);
+        Assert.DoesNotContain(diff.Differences, row => row.Kind == IlBodyDiffChangeKind.Changed);
+    }
+
+    [Fact]
+    public void Compare_BranchTargetOffsetShift_DoesNotMarkBranchChanged()
+    {
+        // br.s targets the final ret in both bodies. The inserted nop shifts the
+        // absolute target from IL_0003 to IL_0004, but the branch operation itself
+        // is unchanged for this first substrate.
+        var left = MethodInstructions.Decode([0x2b, 0x01, 0x00, 0x2a], 4, []);
+        var right = MethodInstructions.Decode([0x2b, 0x02, 0x00, 0x00, 0x2a], 5, []);
+
+        var diff = IlBodyDiff.Compare(left, right);
+
+        Assert.False(diff.IsExact);
+        Assert.Single(diff.Differences);
+        Assert.Equal(IlBodyDiffChangeKind.Added, diff.Differences[0].Kind);
+        Assert.Equal(ILOpCode.Nop, diff.Differences[0].NewOpCode);
     }
 
     [Fact]

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -15,7 +15,7 @@ public class IlBodyDiffTests
 
         Assert.True(diff.IsExact);
         Assert.Null(diff.Failure);
-        Assert.Empty(diff.Differences);
+        Assert.Empty(diff.Rows);
     }
 
     [Fact]
@@ -27,10 +27,10 @@ public class IlBodyDiffTests
         var diff = IlBodyDiff.Compare(left, right);
 
         Assert.False(diff.IsExact);
-        var added = Assert.Single(diff.Differences, row => row.Kind == IlBodyDiffChangeKind.Added);
-        Assert.Null(added.OldOpCode);
-        Assert.Equal(ILOpCode.Nop, added.NewOpCode);
-        Assert.DoesNotContain(diff.Differences, row => row.Kind == IlBodyDiffChangeKind.Changed);
+        var added = Assert.Single(diff.Rows, row => row.Kind == IlDiffKind.Add);
+        Assert.Equal(0x0001, added.Operation.Offset);
+        Assert.Equal("nop", added.Operation.OpcodeFamily);
+        Assert.DoesNotContain(diff.Rows, row => row.Kind == IlDiffKind.Remove);
     }
 
     [Fact]
@@ -45,9 +45,9 @@ public class IlBodyDiffTests
         var diff = IlBodyDiff.Compare(left, right);
 
         Assert.False(diff.IsExact);
-        Assert.Single(diff.Differences);
-        Assert.Equal(IlBodyDiffChangeKind.Added, diff.Differences[0].Kind);
-        Assert.Equal(ILOpCode.Nop, diff.Differences[0].NewOpCode);
+        Assert.Single(diff.Rows);
+        Assert.Equal(IlDiffKind.Add, diff.Rows[0].Kind);
+        Assert.Equal("nop", diff.Rows[0].Operation.OpcodeFamily);
     }
 
     [Fact]
@@ -61,10 +61,22 @@ public class IlBodyDiffTests
 
         var diff = IlBodyDiff.Compare(left, right);
 
-        var changed = Assert.Single(diff.Differences);
-        Assert.Equal(IlBodyDiffChangeKind.Changed, changed.Kind);
-        Assert.Equal(ILOpCode.Br_s, changed.OldOpCode);
-        Assert.Equal(ILOpCode.Br_s, changed.NewOpCode);
+        Assert.Collection(
+            diff.Rows,
+            removed =>
+            {
+                Assert.Equal(IlDiffKind.Remove, removed.Kind);
+                Assert.Equal(0, removed.Operation.Offset);
+                Assert.Equal("br", removed.Operation.OpcodeFamily);
+                Assert.Equal("IL_0005", removed.Operation.Operand?.Value);
+            },
+            added =>
+            {
+                Assert.Equal(IlDiffKind.Add, added.Kind);
+                Assert.Equal(0, added.Operation.Offset);
+                Assert.Equal("br", added.Operation.OpcodeFamily);
+                Assert.Equal("IL_0003", added.Operation.Operand?.Value);
+            });
     }
 
     [Fact]
@@ -76,17 +88,26 @@ public class IlBodyDiffTests
         var diff = IlBodyDiff.Compare(left, right);
 
         Assert.Collection(
-            diff.Differences,
-            changed =>
+            diff.Rows,
+            removedBranch =>
             {
-                Assert.Equal(IlBodyDiffChangeKind.Changed, changed.Kind);
-                Assert.Equal(0, changed.OldOffset);
-                Assert.Equal(0, changed.NewOffset);
+                Assert.Equal(IlDiffKind.Remove, removedBranch.Kind);
+                Assert.Equal(0, removedBranch.Operation.Offset);
+                Assert.Equal("br", removedBranch.Operation.OpcodeFamily);
+                Assert.Equal("IL_0005", removedBranch.Operation.Operand?.Value);
             },
-            removed =>
+            addedBranch =>
             {
-                Assert.Equal(IlBodyDiffChangeKind.Removed, removed.Kind);
-                Assert.Equal(2, removed.OldOffset);
+                Assert.Equal(IlDiffKind.Add, addedBranch.Kind);
+                Assert.Equal(0, addedBranch.Operation.Offset);
+                Assert.Equal("br", addedBranch.Operation.OpcodeFamily);
+                Assert.Equal("IL_0002", addedBranch.Operation.Operand?.Value);
+            },
+            removedNop =>
+            {
+                Assert.Equal(IlDiffKind.Remove, removedNop.Kind);
+                Assert.Equal(2, removedNop.Operation.Offset);
+                Assert.Equal("nop", removedNop.Operation.OpcodeFamily);
             });
     }
 

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -81,6 +81,30 @@ public class IlBodyDiffTests
     }
 
     [Fact]
+    public void Compare_BranchTargetInstructionChanged_DoesNotCascadeToBranch()
+    {
+        var left = MethodInstructions.Decode([0x2b, 0x00, 0x16, 0x2a], 4, []);
+        var right = MethodInstructions.Decode([0x2b, 0x00, 0x17, 0x2a], 4, []);
+
+        var diff = IlBodyDiff.Compare(left, right);
+
+        Assert.Collection(
+            diff.Rows,
+            removed =>
+            {
+                Assert.Equal(IlDiffKind.Remove, removed.Kind);
+                Assert.Equal("ldc.i4", removed.Operation.OpcodeFamily);
+                Assert.Equal("0", removed.Operation.Operand?.Value);
+            },
+            added =>
+            {
+                Assert.Equal(IlDiffKind.Add, added.Kind);
+                Assert.Equal("ldc.i4", added.Operation.OpcodeFamily);
+                Assert.Equal("1", added.Operation.Operand?.Value);
+            });
+    }
+
+    [Fact]
     public void Compare_CompiledFixtureConstantValueChange_ReportsImmediateChange()
     {
         var diff = DiffFixtureDiff("ConstantValue");

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -1,5 +1,6 @@
 using ILInspector.Instructions;
 using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 
 namespace ILInspector.Analysis.Tests;
 
@@ -80,6 +81,55 @@ public class IlBodyDiffTests
     }
 
     [Fact]
+    public void Compare_CompiledFixtureConstantValueChange_ReportsImmediateChange()
+    {
+        var left = DiffFixtureMethod("DiffFixtures.V1", "ConstantValue");
+        var right = DiffFixtureMethod("DiffFixtures.V2", "ConstantValue");
+
+        var diff = IlBodyDiff.Compare(left, right);
+
+        Assert.Collection(
+            diff.Rows,
+            removed =>
+            {
+                Assert.Equal(IlDiffKind.Remove, removed.Kind);
+                Assert.Equal("ldc.i4", removed.Operation.OpcodeFamily);
+                Assert.Equal("1", removed.Operation.Operand?.Value);
+            },
+            added =>
+            {
+                Assert.Equal(IlDiffKind.Add, added.Kind);
+                Assert.Equal("ldc.i4", added.Operation.OpcodeFamily);
+                Assert.Equal("2", added.Operation.Operand?.Value);
+            });
+    }
+
+    [Fact]
+    public void Compare_CompiledFixtureBranchTargetOffsetShift_DoesNotMarkBranchChanged()
+    {
+        var left = DiffFixtureMethod("DiffFixtures.V1", "BranchTargetOffsetShift");
+        var right = DiffFixtureMethod("DiffFixtures.V2", "BranchTargetOffsetShift");
+
+        var diff = IlBodyDiff.Compare(left, right);
+
+        Assert.NotEmpty(diff.Rows);
+        Assert.Contains(diff.Rows, row => row.Kind == IlDiffKind.Add && row.Operation.OpcodeFamily == "call");
+        Assert.DoesNotContain(diff.Rows, IsBranchRow);
+    }
+
+    [Fact]
+    public void Compare_CompiledFixtureBranchRetarget_ReportsChangedBranch()
+    {
+        var left = DiffFixtureMethod("DiffFixtures.V1", "BranchRetarget");
+        var right = DiffFixtureMethod("DiffFixtures.V2", "BranchRetarget");
+
+        var diff = IlBodyDiff.Compare(left, right);
+
+        Assert.Contains(diff.Rows, row => row.Kind == IlDiffKind.Remove && IsBranchRow(row));
+        Assert.Contains(diff.Rows, row => row.Kind == IlDiffKind.Add && IsBranchRow(row));
+    }
+
+    [Fact]
     public void Compare_RetargetedBranchAndRemovedInstruction_ReportsInProgramOrder()
     {
         var left = MethodInstructions.Decode([0x2b, 0x03, 0x00, 0x16, 0x2a, 0x17, 0x2a], 7, []);
@@ -121,5 +171,33 @@ public class IlBodyDiffTests
 
         Assert.False(diff.IsExact);
         Assert.NotNull(diff.Failure);
+    }
+
+    static bool IsBranchRow(IlDiffRow row)
+        => row.Operation.OpcodeFamily.StartsWith("br", StringComparison.Ordinal);
+
+    static MethodInstructions DiffFixtureMethod(string project, string name)
+    {
+        using var stream = File.OpenRead(DiffFixturePath(project));
+        using var peReader = new PEReader(stream);
+        var metadataReader = peReader.GetMetadataReader();
+        foreach (var handle in metadataReader.MethodDefinitions)
+        {
+            var method = metadataReader.GetMethodDefinition(handle);
+            if (metadataReader.GetString(method.Name) == name)
+                return MethodInstructions.Decode(peReader.GetMethodBody(method.RelativeVirtualAddress));
+        }
+
+        throw new InvalidOperationException($"Could not find method '{name}' in {project}.");
+    }
+
+    static string DiffFixturePath(string project)
+    {
+        var outputDirectory = new DirectoryInfo(
+            AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string path = Path.GetFullPath(Path.Combine(
+            outputDirectory.FullName, "..", "..", project, outputDirectory.Name, "DiffFixtureSample.dll"));
+        Assert.True(File.Exists(path), $"Expected diff fixture assembly at {path}");
+        return path;
     }
 }

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -1,0 +1,49 @@
+using ILInspector.Instructions;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Analysis.Tests;
+
+public class IlBodyDiffTests
+{
+    [Fact]
+    public void Compare_ExactBodies_HasNoDifferences()
+    {
+        var left = MethodInstructions.Decode([0x00, 0x2a], 2, []);
+        var right = MethodInstructions.Decode([0x00, 0x2a], 2, []);
+
+        var diff = IlBodyDiff.Compare(left, right);
+
+        Assert.True(diff.IsExact);
+        Assert.Null(diff.Failure);
+        Assert.Empty(diff.Differences);
+    }
+
+    [Fact]
+    public void Compare_AddedInstruction_ReportsAddedRow()
+    {
+        var left = MethodInstructions.Decode([0x00, 0x2a], 2, []);
+        var right = MethodInstructions.Decode([0x00, 0x00, 0x2a], 3, []);
+
+        var diff = IlBodyDiff.Compare(left, right);
+
+        Assert.False(diff.IsExact);
+        var changed = Assert.Single(diff.Differences, row => row.Kind == IlBodyDiffChangeKind.Changed);
+        Assert.Equal(ILOpCode.Ret, changed.OldOpCode);
+        Assert.Equal(ILOpCode.Nop, changed.NewOpCode);
+        var added = Assert.Single(diff.Differences, row => row.Kind == IlBodyDiffChangeKind.Added);
+        Assert.Null(added.OldOpCode);
+        Assert.Equal(ILOpCode.Ret, added.NewOpCode);
+    }
+
+    [Fact]
+    public void Compare_MalformedBody_ReportsFailure()
+    {
+        var malformed = MethodInstructions.Decode([0xfe], 1, []);
+        var valid = MethodInstructions.Decode([0x2a], 1, []);
+
+        var diff = IlBodyDiff.Compare(malformed, valid);
+
+        Assert.False(diff.IsExact);
+        Assert.NotNull(diff.Failure);
+    }
+}

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -51,6 +51,23 @@ public class IlBodyDiffTests
     }
 
     [Fact]
+    public void Compare_BranchTargetRetarget_ReportsChangedBranch()
+    {
+        // Same opcode sequence, but the first branch retargets from IL_0005 to
+        // IL_0003. LCS can align the branch instructions, then target validation
+        // must still report the control-flow change.
+        var left = MethodInstructions.Decode([0x2b, 0x03, 0x00, 0x2a, 0x00, 0x2a], 6, []);
+        var right = MethodInstructions.Decode([0x2b, 0x01, 0x00, 0x2a, 0x00, 0x2a], 6, []);
+
+        var diff = IlBodyDiff.Compare(left, right);
+
+        var changed = Assert.Single(diff.Differences);
+        Assert.Equal(IlBodyDiffChangeKind.Changed, changed.Kind);
+        Assert.Equal(ILOpCode.Br_s, changed.OldOpCode);
+        Assert.Equal(ILOpCode.Br_s, changed.NewOpCode);
+    }
+
+    [Fact]
     public void Compare_MalformedBody_ReportsFailure()
     {
         var malformed = MethodInstructions.Decode([0xfe], 1, []);

--- a/src/ILInspector.Analysis/BodySignalDiff.cs
+++ b/src/ILInspector.Analysis/BodySignalDiff.cs
@@ -43,14 +43,36 @@ public static class BodySignalDiff
             oldGroup ??= [];
             newGroup ??= [];
 
-            for (int i = oldGroup.Length; i < newGroup.Length; i++)
-                rows.Add(ToRow(BodySignalDiffKind.Added, newGroup[i]));
-            for (int i = newGroup.Length; i < oldGroup.Length; i++)
-                rows.Add(ToRow(BodySignalDiffKind.Removed, oldGroup[i]));
+            foreach (var fact in Difference(newGroup, oldGroup))
+                rows.Add(ToRow(BodySignalDiffKind.Added, fact));
+            foreach (var fact in Difference(oldGroup, newGroup))
+                rows.Add(ToRow(BodySignalDiffKind.Removed, fact));
         }
 
         return new BodySignalDiffResult(rows.ToImmutable());
     }
+
+    static IEnumerable<UnsafeFact> Difference(UnsafeFact[] candidate, UnsafeFact[] baseline)
+    {
+        var baselineOffsets = baseline
+            .GroupBy(fact => fact.ILOffset)
+            .ToDictionary(group => OffsetKey(group.Key), group => group.Count(), StringComparer.Ordinal);
+
+        foreach (var fact in candidate)
+        {
+            string offsetKey = OffsetKey(fact.ILOffset);
+            if (baselineOffsets.TryGetValue(offsetKey, out int count) && count > 0)
+            {
+                baselineOffsets[offsetKey] = count - 1;
+                continue;
+            }
+
+            yield return fact;
+        }
+    }
+
+    static string OffsetKey(int? offset)
+        => offset?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "<null>";
 
     static Dictionary<string, UnsafeFact[]> UnsafeFactGroups(LibraryBodyIndex index)
     {

--- a/src/ILInspector.Analysis/BodySignalDiff.cs
+++ b/src/ILInspector.Analysis/BodySignalDiff.cs
@@ -1,0 +1,75 @@
+using System.Collections.Immutable;
+
+namespace ILInspector.Analysis;
+
+public enum BodySignalDiffKind
+{
+    Added,
+    Removed,
+}
+
+public sealed record BodySignalDiffRow(
+    BodySignalDiffKind Kind,
+    string Signal,
+    string Member,
+    string Operation,
+    int? ILOffset,
+    string Evidence);
+
+public sealed record BodySignalDiffResult(ImmutableArray<BodySignalDiffRow> Rows)
+{
+    public bool IsEmpty => Rows.IsEmpty;
+}
+
+/// <summary>
+/// Product-level body signal diff over Analysis facts.
+/// </summary>
+public static class BodySignalDiff
+{
+    public static BodySignalDiffResult CompareUnsafe(LibraryBodyIndex oldIndex, LibraryBodyIndex newIndex)
+    {
+        ArgumentNullException.ThrowIfNull(oldIndex);
+        ArgumentNullException.ThrowIfNull(newIndex);
+
+        var oldFacts = UnsafeFactKeys(oldIndex);
+        var newFacts = UnsafeFactKeys(newIndex);
+        var rows = ImmutableArray.CreateBuilder<BodySignalDiffRow>();
+
+        foreach (var added in newFacts.Keys.Except(oldFacts.Keys).Order(StringComparer.Ordinal))
+            rows.Add(ToRow(BodySignalDiffKind.Added, newFacts[added]));
+        foreach (var removed in oldFacts.Keys.Except(newFacts.Keys).Order(StringComparer.Ordinal))
+            rows.Add(ToRow(BodySignalDiffKind.Removed, oldFacts[removed]));
+
+        return new BodySignalDiffResult(rows.ToImmutable());
+    }
+
+    static Dictionary<string, UnsafeFact> UnsafeFactKeys(LibraryBodyIndex index)
+    {
+        var facts = SemanticFactProjection.SafetyFacts(
+            index.GetUnsafeEvidenceByMember().Values.SelectMany(group => group).ToImmutableArray(),
+            index.GetUnsafetyOccurrences());
+        return facts
+            .Select(fact => new UnsafeFact(
+                MethodKey(fact.Method),
+                fact.SafetyKind,
+                fact.Operation,
+                fact.ILOffset,
+                fact.Evidence))
+            .GroupBy(fact => $"{fact.MemberKey}|{fact.Signal}|{fact.Operation}|{fact.Evidence}", StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+    }
+
+    static BodySignalDiffRow ToRow(BodySignalDiffKind kind, UnsafeFact fact)
+        => new(
+            kind,
+            fact.Signal,
+            fact.MemberKey,
+            fact.Operation,
+            fact.ILOffset,
+            fact.Evidence);
+
+    static string MethodKey(MethodIdentity method)
+        => $"{method.DeclaringType.ToQualifiedDisplayString()}.{method.Name}({string.Join(", ", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()))}):{method.ReturnType.ToQualifiedDisplayString()}";
+
+    sealed record UnsafeFact(string MemberKey, string Signal, string Operation, int? ILOffset, string Evidence);
+}

--- a/src/ILInspector.Analysis/BodySignalDiff.cs
+++ b/src/ILInspector.Analysis/BodySignalDiff.cs
@@ -31,19 +31,28 @@ public static class BodySignalDiff
         ArgumentNullException.ThrowIfNull(oldIndex);
         ArgumentNullException.ThrowIfNull(newIndex);
 
-        var oldFacts = UnsafeFactKeys(oldIndex);
-        var newFacts = UnsafeFactKeys(newIndex);
+        var oldFacts = UnsafeFactGroups(oldIndex);
+        var newFacts = UnsafeFactGroups(newIndex);
         var rows = ImmutableArray.CreateBuilder<BodySignalDiffRow>();
+        var keys = new SortedSet<string>(oldFacts.Keys.Concat(newFacts.Keys), StringComparer.Ordinal);
 
-        foreach (var added in newFacts.Keys.Except(oldFacts.Keys).Order(StringComparer.Ordinal))
-            rows.Add(ToRow(BodySignalDiffKind.Added, newFacts[added]));
-        foreach (var removed in oldFacts.Keys.Except(newFacts.Keys).Order(StringComparer.Ordinal))
-            rows.Add(ToRow(BodySignalDiffKind.Removed, oldFacts[removed]));
+        foreach (var key in keys)
+        {
+            oldFacts.TryGetValue(key, out var oldGroup);
+            newFacts.TryGetValue(key, out var newGroup);
+            oldGroup ??= [];
+            newGroup ??= [];
+
+            for (int i = oldGroup.Length; i < newGroup.Length; i++)
+                rows.Add(ToRow(BodySignalDiffKind.Added, newGroup[i]));
+            for (int i = newGroup.Length; i < oldGroup.Length; i++)
+                rows.Add(ToRow(BodySignalDiffKind.Removed, oldGroup[i]));
+        }
 
         return new BodySignalDiffResult(rows.ToImmutable());
     }
 
-    static Dictionary<string, UnsafeFact> UnsafeFactKeys(LibraryBodyIndex index)
+    static Dictionary<string, UnsafeFact[]> UnsafeFactGroups(LibraryBodyIndex index)
     {
         var facts = SemanticFactProjection.SafetyFacts(
             index.GetUnsafeEvidenceByMember().Values.SelectMany(group => group).ToImmutableArray(),
@@ -56,7 +65,10 @@ public static class BodySignalDiff
                 fact.ILOffset,
                 fact.Evidence))
             .GroupBy(fact => $"{fact.MemberKey}|{fact.Signal}|{fact.Operation}|{fact.Evidence}", StringComparer.Ordinal)
-            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+            .ToDictionary(
+                group => group.Key,
+                group => group.OrderBy(fact => fact.ILOffset ?? -1).ToArray(),
+                StringComparer.Ordinal);
     }
 
     static BodySignalDiffRow ToRow(BodySignalDiffKind kind, UnsafeFact fact)
@@ -69,7 +81,7 @@ public static class BodySignalDiff
             fact.Evidence);
 
     static string MethodKey(MethodIdentity method)
-        => $"{method.DeclaringType.ToQualifiedDisplayString()}.{method.Name}({string.Join(", ", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()))}):{method.ReturnType.ToQualifiedDisplayString()}";
+        => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
 
     sealed record UnsafeFact(string MemberKey, string Signal, string Operation, int? ILOffset, string Evidence);
 }

--- a/src/ILInspector.Analysis/BodySignalDiff.cs
+++ b/src/ILInspector.Analysis/BodySignalDiff.cs
@@ -43,21 +43,50 @@ public static class BodySignalDiff
             oldGroup ??= [];
             newGroup ??= [];
 
-            foreach (var fact in Difference(newGroup, oldGroup))
-                rows.Add(ToRow(BodySignalDiffKind.Added, fact));
-            foreach (var fact in Difference(oldGroup, newGroup))
-                rows.Add(ToRow(BodySignalDiffKind.Removed, fact));
+            AddDifferenceRows(rows, oldGroup, newGroup);
         }
 
         return new BodySignalDiffResult(rows.ToImmutable());
     }
 
-    static IEnumerable<UnsafeFact> Difference(UnsafeFact[] candidate, UnsafeFact[] baseline)
+    static void AddDifferenceRows(
+        ImmutableArray<BodySignalDiffRow>.Builder rows,
+        UnsafeFact[] oldGroup,
+        UnsafeFact[] newGroup)
+    {
+        int addedCount = newGroup.Length - oldGroup.Length;
+        int removedCount = oldGroup.Length - newGroup.Length;
+        if (addedCount > 0)
+            AddDeltaRows(rows, BodySignalDiffKind.Added, UnmatchedByOffset(newGroup, oldGroup), UnmatchedByOffset(oldGroup, newGroup), addedCount);
+        if (removedCount > 0)
+            AddDeltaRows(rows, BodySignalDiffKind.Removed, UnmatchedByOffset(oldGroup, newGroup), UnmatchedByOffset(newGroup, oldGroup), removedCount);
+    }
+
+    static void AddDeltaRows(
+        ImmutableArray<BodySignalDiffRow>.Builder rows,
+        BodySignalDiffKind kind,
+        UnsafeFact[] candidate,
+        UnsafeFact[] opposite,
+        int count)
+    {
+        if (candidate.Length == count && opposite.Length == 0)
+        {
+            foreach (var fact in candidate)
+                rows.Add(ToRow(kind, fact));
+            return;
+        }
+
+        for (int i = 0; i < count; i++)
+            rows.Add(ToRow(kind, candidate[Math.Min(i, candidate.Length - 1)] with { ILOffset = null }));
+    }
+
+    static UnsafeFact[] UnmatchedByOffset(UnsafeFact[] candidate, UnsafeFact[] baseline)
     {
         var baselineOffsets = baseline
             .GroupBy(fact => fact.ILOffset)
             .ToDictionary(group => OffsetKey(group.Key), group => group.Count(), StringComparer.Ordinal);
 
+        var result = ImmutableArray.CreateBuilder<UnsafeFact>();
         foreach (var fact in candidate)
         {
             string offsetKey = OffsetKey(fact.ILOffset);
@@ -67,8 +96,10 @@ public static class BodySignalDiff
                 continue;
             }
 
-            yield return fact;
+            result.Add(fact);
         }
+
+        return result.ToArray();
     }
 
     static string OffsetKey(int? offset)

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -737,6 +737,31 @@ public sealed class LibraryBodyIndex
     public static LibraryBodyIndex Open(string path)
         => Open(path, resolver: null);
 
+    internal static LibraryBodyIndex FromEvidence(
+        ImmutableArray<MethodIdentity> methods,
+        ImmutableArray<UnsafeEvidence> unsafeEvidence)
+        => new(
+            path: "",
+            methods,
+            directCalls: [],
+            unsafeEvidence,
+            diagnostics: [],
+            optimizationOpportunities: [],
+            unsafeLeverageMethods: [],
+            memorySafetyRulesEnabled: false,
+            unsafeModes: new UnsafeModeBreakdown(
+                methods.Count(method => method.CallerUnsafeMode == CallerUnsafeMode.None),
+                methods.Count(method => method.CallerUnsafeMode == CallerUnsafeMode.Implicit),
+                methods.Count(method => method.CallerUnsafeMode == CallerUnsafeMode.Explicit)),
+            bodySignals: new Dictionary<int, BodySignals>(),
+            allocationOccurrences: new Dictionary<int, ImmutableArray<AllocationOccurrence>>(),
+            unsafetyOccurrences: new Dictionary<int, ImmutableArray<UnsafetyOccurrence>>(),
+            inAssemblyTypeIsException: new Dictionary<(string Namespace, string Name), bool>(),
+            suppressedOpportunityTokens: new HashSet<int>(),
+            exceptionTypeNames: new HashSet<string>(StringComparer.Ordinal),
+            nonHeapNewObjOperandTokens: new HashSet<int>(),
+            opportunitiesComputed: false);
+
     public static LibraryBodyIndex Open(string path, IAssemblyReferenceResolver? resolver = null,
         bool includeAllocations = true, bool includeOpportunities = true, IReadOnlySet<int>? bodyScope = null, Func<TypeRef, bool>? bodyTypeScope = null)
     {

--- a/src/ILInspector.Decompiler.Tests/DiffFixtureFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DiffFixtureFidelityTests.cs
@@ -8,6 +8,7 @@ public class DiffFixtureFidelityTests
     static readonly string[] DiffFocusedMethods =
     [
         "ConstantValue",
+        "MultipleHunks",
         "BranchTargetOffsetShift",
         "BranchRetarget",
         "AddsUnsafe",

--- a/src/ILInspector.Decompiler.Tests/DiffFixtureFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DiffFixtureFidelityTests.cs
@@ -9,6 +9,8 @@ public class DiffFixtureFidelityTests
     [
         "ConstantValue",
         "MultipleHunks",
+        "StringToken",
+        "CallToken",
         "BranchTargetOffsetShift",
         "BranchRetarget",
         "AddsUnsafe",

--- a/src/ILInspector.Decompiler.Tests/DiffFixtureFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DiffFixtureFidelityTests.cs
@@ -1,0 +1,45 @@
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+[Trait("Speed", "Slow")]
+public class DiffFixtureFidelityTests
+{
+    static readonly string[] DiffFocusedMethods =
+    [
+        "ConstantValue",
+        "BranchTargetOffsetShift",
+        "BranchRetarget",
+        "AddsUnsafe",
+    ];
+
+    [Theory]
+    [InlineData("DiffFixtures.V1")]
+    [InlineData("DiffFixtures.V2")]
+    public void DiffFocusedFixtures_StayCompileBackCheckable(string project)
+    {
+        var results = FidelityCheck.Evaluate(DiffFixturePath(project));
+        foreach (string method in DiffFocusedMethods)
+        {
+            var matches = results.Where(result => result.Method == method).ToArray();
+            Assert.True(matches.Length > 0, $"Expected fidelity check to evaluate {project}.{method}.");
+            Assert.All(matches, result =>
+                Assert.True(
+                    result.Status is FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff,
+                    $"{project}.{method} regressed to {result.Status}: the paired diff fixture must remain decompiler compile-back checkable.\n"
+                        + $"  original : {result.OriginalOpcodes}\n"
+                        + $"  recompiled: {result.RecompiledOpcodes}\n"
+                        + $"  detail   : {result.Detail}"));
+        }
+    }
+
+    static string DiffFixturePath(string project)
+    {
+        var outputDirectory = new DirectoryInfo(
+            AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string path = Path.GetFullPath(Path.Combine(
+            outputDirectory.FullName, "..", "..", project, outputDirectory.Name, "DiffFixtureSample.dll"));
+        Assert.True(File.Exists(path), $"Expected diff fixture assembly at {path}");
+        return path;
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -39,6 +39,8 @@
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung5\ILInspector.Decompiler.Fixtures.LadderRung5.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderRung9\ILInspector.Decompiler.Fixtures.LadderRung9.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderIterator\ILInspector.Decompiler.Fixtures.LadderIterator.csproj" />
+    <ProjectReference Include="..\DiffFixtures.V1\DiffFixtures.V1.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\DiffFixtures.V2\DiffFixtures.V2.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <!--

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -38,55 +38,123 @@ public static class IlBodyDiff
         if (!newBody.IsComplete)
             return new IlBodyDiffResult(false, newBody.Blocks.IncompleteReason ?? "new body decode failed", []);
 
+        var oldInstructions = oldBody.Instructions;
+        var newInstructions = newBody.Instructions;
+        var lcs = LongestCommonSubsequence(oldInstructions, newInstructions);
         var differences = ImmutableArray.CreateBuilder<IlInstructionDiff>();
-        int shared = Math.Min(oldBody.Instructions.Length, newBody.Instructions.Length);
-        for (int i = 0; i < shared; i++)
+        int oldIndex = 0;
+        int newIndex = 0;
+        int diffIndex = 0;
+        foreach (var (nextOld, nextNew) in lcs)
         {
-            var oldInstruction = oldBody.Instructions[i];
-            var newInstruction = newBody.Instructions[i];
-            if (CanonicalEquals(oldInstruction, newInstruction))
-                continue;
-
-            differences.Add(new IlInstructionDiff(
-                IlBodyDiffChangeKind.Changed,
-                i,
-                oldInstruction.Offset,
-                oldInstruction.OpCode,
-                newInstruction.Offset,
-                newInstruction.OpCode));
+            AddUnmatched(oldInstructions, oldIndex, nextOld, newInstructions, newIndex, nextNew, differences, ref diffIndex);
+            oldIndex = nextOld + 1;
+            newIndex = nextNew + 1;
         }
 
-        for (int i = shared; i < oldBody.Instructions.Length; i++)
+        AddUnmatched(oldInstructions, oldIndex, oldInstructions.Length, newInstructions, newIndex, newInstructions.Length, differences, ref diffIndex);
+
+        var rows = differences.ToImmutable();
+        return new IlBodyDiffResult(rows.Length == 0, Failure: null, rows);
+    }
+
+    static void AddUnmatched(
+        ImmutableArray<DecodedInstruction> oldInstructions,
+        int oldStart,
+        int oldEnd,
+        ImmutableArray<DecodedInstruction> newInstructions,
+        int newStart,
+        int newEnd,
+        ImmutableArray<IlInstructionDiff>.Builder differences,
+        ref int diffIndex)
+    {
+        int oldIndex = oldStart;
+        int newIndex = newStart;
+        while (oldIndex < oldEnd && newIndex < newEnd)
         {
-            var oldInstruction = oldBody.Instructions[i];
+            differences.Add(new IlInstructionDiff(
+                IlBodyDiffChangeKind.Changed,
+                diffIndex++,
+                oldInstructions[oldIndex].Offset,
+                oldInstructions[oldIndex].OpCode,
+                newInstructions[newIndex].Offset,
+                newInstructions[newIndex].OpCode));
+            oldIndex++;
+            newIndex++;
+        }
+
+        while (oldIndex < oldEnd)
+        {
+            var oldInstruction = oldInstructions[oldIndex++];
             differences.Add(new IlInstructionDiff(
                 IlBodyDiffChangeKind.Removed,
-                i,
+                diffIndex++,
                 oldInstruction.Offset,
                 oldInstruction.OpCode,
                 NewOffset: null,
                 NewOpCode: null));
         }
 
-        for (int i = shared; i < newBody.Instructions.Length; i++)
+        while (newIndex < newEnd)
         {
-            var newInstruction = newBody.Instructions[i];
+            var newInstruction = newInstructions[newIndex++];
             differences.Add(new IlInstructionDiff(
                 IlBodyDiffChangeKind.Added,
-                i,
+                diffIndex++,
                 OldOffset: null,
                 OldOpCode: null,
                 newInstruction.Offset,
                 newInstruction.OpCode));
         }
+    }
 
-        var rows = differences.ToImmutable();
-        return new IlBodyDiffResult(rows.Length == 0, Failure: null, rows);
+    static List<(int OldIndex, int NewIndex)> LongestCommonSubsequence(
+        ImmutableArray<DecodedInstruction> oldInstructions,
+        ImmutableArray<DecodedInstruction> newInstructions)
+    {
+        var lengths = new int[oldInstructions.Length + 1, newInstructions.Length + 1];
+        for (int oldIndex = oldInstructions.Length - 1; oldIndex >= 0; oldIndex--)
+        {
+            for (int newIndex = newInstructions.Length - 1; newIndex >= 0; newIndex--)
+            {
+                lengths[oldIndex, newIndex] = CanonicalEquals(oldInstructions[oldIndex], newInstructions[newIndex])
+                    ? lengths[oldIndex + 1, newIndex + 1] + 1
+                    : Math.Max(lengths[oldIndex + 1, newIndex], lengths[oldIndex, newIndex + 1]);
+            }
+        }
+
+        var pairs = new List<(int OldIndex, int NewIndex)>();
+        int i = 0;
+        int j = 0;
+        while (i < oldInstructions.Length && j < newInstructions.Length)
+        {
+            if (CanonicalEquals(oldInstructions[i], newInstructions[j]))
+            {
+                pairs.Add((i, j));
+                i++;
+                j++;
+            }
+            else if (lengths[i + 1, j] >= lengths[i, j + 1])
+            {
+                i++;
+            }
+            else
+            {
+                j++;
+            }
+        }
+
+        return pairs;
     }
 
     static bool CanonicalEquals(DecodedInstruction oldInstruction, DecodedInstruction newInstruction)
-        => oldInstruction.OpCode == newInstruction.OpCode
-            && oldInstruction.Operand == newInstruction.Operand
-            && oldInstruction.OperandValue == newInstruction.OperandValue
-            && oldInstruction.BranchTargets.SequenceEqual(newInstruction.BranchTargets);
+    {
+        if (oldInstruction.OpCode != newInstruction.OpCode || oldInstruction.Operand != newInstruction.Operand)
+            return false;
+        if (oldInstruction.Operand is OperandKind.ShortInlineBrTarget or OperandKind.InlineBrTarget)
+            return true;
+        if (oldInstruction.Operand == OperandKind.InlineSwitch)
+            return oldInstruction.BranchTargets.Length == newInstruction.BranchTargets.Length;
+        return oldInstruction.OperandValue == newInstruction.OperandValue;
+    }
 }

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -56,7 +56,9 @@ public static class IlBodyDiff
 
         var oldInstructions = oldBody.Instructions;
         var newInstructions = newBody.Instructions;
-        var lcs = LongestCommonSubsequence(oldInstructions, newInstructions);
+        var oldOperations = oldInstructions.Select(ToOperation).ToImmutableArray();
+        var newOperations = newInstructions.Select(ToOperation).ToImmutableArray();
+        var lcs = LongestCommonSubsequence(oldOperations, newOperations);
         var oldToNew = lcs.ToDictionary(pair => pair.OldIndex, pair => pair.NewIndex);
         var rows = ImmutableArray.CreateBuilder<IlDiffRow>();
         int oldIndex = 0;
@@ -64,28 +66,28 @@ public static class IlBodyDiff
         int hunkId = 0;
         foreach (var (nextOld, nextNew) in lcs)
         {
-            AddUnmatched(oldInstructions, oldIndex, nextOld, newInstructions, newIndex, nextNew, rows, ref hunkId);
+            AddUnmatched(oldOperations, oldIndex, nextOld, newOperations, newIndex, nextNew, rows, ref hunkId);
             if (!BranchTargetsMatch(oldInstructions, nextOld, newInstructions, nextNew, oldToNew))
             {
                 int hunk = hunkId++;
-                rows.Add(new IlDiffRow(hunk, IlDiffKind.Remove, ToOperation(oldInstructions[nextOld])));
-                rows.Add(new IlDiffRow(hunk, IlDiffKind.Add, ToOperation(newInstructions[nextNew])));
+                rows.Add(new IlDiffRow(hunk, IlDiffKind.Remove, oldOperations[nextOld]));
+                rows.Add(new IlDiffRow(hunk, IlDiffKind.Add, newOperations[nextNew]));
             }
             oldIndex = nextOld + 1;
             newIndex = nextNew + 1;
         }
 
-        AddUnmatched(oldInstructions, oldIndex, oldInstructions.Length, newInstructions, newIndex, newInstructions.Length, rows, ref hunkId);
+        AddUnmatched(oldOperations, oldIndex, oldOperations.Length, newOperations, newIndex, newOperations.Length, rows, ref hunkId);
 
         var diffRows = rows.ToImmutable();
         return new IlBodyDiffResult(diffRows.Length == 0, Failure: null, diffRows);
     }
 
     static void AddUnmatched(
-        ImmutableArray<DecodedInstruction> oldInstructions,
+        ImmutableArray<CanonicalIlOperation> oldOperations,
         int oldStart,
         int oldEnd,
-        ImmutableArray<DecodedInstruction> newInstructions,
+        ImmutableArray<CanonicalIlOperation> newOperations,
         int newStart,
         int newEnd,
         ImmutableArray<IlDiffRow>.Builder rows,
@@ -98,21 +100,21 @@ public static class IlBodyDiff
         int oldIndex = oldStart;
         int newIndex = newStart;
         while (oldIndex < oldEnd)
-            rows.Add(new IlDiffRow(hunk, IlDiffKind.Remove, ToOperation(oldInstructions[oldIndex++])));
+            rows.Add(new IlDiffRow(hunk, IlDiffKind.Remove, oldOperations[oldIndex++]));
         while (newIndex < newEnd)
-            rows.Add(new IlDiffRow(hunk, IlDiffKind.Add, ToOperation(newInstructions[newIndex++])));
+            rows.Add(new IlDiffRow(hunk, IlDiffKind.Add, newOperations[newIndex++]));
     }
 
     static List<(int OldIndex, int NewIndex)> LongestCommonSubsequence(
-        ImmutableArray<DecodedInstruction> oldInstructions,
-        ImmutableArray<DecodedInstruction> newInstructions)
+        ImmutableArray<CanonicalIlOperation> oldOperations,
+        ImmutableArray<CanonicalIlOperation> newOperations)
     {
-        var lengths = new int[oldInstructions.Length + 1, newInstructions.Length + 1];
-        for (int oldIndex = oldInstructions.Length - 1; oldIndex >= 0; oldIndex--)
+        var lengths = new int[oldOperations.Length + 1, newOperations.Length + 1];
+        for (int oldIndex = oldOperations.Length - 1; oldIndex >= 0; oldIndex--)
         {
-            for (int newIndex = newInstructions.Length - 1; newIndex >= 0; newIndex--)
+            for (int newIndex = newOperations.Length - 1; newIndex >= 0; newIndex--)
             {
-                lengths[oldIndex, newIndex] = CanonicalEquals(oldInstructions[oldIndex], newInstructions[newIndex])
+                lengths[oldIndex, newIndex] = CanonicalEquals(oldOperations[oldIndex], newOperations[newIndex])
                     ? lengths[oldIndex + 1, newIndex + 1] + 1
                     : Math.Max(lengths[oldIndex + 1, newIndex], lengths[oldIndex, newIndex + 1]);
             }
@@ -121,9 +123,9 @@ public static class IlBodyDiff
         var pairs = new List<(int OldIndex, int NewIndex)>();
         int i = 0;
         int j = 0;
-        while (i < oldInstructions.Length && j < newInstructions.Length)
+        while (i < oldOperations.Length && j < newOperations.Length)
         {
-            if (CanonicalEquals(oldInstructions[i], newInstructions[j]))
+            if (CanonicalEquals(oldOperations[i], newOperations[j]))
             {
                 pairs.Add((i, j));
                 i++;
@@ -142,16 +144,14 @@ public static class IlBodyDiff
         return pairs;
     }
 
-    static bool CanonicalEquals(DecodedInstruction oldInstruction, DecodedInstruction newInstruction)
+    static bool CanonicalEquals(CanonicalIlOperation oldOperation, CanonicalIlOperation newOperation)
     {
-        var oldOperation = ToOperation(oldInstruction);
-        var newOperation = ToOperation(newInstruction);
         if (oldOperation.OpcodeFamily != newOperation.OpcodeFamily)
             return false;
-        if (oldInstruction.Operand is OperandKind.ShortInlineBrTarget or OperandKind.InlineBrTarget)
+        if (oldOperation.Operand?.Kind is IlOperandIdentityKind.BranchTarget)
             return true;
-        if (oldInstruction.Operand == OperandKind.InlineSwitch)
-            return oldInstruction.BranchTargets.Length == newInstruction.BranchTargets.Length;
+        if (oldOperation.Operand?.Kind is IlOperandIdentityKind.SwitchTargets)
+            return oldOperation.Operand.Value.Split(',').Length == newOperation.Operand?.Value.Split(',').Length;
         return oldOperation.Operand == newOperation.Operand;
     }
 

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -41,6 +41,7 @@ public static class IlBodyDiff
         var oldInstructions = oldBody.Instructions;
         var newInstructions = newBody.Instructions;
         var lcs = LongestCommonSubsequence(oldInstructions, newInstructions);
+        var oldToNew = lcs.ToDictionary(pair => pair.OldIndex, pair => pair.NewIndex);
         var differences = ImmutableArray.CreateBuilder<IlInstructionDiff>();
         int oldIndex = 0;
         int newIndex = 0;
@@ -50,6 +51,21 @@ public static class IlBodyDiff
             AddUnmatched(oldInstructions, oldIndex, nextOld, newInstructions, newIndex, nextNew, differences, ref diffIndex);
             oldIndex = nextOld + 1;
             newIndex = nextNew + 1;
+        }
+
+        foreach (var (mappedOld, mappedNew) in lcs)
+        {
+            if (BranchTargetsMatch(oldInstructions, mappedOld, newInstructions, mappedNew, oldToNew))
+                continue;
+            var oldInstruction = oldInstructions[mappedOld];
+            var newInstruction = newInstructions[mappedNew];
+            differences.Add(new IlInstructionDiff(
+                IlBodyDiffChangeKind.Changed,
+                diffIndex++,
+                oldInstruction.Offset,
+                oldInstruction.OpCode,
+                newInstruction.Offset,
+                newInstruction.OpCode));
         }
 
         AddUnmatched(oldInstructions, oldIndex, oldInstructions.Length, newInstructions, newIndex, newInstructions.Length, differences, ref diffIndex);
@@ -156,5 +172,42 @@ public static class IlBodyDiff
         if (oldInstruction.Operand == OperandKind.InlineSwitch)
             return oldInstruction.BranchTargets.Length == newInstruction.BranchTargets.Length;
         return oldInstruction.OperandValue == newInstruction.OperandValue;
+    }
+
+    static bool BranchTargetsMatch(
+        ImmutableArray<DecodedInstruction> oldInstructions,
+        int oldIndex,
+        ImmutableArray<DecodedInstruction> newInstructions,
+        int newIndex,
+        IReadOnlyDictionary<int, int> oldToNew)
+    {
+        var oldInstruction = oldInstructions[oldIndex];
+        var newInstruction = newInstructions[newIndex];
+        if (oldInstruction.Operand is not (OperandKind.ShortInlineBrTarget or OperandKind.InlineBrTarget or OperandKind.InlineSwitch))
+            return true;
+        if (oldInstruction.BranchTargets.Length != newInstruction.BranchTargets.Length)
+            return false;
+
+        for (int i = 0; i < oldInstruction.BranchTargets.Length; i++)
+        {
+            int oldTargetIndex = InstructionIndexAt(oldInstructions, oldInstruction.BranchTargets[i]);
+            int newTargetIndex = InstructionIndexAt(newInstructions, newInstruction.BranchTargets[i]);
+            if (oldTargetIndex < 0 || newTargetIndex < 0)
+                return oldInstruction.BranchTargets[i] == newInstruction.BranchTargets[i];
+            if (!oldToNew.TryGetValue(oldTargetIndex, out int mappedNewTarget))
+                return false;
+            if (mappedNewTarget != newTargetIndex)
+                return false;
+        }
+
+        return true;
+    }
+
+    static int InstructionIndexAt(ImmutableArray<DecodedInstruction> instructions, int offset)
+    {
+        for (int i = 0; i < instructions.Length; i++)
+            if (instructions[i].Offset == offset)
+                return i;
+        return -1;
     }
 }

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -87,7 +87,7 @@ public static class IlBodyDiff
         if (!TryBuildOperations(newInstructions, newResolver, "new", out var newOperations, out var newFailure))
             return new IlBodyDiffResult(false, newFailure, []);
         var lcs = LongestCommonSubsequence(oldOperations, newOperations);
-        var oldToNew = lcs.ToDictionary(pair => pair.OldIndex, pair => pair.NewIndex);
+        var oldToNew = BuildAlignmentMap(lcs, oldOperations.Length, newOperations.Length);
         var rows = ImmutableArray.CreateBuilder<IlDiffRow>();
         int oldIndex = 0;
         int newIndex = 0;
@@ -195,6 +195,42 @@ public static class IlBodyDiff
         }
 
         return pairs;
+    }
+
+    static IReadOnlyDictionary<int, int> BuildAlignmentMap(
+        IReadOnlyList<(int OldIndex, int NewIndex)> lcs,
+        int oldLength,
+        int newLength)
+    {
+        var map = new Dictionary<int, int>();
+        int oldIndex = 0;
+        int newIndex = 0;
+        foreach (var (nextOld, nextNew) in lcs)
+        {
+            AddGapPairs(map, oldIndex, nextOld, newIndex, nextNew);
+            map[nextOld] = nextNew;
+            oldIndex = nextOld + 1;
+            newIndex = nextNew + 1;
+        }
+
+        AddGapPairs(map, oldIndex, oldLength, newIndex, newLength);
+        return map;
+    }
+
+    static void AddGapPairs(
+        Dictionary<int, int> map,
+        int oldStart,
+        int oldEnd,
+        int newStart,
+        int newEnd)
+    {
+        int oldCount = oldEnd - oldStart;
+        int newCount = newEnd - newStart;
+        if (oldCount != newCount)
+            return;
+
+        for (int i = 0; i < oldCount; i++)
+            map[oldStart + i] = newStart + i;
     }
 
     static bool CanonicalEquals(CanonicalIlOperation oldOperation, CanonicalIlOperation newOperation)

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -3,25 +3,41 @@ using System.Reflection.Metadata;
 
 namespace ILInspector.Instructions;
 
-public enum IlBodyDiffChangeKind
+public enum IlDiffKind
 {
-    Changed,
-    Added,
-    Removed,
+    Context,
+    Remove,
+    Add,
 }
 
-public sealed record IlInstructionDiff(
-    IlBodyDiffChangeKind Kind,
-    int InstructionIndex,
-    int? OldOffset,
-    ILOpCode? OldOpCode,
-    int? NewOffset,
-    ILOpCode? NewOpCode);
+public enum IlOperandIdentityKind
+{
+    Immediate,
+    Token,
+    Slot,
+    BranchTarget,
+    SwitchTargets,
+}
+
+public sealed record IlOperandIdentity(IlOperandIdentityKind Kind, string Value);
+
+public sealed record CanonicalIlOperation(
+    int Offset,
+    string OpcodeFamily,
+    IlOperandIdentity? Operand)
+{
+    public string Display => Operand is null ? OpcodeFamily : $"{OpcodeFamily} {Operand.Value}";
+}
+
+public sealed record IlDiffRow(
+    int HunkId,
+    IlDiffKind Kind,
+    CanonicalIlOperation Operation);
 
 public sealed record IlBodyDiffResult(
     bool IsExact,
     string? Failure,
-    ImmutableArray<IlInstructionDiff> Differences);
+    ImmutableArray<IlDiffRow> Rows);
 
 /// <summary>
 /// Low-level IL body diff substrate over decoded instruction streams.
@@ -42,33 +58,27 @@ public static class IlBodyDiff
         var newInstructions = newBody.Instructions;
         var lcs = LongestCommonSubsequence(oldInstructions, newInstructions);
         var oldToNew = lcs.ToDictionary(pair => pair.OldIndex, pair => pair.NewIndex);
-        var differences = ImmutableArray.CreateBuilder<IlInstructionDiff>();
+        var rows = ImmutableArray.CreateBuilder<IlDiffRow>();
         int oldIndex = 0;
         int newIndex = 0;
-        int diffIndex = 0;
+        int hunkId = 0;
         foreach (var (nextOld, nextNew) in lcs)
         {
-            AddUnmatched(oldInstructions, oldIndex, nextOld, newInstructions, newIndex, nextNew, differences, ref diffIndex);
+            AddUnmatched(oldInstructions, oldIndex, nextOld, newInstructions, newIndex, nextNew, rows, ref hunkId);
             if (!BranchTargetsMatch(oldInstructions, nextOld, newInstructions, nextNew, oldToNew))
             {
-                var oldInstruction = oldInstructions[nextOld];
-                var newInstruction = newInstructions[nextNew];
-                differences.Add(new IlInstructionDiff(
-                    IlBodyDiffChangeKind.Changed,
-                    diffIndex++,
-                    oldInstruction.Offset,
-                    oldInstruction.OpCode,
-                    newInstruction.Offset,
-                    newInstruction.OpCode));
+                int hunk = hunkId++;
+                rows.Add(new IlDiffRow(hunk, IlDiffKind.Remove, ToOperation(oldInstructions[nextOld])));
+                rows.Add(new IlDiffRow(hunk, IlDiffKind.Add, ToOperation(newInstructions[nextNew])));
             }
             oldIndex = nextOld + 1;
             newIndex = nextNew + 1;
         }
 
-        AddUnmatched(oldInstructions, oldIndex, oldInstructions.Length, newInstructions, newIndex, newInstructions.Length, differences, ref diffIndex);
+        AddUnmatched(oldInstructions, oldIndex, oldInstructions.Length, newInstructions, newIndex, newInstructions.Length, rows, ref hunkId);
 
-        var rows = differences.ToImmutable();
-        return new IlBodyDiffResult(rows.Length == 0, Failure: null, rows);
+        var diffRows = rows.ToImmutable();
+        return new IlBodyDiffResult(diffRows.Length == 0, Failure: null, diffRows);
     }
 
     static void AddUnmatched(
@@ -78,47 +88,19 @@ public static class IlBodyDiff
         ImmutableArray<DecodedInstruction> newInstructions,
         int newStart,
         int newEnd,
-        ImmutableArray<IlInstructionDiff>.Builder differences,
-        ref int diffIndex)
+        ImmutableArray<IlDiffRow>.Builder rows,
+        ref int hunkId)
     {
+        if (oldStart == oldEnd && newStart == newEnd)
+            return;
+
+        int hunk = hunkId++;
         int oldIndex = oldStart;
         int newIndex = newStart;
-        while (oldIndex < oldEnd && newIndex < newEnd)
-        {
-            differences.Add(new IlInstructionDiff(
-                IlBodyDiffChangeKind.Changed,
-                diffIndex++,
-                oldInstructions[oldIndex].Offset,
-                oldInstructions[oldIndex].OpCode,
-                newInstructions[newIndex].Offset,
-                newInstructions[newIndex].OpCode));
-            oldIndex++;
-            newIndex++;
-        }
-
         while (oldIndex < oldEnd)
-        {
-            var oldInstruction = oldInstructions[oldIndex++];
-            differences.Add(new IlInstructionDiff(
-                IlBodyDiffChangeKind.Removed,
-                diffIndex++,
-                oldInstruction.Offset,
-                oldInstruction.OpCode,
-                NewOffset: null,
-                NewOpCode: null));
-        }
-
+            rows.Add(new IlDiffRow(hunk, IlDiffKind.Remove, ToOperation(oldInstructions[oldIndex++])));
         while (newIndex < newEnd)
-        {
-            var newInstruction = newInstructions[newIndex++];
-            differences.Add(new IlInstructionDiff(
-                IlBodyDiffChangeKind.Added,
-                diffIndex++,
-                OldOffset: null,
-                OldOpCode: null,
-                newInstruction.Offset,
-                newInstruction.OpCode));
-        }
+            rows.Add(new IlDiffRow(hunk, IlDiffKind.Add, ToOperation(newInstructions[newIndex++])));
     }
 
     static List<(int OldIndex, int NewIndex)> LongestCommonSubsequence(
@@ -162,14 +144,72 @@ public static class IlBodyDiff
 
     static bool CanonicalEquals(DecodedInstruction oldInstruction, DecodedInstruction newInstruction)
     {
-        if (oldInstruction.OpCode != newInstruction.OpCode || oldInstruction.Operand != newInstruction.Operand)
+        var oldOperation = ToOperation(oldInstruction);
+        var newOperation = ToOperation(newInstruction);
+        if (oldOperation.OpcodeFamily != newOperation.OpcodeFamily)
             return false;
         if (oldInstruction.Operand is OperandKind.ShortInlineBrTarget or OperandKind.InlineBrTarget)
             return true;
         if (oldInstruction.Operand == OperandKind.InlineSwitch)
             return oldInstruction.BranchTargets.Length == newInstruction.BranchTargets.Length;
-        return oldInstruction.OperandValue == newInstruction.OperandValue;
+        return oldOperation.Operand == newOperation.Operand;
     }
+
+    static CanonicalIlOperation ToOperation(DecodedInstruction instruction)
+        => new(
+            instruction.Offset,
+            OpcodeFamily(instruction),
+            OperandIdentity(instruction));
+
+    static string OpcodeFamily(DecodedInstruction instruction)
+    {
+        var opcode = instruction.OpCode;
+        if (opcode is ILOpCode.Ldc_i4_m1 or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1
+            or ILOpCode.Ldc_i4_2 or ILOpCode.Ldc_i4_3 or ILOpCode.Ldc_i4_4
+            or ILOpCode.Ldc_i4_5 or ILOpCode.Ldc_i4_6 or ILOpCode.Ldc_i4_7
+            or ILOpCode.Ldc_i4_8 or ILOpCode.Ldc_i4_s or ILOpCode.Ldc_i4)
+        {
+            return "ldc.i4";
+        }
+
+        return opcode.IsShortBranch()
+            ? opcode.ToString()[..^"_s".Length].Replace('_', '.').ToLowerInvariant()
+            : opcode.ToString().Replace('_', '.').ToLowerInvariant();
+    }
+
+    static IlOperandIdentity? OperandIdentity(DecodedInstruction instruction)
+        => instruction.OpCode switch
+        {
+            ILOpCode.Ldc_i4_m1 => new(IlOperandIdentityKind.Immediate, "-1"),
+            ILOpCode.Ldc_i4_0 => new(IlOperandIdentityKind.Immediate, "0"),
+            ILOpCode.Ldc_i4_1 => new(IlOperandIdentityKind.Immediate, "1"),
+            ILOpCode.Ldc_i4_2 => new(IlOperandIdentityKind.Immediate, "2"),
+            ILOpCode.Ldc_i4_3 => new(IlOperandIdentityKind.Immediate, "3"),
+            ILOpCode.Ldc_i4_4 => new(IlOperandIdentityKind.Immediate, "4"),
+            ILOpCode.Ldc_i4_5 => new(IlOperandIdentityKind.Immediate, "5"),
+            ILOpCode.Ldc_i4_6 => new(IlOperandIdentityKind.Immediate, "6"),
+            ILOpCode.Ldc_i4_7 => new(IlOperandIdentityKind.Immediate, "7"),
+            ILOpCode.Ldc_i4_8 => new(IlOperandIdentityKind.Immediate, "8"),
+            _ => OperandIdentityByKind(instruction),
+        };
+
+    static IlOperandIdentity? OperandIdentityByKind(DecodedInstruction instruction)
+        => instruction.Operand switch
+        {
+            OperandKind.ShortInlineI or OperandKind.InlineI or OperandKind.InlineI8
+                or OperandKind.ShortInlineR or OperandKind.InlineR
+                => new(IlOperandIdentityKind.Immediate, instruction.OperandValue.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+            OperandKind.ShortInlineVar or OperandKind.InlineVar
+                => new(IlOperandIdentityKind.Slot, instruction.OperandValue.ToString(System.Globalization.CultureInfo.InvariantCulture)),
+            OperandKind.ShortInlineBrTarget or OperandKind.InlineBrTarget
+                => new(IlOperandIdentityKind.BranchTarget, $"IL_{instruction.BranchTargets[0]:X4}"),
+            OperandKind.InlineSwitch
+                => new(IlOperandIdentityKind.SwitchTargets, string.Join(", ", instruction.BranchTargets.Select(target => $"IL_{target:X4}"))),
+            OperandKind.InlineString or OperandKind.InlineMethod or OperandKind.InlineField
+                or OperandKind.InlineType or OperandKind.InlineSig or OperandKind.InlineTok
+                => new(IlOperandIdentityKind.Token, $"0x{instruction.OperandValue:X8}"),
+            _ => null,
+        };
 
     static bool BranchTargetsMatch(
         ImmutableArray<DecodedInstruction> oldInstructions,

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -1,0 +1,92 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+namespace ILInspector.Instructions;
+
+public enum IlBodyDiffChangeKind
+{
+    Changed,
+    Added,
+    Removed,
+}
+
+public sealed record IlInstructionDiff(
+    IlBodyDiffChangeKind Kind,
+    int InstructionIndex,
+    int? OldOffset,
+    ILOpCode? OldOpCode,
+    int? NewOffset,
+    ILOpCode? NewOpCode);
+
+public sealed record IlBodyDiffResult(
+    bool IsExact,
+    string? Failure,
+    ImmutableArray<IlInstructionDiff> Differences);
+
+/// <summary>
+/// Low-level IL body diff substrate over decoded instruction streams.
+/// </summary>
+public static class IlBodyDiff
+{
+    public static IlBodyDiffResult Compare(MethodInstructions oldBody, MethodInstructions newBody)
+    {
+        ArgumentNullException.ThrowIfNull(oldBody);
+        ArgumentNullException.ThrowIfNull(newBody);
+
+        if (!oldBody.IsComplete)
+            return new IlBodyDiffResult(false, oldBody.Blocks.IncompleteReason ?? "old body decode failed", []);
+        if (!newBody.IsComplete)
+            return new IlBodyDiffResult(false, newBody.Blocks.IncompleteReason ?? "new body decode failed", []);
+
+        var differences = ImmutableArray.CreateBuilder<IlInstructionDiff>();
+        int shared = Math.Min(oldBody.Instructions.Length, newBody.Instructions.Length);
+        for (int i = 0; i < shared; i++)
+        {
+            var oldInstruction = oldBody.Instructions[i];
+            var newInstruction = newBody.Instructions[i];
+            if (CanonicalEquals(oldInstruction, newInstruction))
+                continue;
+
+            differences.Add(new IlInstructionDiff(
+                IlBodyDiffChangeKind.Changed,
+                i,
+                oldInstruction.Offset,
+                oldInstruction.OpCode,
+                newInstruction.Offset,
+                newInstruction.OpCode));
+        }
+
+        for (int i = shared; i < oldBody.Instructions.Length; i++)
+        {
+            var oldInstruction = oldBody.Instructions[i];
+            differences.Add(new IlInstructionDiff(
+                IlBodyDiffChangeKind.Removed,
+                i,
+                oldInstruction.Offset,
+                oldInstruction.OpCode,
+                NewOffset: null,
+                NewOpCode: null));
+        }
+
+        for (int i = shared; i < newBody.Instructions.Length; i++)
+        {
+            var newInstruction = newBody.Instructions[i];
+            differences.Add(new IlInstructionDiff(
+                IlBodyDiffChangeKind.Added,
+                i,
+                OldOffset: null,
+                OldOpCode: null,
+                newInstruction.Offset,
+                newInstruction.OpCode));
+        }
+
+        var rows = differences.ToImmutable();
+        return new IlBodyDiffResult(rows.Length == 0, Failure: null, rows);
+    }
+
+    static bool CanonicalEquals(DecodedInstruction oldInstruction, DecodedInstruction newInstruction)
+        => oldInstruction.OpCode == newInstruction.OpCode
+            && oldInstruction.Operand == newInstruction.Operand
+            && oldInstruction.OperandValue == newInstruction.OperandValue
+            && oldInstruction.BranchTargets.SequenceEqual(newInstruction.BranchTargets);
+}

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 
 namespace ILInspector.Instructions;
 
@@ -45,6 +46,31 @@ public sealed record IlBodyDiffResult(
 public static class IlBodyDiff
 {
     public static IlBodyDiffResult Compare(MethodInstructions oldBody, MethodInstructions newBody)
+        => Compare(oldBody, newBody, oldResolver: null, newResolver: null);
+
+    public static IlBodyDiffResult Compare(
+        MetadataReader oldReader,
+        MethodBodyBlock oldBody,
+        MetadataReader newReader,
+        MethodBodyBlock newBody)
+    {
+        ArgumentNullException.ThrowIfNull(oldReader);
+        ArgumentNullException.ThrowIfNull(oldBody);
+        ArgumentNullException.ThrowIfNull(newReader);
+        ArgumentNullException.ThrowIfNull(newBody);
+
+        return Compare(
+            MethodInstructions.Decode(oldBody),
+            MethodInstructions.Decode(newBody),
+            new MetadataOperandResolver(oldReader),
+            new MetadataOperandResolver(newReader));
+    }
+
+    static IlBodyDiffResult Compare(
+        MethodInstructions oldBody,
+        MethodInstructions newBody,
+        MetadataOperandResolver? oldResolver,
+        MetadataOperandResolver? newResolver)
     {
         ArgumentNullException.ThrowIfNull(oldBody);
         ArgumentNullException.ThrowIfNull(newBody);
@@ -56,8 +82,10 @@ public static class IlBodyDiff
 
         var oldInstructions = oldBody.Instructions;
         var newInstructions = newBody.Instructions;
-        var oldOperations = oldInstructions.Select(ToOperation).ToImmutableArray();
-        var newOperations = newInstructions.Select(ToOperation).ToImmutableArray();
+        if (!TryBuildOperations(oldInstructions, oldResolver, "old", out var oldOperations, out var oldFailure))
+            return new IlBodyDiffResult(false, oldFailure, []);
+        if (!TryBuildOperations(newInstructions, newResolver, "new", out var newOperations, out var newFailure))
+            return new IlBodyDiffResult(false, newFailure, []);
         var lcs = LongestCommonSubsequence(oldOperations, newOperations);
         var oldToNew = lcs.ToDictionary(pair => pair.OldIndex, pair => pair.NewIndex);
         var rows = ImmutableArray.CreateBuilder<IlDiffRow>();
@@ -81,6 +109,31 @@ public static class IlBodyDiff
 
         var diffRows = rows.ToImmutable();
         return new IlBodyDiffResult(diffRows.Length == 0, Failure: null, diffRows);
+    }
+
+    static bool TryBuildOperations(
+        ImmutableArray<DecodedInstruction> instructions,
+        MetadataOperandResolver? resolver,
+        string side,
+        out ImmutableArray<CanonicalIlOperation> operations,
+        out string? failure)
+    {
+        var builder = ImmutableArray.CreateBuilder<CanonicalIlOperation>(instructions.Length);
+        foreach (var instruction in instructions)
+        {
+            if (!TryToOperation(instruction, resolver, out var operation, out var operationFailure))
+            {
+                operations = [];
+                failure = $"{side} body {operationFailure}";
+                return false;
+            }
+
+            builder.Add(operation);
+        }
+
+        operations = builder.MoveToImmutable();
+        failure = null;
+        return true;
     }
 
     static void AddUnmatched(
@@ -155,11 +208,24 @@ public static class IlBodyDiff
         return oldOperation.Operand == newOperation.Operand;
     }
 
-    static CanonicalIlOperation ToOperation(DecodedInstruction instruction)
-        => new(
+    static bool TryToOperation(
+        DecodedInstruction instruction,
+        MetadataOperandResolver? resolver,
+        out CanonicalIlOperation operation,
+        out string? failure)
+    {
+        if (!TryOperandIdentity(instruction, resolver, out var operand, out failure))
+        {
+            operation = new CanonicalIlOperation(instruction.Offset, OpcodeFamily(instruction), Operand: null);
+            return false;
+        }
+
+        operation = new CanonicalIlOperation(
             instruction.Offset,
             OpcodeFamily(instruction),
-            OperandIdentity(instruction));
+            operand);
+        return true;
+    }
 
     static string OpcodeFamily(DecodedInstruction instruction)
     {
@@ -177,7 +243,30 @@ public static class IlBodyDiff
             : opcode.ToString().Replace('_', '.').ToLowerInvariant();
     }
 
-    static IlOperandIdentity? OperandIdentity(DecodedInstruction instruction)
+    static bool TryOperandIdentity(
+        DecodedInstruction instruction,
+        MetadataOperandResolver? resolver,
+        out IlOperandIdentity? operand,
+        out string? failure)
+    {
+        if (IsMetadataTokenOperand(instruction.Operand))
+        {
+            if (resolver is null)
+            {
+                operand = null;
+                failure = $"metadata token operand at IL_{instruction.Offset:X4} requires a MetadataReader-backed comparison";
+                return false;
+            }
+
+            return resolver.TryResolve(instruction, out operand, out failure);
+        }
+
+        operand = ImmediateOperandIdentity(instruction) ?? OperandIdentityByKind(instruction);
+        failure = null;
+        return true;
+    }
+
+    static IlOperandIdentity? ImmediateOperandIdentity(DecodedInstruction instruction)
         => instruction.OpCode switch
         {
             ILOpCode.Ldc_i4_m1 => new(IlOperandIdentityKind.Immediate, "-1"),
@@ -190,7 +279,7 @@ public static class IlBodyDiff
             ILOpCode.Ldc_i4_6 => new(IlOperandIdentityKind.Immediate, "6"),
             ILOpCode.Ldc_i4_7 => new(IlOperandIdentityKind.Immediate, "7"),
             ILOpCode.Ldc_i4_8 => new(IlOperandIdentityKind.Immediate, "8"),
-            _ => OperandIdentityByKind(instruction),
+            _ => null,
         };
 
     static IlOperandIdentity? OperandIdentityByKind(DecodedInstruction instruction)
@@ -205,11 +294,12 @@ public static class IlBodyDiff
                 => new(IlOperandIdentityKind.BranchTarget, $"IL_{instruction.BranchTargets[0]:X4}"),
             OperandKind.InlineSwitch
                 => new(IlOperandIdentityKind.SwitchTargets, string.Join(", ", instruction.BranchTargets.Select(target => $"IL_{target:X4}"))),
-            OperandKind.InlineString or OperandKind.InlineMethod or OperandKind.InlineField
-                or OperandKind.InlineType or OperandKind.InlineSig or OperandKind.InlineTok
-                => new(IlOperandIdentityKind.Token, $"0x{instruction.OperandValue:X8}"),
             _ => null,
         };
+
+    static bool IsMetadataTokenOperand(OperandKind kind)
+        => kind is OperandKind.InlineString or OperandKind.InlineMethod or OperandKind.InlineField
+            or OperandKind.InlineType or OperandKind.InlineSig or OperandKind.InlineTok;
 
     static bool BranchTargetsMatch(
         ImmutableArray<DecodedInstruction> oldInstructions,
@@ -246,5 +336,294 @@ public static class IlBodyDiff
             if (instructions[i].Offset == offset)
                 return i;
         return -1;
+    }
+
+    sealed class MetadataOperandResolver(MetadataReader reader)
+    {
+        public bool TryResolve(DecodedInstruction instruction, out IlOperandIdentity? operand, out string? failure)
+        {
+            try
+            {
+                string value = instruction.Operand switch
+                {
+                    OperandKind.InlineString => ResolveString((int)instruction.OperandValue),
+                    OperandKind.InlineMethod => ResolveMethod((int)instruction.OperandValue),
+                    OperandKind.InlineField => ResolveField((int)instruction.OperandValue),
+                    OperandKind.InlineType => ResolveType((int)instruction.OperandValue),
+                    OperandKind.InlineTok => ResolveToken((int)instruction.OperandValue),
+                    OperandKind.InlineSig => ResolveSignature((int)instruction.OperandValue),
+                    _ => throw new InvalidOperationException($"Operand kind {instruction.Operand} is not a metadata token."),
+                };
+                operand = new IlOperandIdentity(IlOperandIdentityKind.Token, value);
+                failure = null;
+                return true;
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or ArgumentException or InvalidOperationException)
+            {
+                operand = null;
+                failure = $"metadata token operand at IL_{instruction.Offset:X4} could not be resolved: {ex.Message}";
+                return false;
+            }
+        }
+
+        string ResolveString(int token)
+        {
+            var handle = MetadataTokens.UserStringHandle(token);
+            return $"string \"{Escape(reader.GetUserString(handle))}\"";
+        }
+
+        string ResolveMethod(int token)
+        {
+            var handle = MetadataTokens.EntityHandle(token);
+            return handle.Kind switch
+            {
+                HandleKind.MethodDefinition => FormatMethodDefinition((MethodDefinitionHandle)handle),
+                HandleKind.MemberReference => FormatMemberReference((MemberReferenceHandle)handle),
+                HandleKind.MethodSpecification => FormatMethodSpecification((MethodSpecificationHandle)handle),
+                _ => throw new BadImageFormatException($"Expected method token, got {handle.Kind}."),
+            };
+        }
+
+        string ResolveField(int token)
+        {
+            var handle = MetadataTokens.EntityHandle(token);
+            return handle.Kind switch
+            {
+                HandleKind.FieldDefinition => FormatFieldDefinition((FieldDefinitionHandle)handle),
+                HandleKind.MemberReference => FormatFieldMemberReference((MemberReferenceHandle)handle),
+                _ => throw new BadImageFormatException($"Expected field token, got {handle.Kind}."),
+            };
+        }
+
+        string ResolveType(int token)
+            => FormatType(MetadataTokens.EntityHandle(token));
+
+        string ResolveToken(int token)
+        {
+            var handle = MetadataTokens.EntityHandle(token);
+            return handle.Kind switch
+            {
+                HandleKind.TypeDefinition or HandleKind.TypeReference or HandleKind.TypeSpecification
+                    => $"type {FormatType(handle)}",
+                HandleKind.MethodDefinition => $"method {FormatMethodDefinition((MethodDefinitionHandle)handle)}",
+                HandleKind.MemberReference when reader.GetMemberReference((MemberReferenceHandle)handle).GetKind() == MemberReferenceKind.Method
+                    => $"method {FormatMemberReference((MemberReferenceHandle)handle)}",
+                HandleKind.MemberReference => $"field {FormatFieldMemberReference((MemberReferenceHandle)handle)}",
+                HandleKind.MethodSpecification => $"method {FormatMethodSpecification((MethodSpecificationHandle)handle)}",
+                HandleKind.FieldDefinition => $"field {FormatFieldDefinition((FieldDefinitionHandle)handle)}",
+                _ => throw new BadImageFormatException($"Unsupported ldtoken handle kind {handle.Kind}."),
+            };
+        }
+
+        string ResolveSignature(int token)
+        {
+            var handle = MetadataTokens.EntityHandle(token);
+            if (handle.Kind != HandleKind.StandaloneSignature)
+                throw new BadImageFormatException($"Expected standalone signature token, got {handle.Kind}.");
+
+            var signature = reader.GetStandaloneSignature((StandaloneSignatureHandle)handle);
+            return $"signature {Convert.ToHexString(reader.GetBlobBytes(signature.Signature))}";
+        }
+
+        string FormatMethodDefinition(MethodDefinitionHandle handle)
+        {
+            var method = reader.GetMethodDefinition(handle);
+            var signature = method.DecodeSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            return FormatCall(signature, FormatType(method.GetDeclaringType()), reader.GetString(method.Name), genericArgs: null);
+        }
+
+        string FormatMemberReference(MemberReferenceHandle handle)
+        {
+            var member = reader.GetMemberReference(handle);
+            if (member.GetKind() != MemberReferenceKind.Method)
+                throw new BadImageFormatException("Expected method member reference.");
+
+            var signature = member.DecodeMethodSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            return FormatCall(signature, FormatMemberParent(member.Parent), reader.GetString(member.Name), genericArgs: null);
+        }
+
+        string FormatMethodSpecification(MethodSpecificationHandle handle)
+        {
+            var spec = reader.GetMethodSpecification(handle);
+            var typeArguments = spec.DecodeSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            string genericArgs = $"<{string.Join(", ", typeArguments)}>";
+
+            return spec.Method.Kind switch
+            {
+                HandleKind.MethodDefinition => FormatMethodSpecificationDefinition((MethodDefinitionHandle)spec.Method, genericArgs),
+                HandleKind.MemberReference => FormatMethodSpecificationReference((MemberReferenceHandle)spec.Method, genericArgs),
+                _ => throw new BadImageFormatException($"Unsupported method specification target {spec.Method.Kind}."),
+            };
+        }
+
+        string FormatMethodSpecificationDefinition(MethodDefinitionHandle handle, string genericArgs)
+        {
+            var method = reader.GetMethodDefinition(handle);
+            var signature = method.DecodeSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            return FormatCall(signature, FormatType(method.GetDeclaringType()), reader.GetString(method.Name), genericArgs);
+        }
+
+        string FormatMethodSpecificationReference(MemberReferenceHandle handle, string genericArgs)
+        {
+            var member = reader.GetMemberReference(handle);
+            var signature = member.DecodeMethodSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            return FormatCall(signature, FormatMemberParent(member.Parent), reader.GetString(member.Name), genericArgs);
+        }
+
+        string FormatFieldDefinition(FieldDefinitionHandle handle)
+        {
+            var field = reader.GetFieldDefinition(handle);
+            string fieldType = field.DecodeSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            return $"{fieldType} {FormatType(field.GetDeclaringType())}::{reader.GetString(field.Name)}";
+        }
+
+        string FormatFieldMemberReference(MemberReferenceHandle handle)
+        {
+            var member = reader.GetMemberReference(handle);
+            if (member.GetKind() != MemberReferenceKind.Field)
+                throw new BadImageFormatException("Expected field member reference.");
+
+            string fieldType = member.DecodeFieldSignature(SignatureIdentityProvider.Instance, genericContext: null);
+            return $"{fieldType} {FormatMemberParent(member.Parent)}::{reader.GetString(member.Name)}";
+        }
+
+        string FormatCall(MethodSignature<string> signature, string parent, string name, string? genericArgs)
+        {
+            string instance = signature.Header.IsInstance ? "instance " : "";
+            return $"{instance}{signature.ReturnType} {parent}::{name}{genericArgs}({string.Join(", ", signature.ParameterTypes)})";
+        }
+
+        string FormatMemberParent(EntityHandle parent)
+            => parent.Kind switch
+            {
+                HandleKind.TypeDefinition or HandleKind.TypeReference or HandleKind.TypeSpecification
+                    => FormatType(parent),
+                _ => throw new BadImageFormatException($"Unsupported member parent {parent.Kind}."),
+            };
+
+        string FormatType(EntityHandle handle)
+            => handle.Kind switch
+            {
+                HandleKind.TypeDefinition => FormatTypeDefinition((TypeDefinitionHandle)handle),
+                HandleKind.TypeReference => FormatTypeReference((TypeReferenceHandle)handle),
+                HandleKind.TypeSpecification => reader.GetTypeSpecification((TypeSpecificationHandle)handle)
+                    .DecodeSignature(SignatureIdentityProvider.Instance, null),
+                _ => throw new BadImageFormatException($"Unsupported type handle {handle.Kind}."),
+            };
+
+        string FormatTypeDefinition(TypeDefinitionHandle handle)
+        {
+            var type = reader.GetTypeDefinition(handle);
+            string name = reader.GetString(type.Name);
+            var declaring = type.GetDeclaringType();
+            string fullName = declaring.IsNil
+                ? Dotted(reader.GetString(type.Namespace), name)
+                : $"{FormatTypeDefinition(declaring)}+{name}";
+            return $"[{CurrentAssemblyName()}]{fullName}";
+        }
+
+        string FormatTypeReference(TypeReferenceHandle handle)
+        {
+            var type = reader.GetTypeReference(handle);
+            string name = reader.GetString(type.Name);
+            string fullName = Dotted(reader.GetString(type.Namespace), name);
+            return type.ResolutionScope.Kind switch
+            {
+                HandleKind.AssemblyReference =>
+                    $"[{reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)type.ResolutionScope).Name)}]{fullName}",
+                HandleKind.TypeReference =>
+                    $"{FormatTypeReference((TypeReferenceHandle)type.ResolutionScope)}+{fullName}",
+                _ => $"[{CurrentAssemblyName()}]{fullName}",
+            };
+        }
+
+        string CurrentAssemblyName()
+            => reader.IsAssembly ? reader.GetString(reader.GetAssemblyDefinition().Name) : "";
+
+        static string Dotted(string ns, string name)
+            => ns.Length == 0 ? name : $"{ns}.{name}";
+
+        static string Escape(string value)
+            => value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal);
+    }
+
+    sealed class SignatureIdentityProvider : ISignatureTypeProvider<string, object?>
+    {
+        public static SignatureIdentityProvider Instance { get; } = new();
+
+        public string GetPrimitiveType(PrimitiveTypeCode typeCode)
+            => typeCode switch
+            {
+                PrimitiveTypeCode.Void => "void",
+                PrimitiveTypeCode.Boolean => "bool",
+                PrimitiveTypeCode.Char => "char",
+                PrimitiveTypeCode.SByte => "int8",
+                PrimitiveTypeCode.Byte => "uint8",
+                PrimitiveTypeCode.Int16 => "int16",
+                PrimitiveTypeCode.UInt16 => "uint16",
+                PrimitiveTypeCode.Int32 => "int32",
+                PrimitiveTypeCode.UInt32 => "uint32",
+                PrimitiveTypeCode.Int64 => "int64",
+                PrimitiveTypeCode.UInt64 => "uint64",
+                PrimitiveTypeCode.Single => "float32",
+                PrimitiveTypeCode.Double => "float64",
+                PrimitiveTypeCode.String => "string",
+                PrimitiveTypeCode.Object => "object",
+                PrimitiveTypeCode.IntPtr => "native int",
+                PrimitiveTypeCode.UIntPtr => "native uint",
+                PrimitiveTypeCode.TypedReference => "typedref",
+                _ => typeCode.ToString(),
+            };
+
+        public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+            => TypeName(reader, handle);
+
+        public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+            => TypeName(reader, handle);
+
+        public string GetTypeFromSpecification(MetadataReader reader, object? genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+            => reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+
+        public string GetSZArrayType(string elementType) => $"{elementType}[]";
+        public string GetArrayType(string elementType, ArrayShape shape) => $"{elementType}[{new string(',', Math.Max(shape.Rank - 1, 0))}]";
+        public string GetByReferenceType(string elementType) => $"{elementType}&";
+        public string GetPointerType(string elementType) => $"{elementType}*";
+        public string GetPinnedType(string elementType) => $"{elementType} pinned";
+        public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments)
+            => $"{genericType}<{string.Join(", ", typeArguments)}>";
+        public string GetGenericTypeParameter(object? genericContext, int index) => $"!{index}";
+        public string GetGenericMethodParameter(object? genericContext, int index) => $"!!{index}";
+        public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired)
+            => $"{(isRequired ? "modreq" : "modopt")}({modifier}) {unmodifiedType}";
+        public string GetFunctionPointerType(MethodSignature<string> signature)
+            => $"method {signature.ReturnType} *({string.Join(", ", signature.ParameterTypes)})";
+
+        static string TypeName(MetadataReader reader, TypeDefinitionHandle handle)
+        {
+            var type = reader.GetTypeDefinition(handle);
+            string name = reader.GetString(type.Name);
+            var declaring = type.GetDeclaringType();
+            if (!declaring.IsNil)
+                return $"{TypeName(reader, declaring)}+{name}";
+            string ns = reader.GetString(type.Namespace);
+            string assembly = reader.IsAssembly ? reader.GetString(reader.GetAssemblyDefinition().Name) : "";
+            return $"[{assembly}]{(ns.Length == 0 ? name : $"{ns}.{name}")}";
+        }
+
+        static string TypeName(MetadataReader reader, TypeReferenceHandle handle)
+        {
+            var type = reader.GetTypeReference(handle);
+            string name = reader.GetString(type.Name);
+            string ns = reader.GetString(type.Namespace);
+            string fullName = ns.Length == 0 ? name : $"{ns}.{name}";
+            return type.ResolutionScope.Kind switch
+            {
+                HandleKind.AssemblyReference =>
+                    $"[{reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)type.ResolutionScope).Name)}]{fullName}",
+                HandleKind.TypeReference =>
+                    $"{TypeName(reader, (TypeReferenceHandle)type.ResolutionScope)}+{fullName}",
+                _ => fullName,
+            };
+        }
     }
 }

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -49,23 +49,20 @@ public static class IlBodyDiff
         foreach (var (nextOld, nextNew) in lcs)
         {
             AddUnmatched(oldInstructions, oldIndex, nextOld, newInstructions, newIndex, nextNew, differences, ref diffIndex);
+            if (!BranchTargetsMatch(oldInstructions, nextOld, newInstructions, nextNew, oldToNew))
+            {
+                var oldInstruction = oldInstructions[nextOld];
+                var newInstruction = newInstructions[nextNew];
+                differences.Add(new IlInstructionDiff(
+                    IlBodyDiffChangeKind.Changed,
+                    diffIndex++,
+                    oldInstruction.Offset,
+                    oldInstruction.OpCode,
+                    newInstruction.Offset,
+                    newInstruction.OpCode));
+            }
             oldIndex = nextOld + 1;
             newIndex = nextNew + 1;
-        }
-
-        foreach (var (mappedOld, mappedNew) in lcs)
-        {
-            if (BranchTargetsMatch(oldInstructions, mappedOld, newInstructions, mappedNew, oldToNew))
-                continue;
-            var oldInstruction = oldInstructions[mappedOld];
-            var newInstruction = newInstructions[mappedNew];
-            differences.Add(new IlInstructionDiff(
-                IlBodyDiffChangeKind.Changed,
-                diffIndex++,
-                oldInstruction.Offset,
-                oldInstruction.OpCode,
-                newInstruction.Offset,
-                newInstruction.OpCode));
         }
 
         AddUnmatched(oldInstructions, oldIndex, oldInstructions.Length, newInstructions, newIndex, newInstructions.Length, differences, ref diffIndex);


### PR DESCRIPTION
- Advances #2291
- Adds first product IL/body diff pilot: Instructions substrate + Analysis unsafe body-signal diff
- Evidence revision: `0b7ad960`

## Change

**Conclusion:** **PASS** — this starts the product diff stack with a low-level IL body diff primitive in `ILInspector.Instructions` and a higher-level Analysis API that answers the first product question: whether unsafe evidence was added or removed.

## Scope and safety

- **Instructions:** adds `IlBodyDiff.Compare(MethodInstructions oldBody, MethodInstructions newBody)` with canonical decoded-instruction comparison, changed/added/removed rows, and decode-failure reporting.
- **Analysis:** adds `BodySignalDiff.CompareUnsafe(LibraryBodyIndex oldIndex, LibraryBodyIndex newIndex)` over existing unsafe evidence / unsafety occurrence facts.
- **Fixtures:** extends existing versioned diff fixtures with a matched method whose V2 body adds a visible `stackalloc` unsafe operation.
- **Product impact:** new APIs only; no CLI surface yet and no decompiler/RTS behavior change.
- **Layering:** raw decoded-IL diff lives in Instructions; product body-signal UX starts in Analysis.

## Evidence

| Check | Result |
| --- | --- |
| Focused Instructions diff tests | `IlBodyDiffTests` passed, 3/3 |
| Focused Analysis diff tests | `BodySignalDiffTests` passed, 2/2 |
| Full Analysis tests | `ILInspector.Analysis.Tests` passed, 347/347 |
| Product build | `dotnet build src/dotnet-inspect -c Release --no-restore --verbosity minimal` passed |
| Diff hygiene | `git diff --check` passed |

## Why this shape

The broader vision is a unified Research diff over API/IL/C# evidence, but the first assignment is deliberately narrow:

```text
Instructions: canonical IL/body diff substrate
Analysis: unsafe body-signal diff UX
CLI/RTS: future consumers
```

This keeps the primitive reusable for product questions like "was unsafe code added?" and for future RTS artifact proof without creating an RTS-only comparator.

## Validation

```bash
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-restore -- -filter "/*/*/IlBodyDiffTests/*"
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-restore -- -filter "/*/*/BodySignalDiffTests/*"
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-restore
dotnet restore src/dotnet-inspect/dotnet-inspect.csproj --configfile nuget.config --verbosity minimal
dotnet build src/dotnet-inspect -c Release --no-restore --verbosity minimal
git diff --check
```

Adversarial review requested per analysis PR policy.
