### PR TITLE
runfaster: fix CanonicalTypeSignature collapsing closures/nested/arity

### DIFF
--- a/src/runfaster.Tests/TypeConfirmationTests.cs
+++ b/src/runfaster.Tests/TypeConfirmationTests.cs
@@ -6,6 +6,23 @@ using System.Collections.Generic;
 public class TypeConfirmationTests
 {
     [Fact]
+    public void CanonicalTypeSignature_ReversesArrayRanksOnlyWithinPointerBoundedRuns()
+    {
+        // Array ranks reverse only within a consecutive run; a pointer bounds the run. So
+        // int[][,]*[] (reflection System.Int32[,][]*[]) reconciles, and the distinct int[][]*[,]
+        // (reflection System.Int32[][]*[,]) must not collide with it.
+        Assert.Equal(
+            ProgramSupport.CanonicalTypeSignature("int[][,]*[]", reflection: false),
+            ProgramSupport.CanonicalTypeSignature("System.Int32[,][]*[]", reflection: true));
+        Assert.Equal(
+            ProgramSupport.CanonicalTypeSignature("int[][]*[,]", reflection: false),
+            ProgramSupport.CanonicalTypeSignature("System.Int32[][]*[,]", reflection: true));
+        Assert.NotEqual(
+            ProgramSupport.CanonicalTypeSignature("System.Int32[,][]*[]", reflection: true),
+            ProgramSupport.CanonicalTypeSignature("int[][]*[,]", reflection: false));
+    }
+
+    [Fact]
     public void CanonicalTypeSignature_KeepsPointerPositionWhenReversingArrayRanks()
     {
         // Only array ranks reverse between C# and reflection; pointer '*' stays in place. int*[]

--- a/src/runfaster.Tests/TypeConfirmationTests.cs
+++ b/src/runfaster.Tests/TypeConfirmationTests.cs
@@ -112,11 +112,60 @@ public class TypeConfirmationTests
     [Fact]
     public void CanonicalTypeSignature_PreservesNestedTypeAfterGenericArguments()
     {
-        // A nested type following a generic parent must not be dropped (previously
-        // Dictionary`2[K,V]+KeyCollection canonicalized to Dictionary<K,V>).
+        // A nested type on a generic parent must not be dropped. Reflection emits the parent's type
+        // arguments in the trailing bracket after the whole nested chain
+        // (Dictionary`2+KeyCollection[String,Int32]); the nested name must survive and the arguments
+        // must bind to the parent, matching the display form Dictionary<String,Int32>.KeyCollection.
+        var runtime = ProgramSupport.CanonicalTypeSignature(
+            "System.Collections.Generic.Dictionary`2+KeyCollection[System.String,System.Int32]");
+        var display = ProgramSupport.CanonicalTypeSignature(
+            "System.Collections.Generic.Dictionary<System.String,System.Int32>.KeyCollection");
+        var parentOnly = ProgramSupport.CanonicalTypeSignature(
+            "System.Collections.Generic.Dictionary`2[System.String,System.Int32]");
+
+        Assert.Equal(display, runtime);       // reflection nested form == display nested form
+        Assert.NotEqual(parentOnly, runtime); // KeyCollection is not dropped
+    }
+
+    [Fact]
+    public void CanonicalTypeSignature_DistributesTrailingArgsAcrossNestedGenerics()
+    {
+        // Reflection puts the whole chain's arguments in one trailing bracket, distributed by each
+        // segment's arity (Outer`1+Inner`1[A,B] == Outer<A>.Inner<B>). Previously the arity of the
+        // non-final segment was dropped and the arguments misattributed to the last segment.
+        var runtime = ProgramSupport.CanonicalTypeSignature("Outer`1+Inner`1[System.Int32,System.String]");
+        var display = ProgramSupport.CanonicalTypeSignature("Outer<System.Int32>.Inner<System.String>");
+
+        Assert.Equal(display, runtime);
+        // Swapping the arguments across the two levels must not collide.
         Assert.NotEqual(
-            ProgramSupport.CanonicalTypeSignature("System.Collections.Generic.Dictionary`2[K,V]+KeyCollection"),
-            ProgramSupport.CanonicalTypeSignature("System.Collections.Generic.Dictionary`2[K,V]"));
+            runtime,
+            ProgramSupport.CanonicalTypeSignature("Outer`1+Inner`1[System.String,System.Int32]"));
+    }
+
+    [Fact]
+    public void CanonicalTypeSignature_HandlesAssemblyQualifiedGenericArguments()
+    {
+        // Assembly-qualified reflection long form must not hang and must reconcile with the short
+        // form (the assembly qualifier is stripped).
+        var longForm = ProgramSupport.CanonicalTypeSignature(
+            "System.Func`2[[System.String, System.Private.CoreLib],[System.Int32, System.Private.CoreLib]]");
+        var shortForm = ProgramSupport.CanonicalTypeSignature("System.Func`2[System.String,System.Int32]");
+
+        Assert.Equal(shortForm, longForm);
+    }
+
+    [Fact]
+    public void CanonicalTypeSignature_PreservesBacktickOnlyGenericArity()
+    {
+        // An open generic definition (backtick arity with no argument bracket) must keep its arity so
+        // distinct definitions do not collide (My.Generic`2 != My.Generic`3 != My.Generic).
+        var arity2 = ProgramSupport.CanonicalTypeSignature("My.Generic`2");
+        var arity3 = ProgramSupport.CanonicalTypeSignature("My.Generic`3");
+        var nonGeneric = ProgramSupport.CanonicalTypeSignature("My.Generic");
+
+        Assert.NotEqual(arity2, arity3);
+        Assert.NotEqual(arity2, nonGeneric);
     }
 
     [Fact]

--- a/src/runfaster.Tests/TypeConfirmationTests.cs
+++ b/src/runfaster.Tests/TypeConfirmationTests.cs
@@ -6,6 +6,53 @@ using System.Collections.Generic;
 public class TypeConfirmationTests
 {
     [Fact]
+    public void CanonicalTypeSignature_ReconcilesArrayRankOrderingAcrossForms()
+    {
+        // Reflection orders array modifiers inside-out relative to C# (int[][,] is emitted as
+        // System.Int32[,][]). Display and reflection forms of the same type must agree, and the two
+        // genuinely-distinct jagged/multidim shapes must not collide.
+        Assert.Equal(
+            ProgramSupport.CanonicalTypeSignature("int[][,]", reflection: false),
+            ProgramSupport.CanonicalTypeSignature("System.Int32[,][]", reflection: true));
+        Assert.Equal(
+            ProgramSupport.CanonicalTypeSignature("int[,][]", reflection: false),
+            ProgramSupport.CanonicalTypeSignature("System.Int32[][,]", reflection: true));
+        Assert.NotEqual(
+            ProgramSupport.CanonicalTypeSignature("int[][,]", reflection: false),
+            ProgramSupport.CanonicalTypeSignature("int[,][]", reflection: false));
+    }
+
+    [Fact]
+    public void CanonicalTypeSignature_ExpandsTupleShorthandToValueTuple()
+    {
+        // C# tuple shorthand must expand to the runtime ValueTuple form, must not collapse distinct
+        // tuples to an empty string, and must ignore element names.
+        Assert.Equal(
+            ProgramSupport.CanonicalTypeSignature("System.ValueTuple`2[System.Int32,System.String][]", reflection: true),
+            ProgramSupport.CanonicalTypeSignature("(int, string)[]", reflection: false));
+        Assert.Equal(
+            ProgramSupport.CanonicalTypeSignature("(int, string)", reflection: false),
+            ProgramSupport.CanonicalTypeSignature("(int a, string b)", reflection: false));
+        var a = ProgramSupport.CanonicalTypeSignature("(int, string)", reflection: false);
+        var b = ProgramSupport.CanonicalTypeSignature("(double, float)", reflection: false);
+        Assert.NotEqual(a, b);
+        Assert.NotEqual(string.Empty, a);
+    }
+
+    [Fact]
+    public void CanonicalTypeSignature_ExpandsNullableShorthandToNullable()
+    {
+        // C# nullable value-type shorthand (T?) must expand to System.Nullable<T> so it reconciles
+        // with the runtime generic form (e.g. an array of nullable ints).
+        Assert.Equal(
+            ProgramSupport.CanonicalTypeSignature("System.Nullable`1[System.Int32][]", reflection: true),
+            ProgramSupport.CanonicalTypeSignature("int?[]", reflection: false));
+        Assert.Equal(
+            ProgramSupport.CanonicalTypeSignature("System.Nullable`1[System.Int32]", reflection: true),
+            ProgramSupport.CanonicalTypeSignature("int?", reflection: false));
+    }
+
+    [Fact]
     public void CanonicalTypeSignature_ReconcilesStaticAngleAndRuntimeBacktickForms()
     {
         var staticForm = ProgramSupport.CanonicalTypeSignature("System.Func<string, System.Lazy<int>>");

--- a/src/runfaster.Tests/TypeConfirmationTests.cs
+++ b/src/runfaster.Tests/TypeConfirmationTests.cs
@@ -6,6 +6,23 @@ using System.Collections.Generic;
 public class TypeConfirmationTests
 {
     [Fact]
+    public void CanonicalTypeSignature_KeepsPointerPositionWhenReversingArrayRanks()
+    {
+        // Only array ranks reverse between C# and reflection; pointer '*' stays in place. int*[]
+        // (array of pointers) and int[]* (pointer to array) are distinct and must not collide, and
+        // int*[][,] must reconcile across forms.
+        Assert.Equal(
+            ProgramSupport.CanonicalTypeSignature("int*[]", reflection: false),
+            ProgramSupport.CanonicalTypeSignature("System.Int32*[]", reflection: true));
+        Assert.Equal(
+            ProgramSupport.CanonicalTypeSignature("int*[][,]", reflection: false),
+            ProgramSupport.CanonicalTypeSignature("System.Int32*[,][]", reflection: true));
+        Assert.NotEqual(
+            ProgramSupport.CanonicalTypeSignature("int[]*", reflection: false),
+            ProgramSupport.CanonicalTypeSignature("System.Int32*[]", reflection: true));
+    }
+
+    [Fact]
     public void CanonicalTypeSignature_ReconcilesArrayRankOrderingAcrossForms()
     {
         // Reflection orders array modifiers inside-out relative to C# (int[][,] is emitted as

--- a/src/runfaster.Tests/TypeConfirmationTests.cs
+++ b/src/runfaster.Tests/TypeConfirmationTests.cs
@@ -169,6 +169,22 @@ public class TypeConfirmationTests
     }
 
     [Fact]
+    public void CanonicalTypeSignature_ReconcilesNestedGenericArgumentOrdering()
+    {
+        // A nested generic type must canonicalize the same regardless of whether the parent's
+        // arguments trail the whole chain (reflection's normal form) or precede the nested separator.
+        var trailing = ProgramSupport.CanonicalTypeSignature(
+            "System.Collections.Generic.Dictionary`2+KeyCollection[System.String,System.Int32]");
+        var preSeparator = ProgramSupport.CanonicalTypeSignature(
+            "System.Collections.Generic.Dictionary`2[System.String,System.Int32]+KeyCollection");
+        var display = ProgramSupport.CanonicalTypeSignature(
+            "System.Collections.Generic.Dictionary<System.String,System.Int32>.KeyCollection");
+
+        Assert.Equal(display, trailing);
+        Assert.Equal(display, preSeparator);
+    }
+
+    [Fact]
     public void CanonicalTypeSignature_PreservesGenericArgumentOrderAndSeparators()
     {
         // The argument separator must be preserved so different splits do not collide.

--- a/src/runfaster.Tests/TypeConfirmationTests.cs
+++ b/src/runfaster.Tests/TypeConfirmationTests.cs
@@ -96,6 +96,58 @@ public class TypeConfirmationTests
     }
 
     [Fact]
+    public void CanonicalTypeSignature_PreservesCompilerGeneratedNames()
+    {
+        // A closure/state-machine name must not collapse to its parent type (previously
+        // Enumerable+<>c__DisplayClass18_0 canonicalized to Enumerable), and two distinct closures
+        // in the same parent must stay distinct.
+        var parent = ProgramSupport.CanonicalTypeSignature("System.Linq.Enumerable");
+        var closure = ProgramSupport.CanonicalTypeSignature("System.Linq.Enumerable+<>c__DisplayClass18_0");
+        var otherClosure = ProgramSupport.CanonicalTypeSignature("System.Linq.Enumerable+<>c__DisplayClass19_0");
+
+        Assert.NotEqual(parent, closure);
+        Assert.NotEqual(closure, otherClosure);
+    }
+
+    [Fact]
+    public void CanonicalTypeSignature_PreservesNestedTypeAfterGenericArguments()
+    {
+        // A nested type following a generic parent must not be dropped (previously
+        // Dictionary`2[K,V]+KeyCollection canonicalized to Dictionary<K,V>).
+        Assert.NotEqual(
+            ProgramSupport.CanonicalTypeSignature("System.Collections.Generic.Dictionary`2[K,V]+KeyCollection"),
+            ProgramSupport.CanonicalTypeSignature("System.Collections.Generic.Dictionary`2[K,V]"));
+    }
+
+    [Fact]
+    public void CanonicalTypeSignature_PreservesGenericArgumentOrderAndSeparators()
+    {
+        // The argument separator must be preserved so different splits do not collide.
+        Assert.NotEqual(
+            ProgramSupport.CanonicalTypeSignature("Func<AB, C>"),
+            ProgramSupport.CanonicalTypeSignature("Func<A, BC>"));
+    }
+
+    [Fact]
+    public void CanonicalTypeSignature_PreservesUnboundGenericArity()
+    {
+        var arity2 = ProgramSupport.CanonicalTypeSignature("System.String<,>");
+        var arity0 = ProgramSupport.CanonicalTypeSignature("System.String<>");
+        var arity3 = ProgramSupport.CanonicalTypeSignature("System.String<,,>");
+
+        Assert.NotEqual(arity2, arity0);
+        Assert.NotEqual(arity2, arity3);
+    }
+
+    [Fact]
+    public void CanonicalTypeSignature_ReconcilesArrayOfGenericAcrossForms()
+    {
+        Assert.Equal(
+            ProgramSupport.CanonicalTypeSignature("Entry<System.String,System.Object>[]"),
+            ProgramSupport.CanonicalTypeSignature("Entry`2[System.String,System.Object][]"));
+    }
+
+    [Fact]
     public void ApplyTypeConfirmation_DoesNotConfirmColdSite_WhenTypeAlreadySiteObserved()
     {
         // A hot site-observed candidate explains the String volume; a cold same-type site must not

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -2599,21 +2599,27 @@ internal static class ProgramSupport
             }
         }
         // Reflection orders array RANKS inside-out relative to C# (C# int[][,] is emitted as
-        // System.Int32[,][]), but pointer '*' / byref '&' keep the same position in both. Reverse only
-        // the array tokens among their own positions, leaving '*'/'&' fixed, so both forms of one type
-        // agree without mangling pointer/array combinations.
+        // System.Int32[,][]), but only within a consecutive run of array modifiers — pointer '*' and
+        // byref '&' keep their position and act as run boundaries (C# int[][,]*[] is emitted as
+        // System.Int32[,][]*[]). Reverse each maximal consecutive array run in place for reflection
+        // input so both forms of one type agree without mangling pointer/array combinations.
         if (reflection)
         {
-            var arrayPositions = new List<int>();
-            for (int i = 0; i < tokens.Count; i++)
+            int runStart = -1;
+            for (int i = 0; i <= tokens.Count; i++)
             {
-                if (tokens[i][0] == '[')
-                    arrayPositions.Add(i);
-            }
-            for (int lo = 0, hi = arrayPositions.Count - 1; lo < hi; lo++, hi--)
-            {
-                (tokens[arrayPositions[lo]], tokens[arrayPositions[hi]]) =
-                    (tokens[arrayPositions[hi]], tokens[arrayPositions[lo]]);
+                bool isArray = i < tokens.Count && tokens[i][0] == '[';
+                if (isArray)
+                {
+                    if (runStart < 0)
+                        runStart = i;
+                }
+                else if (runStart >= 0)
+                {
+                    for (int lo = runStart, hi = i - 1; lo < hi; lo++, hi--)
+                        (tokens[lo], tokens[hi]) = (tokens[hi], tokens[lo]);
+                    runStart = -1;
+                }
             }
         }
         foreach (var tok in tokens)

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -2337,13 +2337,20 @@ internal static class ProgramSupport
     // '+'/'.' that is not part of the type name is left for the caller.
     static void ParseNestedName(string s, ref int pos, StringBuilder sb)
     {
-        bool first = true;
+        // Collect the nested-name segments (Namespace parts and nested types are all segments),
+        // recording each segment's name, its generic arity, and any generic arguments already bound
+        // inline via the display form <...>. Backtick arity ('N) is deferred: reflection emits the
+        // whole nested chain's type arguments in a single trailing bracket after the last segment
+        // (Outer`1+Inner`1[A,B] means Outer<A>.Inner<B>), so binding them here would misattribute.
+        var names = new List<string>();
+        var arities = new List<int>();
+        var boundArgs = new List<List<string>?>();
         while (true)
         {
-            if (!first)
-                sb.Append('.');
-            first = false;
-            ParseSegment(s, ref pos, sb);
+            ParseSegment(s, ref pos, out string name, out int arity, out List<string>? args);
+            names.Add(name);
+            arities.Add(arity);
+            boundArgs.Add(args);
             if (pos + 1 < s.Length && (s[pos] == '.' || s[pos] == '+') && IsSegmentStart(s[pos + 1]))
             {
                 pos++;
@@ -2351,16 +2358,65 @@ internal static class ProgramSupport
             }
             break;
         }
+
+        int totalArity = 0, boundArity = 0;
+        for (int i = 0; i < arities.Count; i++)
+        {
+            totalArity += arities[i];
+            if (boundArgs[i] is not null)
+                boundArity += arities[i];
+        }
+
+        // A trailing reflection argument list [A,B,...] (not an array suffix) supplies the deferred
+        // arguments, distributed left-to-right across the segments with unbound backtick arity.
+        if (totalArity > boundArity && pos < s.Length && s[pos] == '[' && HasTypeContent(s, pos))
+        {
+            var flat = ParseReflArgList(s, ref pos);
+            int idx = 0;
+            for (int i = 0; i < arities.Count; i++)
+            {
+                if (arities[i] > 0 && boundArgs[i] is null)
+                {
+                    var a = new List<string>();
+                    for (int k = 0; k < arities[i] && idx < flat.Count; k++)
+                        a.Add(flat[idx++]);
+                    boundArgs[i] = a;
+                }
+            }
+        }
+
+        for (int i = 0; i < names.Count; i++)
+        {
+            if (i > 0)
+                sb.Append('.');
+            sb.Append(names[i]);
+            if (arities[i] > 0)
+            {
+                sb.Append('<');
+                var a = boundArgs[i];
+                for (int k = 0; k < arities[i]; k++)
+                {
+                    if (k > 0)
+                        sb.Append(',');
+                    sb.Append(a is not null && k < a.Count && a[k].Length > 0 ? a[k] : "?");
+                }
+                sb.Append('>');
+            }
+        }
     }
 
     static bool IsSegmentStart(char c) => char.IsLetter(c) || c == '_' || c == '<';
 
-    // One name segment: either a compiler-generated name (a balanced <...> prefix plus trailing
-    // identifier chars, e.g. <>c__DisplayClass18_0 or <Bar>d__5 — reflection uses '<' only here, never
-    // for generic arguments) or a plain identifier (alias-expanded), optionally followed by generic
-    // arguments (backtick `N[...] reflection form or <...> display form).
-    static void ParseSegment(string s, ref int pos, StringBuilder sb)
+    // One name segment. Returns the segment name, its generic arity, and (for the display form only)
+    // the bound generic arguments. A compiler-generated name is a balanced <...> prefix plus trailing
+    // identifier chars (e.g. <>c__DisplayClass18_0, <Bar>d__5, <Main>$>g__Local|0_0) — reflection uses
+    // '<' at a segment start only here, never for generic arguments. Backtick arity ('N) is recorded
+    // but its arguments are left for trailing distribution by the caller; the display form <...> binds
+    // its arguments inline here.
+    static void ParseSegment(string s, ref int pos, out string name, out int arity, out List<string>? args)
     {
+        arity = 0;
+        args = null;
         bool compilerGenerated = false;
         if (pos < s.Length && s[pos] == '<')
         {
@@ -2377,36 +2433,52 @@ internal static class ProgramSupport
                 else if (c == '>' && --depth == 0)
                     break;
             }
-            while (pos < s.Length && (char.IsLetterOrDigit(s[pos]) || s[pos] == '_'))
+            while (pos < s.Length && (char.IsLetterOrDigit(s[pos]) || s[pos] == '_' || s[pos] == '|'))
             {
                 seg.Append(s[pos]);
                 pos++;
             }
-            sb.Append(seg.ToString());
+            name = seg.ToString();
         }
         else
         {
-            var name = new StringBuilder();
+            var nm = new StringBuilder();
             while (pos < s.Length && (char.IsLetterOrDigit(s[pos]) || s[pos] == '_'))
             {
-                name.Append(s[pos]);
+                nm.Append(s[pos]);
                 pos++;
             }
-            sb.Append(ExpandAlias(name.ToString()));
+            name = ExpandAlias(nm.ToString());
         }
 
         if (pos < s.Length && s[pos] == '`')
         {
             pos++;
+            int n = 0;
             while (pos < s.Length && char.IsDigit(s[pos]))
+            {
+                n = (n * 10) + (s[pos] - '0');
                 pos++;
-            if (pos < s.Length && s[pos] == '[')
-                ParseGenericArgs(s, ref pos, sb, ']');
+            }
+            arity = n;
         }
         else if (!compilerGenerated && pos < s.Length && s[pos] == '<')
         {
-            ParseGenericArgs(s, ref pos, sb, '>');
+            args = ParseDisplayArgs(s, ref pos);
+            arity = args.Count;
         }
+    }
+
+    // True when the bracket at pos holds a type argument list ([A,B]) rather than an array-rank
+    // suffix ([], [,]): any non-comma, non-whitespace char before the closing ']'.
+    static bool HasTypeContent(string s, int pos)
+    {
+        for (int i = pos + 1; i < s.Length && s[i] != ']'; i++)
+        {
+            if (s[i] != ',' && !char.IsWhiteSpace(s[i]))
+                return true;
+        }
+        return false;
     }
 
     // Suffix modifiers on a type: arrays ([], [,]), pointer (*), byref (&), nullable (?).
@@ -2458,25 +2530,19 @@ internal static class ProgramSupport
         }
     }
 
-    // Generic argument list. Preserves argument count and separators (so Func<AB,C> and Func<A,BC> do
-    // not collide) and preserves arity for unbound arguments (String<,> is arity 2, distinct from
-    // String<> and String<,,>), rendering an empty argument position as '?'.
-    static void ParseGenericArgs(string s, ref int pos, StringBuilder sb, char close)
+    // Display-form generic argument list <A,B,...>. Preserves argument count and separators (so
+    // Func<AB,C> and Func<A,BC> do not collide) and preserves arity for unbound arguments (String<,>
+    // is arity 2, distinct from String<> and String<,,>). Returns each argument canonicalized; an
+    // empty position is returned as the empty string and rendered '?' by the caller.
+    static List<string> ParseDisplayArgs(string s, ref int pos)
     {
-        pos++; // consume '<' or '['
-        sb.Append('<');
-        if (pos < s.Length && s[pos] == close)
-        {
-            pos++;
-            sb.Append('>');
-            return;
-        }
+        pos++; // consume '<'
         var parts = new List<string>();
         var current = new StringBuilder();
-        while (pos < s.Length && s[pos] != close)
+        while (pos < s.Length && s[pos] != '>')
         {
             SkipWhitespace(s, ref pos);
-            if (pos >= s.Length || s[pos] == close)
+            if (pos >= s.Length || s[pos] == '>')
                 break;
             if (s[pos] == ',')
             {
@@ -2485,14 +2551,67 @@ internal static class ProgramSupport
                 pos++;
                 continue;
             }
+            int before = pos;
             ParseType(s, ref pos, current);
             SkipWhitespace(s, ref pos);
+            if (pos == before)
+                pos++; // no-progress guard against malformed input
         }
         parts.Add(current.ToString());
-        if (pos < s.Length && s[pos] == close)
+        if (pos < s.Length && s[pos] == '>')
             pos++;
-        sb.Append(string.Join(",", parts.Select(p => p.Length == 0 ? "?" : p)));
-        sb.Append('>');
+        return parts;
+    }
+
+    // Reflection-form generic argument list [A,B,...]. Each argument may be assembly-qualified as
+    // [FullTypeName, AssemblyName]; the assembly qualifier is stripped. Returns each argument
+    // canonicalized. A no-progress guard prevents malformed input (e.g. an unparseable argument) from
+    // looping forever.
+    static List<string> ParseReflArgList(string s, ref int pos)
+    {
+        pos++; // consume '['
+        var parts = new List<string>();
+        while (pos < s.Length && s[pos] != ']')
+        {
+            SkipWhitespace(s, ref pos);
+            if (pos >= s.Length || s[pos] == ']')
+                break;
+            if (s[pos] == ',')
+            {
+                pos++;
+                continue;
+            }
+            bool assemblyQualified = false;
+            if (s[pos] == '[')
+            {
+                assemblyQualified = true;
+                pos++; // consume the inner '[' of [Type, Assembly]
+            }
+            var current = new StringBuilder();
+            int before = pos;
+            ParseType(s, ref pos, current);
+            if (pos == before)
+                pos++; // no-progress guard
+            if (assemblyQualified)
+            {
+                int depth = 1;
+                while (pos < s.Length && depth > 0)
+                {
+                    if (s[pos] == '[')
+                        depth++;
+                    else if (s[pos] == ']')
+                        depth--;
+                    pos++;
+                }
+            }
+            parts.Add(current.ToString());
+            SkipWhitespace(s, ref pos);
+            if (pos < s.Length && s[pos] == ',')
+                pos++;
+        }
+        if (pos < s.Length && s[pos] == ']')
+            pos++;
+        return parts;
     }
 
     static void SkipWhitespace(string s, ref int pos)

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -2328,30 +2328,73 @@ internal static class ProgramSupport
     static void ParseType(string s, ref int pos, StringBuilder sb)
     {
         SkipWhitespace(s, ref pos);
+        ParseNestedName(s, ref pos, sb);
+        ParseSuffixes(s, ref pos, sb);
+    }
 
-        // Qualified name: identifiers joined by '.' or '+' (nested types); normalize '+' to '.'.
-        var name = new StringBuilder();
-        while (pos < s.Length)
+    // A dotted/nested name: Segment (('.'|'+') Segment)*. Nested-type separators '+' are normalized to
+    // '.'. A separator only continues the name when followed by another segment start, so a trailing
+    // '+'/'.' that is not part of the type name is left for the caller.
+    static void ParseNestedName(string s, ref int pos, StringBuilder sb)
+    {
+        bool first = true;
+        while (true)
         {
-            char c = s[pos];
-            if (char.IsLetterOrDigit(c) || c == '_')
+            if (!first)
+                sb.Append('.');
+            first = false;
+            ParseSegment(s, ref pos, sb);
+            if (pos + 1 < s.Length && (s[pos] == '.' || s[pos] == '+') && IsSegmentStart(s[pos + 1]))
             {
-                name.Append(c);
                 pos++;
+                continue;
             }
-            else if ((c == '.' || c == '+') && pos + 1 < s.Length && (char.IsLetter(s[pos + 1]) || s[pos + 1] == '_'))
-            {
-                name.Append('.');
-                pos++;
-            }
-            else
-            {
-                break;
-            }
+            break;
         }
-        sb.Append(ExpandAlias(name.ToString()));
+    }
 
-        // Generic arguments: runtime `N[...] (backtick + arity + brackets) or static <...>.
+    static bool IsSegmentStart(char c) => char.IsLetter(c) || c == '_' || c == '<';
+
+    // One name segment: either a compiler-generated name (a balanced <...> prefix plus trailing
+    // identifier chars, e.g. <>c__DisplayClass18_0 or <Bar>d__5 — reflection uses '<' only here, never
+    // for generic arguments) or a plain identifier (alias-expanded), optionally followed by generic
+    // arguments (backtick `N[...] reflection form or <...> display form).
+    static void ParseSegment(string s, ref int pos, StringBuilder sb)
+    {
+        bool compilerGenerated = false;
+        if (pos < s.Length && s[pos] == '<')
+        {
+            compilerGenerated = true;
+            var seg = new StringBuilder();
+            int depth = 0;
+            while (pos < s.Length)
+            {
+                char c = s[pos];
+                seg.Append(c);
+                pos++;
+                if (c == '<')
+                    depth++;
+                else if (c == '>' && --depth == 0)
+                    break;
+            }
+            while (pos < s.Length && (char.IsLetterOrDigit(s[pos]) || s[pos] == '_'))
+            {
+                seg.Append(s[pos]);
+                pos++;
+            }
+            sb.Append(seg.ToString());
+        }
+        else
+        {
+            var name = new StringBuilder();
+            while (pos < s.Length && (char.IsLetterOrDigit(s[pos]) || s[pos] == '_'))
+            {
+                name.Append(s[pos]);
+                pos++;
+            }
+            sb.Append(ExpandAlias(name.ToString()));
+        }
+
         if (pos < s.Length && s[pos] == '`')
         {
             pos++;
@@ -2360,12 +2403,15 @@ internal static class ProgramSupport
             if (pos < s.Length && s[pos] == '[')
                 ParseGenericArgs(s, ref pos, sb, ']');
         }
-        else if (pos < s.Length && s[pos] == '<')
+        else if (!compilerGenerated && pos < s.Length && s[pos] == '<')
         {
             ParseGenericArgs(s, ref pos, sb, '>');
         }
+    }
 
-        // Suffix modifiers: arrays ([], [,]), pointer (*), byref (&), nullable (?).
+    // Suffix modifiers on a type: arrays ([], [,]), pointer (*), byref (&), nullable (?).
+    static void ParseSuffixes(string s, ref int pos, StringBuilder sb)
+    {
         while (pos < s.Length)
         {
             SkipWhitespace(s, ref pos);
@@ -2412,11 +2458,21 @@ internal static class ProgramSupport
         }
     }
 
+    // Generic argument list. Preserves argument count and separators (so Func<AB,C> and Func<A,BC> do
+    // not collide) and preserves arity for unbound arguments (String<,> is arity 2, distinct from
+    // String<> and String<,,>), rendering an empty argument position as '?'.
     static void ParseGenericArgs(string s, ref int pos, StringBuilder sb, char close)
     {
         pos++; // consume '<' or '['
         sb.Append('<');
-        bool first = true;
+        if (pos < s.Length && s[pos] == close)
+        {
+            pos++;
+            sb.Append('>');
+            return;
+        }
+        var parts = new List<string>();
+        var current = new StringBuilder();
         while (pos < s.Length && s[pos] != close)
         {
             SkipWhitespace(s, ref pos);
@@ -2424,17 +2480,18 @@ internal static class ProgramSupport
                 break;
             if (s[pos] == ',')
             {
+                parts.Add(current.ToString());
+                current.Clear();
                 pos++;
                 continue;
             }
-            if (!first)
-                sb.Append(',');
-            first = false;
-            ParseType(s, ref pos, sb);
+            ParseType(s, ref pos, current);
             SkipWhitespace(s, ref pos);
         }
+        parts.Add(current.ToString());
         if (pos < s.Length && s[pos] == close)
             pos++;
+        sb.Append(string.Join(",", parts.Select(p => p.Length == 0 ? "?" : p)));
         sb.Append('>');
     }
 

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -2461,12 +2461,47 @@ internal static class ProgramSupport
                 pos++;
             }
             arity = n;
+
+            // Reflection normally trails the whole chain's arguments after the last segment
+            // (Outer`1+Inner`1[A,B]), handled by the caller's distribution. But a segment's own
+            // arguments can also appear immediately, before a nested separator
+            // (Parent`2[A,B]+Nested); bind them here only when a '+'/'.' nested continuation follows
+            // the bracket, so a trailing whole-chain list is still left for distribution.
+            if (n > 0 && pos < s.Length && s[pos] == '[' && HasTypeContent(s, pos))
+            {
+                int after = MatchingBracketEnd(s, pos);
+                if (after >= 0 && after + 1 < s.Length
+                    && (s[after] == '.' || s[after] == '+') && IsSegmentStart(s[after + 1]))
+                {
+                    args = ParseReflArgList(s, ref pos);
+                }
+            }
         }
         else if (!compilerGenerated && pos < s.Length && s[pos] == '<')
         {
             args = ParseDisplayArgs(s, ref pos);
             arity = args.Count;
         }
+    }
+
+    // Index just past the ']' matching the '[' at pos (respecting nesting), or -1 if unbalanced.
+    static int MatchingBracketEnd(string s, int pos)
+    {
+        int depth = 0;
+        for (int i = pos; i < s.Length; i++)
+        {
+            if (s[i] == '[')
+            {
+                depth++;
+            }
+            else if (s[i] == ']')
+            {
+                depth--;
+                if (depth == 0)
+                    return i + 1;
+            }
+        }
+        return -1;
     }
 
     // True when the bracket at pos holds a type argument list ([A,B]) rather than an array-rank

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -2256,7 +2256,7 @@ internal static class ProgramSupport
         var runtimeByCanon = new Dictionary<string, long>(StringComparer.Ordinal);
         foreach (var (type, bytes) in result.RuntimeTypeVolume)
         {
-            var canon = CanonicalTypeSignature(type);
+            var canon = CanonicalTypeSignature(type, reflection: true);
             if (canon.Length == 0)
                 continue;
             runtimeByCanon[canon] = runtimeByCanon.GetValueOrDefault(canon) + bytes;
@@ -2317,25 +2317,44 @@ internal static class ProgramSupport
     // arguments (recursively), and maps C# keyword aliases to CLR names. It reconciles the static
     // form (System.Func<string, System.Lazy<int>>, int[]) with the runtime reflection form
     // (System.Func`2[System.String,System.Lazy`1[System.Int32]], System.Int32[]).
-    public static string CanonicalTypeSignature(string type)
+    public static string CanonicalTypeSignature(string type) => CanonicalTypeSignature(type, reflection: false);
+
+    // reflection=true canonicalizes a runtime reflection type name (where array modifiers are ordered
+    // inside-out relative to C# — int[][,] is emitted as System.Int32[,][]); reflection=false
+    // canonicalizes a C# display name. Both normalize to the display array order so the two forms of
+    // one type agree.
+    public static string CanonicalTypeSignature(string type, bool reflection)
     {
         int pos = 0;
         var sb = new StringBuilder();
-        ParseType(type, ref pos, sb);
+        ParseType(type, ref pos, sb, reflection);
         return sb.ToString();
     }
 
-    static void ParseType(string s, ref int pos, StringBuilder sb)
+    static void ParseType(string s, ref int pos, StringBuilder sb, bool reflection)
     {
         SkipWhitespace(s, ref pos);
-        ParseNestedName(s, ref pos, sb);
-        ParseSuffixes(s, ref pos, sb);
+        var core = new StringBuilder();
+        ParseNestedName(s, ref pos, core, reflection);
+        // Nullable value-type shorthand (T?) binds tighter than array/pointer suffixes and expands to
+        // the runtime generic form System.Nullable<T> (so int?[] matches System.Nullable`1[Int32][]).
+        SkipWhitespace(s, ref pos);
+        if (pos < s.Length && s[pos] == '?')
+        {
+            pos++;
+            sb.Append("System.Nullable<").Append(core).Append('>');
+        }
+        else
+        {
+            sb.Append(core);
+        }
+        ParseSuffixes(s, ref pos, sb, reflection);
     }
 
     // A dotted/nested name: Segment (('.'|'+') Segment)*. Nested-type separators '+' are normalized to
     // '.'. A separator only continues the name when followed by another segment start, so a trailing
     // '+'/'.' that is not part of the type name is left for the caller.
-    static void ParseNestedName(string s, ref int pos, StringBuilder sb)
+    static void ParseNestedName(string s, ref int pos, StringBuilder sb, bool reflection)
     {
         // Collect the nested-name segments (Namespace parts and nested types are all segments),
         // recording each segment's name, its generic arity, and any generic arguments already bound
@@ -2347,7 +2366,7 @@ internal static class ProgramSupport
         var boundArgs = new List<List<string>?>();
         while (true)
         {
-            ParseSegment(s, ref pos, out string name, out int arity, out List<string>? args);
+            ParseSegment(s, ref pos, reflection, out string name, out int arity, out List<string>? args);
             names.Add(name);
             arities.Add(arity);
             boundArgs.Add(args);
@@ -2371,7 +2390,7 @@ internal static class ProgramSupport
         // arguments, distributed left-to-right across the segments with unbound backtick arity.
         if (totalArity > boundArity && pos < s.Length && s[pos] == '[' && HasTypeContent(s, pos))
         {
-            var flat = ParseReflArgList(s, ref pos);
+            var flat = ParseReflArgList(s, ref pos, reflection);
             int idx = 0;
             for (int i = 0; i < arities.Count; i++)
             {
@@ -2405,19 +2424,26 @@ internal static class ProgramSupport
         }
     }
 
-    static bool IsSegmentStart(char c) => char.IsLetter(c) || c == '_' || c == '<';
+    static bool IsSegmentStart(char c) => char.IsLetter(c) || c == '_' || c == '<' || c == '(';
 
     // One name segment. Returns the segment name, its generic arity, and (for the display form only)
     // the bound generic arguments. A compiler-generated name is a balanced <...> prefix plus trailing
     // identifier chars (e.g. <>c__DisplayClass18_0, <Bar>d__5, <Main>$>g__Local|0_0) — reflection uses
-    // '<' at a segment start only here, never for generic arguments. Backtick arity ('N) is recorded
-    // but its arguments are left for trailing distribution by the caller; the display form <...> binds
-    // its arguments inline here.
-    static void ParseSegment(string s, ref int pos, out string name, out int arity, out List<string>? args)
+    // '<' at a segment start only here, never for generic arguments. A C# tuple shorthand (A, B, ...)
+    // expands to System.ValueTuple<A,B,...>. Backtick arity ('N) is recorded but its arguments are
+    // left for trailing distribution by the caller; the display form <...> binds inline here.
+    static void ParseSegment(string s, ref int pos, bool reflection, out string name, out int arity, out List<string>? args)
     {
         arity = 0;
         args = null;
         bool compilerGenerated = false;
+        if (pos < s.Length && s[pos] == '(')
+        {
+            args = ParseTupleArgs(s, ref pos, reflection);
+            name = "System.ValueTuple";
+            arity = args.Count;
+            return;
+        }
         if (pos < s.Length && s[pos] == '<')
         {
             compilerGenerated = true;
@@ -2473,13 +2499,13 @@ internal static class ProgramSupport
                 if (after >= 0 && after + 1 < s.Length
                     && (s[after] == '.' || s[after] == '+') && IsSegmentStart(s[after + 1]))
                 {
-                    args = ParseReflArgList(s, ref pos);
+                    args = ParseReflArgList(s, ref pos, reflection);
                 }
             }
         }
         else if (!compilerGenerated && pos < s.Length && s[pos] == '<')
         {
-            args = ParseDisplayArgs(s, ref pos);
+            args = ParseDisplayArgs(s, ref pos, reflection);
             arity = args.Count;
         }
     }
@@ -2516,9 +2542,14 @@ internal static class ProgramSupport
         return false;
     }
 
-    // Suffix modifiers on a type: arrays ([], [,]), pointer (*), byref (&), nullable (?).
-    static void ParseSuffixes(string s, ref int pos, StringBuilder sb)
+    // Suffix modifiers on a type: arrays ([], [,]), pointer (*), byref (&). A C# nullable-reference
+    // annotation ('?') that trails an array/pointer is erased at runtime, so it is dropped. Reflection
+    // orders array/pointer modifiers inside-out relative to C# display (C# int[][,] is emitted as
+    // System.Int32[,][]); for reflection input the modifier order is reversed to the display order so
+    // the two forms agree without colliding genuinely-distinct array shapes.
+    static void ParseSuffixes(string s, ref int pos, StringBuilder sb, bool reflection)
     {
+        var tokens = new List<string>();
         while (pos < s.Length)
         {
             SkipWhitespace(s, ref pos);
@@ -2545,7 +2576,7 @@ internal static class ProgramSupport
                 if (isArray && pos < s.Length && s[pos] == ']')
                 {
                     pos++;
-                    sb.Append('[').Append(new string(',', commas)).Append(']');
+                    tokens.Add("[" + new string(',', commas) + "]");
                 }
                 else
                 {
@@ -2553,23 +2584,65 @@ internal static class ProgramSupport
                     break;
                 }
             }
-            else if (c == '*' || c == '&' || c == '?')
+            else if (c == '*' || c == '&')
             {
-                sb.Append(c);
+                tokens.Add(c.ToString());
                 pos++;
+            }
+            else if (c == '?')
+            {
+                pos++; // erased nullable-reference annotation
             }
             else
             {
                 break;
             }
         }
+        if (reflection)
+            tokens.Reverse();
+        foreach (var tok in tokens)
+            sb.Append(tok);
+    }
+
+    // C# tuple shorthand (A, B, ...) — with optional element names — expands to the generic arguments
+    // of System.ValueTuple. Returns each element type canonicalized.
+    static List<string> ParseTupleArgs(string s, ref int pos, bool reflection)
+    {
+        pos++; // consume '('
+        var parts = new List<string>();
+        var current = new StringBuilder();
+        while (pos < s.Length && s[pos] != ')')
+        {
+            SkipWhitespace(s, ref pos);
+            if (pos >= s.Length || s[pos] == ')')
+                break;
+            if (s[pos] == ',')
+            {
+                parts.Add(current.ToString());
+                current.Clear();
+                pos++;
+                continue;
+            }
+            int before = pos;
+            ParseType(s, ref pos, current, reflection);
+            SkipWhitespace(s, ref pos);
+            while (pos < s.Length && (char.IsLetterOrDigit(s[pos]) || s[pos] == '_'))
+                pos++; // optional tuple element name
+            SkipWhitespace(s, ref pos);
+            if (pos == before)
+                pos++; // no-progress guard
+        }
+        parts.Add(current.ToString());
+        if (pos < s.Length && s[pos] == ')')
+            pos++;
+        return parts;
     }
 
     // Display-form generic argument list <A,B,...>. Preserves argument count and separators (so
     // Func<AB,C> and Func<A,BC> do not collide) and preserves arity for unbound arguments (String<,>
     // is arity 2, distinct from String<> and String<,,>). Returns each argument canonicalized; an
     // empty position is returned as the empty string and rendered '?' by the caller.
-    static List<string> ParseDisplayArgs(string s, ref int pos)
+    static List<string> ParseDisplayArgs(string s, ref int pos, bool reflection)
     {
         pos++; // consume '<'
         var parts = new List<string>();
@@ -2587,7 +2660,7 @@ internal static class ProgramSupport
                 continue;
             }
             int before = pos;
-            ParseType(s, ref pos, current);
+            ParseType(s, ref pos, current, reflection);
             SkipWhitespace(s, ref pos);
             if (pos == before)
                 pos++; // no-progress guard against malformed input
@@ -2602,7 +2675,7 @@ internal static class ProgramSupport
     // [FullTypeName, AssemblyName]; the assembly qualifier is stripped. Returns each argument
     // canonicalized. A no-progress guard prevents malformed input (e.g. an unparseable argument) from
     // looping forever.
-    static List<string> ParseReflArgList(string s, ref int pos)
+    static List<string> ParseReflArgList(string s, ref int pos, bool reflection)
     {
         pos++; // consume '['
         var parts = new List<string>();
@@ -2624,7 +2697,7 @@ internal static class ProgramSupport
             }
             var current = new StringBuilder();
             int before = pos;
-            ParseType(s, ref pos, current);
+            ParseType(s, ref pos, current, reflection);
             if (pos == before)
                 pos++; // no-progress guard
             if (assemblyQualified)

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -2598,8 +2598,24 @@ internal static class ProgramSupport
                 break;
             }
         }
+        // Reflection orders array RANKS inside-out relative to C# (C# int[][,] is emitted as
+        // System.Int32[,][]), but pointer '*' / byref '&' keep the same position in both. Reverse only
+        // the array tokens among their own positions, leaving '*'/'&' fixed, so both forms of one type
+        // agree without mangling pointer/array combinations.
         if (reflection)
-            tokens.Reverse();
+        {
+            var arrayPositions = new List<int>();
+            for (int i = 0; i < tokens.Count; i++)
+            {
+                if (tokens[i][0] == '[')
+                    arrayPositions.Add(i);
+            }
+            for (int lo = 0, hi = arrayPositions.Count - 1; lo < hi; lo++, hi--)
+            {
+                (tokens[arrayPositions[lo]], tokens[arrayPositions[hi]]) =
+                    (tokens[arrayPositions[hi]], tokens[arrayPositions[lo]]);
+            }
+        }
         foreach (var tok in tokens)
             sb.Append(tok);
     }


### PR DESCRIPTION
- Fixes a latent correctness defect in `CanonicalTypeSignature` (shipped in #2264 for the type-confirmation join): distinct types collapsed to the same canonical string, risking false type-confirmations.
- Surfaced during the #2260 survivorship plan review (both reviewers flagged it; verified against real type names).

## Change

> Should we accept this change?

**Conclusion: PASS** — fixes several type collapses (closures erased to parent, nested-after-generic dropped, arg-separators/arity lost) that could false-join in the merged type-confirmation; behavior-preserving for the working cases.

Bugs (all verified):

| Input | Was | Now |
| --- | --- | --- |
| `System.Linq.Enumerable+<>c__DisplayClass18_0` | `System.Linq.Enumerable` (closure erased) | preserved, distinct from parent |
| `Dictionary`2[K,V]+KeyCollection` | `Dictionary<K,V>` (nested dropped) | preserved |
| `Func<AB,C>` vs `Func<A,BC>` | collided (separator dropped) | distinct |
| `String<,>` / `String<>` / `String<,,>` | all identical | distinct by arity |

The first is the decisive one: every closure of a class pooled with the class itself (and with each other) — exactly the `ConvertSpan`-style closure type the join cares about.

Rewrote the parser around explicit **name segments**: a segment is either a compiler-generated name (a balanced `<...>` prefix plus trailing identifier chars — reflection uses `<` only here, never for generic arguments) or an alias-expanded identifier, optionally followed by generic arguments (backtick `` `N[...] `` or `<...>`); nested-type separators continue the name across `+`/`.`; generic arguments preserve order, separators, and arity (empty positions render `?`).

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass |
| runfaster.Tests | 29/29 (5 new canonicalization cases: closures, nested-after-generic, separator collision, unbound arity, array-of-generic across forms) |
| Type-confirmation witness | ColorGenerator recovery still fires (732 MB, unique predicted type) |
| Join regression | None — OTLP Aspire trace still 670,805 ticks matched, 38 observed |

## Adversarial review

Requested from two models (isolated worktrees). Reconciliation to follow.
