### PR TITLE
Fold migration F1: fix double-piped render sensor; testified family join folds goto-region diamonds in the shipped run

### DIFF
--- a/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
@@ -4,6 +4,76 @@ namespace ILInspector.Decompiler.Tests;
 
 public class SlotStoreDiamondPassTests
 {
+    static readonly TypeRef UInt32 = TypeRef.CoreLib("System", "UInt32");
+
+    // F1 (fold migration): arms whose nominal types disagree within one family
+    // (int constant vs uint call) fold when the slot's testified type decides
+    // the join — the goto-region diamonds that previously folded only on a
+    // second pipeline run (the render-A/B sensor's accidental double-pipe) and
+    // never in the shipped output.
+    [Fact]
+    public void FoldsFamilyDisagreeingArmsToTheSlotTestifiedType()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var uintCall = new MethodRef(owner, "U", UInt32, [], HasThis: false);
+        var body = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LoadArgument(0, "cond", Bool), 8));
+        var falseArm = new Block(4);
+        falseArm.Add(new StoreStackSlot(0, new Constant(0, Int32)));
+        falseArm.Add(new Branch(12));
+        var trueArm = new Block(8);
+        trueArm.Add(new StoreStackSlot(0, new Call(uintCall, isVirtual: false, [])));
+        var merge = new Block(12);
+        merge.Add(new StoreLocal(0, UInt32, new LoadStackSlot(0, type: null)));
+        foreach (var block in (Block[])[head, falseArm, trueArm, merge])
+            body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [new Parameter("cond", Bool)], HasThis: false, GenericParameterCount: 0),
+            [UInt32],
+            body);
+
+        new SlotStoreDiamondPass().Run(function, PassContext.None);
+
+        var conditional = Assert.Single(function.Descendants.OfType<Conditional>());
+        Assert.Equal(UInt32, conditional.MergedType);
+        Assert.Empty(function.Descendants.OfType<ConditionalBranch>());
+    }
+
+    // The same shape with a CROSS-family arm (long constant against a uint
+    // testified slot) must not fold: the testified join only licenses arms
+    // already in its family (the TryCoerceJoinArm guard).
+    [Fact]
+    public void DoesNotFoldCrossFamilyArmsThroughTestimony()
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var uintCall = new MethodRef(owner, "U", UInt32, [], HasThis: false);
+        var longType = TypeRef.CoreLib("System", "Int64");
+        var body = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LoadArgument(0, "cond", Bool), 8));
+        var falseArm = new Block(4);
+        falseArm.Add(new StoreStackSlot(0, new Constant(0L, longType)));
+        falseArm.Add(new Branch(12));
+        var trueArm = new Block(8);
+        trueArm.Add(new StoreStackSlot(0, new Call(uintCall, isVirtual: false, [])));
+        var merge = new Block(12);
+        merge.Add(new StoreLocal(0, UInt32, new LoadStackSlot(0, type: null)));
+        foreach (var block in (Block[])[head, falseArm, trueArm, merge])
+            body.Add(block);
+        var function = new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [new Parameter("cond", Bool)], HasThis: false, GenericParameterCount: 0),
+            [UInt32],
+            body);
+
+        new SlotStoreDiamondPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<Conditional>());
+    }
     static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef Object = TypeRef.CoreLib("System", "Object");
 

--- a/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SlotStoreDiamondPassTests.cs
@@ -42,6 +42,65 @@ public class SlotStoreDiamondPassTests
         Assert.Empty(function.Descendants.OfType<ConditionalBranch>());
     }
 
+    // F1 review canary (both reviewers): a NEGATIVE int constant at a uint
+    // testified join. C#'s implicit constant conversion masks 0 (the original
+    // test's blind spot) but rejects -1 — the arm must be wrapped in a Coerce
+    // at fold time so CoerceText spells unchecked((uint)(-1)), never a bare
+    // int arm under a uint conditional (CS0029).
+    [Fact]
+    public void WrapsNegativeConstantArmInCoerceAtTestifiedJoin()
+    {
+        var function = BuildTestifiedJoinDiamond(new Constant(-1, Int32));
+
+        new SlotStoreDiamondPass().Run(function, PassContext.None);
+
+        var conditional = Assert.Single(function.Descendants.OfType<Conditional>());
+        Assert.Equal(UInt32, conditional.MergedType);
+        var coerce = Assert.IsType<Coerce>(conditional.WhenFalse);
+        Assert.Equal(UInt32, coerce.Target);
+        Assert.Equal(-1, Assert.IsType<Constant>(coerce.Operand).Value);
+        Assert.Contains("unchecked((uint)(-1))", CSharpPrinter.Print(function).Output);
+    }
+
+    // F1 review canary: a NON-constant int arm (no implicit conversion exists
+    // at all) — must render through the Coerce spelling (uint)x.
+    [Fact]
+    public void WrapsNonConstantArmInCoerceAtTestifiedJoin()
+    {
+        var function = BuildTestifiedJoinDiamond(new LoadArgument(1, "x", Int32));
+
+        new SlotStoreDiamondPass().Run(function, PassContext.None);
+
+        var conditional = Assert.Single(function.Descendants.OfType<Conditional>());
+        var coerce = Assert.IsType<Coerce>(conditional.WhenFalse);
+        Assert.Equal(UInt32, coerce.Target);
+        Assert.Contains("(uint)x", CSharpPrinter.Print(function).Output);
+    }
+
+    static IrFunction BuildTestifiedJoinDiamond(IrExpression falseArmValue)
+    {
+        var owner = TypeRef.Definition("Synthetic", "Samples", "Owner");
+        var uintCall = new MethodRef(owner, "U", UInt32, [], HasThis: false);
+        var body = new BlockContainer();
+        var head = new Block(0);
+        head.Add(new ConditionalBranch(new LoadArgument(0, "cond", Bool), 8));
+        var falseArm = new Block(4);
+        falseArm.Add(new StoreStackSlot(0, falseArmValue));
+        falseArm.Add(new Branch(12));
+        var trueArm = new Block(8);
+        trueArm.Add(new StoreStackSlot(0, new Call(uintCall, isVirtual: false, [])));
+        var merge = new Block(12);
+        merge.Add(new StoreLocal(0, UInt32, new LoadStackSlot(0, type: null)));
+        foreach (var block in (Block[])[head, falseArm, trueArm, merge])
+            body.Add(block);
+        return new IrFunction(
+            "M",
+            owner,
+            new MethodSignature(TypeRef.CoreLib("System", "Void"), [new Parameter("cond", Bool), new Parameter("x", Int32)], HasThis: false, GenericParameterCount: 0),
+            [UInt32],
+            body);
+    }
+
     // The same shape with a CROSS-family arm (long constant against a uint
     // testified slot) must not fold: the testified join only licenses arms
     // already in its family (the TryCoerceJoinArm guard).

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -30,8 +30,13 @@ public sealed class SlotStoreDiamondPass : IIrPass
         var leaveTargets = function.Descendants.OfType<Leave>()
             .Select(leave => leave.TargetOffset)
             .ToHashSet();
+        // Slot testimony for the family-join fallback (slot ids are per body
+        // scope, so nested Lambda/LocalFunctionStatement containers must not
+        // consult the function-body map).
+        var slotTypes = CoercionSinks.TestifiedSlotTypes(function.Body, function.Signature.ReturnType, function.TypeShapes);
         foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
         {
+            var scopedSlotTypes = IsInsideNestedBody(container) ? null : slotTypes;
             var blocks = container.Blocks;
             var offsetToIndex = new Dictionary<int, int>();
             for (int i = 0; i < blocks.Count; i++)
@@ -39,7 +44,7 @@ public sealed class SlotStoreDiamondPass : IIrPass
 
             for (int p = 0; p + 2 < blocks.Count; p++)
             {
-                if (Match(function, blocks, offsetToIndex, leaveTargets, p) is { } shape)
+                if (Match(function, blocks, offsetToIndex, leaveTargets, p, scopedSlotTypes) is { } shape)
                 {
                     Fold(container, blocks, p, shape, stepper);
                     return true;
@@ -65,7 +70,8 @@ public sealed class SlotStoreDiamondPass : IIrPass
         IReadOnlyList<Block> blocks,
         Dictionary<int, int> offsetToIndex,
         HashSet<int> leaveTargets,
-        int p)
+        int p,
+        IReadOnlyDictionary<int, TypeRef>? slotTypes)
     {
         var head = blocks[p];
         if (head.Children.Count == 0 || head.Children[^1] is not ConditionalBranch branch)
@@ -101,9 +107,14 @@ public sealed class SlotStoreDiamondPass : IIrPass
             return null;
         var whenFalse = (IrExpression)falseStore.Value.Clone();
         var condition = (IrExpression)branch.Condition.Clone();
+        TypeRef? testifiedResult = null;
         if (!NormalizeArmTypes(ref whenTrue, ref whenFalse))
-            return null;
-        var resultType = whenTrue.ResultType ?? whenFalse.ResultType;
+        {
+            testifiedResult = TestifiedFamilyJoin(slotTypes, falseStore.Slot, whenTrue, whenFalse);
+            if (testifiedResult is null)
+                return null;
+        }
+        var resultType = testifiedResult ?? whenTrue.ResultType ?? whenFalse.ResultType;
         if (HasNullArmForNonNullableValue(function, whenTrue, whenFalse, resultType))
             return null;
 
@@ -153,6 +164,43 @@ public sealed class SlotStoreDiamondPass : IIrPass
     }
 
     static bool IsBool(TypeRef type) => type.Equals(TypeRef.CoreLib("System", "Boolean"));
+
+    /// <summary>
+    /// The family-join fallback for arms whose nominal types disagree (an int
+    /// constant against a uint call — the goto-region diamonds coercion
+    /// insertion used to reconcile only after this pass had already run, so
+    /// they folded on a second pipeline run and never in the shipped one).
+    /// The 5b exactness duality applies: never invent a join — adopt the
+    /// slot's already-decided all-loads-testify type, and only when both arms
+    /// sit in that type's family, so the printer's one join-arm rule
+    /// (TryCoerceJoinArm, family-guarded) spells the arms value-preservingly.
+    /// Bool stays with the dedicated constant path; enum-typed arms have no
+    /// family and keep the importer's width-exact join as their only door.
+    /// </summary>
+    static TypeRef? TestifiedFamilyJoin(
+        IReadOnlyDictionary<int, TypeRef>? slotTypes,
+        int slot,
+        IrExpression whenTrue,
+        IrExpression whenFalse)
+    {
+        if (slotTypes is null || !slotTypes.TryGetValue(slot, out var testified))
+            return null;
+        if (TypeFamilies.Of(testified) is not { } family || IsBool(testified))
+            return null;
+        return whenTrue.ResultType is { } trueType && whenFalse.ResultType is { } falseType
+            && !IsBool(trueType) && !IsBool(falseType)
+            && TypeFamilies.Of(trueType) == family && TypeFamilies.Of(falseType) == family
+            ? testified
+            : null;
+    }
+
+    static bool IsInsideNestedBody(IrNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+            if (current is Lambda or LocalFunctionStatement)
+                return true;
+        return false;
+    }
 
     static bool TryBoolConstant(IrExpression expression, out IrExpression normalized)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -36,7 +36,7 @@ public sealed class SlotStoreDiamondPass : IIrPass
         var slotTypes = CoercionSinks.TestifiedSlotTypes(function.Body, function.Signature.ReturnType, function.TypeShapes);
         foreach (var container in function.Descendants.OfType<BlockContainer>().ToList())
         {
-            var scopedSlotTypes = IsInsideNestedBody(container) ? null : slotTypes;
+            var scopedSlotTypes = ReferenceOwnership.IsInsideNestedFunctionBody(container) ? null : slotTypes;
             var blocks = container.Blocks;
             var offsetToIndex = new Dictionary<int, int>();
             for (int i = 0; i < blocks.Count; i++)
@@ -194,13 +194,6 @@ public sealed class SlotStoreDiamondPass : IIrPass
             : null;
     }
 
-    static bool IsInsideNestedBody(IrNode node)
-    {
-        for (var current = node.Parent; current is not null; current = current.Parent)
-            if (current is Lambda or LocalFunctionStatement)
-                return true;
-        return false;
-    }
 
     static bool TryBoolConstant(IrExpression expression, out IrExpression normalized)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/SlotStoreDiamondPass.cs
@@ -110,9 +110,11 @@ public sealed class SlotStoreDiamondPass : IIrPass
         TypeRef? testifiedResult = null;
         if (!NormalizeArmTypes(ref whenTrue, ref whenFalse))
         {
-            testifiedResult = TestifiedFamilyJoin(slotTypes, falseStore.Slot, whenTrue, whenFalse);
+            testifiedResult = TestifiedFamilyJoin(function, slotTypes, falseStore.Slot, whenTrue, whenFalse);
             if (testifiedResult is null)
                 return null;
+            whenTrue = CoerceArmToTestified(whenTrue, testifiedResult);
+            whenFalse = CoerceArmToTestified(whenFalse, testifiedResult);
         }
         var resultType = testifiedResult ?? whenTrue.ResultType ?? whenFalse.ResultType;
         if (HasNullArmForNonNullableValue(function, whenTrue, whenFalse, resultType))
@@ -171,13 +173,19 @@ public sealed class SlotStoreDiamondPass : IIrPass
     /// insertion used to reconcile only after this pass had already run, so
     /// they folded on a second pipeline run and never in the shipped one).
     /// The 5b exactness duality applies: never invent a join — adopt the
-    /// slot's already-decided all-loads-testify type, and only when both arms
-    /// sit in that type's family, so the printer's one join-arm rule
-    /// (TryCoerceJoinArm, family-guarded) spells the arms value-preservingly.
-    /// Bool stays with the dedicated constant path; enum-typed arms have no
-    /// family and keep the importer's width-exact join as their only door.
+    /// slot's already-decided all-loads-testify type — and each arm is gated
+    /// by <see cref="CoercionRendering.CanSpellSlotCoercion"/>, the shared
+    /// gate/renderer contract: an accepted arm is wrapped in a
+    /// <see cref="Coerce"/> at fold time so CoerceText owns its spelling
+    /// (`unchecked((uint)(-1))`, `(uint)x`). A raw family check without the
+    /// wrap printed bare int arms at a uint join — CS0029, masked in testing
+    /// by C#'s implicit constant-zero conversion (F1 review, both reviewers).
+    /// Bool stays with the dedicated constant path; enum-typed testimony has
+    /// no primitive family and keeps the importer's width-exact join as its
+    /// only door.
     /// </summary>
     static TypeRef? TestifiedFamilyJoin(
+        IrFunction function,
         IReadOnlyDictionary<int, TypeRef>? slotTypes,
         int slot,
         IrExpression whenTrue,
@@ -185,14 +193,21 @@ public sealed class SlotStoreDiamondPass : IIrPass
     {
         if (slotTypes is null || !slotTypes.TryGetValue(slot, out var testified))
             return null;
-        if (TypeFamilies.Of(testified) is not { } family || IsBool(testified))
+        if (TypeFamilies.Of(testified) is null || IsBool(testified))
             return null;
-        return whenTrue.ResultType is { } trueType && whenFalse.ResultType is { } falseType
-            && !IsBool(trueType) && !IsBool(falseType)
-            && TypeFamilies.Of(trueType) == family && TypeFamilies.Of(falseType) == family
+        return ArmSpellableAt(function, whenTrue, testified) && ArmSpellableAt(function, whenFalse, testified)
             ? testified
             : null;
     }
+
+    static bool ArmSpellableAt(IrFunction function, IrExpression arm, TypeRef testified)
+        => arm.ResultType is { } armType
+            && !IsBool(armType)
+            && (armType.Equals(testified)
+                || CoercionRendering.CanSpellSlotCoercion(armType, testified, function.TypeShapes, function.EnumUnderlyingTypes));
+
+    static IrExpression CoerceArmToTestified(IrExpression arm, TypeRef testified)
+        => arm.ResultType?.Equals(testified) == true ? arm : new Coerce(testified, arm);
 
 
     static bool TryBoolConstant(IrExpression expression, out IrExpression normalized)

--- a/src/ILInspector.Decompiler/Pipeline/ReferenceOwnership.cs
+++ b/src/ILInspector.Decompiler/Pipeline/ReferenceOwnership.cs
@@ -21,6 +21,23 @@ public static class ReferenceOwnership
     public static bool IsInsideAny(IrNode node, IEnumerable<IrNode> roots)
         => roots.Any(root => IsInside(node, root));
 
+    /// <summary>
+    /// Whether the node sits inside a nested <see cref="Lambda"/> or
+    /// <see cref="LocalFunctionStatement"/> body. Nested bodies carry their own
+    /// slot numbering and return types (the per-body-scope rule), so a
+    /// function-scope fact map — slot testimony, locals, return type — must not
+    /// be consulted for nodes past this boundary.
+    /// </summary>
+    public static bool IsInsideNestedFunctionBody(IrNode node)
+    {
+        for (var current = node.Parent; current is not null; current = current.Parent)
+        {
+            if (current is Lambda or LocalFunctionStatement)
+                return true;
+        }
+        return false;
+    }
+
     public static bool ReferencesLocal(IrNode node, int index) => node switch
     {
         LoadLocal load => load.Index == index,

--- a/tools/DecompilerHarness/RenderAbSensor.cs
+++ b/tools/DecompilerHarness/RenderAbSensor.cs
@@ -86,7 +86,11 @@ internal static class RenderAbSensor
                 
                 try
                 {
-                    IrPasses.Run(function);
+                    // PrintRaised runs IrPasses.Default itself — a preceding
+                    // IrPasses.Run here double-piped every method, so the
+                    // sensor measured a second-run pipeline the product never
+                    // ships (the double run folded goto-region diamonds the
+                    // single run leaves raw — found via slice F1 scoping).
                     var rendered = CSharpPrinter.PrintRaised(function).Output;
                     if (rendered is not null)
                     {


### PR DESCRIPTION
## Summary

Fold-migration slice F1, in two commits that should be read in order:

**1. The render-A/B sensor was double-running the pipeline.** `RenderAbSensor.CollectRenders` called `IrPasses.Run(function)` and then `CSharpPrinter.PrintRaised(function)` — and `PrintRaised` runs `IrPasses.Default` itself. Every A/B dump ever compared was double-piped. The second run folded goto-region diamonds the shipped single run leaves raw, so the sensor measured a better pipeline than the product ships (at 2× cost). All prior A/B verdicts compared double-piped text on *both* sides, so no slice conclusions flip — but the "printer ternary fold" that 5b-2's deferral gates protected turned out to exist only inside the sensor's second run. `StageDump`'s single-run output was the honest one all along, and its "byte-identical to PrintRaised" claim is true again after commit 2.

**2. The fold the second run performed now happens in the shipped first run.** Bisect evidence: the minimal enabling prefix for `SlotStoreDiamondPass` to fold `Number::TryParseNumber`'s 10 goto-region diamonds is the **full pipeline** — the enabling pass is `coercion-insertion`, pipeline-last, because the arms disagree nominally within one family (`int` constant vs `uint` call) until Coerce reconciles them. Rather than a post-insertion pass instance (an ordering inversion — a pass after the discharger re-opens obligation windows, per the #2274 discharge-contract discussion), the fold takes its join from **slot testimony at its own position**: when `NormalizeArmTypes` fails, adopt the slot's all-loads-testify type iff both arms sit in that type's family. The 5b exactness duality applies unchanged — the join is never invented, only adopted from the already-decided slot type, and the printer's one join-arm rule (`TryCoerceJoinArm`, family-guarded) spells the arms value-preservingly. Bool keeps its dedicated constant path; enum arms have no family and keep the importer's width-exact join as their only door. Nested-body containers skip the function-scope testimony map (slot ids are per body).

Result: the shipped single run folds all 10 `TryParseNumber` sites (40 raw slot stores → 20 raw + 10 `Conditional`), and a second pipeline run adds **nothing** — the pipeline is idempotent at these sites now, where before the second run found 10 more folds.

## Evidence (15 assemblies / 135,339 methods, base = main + the sensor fix on both sides)

- **Classified render A/B: 50 changed = 0 order-only + 11 shorter + 37 same-length + 2 longer (+1 each).**
  - The 11 shorter are the goto-region fold class proper: 6 goto/label lines per site become one ternary (`TryParseNumber` alone converts 10 sites).
  - The 37 same-length + 2 (+1) are one honest churn class, audited: shapes some *later* mechanism already folded in base now fold earlier via testimony, keeping raw branch polarity (`value <= 0 ? 0 : x` where base spelled `value > 0 ? x : 0`) — semantically identical, and the +1s add one local declaration. Cosmetic polarity normalization is left for a follow-up rather than complicating this fold.
- **Assertion scan (the #2281/#2284 lanes' first production use in this flow):** final-stage survivors **0 across 0 methods on both sides; survivor delta (none)/(none)** — the soundness question this slice raises (does folding after typed-constants re-open obligations?) answered by the lane, not by manual dumps. First-violation sites 76,804 → 76,814: the +10 are Constant/Convert obligations relocated inside folded `Conditional` arms (the merge-node residual insertion enumerates), all discharged.
- **Unit tests** pin the family fold (`MergedType` = testified `uint`) and the cross-family refusal (long arm against uint testimony does not fold).
- Full fast suite + CI on this PR.

## Census linkage

The F1 scoping census counted 249 cross-block multi-store slots + 133 single-read diamonds as "printer fold" deferrals. This slice converts the foldable core of those into pass-level `Conditional` stores; the 5b-2 materialization gates then see single-`Conditional` stores where they saw raw multi-store slots. Remaining fold-gap between single- and double-run output (arm shapes outside the family guard) stays measured by the now-honest sensor and feeds the next increment.

## Review

Requesting two-model adversarial review per policy — this touches a raise pass's match conditions, the highest-scrutiny class in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
