### PR TITLE
Align Research diff row contracts

### DIFF
--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -116,12 +116,14 @@ public class IlBodyDiffTests
                 Assert.Equal(IlDiffKind.Remove, removed.Kind);
                 Assert.Equal("ldc.i4", removed.Operation.OpcodeFamily);
                 Assert.Equal("1", removed.Operation.Operand?.Value);
+                Assert.Equal("Removed IL operation 'ldc.i4 1'", removed.Message);
             },
             added =>
             {
                 Assert.Equal(IlDiffKind.Add, added.Kind);
                 Assert.Equal("ldc.i4", added.Operation.OpcodeFamily);
                 Assert.Equal("2", added.Operation.Operand?.Value);
+                Assert.Equal("Added IL operation 'ldc.i4 2'", added.Message);
             });
     }
 
@@ -253,6 +255,7 @@ public class IlBodyDiffTests
                 Assert.Equal(0, removedBranch.Operation.Offset);
                 Assert.Equal("br", removedBranch.Operation.OpcodeFamily);
                 Assert.Equal("IL_0005", removedBranch.Operation.Operand?.Value);
+                Assert.Equal("Removed IL branch 'br IL_0005'", removedBranch.Message);
             },
             addedBranch =>
             {
@@ -260,6 +263,7 @@ public class IlBodyDiffTests
                 Assert.Equal(0, addedBranch.Operation.Offset);
                 Assert.Equal("br", addedBranch.Operation.OpcodeFamily);
                 Assert.Equal("IL_0002", addedBranch.Operation.Operand?.Value);
+                Assert.Equal("Added IL branch 'br IL_0002'", addedBranch.Message);
             },
             removedNop =>
             {

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -33,7 +33,8 @@ public sealed record CanonicalIlOperation(
 public sealed record IlDiffRow(
     int HunkId,
     IlDiffKind Kind,
-    CanonicalIlOperation Operation);
+    CanonicalIlOperation Operation,
+    string Message);
 
 public sealed record IlBodyDiffResult(
     bool IsExact,
@@ -98,8 +99,8 @@ public static class IlBodyDiff
             if (!BranchTargetsMatch(oldInstructions, nextOld, newInstructions, nextNew, oldToNew))
             {
                 int hunk = hunkId++;
-                rows.Add(new IlDiffRow(hunk, IlDiffKind.Remove, oldOperations[nextOld]));
-                rows.Add(new IlDiffRow(hunk, IlDiffKind.Add, newOperations[nextNew]));
+                rows.Add(Row(hunk, IlDiffKind.Remove, oldOperations[nextOld]));
+                rows.Add(Row(hunk, IlDiffKind.Add, newOperations[nextNew]));
             }
             oldIndex = nextOld + 1;
             newIndex = nextNew + 1;
@@ -153,9 +154,27 @@ public static class IlBodyDiff
         int oldIndex = oldStart;
         int newIndex = newStart;
         while (oldIndex < oldEnd)
-            rows.Add(new IlDiffRow(hunk, IlDiffKind.Remove, oldOperations[oldIndex++]));
+            rows.Add(Row(hunk, IlDiffKind.Remove, oldOperations[oldIndex++]));
         while (newIndex < newEnd)
-            rows.Add(new IlDiffRow(hunk, IlDiffKind.Add, newOperations[newIndex++]));
+            rows.Add(Row(hunk, IlDiffKind.Add, newOperations[newIndex++]));
+    }
+
+    static IlDiffRow Row(int hunkId, IlDiffKind kind, CanonicalIlOperation operation)
+        => new(hunkId, kind, operation, Message(kind, operation));
+
+    static string Message(IlDiffKind kind, CanonicalIlOperation operation)
+    {
+        string action = kind switch
+        {
+            IlDiffKind.Add => "Added",
+            IlDiffKind.Remove => "Removed",
+            IlDiffKind.Context => "Unchanged",
+            _ => kind.ToString(),
+        };
+        string subject = operation.Operand?.Kind is IlOperandIdentityKind.BranchTarget or IlOperandIdentityKind.SwitchTargets
+            ? "IL branch"
+            : "IL operation";
+        return $"{action} {subject} '{operation.Display}'";
     }
 
     static List<(int OldIndex, int NewIndex)> LongestCommonSubsequence(

--- a/src/ILInspector.Metadata/ApiDiffAnalyzer.cs
+++ b/src/ILInspector.Metadata/ApiDiffAnalyzer.cs
@@ -43,6 +43,25 @@ public enum ChangeKind
     EnumValueChanged
 }
 
+public enum ApiChangeCategory
+{
+    Signature,
+    Attribute
+}
+
+public enum ApiChangeSubjectKind
+{
+    Type,
+    Member
+}
+
+public sealed record ApiChangeSubject(
+    ApiChangeSubjectKind Kind,
+    string TypeFullName,
+    string? MemberName = null,
+    string? OldIdentity = null,
+    string? NewIdentity = null);
+
 /// <summary>
 /// A single detected API change.
 /// </summary>
@@ -51,7 +70,9 @@ public record ApiChange(
     ChangeClassification Classification,
     string Message,
     string? OldValue = null,
-    string? NewValue = null);
+    string? NewValue = null,
+    ApiChangeCategory Category = ApiChangeCategory.Signature,
+    ApiChangeSubject? Subject = null);
 
 /// <summary>
 /// All changes detected for a single type.
@@ -119,12 +140,14 @@ public static class ApiDiffAnalyzer
             if (inOld && !inNew)
             {
                 changes = [new ApiChange(ChangeKind.TypeRemoved, ChangeClassification.Breaking,
-                    $"Type '{typeName}' was removed")];
+                    $"Type '{typeName}' was removed",
+                    Subject: TypeSubject(typeName))];
             }
             else if (!inOld && inNew)
             {
                 changes = [new ApiChange(ChangeKind.TypeAdded, ChangeClassification.Additive,
-                    $"Type '{typeName}' was added")];
+                    $"Type '{typeName}' was added",
+                    Subject: TypeSubject(typeName))];
             }
             else
             {
@@ -166,7 +189,7 @@ public static class ApiDiffAnalyzer
         CompareTypeMetadata(oldType, newType, changes);
         CompareTypeParameters(oldType, newType, changes);
         CompareMembers(oldType, newType, changes);
-        return changes;
+        return [.. changes.Select(change => change.Subject is null ? change with { Subject = TypeSubject(newType.FullName) } : change)];
     }
 
     private static void CompareTypeMetadata(ApiType oldType, ApiType newType, List<ApiChange> changes)
@@ -350,7 +373,8 @@ public static class ApiDiffAnalyzer
 
                     changes.Add(new ApiChange(ChangeKind.MemberSignatureChanged, ChangeClassification.Breaking,
                         $"Member '{oldMember.Name}' signature changed",
-                        GetMemberKey(oldMember), GetMemberKey(newMember)));
+                        GetMemberKey(oldMember), GetMemberKey(newMember),
+                        Subject: MemberSubject(newType.FullName, oldMember.Name, GetMemberKey(oldMember), GetMemberKey(newMember))));
                     break;
                 }
             }
@@ -362,7 +386,8 @@ public static class ApiDiffAnalyzer
             if (!pairedOld.Contains(oldMember))
             {
                 changes.Add(new ApiChange(ChangeKind.MemberRemoved, ChangeClassification.Breaking,
-                    $"Member '{oldMember.Name}' was removed"));
+                    $"Member '{oldMember.Name}' was removed",
+                    Subject: MemberSubject(oldType.FullName, oldMember.Name, GetMemberKey(oldMember), null)));
             }
         }
 
@@ -376,7 +401,8 @@ public static class ApiDiffAnalyzer
                     : ChangeClassification.Additive;
 
                 changes.Add(new ApiChange(ChangeKind.MemberAdded, classification,
-                    $"Member '{newMember.Name}' was added"));
+                    $"Member '{newMember.Name}' was added",
+                    Subject: MemberSubject(newType.FullName, newMember.Name, null, GetMemberKey(newMember))));
             }
         }
 
@@ -385,24 +411,26 @@ public static class ApiDiffAnalyzer
         {
             var oldMember = oldBySignature[key];
             var newMember = newBySignature[key];
-            CompareMemberModifiers(oldMember, newMember, changes);
+            CompareMemberModifiers(newType.FullName, oldMember, newMember, changes);
         }
     }
 
-    private static void CompareMemberModifiers(ApiMember oldMember, ApiMember newMember, List<ApiChange> changes)
+    private static void CompareMemberModifiers(string typeFullName, ApiMember oldMember, ApiMember newMember, List<ApiChange> changes)
     {
         // Virtual removed
         if (oldMember.IsVirtual && !newMember.IsVirtual)
         {
             changes.Add(new ApiChange(ChangeKind.VirtualRemoved, ChangeClassification.Breaking,
-                $"Member '{oldMember.Name}' is no longer virtual"));
+                $"Member '{oldMember.Name}' is no longer virtual",
+                Subject: MemberSubject(typeFullName, oldMember.Name, GetMemberKey(oldMember), GetMemberKey(newMember))));
         }
 
         // Abstract added
         if (!oldMember.IsAbstract && newMember.IsAbstract)
         {
             changes.Add(new ApiChange(ChangeKind.AbstractMemberAdded, ChangeClassification.Breaking,
-                $"Member '{oldMember.Name}' was made abstract"));
+                $"Member '{oldMember.Name}' was made abstract",
+                Subject: MemberSubject(typeFullName, oldMember.Name, GetMemberKey(oldMember), GetMemberKey(newMember))));
         }
 
         // Enum value changed
@@ -411,7 +439,8 @@ public static class ApiDiffAnalyzer
         {
             changes.Add(new ApiChange(ChangeKind.EnumValueChanged, ChangeClassification.PotentiallyBreaking,
                 $"Enum member '{oldMember.Name}' value changed from {oldMember.EnumValue} to {newMember.EnumValue}",
-                oldMember.EnumValue.Value.ToString(), newMember.EnumValue.Value.ToString()));
+                oldMember.EnumValue.Value.ToString(), newMember.EnumValue.Value.ToString(),
+                Subject: MemberSubject(typeFullName, oldMember.Name, GetMemberKey(oldMember), GetMemberKey(newMember))));
         }
     }
 
@@ -434,4 +463,10 @@ public static class ApiDiffAnalyzer
         // Use signature when available (methods, properties), else fall back to kind + name
         return member.Signature ?? $"{member.Kind}:{member.Name}";
     }
+
+    static ApiChangeSubject TypeSubject(string typeFullName)
+        => new(ApiChangeSubjectKind.Type, typeFullName);
+
+    static ApiChangeSubject MemberSubject(string typeFullName, string memberName, string? oldIdentity, string? newIdentity)
+        => new(ApiChangeSubjectKind.Member, typeFullName, memberName, oldIdentity, newIdentity);
 }

--- a/src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj
+++ b/src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj
@@ -19,6 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\DiffFixtures.V1\DiffFixtures.V1.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\DiffFixtures.V2\DiffFixtures.V2.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Research\ILInspector.Research.csproj" />
   </ItemGroup>
 

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -1,0 +1,121 @@
+using ILInspector.Analysis;
+using ILInspector.Instructions;
+using ILInspector.Metadata;
+using ILInspector.Research;
+using System.Collections.Immutable;
+
+namespace ILInspector.Research.Tests;
+
+public class ResearchDiffTests
+{
+    [Fact]
+    public void FromApiDiff_PreservesApiChangeMessageAndStructuredSubject()
+    {
+        var subject = new ApiChangeSubject(
+            ApiChangeSubjectKind.Member,
+            "Ns.Widget",
+            "Parse",
+            OldIdentity: "method:Parse(System.String)",
+            NewIdentity: "method:Parse(System.ReadOnlySpan<System.Char>)");
+        var change = new ApiChange(
+            ChangeKind.MemberSignatureChanged,
+            ChangeClassification.Breaking,
+            "Member 'Parse' signature changed",
+            OldValue: subject.OldIdentity,
+            NewValue: subject.NewIdentity,
+            Subject: subject);
+        var api = new ApiDiff { TypeDiffs = [new TypeDiff("Ns.Widget", [change])] };
+
+        var result = ResearchDiff.FromApiDiff(api);
+
+        var row = Assert.Single(result.Rows);
+        Assert.Equal("api.member-signature-changed", row.ChangeId);
+        Assert.Equal(ResearchDiffEvidenceKind.MetadataApi, row.EvidenceKind);
+        Assert.Equal(change.Message, row.Message);
+        var apiChange = Assert.IsType<ApiChange>(row.ApiChange);
+        Assert.Same(change, apiChange);
+        Assert.Equal(ApiChangeSubjectKind.Member, apiChange.Subject?.Kind);
+        Assert.Equal("Parse", apiChange.Subject?.MemberName);
+    }
+
+    [Fact]
+    public void FromIlBodyDiff_PreservesIlRowMessageAndOperationIdentity()
+    {
+        var operation = new CanonicalIlOperation(
+            Offset: 0,
+            OpcodeFamily: "ldc.i4",
+            Operand: new IlOperandIdentity(IlOperandIdentityKind.Immediate, "2"));
+        var ilRow = new IlDiffRow(3, IlDiffKind.Add, operation, "Added IL operation 'ldc.i4 2'");
+        var diff = new IlBodyDiffResult(IsExact: false, Failure: null, [ilRow]);
+
+        var result = ResearchDiff.FromIlBodyDiff(diff);
+
+        var row = Assert.Single(result.Rows);
+        Assert.Equal("il.operation.added", row.ChangeId);
+        Assert.Equal(ResearchDiffEvidenceKind.IlBody, row.EvidenceKind);
+        Assert.Equal(ilRow.Message, row.Message);
+        var projectedIlRow = Assert.IsType<IlDiffRow>(row.IlRow);
+        Assert.Same(ilRow, projectedIlRow);
+        Assert.Equal("ldc.i4", projectedIlRow.Operation.OpcodeFamily);
+        Assert.Equal("2", projectedIlRow.Operation.Operand?.Value);
+    }
+
+    [Fact]
+    public void FromIlBodyDiff_PreservesFailureMessageWithoutInventingRowIdentity()
+    {
+        var diff = new IlBodyDiffResult(IsExact: false, Failure: "old body decode failed", []);
+
+        var result = ResearchDiff.FromIlBodyDiff(diff);
+
+        var row = Assert.Single(result.Rows);
+        Assert.Equal("il.diff.failed", row.ChangeId);
+        Assert.Equal("old body decode failed", row.Message);
+        Assert.Null(row.IlRow);
+    }
+
+    [Fact]
+    public void FromBodySignalDiff_PreservesSignalRowAsTypedEvidence()
+    {
+        var signal = new BodySignalDiffRow(
+            BodySignalDiffKind.Added,
+            Signal: "unsafe",
+            Member: "Asm|Ns.UnsafeApi|Use||System.Void",
+            Operation: "stackalloc",
+            ILOffset: 2,
+            Evidence: "stackalloc");
+        var diff = new BodySignalDiffResult([signal]);
+
+        var result = ResearchDiff.FromBodySignalDiff(diff);
+
+        var row = Assert.Single(result.Rows);
+        Assert.Equal("unsafe.stackalloc.added", row.ChangeId);
+        Assert.Equal(ResearchDiffEvidenceKind.BodySignal, row.EvidenceKind);
+        var signalRow = Assert.IsType<BodySignalDiffRow>(row.BodySignalRow);
+        Assert.Same(signal, signalRow);
+        Assert.Equal(2, signalRow.ILOffset);
+    }
+
+    [Fact]
+    public void Combine_AppendsRowsFromAllLowerLayers()
+    {
+        var api = ResearchDiff.FromApiDiff(new ApiDiff
+        {
+            TypeDiffs =
+            [
+                new TypeDiff("Ns.Widget", [
+                    new ApiChange(
+                        ChangeKind.TypeAdded,
+                        ChangeClassification.Additive,
+                        "Type 'Ns.Widget' was added",
+                        Subject: new ApiChangeSubject(ApiChangeSubjectKind.Type, "Ns.Widget"))
+                ])
+            ]
+        });
+        var il = ResearchDiff.FromIlBodyDiff(new IlBodyDiffResult(IsExact: true, Failure: null, []));
+
+        var combined = ResearchDiff.Combine(api, il);
+
+        Assert.Single(combined.Rows);
+        Assert.Equal("api.type-added", combined.Rows[0].ChangeId);
+    }
+}

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -78,9 +78,9 @@ public class ResearchDiffTests
     {
         var signal = new BodySignalDiffRow(
             BodySignalDiffKind.Added,
-            Signal: "unsafe",
+            Signal: "stackalloc",
             Member: "Asm|Ns.UnsafeApi|Use||System.Void",
-            Operation: "stackalloc",
+            Operation: "byte*",
             ILOffset: 2,
             Evidence: "stackalloc");
         var diff = new BodySignalDiffResult([signal]);
@@ -93,6 +93,21 @@ public class ResearchDiffTests
         var signalRow = Assert.IsType<BodySignalDiffRow>(row.BodySignalRow);
         Assert.Same(signal, signalRow);
         Assert.Equal(2, signalRow.ILOffset);
+    }
+
+    [Fact]
+    public void FromBodySignalDiff_UsesActualUnsafeSignalForChangeId()
+    {
+        var oldIndex = LibraryBodyIndex.Open(DiffFixturePath("DiffFixtures.V1"));
+        var newIndex = LibraryBodyIndex.Open(DiffFixturePath("DiffFixtures.V2"));
+        var signalDiff = BodySignalDiff.CompareUnsafe(oldIndex, newIndex);
+
+        var result = ResearchDiff.FromBodySignalDiff(signalDiff);
+
+        Assert.Contains(result.Rows, row =>
+            row.ChangeId == "unsafe.stackalloc.added"
+            && row.BodySignalRow is { Signal: "stackalloc", Operation: "byte*" });
+        Assert.DoesNotContain(result.Rows, row => row.ChangeId == "stackalloc.byte.added");
     }
 
     [Fact]
@@ -117,5 +132,15 @@ public class ResearchDiffTests
 
         Assert.Single(combined.Rows);
         Assert.Equal("api.type-added", combined.Rows[0].ChangeId);
+    }
+
+    static string DiffFixturePath(string project)
+    {
+        var outputDirectory = new DirectoryInfo(
+            AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string path = Path.GetFullPath(Path.Combine(
+            outputDirectory.FullName, "..", "..", project, outputDirectory.Name, "DiffFixtureSample.dll"));
+        Assert.True(File.Exists(path), $"Expected diff fixture assembly at {path}");
+        return path;
     }
 }

--- a/src/ILInspector.Research/ILInspector.Research.csproj
+++ b/src/ILInspector.Research/ILInspector.Research.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
     <ProjectReference Include="..\ILInspector.Decompiler\ILInspector.Decompiler.csproj" />
+    <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
+    <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -74,7 +74,7 @@ public static class ResearchDiff
         ArgumentNullException.ThrowIfNull(diff);
         return new ResearchDiffResult([
             .. diff.Rows.Select(row => new ResearchDiffRow(
-                $"{Kebab(row.Signal)}.{Kebab(row.Operation)}.{Kebab(row.Kind.ToString())}",
+                $"unsafe.{Kebab(row.Signal)}.{Kebab(row.Kind.ToString())}",
                 ResearchDiffEvidenceKind.BodySignal,
                 $"{row.Kind} {row.Signal}: {row.Operation}",
                 BodySignalRow: row))

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -1,0 +1,123 @@
+using System.Collections.Immutable;
+using ILInspector.Analysis;
+using ILInspector.Instructions;
+using ILInspector.Metadata;
+
+namespace ILInspector.Research;
+
+public enum ResearchDiffEvidenceKind
+{
+    MetadataApi,
+    IlBody,
+    BodySignal
+}
+
+public sealed record ResearchDiffRow(
+    string ChangeId,
+    ResearchDiffEvidenceKind EvidenceKind,
+    string Message,
+    ApiChange? ApiChange = null,
+    IlDiffRow? IlRow = null,
+    BodySignalDiffRow? BodySignalRow = null);
+
+public sealed record ResearchDiffResult(ImmutableArray<ResearchDiffRow> Rows)
+{
+    public bool IsEmpty => Rows.IsEmpty;
+}
+
+/// <summary>
+/// Product-level diff projector. It preserves producer-owned lower-layer rows as
+/// typed evidence and adds stable product change IDs without parsing messages.
+/// </summary>
+public static class ResearchDiff
+{
+    public static ResearchDiffResult FromApiDiff(ApiDiff diff)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+        var rows = ImmutableArray.CreateBuilder<ResearchDiffRow>();
+        foreach (var typeDiff in diff.TypeDiffs)
+        {
+            foreach (var change in typeDiff.Changes)
+            {
+                rows.Add(new ResearchDiffRow(
+                    $"api.{Kebab(change.Kind.ToString())}",
+                    ResearchDiffEvidenceKind.MetadataApi,
+                    change.Message,
+                    ApiChange: change));
+            }
+        }
+
+        return new ResearchDiffResult(rows.ToImmutable());
+    }
+
+    public static ResearchDiffResult FromIlBodyDiff(IlBodyDiffResult diff)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+        if (diff.Failure is { Length: > 0 } failure)
+        {
+            return new ResearchDiffResult([
+                new ResearchDiffRow("il.diff.failed", ResearchDiffEvidenceKind.IlBody, failure)
+            ]);
+        }
+
+        return new ResearchDiffResult([
+            .. diff.Rows.Select(row => new ResearchDiffRow(
+                $"il.operation.{ChangeIdSuffix(row.Kind)}",
+                ResearchDiffEvidenceKind.IlBody,
+                row.Message,
+                IlRow: row))
+        ]);
+    }
+
+    public static ResearchDiffResult FromBodySignalDiff(BodySignalDiffResult diff)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+        return new ResearchDiffResult([
+            .. diff.Rows.Select(row => new ResearchDiffRow(
+                $"{Kebab(row.Signal)}.{Kebab(row.Operation)}.{Kebab(row.Kind.ToString())}",
+                ResearchDiffEvidenceKind.BodySignal,
+                $"{row.Kind} {row.Signal}: {row.Operation}",
+                BodySignalRow: row))
+        ]);
+    }
+
+    public static ResearchDiffResult Combine(params ResearchDiffResult[] results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        return new ResearchDiffResult([.. results.SelectMany(result => result.Rows)]);
+    }
+
+    static string Kebab(string value)
+    {
+        var builder = new System.Text.StringBuilder(value.Length + 8);
+        for (int i = 0; i < value.Length; i++)
+        {
+            char c = value[i];
+            if (char.IsUpper(c))
+            {
+                if (builder.Length > 0 && builder[^1] != '-')
+                    builder.Append('-');
+                builder.Append(char.ToLowerInvariant(c));
+            }
+            else if (char.IsLetterOrDigit(c))
+            {
+                builder.Append(char.ToLowerInvariant(c));
+            }
+            else if (builder.Length > 0 && builder[^1] != '-')
+            {
+                builder.Append('-');
+            }
+        }
+
+        return builder.ToString().Trim('-');
+    }
+
+    static string ChangeIdSuffix(IlDiffKind kind)
+        => kind switch
+        {
+            IlDiffKind.Add => "added",
+            IlDiffKind.Remove => "removed",
+            IlDiffKind.Context => "context",
+            _ => Kebab(kind.ToString()),
+        };
+}

--- a/tests/ILInspector.Metadata.Tests/ApiDiffAnalyzerTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiDiffAnalyzerTests.cs
@@ -95,6 +95,10 @@ public class ApiDiffAnalyzerTests
         var typeDiff = diff.TypeDiffs[0];
         Assert.True(typeDiff.IsAdded);
         Assert.False(typeDiff.IsRemoved);
+        var change = Assert.Single(typeDiff.Changes);
+        Assert.Equal(ApiChangeCategory.Signature, change.Category);
+        Assert.Equal(ApiChangeSubjectKind.Type, change.Subject?.Kind);
+        Assert.Equal("TestNamespace.Foo", change.Subject?.TypeFullName);
         Assert.Equal(1, diff.TotalAdditive);
         Assert.Equal(0, diff.TotalBreaking);
     }
@@ -321,6 +325,11 @@ public class ApiDiffAnalyzerTests
             .Single(c => c.Kind == ChangeKind.MemberAdded);
         Assert.Equal(ChangeClassification.Additive, change.Classification);
         Assert.Contains("Baz", change.Message);
+        Assert.Equal(ApiChangeSubjectKind.Member, change.Subject?.Kind);
+        Assert.Equal("TestNamespace.Foo", change.Subject?.TypeFullName);
+        Assert.Equal("Baz", change.Subject?.MemberName);
+        Assert.Null(change.Subject?.OldIdentity);
+        Assert.Equal("void Baz()", change.Subject?.NewIdentity);
     }
 
     [Fact]
@@ -368,6 +377,10 @@ public class ApiDiffAnalyzerTests
         Assert.Equal(ChangeClassification.Breaking, change.Classification);
         Assert.Equal("void Bar(int x)", change.OldValue);
         Assert.Equal("void Bar(string x)", change.NewValue);
+        Assert.Equal(ApiChangeSubjectKind.Member, change.Subject?.Kind);
+        Assert.Equal("Bar", change.Subject?.MemberName);
+        Assert.Equal("void Bar(int x)", change.Subject?.OldIdentity);
+        Assert.Equal("void Bar(string x)", change.Subject?.NewIdentity);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- add producer-owned `Message` to `IlDiffRow`
- add structured `ApiChangeCategory` / `ApiChangeSubject` to Metadata API diff rows
- add `ResearchDiff` as a typed projector over Metadata, IL, and body-signal diff evidence

Fixes #2296.

## Validation

```text
dotnet run --project src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj -c Release --no-restore -- -filter "/*/*/ResearchDiffTests/*"
dotnet run --project tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj -c Release --no-restore -- -filter "/*/*/ApiDiffAnalyzerTests/*"
dotnet run --project src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj -c Release --no-restore -- -filter "/*/*/IlBodyDiffTests/*"
dotnet run --project src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj -c Release --no-restore -- -filter "/*/*/DiffCommandTests/*"
dotnet run --project src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj -c Release --no-restore
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config --verbosity quiet
```
