### PR TITLE
Add solution build graph for fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
               eng/prepare-decompiler-assertion-corpus.sh) CODE=true ;;
               eng/prepare-decompiler-corpus.sh) CODE=true ;;
               eng/prepare-decompiler-pr-corpus.sh) CODE=true ;;
-              *.props|*.sln) CODE=true ;;
+              *.props|*.sln|*.slnx) CODE=true ;;
               .github/workflows/*) CODE=true ;;
             esac
             case "$file" in
@@ -73,7 +73,7 @@ jobs:
               eng/restore-ilassembler.sh) ILROUNDTRIP=true ;;
               src/ILInspector.Metadata*) ILROUNDTRIP=true ;;
               src/DotnetInspector.Core/*) ILROUNDTRIP=true ;;
-              *.props|*.sln) ILROUNDTRIP=true ;;
+              *.props|*.sln|*.slnx) ILROUNDTRIP=true ;;
             esac
             # Packaging/pack-smoke validation only needs to run when something
             # that affects the *packaged* tool changes. pack/pack-rid only run
@@ -152,12 +152,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets') }}
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/*.slnx') }}
           restore-keys: |
             nuget-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Build
-        run: dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+        run: dotnet build dotnet-inspect.slnx -c Release
 
       - name: Prepare PR decompiler corpus
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
               eng/prepare-decompiler-assertion-corpus.sh) CODE=true ;;
               eng/prepare-decompiler-corpus.sh) CODE=true ;;
               eng/prepare-decompiler-pr-corpus.sh) CODE=true ;;
-              *.props|*.sln|*.slnx) CODE=true ;;
+              *.props|*.targets|*.sln|*.slnx) CODE=true ;;
               .github/workflows/*) CODE=true ;;
             esac
             case "$file" in
@@ -74,7 +74,7 @@ jobs:
               eng/restore-ilassembler.sh) ILROUNDTRIP=true ;;
               src/ILInspector.Metadata*) ILROUNDTRIP=true ;;
               src/DotnetInspector.Core/*) ILROUNDTRIP=true ;;
-              *.props|*.sln|*.slnx) ILROUNDTRIP=true ;;
+              *.props|*.targets|*.sln|*.slnx) ILROUNDTRIP=true ;;
             esac
             # Packaging/pack-smoke validation only needs to run when something
             # that affects the *packaged* tool changes. pack/pack-rid only run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           while IFS= read -r file; do
             case "$file" in
               src/*) CODE=true ;;
+              tests/*) CODE=true ;;
               tools/DecompilerHarness/*.md|tools/DecompilerHarness/*.txt) ;;
               tools/DecompilerHarness/*) CODE=true ;;
               eng/prepare-decompiler-assertion-corpus.sh) CODE=true ;;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,11 +65,16 @@ Console.WriteLine($"Found {items.Count} items");
 
 ## Building and Testing
 
-Build the main project:
+Build the normal product/test/fixture graph:
 
 ```bash
-dotnet build src/dotnet-inspect -c Release
+dotnet build dotnet-inspect.slnx -c Release
 ```
+
+Pack and publish flows remain separate and continue to build/pack
+`src/dotnet-inspect` directly. `DotnetInspector.ILRoundtrip.Tests` is not in the
+default solution because it requires the vendored ILAssembler; run
+`eng/restore-ilassembler.sh` before its targeted test command.
 
 **IMPORTANT: Tests use xunit v3 with `OutputType Exe`. You MUST use `dotnet run`, NOT `dotnet test`. Using `dotnet test` will silently produce no output.**
 

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -65,10 +65,10 @@ entry gate invalidates every later result, so run it first and report it.
 
 "100% green" means all of the following pass on the changed revision:
 
-1. **Build** the product:
+1. **Build** the product/test/fixture graph:
 
    ```bash
-   dotnet build src/dotnet-inspect -c Release
+   dotnet build dotnet-inspect.slnx -c Release
    ```
 
 2. **Focused tests** for the area you touched, run with `dotnet run --project`,

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -1,0 +1,68 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/DiffAsmFixtures.Caller/DiffAsmFixtures.Caller.csproj" />
+    <Project Path="src/DiffAsmFixtures.LibA/DiffAsmFixtures.LibA.csproj" />
+    <Project Path="src/DiffAsmFixtures.LibB/DiffAsmFixtures.LibB.csproj" />
+    <Project Path="src/DiffAsmFixtures.Target/DiffAsmFixtures.Target.csproj" />
+    <Project Path="src/DiffFixtures.V1/DiffFixtures.V1.csproj" />
+    <Project Path="src/DiffFixtures.V2/DiffFixtures.V2.csproj" />
+    <Project Path="src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj" />
+    <Project Path="src/dotnet-inspect/dotnet-inspect.csproj" />
+    <Project Path="src/DotnetInspector.Core/DotnetInspector.Core.csproj" />
+    <Project Path="src/DotnetInspector.Packages/DotnetInspector.Packages.csproj" />
+    <Project Path="src/DotnetInspector.Services.Tests/DotnetInspector.Services.Tests.csproj" />
+    <Project Path="src/DotnetInspector.Services/DotnetInspector.Services.csproj" />
+    <Project Path="src/ILInspector.Analysis.App/ILInspector.Analysis.App.csproj" />
+    <Project Path="src/ILInspector.Analysis.CallerGraphCaller/ILInspector.Analysis.CallerGraphCaller.csproj" />
+    <Project Path="src/ILInspector.Analysis.CallerGraphCallerTwin/ILInspector.Analysis.CallerGraphCallerTwin.csproj" />
+    <Project Path="src/ILInspector.Analysis.CallerGraphLookalikeCaller/ILInspector.Analysis.CallerGraphLookalikeCaller.csproj" />
+    <Project Path="src/ILInspector.Analysis.CallerGraphTarget/ILInspector.Analysis.CallerGraphTarget.csproj" />
+    <Project Path="src/ILInspector.Analysis.CrossAsmCollisionFixtures/ILInspector.Analysis.CrossAsmCollisionFixtures.csproj" />
+    <Project Path="src/ILInspector.Analysis.CrossAsmShapeFixtures/ILInspector.Analysis.CrossAsmShapeFixtures.csproj" />
+    <Project Path="src/ILInspector.Analysis.ExceptionBaseFixtures/ILInspector.Analysis.ExceptionBaseFixtures.csproj" />
+    <Project Path="src/ILInspector.Analysis.FacadeFixtures/ILInspector.Analysis.FacadeFixtures.csproj" />
+    <Project Path="src/ILInspector.Analysis.LookalikeFixtures/ILInspector.Analysis.LookalikeFixtures.csproj" />
+    <Project Path="src/ILInspector.Analysis.ProtobufFixtures/ILInspector.Analysis.ProtobufFixtures.csproj" />
+    <Project Path="src/ILInspector.Analysis.RenderFixtures/ILInspector.Analysis.RenderFixtures.csproj" />
+    <Project Path="src/ILInspector.Analysis.SpoofFixtures/ILInspector.Analysis.SpoofFixtures.csproj" />
+    <Project Path="src/ILInspector.Analysis.SpoofRuntimeFixtures/ILInspector.Analysis.SpoofRuntimeFixtures.csproj" />
+    <Project Path="src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj" />
+    <Project Path="src/ILInspector.Analysis/ILInspector.Analysis.csproj" />
+    <Project Path="src/ILInspector.ControlFlow/ILInspector.ControlFlow.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.CheckedArithmetic/ILInspector.Decompiler.Fixtures.CheckedArithmetic.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.ClassicAsync/ILInspector.Decompiler.Fixtures.ClassicAsync.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.LadderIterator/ILInspector.Decompiler.Fixtures.LadderIterator.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.LadderRung1/ILInspector.Decompiler.Fixtures.LadderRung1.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.LadderRung2/ILInspector.Decompiler.Fixtures.LadderRung2.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.LadderRung3/ILInspector.Decompiler.Fixtures.LadderRung3.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.LadderRung4/ILInspector.Decompiler.Fixtures.LadderRung4.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.LadderRung5/ILInspector.Decompiler.Fixtures.LadderRung5.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.LadderRung9/ILInspector.Decompiler.Fixtures.LadderRung9.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/ILInspector.Decompiler.Fixtures.LegacyUnsafe.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.NewUnsafe/ILInspector.Decompiler.Fixtures.NewUnsafe.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.UnsafeChainA/ILInspector.Decompiler.Fixtures.UnsafeChainA.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.UnsafeChainB/ILInspector.Decompiler.Fixtures.UnsafeChainB.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Fixtures.UnsafeChainC/ILInspector.Decompiler.Fixtures.UnsafeChainC.csproj" />
+    <Project Path="src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj" />
+    <Project Path="src/ILInspector.Decompiler/ILInspector.Decompiler.csproj" />
+    <Project Path="src/ILInspector.Instructions.Tests/ILInspector.Instructions.Tests.csproj" />
+    <Project Path="src/ILInspector.Instructions/ILInspector.Instructions.csproj" />
+    <Project Path="src/ILInspector.Metadata/ILInspector.Metadata.csproj" />
+    <Project Path="src/ILInspector.MetadataPrimitives/ILInspector.MetadataPrimitives.csproj" />
+    <Project Path="src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj" />
+    <Project Path="src/ILInspector.Research/ILInspector.Research.csproj" />
+    <Project Path="src/runfaster.Tests/runfaster.Tests.csproj" />
+    <Project Path="src/runfaster/runfaster.csproj" />
+  </Folder>
+  <Folder Name="/src/runfaster.Tests/Fixtures/">
+    <Project Path="src/runfaster.Tests/Fixtures/RunFaster.AllocationFixture/RunFaster.AllocationFixture.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj" />
+    <Project Path="tests/TestExtensions/TestExtensions.csproj" />
+  </Folder>
+  <Folder Name="/tools/">
+    <Project Path="tools/AnalysisHarness/AnalysisHarness.csproj" />
+    <Project Path="tools/DecompilerHarness/DecompilerHarness.csproj" />
+  </Folder>
+</Solution>

--- a/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
+++ b/src/ILInspector.Metadata/MetadataDeclarationQuery.cs
@@ -157,7 +157,7 @@ public static class MetadataDeclarationQuery
         {
             var field = reader.GetFieldDefinition(fieldHandle);
             var fieldName = reader.GetString(field.Name);
-            if (fieldName.StartsWith('<', StringComparison.Ordinal))
+            if (fieldName.StartsWith("<", StringComparison.Ordinal))
                 continue;
 
             var declaration = GetField(reader, typeDef, field);


### PR DESCRIPTION
## Change

Adds `dotnet-inspect.slnx` as the normal product/test/fixture build graph and updates CI to build it instead of only `src/dotnet-inspect`. Pack/publish paths remain separate and continue to use direct `dotnet pack src/dotnet-inspect` commands.

The default solution includes fixture projects so fixture binaries are produced by the normal build. `DotnetInspector.ILRoundtrip.Tests` stays out of the solution because it requires the vendored ILAssembler and already has a targeted restore/test path.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity minimal
dotnet run --project src/ILInspector.Instructions.Tests -c Release --no-build
npx markdownlint-cli AGENTS.md docs/decompiler-correctness-pipeline.md
git diff --check
```

Low-risk build graph / CI structure change; adversarial review not requested.
