### PR TITLE
Add IL diff display projection

### DIFF
--- a/src/ILInspector.Instructions.Tests/IlDiffPrinterTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlDiffPrinterTests.cs
@@ -1,0 +1,75 @@
+using ILInspector.Instructions;
+
+namespace ILInspector.Instructions.Tests;
+
+public class IlDiffPrinterTests
+{
+    [Fact]
+    public void ToDisplayRow_ProjectsStructuredFieldsWithoutParsingMessage()
+    {
+        var operation = new CanonicalIlOperation(
+            Offset: 10,
+            OpcodeFamily: "call",
+            Operand: new IlOperandIdentity(IlOperandIdentityKind.Token, "int32 [System.Runtime]System.Math::Abs(int32)"));
+        var row = new IlDiffRow(7, IlDiffKind.Add, operation, "Added IL operation 'call int32 [System.Runtime]System.Math::Abs(int32)'");
+
+        var display = IlDiffPrinter.ToDisplayRow(row);
+
+        Assert.Equal(7, display.HunkId);
+        Assert.Equal(IlDiffKind.Add, display.Kind);
+        Assert.Equal("+", display.Marker);
+        Assert.Equal("IL_000A", display.Offset);
+        Assert.Equal("call int32 [System.Runtime]System.Math::Abs(int32)", display.Operation);
+        Assert.Equal(row.Message, display.Message);
+        Assert.Equal("h7 + IL_000A call int32 [System.Runtime]System.Math::Abs(int32)", display.UnifiedLine);
+    }
+
+    [Theory]
+    [InlineData(IlDiffKind.Add, "+")]
+    [InlineData(IlDiffKind.Remove, "-")]
+    [InlineData(IlDiffKind.Context, " ")]
+    public void ToDisplayRow_UsesUnifiedDiffMarkers(IlDiffKind kind, string marker)
+    {
+        var row = new IlDiffRow(
+            0,
+            kind,
+            new CanonicalIlOperation(0, "nop", Operand: null),
+            "row message");
+
+        var display = IlDiffPrinter.ToDisplayRow(row);
+
+        Assert.Equal(marker, display.Marker);
+    }
+
+    [Fact]
+    public void RenderUnified_RendersRowsInProducerFormat()
+    {
+        var left = MethodInstructions.Decode([0x16, 0x2a], 2, []);
+        var right = MethodInstructions.Decode([0x17, 0x2a], 2, []);
+        var diff = IlBodyDiff.Compare(left, right);
+
+        var text = IlDiffPrinter.RenderUnified(diff);
+
+        Assert.Equal(
+            """
+            h0 - IL_0000 ldc.i4 0
+            h0 + IL_0000 ldc.i4 1
+            """,
+            text);
+    }
+
+    [Fact]
+    public void ToDisplayResult_PreservesFailureAsProducerOwnedDisplay()
+    {
+        var diff = new IlBodyDiffResult(
+            IsExact: false,
+            Failure: "old body decode failed",
+            Rows: []);
+
+        var display = IlDiffPrinter.ToDisplayResult(diff);
+
+        Assert.Equal("IL diff failed: old body decode failed", display.Failure);
+        Assert.Empty(display.Rows);
+        Assert.Equal(["IL diff failed: old body decode failed"], IlDiffPrinter.ToUnifiedLines(diff));
+    }
+}

--- a/src/ILInspector.Instructions.Tests/IlDiffPrinterTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlDiffPrinterTests.cs
@@ -18,7 +18,11 @@ public class IlDiffPrinterTests
         Assert.Equal(7, display.HunkId);
         Assert.Equal(IlDiffKind.Add, display.Kind);
         Assert.Equal("+", display.Marker);
+        Assert.Equal(10, display.RawOffset);
         Assert.Equal("IL_000A", display.Offset);
+        Assert.Equal("call", display.OpcodeFamily);
+        Assert.Equal(IlOperandIdentityKind.Token, display.OperandKind);
+        Assert.Equal("int32 [System.Runtime]System.Math::Abs(int32)", display.OperandValue);
         Assert.Equal("call int32 [System.Runtime]System.Math::Abs(int32)", display.Operation);
         Assert.Equal(row.Message, display.Message);
         Assert.Equal("h7 + IL_000A call int32 [System.Runtime]System.Math::Abs(int32)", display.UnifiedLine);
@@ -71,5 +75,28 @@ public class IlDiffPrinterTests
         Assert.Equal("IL diff failed: old body decode failed", display.Failure);
         Assert.Empty(display.Rows);
         Assert.Equal(["IL diff failed: old body decode failed"], IlDiffPrinter.ToUnifiedLines(diff));
+    }
+
+    [Fact]
+    public void ToUnifiedLines_PreservesRowsWhenFailureCarriesPartialEvidence()
+    {
+        var row = new IlDiffRow(
+            0,
+            IlDiffKind.Remove,
+            new CanonicalIlOperation(0, "nop", Operand: null),
+            "Removed IL operation 'nop'");
+        var diff = new IlBodyDiffResult(
+            IsExact: false,
+            Failure: "partial decode failed",
+            Rows: [row]);
+
+        var lines = IlDiffPrinter.ToUnifiedLines(diff);
+
+        Assert.Equal(
+            [
+                "IL diff failed: partial decode failed",
+                "h0 - IL_0000 nop",
+            ],
+            lines);
     }
 }

--- a/src/ILInspector.Instructions/IlDiffPrinter.cs
+++ b/src/ILInspector.Instructions/IlDiffPrinter.cs
@@ -7,7 +7,11 @@ public sealed record IlDiffDisplayRow(
     int HunkId,
     IlDiffKind Kind,
     string Marker,
+    int RawOffset,
     string Offset,
+    string OpcodeFamily,
+    IlOperandIdentityKind? OperandKind,
+    string? OperandValue,
     string Operation,
     string Message)
 {
@@ -31,7 +35,11 @@ public static class IlDiffPrinter
             row.HunkId,
             row.Kind,
             Marker(row.Kind),
+            row.Operation.Offset,
             $"IL_{row.Operation.Offset:X4}",
+            row.Operation.OpcodeFamily,
+            row.Operation.Operand?.Kind,
+            row.Operation.Operand?.Value,
             row.Operation.Display,
             row.Message);
 
@@ -52,9 +60,10 @@ public static class IlDiffPrinter
     public static ImmutableArray<string> ToUnifiedLines(IlBodyDiffResult result)
     {
         var display = ToDisplayResult(result);
-        if (display.Failure is { } failure)
-            return [failure];
-        return [.. display.Rows.Select(row => row.UnifiedLine)];
+        var rows = display.Rows.Select(row => row.UnifiedLine);
+        return display.Failure is { } failure
+            ? [failure, .. rows]
+            : [.. rows];
     }
 
     public static string RenderUnified(IlBodyDiffResult result)

--- a/src/ILInspector.Instructions/IlDiffPrinter.cs
+++ b/src/ILInspector.Instructions/IlDiffPrinter.cs
@@ -1,0 +1,80 @@
+using System.Collections.Immutable;
+using System.Text;
+
+namespace ILInspector.Instructions;
+
+public sealed record IlDiffDisplayRow(
+    int HunkId,
+    IlDiffKind Kind,
+    string Marker,
+    string Offset,
+    string Operation,
+    string Message)
+{
+    public string UnifiedLine => $"h{HunkId} {Marker} {Offset} {Operation}";
+}
+
+public sealed record IlDiffDisplayResult(
+    string? Failure,
+    ImmutableArray<IlDiffDisplayRow> Rows)
+{
+    public bool IsEmpty => Failure is null && Rows.IsEmpty;
+}
+
+/// <summary>
+/// Producer-owned display projection for IL body diff evidence.
+/// </summary>
+public static class IlDiffPrinter
+{
+    public static IlDiffDisplayRow ToDisplayRow(IlDiffRow row)
+        => new(
+            row.HunkId,
+            row.Kind,
+            Marker(row.Kind),
+            $"IL_{row.Operation.Offset:X4}",
+            row.Operation.Display,
+            row.Message);
+
+    public static ImmutableArray<IlDiffDisplayRow> ToDisplayRows(IEnumerable<IlDiffRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        return [.. rows.Select(ToDisplayRow)];
+    }
+
+    public static IlDiffDisplayResult ToDisplayResult(IlBodyDiffResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        return new IlDiffDisplayResult(
+            result.Failure is { Length: > 0 } failure ? $"IL diff failed: {failure}" : null,
+            ToDisplayRows(result.Rows));
+    }
+
+    public static ImmutableArray<string> ToUnifiedLines(IlBodyDiffResult result)
+    {
+        var display = ToDisplayResult(result);
+        if (display.Failure is { } failure)
+            return [failure];
+        return [.. display.Rows.Select(row => row.UnifiedLine)];
+    }
+
+    public static string RenderUnified(IlBodyDiffResult result)
+    {
+        var lines = ToUnifiedLines(result);
+        if (lines.IsEmpty)
+            return "";
+
+        var builder = new StringBuilder();
+        foreach (string line in lines)
+            builder.AppendLine(line);
+        return builder.ToString().TrimEnd();
+    }
+
+    static string Marker(IlDiffKind kind)
+        => kind switch
+        {
+            IlDiffKind.Add => "+",
+            IlDiffKind.Remove => "-",
+            IlDiffKind.Context => " ",
+            _ => "?",
+        };
+}


### PR DESCRIPTION
## Summary

- add `IlDiffPrinter` in `ILInspector.Instructions` as the producer-owned display projection for IL diff evidence
- expose structured `IlDiffDisplayRow` fields plus unified diff line rendering
- cover add/remove/context markers, IL offset formatting, row message preservation, unified rendering, and failure display

This follows the #2291 direction that each lower-layer differ owns its row/evidence printer while ResearchDiff composes/projects typed rows.

## Validation

```text
dotnet run --project src/ILInspector.Instructions.Tests/ILInspector.Instructions.Tests.csproj -c Release --no-restore -- -filter "/*/*/IlDiffPrinterTests/*"
dotnet run --project src/ILInspector.Instructions.Tests/ILInspector.Instructions.Tests.csproj -c Release --no-restore
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config --verbosity quiet
```
