### PR TITLE
Score fixture guarantee per declared fixture, not the global union (#2293)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
@@ -237,6 +237,35 @@ public class AssertionScanTests
     }
 
     [Fact]
+    public void ObservedFromDeclaredFixtures_IgnoresSiblingFixtureIncidentalProduction()
+    {
+        // A node is scored only against the fixtures that DECLARE it. A sibling
+        // fixture incidentally producing the node must not count — otherwise an
+        // inert declared producer free-rides on the sibling's coverage (#2289's
+        // IsPattern masking, tracked as #2293).
+        var perFixture = new Dictionary<string, IReadOnlyDictionary<string, int>>(StringComparer.Ordinal)
+        {
+            ["assertion.inverse-node-coverage"] = new Dictionary<string, int>(StringComparer.Ordinal),
+            ["assertion.union-switch"] = new Dictionary<string, int>(StringComparer.Ordinal) { ["IsPattern"] = 3 },
+        };
+
+        // Declared only against the coverage fixture, which does not produce it here,
+        // so the sibling union-switch coverage is ignored and it scores 0 (a regression).
+        Assert.Equal(0, AssertionScan.ObservedFromDeclaredFixtures(
+            ["assertion.inverse-node-coverage"], perFixture, "IsPattern"));
+
+        // Once the declared fixture itself produces the node, it counts.
+        perFixture["assertion.inverse-node-coverage"] =
+            new Dictionary<string, int>(StringComparer.Ordinal) { ["IsPattern"] = 2 };
+        Assert.Equal(2, AssertionScan.ObservedFromDeclaredFixtures(
+            ["assertion.inverse-node-coverage"], perFixture, "IsPattern"));
+
+        // A node covered by a declared fixture that was never scanned scores 0.
+        Assert.Equal(0, AssertionScan.ObservedFromDeclaredFixtures(
+            ["assertion.missing"], perFixture, "IsPattern"));
+    }
+
+    [Fact]
     public void AssertionPrinter_MarksNonFinalStagesObligation_FinalStageUnsound()
     {
         // A LoadArgument occupying an enum sink with no Coerce is an undischarged

--- a/tools/DecompilerHarness/AssertionScan.cs
+++ b/tools/DecompilerHarness/AssertionScan.cs
@@ -369,13 +369,17 @@ internal static class AssertionScan
             }
         }
 
-        var aggregate = scans.Aggregate(Merge);
         var guarantee = BuildFixtureGuarantee(
             string.Join(", ", declaredFixtureIds.Order(StringComparer.Ordinal)),
             annotatedNodes,
             causeByNode,
             perFixtureCoverage);
-        return aggregate with { FixtureGuarantee = guarantee };
+        // scans is empty only in a broken dev state (every declared fixture id missing
+        // from the catalog and no unbox fixture); report it as zero coverage — every
+        // node regresses — rather than throwing an opaque Aggregate-on-empty exception.
+        if (scans.Count == 0)
+            return new Result([], new SortedDictionary<string, int>(StringComparer.Ordinal), annotatedNodes, causeByNode, guarantee);
+        return scans.Aggregate(Merge) with { FixtureGuarantee = guarantee };
     }
 
     static AssertionFixtureGuaranteeResult BuildFixtureGuarantee(

--- a/tools/DecompilerHarness/AssertionScan.cs
+++ b/tools/DecompilerHarness/AssertionScan.cs
@@ -326,60 +326,102 @@ internal static class AssertionScan
         int? workers,
         bool sequential)
     {
-        var fixtureIds = AssertionFixtureGuarantees
-            .SelectMany(pair => pair.FixtureIds)
-            .Where(id => id != AssertionIlUnboxFixture)
+        var declaredFixtureIds = AssertionFixtureGuarantees
+            .SelectMany(g => g.FixtureIds)
             .Distinct(StringComparer.Ordinal)
-            .ToHashSet(StringComparer.Ordinal);
-        var fixtures = GeneratedFixtureCatalog.Catalog
-            .Where(fixture => fixtureIds.Contains(fixture.Id))
             .ToArray();
-        var csharpResult = GeneratedFixtureRunner.RunWithMaterializedFixtures(
-            fixtures,
-            GeneratedFixtureRunOptions.Default,
-            (_, assemblyPath) =>
-            {
-                return EvaluateAssemblies([assemblyPath], null, workers, sequential, annotatedNodes, causeByNode);
-            });
 
-        var unboxFixture = BuildUnboxFixtureAssembly();
-        try
+        // Score each node against coverage from its OWN declared fixture(s). The C#
+        // fixtures compile into one combined assembly, so scanning them together mixes
+        // their coverage — a sibling fixture's incidental production would then mask an
+        // inert declared producer (the #2289 IsPattern masking). Build and scan each
+        // declared fixture in isolation so the declared producer must exercise the node.
+        var perFixtureCoverage = new Dictionary<string, IReadOnlyDictionary<string, int>>(StringComparer.Ordinal);
+        var scans = new List<Result>();
+
+        foreach (var fixtureId in declaredFixtureIds
+            .Where(id => id != AssertionIlUnboxFixture)
+            .Order(StringComparer.Ordinal))
         {
-            var unboxResult = EvaluateAssemblies([unboxFixture.Path], null, workers, sequential, annotatedNodes, causeByNode);
-            var scan = Merge(csharpResult, unboxResult);
-            var guarantee = BuildFixtureGuarantee(
-                string.Join(", ", AssertionFixtureGuarantees
-                    .SelectMany(g => g.FixtureIds)
-                    .Distinct(StringComparer.Ordinal)
-                    .Order(StringComparer.Ordinal)),
-                annotatedNodes,
-                causeByNode,
-                scan.CoverageByNode);
-            return scan with { FixtureGuarantee = guarantee };
+            var fixture = GeneratedFixtureCatalog.Catalog.FirstOrDefault(f => f.Id == fixtureId);
+            if (fixture is null)
+                continue;
+            var fixtureScan = GeneratedFixtureRunner.RunWithMaterializedFixtures(
+                [fixture],
+                GeneratedFixtureRunOptions.Default,
+                (_, assemblyPath) => EvaluateAssemblies([assemblyPath], null, workers, sequential, annotatedNodes, causeByNode));
+            perFixtureCoverage[fixtureId] = fixtureScan.CoverageByNode;
+            scans.Add(fixtureScan);
         }
-        finally
+
+        if (declaredFixtureIds.Contains(AssertionIlUnboxFixture))
         {
-            TryDeleteDirectory(unboxFixture.Directory);
+            var unboxFixture = BuildUnboxFixtureAssembly();
+            try
+            {
+                var unboxScan = EvaluateAssemblies([unboxFixture.Path], null, workers, sequential, annotatedNodes, causeByNode);
+                perFixtureCoverage[AssertionIlUnboxFixture] = unboxScan.CoverageByNode;
+                scans.Add(unboxScan);
+            }
+            finally
+            {
+                TryDeleteDirectory(unboxFixture.Directory);
+            }
         }
+
+        var aggregate = scans.Aggregate(Merge);
+        var guarantee = BuildFixtureGuarantee(
+            string.Join(", ", declaredFixtureIds.Order(StringComparer.Ordinal)),
+            annotatedNodes,
+            causeByNode,
+            perFixtureCoverage);
+        return aggregate with { FixtureGuarantee = guarantee };
     }
 
     static AssertionFixtureGuaranteeResult BuildFixtureGuarantee(
-        string assemblyPath,
+        string fixtureIds,
         IReadOnlyList<string> annotatedNodes,
         IReadOnlyDictionary<string, InverseLedger.NodeCause> causeByNode,
-        IReadOnlyDictionary<string, int> coverageByNode)
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> perFixtureCoverage)
     {
         var fixturesByNode = AssertionFixtureGuarantees
             .ToDictionary(g => g.Node, g => g.FixtureIds, StringComparer.Ordinal);
         var rows = annotatedNodes
-            .Select(node => new AssertionFixtureNodeResult(
-                node,
-                causeByNode.TryGetValue(node, out var cause) ? cause : InverseLedger.CauseFor(node),
-                fixturesByNode.TryGetValue(node, out var fixtures) ? fixtures : [],
-                coverageByNode.GetValueOrDefault(node)))
+            .Select(node =>
+            {
+                var declared = fixturesByNode.TryGetValue(node, out var fixtures) ? fixtures : [];
+                return new AssertionFixtureNodeResult(
+                    node,
+                    causeByNode.TryGetValue(node, out var cause) ? cause : InverseLedger.CauseFor(node),
+                    declared,
+                    ObservedFromDeclaredFixtures(declared, perFixtureCoverage, node));
+            })
             .OrderBy(row => row.Node, StringComparer.Ordinal)
             .ToArray();
-        return new AssertionFixtureGuaranteeResult(assemblyPath, coverageByNode, rows);
+        return new AssertionFixtureGuaranteeResult(fixtureIds, AggregateCoverage(perFixtureCoverage), rows);
+    }
+
+    /// <summary>
+    /// A node's observed coverage counted only from the fixtures that DECLARE it. A
+    /// sibling fixture's incidental production of the node does not count — the declared
+    /// producer must itself exercise the node, so an inert declared fixture cannot pass
+    /// by free-riding on another fixture's coverage (#2293).
+    /// </summary>
+    internal static int ObservedFromDeclaredFixtures(
+        IReadOnlyList<string> declaredFixtureIds,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> perFixtureCoverage,
+        string node)
+        => declaredFixtureIds.Sum(id =>
+            perFixtureCoverage.TryGetValue(id, out var coverage) ? coverage.GetValueOrDefault(node) : 0);
+
+    static IReadOnlyDictionary<string, int> AggregateCoverage(
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, int>> perFixtureCoverage)
+    {
+        var coverage = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        foreach (var fixtureCoverage in perFixtureCoverage.Values)
+            foreach (var (node, count) in fixtureCoverage)
+                coverage[node] = coverage.GetValueOrDefault(node) + count;
+        return coverage;
     }
 
     internal static IReadOnlyList<string> NodesWithoutFixtureGuarantee(IReadOnlyList<string> annotatedNodes)


### PR DESCRIPTION
## Summary

Closes #2293. `BuildFixtureGuarantee` marked a node `Pass` from the **global** coverage union across all guarantee fixtures, so a node whose *declared* fixture failed to produce it still passed if any **sibling** fixture produced it incidentally. This masked the #2289 `IsPattern` gap: the inert ternary `IsPatternBind` reported `Pass` only because `assertion.union-switch`'s type-pattern arms produced `IsPattern`.

## Change (harness/test only — product-inert)

- The C# guarantee fixtures compile into one combined assembly, so scanning them together mixes their coverage. `EvaluateFixtureGuarantee` now **builds and scans each declared fixture in isolation** and records per-fixture coverage.
- `BuildFixtureGuarantee` scores every node against coverage from its **own declared `FixtureIds`** via `ObservedFromDeclaredFixtures` — a sibling fixture's incidental production no longer counts, so an inert declared producer regresses instead of free-riding.
- The report's aggregate `CoverageByNode` (informational "distinct nodes exercised") stays the global union.

## Evidence

- **Corpus guarantee stays `66/66`, alarms `(none)`** under per-fixture scoring — post-#2289 every declared producer genuinely produces its own node, so the tightening is behavior-preserving for the current tree while closing the loophole.
- New unit test `ObservedFromDeclaredFixtures_IgnoresSiblingFixtureIncidentalProduction`: a node declared against the coverage fixture scores 0 when only a sibling (`union-switch`) produces it, and >0 once its declared fixture produces it.
- `AssertionScanTests` 16/16.

Cost: the guarantee lane now runs one build per distinct declared C# fixture (coverage + union-switch) instead of one combined build — a couple extra builds in a scheduled/local lane, not the per-PR loop.

## Review

Harness correctness change to the assertion lane — requesting two-model adversarial review per policy.
