### PR TITLE
Add RTS IL diff diagnostics

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1073,6 +1073,7 @@ public class GeneratedFixtureCatalogTests
             && result.Method == "get_Method1");
         Assert.Equal(GeneratedFixtureReturnToSenderStatus.Pass, propertyGetter.Status);
         Assert.Equal(FidelityCheck.CompileBackStatus.Exact, propertyGetter.ActualStatus);
+        Assert.Null(propertyGetter.IlDiffDiagnostic);
 
         Assert.Contains(run.Results, result =>
             result.FixtureId == "minimal.method-call.same-type"
@@ -1090,6 +1091,39 @@ public class GeneratedFixtureCatalogTests
             result => result.GetProperty("Status").GetString() == "Pass");
         Assert.DoesNotContain(document.RootElement.GetProperty("Results").EnumerateArray(),
             result => result.GetProperty("Reason").GetString() == "constructor-target");
+    }
+
+    [Fact]
+    public void ReturnToSenderCatalogReport_IncludesIlDiffDiagnosticsWhenPresent()
+    {
+        var run = new GeneratedFixtureReturnToSenderRunResult(
+            ProjectDirectory: "",
+            AssemblyPath: "",
+            Results:
+            [
+                new GeneratedFixtureReturnToSenderResult(
+                    "test.il-diff-diagnostic",
+                    "TestType",
+                    "Method1",
+                    Overload: 0,
+                    GeneratedFixtureReturnToSenderStatus.Fail,
+                    FidelityCheck.CompileBackStatus.OpcodeDiff,
+                    "opcode-diff",
+                    Detail: null,
+                    IlDiffDiagnostic:
+                    """
+                    h0 - IL_0000 ldc.i4 1
+                    h0 + IL_0000 ldc.i4 2
+                    """,
+                    IsFrontier: false,
+                    Note: null),
+            ]);
+
+        string report = GeneratedFixtureRunner.FormatReturnToSenderCatalogReport(run, maxExamples: 10);
+
+        Assert.Contains("il-diff:", report);
+        Assert.Contains("h0 - IL_0000 ldc.i4 1", report);
+        Assert.Contains("h0 + IL_0000 ldc.i4 2", report);
     }
 
     [Fact]
@@ -1226,6 +1260,8 @@ public class GeneratedFixtureCatalogTests
         Assert.Equal(GeneratedFixtureReturnToSenderStatus.Fail, result.Status);
         Assert.Equal(FidelityCheck.CompileBackStatus.OpcodeDiff, result.ActualStatus);
         Assert.Equal("opcode-diff", result.Reason);
+        Assert.NotNull(result.IlDiffDiagnostic);
+        Assert.Contains("IL_", result.IlDiffDiagnostic);
         Assert.DoesNotContain("target-body-fragment-missing", report);
     }
 

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -2062,6 +2062,7 @@ internal sealed record GeneratedFixtureReturnToSenderResult(
     FidelityCheck.CompileBackStatus? ActualStatus,
     string Reason,
     string? Detail,
+    string? IlDiffDiagnostic,
     bool IsFrontier,
     string? Note)
 {
@@ -2194,6 +2195,7 @@ internal static class GeneratedFixtureRunner
                             : missingTargetBodyFragment is not null
                                 ? $"missing expected target body fragment: {missingTargetBodyFragment}"
                                 : actual.Detail,
+                        actual.IlDiffDiagnostic,
                         target.IsFrontier,
                         target.Note));
                 }
@@ -2227,6 +2229,7 @@ internal static class GeneratedFixtureRunner
             ActualStatus: null,
             reason,
             Detail: null,
+            IlDiffDiagnostic: null,
             target.IsFrontier,
             target.Note);
 
@@ -2389,6 +2392,12 @@ internal static class GeneratedFixtureRunner
                     sb.AppendLine($"      {row.DisplayMember}  rts={actual}  bucket={row.Reason}");
                     if (!string.IsNullOrWhiteSpace(row.Detail))
                         sb.AppendLine($"      detail: {row.Detail}");
+                    if (!string.IsNullOrWhiteSpace(row.IlDiffDiagnostic))
+                    {
+                        sb.AppendLine("      il-diff:");
+                        foreach (string line in row.IlDiffDiagnostic.Split('\n'))
+                            sb.AppendLine($"        {line.TrimEnd('\r')}");
+                    }
                 }
             }
         }

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -7,6 +7,7 @@ using System.Text;
 using DotnetInspector.Services;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Instructions;
 using ILInspector.Metadata;
 
 using Microsoft.CodeAnalysis;
@@ -27,7 +28,8 @@ static class ReturnToSender
         string OriginalOpcodes,
         string RecompiledOpcodes,
         string? Detail,
-        string TargetBody = "");
+        string TargetBody = "",
+        string? IlDiffDiagnostic = null);
 
     public sealed record RequestedTarget(string Type, string Method, int Overload);
 
@@ -668,6 +670,7 @@ static class ReturnToSender
                 var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
                     ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
                     .ToArray();
+                var ilDiffDiagnostic = BuildIlDiffDiagnostic(reader, pe, getter, recompiled, fullType, methodName, overload: 0);
 
                 if (recompiledOps is null)
                 {
@@ -689,7 +692,8 @@ static class ReturnToSender
                     string.Join(" ", originalOps),
                     string.Join(" ", recompiledOps),
                     null,
-                    TargetBody: printed.Output);
+                    TargetBody: printed.Output,
+                    IlDiffDiagnostic: ilDiffDiagnostic);
             }
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
@@ -816,6 +820,7 @@ static class ReturnToSender
                 var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
                     ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
                     .ToArray();
+                var ilDiffDiagnostic = BuildIlDiffDiagnostic(reader, pe, method, recompiled, fullType, methodName, overload: 0);
 
                 if (recompiledOps is null)
                 {
@@ -837,7 +842,8 @@ static class ReturnToSender
                     string.Join(" ", originalOps),
                     string.Join(" ", recompiledOps),
                     null,
-                    TargetBody: printed.Output);
+                    TargetBody: printed.Output,
+                    IlDiffDiagnostic: ilDiffDiagnostic);
             }
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
@@ -965,6 +971,7 @@ static class ReturnToSender
                 var recompiledOps = FindAndDisassemble(recompiled, fullType, methodName, overload: 0)
                     ?.Select(instruction => CanonicalOpcode(instruction.OpCodeName))
                     .ToArray();
+                var ilDiffDiagnostic = BuildIlDiffDiagnostic(reader, pe, setter, recompiled, fullType, methodName, overload: 0);
 
                 if (recompiledOps is null)
                 {
@@ -986,7 +993,8 @@ static class ReturnToSender
                     string.Join(" ", originalOps),
                     string.Join(" ", recompiledOps),
                     null,
-                    TargetBody: printed.Output);
+                    TargetBody: printed.Output,
+                    IlDiffDiagnostic: ilDiffDiagnostic);
             }
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
@@ -1199,6 +1207,15 @@ static class ReturnToSender
         string fullType,
         string methodName,
         int overload)
+        => FindMethodDefinition(pe, fullType, methodName, overload) is { } found
+            ? ILDisassembler.Disassemble(pe, found.Reader, found.Method)
+            : null;
+
+    static (MetadataReader Reader, MethodDefinition Method)? FindMethodDefinition(
+        PEReader pe,
+        string fullType,
+        string methodName,
+        int overload)
     {
         if (!pe.HasMetadata)
             return null;
@@ -1218,11 +1235,36 @@ static class ReturnToSender
                     continue;
                 if (seen++ != overload)
                     continue;
-                return ILDisassembler.Disassemble(pe, reader, method);
+                return (reader, method);
             }
         }
 
         return null;
+    }
+
+    static string? BuildIlDiffDiagnostic(
+        MetadataReader originalReader,
+        PEReader originalPe,
+        MethodDefinition originalMethod,
+        PEReader recompiledPe,
+        string fullType,
+        string methodName,
+        int overload)
+    {
+        if (originalMethod.RelativeVirtualAddress == 0)
+            return null;
+        if (FindMethodDefinition(recompiledPe, fullType, methodName, overload) is not { } recompiled)
+            return null;
+        if (recompiled.Method.RelativeVirtualAddress == 0)
+            return null;
+
+        var diff = IlBodyDiff.Compare(
+            originalReader,
+            originalPe.GetMethodBody(originalMethod.RelativeVirtualAddress),
+            recompiled.Reader,
+            recompiledPe.GetMethodBody(recompiled.Method.RelativeVirtualAddress));
+        string rendered = IlDiffPrinter.RenderUnified(diff);
+        return string.IsNullOrWhiteSpace(rendered) ? null : rendered;
     }
 
     static IEnumerable<MetadataReference> CompilationReferences(string targetPath)


### PR DESCRIPTION
## Summary

- add non-gating `IlDiffDiagnostic` evidence to `ReturnToSender.Result`
- compute diagnostics from successful RTS recompiles via `IlBodyDiff` + `IlDiffPrinter`
- surface IL diff diagnostics in generated RTS catalog failure examples
- cover exact no-diagnostic and opcode-diff diagnostic paths in generated fixture tests

This starts RTS as a consumer of the product IL diff/printer substrate without changing pass/fail classification.

## Validation

```text
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-restore -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release -- --return-to-sender-catalog minimal.property.literal --max-examples 3
```
