### PR TITLE
Cast cross-signedness conditional arms at a numeric join (#2302)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -4328,6 +4328,14 @@ public static class EnumCastSamples
 
     // #1806: the fallback of `Nullable<cross-assembly enum> ?? enumConstant`
     // needs the same structural enum cast as conditional arms.
+    // #2302: a same-width cross-signedness constant arm at a numeric join. A `uint`
+    // coalesce fallback of `uint.MaxValue` lowers to `ldc.i4.m1`, so a bare `-1` arm
+    // at the `uint` join is CS0019 (`??`) / CS0029; it must render the target-aware
+    // `unchecked((uint)(-1))`. Mirrors the enum coalesce/conditional arm contract for
+    // the plain numeric-primitive join.
+    public static uint CrossSignCoalesceConstant(uint? value)
+        => value ?? uint.MaxValue;
+
     public static System.StringComparison EnumCoalesce(System.StringComparison? value)
         => value ?? System.StringComparison.Ordinal;
 

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -65,6 +65,18 @@ public class EnumCastPrinterTests
         AssertCompiles("public static StringComparison M(StringComparison? value)", body);
     }
 
+    // #2302: the same join-arm contract for a plain numeric-primitive out-of-range
+    // constant — a bare `-1` at a `uint` coalesce is CS0019, so it must reinterpret.
+    [Fact]
+    public void CrossSignCoalesce_OutOfRangeConstant_UncheckedReinterprets()
+    {
+        string body = RenderFixture(nameof(EnumCastSamples.CrossSignCoalesceConstant));
+
+        Assert.Contains("unchecked((uint)(-1))", body);
+        Assert.DoesNotContain("?? -1", body);
+        AssertCompiles("public static uint M(uint? value)", body);
+    }
+
     [Fact]
     public void EnumSwitchExpression_ReturningCrossAssemblyEnum_CastsArms()
     {

--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -101,6 +101,53 @@ public class PrinterPrecedenceTests
         Assert.DoesNotContain(": u;", output);
     }
 
+    // Issue #2302: a same-width cross-signedness *constant* arm keeps the
+    // target-aware spelling — in-range bare, out-of-range unchecked reinterpret —
+    // so a negative int constant at a uint join is `unchecked((uint)(-1))`, not
+    // the bare `-1` that is CS0173.
+    [Fact]
+    public void Conditional_OutOfRangeConstantArm_UncheckedReinterpretsToJoin()
+    {
+        var conditional = new Conditional(
+            new LoadArgument(0, "flag", s_bool),
+            new LoadArgument(1, "u", s_uint),
+            new Constant(-1, s_int))
+        {
+            MergedType = s_uint,
+        };
+
+        var output = PrintReturn(
+            conditional,
+            s_uint,
+            [new Parameter("flag", s_bool), new Parameter("u", s_uint)]);
+
+        Assert.Contains("unchecked((uint)(-1))", output);
+        Assert.DoesNotContain(": -1", output);
+    }
+
+    // Issue #2302 (Gemini review): the cast is only spelled for a *same-width*
+    // sibling. A differing-width join (int arm at a short join) is a narrowing the
+    // printer must not silently introduce, so no truncating `(short)` cast appears.
+    [Fact]
+    public void Conditional_DifferingWidthArm_DoesNotEmitNarrowingCast()
+    {
+        var s_short = TypeRef.CoreLib("System", "Int16");
+        var conditional = new Conditional(
+            new LoadArgument(0, "flag", s_bool),
+            new LoadArgument(1, "s", s_short),
+            new LoadArgument(2, "i", s_int))
+        {
+            MergedType = s_short,
+        };
+
+        var output = PrintReturn(
+            conditional,
+            s_short,
+            [new Parameter("flag", s_bool), new Parameter("s", s_short), new Parameter("i", s_int)]);
+
+        Assert.DoesNotContain("(short)i", output);
+    }
+
     static string PrintReturn(IrExpression value, TypeRef returnType, ImmutableArray<Parameter> parameters)
     {
         var block = new Block();

--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -10,6 +10,7 @@ public class PrinterPrecedenceTests
 {
     static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef s_uint = TypeRef.CoreLib("System", "UInt32");
 
     static IrFunction Raised(string methodName)
     {
@@ -73,6 +74,31 @@ public class PrinterPrecedenceTests
 
         Assert.Contains("(a ? b : c) ? d : e", output);
         Assert.DoesNotContain("a ? b : c ? d", output);
+    }
+
+    // Issue #2302: an arm whose signedness (or width) disagrees with the numeric
+    // join renders CS0266 bare (`flag ? s : u` with `u` a uint at an int join).
+    // The join spells the faithful same-stack-family reinterpretation cast on the
+    // disagreeing arm; the agreeing arm and implicit widenings stay bare.
+    [Fact]
+    public void Conditional_CrossSignednessArm_CastsToJoinType()
+    {
+        var conditional = new Conditional(
+            new LoadArgument(0, "flag", s_bool),
+            new LoadArgument(1, "s", s_int),
+            new LoadArgument(2, "u", s_uint))
+        {
+            MergedType = s_int,
+        };
+
+        var output = PrintReturn(
+            conditional,
+            s_int,
+            [new Parameter("flag", s_bool), new Parameter("s", s_int), new Parameter("u", s_uint)]);
+
+        // The int arm stays bare; the uint arm takes the reinterpretation cast.
+        Assert.Contains("flag ? s : (int)u", output);
+        Assert.DoesNotContain(": u;", output);
     }
 
     static string PrintReturn(IrExpression value, TypeRef returnType, ImmutableArray<Parameter> parameters)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1279,17 +1279,19 @@ public sealed partial class CSharpPrinter
             && EnumUnderlyingType(EffectiveType(arm)) is { } underlying
             && TypeFamilies.Of(underlying) == TypeFamilies.Of(integerTarget))
             return $"({TypeText(integerTarget)}){Operand(arm)}";
-        // A non-constant same-stack-family arm whose signedness or width disagrees
-        // with the numeric join is CS0266 bare (a `uint` arm at an `int` join, or a
-        // narrowing sibling). Reinterpret its bits with the join cast — unchecked
-        // inside a checked region so the faithful reinterpretation cannot become a
-        // runtime overflow (#2302, #2301). NeedsNumericCast gates to exactly the
-        // same-family casts that are not implicit widenings; a constant keeps its own
-        // in-range/unchecked spelling and converts to the join implicitly when in range.
-        if (arm is not Constant
-            && target is { } numericTarget
-            && TypeFamilies.NeedsNumericCast(EffectiveType(arm), numericTarget))
-            return CheckedSafeCast($"({TypeText(numericTarget)}){Operand(arm)}");
+        // A same-WIDTH cross-signedness arm at a numeric join is CS0266 bare (a `uint`
+        // arm at an `int` join). Reinterpret its bits with the join cast — unchecked
+        // inside a checked region so the value-preserving reinterpretation cannot become
+        // a runtime overflow (#2302, #2301). SameWidth keeps this to the genuinely
+        // lossless sibling casts (int/uint, short/ushort, byte/sbyte, long/ulong,
+        // ushort/char); a differing-width join is a narrowing the printer must not
+        // silently introduce, so it is left to a real Convert node in the IL.
+        if (target is { } numericTarget
+            && TypeFamilies.NeedsNumericCast(EffectiveType(arm), numericTarget)
+            && TypeFamilies.SameWidth(EffectiveType(arm), numericTarget))
+            return arm is Constant { Value: int or long } constArm
+                ? NumericConstant(constArm, numericTarget)
+                : CheckedSafeCast($"({TypeText(numericTarget)}){Operand(arm)}");
         return null;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1275,11 +1275,22 @@ public sealed partial class CSharpPrinter
         // Same stack family only: `(int)longBackedEnum` would truncate. The
         // importer's family merge should never build such a join, but the cast
         // must not be the place that finds out (slice-4 review's verify item).
-        return target is { } integerTarget && TypeFamilies.IsIntegerLike(integerTarget)
+        if (target is { } integerTarget && TypeFamilies.IsIntegerLike(integerTarget)
             && EnumUnderlyingType(EffectiveType(arm)) is { } underlying
-            && TypeFamilies.Of(underlying) == TypeFamilies.Of(integerTarget)
-            ? $"({TypeText(integerTarget)}){Operand(arm)}"
-            : null;
+            && TypeFamilies.Of(underlying) == TypeFamilies.Of(integerTarget))
+            return $"({TypeText(integerTarget)}){Operand(arm)}";
+        // A non-constant same-stack-family arm whose signedness or width disagrees
+        // with the numeric join is CS0266 bare (a `uint` arm at an `int` join, or a
+        // narrowing sibling). Reinterpret its bits with the join cast — unchecked
+        // inside a checked region so the faithful reinterpretation cannot become a
+        // runtime overflow (#2302, #2301). NeedsNumericCast gates to exactly the
+        // same-family casts that are not implicit widenings; a constant keeps its own
+        // in-range/unchecked spelling and converts to the join implicitly when in range.
+        if (arm is not Constant
+            && target is { } numericTarget
+            && TypeFamilies.NeedsNumericCast(EffectiveType(arm), numericTarget))
+            return CheckedSafeCast($"({TypeText(numericTarget)}){Operand(arm)}");
+        return null;
     }
 
     string? TryConditionalTextForTarget(Conditional conditional, TypeRef target)


### PR DESCRIPTION
## Summary

Closes #2302 (and closes the checked-region hazard #2301 for the conditional-arm path). A conditional / switch-expression / coalesce **arm** whose signedness or width disagrees with the numeric join rendered **CS0266 bare** — a `uint` arm at an `int` join (`flag ? s : u`). F1 (#2295) cleared the shipped corpus population by wrapping such arms in `Coerce` at fold time, but the printer's own arm path (`TryCoerceJoinArm`) still emitted the bare form for any shape the fold gate refuses to wrap. This routes the arm rendering through the same spelling contract, so the printer is not a second, weaker spelling authority.

## Change

`CSharpPrinter.TryCoerceJoinArm` gains one branch: a non-constant arm whose `EffectiveType` needs a numeric cast to the join spells the faithful reinterpretation cast on that arm.

- Gated by `TypeFamilies.NeedsNumericCast` — exactly the **same-stack-family** casts that are **not** implicit widenings (`uint`→`int`, narrowing siblings). A `byte` arm at an `int` join stays bare (implicit); a constant keeps its own in-range/unchecked spelling.
- The cast goes through `CheckedSafeCast`, so inside a lexical `checked { }` region it spells `unchecked((T)x)` — the reinterpretation cannot become a runtime `OverflowException` (#2301, for this path).
- Only the **disagreeing arm** is cast (the merge node itself is never cast — CoerceText's CS0030 bail is preserved).

## Evidence

- **Render-text A/B vs merge-base (`74d70793`): `Changed: 0`, `Regressions: 0` across 89,065 methods.** The change is inert on the live corpus — F1 already wraps the reachable cases at fold time — so this is a **defensive renderer hardening** that closes the latent class for shapes the fold gate refuses, with zero corpus churn.
- Synthetic printer test `Conditional_CrossSignednessArm_CastsToJoinType` (`PrinterPrecedenceTests`): a `uint` arm at an `int` join renders `flag ? s : (int)u`, the `int` arm stays bare. (Synthetic IR, matching the file's existing unreachable-shape convention.)
- `ILInspector.Decompiler.Tests` fast suite: **1860/1860**.

## Scope note

The related `SpinThenBlockingWait` live CS0266 (`uint V_1 = V_0 ? 0 : Environment.TickCount`) is a **store**-coercion gap (an `int` ternary stored to a `uint` slot), not an arm-vs-join gap — the arm renderer never sees the `uint` slot target. That is a distinct mechanism (coercion-insertion) tracked separately per the #2302 triage comment.

## Review

Decompiler/printer change — requesting two-model adversarial review per policy.
