### PR TITLE
Add shared fixture catalog loader

### DIFF
--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -58,6 +58,7 @@
     <Project Path="src/runfaster.Tests/Fixtures/RunFaster.AllocationFixture/RunFaster.AllocationFixture.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/DotnetInspector.Fixtures/DotnetInspector.Fixtures.csproj" />
     <Project Path="tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj" />
     <Project Path="tests/TestExtensions/TestExtensions.csproj" />
   </Folder>

--- a/src/ILInspector.Analysis.Tests/BodySignalDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/BodySignalDiffTests.cs
@@ -1,4 +1,5 @@
 using ILInspector.Analysis;
+using DotnetInspector.Fixtures;
 
 namespace ILInspector.Analysis.Tests;
 
@@ -7,8 +8,8 @@ public class BodySignalDiffTests
     [Fact]
     public void CompareUnsafe_SurfacesAddedUnsafeOperation()
     {
-        var oldIndex = LibraryBodyIndex.Open(DiffFixturePath("DiffFixtures.V1"));
-        var newIndex = LibraryBodyIndex.Open(DiffFixturePath("DiffFixtures.V2"));
+        var oldIndex = LibraryBodyIndex.Open(FixtureCatalog.DiffPair.OldAssemblyPath());
+        var newIndex = LibraryBodyIndex.Open(FixtureCatalog.DiffPair.NewAssemblyPath());
 
         var diff = BodySignalDiff.CompareUnsafe(oldIndex, newIndex);
 
@@ -21,7 +22,7 @@ public class BodySignalDiffTests
     [Fact]
     public void CompareUnsafe_SelfDiffHasNoRows()
     {
-        var index = LibraryBodyIndex.Open(DiffFixturePath("DiffFixtures.V2"));
+        var index = LibraryBodyIndex.Open(FixtureCatalog.DiffPair.NewAssemblyPath());
 
         var diff = BodySignalDiff.CompareUnsafe(index, index);
 
@@ -115,16 +116,6 @@ public class BodySignalDiffTests
         var added = Assert.Single(diff.Rows);
         Assert.Equal(BodySignalDiffKind.Added, added.Kind);
         Assert.Null(added.ILOffset);
-    }
-
-    static string DiffFixturePath(string project)
-    {
-        var outputDirectory = new DirectoryInfo(
-            AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        string path = Path.GetFullPath(Path.Combine(
-            outputDirectory.FullName, "..", "..", project, outputDirectory.Name, "DiffFixtureSample.dll"));
-        Assert.True(File.Exists(path), $"Expected diff fixture assembly at {path}");
-        return path;
     }
 
     static MethodIdentity DiffMethod(TypeRef declaring, string name)

--- a/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
+++ b/src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj
@@ -42,6 +42,7 @@
     <ProjectReference Include="..\ILInspector.Analysis\ILInspector.Analysis.csproj" />
     <ProjectReference Include="..\DotnetInspector.Services\DotnetInspector.Services.csproj" />
     <ProjectReference Include="..\..\tools\AnalysisHarness\AnalysisHarness.csproj" />
+    <ProjectReference Include="..\..\tests\DotnetInspector.Fixtures\DotnetInspector.Fixtures.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Fixtures;
 using ILInspector.Instructions;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
@@ -172,8 +173,8 @@ public class IlBodyDiffTests
     [Fact]
     public void Compare_TokenOperandWithoutMetadata_FailsClosed()
     {
-        var left = DiffFixtureMethod("DiffFixtures.V1", "StringToken");
-        var right = DiffFixtureMethod("DiffFixtures.V2", "StringToken");
+        var left = DiffFixtureMethod(FixtureCatalog.DiffPair.Old, "StringToken");
+        var right = DiffFixtureMethod(FixtureCatalog.DiffPair.New, "StringToken");
 
         var diff = IlBodyDiff.Compare(left, right);
 
@@ -290,8 +291,8 @@ public class IlBodyDiffTests
 
     static IlBodyDiffResult DiffFixtureDiff(string name)
     {
-        using var oldStream = File.OpenRead(DiffFixturePath("DiffFixtures.V1"));
-        using var newStream = File.OpenRead(DiffFixturePath("DiffFixtures.V2"));
+        using var oldStream = File.OpenRead(FixtureCatalog.DiffPair.OldAssemblyPath());
+        using var newStream = File.OpenRead(FixtureCatalog.DiffPair.NewAssemblyPath());
         using var oldPe = new PEReader(oldStream);
         using var newPe = new PEReader(newStream);
         var oldReader = oldPe.GetMetadataReader();
@@ -303,9 +304,9 @@ public class IlBodyDiffTests
             DiffFixtureMethodBody(newPe, newReader, name));
     }
 
-    static MethodInstructions DiffFixtureMethod(string project, string name)
+    static MethodInstructions DiffFixtureMethod(FixtureDefinition fixture, string name)
     {
-        using var stream = File.OpenRead(DiffFixturePath(project));
+        using var stream = File.OpenRead(fixture.AssemblyPath());
         using var peReader = new PEReader(stream);
         var metadataReader = peReader.GetMetadataReader();
         return MethodInstructions.Decode(DiffFixtureMethodBody(peReader, metadataReader, name));
@@ -323,13 +324,4 @@ public class IlBodyDiffTests
         throw new InvalidOperationException($"Could not find method '{name}'.");
     }
 
-    static string DiffFixturePath(string project)
-    {
-        var outputDirectory = new DirectoryInfo(
-            AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        string path = Path.GetFullPath(Path.Combine(
-            outputDirectory.FullName, "..", "..", project, outputDirectory.Name, "DiffFixtureSample.dll"));
-        Assert.True(File.Exists(path), $"Expected diff fixture assembly at {path}");
-        return path;
-    }
 }

--- a/src/ILInspector.Decompiler.Fixtures.ClassicAsync/ILInspector.Decompiler.Fixtures.ClassicAsync.csproj
+++ b/src/ILInspector.Decompiler.Fixtures.ClassicAsync/ILInspector.Decompiler.Fixtures.ClassicAsync.csproj
@@ -6,8 +6,8 @@
     AsyncTaskMethodBuilder state machines — the dominant real-world async form, which
     the runtime-async CoreLib corpus never exercises.
 
-    On-demand only: deliberately NOT referenced by the test project or any CI gate.
-    Build it, then point the harness at the DLL in library-report mode to measure the
+    Built by the normal solution graph and addressable through FixtureCatalog.
+    Point the harness at the built DLL in library-report mode to measure the
     classic-async gap (see tools/DecompilerHarness/README.md).
   -->
   <PropertyGroup>

--- a/src/ILInspector.Decompiler.Tests/ClassicAsyncTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ClassicAsyncTests.cs
@@ -1,5 +1,5 @@
+using DotnetInspector.Fixtures;
 using System;
-using System.IO;
 using System.Linq;
 using Xunit;
 using ILInspector.Decompiler.Pipeline;
@@ -11,13 +11,7 @@ public class ClassicAsyncTests
     [Fact]
     public void DumpMethod_WithClassicAsync_ResolvesImportAndReconstructsAwait()
     {
-        string fixturePath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "artifacts", "bin", "ILInspector.Decompiler.Fixtures.ClassicAsync", "release", "ILInspector.Decompiler.Fixtures.ClassicAsync.dll");
-        if (!File.Exists(fixturePath))
-            fixturePath = Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "artifacts", "bin", "ILInspector.Decompiler.Fixtures.ClassicAsync", "release", "ILInspector.Decompiler.Fixtures.ClassicAsync.dll");
-            
-        Assert.True(File.Exists(fixturePath), "ClassicAsync fixture DLL not found");
-
-        var source = MetadataSource.OpenWithoutSymbols(fixturePath);
+        var source = MetadataSource.OpenWithoutSymbols(FixtureCatalog.DecompilerClassicAsync.AssemblyPath());
         var dump = StageDump.DumpMethod(source, "ILInspector.Decompiler.Fixtures.ClassicAsync.AsyncFixtures", "AwaitValue");
         
         Assert.NotNull(dump.Output);

--- a/src/ILInspector.Decompiler.Tests/DiffFixtureFidelityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DiffFixtureFidelityTests.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Fixtures;
 using ILInspector.DecompilerHarness;
 
 namespace ILInspector.Decompiler.Tests;
@@ -17,32 +18,23 @@ public class DiffFixtureFidelityTests
     ];
 
     [Theory]
-    [InlineData("DiffFixtures.V1")]
-    [InlineData("DiffFixtures.V2")]
-    public void DiffFocusedFixtures_StayCompileBackCheckable(string project)
+    [InlineData(FixtureIds.DiffV1)]
+    [InlineData(FixtureIds.DiffV2)]
+    public void DiffFocusedFixtures_StayCompileBackCheckable(string fixtureId)
     {
-        var results = FidelityCheck.Evaluate(DiffFixturePath(project));
+        var fixture = FixtureCatalog.Get(fixtureId);
+        var results = FidelityCheck.Evaluate(fixture.AssemblyPath());
         foreach (string method in DiffFocusedMethods)
         {
             var matches = results.Where(result => result.Method == method).ToArray();
-            Assert.True(matches.Length > 0, $"Expected fidelity check to evaluate {project}.{method}.");
+            Assert.True(matches.Length > 0, $"Expected fidelity check to evaluate {fixture.Id}.{method}.");
             Assert.All(matches, result =>
                 Assert.True(
                     result.Status is FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff,
-                    $"{project}.{method} regressed to {result.Status}: the paired diff fixture must remain decompiler compile-back checkable.\n"
+                    $"{fixture.Id}.{method} regressed to {result.Status}: the paired diff fixture must remain decompiler compile-back checkable.\n"
                         + $"  original : {result.OriginalOpcodes}\n"
                         + $"  recompiled: {result.RecompiledOpcodes}\n"
                         + $"  detail   : {result.Detail}"));
         }
-    }
-
-    static string DiffFixturePath(string project)
-    {
-        var outputDirectory = new DirectoryInfo(
-            AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        string path = Path.GetFullPath(Path.Combine(
-            outputDirectory.FullName, "..", "..", project, outputDirectory.Name, "DiffFixtureSample.dll"));
-        Assert.True(File.Exists(path), $"Expected diff fixture assembly at {path}");
-        return path;
     }
 }

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -41,6 +41,7 @@
     <ProjectReference Include="..\ILInspector.Decompiler.Fixtures.LadderIterator\ILInspector.Decompiler.Fixtures.LadderIterator.csproj" />
     <ProjectReference Include="..\DiffFixtures.V1\DiffFixtures.V1.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffFixtures.V2\DiffFixtures.V2.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\tests\DotnetInspector.Fixtures\DotnetInspector.Fixtures.csproj" />
   </ItemGroup>
 
   <!--

--- a/src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj
+++ b/src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\DiffFixtures.V2\DiffFixtures.V2.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
     <ProjectReference Include="..\ILInspector.Research\ILInspector.Research.csproj" />
+    <ProjectReference Include="..\..\tests\DotnetInspector.Fixtures\DotnetInspector.Fixtures.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Fixtures;
 using ILInspector.Metadata;
 using ILInspector.Instructions;
 
@@ -176,8 +177,8 @@ public class ResearchDiffTests
     public void CompareAssemblies_BodySignals_QueryUnsafeAddedChange()
     {
         var diff = ResearchDiff.CompareAssemblies(
-            DiffFixturePath("DiffFixtures.V1"),
-            DiffFixturePath("DiffFixtures.V2"),
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
             new ResearchDiffOptions(ResearchDiffMechanism.BodySignals));
 
         var unsafeMembers = diff.MembersWhere(member => member.HasChange("unsafe.stackalloc.added"));
@@ -192,8 +193,8 @@ public class ResearchDiffTests
     public void CompareAssemblies_IlBody_QueryImplementationChanges()
     {
         var diff = ResearchDiff.CompareAssemblies(
-            DiffFixturePath("DiffFixtures.V1"),
-            DiffFixturePath("DiffFixtures.V2"),
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
             new ResearchDiffOptions(ResearchDiffMechanism.IlBody));
 
         var changedMembers = diff.MembersWhere(member => member.ImplementationChanged);
@@ -234,13 +235,4 @@ public class ResearchDiffTests
             Attributes = attributes?.ToList() ?? [],
         };
 
-    static string DiffFixturePath(string project)
-    {
-        var outputDirectory = new DirectoryInfo(
-            AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        string path = Path.GetFullPath(Path.Combine(
-            outputDirectory.FullName, "..", "..", project, outputDirectory.Name, "DiffFixtureSample.dll"));
-        Assert.True(File.Exists(path), $"Expected diff fixture assembly at {path}");
-        return path;
-    }
 }

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -1,5 +1,6 @@
 using System.IO.Compression;
 using System.Text.Json;
+using DotnetInspector.Fixtures;
 using DotnetInspector.Commands;
 using DotnetInspector.Core;
 using DotnetInspector.Models;
@@ -4498,12 +4499,8 @@ public class CommandExecutionTests
         var (packagePath, tempDir) = CreateLocalRefPackage("System.Runtime");
         try
         {
-            var diffV1 = Path.GetFullPath(Path.Combine(
-                Path.GetDirectoryName(TestAssemblyPath)!, "..", "..",
-                "DiffFixtures.V1", "release", "DiffFixtureSample.dll"));
-            var diffV2 = Path.GetFullPath(Path.Combine(
-                Path.GetDirectoryName(TestAssemblyPath)!, "..", "..",
-                "DiffFixtures.V2", "release", "DiffFixtureSample.dll"));
+            var diffV1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+            var diffV2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
             List<string[]> commands =
             [

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Fixtures;
 using ILInspector.Metadata;
 using DotnetInspector.Commands;
 using DotnetInspector.Output;
@@ -232,8 +233,8 @@ public class DiffCommandTests
     [Fact]
     public void BuildAnalysisDiff_VersionPair_SurfacesSeededRegressionAndImprovement()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var result = DiffCommand.BuildAnalysisDiff([v1], [v2], new DiffOptions { ChangedOnly = true });
 
@@ -258,8 +259,8 @@ public class DiffCommandTests
     [Fact]
     public void BuildAnalysisDiff_VersionPair_SurfacesHotnessOnlyAllocationRegression()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var result = DiffCommand.BuildAnalysisDiff([v1], [v2], new DiffOptions { ChangedOnly = true });
 
@@ -294,7 +295,7 @@ public class DiffCommandTests
     [Fact]
     public void BuildAnalysisDiff_Identity_SelfDiffHasNoSpuriousDeltas()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
 
         // Full diff: self-diff must have neither in-place deltas nor spurious
         // added/removed rows.
@@ -306,16 +307,6 @@ public class DiffCommandTests
         var changedOnly = DiffCommand.BuildAnalysisDiff([v1], [v1], new DiffOptions { ChangedOnly = true });
         Assert.Empty(changedOnly.Rows);
         Assert.Equal("No in-place analysis signal changes detected.", changedOnly.Summary);
-    }
-
-    static string DiffFixturePath(string project)
-    {
-        var outputDirectory = new System.IO.DirectoryInfo(
-            System.AppContext.BaseDirectory.TrimEnd(System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar));
-        string path = System.IO.Path.GetFullPath(System.IO.Path.Combine(
-            outputDirectory.FullName, "..", "..", project, outputDirectory.Name, "DiffFixtureSample.dll"));
-        Assert.True(System.IO.File.Exists(path), $"Expected diff fixture assembly at {path}");
-        return path;
     }
 
     static ApiSurface DiffSurface(params ApiMember[] members)

--- a/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
+++ b/src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\dotnet-inspect\dotnet-inspect.csproj" />
     <ProjectReference Include="..\DiffFixtures.V1\DiffFixtures.V1.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffFixtures.V2\DiffFixtures.V2.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\tests\DotnetInspector.Fixtures\DotnetInspector.Fixtures.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/DotnetInspector.Fixtures/DotnetInspector.Fixtures.csproj
+++ b/tests/DotnetInspector.Fixtures/DotnetInspector.Fixtures.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
+++ b/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
@@ -1,0 +1,104 @@
+namespace DotnetInspector.Fixtures;
+
+public sealed record FixtureDefinition(
+    string Id,
+    string ProjectName,
+    string AssemblyFileName,
+    IReadOnlyList<string> Tags)
+{
+    public string AssemblyPath() => FixtureCatalog.AssemblyPath(Id);
+}
+
+public sealed record FixturePair(string Id, FixtureDefinition Old, FixtureDefinition New)
+{
+    public string OldAssemblyPath() => Old.AssemblyPath();
+    public string NewAssemblyPath() => New.AssemblyPath();
+}
+
+public sealed record FixtureGroup(string Id, IReadOnlyList<FixtureDefinition> Fixtures);
+
+public static class FixtureIds
+{
+    public const string DiffV1 = "diff.v1";
+    public const string DiffV2 = "diff.v2";
+    public const string DecompilerClassicAsync = "decompiler.classic-async";
+}
+
+public static class FixtureCatalog
+{
+    public static readonly FixtureDefinition DiffV1 = new(
+        FixtureIds.DiffV1,
+        "DiffFixtures.V1",
+        "DiffFixtureSample.dll",
+        ["diff", "version-pair", "analysis", "decompiler", "rts-candidate"]);
+
+    public static readonly FixtureDefinition DiffV2 = new(
+        FixtureIds.DiffV2,
+        "DiffFixtures.V2",
+        "DiffFixtureSample.dll",
+        ["diff", "version-pair", "analysis", "decompiler", "rts-candidate"]);
+
+    public static readonly FixtureDefinition DecompilerClassicAsync = new(
+        FixtureIds.DecompilerClassicAsync,
+        "ILInspector.Decompiler.Fixtures.ClassicAsync",
+        "ILInspector.Decompiler.Fixtures.ClassicAsync.dll",
+        ["decompiler", "async", "classic-async", "rts-candidate"]);
+
+    public static readonly FixturePair DiffPair = new("diff", DiffV1, DiffV2);
+
+    public static readonly FixtureGroup ReturnToSenderCandidates = new(
+        "rts.candidates",
+        [DiffV1, DiffV2, DecompilerClassicAsync]);
+
+    static readonly Dictionary<string, FixtureDefinition> s_byId = new(StringComparer.Ordinal)
+    {
+        [DiffV1.Id] = DiffV1,
+        [DiffV2.Id] = DiffV2,
+        [DecompilerClassicAsync.Id] = DecompilerClassicAsync,
+    };
+
+    public static FixtureDefinition Get(string id)
+        => s_byId.TryGetValue(id, out var fixture)
+            ? fixture
+            : throw new ArgumentException($"Unknown fixture id '{id}'.", nameof(id));
+
+    public static string AssemblyPath(string id)
+    {
+        var fixture = Get(id);
+        string configuration = CurrentConfiguration();
+        string root = RepositoryRoot();
+        string path = Path.Combine(
+            root,
+            "artifacts",
+            "bin",
+            fixture.ProjectName,
+            configuration,
+            fixture.AssemblyFileName);
+
+        if (File.Exists(path))
+            return path;
+
+        throw new FileNotFoundException(
+            $"Expected built fixture '{fixture.Id}' at {path}. Run 'dotnet build dotnet-inspect.slnx -c Release' before running harnesses or tests that consume fixture binaries.",
+            path);
+    }
+
+    static string CurrentConfiguration()
+    {
+        var outputDirectory = new DirectoryInfo(
+            AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        return outputDirectory.Name;
+    }
+
+    static string RepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "dotnet-inspect.slnx")))
+                return directory.FullName;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate the repository root from '{AppContext.BaseDirectory}'. Run tests from a dotnet-inspect checkout after building 'dotnet-inspect.slnx'.");
+    }
+}


### PR DESCRIPTION
## Change

Adds a neutral `DotnetInspector.Fixtures` test utility project with a stable fixture catalog and loader for already-built fixture binaries. The loader resolves fixture assemblies from the normal `dotnet-inspect.slnx` artifacts and fails with an explicit build instruction instead of compiling or probing ad hoc paths.

Initial catalog entries:

- `diff.v1` / `diff.v2` plus the `diff` pair
- `decompiler.classic-async`
- `rts.candidates` group metadata for forward-looking Return-to-Sender consumers

Migrates the duplicated DiffFixtures and ClassicAsync fixture path helpers in analysis, CLI, and decompiler tests to the shared loader. Compile-back coverage is kept working but not expanded.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity minimal
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/BodySignalDiffTests/*"
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/IlBodyDiffTests/*"
dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -filter "/*/*/DiffCommandTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -filter "/*/*/ClassicAsyncTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -filter "/*/*/DiffFixtureFidelityTests/*"
git diff --check
```

Fixture/test infrastructure only; no product behavior change.
