### PR TITLE
Join-arm third direction + checked-region reinterpret wrap: 3 live CS0266 fixes (#2302, #2301)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -183,6 +183,132 @@ public class CoerceChokePointTests
         AssertCompiles("public static LEnum M()", body, "public enum LEnum : long { Low = 0, High = 2 }");
     }
 
+    // #2302 canaries: the join-arm rule's third direction — a primitive arm at
+    // a same-family primitive MergedType it cannot reach implicitly. The
+    // pre-F1 fold shipped these bare (CS0029/CS0266); the latent class needs
+    // synthetic fixtures because F1 cleared the live corpus population.
+    [Fact]
+    public void NegativeConstantArm_AtUnsignedMergedType_ReintepretsUnchecked()
+    {
+        var uintType = TypeRef.CoreLib("System", "UInt32");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var conditional = new Conditional(
+            new LoadArgument(0, "c", boolType),
+            new LoadArgument(1, "u", uintType),
+            new Constant(-1, intType))
+        {
+            MergedType = uintType,
+        };
+        string body = RenderReturn(
+            conditional,
+            uintType,
+            [new Parameter("c", boolType), new Parameter("u", uintType)],
+            TypeRef.Definition("synthetic", "", "UnusedEnum"));
+
+        Assert.Contains("c ? u : unchecked((uint)(-1))", body);
+        AssertCompiles("public static uint M(bool c, uint u)", body);
+    }
+
+    [Fact]
+    public void NonConstantIntArm_AtUnsignedMergedType_TakesReinterpretCast()
+    {
+        var uintType = TypeRef.CoreLib("System", "UInt32");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var conditional = new Conditional(
+            new LoadArgument(0, "c", boolType),
+            new LoadArgument(1, "u", uintType),
+            new LoadArgument(2, "x", intType))
+        {
+            MergedType = uintType,
+        };
+        string body = RenderReturn(
+            conditional,
+            uintType,
+            [new Parameter("c", boolType), new Parameter("u", uintType), new Parameter("x", intType)],
+            TypeRef.Definition("synthetic", "", "UnusedEnum"));
+
+        Assert.Contains("c ? u : (uint)x", body);
+        AssertCompiles("public static uint M(bool c, uint u, int x)", body);
+    }
+
+    [Fact]
+    public void InRangeConstantArm_AtUnsignedMergedType_StaysBare()
+    {
+        // C#'s implicit constant conversion covers in-range constants — the
+        // masked case the F1 review exposed. It must stay bare (no cast churn).
+        var uintType = TypeRef.CoreLib("System", "UInt32");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var conditional = new Conditional(
+            new LoadArgument(0, "c", boolType),
+            new LoadArgument(1, "u", uintType),
+            new Constant(0, intType))
+        {
+            MergedType = uintType,
+        };
+        string body = RenderReturn(
+            conditional,
+            uintType,
+            [new Parameter("c", boolType), new Parameter("u", uintType)],
+            TypeRef.Definition("synthetic", "", "UnusedEnum"));
+
+        Assert.Contains("c ? u : 0", body);
+        Assert.DoesNotContain("(uint)0", body);
+        AssertCompiles("public static uint M(bool c, uint u)", body);
+    }
+
+    [Fact]
+    public void ImplicitlyWideningArm_AtLongMergedType_StaysBare()
+    {
+        // int -> long is an implicit conversion; NeedsNumericCast gates the
+        // third direction so implicitly-reachable arms never gain cast churn.
+        var longType = TypeRef.CoreLib("System", "Int64");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var conditional = new Conditional(
+            new LoadArgument(0, "c", boolType),
+            new LoadArgument(1, "l", longType),
+            new LoadArgument(2, "x", intType))
+        {
+            MergedType = longType,
+        };
+        string body = RenderReturn(
+            conditional,
+            longType,
+            [new Parameter("c", boolType), new Parameter("l", longType), new Parameter("x", intType)],
+            TypeRef.Definition("synthetic", "", "UnusedEnum"));
+
+        Assert.Contains("c ? l : x", body);
+        Assert.DoesNotContain("(long)x", body);
+        AssertCompiles("public static long M(bool c, long l, int x)", body);
+    }
+
+    // #2301: a cross-signedness reinterpret cast rendered inside a lexical
+    // checked region must wrap in unchecked(...) — bare `(uint)x` there
+    // recompiles to a conv.ovf.u4 the IL never had (and throws on negative x).
+    [Fact]
+    public void CrossSignednessCoerce_InsideCheckedBinary_WrapsUnchecked()
+    {
+        var uintType = TypeRef.CoreLib("System", "UInt32");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var checkedAdd = new Binary(
+            BinaryKind.Add,
+            isChecked: true,
+            isUnsigned: false,
+            new LoadArgument(0, "u", uintType),
+            new Coerce(uintType, new LoadArgument(1, "x", intType)));
+        string body = RenderReturn(
+            checkedAdd,
+            uintType,
+            [new Parameter("u", uintType), new Parameter("x", intType)],
+            TypeRef.Definition("synthetic", "", "UnusedEnum"));
+
+        Assert.Contains("unchecked((uint)x)", body);
+        AssertCompiles("public static uint M(uint u, int x)", body);
+    }
+
     static string RenderReturn(
         IrExpression value,
         TypeRef returnType,

--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -391,6 +391,33 @@ public class CoerceChokePointTests
         AssertCompiles("public static uint M(bool c, uint u, int a, int b)", body);
     }
 
+    // The CI-caught dual pair: an enum->underlying cast in a checked region
+    // wraps only when the checked conversion can actually throw. Identity
+    // (int-backed -> int) stays bare — EnumUnderlyingCastTests pins that side;
+    // cross-signedness (uint-backed -> int) must wrap.
+    [Fact]
+    public void UnsignedBackedEnumCast_ToInt_InCheckedRegion_WrapsUnchecked()
+    {
+        var enumType = TypeRef.Definition("synthetic", "", "UFlags");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var uintType = TypeRef.CoreLib("System", "UInt32");
+        var checkedAdd = new Binary(
+            BinaryKind.Add,
+            isChecked: true,
+            isUnsigned: false,
+            new Coerce(intType, new LoadArgument(0, "f", enumType)),
+            new LoadArgument(1, "x", intType));
+        string body = RenderReturn(
+            checkedAdd,
+            intType,
+            [new Parameter("f", enumType), new Parameter("x", intType)],
+            enumType,
+            underlying: uintType);
+
+        Assert.Contains("unchecked((int)f)", body);
+        AssertCompiles("public static int M(UFlags f, int x)", body, "public enum UFlags : uint { }");
+    }
+
     // #2301: a cross-signedness reinterpret cast rendered inside a lexical
     // checked region must wrap in unchecked(...) — bare `(uint)x` there
     // recompiles to a conv.ovf.u4 the IL never had (and throws on negative x).

--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -285,6 +285,112 @@ public class CoerceChokePointTests
         AssertCompiles("public static long M(bool c, long l, int x)", body);
     }
 
+    // work-2302 review (both reviewers, blocking): the unchecked(...) wrapper
+    // must not absorb NESTED checked operations — a checked add renders bare
+    // under an ambient checked region, so wrapping its pre-rendered text
+    // silenced its overflow check (`unchecked((uint)(a + b))` where the IL
+    // demands `unchecked((uint)checked(a + b))`). CheckedSafeCast now renders
+    // its operand with the context cleared so nested checked nodes self-wrap.
+    [Fact]
+    public void CheckedAddUnderCoerce_InCheckedRegion_KeepsItsOwnCheckedWrapper()
+    {
+        var uintType = TypeRef.CoreLib("System", "UInt32");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var checkedInner = new Binary(
+            BinaryKind.Add,
+            isChecked: true,
+            isUnsigned: false,
+            new LoadArgument(1, "a", intType),
+            new LoadArgument(2, "b", intType));
+        var outer = new Binary(
+            BinaryKind.Add,
+            isChecked: true,
+            isUnsigned: false,
+            new LoadArgument(0, "u", uintType),
+            new Coerce(uintType, checkedInner));
+        string body = RenderReturn(
+            outer,
+            uintType,
+            [new Parameter("u", uintType), new Parameter("a", intType), new Parameter("b", intType)],
+            TypeRef.Definition("synthetic", "", "UnusedEnum"));
+
+        Assert.Contains("unchecked((uint)checked(a + b))", body);
+        AssertCompiles("public static uint M(uint u, int a, int b)", body);
+    }
+
+    [Fact]
+    public void PlainAddUnderCoerce_InCheckedRegion_StaysInsideTheUncheckedWrapper()
+    {
+        // The dual: a PLAIN add under the reinterpret needs no checked(...) —
+        // the cleared context renders it bare and the unchecked wrapper is its
+        // faithful home (no double-wrap noise).
+        var uintType = TypeRef.CoreLib("System", "UInt32");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var plainInner = new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(1, "a", intType),
+            new LoadArgument(2, "b", intType));
+        var outer = new Binary(
+            BinaryKind.Add,
+            isChecked: true,
+            isUnsigned: false,
+            new LoadArgument(0, "u", uintType),
+            new Coerce(uintType, plainInner));
+        string body = RenderReturn(
+            outer,
+            uintType,
+            [new Parameter("u", uintType), new Parameter("a", intType), new Parameter("b", intType)],
+            TypeRef.Definition("synthetic", "", "UnusedEnum"));
+
+        Assert.Contains("unchecked((uint)(a + b))", body);
+        Assert.DoesNotContain("checked(a + b)", body.Replace("unchecked((uint)(a + b))", ""));
+        AssertCompiles("public static uint M(uint u, int a, int b)", body);
+    }
+
+    [Fact]
+    public void CheckedAddArm_AtUnsignedMergedType_InCheckedRegion_KeepsItsCheckedWrapper()
+    {
+        // The join-arm form of the same finding: the third-direction arm cast
+        // must protect checked arithmetic inside the arm.
+        var uintType = TypeRef.CoreLib("System", "UInt32");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var checkedArm = new Binary(
+            BinaryKind.Add,
+            isChecked: true,
+            isUnsigned: false,
+            new LoadArgument(2, "a", intType),
+            new LoadArgument(3, "b", intType));
+        var conditional = new Conditional(
+            new LoadArgument(0, "c", boolType),
+            new LoadArgument(1, "u", uintType),
+            checkedArm)
+        {
+            MergedType = uintType,
+        };
+        var outer = new Binary(
+            BinaryKind.Add,
+            isChecked: true,
+            isUnsigned: false,
+            new Constant(0, uintType),
+            conditional);
+        string body = RenderReturn(
+            outer,
+            uintType,
+            [
+                new Parameter("c", boolType),
+                new Parameter("u", uintType),
+                new Parameter("a", intType),
+                new Parameter("b", intType),
+            ],
+            TypeRef.Definition("synthetic", "", "UnusedEnum"));
+
+        Assert.Contains("unchecked((uint)checked(a + b))", body);
+        AssertCompiles("public static uint M(bool c, uint u, int a, int b)", body);
+    }
+
     // #2301: a cross-signedness reinterpret cast rendered inside a lexical
     // checked region must wrap in unchecked(...) — bare `(uint)x` there
     // recompiles to a conv.ovf.u4 the IL never had (and throws on negative x).

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -164,9 +164,35 @@ public sealed partial class CSharpPrinter
     /// <c>conv.ovf.*.un</c> it never had if it falls inside a <c>checked</c> context,
     /// silently adding an overflow check; the wrapper keeps the reinterpretation
     /// range-check-free. A no-op outside a checked region.
+    ///
+    /// The cast text renders THROUGH the thunk with the checked context
+    /// CLEARED whenever the wrapper will apply: nested checked nodes
+    /// (<c>add.ovf</c>/<c>conv.ovf</c>) omit their own <c>checked(...)</c>
+    /// under an ambient checked region, so wrapping their pre-rendered text in
+    /// <c>unchecked(...)</c> silently turned their overflow checks off —
+    /// <c>unchecked((uint)(a + b))</c> where the IL demands
+    /// <c>unchecked((uint)checked(a + b))</c> (work-2302 review, both
+    /// reviewers, product-path repro). Clearing the flag makes the nested
+    /// nodes re-emit their explicit wrappers; only the reinterpret itself goes
+    /// unchecked.
     /// </summary>
-    string CheckedSafeCast(string castText, bool force = false)
-        => _checkedContext || force ? $"unchecked({castText})" : castText;
+    string CheckedSafeCast(Func<string> renderCast, bool force = false)
+    {
+        if (!_checkedContext && !force)
+            return renderCast();
+        bool enclosing = _checkedContext;
+        _checkedContext = false;
+        string castText;
+        try
+        {
+            castText = renderCast();
+        }
+        finally
+        {
+            _checkedContext = enclosing;
+        }
+        return $"unchecked({castText})";
+    }
 
     /// <summary>
     /// Casts an integer operand to the enum type it is compared or combined with
@@ -184,7 +210,7 @@ public sealed partial class CSharpPrinter
             || value is Constant { Value: long lv } && lv < 0;
         bool forceUnchecked = MayOverflowEnumBackingType(value, enumType);
         return CheckedSafeCast(
-            $"({TypeText(enumType)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}",
+            () => $"({TypeText(enumType)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}",
             force: forceUnchecked);
     }
 
@@ -223,7 +249,7 @@ public sealed partial class CSharpPrinter
         if (enumSide is null || !IsEnumLikeInteger(enumSide))
             return null;
         if (TypeFamilies.IsBoolean(EffectiveType(value)))
-            return CheckedSafeCast($"({TypeText(enumSide)})({Condition(value)} ? 1 : 0)");
+            return CheckedSafeCast(() => $"({TypeText(enumSide)})({Condition(value)} ? 1 : 0)");
         if (value.ResultType is not { } valueType || !TypeFamilies.IsIntegerLike(valueType))
             return null;
         return value is Constant { Value: int or long } konst
@@ -690,9 +716,8 @@ public sealed partial class CSharpPrinter
         var unsigned = TypeFamilies.UnsignedCounterpart(EffectiveType(operand));
         if (unsigned is null)
             return Operand(operand);
-        string cast = $"({TypeText(unsigned)}){Operand(operand)}";
         bool constantOutOfRange = wrapConstantCast && TryGetIntegerConstant(operand, out long value) && !TypeFamilies.ConstantFits(value, unsigned);
-        return CheckedSafeCast(cast, force: constantOutOfRange);
+        return CheckedSafeCast(() => $"({TypeText(unsigned)}){Operand(operand)}", force: constantOutOfRange);
     }
 
     /// <summary>
@@ -761,7 +786,7 @@ public sealed partial class CSharpPrinter
     // already carries its own narrowing Convert (int32-typed by the time it lands
     // here), and small ints widen to int implicitly, so neither needs a cast.
     string IntShiftCount(IrExpression count)
-        => NeedsIntShiftCast(EffectiveType(count)) ? CheckedSafeCast($"(int){Operand(count)}") : Operand(count);
+        => NeedsIntShiftCast(EffectiveType(count)) ? CheckedSafeCast(() => $"(int){Operand(count)}") : Operand(count);
 
     bool NeedsIntShiftCast(TypeRef? type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "UInt32" }
@@ -989,8 +1014,9 @@ public sealed partial class CSharpPrinter
         string? cast = TypeFamilies.UnsignedCastKeyword(operand.ResultType);
         if (cast is null)
             return Operand(operand);
-        string text = $"({cast}){Operand(operand)}";
-        return checkedSafe ? CheckedSafeCast(text, force: IsOutOfRangeUnsignedConstant(operand)) : text;
+        return checkedSafe
+            ? CheckedSafeCast(() => $"({cast}){Operand(operand)}", force: IsOutOfRangeUnsignedConstant(operand))
+            : $"({cast}){Operand(operand)}";
     }
 
     /// <summary>
@@ -1009,12 +1035,11 @@ public sealed partial class CSharpPrinter
         var signed = TypeFamilies.SignedCounterpart(EffectiveType(operand));
         if (signed is null)
             return Operand(operand);
-        string cast = $"({TypeText(signed)}){Operand(operand)}";
         // A constant unsigned operand's value may exceed the signed range
         // (e.g. (long)ulong.MaxValue), which is CS0221 without unchecked; the
         // unsigned value, not the peeled signed value, is what overflows, so wrap
         // any constant operand defensively (a no-op for a fitting constant).
-        return CheckedSafeCast(cast, force: TryGetIntegerConstant(operand, out _));
+        return CheckedSafeCast(() => $"({TypeText(signed)}){Operand(operand)}", force: TryGetIntegerConstant(operand, out _));
     }
 
     /// <summary>
@@ -1100,7 +1125,7 @@ public sealed partial class CSharpPrinter
                 _function.TypeShapes,
                 _function.EnumUnderlyingTypes))
         {
-            return CheckedSafeCast($"({TypeText(primitiveTarget)}){Operand(value)}");
+            return CheckedSafeCast(() => $"({TypeText(primitiveTarget)}){Operand(value)}");
         }
         // Enum → enum: C# permits the explicit conversion between any two enum
         // types directly. Reached when a slot join carries one enum and a
@@ -1114,7 +1139,7 @@ public sealed partial class CSharpPrinter
                 _function.TypeShapes,
                 _function.EnumUnderlyingTypes))
         {
-            return CheckedSafeCast($"({TypeText(enumToEnumTarget)}){Operand(value)}");
+            return CheckedSafeCast(() => $"({TypeText(enumToEnumTarget)}){Operand(value)}");
         }
         // The same cast, for a cross-assembly enum. ClassifyShape only sees types
         // defined in the inspected assembly, so a framework enum like
@@ -1150,7 +1175,7 @@ public sealed partial class CSharpPrinter
             // these severed single live ranges into unassigned reads).
             return intTarget is { Namespace: "System", Name: "Int32" or "Int64", Assembly: TypeRef.CoreLibrary }
                 ? $"{Condition(value)} ? 1 : 0"
-                : CheckedSafeCast($"({TypeText(intTarget)})({Condition(value)} ? 1 : 0)");
+                : CheckedSafeCast(() => $"({TypeText(intTarget)})({Condition(value)} ? 1 : 0)");
         }
         if (value is Conditional conditional
             && target is { } conditionalTarget
@@ -1195,8 +1220,8 @@ public sealed partial class CSharpPrinter
         if (value is Convert { IsChecked: false, IsUnsigned: false } conv && SameNumericSlotWidth(conv.Target, target))
             return conv.Operand is Constant { Value: int or long } convConst
                 ? NumericConstant(convConst, target!)
-                : CheckedSafeCast($"({TypeText(target!)}){Operand(conv.Operand)}");
-        return CheckedSafeCast($"({TypeText(target!)}){Operand(value)}");
+                : CheckedSafeCast(() => $"({TypeText(target!)}){Operand(conv.Operand)}");
+        return CheckedSafeCast(() => $"({TypeText(target!)}){Operand(value)}");
     }
 
     static IrExpression? AddressOfValue(IrExpression value)
@@ -1296,7 +1321,7 @@ public sealed partial class CSharpPrinter
         {
             return arm is Constant { Value: int or long } konst
                 ? NumericConstant(konst, numericTarget)
-                : CheckedSafeCast($"({TypeText(numericTarget)}){Operand(arm)}");
+                : CheckedSafeCast(() => $"({TypeText(numericTarget)}){Operand(arm)}");
         }
         return null;
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1125,7 +1125,16 @@ public sealed partial class CSharpPrinter
                 _function.TypeShapes,
                 _function.EnumUnderlyingTypes))
         {
-            return CheckedSafeCast(() => $"({TypeText(primitiveTarget)}){Operand(value)}");
+            // Wrap only when the checked underlying->target conversion can
+            // actually throw (cross-signedness, signed->unsigned): an
+            // identity/widening enum cast is overflow-free in checked C# too,
+            // and wrapping it is noise — `checked((int)intBackedEnum + 1)`
+            // must stay bare (work-2302 CI canary). A missing value__ assumes
+            // the I4-signed shape, matching EnumSemanticFamily.
+            var underlying = EnumUnderlyingType(EffectiveType(value)) ?? TypeRef.CoreLib("System", "Int32");
+            return TypeFamilies.CheckedConversionCanThrow(underlying, primitiveTarget)
+                ? CheckedSafeCast(() => $"({TypeText(primitiveTarget)}){Operand(value)}")
+                : $"({TypeText(primitiveTarget)}){Operand(value)}";
         }
         // Enum → enum: C# permits the explicit conversion between any two enum
         // types directly. Reached when a slot join carries one enum and a

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1100,7 +1100,7 @@ public sealed partial class CSharpPrinter
                 _function.TypeShapes,
                 _function.EnumUnderlyingTypes))
         {
-            return $"({TypeText(primitiveTarget)}){Operand(value)}";
+            return CheckedSafeCast($"({TypeText(primitiveTarget)}){Operand(value)}");
         }
         // Enum → enum: C# permits the explicit conversion between any two enum
         // types directly. Reached when a slot join carries one enum and a
@@ -1188,11 +1188,15 @@ public sealed partial class CSharpPrinter
         // char slot) is subsumed by the boundary cast: emit one cast to the
         // target on the conversion's operand, not (char)((ushort)x). An
         // out-of-range constant operand still needs the unchecked spelling.
+        // The remaining casts are same-width reinterprets (cross-signedness or
+        // sibling-width): inside a lexical checked region a bare spelling
+        // recompiles to a conv.ovf the IL never had (#2301), so they route
+        // through CheckedSafeCast like the enum reinterprets above.
         if (value is Convert { IsChecked: false, IsUnsigned: false } conv && SameNumericSlotWidth(conv.Target, target))
             return conv.Operand is Constant { Value: int or long } convConst
                 ? NumericConstant(convConst, target!)
-                : $"({TypeText(target!)}){Operand(conv.Operand)}";
-        return $"({TypeText(target!)}){Operand(value)}";
+                : CheckedSafeCast($"({TypeText(target!)}){Operand(conv.Operand)}");
+        return CheckedSafeCast($"({TypeText(target!)}){Operand(value)}");
     }
 
     static IrExpression? AddressOfValue(IrExpression value)
@@ -1260,13 +1264,14 @@ public sealed partial class CSharpPrinter
                 : Operand(arm);
 
     /// <summary>
-    /// The one join-arm coercion, both directions: an integer-family arm at an
-    /// enum-typed join takes the enum cast/name (<see cref="TryCoerceEnumOperand"/>),
-    /// and an enum arm at an integer-typed join takes the underlying cast —
+    /// The one join-arm coercion, all three directions: an integer-family arm
+    /// at an enum-typed join takes the enum cast/name (<see cref="TryCoerceEnumOperand"/>),
+    /// an enum arm at an integer-typed join takes the underlying cast —
     /// `c ? E.One : e` merged as int is CS0266 bare, in a conditional arm, a
     /// switch-expression arm, or a coalesce right side alike (#2145; slice-4
-    /// second-family review found the rule present in only one of the three).
-    /// Null when the arm needs no join coercion.
+    /// second-family review found the rule present in only one of the three) —
+    /// and a primitive arm at a same-family primitive join takes the
+    /// reinterpret cast (#2302). Null when the arm needs no join coercion.
     /// </summary>
     string? TryCoerceJoinArm(IrExpression arm, TypeRef? target)
     {
@@ -1275,11 +1280,25 @@ public sealed partial class CSharpPrinter
         // Same stack family only: `(int)longBackedEnum` would truncate. The
         // importer's family merge should never build such a join, but the cast
         // must not be the place that finds out (slice-4 review's verify item).
-        return target is { } integerTarget && TypeFamilies.IsIntegerLike(integerTarget)
+        if (target is { } integerTarget && TypeFamilies.IsIntegerLike(integerTarget)
             && EnumUnderlyingType(EffectiveType(arm)) is { } underlying
-            && TypeFamilies.Of(underlying) == TypeFamilies.Of(integerTarget)
-            ? $"({TypeText(integerTarget)}){Operand(arm)}"
-            : null;
+            && TypeFamilies.Of(underlying) == TypeFamilies.Of(integerTarget))
+        {
+            return $"({TypeText(integerTarget)}){Operand(arm)}";
+        }
+        // Third direction (#2302): a primitive arm at a same-family primitive
+        // join it cannot reach implicitly — `c ? uintValue : -1` merged as
+        // uint is CS0029 bare (latent post-F1; live in the pre-F1 fold's
+        // output). Constants defer to NumericConstant (in-range stays bare,
+        // out-of-range reinterprets); implicitly-convertible non-constants
+        // stay bare via the NeedsNumericCast gate.
+        if (target is { } numericTarget && TypeFamilies.NeedsNumericCast(EffectiveType(arm), numericTarget))
+        {
+            return arm is Constant { Value: int or long } konst
+                ? NumericConstant(konst, numericTarget)
+                : CheckedSafeCast($"({TypeText(numericTarget)}){Operand(arm)}");
+        }
+        return null;
     }
 
     string? TryConditionalTextForTarget(Conditional conditional, TypeRef target)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -170,6 +170,40 @@ public static class TypeFamilies
     /// <summary>True when two fixed-width integer primitives occupy the same byte width (ushort/char, int/uint) — a same-width cast subsumes any inner conversion to the sibling.</summary>
     public static bool SameWidth(TypeRef? a, TypeRef? b) => Width(a) is { } wa && wa == Width(b);
 
+    /// <summary>True for the unsigned fixed-width integer primitives (char included; nuint excluded — platform width is unknown here).</summary>
+    static bool IsUnsignedInteger(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Byte" or "UInt16" or "Char" or "UInt32" or "UInt64" };
+
+    /// <summary>
+    /// True when the C# <em>checked</em> conversion <paramref name="source"/> →
+    /// <paramref name="target"/> can throw for some value — i.e. when a bare
+    /// cast inside a lexical <c>checked</c> region recompiles to a
+    /// <c>conv.ovf</c> that changes IL semantics, so a synthesized reinterpret
+    /// cast there must wrap in <c>unchecked(...)</c>. False exactly for the
+    /// value-preserving-for-all-values pairs — identity, same-signedness
+    /// widening, and unsigned into strictly-wider signed — where the checked
+    /// and unchecked conversions agree and the wrap would be pure noise
+    /// (`checked((int)intBackedEnum + 1)` must stay bare — the work-2302 CI
+    /// canary). Platform-width (nint/nuint) and unknown pairs answer true:
+    /// when the width is unknown, the wrap is the safe direction.
+    /// </summary>
+    public static bool CheckedConversionCanThrow(TypeRef? source, TypeRef? target)
+    {
+        if (source is null || target is null)
+            return true;
+        if (source.Equals(target))
+            return false;
+        if (Width(source) is not { } sourceWidth || Width(target) is not { } targetWidth)
+            return true;
+        bool sourceUnsigned = IsUnsignedInteger(source);
+        bool targetUnsigned = IsUnsignedInteger(target);
+        if (sourceUnsigned == targetUnsigned)
+            return targetWidth < sourceWidth;
+        if (sourceUnsigned)
+            return targetWidth <= sourceWidth;
+        return true;
+    }
+
     /// <summary>
     /// True when an integer constant is in <paramref name="target"/>'s range, so
     /// C# converts it implicitly (a constant-expression conversion) and no cast


### PR DESCRIPTION
## Summary

Closes #2302 and #2301 — two fixes in the renderer's one spelling authority (`TryCoerceJoinArm` / `CoerceText`), per the #2302 triage's recommended split (the live merge-store gap is #2306, next PR).

**#2302 — the join-arm rule's third direction.** `TryCoerceJoinArm` covered integer→enum and enum→integer; a *primitive* arm at a same-family primitive join it cannot reach implicitly rendered bare (the pre-F1 fold's CS0266/CS0029 class, and what F1's round-1 review caught in my own fold before `Coerce`-wrapping). The third direction: gated by `TypeFamilies.NeedsNumericCast` — so in-range constants (C#'s implicit constant conversion, the F1 review's mask) and implicitly-widening arms stay bare, zero churn — constants defer to `NumericConstant` (out-of-range reinterprets as `unchecked((uint)(-1))`), non-constants take `CheckedSafeCast("(uint)x")`. One rule serves conditional, switch-expression, and coalesce arms alike (the #2145 discipline).

**#2301 — checked-region reinterpret hazard** (F1 second-round review note): the three bare-cast exits of `CoerceText` (enum→integer, Convert-subsumed sibling width, final fallback) now route through the existing `CheckedSafeCast`, so a same-width reinterpret inside a lexical `checked` region spells `unchecked((uint)x)` instead of recompiling to a `conv.ovf` the IL never had (which throws on negative input — silent semantics change, the recompiles-to-a-different-program class).

## Evidence (15 assemblies / 135,369 methods, base = clean `origin/main` worktree)

- **Render A/B: 4 changed, all audited, zero churn.** Three are **live CS0266 fixes the capped triage census missed** (its 6,000-method compile cap sampled past them — blind spot filed as #2312):
  - `DateTime.AddMonths` — bare `uint` arm at `int` join → `(int)((uint)(V_5 - 1) / (uint)12)`
  - `PortableThreadPool...GetNextDelay` — same class → `(int)((uint)500 - V_0)`
  - `IdnMapping.PunycodeDecode` — bare `int` arm at `char` join → `(char)(...)`
  - `Number.ComputeProductApproximation` — honest partial: base was CS0173 (ulong/long arms, no common type); arms now unify at the `long` MergedType, leaving the store-level mismatch that is exactly the **#2306** class. Pre-existing invalid, improved here, completed there.
- **No-churn gates held**: 135,365 methods byte-identical; no in-range constant or implicit widening gained a cast.
- **Assertion lane inert**: 0 regressed / 0 improved keys; survivors 0 across 0 methods on both sides; survivor delta (none)/(none).
- **Witnesses** (`CoerceChokePointTests`, all `AssertCompiles`-backed): negative-constant arm → `unchecked((uint)(-1))`; non-constant arm → `(uint)x`; in-range constant stays bare; implicit `int→long` widening stays bare; `Coerce` inside a checked `Binary` → `unchecked((uint)x)`. Renderer-adjacent surface 89/89 with zero expectation churn.
- No checked-region wraps surfaced on corpus (that path is fixture-witnessed; no live population).

## Review

Adversarial review in progress on this branch per policy (requested at `ccb98271`). Suggested attack surfaces posted with the review request: `NeedsNumericCast` edges (`nint`/`nuint`, `char`, float family), `EffectiveType` interaction (unsigned div/rem/shr rendered types), over-wrap risk on the final fallback, and the three-consumer sibling discipline.

## Issues

Closes #2301, #2302. Filed from this work: #2312 (census blind spot). Next: #2306 (live merge-store gap, own branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
