### PR TITLE
Preserve structured RTS IL diff diagnostics

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 
 using ILInspector.DecompilerHarness;
+using ILInspector.Instructions;
 
 using Microsoft.CodeAnalysis.CSharp;
 
@@ -1110,11 +1111,33 @@ public class GeneratedFixtureCatalogTests
                     FidelityCheck.CompileBackStatus.OpcodeDiff,
                     "opcode-diff",
                     Detail: null,
-                    IlDiffDiagnostic:
-                    """
-                    h0 - IL_0000 ldc.i4 1
-                    h0 + IL_0000 ldc.i4 2
-                    """,
+                    IlDiffDiagnostic: new IlDiffDisplayResult(
+                        Failure: null,
+                        Rows:
+                        [
+                            new IlDiffDisplayRow(
+                                0,
+                                IlDiffKind.Remove,
+                                "-",
+                                0,
+                                "IL_0000",
+                                "ldc.i4",
+                                IlOperandIdentityKind.Immediate,
+                                "1",
+                                "ldc.i4 1",
+                                "Removed IL operation 'ldc.i4 1'"),
+                            new IlDiffDisplayRow(
+                                0,
+                                IlDiffKind.Add,
+                                "+",
+                                0,
+                                "IL_0000",
+                                "ldc.i4",
+                                IlOperandIdentityKind.Immediate,
+                                "2",
+                                "ldc.i4 2",
+                                "Added IL operation 'ldc.i4 2'"),
+                        ]),
                     IsFrontier: false,
                     Note: null),
             ]);
@@ -1261,8 +1284,18 @@ public class GeneratedFixtureCatalogTests
         Assert.Equal(FidelityCheck.CompileBackStatus.OpcodeDiff, result.ActualStatus);
         Assert.Equal("opcode-diff", result.Reason);
         Assert.NotNull(result.IlDiffDiagnostic);
-        Assert.Contains("IL_", result.IlDiffDiagnostic);
+        Assert.NotEmpty(result.IlDiffDiagnostic.Rows);
+        Assert.Contains(result.IlDiffDiagnostic.Rows, row => row.Offset.StartsWith("IL_", StringComparison.Ordinal));
         Assert.DoesNotContain("target-body-fragment-missing", report);
+
+        string json = GeneratedFixtureRunner.FormatReturnToSenderCatalogJson(run);
+        using var document = JsonDocument.Parse(json);
+        var jsonResult = Assert.Single(document.RootElement.GetProperty("Results").EnumerateArray());
+        var rows = jsonResult.GetProperty("IlDiffDiagnostic").GetProperty("Rows").EnumerateArray().ToArray();
+        Assert.NotEmpty(rows);
+        Assert.Contains(rows, row =>
+            row.GetProperty("Offset").GetString()?.StartsWith("IL_", StringComparison.Ordinal) == true
+            && row.GetProperty("OpcodeFamily").GetString() is { Length: > 0 });
     }
 
     [Fact]

--- a/src/ILInspector.Instructions.Tests/IlDiffPrinterTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlDiffPrinterTests.cs
@@ -100,4 +100,23 @@ public class IlDiffPrinterTests
             ],
             lines);
     }
+
+    [Fact]
+    public void ToUnifiedLines_TreatsDefaultRowsAsEmpty()
+    {
+        var display = new IlDiffDisplayResult(Failure: null, Rows: default);
+
+        Assert.True(display.IsEmpty);
+        Assert.Empty(IlDiffPrinter.ToUnifiedLines(display));
+        Assert.Equal("", IlDiffPrinter.RenderUnified(display));
+    }
+
+    [Fact]
+    public void ToUnifiedLines_PreservesFailureWhenRowsAreDefault()
+    {
+        var display = new IlDiffDisplayResult(Failure: "IL diff failed: old body decode failed", Rows: default);
+
+        Assert.False(display.IsEmpty);
+        Assert.Equal(["IL diff failed: old body decode failed"], IlDiffPrinter.ToUnifiedLines(display));
+    }
 }

--- a/src/ILInspector.Instructions.Tests/IlDiffPrinterTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlDiffPrinterTests.cs
@@ -75,6 +75,7 @@ public class IlDiffPrinterTests
         Assert.Equal("IL diff failed: old body decode failed", display.Failure);
         Assert.Empty(display.Rows);
         Assert.Equal(["IL diff failed: old body decode failed"], IlDiffPrinter.ToUnifiedLines(diff));
+        Assert.Equal(["IL diff failed: old body decode failed"], IlDiffPrinter.ToUnifiedLines(display));
     }
 
     [Fact]

--- a/src/ILInspector.Instructions/IlDiffPrinter.cs
+++ b/src/ILInspector.Instructions/IlDiffPrinter.cs
@@ -58,8 +58,11 @@ public static class IlDiffPrinter
     }
 
     public static ImmutableArray<string> ToUnifiedLines(IlBodyDiffResult result)
+        => ToUnifiedLines(ToDisplayResult(result));
+
+    public static ImmutableArray<string> ToUnifiedLines(IlDiffDisplayResult display)
     {
-        var display = ToDisplayResult(result);
+        ArgumentNullException.ThrowIfNull(display);
         var rows = display.Rows.Select(row => row.UnifiedLine);
         return display.Failure is { } failure
             ? [failure, .. rows]
@@ -67,6 +70,9 @@ public static class IlDiffPrinter
     }
 
     public static string RenderUnified(IlBodyDiffResult result)
+        => RenderUnified(ToDisplayResult(result));
+
+    public static string RenderUnified(IlDiffDisplayResult result)
     {
         var lines = ToUnifiedLines(result);
         if (lines.IsEmpty)

--- a/src/ILInspector.Instructions/IlDiffPrinter.cs
+++ b/src/ILInspector.Instructions/IlDiffPrinter.cs
@@ -22,7 +22,7 @@ public sealed record IlDiffDisplayResult(
     string? Failure,
     ImmutableArray<IlDiffDisplayRow> Rows)
 {
-    public bool IsEmpty => Failure is null && Rows.IsEmpty;
+    public bool IsEmpty => Failure is null && Rows.IsDefaultOrEmpty;
 }
 
 /// <summary>
@@ -63,7 +63,9 @@ public static class IlDiffPrinter
     public static ImmutableArray<string> ToUnifiedLines(IlDiffDisplayResult display)
     {
         ArgumentNullException.ThrowIfNull(display);
-        var rows = display.Rows.Select(row => row.UnifiedLine);
+        var rows = display.Rows.IsDefault
+            ? []
+            : display.Rows.Select(row => row.UnifiedLine);
         return display.Failure is { } failure
             ? [failure, .. rows]
             : [.. rows];

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 using ILInspector.Decompiler.Pipeline;
+using ILInspector.Instructions;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -2062,7 +2063,7 @@ internal sealed record GeneratedFixtureReturnToSenderResult(
     FidelityCheck.CompileBackStatus? ActualStatus,
     string Reason,
     string? Detail,
-    string? IlDiffDiagnostic,
+    IlDiffDisplayResult? IlDiffDiagnostic,
     bool IsFrontier,
     string? Note)
 {
@@ -2392,11 +2393,11 @@ internal static class GeneratedFixtureRunner
                     sb.AppendLine($"      {row.DisplayMember}  rts={actual}  bucket={row.Reason}");
                     if (!string.IsNullOrWhiteSpace(row.Detail))
                         sb.AppendLine($"      detail: {row.Detail}");
-                    if (!string.IsNullOrWhiteSpace(row.IlDiffDiagnostic))
+                    if (row.IlDiffDiagnostic is not null)
                     {
                         sb.AppendLine("      il-diff:");
-                        foreach (string line in row.IlDiffDiagnostic.Split('\n'))
-                            sb.AppendLine($"        {line.TrimEnd('\r')}");
+                        foreach (string line in IlDiffPrinter.ToUnifiedLines(row.IlDiffDiagnostic))
+                            sb.AppendLine($"        {line}");
                     }
                 }
             }

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -29,7 +29,7 @@ static class ReturnToSender
         string RecompiledOpcodes,
         string? Detail,
         string TargetBody = "",
-        string? IlDiffDiagnostic = null);
+        IlDiffDisplayResult? IlDiffDiagnostic = null);
 
     public sealed record RequestedTarget(string Type, string Method, int Overload);
 
@@ -1242,7 +1242,7 @@ static class ReturnToSender
         return null;
     }
 
-    static string? BuildIlDiffDiagnostic(
+    static IlDiffDisplayResult? BuildIlDiffDiagnostic(
         MetadataReader originalReader,
         PEReader originalPe,
         MethodDefinition originalMethod,
@@ -1263,8 +1263,8 @@ static class ReturnToSender
             originalPe.GetMethodBody(originalMethod.RelativeVirtualAddress),
             recompiled.Reader,
             recompiledPe.GetMethodBody(recompiled.Method.RelativeVirtualAddress));
-        string rendered = IlDiffPrinter.RenderUnified(diff);
-        return string.IsNullOrWhiteSpace(rendered) ? null : rendered;
+        var display = IlDiffPrinter.ToDisplayResult(diff);
+        return display.IsEmpty ? null : display;
     }
 
     static IEnumerable<MetadataReference> CompilationReferences(string targetPath)


### PR DESCRIPTION
## Summary

- carry RTS IL diff diagnostics as structured `IlDiffDisplayResult` / `IlDiffDisplayRow` evidence instead of pre-rendered text
- render unified IL diff text only at the generated RTS catalog report boundary
- preserve typed rows in generated RTS catalog JSON
- add `IlDiffPrinter` display-result overloads used by the report boundary

This keeps RTS as a consumer of product IL diff/printer evidence while preserving typed rows for future Research/CLI/stable-member-currency consumers.

## Validation

```text
dotnet run --project src/ILInspector.Instructions.Tests/ILInspector.Instructions.Tests.csproj -c Release --no-restore -- -filter "/*/*/IlDiffPrinterTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-restore -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release -- --return-to-sender-catalog minimal.property.literal --max-examples 3
```
