### PR TITLE
Add Research C# body diff

### DIFF
--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -268,6 +268,19 @@ namespace DiffFixtureSample
         public static implicit operator string(ConversionSample value) => "stable";
     }
 
+    public readonly struct OperatorSample
+    {
+        readonly int _value;
+
+        public OperatorSample(int value)
+        {
+            _value = value;
+        }
+
+        public static OperatorSample operator +(OperatorSample left, OperatorSample right)
+            => new(left._value + right._value + 1);
+    }
+
     public readonly struct CheckedConversionSample
     {
         readonly int _value;

--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -151,6 +151,11 @@ namespace DiffFixtureSample
         // V1: safe body. V2 adds a visible unsafe operation.
         public static int AddsUnsafe(int value) => value;
 
+        // Generic parameter rename in V2 must not break method identity.
+        public static T GenericIdentity<T>(T value) => value;
+
+        public static int GenericParamBody<T>(T value) => 1;
+
         static int TokenTargetA(int value) => value + 1;
 
         static void Sink(int value)
@@ -176,5 +181,129 @@ namespace DiffFixtureSample
         {
             public int Value = 1;
         }
+    }
+
+    public class ProtectedSample
+    {
+        protected int ProtectedConstant() => 1;
+    }
+
+    public class GenericOverloadSample
+    {
+        public int M() => 1;
+        public int M<T>() => 10;
+    }
+
+    public class GenericTypeAritySample<T>
+    {
+        public int M() => 1;
+    }
+
+    public class GenericTypeAritySample<T1, T2>
+    {
+        public int M() => 10;
+    }
+
+    internal class InternalSurfaceSample
+    {
+        public int PublicBody() => 1;
+
+        public class NestedPublic
+        {
+            public int PublicBody() => 1;
+        }
+    }
+
+    public class NestedGenericOuter<T>
+    {
+        public class Inner<TInner>
+        {
+            public int M() => 1;
+        }
+    }
+
+    public class NestedGenericOuter<T1, T2>
+    {
+        public class Inner<TInner>
+        {
+            public int M() => 10;
+        }
+    }
+
+    public class ConstructorSample
+    {
+        readonly int _value;
+
+        public ConstructorSample()
+        {
+            _value = 1;
+        }
+
+        public int Value => _value;
+    }
+
+    public readonly struct ConversionSample
+    {
+        readonly int _value;
+
+        public ConversionSample(int value)
+        {
+            _value = value;
+        }
+
+        public static implicit operator int(ConversionSample value) => value._value + 1;
+
+        public static implicit operator string(ConversionSample value) => "stable";
+    }
+
+    public readonly struct CheckedConversionSample
+    {
+        readonly int _value;
+
+        public CheckedConversionSample(int value)
+        {
+            _value = value;
+        }
+
+        public static explicit operator int(CheckedConversionSample value) => value._value;
+
+        public static explicit operator checked int(CheckedConversionSample value) => checked(value._value + 1);
+    }
+
+    public class GenericParameterCollisionSample<T>
+    {
+        public int M<U>(T value) => 1;
+
+        public int M<U>(U value) => 10;
+    }
+
+    public class MethodRemovalSample
+    {
+        public int Removed() => 1;
+    }
+
+    public abstract class BodyStateSample
+    {
+        public abstract int BodyState();
+    }
+
+    public interface IExplicitSurface
+    {
+        int Get();
+    }
+
+    public class ExplicitSurface : IExplicitSurface
+    {
+        int IExplicitSurface.Get() => 1;
+    }
+
+    internal interface IInternalExplicitSurface
+    {
+        int Get();
+    }
+
+    public class InternalExplicitSurface : IInternalExplicitSurface
+    {
+        int IInternalExplicitSurface.Get() => 1;
     }
 }

--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -280,6 +280,8 @@ namespace DiffFixtureSample
     public class MethodRemovalSample
     {
         public int Removed() => 1;
+
+        public int Removed(int value) => value + 1;
     }
 
     public abstract class BodyStateSample

--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -183,6 +183,11 @@ namespace DiffFixtureSample
         }
     }
 
+    public static class ExtensionSample
+    {
+        public static int Twice(this int value) => value * 2;
+    }
+
     public class ProtectedSample
     {
         protected int ProtectedConstant() => 1;

--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -242,6 +242,18 @@ namespace DiffFixtureSample
         public int Value => _value;
     }
 
+    public class ConstructorRemovalSample
+    {
+        readonly int _value;
+
+        public ConstructorRemovalSample(int value)
+        {
+            _value = value;
+        }
+
+        public int Value => _value;
+    }
+
     public readonly struct ConversionSample
     {
         readonly int _value;

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -270,6 +270,19 @@ namespace DiffFixtureSample
         public static implicit operator string(ConversionSample value) => "stable";
     }
 
+    public readonly struct OperatorSample
+    {
+        readonly int _value;
+
+        public OperatorSample(int value)
+        {
+            _value = value;
+        }
+
+        public static OperatorSample operator +(OperatorSample left, OperatorSample right)
+            => new(left._value + right._value + 2);
+    }
+
     public readonly struct CheckedConversionSample
     {
         readonly int _value;

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -192,6 +192,11 @@ namespace DiffFixtureSample
         }
     }
 
+    public static class ExtensionSample
+    {
+        public static int Twice(this int value) => value * 3;
+    }
+
     public class ProtectedSample
     {
         protected int ProtectedConstant() => 2;

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -251,6 +251,11 @@ namespace DiffFixtureSample
         public int Value => _value;
     }
 
+    public class ConstructorRemovalSample
+    {
+        public int Value => 0;
+    }
+
     public readonly struct ConversionSample
     {
         readonly int _value;

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -163,7 +163,7 @@ namespace DiffFixtureSample
         // Generic parameter rename from V1 must not break method identity.
         public static TElement GenericIdentity<TElement>(TElement value) => value;
 
-        public static int GenericParamBody<TElement>(TElement value) => 2;
+        public static int GenericParamBody<T>(T value) => 2;
 
         static int TokenTargetB(int value) => value + 2;
 

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -160,6 +160,11 @@ namespace DiffFixtureSample
             return values[0];
         }
 
+        // Generic parameter rename from V1 must not break method identity.
+        public static TElement GenericIdentity<TElement>(TElement value) => value;
+
+        public static int GenericParamBody<TElement>(TElement value) => 2;
+
         static int TokenTargetB(int value) => value + 2;
 
         static void Sink(int value)
@@ -185,5 +190,128 @@ namespace DiffFixtureSample
         {
             public int Value = 1;
         }
+    }
+
+    public class ProtectedSample
+    {
+        protected int ProtectedConstant() => 2;
+    }
+
+    public class GenericOverloadSample
+    {
+        public int M() => 2;
+        public int M<T>() => 10;
+    }
+
+    public class GenericTypeAritySample<T>
+    {
+        public int M() => 2;
+    }
+
+    public class GenericTypeAritySample<T1, T2>
+    {
+        public int M() => 10;
+    }
+
+    internal class InternalSurfaceSample
+    {
+        public int PublicBody() => 2;
+
+        public class NestedPublic
+        {
+            public int PublicBody() => 2;
+        }
+    }
+
+    public class NestedGenericOuter<T>
+    {
+        public class Inner<TInner>
+        {
+            public int M() => 2;
+        }
+    }
+
+    public class NestedGenericOuter<T1, T2>
+    {
+        public class Inner<TInner>
+        {
+            public int M() => 10;
+        }
+    }
+
+    public class ConstructorSample
+    {
+        readonly int _value;
+
+        public ConstructorSample()
+        {
+            _value = 2;
+        }
+
+        public int Value => _value;
+    }
+
+    public readonly struct ConversionSample
+    {
+        readonly int _value;
+
+        public ConversionSample(int value)
+        {
+            _value = value;
+        }
+
+        public static implicit operator int(ConversionSample value) => value._value + 2;
+
+        public static implicit operator string(ConversionSample value) => "stable";
+    }
+
+    public readonly struct CheckedConversionSample
+    {
+        readonly int _value;
+
+        public CheckedConversionSample(int value)
+        {
+            _value = value;
+        }
+
+        public static explicit operator int(CheckedConversionSample value) => value._value;
+
+        public static explicit operator checked int(CheckedConversionSample value) => checked(value._value + 2);
+    }
+
+    public class GenericParameterCollisionSample<T>
+    {
+        public int M<U>(T value) => 1;
+
+        public int M<U>(U value) => 20;
+    }
+
+    public class MethodRemovalSample
+    {
+    }
+
+    public class BodyStateSample
+    {
+        public int BodyState() => 2;
+    }
+
+    public interface IExplicitSurface
+    {
+        int Get();
+    }
+
+    public class ExplicitSurface : IExplicitSurface
+    {
+        int IExplicitSurface.Get() => 2;
+    }
+
+    internal interface IInternalExplicitSurface
+    {
+        int Get();
+    }
+
+    public class InternalExplicitSurface : IInternalExplicitSurface
+    {
+        int IInternalExplicitSurface.Get() => 2;
     }
 }

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -2428,7 +2428,19 @@ public sealed class LibraryBodyIndex
                 (methodDef.Attributes & MethodAttributes.Static) != 0,
                 IsExtensionMethod(typeHandle, methodDef),
                 ComputeCallerUnsafeMode(typeHandle, methodDef, signature.ParameterTypes, signature.ReturnType),
-                methodDef.GetGenericParameters().Count);
+                methodDef.GetGenericParameters().Count,
+                GenericParameterNames(methodDef));
+        }
+
+        ImmutableArray<string> GenericParameterNames(MethodDefinition methodDef)
+        {
+            var handles = methodDef.GetGenericParameters();
+            if (handles.Count == 0)
+                return [];
+            var names = ImmutableArray.CreateBuilder<string>(handles.Count);
+            foreach (var handle in handles)
+                names.Add(_reader.GetString(_reader.GetGenericParameter(handle).Name));
+            return names.MoveToImmutable();
         }
 
         bool IsExtensionMethod(TypeDefinitionHandle typeHandle, MethodDefinition methodDef)

--- a/src/ILInspector.Analysis/LibraryBodyIndex.cs
+++ b/src/ILInspector.Analysis/LibraryBodyIndex.cs
@@ -2426,7 +2426,19 @@ public sealed class LibraryBodyIndex
                 signature.ReturnType,
                 MetadataTokens.GetToken(methodHandle),
                 (methodDef.Attributes & MethodAttributes.Static) != 0,
-                ComputeCallerUnsafeMode(typeHandle, methodDef, signature.ParameterTypes, signature.ReturnType));
+                IsExtensionMethod(typeHandle, methodDef),
+                ComputeCallerUnsafeMode(typeHandle, methodDef, signature.ParameterTypes, signature.ReturnType),
+                methodDef.GetGenericParameters().Count);
+        }
+
+        bool IsExtensionMethod(TypeDefinitionHandle typeHandle, MethodDefinition methodDef)
+        {
+            var type = _reader.GetTypeDefinition(typeHandle);
+            return (type.Attributes & TypeAttributes.Abstract) != 0
+                && (type.Attributes & TypeAttributes.Sealed) != 0
+                && (methodDef.Attributes & MethodAttributes.Static) != 0
+                && AttributeReader.HasExtensionAttribute(_reader, type.GetCustomAttributes())
+                && AttributeReader.HasExtensionAttribute(_reader, methodDef.GetCustomAttributes());
         }
 
         // Mirrors Roslyn's PEMethodSymbol.CallerUnsafeMode: a member "requires

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -70,7 +70,8 @@ public sealed record MethodIdentity(
     bool IsStatic,
     bool IsExtension = false,
     CallerUnsafeMode CallerUnsafeMode = CallerUnsafeMode.None,
-    int GenericArity = 0);
+    int GenericArity = 0,
+    ImmutableArray<string> GenericParameterNames = default);
 
 public sealed record MemberRef(
     TypeRef DeclaringType,

--- a/src/ILInspector.Analysis/MemberIdentity.cs
+++ b/src/ILInspector.Analysis/MemberIdentity.cs
@@ -68,7 +68,9 @@ public sealed record MethodIdentity(
     TypeRef ReturnType,
     int MetadataToken,
     bool IsStatic,
-    CallerUnsafeMode CallerUnsafeMode = CallerUnsafeMode.None);
+    bool IsExtension = false,
+    CallerUnsafeMode CallerUnsafeMode = CallerUnsafeMode.None,
+    int GenericArity = 0);
 
 public sealed record MemberRef(
     TypeRef DeclaringType,

--- a/src/ILInspector.Decompiler/ILInspector.Decompiler.csproj
+++ b/src/ILInspector.Decompiler/ILInspector.Decompiler.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ILInspector.Decompiler.Tests" />
+    <InternalsVisibleTo Include="ILInspector.Research" />
     <!-- The diagnostic harness reuses the runtime-ported ILReader to walk raw IL
          independently of the semantic importer (the annotation check oracle). -->
     <InternalsVisibleTo Include="decompiler-harness" />

--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -31,12 +31,12 @@ public class CSharpBodyDiffTests
             && row.Text.Contains("2", StringComparison.Ordinal));
         Assert.All(diff.Rows.Where(row => row.Member.Contains("ConstantValue", StringComparison.Ordinal)), row =>
         {
-            Assert.StartsWith("ConstantValue~", row.StableMemberSelector, StringComparison.Ordinal);
-            Assert.StartsWith("M:DiffFixtureSample.DiffSample.ConstantValue()", row.CanonicalSignature, StringComparison.Ordinal);
+            Assert.StartsWith("ConstantValue~", row.Anchor.StableSelector, StringComparison.Ordinal);
+            Assert.StartsWith("M:DiffFixtureSample.DiffSample.ConstantValue()", row.Anchor.CanonicalSignature, StringComparison.Ordinal);
             Assert.Contains("DiffFixtureSample|neutral|", row.AssemblyIdentity, StringComparison.Ordinal);
             Assert.StartsWith(row.AssemblyIdentity + "|", row.StableMemberKey, StringComparison.Ordinal);
-            Assert.Contains(row.CanonicalSignature + "#", row.StableMemberKey, StringComparison.Ordinal);
-            Assert.Equal(10, row.Digest.Length);
+            Assert.Contains(row.Anchor.CanonicalSignature + "#", row.StableMemberKey, StringComparison.Ordinal);
+            Assert.Equal(10, row.Anchor.Fingerprint.Length);
             Assert.StartsWith("csharp.line.", row.ChangeId, StringComparison.Ordinal);
             Assert.NotEmpty(row.Message);
             Assert.NotNull(row.SourceCoordinate);
@@ -66,8 +66,8 @@ public class CSharpBodyDiffTests
         var row = Assert.Single(diff.Rows, row =>
             row.Member.Contains("GenericParamBody`1", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
-        Assert.StartsWith("GenericParamBody~", row.StableMemberSelector, StringComparison.Ordinal);
-        Assert.Equal("M:DiffFixtureSample.DiffSample.GenericParamBody<!!0>(!!0)", row.CanonicalSignature);
+        Assert.StartsWith("GenericParamBody~", row.Anchor.StableSelector, StringComparison.Ordinal);
+        Assert.Equal("M:DiffFixtureSample.DiffSample.GenericParamBody<!!0>(!!0)", row.Anchor.CanonicalSignature);
     }
 
     [Fact]
@@ -221,8 +221,8 @@ public class CSharpBodyDiffTests
         var row = Assert.Single(diff.Rows, row =>
             row.Member.Contains("ConstructorSample.#ctor()", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
-        Assert.StartsWith("#ctor~", row.StableMemberSelector, StringComparison.Ordinal);
-        Assert.Equal("M:DiffFixtureSample.ConstructorSample.#ctor()", row.CanonicalSignature);
+        Assert.StartsWith("#ctor~", row.Anchor.StableSelector, StringComparison.Ordinal);
+        Assert.Equal("M:DiffFixtureSample.ConstructorSample.#ctor()", row.Anchor.CanonicalSignature);
     }
 
     [Fact]
@@ -234,10 +234,10 @@ public class CSharpBodyDiffTests
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConversionSample" });
 
         var row = Assert.Single(diff.Rows, row =>
-            row.CanonicalSignature.Contains("op_Implicit", StringComparison.Ordinal)
+            row.Anchor.CanonicalSignature.Contains("op_Implicit", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
-        Assert.EndsWith("~System.Int32", row.CanonicalSignature, StringComparison.Ordinal);
-        Assert.DoesNotContain(diff.Rows, row => row.CanonicalSignature.EndsWith("~System.String", StringComparison.Ordinal));
+        Assert.EndsWith("~System.Int32", row.Anchor.CanonicalSignature, StringComparison.Ordinal);
+        Assert.DoesNotContain(diff.Rows, row => row.Anchor.CanonicalSignature.EndsWith("~System.String", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -249,9 +249,9 @@ public class CSharpBodyDiffTests
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CheckedConversionSample" });
 
         var row = Assert.Single(diff.Rows, row =>
-            row.CanonicalSignature.Contains("op_CheckedExplicit", StringComparison.Ordinal)
+            row.Anchor.CanonicalSignature.Contains("op_CheckedExplicit", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
-        Assert.EndsWith("~System.Int32", row.CanonicalSignature, StringComparison.Ordinal);
+        Assert.EndsWith("~System.Int32", row.Anchor.CanonicalSignature, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -265,8 +265,8 @@ public class CSharpBodyDiffTests
         var row = Assert.Single(diff.Rows, row =>
             row.Member.Contains("GenericParameterCollisionSample`1.M`1", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
-        Assert.Equal("M:DiffFixtureSample.GenericParameterCollisionSample`1.M<!!0>(!!0)", row.CanonicalSignature);
-        Assert.DoesNotContain(diff.Rows, row => row.CanonicalSignature.EndsWith("(!0)", StringComparison.Ordinal));
+        Assert.Equal("M:DiffFixtureSample.GenericParameterCollisionSample`1.M<!!0>(!!0)", row.Anchor.CanonicalSignature);
+        Assert.DoesNotContain(diff.Rows, row => row.Anchor.CanonicalSignature.EndsWith("(!0)", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -279,7 +279,7 @@ public class CSharpBodyDiffTests
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MethodRemovalSample" });
 
-        var row = Assert.Single(diff.Rows);
+        var row = Assert.Single(diff.Rows, row => row.Member.EndsWith("Removed()", StringComparison.Ordinal));
         Assert.Equal(CSharpDiffKind.Remove, row.Kind);
         Assert.Equal("csharp.method.removed", row.ChangeId);
         Assert.Equal("Removed C# method.", row.Message);

--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -1,0 +1,384 @@
+namespace ILInspector.Research.Tests;
+
+public class CSharpBodyDiffTests
+{
+    [Fact]
+    public void CompareAssemblies_SelfDiffHasNoRows()
+    {
+        var path = DiffFixturePath("DiffFixtures.V1");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(path, path);
+
+        Assert.True(diff.IsExact);
+        Assert.Empty(diff.Rows);
+    }
+
+    [Fact]
+    public void CompareAssemblies_ConstantChangeSurfacesProductCSharpRows()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("ConstantValue", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove
+            && row.Text.Contains("1", StringComparison.Ordinal));
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("ConstantValue", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Add
+            && row.Text.Contains("2", StringComparison.Ordinal));
+        Assert.All(diff.Rows.Where(row => row.Member.Contains("ConstantValue", StringComparison.Ordinal)), row =>
+        {
+            Assert.StartsWith("ConstantValue~", row.StableMemberSelector, StringComparison.Ordinal);
+            Assert.StartsWith("M:DiffFixtureSample.DiffSample.ConstantValue()", row.CanonicalSignature, StringComparison.Ordinal);
+            Assert.Contains("DiffFixtureSample|neutral|", row.AssemblyIdentity, StringComparison.Ordinal);
+            Assert.StartsWith(row.AssemblyIdentity + "|", row.StableMemberKey, StringComparison.Ordinal);
+            Assert.Contains(row.CanonicalSignature + "#", row.StableMemberKey, StringComparison.Ordinal);
+            Assert.Equal(10, row.Digest.Length);
+            Assert.StartsWith("csharp.line.", row.ChangeId, StringComparison.Ordinal);
+            Assert.NotEmpty(row.Message);
+            Assert.NotNull(row.SourceCoordinate);
+            Assert.Equal("Full", row.Fidelity);
+        });
+    }
+
+    [Fact]
+    public void CompareAssemblies_GenericParameterRenameDoesNotBreakMethodIdentity()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+        Assert.DoesNotContain(diff.Rows, row => row.Member.Contains("GenericIdentity", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareAssemblies_GenericMethodCanonicalSignatureUsesMethodGenericParameter()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+        var row = Assert.Single(diff.Rows, row =>
+            row.Member.Contains("GenericParamBody`1", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove);
+        Assert.StartsWith("GenericParamBody~", row.StableMemberSelector, StringComparison.Ordinal);
+        Assert.Equal("M:DiffFixtureSample.DiffSample.GenericParamBody<!!0>(!!0)", row.CanonicalSignature);
+    }
+
+    [Fact]
+    public void CompareAssemblies_TokenTargetChangeIsNotSkippedByFastPath()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("StringToken", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove
+            && row.Text.Contains("\"alpha\"", StringComparison.Ordinal));
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("StringToken", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Add
+            && row.Text.Contains("\"beta\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareAssemblies_ProtectedMethodsAreIncludedInDefaultSurface()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ProtectedSample" });
+
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("ProtectedConstant", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove
+            && row.Text.Contains("1", StringComparison.Ordinal));
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("ProtectedConstant", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Add
+            && row.Text.Contains("2", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareAssemblies_GenericArityOverloadsDoNotCollide()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GenericOverloadSample" });
+
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("GenericOverloadSample.M()", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove
+            && row.Text.Contains("1", StringComparison.Ordinal));
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("GenericOverloadSample.M()", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Add
+            && row.Text.Contains("2", StringComparison.Ordinal));
+        Assert.DoesNotContain(diff.Rows, row => row.Member.Contains("GenericOverloadSample.M`1", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareAssemblies_DuplicateInputPathsDoNotThrowOrCreateRows()
+    {
+        var path = DiffFixturePath("DiffFixtures.V1");
+
+        var diff = CSharpBodyDiff.CompareAssemblies([path, path], [path, path], typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+        Assert.Empty(diff.Rows);
+    }
+
+    [Fact]
+    public void CompareAssemblies_OneSidedDuplicateInputPathsKeepMatchingStable()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies([v1, v1], [v2], typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("ConstantValue", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove
+            && row.Text.Contains("1", StringComparison.Ordinal));
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("ConstantValue", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Add
+            && row.Text.Contains("2", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareAssemblies_DistinctPathsWithSameAssemblyIdentityRemainOccurrenceDistinct()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var copy = Path.Combine(Path.GetTempPath(), $"DiffFixtureSample-{Guid.NewGuid():N}.dll");
+        File.Copy(v1, copy);
+        try
+        {
+            var diff = CSharpBodyDiff.CompareAssemblies([v1, copy], [v1], typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+            Assert.Contains(diff.Rows, row => row.AssemblyIdentity.EndsWith("#1", StringComparison.Ordinal));
+            Assert.All(diff.Rows, row => Assert.StartsWith(row.AssemblyIdentity + "|", row.StableMemberKey, StringComparison.Ordinal));
+        }
+        finally
+        {
+            File.Delete(copy);
+        }
+    }
+
+    [Fact]
+    public void CompareAssemblies_GenericTypeArityDoesNotCollapseDeclaringTypes()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "*GenericTypeAritySample*" });
+
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("GenericTypeAritySample`1.M()", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove
+            && row.Text.Contains("1", StringComparison.Ordinal));
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("GenericTypeAritySample`1.M()", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Add
+            && row.Text.Contains("2", StringComparison.Ordinal));
+        Assert.DoesNotContain(diff.Rows, row => row.Member.Contains("GenericTypeAritySample`2.M()", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareAssemblies_NestedGenericDeclaringArityDoesNotCollapse()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "*NestedGenericOuter*" });
+
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("NestedGenericOuter`1.Inner`1.M()", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove
+            && row.Text.Contains("1", StringComparison.Ordinal));
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("NestedGenericOuter`1.Inner`1.M()", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Add
+            && row.Text.Contains("2", StringComparison.Ordinal));
+        Assert.DoesNotContain(diff.Rows, row => row.Member.Contains("NestedGenericOuter`2.Inner`1.M()", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareAssemblies_ConstructorsUseMemberIndexCanonicalName()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConstructorSample" });
+
+        var row = Assert.Single(diff.Rows, row =>
+            row.Member.Contains("ConstructorSample.#ctor()", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove);
+        Assert.StartsWith("#ctor~", row.StableMemberSelector, StringComparison.Ordinal);
+        Assert.Equal("M:DiffFixtureSample.ConstructorSample.#ctor()", row.CanonicalSignature);
+    }
+
+    [Fact]
+    public void CompareAssemblies_ConversionOperatorsIncludeReturnTypeInCanonicalSignature()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConversionSample" });
+
+        var row = Assert.Single(diff.Rows, row =>
+            row.CanonicalSignature.Contains("op_Implicit", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove);
+        Assert.EndsWith("~System.Int32", row.CanonicalSignature, StringComparison.Ordinal);
+        Assert.DoesNotContain(diff.Rows, row => row.CanonicalSignature.EndsWith("~System.String", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareAssemblies_CheckedConversionOperatorsIncludeReturnTypeInCanonicalSignature()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CheckedConversionSample" });
+
+        var row = Assert.Single(diff.Rows, row =>
+            row.CanonicalSignature.Contains("op_CheckedExplicit", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove);
+        Assert.EndsWith("~System.Int32", row.CanonicalSignature, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CompareAssemblies_TypeAndMethodGenericParametersStayDistinct()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "*GenericParameterCollisionSample*" });
+
+        var row = Assert.Single(diff.Rows, row =>
+            row.Member.Contains("GenericParameterCollisionSample`1.M`1", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove);
+        Assert.Equal("M:DiffFixtureSample.GenericParameterCollisionSample`1.M<!!0>(!!0)", row.CanonicalSignature);
+        Assert.DoesNotContain(diff.Rows, row => row.CanonicalSignature.EndsWith("(!0)", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareAssemblies_MethodRemovalUsesMethodLevelMessage()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MethodRemovalSample" });
+
+        var row = Assert.Single(diff.Rows);
+        Assert.Equal(CSharpDiffKind.Remove, row.Kind);
+        Assert.Equal("csharp.method.removed", row.ChangeId);
+        Assert.Equal("Removed C# method.", row.Message);
+        Assert.Equal("/* method removed */", row.Text);
+        Assert.Null(row.SourceCoordinate);
+    }
+
+    [Fact]
+    public void CompareAssemblies_NoBodyToBodyUsesSyntheticBodyAddedRow()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "BodyStateSample" });
+
+        var row = Assert.Single(diff.Rows);
+        Assert.Equal(CSharpDiffKind.Add, row.Kind);
+        Assert.Equal("csharp.method.body-added", row.ChangeId);
+        Assert.Equal("Added C# method body.", row.Message);
+        Assert.Equal("/* method body added */", row.Text);
+        Assert.Null(row.SourceCoordinate);
+    }
+
+    [Fact]
+    public void CompareAssemblies_BodyToNoBodyUsesSyntheticBodyRemovedRow()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v2, v1, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "BodyStateSample" });
+
+        var row = Assert.Single(diff.Rows);
+        Assert.Equal(CSharpDiffKind.Remove, row.Kind);
+        Assert.Equal("csharp.method.body-removed", row.ChangeId);
+        Assert.Equal("Removed C# method body.", row.Message);
+        Assert.Equal("/* method body removed */", row.Text);
+        Assert.Null(row.SourceCoordinate);
+    }
+
+    [Fact]
+    public void CompareAssemblies_ExplicitInterfaceImplementationsAreInDefaultSurface()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ExplicitSurface" });
+
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("IExplicitSurface.Get", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove
+            && row.Text.Contains("1", StringComparison.Ordinal));
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("IExplicitSurface.Get", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Add
+            && row.Text.Contains("2", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareAssemblies_InternalExplicitInterfaceImplementationsStayOutOfDefaultSurface()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "InternalExplicitSurface" });
+
+        Assert.Empty(diff.Rows);
+    }
+
+    [Fact]
+    public void CompareAssemblies_DefaultSurfaceSkipsInternalTypesAndTheirNestedPublicTypes()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "InternalSurfaceSample" });
+
+        Assert.Empty(diff.Rows);
+
+        var nested = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "*InternalSurfaceSample*" });
+
+        Assert.Empty(nested.Rows);
+    }
+
+    [Fact]
+    public void CompareAssemblies_GlobTypeFilterCanLimitRows()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "*NoSuchType" });
+
+        Assert.Empty(diff.Rows);
+    }
+
+    static string DiffFixturePath(string project)
+    {
+        var outputDirectory = new DirectoryInfo(
+            AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        string path = Path.GetFullPath(Path.Combine(
+            outputDirectory.FullName, "..", "..", project, outputDirectory.Name, "DiffFixtureSample.dll"));
+        Assert.True(File.Exists(path), $"Expected diff fixture assembly at {path}");
+        return path;
+    }
+}

--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -69,7 +69,7 @@ public class CSharpBodyDiffTests
             row.Member.Contains("GenericParamBody`1", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
         Assert.StartsWith("GenericParamBody~", row.Anchor.StableSelector, StringComparison.Ordinal);
-        Assert.Equal("M:DiffFixtureSample.DiffSample.GenericParamBody<!!0>(!!0)", row.Anchor.CanonicalSignature);
+        Assert.Equal("M:DiffFixtureSample.DiffSample.GenericParamBody<T>(T)", row.Anchor.CanonicalSignature);
     }
 
     [Fact]
@@ -239,7 +239,7 @@ public class CSharpBodyDiffTests
             row.Anchor.CanonicalSignature.Contains("op_Implicit", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
         Assert.StartsWith("operator:op_Implicit~", row.Anchor.StableSelector, StringComparison.Ordinal);
-        Assert.EndsWith("~System.Int32", row.Anchor.CanonicalSignature, StringComparison.Ordinal);
+        Assert.Equal("M:DiffFixtureSample.ConversionSample.op_Implicit(DiffFixtureSample.ConversionSample)", row.Anchor.CanonicalSignature);
         Assert.DoesNotContain(diff.Rows, row => row.Anchor.CanonicalSignature.EndsWith("~System.String", StringComparison.Ordinal));
     }
 
@@ -297,7 +297,7 @@ public class CSharpBodyDiffTests
             row.Anchor.CanonicalSignature.Contains("op_CheckedExplicit", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
         Assert.StartsWith("operator:op_CheckedExplicit~", row.Anchor.StableSelector, StringComparison.Ordinal);
-        Assert.EndsWith("~System.Int32", row.Anchor.CanonicalSignature, StringComparison.Ordinal);
+        Assert.Equal("M:DiffFixtureSample.CheckedConversionSample.op_CheckedExplicit(DiffFixtureSample.CheckedConversionSample)", row.Anchor.CanonicalSignature);
     }
 
     [Fact]
@@ -311,7 +311,7 @@ public class CSharpBodyDiffTests
         var row = Assert.Single(diff.Rows, row =>
             row.Member.Contains("GenericParameterCollisionSample`1.M`1", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
-        Assert.Equal("M:DiffFixtureSample.GenericParameterCollisionSample`1.M<!!0>(!!0)", row.Anchor.CanonicalSignature);
+        Assert.Equal("M:DiffFixtureSample.GenericParameterCollisionSample<T>.M<U>(U)", row.Anchor.CanonicalSignature);
         Assert.DoesNotContain(diff.Rows, row => row.Anchor.CanonicalSignature.EndsWith("(!0)", StringComparison.Ordinal));
     }
 

--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -236,6 +236,7 @@ public class CSharpBodyDiffTests
         var row = Assert.Single(diff.Rows, row =>
             row.Anchor.CanonicalSignature.Contains("op_Implicit", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
+        Assert.StartsWith("operator:op_Implicit~", row.Anchor.StableSelector, StringComparison.Ordinal);
         Assert.EndsWith("~System.Int32", row.Anchor.CanonicalSignature, StringComparison.Ordinal);
         Assert.DoesNotContain(diff.Rows, row => row.Anchor.CanonicalSignature.EndsWith("~System.String", StringComparison.Ordinal));
     }
@@ -251,6 +252,7 @@ public class CSharpBodyDiffTests
         var row = Assert.Single(diff.Rows, row =>
             row.Anchor.CanonicalSignature.Contains("op_CheckedExplicit", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
+        Assert.StartsWith("operator:op_CheckedExplicit~", row.Anchor.StableSelector, StringComparison.Ordinal);
         Assert.EndsWith("~System.Int32", row.Anchor.CanonicalSignature, StringComparison.Ordinal);
     }
 

--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -1,3 +1,5 @@
+using DotnetInspector.Fixtures;
+
 namespace ILInspector.Research.Tests;
 
 public class CSharpBodyDiffTests
@@ -239,6 +241,34 @@ public class CSharpBodyDiffTests
         Assert.StartsWith("operator:op_Implicit~", row.Anchor.StableSelector, StringComparison.Ordinal);
         Assert.EndsWith("~System.Int32", row.Anchor.CanonicalSignature, StringComparison.Ordinal);
         Assert.DoesNotContain(diff.Rows, row => row.Anchor.CanonicalSignature.EndsWith("~System.String", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareAssemblies_OperatorsUseMemberIndexSelectorPrefix()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "OperatorSample" });
+
+        var row = Assert.Single(diff.Rows, row =>
+            row.Anchor.CanonicalSignature.Contains("op_Addition", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove);
+        Assert.StartsWith("operator:op_Addition~", row.Anchor.StableSelector, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CompareAssemblies_ExplicitImplementationsUseMemberIndexSelectorPrefix()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ExplicitSurface" });
+
+        var row = Assert.Single(diff.Rows, row =>
+            row.Anchor.CanonicalSignature.Contains("IExplicitSurface.Get", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove);
+        Assert.StartsWith("explicit:DiffFixtureSample.IExplicitSurface.Get~", row.Anchor.StableSelector, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -221,7 +221,7 @@ public class CSharpBodyDiffTests
         var row = Assert.Single(diff.Rows, row =>
             row.Member.Contains("ConstructorSample.#ctor()", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
-        Assert.StartsWith("#ctor~", row.Anchor.StableSelector, StringComparison.Ordinal);
+        Assert.StartsWith(".ctor~", row.Anchor.StableSelector, StringComparison.Ordinal);
         Assert.Equal("M:DiffFixtureSample.ConstructorSample.#ctor()", row.Anchor.CanonicalSignature);
     }
 

--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -272,6 +272,20 @@ public class CSharpBodyDiffTests
     }
 
     [Fact]
+    public void CompareAssemblies_ExtensionMethodsUseMemberIndexSelectorPrefix()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ExtensionSample" });
+
+        var row = Assert.Single(diff.Rows, row =>
+            row.Anchor.CanonicalSignature.Contains("Twice", StringComparison.Ordinal)
+            && row.Kind == CSharpDiffKind.Remove);
+        Assert.StartsWith("extension:Twice~", row.Anchor.StableSelector, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CompareAssemblies_CheckedConversionOperatorsIncludeReturnTypeInCanonicalSignature()
     {
         var v1 = DiffFixturePath("DiffFixtures.V1");

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -244,6 +244,18 @@ public class ResearchDiffTests
             member.Subject.Display.Contains("Stable", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void CompareAssemblies_DefaultMechanisms_IncludeCSharpChanges()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            DiffFixturePath("DiffFixtures.V1"),
+            DiffFixturePath("DiffFixtures.V2"));
+
+        Assert.Contains(diff.MembersWhere(member => member.ImplementationChanged), member =>
+            member.Subject.Display.Contains("ConstantValue", StringComparison.Ordinal)
+            && member.HasMechanism(ResearchDiffMechanism.CSharp));
+    }
+
     static ApiSurface Surface(string typeName, params ApiMember[] members)
         => new()
         {

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -293,6 +293,22 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void CompareAssemblies_CSharpAndIlEvidence_GroupOnOperatorAnchor()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(ResearchDiffMechanism.CSharp | ResearchDiffMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "OperatorSample" }));
+
+        var changed = Assert.Single(diff.MembersWhere(member =>
+            member.Subject.MemberName == "op_Addition"
+            && member.HasMechanism(ResearchDiffMechanism.CSharp)
+            && member.HasMechanism(ResearchDiffMechanism.IlBody)));
+
+        Assert.StartsWith("operator:op_Addition~", changed.Subject.Id, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CompareAssemblies_DefaultMechanisms_IncludeCSharpChanges()
     {
         var diff = ResearchDiff.CompareAssemblies(

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -357,6 +357,22 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void CompareAssemblies_CSharpAndIlEvidence_GroupOnExplicitImplementationAnchor()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(ResearchDiffMechanism.CSharp | ResearchDiffMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ExplicitSurface" }));
+
+        var changed = Assert.Single(diff.MembersWhere(member =>
+            member.Subject.MemberName == "DiffFixtureSample.IExplicitSurface.Get"
+            && member.HasMechanism(ResearchDiffMechanism.CSharp)
+            && member.HasMechanism(ResearchDiffMechanism.IlBody)));
+
+        Assert.StartsWith("explicit:DiffFixtureSample.IExplicitSurface.Get~", changed.Subject.Id, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CompareAssemblies_DefaultMechanisms_IncludeCSharpChanges()
     {
         var diff = ResearchDiff.CompareAssemblies(

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -128,8 +128,8 @@ public class ResearchDiffTests
     public void FromCSharpBodyDiff_PreservesProducerMessageAndTypedRow()
     {
         var csharpRow = Assert.Single(CSharpBodyDiff.CompareAssemblies(
-            DiffFixturePath("DiffFixtures.V1"),
-            DiffFixturePath("DiffFixtures.V2"),
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
             typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConstructorSample" }).Rows,
             row => row.ChangeId == "csharp.line.removed");
 
@@ -228,8 +228,8 @@ public class ResearchDiffTests
     public void CompareAssemblies_CSharp_QueryImplementationChanges()
     {
         var diff = ResearchDiff.CompareAssemblies(
-            DiffFixturePath("DiffFixtures.V1"),
-            DiffFixturePath("DiffFixtures.V2"),
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
             new ResearchDiffOptions(ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
 
         var changedMembers = diff.MembersWhere(member => member.ImplementationChanged);
@@ -248,8 +248,8 @@ public class ResearchDiffTests
     public void CompareAssemblies_CSharpAndApiEvidence_GroupOnMemberAnchor()
     {
         var diff = ResearchDiff.CompareAssemblies(
-            DiffFixturePath("DiffFixtures.V1"),
-            DiffFixturePath("DiffFixtures.V2"),
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
             new ResearchDiffOptions(ResearchDiffMechanism.Api | ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MethodRemovalSample" }));
 
         var changed = Assert.Single(diff.MembersWhere(member =>
@@ -264,8 +264,8 @@ public class ResearchDiffTests
     public void CompareAssemblies_CSharpAndApiEvidence_GroupOnOverloadAnchorDespiteDisplayDifferences()
     {
         var diff = ResearchDiff.CompareAssemblies(
-            DiffFixturePath("DiffFixtures.V1"),
-            DiffFixturePath("DiffFixtures.V2"),
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
             new ResearchDiffOptions(ResearchDiffMechanism.Api | ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MethodRemovalSample" }));
 
         Assert.Contains(diff.MembersWhere(member =>
@@ -280,8 +280,8 @@ public class ResearchDiffTests
     public void CompareAssemblies_DefaultMechanisms_IncludeCSharpChanges()
     {
         var diff = ResearchDiff.CompareAssemblies(
-            DiffFixturePath("DiffFixtures.V1"),
-            DiffFixturePath("DiffFixtures.V2"));
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath());
 
         Assert.Contains(diff.MembersWhere(member => member.ImplementationChanged), member =>
             member.Subject.Display.Contains("ConstantValue", StringComparison.Ordinal)
@@ -292,8 +292,8 @@ public class ResearchDiffTests
     public void CompareAssemblies_DefaultMechanisms_GroupCSharpAndIlEvidence()
     {
         var diff = ResearchDiff.CompareAssemblies(
-            DiffFixturePath("DiffFixtures.V1"),
-            DiffFixturePath("DiffFixtures.V2"));
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath());
 
         var changed = Assert.Single(diff.MembersWhere(member =>
             member.Subject.MemberName == "ConstantValue"

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -245,6 +245,22 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void CompareAssemblies_CSharpAndApiEvidence_GroupOnMemberAnchor()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            DiffFixturePath("DiffFixtures.V1"),
+            DiffFixturePath("DiffFixtures.V2"),
+            new ResearchDiffOptions(ResearchDiffMechanism.Api | ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MethodRemovalSample" }));
+
+        var changed = Assert.Single(diff.MembersWhere(member =>
+            member.Subject.MemberName == "Removed"
+            && member.HasMechanism(ResearchDiffMechanism.Api)
+            && member.HasMechanism(ResearchDiffMechanism.CSharp)));
+
+        Assert.StartsWith("Removed~", changed.Subject.Id, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CompareAssemblies_DefaultMechanisms_IncludeCSharpChanges()
     {
         var diff = ResearchDiff.CompareAssemblies(

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -125,6 +125,24 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void FromCSharpBodyDiff_PreservesProducerMessageAndTypedRow()
+    {
+        var csharpRow = Assert.Single(CSharpBodyDiff.CompareAssemblies(
+            DiffFixturePath("DiffFixtures.V1"),
+            DiffFixturePath("DiffFixtures.V2"),
+            typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConstructorSample" }).Rows,
+            row => row.ChangeId == "csharp.line.removed");
+
+        var diff = ResearchDiff.FromCSharpBodyDiff(new CSharpBodyDiffResult([csharpRow]));
+
+        var row = Assert.Single(diff.Rows);
+        Assert.Equal(csharpRow.ChangeId, row.ChangeId);
+        Assert.Equal(ResearchDiffEvidenceKind.CSharp, row.EvidenceKind);
+        Assert.Equal(csharpRow.Message, row.Message);
+        Assert.Same(csharpRow, row.CSharpRow);
+    }
+
+    [Fact]
     public void Combine_PreservesStructuredApiDiff()
     {
         var oldSurface = Surface("Widget", Member("Existing"));
@@ -202,6 +220,26 @@ public class ResearchDiffTests
         Assert.Contains(changedMembers, member =>
             member.Subject.Display.Contains("ConstantValue", StringComparison.Ordinal)
             && member.HasChange("il.hunk.changed"));
+        Assert.DoesNotContain(changedMembers, member =>
+            member.Subject.Display.Contains("Stable", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareAssemblies_CSharp_QueryImplementationChanges()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            DiffFixturePath("DiffFixtures.V1"),
+            DiffFixturePath("DiffFixtures.V2"),
+            new ResearchDiffOptions(ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
+
+        var changedMembers = diff.MembersWhere(member => member.ImplementationChanged);
+
+        Assert.Contains(changedMembers, member =>
+            member.Subject.Display.Contains("ConstantValue", StringComparison.Ordinal)
+            && member.HasChange("csharp.line.removed"));
+        Assert.Contains(changedMembers, member =>
+            member.Subject.Display.Contains("ConstantValue", StringComparison.Ordinal)
+            && member.HasChange("csharp.line.added"));
         Assert.DoesNotContain(changedMembers, member =>
             member.Subject.Display.Contains("Stable", StringComparison.Ordinal));
     }

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -261,6 +261,22 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void CompareAssemblies_CSharpAndApiEvidence_GroupOnOverloadAnchorDespiteDisplayDifferences()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            DiffFixturePath("DiffFixtures.V1"),
+            DiffFixturePath("DiffFixtures.V2"),
+            new ResearchDiffOptions(ResearchDiffMechanism.Api | ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MethodRemovalSample" }));
+
+        Assert.Contains(diff.MembersWhere(member =>
+            member.Subject.MemberName == "Removed"
+            && member.HasMechanism(ResearchDiffMechanism.Api)
+            && member.HasMechanism(ResearchDiffMechanism.CSharp)), member =>
+            member.Subject.Id.StartsWith("Removed~", StringComparison.Ordinal)
+            && member.Evidence.Any(evidence => evidence.Mechanism == ResearchDiffMechanism.CSharp && evidence.OldValue?.Contains("method removed", StringComparison.Ordinal) == true));
+    }
+
+    [Fact]
     public void CompareAssemblies_DefaultMechanisms_IncludeCSharpChanges()
     {
         var diff = ResearchDiff.CompareAssemblies(

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -277,6 +277,22 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void CompareAssemblies_CSharpAndApiEvidence_GroupOnConstructorAnchor()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(ResearchDiffMechanism.Api | ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConstructorRemovalSample" }));
+
+        var changed = Assert.Single(diff.MembersWhere(member =>
+            member.Subject.MemberName == ".ctor"
+            && member.HasMechanism(ResearchDiffMechanism.Api)
+            && member.HasMechanism(ResearchDiffMechanism.CSharp)));
+
+        Assert.StartsWith(".ctor~", changed.Subject.Id, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CompareAssemblies_DefaultMechanisms_IncludeCSharpChanges()
     {
         var diff = ResearchDiff.CompareAssemblies(

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -309,6 +309,54 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void CompareAssemblies_CSharpAndIlEvidence_GroupOnConversionOperatorAnchor()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(ResearchDiffMechanism.CSharp | ResearchDiffMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConversionSample" }));
+
+        var changed = Assert.Single(diff.MembersWhere(member =>
+            member.Subject.MemberName == "op_Implicit"
+            && member.HasMechanism(ResearchDiffMechanism.CSharp)
+            && member.HasMechanism(ResearchDiffMechanism.IlBody)));
+
+        Assert.StartsWith("operator:op_Implicit~", changed.Subject.Id, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CompareAssemblies_CSharpAndIlEvidence_GroupOnGenericMethodAnchor()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(ResearchDiffMechanism.CSharp | ResearchDiffMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
+
+        var changed = Assert.Single(diff.MembersWhere(member =>
+            member.Subject.MemberName == "GenericParamBody"
+            && member.HasMechanism(ResearchDiffMechanism.CSharp)
+            && member.HasMechanism(ResearchDiffMechanism.IlBody)));
+
+        Assert.StartsWith("GenericParamBody~", changed.Subject.Id, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CompareAssemblies_CSharpAndIlEvidence_GroupOnExtensionAnchor()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(ResearchDiffMechanism.CSharp | ResearchDiffMechanism.IlBody, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ExtensionSample" }));
+
+        var changed = Assert.Single(diff.MembersWhere(member =>
+            member.Subject.MemberName == "Twice"
+            && member.HasMechanism(ResearchDiffMechanism.CSharp)
+            && member.HasMechanism(ResearchDiffMechanism.IlBody)));
+
+        Assert.StartsWith("extension:Twice~", changed.Subject.Id, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CompareAssemblies_DefaultMechanisms_IncludeCSharpChanges()
     {
         var diff = ResearchDiff.CompareAssemblies(

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -288,6 +288,21 @@ public class ResearchDiffTests
             && member.HasMechanism(ResearchDiffMechanism.CSharp));
     }
 
+    [Fact]
+    public void CompareAssemblies_DefaultMechanisms_GroupCSharpAndIlEvidence()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            DiffFixturePath("DiffFixtures.V1"),
+            DiffFixturePath("DiffFixtures.V2"));
+
+        var changed = Assert.Single(diff.MembersWhere(member =>
+            member.Subject.MemberName == "ConstantValue"
+            && member.HasMechanism(ResearchDiffMechanism.CSharp)
+            && member.HasMechanism(ResearchDiffMechanism.IlBody)));
+
+        Assert.StartsWith("ConstantValue~", changed.Subject.Id, StringComparison.Ordinal);
+    }
+
     static ApiSurface Surface(string typeName, params ApiMember[] members)
         => new()
         {

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -172,6 +172,9 @@ public static class CSharpBodyDiff
                     continue;
 
                 var signature = method.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+                var apiSignature = method.DecodeSignature(
+                    TypeRefDecoder.Instance,
+                    new GenericScope(TypeParameterNames(reader, type), MethodParameterNames(reader, method)));
                 string returnType = CanonicalTypeName(signature.ReturnType);
                 var parameters = signature.ParameterTypes.Select(CanonicalTypeName).ToImmutableArray();
                 int genericArity = method.GetGenericParameters().Count;
@@ -179,8 +182,10 @@ public static class CSharpBodyDiff
                 string selectorName = ResearchDiff.ResearchMemberSelector.ForMetadataName(methodName, IsExtensionMethod(reader, type, method));
                 string returnSuffix = IsConversionOperator(methodName) ? $"~{returnType}" : "";
                 string canonicalName = CanonicalMemberName(methodName);
-                string canonicalSignature = $"M:{typeKey}.{canonicalName}{methodGeneric}({string.Join(",", parameters)}){returnSuffix}";
-                var anchor = CreateMemberAnchor(typeKey, selectorName, canonicalName, canonicalSignature);
+                string rawKey = $"M:{typeKey}.{canonicalName}{methodGeneric}({string.Join(",", parameters)}){returnSuffix}";
+                string apiMemberName = ApiMemberName(reader, methodName, method);
+                string anchorCanonical = $"M:{ApiTypeName(reader, typeHandle)}.{apiMemberName}{ApiParameterList(apiSignature.ParameterTypes)}";
+                var anchor = CreateMemberAnchor(ApiTypeName(reader, typeHandle), selectorName, apiMemberName, anchorCanonical);
                 string displayName = methodName == ".ctor" ? "#ctor" : methodName;
                 string display = $"{typeDisplay}.{displayName}{GenericAritySuffix(genericArity)}({string.Join(", ", parameters)})";
                 yield return new CSharpMethodEntry(
@@ -188,7 +193,8 @@ public static class CSharpBodyDiff
                     source.AssemblyName,
                     stableAssemblyKey,
                     anchor,
-                    $"{stableAssemblyKey}|{anchor.CanonicalSignature}",
+                    rawKey,
+                    $"{stableAssemblyKey}|{rawKey}",
                     DuplicateDiscriminator(reader, method),
                     display,
                     typeFullName,
@@ -205,6 +211,70 @@ public static class CSharpBodyDiff
 
     static string CanonicalMemberName(string methodName)
         => methodName == ".ctor" ? "#ctor" : methodName;
+
+    static string ApiTypeName(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        var type = reader.GetTypeDefinition(handle);
+        var genericNames = type.GetGenericParameters()
+            .Select(parameter => reader.GetString(reader.GetGenericParameter(parameter).Name))
+            .ToArray();
+        string name = reader.GetString(type.Name);
+        int tick = name.IndexOf('`');
+        string simple = tick < 0 ? name : name[..tick];
+        if (genericNames.Length > 0)
+            simple += $"<{string.Join(",", genericNames)}>";
+        var declaring = type.GetDeclaringType();
+        if (!declaring.IsNil)
+            return $"{ApiTypeName(reader, declaring)}.{simple}";
+        string ns = reader.GetString(type.Namespace);
+        return string.IsNullOrEmpty(ns) ? simple : $"{ns}.{simple}";
+    }
+
+    static string ApiMemberName(MetadataReader reader, string methodName, MethodDefinition method)
+    {
+        if (methodName == ".ctor")
+            return "#ctor";
+        var genericNames = MethodParameterNames(reader, method)
+            .ToArray();
+        return genericNames.Length == 0 ? methodName : $"{methodName}<{string.Join(",", genericNames)}>";
+    }
+
+    static string ApiParameterList(IEnumerable<TypeRef> parameterTypes)
+        => $"({string.Join(",", parameterTypes.Select(ApiTypeName))})";
+
+    static string ApiTypeName(TypeRef type)
+        => type.Kind switch
+        {
+            TypeRefKind.Definition => type.Namespace.Length == 0
+                ? type.Name.Replace("+", ".", StringComparison.Ordinal)
+                : $"{type.Namespace}.{type.Name.Replace("+", ".", StringComparison.Ordinal)}",
+            TypeRefKind.GenericInstance => $"{ApiTypeName(type.ElementType!)}<{string.Join(",", type.TypeArguments.Select(ApiTypeName))}>",
+            TypeRefKind.SzArray => $"{ApiTypeName(type.ElementType!)}[]",
+            TypeRefKind.Array => $"{ApiTypeName(type.ElementType!)}[{(type.Rank == 1 ? "*" : new string(',', type.Rank - 1))}]",
+            TypeRefKind.ByRef => $"{ApiTypeName(type.ElementType!)}&",
+            TypeRefKind.Pointer => $"{ApiTypeName(type.ElementType!)}*",
+            TypeRefKind.Pinned => $"pinned {ApiTypeName(type.ElementType!)}",
+            TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter
+                => type.GenericParameterName.Length == 0 ? $"!{type.GenericParameterIndex}" : type.GenericParameterName,
+            TypeRefKind.FunctionPointer => $"delegate*<{string.Join(",", type.TypeArguments.Select(ApiTypeName).Append(ApiTypeName(type.ElementType!)))}>",
+            _ => $"<unsupported:{type.UnsupportedReason}>",
+        };
+
+    static ImmutableArray<string> TypeParameterNames(MetadataReader reader, TypeDefinition type)
+        => ParameterNames(reader, type.GetGenericParameters());
+
+    static ImmutableArray<string> MethodParameterNames(MetadataReader reader, MethodDefinition method)
+        => ParameterNames(reader, method.GetGenericParameters());
+
+    static ImmutableArray<string> ParameterNames(MetadataReader reader, GenericParameterHandleCollection handles)
+    {
+        if (handles.Count == 0)
+            return [];
+        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
+        foreach (var handle in handles)
+            names.Add(reader.GetString(reader.GetGenericParameter(handle).Name));
+        return names.MoveToImmutable();
+    }
 
     static bool IsExtensionMethod(MetadataReader reader, TypeDefinition type, MethodDefinition method)
         => type.Attributes.HasFlag(TypeAttributes.Abstract)
@@ -803,6 +873,7 @@ public static class CSharpBodyDiff
         string AssemblyName,
         string StableAssemblyKey,
         MemberAnchor Anchor,
+        string RawKey,
         string StableMemberKey,
         string DuplicateDiscriminator,
         string Display,
@@ -810,10 +881,7 @@ public static class CSharpBodyDiff
         string MethodName,
         int OverloadIndex,
         bool HasBody,
-        string BodyFingerprint)
-    {
-        public string RawKey => Anchor.CanonicalSignature;
-    }
+        string BodyFingerprint);
 
     enum CSharpMethodRenderState
     {

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -209,7 +209,7 @@ public static class CSharpBodyDiff
     static string MemberSelectorName(string methodName)
         => methodName switch
         {
-            ".ctor" => "#ctor",
+            ".ctor" => ".ctor",
             "op_Implicit" or "op_Explicit" or "op_CheckedExplicit" => $"operator:{methodName}",
             _ when methodName.Contains('.') => $"explicit:{methodName}",
             _ => methodName,

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -1,0 +1,846 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Security.Cryptography;
+using System.Text;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Instructions;
+using ILInspector.Metadata;
+
+namespace ILInspector.Research;
+
+public enum CSharpDiffKind
+{
+    Remove,
+    Add,
+}
+
+public sealed record CSharpDiffRow(
+    string AssemblyIdentity,
+    string StableMemberKey,
+    string StableMemberSelector,
+    string CanonicalSignature,
+    string Digest,
+    string Member,
+    string ChangeId,
+    string Message,
+    int HunkId,
+    CSharpDiffKind Kind,
+    int? Line,
+    string? SourceCoordinate,
+    string Fidelity,
+    string Text);
+
+public sealed record CSharpBodyDiffResult(ImmutableArray<CSharpDiffRow> Rows)
+{
+    public bool IsExact => Rows.IsEmpty;
+}
+
+/// <summary>
+/// Research-owned C# body diff over the shipped decompiler output for matched
+/// method bodies.
+/// </summary>
+public static class CSharpBodyDiff
+{
+    internal const int MaxLcsLines = 4096;
+
+    public static CSharpBodyDiffResult CompareAssemblies(string oldPath, string newPath, bool includeNonPublic = false, IReadOnlySet<string>? typeFilters = null)
+        => CompareAssemblies([oldPath], [newPath], includeNonPublic, typeFilters);
+
+    public static CSharpBodyDiffResult CompareAssemblies(IReadOnlyList<string> oldPaths, IReadOnlyList<string> newPaths, bool includeNonPublic = false, IReadOnlySet<string>? typeFilters = null)
+    {
+        ArgumentNullException.ThrowIfNull(oldPaths);
+        ArgumentNullException.ThrowIfNull(newPaths);
+
+        var oldMethods = BuildMethodIndex(oldPaths, includeNonPublic, typeFilters);
+        var newMethods = BuildMethodIndex(newPaths, includeNonPublic, typeFilters);
+        var rows = ImmutableArray.CreateBuilder<CSharpDiffRow>();
+        var sources = new SourceCache();
+        int hunkId = 0;
+
+        try
+        {
+            foreach (var key in oldMethods.Keys.Union(newMethods.Keys).OrderBy(key => key, StringComparer.Ordinal))
+            {
+                oldMethods.TryGetValue(key, out var oldMethod);
+                newMethods.TryGetValue(key, out var newMethod);
+
+                if (oldMethod is null)
+                {
+                    AddWholeMethod(rows, newMethod!, ref hunkId, CSharpDiffKind.Add);
+                    continue;
+                }
+
+                if (newMethod is null)
+                {
+                    AddWholeMethod(rows, oldMethod, ref hunkId, CSharpDiffKind.Remove);
+                    continue;
+                }
+
+                if (oldMethod.BodyFingerprint == newMethod.BodyFingerprint)
+                    continue;
+
+                AddLineDiffRows(rows, oldMethod, Decompile(oldMethod, sources), Decompile(newMethod, sources), ref hunkId);
+            }
+        }
+        finally
+        {
+            sources.Dispose();
+        }
+
+        return new CSharpBodyDiffResult(rows.ToImmutable());
+    }
+
+    static Dictionary<string, CSharpMethodEntry> BuildMethodIndex(IReadOnlyList<string> paths, bool includeNonPublic, IReadOnlySet<string>? typeFilters)
+    {
+        var entries = new List<CSharpMethodEntry>();
+        var assemblyOccurrences = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var path in paths.Distinct(StringComparer.Ordinal))
+        {
+            using var source = MetadataSource.OpenWithoutSymbols(path);
+            string assemblyKey = StableAssemblyKey(source);
+            int occurrence = assemblyOccurrences.GetValueOrDefault(assemblyKey);
+            assemblyOccurrences[assemblyKey] = occurrence + 1;
+            string occurrenceKey = $"{assemblyKey}#{occurrence}";
+            entries.AddRange(EnumerateMethods(source, path, occurrenceKey, includeNonPublic, typeFilters));
+        }
+
+        return entries
+            .GroupBy(entry => $"{entry.StableAssemblyKey}|{entry.RawKey}", StringComparer.Ordinal)
+            .SelectMany(group => group
+                .GroupBy(entry => entry.DuplicateDiscriminator, StringComparer.Ordinal)
+                .OrderBy(discriminatorGroup => discriminatorGroup.Key, StringComparer.Ordinal)
+                .SelectMany(discriminatorGroup => discriminatorGroup
+                    .OrderBy(entry => entry.Path, StringComparer.Ordinal)
+                    .ThenBy(entry => entry.OverloadIndex)
+                    .Select((entry, index) => entry with
+                    {
+                        StableMemberKey = discriminatorGroup.Count() == 1
+                            ? $"{entry.StableAssemblyKey}|{entry.RawKey}#{entry.DuplicateDiscriminator}"
+                            : $"{entry.StableAssemblyKey}|{entry.RawKey}#{entry.DuplicateDiscriminator}:{index}"
+                    }))
+                .Select(entry => (Key: entry.StableMemberKey, Entry: entry)))
+            .ToDictionary(pair => pair.Key, pair => pair.Entry, StringComparer.Ordinal);
+    }
+
+    static CSharpMethodRender Decompile(CSharpMethodEntry entry, SourceCache sources)
+    {
+        if (!entry.HasBody)
+            return new CSharpMethodRender(CSharpMethodRenderState.NoBody, ["/* no method body */"], DecompilationFidelity.IlOnly);
+
+        var source = sources.Open(entry.Path);
+        var function = IrImporter.Import(source, entry.TypeFullName, entry.MethodName, entry.OverloadIndex, publicOnly: false);
+        if (function is null)
+            return new CSharpMethodRender(CSharpMethodRenderState.NoBody, ["/* no method body */"], DecompilationFidelity.IlOnly);
+
+        var result = CSharpPrinter.PrintRaised(function);
+        return result.Succeeded
+            ? new CSharpMethodRender(CSharpMethodRenderState.Body, SplitLines(result.Output), result.Fidelity)
+            : new CSharpMethodRender(
+                CSharpMethodRenderState.Failed,
+                [$"/* decompile failed: {string.Join("; ", result.Diagnostics.Select(diagnostic => diagnostic.Message))} */"],
+                result.Fidelity);
+    }
+
+    static IEnumerable<CSharpMethodEntry> EnumerateMethods(MetadataSource source, string path, string stableAssemblyKey, bool includeNonPublic, IReadOnlySet<string>? typeFilters)
+    {
+        var reader = source.Reader;
+        var typeDefinitionsByName = BuildTypeDefinitionMap(reader);
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            string typeFullName = reader.GetFullTypeName(type);
+            string typeKey = TypeIdentityKey(reader, typeHandle);
+            string typeDisplay = typeFullName;
+            if (!includeNonPublic && !IsVisibleSurfaceType(reader, typeHandle, typeDefinitionsByName))
+                continue;
+            if (!MatchesTypeFilters(typeFullName, typeFilters))
+                continue;
+
+            var explicitImplementationBodies = GetExplicitImplementationBodies(reader, type, typeDefinitionsByName);
+            var nameOrdinals = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                string methodName = reader.GetString(method.Name);
+                int overloadIndex = nameOrdinals.GetValueOrDefault(methodName);
+                nameOrdinals[methodName] = overloadIndex + 1;
+
+                if (!includeNonPublic && !IsPublicSurface(method) && !explicitImplementationBodies.Contains(methodHandle))
+                    continue;
+
+                var signature = method.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+                string returnType = CanonicalTypeName(signature.ReturnType);
+                var parameters = signature.ParameterTypes.Select(CanonicalTypeName).ToImmutableArray();
+                int genericArity = method.GetGenericParameters().Count;
+                string methodGeneric = GenericParameterList(genericArity, isMethod: true);
+                string selectorName = CanonicalMemberName(methodName);
+                string returnSuffix = IsConversionOperator(methodName) ? $"~{returnType}" : "";
+                string canonicalSignature = $"M:{typeKey}.{selectorName}{methodGeneric}({string.Join(",", parameters)}){returnSuffix}";
+                string digest = GetMemberDigest(canonicalSignature);
+                string displayName = methodName == ".ctor" ? "#ctor" : methodName;
+                string display = $"{typeDisplay}.{displayName}{GenericAritySuffix(genericArity)}({string.Join(", ", parameters)})";
+                yield return new CSharpMethodEntry(
+                    path,
+                    source.AssemblyName,
+                    stableAssemblyKey,
+                    canonicalSignature,
+                    $"{stableAssemblyKey}|{canonicalSignature}",
+                    DuplicateDiscriminator(reader, method),
+                    $"{selectorName}~{digest}",
+                    digest,
+                    display,
+                    typeFullName,
+                    methodName,
+                    overloadIndex,
+                    method.RelativeVirtualAddress != 0,
+                    BodyFingerprint(source, method));
+            }
+        }
+    }
+
+    static string GenericAritySuffix(int arity)
+        => arity == 0 ? "" : $"`{arity}";
+
+    static string CanonicalMemberName(string methodName)
+        => methodName == ".ctor" ? "#ctor" : methodName;
+
+    static bool IsConversionOperator(string methodName)
+        => methodName is "op_Implicit" or "op_Explicit" or "op_CheckedExplicit";
+
+    static string TypeIdentityKey(MetadataReader reader, TypeDefinitionHandle handle)
+        => reader.GetFullTypeName(reader.GetTypeDefinition(handle));
+
+    static string CanonicalTypeName(TypeRef type)
+        => type.Kind switch
+        {
+            TypeRefKind.Definition => type.Namespace.Length == 0
+                ? type.Name.Replace("+", ".", StringComparison.Ordinal)
+                : $"{type.Namespace}.{type.Name.Replace("+", ".", StringComparison.Ordinal)}",
+            TypeRefKind.GenericInstance => $"{CanonicalTypeName(type.ElementType!)}<{string.Join(",", type.TypeArguments.Select(CanonicalTypeName))}>",
+            TypeRefKind.SzArray => $"{CanonicalTypeName(type.ElementType!)}[]",
+            TypeRefKind.Array => $"{CanonicalTypeName(type.ElementType!)}[{(type.Rank == 1 ? "*" : new string(',', type.Rank - 1))}]",
+            TypeRefKind.ByRef => $"{CanonicalTypeName(type.ElementType!)}&",
+            TypeRefKind.Pointer => $"{CanonicalTypeName(type.ElementType!)}*",
+            TypeRefKind.Pinned => $"pinned {CanonicalTypeName(type.ElementType!)}",
+            TypeRefKind.GenericParameter => $"!{type.GenericParameterIndex}",
+            TypeRefKind.MethodGenericParameter => $"!!{type.GenericParameterIndex}",
+            TypeRefKind.FunctionPointer => CanonicalFunctionPointer(type),
+            _ => $"<unsupported:{type.UnsupportedReason}>",
+        };
+
+    static string CanonicalFunctionPointer(TypeRef type)
+        => $"delegate*<{string.Join(",", type.TypeArguments.Select(CanonicalTypeName).Append(CanonicalTypeName(type.ElementType!)))}>";
+
+    static string GenericParameterList(int arity, bool isMethod)
+    {
+        if (arity == 0)
+            return "";
+        var prefix = isMethod ? "!!" : "!";
+        return $"<{string.Join(",", Enumerable.Range(0, arity).Select(index => $"{prefix}{index}"))}>";
+    }
+
+    static string GetMemberDigest(string canonicalSignature)
+    {
+        var input = Encoding.UTF8.GetBytes("dotnet-inspect.member-index.v1\n" + canonicalSignature);
+        var hash = SHA256.HashData(input);
+        return System.Convert.ToHexString(hash).ToLowerInvariant()[..10];
+    }
+
+    static string DuplicateDiscriminator(MetadataReader reader, MethodDefinition method)
+    {
+        var builder = new StringBuilder();
+        builder.Append("sig:").Append(System.Convert.ToHexString(reader.GetBlobBytes(method.Signature)));
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()));
+        return System.Convert.ToHexString(hash).ToLowerInvariant()[..10];
+    }
+
+    static string StableAssemblyKey(MetadataSource source)
+    {
+        var reader = source.Reader;
+        if (!reader.IsAssembly)
+            return source.AssemblyName;
+
+        var assembly = reader.GetAssemblyDefinition();
+        string name = reader.GetString(assembly.Name);
+        string culture = reader.GetString(assembly.Culture);
+        string publicKeyToken = PublicKeyToken(reader.GetBlobBytes(assembly.PublicKey));
+        return $"{name}|{(string.IsNullOrEmpty(culture) ? "neutral" : culture)}|{publicKeyToken}";
+    }
+
+    static string PublicKeyToken(byte[] publicKey)
+    {
+        if (publicKey.Length == 0)
+            return "";
+        Span<byte> hash = stackalloc byte[20];
+        SHA1.HashData(publicKey, hash);
+        Span<byte> token = stackalloc byte[8];
+        hash[^8..].CopyTo(token);
+        token.Reverse();
+        return System.Convert.ToHexString(token).ToLowerInvariant();
+    }
+
+    static string BodyFingerprint(MetadataSource source, MethodDefinition method)
+    {
+        var reader = source.Reader;
+        var builder = new StringBuilder();
+        builder.Append((int)method.Attributes).Append('|')
+            .Append((int)method.ImplAttributes).Append('|')
+            .Append(MethodSignatureFingerprint(reader, method)).Append('|');
+
+        if (method.RelativeVirtualAddress == 0)
+        {
+            var noBodyHash = SHA256.HashData(Encoding.UTF8.GetBytes(builder.Append("<no-body>").ToString()));
+            return System.Convert.ToHexString(noBodyHash);
+        }
+
+        var body = source.Pe.GetMethodBody(method.RelativeVirtualAddress);
+        builder
+            .Append(body.MaxStack).Append('|')
+            .Append(body.LocalVariablesInitialized).Append('|')
+            .Append(StandaloneSignatureFingerprint(reader, body.LocalSignature)).Append('|');
+        var decoded = MethodInstructions.Decode(body);
+        if (decoded.IsComplete)
+        {
+            foreach (var instruction in decoded.Instructions)
+            {
+                builder.Append(instruction.Offset).Append(':')
+                    .Append(instruction.OpCode).Append(':')
+                    .Append(instruction.Operand).Append(':')
+                    .Append(OperandFingerprint(reader, instruction)).Append(';');
+            }
+        }
+        else
+        {
+            builder.Append(System.Convert.ToHexString(body.GetILBytes() ?? []));
+        }
+
+        foreach (var region in body.ExceptionRegions)
+        {
+            builder.Append('|')
+                .Append(region.Kind).Append(':')
+                .Append(region.TryOffset).Append(':')
+                .Append(region.TryLength).Append(':')
+                .Append(region.HandlerOffset).Append(':')
+                .Append(region.HandlerLength).Append(':')
+                .Append(region.FilterOffset).Append(':')
+                .Append(EntityFingerprint(reader, region.CatchType));
+        }
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(builder.ToString()));
+        return System.Convert.ToHexString(hash);
+    }
+
+    static string OperandFingerprint(MetadataReader reader, DecodedInstruction instruction)
+        => instruction.Operand switch
+        {
+            OperandKind.InlineString => $"string:{reader.GetUserString(MetadataTokens.UserStringHandle((int)instruction.OperandValue))}",
+            OperandKind.InlineMethod or OperandKind.InlineField or OperandKind.InlineType or OperandKind.InlineTok
+                => EntityFingerprint(reader, MetadataTokens.EntityHandle((int)instruction.OperandValue)),
+            OperandKind.InlineSig => StandaloneSignatureFingerprint(reader, (StandaloneSignatureHandle)MetadataTokens.EntityHandle((int)instruction.OperandValue)),
+            OperandKind.InlineSwitch => string.Join(",", instruction.BranchTargets),
+            _ => instruction.OperandValue.ToString(CultureInfo.InvariantCulture),
+        };
+
+    static string EntityFingerprint(MetadataReader reader, EntityHandle handle)
+        => handle.Kind switch
+        {
+            HandleKind.TypeDefinition => $"type-def:{reader.GetFullTypeName(reader.GetTypeDefinition((TypeDefinitionHandle)handle))}",
+            HandleKind.TypeReference => $"type-ref:{reader.GetFullTypeName(reader.GetTypeReference((TypeReferenceHandle)handle))}",
+            HandleKind.TypeSpecification => $"type-spec:{CanonicalTypeName(reader.GetTypeSpecification((TypeSpecificationHandle)handle).DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty))}",
+            HandleKind.MethodDefinition => MethodDefinitionFingerprint(reader, (MethodDefinitionHandle)handle),
+            HandleKind.MemberReference => MemberReferenceFingerprint(reader, (MemberReferenceHandle)handle),
+            HandleKind.MethodSpecification => MethodSpecificationFingerprint(reader, (MethodSpecificationHandle)handle),
+            HandleKind.FieldDefinition => FieldDefinitionFingerprint(reader, (FieldDefinitionHandle)handle),
+            _ => $"{handle.Kind}:{MetadataTokens.GetToken(handle).ToString(CultureInfo.InvariantCulture)}",
+        };
+
+    static string MethodDefinitionFingerprint(MetadataReader reader, MethodDefinitionHandle handle)
+    {
+        var method = reader.GetMethodDefinition(handle);
+        return $"method-def:{reader.GetFullTypeName(reader.GetTypeDefinition(method.GetDeclaringType()))}.{reader.GetString(method.Name)}:{MethodSignatureFingerprint(reader, method)}";
+    }
+
+    static string MemberReferenceFingerprint(MetadataReader reader, MemberReferenceHandle handle)
+    {
+        var member = reader.GetMemberReference(handle);
+        string signature = member.GetKind() == MemberReferenceKind.Method
+            ? MethodSignatureFingerprint(member.DecodeMethodSignature(TypeRefDecoder.Instance, GenericScope.Empty))
+            : CanonicalTypeName(member.DecodeFieldSignature(TypeRefDecoder.Instance, GenericScope.Empty));
+        return $"member-ref:{MemberParentFingerprint(reader, member.Parent)}.{reader.GetString(member.Name)}:{signature}";
+    }
+
+    static string MethodSpecificationFingerprint(MetadataReader reader, MethodSpecificationHandle handle)
+    {
+        var spec = reader.GetMethodSpecification(handle);
+        var typeArguments = spec.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+        return $"method-spec:{EntityFingerprint(reader, spec.Method)}<{string.Join(",", typeArguments.Select(CanonicalTypeName))}>";
+    }
+
+    static string FieldDefinitionFingerprint(MetadataReader reader, FieldDefinitionHandle handle)
+    {
+        var field = reader.GetFieldDefinition(handle);
+        return $"field-def:{reader.GetFullTypeName(reader.GetTypeDefinition(field.GetDeclaringType()))}.{reader.GetString(field.Name)}:{CanonicalTypeName(field.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty))}";
+    }
+
+    static string MemberParentFingerprint(MetadataReader reader, EntityHandle handle)
+        => handle.Kind switch
+        {
+            HandleKind.TypeDefinition or HandleKind.TypeReference or HandleKind.TypeSpecification => EntityFingerprint(reader, handle),
+            _ => $"{handle.Kind}:{MetadataTokens.GetToken(handle).ToString(CultureInfo.InvariantCulture)}",
+        };
+
+    static string MethodSignatureFingerprint(MetadataReader reader, MethodDefinition method)
+        => MethodSignatureFingerprint(method.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty));
+
+    static string MethodSignatureFingerprint(System.Reflection.Metadata.MethodSignature<TypeRef> signature)
+        => $"{(signature.Header.IsInstance ? "instance" : "static")}:{signature.GenericParameterCount}:{CanonicalTypeName(signature.ReturnType)}({string.Join(",", signature.ParameterTypes.Select(CanonicalTypeName))})";
+
+    static string StandaloneSignatureFingerprint(MetadataReader reader, StandaloneSignatureHandle handle)
+    {
+        if (handle.IsNil)
+            return "";
+
+        var signature = reader.GetStandaloneSignature(handle);
+        try
+        {
+            var locals = signature.DecodeLocalSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+            return $"locals({string.Join(",", locals.Select(CanonicalTypeName))})";
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+        {
+            try
+            {
+                return $"method({MethodSignatureFingerprint(signature.DecodeMethodSignature(TypeRefDecoder.Instance, GenericScope.Empty))})";
+            }
+            catch (Exception inner) when (inner is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return System.Convert.ToHexString(reader.GetBlobBytes(signature.Signature));
+            }
+        }
+    }
+
+    static IReadOnlyDictionary<string, TypeDefinitionHandle> BuildTypeDefinitionMap(MetadataReader reader)
+    {
+        var map = new Dictionary<string, TypeDefinitionHandle>(StringComparer.Ordinal);
+        foreach (var handle in reader.TypeDefinitions)
+            map.TryAdd(reader.GetFullTypeName(reader.GetTypeDefinition(handle)), handle);
+        return map;
+    }
+
+    static bool IsVisibleSurfaceType(
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        IReadOnlyDictionary<string, TypeDefinitionHandle> typeDefinitionsByName)
+    {
+        var type = reader.GetTypeDefinition(handle);
+        bool visible = (type.Attributes & TypeAttributes.VisibilityMask) is
+            TypeAttributes.Public or TypeAttributes.NestedPublic or TypeAttributes.NestedFamily or TypeAttributes.NestedFamORAssem;
+        if (!visible)
+            return false;
+        var declaring = type.GetDeclaringType();
+        return declaring.IsNil || IsVisibleSurfaceType(reader, declaring, typeDefinitionsByName);
+    }
+
+    static bool IsPublicSurface(MethodDefinition method)
+        => (method.Attributes & MethodAttributes.MemberAccessMask) is
+            MethodAttributes.Public or MethodAttributes.Family or MethodAttributes.FamORAssem;
+
+    static HashSet<MethodDefinitionHandle> GetExplicitImplementationBodies(
+        MetadataReader reader,
+        TypeDefinition type,
+        IReadOnlyDictionary<string, TypeDefinitionHandle> typeDefinitionsByName)
+    {
+        HashSet<MethodDefinitionHandle> handles = [];
+        foreach (var implementationHandle in type.GetMethodImplementations())
+        {
+            var implementation = reader.GetMethodImplementation(implementationHandle);
+            if (implementation.MethodBody.Kind == HandleKind.MethodDefinition
+                && IsVisibleImplementedMember(reader, implementation.MethodDeclaration, typeDefinitionsByName))
+            {
+                handles.Add((MethodDefinitionHandle)implementation.MethodBody);
+            }
+        }
+
+        return handles;
+    }
+
+    static bool IsVisibleImplementedMember(
+        MetadataReader reader,
+        EntityHandle declaration,
+        IReadOnlyDictionary<string, TypeDefinitionHandle> typeDefinitionsByName)
+        => declaration.Kind switch
+        {
+            HandleKind.MethodDefinition => IsVisibleImplementedMethodDefinition(reader, (MethodDefinitionHandle)declaration, typeDefinitionsByName),
+            HandleKind.MemberReference => IsVisibleMemberReferenceParent(reader, reader.GetMemberReference((MemberReferenceHandle)declaration).Parent, typeDefinitionsByName),
+            _ => false,
+        };
+
+    static bool IsVisibleImplementedMethodDefinition(
+        MetadataReader reader,
+        MethodDefinitionHandle handle,
+        IReadOnlyDictionary<string, TypeDefinitionHandle> typeDefinitionsByName)
+    {
+        var method = reader.GetMethodDefinition(handle);
+        var declaring = method.GetDeclaringType();
+        return IsVisibleSurfaceType(reader, declaring, typeDefinitionsByName)
+            && (reader.GetTypeDefinition(declaring).Attributes & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Interface;
+    }
+
+    static bool IsVisibleMemberReferenceParent(
+        MetadataReader reader,
+        EntityHandle parent,
+        IReadOnlyDictionary<string, TypeDefinitionHandle> typeDefinitionsByName)
+        => parent.Kind switch
+        {
+            HandleKind.TypeDefinition => IsVisibleSurfaceType(reader, (TypeDefinitionHandle)parent, typeDefinitionsByName)
+                && (reader.GetTypeDefinition((TypeDefinitionHandle)parent).Attributes & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Interface,
+            HandleKind.TypeReference => IsVisibleTypeReferenceParent(reader, (TypeReferenceHandle)parent, typeDefinitionsByName),
+            HandleKind.TypeSpecification => IsVisibleTypeSpecificationParent(reader, (TypeSpecificationHandle)parent, typeDefinitionsByName),
+            _ => false,
+        };
+
+    static bool IsVisibleTypeReferenceParent(
+        MetadataReader reader,
+        TypeReferenceHandle handle,
+        IReadOnlyDictionary<string, TypeDefinitionHandle> typeDefinitionsByName)
+    {
+        var reference = reader.GetTypeReference(handle);
+        if (reference.ResolutionScope.Kind == HandleKind.AssemblyReference)
+            return true;
+
+        string metadataName = reader.GetFullTypeName(reference);
+        if (typeDefinitionsByName.TryGetValue(metadataName, out var typeHandle))
+            return IsVisibleInterfaceDefinition(reader, typeHandle, typeDefinitionsByName);
+
+        return false;
+    }
+
+    static bool IsVisibleTypeSpecificationParent(
+        MetadataReader reader,
+        TypeSpecificationHandle handle,
+        IReadOnlyDictionary<string, TypeDefinitionHandle> typeDefinitionsByName)
+    {
+        var type = reader.GetTypeSpecification(handle).DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty);
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType : type;
+        if (definition is not { Kind: TypeRefKind.Definition })
+            return true;
+
+        string currentAssembly = reader.IsAssembly ? reader.GetString(reader.GetAssemblyDefinition().Name) : "";
+        if (definition.Assembly.Length > 0 && definition.Assembly != currentAssembly)
+            return true;
+
+        string metadataName = definition.Namespace.Length == 0
+            ? definition.Name.Replace("+", ".", StringComparison.Ordinal)
+            : $"{definition.Namespace}.{definition.Name.Replace("+", ".", StringComparison.Ordinal)}";
+        if (typeDefinitionsByName.TryGetValue(metadataName, out var typeHandle))
+            return IsVisibleInterfaceDefinition(reader, typeHandle, typeDefinitionsByName);
+
+        return true;
+    }
+
+    static bool IsVisibleInterfaceDefinition(
+        MetadataReader reader,
+        TypeDefinitionHandle handle,
+        IReadOnlyDictionary<string, TypeDefinitionHandle> typeDefinitionsByName)
+    {
+        var type = reader.GetTypeDefinition(handle);
+        return IsVisibleSurfaceType(reader, handle, typeDefinitionsByName)
+            && (type.Attributes & TypeAttributes.ClassSemanticsMask) == TypeAttributes.Interface;
+    }
+
+    static bool MatchesTypeFilters(string typeFullName, IReadOnlySet<string>? filters)
+    {
+        if (filters is null || filters.Count == 0)
+            return true;
+        foreach (string filter in filters)
+        {
+            if (MatchesTypeFilter(typeFullName, filter))
+                return true;
+        }
+
+        return false;
+    }
+
+    static bool MatchesTypeFilter(string typeFullName, string filter)
+    {
+        if (filter.Contains('*') || filter.Contains('?'))
+            return GlobMatches(typeFullName, filter);
+        return string.Equals(typeFullName, filter, StringComparison.OrdinalIgnoreCase)
+            || typeFullName.EndsWith("." + filter, StringComparison.OrdinalIgnoreCase)
+            || typeFullName.Contains("." + filter + ".", StringComparison.OrdinalIgnoreCase);
+    }
+
+    static bool GlobMatches(string value, string pattern)
+    {
+        int valueIndex = 0;
+        int patternIndex = 0;
+        int starIndex = -1;
+        int retryIndex = 0;
+
+        while (valueIndex < value.Length)
+        {
+            if (patternIndex < pattern.Length
+                && (pattern[patternIndex] == '?' || char.ToUpperInvariant(pattern[patternIndex]) == char.ToUpperInvariant(value[valueIndex])))
+            {
+                valueIndex++;
+                patternIndex++;
+            }
+            else if (patternIndex < pattern.Length && pattern[patternIndex] == '*')
+            {
+                starIndex = patternIndex++;
+                retryIndex = valueIndex;
+            }
+            else if (starIndex >= 0)
+            {
+                patternIndex = starIndex + 1;
+                valueIndex = ++retryIndex;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        while (patternIndex < pattern.Length && pattern[patternIndex] == '*')
+            patternIndex++;
+        return patternIndex == pattern.Length;
+    }
+
+    static void AddWholeMethod(
+        ImmutableArray<CSharpDiffRow>.Builder rows,
+        CSharpMethodEntry entry,
+        ref int hunkId,
+        CSharpDiffKind kind)
+    {
+        int hunk = hunkId++;
+        string text = kind == CSharpDiffKind.Add ? "/* method added */" : "/* method removed */";
+        string changeId = kind == CSharpDiffKind.Add ? "csharp.method.added" : "csharp.method.removed";
+        string message = kind == CSharpDiffKind.Add ? "Added C# method." : "Removed C# method.";
+        rows.Add(CreateRow(entry, hunk, kind, null, "NotRun", text, changeId, message));
+    }
+
+    static void AddLineDiffRows(
+        ImmutableArray<CSharpDiffRow>.Builder rows,
+        CSharpMethodEntry entry,
+        CSharpMethodRender oldRender,
+        CSharpMethodRender newRender,
+        ref int hunkId)
+    {
+        var oldLines = oldRender.Lines;
+        var newLines = newRender.Lines;
+        if (oldRender.State == newRender.State && oldLines.SequenceEqual(newLines))
+            return;
+
+        if (oldRender.State != CSharpMethodRenderState.Body || newRender.State != CSharpMethodRenderState.Body)
+        {
+            AddRenderStateRows(rows, entry, oldRender, newRender, ref hunkId);
+            return;
+        }
+
+        if (oldLines.Length > MaxLcsLines || newLines.Length > MaxLcsLines)
+        {
+            int hunk = hunkId++;
+            string message = $"/* C# diff skipped: old body has {oldLines.Length} lines, new body has {newLines.Length} lines; limit is {MaxLcsLines} */";
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), message, "csharp.body-diff.skipped", "Skipped C# body diff; old body exceeds line limit."));
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), message, "csharp.body-diff.skipped", "Skipped C# body diff; new body exceeds line limit."));
+            return;
+        }
+
+        var lcs = LongestCommonSubsequence(oldLines, newLines);
+        int oldIndex = 0;
+        int newIndex = 0;
+        foreach (var (nextOld, nextNew) in lcs)
+        {
+            AddUnmatched(rows, entry, oldRender, oldIndex, nextOld, newRender, newIndex, nextNew, ref hunkId);
+            oldIndex = nextOld + 1;
+            newIndex = nextNew + 1;
+        }
+
+        AddUnmatched(rows, entry, oldRender, oldIndex, oldLines.Length, newRender, newIndex, newLines.Length, ref hunkId);
+    }
+
+    static void AddUnmatched(
+        ImmutableArray<CSharpDiffRow>.Builder rows,
+        CSharpMethodEntry entry,
+        CSharpMethodRender oldRender,
+        int oldStart,
+        int oldEnd,
+        CSharpMethodRender newRender,
+        int newStart,
+        int newEnd,
+        ref int hunkId)
+    {
+        if (oldStart == oldEnd && newStart == newEnd)
+            return;
+
+        int hunk = hunkId++;
+        for (int i = oldStart; i < oldEnd; i++)
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, i + 1, oldRender.Fidelity.ToString(), oldRender.Lines[i]));
+        for (int i = newStart; i < newEnd; i++)
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, i + 1, newRender.Fidelity.ToString(), newRender.Lines[i]));
+    }
+
+    static void AddRenderStateRows(
+        ImmutableArray<CSharpDiffRow>.Builder rows,
+        CSharpMethodEntry entry,
+        CSharpMethodRender oldRender,
+        CSharpMethodRender newRender,
+        ref int hunkId)
+    {
+        int hunk = hunkId++;
+        if (oldRender.State is CSharpMethodRenderState.Body && newRender.State is CSharpMethodRenderState.NoBody)
+        {
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), "/* method body removed */", "csharp.method.body-removed", "Removed C# method body."));
+            return;
+        }
+
+        if (oldRender.State is CSharpMethodRenderState.NoBody && newRender.State is CSharpMethodRenderState.Body)
+        {
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), "/* method body added */", "csharp.method.body-added", "Added C# method body."));
+            return;
+        }
+
+        if (oldRender.State is CSharpMethodRenderState.Failed)
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), oldRender.Lines[0], "csharp.decompile.failed", "Old method body decompilation failed."));
+        if (newRender.State is CSharpMethodRenderState.Failed)
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), newRender.Lines[0], "csharp.decompile.failed", "New method body decompilation failed."));
+        if (oldRender.State is CSharpMethodRenderState.NoBody)
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), oldRender.Lines[0], "csharp.method.no-body", "Old method has no C# body."));
+        if (newRender.State is CSharpMethodRenderState.NoBody)
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), newRender.Lines[0], "csharp.method.no-body", "New method has no C# body."));
+        if (oldRender.State is CSharpMethodRenderState.Body)
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), "/* method body removed */", "csharp.method.body-removed", "Removed C# method body."));
+        if (newRender.State is CSharpMethodRenderState.Body)
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), "/* method body added */", "csharp.method.body-added", "Added C# method body."));
+    }
+
+    static CSharpDiffRow CreateRow(
+        CSharpMethodEntry entry,
+        int hunk,
+        CSharpDiffKind kind,
+        int? line,
+        string fidelity,
+        string text,
+        string? changeId = null,
+        string? message = null)
+    {
+        changeId ??= kind == CSharpDiffKind.Add ? "csharp.line.added" : "csharp.line.removed";
+        message ??= kind == CSharpDiffKind.Add
+            ? $"Added C# line '{text}'"
+            : $"Removed C# line '{text}'";
+        return new CSharpDiffRow(
+            entry.StableAssemblyKey,
+            entry.StableMemberKey,
+            entry.StableMemberSelector,
+            entry.CanonicalSignature,
+            entry.Digest,
+            entry.Display,
+            changeId,
+            message,
+            hunk,
+            kind,
+            line,
+            line is null ? null : $"line:{line.Value}",
+            fidelity,
+            text);
+    }
+
+    static List<(int OldIndex, int NewIndex)> LongestCommonSubsequence(IReadOnlyList<string> oldLines, IReadOnlyList<string> newLines)
+    {
+        var lengths = new int[oldLines.Count + 1, newLines.Count + 1];
+        for (int oldIndex = oldLines.Count - 1; oldIndex >= 0; oldIndex--)
+        {
+            for (int newIndex = newLines.Count - 1; newIndex >= 0; newIndex--)
+            {
+                lengths[oldIndex, newIndex] = string.Equals(oldLines[oldIndex], newLines[newIndex], StringComparison.Ordinal)
+                    ? lengths[oldIndex + 1, newIndex + 1] + 1
+                    : Math.Max(lengths[oldIndex + 1, newIndex], lengths[oldIndex, newIndex + 1]);
+            }
+        }
+
+        var pairs = new List<(int OldIndex, int NewIndex)>();
+        int i = 0;
+        int j = 0;
+        while (i < oldLines.Count && j < newLines.Count)
+        {
+            if (string.Equals(oldLines[i], newLines[j], StringComparison.Ordinal))
+            {
+                pairs.Add((i, j));
+                i++;
+                j++;
+            }
+            else if (lengths[i + 1, j] >= lengths[i, j + 1])
+            {
+                i++;
+            }
+            else
+            {
+                j++;
+            }
+        }
+
+        return pairs;
+    }
+
+    static string[] SplitLines(string? text)
+    {
+        string normalized = (text ?? "").Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+        while (normalized.EndsWith('\n'))
+            normalized = normalized[..^1];
+        return normalized.Length == 0 ? [] : normalized.Split('\n');
+    }
+
+    sealed record CSharpMethodEntry(
+        string Path,
+        string AssemblyName,
+        string StableAssemblyKey,
+        string CanonicalSignature,
+        string StableMemberKey,
+        string DuplicateDiscriminator,
+        string StableMemberSelector,
+        string Digest,
+        string Display,
+        string TypeFullName,
+        string MethodName,
+        int OverloadIndex,
+        bool HasBody,
+        string BodyFingerprint)
+    {
+        public string RawKey => CanonicalSignature;
+    }
+
+    enum CSharpMethodRenderState
+    {
+        Body,
+        NoBody,
+        Failed,
+    }
+
+    sealed record CSharpMethodRender(CSharpMethodRenderState State, string[] Lines, DecompilationFidelity Fidelity);
+
+    sealed class SourceCache : IDisposable
+    {
+        readonly Dictionary<string, MetadataSource> _sources = new(StringComparer.Ordinal);
+
+        public MetadataSource Open(string path)
+        {
+            if (!_sources.TryGetValue(path, out var source))
+            {
+                source = MetadataSource.OpenWithoutSymbols(path);
+                _sources.Add(path, source);
+            }
+
+            return source;
+        }
+
+        public void Dispose()
+        {
+            foreach (var source in _sources.Values)
+                source.Dispose();
+        }
+    }
+}

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -176,7 +176,7 @@ public static class CSharpBodyDiff
                 var parameters = signature.ParameterTypes.Select(CanonicalTypeName).ToImmutableArray();
                 int genericArity = method.GetGenericParameters().Count;
                 string methodGeneric = GenericParameterList(genericArity, isMethod: true);
-                string selectorName = MemberSelectorName(methodName);
+                string selectorName = ResearchDiff.ResearchMemberSelector.ForMetadataName(methodName, IsExtensionMethod(reader, type, method));
                 string returnSuffix = IsConversionOperator(methodName) ? $"~{returnType}" : "";
                 string canonicalName = CanonicalMemberName(methodName);
                 string canonicalSignature = $"M:{typeKey}.{canonicalName}{methodGeneric}({string.Join(",", parameters)}){returnSuffix}";
@@ -206,14 +206,12 @@ public static class CSharpBodyDiff
     static string CanonicalMemberName(string methodName)
         => methodName == ".ctor" ? "#ctor" : methodName;
 
-    static string MemberSelectorName(string methodName)
-        => methodName switch
-        {
-            ".ctor" => ".ctor",
-            "op_Implicit" or "op_Explicit" or "op_CheckedExplicit" => $"operator:{methodName}",
-            _ when methodName.Contains('.') => $"explicit:{methodName}",
-            _ => methodName,
-        };
+    static bool IsExtensionMethod(MetadataReader reader, TypeDefinition type, MethodDefinition method)
+        => type.Attributes.HasFlag(TypeAttributes.Abstract)
+           && type.Attributes.HasFlag(TypeAttributes.Sealed)
+           && method.Attributes.HasFlag(MethodAttributes.Static)
+           && AttributeReader.HasExtensionAttribute(reader, type.GetCustomAttributes())
+           && AttributeReader.HasExtensionAttribute(reader, method.GetCustomAttributes());
 
     static bool IsConversionOperator(string methodName)
         => methodName is "op_Implicit" or "op_Explicit" or "op_CheckedExplicit";

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -180,7 +180,7 @@ public static class CSharpBodyDiff
                 string returnSuffix = IsConversionOperator(methodName) ? $"~{returnType}" : "";
                 string canonicalName = CanonicalMemberName(methodName);
                 string canonicalSignature = $"M:{typeKey}.{canonicalName}{methodGeneric}({string.Join(",", parameters)}){returnSuffix}";
-                var anchor = CreateMemberAnchor(typeKey, selectorName, canonicalSignature);
+                var anchor = CreateMemberAnchor(typeKey, selectorName, canonicalName, canonicalSignature);
                 string displayName = methodName == ".ctor" ? "#ctor" : methodName;
                 string display = $"{typeDisplay}.{displayName}{GenericAritySuffix(genericArity)}({string.Join(", ", parameters)})";
                 yield return new CSharpMethodEntry(
@@ -248,9 +248,9 @@ public static class CSharpBodyDiff
         return $"<{string.Join(",", Enumerable.Range(0, arity).Select(index => $"{prefix}{index}"))}>";
     }
 
-    static MemberAnchor CreateMemberAnchor(string typeFullName, string memberName, string canonicalSignature)
+    static MemberAnchor CreateMemberAnchor(string typeFullName, string selectorName, string memberName, string canonicalSignature)
         => new(
-            $"{memberName}~{MemberAnchor.ComputeFingerprint(canonicalSignature)}",
+            $"{selectorName}~{MemberAnchor.ComputeFingerprint(canonicalSignature)}",
             canonicalSignature,
             MemberAnchor.ComputeFingerprint(canonicalSignature),
             typeFullName,

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -176,9 +176,10 @@ public static class CSharpBodyDiff
                 var parameters = signature.ParameterTypes.Select(CanonicalTypeName).ToImmutableArray();
                 int genericArity = method.GetGenericParameters().Count;
                 string methodGeneric = GenericParameterList(genericArity, isMethod: true);
-                string selectorName = CanonicalMemberName(methodName);
+                string selectorName = MemberSelectorName(methodName);
                 string returnSuffix = IsConversionOperator(methodName) ? $"~{returnType}" : "";
-                string canonicalSignature = $"M:{typeKey}.{selectorName}{methodGeneric}({string.Join(",", parameters)}){returnSuffix}";
+                string canonicalName = CanonicalMemberName(methodName);
+                string canonicalSignature = $"M:{typeKey}.{canonicalName}{methodGeneric}({string.Join(",", parameters)}){returnSuffix}";
                 var anchor = CreateMemberAnchor(typeKey, selectorName, canonicalSignature);
                 string displayName = methodName == ".ctor" ? "#ctor" : methodName;
                 string display = $"{typeDisplay}.{displayName}{GenericAritySuffix(genericArity)}({string.Join(", ", parameters)})";
@@ -204,6 +205,15 @@ public static class CSharpBodyDiff
 
     static string CanonicalMemberName(string methodName)
         => methodName == ".ctor" ? "#ctor" : methodName;
+
+    static string MemberSelectorName(string methodName)
+        => methodName switch
+        {
+            ".ctor" => "#ctor",
+            "op_Implicit" or "op_Explicit" or "op_CheckedExplicit" => $"operator:{methodName}",
+            _ when methodName.Contains('.') => $"explicit:{methodName}",
+            _ => methodName,
+        };
 
     static bool IsConversionOperator(string methodName)
         => methodName is "op_Implicit" or "op_Explicit" or "op_CheckedExplicit";

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -9,6 +9,7 @@ using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Research;
 
@@ -21,9 +22,7 @@ public enum CSharpDiffKind
 public sealed record CSharpDiffRow(
     string AssemblyIdentity,
     string StableMemberKey,
-    string StableMemberSelector,
-    string CanonicalSignature,
-    string Digest,
+    MemberAnchor Anchor,
     string Member,
     string ChangeId,
     string Message,
@@ -180,18 +179,16 @@ public static class CSharpBodyDiff
                 string selectorName = CanonicalMemberName(methodName);
                 string returnSuffix = IsConversionOperator(methodName) ? $"~{returnType}" : "";
                 string canonicalSignature = $"M:{typeKey}.{selectorName}{methodGeneric}({string.Join(",", parameters)}){returnSuffix}";
-                string digest = GetMemberDigest(canonicalSignature);
+                var anchor = CreateMemberAnchor(typeKey, selectorName, canonicalSignature);
                 string displayName = methodName == ".ctor" ? "#ctor" : methodName;
                 string display = $"{typeDisplay}.{displayName}{GenericAritySuffix(genericArity)}({string.Join(", ", parameters)})";
                 yield return new CSharpMethodEntry(
                     path,
                     source.AssemblyName,
                     stableAssemblyKey,
-                    canonicalSignature,
-                    $"{stableAssemblyKey}|{canonicalSignature}",
+                    anchor,
+                    $"{stableAssemblyKey}|{anchor.CanonicalSignature}",
                     DuplicateDiscriminator(reader, method),
-                    $"{selectorName}~{digest}",
-                    digest,
                     display,
                     typeFullName,
                     methodName,
@@ -243,12 +240,13 @@ public static class CSharpBodyDiff
         return $"<{string.Join(",", Enumerable.Range(0, arity).Select(index => $"{prefix}{index}"))}>";
     }
 
-    static string GetMemberDigest(string canonicalSignature)
-    {
-        var input = Encoding.UTF8.GetBytes("dotnet-inspect.member-index.v1\n" + canonicalSignature);
-        var hash = SHA256.HashData(input);
-        return System.Convert.ToHexString(hash).ToLowerInvariant()[..10];
-    }
+    static MemberAnchor CreateMemberAnchor(string typeFullName, string memberName, string canonicalSignature)
+        => new(
+            $"{memberName}~{MemberAnchor.ComputeFingerprint(canonicalSignature)}",
+            canonicalSignature,
+            MemberAnchor.ComputeFingerprint(canonicalSignature),
+            typeFullName,
+            memberName);
 
     static string DuplicateDiscriminator(MetadataReader reader, MethodDefinition method)
     {
@@ -735,9 +733,7 @@ public static class CSharpBodyDiff
         return new CSharpDiffRow(
             entry.StableAssemblyKey,
             entry.StableMemberKey,
-            entry.StableMemberSelector,
-            entry.CanonicalSignature,
-            entry.Digest,
+            entry.Anchor,
             entry.Display,
             changeId,
             message,
@@ -798,11 +794,9 @@ public static class CSharpBodyDiff
         string Path,
         string AssemblyName,
         string StableAssemblyKey,
-        string CanonicalSignature,
+        MemberAnchor Anchor,
         string StableMemberKey,
         string DuplicateDiscriminator,
-        string StableMemberSelector,
-        string Digest,
         string Display,
         string TypeFullName,
         string MethodName,
@@ -810,7 +804,7 @@ public static class CSharpBodyDiff
         bool HasBody,
         string BodyFingerprint)
     {
-        public string RawKey => CanonicalSignature;
+        public string RawKey => Anchor.CanonicalSignature;
     }
 
     enum CSharpMethodRenderState

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -16,7 +16,7 @@ public enum ResearchDiffMechanism
     BodySignals = 2,
     IlBody = 4,
     CSharp = 8,
-    AllAvailable = Api | BodySignals | IlBody,
+    AllAvailable = Api | BodySignals | IlBody | CSharp,
 }
 
 public enum ResearchDiffSubjectKind

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -582,8 +582,8 @@ public static class ResearchDiff
         {
             var subject = new ResearchSubjectKey(
                 ResearchDiffSubjectKind.Member,
-                row.StableMemberKey,
-                row.Member,
+                row.Anchor.StableSelector,
+                $"{row.Anchor.TypeFullName}.{row.Anchor.MemberName}",
                 row.Anchor.TypeFullName,
                 row.Anchor.MemberName);
             var direction = row.Kind == CSharpDiffKind.Add ? ResearchDiffDirection.Added : ResearchDiffDirection.Removed;

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -722,10 +722,12 @@ public static class ResearchDiff
     {
         var typeName = method.DeclaringType.ToQualifiedDisplayString();
         var memberName = method.Name == ".ctor" ? "#ctor" : method.Name;
-        var selectorName = ResearchMemberSelector.ForMetadataName(method.Name);
-        var parameters = string.Join(",", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
+        var selectorName = ResearchMemberSelector.ForMetadataName(method.Name, method.IsExtension);
+        var parameters = string.Join(",", method.ParameterTypes.Select(CanonicalTypeName));
         var displayParameters = string.Join(", ", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
-        var canonical = $"M:{typeName}.{memberName}({parameters})";
+        var methodGeneric = GenericParameterList(method.GenericArity, isMethod: true);
+        var returnSuffix = IsConversionOperator(method.Name) ? $"~{CanonicalTypeName(method.ReturnType)}" : "";
+        var canonical = $"M:{typeName}.{memberName}{methodGeneric}({parameters}){returnSuffix}";
         var fingerprint = MemberAnchor.ComputeFingerprint(canonical);
         return new ResearchSubjectKey(
             ResearchDiffSubjectKind.Member,
@@ -734,6 +736,34 @@ public static class ResearchDiff
             typeName,
             memberName);
     }
+
+    static string CanonicalTypeName(TypeRef type)
+        => type.Kind switch
+        {
+            TypeRefKind.Definition => type.Namespace.Length == 0
+                ? type.Name.Replace("+", ".", StringComparison.Ordinal)
+                : $"{type.Namespace}.{type.Name.Replace("+", ".", StringComparison.Ordinal)}",
+            TypeRefKind.GenericInstance => $"{CanonicalTypeName(type.ElementType!)}<{string.Join(",", type.TypeArguments.Select(CanonicalTypeName))}>",
+            TypeRefKind.SzArray => $"{CanonicalTypeName(type.ElementType!)}[]",
+            TypeRefKind.Array => $"{CanonicalTypeName(type.ElementType!)}[{(type.Rank == 1 ? "*" : new string(',', type.Rank - 1))}]",
+            TypeRefKind.ByRef => $"{CanonicalTypeName(type.ElementType!)}&",
+            TypeRefKind.Pointer => $"{CanonicalTypeName(type.ElementType!)}*",
+            TypeRefKind.Pinned => $"pinned {CanonicalTypeName(type.ElementType!)}",
+            TypeRefKind.GenericParameter => $"!{type.GenericParameterIndex}",
+            TypeRefKind.MethodGenericParameter => $"!!{type.GenericParameterIndex}",
+            _ => type.ToQualifiedDisplayString(),
+        };
+
+    static string GenericParameterList(int arity, bool isMethod)
+    {
+        if (arity == 0)
+            return "";
+        var prefix = isMethod ? "!!" : "!";
+        return $"<{string.Join(",", Enumerable.Range(0, arity).Select(index => $"{prefix}{index}"))}>";
+    }
+
+    static bool IsConversionOperator(string methodName)
+        => methodName is "op_Implicit" or "op_Explicit" or "op_CheckedExplicit";
 
     static ResearchSubjectKey UnknownMemberSubject(string key)
         => new(ResearchDiffSubjectKind.Member, $"member:{key}", key);

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using ILInspector.Analysis;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Research;
 
@@ -723,9 +724,11 @@ public static class ResearchDiff
         var memberName = method.Name == ".ctor" ? "#ctor" : method.Name;
         var parameters = string.Join(",", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
         var displayParameters = string.Join(", ", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
+        var canonical = $"M:{typeName}.{memberName}({parameters})";
+        var fingerprint = MemberAnchor.ComputeFingerprint(canonical);
         return new ResearchSubjectKey(
             ResearchDiffSubjectKind.Member,
-            $"member:M:{typeName}.{memberName}({parameters})",
+            $"{memberName}~{fingerprint}",
             $"{typeName}.{memberName}({displayParameters})",
             typeName,
             memberName);

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -723,10 +723,10 @@ public static class ResearchDiff
         var typeName = method.DeclaringType.ToQualifiedDisplayString();
         var memberName = method.Name == ".ctor" ? "#ctor" : method.Name;
         var selectorName = ResearchMemberSelector.ForMetadataName(method.Name, method.IsExtension);
-        var parameters = string.Join(",", method.ParameterTypes.Select(CanonicalTypeName));
+        var parameters = string.Join(",", method.ParameterTypes.Select(ApiTypeName));
         var displayParameters = string.Join(", ", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
-        var methodGeneric = GenericParameterList(method.GenericArity, isMethod: true);
-        var returnSuffix = IsConversionOperator(method.Name) ? $"~{CanonicalTypeName(method.ReturnType)}" : "";
+        var methodGeneric = ApiMethodGenericList(method);
+        var returnSuffix = "";
         var canonical = $"M:{typeName}.{memberName}{methodGeneric}({parameters}){returnSuffix}";
         var fingerprint = MemberAnchor.ComputeFingerprint(canonical);
         return new ResearchSubjectKey(
@@ -737,29 +737,31 @@ public static class ResearchDiff
             memberName);
     }
 
-    static string CanonicalTypeName(TypeRef type)
+    static string ApiTypeName(TypeRef type)
         => type.Kind switch
         {
             TypeRefKind.Definition => type.Namespace.Length == 0
                 ? type.Name.Replace("+", ".", StringComparison.Ordinal)
                 : $"{type.Namespace}.{type.Name.Replace("+", ".", StringComparison.Ordinal)}",
-            TypeRefKind.GenericInstance => $"{CanonicalTypeName(type.ElementType!)}<{string.Join(",", type.TypeArguments.Select(CanonicalTypeName))}>",
-            TypeRefKind.SzArray => $"{CanonicalTypeName(type.ElementType!)}[]",
-            TypeRefKind.Array => $"{CanonicalTypeName(type.ElementType!)}[{(type.Rank == 1 ? "*" : new string(',', type.Rank - 1))}]",
-            TypeRefKind.ByRef => $"{CanonicalTypeName(type.ElementType!)}&",
-            TypeRefKind.Pointer => $"{CanonicalTypeName(type.ElementType!)}*",
-            TypeRefKind.Pinned => $"pinned {CanonicalTypeName(type.ElementType!)}",
-            TypeRefKind.GenericParameter => $"!{type.GenericParameterIndex}",
-            TypeRefKind.MethodGenericParameter => $"!!{type.GenericParameterIndex}",
+            TypeRefKind.GenericInstance => $"{ApiTypeName(type.ElementType!)}<{string.Join(",", type.TypeArguments.Select(ApiTypeName))}>",
+            TypeRefKind.SzArray => $"{ApiTypeName(type.ElementType!)}[]",
+            TypeRefKind.Array => $"{ApiTypeName(type.ElementType!)}[{(type.Rank == 1 ? "*" : new string(',', type.Rank - 1))}]",
+            TypeRefKind.ByRef => $"{ApiTypeName(type.ElementType!)}&",
+            TypeRefKind.Pointer => $"{ApiTypeName(type.ElementType!)}*",
+            TypeRefKind.Pinned => $"pinned {ApiTypeName(type.ElementType!)}",
+            TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter
+                => type.GenericParameterName.Length == 0 ? $"!{type.GenericParameterIndex}" : type.GenericParameterName,
             _ => type.ToQualifiedDisplayString(),
         };
 
-    static string GenericParameterList(int arity, bool isMethod)
+    static string ApiMethodGenericList(MethodIdentity method)
     {
-        if (arity == 0)
+        if (method.GenericArity == 0)
             return "";
-        var prefix = isMethod ? "!!" : "!";
-        return $"<{string.Join(",", Enumerable.Range(0, arity).Select(index => $"{prefix}{index}"))}>";
+        return $"<{string.Join(",", Enumerable.Range(0, method.GenericArity).Select(index =>
+            index < method.GenericParameterNames.Length && method.GenericParameterNames[index].Length > 0
+                ? method.GenericParameterNames[index]
+                : $"!!{index}"))}>";
     }
 
     static bool IsConversionOperator(string methodName)

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -722,7 +722,7 @@ public static class ResearchDiff
     {
         var typeName = method.DeclaringType.ToQualifiedDisplayString();
         var memberName = method.Name == ".ctor" ? "#ctor" : method.Name;
-        var selectorName = method.Name == ".ctor" ? ".ctor" : memberName;
+        var selectorName = ResearchMemberSelector.ForMetadataName(method.Name);
         var parameters = string.Join(",", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
         var displayParameters = string.Join(", ", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
         var canonical = $"M:{typeName}.{memberName}({parameters})";
@@ -737,6 +737,19 @@ public static class ResearchDiff
 
     static ResearchSubjectKey UnknownMemberSubject(string key)
         => new(ResearchDiffSubjectKind.Member, $"member:{key}", key);
+
+    internal static class ResearchMemberSelector
+    {
+        public static string ForMetadataName(string methodName, bool isExtensionMethod = false)
+            => methodName switch
+            {
+                ".ctor" => ".ctor",
+                _ when isExtensionMethod => $"extension:{methodName}",
+                _ when methodName.StartsWith("op_", StringComparison.Ordinal) => $"operator:{methodName}",
+                _ when methodName.Contains('.') => $"explicit:{methodName}",
+                _ => methodName,
+            };
+    }
 
     static string BodySignalMethodKey(MethodIdentity method)
         => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -47,6 +47,7 @@ public enum ResearchDiffEvidenceKind
     MetadataApi,
     IlBody,
     BodySignal,
+    CSharp,
 }
 
 public sealed record ResearchDiffRow(
@@ -55,7 +56,8 @@ public sealed record ResearchDiffRow(
     string Message,
     ApiChange? ApiChange = null,
     IlDiffRow? IlRow = null,
-    BodySignalDiffRow? BodySignalRow = null);
+    BodySignalDiffRow? BodySignalRow = null,
+    CSharpDiffRow? CSharpRow = null);
 
 public sealed record ResearchDiffOptions(
     ResearchDiffMechanism Mechanisms = ResearchDiffMechanism.AllAvailable,
@@ -200,6 +202,21 @@ public static class ResearchDiff
             ]);
     }
 
+    public static ResearchDiffResult FromCSharpBodyDiff(CSharpBodyDiffResult diff)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+        return new ResearchDiffResult(
+            [],
+            Rows:
+            [
+                .. diff.Rows.Select(row => new ResearchDiffRow(
+                    row.ChangeId,
+                    ResearchDiffEvidenceKind.CSharp,
+                    row.Message,
+                    CSharpRow: row))
+            ]);
+    }
+
     public static ResearchDiffResult Combine(params ResearchDiffResult[] results)
     {
         ArgumentNullException.ThrowIfNull(results);
@@ -232,6 +249,9 @@ public static class ResearchDiff
 
         if (options.Mechanisms.HasFlag(ResearchDiffMechanism.IlBody))
             AddIlBodyDiff(builder, oldInput, newInput);
+
+        if (options.Mechanisms.HasFlag(ResearchDiffMechanism.CSharp))
+            AddCSharpDiff(builder, oldInput, newInput, options.TypeFilters);
 
         return builder.ToResult();
     }
@@ -550,6 +570,31 @@ public static class ResearchDiff
                         Category: ResearchDiffChangeCategory.IlBody));
                 }
             }
+        }
+    }
+
+    static void AddCSharpDiff(ResultBuilder builder, ResearchDiffInput oldInput, ResearchDiffInput newInput, IReadOnlySet<string>? typeFilters)
+    {
+        if (oldInput.AssemblyPaths.Count == 0 || newInput.AssemblyPaths.Count == 0)
+            return;
+
+        foreach (var row in CSharpBodyDiff.CompareAssemblies(oldInput.AssemblyPaths, newInput.AssemblyPaths, typeFilters: typeFilters).Rows)
+        {
+            var subject = new ResearchSubjectKey(
+                ResearchDiffSubjectKind.Member,
+                row.StableMemberKey,
+                row.Member,
+                row.Anchor.TypeFullName,
+                row.Anchor.MemberName);
+            var direction = row.Kind == CSharpDiffKind.Add ? ResearchDiffDirection.Added : ResearchDiffDirection.Removed;
+            builder.Add(subject, new ResearchDiffEvidence(
+                ResearchDiffMechanism.CSharp,
+                row.ChangeId,
+                direction,
+                OldValue: direction == ResearchDiffDirection.Removed ? row.Text : null,
+                NewValue: direction == ResearchDiffDirection.Added ? row.Text : null,
+                Detail: row.Message,
+                Category: ResearchDiffChangeCategory.CSharp));
         }
     }
 

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -722,13 +722,14 @@ public static class ResearchDiff
     {
         var typeName = method.DeclaringType.ToQualifiedDisplayString();
         var memberName = method.Name == ".ctor" ? "#ctor" : method.Name;
+        var selectorName = method.Name == ".ctor" ? ".ctor" : memberName;
         var parameters = string.Join(",", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
         var displayParameters = string.Join(", ", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
         var canonical = $"M:{typeName}.{memberName}({parameters})";
         var fingerprint = MemberAnchor.ComputeFingerprint(canonical);
         return new ResearchSubjectKey(
             ResearchDiffSubjectKind.Member,
-            $"{memberName}~{fingerprint}",
+            $"{selectorName}~{fingerprint}",
             $"{typeName}.{memberName}({displayParameters})",
             typeName,
             memberName);

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -782,10 +782,10 @@ public static class ResearchDiff
     }
 
     static string BodySignalMethodKey(MethodIdentity method)
-        => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
+        => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{method.GenericArity}|{method.IsExtension}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
 
     static string MethodMatchKey(MethodIdentity method)
-        => $"{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
+        => $"{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{method.GenericArity}|{method.IsExtension}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
 
     static Dictionary<string, MethodIdentity> MethodLookup(LibraryBodyIndex index)
     {

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -857,7 +857,7 @@ public static class ResearchDiff
 
     sealed class ResultBuilder
     {
-        readonly Dictionary<ResearchSubjectKey, List<ResearchDiffEvidence>> _rows = [];
+        readonly Dictionary<ResearchSubjectKey, List<ResearchDiffEvidence>> _rows = new(ResearchSubjectKeyIdentityComparer.Instance);
 
         public ApiDiff? ApiDiff { get; set; }
 
@@ -882,6 +882,21 @@ public static class ResearchDiff
                     .ThenBy(evidence => evidence.NewIlOffset)]))],
                 ApiDiff,
                 Rows: []);
+    }
+
+    sealed class ResearchSubjectKeyIdentityComparer : IEqualityComparer<ResearchSubjectKey>
+    {
+        public static ResearchSubjectKeyIdentityComparer Instance { get; } = new();
+
+        public bool Equals(ResearchSubjectKey? x, ResearchSubjectKey? y)
+            => ReferenceEquals(x, y)
+               || (x is not null
+                   && y is not null
+                   && x.Kind == y.Kind
+                   && string.Equals(x.Id, y.Id, StringComparison.Ordinal));
+
+        public int GetHashCode(ResearchSubjectKey obj)
+            => HashCode.Combine(obj.Kind, StringComparer.Ordinal.GetHashCode(obj.Id));
     }
 
     sealed class MethodBodyLookup : IDisposable


### PR DESCRIPTION
## Summary

Adds a Research-owned C# body diff primitive for matched method bodies, with no direct CLI enablement. The API compares shipped decompiler output and emits flat C# diff rows carrying stable member currency, typed change IDs, producer-owned messages, and C#-native row coordinates per #2299.

## Details

- Adds `ILInspector.Research.CSharpBodyDiff` and `CSharpDiffRow`/`CSharpBodyDiffResult`.
- Adapts to the #2309 ResearchDiff shape:
  - C# rows carry `MemberAnchor` currency.
  - `ResearchDiffEvidenceKind.CSharp` preserves typed C# rows.
  - `ResearchDiffMechanism.CSharp` projects rows into `ResearchDiff` subjects/evidence.
  - `ResearchDiffMechanism.AllAvailable` includes `CSharp`, so default ResearchDiff composition sees C# body evidence.
  - `ResearchDiff` aggregates member subjects by semantic identity (`Kind` + `Id`), and API/CSharp/IL/body-signal member subjects now use compatible metadata-owned `MemberAnchor` ids so evidence coalesces across mechanisms.
- Keeps matching SRM-only and NativeAOT-friendly: metadata readers, semantic IL/body fingerprints, and lazy decompilation only for changed matched bodies.
- Covers edge cases in fixtures/tests: token target changes, generic method/type/nested arity, constructors, conversion operators including checked explicit conversions, duplicate same-identity assemblies, duplicate canonical signatures, explicit interface implementations, extension methods, public/protected visibility, internal exclusions, method add/remove, and body/no-body transitions.

Refs #2291.
Refs #2299.

## Validation

- `dotnet run --no-restore --project src/ILInspector.Research.Tests -c Release`
- `dotnet run --no-restore --project src/ILInspector.Analysis.Tests -c Release -- -filter "/*/*/LibraryBodyIndexTests/*"`
- `dotnet run --no-restore --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/DiffCommandTests/*"`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore --verbosity minimal`
- `git diff --check`

## Adversarial review

Review findings resolved in this branch include: CLI surface removal, Research placement, C# in `AllAvailable`, API/CSharp/IL/body-signal subject coalescing, metadata-owned `MemberAnchor` canonical shape alignment, method/assembly occurrence currency, duplicate canonical signatures, constructor/operator/explicit/extension selector alignment, conversion-operator and generic-method identity, explicit-interface visibility, no-body fingerprints, semantic signature fingerprinting, and synthetic row messages/state transitions.

A final focused review round is running on the current PR head.
