### PR TITLE
Add pipeline idempotence sensor (--idempotence-check) (#2303)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -76,6 +76,8 @@
              Link="AssertionPrinter.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AssertionScan.cs"
              Link="AssertionScan.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\IdempotenceSensor.cs"
+             Link="IdempotenceSensor.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AnnotationCheck.cs"
              Link="AnnotationCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\VolatileFieldDetector.cs"

--- a/src/ILInspector.Decompiler.Tests/IdempotenceSensorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IdempotenceSensorTests.cs
@@ -1,0 +1,30 @@
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class IdempotenceSensorTests
+{
+    // A trivial `return 1` reaches its fixed point on the first pipeline run, so
+    // the second run must rewrite nothing — the sensor's stable-method baseline.
+    // This also exercises the two-run-with-one-seam contract the sensor relies on.
+    [Fact]
+    public void SecondRunChangedPasses_IdempotentFunction_ReportsNoRewrites()
+    {
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var block = new Block();
+        block.Add(new Return(new Constant(1, intType)));
+        var body = new BlockContainer();
+        body.Add(block);
+        var function = new IrFunction(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(intType, [], HasThis: false, GenericParameterCount: 0),
+            [],
+            body);
+
+        var changed = IdempotenceSensor.SecondRunChangedPasses(function, _ => null);
+
+        Assert.Empty(changed);
+    }
+}

--- a/tools/DecompilerHarness/IdempotenceSensor.cs
+++ b/tools/DecompilerHarness/IdempotenceSensor.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ILInspector.Decompiler;
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.DecompilerHarness;
+
+/// <summary>
+/// Pipeline idempotence sensor (#2303). Runs the IR pass pipeline once to raise a
+/// method, then runs it a second time and reports every method the second run
+/// still rewrites. A second-run-only rewrite is either a missed raise the single
+/// shipped pipeline should have caught (an ordering gap between an enabling pass
+/// and its consumer, F1's class) or an unstable pass — both are findings, and zero
+/// is the target. The run-2 rewrite is bucketed by the pass that fired, so the
+/// report is a burn-down list of ordering gaps. This is a 2x-pipeline lane by
+/// construction, so it belongs in scheduled/deep runs, not the per-PR loop.
+/// </summary>
+internal static class IdempotenceSensor
+{
+    public static int Run(
+        IReadOnlyList<string> assemblies,
+        int maxExamples,
+        int methodCap,
+        int? workers,
+        bool sequential)
+    {
+        Console.WriteLine("Evaluating pipeline idempotence (second-run rewrites)...");
+        var options = new ParallelOptions
+        {
+            MaxDegreeOfParallelism = sequential ? 1 : (workers ?? Math.Max(1, Environment.ProcessorCount - 2)),
+        };
+
+        long total = 0;
+        long unstable = 0;
+        long crashes = 0;
+        var byPass = new ConcurrentDictionary<string, long>(StringComparer.Ordinal);
+        var examples = new ConcurrentBag<Example>();
+        int exampleBudget = Math.Max(0, maxExamples);
+
+        using var metadata = CorpusMetadata.Create(assemblies);
+        foreach (var assemblyPath in assemblies)
+        {
+            var portablePath = CorpusSensor.PortablePath(assemblyPath);
+            using var source = MetadataSource.Open(assemblyPath, context: metadata);
+            _ = source.ResolveShape(TypeRef.CoreLib("System", "Int32"));
+            // The cross-method import seam must be identical across both runs, or a
+            // cross-method pass (classic-async MoveNext pull-in) would no-op in one
+            // run and fire in the other and register as a false idempotence break.
+            Func<MethodRef, IrFunction?> seam = method => IrImporter.Import(source, method);
+            var candidates = IrImporter.GetStableSampleCandidates(source, methodCap).ToList();
+
+            Parallel.ForEach(candidates, options, item =>
+            {
+                Interlocked.Increment(ref total);
+                try
+                {
+                    var function = item.Build(source);
+                    var changed = SecondRunChangedPasses(function, seam);
+                    if (changed.Count == 0)
+                        return;
+
+                    Interlocked.Increment(ref unstable);
+                    foreach (var pass in changed)
+                        byPass.AddOrUpdate(pass, 1, (_, count) => count + 1);
+                    if (examples.Count < exampleBudget)
+                    {
+                        string key = $"{portablePath}!{item.TypeName}::{item.MethodName}";
+                        examples.Add(new Example(key, changed.OrderBy(p => p, StringComparer.Ordinal).ToArray()));
+                    }
+                }
+                catch
+                {
+                    // A crash only on the second run is itself an instability signal,
+                    // but it is not a render difference; count it separately.
+                    Interlocked.Increment(ref crashes);
+                }
+            });
+        }
+
+        return Report(total, unstable, crashes, byPass, examples, exampleBudget);
+    }
+
+    /// <summary>
+    /// Raises <paramref name="rawFunction"/> once, then runs the pipeline a second
+    /// time and returns the passes that still rewrote the tree — empty when the
+    /// pipeline reached a fixed point on the first run. Both runs use the same
+    /// import seam, so a cross-method pass cannot register as a false break by
+    /// no-op'ing in one run and firing in the other.
+    /// </summary>
+    internal static IReadOnlyCollection<string> SecondRunChangedPasses(
+        IrFunction rawFunction,
+        Func<MethodRef, IrFunction?> seam)
+    {
+        IrPasses.Run(rawFunction, IrPasses.Default, PassContext.ForImport(seam));
+        var secondRun = IrPasses.RunWithStages(rawFunction, seam);
+        return StageDump.PassesThatChanged(secondRun);
+    }
+
+    static int Report(
+        long total,
+        long unstable,
+        long crashes,
+        IReadOnlyDictionary<string, long> byPass,
+        IReadOnlyCollection<Example> examples,
+        int exampleBudget)
+    {
+        Console.WriteLine($"Pipeline idempotence: {total} methods evaluated");
+        Console.WriteLine($"Second-run rewrites: {unstable}");
+        Console.WriteLine($"Second-run crashes:  {crashes}");
+
+        if (byPass.Count > 0)
+        {
+            Console.WriteLine("\nBy discharging pass (second run):");
+            foreach (var (pass, count) in byPass.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key, StringComparer.Ordinal))
+                Console.WriteLine($"  {count,6}  {pass}");
+        }
+
+        if (exampleBudget > 0 && examples.Count > 0)
+        {
+            Console.WriteLine("\nExamples (method — passes that fired on the second run):");
+            foreach (var example in examples.OrderBy(e => e.Key, StringComparer.Ordinal).Take(exampleBudget))
+                Console.WriteLine($"  {example.Key}  [{string.Join(", ", example.Passes)}]");
+        }
+
+        if (unstable == 0)
+        {
+            Console.WriteLine("\nPipeline is idempotent: the second run rewrote nothing.");
+            return 0;
+        }
+
+        return 1;
+    }
+
+    readonly record struct Example(string Key, IReadOnlyList<string> Passes);
+}

--- a/tools/DecompilerHarness/IdempotenceSensor.cs
+++ b/tools/DecompilerHarness/IdempotenceSensor.cs
@@ -126,7 +126,7 @@ internal static class IdempotenceSensor
                 Console.WriteLine($"  {example.Key}  [{string.Join(", ", example.Passes)}]");
         }
 
-        if (unstable == 0)
+        if (unstable == 0 && crashes == 0)
         {
             Console.WriteLine("\nPipeline is idempotent: the second run rewrote nothing.");
             return 0;

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -32,6 +32,7 @@ static class Program
         bool sequential = false;
         string? renderAb = null;
         string? emitRenderAb = null;
+        bool idempotenceCheck = false;
 
         string? dumpMethod = null;
         int dumpIndex = 0;
@@ -201,6 +202,7 @@ static class Program
                 case "--sequential": sequential = true; break;
                 case "--render-ab": renderAb = args[++i]; break;
                 case "--emit-render-ab": emitRenderAb = args[++i]; break;
+                case "--idempotence-check": idempotenceCheck = true; break;
                 case "--help" or "-h": PrintUsage(); return 0;
                 default: inputs.Add(args[i]); break;
             }
@@ -289,6 +291,9 @@ static class Program
 
         if (renderAb is not null || emitRenderAb is not null)
             return RenderAbSensor.Run(assemblies, renderAb, emitRenderAb, maxExamples, corpusMethodCap, workers, sequential);
+
+        if (idempotenceCheck)
+            return IdempotenceSensor.Run(assemblies, maxExamples, corpusMethodCap, workers, sequential);
 
         if (libraryReport)
             return LibraryReport.Run(assemblies, compileCap, maxExamples, json, topPatterns, topLibraries);
@@ -1420,6 +1425,10 @@ static class Program
           --emit-validity-defects <f>    with --validity-check, write per-method defect codes to <f>
           --diff-validity-defects <f>    with --validity-check, diff per-method defects against baseline <f>
           --fidelity-check        decompile, recompile in-context, and compare IL opcodes (semantic fidelity)
+          --idempotence-check     run the IR pipeline twice and report methods the
+                                second run still rewrites (ordering gaps / instability);
+                                bucketed by the pass that fired. Zero is the target.
+                                A 2x-pipeline lane — for scheduled/deep runs.
           --return-to-sender      prototype fact-planned compile-back harness:
                                 build module/type shells for the first property
                                 getter in each assembly, compile, and compare IL


### PR DESCRIPTION
## Summary

Closes #2303. Adds a `--idempotence-check` harness lane: run the IR pass pipeline once to raise a method, then run it a **second time** and report every method the second run still rewrites. A second-run-only rewrite is either a **missed raise** the single shipped pipeline should have caught — an ordering gap between an enabling pass and its consumer (F1/#2295's class) — or an **unstable pass**. Both are findings; zero is the target. The report buckets by the pass that fired on the second run, so it's a burn-down list of ordering gaps.

This generalizes the accident behind F1: the render-A/B sensor was double-running the pipeline and the second run produced *better* output (goto-region diamonds folded). Nothing measured that gap; now a standing lane does.

## Design

- Per method: `IrPasses.Run` once (raise), then `IrPasses.RunWithStages` again; `StageDump.PassesThatChanged` on the second run is the signal (empty ⇒ fixed point). Both runs share **one import seam** so a cross-method pass can't register as a false break by no-op'ing in one run and firing in the other.
- Mirrors `RenderAbSensor`'s enumeration/parallelism; exit code `1` when any second-run rewrite exists, `0` when idempotent.
- **Cost**: a 2x-pipeline lane by construction — for scheduled/deep runs (`decompiler-daily`), not the per-PR loop (documented in `--help`).

## Evidence (the current burndown it enumerates)

CoreLib, 36,427 methods:

```text
Second-run rewrites: 276
Second-run crashes:  0

By discharging pass (second run):
     110  expression-inlining
      67  boolean-folding
      42  slot-materialization
      35  structuring
      29  function-pointer-diagnostics
      18  deconstruction-assignment
      11  or-chain-guard
      10  slot-store-diamond
       ...
```

These are the ordering gaps F1 left — arm shapes the testified-join gate refuses and other enabling-pass-after-consumer pairs — and feed the fold-migration increments (F2+).

## Tests

- `IdempotenceSensorTests.SecondRunChangedPasses_IdempotentFunction_ReportsNoRewrites`: a trivial `return 1` reaches its fixed point on run 1, so run 2 rewrites nothing — validates the two-run/one-seam machinery and the stable-method baseline.
- Product-inert: harness/test only; no decompiler or product behavior change.

## Review

New harness lane over the decompiler pipeline — requesting two-model adversarial review per policy.
