### PR TITLE
Add IL diff operand fixture coverage

### DIFF
--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -44,6 +44,57 @@ namespace DiffFixtureSample
         // V1/V2 differ only in a member-reference token operand.
         public static int CallToken(int value) => System.Math.Abs(value);
 
+        // V1/V2 differ in instance and static field token operands.
+        public static int FieldToken(FieldTokenHolder holder, int value)
+        {
+            holder.InstanceA = value;
+            FieldTokenHolder.StaticA = value + 1;
+            return holder.InstanceA + FieldTokenHolder.StaticA;
+        }
+
+        // V1/V2 differ in type token operands across common type-bearing opcodes.
+        public static int TypeTokenShapes(object input, int length)
+        {
+            System.Type type = typeof(TypeTokenA);
+            int matches = input is TypeTokenA ? 1 : 0;
+            object typedInput = input ?? new TypeTokenA();
+            TypeTokenA cast = (TypeTokenA)typedInput;
+            TypeTokenA[] values = new TypeTokenA[length];
+            return type.Name.Length + matches + cast.Value + values.Length;
+        }
+
+        // V1/V2 differ in primitive type token operands for box/unbox.any.
+        public static int BoxToken(int value)
+        {
+            object boxed = (short)value;
+            return (short)boxed;
+        }
+
+        // C# emits ldtoken for the type handle.
+        public static int LdTokenType()
+        {
+            System.Type type = typeof(TypeTokenA);
+            return type.Name.Length;
+        }
+
+        // C# emits ldtoken for the backing data field used by InitializeArray.
+        public static int LdTokenField()
+        {
+            int[] values = new int[]
+            {
+                1, 2, 3, 4, 5, 6, 7, 8,
+                9, 10, 11, 12, 13, 14, 15, 16,
+            };
+            return values[0];
+        }
+
+        // C# emits a method token operand for the function pointer target.
+        public static unsafe int MethodToken(int value)
+        {
+            delegate*<int, int> target = &TokenTargetA;
+            return target(value);
+        }
+
         // V2 inserts an operation before the label target. The branch target's
         // raw IL offset shifts, but it still targets the same logical return.
         public static int BranchTargetOffsetShift(bool skip)
@@ -72,13 +123,58 @@ namespace DiffFixtureSample
             return 2;
         }
 
+        // V1/V2 keep the same switch target count but retarget case arms.
+        public static int SwitchRetarget(int value)
+        {
+            switch (value)
+            {
+                case 0:
+                    goto First;
+                case 1:
+                    goto Second;
+                case 2:
+                    goto Third;
+                default:
+                    return 4;
+            }
+
+        First:
+            return 1;
+
+        Second:
+            return 2;
+
+        Third:
+            return 3;
+        }
+
         // V1: safe body. V2 adds a visible unsafe operation.
         public static int AddsUnsafe(int value) => value;
+
+        static int TokenTargetA(int value) => value + 1;
 
         static void Sink(int value)
         {
             if (value == int.MinValue)
                 throw new System.InvalidOperationException();
+        }
+
+        public sealed class FieldTokenHolder
+        {
+            public int InstanceA;
+            public int InstanceB;
+            public static int StaticA;
+            public static int StaticB;
+        }
+
+        sealed class TypeTokenA
+        {
+            public int Value = 1;
+        }
+
+        sealed class TypeTokenB
+        {
+            public int Value = 1;
         }
     }
 }

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -47,6 +47,57 @@ namespace DiffFixtureSample
         // V1/V2 differ only in a member-reference token operand.
         public static int CallToken(int value) => System.Math.Sign(value);
 
+        // V1/V2 differ in instance and static field token operands.
+        public static int FieldToken(FieldTokenHolder holder, int value)
+        {
+            holder.InstanceB = value;
+            FieldTokenHolder.StaticB = value + 1;
+            return holder.InstanceB + FieldTokenHolder.StaticB;
+        }
+
+        // V1/V2 differ in type token operands across common type-bearing opcodes.
+        public static int TypeTokenShapes(object input, int length)
+        {
+            System.Type type = typeof(TypeTokenB);
+            int matches = input is TypeTokenB ? 1 : 0;
+            object typedInput = input ?? new TypeTokenB();
+            TypeTokenB cast = (TypeTokenB)typedInput;
+            TypeTokenB[] values = new TypeTokenB[length];
+            return type.Name.Length + matches + cast.Value + values.Length;
+        }
+
+        // V1/V2 differ in primitive type token operands for box/unbox.any.
+        public static int BoxToken(int value)
+        {
+            object boxed = (long)value;
+            return (int)(long)boxed;
+        }
+
+        // C# emits ldtoken for the type handle.
+        public static int LdTokenType()
+        {
+            System.Type type = typeof(TypeTokenB);
+            return type.Name.Length;
+        }
+
+        // C# emits ldtoken for the backing data field used by InitializeArray.
+        public static int LdTokenField()
+        {
+            int[] values = new int[]
+            {
+                16, 15, 14, 13, 12, 11, 10, 9,
+                8, 7, 6, 5, 4, 3, 2, 1,
+            };
+            return values[0];
+        }
+
+        // C# emits a method token operand for the function pointer target.
+        public static unsafe int MethodToken(int value)
+        {
+            delegate*<int, int> target = &TokenTargetB;
+            return target(value);
+        }
+
         // V2 inserts an operation before the label target. The branch target's
         // raw IL offset shifts, but it still targets the same logical return.
         public static int BranchTargetOffsetShift(bool skip)
@@ -76,6 +127,31 @@ namespace DiffFixtureSample
             return 2;
         }
 
+        // V1/V2 keep the same switch target count but retarget case arms.
+        public static int SwitchRetarget(int value)
+        {
+            switch (value)
+            {
+                case 0:
+                    goto Second;
+                case 1:
+                    goto First;
+                case 2:
+                    goto Third;
+                default:
+                    return 4;
+            }
+
+        First:
+            return 1;
+
+        Second:
+            return 2;
+
+        Third:
+            return 3;
+        }
+
         // V2: visible unsafe operation added relative to V1.
         public static unsafe int AddsUnsafe(int value)
         {
@@ -84,10 +160,30 @@ namespace DiffFixtureSample
             return values[0];
         }
 
+        static int TokenTargetB(int value) => value + 2;
+
         static void Sink(int value)
         {
             if (value == int.MinValue)
                 throw new System.InvalidOperationException();
+        }
+
+        public sealed class FieldTokenHolder
+        {
+            public int InstanceA;
+            public int InstanceB;
+            public static int StaticA;
+            public static int StaticB;
+        }
+
+        sealed class TypeTokenA
+        {
+            public int Value = 1;
+        }
+
+        sealed class TypeTokenB
+        {
+            public int Value = 1;
         }
     }
 }

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -202,22 +202,17 @@ public class IlBodyDiffTests
     }
 
     [Fact]
-    public void Compare_CompiledFixtureLdTokenChange_ReportsTokenVariants()
+    public void Compare_CompiledFixtureTokenOpcodes_ReportsTokenVariants()
     {
         var typeDiff = DiffFixtureDiff("LdTokenType");
         AssertTokenOperandPair(typeDiff, "ldtoken", "TypeTokenA", "TypeTokenB");
 
         var fieldDiff = DiffFixtureDiff("LdTokenField");
-        Assert.Contains(fieldDiff.Rows, row =>
-            row.Kind == IlDiffKind.Remove
-            && row.Operation.OpcodeFamily == "ldtoken"
-            && row.Operation.Operand?.Kind == IlOperandIdentityKind.Token
-            && row.Operation.Operand.Value.Contains("field ", StringComparison.Ordinal));
-        Assert.Contains(fieldDiff.Rows, row =>
-            row.Kind == IlDiffKind.Add
-            && row.Operation.OpcodeFamily == "ldtoken"
-            && row.Operation.Operand?.Kind == IlOperandIdentityKind.Token
-            && row.Operation.Operand.Value.Contains("field ", StringComparison.Ordinal));
+        var removedFieldToken = SingleTokenOperand(fieldDiff, IlDiffKind.Remove, "ldtoken", "field ");
+        var addedFieldToken = SingleTokenOperand(fieldDiff, IlDiffKind.Add, "ldtoken", "field ");
+        Assert.Contains("<PrivateImplementationDetails>", removedFieldToken.Value, StringComparison.Ordinal);
+        Assert.Contains("<PrivateImplementationDetails>", addedFieldToken.Value, StringComparison.Ordinal);
+        Assert.NotEqual(removedFieldToken.Value, addedFieldToken.Value);
 
         var methodDiff = DiffFixtureDiff("MethodToken");
         AssertTokenOperandPair(methodDiff, "ldftn", "::TokenTargetA(", "::TokenTargetB(");
@@ -228,14 +223,12 @@ public class IlBodyDiffTests
     {
         var diff = DiffFixtureDiff("SwitchRetarget");
 
-        Assert.Contains(diff.Rows, row =>
-            row.Kind == IlDiffKind.Remove
-            && row.Operation.OpcodeFamily == "switch"
-            && row.Operation.Operand?.Kind == IlOperandIdentityKind.SwitchTargets);
-        Assert.Contains(diff.Rows, row =>
-            row.Kind == IlDiffKind.Add
-            && row.Operation.OpcodeFamily == "switch"
-            && row.Operation.Operand?.Kind == IlOperandIdentityKind.SwitchTargets);
+        var removedSwitchTargets = SingleOperand(diff, IlDiffKind.Remove, "switch", IlOperandIdentityKind.SwitchTargets);
+        var addedSwitchTargets = SingleOperand(diff, IlDiffKind.Add, "switch", IlOperandIdentityKind.SwitchTargets);
+        Assert.Equal(
+            removedSwitchTargets.Value.Split(',').Length,
+            addedSwitchTargets.Value.Split(',').Length);
+        Assert.NotEqual(removedSwitchTargets.Value, addedSwitchTargets.Value);
     }
 
     [Fact]
@@ -386,16 +379,30 @@ public class IlBodyDiffTests
         string removedOperandFragment,
         string addedOperandFragment)
     {
-        Assert.Contains(diff.Rows, row =>
-            row.Kind == IlDiffKind.Remove
+        _ = SingleTokenOperand(diff, IlDiffKind.Remove, opcodeFamily, removedOperandFragment);
+        _ = SingleTokenOperand(diff, IlDiffKind.Add, opcodeFamily, addedOperandFragment);
+    }
+
+    static IlOperandIdentity SingleTokenOperand(
+        IlBodyDiffResult diff,
+        IlDiffKind kind,
+        string opcodeFamily,
+        string operandFragment)
+        => SingleOperand(diff, kind, opcodeFamily, IlOperandIdentityKind.Token, operandFragment);
+
+    static IlOperandIdentity SingleOperand(
+        IlBodyDiffResult diff,
+        IlDiffKind kind,
+        string opcodeFamily,
+        IlOperandIdentityKind operandKind,
+        string? operandFragment = null)
+    {
+        var row = Assert.Single(diff.Rows, row =>
+            row.Kind == kind
             && row.Operation.OpcodeFamily == opcodeFamily
-            && row.Operation.Operand?.Kind == IlOperandIdentityKind.Token
-            && row.Operation.Operand.Value.Contains(removedOperandFragment, StringComparison.Ordinal));
-        Assert.Contains(diff.Rows, row =>
-            row.Kind == IlDiffKind.Add
-            && row.Operation.OpcodeFamily == opcodeFamily
-            && row.Operation.Operand?.Kind == IlOperandIdentityKind.Token
-            && row.Operation.Operand.Value.Contains(addedOperandFragment, StringComparison.Ordinal));
+            && row.Operation.Operand?.Kind == operandKind
+            && (operandFragment is null || row.Operation.Operand.Value.Contains(operandFragment, StringComparison.Ordinal)));
+        return Assert.IsType<IlOperandIdentity>(row.Operation.Operand);
     }
 
     static IlBodyDiffResult DiffFixtureDiff(string name)

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -171,6 +171,97 @@ public class IlBodyDiffTests
     }
 
     [Fact]
+    public void Compare_CompiledFixtureFieldTokenChange_ReportsFieldOperandChanges()
+    {
+        var diff = DiffFixtureDiff("FieldToken");
+
+        AssertTokenOperandPair(diff, "stfld", "::InstanceA", "::InstanceB");
+        AssertTokenOperandPair(diff, "ldfld", "::InstanceA", "::InstanceB");
+        AssertTokenOperandPair(diff, "stsfld", "::StaticA", "::StaticB");
+        AssertTokenOperandPair(diff, "ldsfld", "::StaticA", "::StaticB");
+    }
+
+    [Fact]
+    public void Compare_CompiledFixtureTypeTokenChange_ReportsTypeOperandChanges()
+    {
+        var diff = DiffFixtureDiff("TypeTokenShapes");
+
+        AssertTokenOperandPair(diff, "ldtoken", "TypeTokenA", "TypeTokenB");
+        AssertTokenOperandPair(diff, "isinst", "TypeTokenA", "TypeTokenB");
+        AssertTokenOperandPair(diff, "castclass", "TypeTokenA", "TypeTokenB");
+        AssertTokenOperandPair(diff, "newarr", "TypeTokenA", "TypeTokenB");
+    }
+
+    [Fact]
+    public void Compare_CompiledFixtureBoxTokenChange_ReportsBoxAndUnboxOperandChanges()
+    {
+        var diff = DiffFixtureDiff("BoxToken");
+
+        AssertTokenOperandPair(diff, "box", "System.Int16", "System.Int64");
+        AssertTokenOperandPair(diff, "unbox.any", "System.Int16", "System.Int64");
+    }
+
+    [Fact]
+    public void Compare_CompiledFixtureLdTokenChange_ReportsTokenVariants()
+    {
+        var typeDiff = DiffFixtureDiff("LdTokenType");
+        AssertTokenOperandPair(typeDiff, "ldtoken", "TypeTokenA", "TypeTokenB");
+
+        var fieldDiff = DiffFixtureDiff("LdTokenField");
+        Assert.Contains(fieldDiff.Rows, row =>
+            row.Kind == IlDiffKind.Remove
+            && row.Operation.OpcodeFamily == "ldtoken"
+            && row.Operation.Operand?.Kind == IlOperandIdentityKind.Token
+            && row.Operation.Operand.Value.Contains("field ", StringComparison.Ordinal));
+        Assert.Contains(fieldDiff.Rows, row =>
+            row.Kind == IlDiffKind.Add
+            && row.Operation.OpcodeFamily == "ldtoken"
+            && row.Operation.Operand?.Kind == IlOperandIdentityKind.Token
+            && row.Operation.Operand.Value.Contains("field ", StringComparison.Ordinal));
+
+        var methodDiff = DiffFixtureDiff("MethodToken");
+        AssertTokenOperandPair(methodDiff, "ldftn", "::TokenTargetA(", "::TokenTargetB(");
+    }
+
+    [Fact]
+    public void Compare_CompiledFixtureSwitchRetarget_ReportsChangedSwitch()
+    {
+        var diff = DiffFixtureDiff("SwitchRetarget");
+
+        Assert.Contains(diff.Rows, row =>
+            row.Kind == IlDiffKind.Remove
+            && row.Operation.OpcodeFamily == "switch"
+            && row.Operation.Operand?.Kind == IlOperandIdentityKind.SwitchTargets);
+        Assert.Contains(diff.Rows, row =>
+            row.Kind == IlDiffKind.Add
+            && row.Operation.OpcodeFamily == "switch"
+            && row.Operation.Operand?.Kind == IlOperandIdentityKind.SwitchTargets);
+    }
+
+    [Fact]
+    public void Printer_CompiledFixtureTokenRows_PreservesTypedOperandDisplay()
+    {
+        var diff = DiffFixtureDiff("FieldToken");
+        var source = diff.Rows.Single(row =>
+            row.Kind == IlDiffKind.Remove
+            && row.Operation.OpcodeFamily == "stfld"
+            && row.Operation.Operand?.Value.Contains("::InstanceA", StringComparison.Ordinal) == true);
+
+        var display = IlDiffPrinter.ToDisplayRow(source);
+
+        Assert.Equal(source.HunkId, display.HunkId);
+        Assert.Equal(source.Kind, display.Kind);
+        Assert.Equal(source.Operation.Offset, display.RawOffset);
+        Assert.Equal(source.Operation.OpcodeFamily, display.OpcodeFamily);
+        Assert.Equal(IlOperandIdentityKind.Token, display.OperandKind);
+        Assert.Equal(source.Operation.Operand?.Value, display.OperandValue);
+        Assert.Equal(source.Operation.Display, display.Operation);
+        Assert.Equal(source.Message, display.Message);
+        Assert.Contains("stfld", display.UnifiedLine, StringComparison.Ordinal);
+        Assert.Contains("::InstanceA", display.UnifiedLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Compare_TokenOperandWithoutMetadata_FailsClosed()
     {
         var left = DiffFixtureMethod(FixtureCatalog.DiffPair.Old, "StringToken");
@@ -288,6 +379,24 @@ public class IlBodyDiffTests
 
     static bool IsBranchRow(IlDiffRow row)
         => row.Operation.OpcodeFamily.StartsWith("br", StringComparison.Ordinal);
+
+    static void AssertTokenOperandPair(
+        IlBodyDiffResult diff,
+        string opcodeFamily,
+        string removedOperandFragment,
+        string addedOperandFragment)
+    {
+        Assert.Contains(diff.Rows, row =>
+            row.Kind == IlDiffKind.Remove
+            && row.Operation.OpcodeFamily == opcodeFamily
+            && row.Operation.Operand?.Kind == IlOperandIdentityKind.Token
+            && row.Operation.Operand.Value.Contains(removedOperandFragment, StringComparison.Ordinal));
+        Assert.Contains(diff.Rows, row =>
+            row.Kind == IlDiffKind.Add
+            && row.Operation.OpcodeFamily == opcodeFamily
+            && row.Operation.Operand?.Kind == IlOperandIdentityKind.Token
+            && row.Operation.Operand.Value.Contains(addedOperandFragment, StringComparison.Ordinal));
+    }
 
     static IlBodyDiffResult DiffFixtureDiff(string name)
     {


### PR DESCRIPTION
## Summary

Adds the first #2318 IL Diff coverage slice over paired compiled fixtures:

- field operand token changes for instance/static load/store;
- type operand token changes for `ldtoken`, `isinst`, `castclass`, `newarr`, `box`, and `unbox.any`;
- ldtoken-reachable type/field fixture coverage plus method-token function-pointer coverage;
- switch retarget coverage where target count stays stable but case arms change;
- typed `IlDiffPrinter` projection assertion for metadata-token rows.

Refs #2318.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -filter "/*/*/IlBodyDiffTests/*"`
- `dotnet run --project src/ILInspector.Instructions.Tests -c Release`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`

## Review

Adversarial review pending for the Analysis/Instructions coverage change.
