### PR TITLE
Fix conditional store coercion rendering

### DIFF
--- a/docs/design/value-typed-emission.md
+++ b/docs/design/value-typed-emission.md
@@ -441,7 +441,9 @@ measurable, unlike the control-flow rewrite's all-or-nothing invariant relaxatio
    slot-carried values (the unifier owns their type until instance 2), lambda
    returns (delegate `Invoke` signature not yet resolved), merge-node values
    (CoerceText's own targeted branches render them, statement-position
-   formatting included), `Box` operands (the unbox-over-box spelling renders
+   formatting included; primitive same-family `Conditional` values route
+   through `CoercionRendering.CanSpellSlotCoercion` and distribute target
+   casts into arms), `Box` operands (the unbox-over-box spelling renders
    through `ConvertText`, and a bare constant under `(object)` boxes the
    literal's own type), `StoreIndirect` targets (printer's `IndirectStoreType`
    not yet shared), `switch` labels (outside the rewritable tree), and operand

--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -204,6 +204,39 @@ public class CoerceChokePointTests
     }
 
     [Fact]
+    public void Conditional_WithNarrowSignedArmsAtPrimitiveStoreTarget_CastsThroughMergedWidth()
+    {
+        // Clean Gemini review: the target cast is licensed by the conditional's
+        // merged stack width, not the source spelling width of each arm. Two
+        // sbyte arms can be int-merged by the IR and still need uint casts at a
+        // uint store target.
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var sbyteType = TypeRef.CoreLib("System", "SByte");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var uintType = TypeRef.CoreLib("System", "UInt32");
+        var conditional = new Conditional(
+            new LoadArgument(0, "flag", boolType),
+            new LoadArgument(1, "sb1", sbyteType),
+            new LoadArgument(2, "sb2", sbyteType))
+        {
+            MergedType = intType,
+        };
+
+        string body = RenderBody(
+            [
+                new StoreLocal(0, uintType, conditional),
+                new Return(new LoadLocal(0, uintType)),
+            ],
+            uintType,
+            [new Parameter("flag", boolType), new Parameter("sb1", sbyteType), new Parameter("sb2", sbyteType)],
+            [uintType]);
+
+        Assert.Contains("flag ? (uint)sb1 : (uint)sb2", body);
+        Assert.DoesNotContain("? sb1 : sb2", body);
+        AssertCompiles("public static uint M(bool flag, sbyte sb1, sbyte sb2)", body);
+    }
+
+    [Fact]
     public void UnnamedHighBitConstantArm_KeepsUncheckedCast()
     {
         // The cast half of the name-or-cast rule at the #2076 conditional-arm

--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -141,6 +141,69 @@ public class CoerceChokePointTests
     }
 
     [Fact]
+    public void Conditional_AtNativePrimitiveStoreTarget_DistributesCoercionToArms()
+    {
+        // Gemini review: nint/nuint have platform-sized width, so the native
+        // family must use the same slot-width helper as CoerceText instead of
+        // the fixed-width SameWidth table.
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var intPtrType = TypeRef.CoreLib("System", "IntPtr");
+        var uintPtrType = TypeRef.CoreLib("System", "UIntPtr");
+        var conditional = new Conditional(
+            new LoadArgument(0, "flag", boolType),
+            new LoadArgument(1, "a", intPtrType),
+            new LoadArgument(2, "b", intPtrType))
+        {
+            MergedType = intPtrType,
+        };
+
+        string body = RenderBody(
+            [
+                new StoreLocal(0, uintPtrType, conditional),
+                new Return(new LoadLocal(0, uintPtrType)),
+            ],
+            uintPtrType,
+            [new Parameter("flag", boolType), new Parameter("a", intPtrType), new Parameter("b", intPtrType)],
+            [uintPtrType]);
+
+        Assert.Contains("flag ? (nuint)a : (nuint)b", body);
+        Assert.DoesNotContain("? a : b", body);
+        AssertCompiles("public static nuint M(bool flag, nint a, nint b)", body);
+    }
+
+    [Fact]
+    public void Conditional_WithBoolArmAtPrimitiveStoreTarget_CastsComposedBoolArm()
+    {
+        // Gemini review: bool remains outside the primitive conditional's
+        // merged type, but an integer-merged conditional can still contain a
+        // bool-typed arm. The arm composes bool->int and then casts to the
+        // unsigned target instead of vetoing target-aware rendering.
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var uintType = TypeRef.CoreLib("System", "UInt32");
+        var conditional = new Conditional(
+            new LoadArgument(0, "flag", boolType),
+            new LoadArgument(1, "b", boolType),
+            new LoadArgument(2, "tick", intType))
+        {
+            MergedType = intType,
+        };
+
+        string body = RenderBody(
+            [
+                new StoreLocal(0, uintType, conditional),
+                new Return(new LoadLocal(0, uintType)),
+            ],
+            uintType,
+            [new Parameter("flag", boolType), new Parameter("b", boolType), new Parameter("tick", intType)],
+            [uintType]);
+
+        Assert.Contains("flag ? (uint)(b ? 1 : 0) : (uint)tick", body);
+        Assert.DoesNotContain("? (b ? 1 : 0) : tick", body);
+        AssertCompiles("public static uint M(bool flag, bool b, int tick)", body);
+    }
+
+    [Fact]
     public void UnnamedHighBitConstantArm_KeepsUncheckedCast()
     {
         // The cast half of the name-or-cast rule at the #2076 conditional-arm

--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -109,6 +109,38 @@ public class CoerceChokePointTests
     }
 
     [Fact]
+    public void Conditional_AtPrimitiveStoreTarget_DistributesCoercionToArms()
+    {
+        // Issue #2306: the conditional's own join is int, but the store target
+        // is uint. The arms agree with each other, so join-arm typing does not
+        // intervene; the target-aware merge renderer must still route through
+        // the shared slot-coercion contract and cast the non-constant arm.
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var uintType = TypeRef.CoreLib("System", "UInt32");
+        var conditional = new Conditional(
+            new LoadArgument(0, "flag", boolType),
+            new Constant(0, intType),
+            new LoadArgument(1, "tick", intType))
+        {
+            MergedType = intType,
+        };
+
+        string body = RenderBody(
+            [
+                new StoreLocal(0, uintType, conditional),
+                new Return(new LoadLocal(0, uintType)),
+            ],
+            uintType,
+            [new Parameter("flag", boolType), new Parameter("tick", intType)],
+            [uintType]);
+
+        Assert.Contains("flag ? 0 : (uint)tick", body);
+        Assert.DoesNotContain("? 0 : tick", body);
+        AssertCompiles("public static uint M(bool flag, int tick)", body);
+    }
+
+    [Fact]
     public void UnnamedHighBitConstantArm_KeepsUncheckedCast()
     {
         // The cast half of the name-or-cast rule at the #2076 conditional-arm
@@ -207,6 +239,22 @@ public class CoerceChokePointTests
                 : new Dictionary<TypeRef, IReadOnlyDictionary<long, string>> { [enumType] = members },
         };
 
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    static string RenderBody(
+        IReadOnlyList<IrNode> statements,
+        TypeRef returnType,
+        IReadOnlyList<Parameter> parameters,
+        IReadOnlyList<TypeRef> locals)
+    {
+        var block = new Block(0);
+        foreach (var statement in statements)
+            block.Add(statement);
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(returnType, [.. parameters], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [.. locals], container);
         return CSharpPrinter.Print(function).Output!.Trim();
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1231,7 +1231,14 @@ public sealed partial class CSharpPrinter
         var condition = conditional.Condition is Conditional
             ? $"({Condition(conditional.Condition)})"
             : Condition(conditional.Condition);
-        return $"{condition} ? {ConditionalArm(conditional.WhenTrue, target)} : {ConditionalArm(conditional.WhenFalse, target)}";
+        TypeRef? primitiveCoercionSourceType =
+            target is not null
+            && EffectiveType(conditional) is { } conditionalType
+            && !conditionalType.Equals(target)
+            && CanRenderPrimitiveConditionalForTarget(conditional, target)
+                ? conditionalType
+                : null;
+        return $"{condition} ? {ConditionalArm(conditional.WhenTrue, target, primitiveCoercionSourceType)} : {ConditionalArm(conditional.WhenFalse, target, primitiveCoercionSourceType)}";
     }
 
     static bool IsFalseConstant(IrExpression expression)
@@ -1240,7 +1247,7 @@ public sealed partial class CSharpPrinter
     static bool IsBooleanLike(IrExpression expression)
         => expression.ResultType is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary };
 
-    string ConditionalArm(IrExpression arm, TypeRef? target)
+    string ConditionalArm(IrExpression arm, TypeRef? target, TypeRef? primitiveCoercionSourceType = null)
         => target is { } charTarget && IsCoreChar(charTarget) && TryCharConstantText(arm, out var charText)
             ? charText
             // An integer arm flowing into an enum-typed conditional (`ci ? 4 : raw`
@@ -1250,7 +1257,7 @@ public sealed partial class CSharpPrinter
             // structural test catches it), the composed `(E)(cond ? 1 : 0)` for a
             // bool arm. A same-assembly enum arm is enum-typed (not integer-like)
             // and renders its member name via Operand.
-            : TryCoerceJoinArm(arm, target) is { } coercedArm
+            : TryCoerceJoinArm(arm, target, primitiveCoercionSourceType) is { } coercedArm
                 ? coercedArm
             : target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
             && EffectiveType(arm) is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary }
@@ -1271,7 +1278,7 @@ public sealed partial class CSharpPrinter
     /// second-family review found the rule present in only one of the three).
     /// Null when the arm needs no join coercion.
     /// </summary>
-    string? TryCoerceJoinArm(IrExpression arm, TypeRef? target)
+    string? TryCoerceJoinArm(IrExpression arm, TypeRef? target, TypeRef? primitiveCoercionSourceType = null)
     {
         if (TryCoerceEnumOperand(arm, target) is { } coerced)
             return coerced;
@@ -1290,8 +1297,9 @@ public sealed partial class CSharpPrinter
         // ushort/char); a differing-width join is a narrowing the printer must not
         // silently introduce, so it is left to a real Convert node in the IL.
         if (target is { } numericTarget
-            && TypeFamilies.NeedsNumericCast(EffectiveType(arm), numericTarget)
-            && CanCoercePrimitiveJoinArm(arm, numericTarget))
+            && EffectiveType(arm) is { } armType
+            && TypeFamilies.NeedsNumericCast(armType, numericTarget)
+            && CanCoercePrimitiveJoinArm(armType, numericTarget, primitiveCoercionSourceType ?? armType))
             return arm is Constant { Value: int or long } constArm
                 ? NumericConstant(constArm, numericTarget)
                 : CheckedSafeCast($"({TypeText(numericTarget)}){Operand(arm)}");
@@ -1327,25 +1335,29 @@ public sealed partial class CSharpPrinter
                 target,
                 _function.TypeShapes,
                 _function.EnumUnderlyingTypes)
-            && CanRenderPrimitiveJoinArm(conditional.WhenTrue, target)
-            && CanRenderPrimitiveJoinArm(conditional.WhenFalse, target);
+            && CanRenderPrimitiveJoinArm(conditional.WhenTrue, target, conditionalType)
+            && CanRenderPrimitiveJoinArm(conditional.WhenFalse, target, conditionalType);
 
-    bool CanRenderPrimitiveJoinArm(IrExpression arm, TypeRef target)
+    bool CanRenderPrimitiveJoinArm(IrExpression arm, TypeRef target, TypeRef coercionSourceType)
         => EffectiveType(arm) is { } armType
             && (CoercionRendering.CanSpellBoolToInteger(armType, target)
                 || (TypeFamilies.IsIntegerLike(armType)
                     && (!TypeFamilies.NeedsNumericCast(armType, target)
-                        || CanCoercePrimitiveJoinArm(arm, target))));
+                        || CanCoercePrimitiveJoinArm(armType, target, coercionSourceType))));
 
     bool CanCoercePrimitiveJoinArm(IrExpression arm, TypeRef target)
         => EffectiveType(arm) is { } armType
+            && CanCoercePrimitiveJoinArm(armType, target, armType);
+
+    bool CanCoercePrimitiveJoinArm(TypeRef armType, TypeRef target, TypeRef coercionSourceType)
+        => TypeFamilies.IsIntegerLike(armType)
             && TypeFamilies.IsIntegerLike(target)
             && CoercionRendering.CanSpellSlotCoercion(
                 armType,
                 target,
                 _function.TypeShapes,
                 _function.EnumUnderlyingTypes)
-            && SameNumericSlotWidth(armType, target);
+            && SameNumericSlotWidth(coercionSourceType, target);
 
     bool CanRenderSwitchExpressionForTarget(SwitchExpression expression, TypeRef target)
         => IsEnumLikeInteger(target) && expression.Arms.All(arm => IsIntegerArm(arm.Value));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1288,7 +1288,7 @@ public sealed partial class CSharpPrinter
         // silently introduce, so it is left to a real Convert node in the IL.
         if (target is { } numericTarget
             && TypeFamilies.NeedsNumericCast(EffectiveType(arm), numericTarget)
-            && TypeFamilies.SameWidth(EffectiveType(arm), numericTarget))
+            && CanCoercePrimitiveJoinArm(arm, numericTarget))
             return arm is Constant { Value: int or long } constArm
                 ? NumericConstant(constArm, numericTarget)
                 : CheckedSafeCast($"({TypeText(numericTarget)}){Operand(arm)}");
@@ -1307,12 +1307,41 @@ public sealed partial class CSharpPrinter
             || (IsEnumLikeInteger(target)
                 && IsIntegerArm(conditional.WhenTrue)
                 && IsIntegerArm(conditional.WhenFalse))
+            || CanRenderPrimitiveConditionalForTarget(conditional, target)
             || (IsKnownReferenceLike(target)
                 && CanAssignTo(conditional.WhenTrue, target)
                 && CanAssignTo(conditional.WhenFalse, target));
 
     static bool IsIntegerArm(IrExpression arm)
         => arm.ResultType is { } type && TypeFamilies.IsIntegerLike(type);
+
+    bool CanRenderPrimitiveConditionalForTarget(Conditional conditional, TypeRef target)
+        => EffectiveType(conditional) is { } conditionalType
+            && TypeFamilies.IsIntegerLike(conditionalType)
+            && TypeFamilies.IsIntegerLike(target)
+            && CoercionRendering.CanSpellSlotCoercion(
+                conditionalType,
+                target,
+                _function.TypeShapes,
+                _function.EnumUnderlyingTypes)
+            && CanRenderPrimitiveJoinArm(conditional.WhenTrue, target)
+            && CanRenderPrimitiveJoinArm(conditional.WhenFalse, target);
+
+    bool CanRenderPrimitiveJoinArm(IrExpression arm, TypeRef target)
+        => EffectiveType(arm) is { } armType
+            && TypeFamilies.IsIntegerLike(armType)
+            && (!TypeFamilies.NeedsNumericCast(armType, target)
+                || CanCoercePrimitiveJoinArm(arm, target));
+
+    bool CanCoercePrimitiveJoinArm(IrExpression arm, TypeRef target)
+        => EffectiveType(arm) is { } armType
+            && TypeFamilies.IsIntegerLike(target)
+            && CoercionRendering.CanSpellSlotCoercion(
+                armType,
+                target,
+                _function.TypeShapes,
+                _function.EnumUnderlyingTypes)
+            && TypeFamilies.SameWidth(armType, target);
 
     bool CanRenderSwitchExpressionForTarget(SwitchExpression expression, TypeRef target)
         => IsEnumLikeInteger(target) && expression.Arms.All(arm => IsIntegerArm(arm.Value));

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1148,9 +1148,7 @@ public sealed partial class CSharpPrinter
             // and wider signed targets; narrow and unsigned targets need the
             // explicit cast — `(byte)(b ? 1 : 0)` (slice-5b round 4: denying
             // these severed single live ranges into unassigned reads).
-            return intTarget is { Namespace: "System", Name: "Int32" or "Int64", Assembly: TypeRef.CoreLibrary }
-                ? $"{Condition(value)} ? 1 : 0"
-                : CheckedSafeCast($"({TypeText(intTarget)})({Condition(value)} ? 1 : 0)");
+            return BoolToIntegerText(value, intTarget);
         }
         if (value is Conditional conditional
             && target is { } conditionalTarget
@@ -1256,8 +1254,13 @@ public sealed partial class CSharpPrinter
                 ? coercedArm
             : target is { } intTarget && TypeFamilies.IsIntegerLike(intTarget)
             && EffectiveType(arm) is { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary }
-                ? $"({Condition(arm)} ? 1 : 0)"
+                ? BoolToIntegerText(arm, intTarget)
                 : Operand(arm);
+
+    string BoolToIntegerText(IrExpression value, TypeRef target)
+        => target is { Namespace: "System", Name: "Int32" or "Int64", Assembly: TypeRef.CoreLibrary }
+            ? $"{Condition(value)} ? 1 : 0"
+            : CheckedSafeCast($"({TypeText(target)})({Condition(value)} ? 1 : 0)");
 
     /// <summary>
     /// The one join-arm coercion, both directions: an integer-family arm at an
@@ -1329,9 +1332,10 @@ public sealed partial class CSharpPrinter
 
     bool CanRenderPrimitiveJoinArm(IrExpression arm, TypeRef target)
         => EffectiveType(arm) is { } armType
-            && TypeFamilies.IsIntegerLike(armType)
-            && (!TypeFamilies.NeedsNumericCast(armType, target)
-                || CanCoercePrimitiveJoinArm(arm, target));
+            && (CoercionRendering.CanSpellBoolToInteger(armType, target)
+                || (TypeFamilies.IsIntegerLike(armType)
+                    && (!TypeFamilies.NeedsNumericCast(armType, target)
+                        || CanCoercePrimitiveJoinArm(arm, target))));
 
     bool CanCoercePrimitiveJoinArm(IrExpression arm, TypeRef target)
         => EffectiveType(arm) is { } armType
@@ -1341,7 +1345,7 @@ public sealed partial class CSharpPrinter
                 target,
                 _function.TypeShapes,
                 _function.EnumUnderlyingTypes)
-            && TypeFamilies.SameWidth(armType, target);
+            && SameNumericSlotWidth(armType, target);
 
     bool CanRenderSwitchExpressionForTarget(SwitchExpression expression, TypeRef target)
         => IsEnumLikeInteger(target) && expression.Arms.All(arm => IsIntegerArm(arm.Value));


### PR DESCRIPTION
Fixes #2306

## Change

**Conclusion:** **PASS** — primitive same-family `Conditional` values at typed store/return targets now render through the existing `CoercionRendering.CanSpellSlotCoercion` contract instead of leaving invalid bare arms.

Before:

```csharp
uint startTimeTicks = infiniteWait ? 0 : Environment.TickCount;
```

After:

```csharp
uint startTimeTicks = infiniteWait ? 0 : (uint)Environment.TickCount;
```

The fix keeps merge-node values renderer-owned rather than inserting `Coerce` nodes in the pass. `CoercionInsertionPass` therefore continues to decline merge-node values; the targeted `CoerceText` branch now covers integer-like primitive conditionals and distributes the same shared arm casts used by #2302. Bool and non-integer numeric cases remain outside this primitive path.

## Evidence

| Check | Result |
| --- | --- |
| Product build | Pass: `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore --verbosity minimal` |
| Focused regression | Pass: `CoerceChokePointTests/Conditional_AtPrimitiveStoreTarget_DistributesCoercionToArms` |
| Bool near-miss regression | Pass: `StackSlotReuseRenderingTests/BoolSlotWithIntegerTypedConsumerUsesBoolNameWhenTargetIsBool` |
| Decompiler fast suite | Pass: 1,865 tests with `-trait- "Speed=Slow"` |
| Markdown | Pass: `npx markdownlint-cli docs/design/value-typed-emission.md` |
| Real witness | Fixed: `Task::SpinThenBlockingWait` renders `(uint)Environment.TickCount` |
| Render A/B | 89,065 methods evaluated; 5 changed methods, all classified as intended primitive same-family target-cast insertions |

Render A/B changed methods:

- `Microsoft.CodeAnalysis.BitVector::get_Item` — casts `ulong` conditional arms for `BitVector.IsTrue`.
- `Microsoft.CodeAnalysis.Collections.SegmentedDictionary<TKey,TValue>::Remove(TKey)` — casts `GetHashCode()` arms at `uint hashCode`.
- `Microsoft.CodeAnalysis.Collections.SegmentedDictionary<TKey,TValue>::Remove(TKey, ref TValue)` — same `uint hashCode` fix.
- `Microsoft.CodeAnalysis.Collections.SegmentedDictionary<TKey,TValue>::TryInsert(...)` — same `uint hashCode` fix.
- `Microsoft.CodeAnalysis.RealParser::ConvertDecimalToFloatingPointBits(...)` — casts the `int` arm at `uint fractionalShift`.

## Decompiler quality

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity sampled 350 / 89,065 (0.39%); fidelity sampled 24 / 89,065 (0.03%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,405 (88.03%) | +6 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — sampled 25,179 / 89,065 (28.27%) | 1/350 — sampled 350 / 89,065 (0.39%) | -73 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 2/24, exact 22, recompile-failed 0, context-failed 0; sampled 24 / 89,065 (0.03%) | -3 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.03% (+0.01 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 2 (-3).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25179, current 350)
- fidelity checked methods lower than baseline (baseline 36, current 24)
QUALITY_CARD_EXIT=1

The quality card exits nonzero only because this PR quick run uses lower validity/fidelity caps than the daily baseline. The pinned-subset gate improves: fully raised +0.01 pp, conditional residual unchanged, Full malformed 0, opcode diffs 5 -> 2.

## Review

Adversarial reviews are running in isolated detached worktrees:

| Reviewer | Result | Notes |
| --- | --- | --- |
| Claude Opus 4.8 | Pending | `/home/rich/git/dotnet-inspect/.worktrees/review-2306-opus` |
| Gemini 3.1 Pro | Pending | `/home/rich/git/dotnet-inspect/.worktrees/review-2306-gemini` |

A follow-up PR comment will summarize findings, resolutions, and any explicit non-actions before this is marked ready.
