### PR TITLE
Add fixture catalog contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,9 @@ jobs:
       - name: Run metadata tests
         run: dotnet run --project tests/ILInspector.Metadata.Tests -c Release
 
+      - name: Run fixture catalog tests
+        run: dotnet run --project tests/DotnetInspector.Fixtures.Tests -c Release
+
       - name: Run services tests
         run: dotnet run --project src/DotnetInspector.Services.Tests -c Release
 

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -59,6 +59,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/DotnetInspector.Fixtures/DotnetInspector.Fixtures.csproj" />
+    <Project Path="tests/DotnetInspector.Fixtures.Tests/DotnetInspector.Fixtures.Tests.csproj" />
     <Project Path="tests/ILInspector.Metadata.Tests/ILInspector.Metadata.Tests.csproj" />
     <Project Path="tests/TestExtensions/TestExtensions.csproj" />
   </Folder>

--- a/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
+++ b/src/ILInspector.Analysis.Tests/LibraryBodyIndexTests.cs
@@ -6,6 +6,7 @@ using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+using DotnetInspector.Fixtures;
 using DotnetInspector.Services;
 using ILInspector.Analysis;
 using ILInspector.Metadata;
@@ -1043,7 +1044,7 @@ public class LibraryBodyIndexTests
     [Fact]
     public void GoogleProtobufIdentity_AuthenticatesByPublicKeyToken()
     {
-        using (var pe = new System.Reflection.PortableExecutable.PEReader(System.IO.File.OpenRead(ProtobufSpoofAssemblyPath())))
+        using (var pe = new System.Reflection.PortableExecutable.PEReader(System.IO.File.OpenRead(FixtureCatalog.AnalysisProtobuf.AssemblyPath())))
             Assert.False(FrameworkAssemblyKeys.IsAuthenticProtobufDefinition(pe.GetMetadataReader()),
                 "an unsigned same-name assembly must not be treated as the real Google.Protobuf");
 
@@ -1054,15 +1055,6 @@ public class LibraryBodyIndexTests
         using var realPe = new System.Reflection.PortableExecutable.PEReader(System.IO.File.OpenRead(realProtobuf));
         Assert.True(FrameworkAssemblyKeys.IsAuthenticProtobufDefinition(realPe.GetMetadataReader()),
             "the real strong-named Google.Protobuf must be authentic");
-    }
-
-    static string ProtobufSpoofAssemblyPath()
-    {
-        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        string path = Path.GetFullPath(Path.Combine(
-            outputDirectory.FullName, "..", "..", "ILInspector.Analysis.ProtobufFixtures", outputDirectory.Name, "Google.Protobuf.dll"));
-        Assert.True(File.Exists(path), $"Expected protobuf spoof fixture at {path}");
-        return path;
     }
 
     static string? FindRealGoogleProtobufAssembly()
@@ -1083,7 +1075,7 @@ public class LibraryBodyIndexTests
         // Google.Protobuf.* bootstrap-shaped types and calls them from product code. The
         // protobuf generated-bootstrap predicates require real Google.Protobuf assembly
         // identity, so the calling product type must not be classified as generated (#1580).
-        var index = LibraryBodyIndex.Open(LookalikeFixturePath());
+        var index = LibraryBodyIndex.Open(FixtureCatalog.AnalysisLookalike.AssemblyPath());
         var generated = index.GeneratedFrameworkTypeNames;
 
         const string lookalikeType = "ILInspector.Analysis.LookalikeFixtures.ProtobufBootstrapLookalike";
@@ -1828,7 +1820,7 @@ public class LibraryBodyIndexTests
         // The REAL framework RenderTreeBuilder (trusted public-key-token, from
         // Microsoft.AspNetCore.App) marks a method as Razor render plumbing, so its capturing
         // delegate is suppressed (intrinsic component-model cost, not actionable).
-        var index = LibraryBodyIndex.Open(RenderFixturePath());
+        var index = LibraryBodyIndex.Open(FixtureCatalog.AnalysisRender.AssemblyPath());
 
         Assert.DoesNotContain(index.OptimizationOpportunities, o =>
             o.Method.Name == "RenderWithDelegateLoop");
@@ -3058,7 +3050,7 @@ public class LibraryBodyIndexTests
     [Fact]
     public void FrameworkApiPredicates_IgnoreUserDefinedLookalikes()
     {
-        var index = LibraryBodyIndex.Open(LookalikeFixturePath());
+        var index = LibraryBodyIndex.Open(FixtureCatalog.AnalysisLookalike.AssemblyPath());
         var signals = index.GetMethodSignals();
 
         var fakeReflection = Assert.Single(index.Methods.Where(method =>
@@ -3075,62 +3067,6 @@ public class LibraryBodyIndexTests
             && opportunity.Shape == "temporary-byte-array-copy");
     }
 
-    static string LookalikeFixturePath()
-    {
-        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        string path = Path.GetFullPath(Path.Combine(
-            outputDirectory.FullName,
-            "..",
-            "..",
-            "ILInspector.Analysis.LookalikeFixtures",
-            outputDirectory.Name,
-            "ILInspector.Analysis.LookalikeFixtures.dll"));
-        Assert.True(File.Exists(path), $"Expected lookalike fixture assembly at {path}");
-        return path;
-    }
-
-    static string FacadeFixturePath()
-    {
-        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        string path = Path.GetFullPath(Path.Combine(
-            outputDirectory.FullName,
-            "..",
-            "..",
-            "ILInspector.Analysis.FacadeFixtures",
-            outputDirectory.Name,
-            "ILInspector.Analysis.FacadeFixtures.dll"));
-        Assert.True(File.Exists(path), $"Expected facade fixture assembly at {path}");
-        return path;
-    }
-
-    static string SpoofFixturePath()
-    {
-        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        string path = Path.GetFullPath(Path.Combine(
-            outputDirectory.FullName,
-            "..",
-            "..",
-            "ILInspector.Analysis.SpoofFixtures",
-            outputDirectory.Name,
-            "System.Linq.dll"));
-        Assert.True(File.Exists(path), $"Expected spoof fixture assembly at {path}");
-        return path;
-    }
-
-    static string RenderFixturePath()
-    {
-        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        string path = Path.GetFullPath(Path.Combine(
-            outputDirectory.FullName,
-            "..",
-            "..",
-            "ILInspector.Analysis.RenderFixtures",
-            outputDirectory.Name,
-            "ILInspector.Analysis.RenderFixtures.dll"));
-        Assert.True(File.Exists(path), $"Expected render fixture assembly at {path}");
-        return path;
-    }
-
     // #1708 Row A end-to-end. A real assembly literally named "System.Linq" (unsigned,
     // so no framework public-key-token) exposes a System.Linq.Enumerable.ToArray
     // lookalike. Simple-name identity accepted it as a framework copy; strong
@@ -3139,26 +3075,12 @@ public class LibraryBodyIndexTests
     [Fact]
     public void MethodSignals_CopyApis_RejectSimpleNameSpoofWithoutFrameworkKey()
     {
-        var index = LibraryBodyIndex.Open(SpoofFixturePath());
+        var index = LibraryBodyIndex.Open(FixtureCatalog.AnalysisSpoofSystemLinq.AssemblyPath());
         var signals = index.GetMethodSignals();
         var method = Assert.Single(index.Methods.Where(m => m.Name == "CallsFakeEnumerableToArray"));
 
         int copies = signals.TryGetValue(method.MetadataToken, out var s) ? s.Copies : 0;
         Assert.Equal(0, copies);
-    }
-
-    static string SpoofRuntimeFixturePath()
-    {
-        var outputDirectory = new DirectoryInfo(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        string path = Path.GetFullPath(Path.Combine(
-            outputDirectory.FullName,
-            "..",
-            "..",
-            "ILInspector.Analysis.SpoofRuntimeFixtures",
-            outputDirectory.Name,
-            "System.Runtime.dll"));
-        Assert.True(File.Exists(path), $"Expected runtime spoof fixture assembly at {path}");
-        return path;
     }
 
     // #1708 Row A, span-to-array opportunity path. An assembly named "System.Runtime"
@@ -3168,7 +3090,7 @@ public class LibraryBodyIndexTests
     [Fact]
     public void OptimizationOpportunities_SpanToArray_RejectSimpleNameSpoofWithoutFrameworkKey()
     {
-        var index = LibraryBodyIndex.Open(SpoofRuntimeFixturePath());
+        var index = LibraryBodyIndex.Open(FixtureCatalog.AnalysisSpoofSystemRuntime.AssemblyPath());
 
         Assert.DoesNotContain(index.OptimizationOpportunities, o =>
             o.Method.Name == "CallsFakeSpanToArray" && o.Shape == "span-to-array-copy");
@@ -3180,7 +3102,7 @@ public class LibraryBodyIndexTests
     [InlineData("EnumerableToListCopy")]
     public void MethodSignals_CopyApis_RecognizeLegacyFacadeAssemblies(string methodName)
     {
-        var index = LibraryBodyIndex.Open(FacadeFixturePath());
+        var index = LibraryBodyIndex.Open(FixtureCatalog.AnalysisFacade.AssemblyPath());
         var signals = index.GetMethodSignals();
         var method = Assert.Single(index.Methods.Where(m => m.Name == methodName));
 
@@ -3191,7 +3113,7 @@ public class LibraryBodyIndexTests
     [Fact]
     public void MethodSignals_Reflection_RecognizesLegacyFacadeExpressions()
     {
-        var index = LibraryBodyIndex.Open(FacadeFixturePath());
+        var index = LibraryBodyIndex.Open(FixtureCatalog.AnalysisFacade.AssemblyPath());
         var signals = index.GetMethodSignals();
         var method = Assert.Single(index.Methods.Where(m => m.Name == "BuildsExpression"));
 

--- a/tests/DotnetInspector.Fixtures.Tests/DotnetInspector.Fixtures.Tests.csproj
+++ b/tests/DotnetInspector.Fixtures.Tests/DotnetInspector.Fixtures.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsAotCompatible>false</IsAotCompatible>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotnetInspector.Fixtures\DotnetInspector.Fixtures.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
+++ b/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
@@ -50,9 +50,16 @@ public class FixtureCatalogTests
     [Fact]
     public void AssemblyNameAxisFixtures_ResolveIntentionalFileNames()
     {
-        Assert.EndsWith(Path.Combine("ILInspector.Analysis.ProtobufFixtures", "release", "Google.Protobuf.dll"), FixtureCatalog.AnalysisProtobuf.AssemblyPath());
-        Assert.EndsWith(Path.Combine("ILInspector.Analysis.SpoofFixtures", "release", "System.Linq.dll"), FixtureCatalog.AnalysisSpoofSystemLinq.AssemblyPath());
-        Assert.EndsWith(Path.Combine("ILInspector.Analysis.SpoofRuntimeFixtures", "release", "System.Runtime.dll"), FixtureCatalog.AnalysisSpoofSystemRuntime.AssemblyPath());
+        AssertFixtureFileName(FixtureCatalog.AnalysisProtobuf, "Google.Protobuf.dll");
+        AssertFixtureFileName(FixtureCatalog.AnalysisSpoofSystemLinq, "System.Linq.dll");
+        AssertFixtureFileName(FixtureCatalog.AnalysisSpoofSystemRuntime, "System.Runtime.dll");
+    }
+
+    static void AssertFixtureFileName(FixtureDefinition fixture, string expectedFileName)
+    {
+        string path = fixture.AssemblyPath();
+        Assert.Equal(expectedFileName, Path.GetFileName(path));
+        Assert.Equal(fixture.ProjectName, new DirectoryInfo(path).Parent?.Parent?.Name);
     }
 
     static IReadOnlyList<FixtureGroup> Groups() =>

--- a/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
+++ b/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
@@ -1,0 +1,68 @@
+using DotnetInspector.Fixtures;
+
+namespace DotnetInspector.Fixtures.Tests;
+
+public class FixtureCatalogTests
+{
+    [Fact]
+    public void All_FixtureIdsAreUnique()
+    {
+        var duplicate = FixtureCatalog.All
+            .GroupBy(fixture => fixture.Id, StringComparer.Ordinal)
+            .FirstOrDefault(group => group.Count() > 1);
+
+        Assert.Null(duplicate);
+    }
+
+    [Fact]
+    public void All_FixturesResolveToBuiltAssemblies()
+    {
+        foreach (var fixture in FixtureCatalog.All)
+        {
+            string path = fixture.AssemblyPath();
+            Assert.True(File.Exists(path), $"Expected fixture {fixture.Id} at {path}");
+        }
+    }
+
+    [Fact]
+    public void Groups_ReferenceRegisteredFixtures()
+    {
+        var all = FixtureCatalog.All.ToHashSet();
+        foreach (var group in Groups())
+        {
+            Assert.NotEmpty(group.Fixtures);
+            Assert.All(group.Fixtures, fixture =>
+                Assert.Contains(fixture, all));
+        }
+    }
+
+    [Fact]
+    public void ReturnToSenderCandidates_AreRegisteredAndTagged()
+    {
+        var all = FixtureCatalog.All.ToHashSet();
+        Assert.All(FixtureCatalog.ReturnToSenderCandidates.Fixtures, fixture =>
+        {
+            Assert.Contains(fixture, all);
+            Assert.Contains("rts-candidate", fixture.Tags);
+        });
+    }
+
+    [Fact]
+    public void AssemblyNameAxisFixtures_ResolveIntentionalFileNames()
+    {
+        Assert.EndsWith(Path.Combine("ILInspector.Analysis.ProtobufFixtures", "release", "Google.Protobuf.dll"), FixtureCatalog.AnalysisProtobuf.AssemblyPath());
+        Assert.EndsWith(Path.Combine("ILInspector.Analysis.SpoofFixtures", "release", "System.Linq.dll"), FixtureCatalog.AnalysisSpoofSystemLinq.AssemblyPath());
+        Assert.EndsWith(Path.Combine("ILInspector.Analysis.SpoofRuntimeFixtures", "release", "System.Runtime.dll"), FixtureCatalog.AnalysisSpoofSystemRuntime.AssemblyPath());
+    }
+
+    static IReadOnlyList<FixtureGroup> Groups() =>
+    [
+        FixtureCatalog.DiffAssemblyFixtures,
+        FixtureCatalog.AnalysisFixtures,
+        FixtureCatalog.DecompilerFixtures,
+        FixtureCatalog.DecompilerLadderFixtures,
+        FixtureCatalog.DecompilerUnsafeFixtures,
+        FixtureCatalog.RunFasterFixtures,
+        FixtureCatalog.ReturnToSenderCandidates,
+    ];
+}

--- a/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
+++ b/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
@@ -409,10 +409,19 @@ public static class FixtureCatalog
 
     static string CurrentConfiguration()
     {
-        var outputDirectory = new DirectoryInfo(
-            AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        return outputDirectory.Name;
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            if (IsConfigurationDirectory(directory.Name))
+                return directory.Name.ToLowerInvariant();
+        }
+
+        throw new InvalidOperationException(
+            $"Could not infer build configuration from '{AppContext.BaseDirectory}'. Run tests from a built dotnet-inspect checkout.");
     }
+
+    static bool IsConfigurationDirectory(string name)
+        => string.Equals(name, "debug", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(name, "release", StringComparison.OrdinalIgnoreCase);
 
     static string RepositoryRoot()
     {


### PR DESCRIPTION
## Change

Adds a dedicated `DotnetInspector.Fixtures.Tests` executable test project and wires it into the normal solution/CI test path. The tests lock down the fixture catalog contract:

- `FixtureCatalog.All` IDs are unique
- every catalog entry resolves to a built assembly after the solution build
- groups only reference registered fixtures
- RTS candidates are registered and tagged
- assembly-name-axis fixtures resolve to intentional file names (`Google.Protobuf.dll`, `System.Linq.dll`, `System.Runtime.dll`)

Also migrates the selected `LibraryBodyIndexTests` analysis fixture helpers to the shared catalog for lookalike, facade, spoof, spoof-runtime, render, and protobuf fixture assemblies. This removes local path-building helpers for that fixture family and exercises catalog resolution from the analysis test suite.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity minimal
dotnet run --project tests/DotnetInspector.Fixtures.Tests -c Release --no-build
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/LibraryBodyIndexTests/GoogleProtobufIdentity_AuthenticatesByPublicKeyToken"
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/LibraryBodyIndexTests/GeneratedFrameworkTypeNames_IgnoresUserDefinedProtobufLookalikes"
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/LibraryBodyIndexTests/OptimizationOpportunities_SuppressesRealBlazorRenderMethods"
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/LibraryBodyIndexTests/FrameworkApiPredicates_IgnoreUserDefinedLookalikes"
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/LibraryBodyIndexTests/MethodSignals_CopyApis_RejectSimpleNameSpoofWithoutFrameworkKey"
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/LibraryBodyIndexTests/OptimizationOpportunities_SpanToArray_RejectSimpleNameSpoofWithoutFrameworkKey"
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/LibraryBodyIndexTests/MethodSignals_CopyApis_RecognizeLegacyFacadeAssemblies"
dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/LibraryBodyIndexTests/MethodSignals_Reflection_RecognizesLegacyFacadeExpressions"
git diff --check
```

Fixture/test infrastructure only; no product behavior change.
