### PR TITLE
Add IL diff EH and near-miss coverage

### DIFF
--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -148,10 +148,63 @@ namespace DiffFixtureSample
             return 3;
         }
 
+        // V2 wraps equivalent work in a catch region.
+        public static int TryCatchAvailability(int value)
+        {
+            MaybeThrow(value);
+            return value + 1;
+        }
+
+        // V2 wraps equivalent work in a finally region.
+        public static int FinallyAvailability(int value)
+        {
+            Sink(value);
+            return value;
+        }
+
+        // V1/V2 both have a catch region, but V2 extends the protected range.
+        public static int TryCatchRegionShape(int value)
+        {
+            try
+            {
+                MaybeThrow(value);
+            }
+            catch (System.InvalidOperationException)
+            {
+                return -1;
+            }
+
+            return value;
+        }
+
+        // V1/V2 have repeated calls where only the second occurrence changes.
+        public static int RepeatedCallOneOccurrence(int first, int second)
+        {
+            return System.Math.Abs(first) + System.Math.Abs(second);
+        }
+
+        // V1/V2 are a slot/local near-miss: raw slot identity is still surfaced.
+        public static int SlotLocalShapeNearMiss(int value)
+        {
+            int first;
+            int second;
+            Assign(out first, value + 1);
+            Assign(out second, value + 2);
+            return first + second;
+        }
+
         // V1: safe body. V2 adds a visible unsafe operation.
         public static int AddsUnsafe(int value) => value;
 
         static int TokenTargetA(int value) => value + 1;
+
+        static void Assign(out int target, int value) => target = value;
+
+        static void MaybeThrow(int value)
+        {
+            if (value == int.MinValue)
+                throw new System.InvalidOperationException();
+        }
 
         static void Sink(int value)
         {

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -152,6 +152,66 @@ namespace DiffFixtureSample
             return 3;
         }
 
+        // V2 wraps equivalent work in a catch region.
+        public static int TryCatchAvailability(int value)
+        {
+            try
+            {
+                MaybeThrow(value);
+                return value + 1;
+            }
+            catch (System.InvalidOperationException)
+            {
+                return -1;
+            }
+        }
+
+        // V2 wraps equivalent work in a finally region.
+        public static int FinallyAvailability(int value)
+        {
+            try
+            {
+                Sink(value);
+                return value;
+            }
+            finally
+            {
+                Sink(-value);
+            }
+        }
+
+        // V1/V2 both have a catch region, but V2 extends the protected range.
+        public static int TryCatchRegionShape(int value)
+        {
+            try
+            {
+                MaybeThrow(value);
+                Sink(value + 1);
+            }
+            catch (System.InvalidOperationException)
+            {
+                return -1;
+            }
+
+            return value;
+        }
+
+        // V1/V2 have repeated calls where only the second occurrence changes.
+        public static int RepeatedCallOneOccurrence(int first, int second)
+        {
+            return System.Math.Abs(first) + System.Math.Sign(second);
+        }
+
+        // V1/V2 are a slot/local near-miss: raw slot identity is still surfaced.
+        public static int SlotLocalShapeNearMiss(int value)
+        {
+            int second;
+            int first;
+            Assign(out second, value + 2);
+            Assign(out first, value + 1);
+            return first + second;
+        }
+
         // V2: visible unsafe operation added relative to V1.
         public static unsafe int AddsUnsafe(int value)
         {
@@ -161,6 +221,14 @@ namespace DiffFixtureSample
         }
 
         static int TokenTargetB(int value) => value + 2;
+
+        static void Assign(out int target, int value) => target = value;
+
+        static void MaybeThrow(int value)
+        {
+            if (value == int.MinValue)
+                throw new System.InvalidOperationException();
+        }
 
         static void Sink(int value)
         {

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -261,7 +261,7 @@ public class IlBodyDiffTests
     }
 
     [Fact]
-    public void Compare_CompiledFixtureTryCatchRegionShape_RecordsRegionNearMiss()
+    public void Compare_CompiledFixtureTryCatchRegionShape_SurfacesOperationRows()
     {
         var oldRegion = Assert.Single(ExceptionRegionShapes(FixtureCatalog.DiffPair.Old, "TryCatchRegionShape"));
         var newRegion = Assert.Single(ExceptionRegionShapes(FixtureCatalog.DiffPair.New, "TryCatchRegionShape"));
@@ -305,12 +305,13 @@ public class IlBodyDiffTests
 
         Assert.False(diff.IsExact);
         Assert.Null(diff.Failure);
-        Assert.Contains(diff.Rows, row =>
-            row.Kind == IlDiffKind.Remove
-            && IsRawLocalRow(row));
-        Assert.Contains(diff.Rows, row =>
-            row.Kind == IlDiffKind.Add
-            && IsRawLocalRow(row));
+        var localRows = diff.Rows
+            .Where(IsRawLocalRow)
+            .ToArray();
+        Assert.Collection(
+            localRows,
+            removed => Assert.Equal(IlDiffKind.Remove, removed.Kind),
+            added => Assert.Equal(IlDiffKind.Add, added.Kind));
     }
 
     [Fact]

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -232,6 +232,88 @@ public class IlBodyDiffTests
     }
 
     [Fact]
+    public void Compare_CompiledFixtureTryCatchAvailability_SurfacesOperationRows()
+    {
+        Assert.Empty(ExceptionRegionShapes(FixtureCatalog.DiffPair.Old, "TryCatchAvailability"));
+        var newRegion = Assert.Single(ExceptionRegionShapes(FixtureCatalog.DiffPair.New, "TryCatchAvailability"));
+        Assert.Equal(ExceptionRegionKind.Catch, newRegion.Kind);
+
+        var diff = DiffFixtureDiff("TryCatchAvailability");
+
+        Assert.False(diff.IsExact);
+        Assert.Null(diff.Failure);
+        Assert.Contains(diff.Rows, row => row.Operation.OpcodeFamily == "leave");
+        Assert.Contains(diff.Rows, row => row.Operation.OpcodeFamily == "pop");
+    }
+
+    [Fact]
+    public void Compare_CompiledFixtureFinallyAvailability_SurfacesOperationRows()
+    {
+        Assert.Empty(ExceptionRegionShapes(FixtureCatalog.DiffPair.Old, "FinallyAvailability"));
+        var newRegion = Assert.Single(ExceptionRegionShapes(FixtureCatalog.DiffPair.New, "FinallyAvailability"));
+        Assert.Equal(ExceptionRegionKind.Finally, newRegion.Kind);
+
+        var diff = DiffFixtureDiff("FinallyAvailability");
+
+        Assert.False(diff.IsExact);
+        Assert.Null(diff.Failure);
+        Assert.Contains(diff.Rows, row => row.Operation.OpcodeFamily == "endfinally");
+    }
+
+    [Fact]
+    public void Compare_CompiledFixtureTryCatchRegionShape_RecordsRegionNearMiss()
+    {
+        var oldRegion = Assert.Single(ExceptionRegionShapes(FixtureCatalog.DiffPair.Old, "TryCatchRegionShape"));
+        var newRegion = Assert.Single(ExceptionRegionShapes(FixtureCatalog.DiffPair.New, "TryCatchRegionShape"));
+        Assert.Equal(ExceptionRegionKind.Catch, oldRegion.Kind);
+        Assert.Equal(ExceptionRegionKind.Catch, newRegion.Kind);
+        Assert.NotEqual(oldRegion.TryLength, newRegion.TryLength);
+
+        var diff = DiffFixtureDiff("TryCatchRegionShape");
+
+        Assert.False(diff.IsExact);
+        Assert.Null(diff.Failure);
+        Assert.Contains(diff.Rows, row => row.Operation.OpcodeFamily == "call");
+    }
+
+    [Fact]
+    public void Compare_CompiledFixtureRepeatedCallOneOccurrence_ReportsOnlyChangedCall()
+    {
+        var diff = DiffFixtureDiff("RepeatedCallOneOccurrence");
+
+        var callRows = diff.Rows
+            .Where(row => row.Operation.OpcodeFamily == "call")
+            .ToArray();
+        Assert.Collection(
+            callRows,
+            removed =>
+            {
+                Assert.Equal(IlDiffKind.Remove, removed.Kind);
+                Assert.Contains("::Abs(", removed.Operation.Operand?.Value, StringComparison.Ordinal);
+            },
+            added =>
+            {
+                Assert.Equal(IlDiffKind.Add, added.Kind);
+                Assert.Contains("::Sign(", added.Operation.Operand?.Value, StringComparison.Ordinal);
+            });
+    }
+
+    [Fact]
+    public void Compare_CompiledFixtureSlotLocalShapeNearMiss_SurfacesRawSlotRows()
+    {
+        var diff = DiffFixtureDiff("SlotLocalShapeNearMiss");
+
+        Assert.False(diff.IsExact);
+        Assert.Null(diff.Failure);
+        Assert.Contains(diff.Rows, row =>
+            row.Kind == IlDiffKind.Remove
+            && IsRawLocalRow(row));
+        Assert.Contains(diff.Rows, row =>
+            row.Kind == IlDiffKind.Add
+            && IsRawLocalRow(row));
+    }
+
+    [Fact]
     public void Printer_CompiledFixtureTokenRows_PreservesTypedOperandDisplay()
     {
         var diff = DiffFixtureDiff("FieldToken");
@@ -373,6 +455,11 @@ public class IlBodyDiffTests
     static bool IsBranchRow(IlDiffRow row)
         => row.Operation.OpcodeFamily.StartsWith("br", StringComparison.Ordinal);
 
+    static bool IsRawLocalRow(IlDiffRow row)
+        => row.Operation.Operand?.Kind == IlOperandIdentityKind.Slot
+            || row.Operation.OpcodeFamily.StartsWith("ldloc.", StringComparison.Ordinal)
+            || row.Operation.OpcodeFamily.StartsWith("stloc.", StringComparison.Ordinal);
+
     static void AssertTokenOperandPair(
         IlBodyDiffResult diff,
         string opcodeFamily,
@@ -404,6 +491,29 @@ public class IlBodyDiffTests
             && (operandFragment is null || row.Operation.Operand.Value.Contains(operandFragment, StringComparison.Ordinal)));
         return Assert.IsType<IlOperandIdentity>(row.Operation.Operand);
     }
+
+    static ExceptionRegionShape[] ExceptionRegionShapes(FixtureDefinition fixture, string name)
+    {
+        using var stream = File.OpenRead(fixture.AssemblyPath());
+        using var peReader = new PEReader(stream);
+        var metadataReader = peReader.GetMetadataReader();
+        var body = DiffFixtureMethodBody(peReader, metadataReader, name);
+        return body.ExceptionRegions
+            .Select(region => new ExceptionRegionShape(
+                region.Kind,
+                region.TryOffset,
+                region.TryLength,
+                region.HandlerOffset,
+                region.HandlerLength))
+            .ToArray();
+    }
+
+    readonly record struct ExceptionRegionShape(
+        ExceptionRegionKind Kind,
+        int TryOffset,
+        int TryLength,
+        int HandlerOffset,
+        int HandlerLength);
 
     static IlBodyDiffResult DiffFixtureDiff(string name)
     {


### PR DESCRIPTION
## Summary

Adds the next #2318 IL Diff coverage slice over paired compiled fixtures:

- EH availability coverage for catch and finally regions, with tests proving region metadata changed and current `IlBodyDiff` evidence surfaces as operation rows;
- EH region-shape near-miss coverage where both sides have a catch region but the protected range changes;
- repeated token-bearing call coverage where only the second repeated call changes, proving the stable call aligns;
- slot/local shape near-miss coverage documenting current raw local identity surfacing via explicit slot operands or local macro opcodes.

Refs #2318.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -filter "/*/*/IlBodyDiffTests/*"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release`

## Review

Adversarial review pending for the Analysis/Instructions coverage change.
