### PR TITLE
Document IL diff canonicalization boundary

### DIFF
--- a/docs/design/il-diff-canonicalization.md
+++ b/docs/design/il-diff-canonicalization.md
@@ -1,0 +1,123 @@
+# IL Diff Canonicalization Boundary
+
+`IlBodyDiff` is a low-level body-diff substrate in
+`ILInspector.Instructions`. It compares decoded IL operations after a small
+amount of canonicalization, then projects producer-owned rows through
+`IlDiffPrinter`.
+
+The boundary is intentionally narrow: the diff answers "which decoded IL
+operations changed?" It does not claim source equivalence, semantic equivalence,
+or durable identity for every operand category.
+
+## Compared operation shape
+
+Each instruction becomes a `CanonicalIlOperation`:
+
+- `Offset`: the original IL offset, retained as evidence and display context.
+- `OpcodeFamily`: the opcode name after limited macro folding.
+- `Operand`: an optional typed operand identity.
+
+Two operations match when their opcode family and operand identity match, with
+special target-handling rules for branches and switches. Unmatched operations
+become `IlDiffRow` entries. Rows retain the original offset so display and
+diagnostics can point back to the body, but the offset is not the row's durable
+identity.
+
+## Guarantees
+
+### Opcode macro folding
+
+`ldc.i4.*`, `ldc.i4.s`, and `ldc.i4` all fold to `ldc.i4`, with the integer
+value carried as an `Immediate` operand. Short branch opcodes fold to their long
+family name, so `br.s` and `br` compare as `br`.
+
+Other opcode names are preserved after lower-casing and replacing underscores
+with dots. Local macro opcodes such as `ldloc.0` remain distinct opcode families
+today; they are not normalized to `ldloc` plus a slot operand.
+
+### Branch and switch target alignment
+
+Branch target operands are represented as displayable `IL_####` offsets, but a
+matched branch operation does not compare the raw target text directly. After
+LCS alignment, `IlBodyDiff` validates whether the old target instruction maps to
+the new target instruction. A pure target-offset shift caused by inserted
+instructions before the same logical target should not report the branch as
+changed.
+
+Retargeting is still reported. If a branch now points at a different aligned
+instruction, the branch is emitted as a remove/add pair.
+
+Switch operands are similar but coarser. The canonical equality rule aligns
+switches with the same target count, then target validation checks each target
+against the aligned instruction map. A target-count change is a shape change and
+does not align as the same canonical switch operation.
+
+### Symbolic metadata token operands
+
+When comparison is backed by `MetadataReader`, metadata token operands are
+resolved to symbolic identities before comparison:
+
+- strings resolve as user-string values;
+- method, field, type, and `ldtoken` operands resolve to formatted symbolic
+  identities;
+- standalone signatures resolve to a signature-byte identity.
+
+Without a metadata-backed comparison, token operands fail closed. This prevents
+raw token numbers from being treated as comparable identities across assemblies
+or builds.
+
+### Hunk and display ownership
+
+`IlBodyDiff` owns row messages and hunk IDs. `IlDiffPrinter` owns display rows
+and unified text projection. Research and CLI layers should preserve or wrap
+these typed rows rather than reformatting lower-layer wording.
+
+## Current non-guarantees
+
+### Raw slot policy
+
+Slot operands are raw local/argument slot numbers. They are useful evidence for
+small local changes, but they are not stable semantic identities. Compiler
+rewrites, Debug/Release differences, or equivalent local reordering can produce
+slot noise.
+
+Some local macros currently surface as opcode-family changes (`ldloc.0`,
+`stloc.1`) rather than as `Slot` operands. That is part of the current boundary,
+not a stronger local identity contract.
+
+### Exception-region shape
+
+The body decoder is EH-aware, and malformed EH regions fail closed through
+`MethodInstructions`. `IlBodyDiff` does not currently emit producer-owned EH
+region rows. Catch/finally availability or protected-range changes surface only
+through operation-level rows unless a future substrate layer adds explicit EH
+row kinds.
+
+### Offset identity
+
+Offsets are evidence and display hints. They are not durable identity across
+versions. Insertions, compiler shape changes, and EH/layout changes can shift
+offsets while preserving the same logical operation. Callers that know a member
+or artifact identity should wrap diff rows with that higher-level identity
+(for example, `MemberAnchor`) instead of treating raw offsets as stable.
+
+### Semantic equivalence
+
+The canonical operation sequence is not a verifier, optimizer, or source-level
+normalizer. It does not prove that two bodies have the same stack behavior,
+exception behavior, locals, source shape, or runtime semantics. It is an
+operation-diff substrate for evidence and display.
+
+## When to extend the boundary
+
+Prefer extending the substrate only when a measured fixture or corpus case shows
+that current rows are too noisy or too weak for a product consumer. Likely
+extensions should remain Instructions-owned:
+
+- explicit EH availability/shape rows;
+- improved local/argument identity beyond raw slots;
+- unsupported-boundary diagnostics when a row is intentionally approximate;
+- display rows for decode or token-resolution failures.
+
+Research, RTS, and CLI consumers should request or preserve these typed rows
+rather than synthesizing their own IL wording.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -39,6 +39,7 @@ Agents working in this repo should preserve these principles:
 - [Row query and ordering](design/row-query-order.md): proposed field-scoped row predicates, ordering, `--top`, and schema-discoverable defaults.
 - [Analysis UX scopes](design/analysis-ux-scopes.md): shared analysis vocabulary across offset, member, type, and library scopes.
 - [IL coordinate workflows](design/il-coordinate-workflows.md): prototype workflows for explaining sparse runtime coordinates from debugger, profiler, or analyzer artifacts.
+- [IL Diff canonicalization](design/il-diff-canonicalization.md): current `CanonicalIlOperation` guarantees, boundaries, and extension points.
 - [Integrations](design/integrations.md): library ecosystem integration roll-ups and focused API currency.
 - [Section model](design/section-model.md): section selection and query behavior.
 - [Hidden-fact annotations](design/hidden-fact-annotations.md): offset-keyed fact overlay semantics, validation, and projections.


### PR DESCRIPTION
## Summary

Adds a focused #2318 design note for the current IL Diff canonicalization boundary:

- what `CanonicalIlOperation` compares;
- opcode macro folding and branch/switch target alignment rules;
- symbolic metadata token operands;
- raw slot, EH-region, offset, and semantic-equivalence non-guarantees;
- Instructions-owned extension points for future row kinds/diagnostics.

Links the note from `docs/overview.md`.

Refs #2318.

## Validation

- `npx markdownlint-cli --fix docs/design/il-diff-canonicalization.md docs/overview.md`
- `npx markdownlint-cli docs/design/il-diff-canonicalization.md docs/overview.md`

## Review

Docs-only PR. No measured behavior change; adversarial review is not required.
