### PR TITLE
Add semantic C# diff rows

### DIFF
--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -193,6 +193,41 @@ namespace DiffFixtureSample
             return first + second;
         }
 
+        public static int SemanticSwitchCase(int value)
+        {
+            switch (value)
+            {
+                case 0:
+                    goto Zero;
+                case 1:
+                    goto One;
+                case 3:
+                    goto Three;
+                default:
+                    return -1;
+            }
+
+        Zero:
+            return 10;
+
+        One:
+            return 11;
+
+        Three:
+            return 13;
+        }
+
+        public static int SemanticReturnExpression(int value)
+        {
+            return value + 1;
+        }
+
+        public static int SemanticCallChange(int value)
+        {
+            Sink(value);
+            return value;
+        }
+
         // V1: safe body. V2 adds a visible unsafe operation.
         public static int AddsUnsafe(int value) => value;
 

--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -228,6 +228,19 @@ namespace DiffFixtureSample
             return value;
         }
 
+        public static int SemanticMultiCallChange(int value)
+        {
+            Sink(value);
+            Sink(value + 1);
+            return value;
+        }
+
+        public static string SemanticCallStringLiteralNearMiss()
+        {
+            string value = "John (Doe)";
+            return value;
+        }
+
         // V1: safe body. V2 adds a visible unsafe operation.
         public static int AddsUnsafe(int value) => value;
 

--- a/src/DiffFixtures.V1/DiffSample.cs
+++ b/src/DiffFixtures.V1/DiffSample.cs
@@ -201,8 +201,18 @@ namespace DiffFixtureSample
                     goto Zero;
                 case 1:
                     goto One;
+                case 2:
+                    goto Two;
                 case 3:
                     goto Three;
+                case 4:
+                    goto Four;
+                case 5:
+                    goto Five;
+                case 6:
+                    goto Six;
+                case 8:
+                    goto Eight;
                 default:
                     return -1;
             }
@@ -213,8 +223,23 @@ namespace DiffFixtureSample
         One:
             return 11;
 
+        Two:
+            return 12;
+
         Three:
             return 13;
+
+        Four:
+            return 14;
+
+        Five:
+            return 15;
+
+        Six:
+            return 16;
+
+        Eight:
+            return 18;
         }
 
         public static int SemanticReturnExpression(int value)
@@ -239,6 +264,17 @@ namespace DiffFixtureSample
         {
             string value = "John (Doe)";
             return value;
+        }
+
+        public static int SemanticCallArithmeticGroupingNearMiss(int value)
+        {
+            int adjusted = value * (value + 2);
+            return adjusted;
+        }
+
+        public static int SemanticCallTrailingExpression(int value)
+        {
+            return System.Math.Abs(value) + 1;
         }
 
         // V1: safe body. V2 adds a visible unsafe operation.

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -218,10 +218,20 @@ namespace DiffFixtureSample
             {
                 case 0:
                     goto Zero;
+                case 1:
+                    goto One;
                 case 2:
                     goto Two;
                 case 3:
                     goto Three;
+                case 4:
+                    goto Four;
+                case 5:
+                    goto Five;
+                case 7:
+                    goto Seven;
+                case 8:
+                    goto Eight;
                 default:
                     return -1;
             }
@@ -229,11 +239,26 @@ namespace DiffFixtureSample
         Zero:
             return 10;
 
+        One:
+            return 11;
+
         Two:
             return 12;
 
         Three:
             return 13;
+
+        Four:
+            return 14;
+
+        Five:
+            return 15;
+
+        Seven:
+            return 17;
+
+        Eight:
+            return 18;
         }
 
         public static int SemanticReturnExpression(int value)
@@ -258,6 +283,17 @@ namespace DiffFixtureSample
         {
             string value = "Jane (Doe)";
             return value;
+        }
+
+        public static int SemanticCallArithmeticGroupingNearMiss(int value)
+        {
+            int adjusted = value * (value + 3);
+            return adjusted;
+        }
+
+        public static int SemanticCallTrailingExpression(int value)
+        {
+            return System.Math.Sign(value) + 1;
         }
 
         // V2: visible unsafe operation added relative to V1.

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -212,6 +212,41 @@ namespace DiffFixtureSample
             return first + second;
         }
 
+        public static int SemanticSwitchCase(int value)
+        {
+            switch (value)
+            {
+                case 0:
+                    goto Zero;
+                case 2:
+                    goto Two;
+                case 3:
+                    goto Three;
+                default:
+                    return -1;
+            }
+
+        Zero:
+            return 10;
+
+        Two:
+            return 12;
+
+        Three:
+            return 13;
+        }
+
+        public static int SemanticReturnExpression(int value)
+        {
+            return value + 2;
+        }
+
+        public static int SemanticCallChange(int value)
+        {
+            MaybeThrow(value);
+            return value;
+        }
+
         // V2: visible unsafe operation added relative to V1.
         public static unsafe int AddsUnsafe(int value)
         {

--- a/src/DiffFixtures.V2/DiffSample.cs
+++ b/src/DiffFixtures.V2/DiffSample.cs
@@ -247,6 +247,19 @@ namespace DiffFixtureSample
             return value;
         }
 
+        public static int SemanticMultiCallChange(int value)
+        {
+            MaybeThrow(value);
+            MaybeThrow(value + 1);
+            return value;
+        }
+
+        public static string SemanticCallStringLiteralNearMiss()
+        {
+            string value = "Jane (Doe)";
+            return value;
+        }
+
         // V2: visible unsafe operation added relative to V1.
         public static unsafe int AddsUnsafe(int value)
         {

--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -176,6 +176,45 @@ public class CSharpBodyDiffTests
     }
 
     [Fact]
+    public void CompareAssemblies_SemanticMultiCallHunkEmitsAllChangedRows()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+        var rows = diff.Rows
+            .Where(row => row.Member.Contains("SemanticMultiCallChange", StringComparison.Ordinal)
+                && row.ChangeId == "csharp.call.changed")
+            .OrderBy(row => row.Line)
+            .ToArray();
+        Assert.Equal(2, rows.Length);
+        Assert.Equal("DiffSample.Sink(value)", rows[0].OldValue);
+        Assert.Equal("DiffSample.MaybeThrow(value)", rows[0].NewValue);
+        Assert.Equal("DiffSample.Sink(value + 1)", rows[1].OldValue);
+        Assert.Equal("DiffSample.MaybeThrow(value + 1)", rows[1].NewValue);
+    }
+
+    [Fact]
+    public void CompareAssemblies_SemanticCallIgnoresStringLiteralParentheses()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+        Assert.DoesNotContain(diff.Rows, row =>
+            row.Member.Contains("SemanticCallStringLiteralNearMiss", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.call.changed");
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("SemanticCallStringLiteralNearMiss", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.line.removed");
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("SemanticCallStringLiteralNearMiss", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.line.added");
+    }
+
+    [Fact]
     public void CompareAssemblies_ProtectedMethodsAreIncludedInDefaultSurface()
     {
         var v1 = DiffFixturePath("DiffFixtures.V1");

--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -107,17 +107,17 @@ public class CSharpBodyDiffTests
             row.Member.Contains("SemanticSwitchCase", StringComparison.Ordinal)
             && row.ChangeId == "csharp.switch.case.removed");
         Assert.Equal(CSharpDiffKind.Remove, removed.Kind);
-        Assert.Equal("2", removed.OldValue);
+        Assert.Equal("7", removed.OldValue);
         Assert.Null(removed.NewValue);
-        Assert.Equal("Removed switch case '2'", removed.Message);
+        Assert.Equal("Removed switch case '7'", removed.Message);
 
         var added = Assert.Single(diff.Rows, row =>
             row.Member.Contains("SemanticSwitchCase", StringComparison.Ordinal)
             && row.ChangeId == "csharp.switch.case.added");
         Assert.Equal(CSharpDiffKind.Add, added.Kind);
         Assert.Null(added.OldValue);
-        Assert.Equal("2", added.NewValue);
-        Assert.Equal("Added switch case '2'", added.Message);
+        Assert.Equal("7", added.NewValue);
+        Assert.Equal("Added switch case '7'", added.Message);
 
         Assert.Contains(diff.Rows, row =>
             row.Member.Contains("SemanticSwitchCase", StringComparison.Ordinal)
@@ -212,6 +212,41 @@ public class CSharpBodyDiffTests
         Assert.Contains(diff.Rows, row =>
             row.Member.Contains("SemanticCallStringLiteralNearMiss", StringComparison.Ordinal)
             && row.ChangeId == "csharp.line.added");
+    }
+
+    [Fact]
+    public void CompareAssemblies_SemanticCallIgnoresArithmeticGroupingParentheses()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+        Assert.DoesNotContain(diff.Rows, row =>
+            row.Member.Contains("SemanticCallArithmeticGroupingNearMiss", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.call.changed");
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("SemanticCallArithmeticGroupingNearMiss", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.line.removed");
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("SemanticCallArithmeticGroupingNearMiss", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.line.added");
+    }
+
+    [Fact]
+    public void CompareAssemblies_SemanticCallExtractsTrailingExpressionInvocation()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+        var row = Assert.Single(diff.Rows, row =>
+            row.Member.Contains("SemanticCallTrailingExpression", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.call.changed");
+        Assert.Equal(CSharpDiffKind.Changed, row.Kind);
+        Assert.Contains("Abs(value)", row.OldValue);
+        Assert.Contains("Sign(value)", row.NewValue);
     }
 
     [Fact]

--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -29,9 +29,14 @@ public class CSharpBodyDiffTests
             && row.Text.Contains("1", StringComparison.Ordinal));
         Assert.Contains(diff.Rows, row =>
             row.Member.Contains("ConstantValue", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.return-expression.changed"
+            && row.OldValue == "1"
+            && row.NewValue == "2");
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("ConstantValue", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Add
             && row.Text.Contains("2", StringComparison.Ordinal));
-        Assert.All(diff.Rows.Where(row => row.Member.Contains("ConstantValue", StringComparison.Ordinal)), row =>
+        Assert.All(diff.Rows.Where(row => row.Member.Contains("ConstantValue", StringComparison.Ordinal) && row.ChangeId.StartsWith("csharp.line.", StringComparison.Ordinal)), row =>
         {
             Assert.StartsWith("ConstantValue~", row.Anchor.StableSelector, StringComparison.Ordinal);
             Assert.StartsWith("M:DiffFixtureSample.DiffSample.ConstantValue()", row.Anchor.CanonicalSignature, StringComparison.Ordinal);
@@ -88,6 +93,86 @@ public class CSharpBodyDiffTests
             row.Member.Contains("StringToken", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Add
             && row.Text.Contains("\"beta\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CompareAssemblies_SemanticSwitchCaseRowsPreserveLineFallback()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+        var removed = Assert.Single(diff.Rows, row =>
+            row.Member.Contains("SemanticSwitchCase", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.switch.case.removed");
+        Assert.Equal(CSharpDiffKind.Remove, removed.Kind);
+        Assert.Equal("2", removed.OldValue);
+        Assert.Null(removed.NewValue);
+        Assert.Equal("Removed switch case '2'", removed.Message);
+
+        var added = Assert.Single(diff.Rows, row =>
+            row.Member.Contains("SemanticSwitchCase", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.switch.case.added");
+        Assert.Equal(CSharpDiffKind.Add, added.Kind);
+        Assert.Null(added.OldValue);
+        Assert.Equal("2", added.NewValue);
+        Assert.Equal("Added switch case '2'", added.Message);
+
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("SemanticSwitchCase", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.line.removed");
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("SemanticSwitchCase", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.line.added");
+    }
+
+    [Fact]
+    public void CompareAssemblies_SemanticReturnExpressionChangedRowPreservesLineFallback()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+        var row = Assert.Single(diff.Rows, row =>
+            row.Member.Contains("SemanticReturnExpression", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.return-expression.changed");
+        Assert.Equal(CSharpDiffKind.Changed, row.Kind);
+        Assert.Equal("value + 1", row.OldValue);
+        Assert.Equal("value + 2", row.NewValue);
+        Assert.Equal("Changed return expression from 'value + 1' to 'value + 2'", row.Message);
+
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("SemanticReturnExpression", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.line.removed");
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("SemanticReturnExpression", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.line.added");
+    }
+
+    [Fact]
+    public void CompareAssemblies_SemanticCallChangedRowPreservesLineFallback()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+
+        var row = Assert.Single(diff.Rows, row =>
+            row.Member.Contains("SemanticCallChange", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.call.changed");
+        Assert.Equal(CSharpDiffKind.Changed, row.Kind);
+        Assert.Contains("Sink(value)", row.OldValue);
+        Assert.Contains("MaybeThrow(value)", row.NewValue);
+        Assert.Contains("Changed call", row.Message);
+
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("SemanticCallChange", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.line.removed");
+        Assert.Contains(diff.Rows, row =>
+            row.Member.Contains("SemanticCallChange", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.line.added");
     }
 
     [Fact]

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -245,6 +245,22 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void CompareAssemblies_CSharp_QuerySemanticReturnExpressionChange()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" }));
+
+        var changed = Assert.Single(diff.MembersWhere(member =>
+            member.Subject.Display.Contains("SemanticReturnExpression", StringComparison.Ordinal)
+            && member.HasChange("csharp.return-expression.changed")));
+        var evidence = Assert.Single(changed.Evidence, evidence => evidence.ChangeId == "csharp.return-expression.changed");
+        Assert.Equal("value + 1", evidence.OldValue);
+        Assert.Equal("value + 2", evidence.NewValue);
+    }
+
+    [Fact]
     public void CompareAssemblies_CSharpAndApiEvidence_GroupOnMemberAnchor()
     {
         var diff = ResearchDiff.CompareAssemblies(

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -1051,23 +1051,273 @@ public static class CSharpBodyDiff
 
         if (expression.StartsWith("await ", StringComparison.Ordinal))
             expression = expression["await ".Length..].Trim();
-        if (expression.StartsWith("new ", StringComparison.Ordinal) || expression.Length == 0 || expression[^1] != ')')
+        if (expression.StartsWith("new ", StringComparison.Ordinal) || expression.Length == 0)
             return false;
 
-        var paren = IndexOfUnquoted(expression, '(');
-        if (paren <= 0)
+        var invocations = ExtractInvocations(expression);
+        if (invocations.Count == 0)
             return false;
-        var head = expression[..paren].Trim();
-        var lastSpace = head.LastIndexOf(' ');
-        if (lastSpace >= 0)
-            head = head[(lastSpace + 1)..];
-        if (head.Length == 0 || head is "new" or "return" or "typeof" or "sizeof" or "nameof" or "default" or "checked" or "unchecked")
-            return false;
-        var end = expression.LastIndexOf(')');
-        if (end < paren)
-            return false;
-        call = expression[..(end + 1)].Trim();
+
+        call = string.Join(" | ", invocations);
         return true;
+    }
+
+    static List<string> ExtractInvocations(string expression)
+    {
+        var invocations = new List<string>();
+        for (int i = 0; i < expression.Length; i++)
+        {
+            if (expression[i] != '(' || IsQuoted(expression, i))
+                continue;
+
+            int close = FindMatchingCloseParen(expression, i);
+            if (close < 0)
+                continue;
+
+            int nameEnd = PreviousNonWhitespace(expression, i - 1);
+            if (nameEnd < 0 || !IsInvocationNameEnd(expression[nameEnd]))
+            {
+                i = close;
+                continue;
+            }
+
+            int nameStart = FindNameStart(expression, nameEnd);
+            if (nameStart < 0)
+            {
+                i = close;
+                continue;
+            }
+
+            var name = expression[nameStart..(nameEnd + 1)].Trim();
+            if (name is "new" or "return" or "typeof" or "sizeof" or "nameof" or "default" or "checked" or "unchecked")
+            {
+                i = close;
+                continue;
+            }
+
+            int start = FindInvocationStart(expression, nameStart);
+            var invocation = expression[start..(close + 1)].Trim();
+            if (invocation.StartsWith("new ", StringComparison.Ordinal))
+            {
+                i = close;
+                continue;
+            }
+
+            invocations.Add(invocation);
+            i = close;
+        }
+
+        return invocations;
+    }
+
+    static bool IsInvocationNameEnd(char c)
+        => char.IsLetterOrDigit(c) || c == '_' || c == '>' || c == '`';
+
+    static int FindNameStart(string expression, int nameEnd)
+    {
+        int i = nameEnd;
+        if (expression[i] == '>')
+        {
+            int genericDepth = 1;
+            i--;
+            while (i >= 0)
+            {
+                if (expression[i] == '>')
+                    genericDepth++;
+                else if (expression[i] == '<' && --genericDepth == 0)
+                {
+                    i--;
+                    break;
+                }
+
+                i--;
+            }
+        }
+
+        while (i >= 0 && (char.IsLetterOrDigit(expression[i]) || expression[i] == '_' || expression[i] == '`'))
+            i--;
+
+        int start = i + 1;
+        return start <= nameEnd ? start : -1;
+    }
+
+    static int FindInvocationStart(string expression, int nameStart)
+    {
+        int start = nameStart;
+        int previous = PreviousNonWhitespace(expression, start - 1);
+        if (previous < 0 || expression[previous] != '.')
+            return start;
+
+        int depth = 0;
+        bool inString = false;
+        bool inChar = false;
+        bool escape = false;
+        for (int i = previous - 1; i >= 0; i--)
+        {
+            char c = expression[i];
+            if (escape)
+            {
+                escape = false;
+                continue;
+            }
+
+            if (inString || inChar)
+            {
+                if (c == '\\')
+                {
+                    escape = true;
+                    continue;
+                }
+
+                if (inString && c == '"')
+                    inString = false;
+                else if (inChar && c == '\'')
+                    inChar = false;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                inString = true;
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                inChar = true;
+                continue;
+            }
+
+            if (c is ')' or ']' or '}')
+            {
+                depth++;
+                continue;
+            }
+
+            if (c is '(' or '[' or '{')
+            {
+                if (depth > 0)
+                {
+                    depth--;
+                    continue;
+                }
+
+                start = i + 1;
+                break;
+            }
+
+            if (depth == 0 && IsInvocationBoundary(c))
+            {
+                start = i + 1;
+                break;
+            }
+
+            start = i;
+        }
+
+        return start;
+    }
+
+    static bool IsInvocationBoundary(char c)
+        => c is ' ' or '\t' or '+' or '-' or '*' or '/' or '%' or '=' or '!' or '<' or '>' or '&' or '|' or '^' or '?' or ':' or ',' or ';';
+
+    static int PreviousNonWhitespace(string text, int index)
+    {
+        for (int i = index; i >= 0; i--)
+            if (!char.IsWhiteSpace(text[i]))
+                return i;
+        return -1;
+    }
+
+    static int FindMatchingCloseParen(string text, int open)
+    {
+        int depth = 0;
+        bool inString = false;
+        bool inChar = false;
+        bool escape = false;
+
+        for (int i = open; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (escape)
+            {
+                escape = false;
+                continue;
+            }
+
+            if (inString || inChar)
+            {
+                if (c == '\\')
+                {
+                    escape = true;
+                    continue;
+                }
+
+                if (inString && c == '"')
+                    inString = false;
+                else if (inChar && c == '\'')
+                    inChar = false;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                inString = true;
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                inChar = true;
+                continue;
+            }
+
+            if (c == '(')
+                depth++;
+            else if (c == ')' && --depth == 0)
+                return i;
+        }
+
+        return -1;
+    }
+
+    static bool IsQuoted(string text, int index)
+    {
+        bool inString = false;
+        bool inChar = false;
+        bool escape = false;
+
+        for (int i = 0; i < index; i++)
+        {
+            char c = text[i];
+            if (escape)
+            {
+                escape = false;
+                continue;
+            }
+
+            if (inString || inChar)
+            {
+                if (c == '\\')
+                {
+                    escape = true;
+                    continue;
+                }
+
+                if (inString && c == '"')
+                    inString = false;
+                else if (inChar && c == '\'')
+                    inChar = false;
+                continue;
+            }
+
+            if (c == '"')
+                inString = true;
+            else if (c == '\'')
+                inChar = true;
+        }
+
+        return inString || inChar;
     }
 
     static int LastTopLevelAssignment(string text)

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -17,6 +17,7 @@ public enum CSharpDiffKind
 {
     Remove,
     Add,
+    Changed,
 }
 
 public sealed record CSharpDiffRow(
@@ -31,7 +32,9 @@ public sealed record CSharpDiffRow(
     int? Line,
     string? SourceCoordinate,
     string Fidelity,
-    string Text);
+    string Text,
+    string? OldValue = null,
+    string? NewValue = null);
 
 public sealed record CSharpBodyDiffResult(ImmutableArray<CSharpDiffRow> Rows)
 {
@@ -754,6 +757,7 @@ public static class CSharpBodyDiff
             return;
 
         int hunk = hunkId++;
+        AddSemanticRows(rows, entry, hunk, oldRender, oldStart, oldEnd, newRender, newStart, newEnd);
         for (int i = oldStart; i < oldEnd; i++)
             rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, i + 1, oldRender.Fidelity.ToString(), oldRender.Lines[i]));
         for (int i = newStart; i < newEnd; i++)
@@ -803,11 +807,32 @@ public static class CSharpBodyDiff
         string text,
         string? changeId = null,
         string? message = null)
+        => CreateRow(entry, hunk, kind, line, fidelity, text, changeId, message, oldValue: null, newValue: null);
+
+    static CSharpDiffRow CreateRow(
+        CSharpMethodEntry entry,
+        int hunk,
+        CSharpDiffKind kind,
+        int? line,
+        string fidelity,
+        string text,
+        string? changeId,
+        string? message,
+        string? oldValue,
+        string? newValue)
     {
-        changeId ??= kind == CSharpDiffKind.Add ? "csharp.line.added" : "csharp.line.removed";
-        message ??= kind == CSharpDiffKind.Add
-            ? $"Added C# line '{text}'"
-            : $"Removed C# line '{text}'";
+        changeId ??= kind switch
+        {
+            CSharpDiffKind.Add => "csharp.line.added",
+            CSharpDiffKind.Remove => "csharp.line.removed",
+            _ => "csharp.line.changed",
+        };
+        message ??= kind switch
+        {
+            CSharpDiffKind.Add => $"Added C# line '{text}'",
+            CSharpDiffKind.Remove => $"Removed C# line '{text}'",
+            _ => $"Changed C# line '{text}'",
+        };
         return new CSharpDiffRow(
             entry.StableAssemblyKey,
             entry.StableMemberKey,
@@ -820,7 +845,166 @@ public static class CSharpBodyDiff
             line,
             line is null ? null : $"line:{line.Value}",
             fidelity,
-            text);
+            text,
+            oldValue,
+            newValue);
+    }
+
+    static void AddSemanticRows(
+        ImmutableArray<CSharpDiffRow>.Builder rows,
+        CSharpMethodEntry entry,
+        int hunk,
+        CSharpMethodRender oldRender,
+        int oldStart,
+        int oldEnd,
+        CSharpMethodRender newRender,
+        int newStart,
+        int newEnd)
+    {
+        if (oldRender.Fidelity != DecompilationFidelity.Full || newRender.Fidelity != DecompilationFidelity.Full)
+            return;
+
+        for (int i = oldStart; i < oldEnd; i++)
+        {
+            if (TryParseSwitchCase(oldRender.Lines[i], out var label))
+            {
+                rows.Add(CreateRow(
+                    entry,
+                    hunk,
+                    CSharpDiffKind.Remove,
+                    i + 1,
+                    oldRender.Fidelity.ToString(),
+                    oldRender.Lines[i],
+                    "csharp.switch.case.removed",
+                    $"Removed switch case '{label}'",
+                    oldValue: label,
+                    newValue: null));
+            }
+        }
+
+        for (int i = newStart; i < newEnd; i++)
+        {
+            if (TryParseSwitchCase(newRender.Lines[i], out var label))
+            {
+                rows.Add(CreateRow(
+                    entry,
+                    hunk,
+                    CSharpDiffKind.Add,
+                    i + 1,
+                    newRender.Fidelity.ToString(),
+                    newRender.Lines[i],
+                    "csharp.switch.case.added",
+                    $"Added switch case '{label}'",
+                    oldValue: null,
+                    newValue: label));
+            }
+        }
+
+        var oldReturn = FirstParsed(oldRender.Lines, oldStart, oldEnd, TryParseReturnExpression);
+        var newReturn = FirstParsed(newRender.Lines, newStart, newEnd, TryParseReturnExpression);
+        if (oldReturn is { } oldRet && newReturn is { } newRet && oldRet.Value != newRet.Value)
+        {
+            rows.Add(CreateRow(
+                entry,
+                hunk,
+                CSharpDiffKind.Changed,
+                newRet.Line,
+                newRender.Fidelity.ToString(),
+                newRender.Lines[newRet.Line - 1],
+                "csharp.return-expression.changed",
+                $"Changed return expression from '{oldRet.Value}' to '{newRet.Value}'",
+                oldRet.Value,
+                newRet.Value));
+        }
+
+        var oldCall = FirstParsed(oldRender.Lines, oldStart, oldEnd, TryParseCallExpression);
+        var newCall = FirstParsed(newRender.Lines, newStart, newEnd, TryParseCallExpression);
+        if (oldCall is { } oldCallValue && newCall is { } newCallValue && oldCallValue.Value != newCallValue.Value)
+        {
+            rows.Add(CreateRow(
+                entry,
+                hunk,
+                CSharpDiffKind.Changed,
+                newCallValue.Line,
+                newRender.Fidelity.ToString(),
+                newRender.Lines[newCallValue.Line - 1],
+                "csharp.call.changed",
+                $"Changed call from '{oldCallValue.Value}' to '{newCallValue.Value}'",
+                oldCallValue.Value,
+                newCallValue.Value));
+        }
+    }
+
+    delegate bool TryParseLine(string line, out string value);
+
+    static (int Line, string Value)? FirstParsed(string[] lines, int start, int end, TryParseLine parser)
+    {
+        for (int i = start; i < end; i++)
+            if (parser(lines[i], out var value))
+                return (i + 1, value);
+        return null;
+    }
+
+    static bool TryParseSwitchCase(string line, out string label)
+    {
+        var trimmed = line.Trim();
+        if (!trimmed.StartsWith("case ", StringComparison.Ordinal) || !trimmed.EndsWith(":", StringComparison.Ordinal))
+        {
+            label = "";
+            return false;
+        }
+
+        label = trimmed["case ".Length..^1].Trim();
+        return label.Length > 0;
+    }
+
+    static bool TryParseReturnExpression(string line, out string expression)
+    {
+        var trimmed = line.Trim();
+        if (!trimmed.StartsWith("return ", StringComparison.Ordinal) || !trimmed.EndsWith(";", StringComparison.Ordinal))
+        {
+            expression = "";
+            return false;
+        }
+
+        expression = trimmed["return ".Length..^1].Trim();
+        return expression.Length > 0;
+    }
+
+    static bool TryParseCallExpression(string line, out string call)
+    {
+        call = "";
+        var trimmed = line.Trim();
+        if (trimmed.StartsWith("return ", StringComparison.Ordinal)
+            || trimmed.StartsWith("if ", StringComparison.Ordinal)
+            || trimmed.StartsWith("if(", StringComparison.Ordinal)
+            || trimmed.StartsWith("for ", StringComparison.Ordinal)
+            || trimmed.StartsWith("for(", StringComparison.Ordinal)
+            || trimmed.StartsWith("while ", StringComparison.Ordinal)
+            || trimmed.StartsWith("while(", StringComparison.Ordinal)
+            || trimmed.StartsWith("switch ", StringComparison.Ordinal)
+            || trimmed.StartsWith("switch(", StringComparison.Ordinal)
+            || trimmed.StartsWith("catch ", StringComparison.Ordinal)
+            || trimmed.StartsWith("catch(", StringComparison.Ordinal)
+            || !trimmed.EndsWith(";", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var paren = trimmed.IndexOf('(');
+        if (paren <= 0)
+            return false;
+        var head = trimmed[..paren].Trim();
+        var lastSpace = head.LastIndexOf(' ');
+        if (lastSpace >= 0)
+            head = head[(lastSpace + 1)..];
+        if (head.Length == 0 || head is "new" or "return")
+            return false;
+        var end = trimmed.LastIndexOf(')');
+        if (end < paren)
+            return false;
+        call = trimmed[..(end + 1)].Trim();
+        return true;
     }
 
     static List<(int OldIndex, int NewIndex)> LongestCommonSubsequence(IReadOnlyList<string> oldLines, IReadOnlyList<string> newLines)

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -900,62 +900,109 @@ public static class CSharpBodyDiff
             }
         }
 
-        var oldReturn = FirstParsed(oldRender.Lines, oldStart, oldEnd, TryParseReturnExpression);
-        var newReturn = FirstParsed(newRender.Lines, newStart, newEnd, TryParseReturnExpression);
-        if (oldReturn is { } oldRet && newReturn is { } newRet && oldRet.Value != newRet.Value)
-        {
-            rows.Add(CreateRow(
-                entry,
-                hunk,
-                CSharpDiffKind.Changed,
-                newRet.Line,
-                newRender.Fidelity.ToString(),
-                newRender.Lines[newRet.Line - 1],
-                "csharp.return-expression.changed",
-                $"Changed return expression from '{oldRet.Value}' to '{newRet.Value}'",
-                oldRet.Value,
-                newRet.Value));
-        }
+        AddChangedSemanticRows(
+            rows,
+            entry,
+            hunk,
+            oldRender,
+            oldStart,
+            oldEnd,
+            newRender,
+            newStart,
+            newEnd,
+            TryParseReturnExpression,
+            "csharp.return-expression.changed",
+            static (oldValue, newValue) => $"Changed return expression from '{oldValue}' to '{newValue}'");
 
-        var oldCall = FirstParsed(oldRender.Lines, oldStart, oldEnd, TryParseCallExpression);
-        var newCall = FirstParsed(newRender.Lines, newStart, newEnd, TryParseCallExpression);
-        if (oldCall is { } oldCallValue && newCall is { } newCallValue && oldCallValue.Value != newCallValue.Value)
-        {
-            rows.Add(CreateRow(
-                entry,
-                hunk,
-                CSharpDiffKind.Changed,
-                newCallValue.Line,
-                newRender.Fidelity.ToString(),
-                newRender.Lines[newCallValue.Line - 1],
-                "csharp.call.changed",
-                $"Changed call from '{oldCallValue.Value}' to '{newCallValue.Value}'",
-                oldCallValue.Value,
-                newCallValue.Value));
-        }
+        AddChangedSemanticRows(
+            rows,
+            entry,
+            hunk,
+            oldRender,
+            oldStart,
+            oldEnd,
+            newRender,
+            newStart,
+            newEnd,
+            TryParseCallExpression,
+            "csharp.call.changed",
+            static (oldValue, newValue) => $"Changed call from '{oldValue}' to '{newValue}'");
     }
 
     delegate bool TryParseLine(string line, out string value);
 
-    static (int Line, string Value)? FirstParsed(string[] lines, int start, int end, TryParseLine parser)
+    static void AddChangedSemanticRows(
+        ImmutableArray<CSharpDiffRow>.Builder rows,
+        CSharpMethodEntry entry,
+        int hunk,
+        CSharpMethodRender oldRender,
+        int oldStart,
+        int oldEnd,
+        CSharpMethodRender newRender,
+        int newStart,
+        int newEnd,
+        TryParseLine parser,
+        string changeId,
+        Func<string, string, string> messageFactory)
     {
+        var oldValues = ParsedLines(oldRender.Lines, oldStart, oldEnd, parser);
+        var newValues = ParsedLines(newRender.Lines, newStart, newEnd, parser);
+        if (oldValues.Count == 0 || oldValues.Count != newValues.Count)
+            return;
+
+        for (int i = 0; i < oldValues.Count; i++)
+        {
+            var oldValue = oldValues[i];
+            var newValue = newValues[i];
+            if (oldValue.Value == newValue.Value)
+                continue;
+
+            rows.Add(CreateRow(
+                entry,
+                hunk,
+                CSharpDiffKind.Changed,
+                newValue.Line,
+                newRender.Fidelity.ToString(),
+                newRender.Lines[newValue.Line - 1],
+                changeId,
+                messageFactory(oldValue.Value, newValue.Value),
+                oldValue.Value,
+                newValue.Value));
+        }
+    }
+
+    static List<(int Line, string Value)> ParsedLines(string[] lines, int start, int end, TryParseLine parser)
+    {
+        var values = new List<(int Line, string Value)>();
         for (int i = start; i < end; i++)
             if (parser(lines[i], out var value))
-                return (i + 1, value);
-        return null;
+                values.Add((i + 1, value));
+        return values;
     }
 
     static bool TryParseSwitchCase(string line, out string label)
     {
         var trimmed = line.Trim();
-        if (!trimmed.StartsWith("case ", StringComparison.Ordinal) || !trimmed.EndsWith(":", StringComparison.Ordinal))
+        if (!trimmed.EndsWith(":", StringComparison.Ordinal))
         {
             label = "";
             return false;
         }
 
-        label = trimmed["case ".Length..^1].Trim();
-        return label.Length > 0;
+        if (trimmed == "default:")
+        {
+            label = "default";
+            return true;
+        }
+
+        if (trimmed.StartsWith("case ", StringComparison.Ordinal))
+        {
+            label = trimmed["case ".Length..^1].Trim();
+            return label.Length > 0;
+        }
+
+        label = "";
+        return false;
     }
 
     static bool TryParseReturnExpression(string line, out string expression)
@@ -975,8 +1022,7 @@ public static class CSharpBodyDiff
     {
         call = "";
         var trimmed = line.Trim();
-        if (trimmed.StartsWith("return ", StringComparison.Ordinal)
-            || trimmed.StartsWith("if ", StringComparison.Ordinal)
+        if (trimmed.StartsWith("if ", StringComparison.Ordinal)
             || trimmed.StartsWith("if(", StringComparison.Ordinal)
             || trimmed.StartsWith("for ", StringComparison.Ordinal)
             || trimmed.StartsWith("for(", StringComparison.Ordinal)
@@ -991,20 +1037,155 @@ public static class CSharpBodyDiff
             return false;
         }
 
-        var paren = trimmed.IndexOf('(');
+        var expression = trimmed[..^1].Trim();
+        if (expression.StartsWith("return ", StringComparison.Ordinal))
+        {
+            expression = expression["return ".Length..].Trim();
+        }
+        else
+        {
+            int assignment = LastTopLevelAssignment(expression);
+            if (assignment >= 0)
+                expression = expression[(assignment + 1)..].Trim();
+        }
+
+        if (expression.StartsWith("await ", StringComparison.Ordinal))
+            expression = expression["await ".Length..].Trim();
+        if (expression.StartsWith("new ", StringComparison.Ordinal) || expression.Length == 0 || expression[^1] != ')')
+            return false;
+
+        var paren = IndexOfUnquoted(expression, '(');
         if (paren <= 0)
             return false;
-        var head = trimmed[..paren].Trim();
+        var head = expression[..paren].Trim();
         var lastSpace = head.LastIndexOf(' ');
         if (lastSpace >= 0)
             head = head[(lastSpace + 1)..];
-        if (head.Length == 0 || head is "new" or "return")
+        if (head.Length == 0 || head is "new" or "return" or "typeof" or "sizeof" or "nameof" or "default" or "checked" or "unchecked")
             return false;
-        var end = trimmed.LastIndexOf(')');
+        var end = expression.LastIndexOf(')');
         if (end < paren)
             return false;
-        call = trimmed[..(end + 1)].Trim();
+        call = expression[..(end + 1)].Trim();
         return true;
+    }
+
+    static int LastTopLevelAssignment(string text)
+    {
+        int depth = 0;
+        int last = -1;
+        bool inString = false;
+        bool inChar = false;
+        bool escape = false;
+
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (escape)
+            {
+                escape = false;
+                continue;
+            }
+
+            if (inString || inChar)
+            {
+                if (c == '\\')
+                {
+                    escape = true;
+                    continue;
+                }
+
+                if (inString && c == '"')
+                    inString = false;
+                else if (inChar && c == '\'')
+                    inChar = false;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                inString = true;
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                inChar = true;
+                continue;
+            }
+
+            if (c is '(' or '[' or '{')
+            {
+                depth++;
+                continue;
+            }
+
+            if (c is ')' or ']' or '}')
+            {
+                if (depth > 0)
+                    depth--;
+                continue;
+            }
+
+            if (depth == 0
+                && c == '='
+                && (i == 0 || text[i - 1] is not ('=' or '!' or '<' or '>' or '='))
+                && (i + 1 == text.Length || text[i + 1] is not ('=' or '>')))
+            {
+                last = i;
+            }
+        }
+
+        return last;
+    }
+
+    static int IndexOfUnquoted(string text, char target)
+    {
+        bool inString = false;
+        bool inChar = false;
+        bool escape = false;
+
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (escape)
+            {
+                escape = false;
+                continue;
+            }
+
+            if (inString || inChar)
+            {
+                if (c == '\\')
+                {
+                    escape = true;
+                    continue;
+                }
+
+                if (inString && c == '"')
+                    inString = false;
+                else if (inChar && c == '\'')
+                    inChar = false;
+                continue;
+            }
+
+            if (c == '"')
+            {
+                inString = true;
+                continue;
+            }
+
+            if (c == '\'')
+            {
+                inChar = true;
+                continue;
+            }
+
+            if (c == target)
+                return i;
+        }
+
+        return -1;
     }
 
     static List<(int OldIndex, int NewIndex)> LongestCommonSubsequence(IReadOnlyList<string> oldLines, IReadOnlyList<string> newLines)

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -587,13 +587,18 @@ public static class ResearchDiff
                 $"{row.Anchor.TypeFullName}.{row.Anchor.MemberName}",
                 row.Anchor.TypeFullName,
                 row.Anchor.MemberName);
-            var direction = row.Kind == CSharpDiffKind.Add ? ResearchDiffDirection.Added : ResearchDiffDirection.Removed;
+            var direction = row.Kind switch
+            {
+                CSharpDiffKind.Add => ResearchDiffDirection.Added,
+                CSharpDiffKind.Remove => ResearchDiffDirection.Removed,
+                _ => ResearchDiffDirection.Changed,
+            };
             builder.Add(subject, new ResearchDiffEvidence(
                 ResearchDiffMechanism.CSharp,
                 row.ChangeId,
                 direction,
-                OldValue: direction == ResearchDiffDirection.Removed ? row.Text : null,
-                NewValue: direction == ResearchDiffDirection.Added ? row.Text : null,
+                OldValue: row.OldValue ?? (direction == ResearchDiffDirection.Removed ? row.Text : null),
+                NewValue: row.NewValue ?? (direction == ResearchDiffDirection.Added ? row.Text : null),
                 Detail: row.Message,
                 Category: ResearchDiffChangeCategory.CSharp));
         }


### PR DESCRIPTION
## Summary

Adds typed semantic C# diff rows on top of the existing Research-owned C# line diff fallback.

## Details

- Adds semantic row emission for:
  - `csharp.switch.case.added`
  - `csharp.switch.case.removed`
  - `csharp.return-expression.changed`
  - `csharp.call.changed`
- Preserves existing line add/remove rows as fallback evidence.
- Emits semantic rows only for `Full` fidelity C# renders; partial/failure paths keep native line/synthetic evidence only.
- Projects semantic row payloads through `ResearchDiff` using row-owned `OldValue` / `NewValue`.
- Adds fixture coverage for switch-case, return-expression, and call changes.

Refs #2325.

## Validation

- `dotnet run --no-build --project src/ILInspector.Research.Tests -c Release`
- `dotnet run --no-build --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/DiffCommandTests/*"`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore --verbosity minimal`
- `git diff --check`

## Review

Adversarial review is required for this Research/C# diff behavior change and will be posted before marking ready.
