### PR TITLE
Project RTS evidence to ResearchDiff

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -67,6 +67,8 @@
              Link="HarnessOpcode.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ReturnToSender.cs"
              Link="ReturnToSender.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\ReturnToSenderEvidence.cs"
+             Link="ReturnToSenderEvidence.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\GeneratedFixtures.cs"
              Link="GeneratedFixtures.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ValidityCheck.cs"

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
@@ -1,0 +1,99 @@
+using ILInspector.DecompilerHarness;
+using ILInspector.Instructions;
+using ILInspector.MetadataPrimitives;
+using ILInspector.Research;
+
+namespace ILInspector.Decompiler.Tests;
+
+[Trait("Speed", "Slow")]
+public class ReturnToSenderEvidenceTests
+{
+    [Fact]
+    public void FromCatalog_PreservesExactRtsStatusAndMemberAnchor()
+    {
+        var run = GeneratedFixtureRunner.RunReturnToSenderCatalog(
+            [GeneratedFixtureCatalog.MinimalPropertyLiteral]);
+
+        var evidence = ReturnToSenderEvidence.FromCatalog(run);
+        var row = Assert.Single(evidence, row => row.Method == "get_Method1");
+
+        Assert.Equal(GeneratedFixtureReturnToSenderStatus.Pass, row.Status);
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, row.CompileBackStatus);
+        Assert.NotNull(row.Anchor);
+        Assert.StartsWith("Method1~", row.Anchor.StableSelector, StringComparison.Ordinal);
+        Assert.Null(row.IlDiffDiagnostic);
+
+        var research = ReturnToSenderEvidence.ToResearchDiff(evidence);
+        var subject = Assert.Single(research.MembersWhere(member => member.Subject.Id == row.Anchor.StableSelector));
+        Assert.Contains(subject.Evidence, item =>
+            item.Mechanism == ResearchDiffMechanism.ReturnToSender
+            && item.ChangeId == "rts.status.pass"
+            && item.Category == ResearchDiffChangeCategory.RoundTrip);
+        Assert.DoesNotContain(subject.Evidence, item => item.Mechanism == ResearchDiffMechanism.IlBody);
+    }
+
+    [Fact]
+    public void ToResearchDiff_ProjectsStructuredIlDiffRowsWithoutReportTextParsing()
+    {
+        var anchor = new MemberAnchor(
+            "Method1~abcdef1234",
+            "M:TestType.Method1()",
+            "abcdef1234",
+            "TestType",
+            "Method1");
+        var evidence = new ReturnToSenderEvidenceRow(
+            anchor,
+            "TestType",
+            "Method1",
+            Overload: 0,
+            GeneratedFixtureReturnToSenderStatus.Fail,
+            FidelityCheck.CompileBackStatus.OpcodeDiff,
+            "opcode-diff",
+            Detail: null,
+            IlDiffDiagnostic: new IlDiffDisplayResult(
+                Failure: null,
+                Rows:
+                [
+                    new IlDiffDisplayRow(
+                        0,
+                        IlDiffKind.Remove,
+                        "-",
+                        0,
+                        "IL_0000",
+                        "ldc.i4",
+                        IlOperandIdentityKind.Immediate,
+                        "1",
+                        "ldc.i4 1",
+                        "Removed IL operation 'ldc.i4 1'"),
+                    new IlDiffDisplayRow(
+                        0,
+                        IlDiffKind.Add,
+                        "+",
+                        0,
+                        "IL_0000",
+                        "ldc.i4",
+                        IlOperandIdentityKind.Immediate,
+                        "2",
+                        "ldc.i4 2",
+                        "Added IL operation 'ldc.i4 2'"),
+                ]));
+
+        var research = ReturnToSenderEvidence.ToResearchDiff([evidence]);
+
+        var subject = Assert.Single(research.Subjects);
+        Assert.Equal(anchor.StableSelector, subject.Subject.Id);
+        Assert.Contains(subject.Evidence, item =>
+            item.Mechanism == ResearchDiffMechanism.ReturnToSender
+            && item.ChangeId == "rts.status.fail");
+        Assert.Contains(subject.Evidence, item =>
+            item.Mechanism == ResearchDiffMechanism.IlBody
+            && item.ChangeId == "il.operation.removed"
+            && item.OldValue == "ldc.i4 1"
+            && item.OldIlOffset == 0);
+        Assert.Contains(subject.Evidence, item =>
+            item.Mechanism == ResearchDiffMechanism.IlBody
+            && item.ChangeId == "il.operation.added"
+            && item.NewValue == "ldc.i4 2"
+            && item.NewIlOffset == 0);
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
@@ -11,6 +11,8 @@ public class ReturnToSenderEvidenceTests
     [Fact]
     public void FromCatalog_PreservesExactRtsStatusAndMemberAnchor()
     {
+        Assert.True(ResearchDiffMechanism.AllAvailable.HasFlag(ResearchDiffMechanism.ReturnToSender));
+
         var run = GeneratedFixtureRunner.RunReturnToSenderCatalog(
             [GeneratedFixtureCatalog.MinimalPropertyLiteral]);
 

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
@@ -56,21 +56,32 @@ public class ReturnToSenderEvidenceTests
                 [
                     new IlDiffDisplayRow(
                         0,
-                        IlDiffKind.Remove,
-                        "-",
+                        IlDiffKind.Context,
+                        " ",
                         0,
                         "IL_0000",
+                        "nop",
+                        OperandKind: null,
+                        OperandValue: null,
+                        "nop",
+                        "Unchanged IL operation 'nop'"),
+                    new IlDiffDisplayRow(
+                        1,
+                        IlDiffKind.Remove,
+                        "-",
+                        1,
+                        "IL_0001",
                         "ldc.i4",
                         IlOperandIdentityKind.Immediate,
                         "1",
                         "ldc.i4 1",
                         "Removed IL operation 'ldc.i4 1'"),
                     new IlDiffDisplayRow(
-                        0,
+                        1,
                         IlDiffKind.Add,
                         "+",
-                        0,
-                        "IL_0000",
+                        1,
+                        "IL_0001",
                         "ldc.i4",
                         IlOperandIdentityKind.Immediate,
                         "2",
@@ -89,11 +100,12 @@ public class ReturnToSenderEvidenceTests
             item.Mechanism == ResearchDiffMechanism.IlBody
             && item.ChangeId == "il.operation.removed"
             && item.OldValue == "ldc.i4 1"
-            && item.OldIlOffset == 0);
+            && item.OldIlOffset == 1);
         Assert.Contains(subject.Evidence, item =>
             item.Mechanism == ResearchDiffMechanism.IlBody
             && item.ChangeId == "il.operation.added"
             && item.NewValue == "ldc.i4 2"
-            && item.NewIlOffset == 0);
+            && item.NewIlOffset == 1);
+        Assert.DoesNotContain(subject.Evidence, item => item.ChangeId == "il.operation.context");
     }
 }

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -17,6 +17,7 @@ public enum ResearchDiffMechanism
     BodySignals = 2,
     IlBody = 4,
     CSharp = 8,
+    ReturnToSender = 16,
     AllAvailable = Api | BodySignals | IlBody | CSharp,
 }
 
@@ -41,6 +42,7 @@ public enum ResearchDiffChangeCategory
     BodySignal,
     IlBody,
     CSharp,
+    RoundTrip,
 }
 
 public enum ResearchDiffEvidenceKind

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -18,7 +18,7 @@ public enum ResearchDiffMechanism
     IlBody = 4,
     CSharp = 8,
     ReturnToSender = 16,
-    AllAvailable = Api | BodySignals | IlBody | CSharp,
+    AllAvailable = Api | BodySignals | IlBody | CSharp | ReturnToSender,
 }
 
 public enum ResearchDiffSubjectKind

--- a/tools/DecompilerHarness/ReturnToSenderEvidence.cs
+++ b/tools/DecompilerHarness/ReturnToSenderEvidence.cs
@@ -96,20 +96,15 @@ internal static class ReturnToSenderEvidence
             : diagnostic.Rows;
         foreach (var displayRow in displayRows)
         {
-            var direction = displayRow.Kind switch
-            {
-                IlDiffKind.Add => ResearchDiffDirection.Added,
-                IlDiffKind.Remove => ResearchDiffDirection.Removed,
-                _ => ResearchDiffDirection.Changed,
-            };
+            if (displayRow.Kind == IlDiffKind.Context)
+                continue;
+
+            var direction = displayRow.Kind == IlDiffKind.Add
+                ? ResearchDiffDirection.Added
+                : ResearchDiffDirection.Removed;
             yield return new ResearchDiffEvidence(
                 ResearchDiffMechanism.IlBody,
-                displayRow.Kind switch
-                {
-                    IlDiffKind.Add => "il.operation.added",
-                    IlDiffKind.Remove => "il.operation.removed",
-                    _ => "il.operation.context",
-                },
+                displayRow.Kind == IlDiffKind.Add ? "il.operation.added" : "il.operation.removed",
                 direction,
                 OldValue: displayRow.Kind == IlDiffKind.Remove ? displayRow.Operation : null,
                 NewValue: displayRow.Kind == IlDiffKind.Add ? displayRow.Operation : null,

--- a/tools/DecompilerHarness/ReturnToSenderEvidence.cs
+++ b/tools/DecompilerHarness/ReturnToSenderEvidence.cs
@@ -1,0 +1,131 @@
+using ILInspector.Instructions;
+using ILInspector.MetadataPrimitives;
+using ILInspector.Research;
+
+namespace ILInspector.DecompilerHarness;
+
+internal sealed record ReturnToSenderEvidenceRow(
+    MemberAnchor? Anchor,
+    string Type,
+    string Method,
+    int Overload,
+    GeneratedFixtureReturnToSenderStatus Status,
+    FidelityCheck.CompileBackStatus? CompileBackStatus,
+    string Reason,
+    string? Detail,
+    IlDiffDisplayResult? IlDiffDiagnostic)
+{
+    public string DisplayMember => $"{Type}::{Method}#{Overload}";
+}
+
+internal static class ReturnToSenderEvidence
+{
+    public static IReadOnlyList<ReturnToSenderEvidenceRow> FromCatalog(GeneratedFixtureReturnToSenderRunResult run)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+        return [.. run.Results.Select(result => new ReturnToSenderEvidenceRow(
+            result.MemberAnchor,
+            result.Type,
+            result.Method,
+            result.Overload,
+            result.Status,
+            result.ActualStatus,
+            result.Reason,
+            result.Detail,
+            result.IlDiffDiagnostic))];
+    }
+
+    public static ResearchDiffResult ToResearchDiff(IEnumerable<ReturnToSenderEvidenceRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+
+        var subjects = rows
+            .GroupBy(SubjectKey)
+            .Select(group => new ResearchSubjectDiff(group.Key, [.. group.SelectMany(Evidence)]))
+            .Where(subject => subject.Evidence.Count > 0)
+            .ToArray();
+        return new ResearchDiffResult(subjects);
+    }
+
+    static ResearchSubjectKey SubjectKey(ReturnToSenderEvidenceRow row)
+    {
+        if (row.Anchor is { } anchor)
+        {
+            return new ResearchSubjectKey(
+                ResearchDiffSubjectKind.Member,
+                anchor.StableSelector,
+                $"{anchor.TypeFullName}.{anchor.MemberName}",
+                anchor.TypeFullName,
+                anchor.MemberName);
+        }
+
+        return new ResearchSubjectKey(
+            ResearchDiffSubjectKind.Member,
+            $"rts:{row.DisplayMember}",
+            $"{row.Type}.{row.Method}",
+            row.Type,
+            row.Method);
+    }
+
+    static IEnumerable<ResearchDiffEvidence> Evidence(ReturnToSenderEvidenceRow row)
+    {
+        yield return new ResearchDiffEvidence(
+            ResearchDiffMechanism.ReturnToSender,
+            $"rts.status.{StatusId(row.Status)}",
+            ResearchDiffDirection.Changed,
+            OldValue: null,
+            NewValue: row.CompileBackStatus?.ToString(),
+            Detail: row.Detail ?? row.Reason,
+            Category: ResearchDiffChangeCategory.RoundTrip);
+
+        if (row.IlDiffDiagnostic is not { } diagnostic)
+            yield break;
+
+        if (diagnostic.Failure is { Length: > 0 } failure)
+        {
+            yield return new ResearchDiffEvidence(
+                ResearchDiffMechanism.IlBody,
+                "il.diff.failed",
+                ResearchDiffDirection.Changed,
+                Detail: failure,
+                Category: ResearchDiffChangeCategory.IlBody);
+        }
+
+        var displayRows = diagnostic.Rows.IsDefault
+            ? []
+            : diagnostic.Rows;
+        foreach (var displayRow in displayRows)
+        {
+            var direction = displayRow.Kind switch
+            {
+                IlDiffKind.Add => ResearchDiffDirection.Added,
+                IlDiffKind.Remove => ResearchDiffDirection.Removed,
+                _ => ResearchDiffDirection.Changed,
+            };
+            yield return new ResearchDiffEvidence(
+                ResearchDiffMechanism.IlBody,
+                displayRow.Kind switch
+                {
+                    IlDiffKind.Add => "il.operation.added",
+                    IlDiffKind.Remove => "il.operation.removed",
+                    _ => "il.operation.context",
+                },
+                direction,
+                OldValue: displayRow.Kind == IlDiffKind.Remove ? displayRow.Operation : null,
+                NewValue: displayRow.Kind == IlDiffKind.Add ? displayRow.Operation : null,
+                OldIlOffset: displayRow.Kind == IlDiffKind.Remove ? displayRow.RawOffset : null,
+                NewIlOffset: displayRow.Kind == IlDiffKind.Add ? displayRow.RawOffset : null,
+                Detail: displayRow.Message,
+                Category: ResearchDiffChangeCategory.IlBody);
+        }
+    }
+
+    static string StatusId(GeneratedFixtureReturnToSenderStatus status)
+        => status switch
+        {
+            GeneratedFixtureReturnToSenderStatus.Pass => "pass",
+            GeneratedFixtureReturnToSenderStatus.Skip => "skip",
+            GeneratedFixtureReturnToSenderStatus.Fail => "fail",
+            _ => status.ToString().ToLowerInvariant(),
+        };
+}


### PR DESCRIPTION
## Summary

- add `ReturnToSenderEvidenceRow` and `ReturnToSenderEvidence` projection helpers in DecompilerHarness
- project RTS catalog results into `ResearchDiffResult` using existing `MemberAnchor` subject identity
- add `ResearchDiffMechanism.ReturnToSender` and `ResearchDiffChangeCategory.RoundTrip`
- preserve structured IL diff display rows as IL body evidence without parsing report text

This keeps ResearchDiff as the common evidence shape while avoiding RTS-local member identity or IL diff logic.

## Validation

```text
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-restore -- -filter "/*/*/ReturnToSenderEvidenceTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-restore -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet run --project src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj -c Release --no-restore -- -filter "/*/*/ResearchDiffTests/*"
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release -- --return-to-sender-catalog minimal.property.literal --max-examples 3
```
