### PR TITLE
Add typed IL diff failure rows

### DIFF
--- a/docs/design/il-diff-canonicalization.md
+++ b/docs/design/il-diff-canonicalization.md
@@ -68,9 +68,14 @@ or builds.
 
 ### Hunk and display ownership
 
-`IlBodyDiff` owns row messages and hunk IDs. `IlDiffPrinter` owns display rows
-and unified text projection. Research and CLI layers should preserve or wrap
-these typed rows rather than reformatting lower-layer wording.
+`IlBodyDiff` owns operation row messages, hunk IDs, and failure rows. Failure
+rows carry a producer-owned kind and message for availability, decode,
+token-resolution, and unsupported-boundary cases while retaining the legacy
+single `Failure` string for compatibility.
+
+`IlDiffPrinter` owns display rows and unified text projection. Research and CLI
+layers should preserve or wrap these typed rows rather than reformatting
+lower-layer wording.
 
 ## Current non-guarantees
 
@@ -117,7 +122,7 @@ extensions should remain Instructions-owned:
 - explicit EH availability/shape rows;
 - improved local/argument identity beyond raw slots;
 - unsupported-boundary diagnostics when a row is intentionally approximate;
-- display rows for decode or token-resolution failures.
+- more precise failure row kinds when a new unsupported boundary is measured.
 
 Research, RTS, and CLI consumers should request or preserve these typed rows
 rather than synthesizing their own IL wording.

--- a/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/IlBodyDiffTests.cs
@@ -348,6 +348,10 @@ public class IlBodyDiffTests
         Assert.False(diff.IsExact);
         Assert.NotNull(diff.Failure);
         Assert.Contains("requires a MetadataReader-backed comparison", diff.Failure, StringComparison.Ordinal);
+        var failure = Assert.Single(diff.FailureRows);
+        Assert.Equal(IlDiffFailureKind.TokenResolutionFailure, failure.Kind);
+        Assert.Equal("old", failure.Side);
+        Assert.Contains("requires a MetadataReader-backed comparison", failure.Message, StringComparison.Ordinal);
         Assert.Empty(diff.Rows);
     }
 
@@ -451,6 +455,9 @@ public class IlBodyDiffTests
 
         Assert.False(diff.IsExact);
         Assert.NotNull(diff.Failure);
+        var failure = Assert.Single(diff.FailureRows);
+        Assert.Equal(IlDiffFailureKind.DecodeFailure, failure.Kind);
+        Assert.Equal("old", failure.Side);
     }
 
     static bool IsBranchRow(IlDiffRow row)

--- a/src/ILInspector.Instructions.Tests/IlDiffPrinterTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlDiffPrinterTests.cs
@@ -109,6 +109,18 @@ public class IlDiffPrinterTests
     }
 
     [Fact]
+    public void ToDisplayResult_TreatsDefaultResultRowsAsEmpty()
+    {
+        var diff = new IlBodyDiffResult(IsExact: false, Failure: "legacy failure", Rows: default);
+
+        var display = IlDiffPrinter.ToDisplayResult(diff);
+
+        Assert.Equal("IL diff failed: legacy failure", display.Failure);
+        Assert.Empty(display.Rows);
+        Assert.Equal(["IL diff failed: legacy failure"], IlDiffPrinter.ToUnifiedLines(display));
+    }
+
+    [Fact]
     public void ToUnifiedLines_PreservesRowsWhenFailureCarriesPartialEvidence()
     {
         var row = new IlDiffRow(
@@ -126,6 +138,29 @@ public class IlDiffPrinterTests
         Assert.Equal(
             [
                 "IL diff failed: partial decode failed",
+                "h0 - IL_0000 nop",
+            ],
+            lines);
+    }
+
+    [Fact]
+    public void ToUnifiedLines_PreservesRowsWhenTypedFailureCarriesPartialEvidence()
+    {
+        var row = new IlDiffRow(
+            0,
+            IlDiffKind.Remove,
+            new CanonicalIlOperation(0, "nop", Operand: null),
+            "Removed IL operation 'nop'");
+        var diff = IlBodyDiffResult.UnsupportedBoundary(
+            "unsupported canonicalization boundary",
+            [row],
+            detail: "slot identity");
+
+        var lines = IlDiffPrinter.ToUnifiedLines(diff);
+
+        Assert.Equal(
+            [
+                "IL diff failed: unsupported canonicalization boundary",
                 "h0 - IL_0000 nop",
             ],
             lines);

--- a/src/ILInspector.Instructions.Tests/IlDiffPrinterTests.cs
+++ b/src/ILInspector.Instructions.Tests/IlDiffPrinterTests.cs
@@ -65,17 +65,47 @@ public class IlDiffPrinterTests
     [Fact]
     public void ToDisplayResult_PreservesFailureAsProducerOwnedDisplay()
     {
-        var diff = new IlBodyDiffResult(
-            IsExact: false,
-            Failure: "old body decode failed",
-            Rows: []);
+        var diff = IlBodyDiffResult.Failed(
+            IlDiffFailureKind.DecodeFailure,
+            "old body decode failed",
+            side: "old");
 
         var display = IlDiffPrinter.ToDisplayResult(diff);
 
         Assert.Equal("IL diff failed: old body decode failed", display.Failure);
+        var failure = Assert.Single(display.FailureRows);
+        Assert.Equal(IlDiffFailureKind.DecodeFailure, failure.Kind);
+        Assert.Equal("old body decode failed", failure.Message);
+        Assert.Equal("old", failure.Side);
         Assert.Empty(display.Rows);
         Assert.Equal(["IL diff failed: old body decode failed"], IlDiffPrinter.ToUnifiedLines(diff));
         Assert.Equal(["IL diff failed: old body decode failed"], IlDiffPrinter.ToUnifiedLines(display));
+    }
+
+    [Fact]
+    public void ToDisplayResult_ProjectsAvailabilityFailureRows()
+    {
+        var display = IlDiffPrinter.ToDisplayResult(IlBodyDiffResult.OldBodyMissing("no RVA"));
+
+        var failure = Assert.Single(display.FailureRows);
+        Assert.Equal(IlDiffFailureKind.OldBodyMissing, failure.Kind);
+        Assert.Equal("old body missing", failure.Message);
+        Assert.Equal("old", failure.Side);
+        Assert.Equal("no RVA", failure.Detail);
+        Assert.Equal(["IL diff failed: old body missing"], IlDiffPrinter.ToUnifiedLines(display));
+    }
+
+    [Fact]
+    public void ToDisplayResult_ProjectsUnsupportedBoundaryFailureRows()
+    {
+        var display = IlDiffPrinter.ToDisplayResult(
+            IlBodyDiffResult.UnsupportedBoundary("unsupported canonicalization boundary", "slot identity"));
+
+        var failure = Assert.Single(display.FailureRows);
+        Assert.Equal(IlDiffFailureKind.UnsupportedBoundary, failure.Kind);
+        Assert.Equal("unsupported canonicalization boundary", failure.Message);
+        Assert.Null(failure.Side);
+        Assert.Equal("slot identity", failure.Detail);
     }
 
     [Fact]

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -36,10 +36,39 @@ public sealed record IlDiffRow(
     CanonicalIlOperation Operation,
     string Message);
 
+public enum IlDiffFailureKind
+{
+    OldBodyMissing,
+    NewBodyMissing,
+    DecodeFailure,
+    TokenResolutionFailure,
+    UnsupportedBoundary,
+}
+
+public sealed record IlDiffFailureRow(
+    IlDiffFailureKind Kind,
+    string Message,
+    string? Side = null,
+    string? Detail = null);
+
 public sealed record IlBodyDiffResult(
     bool IsExact,
     string? Failure,
-    ImmutableArray<IlDiffRow> Rows);
+    ImmutableArray<IlDiffRow> Rows,
+    ImmutableArray<IlDiffFailureRow> FailureRows = default)
+{
+    public static IlBodyDiffResult OldBodyMissing(string? detail = null)
+        => Failed(IlDiffFailureKind.OldBodyMissing, "old body missing", side: "old", detail);
+
+    public static IlBodyDiffResult NewBodyMissing(string? detail = null)
+        => Failed(IlDiffFailureKind.NewBodyMissing, "new body missing", side: "new", detail);
+
+    public static IlBodyDiffResult UnsupportedBoundary(string message, string? detail = null)
+        => Failed(IlDiffFailureKind.UnsupportedBoundary, message, side: null, detail);
+
+    public static IlBodyDiffResult Failed(IlDiffFailureKind kind, string message, string? side = null, string? detail = null)
+        => new(false, message, [], [new IlDiffFailureRow(kind, message, side, detail)]);
+}
 
 /// <summary>
 /// Low-level IL body diff substrate over decoded instruction streams.
@@ -77,16 +106,28 @@ public static class IlBodyDiff
         ArgumentNullException.ThrowIfNull(newBody);
 
         if (!oldBody.IsComplete)
-            return new IlBodyDiffResult(false, oldBody.Blocks.IncompleteReason ?? "old body decode failed", []);
+            return IlBodyDiffResult.Failed(
+                IlDiffFailureKind.DecodeFailure,
+                oldBody.Blocks.IncompleteReason ?? "old body decode failed",
+                side: "old");
         if (!newBody.IsComplete)
-            return new IlBodyDiffResult(false, newBody.Blocks.IncompleteReason ?? "new body decode failed", []);
+            return IlBodyDiffResult.Failed(
+                IlDiffFailureKind.DecodeFailure,
+                newBody.Blocks.IncompleteReason ?? "new body decode failed",
+                side: "new");
 
         var oldInstructions = oldBody.Instructions;
         var newInstructions = newBody.Instructions;
         if (!TryBuildOperations(oldInstructions, oldResolver, "old", out var oldOperations, out var oldFailure))
-            return new IlBodyDiffResult(false, oldFailure, []);
+            return IlBodyDiffResult.Failed(
+                IlDiffFailureKind.TokenResolutionFailure,
+                oldFailure ?? "old body token resolution failed",
+                side: "old");
         if (!TryBuildOperations(newInstructions, newResolver, "new", out var newOperations, out var newFailure))
-            return new IlBodyDiffResult(false, newFailure, []);
+            return IlBodyDiffResult.Failed(
+                IlDiffFailureKind.TokenResolutionFailure,
+                newFailure ?? "new body token resolution failed",
+                side: "new");
         var lcs = LongestCommonSubsequence(oldOperations, newOperations);
         var oldToNew = BuildAlignmentMap(lcs, oldOperations.Length, newOperations.Length);
         var rows = ImmutableArray.CreateBuilder<IlDiffRow>();

--- a/src/ILInspector.Instructions/IlBodyDiff.cs
+++ b/src/ILInspector.Instructions/IlBodyDiff.cs
@@ -66,6 +66,9 @@ public sealed record IlBodyDiffResult(
     public static IlBodyDiffResult UnsupportedBoundary(string message, string? detail = null)
         => Failed(IlDiffFailureKind.UnsupportedBoundary, message, side: null, detail);
 
+    public static IlBodyDiffResult UnsupportedBoundary(string message, ImmutableArray<IlDiffRow> rows, string? detail = null)
+        => new(false, message, rows, [new IlDiffFailureRow(IlDiffFailureKind.UnsupportedBoundary, message, null, detail)]);
+
     public static IlBodyDiffResult Failed(IlDiffFailureKind kind, string message, string? side = null, string? detail = null)
         => new(false, message, [], [new IlDiffFailureRow(kind, message, side, detail)]);
 }

--- a/src/ILInspector.Instructions/IlDiffPrinter.cs
+++ b/src/ILInspector.Instructions/IlDiffPrinter.cs
@@ -79,7 +79,7 @@ public static class IlDiffPrinter
             : result.Failure is { Length: > 0 } legacyFailure ? $"IL diff failed: {legacyFailure}" : null;
         return new IlDiffDisplayResult(
             failure,
-            ToDisplayRows(result.Rows),
+            result.Rows.IsDefault ? [] : ToDisplayRows(result.Rows),
             failureRows);
     }
 

--- a/src/ILInspector.Instructions/IlDiffPrinter.cs
+++ b/src/ILInspector.Instructions/IlDiffPrinter.cs
@@ -18,11 +18,21 @@ public sealed record IlDiffDisplayRow(
     public string UnifiedLine => $"h{HunkId} {Marker} {Offset} {Operation}";
 }
 
+public sealed record IlDiffDisplayFailureRow(
+    IlDiffFailureKind Kind,
+    string Message,
+    string? Side,
+    string? Detail)
+{
+    public string UnifiedLine => $"IL diff failed: {Message}";
+}
+
 public sealed record IlDiffDisplayResult(
     string? Failure,
-    ImmutableArray<IlDiffDisplayRow> Rows)
+    ImmutableArray<IlDiffDisplayRow> Rows,
+    ImmutableArray<IlDiffDisplayFailureRow> FailureRows = default)
 {
-    public bool IsEmpty => Failure is null && Rows.IsDefaultOrEmpty;
+    public bool IsEmpty => Failure is null && Rows.IsDefaultOrEmpty && FailureRows.IsDefaultOrEmpty;
 }
 
 /// <summary>
@@ -49,12 +59,28 @@ public static class IlDiffPrinter
         return [.. rows.Select(ToDisplayRow)];
     }
 
+    public static IlDiffDisplayFailureRow ToDisplayFailureRow(IlDiffFailureRow row)
+        => new(row.Kind, row.Message, row.Side, row.Detail);
+
+    public static ImmutableArray<IlDiffDisplayFailureRow> ToDisplayFailureRows(IEnumerable<IlDiffFailureRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        return [.. rows.Select(ToDisplayFailureRow)];
+    }
+
     public static IlDiffDisplayResult ToDisplayResult(IlBodyDiffResult result)
     {
         ArgumentNullException.ThrowIfNull(result);
+        ImmutableArray<IlDiffDisplayFailureRow> failureRows = result.FailureRows.IsDefault
+            ? []
+            : ToDisplayFailureRows(result.FailureRows);
+        string? failure = !failureRows.IsDefaultOrEmpty
+            ? failureRows[0].UnifiedLine
+            : result.Failure is { Length: > 0 } legacyFailure ? $"IL diff failed: {legacyFailure}" : null;
         return new IlDiffDisplayResult(
-            result.Failure is { Length: > 0 } failure ? $"IL diff failed: {failure}" : null,
-            ToDisplayRows(result.Rows));
+            failure,
+            ToDisplayRows(result.Rows),
+            failureRows);
     }
 
     public static ImmutableArray<string> ToUnifiedLines(IlBodyDiffResult result)
@@ -66,6 +92,11 @@ public static class IlDiffPrinter
         var rows = display.Rows.IsDefault
             ? []
             : display.Rows.Select(row => row.UnifiedLine);
+        var failureRows = display.FailureRows.IsDefault
+            ? []
+            : display.FailureRows.Select(row => row.UnifiedLine);
+        if (failureRows.Any())
+            return [.. failureRows, .. rows];
         return display.Failure is { } failure
             ? [failure, .. rows]
             : [.. rows];

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -125,6 +125,23 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void FromIlBodyDiff_PreservesProducerFailureRow()
+    {
+        var il = IlBodyDiffResult.NewBodyMissing("metadata row absent");
+
+        var diff = ResearchDiff.FromIlBodyDiff(il);
+
+        var row = Assert.Single(diff.Rows);
+        Assert.Equal("il.diff.new-body-missing", row.ChangeId);
+        Assert.Equal(ResearchDiffEvidenceKind.IlBody, row.EvidenceKind);
+        Assert.Equal("new body missing", row.Message);
+        var failure = Assert.IsType<IlDiffFailureRow>(row.IlFailureRow);
+        Assert.Equal(IlDiffFailureKind.NewBodyMissing, failure.Kind);
+        Assert.Equal("new", failure.Side);
+        Assert.Equal("metadata row absent", failure.Detail);
+    }
+
+    [Fact]
     public void FromCSharpBodyDiff_PreservesProducerMessageAndTypedRow()
     {
         var csharpRow = Assert.Single(CSharpBodyDiff.CompareAssemblies(

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -142,6 +142,37 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void FromIlBodyDiff_PreservesFailureAndPartialOperationRows()
+    {
+        var operation = new CanonicalIlOperation(
+            Offset: 0,
+            OpcodeFamily: "nop",
+            Operand: null);
+        var ilRow = new IlDiffRow(0, IlDiffKind.Remove, operation, "Removed IL operation 'nop'");
+        var il = IlBodyDiffResult.UnsupportedBoundary(
+            "unsupported canonicalization boundary",
+            [ilRow],
+            detail: "slot identity");
+
+        var diff = ResearchDiff.FromIlBodyDiff(il);
+
+        Assert.Collection(
+            diff.Rows,
+            failure =>
+            {
+                Assert.Equal("il.diff.unsupported-boundary", failure.ChangeId);
+                Assert.NotNull(failure.IlFailureRow);
+                Assert.Null(failure.IlRow);
+            },
+            operationRow =>
+            {
+                Assert.Equal("il.operation.removed", operationRow.ChangeId);
+                Assert.Same(ilRow, operationRow.IlRow);
+                Assert.Null(operationRow.IlFailureRow);
+            });
+    }
+
+    [Fact]
     public void FromCSharpBodyDiff_PreservesProducerMessageAndTypedRow()
     {
         var csharpRow = Assert.Single(CSharpBodyDiff.CompareAssemblies(

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -172,37 +172,30 @@ public static class ResearchDiff
     public static ResearchDiffResult FromIlBodyDiff(IlBodyDiffResult diff)
     {
         ArgumentNullException.ThrowIfNull(diff);
+        var rows = ImmutableArray.CreateBuilder<ResearchDiffRow>();
         if (!diff.FailureRows.IsDefaultOrEmpty)
         {
-            return new ResearchDiffResult(
-                [],
-                Rows:
-                [
-                    .. diff.FailureRows.Select(row => new ResearchDiffRow(
-                        $"il.diff.{ToKebabCase(row.Kind.ToString())}",
-                        ResearchDiffEvidenceKind.IlBody,
-                        row.Message,
-                        IlFailureRow: row))
-                ]);
+            rows.AddRange(diff.FailureRows.Select(row => new ResearchDiffRow(
+                $"il.diff.{ToKebabCase(row.Kind.ToString())}",
+                ResearchDiffEvidenceKind.IlBody,
+                row.Message,
+                IlFailureRow: row)));
         }
-
-        if (diff.Failure is { Length: > 0 } failure)
+        else if (diff.Failure is { Length: > 0 } failure)
         {
-            return new ResearchDiffResult(
-                [],
-                Rows: [new ResearchDiffRow("il.diff.failed", ResearchDiffEvidenceKind.IlBody, failure)]);
+            rows.Add(new ResearchDiffRow("il.diff.failed", ResearchDiffEvidenceKind.IlBody, failure));
         }
 
-        return new ResearchDiffResult(
-            [],
-            Rows:
-            [
-                .. diff.Rows.Select(row => new ResearchDiffRow(
-                    $"il.operation.{ChangeIdSuffix(row.Kind)}",
-                    ResearchDiffEvidenceKind.IlBody,
-                    row.Message,
-                    IlRow: row))
-            ]);
+        if (!diff.Rows.IsDefaultOrEmpty)
+        {
+            rows.AddRange(diff.Rows.Select(row => new ResearchDiffRow(
+                $"il.operation.{ChangeIdSuffix(row.Kind)}",
+                ResearchDiffEvidenceKind.IlBody,
+                row.Message,
+                IlRow: row)));
+        }
+
+        return new ResearchDiffResult([], Rows: rows.ToImmutable());
     }
 
     public static ResearchDiffResult FromBodySignalDiff(BodySignalDiffResult diff)
@@ -539,28 +532,33 @@ public static class ResearchDiff
                 {
                     if (!oldAvailable && !newAvailable)
                         continue;
-                    builder.Add(subject, new ResearchDiffEvidence(
-                        ResearchDiffMechanism.IlBody,
-                        !oldAvailable ? "il.body.added" : "il.body.removed",
-                        !oldAvailable ? ResearchDiffDirection.Added : ResearchDiffDirection.Removed,
-                        OldValue: oldReason,
-                        NewValue: newReason,
-                        Category: ResearchDiffChangeCategory.IlBody));
+                    AddIlFailureEvidence(
+                        builder,
+                        subject,
+                        !oldAvailable
+                            ? IlBodyDiffResult.OldBodyMissing(oldReason).FailureRows[0]
+                            : IlBodyDiffResult.NewBodyMissing(newReason).FailureRows[0]);
                     continue;
                 }
 
                 var diff = IlBodyDiff.Compare(oldBody!, newBody!);
                 if (diff.IsExact)
                     continue;
-                if (!string.IsNullOrEmpty(diff.Failure))
+                if (!diff.FailureRows.IsDefaultOrEmpty)
                 {
-                    builder.Add(subject, new ResearchDiffEvidence(
-                        ResearchDiffMechanism.IlBody,
-                        "il.body.decode-failed",
-                        ResearchDiffDirection.Changed,
-                        Detail: diff.Failure,
-                        Category: ResearchDiffChangeCategory.IlBody));
-                    continue;
+                    foreach (var failure in diff.FailureRows)
+                        AddIlFailureEvidence(builder, subject, failure);
+                    if (diff.Rows.IsDefaultOrEmpty)
+                        continue;
+                }
+                else if (!string.IsNullOrEmpty(diff.Failure))
+                {
+                    AddIlFailureEvidence(
+                        builder,
+                        subject,
+                        new IlDiffFailureRow(IlDiffFailureKind.DecodeFailure, diff.Failure));
+                    if (diff.Rows.IsDefaultOrEmpty)
+                        continue;
                 }
 
                 foreach (var hunk in diff.Rows.GroupBy(row => row.HunkId).OrderBy(group => group.Key))
@@ -589,6 +587,24 @@ public static class ResearchDiff
                 }
             }
         }
+    }
+
+    static void AddIlFailureEvidence(ResultBuilder builder, ResearchSubjectKey subject, IlDiffFailureRow failure)
+    {
+        var direction = failure.Kind switch
+        {
+            IlDiffFailureKind.OldBodyMissing => ResearchDiffDirection.Added,
+            IlDiffFailureKind.NewBodyMissing => ResearchDiffDirection.Removed,
+            _ => ResearchDiffDirection.Changed,
+        };
+        builder.Add(subject, new ResearchDiffEvidence(
+            ResearchDiffMechanism.IlBody,
+            $"il.diff.{ToKebabCase(failure.Kind.ToString())}",
+            direction,
+            OldValue: failure.Side == "old" ? failure.Detail ?? failure.Message : null,
+            NewValue: failure.Side == "new" ? failure.Detail ?? failure.Message : null,
+            Detail: failure.Detail ?? failure.Message,
+            Category: ResearchDiffChangeCategory.IlBody));
     }
 
     static void AddCSharpDiff(ResultBuilder builder, ResearchDiffInput oldInput, ResearchDiffInput newInput, IReadOnlySet<string>? typeFilters)

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -59,6 +59,7 @@ public sealed record ResearchDiffRow(
     string Message,
     ApiChange? ApiChange = null,
     IlDiffRow? IlRow = null,
+    IlDiffFailureRow? IlFailureRow = null,
     BodySignalDiffRow? BodySignalRow = null,
     CSharpDiffRow? CSharpRow = null);
 
@@ -171,6 +172,20 @@ public static class ResearchDiff
     public static ResearchDiffResult FromIlBodyDiff(IlBodyDiffResult diff)
     {
         ArgumentNullException.ThrowIfNull(diff);
+        if (!diff.FailureRows.IsDefaultOrEmpty)
+        {
+            return new ResearchDiffResult(
+                [],
+                Rows:
+                [
+                    .. diff.FailureRows.Select(row => new ResearchDiffRow(
+                        $"il.diff.{ToKebabCase(row.Kind.ToString())}",
+                        ResearchDiffEvidenceKind.IlBody,
+                        row.Message,
+                        IlFailureRow: row))
+                ]);
+        }
+
         if (diff.Failure is { Length: > 0 } failure)
         {
             return new ResearchDiffResult(

--- a/tools/IlDiffHarness/Program.cs
+++ b/tools/IlDiffHarness/Program.cs
@@ -105,13 +105,13 @@ static IlDiffCard BuildCard(
     {
         if (!oldMethods.TryGetValue(key, out var oldHandle))
         {
-            Increment(failures, "old body missing");
+            IncrementFailure(failures, IlBodyDiffResult.OldBodyMissing());
             continue;
         }
 
         if (!newMethods.TryGetValue(key, out var newHandle))
         {
-            Increment(failures, "new body missing");
+            IncrementFailure(failures, IlBodyDiffResult.NewBodyMissing());
             continue;
         }
 
@@ -121,12 +121,12 @@ static IlDiffCard BuildCard(
             continue;
         if (oldMethod.RelativeVirtualAddress == 0)
         {
-            Increment(failures, "old body missing");
+            IncrementFailure(failures, IlBodyDiffResult.OldBodyMissing("method has no body"));
             continue;
         }
         if (newMethod.RelativeVirtualAddress == 0)
         {
-            Increment(failures, "new body missing");
+            IncrementFailure(failures, IlBodyDiffResult.NewBodyMissing("method has no body"));
             continue;
         }
 
@@ -148,12 +148,14 @@ static IlDiffCard BuildCard(
         if (self.IsExact)
             selfDiffExact++;
         else
-            Increment(failures, self.Failure ?? "self-diff not exact");
+            IncrementFailure(failures, self.FailureRows.IsDefaultOrEmpty
+                ? IlBodyDiffResult.UnsupportedBoundary(self.Failure ?? "self-diff not exact")
+                : self);
 
         var diff = IlBodyDiff.Compare(oldReader, oldBody, newReader, newBody);
-        if (diff.Failure is { Length: > 0 } failure)
+        if (!diff.FailureRows.IsDefaultOrEmpty || diff.Failure is { Length: > 0 })
         {
-            Increment(failures, failure);
+            IncrementFailure(failures, diff);
             continue;
         }
 
@@ -230,6 +232,18 @@ static ImmutableArray<CardBucket> Top(Dictionary<string, int> counts)
 
 static void Increment(Dictionary<string, int> counts, string key)
     => counts[key] = counts.TryGetValue(key, out int count) ? count + 1 : 1;
+
+static void IncrementFailure(Dictionary<string, int> counts, IlBodyDiffResult result)
+{
+    if (!result.FailureRows.IsDefaultOrEmpty)
+    {
+        foreach (var failure in result.FailureRows)
+            Increment(counts, failure.Message);
+        return;
+    }
+
+    Increment(counts, result.Failure ?? "unknown failure");
+}
 
 static string FormatCard(string oldName, string newName, IlDiffCard card)
 {


### PR DESCRIPTION
## Summary

Adds Instructions-owned typed IL Diff failure rows for #2318:

- introduces `IlDiffFailureKind` / `IlDiffFailureRow` on `IlBodyDiffResult`;
- classifies old/new body missing, decode failure, token-resolution failure, and unsupported-boundary failures;
- projects typed failure rows through `IlDiffPrinter` while preserving the legacy `Failure` string;
- preserves typed IL failure rows through `ResearchDiff.FromIlBodyDiff`;
- updates `IlDiffHarness` failure buckets to consume producer-owned failure rows;
- updates the canonicalization boundary doc.

Refs #2318.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project src/ILInspector.Instructions.Tests -c Release --no-build`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/IlBodyDiffTests/*"`
- `dotnet run --project src/ILInspector.Research.Tests -c Release --no-build -- -filter "/*/*/ResearchDiffTests/*"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build`
- `dotnet run --project tools/IlDiffHarness -c Release --no-build -- artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll artifacts/bin/DiffFixtures.V2/release/DiffFixtureSample.dll --max-examples 1`
- `npx markdownlint-cli --fix docs/design/il-diff-canonicalization.md`
- `npx markdownlint-cli docs/design/il-diff-canonicalization.md`

## Review

Adversarial review pending for the Instructions/Research behavior change.
