### PR TITLE
Add fixture selector APIs for RTS candidates

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -1,0 +1,24 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+using DotnetInspector.Fixtures;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class ReturnToSenderFixtureCatalogTests
+{
+    [Fact]
+    public void ReturnToSenderCandidates_ProvideBuiltAssemblyInputs()
+    {
+        var paths = FixtureCatalog.ReturnToSenderCandidates.AssemblyPaths();
+
+        Assert.NotEmpty(paths);
+        Assert.All(paths, path =>
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            Assert.True(peReader.HasMetadata);
+            Assert.NotEmpty(peReader.GetMetadataReader().MethodDefinitions);
+        });
+    }
+}

--- a/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
+++ b/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
@@ -28,7 +28,7 @@ public class FixtureCatalogTests
     public void Groups_ReferenceRegisteredFixtures()
     {
         var all = FixtureCatalog.All.ToHashSet();
-        foreach (var group in Groups())
+        foreach (var group in FixtureCatalog.Groups)
         {
             Assert.NotEmpty(group.Fixtures);
             Assert.All(group.Fixtures, fixture =>
@@ -48,6 +48,37 @@ public class FixtureCatalogTests
     }
 
     [Fact]
+    public void Group_UnknownIdFailsClearly()
+    {
+        var error = Assert.Throws<ArgumentException>(() => FixtureCatalog.Group("missing"));
+
+        Assert.Contains("Unknown fixture group id 'missing'", error.Message);
+    }
+
+    [Fact]
+    public void SelectByTag_UnknownTagFailsClearly()
+    {
+        var error = Assert.Throws<ArgumentException>(() => FixtureCatalog.SelectByTag("missing"));
+
+        Assert.Contains("Unknown fixture tag 'missing'", error.Message);
+    }
+
+    [Fact]
+    public void SelectByTag_RtsCandidateMatchesReturnToSenderGroup()
+    {
+        Assert.Equal(
+            FixtureCatalog.ReturnToSenderCandidates.Fixtures.Select(fixture => fixture.Id).Order(StringComparer.Ordinal),
+            FixtureCatalog.SelectByTag("rts-candidate").Select(fixture => fixture.Id).Order(StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void ReturnToSenderCandidates_ResolveAssemblyPaths()
+    {
+        Assert.All(FixtureCatalog.ReturnToSenderCandidates.AssemblyPaths(), path =>
+            Assert.True(File.Exists(path), $"Expected RTS candidate fixture at {path}"));
+    }
+
+    [Fact]
     public void AssemblyNameAxisFixtures_ResolveIntentionalFileNames()
     {
         AssertFixtureFileName(FixtureCatalog.AnalysisProtobuf, "Google.Protobuf.dll");
@@ -61,15 +92,4 @@ public class FixtureCatalogTests
         Assert.Equal(expectedFileName, Path.GetFileName(path));
         Assert.Equal(fixture.ProjectName, new DirectoryInfo(path).Parent?.Parent?.Name);
     }
-
-    static IReadOnlyList<FixtureGroup> Groups() =>
-    [
-        FixtureCatalog.DiffAssemblyFixtures,
-        FixtureCatalog.AnalysisFixtures,
-        FixtureCatalog.DecompilerFixtures,
-        FixtureCatalog.DecompilerLadderFixtures,
-        FixtureCatalog.DecompilerUnsafeFixtures,
-        FixtureCatalog.RunFasterFixtures,
-        FixtureCatalog.ReturnToSenderCandidates,
-    ];
 }

--- a/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
+++ b/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
@@ -16,6 +16,11 @@ public sealed record FixturePair(string Id, FixtureDefinition Old, FixtureDefini
 }
 
 public sealed record FixtureGroup(string Id, IReadOnlyList<FixtureDefinition> Fixtures);
+public static class FixtureGroupExtensions
+{
+    public static IReadOnlyList<string> AssemblyPaths(this FixtureGroup group)
+        => [.. group.Fixtures.Select(fixture => fixture.AssemblyPath())];
+}
 
 public static class FixtureIds
 {
@@ -378,10 +383,39 @@ public static class FixtureCatalog
     static readonly Dictionary<string, FixtureDefinition> s_byId =
         All.ToDictionary(fixture => fixture.Id, StringComparer.Ordinal);
 
+    public static readonly IReadOnlyList<FixtureGroup> Groups =
+    [
+        DiffAssemblyFixtures,
+        AnalysisFixtures,
+        DecompilerFixtures,
+        DecompilerLadderFixtures,
+        DecompilerUnsafeFixtures,
+        RunFasterFixtures,
+        ReturnToSenderCandidates,
+    ];
+
+    static readonly Dictionary<string, FixtureGroup> s_groupsById =
+        Groups.ToDictionary(group => group.Id, StringComparer.Ordinal);
+
     public static FixtureDefinition Get(string id)
         => s_byId.TryGetValue(id, out var fixture)
             ? fixture
             : throw new ArgumentException($"Unknown fixture id '{id}'.", nameof(id));
+
+    public static FixtureGroup Group(string id)
+        => s_groupsById.TryGetValue(id, out var group)
+            ? group
+            : throw new ArgumentException($"Unknown fixture group id '{id}'.", nameof(id));
+
+    public static IReadOnlyList<FixtureDefinition> SelectByTag(string tag)
+    {
+        var matches = All
+            .Where(fixture => fixture.Tags.Contains(tag, StringComparer.Ordinal))
+            .ToArray();
+        return matches.Length > 0
+            ? matches
+            : throw new ArgumentException($"Unknown fixture tag '{tag}'.", nameof(tag));
+    }
 
     public static string AssemblyPath(string id)
     {


### PR DESCRIPTION
## Change

Adds selector APIs to `DotnetInspector.Fixtures` so fixture consumers can work with built-binary fixture sets instead of hard-coded IDs:

- `FixtureCatalog.Group(string id)`
- `FixtureCatalog.SelectByTag(string tag)`
- `FixtureCatalog.Groups`
- `FixtureGroup.AssemblyPaths()`

Extends fixture contract tests for unknown group/tag failures, `rts-candidate` tag selection, and RTS candidate assembly path resolution. Adds a small ReturnToSender-facing decompiler test that consumes `FixtureCatalog.ReturnToSenderCandidates.AssemblyPaths()` as built PE/metadata inputs only. No C# generation and no compile-back expansion.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity minimal
dotnet run --project tests/DotnetInspector.Fixtures.Tests -c Release --no-build
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/*"
git diff --check
```

Fixture/test infrastructure only; no product behavior change.
