### PR TITLE
Surface ResearchDiff in RTS catalog output

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1068,6 +1068,8 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("RETURNTOSENDER GENERATED FIXTURE FRONTIER", report);
         Assert.Contains("Passed : 2", report);
         Assert.Contains("Skipped: 0", report);
+        Assert.Contains("Research evidence:", report);
+        Assert.Contains("rts.status.pass:", report);
         Assert.DoesNotContain("constructor-target", report);
 
         var propertyGetter = Assert.Single(run.Results, result =>
@@ -1097,6 +1099,10 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(document.RootElement.GetProperty("Results").EnumerateArray(),
             result => result.GetProperty("Method").GetString() == "get_Method1"
                 && result.GetProperty("MemberAnchor").GetProperty("StableSelector").GetString()!.StartsWith("Method1~", StringComparison.Ordinal));
+        var researchDiff = document.RootElement.GetProperty("ResearchDiff");
+        Assert.Contains(researchDiff.GetProperty("Subjects").EnumerateArray(),
+            subject => subject.GetProperty("Evidence").EnumerateArray()
+                .Any(evidence => evidence.GetProperty("ChangeId").GetString() == "rts.status.pass"));
         Assert.DoesNotContain(document.RootElement.GetProperty("Results").EnumerateArray(),
             result => result.GetProperty("Reason").GetString() == "constructor-target");
     }
@@ -1161,6 +1167,10 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("h0 - IL_0000 ldc.i4 1", report);
         Assert.Contains("h0 + IL_0000 ldc.i4 2", report);
         Assert.Contains("member: Method1~abcdef1234  canonical=M:TestType.Method1()", report);
+        Assert.Contains("Research evidence:", report);
+        Assert.Contains("rts.status.fail: 1", report);
+        Assert.Contains("il.operation.added: 1", report);
+        Assert.Contains("il.operation.removed: 1", report);
     }
 
     [Fact]

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Instructions;
+using ILInspector.Research;
 using ILInspector.MetadataPrimitives;
 
 using Microsoft.CodeAnalysis;
@@ -2352,6 +2353,24 @@ internal static class GeneratedFixtureRunner
         sb.AppendLine($"  Skipped: {skippedTargets}");
         sb.AppendLine($"  Failed : {failedTargets}");
 
+        var research = ReturnToSenderEvidence.ToResearchDiff(ReturnToSenderEvidence.FromCatalog(run));
+        var researchEvidence = research.Subjects.SelectMany(subject => subject.Evidence).ToArray();
+        if (researchEvidence.Length != 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Research evidence:");
+            sb.AppendLine($"  Subjects : {research.Subjects.Count}");
+            sb.AppendLine($"  RTS rows : {researchEvidence.Count(row => row.Mechanism == ResearchDiffMechanism.ReturnToSender)}");
+            sb.AppendLine($"  IL rows  : {researchEvidence.Count(row => row.Mechanism == ResearchDiffMechanism.IlBody)}");
+            foreach (var group in researchEvidence
+                .GroupBy(row => row.ChangeId, StringComparer.Ordinal)
+                .OrderByDescending(group => group.Count())
+                .ThenBy(group => group.Key, StringComparer.Ordinal))
+            {
+                sb.AppendLine($"  {group.Key}: {group.Count()}");
+            }
+        }
+
         var skipBuckets = run.Results
             .Where(row => row.Status == GeneratedFixtureReturnToSenderStatus.Skip)
             .GroupBy(row => row.Reason, StringComparer.Ordinal)
@@ -2443,6 +2462,7 @@ internal static class GeneratedFixtureRunner
             ProjectDirectory = Directory.Exists(run.ProjectDirectory) ? run.ProjectDirectory : null,
             AssemblyPath = File.Exists(run.AssemblyPath) ? run.AssemblyPath : null,
             run.Results,
+            ResearchDiff = ReturnToSenderEvidence.ToResearchDiff(ReturnToSenderEvidence.FromCatalog(run)),
             run.Passed,
         };
         return JsonSerializer.Serialize(payload, s_jsonOptions);

--- a/tools/DecompilerHarness/ReturnToSenderEvidence.cs
+++ b/tools/DecompilerHarness/ReturnToSenderEvidence.cs
@@ -44,7 +44,7 @@ internal static class ReturnToSenderEvidence
             .Select(group => new ResearchSubjectDiff(group.Key, [.. group.SelectMany(Evidence)]))
             .Where(subject => subject.Evidence.Count > 0)
             .ToArray();
-        return new ResearchDiffResult(subjects);
+        return new ResearchDiffResult(subjects, Rows: []);
     }
 
     static ResearchSubjectKey SubjectKey(ReturnToSenderEvidenceRow row)


### PR DESCRIPTION
## Summary

- add a `Research evidence` summary to generated RTS catalog text reports
- include structured `ResearchDiff` in generated RTS catalog JSON
- initialize `ReturnToSenderEvidence.ToResearchDiff(...).Rows` to an empty array for JSON safety

This lets the value of the ResearchDiff projection show up in RTS logs/JSON while preserving existing RTS pass/fail behavior and report layout ownership.

## Validation

```text
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-restore -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-restore -- -filter "/*/*/ReturnToSenderEvidenceTests/*"
dotnet run --project src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj -c Release --no-restore -- -filter "/*/*/ResearchDiffTests/*"
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release -- --return-to-sender-catalog minimal.property.literal --max-examples 3
dotnet run --project tools/DecompilerHarness -c Release -- --return-to-sender-catalog minimal.property.literal --json
```
