### PR TITLE
Add structured C# diff operations

### DIFF
--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -285,6 +285,27 @@ public class CSharpBodyDiffTests
     }
 
     [Fact]
+    public void Printer_LineRows_RenderFromStructuredOperations()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+        var source = diff.Rows.Single(row =>
+            row.Member.Contains("ConstantValue", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.line.removed");
+
+        var display = CSharpDiffPrinter.ToDisplayRow(source);
+
+        Assert.Equal("-", display.Marker);
+        Assert.Equal(CSharpDiffOperationKind.Line, display.OperationKind);
+        Assert.Equal(source.Text, display.OldValue);
+        Assert.Null(display.NewValue);
+        Assert.Equal(source.Text, display.Operation);
+        Assert.Contains(source.Text, display.UnifiedLine, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CompareAssemblies_ProtectedMethodsAreIncludedInDefaultSurface()
     {
         var v1 = DiffFixturePath("DiffFixtures.V1");

--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -109,6 +109,9 @@ public class CSharpBodyDiffTests
         Assert.Equal(CSharpDiffKind.Remove, removed.Kind);
         Assert.Equal("7", removed.OldValue);
         Assert.Null(removed.NewValue);
+        Assert.Equal(CSharpDiffOperationKind.SwitchCase, removed.OldOperation?.Kind);
+        Assert.Equal("7", removed.OldOperation?.Value);
+        Assert.Null(removed.NewOperation);
         Assert.Equal("Removed switch case '7'", removed.Message);
 
         var added = Assert.Single(diff.Rows, row =>
@@ -117,6 +120,9 @@ public class CSharpBodyDiffTests
         Assert.Equal(CSharpDiffKind.Add, added.Kind);
         Assert.Null(added.OldValue);
         Assert.Equal("7", added.NewValue);
+        Assert.Null(added.OldOperation);
+        Assert.Equal(CSharpDiffOperationKind.SwitchCase, added.NewOperation?.Kind);
+        Assert.Equal("7", added.NewOperation?.Value);
         Assert.Equal("Added switch case '7'", added.Message);
 
         Assert.Contains(diff.Rows, row =>
@@ -141,6 +147,10 @@ public class CSharpBodyDiffTests
         Assert.Equal(CSharpDiffKind.Changed, row.Kind);
         Assert.Equal("value + 1", row.OldValue);
         Assert.Equal("value + 2", row.NewValue);
+        Assert.Equal(CSharpDiffOperationKind.ReturnExpression, row.OldOperation?.Kind);
+        Assert.Equal("value + 1", row.OldOperation?.Value);
+        Assert.Equal(CSharpDiffOperationKind.ReturnExpression, row.NewOperation?.Kind);
+        Assert.Equal("value + 2", row.NewOperation?.Value);
         Assert.Equal("Changed return expression from 'value + 1' to 'value + 2'", row.Message);
 
         Assert.Contains(diff.Rows, row =>
@@ -165,6 +175,10 @@ public class CSharpBodyDiffTests
         Assert.Equal(CSharpDiffKind.Changed, row.Kind);
         Assert.Contains("Sink(value)", row.OldValue);
         Assert.Contains("MaybeThrow(value)", row.NewValue);
+        Assert.Equal(CSharpDiffOperationKind.Invocation, row.OldOperation?.Kind);
+        Assert.Contains("Sink(value)", row.OldOperation?.Value);
+        Assert.Equal(CSharpDiffOperationKind.Invocation, row.NewOperation?.Kind);
+        Assert.Contains("MaybeThrow(value)", row.NewOperation?.Value);
         Assert.Contains("Changed call", row.Message);
 
         Assert.Contains(diff.Rows, row =>
@@ -247,6 +261,27 @@ public class CSharpBodyDiffTests
         Assert.Equal(CSharpDiffKind.Changed, row.Kind);
         Assert.Contains("Abs(value)", row.OldValue);
         Assert.Contains("Sign(value)", row.NewValue);
+    }
+
+    [Fact]
+    public void Printer_SemanticRows_RenderFromStructuredOperations()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
+        var row = Assert.Single(diff.Rows, row =>
+            row.Member.Contains("SemanticReturnExpression", StringComparison.Ordinal)
+            && row.ChangeId == "csharp.return-expression.changed");
+
+        var display = CSharpDiffPrinter.ToDisplayRow(row);
+
+        Assert.Equal("~", display.Marker);
+        Assert.Equal(CSharpDiffOperationKind.ReturnExpression, display.OperationKind);
+        Assert.Equal("value + 1", display.OldValue);
+        Assert.Equal("value + 2", display.NewValue);
+        Assert.Equal("return value + 1 => return value + 2", display.Operation);
+        Assert.Contains("return value + 1 => return value + 2", display.UnifiedLine, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -20,6 +20,29 @@ public enum CSharpDiffKind
     Changed,
 }
 
+public enum CSharpDiffOperationKind
+{
+    Line,
+    Method,
+    MethodBody,
+    DecompileFailure,
+    BodyDiffSkipped,
+    SwitchCase,
+    ReturnExpression,
+    Invocation,
+}
+
+public sealed record CSharpDiffOperation(CSharpDiffOperationKind Kind, string Value)
+{
+    public string Display => Kind switch
+    {
+        CSharpDiffOperationKind.SwitchCase => $"case {Value}",
+        CSharpDiffOperationKind.ReturnExpression => $"return {Value}",
+        CSharpDiffOperationKind.Invocation => Value,
+        _ => Value,
+    };
+}
+
 public sealed record CSharpDiffRow(
     string AssemblyIdentity,
     string StableMemberKey,
@@ -34,7 +57,9 @@ public sealed record CSharpDiffRow(
     string Fidelity,
     string Text,
     string? OldValue = null,
-    string? NewValue = null);
+    string? NewValue = null,
+    CSharpDiffOperation? OldOperation = null,
+    CSharpDiffOperation? NewOperation = null);
 
 public sealed record CSharpBodyDiffResult(ImmutableArray<CSharpDiffRow> Rows)
 {
@@ -833,6 +858,13 @@ public static class CSharpBodyDiff
             CSharpDiffKind.Remove => $"Removed C# line '{text}'",
             _ => $"Changed C# line '{text}'",
         };
+        var operationKind = OperationKind(changeId);
+        var oldOperation = kind is CSharpDiffKind.Remove or CSharpDiffKind.Changed
+            ? new CSharpDiffOperation(operationKind, oldValue ?? text)
+            : null;
+        var newOperation = kind is CSharpDiffKind.Add or CSharpDiffKind.Changed
+            ? new CSharpDiffOperation(operationKind, newValue ?? text)
+            : null;
         return new CSharpDiffRow(
             entry.StableAssemblyKey,
             entry.StableMemberKey,
@@ -847,7 +879,28 @@ public static class CSharpBodyDiff
             fidelity,
             text,
             oldValue,
-            newValue);
+            newValue,
+            oldOperation,
+            newOperation);
+    }
+
+    static CSharpDiffOperationKind OperationKind(string changeId)
+    {
+        if (changeId.StartsWith("csharp.switch.case.", StringComparison.Ordinal))
+            return CSharpDiffOperationKind.SwitchCase;
+        if (changeId == "csharp.return-expression.changed")
+            return CSharpDiffOperationKind.ReturnExpression;
+        if (changeId == "csharp.call.changed")
+            return CSharpDiffOperationKind.Invocation;
+        if (changeId is "csharp.method.added" or "csharp.method.removed")
+            return CSharpDiffOperationKind.Method;
+        if (changeId.StartsWith("csharp.method.", StringComparison.Ordinal))
+            return CSharpDiffOperationKind.MethodBody;
+        if (changeId == "csharp.decompile.failed")
+            return CSharpDiffOperationKind.DecompileFailure;
+        if (changeId == "csharp.body-diff.skipped")
+            return CSharpDiffOperationKind.BodyDiffSkipped;
+        return CSharpDiffOperationKind.Line;
     }
 
     static void AddSemanticRows(

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -59,7 +59,76 @@ public sealed record CSharpDiffRow(
     string? OldValue = null,
     string? NewValue = null,
     CSharpDiffOperation? OldOperation = null,
-    CSharpDiffOperation? NewOperation = null);
+    CSharpDiffOperation? NewOperation = null)
+{
+    public CSharpDiffRow(
+        string assemblyIdentity,
+        string stableMemberKey,
+        MemberAnchor anchor,
+        string member,
+        string changeId,
+        string message,
+        int hunkId,
+        CSharpDiffKind kind,
+        int? line,
+        string? sourceCoordinate,
+        string fidelity,
+        string text)
+        : this(
+            assemblyIdentity,
+            stableMemberKey,
+            anchor,
+            member,
+            changeId,
+            message,
+            hunkId,
+            kind,
+            line,
+            sourceCoordinate,
+            fidelity,
+            text,
+            OldValue: null,
+            NewValue: null,
+            OldOperation: null,
+            NewOperation: null)
+    {
+    }
+
+    public CSharpDiffRow(
+        string assemblyIdentity,
+        string stableMemberKey,
+        MemberAnchor anchor,
+        string member,
+        string changeId,
+        string message,
+        int hunkId,
+        CSharpDiffKind kind,
+        int? line,
+        string? sourceCoordinate,
+        string fidelity,
+        string text,
+        string? oldValue,
+        string? newValue)
+        : this(
+            assemblyIdentity,
+            stableMemberKey,
+            anchor,
+            member,
+            changeId,
+            message,
+            hunkId,
+            kind,
+            line,
+            sourceCoordinate,
+            fidelity,
+            text,
+            oldValue,
+            newValue,
+            OldOperation: null,
+            NewOperation: null)
+    {
+    }
+}
 
 public sealed record CSharpBodyDiffResult(ImmutableArray<CSharpDiffRow> Rows)
 {

--- a/src/ILInspector.Research/CSharpDiffPrinter.cs
+++ b/src/ILInspector.Research/CSharpDiffPrinter.cs
@@ -1,0 +1,121 @@
+using System.Collections.Immutable;
+using System.Text;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Research;
+
+public sealed record CSharpDiffDisplayRow(
+    string AssemblyIdentity,
+    string StableMemberKey,
+    MemberAnchor Anchor,
+    string Member,
+    int HunkId,
+    CSharpDiffKind Kind,
+    string Marker,
+    int? Line,
+    string? SourceCoordinate,
+    string Fidelity,
+    CSharpDiffOperationKind? OperationKind,
+    string? OldValue,
+    string? NewValue,
+    string Operation,
+    string Text,
+    string Message)
+{
+    public string UnifiedLine => SourceCoordinate is { Length: > 0 } coordinate
+        ? $"h{HunkId} {Marker} {coordinate} {Operation}"
+        : $"h{HunkId} {Marker} {Operation}";
+}
+
+public sealed record CSharpDiffDisplayResult(ImmutableArray<CSharpDiffDisplayRow> Rows)
+{
+    public bool IsEmpty => Rows.IsDefaultOrEmpty;
+}
+
+/// <summary>
+/// Producer-owned display projection for C# body diff evidence.
+/// </summary>
+public static class CSharpDiffPrinter
+{
+    public static CSharpDiffDisplayRow ToDisplayRow(CSharpDiffRow row)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+
+        return new CSharpDiffDisplayRow(
+            row.AssemblyIdentity,
+            row.StableMemberKey,
+            row.Anchor,
+            row.Member,
+            row.HunkId,
+            row.Kind,
+            Marker(row.Kind),
+            row.Line,
+            row.SourceCoordinate,
+            row.Fidelity,
+            row.NewOperation?.Kind ?? row.OldOperation?.Kind,
+            row.OldOperation?.Value,
+            row.NewOperation?.Value,
+            Operation(row),
+            row.Text,
+            row.Message);
+    }
+
+    public static ImmutableArray<CSharpDiffDisplayRow> ToDisplayRows(IEnumerable<CSharpDiffRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        return [.. rows.Select(ToDisplayRow)];
+    }
+
+    public static CSharpDiffDisplayResult ToDisplayResult(CSharpBodyDiffResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        return new CSharpDiffDisplayResult(ToDisplayRows(result.Rows));
+    }
+
+    public static ImmutableArray<string> ToUnifiedLines(CSharpBodyDiffResult result)
+        => ToUnifiedLines(ToDisplayResult(result));
+
+    public static ImmutableArray<string> ToUnifiedLines(CSharpDiffDisplayResult display)
+    {
+        ArgumentNullException.ThrowIfNull(display);
+        return display.Rows.IsDefault
+            ? []
+            : [.. display.Rows.Select(row => row.UnifiedLine)];
+    }
+
+    public static string RenderUnified(CSharpBodyDiffResult result)
+        => RenderUnified(ToDisplayResult(result));
+
+    public static string RenderUnified(CSharpDiffDisplayResult result)
+    {
+        var lines = ToUnifiedLines(result);
+        if (lines.IsEmpty)
+            return "";
+
+        var builder = new StringBuilder();
+        foreach (string line in lines)
+            builder.AppendLine(line);
+        return builder.ToString().TrimEnd();
+    }
+
+    static string Operation(CSharpDiffRow row)
+        => row.Kind switch
+        {
+            CSharpDiffKind.Changed => $"{Display(row.OldOperation, row.Text)} => {Display(row.NewOperation, row.Text)}",
+            CSharpDiffKind.Add => Display(row.NewOperation, row.Text),
+            CSharpDiffKind.Remove => Display(row.OldOperation, row.Text),
+            _ => row.Text,
+        };
+
+    static string Display(CSharpDiffOperation? operation, string fallback)
+        => operation?.Display ?? fallback;
+
+    static string Marker(CSharpDiffKind kind)
+        => kind switch
+        {
+            CSharpDiffKind.Add => "+",
+            CSharpDiffKind.Remove => "-",
+            CSharpDiffKind.Changed => "~",
+            _ => "?",
+        };
+}

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -599,8 +599,8 @@ public static class ResearchDiff
                 ResearchDiffMechanism.CSharp,
                 row.ChangeId,
                 direction,
-                OldValue: row.OldValue ?? (direction == ResearchDiffDirection.Removed ? row.Text : null),
-                NewValue: row.NewValue ?? (direction == ResearchDiffDirection.Added ? row.Text : null),
+                OldValue: row.OldOperation?.Value ?? row.OldValue ?? (direction == ResearchDiffDirection.Removed ? row.Text : null),
+                NewValue: row.NewOperation?.Value ?? row.NewValue ?? (direction == ResearchDiffDirection.Added ? row.Text : null),
                 Detail: row.Message,
                 Category: ResearchDiffChangeCategory.CSharp));
         }


### PR DESCRIPTION
## Summary

Starts the structured C# diff row direction.

## Details

- Adds `CSharpDiffOperationKind` and `CSharpDiffOperation` so C# diff rows carry typed old/new operations.
- Keeps the existing row fields (`ChangeId`, `Message`, `Text`, `OldValue`, `NewValue`) for compatibility while making structured row data the primary substrate.
- Adds `CSharpDiffPrinter`, mirroring the IL diff printer pattern: callers can consume `CSharpDiffRow` directly or hand rows/results to a printer for unified text.
- Updates ResearchDiff projection to consume structured operation values first, with existing text/value fallbacks preserved.
- Adds coverage for switch-case, return-expression, invocation operation typing, and printer rendering from structured operations.

## Validation

- `dotnet run --project src/ILInspector.Research.Tests -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/DiffCommandTests/*"`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity minimal`
- `git diff --check`

## Review

Adversarial review is required for this Research/C# diff shape change and will be posted before marking ready.
