### PR TITLE
Fix pointer null initialization rendering

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -326,9 +326,36 @@ public class CoerceChokePointTests
             [],
             [bytePointer]);
 
-        Assert.Contains("byte* V_0 = null;", body);
+        Assert.Contains("byte* V_0 = (byte*)null;", body);
         Assert.DoesNotContain("(nuint)0", body);
         AssertCompiles("public static unsafe void M()", body);
+    }
+
+    [Fact]
+    public void PointerArgument_NativeZero_RendersTypedNull()
+    {
+        // Gemini review: bare null is target-typed in a local initializer, but
+        // ambiguous at overloaded pointer call sites. Keep the pointer type.
+        var holder = TypeRef.Definition("synthetic", "", "Holder");
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var nativeUInt = TypeRef.CoreLib("System", "UIntPtr");
+        var consume = new MethodRef(holder, "Consume", TypeRef.CoreLib("System", "Void"), [bytePointer], HasThis: false);
+        string body = RenderBody(
+            [new ExpressionStatement(new Call(
+                consume,
+                isVirtual: false,
+                [new ILInspector.Decompiler.Pipeline.Convert(nativeUInt, isChecked: false, isUnsigned: true, new Constant(0, TypeRef.CoreLib("System", "Int32")))]))],
+            TypeRef.CoreLib("System", "Void"),
+            [],
+            []);
+
+        Assert.Contains("Consume((byte*)null);", body);
+        Assert.DoesNotContain("Consume(null)", body);
+        Assert.DoesNotContain("(nuint)0", body);
+        AssertCompiles(
+            "public static unsafe void M()",
+            body,
+            "public static unsafe class Holder { public static void Consume(byte* p) { } public static void Consume(int* p) { } }");
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -311,6 +311,80 @@ public class CoerceChokePointTests
         AssertCompiles("public static LEnum M()", body, "public enum LEnum : long { Low = 0, High = 2 }");
     }
 
+    [Fact]
+    public void PointerTarget_NativeZero_RendersNull()
+    {
+        // #2338 A1: CoreLib UnmanagedMemoryAccessor initializes byte* locals
+        // from `ldc.i4.0; conv.u`. Rendering the native zero as `(nuint)0` at a
+        // pointer target is CS0266; the pointer null spelling is valid and
+        // matches the IL null pointer.
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var nativeUInt = TypeRef.CoreLib("System", "UIntPtr");
+        string body = RenderBody(
+            [new StoreLocal(0, bytePointer, new ILInspector.Decompiler.Pipeline.Convert(nativeUInt, isChecked: false, isUnsigned: true, new Constant(0, TypeRef.CoreLib("System", "Int32"))))],
+            TypeRef.CoreLib("System", "Void"),
+            [],
+            [bytePointer]);
+
+        Assert.Contains("byte* V_0 = null;", body);
+        Assert.DoesNotContain("(nuint)0", body);
+        AssertCompiles("public static unsafe void M()", body);
+    }
+
+    [Fact]
+    public void NonThrowingNumericCoerce_InCheckedRegion_DoesNotWrapUnchecked()
+    {
+        // #2338 B3: byte->char is explicit but cannot throw in checked C#.
+        // The cast is required, the unchecked wrapper is pure noise.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var byteType = TypeRef.CoreLib("System", "Byte");
+        var charType = TypeRef.CoreLib("System", "Char");
+        var checkedAdd = new Binary(
+            BinaryKind.Add,
+            isChecked: true,
+            isUnsigned: false,
+            new LoadArgument(0, "x", intType),
+            new Coerce(charType, new LoadArgument(1, "b", byteType)));
+
+        string body = RenderReturn(
+            checkedAdd,
+            intType,
+            [new Parameter("x", intType), new Parameter("b", byteType)],
+            TypeRef.Definition("synthetic", "", "UnusedEnum"));
+
+        Assert.Contains("(char)b", body);
+        Assert.DoesNotContain("unchecked((char)b)", body);
+        AssertCompiles("public static int M(int x, byte b)", body);
+    }
+
+    [Fact]
+    public void NonThrowingSubsumedConvert_InCheckedRegion_DoesNotWrapUnchecked()
+    {
+        // Same no-throw rule through the Convert-subsumed exit:
+        // conv.u2 feeding a char target can spell as one `(char)b` cast.
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var byteType = TypeRef.CoreLib("System", "Byte");
+        var ushortType = TypeRef.CoreLib("System", "UInt16");
+        var charType = TypeRef.CoreLib("System", "Char");
+        var checkedAdd = new Binary(
+            BinaryKind.Add,
+            isChecked: true,
+            isUnsigned: false,
+            new LoadArgument(0, "x", intType),
+            new Coerce(charType, new ILInspector.Decompiler.Pipeline.Convert(ushortType, isChecked: false, isUnsigned: false, new LoadArgument(1, "b", byteType))));
+
+        string body = RenderReturn(
+            checkedAdd,
+            intType,
+            [new Parameter("x", intType), new Parameter("b", byteType)],
+            TypeRef.Definition("synthetic", "", "UnusedEnum"));
+
+        Assert.Contains("(char)b", body);
+        Assert.DoesNotContain("unchecked((char)b)", body);
+        Assert.DoesNotContain("(char)((ushort)b)", body);
+        AssertCompiles("public static int M(int x, byte b)", body);
+    }
+
     // #2302 canaries: the join-arm rule's third direction — a primitive arm at
     // a same-family primitive MergedType it cannot reach implicitly. The
     // pre-F1 fold shipped these bare (CS0029/CS0266); the latent class needs

--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -359,6 +359,26 @@ public class CoerceChokePointTests
     }
 
     [Fact]
+    public void PointerTarget_NonZeroNativeInteger_RendersExplicitPointerCast()
+    {
+        // Gemini review round 2: the same pointer-target rule must cover
+        // non-zero native integers, not only null. IL carries conv.u into a
+        // pointer local; C# needs the explicit pointer cast.
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var nativeUInt = TypeRef.CoreLib("System", "UIntPtr");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        string body = RenderBody(
+            [new StoreLocal(0, bytePointer, new ILInspector.Decompiler.Pipeline.Convert(nativeUInt, isChecked: false, isUnsigned: true, new LoadArgument(0, "arg", intType)))],
+            TypeRef.CoreLib("System", "Void"),
+            [new Parameter("arg", intType)],
+            [bytePointer]);
+
+        Assert.Contains("byte* V_0 = (byte*)((nuint)(uint)arg);", body);
+        Assert.DoesNotContain("byte* V_0 = (nuint)arg;", body);
+        AssertCompiles("public static unsafe void M(int arg)", body);
+    }
+
+    [Fact]
     public void NonThrowingNumericCoerce_InCheckedRegion_DoesNotWrapUnchecked()
     {
         // #2338 B3: byte->char is explicit but cannot throw in checked C#.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1058,7 +1058,7 @@ public sealed partial class CSharpPrinter
     {
         if (target is { Kind: TypeRefKind.Pointer } && IsZeroConstant(value))
         {
-            return "null";
+            return $"({TypeText(target)})null";
         }
         if (target is { } nativeTarget
             && IsNativeInteger(nativeTarget)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1056,10 +1056,6 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string CoerceText(IrExpression value, TypeRef? target)
     {
-        if (target is { Kind: TypeRefKind.Pointer } && IsZeroConstant(value))
-        {
-            return $"({TypeText(target)})null";
-        }
         if (target is { } nativeTarget
             && IsNativeInteger(nativeTarget)
             && AddressOfValue(value) is { } address)
@@ -1085,6 +1081,14 @@ public sealed partial class CSharpPrinter
             } addressConvert)
         {
             return $"({TypeText(target)})(&{Deref(addressConvert.Operand)})";
+        }
+        if (target is { Kind: TypeRefKind.Pointer }
+            && value is not Constant { Value: null }
+            && EffectiveType(value) is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "IntPtr" or "UIntPtr" })
+        {
+            return IsZeroConstant(value)
+                ? $"({TypeText(target)})null"
+                : $"({TypeText(target)}){Operand(value)}";
         }
         if (target is { Kind: TypeRefKind.Pointer }
             && EffectiveType(value) is { Kind: TypeRefKind.Pointer } pointerSource

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1056,6 +1056,10 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string CoerceText(IrExpression value, TypeRef? target)
     {
+        if (target is { Kind: TypeRefKind.Pointer } && IsZeroConstant(value))
+        {
+            return "null";
+        }
         if (target is { } nativeTarget
             && IsNativeInteger(nativeTarget)
             && AddressOfValue(value) is { } address)
@@ -1227,9 +1231,14 @@ public sealed partial class CSharpPrinter
         if (value is Convert { IsChecked: false, IsUnsigned: false } conv && SameNumericSlotWidth(conv.Target, target))
             return conv.Operand is Constant { Value: int or long } convConst
                 ? NumericConstant(convConst, target!)
-                : CheckedSafeCast(() => $"({TypeText(target!)}){Operand(conv.Operand)}");
-        return CheckedSafeCast(() => $"({TypeText(target!)}){Operand(value)}");
+                : CheckedSafeNumericCast(EffectiveType(conv.Operand), target!, () => $"({TypeText(target!)}){Operand(conv.Operand)}");
+        return CheckedSafeNumericCast(EffectiveType(value), target!, () => $"({TypeText(target!)}){Operand(value)}");
     }
+
+    string CheckedSafeNumericCast(TypeRef? source, TypeRef target, Func<string> renderCast)
+        => TypeFamilies.CheckedConversionCanThrow(source, target)
+            ? CheckedSafeCast(renderCast)
+            : renderCast();
 
     static IrExpression? AddressOfValue(IrExpression value)
         => value switch


### PR DESCRIPTION
Advances #2338 (A1 + B3)

## Change

**Conclusion:** **PASS** — this fixes the live pointer-init CS0266 class and removes a checked-region over-wrap case without taking the work-2306-owned join-target items.

Included from #2338:

- **A1 pointer-init typing:** native-int zero at pointer sinks now renders as `null`, not `(nuint)0`.
- **B3 checked-region over-wrap:** final numeric boundary casts and Convert-subsumed casts now avoid `unchecked(...)` when `TypeFamilies.CheckedConversionCanThrow(source, target)` says the checked conversion cannot throw.

Not included:

- **C3 ternary polarity** was probed but left open: a broad normalization conflicted with existing common-base/enum-join validity and shape canaries. That needs a narrower standalone pass.
- Claimed/intersecting work-2306 items (A2/A3/B4 and B2) were intentionally avoided.

Before:

```csharp
byte* pointer = (nuint)0;
```

After:

```csharp
byte* pointer = null;
```

## Evidence

| Check | Result |
| --- | --- |
| Focused A1 test | Pass: `CoerceChokePointTests/PointerTarget_NativeZero_RendersNull` |
| Focused B3 tests | Pass: `NonThrowingNumericCoerce_InCheckedRegion_DoesNotWrapUnchecked`, `NonThrowingSubsumedConvert_InCheckedRegion_DoesNotWrapUnchecked` |
| Regression canaries | Pass: common-base ternary and enum/int join canaries |
| Decompiler fast suite | Pass: 1,885 tests with `-trait- "Speed=Slow"` |
| Solution build | Pass: `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore --verbosity minimal` |
| Real witness | `UnmanagedMemoryAccessor.Initialize` now renders `byte* pointer = null;` |
| Render A/B | 89,065 methods evaluated; 7 changed methods, all pointer native-zero-to-null replacements |

Changed methods in render A/B:

- `Microsoft.CodeAnalysis.Collections.Internal.RoslynUnsafe::NullRef<T>`
- `Microsoft.CodeAnalysis.DesktopStrongNameProvider::Sign`
- `Microsoft.DiaSymReader.SymUnmanagedWriterImpl::DefineCustomMetadata`
- `Microsoft.DiaSymReader.SymUnmanagedWriterImpl::GetSignature`
- `Microsoft.DiaSymReader.SymUnmanagedWriterImpl::SetAsyncInfo`
- `Microsoft.DiaSymReader.SymUnmanagedWriterImpl::SetSourceLinkData`
- `Microsoft.DiaSymReader.SymUnmanagedWriterImpl::SetSourceServerData`

## Decompiler quality

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 350 methods (compile-cap 25; per-sample, not corpus-wide); fidelity sampled 21 / 89,065 (0.02%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,405 (88.03%) | +6 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — 25,179 compiled methods | 1/350 — 350 compiled methods | -73 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 3/21, exact 18, recompile-failed 0, context-failed 0; sampled 21 / 89,065 (0.02%) | -2 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.03% (+0.01 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 3 (-2).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25179, current 350)
- fidelity checked methods lower than baseline (baseline 36, current 21)
QUALITY_CARD_EXIT=1

The quality card exits nonzero only because this PR quick run uses lower validity/fidelity caps than the daily baseline. The pinned subset improves: fully raised +0.01 pp, conditional residual unchanged, Full malformed 0, opcode diffs 5 -> 3.

## Review

Adversarial reviews pending. I will post the two-review reconciliation before marking this ready.
