### PR TITLE
Signpost the final raised stage in --dump/--diff (#2270)

### DIFF
--- a/docs/decompiler-ir-dumps.md
+++ b/docs/decompiler-ir-dumps.md
@@ -53,7 +53,10 @@ Every stage header carries an ordinal `[k/N]`; the terminal stage is tagged
 `[N/N · FINAL raised · fidelity …]`. Only that stage and the C# section are the
 result — the earlier stages are a per-pass trace that shows pre-raise IR (async
 state machines, un-raised nodes) by design, so a node appearing in an early stage
-is not the product output.
+is not the product output. The `--diff` and `--assertions` views render the
+stages without a trailing C# section, so their reading guide names only the final
+IR stage; `--diff` also always prints the final stage's full body, even when the
+last pass changed nothing.
 
 A trimmed dump of `string.IsNullOrEmpty`:
 

--- a/docs/decompiler-ir-dumps.md
+++ b/docs/decompiler-ir-dumps.md
@@ -41,17 +41,31 @@ the product-vs-tool boundary.
 ## How to read a dump
 
 Each stage is a block framed by a `====` header, containing the typed IR tree at
-that point, ending with a `// fidelity:` footer. The dump opens with the tree
-**after import** (IL turned into typed nodes, nothing raised yet) and prints the
-tree again **after every pass that ran**, terminating on the raised C# — which is
-**byte-identical to the product's `Decompiled Source`**. The last stage you read
-is exactly the artifact the quality gates grade; there is no drift between what
-you inspect and what is measured.
+that point, ending with a `// fidelity:` footer. The dump opens with a
+`reading guide`, then the tree **after import** (IL turned into typed nodes,
+nothing raised yet), then the tree again **after every pass that ran**,
+terminating on the raised C# — which is **byte-identical to the product's
+`Decompiled Source`**. The last stage you read is exactly the artifact the
+quality gates grade; there is no drift between what you inspect and what is
+measured.
+
+Every stage header carries an ordinal `[k/N]`; the terminal stage is tagged
+`[N/N · FINAL raised · fidelity …]`. Only that stage and the C# section are the
+result — the earlier stages are a per-pass trace that shows pre-raise IR (async
+state machines, un-raised nodes) by design, so a node appearing in an early stage
+is not the product output.
 
 A trimmed dump of `string.IsNullOrEmpty`:
 
 ```text
-==== IR (typed tree after import) ====
+==== reading guide ====
+// Result = the raised C# section plus the FINAL IR stage "IR (after coercion-insertion)"
+// (stage N/N, fidelity Full), tagged [FINAL raised] below.
+// The earlier IR stages are a per-pass trace and show pre-raise IR by design
+// (async state machines, un-raised nodes). A node in an early stage is not the
+// product output — read the final stage, not an intermediate one.
+
+==== IR (typed tree after import) ====  [1/N]
 Function bool IsNullOrEmpty(string value)
   BlockContainer
     Block IL_0000
@@ -69,13 +83,17 @@ Function bool IsNullOrEmpty(string value)
         Constant 1 (int)
 // fidelity: Full
 
-==== IR (after typed-constants) ====
+==== IR (after typed-constants) ====  [2/N]
 ... Constant 1 (int)  becomes  Constant True (bool) ...
 // fidelity: Full
 
   ... one block per pass: identity-convert, redundant-branch-elimination,
       eh-structuring, expression-inlining, ... structuring, boolean-folding,
       is-pattern, ... (passes that change nothing still print, unchanged) ...
+
+==== IR (after coercion-insertion) ====  [N/N · FINAL raised · fidelity Full]
+... the terminal IR tree ...
+// fidelity: Full
 
 ==== C# (raised — the shipped product output) ====
 return value is null || value.Length == 0;
@@ -85,7 +103,9 @@ return value is null || value.Length == 0;
 
 1. **Read the header.** `IR (typed tree after import)` is the ground-truth
    starting point. `IR (after <pass>)` is the tree *immediately after* that named
-   pass ran. The final `C# (raised — …)` block is the shipped output.
+   pass ran. The `[N/N · FINAL raised · …]` stage and the final
+   `C# (raised — …)` block are the shipped output; the `[k/N]` ordinal tells you
+   at a glance whether a stage is intermediate.
 2. **Find the first stage that is wrong.** Scan top-down. Every stage is a valid
    snapshot, so the **first** header after which the tree (or fidelity) goes bad
    names the culprit pass. Everything upstream of it is fine by construction.

--- a/docs/decompiler-ir-dumps.md
+++ b/docs/decompiler-ir-dumps.md
@@ -41,10 +41,11 @@ the product-vs-tool boundary.
 ## How to read a dump
 
 Each stage is a block framed by a `====` header, containing the typed IR tree at
-that point, ending with a `// fidelity:` footer. The dump opens with a
-`reading guide`, then the tree **after import** (IL turned into typed nodes,
-nothing raised yet), then the tree again **after every pass that ran**,
-terminating on the raised C# — which is **byte-identical to the product's
+that point, ending with a `// fidelity:` footer. The IR stages open with a
+`reading guide` (right before the tree **after import**, so with `--il` the
+annotated-IL views precede it), then the tree **after import** (IL turned into
+typed nodes, nothing raised yet), then the tree again **after every pass that
+ran**, terminating on the raised C# — which is **byte-identical to the product's
 `Decompiled Source`**. The last stage you read is exactly the artifact the
 quality gates grade; there is no drift between what you inspect and what is
 measured.
@@ -55,8 +56,8 @@ result — the earlier stages are a per-pass trace that shows pre-raise IR (asyn
 state machines, un-raised nodes) by design, so a node appearing in an early stage
 is not the product output. The `--diff` and `--assertions` views render the
 stages without a trailing C# section, so their reading guide names only the final
-IR stage; `--diff` also always prints the final stage's full body, even when the
-last pass changed nothing.
+IR stage; `--diff` also always prints the final stage's full IR body (not a delta
+hunk), whether or not the last pass changed anything.
 
 A trimmed dump of `string.IsNullOrEmpty`:
 

--- a/src/ILInspector.Decompiler.Tests/PipelineStageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PipelineStageTests.cs
@@ -68,6 +68,41 @@ public class PipelineStageTests
     }
 
     [Fact]
+    public void StageDump_Format_SignpostsTheFinalStageAndReadingGuide()
+    {
+        // Readers/reviewers misread an early pre-raise stage as the result; the
+        // dump must carry a reading guide, per-stage ordinals, and a FINAL tag on
+        // the terminal stage so an intermediate is never mistaken for the answer
+        // (issue #2270).
+        var function = ImportFixture(nameof(CfgSampleClass.Add));
+        var stages = IrPasses.RunWithStages(function);
+
+        string text = StageDump.Format(stages);
+
+        Assert.Contains("==== reading guide ====", text);
+        // Import stage is the first ordinal, never tagged FINAL.
+        Assert.Contains($"==== IR (typed tree after import) ====  [1/{stages.Count}]", text);
+        // The terminal stage carries the FINAL tag with the final fidelity.
+        Assert.Contains(
+            $"[{stages.Count}/{stages.Count} · FINAL raised · fidelity {stages[^1].Fidelity}]",
+            text);
+        // Exactly one stage is tagged FINAL (the middot-delimited tag is unique
+        // to the stage header; the reading guide mentions "[FINAL raised]" too).
+        Assert.Equal(1, CountOccurrences(text, "· FINAL raised ·"));
+    }
+
+    static int CountOccurrences(string haystack, string needle)
+    {
+        int count = 0, i = 0;
+        while ((i = haystack.IndexOf(needle, i, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            i += needle.Length;
+        }
+        return count;
+    }
+
+    [Fact]
     public void StageDump_Title_NamesTheImportBoundary()
     {
         Assert.Equal("IR (typed tree after import)", StageDump.Title(IrPasses.ImportStageName));

--- a/src/ILInspector.Decompiler.Tests/PipelineStageTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PipelineStageTests.cs
@@ -103,6 +103,20 @@ public class PipelineStageTests
     }
 
     [Fact]
+    public void StageDump_Format_ReadingGuideNamesRaisedCSharpOnlyWhenIncluded()
+    {
+        // The guide must not point --diff/--assertions readers at a raised C#
+        // section those renderers do not append; only the C#-appending --dump
+        // path (includesRaisedCSharp: true) names it (issue #2270 review).
+        var function = ImportFixture(nameof(CfgSampleClass.Add));
+        var stages = IrPasses.RunWithStages(function);
+
+        Assert.DoesNotContain("raised C# section", StageDump.Format(stages));
+        Assert.Contains("the FINAL IR stage", StageDump.Format(stages));
+        Assert.Contains("raised C# section", StageDump.Format(stages, includesRaisedCSharp: true));
+    }
+
+    [Fact]
     public void StageDump_Title_NamesTheImportBoundary()
     {
         Assert.Equal("IR (typed tree after import)", StageDump.Title(IrPasses.ImportStageName));

--- a/src/ILInspector.Decompiler.Tests/StageDiffTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StageDiffTests.cs
@@ -22,10 +22,29 @@ public class StageDiffTests
         var diff = StageDump.FormatDiff(
         [
             Stage("(import)", "a\nb\nc\n"),
-            Stage("identity-convert", "a\nb\nc\n"),
+            Stage("identity-convert", "a\nb\nc\n"),   // no change (middle)
+            Stage("property-sugar", "a\nB\nc\n"),     // changed (final)
         ]);
 
         Assert.Contains("==== IR (after identity-convert) (no change) ====", diff);
+    }
+
+    [Fact]
+    public void FormatDiff_ShowsFinalStageBodyEvenWhenUnchanged()
+    {
+        // The terminal stage is the result the reading guide points at, so its
+        // full body is shown even when the last pass changed nothing — otherwise
+        // "read the final stage" lands on an empty header (issue #2270 review).
+        var diff = StageDump.FormatDiff(
+        [
+            Stage("(import)", "a\nb\nc\n"),
+            Stage("property-sugar", "a\nB\nc\n"),        // changed
+            Stage("coercion-insertion", "a\nB\nc\n"),    // no change, FINAL
+        ]);
+
+        Assert.Contains("(after coercion-insertion) (no change) ====", diff);
+        int finalHeader = diff.IndexOf("(after coercion-insertion)", StringComparison.Ordinal);
+        Assert.Contains("a\nB\nc", diff[finalHeader..]);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/StageDiffTests.cs
+++ b/src/ILInspector.Decompiler.Tests/StageDiffTests.cs
@@ -53,16 +53,37 @@ public class StageDiffTests
         var diff = StageDump.FormatDiff(
         [
             Stage("(import)", "a\nb\nc\n"),
-            Stage("property-sugar", "a\nB\nc\n"),
+            Stage("property-sugar", "a\nB\nc\n"),        // changed (middle)
+            Stage("coercion-insertion", "a\nB\nc\n"),    // final (no change)
         ]);
 
-        // The changed stage is not collapsed, and the delta shows the swapped line.
+        // The changed middle stage is not collapsed, and the delta shows the swapped line.
         Assert.Contains("==== IR (after property-sugar) ====", diff);
         Assert.DoesNotContain("(after property-sugar) (no change)", diff);
         Assert.Contains("- b", diff);
         Assert.Contains("+ B", diff);
         // Context line is retained; the far context is elided.
         Assert.Contains("  a", diff);
+    }
+
+    [Fact]
+    public void FormatDiff_ShowsFinalStageFullBodyWhenTheLastPassChanged()
+    {
+        // The terminal stage is the result, so it prints its full IR body — not a
+        // delta hunk the reading guide's "read the final stage" cannot land on
+        // (issue #2270 review) — even when the last pass changed something.
+        var diff = StageDump.FormatDiff(
+        [
+            Stage("(import)", "a\nb\nc\n"),
+            Stage("coercion-insertion", "a\nB\nc\n"),    // changed, FINAL
+        ]);
+
+        Assert.Contains("(after coercion-insertion) ====", diff);
+        Assert.DoesNotContain("(after coercion-insertion) (no change)", diff);
+        int finalHeader = diff.IndexOf("(after coercion-insertion)", StringComparison.Ordinal);
+        Assert.Contains("a\nB\nc", diff[finalHeader..]);
+        // The final stage is a full body, not a delta hunk.
+        Assert.DoesNotContain("- b", diff);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler/Pipeline/PipelineStages.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PipelineStages.cs
@@ -33,13 +33,20 @@ public enum StageDumpView
 /// </summary>
 public static class StageDump
 {
-    public static string Format(IReadOnlyList<PipelineStage> stages)
+    /// <param name="includesRaisedCSharp">
+    /// True when the caller appends a <c>==== C# (raised …) ====</c> section after
+    /// these stages (the <c>--dump</c> path). The reading guide names that section
+    /// as part of the result only when it is actually present, so the
+    /// <c>--diff</c>/<c>--assertions</c> callers (which render stages alone) do
+    /// not point readers at a section that is not there (issue #2270 review).
+    /// </param>
+    public static string Format(IReadOnlyList<PipelineStage> stages, bool includesRaisedCSharp = false)
     {
         var sb = new StringBuilder();
         if (stages.Count == 0)
             return sb.ToString();
 
-        AppendReadingGuide(sb, stages);
+        AppendReadingGuide(sb, stages, includesRaisedCSharp);
         for (int i = 0; i < stages.Count; i++)
         {
             sb.AppendLine();
@@ -52,15 +59,18 @@ public static class StageDump
     /// <summary>
     /// The reading guide printed before a staged dump: the per-pass IR below is a
     /// trace, so early stages show pre-raise IR (async state machines, un-raised
-    /// nodes) by design. The result is the raised C# section and the final IR
-    /// stage — the one tagged <c>FINAL raised</c>. A node in an early stage is not
-    /// the product output; the terminal stage and the C# are (issue #2270).
+    /// nodes) by design. The result is the final IR stage — the one tagged
+    /// <c>FINAL raised</c> — plus the raised C# section when the caller appends
+    /// one. A node in an early stage is not the product output (issue #2270).
     /// </summary>
-    static void AppendReadingGuide(StringBuilder sb, IReadOnlyList<PipelineStage> stages)
+    static void AppendReadingGuide(StringBuilder sb, IReadOnlyList<PipelineStage> stages, bool includesRaisedCSharp)
     {
+        string result = includesRaisedCSharp
+            ? $"the raised C# section plus the FINAL IR stage \"{Title(stages[^1].PassName)}\""
+            : $"the FINAL IR stage \"{Title(stages[^1].PassName)}\"";
         sb.AppendLine();
         sb.AppendLine("==== reading guide ====");
-        sb.AppendLine($"// Result = the raised C# section plus the FINAL IR stage \"{Title(stages[^1].PassName)}\"");
+        sb.AppendLine($"// Result = {result}");
         sb.AppendLine($"// (stage {stages.Count}/{stages.Count}, fidelity {stages[^1].Fidelity}), tagged [FINAL raised] below.");
         sb.AppendLine("// The earlier IR stages are a per-pass trace and show pre-raise IR by design");
         sb.AppendLine("// (async state machines, un-raised nodes). A node in an early stage is not the");
@@ -88,15 +98,18 @@ public static class StageDump
     /// <c>-</c>/<c>+</c> hunk with one line of context). Passes that change
     /// nothing collapse to a one-line "(no change)" header, so "what did this
     /// pass do?" is a glance instead of a manual sed between two stage headers
-    /// (issue #633 item 3). Same stage boundaries as <see cref="Format"/>.
+    /// (issue #633 item 3). The terminal stage is the result, so it always
+    /// renders its full body — even when the last pass changed nothing — rather
+    /// than collapsing to an empty header (issue #2270 review). Same stage
+    /// boundaries as <see cref="Format"/>.
     /// </summary>
-    public static string FormatDiff(IReadOnlyList<PipelineStage> stages)
+    public static string FormatDiff(IReadOnlyList<PipelineStage> stages, bool includesRaisedCSharp = false)
     {
         var sb = new StringBuilder();
         if (stages.Count == 0)
             return sb.ToString();
 
-        AppendReadingGuide(sb, stages);
+        AppendReadingGuide(sb, stages, includesRaisedCSharp);
         sb.AppendLine();
         sb.AppendLine(StageHeader(Title(stages[0].PassName), 0, stages.Count, stages[^1].Fidelity));
         sb.Append(stages[0].Projection);
@@ -105,6 +118,17 @@ public static class StageDump
         {
             var hunks = DiffHunks(stages[i - 1].Projection, stages[i].Projection);
             sb.AppendLine();
+            // The terminal stage is the result the reading guide points at, so
+            // print its full body even when the last pass changed nothing —
+            // otherwise "read the final stage" lands on an empty header. A
+            // changed final stage keeps its delta hunks (the full body is the
+            // first stage plus the hunks above it).
+            if (i == stages.Count - 1 && hunks.Count == 0)
+            {
+                sb.AppendLine(StageHeader(Title(stages[i].PassName), i, stages.Count, stages[^1].Fidelity, suffix: "(no change)"));
+                sb.Append(stages[i].Projection);
+                continue;
+            }
             if (hunks.Count == 0)
             {
                 sb.AppendLine(StageHeader(Title(stages[i].PassName), i, stages.Count, stages[^1].Fidelity, suffix: "(no change)"));
@@ -265,7 +289,7 @@ public static class StageDump
                 }
             }
 
-            sb.Append(Format(IrPasses.RunWithStages(function, method => IrImporter.Import(source, method))));
+            sb.Append(Format(IrPasses.RunWithStages(function, method => IrImporter.Import(source, method)), includesRaisedCSharp: true));
 
             sb.AppendLine();
             // RunWithStages above ran the canonical Default pass list on

--- a/src/ILInspector.Decompiler/Pipeline/PipelineStages.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PipelineStages.cs
@@ -36,13 +36,50 @@ public static class StageDump
     public static string Format(IReadOnlyList<PipelineStage> stages)
     {
         var sb = new StringBuilder();
-        foreach (var stage in stages)
+        if (stages.Count == 0)
+            return sb.ToString();
+
+        AppendReadingGuide(sb, stages);
+        for (int i = 0; i < stages.Count; i++)
         {
             sb.AppendLine();
-            sb.AppendLine($"==== {Title(stage.PassName)} ====");
-            sb.Append(stage.Projection);
+            sb.AppendLine(StageHeader(Title(stages[i].PassName), i, stages.Count, stages[^1].Fidelity));
+            sb.Append(stages[i].Projection);
         }
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// The reading guide printed before a staged dump: the per-pass IR below is a
+    /// trace, so early stages show pre-raise IR (async state machines, un-raised
+    /// nodes) by design. The result is the raised C# section and the final IR
+    /// stage — the one tagged <c>FINAL raised</c>. A node in an early stage is not
+    /// the product output; the terminal stage and the C# are (issue #2270).
+    /// </summary>
+    static void AppendReadingGuide(StringBuilder sb, IReadOnlyList<PipelineStage> stages)
+    {
+        sb.AppendLine();
+        sb.AppendLine("==== reading guide ====");
+        sb.AppendLine($"// Result = the raised C# section plus the FINAL IR stage \"{Title(stages[^1].PassName)}\"");
+        sb.AppendLine($"// (stage {stages.Count}/{stages.Count}, fidelity {stages[^1].Fidelity}), tagged [FINAL raised] below.");
+        sb.AppendLine("// The earlier IR stages are a per-pass trace and show pre-raise IR by design");
+        sb.AppendLine("// (async state machines, un-raised nodes). A node in an early stage is not the");
+        sb.AppendLine("// product output — read the final stage, not an intermediate one.");
+    }
+
+    /// <summary>
+    /// A stage boundary header carrying its ordinal <c>[k/N]</c>, and for the last
+    /// stage a <c>FINAL raised</c> tag with fidelity, so grepping a stage never
+    /// mistakes an intermediate for the result (issue #2270). The base
+    /// <c>==== {title} ====</c> is preserved verbatim; the tag follows it.
+    /// </summary>
+    static string StageHeader(string title, int index, int count, DecompilationFidelity finalFidelity, string? suffix = null)
+    {
+        string body = suffix is null ? $"==== {title} ====" : $"==== {title} {suffix} ====";
+        string tag = index == count - 1
+            ? $"[{index + 1}/{count} · FINAL raised · fidelity {finalFidelity}]"
+            : $"[{index + 1}/{count}]";
+        return $"{body}  {tag}";
     }
 
     /// <summary>
@@ -59,8 +96,9 @@ public static class StageDump
         if (stages.Count == 0)
             return sb.ToString();
 
+        AppendReadingGuide(sb, stages);
         sb.AppendLine();
-        sb.AppendLine($"==== {Title(stages[0].PassName)} ====");
+        sb.AppendLine(StageHeader(Title(stages[0].PassName), 0, stages.Count, stages[^1].Fidelity));
         sb.Append(stages[0].Projection);
 
         for (int i = 1; i < stages.Count; i++)
@@ -69,10 +107,10 @@ public static class StageDump
             sb.AppendLine();
             if (hunks.Count == 0)
             {
-                sb.AppendLine($"==== {Title(stages[i].PassName)} (no change) ====");
+                sb.AppendLine(StageHeader(Title(stages[i].PassName), i, stages.Count, stages[^1].Fidelity, suffix: "(no change)"));
                 continue;
             }
-            sb.AppendLine($"==== {Title(stages[i].PassName)} ====");
+            sb.AppendLine(StageHeader(Title(stages[i].PassName), i, stages.Count, stages[^1].Fidelity));
             foreach (var line in hunks)
                 sb.AppendLine(line);
         }

--- a/src/ILInspector.Decompiler/Pipeline/PipelineStages.cs
+++ b/src/ILInspector.Decompiler/Pipeline/PipelineStages.cs
@@ -99,9 +99,9 @@ public static class StageDump
     /// nothing collapse to a one-line "(no change)" header, so "what did this
     /// pass do?" is a glance instead of a manual sed between two stage headers
     /// (issue #633 item 3). The terminal stage is the result, so it always
-    /// renders its full body — even when the last pass changed nothing — rather
-    /// than collapsing to an empty header (issue #2270 review). Same stage
-    /// boundaries as <see cref="Format"/>.
+    /// renders its full body — whether or not the last pass changed anything —
+    /// rather than a delta the reading guide's "read the final stage" cannot
+    /// land on (issue #2270 review). Same stage boundaries as <see cref="Format"/>.
     /// </summary>
     public static string FormatDiff(IReadOnlyList<PipelineStage> stages, bool includesRaisedCSharp = false)
     {
@@ -118,14 +118,15 @@ public static class StageDump
         {
             var hunks = DiffHunks(stages[i - 1].Projection, stages[i].Projection);
             sb.AppendLine();
-            // The terminal stage is the result the reading guide points at, so
-            // print its full body even when the last pass changed nothing —
-            // otherwise "read the final stage" lands on an empty header. A
-            // changed final stage keeps its delta hunks (the full body is the
-            // first stage plus the hunks above it).
-            if (i == stages.Count - 1 && hunks.Count == 0)
+            // The terminal stage is the result the reading guide points at, so it
+            // always prints its full IR body (with a "(no change)" note when the
+            // last pass changed nothing) rather than a localized delta — otherwise
+            // "read the final stage" lands on a diff fragment, not a tree (#2270
+            // review). Intermediate stages keep their unified `-`/`+` hunks.
+            if (i == stages.Count - 1)
             {
-                sb.AppendLine(StageHeader(Title(stages[i].PassName), i, stages.Count, stages[^1].Fidelity, suffix: "(no change)"));
+                string? suffix = hunks.Count == 0 ? "(no change)" : null;
+                sb.AppendLine(StageHeader(Title(stages[i].PassName), i, stages.Count, stages[^1].Fidelity, suffix));
                 sb.Append(stages[i].Projection);
                 continue;
             }


### PR DESCRIPTION
Fixes #2270.

## What

Staged dumps print every pipeline stage, and early stages necessarily show pre-raise IR (async state machines, un-raised nodes). Readers — including adversarial reviewers — repeatedly grepped an early stage and concluded a method "wasn't reconstructed" (e.g. the #2263 review's false `[HIGH]` on classic-async's `<>t__builder`, which is gone by the final stage). This makes the final raised stage unmistakable.

**Presentation only — no product decompiler change.** `StageDump.Format`/`FormatDiff` (feeding `--dump`, `--diff`, `--assertions`) now:

- open with a `==== reading guide ====` block stating the result is the raised C# section plus the FINAL IR stage, and that earlier stages are a pre-raise trace by design;
- tag every stage header with a `[k/N]` ordinal;
- tag the terminal stage `[N/N · FINAL raised · fidelity …]`.

The base `==== {title} ====` is preserved verbatim (the tag follows it), so existing header/`Contains` assertions and the pinned raised-C# section are unchanged.

## Example (classic-async `AwaitValue`, the #2263 false-positive case)

```text
==== reading guide ====
// Result = the raised C# section plus the FINAL IR stage "IR (after coercion-insertion)"
// (stage 77/77, fidelity Full), tagged [FINAL raised] below.
// The earlier IR stages are a per-pass trace and show pre-raise IR by design
// (async state machines, un-raised nodes). A node in an early stage is not the
// product output — read the final stage, not an intermediate one.

==== IR (typed tree after import) ====  [1/77]
      StoreField <AwaitValue>d__0.<>t__builder      <- an intermediate stage, clearly [1/77]
...
==== IR (after coercion-insertion) ====  [77/77 · FINAL raised · fidelity Full]
...
==== C# (raised — the shipped product output) ====
return await Task.FromResult<int>(42);
```

## Tests / validation

- New `PipelineStageTests.StageDump_Format_SignpostsTheFinalStageAndReadingGuide`: pins the reading guide, the `[1/N]` import ordinal, and exactly one `· FINAL raised ·` tag carrying the final fidelity.
- Existing `PipelineStageTests`, `StageDiffTests`, `ClassicAsyncTests` unchanged and green (header substrings preserved).
- Full fast suite **1883/1883**; `markdownlint` clean on the changed doc.
- `docs/decompiler-ir-dumps.md` updated to document the guide, ordinals, and FINAL tag.

## Risk

Low — diagnostic/harness presentation only; no product decompiler path, heuristic, or shape change. Per the adversarial-review policy this class of change does not require the two-model round.
