### PR TITLE
Add RTS fixture group harness option

### DIFF
--- a/tools/DecompilerHarness/DecompilerHarness.csproj
+++ b/tools/DecompilerHarness/DecompilerHarness.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="../../src/ILInspector.Research/ILInspector.Research.csproj" />
     <ProjectReference Include="../../src/DotnetInspector.Services/DotnetInspector.Services.csproj" />
     <ProjectReference Include="../../src/DotnetInspector.Packages/DotnetInspector.Packages.csproj" />
+    <ProjectReference Include="../../tests/DotnetInspector.Fixtures/DotnetInspector.Fixtures.csproj" />
     <!-- ILReader: the byte-match-validated IL reader the fidelity and annotation checks read the witness IL with. -->
     <ProjectReference Include="../../src/ILInspector.Metadata/ILInspector.Metadata.csproj" />
     <!-- Validity check: parse and bind the decompiled C# to measure validity. -->

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 
 using DotnetInspector.Core;
+using DotnetInspector.Fixtures;
 using DotnetInspector.Packages;
 using DotnetInspector.Services;
 using ILInspector.Decompiler;
@@ -54,6 +55,7 @@ static class Program
         bool returnToSenderAb = false;
         bool returnToSenderCatalog = false;
         bool returnToSenderSourceProbe = false;
+        string? returnToSenderFixtureGroup = null;
         bool fidelityTimings = false;
         int fidelityZeroSignalGuard = 0;
         bool gaps = false;
@@ -138,6 +140,7 @@ static class Program
                 case "--return-to-sender": returnToSender = true; break;
                 case "--return-to-sender-ab": returnToSenderAb = true; break;
                 case "--return-to-sender-source-probe": returnToSenderSourceProbe = true; break;
+                case "--return-to-sender-fixtures": returnToSenderFixtureGroup = args[++i]; break;
                 case "--return-to-sender-catalog":
                     returnToSenderCatalog = true;
                     if (i + 1 < args.Length && !args[i + 1].StartsWith('-')
@@ -219,12 +222,29 @@ static class Program
 
         if (returnToSenderCatalog)
         {
+            if (returnToSenderFixtureGroup is not null)
+                return Fail("--return-to-sender-fixtures supplies built assemblies; do not use it with --return-to-sender-catalog.");
             if (inputs.Count > 0)
                 return Fail("--return-to-sender-catalog generates its own temporary input assembly; do not pass assembly paths.");
             return ReturnToSenderCatalog(returnToSenderCatalogSelector, keepGeneratedFixtures, json, maxExamples);
         }
 
+        if (returnToSenderFixtureGroup is not null
+            && !(returnToSender || returnToSenderAb || returnToSenderSourceProbe))
+        {
+            return Fail("--return-to-sender-fixtures requires --return-to-sender, --return-to-sender-ab, or --return-to-sender-source-probe.");
+        }
+
         using var packageInputs = ResolvePackageAssemblies(packages, packageVersion, packageTfm, packageAssembly);
+        IReadOnlyList<string> fixtureInputs;
+        try
+        {
+            fixtureInputs = ResolveFixtureAssemblies(returnToSenderFixtureGroup);
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or UnauthorizedAccessException)
+        {
+            return Fail(ex.Message);
+        }
 
         if (emitInverseLedger is not null)
         {
@@ -233,9 +253,13 @@ static class Program
             return 0;
         }
 
-        var assemblies = inputs.Count == 0 && packages.Count > 0
-            ? packageInputs.Assemblies.ToList()
-            : ResolveAssemblies(inputs).Concat(packageInputs.Assemblies).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        var assemblies = inputs.Count == 0 && packages.Count == 0 && fixtureInputs.Count == 0
+            ? ResolveAssemblies(inputs)
+            : ResolveAssemblies(inputs, includeDefault: false)
+                .Concat(packageInputs.Assemblies)
+                .Concat(fixtureInputs)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
         if (assemblies.Count == 0)
             return Fail("No managed assemblies found in the given inputs.");
 
@@ -1222,10 +1246,15 @@ static class Program
         return parts.Count == 0 ? "-" : string.Join(", ", parts);
     }
 
-    static List<string> ResolveAssemblies(List<string> inputs)
+    static IReadOnlyList<string> ResolveFixtureAssemblies(string? groupId)
+        => groupId is null
+            ? []
+            : FixtureCatalog.Group(groupId).AssemblyPaths();
+
+    static List<string> ResolveAssemblies(List<string> inputs, bool includeDefault = true)
     {
         if (inputs.Count == 0)
-            return [typeof(object).Assembly.Location];
+            return includeDefault ? [typeof(object).Assembly.Location] : [];
 
         List<string> result = [];
         foreach (var input in inputs)
@@ -1454,6 +1483,11 @@ static class Program
                                 input assemblies, run ReturnToSender over those
                                 targets, and report missing-fragment/source
                                 buckets alongside compile-back status.
+          --return-to-sender-fixtures <group>
+                                add built fixture assemblies from a FixtureCatalog
+                                group (for example rts.candidates) as inputs for
+                                --return-to-sender, --return-to-sender-ab, or
+                                --return-to-sender-source-probe.
           --return-to-sender-catalog [selector]
                                 compile the generated fixture catalog, run
                                 ReturnToSender over supported property getters,

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -144,6 +144,9 @@ machine-readable list/results, and
 The `rts.*` fixtures are focused ReturnToSender parity-burndown probes; for
 example `rts.attribute-shell` protects attribute type shells that must preserve a
 spellable `System.Attribute` base before attribute usages can compile.
+Use `--return-to-sender-fixtures rts.candidates` with `--return-to-sender`,
+`--return-to-sender-ab`, or `--return-to-sender-source-probe` to add built
+fixture assemblies from `FixtureCatalog` as inputs without generating source.
 Rows may carry two independent expectations: a Roslyn `SyntaxKind` shape verdict
 for the intended C# idiom, and a compile-back opcode verdict for semantic
 fidelity. A row can therefore be opcode-exact while still exposing a shape


### PR DESCRIPTION
## Change

Adds `--return-to-sender-fixtures <group>` to `tools/DecompilerHarness`, resolving a `FixtureCatalog` group into built fixture assembly inputs for:

- `--return-to-sender`
- `--return-to-sender-ab`
- `--return-to-sender-source-probe`

This gives RTS a harness-facing built-binary fixture source, e.g. `--return-to-sender --return-to-sender-fixtures rts.candidates`, without generating C# and without expanding compile-back catalog behavior. The option rejects use without an RTS mode and rejects use with `--return-to-sender-catalog` because that path materializes generated source fixtures.

Also documents the option in `tools/DecompilerHarness/README.md`.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity minimal
dotnet run --project tests/DotnetInspector.Fixtures.Tests -c Release --no-build
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/*"
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender --return-to-sender-fixtures rts.candidates --cap 1 --max-examples 1
dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-fixtures rts.candidates # exits 1 with requires-RTS-mode error
npx markdownlint-cli tools/DecompilerHarness/README.md
git diff --check
```

Harness/test infrastructure only; no product behavior change.
