### PR TITLE
Preserve IL diff display rows in Research

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
@@ -102,12 +102,53 @@ public class ReturnToSenderEvidenceTests
             item.Mechanism == ResearchDiffMechanism.IlBody
             && item.ChangeId == "il.operation.removed"
             && item.OldValue == "ldc.i4 1"
-            && item.OldIlOffset == 1);
+            && item.OldIlOffset == 1
+            && item.IlDisplayRows.Length == 1
+            && item.IlDisplayRows[0].UnifiedLine == "h1 - IL_0001 ldc.i4 1");
         Assert.Contains(subject.Evidence, item =>
             item.Mechanism == ResearchDiffMechanism.IlBody
             && item.ChangeId == "il.operation.added"
             && item.NewValue == "ldc.i4 2"
-            && item.NewIlOffset == 1);
+            && item.NewIlOffset == 1
+            && item.IlDisplayRows.Length == 1
+            && item.IlDisplayRows[0].UnifiedLine == "h1 + IL_0001 ldc.i4 2");
         Assert.DoesNotContain(subject.Evidence, item => item.ChangeId == "il.operation.context");
+    }
+
+    [Fact]
+    public void ToResearchDiff_ProjectsStructuredIlDiffFailureRows()
+    {
+        var anchor = new MemberAnchor(
+            "Method1~abcdef1234",
+            "M:TestType.Method1()",
+            "abcdef1234",
+            "TestType",
+            "Method1");
+        var failure = new IlDiffDisplayFailureRow(
+            IlDiffFailureKind.NewBodyMissing,
+            "new body missing",
+            Side: "new",
+            Detail: "method has no body");
+        var evidence = new ReturnToSenderEvidenceRow(
+            anchor,
+            "TestType",
+            "Method1",
+            Overload: 0,
+            GeneratedFixtureReturnToSenderStatus.Fail,
+            FidelityCheck.CompileBackStatus.OpcodeDiff,
+            "opcode-diff",
+            Detail: null,
+            IlDiffDiagnostic: new IlDiffDisplayResult(
+                Failure: failure.UnifiedLine,
+                Rows: [],
+                FailureRows: [failure]));
+
+        var research = ReturnToSenderEvidence.ToResearchDiff([evidence]);
+
+        var subject = Assert.Single(research.Subjects);
+        var ilFailure = Assert.Single(subject.Evidence, item => item.ChangeId == "il.diff.new-body-missing");
+        Assert.Equal(ResearchDiffMechanism.IlBody, ilFailure.Mechanism);
+        Assert.Equal("method has no body", ilFailure.Detail);
+        Assert.Same(failure, ilFailure.IlDisplayFailureRow);
     }
 }

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -122,6 +122,14 @@ public class ResearchDiffTests
         Assert.Equal("il.operation.added", row.ChangeId);
         Assert.Equal(ilRow.Message, row.Message);
         Assert.Same(ilRow, row.IlRow);
+        Assert.NotNull(row.IlDisplayRow);
+        Assert.Equal(3, row.IlDisplayRow.HunkId);
+        Assert.Equal("+", row.IlDisplayRow.Marker);
+        Assert.Equal("IL_0000", row.IlDisplayRow.Offset);
+        Assert.Equal("ldc.i4", row.IlDisplayRow.OpcodeFamily);
+        Assert.Equal(IlOperandIdentityKind.Immediate, row.IlDisplayRow.OperandKind);
+        Assert.Equal("2", row.IlDisplayRow.OperandValue);
+        Assert.Equal("h3 + IL_0000 ldc.i4 2", row.IlDisplayRow.UnifiedLine);
     }
 
     [Fact]
@@ -139,6 +147,12 @@ public class ResearchDiffTests
         Assert.Equal(IlDiffFailureKind.NewBodyMissing, failure.Kind);
         Assert.Equal("new", failure.Side);
         Assert.Equal("metadata row absent", failure.Detail);
+        Assert.NotNull(row.IlDisplayFailureRow);
+        Assert.Equal(IlDiffFailureKind.NewBodyMissing, row.IlDisplayFailureRow.Kind);
+        Assert.Equal("new body missing", row.IlDisplayFailureRow.Message);
+        Assert.Equal("new", row.IlDisplayFailureRow.Side);
+        Assert.Equal("metadata row absent", row.IlDisplayFailureRow.Detail);
+        Assert.Equal("IL diff failed: new body missing", row.IlDisplayFailureRow.UnifiedLine);
     }
 
     [Fact]
@@ -168,6 +182,8 @@ public class ResearchDiffTests
             {
                 Assert.Equal("il.operation.removed", operationRow.ChangeId);
                 Assert.Same(ilRow, operationRow.IlRow);
+                Assert.NotNull(operationRow.IlDisplayRow);
+                Assert.Equal("h0 - IL_0000 nop", operationRow.IlDisplayRow.UnifiedLine);
                 Assert.Null(operationRow.IlFailureRow);
             });
     }
@@ -270,6 +286,18 @@ public class ResearchDiffTests
             && member.HasChange("il.hunk.changed"));
         Assert.DoesNotContain(changedMembers, member =>
             member.Subject.Display.Contains("Stable", StringComparison.Ordinal));
+
+        var constantValue = Assert.Single(changedMembers, member =>
+            member.Subject.Display.Contains("ConstantValue", StringComparison.Ordinal));
+        var ilEvidence = Assert.Single(constantValue.Evidence, evidence => evidence.ChangeId == "il.hunk.changed");
+        Assert.NotEmpty(ilEvidence.IlDisplayRows);
+        Assert.Contains(ilEvidence.IlDisplayRows, row =>
+            row.Kind == IlDiffKind.Remove
+            && row.Marker == "-"
+            && row.OpcodeFamily == "ldc.i4"
+            && row.OperandKind == IlOperandIdentityKind.Immediate
+            && row.OperandValue == "1"
+            && row.UnifiedLine.Contains("ldc.i4 1", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -60,6 +60,8 @@ public sealed record ResearchDiffRow(
     ApiChange? ApiChange = null,
     IlDiffRow? IlRow = null,
     IlDiffFailureRow? IlFailureRow = null,
+    IlDiffDisplayRow? IlDisplayRow = null,
+    IlDiffDisplayFailureRow? IlDisplayFailureRow = null,
     BodySignalDiffRow? BodySignalRow = null,
     CSharpDiffRow? CSharpRow = null);
 
@@ -107,7 +109,9 @@ public sealed record ResearchDiffEvidence(
     int? Magnitude = null,
     int DirectionScore = 0,
     bool SubjectInBoth = true,
-    bool InLoop = false);
+    bool InLoop = false,
+    ImmutableArray<IlDiffDisplayRow> IlDisplayRows = default,
+    IlDiffDisplayFailureRow? IlDisplayFailureRow = null);
 
 public sealed record ResearchSubjectDiff(
     ResearchSubjectKey Subject,
@@ -150,6 +154,9 @@ public sealed record ResearchDiffResult(
 
 public static class ResearchDiff
 {
+    public static string ToChangeIdPart(string value)
+        => ToKebabCase(value);
+
     public static ResearchDiffResult FromApiDiff(ApiDiff diff)
     {
         ArgumentNullException.ThrowIfNull(diff);
@@ -179,7 +186,8 @@ public static class ResearchDiff
                 $"il.diff.{ToKebabCase(row.Kind.ToString())}",
                 ResearchDiffEvidenceKind.IlBody,
                 row.Message,
-                IlFailureRow: row)));
+                IlFailureRow: row,
+                IlDisplayFailureRow: IlDiffPrinter.ToDisplayFailureRow(row))));
         }
         else if (diff.Failure is { Length: > 0 } failure)
         {
@@ -192,7 +200,8 @@ public static class ResearchDiff
                 $"il.operation.{ChangeIdSuffix(row.Kind)}",
                 ResearchDiffEvidenceKind.IlBody,
                 row.Message,
-                IlRow: row)));
+                IlRow: row,
+                IlDisplayRow: IlDiffPrinter.ToDisplayRow(row))));
         }
 
         return new ResearchDiffResult([], Rows: rows.ToImmutable());
@@ -565,6 +574,7 @@ public static class ResearchDiff
                 {
                     var removed = hunk.Where(row => row.Kind == IlDiffKind.Remove).ToArray();
                     var added = hunk.Where(row => row.Kind == IlDiffKind.Add).ToArray();
+                    var displayRows = hunk.Select(IlDiffPrinter.ToDisplayRow).ToImmutableArray();
                     var direction = removed.Length == 0
                         ? ResearchDiffDirection.Added
                         : added.Length == 0
@@ -583,7 +593,8 @@ public static class ResearchDiff
                         NewValue: FormatOperations(added),
                         OldIlOffset: removed.Select(row => (int?)row.Operation.Offset).FirstOrDefault(offset => offset is not null),
                         NewIlOffset: added.Select(row => (int?)row.Operation.Offset).FirstOrDefault(offset => offset is not null),
-                        Category: ResearchDiffChangeCategory.IlBody));
+                        Category: ResearchDiffChangeCategory.IlBody,
+                        IlDisplayRows: displayRows));
                 }
             }
         }
@@ -604,7 +615,8 @@ public static class ResearchDiff
             OldValue: failure.Side == "old" ? failure.Detail ?? failure.Message : null,
             NewValue: failure.Side == "new" ? failure.Detail ?? failure.Message : null,
             Detail: failure.Detail ?? failure.Message,
-            Category: ResearchDiffChangeCategory.IlBody));
+            Category: ResearchDiffChangeCategory.IlBody,
+            IlDisplayFailureRow: IlDiffPrinter.ToDisplayFailureRow(failure)));
     }
 
     static void AddCSharpDiff(ResultBuilder builder, ResearchDiffInput oldInput, ResearchDiffInput newInput, IReadOnlySet<string>? typeFilters)

--- a/tools/DecompilerHarness/ReturnToSenderEvidence.cs
+++ b/tools/DecompilerHarness/ReturnToSenderEvidence.cs
@@ -81,7 +81,21 @@ internal static class ReturnToSenderEvidence
         if (row.IlDiffDiagnostic is not { } diagnostic)
             yield break;
 
-        if (diagnostic.Failure is { Length: > 0 } failure)
+        var failureRows = diagnostic.FailureRows.IsDefault
+            ? []
+            : diagnostic.FailureRows;
+        foreach (var failureRow in failureRows)
+        {
+            yield return new ResearchDiffEvidence(
+                ResearchDiffMechanism.IlBody,
+                $"il.diff.{ResearchDiff.ToChangeIdPart(failureRow.Kind.ToString())}",
+                ResearchDiffDirection.Changed,
+                Detail: failureRow.Detail ?? failureRow.Message,
+                Category: ResearchDiffChangeCategory.IlBody,
+                IlDisplayFailureRow: failureRow);
+        }
+
+        if (failureRows.IsDefaultOrEmpty && diagnostic.Failure is { Length: > 0 } failure)
         {
             yield return new ResearchDiffEvidence(
                 ResearchDiffMechanism.IlBody,
@@ -111,7 +125,8 @@ internal static class ReturnToSenderEvidence
                 OldIlOffset: displayRow.Kind == IlDiffKind.Remove ? displayRow.RawOffset : null,
                 NewIlOffset: displayRow.Kind == IlDiffKind.Add ? displayRow.RawOffset : null,
                 Detail: displayRow.Message,
-                Category: ResearchDiffChangeCategory.IlBody);
+                Category: ResearchDiffChangeCategory.IlBody,
+                IlDisplayRows: [displayRow]);
         }
     }
 
@@ -123,4 +138,5 @@ internal static class ReturnToSenderEvidence
             GeneratedFixtureReturnToSenderStatus.Fail => "fail",
             _ => status.ToString().ToLowerInvariant(),
         };
+
 }


### PR DESCRIPTION
## Summary

Carries producer-owned IL Diff display evidence through Research/RTS surfaces for #2318 without making Research parse or reformat IL:

- adds `IlDiffDisplayRow` / `IlDiffDisplayFailureRow` fields to `ResearchDiffRow` and `ResearchDiffEvidence`;
- populates row-level display fields via `IlDiffPrinter.ToDisplayRow` / `ToDisplayFailureRow`;
- preserves hunk-level display rows on Research subject evidence while keeping existing summary fields for compatibility;
- updates RTS Research wrapping to carry existing `IlDiffDisplayResult` rows/failures directly;
- adds tests for operation rows, failure rows, hunk evidence, and RTS evidence wrapping.

Refs #2318.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project src/ILInspector.Research.Tests -c Release --no-build -- -filter "/*/*/ResearchDiffTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -filter "/*/*/ReturnToSenderEvidenceTests/*"`

## Review

Adversarial review pending for the Research/RTS evidence surface change.
