### PR TITLE
Add fixture sidecar asset support

### DIFF
--- a/src/runfaster.Tests/E2EFixtureTests.cs
+++ b/src/runfaster.Tests/E2EFixtureTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Diagnostics;
 using System.Reflection;
+using DotnetInspector.Fixtures;
 using Xunit;
 
 namespace runfaster.Tests;
@@ -11,9 +12,8 @@ public class E2EFixtureTests
     [Fact]
     public void Correlate_WithNetTrace_JoinsByMethodTokenAndIlOffset()
     {
-        string fixtureDir = Path.Combine(AppContext.BaseDirectory, "Fixtures", "RunFaster.AllocationFixture");
-        string tracePath = Path.Combine(fixtureDir, "fixture.nettrace");
-        string assemblyPath = Path.Combine(AppContext.BaseDirectory, "RunFaster.AllocationFixture.dll");
+        string tracePath = FixtureCatalog.RunFasterAllocation.AssetPath("fixture.nettrace");
+        string assemblyPath = FixtureCatalog.RunFasterAllocation.AssemblyPath();
         string runfasterDll = Path.Combine(AppContext.BaseDirectory, "runfaster.dll");
         var allocateOne = typeof(RunFaster.AllocationFixture.Program).GetMethod(
             "AllocateOne",

--- a/src/runfaster.Tests/runfaster.Tests.csproj
+++ b/src/runfaster.Tests/runfaster.Tests.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\runfaster\runfaster.csproj" />
     <ProjectReference Include="Fixtures\RunFaster.AllocationFixture\RunFaster.AllocationFixture.csproj" ReferenceOutputAssembly="true" />
+    <ProjectReference Include="..\..\tests\DotnetInspector.Fixtures\DotnetInspector.Fixtures.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
+++ b/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
@@ -79,6 +79,25 @@ public class FixtureCatalogTests
     }
 
     [Fact]
+    public void SidecarAssets_ResolveTraceCoupledRunFasterAsset()
+    {
+        var fixture = FixtureCatalog.RunFasterAllocation;
+
+        Assert.Contains("trace-coupled", fixture.Tags);
+        var asset = Assert.Single(fixture.Assets);
+        Assert.Equal("fixture.nettrace", asset.Name);
+        Assert.EndsWith(Path.Combine("Fixtures", "RunFaster.AllocationFixture", "fixture.nettrace"), fixture.AssetPath(asset.Name));
+    }
+
+    [Fact]
+    public void SidecarAssets_UnknownAssetFailsClearly()
+    {
+        var error = Assert.Throws<ArgumentException>(() => FixtureCatalog.RunFasterAllocation.AssetPath("missing"));
+
+        Assert.Contains("Fixture 'runfaster.allocation' has no asset named 'missing'", error.Message);
+    }
+
+    [Fact]
     public void AssemblyNameAxisFixtures_ResolveIntentionalFileNames()
     {
         AssertFixtureFileName(FixtureCatalog.AnalysisProtobuf, "Google.Protobuf.dll");

--- a/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
+++ b/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
@@ -4,10 +4,14 @@ public sealed record FixtureDefinition(
     string Id,
     string ProjectName,
     string AssemblyFileName,
-    IReadOnlyList<string> Tags)
+    IReadOnlyList<string> Tags,
+    IReadOnlyList<FixtureAsset> Assets)
 {
     public string AssemblyPath() => FixtureCatalog.AssemblyPath(Id);
+    public string AssetPath(string name) => FixtureCatalog.AssetPath(Id, name);
 }
+
+public sealed record FixtureAsset(string Name, string ProjectName, string RelativePath);
 
 public sealed record FixturePair(string Id, FixtureDefinition Old, FixtureDefinition New)
 {
@@ -267,7 +271,8 @@ public static class FixtureCatalog
         FixtureIds.RunFasterAllocation,
         "RunFaster.AllocationFixture",
         "RunFaster.AllocationFixture.dll",
-        "runfaster", "allocation", "trace-coupled");
+        ["runfaster", "allocation", "trace-coupled"],
+        Asset("fixture.nettrace", "runfaster.Tests", "Fixtures/RunFaster.AllocationFixture/fixture.nettrace"));
 
     public static readonly IReadOnlyList<FixtureDefinition> All =
     [
@@ -438,8 +443,39 @@ public static class FixtureCatalog
             path);
     }
 
+    public static string AssetPath(string id, string assetName)
+    {
+        var fixture = Get(id);
+        var asset = fixture.Assets.FirstOrDefault(asset => asset.Name == assetName);
+        if (asset is null)
+            throw new ArgumentException($"Fixture '{id}' has no asset named '{assetName}'.", nameof(assetName));
+
+        string configuration = CurrentConfiguration();
+        string root = RepositoryRoot();
+        string path = Path.Combine(
+            root,
+            "artifacts",
+            "bin",
+            asset.ProjectName,
+            configuration,
+            asset.RelativePath.Replace('/', Path.DirectorySeparatorChar));
+
+        if (File.Exists(path))
+            return path;
+
+        throw new FileNotFoundException(
+            $"Expected built fixture asset '{fixture.Id}/{asset.Name}' at {path}. Run 'dotnet build dotnet-inspect.slnx -c Release' before running harnesses or tests that consume fixture assets.",
+            path);
+    }
+
     static FixtureDefinition Fixture(string id, string projectName, string assemblyFileName, params string[] tags)
-        => new(id, projectName, assemblyFileName, tags);
+        => new(id, projectName, assemblyFileName, tags, []);
+
+    static FixtureDefinition Fixture(string id, string projectName, string assemblyFileName, string[] tags, params FixtureAsset[] assets)
+        => new(id, projectName, assemblyFileName, tags, assets);
+
+    static FixtureAsset Asset(string name, string projectName, string relativePath)
+        => new(name, projectName, relativePath);
 
     static string CurrentConfiguration()
     {


### PR DESCRIPTION
## Change

Adds explicit sidecar asset metadata to `DotnetInspector.Fixtures` and attaches the runfaster allocation fixture trace:

- `FixtureAsset` metadata (`Name`, producer project, relative path)
- `FixtureDefinition.Assets` and `FixtureDefinition.AssetPath(name)`
- `FixtureCatalog.AssetPath(id, name)` with the same built-artifact resolution discipline as assembly paths
- `runfaster.allocation` now declares `fixture.nettrace` as a trace-coupled sidecar

Migrates `src/runfaster.Tests/E2EFixtureTests.cs` to resolve both `RunFaster.AllocationFixture.dll` and `fixture.nettrace` through `FixtureCatalog`. Keeps the runfaster product DLL resolution unchanged.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity minimal
dotnet run --project tests/DotnetInspector.Fixtures.Tests -c Release --no-build
dotnet run --project src/runfaster.Tests -c Release --no-build -- -filter "/*/*/E2EFixtureTests/*"
dotnet build dotnet-inspect.slnx -c Debug --configfile nuget.config --verbosity minimal
dotnet run --project tests/DotnetInspector.Fixtures.Tests -c Debug --no-build
dotnet run --project src/runfaster.Tests -c Debug --no-build -- -filter "/*/*/E2EFixtureTests/*"
git diff --check
```

Fixture/test infrastructure only; no product behavior change.
