### PR TITLE
Make C# diff operations producer-owned

### DIFF
--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -543,6 +543,9 @@ public class CSharpBodyDiffTests
         Assert.Equal("csharp.method.removed", row.ChangeId);
         Assert.Equal("Removed C# method.", row.Message);
         Assert.Equal("/* method removed */", row.Text);
+        Assert.Equal(CSharpDiffOperationKind.Method, row.OldOperation?.Kind);
+        Assert.Equal("/* method removed */", row.OldOperation?.Value);
+        Assert.Null(row.NewOperation);
         Assert.Null(row.SourceCoordinate);
     }
 
@@ -559,6 +562,9 @@ public class CSharpBodyDiffTests
         Assert.Equal("csharp.method.body-added", row.ChangeId);
         Assert.Equal("Added C# method body.", row.Message);
         Assert.Equal("/* method body added */", row.Text);
+        Assert.Null(row.OldOperation);
+        Assert.Equal(CSharpDiffOperationKind.MethodBody, row.NewOperation?.Kind);
+        Assert.Equal("/* method body added */", row.NewOperation?.Value);
         Assert.Null(row.SourceCoordinate);
     }
 
@@ -575,6 +581,9 @@ public class CSharpBodyDiffTests
         Assert.Equal("csharp.method.body-removed", row.ChangeId);
         Assert.Equal("Removed C# method body.", row.Message);
         Assert.Equal("/* method body removed */", row.Text);
+        Assert.Equal(CSharpDiffOperationKind.MethodBody, row.OldOperation?.Kind);
+        Assert.Equal("/* method body removed */", row.OldOperation?.Value);
+        Assert.Null(row.NewOperation);
         Assert.Null(row.SourceCoordinate);
     }
 

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -793,7 +793,7 @@ public static class CSharpBodyDiff
         string text = kind == CSharpDiffKind.Add ? "/* method added */" : "/* method removed */";
         string changeId = kind == CSharpDiffKind.Add ? "csharp.method.added" : "csharp.method.removed";
         string message = kind == CSharpDiffKind.Add ? "Added C# method." : "Removed C# method.";
-        rows.Add(CreateRow(entry, hunk, kind, null, "NotRun", text, changeId, message));
+        rows.Add(CreateRow(entry, hunk, kind, null, "NotRun", text, changeId, message, operationKind: CSharpDiffOperationKind.Method));
     }
 
     static void AddLineDiffRows(
@@ -818,8 +818,8 @@ public static class CSharpBodyDiff
         {
             int hunk = hunkId++;
             string message = $"/* C# diff skipped: old body has {oldLines.Length} lines, new body has {newLines.Length} lines; limit is {MaxLcsLines} */";
-            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), message, "csharp.body-diff.skipped", "Skipped C# body diff; old body exceeds line limit."));
-            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), message, "csharp.body-diff.skipped", "Skipped C# body diff; new body exceeds line limit."));
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), message, "csharp.body-diff.skipped", "Skipped C# body diff; old body exceeds line limit.", operationKind: CSharpDiffOperationKind.BodyDiffSkipped));
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), message, "csharp.body-diff.skipped", "Skipped C# body diff; new body exceeds line limit.", operationKind: CSharpDiffOperationKind.BodyDiffSkipped));
             return;
         }
 
@@ -868,28 +868,28 @@ public static class CSharpBodyDiff
         int hunk = hunkId++;
         if (oldRender.State is CSharpMethodRenderState.Body && newRender.State is CSharpMethodRenderState.NoBody)
         {
-            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), "/* method body removed */", "csharp.method.body-removed", "Removed C# method body."));
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), "/* method body removed */", "csharp.method.body-removed", "Removed C# method body.", operationKind: CSharpDiffOperationKind.MethodBody));
             return;
         }
 
         if (oldRender.State is CSharpMethodRenderState.NoBody && newRender.State is CSharpMethodRenderState.Body)
         {
-            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), "/* method body added */", "csharp.method.body-added", "Added C# method body."));
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), "/* method body added */", "csharp.method.body-added", "Added C# method body.", operationKind: CSharpDiffOperationKind.MethodBody));
             return;
         }
 
         if (oldRender.State is CSharpMethodRenderState.Failed)
-            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), oldRender.Lines[0], "csharp.decompile.failed", "Old method body decompilation failed."));
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), oldRender.Lines[0], "csharp.decompile.failed", "Old method body decompilation failed.", operationKind: CSharpDiffOperationKind.DecompileFailure));
         if (newRender.State is CSharpMethodRenderState.Failed)
-            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), newRender.Lines[0], "csharp.decompile.failed", "New method body decompilation failed."));
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), newRender.Lines[0], "csharp.decompile.failed", "New method body decompilation failed.", operationKind: CSharpDiffOperationKind.DecompileFailure));
         if (oldRender.State is CSharpMethodRenderState.NoBody)
-            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), oldRender.Lines[0], "csharp.method.no-body", "Old method has no C# body."));
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), oldRender.Lines[0], "csharp.method.no-body", "Old method has no C# body.", operationKind: CSharpDiffOperationKind.MethodBody));
         if (newRender.State is CSharpMethodRenderState.NoBody)
-            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), newRender.Lines[0], "csharp.method.no-body", "New method has no C# body."));
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), newRender.Lines[0], "csharp.method.no-body", "New method has no C# body.", operationKind: CSharpDiffOperationKind.MethodBody));
         if (oldRender.State is CSharpMethodRenderState.Body)
-            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), "/* method body removed */", "csharp.method.body-removed", "Removed C# method body."));
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), "/* method body removed */", "csharp.method.body-removed", "Removed C# method body.", operationKind: CSharpDiffOperationKind.MethodBody));
         if (newRender.State is CSharpMethodRenderState.Body)
-            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), "/* method body added */", "csharp.method.body-added", "Added C# method body."));
+            rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), "/* method body added */", "csharp.method.body-added", "Added C# method body.", operationKind: CSharpDiffOperationKind.MethodBody));
     }
 
     static CSharpDiffRow CreateRow(
@@ -900,8 +900,9 @@ public static class CSharpBodyDiff
         string fidelity,
         string text,
         string? changeId = null,
-        string? message = null)
-        => CreateRow(entry, hunk, kind, line, fidelity, text, changeId, message, oldValue: null, newValue: null);
+        string? message = null,
+        CSharpDiffOperationKind operationKind = CSharpDiffOperationKind.Line)
+        => CreateRow(entry, hunk, kind, line, fidelity, text, changeId, message, oldValue: null, newValue: null, operationKind);
 
     static CSharpDiffRow CreateRow(
         CSharpMethodEntry entry,
@@ -913,7 +914,8 @@ public static class CSharpBodyDiff
         string? changeId,
         string? message,
         string? oldValue,
-        string? newValue)
+        string? newValue,
+        CSharpDiffOperationKind operationKind = CSharpDiffOperationKind.Line)
     {
         changeId ??= kind switch
         {
@@ -927,7 +929,6 @@ public static class CSharpBodyDiff
             CSharpDiffKind.Remove => $"Removed C# line '{text}'",
             _ => $"Changed C# line '{text}'",
         };
-        var operationKind = OperationKind(changeId);
         var oldOperation = kind is CSharpDiffKind.Remove or CSharpDiffKind.Changed
             ? new CSharpDiffOperation(operationKind, oldValue ?? text)
             : null;
@@ -951,25 +952,6 @@ public static class CSharpBodyDiff
             newValue,
             oldOperation,
             newOperation);
-    }
-
-    static CSharpDiffOperationKind OperationKind(string changeId)
-    {
-        if (changeId.StartsWith("csharp.switch.case.", StringComparison.Ordinal))
-            return CSharpDiffOperationKind.SwitchCase;
-        if (changeId == "csharp.return-expression.changed")
-            return CSharpDiffOperationKind.ReturnExpression;
-        if (changeId == "csharp.call.changed")
-            return CSharpDiffOperationKind.Invocation;
-        if (changeId is "csharp.method.added" or "csharp.method.removed")
-            return CSharpDiffOperationKind.Method;
-        if (changeId.StartsWith("csharp.method.", StringComparison.Ordinal))
-            return CSharpDiffOperationKind.MethodBody;
-        if (changeId == "csharp.decompile.failed")
-            return CSharpDiffOperationKind.DecompileFailure;
-        if (changeId == "csharp.body-diff.skipped")
-            return CSharpDiffOperationKind.BodyDiffSkipped;
-        return CSharpDiffOperationKind.Line;
     }
 
     static void AddSemanticRows(
@@ -1000,7 +982,8 @@ public static class CSharpBodyDiff
                     "csharp.switch.case.removed",
                     $"Removed switch case '{label}'",
                     oldValue: label,
-                    newValue: null));
+                    newValue: null,
+                    operationKind: CSharpDiffOperationKind.SwitchCase));
             }
         }
 
@@ -1018,7 +1001,8 @@ public static class CSharpBodyDiff
                     "csharp.switch.case.added",
                     $"Added switch case '{label}'",
                     oldValue: null,
-                    newValue: label));
+                    newValue: label,
+                    operationKind: CSharpDiffOperationKind.SwitchCase));
             }
         }
 
@@ -1033,6 +1017,7 @@ public static class CSharpBodyDiff
             newStart,
             newEnd,
             TryParseReturnExpression,
+            CSharpDiffOperationKind.ReturnExpression,
             "csharp.return-expression.changed",
             static (oldValue, newValue) => $"Changed return expression from '{oldValue}' to '{newValue}'");
 
@@ -1047,6 +1032,7 @@ public static class CSharpBodyDiff
             newStart,
             newEnd,
             TryParseCallExpression,
+            CSharpDiffOperationKind.Invocation,
             "csharp.call.changed",
             static (oldValue, newValue) => $"Changed call from '{oldValue}' to '{newValue}'");
     }
@@ -1064,6 +1050,7 @@ public static class CSharpBodyDiff
         int newStart,
         int newEnd,
         TryParseLine parser,
+        CSharpDiffOperationKind operationKind,
         string changeId,
         Func<string, string, string> messageFactory)
     {
@@ -1089,7 +1076,8 @@ public static class CSharpBodyDiff
                 changeId,
                 messageFactory(oldValue.Value, newValue.Value),
                 oldValue.Value,
-                newValue.Value));
+                newValue.Value,
+                operationKind));
         }
     }
 


### PR DESCRIPTION
## Summary

Makes C# diff structured operation kinds producer-owned instead of inferred from `ChangeId`.

## Details

- Removes the `ChangeId` -> `CSharpDiffOperationKind` mapper from `CSharpBodyDiff`.
- Passes explicit operation kinds from each row-producing path:
  - line rows default to `Line`;
  - method add/remove rows use `Method`;
  - body state rows use `MethodBody`;
  - decompile failures and body-diff skips use their dedicated operation kinds;
  - semantic switch/return/invocation rows pass their typed operation kind at the producer site.
- Extends tests for method/body-state rows so non-line operation kinds are covered.

This continues the IL differ direction: row producers own typed evidence; `ChangeId` and printer text are projection metadata, not the semantic substrate.

## IL differ watch

Current `main` also has IL typed failure rows (`IlDiffFailureRow` / `IlDiffDisplayFailureRow`). I kept this PR scoped to explicit C# operation production; C# failure-row parity is a good next slice if we want to align failed/decompile/no-body evidence with the newer IL failure-row shape.

## Validation

- `dotnet run --project src/ILInspector.Research.Tests -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/DiffCommandTests/*"`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity minimal`
- `git diff --check`

## Review

Adversarial review is required for this Research/C# diff shape change and will be posted before marking ready.
