### PR TITLE
Summarize actionable RTS Research subjects

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1171,6 +1171,10 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("rts.status.fail: 1", report);
         Assert.Contains("il.operation.added: 1", report);
         Assert.Contains("il.operation.removed: 1", report);
+        Assert.Contains("Actionable subjects (first 1", report);
+        Assert.Contains("Method1~abcdef1234  rts=OpcodeDiff  detail=opcode-diff", report);
+        Assert.Contains("      il.operation.added: 1", report);
+        Assert.Contains("      il.operation.removed: 1", report);
     }
 
     [Fact]
@@ -1320,6 +1324,11 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains(rows, row =>
             row.GetProperty("Offset").GetString()?.StartsWith("IL_", StringComparison.Ordinal) == true
             && row.GetProperty("OpcodeFamily").GetString() is { Length: > 0 });
+        var summary = document.RootElement.GetProperty("ResearchSummary");
+        Assert.Equal(1, summary.GetProperty("FailingMembers").GetInt32());
+        Assert.Equal(1, summary.GetProperty("OpcodeDiffMembers").GetInt32());
+        var actionable = Assert.Single(summary.GetProperty("ActionableSubjects").EnumerateArray());
+        Assert.StartsWith("Method1~", actionable.GetProperty("SubjectId").GetString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -2354,6 +2354,7 @@ internal static class GeneratedFixtureRunner
         sb.AppendLine($"  Failed : {failedTargets}");
 
         var research = ReturnToSenderEvidence.ToResearchDiff(ReturnToSenderEvidence.FromCatalog(run));
+        var researchSummary = ReturnToSenderEvidence.Summarize(research, maxExamples);
         var researchEvidence = research.Subjects.SelectMany(subject => subject.Evidence).ToArray();
         if (researchEvidence.Length != 0)
         {
@@ -2368,6 +2369,19 @@ internal static class GeneratedFixtureRunner
                 .ThenBy(group => group.Key, StringComparer.Ordinal))
             {
                 sb.AppendLine($"  {group.Key}: {group.Count()}");
+            }
+        }
+
+        if (researchSummary.ActionableSubjects.Count != 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"Actionable subjects (first {researchSummary.ActionableSubjects.Count}):");
+            foreach (var subject in researchSummary.ActionableSubjects)
+            {
+                string status = subject.CompileBackStatus ?? subject.RtsStatus ?? "unknown";
+                sb.AppendLine($"  {subject.SubjectId}  rts={status}  detail={subject.Detail ?? "-"}");
+                foreach (var count in subject.ChangeCounts)
+                    sb.AppendLine($"      {count.ChangeId}: {count.Count}");
             }
         }
 
@@ -2457,12 +2471,14 @@ internal static class GeneratedFixtureRunner
 
     public static string FormatReturnToSenderCatalogJson(GeneratedFixtureReturnToSenderRunResult run)
     {
+        var research = ReturnToSenderEvidence.ToResearchDiff(ReturnToSenderEvidence.FromCatalog(run));
         var payload = new
         {
             ProjectDirectory = Directory.Exists(run.ProjectDirectory) ? run.ProjectDirectory : null,
             AssemblyPath = File.Exists(run.AssemblyPath) ? run.AssemblyPath : null,
             run.Results,
-            ResearchDiff = ReturnToSenderEvidence.ToResearchDiff(ReturnToSenderEvidence.FromCatalog(run)),
+            ResearchDiff = research,
+            ResearchSummary = ReturnToSenderEvidence.Summarize(research, int.MaxValue),
             run.Passed,
         };
         return JsonSerializer.Serialize(payload, s_jsonOptions);

--- a/tools/DecompilerHarness/ReturnToSenderEvidence.cs
+++ b/tools/DecompilerHarness/ReturnToSenderEvidence.cs
@@ -18,6 +18,27 @@ internal sealed record ReturnToSenderEvidenceRow(
     public string DisplayMember => $"{Type}::{Method}#{Overload}";
 }
 
+internal sealed record ReturnToSenderResearchSummary(
+    int Subjects,
+    int RtsRows,
+    int IlRows,
+    int FailingMembers,
+    int OpcodeDiffMembers,
+    int RecompileFailMembers,
+    int ContextFailMembers,
+    int MembersWithIlEvidence,
+    IReadOnlyList<ReturnToSenderActionableSubject> ActionableSubjects);
+
+internal sealed record ReturnToSenderActionableSubject(
+    string SubjectId,
+    string Display,
+    string? RtsStatus,
+    string? CompileBackStatus,
+    string? Detail,
+    IReadOnlyList<ReturnToSenderChangeCount> ChangeCounts);
+
+internal sealed record ReturnToSenderChangeCount(string ChangeId, int Count);
+
 internal static class ReturnToSenderEvidence
 {
     public static IReadOnlyList<ReturnToSenderEvidenceRow> FromCatalog(GeneratedFixtureReturnToSenderRunResult run)
@@ -46,6 +67,71 @@ internal static class ReturnToSenderEvidence
             .ToArray();
         return new ResearchDiffResult(subjects, Rows: []);
     }
+
+    public static ReturnToSenderResearchSummary Summarize(ResearchDiffResult research, int maxSubjects)
+    {
+        ArgumentNullException.ThrowIfNull(research);
+        var subjects = research.Subjects;
+        var evidence = subjects.SelectMany(subject => subject.Evidence).ToArray();
+        var actionable = subjects
+            .Select(ActionableSubject)
+            .Where(subject => subject is not null)
+            .Select(subject => subject!)
+            .OrderBy(subject => Rank(subject))
+            .ThenBy(subject => subject.SubjectId, StringComparer.Ordinal)
+            .Take(Math.Max(0, maxSubjects))
+            .ToArray();
+
+        return new ReturnToSenderResearchSummary(
+            subjects.Count,
+            evidence.Count(item => item.Mechanism == ResearchDiffMechanism.ReturnToSender),
+            evidence.Count(item => item.Mechanism == ResearchDiffMechanism.IlBody),
+            subjects.Count(subject => HasRtsStatus(subject, "rts.status.fail")),
+            subjects.Count(subject => HasCompileBackStatus(subject, "OpcodeDiff")),
+            subjects.Count(subject => HasCompileBackStatus(subject, "RecompileFail")),
+            subjects.Count(subject => HasCompileBackStatus(subject, "ContextFail")),
+            subjects.Count(subject => subject.Evidence.Any(item => item.Mechanism == ResearchDiffMechanism.IlBody)),
+            actionable);
+    }
+
+    static ReturnToSenderActionableSubject? ActionableSubject(ResearchSubjectDiff subject)
+    {
+        var rts = subject.Evidence.FirstOrDefault(item => item.Mechanism == ResearchDiffMechanism.ReturnToSender);
+        if (rts is null || rts.ChangeId == "rts.status.pass")
+            return null;
+
+        var changeCounts = subject.Evidence
+            .Where(item => item.Mechanism != ResearchDiffMechanism.ReturnToSender)
+            .GroupBy(item => item.ChangeId, StringComparer.Ordinal)
+            .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key, StringComparer.Ordinal)
+            .Select(group => new ReturnToSenderChangeCount(group.Key, group.Count()))
+            .ToArray();
+        return new ReturnToSenderActionableSubject(
+            subject.Subject.Id,
+            subject.Subject.Display,
+            rts.ChangeId,
+            rts.NewValue,
+            rts.Detail,
+            changeCounts);
+    }
+
+    static bool HasRtsStatus(ResearchSubjectDiff subject, string changeId)
+        => subject.Evidence.Any(item => item.Mechanism == ResearchDiffMechanism.ReturnToSender && item.ChangeId == changeId);
+
+    static bool HasCompileBackStatus(ResearchSubjectDiff subject, string status)
+        => subject.Evidence.Any(item =>
+            item.Mechanism == ResearchDiffMechanism.ReturnToSender
+            && string.Equals(item.NewValue, status, StringComparison.Ordinal));
+
+    static int Rank(ReturnToSenderActionableSubject subject)
+        => subject.CompileBackStatus switch
+        {
+            "RecompileFail" => 0,
+            "ContextFail" => 1,
+            "OpcodeDiff" => 2,
+            _ => 3,
+        };
 
     static ResearchSubjectKey SubjectKey(ReturnToSenderEvidenceRow row)
     {


### PR DESCRIPTION
## Summary

- add a compact RTS `ResearchSummary` derived from `ReturnToSenderEvidence.ToResearchDiff(...)`
- show capped `Actionable subjects` in generated RTS catalog reports
- include the summary in generated RTS catalog JSON
- keep existing RTS pass/fail classification unchanged

This makes the ResearchDiff evidence in RTS logs directly actionable without parsing report text or changing gates.

## Validation

```text
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-restore -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-restore -- -filter "/*/*/ReturnToSenderEvidenceTests/*"
dotnet run --project src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj -c Release --no-restore -- -filter "/*/*/ResearchDiffTests/*"
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet
```
