### PR TITLE
Harden enum operand casts in checked contexts

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -708,6 +708,103 @@ public class CoerceChokePointTests
         AssertCompiles("public static int M(bool c, IFlags f, int x)", body, "public enum IFlags { }");
     }
 
+    [Fact]
+    public void IntBackedEnumOperand_InCheckedRegion_StaysBare()
+    {
+        // #2338 B5: the operand-shaped enum cast shares the same checked-region
+        // rule. int -> int-backed enum cannot throw in checked C#.
+        var enumType = TypeRef.Definition("synthetic", "", "IFlags");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var comparison = new Comparison(
+            ComparisonKind.Equal,
+            isUnsigned: false,
+            new LoadArgument(0, "f", enumType),
+            new LoadArgument(1, "raw", intType));
+        var checkedAdd = new Binary(
+            BinaryKind.Add,
+            isChecked: true,
+            isUnsigned: false,
+            new LoadArgument(2, "x", intType),
+            new Coerce(intType, comparison));
+        string body = RenderReturn(
+            checkedAdd,
+            intType,
+            [new Parameter("f", enumType), new Parameter("raw", intType), new Parameter("x", intType)],
+            enumType,
+            underlying: intType);
+
+        Assert.Contains("(IFlags)raw", body);
+        Assert.DoesNotContain("unchecked((IFlags)raw)", body);
+        AssertCompiles("public static int M(IFlags f, int raw, int x)", body, "public enum IFlags { }");
+    }
+
+    [Fact]
+    public void ByteBackedEnumOperand_InCheckedRegion_WrapsUnchecked()
+    {
+        var enumType = TypeRef.Definition("synthetic", "", "Tiny");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var byteType = TypeRef.CoreLib("System", "Byte");
+        var comparison = new Comparison(
+            ComparisonKind.Equal,
+            isUnsigned: false,
+            new LoadArgument(0, "f", enumType),
+            new LoadArgument(1, "raw", intType));
+        var checkedAdd = new Binary(
+            BinaryKind.Add,
+            isChecked: true,
+            isUnsigned: false,
+            new LoadArgument(2, "x", intType),
+            new Coerce(intType, comparison));
+        string body = RenderReturn(
+            checkedAdd,
+            intType,
+            [new Parameter("f", enumType), new Parameter("raw", intType), new Parameter("x", intType)],
+            enumType,
+            underlying: byteType);
+
+        Assert.Contains("unchecked((Tiny)raw)", body);
+        AssertCompiles("public static int M(Tiny f, int raw, int x)", body, "public enum Tiny : byte { }");
+    }
+
+    [Fact]
+    public void BoolEnumOperand_InCheckedRegion_StaysBare()
+    {
+        var enumType = TypeRef.Definition("synthetic", "", "Tiny");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var byteType = TypeRef.CoreLib("System", "Byte");
+        var boolComparison = new Comparison(
+            ComparisonKind.Equal,
+            isUnsigned: false,
+            new LoadArgument(1, "a", intType),
+            new LoadArgument(2, "b", intType));
+        var enumComparison = new Comparison(
+            ComparisonKind.Equal,
+            isUnsigned: false,
+            new LoadArgument(0, "f", enumType),
+            boolComparison);
+        var checkedAdd = new Binary(
+            BinaryKind.Add,
+            isChecked: true,
+            isUnsigned: false,
+            new LoadArgument(3, "x", intType),
+            new Coerce(intType, enumComparison));
+        string body = RenderReturn(
+            checkedAdd,
+            intType,
+            [
+                new Parameter("f", enumType),
+                new Parameter("a", intType),
+                new Parameter("b", intType),
+                new Parameter("x", intType),
+            ],
+            enumType,
+            underlying: byteType);
+
+        Assert.Contains("(Tiny)(a == b ? 1 : 0)", body);
+        Assert.DoesNotContain("unchecked((Tiny)(a == b ? 1 : 0))", body);
+        AssertCompiles("public static int M(Tiny f, int a, int b, int x)", body, "public enum Tiny : byte { }");
+    }
+
     // The CI-caught dual pair: an enum->underlying cast in a checked region
     // wraps only when the checked conversion can actually throw. Identity
     // (int-backed -> int) stays bare — EnumUnderlyingCastTests pins that side;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -209,9 +209,24 @@ public sealed partial class CSharpPrinter
         bool negativeLiteral = value is Constant { Value: int iv } && iv < 0
             || value is Constant { Value: long lv } && lv < 0;
         bool forceUnchecked = MayOverflowEnumBackingType(value, enumType);
-        return CheckedSafeCast(
+        return CheckedSafeEnumCast(
+            value,
+            enumType,
             () => $"({TypeText(enumType)}){(negativeLiteral ? $"({Operand(value)})" : Operand(value))}",
             force: forceUnchecked);
+    }
+
+    string CheckedSafeEnumCast(IrExpression value, TypeRef enumType, Func<string> renderCast, bool force = false)
+    {
+        if (force)
+            return CheckedSafeCast(renderCast, force: true);
+        // A bool composition is always 0/1, fitting every enum backing type.
+        if (TypeFamilies.IsBoolean(EffectiveType(value)))
+            return renderCast();
+        var underlying = EnumUnderlyingType(enumType);
+        return underlying is not null && !TypeFamilies.CheckedConversionCanThrow(EffectiveType(value), underlying)
+            ? renderCast()
+            : CheckedSafeCast(renderCast);
     }
 
     /// <summary>
@@ -249,7 +264,7 @@ public sealed partial class CSharpPrinter
         if (enumSide is null || !IsEnumLikeInteger(enumSide))
             return null;
         if (TypeFamilies.IsBoolean(EffectiveType(value)))
-            return CheckedSafeCast(() => $"({TypeText(enumSide)})({Condition(value)} ? 1 : 0)");
+            return CheckedSafeEnumCast(value, enumSide, () => $"({TypeText(enumSide)})({Condition(value)} ? 1 : 0)");
         if (value.ResultType is not { } valueType || !TypeFamilies.IsIntegerLike(valueType))
             return null;
         return value is Constant { Value: int or long } konst


### PR DESCRIPTION
Advances #2338 (B5)

## Change

**Conclusion:** **PASS** — this closes the enum-cast part of B5's checked-region hazard audit without changing corpus-rendered text.

`TryCoerceEnumOperand` and `EnumIntegerCast` now share the checked-region decision used by the other numeric exits:

- int → int-backed enum casts stay bare inside checked regions because they cannot throw;
- bool-composed enum casts stay bare because they are always `0`/`1` and fit every enum backing type;
- byte-backed/nonconstant enum casts still wrap in `unchecked(...)` because checked conversion can throw.

This PR does **not** take work-2306-owned join-natural-type items.

## Evidence

| Check | Result |
| --- | --- |
| Focused enum checked-exit tests | Pass: `IntBackedEnumOperand_InCheckedRegion_StaysBare`, `ByteBackedEnumOperand_InCheckedRegion_WrapsUnchecked`, `BoolEnumOperand_InCheckedRegion_StaysBare` |
| Sibling checked-exit tests | Pass: `CheckedUncheckedInsertTests`, `ShiftCountRenderingTests`, `MixedSignComparisonTests`, `CoerceChokePointTests` |
| Decompiler fast suite | Pass: 1,893 tests with `-trait- "Speed=Slow"` |
| Solution build | Pass: `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore --verbosity minimal` |
| Render A/B | Pass: 89,065 methods evaluated, 0 changed |

## Decompiler quality

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 350 methods (compile-cap 25; per-sample, not corpus-wide); fidelity sampled 24 / 89,065 (0.03%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,405 (88.03%) | +6 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — 25,179 compiled methods | 1/350 — 350 compiled methods | -73 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 3/24, exact 21, recompile-failed 0, context-failed 0; sampled 24 / 89,065 (0.03%) | -2 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.03% (+0.01 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 3 (-2).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25179, current 350)
- fidelity checked methods lower than baseline (baseline 36, current 24)
QUALITY_CARD_EXIT=1

The quality card exits nonzero only because this PR quick run uses lower validity/fidelity caps than the daily baseline. The pinned subset improves: fully raised +0.01 pp, conditional residual unchanged, Full malformed 0, opcode diffs 5 -> 3.

## Review

Adversarial reviews pending. I will post the two-review reconciliation before marking ready.
