### PR TITLE
Render RTS Research IL display evidence

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1175,6 +1175,80 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("Method1~abcdef1234  rts=OpcodeDiff  detail=opcode-diff", report);
         Assert.Contains("      il.operation.added: 1", report);
         Assert.Contains("      il.operation.removed: 1", report);
+        Assert.Contains("      il-display:", report);
+        Assert.Contains("        il.operation.removed: h0 - IL_0000 ldc.i4 1", report);
+        Assert.Contains("        il.operation.added: h0 + IL_0000 ldc.i4 2", report);
+
+        string json = GeneratedFixtureRunner.FormatReturnToSenderCatalogJson(run);
+        using var document = JsonDocument.Parse(json);
+        var actionable = Assert.Single(document.RootElement
+            .GetProperty("ResearchSummary")
+            .GetProperty("ActionableSubjects")
+            .EnumerateArray());
+        var ilEvidence = actionable.GetProperty("IlEvidence").EnumerateArray().ToArray();
+        Assert.Contains(ilEvidence, evidence =>
+            evidence.GetProperty("ChangeId").GetString() == "il.operation.removed"
+            && evidence.GetProperty("Rows").EnumerateArray().Single().GetProperty("UnifiedLine").GetString() == "h0 - IL_0000 ldc.i4 1");
+        Assert.Contains(ilEvidence, evidence =>
+            evidence.GetProperty("ChangeId").GetString() == "il.operation.added"
+            && evidence.GetProperty("Rows").EnumerateArray().Single().GetProperty("UnifiedLine").GetString() == "h0 + IL_0000 ldc.i4 2");
+    }
+
+    [Fact]
+    public void ReturnToSenderCatalogReport_IncludesResearchIlFailureRows()
+    {
+        var failure = new IlDiffDisplayFailureRow(
+            IlDiffFailureKind.NewBodyMissing,
+            "new body missing",
+            Side: "new",
+            Detail: "method has no body");
+        var run = new GeneratedFixtureReturnToSenderRunResult(
+            ProjectDirectory: "",
+            AssemblyPath: "",
+            Results:
+            [
+                new GeneratedFixtureReturnToSenderResult(
+                    "test.il-diff-failure",
+                    "TestType",
+                    "Method1",
+                    Overload: 0,
+                    GeneratedFixtureReturnToSenderStatus.Fail,
+                    FidelityCheck.CompileBackStatus.OpcodeDiff,
+                    "opcode-diff",
+                    Detail: null,
+                    IlDiffDiagnostic: new IlDiffDisplayResult(
+                        Failure: failure.UnifiedLine,
+                        Rows: [],
+                        FailureRows: [failure]),
+                    MemberAnchor: new MemberAnchor(
+                        "Method1~abcdef1234",
+                        "M:TestType.Method1()",
+                        "abcdef1234",
+                        "TestType",
+                        "Method1"),
+                    IsFrontier: false,
+                    Note: null),
+            ]);
+
+        string report = GeneratedFixtureRunner.FormatReturnToSenderCatalogReport(run, maxExamples: 10);
+
+        Assert.Contains("      il-display:", report);
+        Assert.Contains("        il.diff.new-body-missing: IL diff failed: new body missing", report);
+
+        string json = GeneratedFixtureRunner.FormatReturnToSenderCatalogJson(run);
+        using var document = JsonDocument.Parse(json);
+        var actionable = Assert.Single(document.RootElement
+            .GetProperty("ResearchSummary")
+            .GetProperty("ActionableSubjects")
+            .EnumerateArray());
+        var evidence = Assert.Single(actionable.GetProperty("IlEvidence").EnumerateArray());
+        Assert.Equal("il.diff.new-body-missing", evidence.GetProperty("ChangeId").GetString());
+        var failureJson = evidence.GetProperty("Failure");
+        Assert.Equal("NewBodyMissing", failureJson.GetProperty("Kind").GetString());
+        Assert.Equal("new body missing", failureJson.GetProperty("Message").GetString());
+        Assert.Equal("new", failureJson.GetProperty("Side").GetString());
+        Assert.Equal("method has no body", failureJson.GetProperty("Detail").GetString());
+        Assert.Equal("IL diff failed: new body missing", failureJson.GetProperty("UnifiedLine").GetString());
     }
 
     [Fact]

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -2382,6 +2382,17 @@ internal static class GeneratedFixtureRunner
                 sb.AppendLine($"  {subject.SubjectId}  rts={status}  detail={subject.Detail ?? "-"}");
                 foreach (var count in subject.ChangeCounts)
                     sb.AppendLine($"      {count.ChangeId}: {count.Count}");
+                if (subject.IlEvidence.Count != 0)
+                {
+                    sb.AppendLine("      il-display:");
+                    foreach (var evidence in subject.IlEvidence)
+                    {
+                        if (evidence.Failure is { } failure)
+                            sb.AppendLine($"        {evidence.ChangeId}: {failure.UnifiedLine}");
+                        foreach (var row in evidence.Rows)
+                            sb.AppendLine($"        {evidence.ChangeId}: {row.UnifiedLine}");
+                    }
+                }
             }
         }
 
@@ -2476,13 +2487,91 @@ internal static class GeneratedFixtureRunner
         {
             ProjectDirectory = Directory.Exists(run.ProjectDirectory) ? run.ProjectDirectory : null,
             AssemblyPath = File.Exists(run.AssemblyPath) ? run.AssemblyPath : null,
-            run.Results,
-            ResearchDiff = research,
+            Results = run.Results.Select(SerializableReturnToSenderResult).ToArray(),
+            ResearchDiff = SerializableResearchDiff(research),
             ResearchSummary = ReturnToSenderEvidence.Summarize(research, int.MaxValue),
             run.Passed,
         };
         return JsonSerializer.Serialize(payload, s_jsonOptions);
     }
+
+    static object SerializableReturnToSenderResult(GeneratedFixtureReturnToSenderResult result)
+        => new
+        {
+            result.FixtureId,
+            result.Type,
+            result.Method,
+            result.Overload,
+            result.Status,
+            result.ActualStatus,
+            result.Reason,
+            result.Detail,
+            IlDiffDiagnostic = SerializableIlDiffDisplayResult(result.IlDiffDiagnostic),
+            result.MemberAnchor,
+            result.IsFrontier,
+            result.Note,
+            result.DisplayMember,
+        };
+
+    static object? SerializableIlDiffDisplayResult(IlDiffDisplayResult? result)
+        => result is null
+            ? null
+            : new
+            {
+                result.Failure,
+                Rows = result.Rows.IsDefault ? Array.Empty<IlDiffDisplayRow>() : result.Rows.ToArray(),
+                FailureRows = result.FailureRows.IsDefault ? Array.Empty<IlDiffDisplayFailureRow>() : result.FailureRows.ToArray(),
+                result.IsEmpty,
+            };
+
+    static object SerializableResearchDiff(ResearchDiffResult research)
+        => new
+        {
+            research.ApiDiff,
+            Subjects = research.Subjects.Select(subject => new
+            {
+                subject.Subject,
+                Evidence = subject.Evidence.Select(SerializableEvidence).ToArray(),
+            }).ToArray(),
+            Rows = research.Rows.IsDefault
+                ? Array.Empty<object>()
+                : research.Rows.Select(row => (object)new
+                {
+                    row.ChangeId,
+                    row.EvidenceKind,
+                    row.Message,
+                    row.ApiChange,
+                    row.IlRow,
+                    row.IlFailureRow,
+                    row.IlDisplayRow,
+                    row.IlDisplayFailureRow,
+                    row.BodySignalRow,
+                    row.CSharpRow,
+                }).ToArray(),
+        };
+
+    static object SerializableEvidence(ResearchDiffEvidence evidence)
+        => new
+        {
+            evidence.Mechanism,
+            evidence.ChangeId,
+            evidence.Direction,
+            evidence.OldValue,
+            evidence.NewValue,
+            evidence.Delta,
+            evidence.OldIlOffset,
+            evidence.NewIlOffset,
+            evidence.Detail,
+            evidence.Category,
+            evidence.Signal,
+            evidence.Shape,
+            evidence.Magnitude,
+            evidence.DirectionScore,
+            evidence.SubjectInBoth,
+            evidence.InLoop,
+            IlDisplayRows = evidence.IlDisplayRows.IsDefault ? Array.Empty<IlDiffDisplayRow>() : evidence.IlDisplayRows.ToArray(),
+            evidence.IlDisplayFailureRow,
+        };
 
     public static string FormatList(IReadOnlyList<GeneratedFixtureDefinition> fixtures)
     {

--- a/tools/DecompilerHarness/ReturnToSenderEvidence.cs
+++ b/tools/DecompilerHarness/ReturnToSenderEvidence.cs
@@ -35,9 +35,15 @@ internal sealed record ReturnToSenderActionableSubject(
     string? RtsStatus,
     string? CompileBackStatus,
     string? Detail,
-    IReadOnlyList<ReturnToSenderChangeCount> ChangeCounts);
+    IReadOnlyList<ReturnToSenderChangeCount> ChangeCounts,
+    IReadOnlyList<ReturnToSenderIlEvidence> IlEvidence);
 
 internal sealed record ReturnToSenderChangeCount(string ChangeId, int Count);
+
+internal sealed record ReturnToSenderIlEvidence(
+    string ChangeId,
+    IlDiffDisplayFailureRow? Failure,
+    IReadOnlyList<IlDiffDisplayRow> Rows);
 
 internal static class ReturnToSenderEvidence
 {
@@ -107,13 +113,22 @@ internal static class ReturnToSenderEvidence
             .ThenBy(group => group.Key, StringComparer.Ordinal)
             .Select(group => new ReturnToSenderChangeCount(group.Key, group.Count()))
             .ToArray();
+        var ilEvidence = subject.Evidence
+            .Where(item => item.Mechanism == ResearchDiffMechanism.IlBody
+                && (item.IlDisplayFailureRow is not null || !item.IlDisplayRows.IsDefaultOrEmpty))
+            .Select(item => new ReturnToSenderIlEvidence(
+                item.ChangeId,
+                item.IlDisplayFailureRow,
+                item.IlDisplayRows.IsDefault ? [] : item.IlDisplayRows.ToArray()))
+            .ToArray();
         return new ReturnToSenderActionableSubject(
             subject.Subject.Id,
             subject.Subject.Display,
             rts.ChangeId,
             rts.NewValue,
             rts.Detail,
-            changeCounts);
+            changeCounts,
+            ilEvidence);
     }
 
     static bool HasRtsStatus(ResearchSubjectDiff subject, string changeId)


### PR DESCRIPTION
## Summary

Projects Research-carried IL display evidence into RTS catalog output for #2318:

- includes typed IL display/failure evidence in `ReturnToSenderResearchSummary.ActionableSubjects`;
- renders producer-owned `UnifiedLine` values from Research evidence in the actionable Markdown section;
- serializes RTS catalog `Results`, `ResearchDiff`, and `ResearchSummary` through JSON-safe projections so default `ImmutableArray` fields do not throw;
- adds tests for operation rows and failure rows in Markdown and JSON.

Refs #2318.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*ReturnToSenderCatalog*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -filter "/*/*/ReturnToSenderEvidenceTests/*"`
- `dotnet run --project src/ILInspector.Research.Tests -c Release --no-build -- -filter "/*/*/ResearchDiffTests/*"`

## Review

Adversarial review pending for the RTS/Research reporting surface change.
