### PR TITLE
Avoid nested printer name collisions

### DIFF
--- a/src/ILInspector.Decompiler.Tests/NestedScopeNameCollisionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NestedScopeNameCollisionTests.cs
@@ -98,6 +98,32 @@ public class NestedScopeNameCollisionTests
     }
 
     [Fact]
+    public void OuterGeneratedName_AvoidsLocalFunctionName()
+    {
+        var localFunction = new LocalFunctionStatement(
+            "S_0",
+            Void,
+            [],
+            isStatic: false,
+            [],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            Body(new Return(null)));
+
+        string body = RenderBody(
+            [Int32],
+            new StoreStackSlot(0, new Constant(1, Int32)),
+            new StoreLocal(0, Int32, new LoadStackSlot(0, Int32)),
+            localFunction);
+
+        Assert.Contains("int S_0_1 = 1;", body);
+        Assert.Contains("void S_0()", body);
+        Assert.DoesNotContain("int S_0 = 1;", body);
+        AssertCompiles(body);
+    }
+
+    [Fact]
     public void DeepNestedLambda_CarriesGrandparentReservedNames()
     {
         var innerBody = Body(

--- a/src/ILInspector.Decompiler.Tests/NestedScopeNameCollisionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NestedScopeNameCollisionTests.cs
@@ -1,0 +1,151 @@
+using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+public class NestedScopeNameCollisionTests
+{
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
+    static readonly TypeRef Action = TypeRef.CoreLib("System", "Action");
+    static readonly TypeRef Owner = TypeRef.Definition("Synthetic", "", "Holder");
+
+    [Fact]
+    public void LambdaStackSlot_AvoidsOuterStackSlotName()
+    {
+        var lambdaBody = Body(
+            new StoreStackSlot(0, new Constant(2, Int32)),
+            new ExpressionStatement(new LoadStackSlot(0, Int32)));
+        var lambda = new Lambda(
+            Action,
+            [],
+            [],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            lambdaBody);
+
+        string body = RenderBody(
+            [Int32, Action],
+            new StoreStackSlot(0, new Constant(1, Int32)),
+            new StoreLocal(0, Int32, new LoadStackSlot(0, Int32)),
+            new StoreLocal(1, Action, lambda));
+
+        Assert.Contains("int S_0 = 1;", body);
+        Assert.Contains("int S_0_1 = 2;", body);
+        Assert.DoesNotContain("() => { int S_0 = 2;", body);
+        AssertCompiles(body);
+    }
+
+    [Fact]
+    public void LambdaFallbackLocal_AvoidsOuterFallbackLocalName()
+    {
+        var lambdaBody = Body(
+            new StoreLocal(0, Int32, new Constant(2, Int32)),
+            new ExpressionStatement(new LoadLocal(0, Int32)));
+        var lambda = new Lambda(
+            Action,
+            [],
+            [Int32],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            lambdaBody);
+
+        string body = RenderBody(
+            [Int32, Action],
+            new StoreLocal(0, Int32, new Constant(1, Int32)),
+            new StoreLocal(1, Action, lambda));
+
+        Assert.Contains("int V_0 = 1;", body);
+        Assert.Contains("int V_0_1 = 2;", body);
+        Assert.DoesNotContain("() => { int V_0 = 2;", body);
+        AssertCompiles(body);
+    }
+
+    [Fact]
+    public void LocalFunctionStackSlot_AvoidsOuterStackSlotName()
+    {
+        var localBody = Body(
+            new StoreStackSlot(0, new Constant(2, Int32)),
+            new ExpressionStatement(new LoadStackSlot(0, Int32)));
+        var localFunction = new LocalFunctionStatement(
+            "Inner",
+            Void,
+            [],
+            isStatic: false,
+            [],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            localBody);
+
+        string body = RenderBody(
+            [Int32],
+            new StoreStackSlot(0, new Constant(1, Int32)),
+            new StoreLocal(0, Int32, new LoadStackSlot(0, Int32)),
+            localFunction);
+
+        Assert.Contains("int S_0 = 1;", body);
+        Assert.Contains("int S_0_1 = 2;", body);
+        Assert.DoesNotContain("void Inner()\n    {\n        int S_0 = 2;", body);
+        AssertCompiles(body);
+    }
+
+    static BlockContainer Body(params IrNode[] statements)
+    {
+        var block = new Block(0);
+        foreach (var statement in statements)
+            block.Add(statement);
+        var body = new BlockContainer();
+        body.Add(block);
+        return body;
+    }
+
+    static string RenderBody(IReadOnlyList<TypeRef> locals, params IrNode[] statements)
+    {
+        var function = new IrFunction(
+            "M",
+            Owner,
+            new MethodSignature(Void, [], HasThis: false, GenericParameterCount: 0),
+            [.. locals],
+            Body(statements));
+        return CSharpPrinter.Print(function).Output!.ReplaceLineEndings("\n").Trim();
+    }
+
+    static void AssertCompiles(string body)
+    {
+        string source = $$"""
+            using System;
+            static class __Gate
+            {
+                public static void M()
+                {
+            {{body}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "__gate",
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        var errors = compilation.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToArray();
+        Assert.True(errors.Length == 0, "Rendered body must compile, got:\n  " + string.Join("\n  ", errors) + "\n--- body ---\n" + body);
+    }
+
+    static IEnumerable<MetadataReference> RuntimeReferences()
+    {
+        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                yield return MetadataReference.CreateFromFile(path);
+        }
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/NestedScopeNameCollisionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NestedScopeNameCollisionTests.cs
@@ -1,4 +1,5 @@
 using ILInspector.Decompiler.Pipeline;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
@@ -9,6 +10,9 @@ public class NestedScopeNameCollisionTests
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef Action = TypeRef.CoreLib("System", "Action");
+    static readonly TypeRef FuncIntInt = TypeRef.GenericInstance(
+        TypeRef.CoreLib("System", "Func`2"),
+        [TypeRef.CoreLib("System", "Int32"), TypeRef.CoreLib("System", "Int32")]);
     static readonly TypeRef Owner = TypeRef.Definition("Synthetic", "", "Holder");
 
     [Fact]
@@ -93,6 +97,88 @@ public class NestedScopeNameCollisionTests
         AssertCompiles(body);
     }
 
+    [Fact]
+    public void DeepNestedLambda_CarriesGrandparentReservedNames()
+    {
+        var innerBody = Body(
+            new StoreStackSlot(0, new Constant(3, Int32)),
+            new ExpressionStatement(new LoadStackSlot(0, Int32)));
+        var inner = new Lambda(
+            Action,
+            [],
+            [],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            innerBody);
+        var middleBody = Body(new StoreLocal(0, Action, inner));
+        var middle = new Lambda(
+            Action,
+            [],
+            [Action],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            middleBody);
+
+        string body = RenderBody(
+            [Int32, Action],
+            new StoreStackSlot(0, new Constant(1, Int32)),
+            new StoreLocal(0, Int32, new LoadStackSlot(0, Int32)),
+            new StoreLocal(1, Action, middle));
+
+        Assert.Contains("int S_0 = 1;", body);
+        Assert.Contains("int S_0_1 = 3;", body);
+        Assert.DoesNotContain("() => { int S_0 = 3;", body);
+        AssertCompiles(body);
+    }
+
+    [Fact]
+    public void NestedSwitchTemp_AvoidsOuterSwitchTemp()
+    {
+        var innerLambda = new Lambda(
+            Action,
+            [],
+            [Int32],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            SwitchBody());
+
+        string body = RenderBody(
+            [Action],
+            new SwitchBranch(new Constant(0, Int32), ImmutableArray.Create(4)),
+            new StoreLocal(0, Action, innerLambda));
+
+        Assert.Contains("int __dotnet_inspect_switch0 = default;", body);
+        Assert.Contains("int __dotnet_inspect_switch0_1 = default;", body);
+        Assert.DoesNotContain("() => { int __dotnet_inspect_switch0 = default;", body);
+    }
+
+    [Fact]
+    public void OuterGeneratedName_AvoidsNestedLambdaParameter()
+    {
+        var lambda = new Lambda(
+            FuncIntInt,
+            [new Parameter("S_0", Int32)],
+            [],
+            [],
+            usesUpdatedMemorySafetyRules: false,
+            skipLocalsInit: false,
+            Body(new Return(new LoadArgument(0, "S_0", Int32))));
+
+        string body = RenderBody(
+            [Int32, FuncIntInt],
+            new StoreStackSlot(0, new Constant(1, Int32)),
+            new StoreLocal(0, Int32, new LoadStackSlot(0, Int32)),
+            new StoreLocal(1, FuncIntInt, lambda));
+
+        Assert.Contains("int S_0_1 = 1;", body);
+        Assert.Contains("S_0 =>", body);
+        Assert.DoesNotContain("int S_0 = 1;", body);
+        AssertCompiles(body);
+    }
+
     static BlockContainer Body(params IrNode[] statements)
     {
         var block = new Block(0);
@@ -100,6 +186,18 @@ public class NestedScopeNameCollisionTests
             block.Add(statement);
         var body = new BlockContainer();
         body.Add(block);
+        return body;
+    }
+
+    static BlockContainer SwitchBody()
+    {
+        var body = new BlockContainer();
+        var entry = new Block(0);
+        entry.Add(new SwitchBranch(new Constant(0, Int32), ImmutableArray.Create(4)));
+        var target = new Block(4);
+        target.Add(new Return(null));
+        body.Add(entry);
+        body.Add(target);
         return body;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -132,7 +132,7 @@ public sealed partial class CSharpPrinter
                 UsesUpdatedMemorySafetyRules = lambda.UsesUpdatedMemorySafetyRules,
                 SkipLocalsInit = lambda.SkipLocalsInit,
             };
-            var text = new CSharpPrinter(function).PrintBody(function).Trim();
+            var text = new CSharpPrinter(function, _options, CurrentScopeNames()).PrintBody(function).Trim();
             return string.Join(" ", text.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).Select(line => line.Trim()));
         }
         finally

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -795,8 +795,11 @@ public sealed partial class CSharpPrinter
             foreach (var parameter in nested.Parameters)
                 names.Add(parameter.Name);
         foreach (var nested in _function.Descendants.OfType<LocalFunctionStatement>())
+        {
+            names.Add(nested.Name);
             foreach (var parameter in nested.Parameters)
                 names.Add(parameter.Name);
+        }
         if (includeLocals)
         {
             for (int i = 0; i < _function.Locals.Length; i++)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -459,7 +459,7 @@ public sealed partial class CSharpPrinter
         int switchIndex = 0;
         foreach (var switchBranch in DescendantsOutsideNestedFunctions(function).OfType<SwitchBranch>())
         {
-            string name = $"__dotnet_inspect_switch{switchIndex++}";
+            string name = ReserveName($"__dotnet_inspect_switch{switchIndex++}", new HashSet<string>(CurrentScopeNames(), StringComparer.Ordinal));
             _switchTemps.TryAdd(switchBranch, name);
             yield return $"int {name} = default;";
         }
@@ -563,11 +563,7 @@ public sealed partial class CSharpPrinter
             _stackSlotStoreTypes[store] = StackSlotRenderType(store.Slot, store.Value.ResultType);
 
         var ordinals = new Dictionary<int, int>();
-        var takenNames = new HashSet<string>(_reservedScopeNames, StringComparer.Ordinal);
-        foreach (var parameter in _function.Signature.Parameters)
-            takenNames.Add(parameter.Name);
-        for (int i = 0; i < _function.Locals.Length; i++)
-            takenNames.Add(LocalName(i));
+        var takenNames = CurrentReservedNames(includeLocals: true);
 
         string NameFor(int slot, TypeRef? type)
         {
@@ -782,15 +778,30 @@ public sealed partial class CSharpPrinter
 
     IReadOnlySet<string> CurrentScopeNames()
     {
-        var names = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var parameter in _function.Signature.Parameters)
-            names.Add(parameter.Name);
-        for (int i = 0; i < _function.Locals.Length; i++)
-            names.Add(LocalName(i));
+        var names = CurrentReservedNames(includeLocals: true);
         foreach (var (_, (name, _)) in _stackSlotDeclarations)
             names.Add(name);
         foreach (var name in _switchTemps.Values)
             names.Add(name);
+        return names;
+    }
+
+    HashSet<string> CurrentReservedNames(bool includeLocals = false)
+    {
+        var names = new HashSet<string>(_reservedScopeNames, StringComparer.Ordinal);
+        foreach (var parameter in _function.Signature.Parameters)
+            names.Add(parameter.Name);
+        foreach (var nested in _function.Descendants.OfType<Lambda>())
+            foreach (var parameter in nested.Parameters)
+                names.Add(parameter.Name);
+        foreach (var nested in _function.Descendants.OfType<LocalFunctionStatement>())
+            foreach (var parameter in nested.Parameters)
+                names.Add(parameter.Name);
+        if (includeLocals)
+        {
+            for (int i = 0; i < _function.Locals.Length; i++)
+                names.Add(LocalName(i));
+        }
         return names;
     }
 
@@ -2909,9 +2920,7 @@ public sealed partial class CSharpPrinter
             for (int i = 0; i < count; i++)
                 display[i] = $"V_{i}";
 
-            var taken = new HashSet<string>(_reservedScopeNames, StringComparer.Ordinal);
-            foreach (var parameter in _function.Signature.Parameters)
-                taken.Add(parameter.Name);
+            var taken = CurrentReservedNames();
 
             var names = _function.LocalNames;
             if (!names.IsDefaultOrEmpty)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -40,13 +40,17 @@ public sealed partial class CSharpPrinter
     int _unsafeDepth;
 
     readonly PrinterOptions _options;
+    readonly HashSet<string> _reservedScopeNames;
 
-    CSharpPrinter(IrFunction function, PrinterOptions? options = null)
+    CSharpPrinter(IrFunction function, PrinterOptions? options = null, IEnumerable<string>? reservedScopeNames = null)
     {
         _function = function;
         _options = options ?? PrinterOptions.Default;
         _newMemorySafetyRules = function.UsesUpdatedMemorySafetyRules;
         _skipLocalsInit = function.SkipLocalsInit;
+        _reservedScopeNames = reservedScopeNames is null
+            ? []
+            : new HashSet<string>(reservedScopeNames, StringComparer.Ordinal);
     }
 
     // The output-path pass context: stepping off, plus the optional cross-method
@@ -559,6 +563,11 @@ public sealed partial class CSharpPrinter
             _stackSlotStoreTypes[store] = StackSlotRenderType(store.Slot, store.Value.ResultType);
 
         var ordinals = new Dictionary<int, int>();
+        var takenNames = new HashSet<string>(_reservedScopeNames, StringComparer.Ordinal);
+        foreach (var parameter in _function.Signature.Parameters)
+            takenNames.Add(parameter.Name);
+        for (int i = 0; i < _function.Locals.Length; i++)
+            takenNames.Add(LocalName(i));
 
         string NameFor(int slot, TypeRef? type)
         {
@@ -568,7 +577,8 @@ public sealed partial class CSharpPrinter
 
             int ordinal = ordinals.GetValueOrDefault(slot);
             ordinals[slot] = ordinal + 1;
-            string name = ordinal == 0 ? $"S_{slot}" : $"S_{slot}_{ordinal}";
+            string baseName = ordinal == 0 ? $"S_{slot}" : $"S_{slot}_{ordinal}";
+            string name = ReserveName(baseName, takenNames);
             _stackSlotNames[key] = name;
             _stackSlotDeclarations[(slot, ordinal)] = (name, type);
             return name;
@@ -768,6 +778,20 @@ public sealed partial class CSharpPrinter
         return _stackSlotNames.TryGetValue(new StackSlotRenderKey(store.Slot, StackSlotTypeKey(type)), out var name)
             ? name
             : $"S_{store.Slot}";
+    }
+
+    IReadOnlySet<string> CurrentScopeNames()
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var parameter in _function.Signature.Parameters)
+            names.Add(parameter.Name);
+        for (int i = 0; i < _function.Locals.Length; i++)
+            names.Add(LocalName(i));
+        foreach (var (_, (name, _)) in _stackSlotDeclarations)
+            names.Add(name);
+        foreach (var name in _switchTemps.Values)
+            names.Add(name);
+        return names;
     }
 
     /// <summary>
@@ -1132,7 +1156,7 @@ public sealed partial class CSharpPrinter
         };
 
         string pad = new(' ', indent * 4);
-        foreach (var line in new CSharpPrinter(function).PrintBody(function).TrimEnd().Split(Environment.NewLine))
+        foreach (var line in new CSharpPrinter(function, _options, CurrentScopeNames()).PrintBody(function).TrimEnd().Split(Environment.NewLine))
             sb.Append(pad).AppendLine(line);
     }
 
@@ -2885,7 +2909,7 @@ public sealed partial class CSharpPrinter
             for (int i = 0; i < count; i++)
                 display[i] = $"V_{i}";
 
-            var taken = new HashSet<string>(StringComparer.Ordinal);
+            var taken = new HashSet<string>(_reservedScopeNames, StringComparer.Ordinal);
             foreach (var parameter in _function.Signature.Parameters)
                 taken.Add(parameter.Name);
 
@@ -2918,12 +2942,31 @@ public sealed partial class CSharpPrinter
                     {
                         display[i] = synthesized;
                         taken.Add(synthesized);
+                        sourceNamed[i] = true;
                     }
                 }
+            }
+            for (int i = 0; i < count; i++)
+            {
+                if (sourceNamed[i])
+                    continue;
+                display[i] = ReserveName(display[i], taken);
             }
             _localDisplayNames = display;
         }
         return index >= 0 && index < _localDisplayNames.Length ? _localDisplayNames[index] : $"V_{index}";
+    }
+
+    static string ReserveName(string baseName, HashSet<string> taken)
+    {
+        if (taken.Add(baseName))
+            return baseName;
+        for (int i = 1; ; i++)
+        {
+            string candidate = $"{baseName}_{i}";
+            if (taken.Add(candidate))
+                return candidate;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #2275

## Change

**Conclusion:** **PASS** — nested lambda/local-function printers now reserve outer-scope names before allocating generated `V_N` and `S_N` names, preventing CS0136 shadowing when stack slot/local numbering restarts inside nested bodies.

Before shape:

```csharp
int S_0 = 1;
Action V_1 = () => { int S_0 = 2; _ = S_0; };
```

After shape:

```csharp
int S_0 = 1;
Action V_1 = () => { int S_0_1 = 2; _ = S_0_1; };
```

The fix preserves existing source/readable-name behavior and only supplies the outer printer's taken names to nested printers that already require isolated local/slot scopes.

## Evidence

| Check | Result |
| --- | --- |
| Focused tests | Pass: `NestedScopeNameCollisionTests` (lambda stack slot, lambda fallback local, local-function stack slot) |
| Sibling tests | Pass: `LocalFunctionKeywordEscapeTests`, `SlotMaterializationPassTests/DefersSlotWhoseNumberAppearsInNestedLambdaScope`, `CoercionInvariantTests/LambdaBodyReturn_IsNotAttributedToTheOuterSignature` |
| Decompiler fast suite | Pass: 1,893 tests with `-trait- "Speed=Slow"` |
| Solution build | Pass: `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore --verbosity minimal` |
| Render A/B | Pass: 89,065 methods evaluated, 0 changed |

## Decompiler quality

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 350 methods (compile-cap 25; per-sample, not corpus-wide); fidelity sampled 24 / 89,065 (0.03%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,405 (88.03%) | +6 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — 25,179 compiled methods | 1/350 — 350 compiled methods | -73 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 3/24, exact 21, recompile-failed 0, context-failed 0; sampled 24 / 89,065 (0.03%) | -2 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.03% (+0.01 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 3 (-2).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25179, current 350)
- fidelity checked methods lower than baseline (baseline 36, current 24)
QUALITY_CARD_EXIT=1

The quality card exits nonzero only because this PR quick run uses lower validity/fidelity caps than the daily baseline. The pinned subset improves: fully raised +0.01 pp, conditional residual unchanged, Full malformed 0, opcode diffs 5 -> 3.

## Review

Adversarial reviews pending. I will post the two-review reconciliation before marking ready.
