### PR TITLE
Add typed C# diff failure rows

### DIFF
--- a/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Research.Tests/CSharpBodyDiffTests.cs
@@ -558,6 +558,12 @@ public class CSharpBodyDiffTests
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "BodyStateSample" });
 
         var row = Assert.Single(diff.Rows);
+        var failure = Assert.Single(diff.FailureRows);
+        Assert.Equal(CSharpDiffFailureKind.OldBodyMissing, failure.Kind);
+        Assert.Equal("old", failure.Side);
+        Assert.Equal("Old method has no C# body.", failure.Message);
+        Assert.Equal(row.HunkId, failure.HunkId);
+        Assert.Contains("BodyStateSample", failure.Member, StringComparison.Ordinal);
         Assert.Equal(CSharpDiffKind.Add, row.Kind);
         Assert.Equal("csharp.method.body-added", row.ChangeId);
         Assert.Equal("Added C# method body.", row.Message);
@@ -577,6 +583,12 @@ public class CSharpBodyDiffTests
         var diff = CSharpBodyDiff.CompareAssemblies(v2, v1, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "BodyStateSample" });
 
         var row = Assert.Single(diff.Rows);
+        var failure = Assert.Single(diff.FailureRows);
+        Assert.Equal(CSharpDiffFailureKind.NewBodyMissing, failure.Kind);
+        Assert.Equal("new", failure.Side);
+        Assert.Equal("New method has no C# body.", failure.Message);
+        Assert.Equal(row.HunkId, failure.HunkId);
+        Assert.Contains("BodyStateSample", failure.Member, StringComparison.Ordinal);
         Assert.Equal(CSharpDiffKind.Remove, row.Kind);
         Assert.Equal("csharp.method.body-removed", row.ChangeId);
         Assert.Equal("Removed C# method body.", row.Message);
@@ -585,6 +597,25 @@ public class CSharpBodyDiffTests
         Assert.Equal("/* method body removed */", row.OldOperation?.Value);
         Assert.Null(row.NewOperation);
         Assert.Null(row.SourceCoordinate);
+    }
+
+    [Fact]
+    public void Printer_FailureRows_RenderFromStructuredFailureRows()
+    {
+        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v2 = DiffFixturePath("DiffFixtures.V2");
+
+        var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "BodyStateSample" });
+
+        var failure = Assert.Single(diff.FailureRows);
+        var display = CSharpDiffPrinter.ToDisplayFailureRow(failure);
+
+        Assert.Equal(CSharpDiffFailureKind.OldBodyMissing, display.Kind);
+        Assert.Equal("old", display.Side);
+        Assert.Equal("Old method has no C# body.", display.Message);
+        Assert.Equal(failure.Detail, display.Detail);
+        Assert.Equal("C# diff failed: Old method has no C# body.", display.UnifiedLine);
+        Assert.Contains(display.UnifiedLine, CSharpDiffPrinter.RenderUnified(diff), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -207,6 +207,29 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void FromCSharpBodyDiff_PreservesProducerFailureRow()
+    {
+        var csharp = CSharpBodyDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "BodyStateSample" });
+        var failureRow = Assert.Single(csharp.FailureRows);
+
+        var diff = ResearchDiff.FromCSharpBodyDiff(csharp);
+
+        var row = Assert.Single(diff.Rows, row => row.CSharpFailureRow is not null);
+        Assert.Equal("csharp.diff.old-body-missing", row.ChangeId);
+        Assert.Equal(ResearchDiffEvidenceKind.CSharp, row.EvidenceKind);
+        Assert.Equal(failureRow.Message, row.Message);
+        Assert.Same(failureRow, row.CSharpFailureRow);
+        Assert.NotNull(row.CSharpDisplayFailureRow);
+        Assert.Equal(CSharpDiffFailureKind.OldBodyMissing, row.CSharpDisplayFailureRow.Kind);
+        Assert.Equal("old", row.CSharpDisplayFailureRow.Side);
+        Assert.Equal("C# diff failed: Old method has no C# body.", row.CSharpDisplayFailureRow.UnifiedLine);
+        Assert.Contains(diff.Rows, row => row.CSharpRow is not null && row.ChangeId == "csharp.method.body-added");
+    }
+
+    [Fact]
     public void Combine_PreservesStructuredApiDiff()
     {
         var oldSurface = Surface("Widget", Member("Existing"));
@@ -334,6 +357,26 @@ public class ResearchDiffTests
         var evidence = Assert.Single(changed.Evidence, evidence => evidence.ChangeId == "csharp.return-expression.changed");
         Assert.Equal("value + 1", evidence.OldValue);
         Assert.Equal("value + 2", evidence.NewValue);
+    }
+
+    [Fact]
+    public void CompareAssemblies_CSharp_QueryFailureRows()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(ResearchDiffMechanism.CSharp, TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "BodyStateSample" }));
+
+        var changed = Assert.Single(diff.MembersWhere(member =>
+            member.Subject.Display.Contains("BodyStateSample", StringComparison.Ordinal)
+            && member.HasChange("csharp.diff.old-body-missing")));
+        var evidence = Assert.Single(changed.Evidence, evidence => evidence.ChangeId == "csharp.diff.old-body-missing");
+        Assert.Equal(ResearchDiffDirection.Added, evidence.Direction);
+        Assert.NotNull(evidence.CSharpDisplayFailureRow);
+        Assert.Equal(CSharpDiffFailureKind.OldBodyMissing, evidence.CSharpDisplayFailureRow.Kind);
+        Assert.Equal("old", evidence.CSharpDisplayFailureRow.Side);
+        Assert.Equal("C# diff failed: Old method has no C# body.", evidence.CSharpDisplayFailureRow.UnifiedLine);
+        Assert.Contains(changed.Evidence, evidence => evidence.ChangeId == "csharp.method.body-added");
     }
 
     [Fact]

--- a/src/ILInspector.Research/CSharpBodyDiff.cs
+++ b/src/ILInspector.Research/CSharpBodyDiff.cs
@@ -130,9 +130,36 @@ public sealed record CSharpDiffRow(
     }
 }
 
-public sealed record CSharpBodyDiffResult(ImmutableArray<CSharpDiffRow> Rows)
+public enum CSharpDiffFailureKind
 {
-    public bool IsExact => Rows.IsEmpty;
+    OldBodyMissing,
+    NewBodyMissing,
+    OldDecompileFailure,
+    NewDecompileFailure,
+    BodyDiffSkipped,
+}
+
+public sealed record CSharpDiffFailureRow(
+    string AssemblyIdentity,
+    string StableMemberKey,
+    MemberAnchor Anchor,
+    string Member,
+    CSharpDiffFailureKind Kind,
+    string Message,
+    string? Side = null,
+    string? Detail = null,
+    int? HunkId = null);
+
+public sealed record CSharpBodyDiffResult(
+    ImmutableArray<CSharpDiffRow> Rows,
+    ImmutableArray<CSharpDiffFailureRow> FailureRows = default)
+{
+    public CSharpBodyDiffResult(ImmutableArray<CSharpDiffRow> rows)
+        : this(rows, FailureRows: [])
+    {
+    }
+
+    public bool IsExact => Rows.IsEmpty && (FailureRows.IsDefaultOrEmpty);
 }
 
 /// <summary>
@@ -154,6 +181,7 @@ public static class CSharpBodyDiff
         var oldMethods = BuildMethodIndex(oldPaths, includeNonPublic, typeFilters);
         var newMethods = BuildMethodIndex(newPaths, includeNonPublic, typeFilters);
         var rows = ImmutableArray.CreateBuilder<CSharpDiffRow>();
+        var failureRows = ImmutableArray.CreateBuilder<CSharpDiffFailureRow>();
         var sources = new SourceCache();
         int hunkId = 0;
 
@@ -179,7 +207,7 @@ public static class CSharpBodyDiff
                 if (oldMethod.BodyFingerprint == newMethod.BodyFingerprint)
                     continue;
 
-                AddLineDiffRows(rows, oldMethod, Decompile(oldMethod, sources), Decompile(newMethod, sources), ref hunkId);
+                AddLineDiffRows(rows, failureRows, oldMethod, Decompile(oldMethod, sources), Decompile(newMethod, sources), ref hunkId);
             }
         }
         finally
@@ -187,7 +215,7 @@ public static class CSharpBodyDiff
             sources.Dispose();
         }
 
-        return new CSharpBodyDiffResult(rows.ToImmutable());
+        return new CSharpBodyDiffResult(rows.ToImmutable(), failureRows.ToImmutable());
     }
 
     static Dictionary<string, CSharpMethodEntry> BuildMethodIndex(IReadOnlyList<string> paths, bool includeNonPublic, IReadOnlySet<string>? typeFilters)
@@ -798,6 +826,7 @@ public static class CSharpBodyDiff
 
     static void AddLineDiffRows(
         ImmutableArray<CSharpDiffRow>.Builder rows,
+        ImmutableArray<CSharpDiffFailureRow>.Builder failureRows,
         CSharpMethodEntry entry,
         CSharpMethodRender oldRender,
         CSharpMethodRender newRender,
@@ -810,7 +839,7 @@ public static class CSharpBodyDiff
 
         if (oldRender.State != CSharpMethodRenderState.Body || newRender.State != CSharpMethodRenderState.Body)
         {
-            AddRenderStateRows(rows, entry, oldRender, newRender, ref hunkId);
+            AddRenderStateRows(rows, failureRows, entry, oldRender, newRender, ref hunkId);
             return;
         }
 
@@ -818,6 +847,13 @@ public static class CSharpBodyDiff
         {
             int hunk = hunkId++;
             string message = $"/* C# diff skipped: old body has {oldLines.Length} lines, new body has {newLines.Length} lines; limit is {MaxLcsLines} */";
+            failureRows.Add(CreateFailureRow(
+                entry,
+                CSharpDiffFailureKind.BodyDiffSkipped,
+                "Skipped C# body diff.",
+                side: null,
+                detail: $"old body has {oldLines.Length} lines, new body has {newLines.Length} lines; limit is {MaxLcsLines}",
+                hunkId: hunk));
             rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), message, "csharp.body-diff.skipped", "Skipped C# body diff; old body exceeds line limit.", operationKind: CSharpDiffOperationKind.BodyDiffSkipped));
             rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), message, "csharp.body-diff.skipped", "Skipped C# body diff; new body exceeds line limit.", operationKind: CSharpDiffOperationKind.BodyDiffSkipped));
             return;
@@ -860,6 +896,7 @@ public static class CSharpBodyDiff
 
     static void AddRenderStateRows(
         ImmutableArray<CSharpDiffRow>.Builder rows,
+        ImmutableArray<CSharpDiffFailureRow>.Builder failureRows,
         CSharpMethodEntry entry,
         CSharpMethodRender oldRender,
         CSharpMethodRender newRender,
@@ -868,29 +905,101 @@ public static class CSharpBodyDiff
         int hunk = hunkId++;
         if (oldRender.State is CSharpMethodRenderState.Body && newRender.State is CSharpMethodRenderState.NoBody)
         {
+            failureRows.Add(CreateFailureRow(
+                entry,
+                CSharpDiffFailureKind.NewBodyMissing,
+                "New method has no C# body.",
+                side: "new",
+                detail: newRender.Lines[0],
+                hunkId: hunk));
             rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), "/* method body removed */", "csharp.method.body-removed", "Removed C# method body.", operationKind: CSharpDiffOperationKind.MethodBody));
             return;
         }
 
         if (oldRender.State is CSharpMethodRenderState.NoBody && newRender.State is CSharpMethodRenderState.Body)
         {
+            failureRows.Add(CreateFailureRow(
+                entry,
+                CSharpDiffFailureKind.OldBodyMissing,
+                "Old method has no C# body.",
+                side: "old",
+                detail: oldRender.Lines[0],
+                hunkId: hunk));
             rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), "/* method body added */", "csharp.method.body-added", "Added C# method body.", operationKind: CSharpDiffOperationKind.MethodBody));
             return;
         }
 
         if (oldRender.State is CSharpMethodRenderState.Failed)
+        {
+            failureRows.Add(CreateFailureRow(
+                entry,
+                CSharpDiffFailureKind.OldDecompileFailure,
+                "Old method body decompilation failed.",
+                side: "old",
+                detail: oldRender.Lines[0],
+                hunkId: hunk));
             rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), oldRender.Lines[0], "csharp.decompile.failed", "Old method body decompilation failed.", operationKind: CSharpDiffOperationKind.DecompileFailure));
+        }
+
         if (newRender.State is CSharpMethodRenderState.Failed)
+        {
+            failureRows.Add(CreateFailureRow(
+                entry,
+                CSharpDiffFailureKind.NewDecompileFailure,
+                "New method body decompilation failed.",
+                side: "new",
+                detail: newRender.Lines[0],
+                hunkId: hunk));
             rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), newRender.Lines[0], "csharp.decompile.failed", "New method body decompilation failed.", operationKind: CSharpDiffOperationKind.DecompileFailure));
+        }
+
         if (oldRender.State is CSharpMethodRenderState.NoBody)
+        {
+            failureRows.Add(CreateFailureRow(
+                entry,
+                CSharpDiffFailureKind.OldBodyMissing,
+                "Old method has no C# body.",
+                side: "old",
+                detail: oldRender.Lines[0],
+                hunkId: hunk));
             rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), oldRender.Lines[0], "csharp.method.no-body", "Old method has no C# body.", operationKind: CSharpDiffOperationKind.MethodBody));
+        }
+
         if (newRender.State is CSharpMethodRenderState.NoBody)
+        {
+            failureRows.Add(CreateFailureRow(
+                entry,
+                CSharpDiffFailureKind.NewBodyMissing,
+                "New method has no C# body.",
+                side: "new",
+                detail: newRender.Lines[0],
+                hunkId: hunk));
             rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), newRender.Lines[0], "csharp.method.no-body", "New method has no C# body.", operationKind: CSharpDiffOperationKind.MethodBody));
+        }
+
         if (oldRender.State is CSharpMethodRenderState.Body)
             rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Remove, null, oldRender.Fidelity.ToString(), "/* method body removed */", "csharp.method.body-removed", "Removed C# method body.", operationKind: CSharpDiffOperationKind.MethodBody));
         if (newRender.State is CSharpMethodRenderState.Body)
             rows.Add(CreateRow(entry, hunk, CSharpDiffKind.Add, null, newRender.Fidelity.ToString(), "/* method body added */", "csharp.method.body-added", "Added C# method body.", operationKind: CSharpDiffOperationKind.MethodBody));
     }
+
+    static CSharpDiffFailureRow CreateFailureRow(
+        CSharpMethodEntry entry,
+        CSharpDiffFailureKind kind,
+        string message,
+        string? side,
+        string? detail,
+        int hunkId)
+        => new(
+            entry.StableAssemblyKey,
+            entry.StableMemberKey,
+            entry.Anchor,
+            entry.Display,
+            kind,
+            message,
+            side,
+            detail,
+            hunkId);
 
     static CSharpDiffRow CreateRow(
         CSharpMethodEntry entry,

--- a/src/ILInspector.Research/CSharpDiffPrinter.cs
+++ b/src/ILInspector.Research/CSharpDiffPrinter.cs
@@ -27,9 +27,25 @@ public sealed record CSharpDiffDisplayRow(
         : $"h{HunkId} {Marker} {Operation}";
 }
 
-public sealed record CSharpDiffDisplayResult(ImmutableArray<CSharpDiffDisplayRow> Rows)
+public sealed record CSharpDiffDisplayFailureRow(
+    string AssemblyIdentity,
+    string StableMemberKey,
+    MemberAnchor Anchor,
+    string Member,
+    CSharpDiffFailureKind Kind,
+    string Message,
+    string? Side,
+    string? Detail,
+    int? HunkId)
 {
-    public bool IsEmpty => Rows.IsDefaultOrEmpty;
+    public string UnifiedLine => $"C# diff failed: {Message}";
+}
+
+public sealed record CSharpDiffDisplayResult(
+    ImmutableArray<CSharpDiffDisplayRow> Rows,
+    ImmutableArray<CSharpDiffDisplayFailureRow> FailureRows = default)
+{
+    public bool IsEmpty => Rows.IsDefaultOrEmpty && FailureRows.IsDefaultOrEmpty;
 }
 
 /// <summary>
@@ -66,10 +82,34 @@ public static class CSharpDiffPrinter
         return [.. rows.Select(ToDisplayRow)];
     }
 
+    public static CSharpDiffDisplayFailureRow ToDisplayFailureRow(CSharpDiffFailureRow row)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+
+        return new CSharpDiffDisplayFailureRow(
+            row.AssemblyIdentity,
+            row.StableMemberKey,
+            row.Anchor,
+            row.Member,
+            row.Kind,
+            row.Message,
+            row.Side,
+            row.Detail,
+            row.HunkId);
+    }
+
+    public static ImmutableArray<CSharpDiffDisplayFailureRow> ToDisplayFailureRows(IEnumerable<CSharpDiffFailureRow> rows)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        return [.. rows.Select(ToDisplayFailureRow)];
+    }
+
     public static CSharpDiffDisplayResult ToDisplayResult(CSharpBodyDiffResult result)
     {
         ArgumentNullException.ThrowIfNull(result);
-        return new CSharpDiffDisplayResult(ToDisplayRows(result.Rows));
+        return new CSharpDiffDisplayResult(
+            result.Rows.IsDefault ? [] : ToDisplayRows(result.Rows),
+            result.FailureRows.IsDefault ? [] : ToDisplayFailureRows(result.FailureRows));
     }
 
     public static ImmutableArray<string> ToUnifiedLines(CSharpBodyDiffResult result)
@@ -78,9 +118,13 @@ public static class CSharpDiffPrinter
     public static ImmutableArray<string> ToUnifiedLines(CSharpDiffDisplayResult display)
     {
         ArgumentNullException.ThrowIfNull(display);
-        return display.Rows.IsDefault
+        var failureRows = display.FailureRows.IsDefault
             ? []
-            : [.. display.Rows.Select(row => row.UnifiedLine)];
+            : display.FailureRows.Select(row => row.UnifiedLine);
+        var rows = display.Rows.IsDefault
+            ? []
+            : display.Rows.Select(row => row.UnifiedLine);
+        return [.. failureRows, .. rows];
     }
 
     public static string RenderUnified(CSharpBodyDiffResult result)

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -63,7 +63,9 @@ public sealed record ResearchDiffRow(
     IlDiffDisplayRow? IlDisplayRow = null,
     IlDiffDisplayFailureRow? IlDisplayFailureRow = null,
     BodySignalDiffRow? BodySignalRow = null,
-    CSharpDiffRow? CSharpRow = null);
+    CSharpDiffRow? CSharpRow = null,
+    CSharpDiffFailureRow? CSharpFailureRow = null,
+    CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow = null);
 
 public sealed record ResearchDiffOptions(
     ResearchDiffMechanism Mechanisms = ResearchDiffMechanism.AllAvailable,
@@ -111,7 +113,8 @@ public sealed record ResearchDiffEvidence(
     bool SubjectInBoth = true,
     bool InLoop = false,
     ImmutableArray<IlDiffDisplayRow> IlDisplayRows = default,
-    IlDiffDisplayFailureRow? IlDisplayFailureRow = null);
+    IlDiffDisplayFailureRow? IlDisplayFailureRow = null,
+    CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow = null);
 
 public sealed record ResearchSubjectDiff(
     ResearchSubjectKey Subject,
@@ -225,16 +228,27 @@ public static class ResearchDiff
     public static ResearchDiffResult FromCSharpBodyDiff(CSharpBodyDiffResult diff)
     {
         ArgumentNullException.ThrowIfNull(diff);
-        return new ResearchDiffResult(
-            [],
-            Rows:
-            [
-                .. diff.Rows.Select(row => new ResearchDiffRow(
-                    row.ChangeId,
-                    ResearchDiffEvidenceKind.CSharp,
-                    row.Message,
-                    CSharpRow: row))
-            ]);
+        var rows = ImmutableArray.CreateBuilder<ResearchDiffRow>();
+        if (!diff.FailureRows.IsDefaultOrEmpty)
+        {
+            rows.AddRange(diff.FailureRows.Select(row => new ResearchDiffRow(
+                $"csharp.diff.{ToKebabCase(row.Kind.ToString())}",
+                ResearchDiffEvidenceKind.CSharp,
+                row.Message,
+                CSharpFailureRow: row,
+                CSharpDisplayFailureRow: CSharpDiffPrinter.ToDisplayFailureRow(row))));
+        }
+
+        if (!diff.Rows.IsDefaultOrEmpty)
+        {
+            rows.AddRange(diff.Rows.Select(row => new ResearchDiffRow(
+                row.ChangeId,
+                ResearchDiffEvidenceKind.CSharp,
+                row.Message,
+                CSharpRow: row)));
+        }
+
+        return new ResearchDiffResult([], Rows: rows.ToImmutable());
     }
 
     public static ResearchDiffResult Combine(params ResearchDiffResult[] results)
@@ -624,7 +638,11 @@ public static class ResearchDiff
         if (oldInput.AssemblyPaths.Count == 0 || newInput.AssemblyPaths.Count == 0)
             return;
 
-        foreach (var row in CSharpBodyDiff.CompareAssemblies(oldInput.AssemblyPaths, newInput.AssemblyPaths, typeFilters: typeFilters).Rows)
+        var diff = CSharpBodyDiff.CompareAssemblies(oldInput.AssemblyPaths, newInput.AssemblyPaths, typeFilters: typeFilters);
+        foreach (var failure in diff.FailureRows.IsDefault ? [] : diff.FailureRows)
+            AddCSharpFailureEvidence(builder, failure);
+
+        foreach (var row in diff.Rows)
         {
             var subject = new ResearchSubjectKey(
                 ResearchDiffSubjectKind.Member,
@@ -647,6 +665,31 @@ public static class ResearchDiff
                 Detail: row.Message,
                 Category: ResearchDiffChangeCategory.CSharp));
         }
+    }
+
+    static void AddCSharpFailureEvidence(ResultBuilder builder, CSharpDiffFailureRow failure)
+    {
+        var subject = new ResearchSubjectKey(
+            ResearchDiffSubjectKind.Member,
+            failure.Anchor.StableSelector,
+            $"{failure.Anchor.TypeFullName}.{failure.Anchor.MemberName}",
+            failure.Anchor.TypeFullName,
+            failure.Anchor.MemberName);
+        var direction = failure.Kind switch
+        {
+            CSharpDiffFailureKind.OldBodyMissing => ResearchDiffDirection.Added,
+            CSharpDiffFailureKind.NewBodyMissing => ResearchDiffDirection.Removed,
+            _ => ResearchDiffDirection.Changed,
+        };
+        builder.Add(subject, new ResearchDiffEvidence(
+            ResearchDiffMechanism.CSharp,
+            $"csharp.diff.{ToKebabCase(failure.Kind.ToString())}",
+            direction,
+            OldValue: failure.Side == "old" ? failure.Detail ?? failure.Message : null,
+            NewValue: failure.Side == "new" ? failure.Detail ?? failure.Message : null,
+            Detail: failure.Detail ?? failure.Message,
+            Category: ResearchDiffChangeCategory.CSharp,
+            CSharpDisplayFailureRow: CSharpDiffPrinter.ToDisplayFailureRow(failure)));
     }
 
     static ApiSurface? ResolveApiSurface(ResearchDiffInput input, bool includeAll)


### PR DESCRIPTION
## Summary

Adds typed C# diff failure rows, mirroring the IL differ's failure-row/display-failure pattern.

## Details

- Adds `CSharpDiffFailureKind` and `CSharpDiffFailureRow` for body-state/decompile/skip evidence.
- Extends `CSharpBodyDiffResult` with `FailureRows` while preserving the existing row-only constructor.
- Emits typed failure rows for:
  - old/new body missing;
  - old/new decompile failure;
  - body diff skipped due to line cap.
- Keeps existing synthetic C# operation rows for compatibility and row currency.
- Adds `CSharpDiffDisplayFailureRow` and printer projection/unified rendering support.
- Preserves C# failure rows through `ResearchDiff.FromCSharpBodyDiff` and `ResearchDiff.CompareAssemblies` evidence.

This follows the current IL differ direction (`IlDiffFailureRow` / `IlDiffDisplayFailureRow`) while keeping the C# product path SRM-only and Roslyn-free.

## Validation

- `dotnet run --project src/ILInspector.Research.Tests -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/DiffCommandTests/*"`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore --verbosity minimal`
- `git diff --check`

## Review

Adversarial review is required for this Research/C# diff shape change and will be posted before marking ready.
