### PR TITLE
Surface typed RTS closure evidence

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1157,6 +1157,20 @@ public class GeneratedFixtureCatalogTests
                         "abcdef1234",
                         "TestType",
                         "Method1"),
+                    ClosureEvidence: new ReturnToSenderClosureEvidence(
+                        RequiredTypes: 2,
+                        RequiredMembers: 1,
+                        RoslynRecoveredTypes: 1,
+                        RoslynRecoveredMemberSurfaces: 1,
+                        Requirements:
+                        [
+                            new ReturnToSenderClosureRequirement(
+                                "TestType",
+                                RequiredMembers: 1,
+                                RoslynRecovered: true,
+                                RoslynRecoveredMemberSurface: true,
+                                Facts: ["roslyn/closure-root: CS0103: Helper"]),
+                        ]),
                     IsFrontier: false,
                     Note: null),
             ]);
@@ -1167,6 +1181,7 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("h0 - IL_0000 ldc.i4 1", report);
         Assert.Contains("h0 + IL_0000 ldc.i4 2", report);
         Assert.Contains("member: Method1~abcdef1234  canonical=M:TestType.Method1()", report);
+        Assert.Contains("closure: types=2 members=1 roslyn-types=1 roslyn-member-surfaces=1", report);
         Assert.Contains("Research evidence:", report);
         Assert.Contains("rts.status.fail: 1", report);
         Assert.Contains("il.operation.added: 1", report);
@@ -1226,6 +1241,7 @@ public class GeneratedFixtureCatalogTests
                         "abcdef1234",
                         "TestType",
                         "Method1"),
+                    ClosureEvidence: null,
                     IsFrontier: false,
                     Note: null),
             ]);

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -69,6 +69,8 @@
              Link="ReturnToSender.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ReturnToSenderEvidence.cs"
              Link="ReturnToSenderEvidence.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\ReturnToSenderClosureEvidence.cs"
+             Link="ReturnToSenderClosureEvidence.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\GeneratedFixtures.cs"
              Link="GeneratedFixtures.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ValidityCheck.cs"

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -183,6 +183,13 @@ public class ReturnToSenderPrototypeTests
                         && requirement.SourceFacts.Any(fact => fact.Id == "closure-root"
                             && fact.Producer == "roslyn"
                             && fact.Detail.StartsWith("CS0246", StringComparison.Ordinal)));
+                    var evidence = ReturnToSenderClosureEvidenceBuilder.FromPlan(first.Plan);
+                    Assert.Equal(2, evidence.RequiredTypes);
+                    Assert.Equal(1, evidence.RoslynRecoveredTypes);
+                    Assert.Contains(evidence.Requirements, requirement =>
+                        requirement.Type == "Helper"
+                        && requirement.RoslynRecovered
+                        && requirement.Facts.Any(fact => fact.StartsWith("roslyn/closure-root: CS0246", StringComparison.Ordinal)));
                 },
                 second =>
                 {

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -2067,6 +2067,7 @@ internal sealed record GeneratedFixtureReturnToSenderResult(
     string? Detail,
     IlDiffDisplayResult? IlDiffDiagnostic,
     MemberAnchor? MemberAnchor,
+    ReturnToSenderClosureEvidence? ClosureEvidence,
     bool IsFrontier,
     string? Note)
 {
@@ -2201,6 +2202,7 @@ internal static class GeneratedFixtureRunner
                                 : actual.Detail,
                         actual.IlDiffDiagnostic,
                         actual.MemberAnchor,
+                        ReturnToSenderClosureEvidenceBuilder.FromPlan(actual.Plan),
                         target.IsFrontier,
                         target.Note));
                 }
@@ -2236,6 +2238,7 @@ internal static class GeneratedFixtureRunner
             Detail: null,
             IlDiffDiagnostic: null,
             MemberAnchor: null,
+            ClosureEvidence: null,
             target.IsFrontier,
             target.Note);
 
@@ -2441,6 +2444,12 @@ internal static class GeneratedFixtureRunner
                     sb.AppendLine($"      {row.DisplayMember}  rts={actual}  bucket={row.Reason}");
                     if (row.MemberAnchor is not null)
                         sb.AppendLine($"      member: {row.MemberAnchor.StableSelector}  canonical={row.MemberAnchor.CanonicalSignature}");
+                    if (row.ClosureEvidence is not null)
+                    {
+                        sb.AppendLine(
+                            $"      closure: types={row.ClosureEvidence.RequiredTypes} members={row.ClosureEvidence.RequiredMembers} " +
+                            $"roslyn-types={row.ClosureEvidence.RoslynRecoveredTypes} roslyn-member-surfaces={row.ClosureEvidence.RoslynRecoveredMemberSurfaces}");
+                    }
                     if (!string.IsNullOrWhiteSpace(row.Detail))
                         sb.AppendLine($"      detail: {row.Detail}");
                     if (row.IlDiffDiagnostic is not null)
@@ -2508,6 +2517,7 @@ internal static class GeneratedFixtureRunner
             result.Detail,
             IlDiffDiagnostic = SerializableIlDiffDisplayResult(result.IlDiffDiagnostic),
             result.MemberAnchor,
+            result.ClosureEvidence,
             result.IsFrontier,
             result.Note,
             result.DisplayMember,

--- a/tools/DecompilerHarness/ReturnToSenderClosureEvidence.cs
+++ b/tools/DecompilerHarness/ReturnToSenderClosureEvidence.cs
@@ -1,0 +1,46 @@
+using ILInspector.Decompiler;
+
+namespace ILInspector.DecompilerHarness;
+
+internal sealed record ReturnToSenderClosureEvidence(
+    int RequiredTypes,
+    int RequiredMembers,
+    int RoslynRecoveredTypes,
+    int RoslynRecoveredMemberSurfaces,
+    IReadOnlyList<ReturnToSenderClosureRequirement> Requirements);
+
+internal sealed record ReturnToSenderClosureRequirement(
+    string Type,
+    int RequiredMembers,
+    bool RoslynRecovered,
+    bool RoslynRecoveredMemberSurface,
+    IReadOnlyList<string> Facts);
+
+internal static class ReturnToSenderClosureEvidenceBuilder
+{
+    public static ReturnToSenderClosureEvidence FromPlan(CompileBackReconstructionPlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+
+        var requirements = plan.TypeRequirements.Select(Requirement).ToArray();
+        return new ReturnToSenderClosureEvidence(
+            plan.TypeRequirements.Count,
+            plan.TypeRequirements.Sum(requirement => requirement.RequiredMembers.Count),
+            requirements.Count(requirement => requirement.RoslynRecovered),
+            requirements.Count(requirement => requirement.RoslynRecoveredMemberSurface),
+            requirements);
+    }
+
+    static ReturnToSenderClosureRequirement Requirement(CompileBackTypeRequirement requirement)
+    {
+        var facts = requirement.SourceFacts
+            .Select(fact => $"{fact.Producer}/{fact.Id}: {fact.Detail}")
+            .ToArray();
+        return new ReturnToSenderClosureRequirement(
+            requirement.Type.FullName,
+            requirement.RequiredMembers.Count,
+            requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-root"),
+            requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member"),
+            facts);
+    }
+}


### PR DESCRIPTION
## Summary

- add `ReturnToSenderClosureEvidence` derived from typed `CompileBackReconstructionPlan.TypeRequirements`
- surface required type/member counts and Roslyn-recovered closure fallback counts in generated RTS catalog result/report/JSON
- add coverage for both synthetic report plumbing and a real same-assembly closure recovery case

This does not remove Roslyn diagnostic fallback yet; it makes the typed product dependency requirements and remaining Roslyn-recovered closure repair visible so the next slice can reduce that fallback.

## Validation

```text
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-restore -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-restore -- -filter "/*/*/ReturnToSenderPrototypeTests/CompileBackPropertyGetters_AddsSameAssemblyReturnTypeClosureRoot"
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release -- --return-to-sender-catalog minimal.property.literal --json
```
