### PR TITLE
Assertion scan: report pass-bug residue as UNKNOWN; guard v1-baseline survivor delta (#2285)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
@@ -378,6 +378,95 @@ public class AssertionScanTests
         Assert.NotEqual(atImport.Identity, atLaterPass.Identity);
     }
 
+    [Fact]
+    public void ClassifyViolationStates_TreatsPassBugViolationsAsUnknownNotSurvivorOrDischarged()
+    {
+        // A pass-bug method's violations were flagged FinalStageSurvivor at the
+        // last *completed* stage, but the pipeline never reached a real final
+        // stage — they are UNKNOWN, not UNSOUND survivors nor discharged (#2285).
+        var survivorSite = Site("Constant", survivor: true);
+        var dischargedSite = Site("LoadArgument", survivor: false);
+        var crashSurvivorSite = Site("BinaryOperation", survivor: true);
+
+        var completedSurvivor = MethodWith("Survives", passBug: null, survivorSite);
+        var completedDischarged = MethodWith("Discharges", passBug: null, dischargedSite);
+        var crashed = MethodWith("Crashes", passBug: "InvalidOperationException: boom", crashSurvivorSite);
+
+        var states = AssertionScan.ClassifyViolationStates([completedSurvivor, completedDischarged, crashed]);
+
+        Assert.Single(states.Survivors);
+        Assert.Equal("Constant", states.Survivors[0].Node);
+        Assert.Equal(1, states.SurvivorMethods);
+        Assert.Single(states.Discharged);
+        Assert.Equal("LoadArgument", states.Discharged[0].Node);
+        Assert.Equal(1, states.UnknownViolations);
+        Assert.Equal(1, states.UnknownMethods);
+    }
+
+    [Fact]
+    public void SurvivorDeltaComparable_RequiresSchemaVersion2()
+    {
+        Assert.False(AssertionScan.SurvivorDeltaComparable(0));
+        Assert.False(AssertionScan.SurvivorDeltaComparable(1));
+        Assert.True(AssertionScan.SurvivorDeltaComparable(2));
+    }
+
+    [Fact]
+    public void SchemaV1Snapshot_DeserializesWithEmptySurvivorSet()
+    {
+        // The migration artifact the differ guards against: a v1 baseline has no
+        // FinalStageSurvivor field, so every record deserializes with it false
+        // and SurvivorIdentities is empty regardless of the real survivor set.
+        const string v1Json = """
+            {
+              "SchemaVersion": 1,
+              "GeneratedUtc": "2020-01-01T00:00:00+00:00",
+              "Methods": [
+                {
+                  "Assembly": "synthetic", "AssemblyPath": "synthetic.dll",
+                  "Type": "Samples.Holder", "Method": "M", "Overload": 0,
+                  "Signature": "() -> corelib:System.Void",
+                  "Key": "synthetic.dll!Samples.Holder::M() -> corelib:System.Void",
+                  "PassBug": null,
+                  "Violations": [
+                    { "Pass": "import", "Predicate": "P", "Node": "Constant",
+                      "SinkType": "bool", "Message": "0 occupies a bool sink without a Coerce",
+                      "Ordinal": 0 }
+                  ]
+                }
+              ]
+            }
+            """;
+
+        var snapshot = JsonSerializer.Deserialize<AssertionScan.AssertionViolationSnapshot>(v1Json);
+
+        Assert.NotNull(snapshot);
+        Assert.Equal(1, snapshot!.SchemaVersion);
+        Assert.False(AssertionScan.SurvivorDeltaComparable(snapshot.SchemaVersion));
+        Assert.Empty(Assert.Single(snapshot.Methods).SurvivorIdentities());
+    }
+
+    static AssertionScan.ViolationSite Site(string node, bool survivor)
+        => new AssertionScan.ViolationSite(
+            Method: "m", Pass: IrPasses.ImportStageName, Predicate: "P",
+            Node: node, SinkType: "bool", Message: $"{node} occupies a bool sink without a Coerce", Ordinal: 0)
+        {
+            FinalStageSurvivor = survivor,
+        };
+
+    static AssertionScan.MethodResult MethodWith(string method, string? passBug, params AssertionScan.ViolationSite[] violations)
+        => new(
+            Assembly: "synthetic",
+            AssemblyPath: "synthetic.dll",
+            Type: "Samples.Holder",
+            Method: method,
+            Overload: 0,
+            Signature: "() -> corelib:System.Void",
+            Key: $"synthetic.dll!Samples.Holder::{method}() -> corelib:System.Void",
+            Violations: violations,
+            CoveredNodes: [],
+            PassBug: passBug);
+
     static IrFunction Function(BlockContainer body, TypeRef returnType, params Parameter[] parameters)
         => new(
             "M",

--- a/tools/DecompilerHarness/AssertionScan.cs
+++ b/tools/DecompilerHarness/AssertionScan.cs
@@ -673,6 +673,32 @@ internal static class AssertionScan
         return match.Success ? match.Groups["sink"].Value : "(unknown)";
     }
 
+    /// <summary>
+    /// The three mutually-exclusive violation states of a scan. Discharged
+    /// obligations and final-stage survivors (UNSOUND) are drawn only from
+    /// methods that completed the pipeline; a pass-bug method never reached a
+    /// real final stage, so its violations are UNKNOWN — folding them into either
+    /// bucket misreads a crash as a soundness or construction signal (#2285).
+    /// </summary>
+    internal readonly record struct ViolationStates(
+        IReadOnlyList<ViolationSite> Survivors,
+        int SurvivorMethods,
+        IReadOnlyList<ViolationSite> Discharged,
+        int UnknownViolations,
+        int UnknownMethods);
+
+    internal static ViolationStates ClassifyViolationStates(IReadOnlyList<MethodResult> methodsWithViolations)
+    {
+        var completed = methodsWithViolations.Where(m => m.PassBug is null).ToArray();
+        var passBug = methodsWithViolations.Where(m => m.PassBug is not null).ToArray();
+        return new ViolationStates(
+            Survivors: completed.SelectMany(m => m.Violations).Where(v => v.FinalStageSurvivor).ToArray(),
+            SurvivorMethods: completed.Count(m => m.Violations.Any(v => v.FinalStageSurvivor)),
+            Discharged: completed.SelectMany(m => m.Violations).Where(v => !v.FinalStageSurvivor).ToArray(),
+            UnknownViolations: passBug.Sum(m => m.Violations.Count),
+            UnknownMethods: passBug.Length);
+    }
+
     static void Report(Result result, int maxExamples, int? sampleSize)
     {
         int total = result.Methods.Count;
@@ -692,10 +718,20 @@ internal static class AssertionScan
         // the pipeline working as designed. The survivor count is the real
         // soundness number; "final stage is zero" for the wrappable population is
         // the target (known PrinterOwned residuals excluded). See #2269.
-        var survivors = methodsWithViolations.SelectMany(m => m.Violations).Where(v => v.FinalStageSurvivor).ToArray();
-        int survivorMethods = methodsWithViolations.Count(m => m.Violations.Any(v => v.FinalStageSurvivor));
-        Console.WriteLine($"  final-stage survivors (UNSOUND): {survivors.Length} across {survivorMethods} method(s)");
-        Console.WriteLine($"  discharged obligations         : {violationCount - survivors.Length}");
+        // A pass-bug method never reached a real final stage, so its violations
+        // are UNKNOWN — neither final-stage survivors (UNSOUND) nor discharged
+        // obligations. Counting them either way misreads a pipeline crash as a
+        // soundness or construction signal, so the survivor/discharge tallies
+        // (and the histograms and lifetime stats below) restrict to methods that
+        // completed the pipeline and the crash residue is a third, explicit
+        // state (#2285; the --diff lane already excludes pass bugs).
+        var states = ClassifyViolationStates(methodsWithViolations);
+        var survivors = states.Survivors;
+        var discharged = states.Discharged;
+        Console.WriteLine($"  final-stage survivors (UNSOUND): {survivors.Count} across {states.SurvivorMethods} method(s)");
+        Console.WriteLine($"  discharged obligations         : {discharged.Count}");
+        if (states.UnknownViolations > 0)
+            Console.WriteLine($"  unknown (pass bug, no final stage): {states.UnknownViolations} across {states.UnknownMethods} method(s)");
         Console.WriteLine();
 
         PrintHistogram("By sink type:", methodsWithViolations.SelectMany(m => m.Violations).GroupBy(v => v.SinkType));
@@ -703,7 +739,7 @@ internal static class AssertionScan
         PrintHistogram("By node:", methodsWithViolations.SelectMany(m => m.Violations).GroupBy(v => v.Node));
         PrintHistogram("By predicate:", methodsWithViolations.SelectMany(m => m.Violations).GroupBy(v => v.Predicate));
 
-        if (survivors.Length > 0)
+        if (survivors.Count > 0)
         {
             Console.WriteLine();
             Console.WriteLine("Final-stage survivors (UNSOUND — the soundness signal):");
@@ -714,10 +750,10 @@ internal static class AssertionScan
         // Obligation lifetime — stages from accrual to discharge — is a
         // construction-quality signal: a short lifetime means a pass decided the
         // type early, a long one means it retrofitted the claim late. Only
-        // discharged obligations have a lifetime (survivors never discharge). See
-        // docs/design/assertion-lane-effects.md.
-        var discharged = methodsWithViolations.SelectMany(m => m.Violations).Where(v => !v.FinalStageSurvivor).ToArray();
-        if (discharged.Length > 0)
+        // discharged obligations have a lifetime (survivors never discharge, and
+        // pass-bug residue is UNKNOWN, not discharged — both are excluded above).
+        // See docs/design/assertion-lane-effects.md.
+        if (discharged.Count > 0)
         {
             var lifetimes = discharged.Select(v => v.LifetimeStages).ToArray();
             Console.WriteLine();
@@ -870,12 +906,33 @@ internal static class AssertionScan
 
         // The survivor deltas are the load-bearing soundness signal: a newly
         // surviving assertion (UNSOUND) is a real regression, distinct from a
-        // gained-but-discharged obligation. See #2269.
+        // gained-but-discharged obligation. See #2269. The FinalStageSurvivor
+        // flag arrived in snapshot schema v2, so a v1 baseline deserializes every
+        // record with it false — comparing survivor sets against it would report
+        // every current survivor as newly gained. Skip that section (and say why)
+        // rather than emit a migration artifact as a regression (#2285).
         Console.WriteLine();
         Console.WriteLine("Final-stage survivors (UNSOUND) delta:");
-        PrintDiffSide("  SURVIVOR REGRESSED (method gained a final-stage survivor)", survivorGained);
-        PrintDiffSide("  SURVIVOR IMPROVED (method discharged a former survivor)", survivorLost);
+        if (SurvivorDeltaComparable(baseline.SchemaVersion))
+        {
+            PrintDiffSide("  SURVIVOR REGRESSED (method gained a final-stage survivor)", survivorGained);
+            PrintDiffSide("  SURVIVOR IMPROVED (method discharged a former survivor)", survivorLost);
+        }
+        else
+        {
+            Console.WriteLine($"  (skipped: baseline schema v{baseline.SchemaVersion} predates the survivor flag (v2).");
+            Console.WriteLine("   Regenerate the baseline with the current tool; a v1-baseline survivor delta is a");
+            Console.WriteLine("   migration artifact, not a regression.)");
+        }
     }
+
+    /// <summary>
+    /// Whether a baseline's survivor set is comparable to the current run. The
+    /// <c>FinalStageSurvivor</c> flag is a schema-v2 field; a v1 (or older)
+    /// baseline records it as false everywhere, so a survivor delta against it is
+    /// a migration artifact rather than a real regression (#2285).
+    /// </summary>
+    internal static bool SurvivorDeltaComparable(int baselineSchemaVersion) => baselineSchemaVersion >= 2;
 
     static void PrintDiffSide(string title, SortedDictionary<string, List<string>> byViolation)
     {

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -34,7 +34,15 @@ is now measured corpus-wide rather than eyeballed from `--dump --assertions`
 exemplars (known `PrinterOwned` residuals excluded). `--emit-assertion-violations`
 persists the survivor flag (snapshot schema v2), and `--diff-assertion-violations`
 reports a dedicated **survivor delta** so a newly surviving assertion is
-distinguished from a gained-but-discharged obligation.
+distinguished from a gained-but-discharged obligation. A pass-bug method (one that
+crashed before reaching a final stage) is reported as a third `unknown (pass bug,
+no final stage)` state — its violations are neither survivors nor discharged.
+
+Regenerate baselines after upgrading to snapshot schema v2: a v1 baseline records
+the survivor flag as false everywhere, so `--diff-assertion-violations` cannot
+compare survivor sets against it. The differ skips the survivor-delta section for a
+pre-v2 baseline (a v1-baseline survivor delta is a migration artifact, not a
+regression), and the regular violation delta is unaffected.
 
 For discharged obligations the scan also reports **obligation lifetime** — the
 number of pipeline stages from accrual (first appearance) to discharge (the stage


### PR DESCRIPTION
Fixes #2285.

Two reporting-honesty edges from the #2281 survivor-lane review (non-blocking there), in `tools/DecompilerHarness/AssertionScan.cs`.

## 1. Crash path conflated "unknown" with "UNSOUND"

On a `PassBug` method, `Finalize` runs with `finalStageIdentities` from the last **completed** stage, so violations present there are flagged `FinalStageSurvivor` even though the pipeline never reached a real final stage. The `--assertion-scan` summary counted those as `final-stage survivors (UNSOUND)`, so a pass crash at stage k could read as k-stage UNSOUND findings — a pipeline-crash regression masquerading as a soundness regression.

The summary now classifies violations three ways via a testable `ClassifyViolationStates`:

- **discharged obligations** and **final-stage survivors (UNSOUND)** — only from methods that completed the pipeline;
- **`unknown (pass bug, no final stage)`** — pass-bug residue, a third explicit line, excluded from both tallies, the survivor histograms, and the obligation-lifetime stats.

`survivors + discharged + unknown == first-violation-sites`. At the current corpus state (0 pass bugs) the numbers are unchanged. The `--diff-assertion-violations` lane already excluded pass bugs.

## 2. v1→v2 baseline migration

A `SchemaVersion: 1` baseline deserializes with `FinalStageSurvivor` false everywhere, so the first `--diff-assertion-violations` against an old baseline reports every current survivor as *newly gained*. The differ now skips the survivor-delta section for a pre-v2 baseline (`SurvivorDeltaComparable`) and prints a notice that a v1-baseline survivor delta is a migration artifact, not a regression; the regular violation delta is unaffected. The README documents regenerating baselines after the schema-v2 upgrade.

## Tests / validation

- `ClassifyViolationStates_TreatsPassBugViolationsAsUnknownNotSurvivorOrDischarged` — a pass-bug method's survivor-flagged violation counts as unknown, not survivor/discharged.
- `SurvivorDeltaComparable_RequiresSchemaVersion2`; `SchemaV1Snapshot_DeserializesWithEmptySurvivorSet` (the migration artifact the guard prevents).
- `AssertionScanTests` 19/19; full fast decompiler suite **1896/1896**; `markdownlint` clean on the changed README.

## Risk

Harness/diagnostic reporting only — no product decompiler path change; three-valued honesty in the summary and a guarded diff section, no behavior change at 0 pass bugs / v2 baselines.
