### PR TITLE
docs: allocation triage pre-filter taxonomy from corpus join evidence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Style Guide](design/style-guide.md) | Output formatting conventions. |
 | [Output Shapes](design/output-shapes.md) | The Document → Table → Vector → Scalar shape ladder, how Markout produces it, and how the output flags select a shape. |
 | [Graph Signal Annotations](design/graph-signal-annotations.md) | Projecting analysis signals (alloc/copy/unsafe, and exception-risk follow-ups) onto call-graph nodes via `--fields`. |
+| [Allocation Triage Pre-Filters](design/allocation-triage-prefilters.md) | Which allocation candidates Performance Triage surfaces, why the pre-filters prune cold-by-construction shapes, and what realized cost the static side cannot predict. |
 | [Rendering Model](design/rendering-model.md) | Historical/current rendering model notes; prefer [Progressive Disclosure](design/progressive-disclosure.md) for current agent-facing behavior. |
 | [Section Model](design/section-model.md) | Section selection design notes; use with [Progressive Disclosure](design/progressive-disclosure.md). |
 | [Schema Query](design/schema-query.md) | `-D`/`-S` schema/query implementation notes. |

--- a/docs/design/allocation-triage-prefilters.md
+++ b/docs/design/allocation-triage-prefilters.md
@@ -1,0 +1,107 @@
+# Allocation Triage Pre-Filters
+
+Which static allocation candidates Performance Triage surfaces, why the
+pre-filters are shaped the way they are, and what the static side can and cannot
+predict about realized cost. Grounded in active corpus use of the static analysis
+joined against real allocation traces.
+
+Related docs:
+
+- [Graph signal annotations](graph-signal-annotations.md) — the signal/leverage
+  triage axes allocation rows plug into
+- [Hidden-fact annotations](hidden-fact-annotations.md) — the per-method
+  allocation-occurrence evidence model
+
+## Two halves of an allocation verdict
+
+An allocation row has two independent components:
+
+1. **Cost-shape** — the objective, per-invocation nature of the allocation: its
+   kind (box/array/closure/delegate/object), whether it sits on a loop back-edge,
+   where the value escapes, how large it is. This is static and knowable from IL.
+2. **Realized frequency** — how many times the containing method actually runs in
+   a given workload. This is dynamic and *not* knowable from IL: the same shape is
+   cold in a rarely-called method and dominant in a hot one.
+
+The static analysis owns the first. A trace join (the `runfaster` prototype, or a
+profiler) owns the second. The pre-filters below follow from keeping that split
+honest: **the static side prunes shapes that are cold by construction and
+describes shape; it does not rank shapes by heat, because heat is frequency and
+frequency is not static.**
+
+## Evidence
+
+Three assemblies, static candidates joined to a real GC-allocation-tick trace,
+spanning the optimization spectrum:
+
+| Target | Static candidates | Trace tick-match | Top realized allocation |
+| --- | ---: | ---: | --- |
+| An un-optimized app path | ~8.5k | ~100% | a capturing `Where` closure, per element |
+| A heavily-optimized generic library | ~0.9k | ~0% (IL-offset) | a constructor-argument state object |
+| The decompiler itself | ~5.2k | ~83% | a per-call iterator state machine + stack |
+
+Two facts recur across all three:
+
+- The IL-offset join is precise on non-inlined code and near-blind on
+  generic/inlined code; type-level confirmation is the necessary complement there.
+- The dominant realized volume is **call-frequency-driven**, not loop-driven.
+
+## What the static side can prune (cold by construction)
+
+These shapes are cold because of what they *are*, independent of workload, so
+pruning or demoting them loses no realized paydirt. Measured hit-rate against the
+join is near zero for each.
+
+| Shape | Rationale | Status |
+| --- | --- | --- |
+| Throw-path / error-path allocation | Exception setup, not steady state | Filtered |
+| Exception-object construction | Same | Filtered |
+| Constructor / type-initializer setup | One execution per instance/type | Demoted (amortized caveat) |
+
+The amortized-setup demotion carries a caveat rather than a hard drop, because a
+constructor invoked from a loop is a genuine transient signal; that case is
+preserved by checking for loop invocation before demoting.
+
+## What the static side must not do
+
+**Rank by shape.** The realized top-volume sites have weak shape signal. In the
+decompiler corpus the highest-volume allocation sits well below the top of any
+static shape ranking (near the top third, with other top-volume sites past the
+median), and the top group is dominated by `Once`/`Conditional` (once-per-call)
+allocations with no escape refinement and no loop membership. Their cost is pure
+call frequency. A ranker that promotes loop or escape shape buries them.
+
+The existing loop gate on the *aggregate* per-method density row is therefore
+scoped deliberately: it applies only to the vague catch-all row, never to
+specific-shape rows. Specific-shape rows stay visible regardless of loop
+membership, so a hot once-per-call closure or delegate is not hidden.
+
+## Negative results worth keeping
+
+Active use ruled out two plausible-looking filters:
+
+- **Static-field escape is not an amortization filter.** Allocations that escape
+  into a static field score near-zero realized heat in the corpus, which suggests
+  demoting them as one-time cache/singleton initialization. That correlation is
+  already explained by two existing behaviors — the compiler's
+  `ldsfld`/`dup`/`brtrue`/`stsfld` cached-delegate pattern is suppressed at
+  detection, and plain static-field object initializers never reach a
+  specific-shape or loop-density row — so no additional filter changes curated
+  output. It would also be unsound as a rule: an unconditional per-call
+  `field = expr` assignment escapes to a static field yet allocates every call.
+  The coldness is a property of existing suppression, not a semantic guarantee of
+  the escape kind.
+
+- **Collection-element escape is workload-correlated, not universal.** It is cold
+  in a decompiler sweep but would be hot in a collection-building workload, so it
+  is a deprioritization signal at most, never a prune.
+
+## Principle
+
+Every pre-filter must be justifiable by *why the shape is cold by construction*
+(throw path, one-time initialization), not by *where it happened to be cold in one
+trace*. Ranking the survivors by heat requires realized frequency, which only a
+trace join supplies. The static side's contribution to precision is a clean,
+semantically-grounded pruning of the un-actionable, plus the shape vocabulary that
+lets a join explain *why* a confirmed-hot site is hot (loop-intrinsic versus
+call-frequency-driven) and therefore *how* to fix it.


### PR DESCRIPTION
Adds `docs/design/allocation-triage-prefilters.md` — the hard-won pre-filter
rationale for Performance Triage, derived from active use of the static analysis
joined against real allocation traces (an un-optimized app path, a heavily-
optimized generic library, and the decompiler itself).

## Why

Performance Triage's pre-filters should be earned from active tool use, including
knowing which plausible filters *not* to add. This note captures that taxonomy so
the rationale is durable rather than re-derived.

## Taxonomy

- **Two halves of a verdict**: static owns objective *cost-shape*
  (kind/loop/escape/size); a trace join owns *realized frequency*. The same shape
  is cold in a rarely-called method and dominant in a hot one.
- **Prune cold-by-construction** (throw-path, exception construction,
  constructor/type-init setup) — measured near-zero realized hit-rate; already
  filtered/demoted in `LibraryBodyIndex`.
- **Never rank survivors by shape** — the top realized volume is
  call-frequency-driven and has weak shape signal (the highest-volume decompiler
  site sits well below the top of any static shape ranking; the top group is
  dominated by `Once`/`Conditional`, no escape refinement, no loop membership).
  The existing loop-gate is therefore scoped to the aggregate density row only.

## Negative results recorded (the point of the exercise)

- **Static-field escape is not a safe amortization filter.** It scores near-zero
  realized heat in the corpus, but that is already produced by the compiler
  cached-delegate suppression plus plain static initializers not surfacing as
  rows — no additional filter changes curated output (verified: 0 curated
  opportunities at any static-escape occurrence across the decompiler, analysis,
  and metadata assemblies). It would also be unsound: an unconditional per-call
  assignment to a static field allocates every call.
- **Collection-element escape is workload-correlated, not universal** — a
  deprioritization signal at most, never a prune.

## Scope

Docs-only. No product behavior change. Registered in `docs/README.md`.
markdownlint clean.
