### PR TITLE
Move C# diff producer to Decompiler

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpBodyDiffTests.cs
@@ -1,6 +1,7 @@
 using DotnetInspector.Fixtures;
+using ILInspector.Decompiler;
 
-namespace ILInspector.Research.Tests;
+namespace ILInspector.Decompiler.Tests;
 
 public class CSharpBodyDiffTests
 {

--- a/src/ILInspector.Decompiler/CSharpBodyDiff.cs
+++ b/src/ILInspector.Decompiler/CSharpBodyDiff.cs
@@ -5,13 +5,12 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Security.Cryptography;
 using System.Text;
-using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
 
-namespace ILInspector.Research;
+namespace ILInspector.Decompiler;
 
 public enum CSharpDiffKind
 {
@@ -169,7 +168,7 @@ public sealed record CSharpBodyDiffResult(
 }
 
 /// <summary>
-/// Research-owned C# body diff over the shipped decompiler output for matched
+/// Decompiler-owned C# body diff over the shipped decompiler output for matched
 /// method bodies.
 /// </summary>
 public static class CSharpBodyDiff
@@ -310,7 +309,7 @@ public static class CSharpBodyDiff
                 var parameters = signature.ParameterTypes.Select(CanonicalTypeName).ToImmutableArray();
                 int genericArity = method.GetGenericParameters().Count;
                 string methodGeneric = GenericParameterList(genericArity, isMethod: true);
-                string selectorName = ResearchDiff.ResearchMemberSelector.ForMetadataName(methodName, IsExtensionMethod(reader, type, method));
+                string selectorName = MemberSelectorForMetadataName(methodName, IsExtensionMethod(reader, type, method));
                 string returnSuffix = IsConversionOperator(methodName) ? $"~{returnType}" : "";
                 string canonicalName = CanonicalMemberName(methodName);
                 string rawKey = $"M:{typeKey}.{canonicalName}{methodGeneric}({string.Join(",", parameters)}){returnSuffix}";
@@ -771,6 +770,16 @@ public static class CSharpBodyDiff
 
         return false;
     }
+
+    static string MemberSelectorForMetadataName(string methodName, bool isExtensionMethod = false)
+        => methodName switch
+        {
+            ".ctor" => ".ctor",
+            _ when isExtensionMethod => $"extension:{methodName}",
+            _ when methodName.StartsWith("op_", StringComparison.Ordinal) => $"operator:{methodName}",
+            _ when methodName.Contains('.') => $"explicit:{methodName}",
+            _ => methodName,
+        };
 
     static bool MatchesTypeFilter(string typeFullName, string filter)
     {

--- a/src/ILInspector.Decompiler/CSharpDiffPrinter.cs
+++ b/src/ILInspector.Decompiler/CSharpDiffPrinter.cs
@@ -2,7 +2,7 @@ using System.Collections.Immutable;
 using System.Text;
 using ILInspector.MetadataPrimitives;
 
-namespace ILInspector.Research;
+namespace ILInspector.Decompiler;
 
 public sealed record CSharpDiffDisplayRow(
     string AssemblyIdentity,

--- a/src/ILInspector.Decompiler/ILInspector.Decompiler.csproj
+++ b/src/ILInspector.Decompiler/ILInspector.Decompiler.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
+    <ProjectReference Include="..\ILInspector.MetadataPrimitives\ILInspector.MetadataPrimitives.csproj" />
     <ProjectReference Include="..\ILInspector.Instructions\ILInspector.Instructions.csproj" />
     <ProjectReference Include="..\ILInspector.ControlFlow\ILInspector.ControlFlow.csproj" />
   </ItemGroup>

--- a/src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj
+++ b/src/ILInspector.Research.Tests/ILInspector.Research.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DiffFixtures.V1\DiffFixtures.V1.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\DiffFixtures.V2\DiffFixtures.V2.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ILInspector.Decompiler\ILInspector.Decompiler.csproj" />
     <ProjectReference Include="..\ILInspector.Metadata\ILInspector.Metadata.csproj" />
     <ProjectReference Include="..\ILInspector.Research\ILInspector.Research.csproj" />
     <ProjectReference Include="..\..\tests\DotnetInspector.Fixtures\DotnetInspector.Fixtures.csproj" />

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Fixtures;
+using ILInspector.Decompiler;
 using ILInspector.Metadata;
 using ILInspector.Instructions;
 

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -3,6 +3,7 @@ using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Collections.Immutable;
 using ILInspector.Analysis;
+using ILInspector.Decompiler;
 using ILInspector.Instructions;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;


### PR DESCRIPTION
## Summary

Moves the C# diff producer out of Research and into Decompiler.

## Details

- Moves `CSharpBodyDiff`, C# diff row/failure-row/display types, semantic operation stream, and `CSharpDiffPrinter` to `ILInspector.Decompiler`.
- Moves producer-focused `CSharpBodyDiffTests` to `ILInspector.Decompiler.Tests`.
- Keeps `ResearchDiff` as the wrapper/projector that consumes producer-owned C# rows/failure rows/display rows and attaches subject/member identity.
- Removes the C# producer's dependency on `ResearchDiff.ResearchMemberSelector` by owning the equivalent member-selector mapping locally in Decompiler.
- Leaves Research C# knowledge limited to typed row/failure row projection.

Fixes #2364.

## Validation

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CSharpBodyDiffTests/*"`
- `dotnet run --project src/ILInspector.Research.Tests -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/DiffCommandTests/*"`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity minimal`
- `git diff --check`

## Review

Adversarial review is required for this Decompiler/Research boundary change and will be posted before marking ready.
