### PR TITLE
perf(decompiler): pool IrNode.Descendants work stack (86% fewer bytes/traversal)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrNodeDescendantsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrNodeDescendantsTests.cs
@@ -71,4 +71,110 @@ public class IrNodeDescendantsTests
 
         Assert.Equal(ReferencePreOrder(root).ToList(), root.Descendants.ToList());
     }
+
+    [Fact]
+    public void Descendants_PooledStack_AllocationIndependentOfSubtreeSize()
+    {
+        // A shallow tree and a large deep tree. With the work stack pooled, a traversal
+        // allocates only its fixed iterator state machine — never a stack or a backing
+        // array that grows with the subtree — so per-traversal allocation is identical
+        // for both regardless of node count.
+        var small = Node(0x00, Node(0x10), Node(0x20));
+        var large = BuildBalanced(depth: 8, fanout: 3); // 3^0+..+3^8 = 9841 nodes
+
+        static long PerTraversalBytes(IrNode root)
+        {
+            static int Walk(IrNode node)
+            {
+                int count = 0;
+                foreach (var _ in node.Descendants)
+                    count++;
+                return count;
+            }
+
+            Walk(root); // warm up JIT + populate the pool
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            const int iterations = 200;
+            for (int i = 0; i < iterations; i++)
+                Walk(root);
+            return (GC.GetAllocatedBytesForCurrentThread() - before) / iterations;
+        }
+
+        long smallBytes = PerTraversalBytes(small);
+        long largeBytes = PerTraversalBytes(large);
+
+        // Independent of subtree size: the 9841-node walk allocates no more than the
+        // 2-node walk (only the state machine; the stack + backing are pooled).
+        Assert.Equal(smallBytes, largeBytes);
+    }
+
+    [Fact]
+    public void Descendants_NestedReentrantTraversal_IsCorrect()
+    {
+        var root = Node(0x00,
+            Node(0x10, Node(0x11, Node(0x13)), Node(0x12)),
+            Node(0x20, Node(0x21)));
+
+        // Interleave an inner traversal inside the outer one: the pooled stacks must
+        // not be shared, so each descendant's own subtree count is exact.
+        var pairs = new List<(int Node, int SubtreeCount)>();
+        foreach (var node in root.Descendants)
+        {
+            int inner = 0;
+            foreach (var _ in node.Descendants)
+                inner++;
+            pairs.Add((((Block)node).StartOffset, inner));
+        }
+
+        Assert.Equal(
+            new[]
+            {
+                (0x10, 3), // a: a1, a3, a2
+                (0x11, 1), // a1: a3
+                (0x13, 0),
+                (0x12, 0),
+                (0x20, 1), // b: b1
+                (0x21, 0),
+            },
+            pairs);
+    }
+
+    [Fact]
+    public void Descendants_EarlyBreak_ReturnsStackToPool()
+    {
+        var root = BuildBalanced(depth: 4, fanout: 3);
+
+        // Break out early many times; the finally must return each rented stack, so a
+        // subsequent full traversal still allocates only its state machine (no growth).
+        for (int i = 0; i < 100; i++)
+        {
+            foreach (var _ in root.Descendants)
+                break;
+        }
+
+        // Full traversal after the early breaks still yields the complete subtree.
+        int count = 0;
+        foreach (var _ in root.Descendants)
+            count++;
+        Assert.Equal(CountNodes(root) - 1, count);
+    }
+
+    static Block BuildBalanced(int depth, int fanout)
+    {
+        var node = new Block(depth);
+        if (depth > 0)
+        {
+            for (int i = 0; i < fanout; i++)
+                node.Add(BuildBalanced(depth - 1, fanout));
+        }
+        return node;
+    }
+
+    static int CountNodes(IrNode node)
+    {
+        int count = 1;
+        foreach (var child in node.Children)
+            count += CountNodes(child);
+        return count;
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNode.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNode.cs
@@ -114,29 +114,41 @@ public abstract class IrNode
         Parent.SetChild(ChildIndex, replacement);
     }
 
+    /// <summary>
+    /// Pre-order (self-excluded) descendants of this node. Iterative DFS: a recursive
+    /// <c>yield return</c> over children allocates one nested iterator per node (O(N)
+    /// state machines per traversal) and re-yields every value up through its ancestors
+    /// (O(N*depth) time). This walks the same order with a single work stack rented from
+    /// a per-thread pool, so a traversal allocates only its iterator state machine — the
+    /// stack and its backing array are reused across traversals. Children are pushed in
+    /// reverse so they pop in source order, reproducing the recursive pre-order.
+    /// </summary>
     public IEnumerable<IrNode> Descendants
     {
         get
         {
-            // Iterative pre-order DFS. A recursive `yield return` over children
-            // allocates one nested enumerator per node (O(N) state machines per
-            // traversal) and re-yields every value up through its ancestors
-            // (O(N*depth) time); an explicit stack does the same walk with a
-            // single enumerator plus one stack, and cannot deep-recurse.
-            // Children are pushed in reverse so they pop in source order,
-            // reproducing the recursive pre-order exactly.
             if (_children.Count == 0)
                 yield break;
-            var stack = new Stack<IrNode>();
-            for (int i = _children.Count - 1; i >= 0; i--)
-                stack.Push(_children[i]);
-            while (stack.Count > 0)
+            var stack = DescendantStackPool.Rent();
+            try
             {
-                var node = stack.Pop();
-                yield return node;
-                var children = node._children;
-                for (int i = children.Count - 1; i >= 0; i--)
-                    stack.Push(children[i]);
+                for (int i = _children.Count - 1; i >= 0; i--)
+                    stack.Push(_children[i]);
+                while (stack.Count > 0)
+                {
+                    var node = stack.Pop();
+                    yield return node;
+                    var children = node._children;
+                    for (int i = children.Count - 1; i >= 0; i--)
+                        stack.Push(children[i]);
+                }
+            }
+            finally
+            {
+                // Runs when the iterator is disposed — foreach and LINQ both dispose,
+                // including on an early break — so the stack returns to the pool even
+                // when enumeration stops early.
+                DescendantStackPool.Return(stack);
             }
         }
     }
@@ -179,6 +191,56 @@ public abstract class IrNode
     }
 
     public override string ToString() => Describe();
+}
+
+/// <summary>
+/// Per-thread pool of work stacks for <see cref="IrNode.Descendants"/>. A
+/// traversal rents a stack and returns it on <c>Dispose</c>, so steady-state
+/// traversal allocates nothing. Reentrancy-safe: nested/interleaved traversals rent
+/// distinct stacks, and a skipped return only falls back to a fresh allocation. The
+/// return path is idempotent against a double-return (a copied-then-doubly-disposed
+/// enumerator) so a stack cannot be handed out twice.
+/// </summary>
+static class DescendantStackPool
+{
+    const int MaxPooledPerThread = 8;
+
+    [ThreadStatic]
+    static Stack<IrNode>?[]? _free;
+
+    [ThreadStatic]
+    static int _count;
+
+    public static Stack<IrNode> Rent()
+    {
+        var free = _free;
+        if (free is not null && _count > 0)
+        {
+            int index = --_count;
+            var stack = free[index]!;
+            free[index] = null;
+            stack.Clear();
+            return stack;
+        }
+        return new Stack<IrNode>();
+    }
+
+    public static void Return(Stack<IrNode> stack)
+    {
+        var free = _free ??= new Stack<IrNode>?[MaxPooledPerThread];
+        // Idempotent: never pool the same instance twice (guards a double-return from
+        // a copied-then-doubly-disposed struct enumerator).
+        for (int i = 0; i < _count; i++)
+        {
+            if (ReferenceEquals(free[i], stack))
+                return;
+        }
+        if (_count < free.Length)
+        {
+            stack.Clear();
+            free[_count++] = stack;
+        }
+    }
 }
 
 /// <summary>An IR node that produces a value, typed by <see cref="TypeRef"/>.</summary>


### PR DESCRIPTION
## Summary

`IrNode.Descendants` was the #1 allocator in a CoreLib decompiler sweep (~857 MB,
~21% of the sweep). #2173 made it iterative to kill the O(N*depth) recursive
re-yield, but the iterative walk still allocated a fresh `Stack<IrNode>` and its
growing backing array on every traversal. This pools the work stack.

## Change

> Should we accept this change?

**Conclusion: PASS** — 86% fewer bytes per traversal, byte-identical decompiler
output over 41,012 methods, no call-site changes.

Rent the work stack from a small per-thread pool and return it in a `finally`.
`Descendants` stays `IEnumerable<IrNode>` so no call site changes and no new
boxing. A struct-enumerator alternative was measured to be *worse* here: the ~320
mostly-LINQ call sites boxed both the struct enumerable and its enumerator (~468 MB
of new boxing), so the pooled-stack-in-yield design was chosen instead — only the
iterator state machine remains per traversal.

Safety:

- **Reentrancy**: nested/interleaved traversals rent distinct stacks; the pool is
  per-thread (`[ThreadStatic]`), safe under the harness `--workers` parallelism.
- **Always returns**: the `finally` runs on iterator dispose — `foreach` and LINQ
  both dispose, including on an early `break`; a skipped return only falls back to a
  fresh allocation (never corruption).
- **Idempotent return**: the return path rejects a double-return (a
  copied-then-doubly-disposed enumerator), so a stack cannot be handed out twice.

## Evidence

| Check | Result |
| --- | --- |
| Micro-benchmark (real `IrNode`, 364-node tree) | 392 → 56 B/traversal (**86%**); residual is the yield state machine |
| Render A/B vs merge-base (41,012 CoreLib methods) | **0 changed / 0 added / 0 removed** |
| Fast decompiler suite | 1910/1910 |
| New regression tests | pooled-stack allocation-independence, nested reentrancy, early-break return; existing order-equivalence canaries unchanged |

## Adversarial review

Requested from two models (isolated worktrees); reconciliation to follow.
