### PR TITLE
Zero-extend signed operands widened to an unsigned target (#2336)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1645,6 +1645,93 @@ public class CSharpPrinterTests
         Assert.Equal("return unchecked((ulong)(-1));", CSharpPrinter.Print(function).Output!.Trim());
     }
 
+    [Fact]
+    public void ConvertU8OfSignedInt_InsertsUnsignedSibling()
+    {
+        // conv.u8 of a non-constant SIGNED int zero-extends the 32-bit stack value;
+        // a bare `(ulong)i` sign-extends (wrong value for negative i). `(ulong)(uint)i`
+        // reinterprets faithfully and round-trips to conv.u8 (#2336).
+        Assert.Equal("return (ulong)(uint)i;", RenderConvertReturn("UInt64", "Int32"));
+    }
+
+    [Fact]
+    public void ConvertU8OfSbyte_ZeroExtendsAtStackWidth_NotDeclaredWidth()
+    {
+        // A sub-int operand is sign-extended to int32 on the CIL stack BEFORE
+        // conv.u8, so the zero-extension is at the stack width: `(ulong)(uint)s`,
+        // never `(ulong)(byte)s` (= 255 for sbyte -1, the wrong value) (#2336).
+        Assert.Equal("return (ulong)(uint)s;", RenderConvertReturn("UInt64", "SByte", "s"));
+    }
+
+    [Fact]
+    public void ConvertU8OfUnsignedOperand_StaysBare()
+    {
+        // An already-unsigned operand's `(ulong)u` already zero-extends — inserting
+        // a redundant `(uint)` would be churn, so the fix must not fire (#2336).
+        Assert.Equal("return (ulong)u;", RenderConvertReturn("UInt64", "UInt32", "u"));
+    }
+
+    [Fact]
+    public void ConvertToNuintOfSignedInt_InsertsUnsignedSibling()
+    {
+        // conv.u (native unsigned) of a signed int zero-extends the 32-bit stack
+        // value on 64-bit; `(nuint)(uint)i` is faithful on both platform widths (#2336).
+        Assert.Equal("return (nuint)(uint)i;", RenderConvertReturn("UIntPtr", "Int32"));
+    }
+
+    [Fact]
+    public void ConvertU8OfLong_StaysBare()
+    {
+        // A long source is already the ulong stack width, so `(ulong)l` is a faithful
+        // reinterpret with no zero/sign-extension choice — the fix must not fire (#2336).
+        Assert.Equal("return (ulong)l;", RenderConvertReturn("UInt64", "Int64", "l"));
+    }
+
+    [Fact]
+    public void SignedWidenToLong_StaysBare()
+    {
+        // A SIGNED target keeps sign-extension (conv.i8): `(long)i` is faithful, the
+        // fix only applies to unsigned/native widening targets (#2336).
+        Assert.Equal("return (long)i;", RenderConvertReturn("Int64", "Int32"));
+    }
+
+    [Fact]
+    public void CheckedConvOvfU8OfSignedInt_StaysBare()
+    {
+        // conv.ovf.u8 (checked) of a signed int throws for a negative value, so
+        // `checked((ulong)i)` already matches it; inserting `(uint)` would recompile
+        // to conv.ovf.u4;conv.u8 (wrong opcodes), so the fix must not fire (#2336).
+        var source = TypeRef.CoreLib("System", "Int32");
+        var conv = new ILInspector.Decompiler.Pipeline.Convert(
+            TypeRef.CoreLib("System", "UInt64"), isChecked: true, isUnsigned: false,
+            new LoadArgument(0, "i", source));
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new Return(conv));
+        var signature = new MethodSignature(
+            TypeRef.CoreLib("System", "UInt64"), [new Parameter("i", source)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+
+        Assert.Equal("return checked((ulong)i);", CSharpPrinter.Print(function).Output!.Trim());
+    }
+
+    static string RenderConvertReturn(string targetType, string sourceType, string paramName = "i")
+    {
+        var source = TypeRef.CoreLib("System", sourceType);
+        var conv = new ILInspector.Decompiler.Pipeline.Convert(
+            TypeRef.CoreLib("System", targetType), isChecked: false, isUnsigned: false,
+            new LoadArgument(0, paramName, source));
+        var container = new BlockContainer();
+        var block = new Block(0);
+        container.Add(block);
+        block.Add(new Return(conv));
+        var signature = new MethodSignature(
+            TypeRef.CoreLib("System", targetType), [new Parameter(paramName, source)], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.CoreLib("Synthetic", "T"), signature, [], container);
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
     static string ReturnConstant(int value, string constType, string returnType)
     {
         var container = new BlockContainer();

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3163,6 +3163,24 @@ public sealed partial class CSharpPrinter
         // conv.r.un and conv.ovf.*.un interpret the SOURCE as unsigned —
         // a signed operand needs its unsigned cast or the value is wrong.
         string operand = convert.IsUnsigned ? UnsignedOperand(convert.Operand, checkedSafe: !convert.IsChecked) : Operand(convert.Operand);
+        // A widening conversion to an unsigned target (`conv.u8`) ZERO-extends the
+        // 32-bit stack value, but a bare `(ulong)x` sign-extends a SIGNED operand —
+        // a silent wrong value for a negative x. C# elides the sibling cast, so
+        // `(ulong)(uint)i` compiles to `ldarg; conv.u8` and the operand is a bare
+        // signed `int`. Reinterpret through the unsigned sibling when the operand
+        // RENDERS signed. The discriminator is EffectiveType, not the ECMA stack
+        // ResultType: an already-unsigned expression such as `(uint)a + b` renders
+        // unsigned (its bare `(ulong)` already zero-extends) and must not be
+        // re-cast — gating on the rendered type keeps this to genuine corrections.
+        // Constants take the value-aware branch above; `.un` operands are already
+        // unsigned (#2336, the non-constant sibling of #2101).
+        // Only the UNCHECKED widening conv.u8/conv.u zero-extends silently. A
+        // checked conv.ovf.u8 of a signed operand throws for a negative value, so
+        // the bare `checked((ulong)i)` already matches it — inserting a `(uint)`
+        // there would recompile to conv.ovf.u4;conv.u8 (wrong opcodes).
+        if (!convert.IsUnsigned && !convert.IsChecked && convert.Operand is not Constant
+            && TypeFamilies.WideningZeroExtendSibling(EffectiveType(convert.Operand), convert.Target) is { } zeroExtendWiden)
+            operand = $"({TypeText(zeroExtendWiden)}){operand}";
         string targetText = TypeText(convert.Target);
         // A cast whose operand begins with a unary `-`/`+` is parsed as binary
         // subtraction/addition (CS0075) unless the target spelling is a predefined

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -174,6 +174,10 @@ public static class TypeFamilies
     static bool IsUnsignedInteger(TypeRef? type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Byte" or "UInt16" or "Char" or "UInt32" or "UInt64" };
 
+    /// <summary>True for the signed fixed-width integer primitives (sbyte/short/int/long); nint excluded — platform width is unknown here.</summary>
+    public static bool IsSignedFixedWidthInteger(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "SByte" or "Int16" or "Int32" or "Int64" };
+
     /// <summary>
     /// For a widening integer conversion to an unsigned <paramref name="target"/>, the
     /// unsigned sibling of <paramref name="source"/>'s width — the cast that
@@ -196,6 +200,37 @@ public static class TypeFamilies
                 _ => null,
             }
             : null;
+
+    /// <summary>
+    /// The unsigned sibling a SIGNED operand must be reinterpreted through when a
+    /// widening conversion to <paramref name="target"/> zero-extends it
+    /// (<c>conv.u8</c>/<c>conv.u</c> of a non-constant). The zero-extension
+    /// operates at the operand's IL STACK width — a sub-int operand is
+    /// sign-extended to int32 first — so an <c>sbyte s</c> widens as
+    /// <c>(ulong)(uint)s</c>, never <c>(ulong)(byte)s</c> (which would discard the
+    /// sign extension and compute the wrong value). A native-unsigned target
+    /// (<c>nuint</c>, <c>conv.u</c>) zero-extends the int32 stack value on 64-bit
+    /// and reinterprets it on 32-bit, so <c>(nuint)(uint)x</c> is faithful on both;
+    /// a <see cref="long"/> source is native-width and left alone. Null when no
+    /// widening reinterpret applies: an unsigned or non-fixed-width source, or a
+    /// <see cref="long"/> source into <see cref="ulong"/>/native (same stack width).
+    /// </summary>
+    public static TypeRef? WideningZeroExtendSibling(TypeRef? signedSource, TypeRef? target)
+    {
+        if (Width(signedSource) is not { } sourceWidth || !IsSignedFixedWidthInteger(signedSource))
+            return null;
+        // A native-unsigned target has no fixed width here, but conv.u of an
+        // int32-stack value zero-extends it, so an int32-stack signed source
+        // (width <= 4) takes the uint sibling regardless of platform width.
+        if (sourceWidth <= 4 && IsNativeUnsignedInteger(target))
+            return TypeRef.CoreLib("System", "UInt32");
+        var stackType = sourceWidth <= 4 ? TypeRef.CoreLib("System", "Int32") : TypeRef.CoreLib("System", "Int64");
+        return ZeroExtendingSource(stackType, target);
+    }
+
+    /// <summary>The native-sized unsigned integer primitive (<c>nuint</c>/<see cref="UIntPtr"/>).</summary>
+    static bool IsNativeUnsignedInteger(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "UIntPtr" };
 
     /// <summary>
     /// True when the C# <em>checked</em> conversion <paramref name="source"/> →


### PR DESCRIPTION
Fixes #2336.

## Problem

`conv.u8`/`conv.u` of a **non-constant SIGNED** operand rendered a bare `(ulong)x`, which **sign-extends** where the IL **zero-extends** the 32-bit stack value — a silent wrong value. csc elides the sibling cast, so `(ulong)(uint)i` compiles to `ldarg; conv.u8` and the decompiler dropped back to `(ulong)i` (`= 18446744073709551615` for `i = -1`, vs the correct `4294967295`). This is the non-constant sibling of the #2101 constant fix.

## Fix

In `ConvertBody`, a non-constant, **unchecked** widening conversion to an unsigned (or native-unsigned) target reinterprets the operand through its unsigned sibling — but only when the operand **renders signed**. The discriminator is `EffectiveType`, not the ECMA stack `ResultType`: an already-unsigned expression like `(uint)a + b` renders unsigned (its bare `(ulong)` already zero-extends) and is left alone, so there is **no redundant-cast churn** (the reason this wasn't folded into #2335). The zero-extension operates at the int32 **stack** width (a sub-int operand is sign-extended to int32 first), so `(ulong)(uint)s` for an `sbyte`, never `(ulong)(byte)s` (= 255, wrong). Checked (`conv.ovf.u8`) and `.un` converts are excluded — already faithful.

## Evidence

**Render A/B vs merge-base (89,065 methods): `Changed: 9, Added: 0, Removed: 0`** — all genuine value corrections, e.g. Roslyn `SegmentedArraySegment<T>::Slice`:

```text
- if ((((ulong)start) + ((ulong)length)) > ((ulong)Length))
+ if ((((ulong)(uint)start) + ((ulong)(uint)length)) > ((ulong)(uint)Length))
```

(the source's deliberate unsigned-compare idiom). `SegmentedArray.Copy` also picks up a genuine **nuint** correction (`(nuint)(uint)(destinationIndex + length)`), while its `(nuint)destinationArray.LongLength` (long source) and `(uint)256 - state.BufferedCount` (already unsigned) correctly stay bare. No CryptoBlobParser-style churn.

**Fidelity (compiled fixture, `--fidelity-check`):** base **3 OpcodeDiff → 7/7 exact** opcode round-trip. The 3 fixed methods are exactly the signed-operand cases (`(ulong)(uint)i`, `(ulong)(uint)s`, `(ulong)(uint)(a+b)`); the checked / unsigned-operand / signed-target near misses stay bare. Values verified by execution (`4294967295`, not `18446744073709551615` or the byte-masked `255`).

**Tests:** full decompiler fast suite **1914/1914**, including 7 new `ConvertBody` render tests (signed int, sbyte stack-width, unsigned-operand no-churn, nuint, long-source, signed-target, checked-conv-ovf).

<details><summary>Tool quality-diff card (quick caps; flagged "regressions" are cap-size artifacts — compile-cap 25 vs baseline 4000 — not real regressions)</summary>

```text
| Metric (desired direction) | Baseline | PR | Count delta |
| Fully raised (+) | 78,399 (88.02%) | 78,405 (88.03%) | +6 |
| Semantic defects (-) | 74/25,179 | 0/350 | -74 |
| Fidelity diffs (-) | opcode-diff 5/36 | opcode-diff 2/23 | -3 |
```

</details>

## Risk

Printer render change (value/opcode fidelity), scoped by `EffectiveType` signedness + `!IsChecked` + `!IsUnsigned` + non-constant, measured churn-free over the corpus. Two-model adversarial review to follow per policy.
