### PR TITLE
Preserve C# display rows in ResearchDiff

### DIFF
--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -205,6 +205,12 @@ public class ResearchDiffTests
         Assert.Equal(ResearchDiffEvidenceKind.CSharp, row.EvidenceKind);
         Assert.Equal(csharpRow.Message, row.Message);
         Assert.Same(csharpRow, row.CSharpRow);
+        Assert.NotNull(row.CSharpDisplayRow);
+        Assert.Equal(csharpRow.HunkId, row.CSharpDisplayRow.HunkId);
+        Assert.Equal("-", row.CSharpDisplayRow.Marker);
+        Assert.Equal(CSharpDiffOperationKind.Line, row.CSharpDisplayRow.OperationKind);
+        Assert.Equal(csharpRow.Text, row.CSharpDisplayRow.Operation);
+        Assert.Contains(csharpRow.Text, row.CSharpDisplayRow.UnifiedLine, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -358,6 +364,11 @@ public class ResearchDiffTests
         var evidence = Assert.Single(changed.Evidence, evidence => evidence.ChangeId == "csharp.return-expression.changed");
         Assert.Equal("value + 1", evidence.OldValue);
         Assert.Equal("value + 2", evidence.NewValue);
+        var displayRow = Assert.Single(evidence.CSharpDisplayRows);
+        Assert.Equal("~", displayRow.Marker);
+        Assert.Equal(CSharpDiffOperationKind.ReturnExpression, displayRow.OperationKind);
+        Assert.Equal("return value + 1 => return value + 2", displayRow.Operation);
+        Assert.Contains("return value + 1 => return value + 2", displayRow.UnifiedLine, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -65,9 +65,11 @@ public sealed record ResearchDiffRow(
     IlDiffDisplayFailureRow? IlDisplayFailureRow = null,
     BodySignalDiffRow? BodySignalRow = null,
     CSharpDiffRow? CSharpRow = null,
-    CSharpDiffDisplayRow? CSharpDisplayRow = null,
     CSharpDiffFailureRow? CSharpFailureRow = null,
-    CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow = null);
+    CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow = null)
+{
+    public CSharpDiffDisplayRow? CSharpDisplayRow { get; init; }
+}
 
 public sealed record ResearchDiffOptions(
     ResearchDiffMechanism Mechanisms = ResearchDiffMechanism.AllAvailable,
@@ -115,9 +117,11 @@ public sealed record ResearchDiffEvidence(
     bool SubjectInBoth = true,
     bool InLoop = false,
     ImmutableArray<IlDiffDisplayRow> IlDisplayRows = default,
-    ImmutableArray<CSharpDiffDisplayRow> CSharpDisplayRows = default,
     IlDiffDisplayFailureRow? IlDisplayFailureRow = null,
-    CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow = null);
+    CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow = null)
+{
+    public ImmutableArray<CSharpDiffDisplayRow> CSharpDisplayRows { get; init; } = default;
+}
 
 public sealed record ResearchSubjectDiff(
     ResearchSubjectKey Subject,
@@ -248,8 +252,10 @@ public static class ResearchDiff
                 row.ChangeId,
                 ResearchDiffEvidenceKind.CSharp,
                 row.Message,
-                CSharpRow: row,
-                CSharpDisplayRow: CSharpDiffPrinter.ToDisplayRow(row))));
+                CSharpRow: row)
+            {
+                CSharpDisplayRow = CSharpDiffPrinter.ToDisplayRow(row)
+            }));
         }
 
         return new ResearchDiffResult([], Rows: rows.ToImmutable());
@@ -667,8 +673,10 @@ public static class ResearchDiff
                 OldValue: row.OldOperation?.Value ?? row.OldValue ?? (direction == ResearchDiffDirection.Removed ? row.Text : null),
                 NewValue: row.NewOperation?.Value ?? row.NewValue ?? (direction == ResearchDiffDirection.Added ? row.Text : null),
                 Detail: row.Message,
-                Category: ResearchDiffChangeCategory.CSharp,
-                CSharpDisplayRows: [CSharpDiffPrinter.ToDisplayRow(row)]));
+                Category: ResearchDiffChangeCategory.CSharp)
+            {
+                CSharpDisplayRows = [CSharpDiffPrinter.ToDisplayRow(row)]
+            });
         }
     }
 

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -65,6 +65,7 @@ public sealed record ResearchDiffRow(
     IlDiffDisplayFailureRow? IlDisplayFailureRow = null,
     BodySignalDiffRow? BodySignalRow = null,
     CSharpDiffRow? CSharpRow = null,
+    CSharpDiffDisplayRow? CSharpDisplayRow = null,
     CSharpDiffFailureRow? CSharpFailureRow = null,
     CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow = null);
 
@@ -114,6 +115,7 @@ public sealed record ResearchDiffEvidence(
     bool SubjectInBoth = true,
     bool InLoop = false,
     ImmutableArray<IlDiffDisplayRow> IlDisplayRows = default,
+    ImmutableArray<CSharpDiffDisplayRow> CSharpDisplayRows = default,
     IlDiffDisplayFailureRow? IlDisplayFailureRow = null,
     CSharpDiffDisplayFailureRow? CSharpDisplayFailureRow = null);
 
@@ -246,7 +248,8 @@ public static class ResearchDiff
                 row.ChangeId,
                 ResearchDiffEvidenceKind.CSharp,
                 row.Message,
-                CSharpRow: row)));
+                CSharpRow: row,
+                CSharpDisplayRow: CSharpDiffPrinter.ToDisplayRow(row))));
         }
 
         return new ResearchDiffResult([], Rows: rows.ToImmutable());
@@ -664,7 +667,8 @@ public static class ResearchDiff
                 OldValue: row.OldOperation?.Value ?? row.OldValue ?? (direction == ResearchDiffDirection.Removed ? row.Text : null),
                 NewValue: row.NewOperation?.Value ?? row.NewValue ?? (direction == ResearchDiffDirection.Added ? row.Text : null),
                 Detail: row.Message,
-                Category: ResearchDiffChangeCategory.CSharp));
+                Category: ResearchDiffChangeCategory.CSharp,
+                CSharpDisplayRows: [CSharpDiffPrinter.ToDisplayRow(row)]));
         }
     }
 


### PR DESCRIPTION
## Summary

Preserves producer-owned C# display rows through ResearchDiff.

## Details

- Adds `CSharpDisplayRow` to `ResearchDiffRow` for direct `FromCSharpBodyDiff` projections.
- Adds `CSharpDisplayRows` to `ResearchDiffEvidence`, mirroring `IlDisplayRows`.
- Populates C# display rows from `CSharpDiffPrinter.ToDisplayRow` in both `FromCSharpBodyDiff` and `CompareAssemblies` evidence.
- Keeps C# failure display rows unchanged.

This keeps Research as a projector over producer-owned C# evidence while allowing downstream consumers to render C# evidence from the producer display row rather than Research-formatted text.

## Validation

- `dotnet run --project src/ILInspector.Research.Tests -c Release`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/DiffCommandTests/*"`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity minimal`
- `git diff --check`

## Review

Adversarial review is required for this Research/C# evidence shape change and will be posted before marking ready.
