### PR TITLE
perf(decompiler): drop capturing closures in StructuringPass retry-leave scan

### DIFF
--- a/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/StructuringPass.cs
@@ -655,7 +655,7 @@ public sealed class StructuringPass : IIrPass
         int latch = -1;
         for (int j = head; j < stop; j++)
         {
-            var retryLeaves = RetryLeavesTo(blocks[j], headOffset).ToList();
+            var retryLeaves = RetryLeavesTo(blocks[j], headOffset);
             if (retryLeaves.Count == 0)
                 continue;
             if (retryLeaves.Any(leave => !CanRaiseRetryLeave(leave)))
@@ -663,13 +663,35 @@ public sealed class StructuringPass : IIrPass
             latch = j;
         }
 
-        bool hasLoopExit = latch >= 0
-            && Enumerable.Range(head, latch - head + 1).Any(index => HasLoopExit(ctx, blocks[index], index, headOffset, head, latch));
+        bool hasLoopExit = false;
+        if (latch >= 0)
+        {
+            for (int index = head; index <= latch; index++)
+            {
+                if (HasLoopExit(ctx, blocks[index], index, headOffset, head, latch))
+                {
+                    hasLoopExit = true;
+                    break;
+                }
+            }
+        }
         return latch == -1 || !hasLoopExit ? null : latch;
     }
 
-    static IEnumerable<Leave> RetryLeavesTo(Block block, int targetOffset)
-        => block.Descendants.OfType<Leave>().Where(leave => leave.TargetOffset == targetOffset);
+    // Descendant Leave nodes targeting a given offset, collected in one pooled-DFS pass.
+    // A `Descendants.OfType<Leave>().Where(l => l.TargetOffset == targetOffset)` allocates a
+    // capturing closure + delegate + OfType/Where iterators on every call; this hot structuring
+    // helper walks once and filters inline, materializing only the result list.
+    static List<Leave> RetryLeavesTo(Block block, int targetOffset)
+    {
+        var result = new List<Leave>();
+        foreach (var node in block.Descendants)
+        {
+            if (node is Leave leave && leave.TargetOffset == targetOffset)
+                result.Add(leave);
+        }
+        return result;
+    }
 
     static bool HasLoopExit(Ctx ctx, Block block, int blockIndex, int headOffset, int head, int latch)
     {
@@ -1322,9 +1344,7 @@ public sealed class StructuringPass : IIrPass
 
     static void ReplaceRetryLeavesWithContinues(IrNode root, int targetOffset)
     {
-        foreach (var leave in root.Descendants.OfType<Leave>()
-            .Where(leave => leave.TargetOffset == targetOffset && CanRaiseRetryLeave(leave))
-            .ToList())
+        foreach (var leave in RaisableLeavesTargeting(root, targetOffset))
         {
             var next = new Continue();
             next.InheritSourceOffset(leave);
@@ -1334,14 +1354,26 @@ public sealed class StructuringPass : IIrPass
 
     static void ReplaceRetryLeavesWithBreaks(IrNode root, int targetOffset)
     {
-        foreach (var leave in root.Descendants.OfType<Leave>()
-            .Where(leave => leave.TargetOffset == targetOffset && CanRaiseRetryLeave(leave))
-            .ToList())
+        foreach (var leave in RaisableLeavesTargeting(root, targetOffset))
         {
             var next = new Break();
             next.InheritSourceOffset(leave);
             leave.ReplaceWith(next);
         }
+    }
+
+    // Raisable descendant Leave nodes targeting a given offset, materialized so the tree can be
+    // rewritten during iteration. Collected in one pooled-DFS pass with inline filtering, avoiding
+    // the per-call closure/delegate/iterator allocations of the equivalent LINQ chain.
+    static List<Leave> RaisableLeavesTargeting(IrNode root, int targetOffset)
+    {
+        var result = new List<Leave>();
+        foreach (var node in root.Descendants)
+        {
+            if (node is Leave leave && leave.TargetOffset == targetOffset && CanRaiseRetryLeave(leave))
+                result.Add(leave);
+        }
+        return result;
     }
 
     static IrExpression BuildWhileCondition(WhileShape loop)


### PR DESCRIPTION
## Summary

A GC-allocation trace of a CoreLib decompiler sweep (post the `IrNode.Descendants`
pooling in #2368) flagged `StructuringPass` retry-leave detection as a hot
allocator (~32 MB): two sites built a capturing LINQ closure per call.

## Change

> Should we accept this change?

**Conclusion: PASS** — removes ~32 MB of per-call closures/iterators; byte-identical
decompiler output over 41,012 methods; same order and predicates.

- `RetryLeavesTo` did `block.Descendants.OfType<Leave>().Where(l => l.TargetOffset == targetOffset)` — captures `targetOffset`, allocates a delegate + OfType/Where iterators every call. The `ReplaceRetryLeavesWith{Continues,Breaks}` helpers did the same plus a `CanRaiseRetryLeave` predicate.
- `FindLeaveRetryLoopShape`'s loop-exit check `Enumerable.Range(...).Any(index => HasLoopExit(ctx, blocks[index], index, headOffset, head, latch))` captured five locals into another display class per call.

Replaced with a single pooled-DFS pass that filters inline (materializing only the
result list the callers already needed) and a plain indexed loop with early exit.

## Evidence

| Check | Result |
| --- | --- |
| Render A/B vs merge-base (41,012 CoreLib methods) | **0 changed / 0 added / 0 removed** |
| runfaster paydirt for these two methods | 7 report rows → **0** (fully eliminated) |
| Fast decompiler suite | 1946/1946 |

The same capturing-LINQ-closure shape recurs across other passes (`SplitOnce`,
`TryFoldValueForm`, `UnionSwitchExpressionPass`, `CountBranchTargets`); left for
follow-up.

## Adversarial review

Requested from two models (isolated worktrees); reconciliation to follow.
