### PR TITLE
Unify a bool-in-int stack slot whose load feeds a boolean position (#2377)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CoercionInvariantTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoercionInvariantTests.cs
@@ -15,6 +15,58 @@ public class CoercionInvariantTests
     static readonly TypeRef Enum32 = TypeRef.Definition("synthetic", "", "E32");
     static readonly TypeRef Int32Type = TypeRef.CoreLib("System", "Int32");
 
+    [Fact]
+    public void BoolSlotLoadedIntoLogicalNot_UnifiesToBool_NoUnassignedSplit()
+    {
+        // #2377: a bool store into an int slot whose load feeds a LogicalNot
+        // (`!S`) must unify the slot to bool. Otherwise the store names `S_0`
+        // (bool) while the `S_0 == 0` consumer names a distinct `int S_0_1`
+        // that nothing assigns (CS0165), and the bool store is dead.
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var container = new BlockContainer();
+        var first = new Block(0);
+        first.Add(new StoreStackSlot(0, new LoadArgument(0, "flag", boolType)));
+        first.Add(new Branch(1));
+        container.Add(first);
+        var second = new Block(1);
+        second.Add(new Return(new LogicalNot(new LoadStackSlot(0, Int32Type))));
+        container.Add(second);
+        var function = Function(container, boolType, new Parameter("flag", boolType));
+
+        string output = CSharpPrinter.Print(function).Output!.Replace("\r", "");
+
+        Assert.DoesNotContain("S_0_1", output);   // no split
+        Assert.DoesNotContain("int S_0", output); // slot is bool, not int
+        Assert.Contains("bool S_0 = flag;", output);
+        Assert.Contains("!S_0", output);          // bool negation, not `S_0 == 0`
+        Assert.DoesNotContain("S_0 == 0", output);
+    }
+
+    [Fact]
+    public void BoolSlotAsDirectBranchCondition_UnifiesToBool_RendersBare()
+    {
+        // #2377 (positive polarity): a bool store into an int slot whose load is a
+        // direct branch condition (`if (S)`) also unifies to bool and renders bare
+        // — `S != 0` would be `bool != int` (CS0019) and the split would be CS0165.
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var container = new BlockContainer();
+        var first = new Block(0);
+        first.Add(new StoreStackSlot(0, new LoadArgument(0, "flag", boolType)));
+        first.Add(new ConditionalBranch(new LoadStackSlot(0, Int32Type), 0x10));
+        container.Add(first);
+        var second = new Block(0x10);
+        second.Add(new Return(new LoadArgument(0, "flag", boolType)));
+        container.Add(second);
+        var function = Function(container, boolType, new Parameter("flag", boolType));
+
+        string output = CSharpPrinter.Print(function).Output!.Replace("\r", "");
+
+        Assert.DoesNotContain("S_0_1", output);
+        Assert.DoesNotContain("int S_0", output);
+        Assert.Contains("bool S_0 = flag;", output);
+        Assert.DoesNotContain("S_0 != 0", output);
+    }
+
     static IrFunction Function(BlockContainer body, TypeRef returnType, params Parameter[] parameters)
         => new("M", TypeRef.Definition("synthetic", "", "Holder"),
             new MethodSignature(returnType, [.. parameters], HasThis: false, GenericParameterCount: 0), [], body)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -651,6 +651,20 @@ public sealed partial class CSharpPrinter
             StoreElement store when ReferenceEquals(store.Value, load) => store.ElementType,
             StoreIndirect store when ReferenceEquals(store.Value, load) => store.Type,
             Return ret when ReferenceEquals(ret.Value, load) => _function.Signature.ReturnType,
+            // A bool-in-int-slot load whose value flows into a boolean operator
+            // or condition position (`!S`, `S && x`, `S ? a : b`, `if (S)`,
+            // `while (S)`) has a boolean target — C# requires bool there. Without
+            // this the slot's bool store and this load get different names (S_1
+            // bool vs S_1_1 int) and the consumer reads an unassigned int split
+            // (CS0165, #2377).
+            LogicalNot not when ReferenceEquals(not.Operand, load) => TypeRef.CoreLib("System", "Boolean"),
+            LogicalBinary logical when ReferenceEquals(logical.Left, load) || ReferenceEquals(logical.Right, load) => TypeRef.CoreLib("System", "Boolean"),
+            Conditional conditional when ReferenceEquals(conditional.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
+            ConditionalBranch branch when ReferenceEquals(branch.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
+            IfStatement ifStatement when ReferenceEquals(ifStatement.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
+            WhileLoop whileLoop when ReferenceEquals(whileLoop.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
+            DoWhileLoop doWhile when ReferenceEquals(doWhile.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
+            ForLoop forLoop when ReferenceEquals(forLoop.Condition, load) => TypeRef.CoreLib("System", "Boolean"),
             _ => null,
         };
 
@@ -2287,8 +2301,12 @@ public sealed partial class CSharpPrinter
     /// (ResultType <c>byte</c>) but the printer spells it as the underlying bool
     /// place, so a branch over it must negate rather than compare to 0.
     /// </summary>
-    static bool RendersAsBoolean(IrExpression operand)
-        => operand is LoadIndirect { Address.ResultType: { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer, ElementType: { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary } } };
+    bool RendersAsBoolean(IrExpression operand)
+        => operand is LoadIndirect { Address.ResultType: { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer, ElementType: { Namespace: "System", Name: "Boolean", Assembly: TypeRef.CoreLibrary } } }
+            // A bool-in-int-slot load whose slot unified to bool (its declaration is
+            // `bool S = …`) renders as a bool place: spelling `S == 0`/`S != 0`
+            // would be `bool == int` (CS0019), so it is its own truth value (#2377).
+            || (operand is LoadStackSlot load && TypeFamilies.IsBoolean(StackSlotRenderType(load.Slot, load.Type)));
 
     /// <summary>Parenthesizes compound operands; leaves atoms bare. Conservative until the precedence visitor exists.</summary>
     string Operand(IrExpression node)


### PR DESCRIPTION
Fixes #2377.

## Problem

A stack slot holding a **bool** value (a folded bool expression) whose load feeds a **boolean** position rendered invalid C#:

```csharp
int S_259_1;                 // hoisted — never assigned
bool S_259 = S_257 is not null && S_2.IsGlobalNamespace;   // assigned — never read
if (S_259_1 == 0) { ... }    // CS0165: use of unassigned local
```

The store named `S_259` (bool) while the consumer kept a distinct int split `S_259_1` that nothing assigns (CS0165), the bool store was dead, and the guard tested garbage (semantic break). Witness: `Microsoft.CodeAnalysis.CSharp.Symbols.NamedTypeSymbol::IsTupleTypeOfCardinality`.

## Root cause

Slots are named by `(slot, typeKey)`; `TryChooseUnifiedStackSlotType` unifies store/load types so a slot gets one name. For a bool store + int-typed load, the `Boolean` candidate requires every load to be loadable-as-bool, which `CanLoadAsType` permits only when the load's **target position** is boolean — computed by `StackSlotLoadTargetType`, which only recognized `Store*`/`Return` targets. A load feeding a boolean **operator/condition** was reported as *no target*, so unification failed and the slot split into `S_259` (bool store) and `S_259_1` (int consumer).

## Fix (printer, two parts)

1. **`StackSlotLoadTargetType`**: a load in a boolean operator/condition position (`LogicalNot`, `LogicalBinary`, `Conditional`, `ConditionalBranch`, `IfStatement`, `WhileLoop`, `DoWhileLoop`, `ForLoop` conditions) has a `Boolean` target → the slot unifies to bool (one live range, one name).
2. **`RendersAsBoolean`**: a `LoadStackSlot` whose slot unified to bool renders as a bool place, so `!S`/`S` are spelled bare rather than `S == 0`/`S != 0` (which would be `bool == int`, CS0019).

## Evidence

**Render A/B vs merge-base (89,065 methods): `Changed: 3, Added: 0, Removed: 0`** — all three invalid→valid, same class:

| Method | before (CS0165) | after |
| --- | --- | --- |
| `NamedTypeSymbol::IsTupleTypeOfCardinality` | `int S_259_1; … if (S_259_1 == 0)` | `if (!S_259)` |
| `Binder::CreateBlockFromExpression` | `int S_263_1; … if (S_263_1 != 0)` | `if (S_263)` |
| `ResumableStateMachineStateAllocator::AllocateState` | `int S_257_1; … if (S_257_1 != 0)` | `if (S_257)` |

The `int S_N_1;` unassigned declarations are removed; polarity is preserved (`!= 0`→bare, `== 0`→`!`). Zero collateral churn.

**Tests:** full decompiler fast suite **1969/1969**, incl. 2 new bool-slot render tests (negated `!S` and direct-condition `if (S)` polarity).

## Risk

Printer slot-naming/spelling change; the only rendered difference corpus-wide is the 3 invalid→valid methods above (A/B-verified). Two-model adversarial review to follow per policy.
