### PR TITLE
Share numeric join conversion rules

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -172,6 +172,34 @@ public class CoerceChokePointTests
     }
 
     [Fact]
+    public void NativeIntegerJoinArm_ReinterpretsToMergedType()
+    {
+        // #2334: nint/nuint are same platform width even though fixed-width
+        // SameWidth cannot answer that statically. The join arm still needs the
+        // reinterpret cast or C# reports CS0029.
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var intPtrType = TypeRef.CoreLib("System", "IntPtr");
+        var uintPtrType = TypeRef.CoreLib("System", "UIntPtr");
+        var conditional = new Conditional(
+            new LoadArgument(0, "flag", boolType),
+            new LoadArgument(1, "u", uintPtrType),
+            new LoadArgument(2, "i", intPtrType))
+        {
+            MergedType = uintPtrType,
+        };
+
+        string body = RenderReturn(
+            conditional,
+            uintPtrType,
+            [new Parameter("flag", boolType), new Parameter("u", uintPtrType), new Parameter("i", intPtrType)],
+            TypeRef.Definition("synthetic", "", "UnusedEnum"));
+
+        Assert.Contains("flag ? u : (nuint)i", body);
+        Assert.DoesNotContain(": i;", body);
+        AssertCompiles("public static nuint M(bool flag, nuint u, nint i)", body);
+    }
+
+    [Fact]
     public void Conditional_WithBoolArmAtPrimitiveStoreTarget_CastsComposedBoolArm()
     {
         // Gemini review: bool remains outside the primitive conditional's
@@ -926,6 +954,35 @@ public class CoerceChokePointTests
         Assert.Contains("c ? l : x", body);
         Assert.DoesNotContain("(long)x", body);
         AssertCompiles("public static long M(bool c, long l, int x)", body);
+    }
+
+    [Fact]
+    public void IntBackedEnumArm_AtLongMergedType_WidensWithCast()
+    {
+        // #2337: the enum->integer join-arm branch must admit the same
+        // value-preserving I4->I8 widening that CoerceText permits. A bare enum
+        // arm at a long join is CS0029.
+        var enumType = TypeRef.Definition("synthetic", "", "IFlags");
+        var longType = TypeRef.CoreLib("System", "Int64");
+        var intType = TypeRef.CoreLib("System", "Int32");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var conditional = new Conditional(
+            new LoadArgument(0, "c", boolType),
+            new Constant(1L, longType),
+            new LoadArgument(1, "f", enumType))
+        {
+            MergedType = longType,
+        };
+        string body = RenderReturn(
+            conditional,
+            longType,
+            [new Parameter("c", boolType), new Parameter("f", enumType)],
+            enumType,
+            underlying: intType);
+
+        Assert.Contains(": (long)f", body);
+        Assert.DoesNotContain(": f;", body);
+        AssertCompiles("public static long M(bool c, IFlags f)", body, "public enum IFlags { }");
     }
 
     // work-2302 review (both reviewers, blocking): the unchecked(...) wrapper

--- a/src/ILInspector.Decompiler/Pipeline/CSharpConversionRules.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpConversionRules.cs
@@ -1,0 +1,18 @@
+namespace ILInspector.Decompiler.Pipeline;
+
+/// <summary>
+/// C# conversion predicates shared by target-typed rendering sites. This is the
+/// narrow start of #2379's conversion model: rules graduate here when multiple
+/// printer/pass seams need the same C# conversion fact.
+/// </summary>
+public static class CSharpConversionRules
+{
+    /// <summary>
+    /// Same storage width for integer reinterpret casts, including the
+    /// platform-sized <c>nint</c>/<c>nuint</c> pair whose runtime width is
+    /// unknown statically but always equal.
+    /// </summary>
+    public static bool SameNumericSlotWidth(TypeRef? source, TypeRef? target)
+        => TypeFamilies.SameWidth(source, target)
+            || TypeFamilies.Of(source) == StackFamily.I && TypeFamilies.Of(target) == StackFamily.I;
+}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1247,7 +1247,7 @@ public sealed partial class CSharpPrinter
         // sibling-width): inside a lexical checked region a bare spelling
         // recompiles to a conv.ovf the IL never had (#2301), so they route
         // through CheckedSafeCast like the enum reinterprets above.
-        if (value is Convert { IsChecked: false, IsUnsigned: false } conv && SameNumericSlotWidth(conv.Target, target))
+        if (value is Convert { IsChecked: false, IsUnsigned: false } conv && CSharpConversionRules.SameNumericSlotWidth(conv.Target, target))
             return conv.Operand is Constant { Value: int or long } convConst
                 ? NumericConstant(convConst, target!)
                 : CheckedSafeNumericCast(EffectiveType(conv.Operand), target!, () => $"({TypeText(target!)}){Operand(conv.Operand)}");
@@ -1270,10 +1270,6 @@ public sealed partial class CSharpPrinter
             } convert => convert.Operand,
             _ => null,
         };
-
-    static bool SameNumericSlotWidth(TypeRef? a, TypeRef? b)
-        => TypeFamilies.SameWidth(a, b)
-            || TypeFamilies.Of(a) == StackFamily.I && TypeFamilies.Of(b) == StackFamily.I;
 
     string ConditionalText(Conditional conditional)
         => ConditionalText(conditional, conditional.MergedType);
@@ -1455,10 +1451,15 @@ public sealed partial class CSharpPrinter
         // to int recompiles to conv.ovf.i4.un inside a lexical checked region
         // — a throw the IL never had — so throw-capable underlying->target
         // pairs wrap; identity/widening pairs stay bare.
-        if (target is { } integerTarget && TypeFamilies.IsIntegerLike(integerTarget)
-            && EnumUnderlyingType(EffectiveType(arm)) is { } underlying
-            && TypeFamilies.Of(underlying) == TypeFamilies.Of(integerTarget))
+        if (target is { } integerTarget
+            && EffectiveType(arm) is { } enumArmType
+            && CoercionRendering.CanSpellEnumToInteger(
+                enumArmType,
+                integerTarget,
+                _function.TypeShapes,
+                _function.EnumUnderlyingTypes))
         {
+            var underlying = EnumUnderlyingType(enumArmType) ?? TypeRef.CoreLib("System", "Int32");
             return TypeFamilies.CheckedConversionCanThrow(underlying, integerTarget)
                 ? CheckedSafeCast(() => $"({TypeText(integerTarget)}){Operand(arm)}")
                 : $"({TypeText(integerTarget)}){Operand(arm)}";
@@ -1595,7 +1596,7 @@ public sealed partial class CSharpPrinter
                 target,
                 _function.TypeShapes,
                 _function.EnumUnderlyingTypes)
-            && SameNumericSlotWidth(coercionSourceType, target);
+            && CSharpConversionRules.SameNumericSlotWidth(coercionSourceType, target);
 
     bool CanRenderSwitchExpressionForTarget(SwitchExpression expression, TypeRef target)
         => (IsEnumLikeInteger(target) && expression.Arms.All(arm => IsIntegerArm(arm.Value)))


### PR DESCRIPTION
Advances #2379 conversion / target-typing model
Fixes #2337
Adds coverage for #2334

## Change

**Conclusion:** **PASS** — this starts #2379's shared conversion-rule module with two narrow clients and no corpus render churn.

What changed:

- Added `CSharpConversionRules.SameNumericSlotWidth`, the shared same-slot-width predicate for integer reinterpret casts, including the platform-sized `nint`/`nuint` pair (#2334).
- Routed primitive join-arm width checks through that helper instead of the printer-local `SameNumericSlotWidth` shard.
- Routed enum→integer join arms through `CoercionRendering.CanSpellEnumToInteger`, so the join-arm path now admits the same value-preserving I4→I8 enum widening that `CoerceText` already allows (#2337).

## Evidence

| Check | Result |
| --- | --- |
| #2334 canary | Pass: `NativeIntegerJoinArm_ReinterpretsToMergedType` |
| #2337 canary | Pass: `IntBackedEnumArm_AtLongMergedType_WidensWithCast` |
| Touched suite | Pass: `CoerceChokePointTests` (46 tests) |
| Decompiler fast suite | Pass: 1,970 tests with `-trait- "Speed=Slow"` |
| Solution build | Pass: `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore --verbosity minimal` |
| Render A/B | Pass: 89,065 methods evaluated, 0 changed |

## Decompiler quality

### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 350 methods (compile-cap 25; per-sample, not corpus-wide); fidelity sampled 23 / 89,065 (0.03%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,405 (88.03%) | +6 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — 25,179 compiled methods | 1/350 — 350 compiled methods | -73 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 3/23, exact 20, recompile-failed 0, context-failed 0; sampled 23 / 89,065 (0.03%) | -2 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.03% (+0.01 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 3 (-2).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25179, current 350)
- fidelity checked methods lower than baseline (baseline 36, current 23)
QUALITY_CARD_EXIT=1

The quality card exits nonzero only because this PR quick run uses lower validity/fidelity caps than the daily baseline. The pinned subset improves: fully raised +0.01 pp, conditional residual unchanged, Full malformed 0, opcode diffs 5 -> 3.

## Review

Adversarial reviews pending. I will post the two-review reconciliation before marking ready.
