### PR TITLE
Share C# conversion rule predicates

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpConversionRulesTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpConversionRulesTests.cs
@@ -1,0 +1,47 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public sealed class CSharpConversionRulesTests
+{
+    static TypeRef Core(string name) => TypeRef.CoreLib("System", name);
+
+    [Fact]
+    public void NeedsNumericCast_IsLimitedToSameStackFamilyPrimitiveReinterpretation()
+    {
+        Assert.True(CSharpConversionRules.NeedsNumericCast(Core("Int32"), Core("UInt32")));
+        Assert.False(CSharpConversionRules.NeedsNumericCast(Core("Int32"), Core("Int64")));
+        Assert.False(CSharpConversionRules.NeedsNumericCast(Core("Boolean"), Core("Int32")));
+        Assert.False(CSharpConversionRules.NeedsNumericCast(Core("Int16"), Core("Int32")));
+    }
+
+    [Fact]
+    public void ConstantFits_ModelsCSharpConstantExpressionConversionRanges()
+    {
+        Assert.True(CSharpConversionRules.ConstantFits(0, Core("UInt32")));
+        Assert.False(CSharpConversionRules.ConstantFits(-1, Core("UInt32")));
+        Assert.True(CSharpConversionRules.ConstantFits(-1, Core("IntPtr")));
+        Assert.False(CSharpConversionRules.ConstantFits(-1, Core("UIntPtr")));
+    }
+
+    [Fact]
+    public void IsImplicitIntegerWidening_ModelsValueRangeContainment()
+    {
+        Assert.True(CSharpConversionRules.IsImplicitIntegerWidening(Core("Int32"), Core("Int64")));
+        Assert.True(CSharpConversionRules.IsImplicitIntegerWidening(Core("UInt32"), Core("Int64")));
+        Assert.True(CSharpConversionRules.IsImplicitIntegerWidening(Core("IntPtr"), Core("Int64")));
+        Assert.True(CSharpConversionRules.IsImplicitIntegerWidening(Core("UIntPtr"), Core("UInt64")));
+        Assert.False(CSharpConversionRules.IsImplicitIntegerWidening(Core("Int32"), Core("UInt32")));
+    }
+
+    [Fact]
+    public void CheckedConversionCanThrow_ModelsCheckedExplicitCastHazards()
+    {
+        Assert.False(CSharpConversionRules.CheckedConversionCanThrow(Core("Int32"), Core("Int64")));
+        Assert.False(CSharpConversionRules.CheckedConversionCanThrow(Core("UInt32"), Core("Int64")));
+        Assert.False(CSharpConversionRules.CheckedConversionCanThrow(Core("Byte"), Core("Char")));
+        Assert.True(CSharpConversionRules.CheckedConversionCanThrow(Core("Int32"), Core("UInt32")));
+        Assert.True(CSharpConversionRules.CheckedConversionCanThrow(Core("UInt32"), Core("Int32")));
+        Assert.True(CSharpConversionRules.CheckedConversionCanThrow(Core("IntPtr"), Core("Int64")));
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/CSharpConversionRulesTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpConversionRulesTests.cs
@@ -20,8 +20,12 @@ public sealed class CSharpConversionRulesTests
     {
         Assert.True(CSharpConversionRules.ConstantFits(0, Core("UInt32")));
         Assert.False(CSharpConversionRules.ConstantFits(-1, Core("UInt32")));
+        Assert.True(CSharpConversionRules.ConstantFits(int.MaxValue, Core("IntPtr")));
         Assert.True(CSharpConversionRules.ConstantFits(-1, Core("IntPtr")));
+        Assert.False(CSharpConversionRules.ConstantFits((long)int.MaxValue + 1, Core("IntPtr")));
+        Assert.True(CSharpConversionRules.ConstantFits(uint.MaxValue, Core("UIntPtr")));
         Assert.False(CSharpConversionRules.ConstantFits(-1, Core("UIntPtr")));
+        Assert.False(CSharpConversionRules.ConstantFits((long)uint.MaxValue + 1, Core("UIntPtr")));
     }
 
     [Fact]
@@ -39,9 +43,11 @@ public sealed class CSharpConversionRulesTests
     {
         Assert.False(CSharpConversionRules.CheckedConversionCanThrow(Core("Int32"), Core("Int64")));
         Assert.False(CSharpConversionRules.CheckedConversionCanThrow(Core("UInt32"), Core("Int64")));
+        Assert.False(CSharpConversionRules.CheckedConversionCanThrow(Core("IntPtr"), Core("Int64")));
+        Assert.False(CSharpConversionRules.CheckedConversionCanThrow(Core("UIntPtr"), Core("UInt64")));
         Assert.False(CSharpConversionRules.CheckedConversionCanThrow(Core("Byte"), Core("Char")));
         Assert.True(CSharpConversionRules.CheckedConversionCanThrow(Core("Int32"), Core("UInt32")));
         Assert.True(CSharpConversionRules.CheckedConversionCanThrow(Core("UInt32"), Core("Int32")));
-        Assert.True(CSharpConversionRules.CheckedConversionCanThrow(Core("IntPtr"), Core("Int64")));
+        Assert.True(CSharpConversionRules.CheckedConversionCanThrow(Core("UIntPtr"), Core("Int64")));
     }
 }

--- a/src/ILInspector.Decompiler/Pipeline/CSharpConversionRules.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpConversionRules.cs
@@ -8,6 +8,27 @@ namespace ILInspector.Decompiler.Pipeline;
 public static class CSharpConversionRules
 {
     /// <summary>
+    /// True when a value of <paramref name="source"/> needs an explicit C# cast
+    /// to flow into <paramref name="target"/>. Restricted to numeric primitives
+    /// in the same stack family where the cast is a value-preserving
+    /// reinterpretation of bits already on the evaluation stack.
+    /// </summary>
+    public static bool NeedsNumericCast(TypeRef? source, TypeRef? target)
+    {
+        if (source is null || target is null || source.Equals(target))
+            return false;
+        if (TypeFamilies.IsBoolean(source)
+            || TypeFamilies.IsBoolean(target)
+            || !TypeFamilies.IsNumericPrimitive(source)
+            || !TypeFamilies.IsNumericPrimitive(target))
+            return false;
+        var family = TypeFamilies.Of(source);
+        if (family is null || family != TypeFamilies.Of(target))
+            return false;
+        return !ImplicitSameFamilyNumericConversion(source.Name, target.Name);
+    }
+
+    /// <summary>
     /// Same storage width for integer reinterpret casts, including the
     /// platform-sized <c>nint</c>/<c>nuint</c> pair whose runtime width is
     /// unknown statically but always equal.
@@ -15,4 +36,89 @@ public static class CSharpConversionRules
     public static bool SameNumericSlotWidth(TypeRef? source, TypeRef? target)
         => TypeFamilies.SameWidth(source, target)
             || TypeFamilies.Of(source) == StackFamily.I && TypeFamilies.Of(target) == StackFamily.I;
+
+    /// <summary>True when the integer constant can flow to <paramref name="target"/> through C#'s implicit constant-expression conversion.</summary>
+    public static bool ConstantFits(long value, TypeRef target) => target switch
+    {
+        { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } => target.Name switch
+        {
+            "SByte" => value is >= sbyte.MinValue and <= sbyte.MaxValue,
+            "Byte" => value is >= byte.MinValue and <= byte.MaxValue,
+            "Int16" => value is >= short.MinValue and <= short.MaxValue,
+            "UInt16" or "Char" => value is >= ushort.MinValue and <= ushort.MaxValue,
+            "Int32" => value is >= int.MinValue and <= int.MaxValue,
+            "UInt32" => value is >= uint.MinValue and <= uint.MaxValue,
+            "Int64" or "IntPtr" => true,
+            "UInt64" or "UIntPtr" => value >= 0,
+            "Single" or "Double" => true,
+            _ => false,
+        },
+        _ => false,
+    };
+
+    /// <summary>
+    /// C# implicit integer/native/char widening: the source value range is wholly
+    /// contained in the target range, so no cast or checked wrapper is needed.
+    /// </summary>
+    public static bool IsImplicitIntegerWidening(TypeRef source, TypeRef target)
+        => TypeFamilies.IsIntegerLike(source) && TypeFamilies.IsIntegerLike(target) && (source.Name, target.Name) switch
+        {
+            ("SByte", "Int16" or "Int32" or "Int64" or "IntPtr") => true,
+            ("Byte", "Int16" or "UInt16" or "Int32" or "UInt32" or "Int64" or "UInt64" or "IntPtr" or "UIntPtr") => true,
+            ("Int16", "Int32" or "Int64" or "IntPtr") => true,
+            ("UInt16", "Int32" or "UInt32" or "Int64" or "UInt64" or "IntPtr" or "UIntPtr") => true,
+            ("Char", "UInt16" or "Int32" or "UInt32" or "Int64" or "UInt64" or "IntPtr" or "UIntPtr") => true,
+            ("Int32", "Int64" or "IntPtr") => true,
+            ("UInt32", "Int64" or "UInt64" or "UIntPtr") => true,
+            ("IntPtr", "Int64") => true,
+            ("UIntPtr", "UInt64") => true,
+            _ => false,
+        };
+
+    /// <summary>
+    /// True when the C# checked conversion can throw for some value. Synthesized
+    /// reinterpret casts in a lexical checked context need <c>unchecked(...)</c>
+    /// exactly for these pairs.
+    /// </summary>
+    public static bool CheckedConversionCanThrow(TypeRef? source, TypeRef? target)
+    {
+        if (source is null || target is null)
+            return true;
+        if (source.Equals(target))
+            return false;
+        if (Width(source) is not { } sourceWidth || Width(target) is not { } targetWidth)
+            return true;
+        bool sourceUnsigned = IsUnsignedInteger(source);
+        bool targetUnsigned = IsUnsignedInteger(target);
+        if (sourceUnsigned == targetUnsigned)
+            return targetWidth < sourceWidth;
+        if (sourceUnsigned)
+            return targetWidth <= sourceWidth;
+        return true;
+    }
+
+    static bool ImplicitSameFamilyNumericConversion(string source, string target) => (source, target) switch
+    {
+        ("SByte", "Int16" or "Int32") => true,
+        ("Byte", "Int16" or "UInt16" or "Int32" or "UInt32") => true,
+        ("Int16", "Int32") => true,
+        ("UInt16", "Int32" or "UInt32") => true,
+        ("Char", "UInt16" or "Int32" or "UInt32") => true,
+        ("Single", "Double") => true,
+        _ => false,
+    };
+
+    static int? Width(TypeRef? type) => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" }
+        ? type.Name switch
+        {
+            "SByte" or "Byte" => 1,
+            "Int16" or "UInt16" or "Char" => 2,
+            "Int32" or "UInt32" => 4,
+            "Int64" or "UInt64" => 8,
+            _ => null,
+        }
+        : null;
+
+    static bool IsUnsignedInteger(TypeRef? type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Byte" or "UInt16" or "Char" or "UInt32" or "UInt64" };
 }

--- a/src/ILInspector.Decompiler/Pipeline/CSharpConversionRules.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpConversionRules.cs
@@ -48,8 +48,10 @@ public static class CSharpConversionRules
             "UInt16" or "Char" => value is >= ushort.MinValue and <= ushort.MaxValue,
             "Int32" => value is >= int.MinValue and <= int.MaxValue,
             "UInt32" => value is >= uint.MinValue and <= uint.MaxValue,
-            "Int64" or "IntPtr" => true,
-            "UInt64" or "UIntPtr" => value >= 0,
+            "Int64" => true,
+            "UInt64" => value >= 0,
+            "IntPtr" => value is >= int.MinValue and <= int.MaxValue,
+            "UIntPtr" => value is >= 0 and <= uint.MaxValue,
             "Single" or "Double" => true,
             _ => false,
         },
@@ -85,6 +87,8 @@ public static class CSharpConversionRules
         if (source is null || target is null)
             return true;
         if (source.Equals(target))
+            return false;
+        if (IsImplicitIntegerWidening(source, target))
             return false;
         if (Width(source) is not { } sourceWidth || Width(target) is not { } targetWidth)
             return true;

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -224,7 +224,7 @@ public sealed partial class CSharpPrinter
         if (TypeFamilies.IsBoolean(EffectiveType(value)))
             return renderCast();
         var underlying = EnumUnderlyingType(enumType);
-        return underlying is not null && !TypeFamilies.CheckedConversionCanThrow(EffectiveType(value), underlying)
+        return underlying is not null && !CSharpConversionRules.CheckedConversionCanThrow(EffectiveType(value), underlying)
             ? renderCast()
             : CheckedSafeCast(renderCast);
     }
@@ -284,7 +284,7 @@ public sealed partial class CSharpPrinter
         // A known backing width: the cast is a constant-expression conversion, so it
         // needs `unchecked` exactly when the value is out of that width's range.
         if (EnumUnderlyingType(enumType) is { } underlying)
-            return !TypeFamilies.ConstantFits(literal, underlying);
+            return !CSharpConversionRules.ConstantFits(literal, underlying);
         // A cross-assembly enum: the width is genuinely unknown and framework enums
         // are often byte/sbyte-backed [Flags], so conservatively assume the narrowest
         // (sbyte) backing and wrap a negative or a value above sbyte's max.
@@ -294,7 +294,7 @@ public sealed partial class CSharpPrinter
         // `value__` field): assume C#'s default `int` backing, so an int-range value
         // (including a negative high-bit constant like int.MinValue) stays a bare
         // cast and only a genuinely out-of-int value is wrapped.
-        return !TypeFamilies.ConstantFits(literal, TypeRef.CoreLib("System", "Int32"));
+        return !CSharpConversionRules.ConstantFits(literal, TypeRef.CoreLib("System", "Int32"));
     }
 
     // The integer literal an enum cast will carry, seeing through a widening
@@ -464,7 +464,7 @@ public sealed partial class CSharpPrinter
                 // An explicit cast of an out-of-range constant to unsigned, e.g. `(uint)(-1)`.
                 if (TypeFamilies.IsUnsignedIntegerPrimitive(target)
                     && TryGetIntegerConstant(convert.Operand, out long value)
-                    && !TypeFamilies.ConstantFits(value, target))
+                    && !CSharpConversionRules.ConstantFits(value, target))
                     return true;
                 return SubtreeReinterpretsOutOfRangeConstant(convert.Operand);
             case Binary binary:
@@ -731,7 +731,7 @@ public sealed partial class CSharpPrinter
         var unsigned = TypeFamilies.UnsignedCounterpart(EffectiveType(operand));
         if (unsigned is null)
             return Operand(operand);
-        bool constantOutOfRange = wrapConstantCast && TryGetIntegerConstant(operand, out long value) && !TypeFamilies.ConstantFits(value, unsigned);
+        bool constantOutOfRange = wrapConstantCast && TryGetIntegerConstant(operand, out long value) && !CSharpConversionRules.ConstantFits(value, unsigned);
         return CheckedSafeCast(() => $"({TypeText(unsigned)}){Operand(operand)}", force: constantOutOfRange);
     }
 
@@ -745,7 +745,7 @@ public sealed partial class CSharpPrinter
         var unsigned = TypeFamilies.UnsignedCounterpart(EffectiveType(operand));
         return unsigned is not null
             && TryGetIntegerConstant(operand, out long value)
-            && !TypeFamilies.ConstantFits(value, unsigned);
+            && !CSharpConversionRules.ConstantFits(value, unsigned);
     }
 
     /// <summary>Whether an operand reduces (through unchecked conv nodes, and nested unchecked +/-/* of constants) to a C# integer constant expression.</summary>
@@ -1065,7 +1065,7 @@ public sealed partial class CSharpPrinter
     /// typed sink spells its value through here — never an open-coded cast — so
     /// the cast/`unchecked` rules live once. The cast reinterprets bits the
     /// evaluation stack already carries (same family), so it is faithful to the
-    /// IL — see <see cref="TypeFamilies.NeedsNumericCast"/>. Operand positions
+    /// IL — see <see cref="CSharpConversionRules.NeedsNumericCast"/>. Operand positions
     /// reconciling against an enum sibling use <see cref="TryCoerceEnumOperand"/>,
     /// the operand-shaped door into the same rules.
     /// </summary>
@@ -1155,7 +1155,7 @@ public sealed partial class CSharpPrinter
             // must stay bare (work-2302 CI canary). A missing value__ assumes
             // the I4-signed shape, matching EnumSemanticFamily.
             var underlying = EnumUnderlyingType(EffectiveType(value)) ?? TypeRef.CoreLib("System", "Int32");
-            return TypeFamilies.CheckedConversionCanThrow(underlying, primitiveTarget)
+            return CSharpConversionRules.CheckedConversionCanThrow(underlying, primitiveTarget)
                 ? CheckedSafeCast(() => $"({TypeText(primitiveTarget)}){Operand(value)}")
                 : $"({TypeText(primitiveTarget)}){Operand(value)}";
         }
@@ -1237,7 +1237,7 @@ public sealed partial class CSharpPrinter
         // unchecked cast (uint.MaxValue's `ldc.i4.m1` → unchecked((uint)(-1))).
         if (value is Constant { Value: int or long } konst && target is { } t && TypeFamilies.IsNumericPrimitive(t))
             return NumericConstant(konst, t);
-        if (!TypeFamilies.NeedsNumericCast(EffectiveType(value), target))
+        if (!CSharpConversionRules.NeedsNumericCast(EffectiveType(value), target))
             return Expression(value);
         // A plain conversion to a same-width sibling (conv.u2 → ushort feeding a
         // char slot) is subsumed by the boundary cast: emit one cast to the
@@ -1255,7 +1255,7 @@ public sealed partial class CSharpPrinter
     }
 
     string CheckedSafeNumericCast(TypeRef? source, TypeRef target, Func<string> renderCast)
-        => TypeFamilies.CheckedConversionCanThrow(source, target)
+        => CSharpConversionRules.CheckedConversionCanThrow(source, target)
             ? CheckedSafeCast(renderCast)
             : renderCast();
 
@@ -1352,7 +1352,7 @@ public sealed partial class CSharpPrinter
         if (bareTypes.Any(t => t is null))
             return false;
         bool hasNatural = bareTypes.Any(candidate => bareTypes.All(other =>
-            other!.Equals(candidate!) || TypeFamilies.IsImplicitIntegerWidening(other!, candidate!)));
+            other!.Equals(candidate!) || CSharpConversionRules.IsImplicitIntegerWidening(other!, candidate!)));
         return !hasNatural && arms.All(arm => ArmConvertsImplicitlyAt(arm, target));
     }
 
@@ -1372,7 +1372,7 @@ public sealed partial class CSharpPrinter
         if (ArmRendersBareSafelyAt(arm, target))
             return true;
         return arm is Constant { Value: int or long } konst
-            && TypeFamilies.ConstantFits(konst.Value is int i ? i : (long)konst.Value!, target);
+            && CSharpConversionRules.ConstantFits(konst.Value is int i ? i : (long)konst.Value!, target);
     }
 
     static bool IsFalseConstant(IrExpression expression)
@@ -1460,7 +1460,7 @@ public sealed partial class CSharpPrinter
                 _function.EnumUnderlyingTypes))
         {
             var underlying = EnumUnderlyingType(enumArmType) ?? TypeRef.CoreLib("System", "Int32");
-            return TypeFamilies.CheckedConversionCanThrow(underlying, integerTarget)
+            return CSharpConversionRules.CheckedConversionCanThrow(underlying, integerTarget)
                 ? CheckedSafeCast(() => $"({TypeText(integerTarget)}){Operand(arm)}")
                 : $"({TypeText(integerTarget)}){Operand(arm)}";
         }
@@ -1490,15 +1490,15 @@ public sealed partial class CSharpPrinter
             if (arm is Constant { Value: int or long } konst)
             {
                 long payload = konst.Value is int ci ? ci : (long)konst.Value!;
-                if (!TypeFamilies.ConstantFits(payload, numericTarget))
+                if (!CSharpConversionRules.ConstantFits(payload, numericTarget))
                     return NumericConstant(konst, numericTarget);
                 var bareType = TypeRef.CoreLib("System", konst.Value is int ? "Int32" : "Int64");
-                return !joinHasExactTypedArm || TypeFamilies.IsImplicitIntegerWidening(numericTarget, bareType)
+                return !joinHasExactTypedArm || CSharpConversionRules.IsImplicitIntegerWidening(numericTarget, bareType)
                     ? $"({TypeText(numericTarget)}){(payload < 0 ? $"({Expression(konst)})" : Expression(konst))}"
                     : null;
             }
             if (EffectiveType(arm) is { } armType
-                && TypeFamilies.NeedsNumericCast(armType, numericTarget)
+                && CSharpConversionRules.NeedsNumericCast(armType, numericTarget)
                 && CanCoercePrimitiveJoinArm(armType, numericTarget, primitiveCoercionSourceType ?? armType))
             {
                 return CheckedSafeCast(() => $"({TypeText(numericTarget)}){Operand(arm)}");
@@ -1528,7 +1528,7 @@ public sealed partial class CSharpPrinter
             ? TypeRef.CoreLib("System", konst.Value is int ? "Int32" : "Int64")
             : EffectiveType(arm);
         return armType is not null
-            && (armType.Equals(target) || TypeFamilies.IsImplicitIntegerWidening(armType, target));
+            && (armType.Equals(target) || CSharpConversionRules.IsImplicitIntegerWidening(armType, target));
     }
 
     string? TryConditionalTextForTarget(Conditional conditional, TypeRef target)
@@ -1581,7 +1581,7 @@ public sealed partial class CSharpPrinter
         => EffectiveType(arm) is { } armType
             && (CoercionRendering.CanSpellBoolToInteger(armType, target)
                 || (TypeFamilies.IsIntegerLike(armType)
-                    && (!TypeFamilies.NeedsNumericCast(armType, target)
+                    && (!CSharpConversionRules.NeedsNumericCast(armType, target)
                         || CanCoercePrimitiveJoinArm(armType, target, coercionSourceType))));
 
     bool CanCoercePrimitiveJoinArm(IrExpression arm, TypeRef target)
@@ -1648,7 +1648,7 @@ public sealed partial class CSharpPrinter
     string NumericConstant(Constant konst, TypeRef target)
     {
         long literal = konst.Value is int i ? i : (long)konst.Value!;
-        return TypeFamilies.ConstantFits(literal, target)
+        return CSharpConversionRules.ConstantFits(literal, target)
             ? Expression(konst)
             : $"unchecked(({TypeText(target)})({Expression(konst)}))";
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3267,7 +3267,7 @@ public sealed partial class CSharpPrinter
             return true;    // float→integer always checks; unknown/pointer source: be safe
         if (source.Equals(convert.Target))
             return false;   // identity: no conv emitted
-        return !TypeFamilies.IsImplicitIntegerWidening(source, convert.Target);
+        return !CSharpConversionRules.IsImplicitIntegerWidening(source, convert.Target);
     }
 
     string ConvertBody(Convert convert, bool wrap, bool uncheckedOverflow)
@@ -3292,7 +3292,7 @@ public sealed partial class CSharpPrinter
             && TypeFamilies.IsNumericPrimitive(convert.Target))
         {
             long literal = c.Value is int i ? i : (long)c.Value!;
-            if (!TypeFamilies.ConstantFits(literal, convert.Target))
+            if (!CSharpConversionRules.ConstantFits(literal, convert.Target))
             {
                 // A widening conversion to an unsigned target ZERO-extends the source
                 // (`conv.u8` of `ldc.i4.m1` is 0x00000000FFFFFFFF = uint.MaxValue),

--- a/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/TypeFamilies.cs
@@ -132,16 +132,7 @@ public static class TypeFamilies
     /// is excluded: it shares the I4 family but `(int)b` is not even legal C#.
     /// </summary>
     public static bool NeedsNumericCast(TypeRef? source, TypeRef? target)
-    {
-        if (source is null || target is null || source.Equals(target))
-            return false;
-        if (IsBoolean(source) || IsBoolean(target) || !IsNumericPrimitive(source) || !IsNumericPrimitive(target))
-            return false;
-        var family = Of(source);
-        if (family is null || family != Of(target))
-            return false;   // same stack family only — guarantees a faithful reinterpretation
-        return !IsImplicitlyConvertible(source.Name, target.Name);
-    }
+        => CSharpConversionRules.NeedsNumericCast(source, target);
 
     public static bool IsBoolean(TypeRef? type)
         => type is { Name: "Boolean", Assembly: TypeRef.CoreLibrary, Namespace: "System" };
@@ -246,21 +237,7 @@ public static class TypeFamilies
     /// when the width is unknown, the wrap is the safe direction.
     /// </summary>
     public static bool CheckedConversionCanThrow(TypeRef? source, TypeRef? target)
-    {
-        if (source is null || target is null)
-            return true;
-        if (source.Equals(target))
-            return false;
-        if (Width(source) is not { } sourceWidth || Width(target) is not { } targetWidth)
-            return true;
-        bool sourceUnsigned = IsUnsignedInteger(source);
-        bool targetUnsigned = IsUnsignedInteger(target);
-        if (sourceUnsigned == targetUnsigned)
-            return targetWidth < sourceWidth;
-        if (sourceUnsigned)
-            return targetWidth <= sourceWidth;
-        return true;
-    }
+        => CSharpConversionRules.CheckedConversionCanThrow(source, target);
 
     /// <summary>
     /// True when an integer constant is in <paramref name="target"/>'s range, so
@@ -268,35 +245,8 @@ public static class TypeFamilies
     /// is needed. A value outside the range — a negative into unsigned, a bitmask
     /// wider than the target — does not convert bare and needs an unchecked cast.
     /// </summary>
-    public static bool ConstantFits(long value, TypeRef target) => target switch
-    {
-        { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System" } => target.Name switch
-        {
-            "SByte" => value is >= sbyte.MinValue and <= sbyte.MaxValue,
-            "Byte" => value is >= byte.MinValue and <= byte.MaxValue,
-            "Int16" => value is >= short.MinValue and <= short.MaxValue,
-            "UInt16" or "Char" => value is >= ushort.MinValue and <= ushort.MaxValue,
-            "Int32" => value is >= int.MinValue and <= int.MaxValue,
-            "UInt32" => value is >= uint.MinValue and <= uint.MaxValue,
-            "Int64" or "IntPtr" => true,
-            "UInt64" or "UIntPtr" => value >= 0,
-            "Single" or "Double" => true,
-            _ => false,
-        },
-        _ => false,
-    };
-
-    /// <summary>C#'s implicit numeric conversions within a stack family — the widenings that need no cast.</summary>
-    static bool IsImplicitlyConvertible(string source, string target) => (source, target) switch
-    {
-        ("SByte", "Int16" or "Int32") => true,
-        ("Byte", "Int16" or "UInt16" or "Int32" or "UInt32") => true,
-        ("Int16", "Int32") => true,
-        ("UInt16", "Int32" or "UInt32") => true,
-        ("Char", "UInt16" or "Int32" or "UInt32") => true,
-        ("Single", "Double") => true,
-        _ => false,
-    };
+    public static bool ConstantFits(long value, TypeRef target)
+        => CSharpConversionRules.ConstantFits(value, target);
 
     /// <summary>
     /// The full C# implicit numeric widening table between integer/native/char
@@ -311,19 +261,7 @@ public static class TypeFamilies
     /// (including <c>nint</c>/<c>nuint</c> and the <c>.un</c> overflow forms).
     /// </summary>
     public static bool IsImplicitIntegerWidening(TypeRef source, TypeRef target)
-        => IsIntegerLike(source) && IsIntegerLike(target) && (source.Name, target.Name) switch
-        {
-            ("SByte", "Int16" or "Int32" or "Int64" or "IntPtr") => true,
-            ("Byte", "Int16" or "UInt16" or "Int32" or "UInt32" or "Int64" or "UInt64" or "IntPtr" or "UIntPtr") => true,
-            ("Int16", "Int32" or "Int64" or "IntPtr") => true,
-            ("UInt16", "Int32" or "UInt32" or "Int64" or "UInt64" or "IntPtr" or "UIntPtr") => true,
-            ("Char", "UInt16" or "Int32" or "UInt32" or "Int64" or "UInt64" or "IntPtr" or "UIntPtr") => true,
-            ("Int32", "Int64" or "IntPtr") => true,
-            ("UInt32", "Int64" or "UInt64" or "UIntPtr") => true,
-            ("IntPtr", "Int64") => true,
-            ("UIntPtr", "UInt64") => true,
-            _ => false,
-        };
+        => CSharpConversionRules.IsImplicitIntegerWidening(source, target);
 
     /// <summary>The unsigned-counterpart TypeRef of a signed integer type; null when already unsigned, float, or unknown.</summary>
     public static TypeRef? UnsignedCounterpart(TypeRef? type) => UnsignedCastKeyword(type) switch


### PR DESCRIPTION
- Advances #2379 topic area 2
- Advances #2242
- Changes C# conversion-rule ownership only; intended render output is byte-identical.
- Card revision: `16948db3`

## Change

**Conclusion:** **PASS** — this is a behavior-preserving consolidation that moves C# conversion predicates into `CSharpConversionRules` and routes printer target-typing call sites through that shared surface.

Before/after output is intentionally unchanged. Render A/B evaluated 89,065 methods with `Changed: 0`, `Added: 0`, `Removed: 0`.

## Evidence

| Check | Result |
| --- | --- |
| Focused tests | `CSharpConversionRulesTests` passed: 4/4 |
| Decompiler fast suite | Passed: 1,974/1,974 |
| Solution build | Passed |
| Product build | Passed |
| Render A/B | Passed: 89,065 methods, 0 changed |
| Quality card | Advisory only: pinned subset improved; capped-sample warnings match PR quick-cap vs daily baseline |

## Decompiler quality

**Conclusion:** **PASS** — pinned-subset gate improved and render A/B is byte-identical; the quality-card nonzero exit is the expected capped-sample baseline-size advisory.

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 350 methods (compile-cap 25; per-sample, not corpus-wide); fidelity sampled 24 / 89,065 (0.03%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,405 (88.03%) | +6 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — 25,179 compiled methods | 1/350 — 350 compiled methods | -73 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 2/24, exact 22, recompile-failed 0, context-failed 0; sampled 24 / 89,065 (0.03%) | -3 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.03% (+0.01 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 2 (-3).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25179, current 350)
- fidelity checked methods lower than baseline (baseline 36, current 24)
```

## Review

Adversarial review pending: Gemini + MAI.

## Validation

```bash
dotnet restore src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj --configfile nuget.config --verbosity minimal
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CSharpConversionRulesTests/*"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet restore dotnet-inspect.slnx --configfile nuget.config --verbosity minimal
dotnet build dotnet-inspect.slnx -c Release --no-restore --verbosity minimal
bash eng/prepare-decompiler-corpus.sh /tmp/corpus-2379c2.txt
git worktree add /tmp/ab-base-2379c2 --detach $(git merge-base origin/main HEAD)
dotnet restore /tmp/ab-base-2379c2/tools/DecompilerHarness/DecompilerHarness.csproj --configfile /tmp/ab-base-2379c2/nuget.config --verbosity minimal
dotnet restore tools/DecompilerHarness/DecompilerHarness.csproj --configfile nuget.config --verbosity minimal
mapfile -t assemblies < /tmp/corpus-2379c2.txt
dotnet run --no-restore --project /tmp/ab-base-2379c2/tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --emit-render-ab /tmp/base-2379c2.renderab
dotnet run --no-restore --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --render-ab /tmp/base-2379c2.renderab
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --configfile nuget.config --no-restore --verbosity minimal
dotnet run --no-restore --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json --quality-diff-card --compile-cap 25 --corpus-fidelity-cap 3 --max-examples 3
```
