### PR TITLE
Add read-only slot def-use webs

### DIFF
--- a/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
+++ b/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
@@ -91,6 +91,113 @@ public class ReachingDefinitionsTests
     }
 
     [Fact]
+    public void DefUseGraph_BranchMerge_ConnectsDefinitionsAndMergedUse()
+    {
+        var graph = ReachingDefinitions.Analyze([
+            Op(ILOpCode.Ldarg_0),
+            Op(ILOpCode.Brfalse_s), 0x04,
+            Op(ILOpCode.Ldc_i4_1),
+            Op(ILOpCode.Stloc_0),
+            Op(ILOpCode.Br_s), 0x02,
+            Op(ILOpCode.Ldc_i4_2),
+            Op(ILOpCode.Stloc_0),
+            Op(ILOpCode.Ldloc_0),
+            Op(ILOpCode.Ret),
+        ], argumentSlotCount: 1).ToDefUseGraph();
+
+        var slotWeb = Assert.Single(graph.WebsFor(new SlotIdentity(0, IsArgument: false)));
+        Assert.Equal([4, 8], slotWeb.Definitions.Select(definition => definition.Offset).ToArray());
+        Assert.Equal([9], slotWeb.Uses.Select(use => use.Offset).ToArray());
+        Assert.True(slotWeb.HasMergedUse);
+        Assert.True(slotWeb.HasMultipleDefinitions);
+        Assert.False(slotWeb.AddressTaken);
+    }
+
+    [Fact]
+    public void DefUseGraph_SlotReuse_ProducesSeparateWebs()
+    {
+        var graph = ReachingDefinitions.Analyze([
+            Op(ILOpCode.Ldc_i4_0),
+            Op(ILOpCode.Stloc_0),
+            Op(ILOpCode.Ldloc_0),
+            Op(ILOpCode.Pop),
+            Op(ILOpCode.Ldc_i4_1),
+            Op(ILOpCode.Stloc_0),
+            Op(ILOpCode.Ldloc_0),
+            Op(ILOpCode.Ret),
+        ], argumentSlotCount: 0).ToDefUseGraph();
+
+        var webs = graph.WebsFor(new SlotIdentity(0, IsArgument: false));
+
+        Assert.Collection(
+            webs,
+            first =>
+            {
+                Assert.Equal([1], first.Definitions.Select(definition => definition.Offset).ToArray());
+                Assert.Equal([2], first.Uses.Select(use => use.Offset).ToArray());
+                Assert.True(first.HasSingleDefinition);
+                Assert.True(first.HasSingleUse);
+            },
+            second =>
+            {
+                Assert.Equal([5], second.Definitions.Select(definition => definition.Offset).ToArray());
+                Assert.Equal([6], second.Uses.Select(use => use.Offset).ToArray());
+                Assert.True(second.HasSingleDefinition);
+                Assert.True(second.HasSingleUse);
+            });
+    }
+
+    [Fact]
+    public void DefUseGraph_AddressLoad_MarksWebAddressTaken()
+    {
+        var graph = ReachingDefinitions.Analyze([
+            Op(ILOpCode.Ldc_i4_0),
+            Op(ILOpCode.Stloc_0),
+            Op(ILOpCode.Ldloca_s), 0x00,
+            Op(ILOpCode.Pop),
+            Op(ILOpCode.Ret),
+        ], argumentSlotCount: 0).ToDefUseGraph();
+
+        var web = Assert.Single(graph.WebsFor(new SlotIdentity(0, IsArgument: false)));
+        Assert.True(web.AddressTaken);
+        Assert.Equal([2], web.Uses.Select(use => use.Offset).ToArray());
+    }
+
+    [Fact]
+    public void DefUseGraph_UnusedDefinition_StillCreatesWeb()
+    {
+        var graph = ReachingDefinitions.Analyze([
+            Op(ILOpCode.Ldc_i4_0),
+            Op(ILOpCode.Stloc_0),
+            Op(ILOpCode.Ret),
+        ], argumentSlotCount: 0).ToDefUseGraph();
+
+        var web = Assert.Single(graph.WebsFor(new SlotIdentity(0, IsArgument: false)));
+        Assert.Equal([1], web.Definitions.Select(definition => definition.Offset).ToArray());
+        Assert.Empty(web.Uses);
+        Assert.True(web.HasSingleDefinition);
+        Assert.False(web.HasSingleUse);
+    }
+
+    [Fact]
+    public void DefUseGraph_ArgumentUse_UsesSyntheticEntryDefinition()
+    {
+        var graph = ReachingDefinitions.Analyze([
+            Op(ILOpCode.Ldarg_0),
+            Op(ILOpCode.Ret),
+        ], argumentSlotCount: 1).ToDefUseGraph();
+
+        var web = Assert.Single(graph.WebsFor(new SlotIdentity(0, IsArgument: true)));
+
+        var definition = Assert.Single(web.Definitions);
+        Assert.True(definition.IsArgument);
+        Assert.Equal(-1, definition.Offset);
+        Assert.Equal([0], web.Uses.Select(use => use.Offset).ToArray());
+        Assert.Equal(-1, web.StartOffset);
+        Assert.Equal(0, web.EndOffset);
+    }
+
+    [Fact]
     public void Analyze_MalformedHugeSwitch_ThrowsBeforeAllocatingTargetTable()
     {
         Assert.Throws<BadImageFormatException>(() => ReachingDefinitions.Analyze([

--- a/src/ILInspector.Analysis/ReachingDefinitions.cs
+++ b/src/ILInspector.Analysis/ReachingDefinitions.cs
@@ -24,6 +24,143 @@ public sealed record ReachingDefinitionsResult(
 {
     public ImmutableArray<LocalUse> UsesOf(LocalDefinition definition)
         => [.. Uses.Where(use => use.ReachingDefinitions.Any(d => d.Id == definition.Id))];
+
+    public SlotDefUseGraph ToDefUseGraph()
+        => SlotDefUseGraph.Create(this);
+}
+
+public readonly record struct SlotIdentity(int Slot, bool IsArgument);
+
+public sealed record SlotDefUseWeb(
+    int Id,
+    SlotIdentity Slot,
+    ImmutableArray<LocalDefinition> Definitions,
+    ImmutableArray<LocalUse> Uses,
+    int StartOffset,
+    int EndOffset,
+    bool AddressTaken,
+    bool HasMergedUse)
+{
+    public bool IsArgument => Slot.IsArgument;
+    public bool HasMultipleDefinitions => Definitions.Length > 1;
+    public bool HasSingleDefinition => Definitions.Length == 1;
+    public bool HasSingleUse => Uses.Length == 1;
+}
+
+public sealed record SlotDefUseGraph(ImmutableArray<SlotDefUseWeb> Webs)
+{
+    public ImmutableArray<SlotDefUseWeb> WebsFor(SlotIdentity slot)
+        => [.. Webs.Where(web => web.Slot == slot)];
+
+    public static SlotDefUseGraph Create(ReachingDefinitionsResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        int definitionCount = result.Definitions.Length;
+        int useCount = result.Uses.Length;
+        int nodeCount = definitionCount + useCount;
+        if (nodeCount == 0)
+            return new SlotDefUseGraph([]);
+
+        var parents = Enumerable.Range(0, nodeCount).ToArray();
+        var definitionIndexById = result.Definitions
+            .Select((definition, index) => (definition.Id, Index: index))
+            .ToDictionary(pair => pair.Id, pair => pair.Index);
+
+        for (int useIndex = 0; useIndex < result.Uses.Length; useIndex++)
+        {
+            int useNode = definitionCount + useIndex;
+            foreach (var definition in result.Uses[useIndex].ReachingDefinitions)
+                if (definitionIndexById.TryGetValue(definition.Id, out int definitionIndex))
+                    Union(useNode, definitionIndex);
+        }
+
+        var groups = new Dictionary<int, List<int>>();
+        for (int node = 0; node < nodeCount; node++)
+        {
+            int root = Find(node);
+            if (!groups.TryGetValue(root, out var nodes))
+                groups[root] = nodes = [];
+            nodes.Add(node);
+        }
+
+        var candidates = groups.Values
+            .Select(nodes =>
+            {
+                var definitions = nodes
+                    .Where(node => node < definitionCount)
+                    .Select(node => result.Definitions[node])
+                    .OrderBy(definition => definition.Offset)
+                    .ThenBy(definition => definition.Id)
+                    .ToImmutableArray();
+                var uses = nodes
+                    .Where(node => node >= definitionCount)
+                    .Select(node => result.Uses[node - definitionCount])
+                    .OrderBy(use => use.Offset)
+                    .ThenBy(use => use.Slot)
+                    .ToImmutableArray();
+                var slot = definitions.Length > 0
+                    ? new SlotIdentity(definitions[0].Slot, definitions[0].IsArgument)
+                    : new SlotIdentity(uses[0].Slot, uses[0].IsArgument);
+                int startOffset = definitions.Select(definition => definition.Offset)
+                    .Concat(uses.Select(use => use.Offset))
+                    .Min();
+                int endOffset = definitions.Select(definition => definition.Offset)
+                    .Concat(uses.Select(use => use.Offset))
+                    .Max();
+                return new
+                {
+                    Slot = slot,
+                    Definitions = definitions,
+                    Uses = uses,
+                    StartOffset = startOffset,
+                    EndOffset = endOffset,
+                    AddressTaken = uses.Any(use => use.Address),
+                    HasMergedUse = uses.Any(use => use.ReachingDefinitions.Length > 1),
+                };
+            })
+            .OrderBy(candidate => candidate.Slot.IsArgument ? 0 : 1)
+            .ThenBy(candidate => candidate.Slot.Slot)
+            .ThenBy(candidate => candidate.StartOffset)
+            .ThenBy(candidate => candidate.EndOffset)
+            .ToArray();
+
+        var webs = ImmutableArray.CreateBuilder<SlotDefUseWeb>(candidates.Length);
+        for (int i = 0; i < candidates.Length; i++)
+        {
+            var candidate = candidates[i];
+            webs.Add(new SlotDefUseWeb(
+                i,
+                candidate.Slot,
+                candidate.Definitions,
+                candidate.Uses,
+                candidate.StartOffset,
+                candidate.EndOffset,
+                candidate.AddressTaken,
+                candidate.HasMergedUse));
+        }
+
+        return new SlotDefUseGraph(webs.MoveToImmutable());
+
+        int Find(int node)
+        {
+            while (parents[node] != node)
+            {
+                parents[node] = parents[parents[node]];
+                node = parents[node];
+            }
+
+            return node;
+        }
+
+        void Union(int left, int right)
+        {
+            int leftRoot = Find(left);
+            int rightRoot = Find(right);
+            if (leftRoot != rightRoot)
+                parents[rightRoot] = leftRoot;
+        }
+    }
 }
 
 public static class ReachingDefinitions


### PR DESCRIPTION
## Summary

Part of #2379 piece 1. Adds a read-only `SlotDefUseGraph` projection over existing `ReachingDefinitions` results, without changing decompiler behavior.

- groups connected local/argument definitions and uses into slot def-use webs
- exposes slot identity, definition/use membership, offset span, address-taken, merged-use, single-use, and multi-definition facts
- adds focused tests for branch merge webs, slot reuse splitting, address loads, unused definitions, and synthetic argument definitions

This is the first substrate slice for future F2/#2209/#2014 consumers; it does not add a broad framework or wire behavior-changing consumers yet.

## Validation

- `dotnet build src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj -c Release --configfile nuget.config --nologo`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/ReachingDefinitionsTests/*"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo`
- `git diff --check`

## Review

Analysis substrate change; adversarial review requested separately per repo policy.
