### PR TITLE
Extract value coercion renderability predicate

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CoercionRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoercionRenderingTests.cs
@@ -1,0 +1,46 @@
+using ILInspector.Decompiler.Pipeline;
+
+namespace ILInspector.Decompiler.Tests;
+
+public sealed class CoercionRenderingTests
+{
+    static readonly TypeRef Bool = TypeRef.CoreLib("System", "Boolean");
+    static readonly TypeRef Byte = TypeRef.CoreLib("System", "Byte");
+    static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef Int64 = TypeRef.CoreLib("System", "Int64");
+    static readonly TypeRef Enum32 = TypeRef.Definition("synthetic", "", "E32");
+    static readonly TypeRef OtherEnum32 = TypeRef.Definition("synthetic", "", "OtherE32");
+
+    static readonly IReadOnlyDictionary<TypeRef, TypeShape> Shapes = new Dictionary<TypeRef, TypeShape>
+    {
+        [Enum32] = TypeShape.Enum,
+        [OtherEnum32] = TypeShape.Enum,
+    };
+
+    static readonly IReadOnlyDictionary<TypeRef, TypeRef> Underlyings = new Dictionary<TypeRef, TypeRef>
+    {
+        [Enum32] = Int32,
+        [OtherEnum32] = Int32,
+    };
+
+    [Fact]
+    public void ValueCoercionDomain_PreservesLoadBearingAsymmetries()
+    {
+        Assert.True(CoercionRendering.CanSpellValueCoercion(Bool, Byte, Shapes, Underlyings));
+        Assert.False(CoercionRendering.CanSpellValueCoercion(Int32, Bool, Shapes, Underlyings));
+        Assert.True(CoercionRendering.CanSpellValueCoercion(Int32, Enum32, Shapes, Underlyings));
+        Assert.True(CoercionRendering.CanSpellValueCoercion(Enum32, Int64, Shapes, Underlyings));
+        Assert.True(CoercionRendering.CanSpellValueCoercion(Enum32, OtherEnum32, Shapes, Underlyings));
+        Assert.False(CoercionRendering.CanSpellValueCoercion(Int32, Int64, Shapes, Underlyings));
+    }
+
+    [Fact]
+    public void SlotCoercionAddsVerifierLiveRangeFamilyFilter()
+    {
+        Assert.True(CoercionRendering.CanSpellSlotCoercion(Bool, Byte, Shapes, Underlyings));
+        Assert.True(CoercionRendering.CanSpellSlotCoercion(Enum32, Int64, Shapes, Underlyings));
+        Assert.False(CoercionRendering.CanSpellSlotCoercion(Int32, Bool, Shapes, Underlyings));
+        Assert.False(CoercionRendering.CanSpellSlotCoercion(Int32, Int64, Shapes, Underlyings));
+        Assert.False(CoercionRendering.CanSpellSlotCoercion(null, Int32, Shapes, Underlyings));
+    }
+}

--- a/src/ILInspector.Decompiler/Pipeline/CoercionRendering.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CoercionRendering.cs
@@ -10,10 +10,11 @@ public static class CoercionRendering
     /// <summary>
     /// The slot-store wrappability contract: every accepted pair is both a
     /// coercion spelling that <c>CoerceText</c> renders and a stack-family
-    /// relation the verifier can carry in one live range. The asymmetries are
-    /// intentional: integer to bool has no spelling, missing enum underlying
-    /// data assumes I4 for same-family enum casts, and slot I4 to I8 enum
-    /// widening requires a resolved enum source.
+    /// relation the verifier can carry in one live range. The spelling half is
+    /// owned by <see cref="CanSpellValueCoercion"/>; the remaining family check
+    /// is slot-specific. The asymmetries are intentional: integer to bool has no
+    /// spelling, missing enum underlying data assumes I4 for same-family enum
+    /// casts, and slot I4 to I8 enum widening requires a resolved enum source.
     /// </summary>
     public static bool CanSpellSlotCoercion(
         TypeRef? valueType,
@@ -23,7 +24,7 @@ public static class CoercionRendering
     {
         if (valueType is null)
             return false;
-        if (!CanSpellSlotValue(valueType, target, shapes, enumUnderlyingTypes))
+        if (!CanSpellValueCoercion(valueType, target, shapes, enumUnderlyingTypes))
             return false;
 
         var valueFamily = SlotSemanticFamily(valueType, shapes, enumUnderlyingTypes);
@@ -33,6 +34,24 @@ public static class CoercionRendering
                 || (valueFamily == StackFamily.I4 && targetFamily == StackFamily.I8
                     && enumUnderlyingTypes.ContainsKey(valueType)));
     }
+
+    /// <summary>
+    /// Type-level coercion spellings owned by <c>CoerceText</c>. This predicate
+    /// intentionally excludes value-sensitive spellings such as numeric constants
+    /// and node-shape spellings such as address-to-pointer casts; callers with
+    /// only source/target types cannot prove those cases.
+    /// </summary>
+    public static bool CanSpellValueCoercion(
+        TypeRef valueType,
+        TypeRef target,
+        IReadOnlyDictionary<TypeRef, TypeShape> shapes,
+        IReadOnlyDictionary<TypeRef, TypeRef> enumUnderlyingTypes)
+        => valueType.Equals(target)
+            || CanSpellBoolToInteger(valueType, target)
+            || CanSpellIntegerToEnum(valueType, target, shapes)
+            || CanSpellEnumToInteger(valueType, target, shapes, enumUnderlyingTypes)
+            || CanSpellEnumToEnum(valueType, target, shapes, enumUnderlyingTypes)
+            || CanSpellPrimitiveNumeric(valueType, target);
 
     public static bool CanSpellIntegerToEnum(
         TypeRef? valueType,
@@ -76,21 +95,11 @@ public static class CoercionRendering
     public static bool CanSpellBoolToInteger(TypeRef? valueType, TypeRef target)
         => TypeFamilies.IsIntegerLike(target) && TypeFamilies.IsBoolean(valueType);
 
-    static bool CanSpellSlotValue(
-        TypeRef valueType,
-        TypeRef target,
-        IReadOnlyDictionary<TypeRef, TypeShape> shapes,
-        IReadOnlyDictionary<TypeRef, TypeRef> enumUnderlyingTypes)
-        => valueType.Equals(target)
-            || CanSpellBoolToInteger(valueType, target)
-            || CanSpellIntegerToEnum(valueType, target, shapes)
-            || CanSpellEnumToInteger(valueType, target, shapes, enumUnderlyingTypes)
-            || CanSpellEnumToEnum(valueType, target, shapes, enumUnderlyingTypes)
-            || CanSpellPrimitiveNumeric(valueType, target);
-
-    static bool CanSpellPrimitiveNumeric(TypeRef valueType, TypeRef target)
+    public static bool CanSpellPrimitiveNumeric(TypeRef? valueType, TypeRef? target)
         => !TypeFamilies.IsBoolean(valueType)
             && !TypeFamilies.IsBoolean(target)
+            && valueType is not null
+            && target is not null
             && TypeFamilies.IsNumericPrimitive(valueType)
             && TypeFamilies.IsNumericPrimitive(target)
             && TypeFamilies.Of(valueType) == TypeFamilies.Of(target);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -1237,6 +1237,8 @@ public sealed partial class CSharpPrinter
         // unchecked cast (uint.MaxValue's `ldc.i4.m1` → unchecked((uint)(-1))).
         if (value is Constant { Value: int or long } konst && target is { } t && TypeFamilies.IsNumericPrimitive(t))
             return NumericConstant(konst, t);
+        if (target is not { } numericTarget || !CoercionRendering.CanSpellPrimitiveNumeric(EffectiveType(value), numericTarget))
+            return Expression(value);
         if (!CSharpConversionRules.NeedsNumericCast(EffectiveType(value), target))
             return Expression(value);
         // A plain conversion to a same-width sibling (conv.u2 → ushort feeding a
@@ -1247,11 +1249,11 @@ public sealed partial class CSharpPrinter
         // sibling-width): inside a lexical checked region a bare spelling
         // recompiles to a conv.ovf the IL never had (#2301), so they route
         // through CheckedSafeCast like the enum reinterprets above.
-        if (value is Convert { IsChecked: false, IsUnsigned: false } conv && CSharpConversionRules.SameNumericSlotWidth(conv.Target, target))
+        if (value is Convert { IsChecked: false, IsUnsigned: false } conv && CSharpConversionRules.SameNumericSlotWidth(conv.Target, numericTarget))
             return conv.Operand is Constant { Value: int or long } convConst
-                ? NumericConstant(convConst, target!)
-                : CheckedSafeNumericCast(EffectiveType(conv.Operand), target!, () => $"({TypeText(target!)}){Operand(conv.Operand)}");
-        return CheckedSafeNumericCast(EffectiveType(value), target!, () => $"({TypeText(target!)}){Operand(value)}");
+                ? NumericConstant(convConst, numericTarget)
+                : CheckedSafeNumericCast(EffectiveType(conv.Operand), numericTarget, () => $"({TypeText(numericTarget)}){Operand(conv.Operand)}");
+        return CheckedSafeNumericCast(EffectiveType(value), numericTarget, () => $"({TypeText(numericTarget)}){Operand(value)}");
     }
 
     string CheckedSafeNumericCast(TypeRef? source, TypeRef target, Func<string> renderCast)


### PR DESCRIPTION
- Fixes #2242
- Advances #2379 topic area 2
- Changes renderability ownership only; intended render output is byte-identical.
- Card revision: `d6436be0`

## Change

**Conclusion:** **PASS** — this extracts the type-level CoerceText renderability domain into `CoercionRendering.CanSpellValueCoercion`, keeps the slot-specific verifier live-range filter in `CanSpellSlotCoercion`, and routes CoerceText's primitive fallback through the same primitive renderability arm.

Before/after output is intentionally unchanged. Render A/B evaluated 89,065 methods with `Changed: 0`, `Added: 0`, `Removed: 0`.

## Evidence

| Check | Result |
| --- | --- |
| Focused tests | `CoercionRenderingTests` passed: 2/2; `CoercionInvariantTests` passed: 17/17 |
| Decompiler fast suite | Passed: 1,978/1,978 |
| Solution build | Passed |
| Product build | Passed |
| Render A/B | Passed: 89,065 methods, 0 changed |
| Quality card | Advisory only: pinned subset improved; capped-sample warnings match PR quick-cap vs daily baseline |

## Decompiler quality

**Conclusion:** **PASS** — pinned-subset gate improved and render A/B is byte-identical; the quality-card nonzero exit is the expected capped-sample baseline-size advisory.

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 350 methods (compile-cap 25; per-sample, not corpus-wide); fidelity sampled 24 / 89,065 (0.03%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,405 (88.03%) | +6 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — 25,179 compiled methods | 1/350 — 350 compiled methods | -73 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 3/24, exact 21, recompile-failed 0, context-failed 0; sampled 24 / 89,065 (0.03%) | -2 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.03% (+0.01 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 3 (-2).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25179, current 350)
- fidelity checked methods lower than baseline (baseline 36, current 24)
```

## Review

Adversarial review pending: Gemini + MAI.

## Validation

```bash
dotnet restore src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj --configfile nuget.config --verbosity minimal
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CoercionRenderingTests/*"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CoercionInvariantTests/*"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet restore dotnet-inspect.slnx --configfile nuget.config --verbosity minimal
dotnet build dotnet-inspect.slnx -c Release --no-restore --verbosity minimal
bash eng/prepare-decompiler-corpus.sh /tmp/corpus-2242.txt
git worktree add /tmp/ab-base-2242 --detach $(git merge-base origin/main HEAD)
dotnet restore /tmp/ab-base-2242/tools/DecompilerHarness/DecompilerHarness.csproj --configfile /tmp/ab-base-2242/nuget.config --verbosity minimal
dotnet restore tools/DecompilerHarness/DecompilerHarness.csproj --configfile nuget.config --verbosity minimal
mapfile -t assemblies < /tmp/corpus-2242.txt
dotnet run --no-restore --project /tmp/ab-base-2242/tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --emit-render-ab /tmp/base-2242.renderab
dotnet run --no-restore --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --render-ab /tmp/base-2242.renderab
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --configfile nuget.config --no-restore --verbosity minimal
dotnet run --no-restore --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json --quality-diff-card --compile-cap 25 --corpus-fidelity-cap 3 --max-examples 3
```
