### PR TITLE
Surface def-use graph completeness

### DIFF
--- a/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
+++ b/src/ILInspector.Analysis.Tests/ReachingDefinitionsTests.cs
@@ -145,6 +145,10 @@ public class ReachingDefinitionsTests
                 Assert.True(second.HasSingleDefinition);
                 Assert.True(second.HasSingleUse);
             });
+
+        Assert.Equal([1, 5], graph.SingleDefinitionSingleUseWebs()
+            .Select(web => Assert.Single(web.Definitions).Offset)
+            .ToArray());
     }
 
     [Fact]
@@ -161,6 +165,7 @@ public class ReachingDefinitionsTests
         var web = Assert.Single(graph.WebsFor(new SlotIdentity(0, IsArgument: false)));
         Assert.True(web.AddressTaken);
         Assert.Equal([2], web.Uses.Select(use => use.Offset).ToArray());
+        Assert.Empty(graph.SingleDefinitionSingleUseWebs());
     }
 
     [Fact]
@@ -195,6 +200,31 @@ public class ReachingDefinitionsTests
         Assert.Equal([0], web.Uses.Select(use => use.Offset).ToArray());
         Assert.Equal(-1, web.StartOffset);
         Assert.Equal(0, web.EndOffset);
+        Assert.Empty(graph.SingleDefinitionSingleUseWebs());
+        Assert.Equal([web], graph.SingleDefinitionSingleUseWebs(includeArguments: true));
+    }
+
+    [Fact]
+    public void DefUseGraph_PreservesIncompleteReason()
+    {
+        var result = ReachingDefinitions.Analyze([
+            Op(ILOpCode.Ret),
+        ], argumentSlotCount: 0, [default(ExceptionRegion)]);
+
+        var graph = result.ToDefUseGraph();
+
+        Assert.False(graph.IsComplete);
+        Assert.Equal(result.IncompleteReason, graph.IncompleteReason);
+    }
+
+    [Fact]
+    public void DefUseGraph_EmptyCompleteResult_IsComplete()
+    {
+        var graph = ReachingDefinitions.Analyze([], argumentSlotCount: 0).ToDefUseGraph();
+
+        Assert.Empty(graph.Webs);
+        Assert.True(graph.IsComplete);
+        Assert.Null(graph.IncompleteReason);
     }
 
     [Fact]

--- a/src/ILInspector.Analysis/ReachingDefinitions.cs
+++ b/src/ILInspector.Analysis/ReachingDefinitions.cs
@@ -45,12 +45,22 @@ public sealed record SlotDefUseWeb(
     public bool HasMultipleDefinitions => Definitions.Length > 1;
     public bool HasSingleDefinition => Definitions.Length == 1;
     public bool HasSingleUse => Uses.Length == 1;
+    public bool HasSingleDefinitionSingleUseWithoutAddress
+        => HasSingleDefinition && HasSingleUse && !AddressTaken;
 }
 
-public sealed record SlotDefUseGraph(ImmutableArray<SlotDefUseWeb> Webs)
+public sealed record SlotDefUseGraph(
+    ImmutableArray<SlotDefUseWeb> Webs,
+    bool IsComplete = true,
+    string? IncompleteReason = null)
 {
     public ImmutableArray<SlotDefUseWeb> WebsFor(SlotIdentity slot)
         => [.. Webs.Where(web => web.Slot == slot)];
+
+    public ImmutableArray<SlotDefUseWeb> SingleDefinitionSingleUseWebs(bool includeArguments = false)
+        => [.. Webs.Where(web =>
+            web.HasSingleDefinitionSingleUseWithoutAddress
+            && (includeArguments || !web.IsArgument))];
 
     public static SlotDefUseGraph Create(ReachingDefinitionsResult result)
     {
@@ -60,7 +70,7 @@ public sealed record SlotDefUseGraph(ImmutableArray<SlotDefUseWeb> Webs)
         int useCount = result.Uses.Length;
         int nodeCount = definitionCount + useCount;
         if (nodeCount == 0)
-            return new SlotDefUseGraph([]);
+            return new SlotDefUseGraph([], result.IsComplete, result.IncompleteReason);
 
         var parents = Enumerable.Range(0, nodeCount).ToArray();
         var definitionIndexById = result.Definitions
@@ -102,12 +112,12 @@ public sealed record SlotDefUseGraph(ImmutableArray<SlotDefUseWeb> Webs)
                 var slot = definitions.Length > 0
                     ? new SlotIdentity(definitions[0].Slot, definitions[0].IsArgument)
                     : new SlotIdentity(uses[0].Slot, uses[0].IsArgument);
-                int startOffset = definitions.Select(definition => definition.Offset)
-                    .Concat(uses.Select(use => use.Offset))
-                    .Min();
-                int endOffset = definitions.Select(definition => definition.Offset)
-                    .Concat(uses.Select(use => use.Offset))
-                    .Max();
+                int startOffset = Math.Min(
+                    definitions.IsEmpty ? int.MaxValue : definitions[0].Offset,
+                    uses.IsEmpty ? int.MaxValue : uses[0].Offset);
+                int endOffset = Math.Max(
+                    definitions.IsEmpty ? int.MinValue : definitions[^1].Offset,
+                    uses.IsEmpty ? int.MinValue : uses[^1].Offset);
                 return new
                 {
                     Slot = slot,
@@ -140,7 +150,7 @@ public sealed record SlotDefUseGraph(ImmutableArray<SlotDefUseWeb> Webs)
                 candidate.HasMergedUse));
         }
 
-        return new SlotDefUseGraph(webs.MoveToImmutable());
+        return new SlotDefUseGraph(webs.MoveToImmutable(), result.IsComplete, result.IncompleteReason);
 
         int Find(int node)
         {


### PR DESCRIPTION
## Summary

Follow-up for #2379 piece 1 after #2383. Keeps this read-only and behavior-neutral.

- carry `ReachingDefinitionsResult.IsComplete` / `IncompleteReason` through `SlotDefUseGraph`
- add a named `SingleDefinitionSingleUseWebs` query for future materialization/F2 consumers
- exclude argument webs by default and exclude address-taken webs from that candidate query
- keep decompiler/product consumers unchanged

## Validation

- `dotnet build src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj -c Release --configfile nuget.config --nologo`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/ReachingDefinitionsTests/*"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo`
- `git diff --check`

## Review

Analysis substrate change; adversarial review requested separately per repo policy.
