### PR TITLE
Share implicit numeric assignment rules

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpConversionRulesTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpConversionRulesTests.cs
@@ -39,6 +39,25 @@ public sealed class CSharpConversionRulesTests
     }
 
     [Fact]
+    public void IsImplicitNumericAssignment_IncludesFloatWideningsAndRejectsExplicitPairs()
+    {
+        Assert.True(CSharpConversionRules.IsImplicitNumericAssignment(Core("Int32"), Core("Single")));
+        Assert.True(CSharpConversionRules.IsImplicitNumericAssignment(Core("Int64"), Core("Single")));
+        Assert.True(CSharpConversionRules.IsImplicitNumericAssignment(Core("UInt64"), Core("Single")));
+        Assert.True(CSharpConversionRules.IsImplicitNumericAssignment(Core("UInt64"), Core("Double")));
+        Assert.True(CSharpConversionRules.IsImplicitNumericAssignment(Core("Int32"), Core("IntPtr")));
+        Assert.True(CSharpConversionRules.IsImplicitNumericAssignment(Core("UInt32"), Core("UIntPtr")));
+        Assert.True(CSharpConversionRules.IsImplicitNumericAssignment(Core("IntPtr"), Core("Double")));
+        Assert.True(CSharpConversionRules.IsImplicitNumericAssignment(Core("UIntPtr"), Core("UInt64")));
+        Assert.True(CSharpConversionRules.IsImplicitNumericAssignment(Core("Char"), Core("UInt16")));
+        Assert.False(CSharpConversionRules.IsImplicitNumericAssignment(Core("Double"), Core("Single")));
+        Assert.False(CSharpConversionRules.IsImplicitNumericAssignment(Core("Int32"), Core("UInt32")));
+        Assert.False(CSharpConversionRules.IsImplicitNumericAssignment(Core("Int64"), Core("IntPtr")));
+        Assert.False(CSharpConversionRules.IsImplicitNumericAssignment(Core("UIntPtr"), Core("Int64")));
+        Assert.False(CSharpConversionRules.IsImplicitNumericAssignment(Core("Boolean"), Core("Int32")));
+    }
+
+    [Fact]
     public void CheckedConversionCanThrow_ModelsCheckedExplicitCastHazards()
     {
         Assert.False(CSharpConversionRules.CheckedConversionCanThrow(Core("Int32"), Core("Int64")));

--- a/src/ILInspector.Decompiler/Pipeline/CSharpConversionRules.cs
+++ b/src/ILInspector.Decompiler/Pipeline/CSharpConversionRules.cs
@@ -78,6 +78,34 @@ public static class CSharpConversionRules
         };
 
     /// <summary>
+    /// C# implicit numeric assignment conversions, including the float/double
+    /// widenings the integer-only predicates intentionally exclude.
+    /// </summary>
+    public static bool IsImplicitNumericAssignment(TypeRef source, TypeRef target)
+    {
+        if (!TypeFamilies.IsNumericPrimitive(source) || !TypeFamilies.IsNumericPrimitive(target))
+            return false;
+        return (source.Name, target.Name) switch
+        {
+            ("SByte", "Int16" or "Int32" or "Int64" or "Single" or "Double") => true,
+            ("Byte", "Int16" or "UInt16" or "Int32" or "UInt32" or "Int64" or "UInt64" or "Single" or "Double") => true,
+            ("Int16", "Int32" or "Int64" or "Single" or "Double") => true,
+            ("UInt16", "Int32" or "UInt32" or "Int64" or "UInt64" or "Single" or "Double") => true,
+            ("Char", "UInt16" or "Int32" or "UInt32" or "Int64" or "UInt64" or "Single" or "Double") => true,
+            ("Int32", "Int64" or "Single" or "Double") => true,
+            ("UInt32", "Int64" or "UInt64" or "Single" or "Double") => true,
+            ("Int64" or "UInt64", "Single" or "Double") => true,
+            ("SByte" or "Int16" or "Int32", "IntPtr") => true,
+            ("Byte" or "UInt16" or "Char" or "UInt32", "UIntPtr") => true,
+            ("Byte" or "UInt16" or "Char", "IntPtr") => true,
+            ("IntPtr", "Int64" or "Single" or "Double") => true,
+            ("UIntPtr", "UInt64" or "Single" or "Double") => true,
+            ("Single", "Double") => true,
+            _ => false,
+        };
+    }
+
+    /// <summary>
     /// True when the C# checked conversion can throw for some value. Synthesized
     /// reinterpret casts in a lexical checked context need <c>unchecked(...)</c>
     /// exactly for these pairs.

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -712,7 +712,7 @@ public sealed partial class CSharpPrinter
     {
         if (source.Equals(target))
             return true;
-        if (IsImplicitNumericAssignment(source, target))
+        if (CSharpConversionRules.IsImplicitNumericAssignment(source, target))
             return true;
         if (IsCoreObject(target) && IsReferenceLike(source))
             return true;
@@ -750,24 +750,6 @@ public sealed partial class CSharpPrinter
 
     static bool IsCoreObject(TypeRef type)
         => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Object" };
-
-    static bool IsImplicitNumericAssignment(TypeRef source, TypeRef target)
-    {
-        if (!TypeFamilies.IsNumericPrimitive(source) || !TypeFamilies.IsNumericPrimitive(target))
-            return false;
-        return (source.Name, target.Name) switch
-        {
-            ("SByte", "Int16" or "Int32" or "Int64" or "Single" or "Double") => true,
-            ("Byte", "Int16" or "UInt16" or "Int32" or "UInt32" or "Int64" or "UInt64" or "Single" or "Double") => true,
-            ("Int16", "Int32" or "Int64" or "Single" or "Double") => true,
-            ("UInt16", "Int32" or "UInt32" or "Int64" or "UInt64" or "Single" or "Double") => true,
-            ("Char", "UInt16" or "Int32" or "UInt32" or "Int64" or "UInt64" or "Single" or "Double") => true,
-            ("Int32", "Int64" or "Single" or "Double") => true,
-            ("UInt32", "Int64" or "UInt64" or "Single" or "Double") => true,
-            ("Int64" or "UInt64" or "Single", "Double") => true,
-            _ => false,
-        };
-    }
 
     TypeRef? StackSlotRenderType(int slot, TypeRef? type)
         => _stackSlotUnifiedTypes.TryGetValue(slot, out var unifiedType) ? unifiedType : type;


### PR DESCRIPTION
- Advances #2379 topic area 2
- Changes C# conversion-rule ownership and corrects the shared implicit numeric assignment matrix; render output is byte-identical.
- Card revision: `2a23545c`

## Change

**Conclusion:** **PASS** — this moves the printer-local implicit numeric assignment table into `CSharpConversionRules`, so slot unification and future target-typing callers use the shared conversion substrate. While moving it, the table was checked against Roslyn and corrected for native-int widenings and `long`/`ulong` to `float`.

Before/after output is intentionally unchanged. Render A/B evaluated 89,065 methods with `Changed: 0`, `Added: 0`, `Removed: 0`.

## Evidence

| Check | Result |
| --- | --- |
| Focused tests | `CSharpConversionRulesTests` passed: 5/5 |
| Roslyn matrix probe | Confirmed native-int and integer-to-float implicit assignment cases |
| Decompiler fast suite | Passed: 2,002/2,002 |
| Solution build | Passed |
| Product build | Passed |
| Render A/B | Passed: 89,065 methods, 0 changed |
| Quality card | Advisory only: pinned subset improved; capped-sample warnings match PR quick-cap vs daily baseline |

## Decompiler quality

**Conclusion:** **PASS** — pinned-subset gate improved and render A/B is byte-identical; the quality-card nonzero exit is the expected capped-sample baseline-size advisory.

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 350 methods (compile-cap 25; per-sample, not corpus-wide); fidelity sampled 21 / 89,065 (0.02%)

| Metric (desired direction) | Baseline | PR | Count delta |
| --- | ---: | ---: | ---: |
| Fully raised (+) | 78,399 (88.02%) | 78,405 (88.03%) | +6 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 — 25,179 compiled methods | 1/350 — 350 compiled methods | -73 |
| Fidelity diffs (-) | opcode-diff 5/36, exact 31, recompile-failed 0, context-failed 0; sampled 36 / 89,065 (0.04%) | opcode-diff 2/21, exact 19, recompile-failed 0, context-failed 0; sampled 21 / 89,065 (0.02%) | -3 |
| Pass bugs (-) | 0 | 0 | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.03% (+0.01 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 2 (-3).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25179, current 350)
- fidelity checked methods lower than baseline (baseline 36, current 21)
```

## Review

Adversarial review pending: Gemini + MAI.

## Validation

```bash
dotnet restore src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj --configfile nuget.config --verbosity minimal
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CSharpConversionRulesTests/*"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet restore dotnet-inspect.slnx --configfile nuget.config --verbosity minimal
dotnet build dotnet-inspect.slnx -c Release --no-restore --verbosity minimal
bash eng/prepare-decompiler-corpus.sh /tmp/corpus-2379c3.txt
git worktree add /tmp/ab-base-2379c3 --detach $(git merge-base origin/main HEAD)
dotnet restore /tmp/ab-base-2379c3/tools/DecompilerHarness/DecompilerHarness.csproj --configfile /tmp/ab-base-2379c3/nuget.config --verbosity minimal
dotnet restore tools/DecompilerHarness/DecompilerHarness.csproj --configfile nuget.config --verbosity minimal
mapfile -t assemblies < /tmp/corpus-2379c3.txt
dotnet run --no-restore --project /tmp/ab-base-2379c3/tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --emit-render-ab /tmp/base-2379c3.renderab
dotnet run --no-restore --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --render-ab /tmp/base-2379c3.renderab
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --configfile nuget.config --no-restore --verbosity minimal
dotnet run --no-restore --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json --quality-diff-card --compile-cap 25 --corpus-fidelity-cap 3 --max-examples 3
```
