### PR TITLE
Pin native integer join coercion

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -1009,34 +1009,12 @@ public class CoerceChokePointTests
     }
 
     [Fact]
-    public void NintArm_AtNuintMergedType_TakesNativeReinterpretCast()
-    {
-        // #2334: platform-sized signed/unsigned siblings have the same runtime
-        // width even though TypeFamilies.Width is null. The join-arm coercion
-        // must therefore use SameNumericSlotWidth, not fixed-width SameWidth.
-        var nuintType = TypeRef.CoreLib("System", "UIntPtr");
-        var nintType = TypeRef.CoreLib("System", "IntPtr");
-        var boolType = TypeRef.CoreLib("System", "Boolean");
-        var conditional = new Conditional(
-            new LoadArgument(0, "c", boolType),
-            new LoadArgument(1, "u", nuintType),
-            new LoadArgument(2, "i", nintType))
-        {
-            MergedType = nuintType,
-        };
-        string body = RenderReturn(
-            conditional,
-            nuintType,
-            [new Parameter("c", boolType), new Parameter("u", nuintType), new Parameter("i", nintType)],
-            TypeRef.Definition("synthetic", "", "UnusedEnum"));
-
-        Assert.Contains("c ? u : (nuint)i", body);
-        AssertCompiles("public static nuint M(bool c, nuint u, nint i)", body);
-    }
-
-    [Fact]
     public void NuintArm_AtNintMergedType_TakesNativeReinterpretCast()
     {
+        // #2334 reverse direction: platform-sized signed/unsigned siblings have
+        // the same runtime width even though TypeFamilies.Width is null. The
+        // join-arm coercion must therefore use SameNumericSlotWidth, not
+        // fixed-width SameWidth.
         var nintType = TypeRef.CoreLib("System", "IntPtr");
         var nuintType = TypeRef.CoreLib("System", "UIntPtr");
         var boolType = TypeRef.CoreLib("System", "Boolean");

--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -1009,6 +1009,55 @@ public class CoerceChokePointTests
     }
 
     [Fact]
+    public void NintArm_AtNuintMergedType_TakesNativeReinterpretCast()
+    {
+        // #2334: platform-sized signed/unsigned siblings have the same runtime
+        // width even though TypeFamilies.Width is null. The join-arm coercion
+        // must therefore use SameNumericSlotWidth, not fixed-width SameWidth.
+        var nuintType = TypeRef.CoreLib("System", "UIntPtr");
+        var nintType = TypeRef.CoreLib("System", "IntPtr");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var conditional = new Conditional(
+            new LoadArgument(0, "c", boolType),
+            new LoadArgument(1, "u", nuintType),
+            new LoadArgument(2, "i", nintType))
+        {
+            MergedType = nuintType,
+        };
+        string body = RenderReturn(
+            conditional,
+            nuintType,
+            [new Parameter("c", boolType), new Parameter("u", nuintType), new Parameter("i", nintType)],
+            TypeRef.Definition("synthetic", "", "UnusedEnum"));
+
+        Assert.Contains("c ? u : (nuint)i", body);
+        AssertCompiles("public static nuint M(bool c, nuint u, nint i)", body);
+    }
+
+    [Fact]
+    public void NuintArm_AtNintMergedType_TakesNativeReinterpretCast()
+    {
+        var nintType = TypeRef.CoreLib("System", "IntPtr");
+        var nuintType = TypeRef.CoreLib("System", "UIntPtr");
+        var boolType = TypeRef.CoreLib("System", "Boolean");
+        var conditional = new Conditional(
+            new LoadArgument(0, "c", boolType),
+            new LoadArgument(1, "i", nintType),
+            new LoadArgument(2, "u", nuintType))
+        {
+            MergedType = nintType,
+        };
+        string body = RenderReturn(
+            conditional,
+            nintType,
+            [new Parameter("c", boolType), new Parameter("i", nintType), new Parameter("u", nuintType)],
+            TypeRef.Definition("synthetic", "", "UnusedEnum"));
+
+        Assert.Contains("c ? i : (nint)u", body);
+        AssertCompiles("public static nint M(bool c, nint i, nuint u)", body);
+    }
+
+    [Fact]
     public void InRangeConstantArm_AtUnsignedMergedType_StaysBare()
     {
         // C#'s implicit constant conversion covers in-range constants — the


### PR DESCRIPTION
- Fixes #2334
- Advances #2379 topic area 2
- Test-only closure for an issue fixed by the shared native-width conversion rule.
- Card revision: `ec4b3309`

## Change

**Conclusion:** **PASS** — current main already renders `nint`/`nuint` join arms with native cross-signedness reinterpret casts through `CSharpConversionRules.SameNumericSlotWidth`; this PR adds canaries in both directions so the old fixed-width `SameWidth` blind spot cannot return.

Before the underlying fix, these shapes rendered bare and did not compile:

```csharp
c ? u : i      // nuint target, nint arm
c ? i : u      // nint target, nuint arm
```

Pinned output now compiles:

```csharp
c ? u : (nuint)i
c ? i : (nint)u
```

## Evidence

| Check | Result |
| --- | --- |
| Focused tests | `CoerceChokePointTests` passed: 51/51 |
| Decompiler fast suite | Passed: 2,004/2,004 |
| Solution build | Passed |
| Render A/B / quality card | Not run: test-only PR, no product or docs changes |

## Review

Adversarial review pending: Gemini + MAI.

## Validation

```bash
dotnet restore src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj --configfile nuget.config --verbosity minimal
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CoerceChokePointTests/*"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet restore dotnet-inspect.slnx --configfile nuget.config --verbosity minimal
dotnet build dotnet-inspect.slnx -c Release --no-restore --verbosity minimal
```
