### PR TITLE
Land ArrayPool leak-triage analyzer + corpus harness sensor, no CLI section (#1992)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Markout" Version="0.15.0" />
+    <PackageVersion Include="Markout" Version="0.16.1" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -1,0 +1,191 @@
+using System.Buffers;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.Analysis.Tests;
+
+public sealed class LeakTriageAnalyzerTests
+{
+    [Fact]
+    public void CleanArrayPoolFixtures_ProduceZeroRows()
+    {
+        var findings = FixtureFindings();
+
+        Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.CorrectRentReturn)));
+        Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.TryFinallyReturn)));
+        Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.TryFinallyThrowReturn)));
+        Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.ReturnOnAllPaths)));
+        Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.CorrelatedReturnOnAllPaths)));
+    }
+
+    [Fact]
+    public void MisuseArrayPoolFixtures_FireExactlyOnceEach()
+    {
+        var findings = FixtureFindings();
+
+        AssertSingleShape(findings, nameof(ArrayPoolLeakFixtures.UseAfterReturn), "arraypool-use-after-return");
+        AssertSingleShape(findings, nameof(ArrayPoolLeakFixtures.RentNotReturnedOnSomePath), "arraypool-rent-not-returned");
+        AssertSingleShape(findings, nameof(ArrayPoolLeakFixtures.DoubleReturn), "arraypool-double-return");
+    }
+
+    [Fact]
+    public void AmbiguousArrayPoolFixtures_FailClosed()
+    {
+        var findings = FixtureFindings();
+
+        Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.CrossMethodReturn)));
+        Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.FieldStoredArray)));
+        Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.NonSharedPoolRent)));
+    }
+
+    [Fact]
+    public void IncompleteDataflow_FailsClosed()
+    {
+        byte[] externalBranch = [0x2B, 0x7F, 0x2A]; // br.s outside the method, then ret
+        var method = new MethodIdentity(
+            "Fixture",
+            Guid.Empty,
+            TypeRef.Definition("Fixture", "Fixtures", "Incomplete"),
+            "Malformed",
+            [],
+            TypeRef.CoreLib("System", "Void"),
+            0x06000001,
+            IsStatic: true);
+
+        var findings = LeakTriageAnalyzer.AnalyzeMethod(
+            method,
+            externalBranch,
+            Array.Empty<ExceptionRegion>(),
+            _ => MemberRef.Unsupported("not used"));
+
+        Assert.Empty(findings);
+    }
+
+    static ImmutableArray<LeakTriageFinding> FixtureFindings()
+        => [.. LeakTriageAnalyzer.AnalyzeAssembly(typeof(ArrayPoolLeakFixtures).Assembly.Location)
+            .Where(finding => finding.Method.DeclaringType.Name == nameof(ArrayPoolLeakFixtures))];
+
+    static IEnumerable<LeakTriageFinding> ForMethod(ImmutableArray<LeakTriageFinding> findings, string methodName)
+        => findings.Where(finding => finding.Method.Name == methodName);
+
+    static void AssertSingleShape(ImmutableArray<LeakTriageFinding> findings, string methodName, string shape)
+    {
+        var finding = Assert.Single(ForMethod(findings, methodName));
+        Assert.Equal(shape, finding.Shape);
+    }
+}
+
+internal sealed class ArrayPoolLeakFixtures
+{
+    static byte[]? s_field;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void CorrectRentReturn()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        buffer[0] = 1;
+        ArrayPool<byte>.Shared.Return(buffer);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void TryFinallyReturn()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        try
+        {
+            buffer[0] = 1;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void TryFinallyThrowReturn()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        try
+        {
+            throw new InvalidOperationException();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ReturnOnAllPaths(bool condition)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        if (condition)
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+            return;
+        }
+
+        ArrayPool<byte>.Shared.Return(buffer);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void CorrelatedReturnOnAllPaths(bool condition)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        if (condition)
+            ArrayPool<byte>.Shared.Return(buffer);
+        if (!condition)
+            ArrayPool<byte>.Shared.Return(buffer);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void UseAfterReturn()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        ArrayPool<byte>.Shared.Return(buffer);
+        buffer[0] = 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void RentNotReturnedOnSomePath(bool condition)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        if (condition)
+            ArrayPool<byte>.Shared.Return(buffer);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void DoubleReturn()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        ArrayPool<byte>.Shared.Return(buffer);
+        ArrayPool<byte>.Shared.Return(buffer);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void CrossMethodReturn()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        ReturnHelper(buffer);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void FieldStoredArray()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        s_field = buffer;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void NonSharedPoolRent(ArrayPool<byte> pool)
+    {
+        var buffer = pool.Rent(16);
+        buffer[0] = 1;
+    }
+
+    static void ReturnHelper(byte[] buffer)
+        => ArrayPool<byte>.Shared.Return(buffer);
+}

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Collections.Immutable;
+using System.Reflection;
 using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 
@@ -19,6 +20,7 @@ public sealed class LeakTriageAnalyzerTests
         Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.TryFinallyThrowReturn)));
         Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.ReturnOnAllPaths)));
         Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.CorrelatedReturnOnAllPaths)));
+        Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.NestedFinallyLeaveReturn)));
     }
 
     [Fact]
@@ -64,9 +66,83 @@ public sealed class LeakTriageAnalyzerTests
         Assert.Empty(findings);
     }
 
+    [Fact]
+    public void FaultHandlerReturn_DoesNotSatisfyNormalLeavePath()
+    {
+        var findings = AnalyzeSynthetic([
+            .. Call(TokenShared),       // IL_0000 ArrayPool<byte>.Shared
+            0x1F, 0x10,                // IL_0005 ldc.i4.s 16
+            .. Callvirt(TokenRent),     // IL_0007 Rent
+            0x0A,                       // IL_000C stloc.0
+            0xDE, 0x0C,                 // IL_000D leave.s IL_001B
+            .. Call(TokenShared),       // IL_000F ArrayPool<byte>.Shared
+            0x06,                       // IL_0014 ldloc.0
+            .. Callvirt(TokenReturn),   // IL_0015 Return
+            0xDC,                       // IL_001A endfinally
+            0x2A,                       // IL_001B ret
+        ], [Region(ExceptionRegionKind.Fault, tryOffset: 13, tryLength: 2, handlerOffset: 15, handlerLength: 12)]);
+
+        AssertSingleShape(findings, nameof(Synthetic), "arraypool-rent-not-returned");
+    }
+
     static ImmutableArray<LeakTriageFinding> FixtureFindings()
         => [.. LeakTriageAnalyzer.AnalyzeAssembly(typeof(ArrayPoolLeakFixtures).Assembly.Location)
             .Where(finding => finding.Method.DeclaringType.Name == nameof(ArrayPoolLeakFixtures))];
+
+    const int TokenShared = 0x0A000001;
+    const int TokenRent = 0x0A000002;
+    const int TokenReturn = 0x0A000003;
+
+    static ImmutableArray<LeakTriageFinding> AnalyzeSynthetic(byte[] il, IReadOnlyCollection<ExceptionRegion> exceptionRegions)
+    {
+        var method = new MethodIdentity(
+            "Fixture",
+            Guid.Empty,
+            TypeRef.Definition("Fixture", "Fixtures", nameof(Synthetic)),
+            nameof(Synthetic),
+            [],
+            TypeRef.CoreLib("System", "Void"),
+            0x06000001,
+            IsStatic: true);
+        return LeakTriageAnalyzer.AnalyzeMethod(method, il, exceptionRegions, ResolveSyntheticMember);
+    }
+
+    static MemberRef ResolveSyntheticMember(int token)
+    {
+        var arrayPoolOfByte = TypeRef.GenericInstance(
+            TypeRef.Definition("System.Buffers", "System.Buffers", "ArrayPool`1"),
+            [TypeRef.CoreLib("System", "Byte")]);
+        var byteArray = TypeRef.SzArray(TypeRef.CoreLib("System", "Byte"));
+
+        return token switch
+        {
+            TokenShared => new MemberRef(arrayPoolOfByte, "get_Shared", [], arrayPoolOfByte, MemberKind.Method),
+            TokenRent => new MemberRef(arrayPoolOfByte, "Rent", [TypeRef.CoreLib("System", "Int32")], byteArray, MemberKind.Method) { HasThis = true },
+            TokenReturn => new MemberRef(arrayPoolOfByte, "Return", [byteArray], TypeRef.CoreLib("System", "Void"), MemberKind.Method) { HasThis = true },
+            _ => MemberRef.Unsupported($"unknown token 0x{token:X8}"),
+        };
+    }
+
+    static byte[] Call(int token) => [0x28, .. TokenBytes(token)];
+    static byte[] Callvirt(int token) => [0x6F, .. TokenBytes(token)];
+    static byte[] TokenBytes(int token) => BitConverter.GetBytes(token);
+
+    static readonly ConstructorInfo s_exceptionRegionConstructor =
+        typeof(ExceptionRegion).GetConstructor(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            [typeof(ExceptionRegionKind), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int)],
+            modifiers: null)
+        ?? throw new InvalidOperationException("ExceptionRegion constructor not found.");
+
+    static ExceptionRegion Region(
+        ExceptionRegionKind kind,
+        int tryOffset,
+        int tryLength,
+        int handlerOffset,
+        int handlerLength,
+        int filterOffset = 0)
+        => (ExceptionRegion)s_exceptionRegionConstructor.Invoke([kind, tryOffset, tryLength, handlerOffset, handlerLength, filterOffset]);
 
     static IEnumerable<LeakTriageFinding> ForMethod(ImmutableArray<LeakTriageFinding> findings, string methodName)
         => findings.Where(finding => finding.Method.Name == methodName);
@@ -76,6 +152,10 @@ public sealed class LeakTriageAnalyzerTests
         var finding = Assert.Single(ForMethod(findings, methodName));
         Assert.Equal(shape, finding.Shape);
     }
+}
+
+internal static class Synthetic
+{
 }
 
 internal sealed class ArrayPoolLeakFixtures
@@ -142,6 +222,30 @@ internal sealed class ArrayPoolLeakFixtures
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void NestedFinallyLeaveReturn()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        try
+        {
+            try
+            {
+                goto Done;
+            }
+            finally
+            {
+                Consume(1);
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+    Done:
+        return;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static void UseAfterReturn()
     {
         var buffer = ArrayPool<byte>.Shared.Rent(16);
@@ -188,4 +292,10 @@ internal sealed class ArrayPoolLeakFixtures
 
     static void ReturnHelper(byte[] buffer)
         => ArrayPool<byte>.Shared.Return(buffer);
+
+    static void Consume(int value)
+    {
+        if (value == int.MinValue)
+            throw new InvalidOperationException();
+    }
 }

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -1,0 +1,527 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Analysis;
+
+public sealed record LeakTriageFinding(
+    MethodIdentity Method,
+    string Shape,
+    string Evidence,
+    string Severity,
+    int RentOffset,
+    int? ILOffset);
+
+public static class LeakTriageAnalyzer
+{
+    public static ImmutableArray<LeakTriageFinding> AnalyzeAssembly(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        using var stream = File.OpenRead(path);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var assembly = reader.GetAssemblyDefinition();
+        var assemblyName = reader.GetString(assembly.Name);
+        var mvid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
+        var findings = ImmutableArray.CreateBuilder<LeakTriageFinding>();
+
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var methodDef = reader.GetMethodDefinition(methodHandle);
+                if (methodDef.RelativeVirtualAddress == 0)
+                    continue;
+
+                try
+                {
+                    var scope = CreateScope(reader, typeDef, methodDef);
+                    var signature = methodDef.DecodeSignature(TypeRefDecoder.Instance, scope);
+                    var method = new MethodIdentity(
+                        assemblyName,
+                        mvid,
+                        TypeRefDecoder.Instance.GetTypeFromDefinition(reader, typeHandle, 0),
+                        reader.GetString(methodDef.Name),
+                        signature.ParameterTypes,
+                        signature.ReturnType,
+                        MetadataTokens.GetToken(methodHandle),
+                        (methodDef.Attributes & MethodAttributes.Static) != 0);
+                    var body = peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
+                    findings.AddRange(AnalyzeMethod(
+                        method,
+                        body.GetILBytes() ?? [],
+                        body.ExceptionRegions,
+                        token => MemberResolver.ResolveMethod(reader, MetadataTokens.EntityHandle(token), scope)));
+                }
+                catch (Exception ex) when (IsRecoverable(ex))
+                {
+                    // Correctness triage is fail-closed: malformed or unsupported method
+                    // evidence yields no accusations for that method.
+                }
+            }
+        }
+
+        return findings.ToImmutable();
+    }
+
+    public static ImmutableArray<LeakTriageFinding> AnalyzeMethod(
+        MethodIdentity method,
+        byte[] il,
+        IReadOnlyCollection<ExceptionRegion> exceptionRegions,
+        Func<int, MemberRef> resolveMethod)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(il);
+        ArgumentNullException.ThrowIfNull(exceptionRegions);
+        ArgumentNullException.ThrowIfNull(resolveMethod);
+
+        if (il.Length == 0)
+            return [];
+
+        try
+        {
+            var instructions = InstructionDecoder.Decode(il);
+            var graph = BlockGraph.Build(il.Length, instructions, exceptionRegions);
+            if (!graph.IsComplete)
+                return [];
+
+            var reaching = ReachingDefinitions.Analyze(il, ArgumentSlotCount(method), exceptionRegions);
+            if (!reaching.IsComplete)
+                return [];
+
+            var calls = BuildCallMap(instructions, resolveMethod);
+            var rents = FindRents(method, instructions, graph, reaching, calls).ToImmutableArray();
+            if (rents.Length == 0)
+                return [];
+
+            var findings = ImmutableArray.CreateBuilder<LeakTriageFinding>();
+            foreach (var rent in rents)
+                AnalyzeRent(method, instructions, graph, reaching, calls, rent, findings);
+
+            return findings.ToImmutable();
+        }
+        catch (Exception ex) when (IsRecoverable(ex))
+        {
+            return [];
+        }
+    }
+
+    static void AnalyzeRent(
+        MethodIdentity method,
+        ImmutableArray<DecodedInstruction> instructions,
+        BlockGraph graph,
+        ReachingDefinitionsResult reaching,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        RentedLocal rent,
+        ImmutableArray<LeakTriageFinding>.Builder findings)
+    {
+        var releases = ImmutableArray.CreateBuilder<int>();
+        var safeUses = ImmutableArray.CreateBuilder<int>();
+        bool ambiguous = false;
+
+        foreach (var use in reaching.UsesOf(rent.Definition))
+        {
+            if (use.Address)
+            {
+                ambiguous = true;
+                break;
+            }
+
+            var kind = ClassifyUse(instructions, calls, use.Offset, rent.Slot);
+            switch (kind)
+            {
+                case UseKind.Release:
+                    releases.Add(use.Offset);
+                    break;
+                case UseKind.LocalUse:
+                    safeUses.Add(use.Offset);
+                    break;
+                default:
+                    ambiguous = true;
+                    break;
+            }
+        }
+
+        if (ambiguous)
+            return;
+
+        var releaseOffsets = releases.ToImmutable();
+        var safeUseOffsets = safeUses.ToImmutable();
+
+        // Multiple releases often encode correlated branch predicates (`if (c) return; if (!c) return`).
+        // Without predicate facts, fail closed on leaks and only keep same-block misuse shapes below.
+        if (releaseOffsets.Length <= 1
+            && PathExitsWithoutRelease(instructions, graph, calls, rent.StoreOffset, releaseOffsets))
+        {
+            findings.Add(new LeakTriageFinding(
+                method,
+                "arraypool-rent-not-returned",
+                $"ArrayPool<T>.Shared.Rent at IL_{rent.RentOffset:X4} is not returned on every modeled path.",
+                "high",
+                rent.RentOffset,
+                rent.RentOffset));
+        }
+
+        // Same-block reachability avoids inventing impossible paths across correlated branches.
+        if (releaseOffsets.Length > 0
+            && safeUseOffsets.Any(use => releaseOffsets.Any(release => ReachesInSameBlock(graph, release, use))))
+        {
+            findings.Add(new LeakTriageFinding(
+                method,
+                "arraypool-use-after-return",
+                $"Use of rented array reaches past Return at IL_{releaseOffsets.Min():X4}.",
+                "high",
+                rent.RentOffset,
+                safeUseOffsets.Where(use => releaseOffsets.Any(release => ReachesInSameBlock(graph, release, use))).Min()));
+        }
+
+        if (releaseOffsets.Length > 1
+            && releaseOffsets.Any(first => releaseOffsets.Any(second => first != second && ReachesInSameBlock(graph, first, second))))
+        {
+            findings.Add(new LeakTriageFinding(
+                method,
+                "arraypool-double-return",
+                $"Rented array can reach a second Return after IL_{releaseOffsets.Min():X4}.",
+                "high",
+                rent.RentOffset,
+                releaseOffsets.Skip(1).DefaultIfEmpty(releaseOffsets[0]).Min()));
+        }
+    }
+
+    static bool PathExitsWithoutRelease(
+        ImmutableArray<DecodedInstruction> instructions,
+        BlockGraph graph,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        int startOffset,
+        ImmutableArray<int> releases)
+    {
+        int startBlock = graph.BlockIndexAt(startOffset);
+        if (startBlock < 0)
+            return false;
+
+        var releaseSet = releases.ToHashSet();
+        var visited = new HashSet<(int Block, bool Released)>();
+        var stack = new Stack<(int Block, bool Released, int StartOffset)>();
+        stack.Push((startBlock, Released: false, StartOffset: startOffset));
+
+        while (stack.Count > 0)
+        {
+            var (blockIndex, releasedIn, blockStartOffset) = stack.Pop();
+            if (!visited.Add((blockIndex, releasedIn)))
+                continue;
+
+            var block = graph.Blocks[blockIndex];
+            bool released = ProcessBlockForRelease(instructions, calls, block, blockStartOffset, releaseSet, releasedIn);
+            var successors = LifecycleSuccessors(instructions, graph, block).ToArray();
+            if (!released && block.Edges.ExitsMethod && successors.Length == 0)
+                return true;
+            foreach (int successor in successors)
+                stack.Push((successor, released, graph.Blocks[successor].Start));
+        }
+
+        return false;
+    }
+
+    static bool ProcessBlockForRelease(
+        ImmutableArray<DecodedInstruction> instructions,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        InstructionBlock block,
+        int startOffset,
+        IReadOnlySet<int> releases,
+        bool released)
+    {
+        foreach (var instruction in instructions)
+        {
+            if (instruction.Offset < block.Start || instruction.Offset >= block.End)
+                continue;
+            if (instruction.Offset < startOffset)
+                continue;
+            if (releases.Contains(instruction.Offset))
+                released = true;
+            if (!released && IsDefinitelyThrowingCall(instruction, calls))
+                return false;
+        }
+        return released;
+    }
+
+    static bool IsDefinitelyThrowingCall(DecodedInstruction instruction, IReadOnlyDictionary<int, MemberRef> calls)
+        => instruction.OpCode is ILOpCode.Throw or ILOpCode.Rethrow
+           || (calls.TryGetValue(instruction.Offset, out var callee)
+               && FrameworkIdentity.IsCoreLibraryType(callee.DeclaringType, "System", "ThrowHelper"));
+
+    static bool ReachesInSameBlock(BlockGraph graph, int fromOffset, int toOffset)
+    {
+        int fromBlock = graph.BlockIndexAt(fromOffset);
+        int toBlock = graph.BlockIndexAt(toOffset);
+        return fromBlock >= 0 && fromBlock == toBlock && fromOffset < toOffset;
+    }
+
+    static IEnumerable<int> LifecycleSuccessors(ImmutableArray<DecodedInstruction> instructions, BlockGraph graph, InstructionBlock block)
+    {
+        if (LastInstruction(instructions, block) is { LeavesRegion: true } terminator)
+        {
+            var finallyHandlers = graph.Regions
+                .Where(region => region.Kind is HandlerKind.Finally or HandlerKind.Fault && region.ContainsTry(terminator.Offset))
+                .OrderBy(region => region.TryEnd - region.TryStart)
+                .Select(region => graph.BlockIndexAt(region.HandlerStart))
+                .Where(index => index >= 0)
+                .Distinct()
+                .ToArray();
+            if (finallyHandlers.Length > 0)
+                return [finallyHandlers[0]];
+        }
+
+        return block.Edges.Successors;
+    }
+
+    static DecodedInstruction? LastInstruction(ImmutableArray<DecodedInstruction> instructions, InstructionBlock block)
+    {
+        DecodedInstruction? last = null;
+        foreach (var instruction in instructions)
+            if (instruction.Offset >= block.Start && instruction.Offset < block.End)
+                last = instruction;
+        return last;
+    }
+
+    static IEnumerable<RentedLocal> FindRents(
+        MethodIdentity method,
+        ImmutableArray<DecodedInstruction> instructions,
+        BlockGraph graph,
+        ReachingDefinitionsResult reaching,
+        IReadOnlyDictionary<int, MemberRef> calls)
+    {
+        foreach (var instruction in instructions)
+        {
+            if (!calls.TryGetValue(instruction.Offset, out var callee) || !IsArrayPoolRent(callee))
+                continue;
+            if (!RentUsesSharedReceiver(instructions, graph, calls, instruction.Offset))
+                continue;
+            if (!TryFindNextNonNop(instructions, instruction.NextOffset, out var store)
+                || !TryReadStoreLocal(store, out int slot))
+                continue;
+
+            var definition = reaching.Definitions.FirstOrDefault(d =>
+                !d.IsArgument && d.Slot == slot && d.Offset == store.Offset);
+            if (definition is null)
+                continue;
+
+            yield return new RentedLocal(instruction.Offset, store.Offset, slot, definition);
+        }
+    }
+
+    static bool RentUsesSharedReceiver(
+        ImmutableArray<DecodedInstruction> instructions,
+        BlockGraph graph,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        int rentOffset)
+    {
+        int blockIndex = graph.BlockIndexAt(rentOffset);
+        if (blockIndex < 0)
+            return false;
+        var block = graph.Blocks[blockIndex];
+        for (int i = instructions.Length - 1, inspected = 0; i >= 0; i--)
+        {
+            var instruction = instructions[i];
+            if (instruction.Offset < block.Start)
+                return false;
+            if (instruction.Offset >= rentOffset || instruction.OpCode == ILOpCode.Nop)
+                continue;
+            if (calls.TryGetValue(instruction.Offset, out var callee))
+                return IsArrayPoolSharedGetter(callee);
+            if (!IsSimpleArgumentPush(instruction.OpCode))
+                return false;
+            if (++inspected > 4)
+                return false;
+        }
+        return false;
+    }
+
+    static UseKind ClassifyUse(
+        ImmutableArray<DecodedInstruction> instructions,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        int loadOffset,
+        int slot)
+    {
+        if (!TryFindInstruction(instructions, loadOffset, out int index, out var load)
+            || !IsLoadLocal(load, slot))
+            return UseKind.Ambiguous;
+
+        int extra = 0;
+        for (int i = index + 1; i < instructions.Length; i++)
+        {
+            var instruction = instructions[i];
+            var opcode = instruction.OpCode;
+            if (IsSimpleArgumentPush(opcode))
+            {
+                extra++;
+                continue;
+            }
+            if (opcode == ILOpCode.Ldlen)
+                return extra == 0 ? UseKind.LocalUse : UseKind.Ambiguous;
+            if (IsElementRead(opcode))
+                return extra == 1 ? UseKind.LocalUse : UseKind.Ambiguous;
+            if (IsElementStore(opcode))
+                return extra == 2 ? UseKind.LocalUse : UseKind.Ambiguous;
+            if (calls.TryGetValue(instruction.Offset, out var callee))
+            {
+                if (IsArrayPoolReturn(callee) && extra < callee.ParameterTypes.Length)
+                    return UseKind.Release;
+                return UseKind.Ambiguous;
+            }
+            return UseKind.Ambiguous;
+        }
+
+        return UseKind.Ambiguous;
+    }
+
+    static IReadOnlyDictionary<int, MemberRef> BuildCallMap(
+        ImmutableArray<DecodedInstruction> instructions,
+        Func<int, MemberRef> resolveMethod)
+    {
+        var calls = new Dictionary<int, MemberRef>();
+        foreach (var instruction in instructions)
+        {
+            if (instruction.OpCode is not (ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj))
+                continue;
+            calls[instruction.Offset] = resolveMethod(checked((int)instruction.OperandValue));
+        }
+        return calls;
+    }
+
+    static bool TryFindNextNonNop(ImmutableArray<DecodedInstruction> instructions, int offset, out DecodedInstruction instruction)
+    {
+        foreach (var candidate in instructions)
+        {
+            if (candidate.Offset < offset || candidate.OpCode == ILOpCode.Nop)
+                continue;
+            instruction = candidate;
+            return true;
+        }
+        instruction = default!;
+        return false;
+    }
+
+    static bool TryFindInstruction(ImmutableArray<DecodedInstruction> instructions, int offset, out int index, out DecodedInstruction instruction)
+    {
+        for (int i = 0; i < instructions.Length; i++)
+        {
+            if (instructions[i].Offset != offset)
+                continue;
+            index = i;
+            instruction = instructions[i];
+            return true;
+        }
+        index = -1;
+        instruction = default!;
+        return false;
+    }
+
+    static bool TryReadStoreLocal(DecodedInstruction instruction, out int slot)
+    {
+        slot = instruction.OpCode switch
+        {
+            ILOpCode.Stloc_0 => 0,
+            ILOpCode.Stloc_1 => 1,
+            ILOpCode.Stloc_2 => 2,
+            ILOpCode.Stloc_3 => 3,
+            ILOpCode.Stloc_s or ILOpCode.Stloc => checked((int)instruction.OperandValue),
+            _ => -1,
+        };
+        return slot >= 0;
+    }
+
+    static bool IsLoadLocal(DecodedInstruction instruction, int slot)
+        => instruction.OpCode switch
+        {
+            ILOpCode.Ldloc_0 => slot == 0,
+            ILOpCode.Ldloc_1 => slot == 1,
+            ILOpCode.Ldloc_2 => slot == 2,
+            ILOpCode.Ldloc_3 => slot == 3,
+            ILOpCode.Ldloc_s or ILOpCode.Ldloc => instruction.OperandValue == slot,
+            _ => false,
+        };
+
+    static bool IsSimpleArgumentPush(ILOpCode opcode)
+        => opcode is ILOpCode.Ldc_i4_m1 or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1 or ILOpCode.Ldc_i4_2
+            or ILOpCode.Ldc_i4_3 or ILOpCode.Ldc_i4_4 or ILOpCode.Ldc_i4_5 or ILOpCode.Ldc_i4_6
+            or ILOpCode.Ldc_i4_7 or ILOpCode.Ldc_i4_8 or ILOpCode.Ldc_i4_s or ILOpCode.Ldc_i4
+            or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3
+            or ILOpCode.Ldarg_s or ILOpCode.Ldarg
+            or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
+            or ILOpCode.Ldloc_s or ILOpCode.Ldloc
+            or ILOpCode.Ldnull;
+
+    static bool IsElementRead(ILOpCode opcode)
+        => opcode is ILOpCode.Ldelem or ILOpCode.Ldelem_i or ILOpCode.Ldelem_i1 or ILOpCode.Ldelem_i2
+            or ILOpCode.Ldelem_i4 or ILOpCode.Ldelem_i8 or ILOpCode.Ldelem_r4 or ILOpCode.Ldelem_r8
+            or ILOpCode.Ldelem_u1 or ILOpCode.Ldelem_u2 or ILOpCode.Ldelem_u4 or ILOpCode.Ldelem_ref;
+
+    static bool IsElementStore(ILOpCode opcode)
+        => opcode is ILOpCode.Stelem or ILOpCode.Stelem_i or ILOpCode.Stelem_i1 or ILOpCode.Stelem_i2
+            or ILOpCode.Stelem_i4 or ILOpCode.Stelem_i8 or ILOpCode.Stelem_r4 or ILOpCode.Stelem_r8
+            or ILOpCode.Stelem_ref;
+
+    static bool IsArrayPoolRent(MemberRef member)
+        => member.Kind != MemberKind.Unsupported
+           && member.Name == "Rent"
+           && member.HasThis
+           && member.ParameterTypes.Length == 1
+           && FrameworkIdentity.IsCoreLibraryType(member.ParameterTypes[0], "System", "Int32")
+           && member.ReturnType.Kind == TypeRefKind.SzArray
+           && IsArrayPoolType(member.DeclaringType);
+
+    static bool IsArrayPoolReturn(MemberRef member)
+        => member.Kind != MemberKind.Unsupported
+           && member.Name == "Return"
+           && member.HasThis
+           && member.ReturnType.Equals(TypeRef.CoreLib("System", "Void"))
+           && member.ParameterTypes.Length is 1 or 2
+           && member.ParameterTypes[0].Kind == TypeRefKind.SzArray
+           && IsArrayPoolType(member.DeclaringType);
+
+    static bool IsArrayPoolSharedGetter(MemberRef member)
+        => member.Kind != MemberKind.Unsupported
+           && member.Name == "get_Shared"
+           && !member.HasThis
+           && member.ParameterTypes.Length == 0
+           && IsArrayPoolType(member.DeclaringType)
+           && IsArrayPoolType(member.ReturnType);
+
+    static bool IsArrayPoolType(TypeRef type)
+        => FrameworkIdentity.IsKnownFrameworkType(type, "System.Buffers", "System.Buffers", "ArrayPool`1")
+           || FrameworkIdentity.IsCoreLibraryType(type, "System.Buffers", "ArrayPool`1");
+
+    static int ArgumentSlotCount(MethodIdentity method)
+        => method.ParameterTypes.Length + (method.IsStatic ? 0 : 1);
+
+    static GenericScope CreateScope(MetadataReader reader, TypeDefinition typeDef, MethodDefinition methodDef)
+        => new(GenericParameterNames(reader, typeDef.GetGenericParameters()), GenericParameterNames(reader, methodDef.GetGenericParameters()));
+
+    static ImmutableArray<string> GenericParameterNames(MetadataReader reader, GenericParameterHandleCollection handles)
+    {
+        if (handles.Count == 0)
+            return [];
+        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
+        foreach (var handle in handles)
+            names.Add(reader.GetString(reader.GetGenericParameter(handle).Name));
+        return names.MoveToImmutable();
+    }
+
+    static bool IsRecoverable(Exception ex)
+        => ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException or IndexOutOfRangeException;
+
+    sealed record RentedLocal(int RentOffset, int StoreOffset, int Slot, LocalDefinition Definition);
+
+    enum UseKind
+    {
+        Release,
+        LocalUse,
+        Ambiguous,
+    }
+}

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -218,8 +218,8 @@ public static class LeakTriageAnalyzer
 
             var block = graph.Blocks[blockIndex];
             bool released = ProcessBlockForRelease(instructions, calls, block, blockStartOffset, releaseSet, releasedIn);
-            var successors = LifecycleSuccessors(instructions, graph, block).ToArray();
-            if (!released && block.Edges.ExitsMethod && successors.Length == 0)
+            var successors = block.Edges.Successors;
+            if (!released && block.Edges.ExitsMethod && successors.Count == 0)
                 return true;
             foreach (int successor in successors)
                 stack.Push((successor, released, graph.Blocks[successor].Start));
@@ -260,33 +260,6 @@ public static class LeakTriageAnalyzer
         int fromBlock = graph.BlockIndexAt(fromOffset);
         int toBlock = graph.BlockIndexAt(toOffset);
         return fromBlock >= 0 && fromBlock == toBlock && fromOffset < toOffset;
-    }
-
-    static IEnumerable<int> LifecycleSuccessors(ImmutableArray<DecodedInstruction> instructions, BlockGraph graph, InstructionBlock block)
-    {
-        if (LastInstruction(instructions, block) is { LeavesRegion: true } terminator)
-        {
-            var finallyHandlers = graph.Regions
-                .Where(region => region.Kind is HandlerKind.Finally or HandlerKind.Fault && region.ContainsTry(terminator.Offset))
-                .OrderBy(region => region.TryEnd - region.TryStart)
-                .Select(region => graph.BlockIndexAt(region.HandlerStart))
-                .Where(index => index >= 0)
-                .Distinct()
-                .ToArray();
-            if (finallyHandlers.Length > 0)
-                return [finallyHandlers[0]];
-        }
-
-        return block.Edges.Successors;
-    }
-
-    static DecodedInstruction? LastInstruction(ImmutableArray<DecodedInstruction> instructions, InstructionBlock block)
-    {
-        DecodedInstruction? last = null;
-        foreach (var instruction in instructions)
-            if (instruction.Offset >= block.Start && instruction.Offset < block.End)
-                last = instruction;
-        return last;
     }
 
     static IEnumerable<RentedLocal> FindRents(

--- a/tools/AnalysisHarness/AnalysisHarness.csproj
+++ b/tools/AnalysisHarness/AnalysisHarness.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Markout" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="corpus/paydirt-reference.json" CopyToOutputDirectory="PreserveNewest" Link="corpus/paydirt-reference.json" />
   </ItemGroup>
 

--- a/tools/AnalysisHarness/LeakTriageSensor.cs
+++ b/tools/AnalysisHarness/LeakTriageSensor.cs
@@ -1,9 +1,12 @@
-using System.Text;
-using System.Text.Json;
+using Markout;
+using Markout.Formatting;
 
 using ILInspector.Analysis;
 
 namespace ILInspector.AnalysisHarness;
+
+/// <summary>One example finding: its shape and the method it fired on.</summary>
+public sealed record LeakTriageExample(string Shape, string Method);
 
 /// <summary>Per-assembly leak-triage result: whether it opened, its finding count, and the shapes hit with a few example methods.</summary>
 public sealed record LeakTriageAssembly(
@@ -12,7 +15,7 @@ public sealed record LeakTriageAssembly(
     bool TimedOut,
     int Findings,
     IReadOnlyDictionary<string, int> Shapes,
-    IReadOnlyList<string> Examples);
+    IReadOnlyList<LeakTriageExample> Examples);
 
 /// <summary>A leak-triage corpus report: per-assembly rows plus aggregate shape totals.</summary>
 public sealed record LeakTriageReport(
@@ -20,18 +23,20 @@ public sealed record LeakTriageReport(
     IReadOnlyDictionary<string, int> TotalsByShape,
     int Total);
 
+public enum LeakTriageFormat { Markdown, Tsv, Jsonl }
+
 /// <summary>
 /// The leak-triage corpus sensor: sweeps <see cref="LeakTriageAnalyzer"/> over a fixed corpus
-/// and reports where the fail-closed ArrayPool analysis fires — total findings, the shape
+/// and reports where the fail-closed ArrayPool analysis fires - total findings, the shape
 /// histogram, and example methods per shape. This is the evidence engine that must show a
 /// non-zero, high-precision signal before any user-facing `Leak Triage` section is wired
 /// (#1992): the analyzer is precision-first, so an empty corpus card means recall, not the
-/// section, is the next lever. There is no product surface here — the harness measures.
+/// section, is the next lever. There is no product surface here - the harness measures. The
+/// card is a single-run census with no baseline, so it renders as plain sectioned rows (no
+/// composite/delta cells); a `--diff-baseline` mode is the natural home for those.
 /// </summary>
 public static class LeakTriageSensor
 {
-    static readonly JsonSerializerOptions s_json = new() { WriteIndented = true };
-
     public static LeakTriageReport Measure(IReadOnlyList<string> assemblyPaths, int perAssemblyTimeoutSeconds = 120, int examplesPerAssembly = 5)
     {
         var assemblies = new List<LeakTriageAssembly>(assemblyPaths.Count);
@@ -67,56 +72,154 @@ public static class LeakTriageSensor
         {
             var findings = LeakTriageAnalyzer.AnalyzeAssembly(path);
             var shapes = new SortedDictionary<string, int>(StringComparer.Ordinal);
-            var examples = new List<string>();
+            var examples = new List<LeakTriageExample>();
             foreach (var finding in findings)
             {
                 shapes[finding.Shape] = shapes.GetValueOrDefault(finding.Shape) + 1;
                 if (examples.Count < examplesPerAssembly)
-                    examples.Add($"{finding.Shape}  {finding.Method.DeclaringType.Name}::{finding.Method.Name}");
+                    examples.Add(new LeakTriageExample(finding.Shape, $"{finding.Method.DeclaringType.Name}::{finding.Method.Name}"));
             }
             return new LeakTriageAssembly(name, Opened: true, TimedOut: false, findings.Length, shapes, examples);
         }
-        catch (Exception ex) when (ex is BadImageFormatException or IOException or InvalidOperationException or ArgumentException)
+        // This is the per-assembly boundary running on a background thread, so ANY unhandled
+        // failure would terminate the whole sweep (a corpus path that is a directory throws
+        // UnauthorizedAccessException, a truncated PE throws BadImageFormatException, etc.). A
+        // sensor over arbitrary user-supplied paths must convert every input failure into a
+        // failed row and keep sweeping.
+        catch (Exception)
         {
             return new LeakTriageAssembly(name, Opened: false, TimedOut: false, 0, new Dictionary<string, int>(), []);
         }
     }
 
-    public static string FormatCard(LeakTriageReport report, int maxExamples)
+    public static string Format(LeakTriageReport report, int maxExamples, LeakTriageFormat format)
     {
-        var sb = new StringBuilder();
-        int opened = report.Assemblies.Count(a => a.Opened);
-        int failed = report.Assemblies.Count(a => !a.Opened && !a.TimedOut);
-        int timedOut = report.Assemblies.Count(a => a.TimedOut);
-
-        sb.AppendLine($"LEAK TRIAGE CORPUS SENSOR over {report.Assemblies.Count} assemblies ({opened} opened, {failed} failed, {timedOut} timed out)");
-        sb.AppendLine($"  total findings: {report.Total}");
-        if (report.TotalsByShape.Count == 0)
+        var output = new StringWriter();
+        if (format == LeakTriageFormat.Markdown)
         {
-            sb.AppendLine("  by shape: (none — the fail-closed gates suppressed every candidate; broaden recall, not the section)");
+            MarkoutSerializer.Serialize(
+                BuildMarkdownView(report, maxExamples),
+                output,
+                new MarkdownFormatter(),
+                LeakTriageViewContext.Default,
+                new MarkoutWriterOptions());
         }
         else
         {
-            sb.AppendLine("  by shape:");
-            foreach (var (shape, count) in report.TotalsByShape.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key, StringComparer.Ordinal))
-                sb.AppendLine($"    {count,6}  {shape}");
+            MarkoutSerializer.Serialize(
+                BuildTableView(report, maxExamples),
+                output,
+                new TableFormatter(showHeader: true),
+                LeakTriageViewContext.Default,
+                format == LeakTriageFormat.Tsv
+                    ? new MarkoutWriterOptions { TableMode = MarkoutTableMode.Tsv }
+                    : new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl });
         }
 
-        var withFindings = report.Assemblies.Where(a => a.Findings > 0).ToList();
-        if (withFindings.Count > 0)
-        {
-            sb.AppendLine();
-            sb.AppendLine("Assemblies with findings:");
-            foreach (var assembly in withFindings.OrderByDescending(a => a.Findings))
-            {
-                sb.AppendLine($"  {assembly.Name}: {assembly.Findings}");
-                foreach (var example in assembly.Examples.Take(maxExamples))
-                    sb.AppendLine($"      {example}");
-            }
-        }
-
-        return sb.ToString();
+        string rendered = output.ToString();
+        return format == LeakTriageFormat.Jsonl
+            ? string.Join(Environment.NewLine, rendered.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)) + Environment.NewLine
+            : rendered;
     }
 
-    public static string ToJson(LeakTriageReport report) => JsonSerializer.Serialize(report, s_json);
+    static IReadOnlyList<(string Metric, string Value)> SummaryRows(LeakTriageReport report)
+        => new (string, string)[]
+        {
+            ("assemblies", report.Assemblies.Count.ToString()),
+            ("opened", report.Assemblies.Count(a => a.Opened).ToString()),
+            ("failed", report.Assemblies.Count(a => !a.Opened && !a.TimedOut).ToString()),
+            ("timed out", report.Assemblies.Count(a => a.TimedOut).ToString()),
+            ("total findings", report.Total.ToString()),
+        };
+
+    static IReadOnlyList<(string Shape, string Count)> ShapeRows(LeakTriageReport report)
+        => [.. report.TotalsByShape
+            .OrderByDescending(kv => kv.Value)
+            .ThenBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => (kv.Key, kv.Value.ToString()))];
+
+    static IReadOnlyList<(string Assembly, string Shape, string Method)> FindingRows(LeakTriageReport report, int maxExamples)
+        => [.. report.Assemblies
+            .Where(a => a.Findings > 0)
+            .OrderByDescending(a => a.Findings)
+            .SelectMany(a => a.Examples.Take(maxExamples).Select(e => (a.Name, e.Shape, e.Method)))];
+
+    static LeakTriageCardMarkdownView BuildMarkdownView(LeakTriageReport report, int maxExamples)
+        => new()
+        {
+            Summary = [.. SummaryRows(report).Select(r => new LeakTriageMetricRow(r.Metric, r.Value))],
+            ByShape = [.. ShapeRows(report).Select(r => new LeakTriageShapeRow(r.Shape, r.Count))],
+            Findings = [.. FindingRows(report, maxExamples).Select(r => new LeakTriageFindingRow(r.Assembly, r.Shape, r.Method))],
+        };
+
+    static LeakTriageCardTableView BuildTableView(LeakTriageReport report, int maxExamples)
+        => new()
+        {
+            Summary = [.. SummaryRows(report).Select(r => new LeakTriageSectionMetricRow("Summary", r.Metric, r.Value))],
+            ByShape = [.. ShapeRows(report).Select(r => new LeakTriageSectionShapeRow("By shape", r.Shape, r.Count))],
+            Findings = [.. FindingRows(report, maxExamples).Select(r => new LeakTriageSectionFindingRow("Findings", r.Assembly, r.Shape, r.Method))],
+        };
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+sealed class LeakTriageCardMarkdownView
+{
+    [MarkoutIgnore]
+    public string Title => "Leak Triage Corpus Sensor";
+
+    [MarkoutSection(Name = "Summary")]
+    public List<LeakTriageMetricRow>? Summary { get; init; }
+
+    [MarkoutSection(Name = "By shape", EmptyText = "None - the fail-closed gates suppressed every candidate; broaden recall, not the section.")]
+    public List<LeakTriageShapeRow>? ByShape { get; init; }
+
+    [MarkoutSection(Name = "Findings", EmptyText = "None")]
+    public List<LeakTriageFindingRow>? Findings { get; init; }
+}
+
+[MarkoutSerializable]
+sealed class LeakTriageCardTableView
+{
+    [MarkoutIgnore]
+    public string Title => "Leak Triage Corpus Sensor";
+
+    [MarkoutSection(Name = "Summary")]
+    public List<LeakTriageSectionMetricRow>? Summary { get; init; }
+
+    [MarkoutSection(Name = "By shape")]
+    public List<LeakTriageSectionShapeRow>? ByShape { get; init; }
+
+    [MarkoutSection(Name = "Findings")]
+    public List<LeakTriageSectionFindingRow>? Findings { get; init; }
+}
+
+[MarkoutSerializable]
+sealed record LeakTriageMetricRow(string Metric, string Count);
+
+[MarkoutSerializable]
+sealed record LeakTriageSectionMetricRow(string Section, string Metric, string Count);
+
+[MarkoutSerializable]
+sealed record LeakTriageShapeRow(string Shape, string Count);
+
+[MarkoutSerializable]
+sealed record LeakTriageSectionShapeRow(string Section, string Shape, string Count);
+
+[MarkoutSerializable]
+sealed record LeakTriageFindingRow(string Assembly, string Shape, string Method);
+
+[MarkoutSerializable]
+sealed record LeakTriageSectionFindingRow(string Section, string Assembly, string Shape, string Method);
+
+[MarkoutContextOptions(SuppressTableWarnings = true)]
+[MarkoutContext(typeof(LeakTriageCardMarkdownView))]
+[MarkoutContext(typeof(LeakTriageCardTableView))]
+[MarkoutContext(typeof(LeakTriageMetricRow))]
+[MarkoutContext(typeof(LeakTriageSectionMetricRow))]
+[MarkoutContext(typeof(LeakTriageShapeRow))]
+[MarkoutContext(typeof(LeakTriageSectionShapeRow))]
+[MarkoutContext(typeof(LeakTriageFindingRow))]
+[MarkoutContext(typeof(LeakTriageSectionFindingRow))]
+partial class LeakTriageViewContext : MarkoutSerializerContext
+{
 }

--- a/tools/AnalysisHarness/LeakTriageSensor.cs
+++ b/tools/AnalysisHarness/LeakTriageSensor.cs
@@ -1,0 +1,122 @@
+using System.Text;
+using System.Text.Json;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.AnalysisHarness;
+
+/// <summary>Per-assembly leak-triage result: whether it opened, its finding count, and the shapes hit with a few example methods.</summary>
+public sealed record LeakTriageAssembly(
+    string Name,
+    bool Opened,
+    bool TimedOut,
+    int Findings,
+    IReadOnlyDictionary<string, int> Shapes,
+    IReadOnlyList<string> Examples);
+
+/// <summary>A leak-triage corpus report: per-assembly rows plus aggregate shape totals.</summary>
+public sealed record LeakTriageReport(
+    IReadOnlyList<LeakTriageAssembly> Assemblies,
+    IReadOnlyDictionary<string, int> TotalsByShape,
+    int Total);
+
+/// <summary>
+/// The leak-triage corpus sensor: sweeps <see cref="LeakTriageAnalyzer"/> over a fixed corpus
+/// and reports where the fail-closed ArrayPool analysis fires — total findings, the shape
+/// histogram, and example methods per shape. This is the evidence engine that must show a
+/// non-zero, high-precision signal before any user-facing `Leak Triage` section is wired
+/// (#1992): the analyzer is precision-first, so an empty corpus card means recall, not the
+/// section, is the next lever. There is no product surface here — the harness measures.
+/// </summary>
+public static class LeakTriageSensor
+{
+    static readonly JsonSerializerOptions s_json = new() { WriteIndented = true };
+
+    public static LeakTriageReport Measure(IReadOnlyList<string> assemblyPaths, int perAssemblyTimeoutSeconds = 120, int examplesPerAssembly = 5)
+    {
+        var assemblies = new List<LeakTriageAssembly>(assemblyPaths.Count);
+        foreach (var path in assemblyPaths)
+            assemblies.Add(MeasureWithTimeout(path, perAssemblyTimeoutSeconds, examplesPerAssembly));
+        assemblies.Sort((a, b) => string.CompareOrdinal(a.Name, b.Name));
+
+        var totals = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        foreach (var assembly in assemblies)
+            foreach (var (shape, count) in assembly.Shapes)
+                totals[shape] = totals.GetValueOrDefault(shape) + count;
+
+        return new LeakTriageReport(assemblies, totals, assemblies.Sum(a => a.Findings));
+    }
+
+    // Bound each assembly so one pathological input cannot hang the sweep; a timeout is a stable
+    // signal, not a crash. The analyzer is already fail-closed per method, so this is belt-and-braces.
+    static LeakTriageAssembly MeasureWithTimeout(string path, int timeoutSeconds, int examplesPerAssembly)
+    {
+        string name = Path.GetFileName(path);
+        LeakTriageAssembly? result = null;
+        var worker = new Thread(() => result = MeasureOne(path, examplesPerAssembly)) { IsBackground = true };
+        worker.Start();
+        if (worker.Join(TimeSpan.FromSeconds(timeoutSeconds)) && result is not null)
+            return result;
+        return new LeakTriageAssembly(name, Opened: false, TimedOut: true, 0, new Dictionary<string, int>(), []);
+    }
+
+    static LeakTriageAssembly MeasureOne(string path, int examplesPerAssembly)
+    {
+        string name = Path.GetFileName(path);
+        try
+        {
+            var findings = LeakTriageAnalyzer.AnalyzeAssembly(path);
+            var shapes = new SortedDictionary<string, int>(StringComparer.Ordinal);
+            var examples = new List<string>();
+            foreach (var finding in findings)
+            {
+                shapes[finding.Shape] = shapes.GetValueOrDefault(finding.Shape) + 1;
+                if (examples.Count < examplesPerAssembly)
+                    examples.Add($"{finding.Shape}  {finding.Method.DeclaringType.Name}::{finding.Method.Name}");
+            }
+            return new LeakTriageAssembly(name, Opened: true, TimedOut: false, findings.Length, shapes, examples);
+        }
+        catch (Exception ex) when (ex is BadImageFormatException or IOException or InvalidOperationException or ArgumentException)
+        {
+            return new LeakTriageAssembly(name, Opened: false, TimedOut: false, 0, new Dictionary<string, int>(), []);
+        }
+    }
+
+    public static string FormatCard(LeakTriageReport report, int maxExamples)
+    {
+        var sb = new StringBuilder();
+        int opened = report.Assemblies.Count(a => a.Opened);
+        int failed = report.Assemblies.Count(a => !a.Opened && !a.TimedOut);
+        int timedOut = report.Assemblies.Count(a => a.TimedOut);
+
+        sb.AppendLine($"LEAK TRIAGE CORPUS SENSOR over {report.Assemblies.Count} assemblies ({opened} opened, {failed} failed, {timedOut} timed out)");
+        sb.AppendLine($"  total findings: {report.Total}");
+        if (report.TotalsByShape.Count == 0)
+        {
+            sb.AppendLine("  by shape: (none — the fail-closed gates suppressed every candidate; broaden recall, not the section)");
+        }
+        else
+        {
+            sb.AppendLine("  by shape:");
+            foreach (var (shape, count) in report.TotalsByShape.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key, StringComparer.Ordinal))
+                sb.AppendLine($"    {count,6}  {shape}");
+        }
+
+        var withFindings = report.Assemblies.Where(a => a.Findings > 0).ToList();
+        if (withFindings.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Assemblies with findings:");
+            foreach (var assembly in withFindings.OrderByDescending(a => a.Findings))
+            {
+                sb.AppendLine($"  {assembly.Name}: {assembly.Findings}");
+                foreach (var example in assembly.Examples.Take(maxExamples))
+                    sb.AppendLine($"      {example}");
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    public static string ToJson(LeakTriageReport report) => JsonSerializer.Serialize(report, s_json);
+}

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -39,12 +39,13 @@ const string Usage =
       --annotation-parity <category> <expected-annotations.json> <actual-annotations.json> [--json]
           Compare annotation rows for one category (Allocation, Unsafety, Lifetime).
 
-      --leak-triage <file> [--top N] [--json]
+      --leak-triage <file> [--top N] [--tsv | --jsonl]
           Sweep the fail-closed ArrayPool leak-triage analyzer over a corpus (one assembly path
           per line in <file>) and report where it fires: total findings, the shape histogram, and
-          example methods per assembly. This is the evidence engine for #1992 — the analyzer is
-          precision-first, so an empty card means recall (not a user-facing section) is the next
-          lever. --top bounds examples per assembly.
+          example methods per assembly, as a Markout card. Default is Markdown; --tsv and --jsonl
+          select the tabular formats (--json is an alias for --jsonl). This is the evidence engine
+          for #1992 - the analyzer is precision-first, so an empty card means recall (not a
+          user-facing section) is the next lever. --top bounds examples per assembly.
 
       Common: --json machine-readable output; --keep keep generated fixture projects.
     """;
@@ -73,6 +74,8 @@ string? annotationParityCategory = null;
 string? annotationParityExpected = null;
 string? annotationParityActual = null;
 string? leakTriageList = null;
+bool tsv = false;
+bool jsonl = false;
 int top = 20;
 
 for (int i = 0; i < args.Length; i++)
@@ -113,6 +116,12 @@ for (int i = 0; i < args.Length; i++)
             break;
         case "--leak-triage":
             leakTriageList = NextPathValue(args, ref i);
+            break;
+        case "--tsv":
+            tsv = true;
+            break;
+        case "--jsonl":
+            jsonl = true;
             break;
         case "--reference":
             referenceFile = NextValue(args, ref i);
@@ -155,7 +164,7 @@ if (annotationParityExpected is not null)
     return RunAnnotationParity(annotationParityCategory ?? "", annotationParityExpected, annotationParityActual, json);
 
 if (leakTriageList is not null)
-    return RunLeakTriage(leakTriageList, top, json);
+    return RunLeakTriage(leakTriageList, top, tsv, jsonl || json);
 
 if (corpusList is not null)
     return RunCorpus(corpusList, diffBaseline, emitSnapshot, json);
@@ -216,13 +225,21 @@ static int RunAllocationReadout(string corpusList, int top, bool json)
     return 0;
 }
 
-static int RunLeakTriage(string corpusList, int top, bool json)
+static int RunLeakTriage(string corpusList, int top, bool tsv, bool jsonl)
 {
     if (!File.Exists(corpusList))
     {
         Console.Error.WriteLine($"Corpus list not found: {corpusList}");
         return 2;
     }
+
+    if (tsv && jsonl)
+    {
+        Console.Error.WriteLine("--tsv and --jsonl are mutually exclusive.");
+        return 2;
+    }
+
+    LeakTriageFormat format = jsonl ? LeakTriageFormat.Jsonl : tsv ? LeakTriageFormat.Tsv : LeakTriageFormat.Markdown;
 
     var paths = File.ReadAllLines(corpusList)
         .Select(line => line.Trim())
@@ -235,9 +252,7 @@ static int RunLeakTriage(string corpusList, int top, bool json)
     }
 
     var report = LeakTriageSensor.Measure(paths, examplesPerAssembly: top);
-    Console.Write(json ? LeakTriageSensor.ToJson(report) : LeakTriageSensor.FormatCard(report, top));
-    if (json)
-        Console.WriteLine();
+    Console.Write(LeakTriageSensor.Format(report, top, format));
     return 0;
 }
 

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -39,6 +39,13 @@ const string Usage =
       --annotation-parity <category> <expected-annotations.json> <actual-annotations.json> [--json]
           Compare annotation rows for one category (Allocation, Unsafety, Lifetime).
 
+      --leak-triage <file> [--top N] [--json]
+          Sweep the fail-closed ArrayPool leak-triage analyzer over a corpus (one assembly path
+          per line in <file>) and report where it fires: total findings, the shape histogram, and
+          example methods per assembly. This is the evidence engine for #1992 — the analyzer is
+          precision-first, so an empty card means recall (not a user-facing section) is the next
+          lever. --top bounds examples per assembly.
+
       Common: --json machine-readable output; --keep keep generated fixture projects.
     """;
 
@@ -65,6 +72,7 @@ string? allocationParityActual = null;
 string? annotationParityCategory = null;
 string? annotationParityExpected = null;
 string? annotationParityActual = null;
+string? leakTriageList = null;
 int top = 20;
 
 for (int i = 0; i < args.Length; i++)
@@ -102,6 +110,9 @@ for (int i = 0; i < args.Length; i++)
             annotationParityCategory = NextValue(args, ref i);
             annotationParityExpected = NextPathValue(args, ref i);
             annotationParityActual = NextPathValue(args, ref i);
+            break;
+        case "--leak-triage":
+            leakTriageList = NextPathValue(args, ref i);
             break;
         case "--reference":
             referenceFile = NextValue(args, ref i);
@@ -142,6 +153,9 @@ if (allocationParityExpected is not null)
 
 if (annotationParityExpected is not null)
     return RunAnnotationParity(annotationParityCategory ?? "", annotationParityExpected, annotationParityActual, json);
+
+if (leakTriageList is not null)
+    return RunLeakTriage(leakTriageList, top, json);
 
 if (corpusList is not null)
     return RunCorpus(corpusList, diffBaseline, emitSnapshot, json);
@@ -197,6 +211,31 @@ static int RunAllocationReadout(string corpusList, int top, bool json)
 
     var readout = AllocationMetadataReadout.Measure(paths);
     Console.Write(json ? AllocationMetadataReadout.ToJson(readout) : AllocationMetadataReadout.FormatCard(readout, top));
+    if (json)
+        Console.WriteLine();
+    return 0;
+}
+
+static int RunLeakTriage(string corpusList, int top, bool json)
+{
+    if (!File.Exists(corpusList))
+    {
+        Console.Error.WriteLine($"Corpus list not found: {corpusList}");
+        return 2;
+    }
+
+    var paths = File.ReadAllLines(corpusList)
+        .Select(line => line.Trim())
+        .Where(line => line.Length > 0 && !line.StartsWith('#'))
+        .ToList();
+    if (paths.Count == 0)
+    {
+        Console.Error.WriteLine($"Corpus list is empty: {corpusList}");
+        return 2;
+    }
+
+    var report = LeakTriageSensor.Measure(paths, examplesPerAssembly: top);
+    Console.Write(json ? LeakTriageSensor.ToJson(report) : LeakTriageSensor.FormatCard(report, top));
     if (json)
         Console.WriteLine();
     return 0;

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -148,6 +148,14 @@ for (int i = 0; i < args.Length; i++)
     }
 }
 
+// --tsv/--jsonl are leak-triage-specific format selectors; other modes use --json.
+// Reject them outside --leak-triage rather than silently accepting-and-ignoring them.
+if ((tsv || jsonl) && leakTriageList is null)
+{
+    Console.Error.WriteLine("--tsv and --jsonl apply only to --leak-triage; other modes use --json.");
+    return 2;
+}
+
 if (recallAssembly is not null)
     return RunRecall(recallAssembly, referenceFile);
 

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -111,6 +111,28 @@ The daily workflow runs the generated-fixture catalogue, corpus stability sensor
 recall gate. Precision labeling, baseline refreshes, and recall-reference edits remain
 maintainer-owned upkeep: they are documented conventions, not automatic CI gates.
 
+## Leak triage corpus sensor (#1992)
+
+`--leak-triage` sweeps the fail-closed ArrayPool leak-triage analyzer
+(`LeakTriageAnalyzer`) over a corpus and reports where it fires:
+
+```bash
+dotnet "$DLL" --leak-triage assemblies.txt --top 5          # findings, shape histogram, examples
+dotnet "$DLL" --leak-triage assemblies.txt --json
+```
+
+It prints the total findings, the shape histogram (`arraypool-rent-not-returned`,
+`arraypool-use-after-return`, `arraypool-double-return`), and example methods per assembly
+(`--top` bounds examples). Each assembly is bounded by a per-assembly timeout.
+
+This is the evidence engine that must earn any user-facing `Leak Triage` section: the analyzer
+is precision-first (it fails closed on incomplete CFG/RD, non-`Shared` pools, aliases, field
+stores, cross-method ownership, and ambiguous uses), so an **empty card on real code means
+recall — not a product section — is the next lever**. A 2026-07-05 run over CoreLib,
+`Microsoft.CodeAnalysis`, and `Microsoft.CodeAnalysis.CSharp` produced **0 findings** (all gates
+suppressed), while the fixture assembly's three known-misuse methods surfaced exactly once each.
+Wire the section only once this card shows non-zero, high-precision rows on real assemblies.
+
 ## Allocation convergence parity
 
 The Rung 4 allocation-convergence build must prove that a candidate

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -114,24 +114,32 @@ maintainer-owned upkeep: they are documented conventions, not automatic CI gates
 ## Leak triage corpus sensor (#1992)
 
 `--leak-triage` sweeps the fail-closed ArrayPool leak-triage analyzer
-(`LeakTriageAnalyzer`) over a corpus and reports where it fires:
+(`LeakTriageAnalyzer`) over a corpus and reports where it fires, as a
+[Markout](https://github.com/richlander/markout) card:
 
 ```bash
-dotnet "$DLL" --leak-triage assemblies.txt --top 5          # findings, shape histogram, examples
-dotnet "$DLL" --leak-triage assemblies.txt --json
+dotnet "$DLL" --leak-triage assemblies.txt --top 5          # Markdown card (default)
+dotnet "$DLL" --leak-triage assemblies.txt --tsv            # section-tagged TSV
+dotnet "$DLL" --leak-triage assemblies.txt --jsonl          # one heterogeneous JSON record per row
 ```
 
-It prints the total findings, the shape histogram (`arraypool-rent-not-returned`,
-`arraypool-use-after-return`, `arraypool-double-return`), and example methods per assembly
-(`--top` bounds examples). Each assembly is bounded by a per-assembly timeout.
+The card has three sections — a **Summary** (assemblies / opened / failed / timed out / total
+findings), a **By shape** histogram (`arraypool-rent-not-returned`, `arraypool-use-after-return`,
+`arraypool-double-return`), and **Findings** (assembly / shape / method, `--top` bounding examples
+per assembly). One declarative Markout model renders the dense Markdown table and decomposes into
+section-tagged TSV/JSONL. It is a single-run census with no baseline, so it uses plain sectioned
+rows, not composite/delta cells; a `--diff-baseline` mode against a committed snapshot is the
+natural home for those (`Change`/`[MarkoutDelta]`). Each assembly is bounded by a per-assembly
+timeout, and any per-assembly input failure (a directory path, a truncated PE) becomes an
+`Opened=false` row rather than crashing the sweep.
 
 This is the evidence engine that must earn any user-facing `Leak Triage` section: the analyzer
-is precision-first (it fails closed on incomplete CFG/RD, non-`Shared` pools, aliases, field
-stores, cross-method ownership, and ambiguous uses), so an **empty card on real code means
-recall — not a product section — is the next lever**. A 2026-07-05 run over CoreLib,
-`Microsoft.CodeAnalysis`, and `Microsoft.CodeAnalysis.CSharp` produced **0 findings** (all gates
-suppressed), while the fixture assembly's three known-misuse methods surfaced exactly once each.
-Wire the section only once this card shows non-zero, high-precision rows on real assemblies.
+fails closed on incomplete CFG/RD, non-`Shared` pools, aliases, field stores, cross-method
+ownership, and ambiguous uses, so an **empty card on real code means recall — not a product
+section — is the next lever**. A 2026-07-05 run over CoreLib, `Microsoft.CodeAnalysis`, and
+`Microsoft.CodeAnalysis.CSharp` produced **0 findings** (all gates suppressed), while the fixture
+assembly's three known-misuse methods surfaced exactly once each. Wire the section only once this
+card shows non-zero, high-precision rows on real assemblies.
 
 ## Allocation convergence parity
 


### PR DESCRIPTION
Advances #1992. Executes the harness-first plan from the #2014 review discussion.

## What

Splits the #2014 ArrayPool leak-triage spike: land the conflict-free analysis and **prove its precision through a harness sensor**, and defer the user-facing section until it earns non-zero, high-precision rows.

- **`src/ILInspector.Analysis/LeakTriage.cs` (+ 4 fixture tests)** — the fail-closed ArrayPool leak-triage analyzer, unchanged from the spike (already two-model reviewed for false positives). Rebuilds clean on current `main` (no substrate drift over the spike's 268-commit gap).
- **`tools/AnalysisHarness` — new `--leak-triage <corpus-list>` sensor** (`LeakTriageSensor`): sweeps `LeakTriageAnalyzer.AnalyzeAssembly` over a corpus and reports total findings, the shape histogram, and example methods per assembly (text + `--json`), with a per-assembly timeout. This is the analysis-side analog of `DecompilerHarness`'s corpus sensors.

**Deliberately not included:** the user-facing `Leak Triage` section wiring (`SectionNames`, `LibrarySections`, `LibraryInspectionView`, `LibraryInspection`, `LibraryMetadataService`, `JsonContext`). That was the spike's only merge conflict and its premature surface — it should be a small follow-up gated on the sensor below.

## Evidence

`--leak-triage` over CoreLib + `Microsoft.CodeAnalysis` + `Microsoft.CodeAnalysis.CSharp` + the fixture assembly:

```text
LEAK TRIAGE CORPUS SENSOR over 4 assemblies (4 opened, 0 failed, 0 timed out)
  total findings: 3
  by shape:
         1  arraypool-double-return
         1  arraypool-rent-not-returned
         1  arraypool-use-after-return
Assemblies with findings:
  ILInspector.Analysis.Tests.dll: 3
      arraypool-use-after-return  ArrayPoolLeakFixtures::UseAfterReturn
      arraypool-rent-not-returned ArrayPoolLeakFixtures::RentNotReturnedOnSomePath
      arraypool-double-return     ArrayPoolLeakFixtures::DoubleReturn
```

**0 findings on the three real assemblies** (all fail-closed gates suppressed); the fixture assembly's three known-misuse methods surface exactly once each. `ILInspector.Analysis` suite **386/386**; markdownlint clean.

## Open scope question (tracked, deferred to the sensor)

My review of #2014 flagged that a rent whose only non-returning path is a bare `throw` (no `try/finally`) is currently flagged `arraypool-rent-not-returned`. It is latent (0 real hits above), and the right way to decide whether exception-path non-returns are in scope is to **measure their rate with this sensor** as the corpus is broadened — not to decide it in the abstract. No behavior change here; the analyzer is as-reviewed.

## Risk

Additive: a new analyzer producer (already reviewed) + a measurement-only harness mode. No product path, no CLI surface. Two-model adversarial review to follow per policy.
