### PR TITLE
Add member target resolver

### DIFF
--- a/docs/design/member-target-resolution.md
+++ b/docs/design/member-target-resolution.md
@@ -1,0 +1,33 @@
+# Member target resolution
+
+Member target resolution is the typed seam between user selectors, API surface
+members, durable member anchors, and physical body evidence.
+
+`MemberTargetResolver` owns semantic selection for a member within an `ApiType`.
+It consumes a `MemberTargetSelector` rather than a loose tuple of strings, so
+selector details survive past command-line parsing:
+
+- normalized member name
+- `Name:N` overload index
+- `Name~digest` stable selector prefix
+- generic method arity from `M<T>` / `M<TKey,TValue>`
+- kind qualifiers: `operator:`, `explicit:`, and `extension:`
+
+The resolver returns `ResolvedMemberTarget`, which carries the API member handle,
+its `MemberAnchor`, selector/declaring overload indexes, and a `BodyTarget` when
+the selected API member maps to a physical declaring member. Projected extension
+methods use this body target to preserve the difference between the API target
+and the member that owns IL/native metadata evidence.
+
+Diagnostics are typed (`MemberTargetDiagnosticKind`) and include candidate
+anchors for ambiguous or out-of-range selections. CLI commands should render the
+diagnostic instead of falling back to partial string matching.
+
+## Boundaries
+
+- Lexical command helpers may still identify source/type/member argument slots,
+  but semantic member resolution should flow through `MemberTargetResolver`.
+- `MemberAnchor` remains the durable user/agent-facing identity; producer-native
+  references remain producer evidence and should not be replaced by selectors.
+- The resolver lives in `ILInspector.Metadata`, so it stays SRM-only and has no
+  decompiler dependency.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -44,6 +44,7 @@ Agents working in this repo should preserve these principles:
 - [Section model](design/section-model.md): section selection and query behavior.
 - [Hidden-fact annotations](design/hidden-fact-annotations.md): offset-keyed fact overlay semantics, validation, and projections.
 - [Member Index](design/member-index.md): overload selector and digest contract.
+- [Member target resolution](design/member-target-resolution.md): typed member selector, anchor, and body-target resolution.
 - [Member ordering](design/member-order.md): canonical type/member section order and member-kind mapping.
 - [Version resolution](design/version-resolution.md): package/platform version and cache behavior.
 - [Skill guidance taste](../taste/skill-guidance.md): how to maintain the embedded agent skill.

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -28,6 +28,46 @@ public static class ApiMemberIdentity
     public static ApiMemberHandle CreateHandle(ApiType type, ApiMember member)
         => new(type, member, GetMemberAnchor(type, member));
 
+    public static string GetMemberSignatureSortKey(ApiMember member)
+    {
+        var signature = member.Signature ?? "";
+        if (signature.Length == 0 || member.Name.Length == 0)
+            return signature;
+
+        var searchStart = 0;
+        while (searchStart < signature.Length)
+        {
+            var nameIndex = signature.IndexOf(member.Name, searchStart, StringComparison.Ordinal);
+            if (nameIndex < 0)
+                return signature;
+
+            var genericStart = nameIndex + member.Name.Length;
+            if (genericStart < signature.Length && signature[genericStart] == '<')
+            {
+                var depth = 0;
+                for (var i = genericStart; i < signature.Length; i++)
+                {
+                    if (signature[i] == '<')
+                        depth++;
+                    else if (signature[i] == '>')
+                    {
+                        depth--;
+                        if (depth == 0)
+                        {
+                            if (i + 1 < signature.Length && signature[i + 1] == '(')
+                                return signature.Remove(genericStart, i - genericStart + 1);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            searchStart = nameIndex + member.Name.Length;
+        }
+
+        return signature;
+    }
+
     public static MemberAnchor GetMemberAnchor(ApiType type, ApiMember member)
         => CreateAnchor(type, member, GetCanonicalSignature(type, member));
 

--- a/src/ILInspector.Metadata/ApiSurface.cs
+++ b/src/ILInspector.Metadata/ApiSurface.cs
@@ -404,6 +404,13 @@ public class ApiMember
     /// </summary>
     public int? DeclaringOverloadIndex { get; set; }
 
+    /// <summary>
+    /// Render-only selector index override for filtered member inventories whose visible order
+    /// is narrower than the declaring overload set.
+    /// </summary>
+    [JsonIgnore]
+    public int? SelectorOverloadIndex { get; set; }
+
     // Enum value (for enum fields only)
     public long? EnumValue { get; set; }
 

--- a/src/ILInspector.Metadata/MemberTargetResolver.cs
+++ b/src/ILInspector.Metadata/MemberTargetResolver.cs
@@ -198,20 +198,21 @@ public static class MemberTargetResolver
         MemberTargetSelector selector,
         IReadOnlyCollection<string>? kindFilter = null)
     {
-        var members = type.Members
+        var declaringMembers = type.Members
             .Where(member => TypeMatcher.MatchesMemberName(member.Name, selector.Name));
 
         if (selector.Kind is { Length: > 0 })
-            members = members.Where(member => string.Equals(member.Kind, selector.Kind, StringComparison.OrdinalIgnoreCase));
-
-        if (selector.GenericArity is { } genericArity)
-            members = members.Where(member => (member.SignatureModel?.TypeParameters.Count ?? 0) == genericArity);
+            declaringMembers = declaringMembers.Where(member => string.Equals(member.Kind, selector.Kind, StringComparison.OrdinalIgnoreCase));
 
         if (kindFilter is { Count: > 0 })
-            members = members.Where(member => kindFilter.Contains(member.Kind));
+            declaringMembers = declaringMembers.Where(member => kindFilter.Contains(member.Kind));
 
-        var original = members.ToList();
-        var display = original
+        var declaring = declaringMembers.ToList();
+        var selected = declaring.AsEnumerable();
+        if (selector.GenericArity is { } genericArity)
+            selected = selected.Where(member => (member.SignatureModel?.TypeParameters.Count ?? 0) == genericArity);
+
+        var display = selected
             .OrderBy(member => member.Name, StringComparer.Ordinal)
             .ThenBy(ApiMemberIdentity.GetMemberSignatureSortKey, StringComparer.Ordinal)
             .ToList();
@@ -229,7 +230,7 @@ public static class MemberTargetResolver
                 member,
                 ApiMemberIdentity.GetMemberAnchor(type, member),
                 selectorIndex,
-                original.IndexOf(member) + 1));
+                declaring.IndexOf(member) + 1));
         }
 
         return candidates;

--- a/src/ILInspector.Metadata/MemberTargetResolver.cs
+++ b/src/ILInspector.Metadata/MemberTargetResolver.cs
@@ -1,0 +1,372 @@
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Metadata;
+
+public enum MemberTargetKind
+{
+    Unknown,
+    Constructor,
+    Field,
+    Property,
+    Method,
+    Operator,
+    ExplicitInterfaceImplementation,
+    ExtensionMethod,
+    Event
+}
+
+public enum MemberTargetDiagnosticKind
+{
+    MissingMember,
+    AmbiguousMember,
+    DigestNotFound,
+    DigestAmbiguous,
+    OverloadOutOfRange,
+    ConflictingSelectors
+}
+
+public sealed record MemberTargetSelector(
+    string RequestedText,
+    string Name,
+    int? OverloadIndex = null,
+    string? DigestPrefix = null,
+    string? Kind = null,
+    int? GenericArity = null)
+{
+    public string NormalizedSelector
+    {
+        get
+        {
+            var kindPrefix = Kind switch
+            {
+                "operator" => "operator:",
+                "explicit-interface-implementation" => "explicit:",
+                "extension-method" => "extension:",
+                _ => ""
+            };
+            var suffix = DigestPrefix is { Length: > 0 }
+                ? $"~{DigestPrefix}"
+                : OverloadIndex is { } index ? $":{index}" : "";
+            return $"{kindPrefix}{Name}{suffix}";
+        }
+    }
+
+    public static MemberTargetSelector Parse(string value)
+    {
+        var requested = value.Trim();
+        var work = requested;
+        string? kind = null;
+
+        foreach (var prefix in (ReadOnlySpan<string>)["operator:", "explicit:", "extension:"])
+        {
+            if (!work.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            kind = NormalizeKind(prefix[..^1]);
+            work = work[prefix.Length..];
+            break;
+        }
+
+        var (digestHead, digest) = SplitDigest(work);
+        var (overloadHead, overloadIndex) = FqnParser.TrySplitOverload(digestHead);
+        var genericArity = TryGetGenericArity(overloadHead);
+        var name = TypeMatcher.NormalizeMemberName(overloadHead);
+        return new MemberTargetSelector(
+            requested,
+            name,
+            overloadIndex,
+            digest,
+            kind,
+            genericArity);
+    }
+
+    public static string? NormalizeKindQualifier(string value)
+        => value.ToLowerInvariant() switch
+        {
+            "operator" => "operator",
+            "explicit" => "explicit-interface-implementation",
+            "extension" => "extension-method",
+            _ => null
+        };
+
+    static string NormalizeKind(string value)
+        => NormalizeKindQualifier(value) ?? value.ToLowerInvariant();
+
+    static (string Head, string? Digest) SplitDigest(string value)
+    {
+        var tilde = value.LastIndexOf('~');
+        if (tilde <= 0 || tilde == value.Length - 1)
+            return (value, null);
+
+        var digest = value[(tilde + 1)..];
+        if (!digest.All(Uri.IsHexDigit))
+            return (value, null);
+
+        return (value[..tilde], digest.ToLowerInvariant());
+    }
+
+    static int? TryGetGenericArity(string value)
+    {
+        var angleStart = value.IndexOf('<');
+        if (angleStart <= 0)
+            return null;
+
+        var angleEnd = value.LastIndexOf('>');
+        if (angleEnd <= angleStart || angleEnd != value.Length - 1)
+            return null;
+
+        var arguments = value.AsSpan((angleStart + 1)..angleEnd);
+        if (arguments.IsEmpty || arguments.IsWhiteSpace())
+            return 0;
+
+        var count = 1;
+        var depth = 0;
+        foreach (var ch in arguments)
+        {
+            if (ch == '<')
+                depth++;
+            else if (ch == '>')
+                depth--;
+            else if (ch == ',' && depth == 0)
+                count++;
+        }
+
+        return count;
+    }
+}
+
+public sealed record BodyTarget(
+    string DeclaringType,
+    string CanonicalSignature,
+    int? MetadataToken = null,
+    int? DeclaringOverloadIndex = null);
+
+public sealed record ResolvedMemberTarget(
+    ApiType ApiType,
+    ApiMemberHandle ApiMember,
+    MemberAnchor Anchor,
+    string RequestedText,
+    string NormalizedSelector,
+    int SelectorIndex,
+    int DeclaringOverloadIndex,
+    int? OverloadIndex,
+    string? DigestPrefix,
+    int? GenericArity,
+    MemberTargetKind Kind,
+    BodyTarget? Body);
+
+public sealed record MemberTargetCandidate(
+    ApiMember Member,
+    MemberAnchor Anchor,
+    int SelectorIndex,
+    int DeclaringOverloadIndex)
+{
+    public string SelectorName => ApiMemberIdentity.GetMemberSelectorName(Member);
+    public string Selector => SelectorIndex > 1 ? $"{SelectorName}:{SelectorIndex}" : SelectorName;
+    public string StableSelector => Anchor.StableSelector;
+    public string CanonicalSignature => Anchor.CanonicalSignature;
+}
+
+public sealed record MemberTargetDiagnostic(
+    MemberTargetDiagnosticKind Kind,
+    string Message,
+    IReadOnlyList<MemberTargetCandidate> Candidates)
+{
+    public void WriteError(TextWriter error)
+    {
+        error.WriteLine(Message);
+        if (Candidates.Count == 0)
+            return;
+
+        foreach (var candidate in Candidates)
+            error.WriteLine($"  {candidate.StableSelector}  {candidate.CanonicalSignature}");
+    }
+}
+
+public sealed record MemberTargetResolution(
+    ResolvedMemberTarget? Target,
+    MemberTargetDiagnostic? Diagnostic,
+    IReadOnlyList<MemberTargetCandidate> Candidates)
+{
+    public bool Found => Target is not null;
+}
+
+public static class MemberTargetResolver
+{
+    public static IReadOnlyList<MemberTargetCandidate> GetCandidates(
+        ApiType type,
+        MemberTargetSelector selector,
+        IReadOnlyCollection<string>? kindFilter = null)
+    {
+        var members = type.Members
+            .Where(member => TypeMatcher.MatchesMemberName(member.Name, selector.Name));
+
+        if (selector.Kind is { Length: > 0 })
+            members = members.Where(member => string.Equals(member.Kind, selector.Kind, StringComparison.OrdinalIgnoreCase));
+
+        if (selector.GenericArity is { } genericArity)
+            members = members.Where(member => (member.SignatureModel?.TypeParameters.Count ?? 0) == genericArity);
+
+        if (kindFilter is { Count: > 0 })
+            members = members.Where(member => kindFilter.Contains(member.Kind));
+
+        var original = members.ToList();
+        var display = original
+            .OrderBy(member => member.Name, StringComparer.Ordinal)
+            .ThenBy(ApiMemberIdentity.GetMemberSignatureSortKey, StringComparer.Ordinal)
+            .ToList();
+
+        var selectorIndices = new Dictionary<string, int>(StringComparer.Ordinal);
+        List<MemberTargetCandidate> candidates = [];
+        foreach (var member in display)
+        {
+            var selectorName = ApiMemberIdentity.GetMemberSelectorName(member);
+            selectorIndices.TryGetValue(selectorName, out var selectorIndex);
+            selectorIndex++;
+            selectorIndices[selectorName] = selectorIndex;
+
+            candidates.Add(new MemberTargetCandidate(
+                member,
+                ApiMemberIdentity.GetMemberAnchor(type, member),
+                selectorIndex,
+                original.IndexOf(member) + 1));
+        }
+
+        return candidates;
+    }
+
+    public static MemberTargetResolution Resolve(
+        ApiType type,
+        MemberTargetSelector selector,
+        IReadOnlyCollection<string>? kindFilter = null)
+    {
+        var candidates = GetCandidates(type, selector, kindFilter);
+        if (candidates.Count == 0)
+        {
+            return Failure(MemberTargetDiagnosticKind.MissingMember,
+                $"Error: No members matched selector '{selector.RequestedText}'.",
+                candidates);
+        }
+
+        if (selector.OverloadIndex.HasValue && selector.DigestPrefix is { Length: > 0 })
+        {
+            return Failure(MemberTargetDiagnosticKind.ConflictingSelectors,
+                "Error: digest selector cannot be combined with --index/Name:N.",
+                candidates);
+        }
+
+        MemberTargetCandidate selected;
+        if (selector.DigestPrefix is { Length: > 0 } digest)
+        {
+            var matches = candidates
+                .Where(candidate => candidate.Anchor.Fingerprint.StartsWith(digest, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (matches.Count == 0)
+            {
+                return Failure(MemberTargetDiagnosticKind.DigestNotFound,
+                    $"Error: No overload of {selector.Name} matches digest '{digest}'. Use -S \"Member Index\" to list digests.",
+                    candidates);
+            }
+
+            if (matches.Count > 1)
+            {
+                return Failure(MemberTargetDiagnosticKind.DigestAmbiguous,
+                    $"Error: Digest '{digest}' is ambiguous. Use a longer digest prefix:",
+                    matches);
+            }
+
+            selected = matches[0];
+        }
+        else if (selector.OverloadIndex is { } index)
+        {
+            if (index < 1 || index > candidates.Count)
+            {
+                return Failure(MemberTargetDiagnosticKind.OverloadOutOfRange,
+                    $"Error: {selector.Name}:{index} is out of range. Use {selector.Name}:1 through {selector.Name}:{candidates.Count}.",
+                    candidates);
+            }
+
+            selected = candidates[index - 1];
+        }
+        else
+        {
+            if (candidates.Count > 1)
+            {
+                return Failure(MemberTargetDiagnosticKind.AmbiguousMember,
+                    $"Error: Member selector '{selector.RequestedText}' is ambiguous. Use {selector.Name}:1 through {selector.Name}:{candidates.Count}, or run -S \"Member Index\" to list stable ~digest selectors.",
+                    candidates);
+            }
+
+            selected = candidates[0];
+        }
+
+        var anchor = selected.Anchor;
+        var member = selected.Member;
+        var body = CreateBodyTarget(type, member, anchor, selected.DeclaringOverloadIndex);
+        var handle = ApiMemberIdentity.CreateHandle(type, member);
+        return new MemberTargetResolution(
+            new ResolvedMemberTarget(
+                type,
+                handle,
+                anchor,
+                selector.RequestedText,
+                selector.NormalizedSelector,
+                selected.SelectorIndex,
+                selected.DeclaringOverloadIndex,
+                selector.OverloadIndex,
+                selector.DigestPrefix,
+                selector.GenericArity,
+                ToTargetKind(member.Kind),
+                body),
+            null,
+            candidates);
+
+        MemberTargetResolution Failure(
+            MemberTargetDiagnosticKind kind,
+            string message,
+            IReadOnlyList<MemberTargetCandidate> diagnosticCandidates)
+            => new(null, new MemberTargetDiagnostic(kind, message, diagnosticCandidates), candidates);
+    }
+
+    static BodyTarget? CreateBodyTarget(
+        ApiType apiType,
+        ApiMember member,
+        MemberAnchor anchor,
+        int declaringOverloadIndex)
+    {
+        var apiTypeName = MetadataTypeNameFormatter.FormatFullName(apiType);
+        var declaringType = string.IsNullOrWhiteSpace(member.DeclaringType)
+            ? apiTypeName
+            : member.DeclaringType!;
+
+        if (declaringType == apiTypeName
+            && member.MetadataToken is null
+            && member.GetterToken is null
+            && member.SetterToken is null
+            && member.DeclaringOverloadIndex is null)
+        {
+            return null;
+        }
+
+        return new BodyTarget(
+            declaringType,
+            anchor.CanonicalSignature,
+            member.MetadataToken ?? member.GetterToken ?? member.SetterToken,
+            member.DeclaringOverloadIndex ?? declaringOverloadIndex);
+    }
+
+    static MemberTargetKind ToTargetKind(string kind)
+        => kind switch
+        {
+            "constructor" => MemberTargetKind.Constructor,
+            "field" => MemberTargetKind.Field,
+            "property" => MemberTargetKind.Property,
+            "method" => MemberTargetKind.Method,
+            "operator" => MemberTargetKind.Operator,
+            "explicit-interface-implementation" => MemberTargetKind.ExplicitInterfaceImplementation,
+            "extension-method" => MemberTargetKind.ExtensionMethod,
+            "event" => MemberTargetKind.Event,
+            _ => MemberTargetKind.Unknown
+        };
+}

--- a/src/dotnet-inspect.Tests/ApiTypeLookupServiceTests.cs
+++ b/src/dotnet-inspect.Tests/ApiTypeLookupServiceTests.cs
@@ -48,6 +48,18 @@ public class ApiTypeLookupServiceTests
     }
 
     [Fact]
+    public void LookupType_FullyQualifiedGenericMember_PeelsTrailingMember()
+    {
+        var api = CreateSurface();
+
+        var result = ApiTypeLookupService.LookupType(api, "System.Text.Json.JsonSerializer.Serialize<TValue>");
+
+        Assert.True(result.Found);
+        Assert.Equal("System.Text.Json.JsonSerializer", result.Match);
+        Assert.Equal("Serialize<TValue>", result.ImpliedMember);
+    }
+
+    [Fact]
     public void LookupType_SimpleTypeMember_PeelsTrailingMember()
     {
         var api = CreateSurface();

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -7053,6 +7053,19 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_GenericTypeName_DoesNotAdmitMemberDetailSections()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", "System.Collections.Generic.List<T>",
+            "--platform", "System.Private.CoreLib",
+            "-S", "Signature", "--tips", "q");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("Select value 'Signature' not found.", error);
+    }
+
+    [Fact]
     public async Task Package_SelectAll_IncludesOptInSignals()
     {
         var (packagePath, tempDir) = CreateLocalRefPackage("System.Runtime");

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -7036,6 +7036,22 @@ public class CommandExecutionTests
         Assert.DoesNotContain("GenericChoice(string value)", output);
     }
 
+    [Theory]
+    [InlineData("GenericChoice<T>")]
+    [InlineData("GenericChoice<T>:1")]
+    public async Task Member_DottedGenericMethodSelector_FiltersByMethodArity(string memberSelector)
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", $"{typeof(MemberGenericSelectorFixture).FullName!}.{memberSelector}",
+            "--library", TestAssemblyPath,
+            "-S", "Signature", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("GenericChoice<T>(T value)", output);
+        Assert.DoesNotContain("GenericChoice(string value)", output);
+    }
+
     [Fact]
     public async Task Package_SelectAll_IncludesOptInSignals()
     {

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -7024,6 +7024,19 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Member_GenericMethodSelector_FiltersByMethodArity()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberGenericSelectorFixture).FullName!, "--library", TestAssemblyPath,
+            "GenericChoice<T>", "-S", "Signature", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("GenericChoice<T>(T value)", output);
+        Assert.DoesNotContain("GenericChoice(string value)", output);
+    }
+
+    [Fact]
     public async Task Package_SelectAll_IncludesOptInSignals()
     {
         var (packagePath, tempDir) = CreateLocalRefPackage("System.Runtime");
@@ -8589,6 +8602,12 @@ public class CommandExecutionTests
 
 public interface EmptyDiscoveryFixture
 {
+}
+
+public sealed class MemberGenericSelectorFixture
+{
+    public string GenericChoice(string value) => value;
+    public T GenericChoice<T>(T value) => value;
 }
 
 public static class FactsTableFixture

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -7049,6 +7049,33 @@ public class CommandExecutionTests
         Assert.DoesNotContain("GenericChoice(string value)", output);
     }
 
+    [Fact]
+    public async Task Member_GenericMethodSelector_MemberIndexSelectorRoundTrips()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberGenericSelectorFixture).FullName!, "--library", TestAssemblyPath,
+            "GenericChoice<T>", "--show-index", "--table");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        var selector = output
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Trim())
+            .Where(line => line.StartsWith("GenericChoice", StringComparison.Ordinal))
+            .Select(line => line.Split(' ', StringSplitOptions.RemoveEmptyEntries)[0])
+            .Single();
+        Assert.Contains(':', selector);
+
+        (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberGenericSelectorFixture).FullName!, "--library", TestAssemblyPath,
+            selector, "-S", "Signature", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("GenericChoice<T>(T value)", output);
+        Assert.DoesNotContain("GenericChoice(string value)", output);
+    }
+
     [Theory]
     [InlineData("GenericChoice<T>")]
     [InlineData("GenericChoice<T>:1")]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -7036,6 +7036,19 @@ public class CommandExecutionTests
         Assert.DoesNotContain("GenericChoice(string value)", output);
     }
 
+    [Fact]
+    public async Task Member_GenericMethodSelector_FiltersInventoryByMethodArity()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", typeof(MemberGenericSelectorFixture).FullName!, "--library", TestAssemblyPath,
+            "GenericChoice<T>", "--rows", "-n", "10", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("GenericChoice<T>(T value)", output);
+        Assert.DoesNotContain("GenericChoice(string value)", output);
+    }
+
     [Theory]
     [InlineData("GenericChoice<T>")]
     [InlineData("GenericChoice<T>:1")]
@@ -7045,6 +7058,20 @@ public class CommandExecutionTests
             "member", $"{typeof(MemberGenericSelectorFixture).FullName!}.{memberSelector}",
             "--library", TestAssemblyPath,
             "-S", "Signature", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.Contains("GenericChoice<T>(T value)", output);
+        Assert.DoesNotContain("GenericChoice(string value)", output);
+    }
+
+    [Fact]
+    public async Task Member_DottedGenericMethodSelector_FiltersInventoryByMethodArity()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "member", $"{typeof(MemberGenericSelectorFixture).FullName!}.GenericChoice<T>",
+            "--library", TestAssemblyPath,
+            "--rows", "-n", "10", "--tips", "q");
 
         Assert.Equal(0, exit);
         Assert.Empty(error);

--- a/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/MemberOptionsParserTests.cs
@@ -621,6 +621,16 @@ public class MemberOptionsParserTests
     }
 
     [Fact]
+    public async Task GenericMethodShorthand_SetsGenericArity()
+    {
+        var options = await ParseSuccessAsync("member", "JsonSerializer", "--package", "System.Text.Json", "-m", "Deserialize<TValue>:2");
+
+        Assert.Contains("Deserialize", options.MemberFilter);
+        Assert.Equal(2, options.OverloadIndex);
+        Assert.Equal(1, options.MemberGenericArity);
+    }
+
+    [Fact]
     public async Task DigestShorthand_SetsMemberDigest()
     {
         var options = await ParseSuccessAsync("member", "JsonSerializer", "--package", "System.Text.Json", "-m", "Deserialize~abc123");

--- a/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
@@ -266,13 +266,14 @@ public class SharedParsersTests
     public void ProcessMemberArguments_ExtractsDottedSyntax()
     {
         var members = new[] { "JsonSerializer.Deserialize", "GetValue" };
-        var (typeFilter, overloadIndex, memberDigest, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Equal("JsonSerializer", typeFilter);
         Assert.Equal("Deserialize", members[0]);
         Assert.Equal("GetValue", members[1]);
         Assert.Null(overloadIndex);
         Assert.Null(memberDigest);
+        Assert.Null(genericArity);
         Assert.Empty(kindFilter);
     }
 
@@ -280,12 +281,13 @@ public class SharedParsersTests
     public void ProcessMemberArguments_ExtractsOverloadShorthand()
     {
         var members = new[] { "GetValue:2" };
-        var (typeFilter, overloadIndex, memberDigest, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Null(typeFilter);
         Assert.Equal("GetValue", members[0]);
         Assert.Equal(2, overloadIndex);
         Assert.Null(memberDigest);
+        Assert.Null(genericArity);
         Assert.Empty(kindFilter);
     }
 
@@ -293,12 +295,13 @@ public class SharedParsersTests
     public void ProcessMemberArguments_ExtractsBoth()
     {
         var members = new[] { "JsonSerializer.Deserialize:1" };
-        var (typeFilter, overloadIndex, memberDigest, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Equal("JsonSerializer", typeFilter);
         Assert.Equal("Deserialize", members[0]);
         Assert.Equal(1, overloadIndex);
         Assert.Null(memberDigest);
+        Assert.Null(genericArity);
         Assert.Empty(kindFilter);
     }
 
@@ -306,12 +309,13 @@ public class SharedParsersTests
     public void ProcessMemberArguments_ExtractsKindQualifiedSelector()
     {
         var members = new[] { "explicit:System.IConvertible.ToBoolean:1" };
-        var (typeFilter, overloadIndex, memberDigest, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Null(typeFilter);
         Assert.Equal("System.IConvertible.ToBoolean", members[0]);
         Assert.Equal(1, overloadIndex);
         Assert.Null(memberDigest);
+        Assert.Null(genericArity);
         Assert.Contains("explicit-interface-implementation", kindFilter);
     }
 
@@ -319,25 +323,41 @@ public class SharedParsersTests
     public void ProcessMemberArguments_ExtractsDottedKindQualifiedSelector()
     {
         var members = new[] { "DateTime.operator:op_Addition:1" };
-        var (typeFilter, overloadIndex, memberDigest, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Equal("DateTime", typeFilter);
         Assert.Equal("op_Addition", members[0]);
         Assert.Equal(1, overloadIndex);
         Assert.Null(memberDigest);
+        Assert.Null(genericArity);
         Assert.Contains("operator", kindFilter);
+    }
+
+    [Fact]
+    public void ProcessMemberArguments_ExtractsGenericMethodArity()
+    {
+        var members = new[] { "Map<T>:1" };
+        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+
+        Assert.Null(typeFilter);
+        Assert.Equal("Map", members[0]);
+        Assert.Equal(1, overloadIndex);
+        Assert.Null(memberDigest);
+        Assert.Equal(1, genericArity);
+        Assert.Empty(kindFilter);
     }
 
     [Fact]
     public void ProcessMemberArguments_ExtractsDigestSelector()
     {
         var members = new[] { "JsonSerializer.Deserialize~abc123" };
-        var (typeFilter, overloadIndex, memberDigest, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+        var (typeFilter, overloadIndex, memberDigest, genericArity, kindFilter) = SharedParsers.ProcessMemberArguments(members);
 
         Assert.Equal("JsonSerializer", typeFilter);
         Assert.Equal("Deserialize", members[0]);
         Assert.Null(overloadIndex);
         Assert.Equal("abc123", memberDigest);
+        Assert.Null(genericArity);
         Assert.Empty(kindFilter);
     }
 

--- a/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
@@ -179,6 +179,20 @@ public class SharedParsersTests
         Assert.Null(memberName);
     }
 
+    [Theory]
+    [InlineData("Sample.Widget.Map<T>:1", "Sample.Widget", "Map<T>:1")]
+    [InlineData("Sample.Widget.Map<T>~abcdef", "Sample.Widget", "Map<T>~abcdef")]
+    public void SplitTrailingMember_SplitsGenericMemberSelectorWithSelectorSuffix(
+        string input,
+        string expectedType,
+        string expectedMember)
+    {
+        var (typeName, memberName) = SharedParsers.SplitTrailingMember(input);
+
+        Assert.Equal(expectedType, typeName);
+        Assert.Equal(expectedMember, memberName);
+    }
+
     [Fact]
     public void SplitTrailingMember_NoDot_ReturnsOriginal()
     {
@@ -186,6 +200,18 @@ public class SharedParsersTests
 
         Assert.Equal("JsonSerializer", typeName);
         Assert.Null(memberName);
+    }
+
+    [Fact]
+    public void TrySplitQualifiedTypeMember_SplitsGenericMemberSelector()
+    {
+        var split = SharedParsers.TrySplitQualifiedTypeMember(
+            "String.GenericChoice<T>",
+            allowPlatformPrefixFallback: true);
+
+        Assert.NotNull(split);
+        Assert.Equal("GenericChoice<T>", split.Value.MemberName);
+        Assert.Equal("System.String", split.Value.Probe.Remainder);
     }
 
     // ── ParseTypeFilter ──────────────────────────────────────────────────

--- a/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
+++ b/src/dotnet-inspect.Tests/Parsers/SharedParsersTests.cs
@@ -316,6 +316,19 @@ public class SharedParsersTests
     }
 
     [Fact]
+    public void ProcessMemberArguments_ExtractsDottedKindQualifiedSelector()
+    {
+        var members = new[] { "DateTime.operator:op_Addition:1" };
+        var (typeFilter, overloadIndex, memberDigest, kindFilter) = SharedParsers.ProcessMemberArguments(members);
+
+        Assert.Equal("DateTime", typeFilter);
+        Assert.Equal("op_Addition", members[0]);
+        Assert.Equal(1, overloadIndex);
+        Assert.Null(memberDigest);
+        Assert.Contains("operator", kindFilter);
+    }
+
+    [Fact]
     public void ProcessMemberArguments_ExtractsDigestSelector()
     {
         var members = new[] { "JsonSerializer.Deserialize~abc123" };

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -191,10 +191,7 @@ public static class RouterCommandDefinition
             if (memberFind.Status == TypeFindIfMissStatus.Found)
             {
                 var match = memberFind.TypeResolution.Match!;
-                var memberSelector = memberFind.OverloadIndex.HasValue
-                    ? $"{memberFind.MemberName}:{memberFind.OverloadIndex.Value}"
-                    : memberFind.MemberName;
-                return ["member", match.FullName, "--platform", match.Library, .. FrameworkArgs(match.Source), "-m", memberSelector, .. tail];
+                return ["member", match.FullName, "--platform", match.Library, .. FrameworkArgs(match.Source), "-m", memberFind.MemberSelector, .. tail];
             }
 
             var typeProbe = SourceResolver.TryResolveQualifiedTypeName(target, allowPlatformPrefixFallback);

--- a/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/MemberOptionsParser.cs
@@ -228,7 +228,7 @@ public static class MemberOptionsParser
         var ctorOnly = parseResult.GetValue(args.CtorOption);
 
         // Process dotted syntax and overload shorthand
-        var (dottedTypeFilter, shorthandIndex, memberDigest, memberKindFilter) = SharedParsers.ProcessMemberArguments(allMembers);
+        var (dottedTypeFilter, shorthandIndex, memberDigest, memberGenericArity, memberKindFilter) = SharedParsers.ProcessMemberArguments(allMembers);
 
         // Use extracted type name if no explicit type was provided
         if (dottedTypeFilter != null && string.IsNullOrEmpty(typeName))
@@ -291,6 +291,7 @@ public static class MemberOptionsParser
             CtorOnly = ctorOnly,
             OverloadIndex = parseResult.GetValue(args.IndexOption) ?? shorthandIndex,
             MemberDigest = memberDigest,
+            MemberGenericArity = memberGenericArity,
             ShowMemberIndex = showMemberIndex,
             CallerScopeDirectories = parseResult.GetValue(args.BinOption) ?? [],
             CallerScopeProjects = projectSourcePath is null

--- a/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
@@ -216,12 +216,7 @@ public static class SharedParsers
 
         for (int i = 0; i < members.Length; i++)
         {
-            var kindQualified = TryParseKindQualifiedMember(members[i], out var kind, out var memberName);
-            if (kindQualified)
-            {
-                kindFilter.Add(kind);
-                members[i] = memberName;
-            }
+            var kindQualified = TryParseKindQualifiedMember(members[i], out _, out _);
 
             // Check for dotted syntax (Type.Member)
             if (!kindQualified)
@@ -234,19 +229,14 @@ public static class SharedParsers
                 }
             }
 
-            // Check for digest shorthand (Name~abc123)
-            var (digestName, digest) = ParseDigestShorthand(members[i]);
-            members[i] = digestName;
-            if (digest != null)
-                memberDigest = digest;
-
-            // Check for overload shorthand (Name:N)
-            var (name, index) = ParseOverloadShorthand(members[i]);
-            members[i] = name;
-            if (index != null)
-            {
+            var selector = MemberTargetSelector.Parse(members[i]);
+            if (selector.Kind is { Length: > 0 })
+                kindFilter.Add(selector.Kind);
+            if (selector.DigestPrefix is { Length: > 0 })
+                memberDigest = selector.DigestPrefix;
+            if (selector.OverloadIndex is { } index)
                 overloadIndex = index;
-            }
+            members[i] = selector.Name;
         }
 
         return (dottedTypeFilter, overloadIndex, memberDigest, kindFilter);

--- a/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
@@ -207,11 +207,12 @@ public static class SharedParsers
     /// </summary>
     /// <param name="members">The member arguments to process.</param>
     /// <returns>Extracted type filter and overload index if found.</returns>
-    public static (string? DottedTypeFilter, int? OverloadIndex, string? MemberDigest, HashSet<string> KindFilter) ProcessMemberArguments(string[] members)
+    public static (string? DottedTypeFilter, int? OverloadIndex, string? MemberDigest, int? GenericArity, HashSet<string> KindFilter) ProcessMemberArguments(string[] members)
     {
         string? dottedTypeFilter = null;
         int? overloadIndex = null;
         string? memberDigest = null;
+        int? genericArity = null;
         HashSet<string> kindFilter = [];
 
         for (int i = 0; i < members.Length; i++)
@@ -234,12 +235,14 @@ public static class SharedParsers
                 kindFilter.Add(selector.Kind);
             if (selector.DigestPrefix is { Length: > 0 })
                 memberDigest = selector.DigestPrefix;
+            if (selector.GenericArity is { } arity)
+                genericArity = arity;
             if (selector.OverloadIndex is { } index)
                 overloadIndex = index;
             members[i] = selector.Name;
         }
 
-        return (dottedTypeFilter, overloadIndex, memberDigest, kindFilter);
+        return (dottedTypeFilter, overloadIndex, memberDigest, genericArity, kindFilter);
     }
 
     public static (string Name, string? Digest) ParseDigestShorthand(string value)

--- a/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
+++ b/src/dotnet-inspect/CommandLine/Parsers/SharedParsers.cs
@@ -88,7 +88,7 @@ public static class SharedParsers
             return (typeName, null);
 
         var rightPart = typeName[(lastDot + 1)..];
-        return rightPart.Contains('<')
+        return rightPart.Contains('<') && !HasGenericMemberSelectorSuffix(rightPart)
             ? (typeName, null)
             : (typeName[..lastDot], rightPart);
     }
@@ -104,7 +104,7 @@ public static class SharedParsers
 
             var typeCandidate = value[..i];
             var memberName = value[(i + 1)..];
-            if (string.IsNullOrWhiteSpace(memberName) || memberName.Contains('<'))
+            if (string.IsNullOrWhiteSpace(memberName))
                 continue;
 
             var probe = SourceResolver.TryResolveQualifiedTypeName(typeCandidate, allowPlatformPrefixFallback);
@@ -124,6 +124,13 @@ public static class SharedParsers
         }
 
         return null;
+    }
+
+    private static bool HasGenericMemberSelectorSuffix(string value)
+    {
+        var selector = MemberTargetSelector.Parse(value);
+        return selector.GenericArity.HasValue
+            && (selector.OverloadIndex.HasValue || selector.DigestPrefix is { Length: > 0 });
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Commands/ApiCommand.cs
+++ b/src/dotnet-inspect/Commands/ApiCommand.cs
@@ -69,6 +69,15 @@ public class ApiCommand
         bool typeNameIsGlob = hasTypeName && (options.TypeName!.Contains('*') || options.TypeName!.Contains('?'));
         bool singleTypeMode = options is MemberOptions || (hasTypeName && !typeNameIsGlob);
         var knownSections = singleTypeMode ? memberPipeline.SelectableSectionNames : typePipeline.SelectableSectionNames;
+        if (options is MemberOptions memberOptions
+            && memberOptions.MemberFilter.Count == 0
+            && MightPeelDottedGenericMemberSelector(memberOptions.TypeName))
+        {
+            knownSections = knownSections
+                .Concat(ApiMemberDetailSectionDescriptors.CreatePipeline().SelectableSectionNames)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
 
         // Discovery mode: -D/--discover lists effective sections (resolves source) by
         // default; --schema opts out to the cheap, offline static schema listing.
@@ -180,6 +189,18 @@ public class ApiCommand
             OutputFormatResolver.WarnIfOneLineDetailMismatch(options.OneLine, options.Verbosity, options.IncludeSections);
 
         return (new PreambleResult(options, typePipeline, memberPipeline), null);
+    }
+
+    static bool MightPeelDottedGenericMemberSelector(string? typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName))
+            return false;
+
+        var lastDot = FqnParser.LastTopLevelDot(typeName);
+        if (lastDot <= 0 || lastDot == typeName.Length - 1)
+            return false;
+
+        return MemberTargetSelector.Parse(typeName[(lastDot + 1)..]).GenericArity.HasValue;
     }
 
     private static bool ValidateApiPrintSelection(HashSet<string>? includeSections)

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -84,16 +84,20 @@ public static class MemberCommand
 
             // If the type resolved by peeling a trailing Type.Member suffix (e.g.
             // "System.String.Length" -> type System.String + member Length), apply the peeled
-            // segment as a member filter. The peeled suffix is always a plain member name
-            // (selector-bearing suffixes like ":N"/"~hash" are split in the parser), so it is
-            // combined with any explicit -m filters rather than replacing or being dropped.
+            // segment as a member filter. Selector-bearing suffixes like ":N"/"~hash" are split
+            // in the parser, but generic arity can still arrive here from Type.M<T>.
             if (lookupResult.ImpliedMember is { } impliedMember)
             {
+                var impliedSelector = MemberTargetSelector.Parse(impliedMember);
                 var mergedFilter = new HashSet<string>(options.MemberFilter, StringComparer.OrdinalIgnoreCase)
                 {
-                    impliedMember
+                    impliedSelector.Name
                 };
-                options = options with { MemberFilter = mergedFilter };
+                options = options with
+                {
+                    MemberFilter = mergedFilter,
+                    MemberGenericArity = options.MemberGenericArity ?? impliedSelector.GenericArity
+                };
             }
 
             // Check each member filter before producing output

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -217,6 +217,22 @@ public static class MemberCommand
             }
 
             if (effectiveOptions.OverloadIndex is null
+                && string.IsNullOrWhiteSpace(effectiveOptions.MemberDigest)
+                && effectiveOptions.MemberGenericArity.HasValue
+                && effectiveOptions.MemberFilter.Count == 1)
+            {
+                var memberName = effectiveOptions.MemberFilter.First();
+                var arityCandidates = GetCandidateMembers(apiType, effectiveOptions, memberName);
+                if (arityCandidates.Count == 0)
+                {
+                    Console.Error.WriteLine($"Error: No members matched selector '{memberName}' with generic arity {effectiveOptions.MemberGenericArity.Value}.");
+                    return 1;
+                }
+
+                apiType.Members = arityCandidates;
+            }
+
+            if (effectiveOptions.OverloadIndex is null
                 && effectiveOptions.IncludeSections?.Contains(SectionNames.UnsafeMembers) == true
                 && (runtimeAssemblyPath ?? apiDllPath) is { } unsafeDllPath)
             {

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -163,7 +163,8 @@ public static class MemberCommand
                     memberName,
                     memberName,
                     effectiveOptions.OverloadIndex,
-                    effectiveOptions.MemberDigest);
+                    effectiveOptions.MemberDigest,
+                    GenericArity: effectiveOptions.MemberGenericArity);
                 var memberResolution = MemberTargetResolver.Resolve(apiType, selector, effectiveOptions.KindFilter);
                 if (memberResolution.Diagnostic is { } diagnostic)
                 {
@@ -477,7 +478,9 @@ public static class MemberCommand
     private static List<ApiMember> GetCandidateMembers(ApiType apiType, MemberOptions options, string memberName)
         => MemberTargetResolver.GetCandidates(
                 apiType,
-                new MemberTargetSelector(memberName, memberName),
+                options.MemberGenericArity is { } arity
+                    ? new MemberTargetSelector(memberName, memberName, GenericArity: arity)
+                    : new MemberTargetSelector(memberName, memberName),
                 options.KindFilter)
             .Select(candidate => candidate.Member)
             .ToList();

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -99,6 +99,19 @@ public static class MemberCommand
                     MemberGenericArity = options.MemberGenericArity ?? impliedSelector.GenericArity
                 };
             }
+            else if (options.MemberFilter.Count == 0 && options.Select is { Length: > 0 })
+            {
+                var actualPipeline = ApiMemberSectionPipelines.Create(options);
+                var actualSelect = SelectResolver.ResolveSelectAsSections(
+                    options.Select,
+                    actualPipeline.SelectableSectionNames,
+                    actualPipeline.InfoSectionNames,
+                    actualPipeline.GetCategoryMap());
+                if (SelectOutput.WriteUnresolved(actualSelect))
+                    return 1;
+                if (actualSelect.Sections != null)
+                    options = options with { IncludeSections = actualSelect.Sections };
+            }
 
             // Check each member filter before producing output
             if (options.MemberFilter.Count > 0)

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -147,90 +147,38 @@ public static class MemberCommand
                     effectiveOptions = effectiveOptions with { OverloadIndex = 1 };
             }
 
-            var digestSelected = false;
-
-            // Name~digest: select a specific overload by canonical member digest.
-            if (!string.IsNullOrWhiteSpace(effectiveOptions.MemberDigest))
+            if (effectiveOptions.OverloadIndex.HasValue
+                || !string.IsNullOrWhiteSpace(effectiveOptions.MemberDigest))
             {
-                if (effectiveOptions.OverloadIndex.HasValue)
-                {
-                    Console.Error.WriteLine("Error: digest selector cannot be combined with --index/Name:N.");
-                    return 1;
-                }
-
                 if (effectiveOptions.MemberFilter.Count != 1)
                 {
-                    Console.Error.WriteLine("Error: Name~digest requires exactly one member name.");
+                    Console.Error.WriteLine(string.IsNullOrWhiteSpace(effectiveOptions.MemberDigest)
+                        ? "Error: --index/Name:N requires exactly one member name."
+                        : "Error: Name~digest requires exactly one member name.");
                     return 1;
                 }
 
                 var memberName = effectiveOptions.MemberFilter.First();
-                var overloads = GetCandidateMembers(apiType, effectiveOptions, memberName);
-                var displayOverloads = overloads
-                    .OrderBy(m => m.Name, StringComparer.Ordinal)
-                    .ThenBy(ApiOutputFormatter.GetMemberSignatureSortKey, StringComparer.Ordinal)
-                    .ToList();
-                var rows = ApiOutputFormatter.BuildMemberIndexRows(apiType, displayOverloads);
-                var matches = rows
-                    .Select((row, index) => (row, index))
-                    .Where(item => item.row.Digest.StartsWith(effectiveOptions.MemberDigest, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
-
-                if (matches.Count == 0)
+                var selector = new MemberTargetSelector(
+                    memberName,
+                    memberName,
+                    effectiveOptions.OverloadIndex,
+                    effectiveOptions.MemberDigest);
+                var memberResolution = MemberTargetResolver.Resolve(apiType, selector, effectiveOptions.KindFilter);
+                if (memberResolution.Diagnostic is { } diagnostic)
                 {
-                    Console.Error.WriteLine($"Error: No overload of {memberName} matches digest '{effectiveOptions.MemberDigest}'. Use -S \"Member Index\" to list digests.");
+                    diagnostic.WriteError(Console.Error);
                     return 1;
                 }
 
-                if (matches.Count > 1)
-                {
-                    Console.Error.WriteLine($"Error: Digest '{effectiveOptions.MemberDigest}' is ambiguous. Use a longer digest prefix:");
-                    foreach (var (row, _) in matches)
-                        Console.Error.WriteLine($"  {row.Stable}  {row.CanonicalSignature}");
-                    return 1;
-                }
-
-                var selected = displayOverloads[matches[0].index];
+                var target = memberResolution.Target!;
+                var selected = target.ApiMember.Member;
                 apiType.Members = [selected];
                 var detailDllPath = apiType.SourceAssemblyPath ?? apiDllPath;
                 effectiveOptions = effectiveOptions with
                 {
                     DllPath = detailDllPath,
-                    OverloadIndex = overloads.IndexOf(selected) + 1
-                };
-                digestSelected = true;
-            }
-
-            // --index: select a specific overload and show IL
-            if (effectiveOptions.OverloadIndex.HasValue && !digestSelected)
-            {
-                if (effectiveOptions.MemberFilter.Count != 1)
-                {
-                    Console.Error.WriteLine("Error: --index/Name:N requires exactly one member name.");
-                    return 1;
-                }
-
-                var memberName = effectiveOptions.MemberFilter.First();
-                var overloads = GetCandidateMembers(apiType, effectiveOptions, memberName);
-                var displayOverloads = overloads
-                    .OrderBy(m => m.Name, StringComparer.Ordinal)
-                    .ThenBy(ApiOutputFormatter.GetMemberSignatureSortKey, StringComparer.Ordinal)
-                    .ToList();
-
-                int idx = effectiveOptions.OverloadIndex.Value;
-                if (idx < 1 || idx > overloads.Count)
-                {
-                    Console.Error.WriteLine($"Error: {memberName}:{idx} is out of range. Use {memberName}:1 through {memberName}:{overloads.Count}.");
-                    return 1;
-                }
-
-                var selected = displayOverloads[idx - 1];
-                apiType.Members = [selected];
-                var detailDllPath = apiType.SourceAssemblyPath ?? apiDllPath;
-                effectiveOptions = effectiveOptions with
-                {
-                    DllPath = detailDllPath,
-                    OverloadIndex = overloads.IndexOf(selected) + 1
+                    OverloadIndex = target.Body?.DeclaringOverloadIndex ?? target.DeclaringOverloadIndex
                 };
             }
 
@@ -527,13 +475,12 @@ public static class MemberCommand
         select is { Length: 1 } && select[0].Equals(name, StringComparison.OrdinalIgnoreCase);
 
     private static List<ApiMember> GetCandidateMembers(ApiType apiType, MemberOptions options, string memberName)
-    {
-        var members = apiType.Members
-            .Where(m => string.Equals(m.Name, memberName, StringComparison.OrdinalIgnoreCase));
-        if (options.KindFilter.Count > 0)
-            members = members.Where(m => options.KindFilter.Contains(m.Kind));
-        return members.ToList();
-    }
+        => MemberTargetResolver.GetCandidates(
+                apiType,
+                new MemberTargetSelector(memberName, memberName),
+                options.KindFilter)
+            .Select(candidate => candidate.Member)
+            .ToList();
 
     private static string GetMemberSectionName(string kind) => kind switch
     {

--- a/src/dotnet-inspect/Commands/MemberCommand.cs
+++ b/src/dotnet-inspect/Commands/MemberCommand.cs
@@ -222,7 +222,18 @@ public static class MemberCommand
                 && effectiveOptions.MemberFilter.Count == 1)
             {
                 var memberName = effectiveOptions.MemberFilter.First();
-                var arityCandidates = GetCandidateMembers(apiType, effectiveOptions, memberName);
+                var arityCandidateTargets = GetTargetCandidates(apiType, effectiveOptions, memberName);
+                var unfilteredSelectorIndices = GetTargetCandidates(
+                        apiType,
+                        effectiveOptions with { MemberGenericArity = null },
+                        memberName)
+                    .ToDictionary(candidate => candidate.Member, candidate => candidate.SelectorIndex);
+                var arityCandidates = arityCandidateTargets.Select(candidate =>
+                {
+                    if (unfilteredSelectorIndices.TryGetValue(candidate.Member, out var selectorIndex))
+                        candidate.Member.SelectorOverloadIndex = selectorIndex;
+                    return candidate.Member;
+                }).ToList();
                 if (arityCandidates.Count == 0)
                 {
                     Console.Error.WriteLine($"Error: No members matched selector '{memberName}' with generic arity {effectiveOptions.MemberGenericArity.Value}.");
@@ -509,14 +520,17 @@ public static class MemberCommand
         select is { Length: 1 } && select[0].Equals(name, StringComparison.OrdinalIgnoreCase);
 
     private static List<ApiMember> GetCandidateMembers(ApiType apiType, MemberOptions options, string memberName)
+        => GetTargetCandidates(apiType, options, memberName)
+            .Select(candidate => candidate.Member)
+            .ToList();
+
+    private static IReadOnlyList<MemberTargetCandidate> GetTargetCandidates(ApiType apiType, MemberOptions options, string memberName)
         => MemberTargetResolver.GetCandidates(
                 apiType,
                 options.MemberGenericArity is { } arity
                     ? new MemberTargetSelector(memberName, memberName, GenericArity: arity)
                     : new MemberTargetSelector(memberName, memberName),
-                options.KindFilter)
-            .Select(candidate => candidate.Member)
-            .ToList();
+                options.KindFilter);
 
     private static string GetMemberSectionName(string kind) => kind switch
     {

--- a/src/dotnet-inspect/Inspectors/ApiTypeLookupService.cs
+++ b/src/dotnet-inspect/Inspectors/ApiTypeLookupService.cs
@@ -79,16 +79,13 @@ internal static class ApiTypeLookupService
         {
             var member = typeName[(dot + 1)..];
             var typeCandidate = typeName[..dot];
-            if (!member.Contains('<'))
-            {
-                var prefixLookup = TypeMatcher.Lookup(api.Types.Select(t => t.FullName), typeCandidate);
-                if (prefixLookup.Match != null)
-                    return new ApiTypeLookupResult(
-                        typeName,
-                        prefixLookup,
-                        api.Types.First(t => t.FullName == prefixLookup.Match),
-                        member);
-            }
+            var prefixLookup = TypeMatcher.Lookup(api.Types.Select(t => t.FullName), typeCandidate);
+            if (prefixLookup.Match != null)
+                return new ApiTypeLookupResult(
+                    typeName,
+                    prefixLookup,
+                    api.Types.First(t => t.FullName == prefixLookup.Match),
+                    member);
         }
 
         return new ApiTypeLookupResult(typeName, lookup, null);

--- a/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
+++ b/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
@@ -62,20 +62,24 @@ internal sealed record TypeMemberFindIfMissResult(
     TypeFindIfMissStatus Status,
     string Query,
     string TypeQuery,
+    string MemberSelector,
     string MemberName,
     int? OverloadIndex,
+    int? GenericArity,
     TypeFindIfMissResult TypeResolution)
 {
     public static TypeMemberFindIfMissResult None(string query) =>
-        new(TypeFindIfMissStatus.None, query, "", "", null, TypeFindIfMissResult.None(query));
+        new(TypeFindIfMissStatus.None, query, "", "", "", null, null, TypeFindIfMissResult.None(query));
 
     public static TypeMemberFindIfMissResult FromTypeResolution(
         string query,
         string typeQuery,
+        string memberSelector,
         string memberName,
         int? overloadIndex,
+        int? genericArity,
         TypeFindIfMissResult typeResolution) =>
-        new(typeResolution.Status, query, typeQuery, memberName, overloadIndex, typeResolution);
+        new(typeResolution.Status, query, typeQuery, memberSelector, memberName, overloadIndex, genericArity, typeResolution);
 
     public MemberOptions ApplyTo(MemberOptions options)
     {
@@ -83,7 +87,8 @@ internal sealed record TypeMemberFindIfMissResult(
         return applied with
         {
             MemberFilter = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { MemberName },
-            OverloadIndex = OverloadIndex
+            OverloadIndex = OverloadIndex,
+            MemberGenericArity = GenericArity
         };
     }
 
@@ -183,10 +188,10 @@ internal static class TypeFindIfMissResolver
         if (!TrySplitMemberQuery(query, out var typeQuery, out var memberSelector))
             return TypeMemberFindIfMissResult.None(query ?? "");
 
-        var (memberName, overloadIndex) = FqnParser.ParseMemberFilter(memberSelector);
+        var selector = MemberTargetSelector.Parse(memberSelector);
         var typeResolution = await ResolvePlatformAsync(typeQuery, includeAll, sourceOptions, httpClient, logger);
         return TypeMemberFindIfMissResult.FromTypeResolution(
-            query!, typeQuery, memberName, overloadIndex, typeResolution);
+            query!, typeQuery, memberSelector, selector.Name, selector.OverloadIndex, selector.GenericArity, typeResolution);
     }
 
     private static bool TrySplitMemberQuery(string? query, out string typeQuery, out string memberSelector)
@@ -204,7 +209,7 @@ internal static class TypeFindIfMissResolver
 
         typeQuery = query[..lastDot];
         memberSelector = query[(lastDot + 1)..];
-        var (memberName, _) = FqnParser.ParseMemberFilter(memberSelector);
+        var memberName = MemberTargetSelector.Parse(memberSelector).Name;
         if (typeQuery.EndsWith(".", StringComparison.Ordinal) &&
             memberName.Equals(".ctor", StringComparison.OrdinalIgnoreCase))
         {

--- a/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
+++ b/src/dotnet-inspect/Inspectors/TypeFindIfMissResolver.cs
@@ -203,7 +203,7 @@ internal static class TypeFindIfMissResolver
             || query.Contains('@') || query.Contains('/') || query.Contains('\\'))
             return false;
 
-        var lastDot = query.LastIndexOf('.');
+        var lastDot = FqnParser.LastTopLevelDot(query);
         if (lastDot <= 0 || lastDot == query.Length - 1)
             return false;
 

--- a/src/dotnet-inspect/Options/ApiOptions.cs
+++ b/src/dotnet-inspect/Options/ApiOptions.cs
@@ -170,6 +170,7 @@ public record MemberOptions : ApiOptions
     public bool CtorOnly { get; init; }
     public int? OverloadIndex { get; init; }
     public string? MemberDigest { get; init; }
+    public int? MemberGenericArity { get; init; }
     public bool ShowMemberIndex { get; init; }
     public MethodSourceContext? MethodSource { get; init; }
 

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -2206,44 +2206,7 @@ public static class ApiOutputFormatter
         => MetadataTypeNameFormatter.FormatFullName(type);
 
     internal static string GetMemberSignatureSortKey(ApiMember member)
-    {
-        var signature = member.Signature ?? "";
-        if (signature.Length == 0 || member.Name.Length == 0)
-            return signature;
-
-        var searchStart = 0;
-        while (searchStart < signature.Length)
-        {
-            var nameIndex = signature.IndexOf(member.Name, searchStart, StringComparison.Ordinal);
-            if (nameIndex < 0)
-                return signature;
-
-            var genericStart = nameIndex + member.Name.Length;
-            if (genericStart < signature.Length && signature[genericStart] == '<')
-            {
-                var depth = 0;
-                for (var i = genericStart; i < signature.Length; i++)
-                {
-                    if (signature[i] == '<')
-                        depth++;
-                    else if (signature[i] == '>')
-                    {
-                        depth--;
-                        if (depth == 0)
-                        {
-                            if (i + 1 < signature.Length && signature[i + 1] == '(')
-                                return signature.Remove(genericStart, i - genericStart + 1);
-                            break;
-                        }
-                    }
-                }
-            }
-
-            searchStart = nameIndex + member.Name.Length;
-        }
-
-        return signature;
-    }
+        => ApiMemberIdentity.GetMemberSignatureSortKey(member);
 
     internal static string GetMemberDisplaySignature(ApiType type, ApiMember member)
         => member.Signature ?? $"{FormatGenericFullName(type)}.{OperatorNames.FormatDisplayName(member.Name)}";

--- a/src/dotnet-inspect/Output/ApiOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/ApiOutputFormatter.cs
@@ -924,8 +924,9 @@ public static class ApiOutputFormatter
             overloadIndices[selectorName] = index;
 
             var anchor = ApiMemberIdentity.GetMemberAnchor(type, member);
-            var selector = overloadCounts[selectorName] > 1
-                ? $"{selectorName}:{index}"
+            var selectorIndex = member.SelectorOverloadIndex ?? index;
+            var selector = overloadCounts[selectorName] > 1 || member.SelectorOverloadIndex.HasValue
+                ? $"{selectorName}:{selectorIndex}"
                 : selectorName;
 
             rows.Add(new MemberIndexRow(

--- a/tests/ILInspector.Metadata.Tests/MemberTargetResolverTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MemberTargetResolverTests.cs
@@ -1,0 +1,192 @@
+namespace ILInspector.Metadata.Tests;
+
+public class MemberTargetResolverTests
+{
+    [Theory]
+    [InlineData("Name", "Name", null, null, null, null)]
+    [InlineData("Name:2", "Name", 2, null, null, null)]
+    [InlineData("Name~abc123", "Name", null, "abc123", null, null)]
+    [InlineData("M<T>", "M", null, null, null, 1)]
+    [InlineData("M<TKey,TValue>:3", "M", 3, null, null, 2)]
+    [InlineData(".ctor", ".ctor", null, null, null, null)]
+    [InlineData(".cctor", ".cctor", null, null, null, null)]
+    [InlineData("operator:op_Implicit:1", "op_Implicit", 1, null, "operator", null)]
+    [InlineData("explicit:System.IConvertible.ToBoolean", "System.IConvertible.ToBoolean", null, null, "explicit-interface-implementation", null)]
+    [InlineData("extension:AsMemory~abcdef", "AsMemory", null, "abcdef", "extension-method", null)]
+    public void Parse_PreservesSelectorSemantics(
+        string input,
+        string name,
+        int? overloadIndex,
+        string? digest,
+        string? kind,
+        int? genericArity)
+    {
+        var selector = MemberTargetSelector.Parse(input);
+
+        Assert.Equal(name, selector.Name);
+        Assert.Equal(overloadIndex, selector.OverloadIndex);
+        Assert.Equal(digest, selector.DigestPrefix);
+        Assert.Equal(kind, selector.Kind);
+        Assert.Equal(genericArity, selector.GenericArity);
+    }
+
+    [Fact]
+    public void Resolve_NameSelectsOnlyOverload()
+    {
+        var type = CreateSurface().Types[0];
+
+        var result = MemberTargetResolver.Resolve(type, MemberTargetSelector.Parse("Count"));
+
+        Assert.True(result.Found);
+        Assert.Equal("Count", result.Target!.ApiMember.Member.Name);
+        Assert.Equal(MemberTargetKind.Property, result.Target.Kind);
+        Assert.Equal("P:Sample.Widget.Count", result.Target.Anchor.CanonicalSignature);
+    }
+
+    [Fact]
+    public void Resolve_OverloadIndexUsesMemberIndexDisplayOrderButReturnsDeclaringIndex()
+    {
+        var type = CreateSurface().Types[0];
+
+        var result = MemberTargetResolver.Resolve(type, MemberTargetSelector.Parse("Run:1"));
+
+        Assert.True(result.Found);
+        Assert.Equal("void Run()", result.Target!.ApiMember.Member.Signature);
+        Assert.Equal(1, result.Target.SelectorIndex);
+        Assert.Equal(2, result.Target.DeclaringOverloadIndex);
+    }
+
+    [Fact]
+    public void Resolve_DigestPrefixSelectsStableAnchor()
+    {
+        var type = CreateSurface().Types[0];
+        var targetMember = type.Members.Single(member => member.Signature == "void Run(string value)");
+        var digest = ApiMemberIdentity.GetMemberAnchor(type, targetMember).Fingerprint[..6];
+
+        var result = MemberTargetResolver.Resolve(type, MemberTargetSelector.Parse($"Run~{digest}"));
+
+        Assert.True(result.Found);
+        Assert.Equal(targetMember.Signature, result.Target!.ApiMember.Member.Signature);
+        Assert.Equal(digest, result.Target.DigestPrefix);
+    }
+
+    [Fact]
+    public void Resolve_DigestPrefixCollisionReturnsTypedDiagnostic()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Sample",
+            Name = "Collision",
+            Members =
+            [
+                new ApiMember { Name = "Run", Kind = "method", Signature = "void Run()" },
+                new ApiMember { Name = "Run", Kind = "method", Signature = "void Run()" }
+            ]
+        };
+        var first = type.Members[0];
+        var digest = ApiMemberIdentity.GetMemberAnchor(type, first).Fingerprint[..1];
+
+        var result = MemberTargetResolver.Resolve(type, MemberTargetSelector.Parse($"Run~{digest}"));
+
+        Assert.False(result.Found);
+        Assert.Equal(MemberTargetDiagnosticKind.DigestAmbiguous, result.Diagnostic!.Kind);
+        Assert.Equal(2, result.Diagnostic.Candidates.Count);
+    }
+
+    [Fact]
+    public void Resolve_KindQualifiedExplicitMemberKeepsDottedMemberNameWhole()
+    {
+        var type = CreateSurface().Types[0];
+
+        var result = MemberTargetResolver.Resolve(
+            type,
+            MemberTargetSelector.Parse("explicit:System.IConvertible.ToBoolean:1"));
+
+        Assert.True(result.Found);
+        Assert.Equal("System.IConvertible.ToBoolean", result.Target!.ApiMember.Member.Name);
+        Assert.Equal(MemberTargetKind.ExplicitInterfaceImplementation, result.Target.Kind);
+    }
+
+    [Fact]
+    public void Resolve_GenericArityFiltersGenericMethod()
+    {
+        var type = CreateSurface().Types[0];
+
+        var result = MemberTargetResolver.Resolve(type, MemberTargetSelector.Parse("Map<T>:1"));
+
+        Assert.True(result.Found);
+        Assert.Equal("T Map<T>(T value)", result.Target!.ApiMember.Member.Signature);
+    }
+
+    [Fact]
+    public void Resolve_ExtensionMethodCarriesPhysicalBodyTarget()
+    {
+        var type = CreateSurface().Types[0];
+
+        var result = MemberTargetResolver.Resolve(type, MemberTargetSelector.Parse("extension:Normalize:1"));
+
+        Assert.True(result.Found);
+        Assert.Equal(MemberTargetKind.ExtensionMethod, result.Target!.Kind);
+        Assert.NotNull(result.Target.Body);
+        Assert.Equal("Sample.WidgetExtensions", result.Target.Body!.DeclaringType);
+        Assert.Equal(7, result.Target.Body.DeclaringOverloadIndex);
+    }
+
+    [Fact]
+    public void Resolve_MissingMemberReturnsTypedDiagnostic()
+    {
+        var type = CreateSurface().Types[0];
+
+        var result = MemberTargetResolver.Resolve(type, MemberTargetSelector.Parse("Missing"));
+
+        Assert.False(result.Found);
+        Assert.Equal(MemberTargetDiagnosticKind.MissingMember, result.Diagnostic!.Kind);
+        Assert.Empty(result.Diagnostic.Candidates);
+    }
+
+    static ApiSurface CreateSurface()
+        => new()
+        {
+            Types =
+            [
+                new ApiType
+                {
+                    Namespace = "Sample",
+                    Name = "Widget",
+                    Members =
+                    [
+                        new ApiMember { Name = "Run", Kind = "method", Signature = "void Run(string value)" },
+                        new ApiMember { Name = "Run", Kind = "method", Signature = "void Run()" },
+                        new ApiMember
+                        {
+                            Name = "Map",
+                            Kind = "method",
+                            Signature = "T Map<T>(T value)",
+                            SignatureModel = new ApiSignature
+                            {
+                                MemberName = "Map",
+                                TypeParameters = [new TypeParameter { Name = "T" }],
+                                Parameters = [new ApiParameter { Name = "value", Type = "T" }]
+                            }
+                        },
+                        new ApiMember { Name = "Count", Kind = "property" },
+                        new ApiMember
+                        {
+                            Name = "System.IConvertible.ToBoolean",
+                            Kind = "explicit-interface-implementation",
+                            Signature = "bool System.IConvertible.ToBoolean(System.IFormatProvider? provider)"
+                        },
+                        new ApiMember
+                        {
+                            Name = "Normalize",
+                            Kind = "extension-method",
+                            Signature = "public static string Normalize(this Sample.Widget widget)",
+                            DeclaringType = "Sample.WidgetExtensions",
+                            DeclaringOverloadIndex = 7,
+                            MetadataToken = 0x06000007
+                        }
+                    ]
+                }
+            ]
+        };
+}

--- a/tests/ILInspector.Metadata.Tests/MemberTargetResolverTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MemberTargetResolverTests.cs
@@ -119,6 +119,39 @@ public class MemberTargetResolverTests
     }
 
     [Fact]
+    public void Resolve_GenericArityPreservesDeclaringOverloadIndex()
+    {
+        var type = new ApiType
+        {
+            Namespace = "Sample",
+            Name = "GenericChoice",
+            Members =
+            [
+                new ApiMember { Name = "Choose", Kind = "method", Signature = "string Choose(string value)" },
+                new ApiMember
+                {
+                    Name = "Choose",
+                    Kind = "method",
+                    Signature = "T Choose<T>(T value)",
+                    SignatureModel = new ApiSignature
+                    {
+                        MemberName = "Choose",
+                        TypeParameters = [new TypeParameter { Name = "T" }],
+                        Parameters = [new ApiParameter { Name = "value", Type = "T" }]
+                    }
+                }
+            ]
+        };
+
+        var result = MemberTargetResolver.Resolve(type, MemberTargetSelector.Parse("Choose<T>:1"));
+
+        Assert.True(result.Found);
+        Assert.Equal("T Choose<T>(T value)", result.Target!.ApiMember.Member.Signature);
+        Assert.Equal(1, result.Target.SelectorIndex);
+        Assert.Equal(2, result.Target.DeclaringOverloadIndex);
+    }
+
+    [Fact]
     public void Resolve_ExtensionMethodCarriesPhysicalBodyTarget()
     {
         var type = CreateSurface().Types[0];


### PR DESCRIPTION
## Summary

- add `MemberTargetResolver` in `ILInspector.Metadata` for typed member selector parsing and semantic overload/digest resolution
- wire `member` selected-overload handling through the resolver while preserving declaring-overload routing for body sections
- document the member target resolution seam and add selector matrix coverage

Fixes #2392 (first implementation slice).

## Validation

- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -p:NoWarn=NU1507`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -class DotnetInspector.Tests.Parsers.SharedParsersTests -class DotnetInspector.Tests.Parsers.MemberOptionsParserTests -class DotnetInspector.Tests.ApiTypeLookupServiceTests`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -method DotnetInspector.Tests.CommandExecutionTests.Member_StringSupplementalSelectors_RoundTrip -method DotnetInspector.Tests.CommandExecutionTests.MemberCommand_AllowsCopiedNestedConstructorSelector -method DotnetInspector.Tests.CommandExecutionTests.MemberCommand_AllowsCopiedNestedConstructorDigestSelector`
- `npx markdownlint-cli docs/overview.md docs/design/member-target-resolution.md`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- smoke: `dotnet run --project src/dotnet-inspect -c Release -p:NoWarn=NU1507 -- member DateTime.operator:op_Addition:1 --platform System.Private.CoreLib -S Signature --tips q`

Full `dotnet-inspect.Tests` was also run; it compiled and ran but hit the pre-existing/network-sensitive `CliDiscoverySections_AreSelectable` SourceLink Integrity selection failure.

## Notes

This PR intentionally does not add a new `diff --target` CLI surface. It centralizes the resolver and wires the `member` command first so later diff/ResearchDiff targeting can consume the same typed shape instead of another parser tuple.
