### PR TITLE
Add RTS catalog Markout renderer

### DIFF
--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1197,6 +1197,14 @@ public class GeneratedFixtureCatalogTests
         Assert.Single(view.Research.Summary.ActionableSubjects);
         Assert.Single(view.FailedTargetBuckets);
         Assert.Single(view.FailedFixtures);
+
+        string markout = GeneratedFixtureRunner.FormatReturnToSenderCatalogMarkout(run, maxExamples: 10);
+        Assert.Contains("# ReturnToSender Catalog", markout);
+        Assert.Contains("## Summary", markout);
+        Assert.Contains("## Research evidence", markout);
+        Assert.Contains("## Actionable subjects", markout);
+        Assert.Contains("Method1~abcdef1234", markout);
+        Assert.Contains("il.operation.added: 1", markout);
         Assert.Contains("      il-display:", report);
         Assert.Contains("        il.operation.removed: h0 - IL_0000 ldc.i4 1", report);
         Assert.Contains("        il.operation.added: h0 + IL_0000 ldc.i4 2", report);

--- a/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/GeneratedFixtureCatalogTests.cs
@@ -1205,6 +1205,10 @@ public class GeneratedFixtureCatalogTests
         Assert.Contains("## Actionable subjects", markout);
         Assert.Contains("Method1~abcdef1234", markout);
         Assert.Contains("il.operation.added: 1", markout);
+        Assert.Contains("IL display:", markout);
+        Assert.Contains("- il.operation.removed: h0 - IL_0000 ldc.i4 1", markout);
+        Assert.Contains("IL diff:", markout);
+        Assert.Contains("- h0 + IL_0000 ldc.i4 2", markout);
         Assert.Contains("      il-display:", report);
         Assert.Contains("        il.operation.removed: h0 - IL_0000 ldc.i4 1", report);
         Assert.Contains("        il.operation.added: h0 + IL_0000 ldc.i4 2", report);

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Markout" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>

--- a/tools/DecompilerHarness/DecompilerHarness.csproj
+++ b/tools/DecompilerHarness/DecompilerHarness.csproj
@@ -21,6 +21,7 @@
     <!-- ILReader: the byte-match-validated IL reader the fidelity and annotation checks read the witness IL with. -->
     <ProjectReference Include="../../src/ILInspector.Metadata/ILInspector.Metadata.csproj" />
     <!-- Validity check: parse and bind the decompiled C# to measure validity. -->
+    <PackageReference Include="Markout" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
 

--- a/tools/DecompilerHarness/GeneratedFixtures.cs
+++ b/tools/DecompilerHarness/GeneratedFixtures.cs
@@ -2321,6 +2321,9 @@ internal static class GeneratedFixtureRunner
     public static string FormatReturnToSenderCatalogReport(GeneratedFixtureReturnToSenderRunResult run, int maxExamples)
         => ReturnToSenderCatalogReport.RenderPlain(ReturnToSenderCatalogReport.Build(run, maxExamples));
 
+    public static string FormatReturnToSenderCatalogMarkout(GeneratedFixtureReturnToSenderRunResult run, int maxExamples)
+        => ReturnToSenderCatalogReport.RenderMarkout(ReturnToSenderCatalogReport.Build(run, maxExamples));
+
     public static string FormatJson(GeneratedFixtureRunResult run)
     {
         var payload = new

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -215,6 +215,9 @@ static class Program
             }
         }
 
+        if (returnToSenderMarkout && !returnToSenderCatalog)
+            return Fail("--return-to-sender-markout requires --return-to-sender-catalog.");
+
         if (generatedFixtures)
         {
             if (inputs.Count > 0)

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -54,6 +54,7 @@ static class Program
         bool returnToSender = false;
         bool returnToSenderAb = false;
         bool returnToSenderCatalog = false;
+        bool returnToSenderMarkout = false;
         bool returnToSenderSourceProbe = false;
         string? returnToSenderFixtureGroup = null;
         bool fidelityTimings = false;
@@ -139,6 +140,7 @@ static class Program
                 case "--fidelity-check": fidelityCheck = true; break;
                 case "--return-to-sender": returnToSender = true; break;
                 case "--return-to-sender-ab": returnToSenderAb = true; break;
+                case "--return-to-sender-markout": returnToSenderMarkout = true; break;
                 case "--return-to-sender-source-probe": returnToSenderSourceProbe = true; break;
                 case "--return-to-sender-fixtures": returnToSenderFixtureGroup = args[++i]; break;
                 case "--return-to-sender-catalog":
@@ -226,7 +228,7 @@ static class Program
                 return Fail("--return-to-sender-fixtures supplies built assemblies; do not use it with --return-to-sender-catalog.");
             if (inputs.Count > 0)
                 return Fail("--return-to-sender-catalog generates its own temporary input assembly; do not pass assembly paths.");
-            return ReturnToSenderCatalog(returnToSenderCatalogSelector, keepGeneratedFixtures, json, maxExamples);
+            return ReturnToSenderCatalog(returnToSenderCatalogSelector, keepGeneratedFixtures, json, returnToSenderMarkout, maxExamples);
         }
 
         if (returnToSenderFixtureGroup is not null
@@ -405,11 +407,16 @@ static class Program
         return run.Passed ? 0 : 1;
     }
 
-    static int ReturnToSenderCatalog(string? selector, bool keepArtifacts, bool json, int maxExamples)
+    static int ReturnToSenderCatalog(string? selector, bool keepArtifacts, bool json, bool markout, int maxExamples)
     {
+        if (json && markout)
+            return Fail("--return-to-sender-markout cannot be combined with --json.");
+
         var fixtures = GeneratedFixtureCatalog.Select(selector);
         if (selector == "list")
         {
+            if (markout)
+                return Fail("--return-to-sender-markout does not apply to --return-to-sender-catalog list.");
             if (json)
                 Console.WriteLine(GeneratedFixtureRunner.FormatListJson(GeneratedFixtureCatalog.Catalog));
             else
@@ -429,7 +436,9 @@ static class Program
         }
         else
         {
-            Console.Write(GeneratedFixtureRunner.FormatReturnToSenderCatalogReport(run, maxExamples));
+            Console.Write(markout
+                ? GeneratedFixtureRunner.FormatReturnToSenderCatalogMarkout(run, maxExamples)
+                : GeneratedFixtureRunner.FormatReturnToSenderCatalogReport(run, maxExamples));
         }
         if (keepArtifacts && !json)
         {
@@ -1494,6 +1503,10 @@ static class Program
                                 and report pass/skip/fail frontier buckets.
                                 Use selector prefix or "list"; supports --json
                                 and --keep-generated-fixtures.
+          --return-to-sender-markout
+                                with --return-to-sender-catalog: render the
+                                catalog report as Markout Markdown instead of
+                                the legacy plain text report.
           --package <id[@version]>
                                 download/extract a NuGet package and add its
                                 selected managed assembly as input (use

--- a/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
+++ b/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
@@ -156,14 +156,14 @@ internal static class ReturnToSenderCatalogReport
             subject.CompileBackStatus ?? subject.RtsStatus ?? "unknown",
             subject.Detail ?? "-",
             string.Join(", ", subject.ChangeCounts.Select(count => $"{count.ChangeId}: {count.Count}")),
-            string.Join(Environment.NewLine, subject.IlEvidence.SelectMany(evidence =>
+            [.. subject.IlEvidence.SelectMany(evidence =>
             {
                 var lines = new List<string>();
                 if (evidence.Failure is { } failure)
                     lines.Add($"{evidence.ChangeId}: {failure.UnifiedLine}");
                 lines.AddRange(evidence.Rows.Select(row => $"{evidence.ChangeId}: {row.UnifiedLine}"));
                 return lines;
-            })));
+            })]);
 
     static ReturnToSenderBucketRow BucketRow(ReturnToSenderCatalogReportBucket bucket)
         => new(bucket.Key, bucket.Count);
@@ -174,9 +174,6 @@ internal static class ReturnToSenderCatalogReport
         string closure = row.ClosureEvidence is null
             ? ""
             : $"types={row.ClosureEvidence.RequiredTypes} members={row.ClosureEvidence.RequiredMembers} roslyn-types={row.ClosureEvidence.RoslynRecoveredTypes} roslyn-member-surfaces={row.ClosureEvidence.RoslynRecoveredMemberSurfaces}";
-        string ilDiff = row.IlDiffDiagnostic is null
-            ? ""
-            : string.Join(Environment.NewLine, IlDiffPrinter.ToUnifiedLines(row.IlDiffDiagnostic));
         return new ReturnToSenderFailedFixtureRow(
             fixtureId,
             row.DisplayMember,
@@ -186,7 +183,7 @@ internal static class ReturnToSenderCatalogReport
             row.MemberAnchor?.CanonicalSignature,
             closure,
             row.Detail,
-            ilDiff);
+            row.IlDiffDiagnostic is null ? [] : [.. IlDiffPrinter.ToUnifiedLines(row.IlDiffDiagnostic)]);
     }
 
     static IReadOnlyList<ReturnToSenderCatalogReportBucket> Buckets(IEnumerable<GeneratedFixtureReturnToSenderResult> rows)
@@ -338,7 +335,7 @@ internal sealed record ReturnToSenderActionableRow(
     string Status,
     string Detail,
     string Changes,
-    [property: MarkoutPropertyName("IL display")] string IlDisplay);
+    [property: MarkoutPropertyName("IL display")] List<string> IlDisplay);
 
 [MarkoutSerializable]
 internal sealed record ReturnToSenderBucketRow(string Bucket, int Count);
@@ -353,7 +350,7 @@ internal sealed record ReturnToSenderFailedFixtureRow(
     [property: MarkoutPropertyName("Canonical signature")] string? CanonicalSignature,
     string? Closure,
     string? Detail,
-    [property: MarkoutPropertyName("IL diff")] string? IlDiff);
+    [property: MarkoutPropertyName("IL diff")] List<string> IlDiff);
 
 [MarkoutSerializable]
 internal sealed record ReturnToSenderPassedFixtureRow(string Fixture);

--- a/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
+++ b/tools/DecompilerHarness/ReturnToSenderCatalogReport.cs
@@ -1,6 +1,8 @@
 using System.Text;
 using ILInspector.Instructions;
 using ILInspector.Research;
+using Markout;
+using Markout.Formatting;
 
 namespace ILInspector.DecompilerHarness;
 
@@ -107,6 +109,84 @@ internal static class ReturnToSenderCatalogReport
         AppendPassedFixtures(sb, view);
 
         return sb.ToString();
+    }
+
+    public static string RenderMarkout(ReturnToSenderCatalogReportView view)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+
+        var output = new StringWriter();
+        MarkoutSerializer.Serialize(
+            BuildMarkoutView(view),
+            output,
+            new MarkdownFormatter(),
+            ReturnToSenderCatalogReportContext.Default,
+            new MarkoutWriterOptions());
+        return output.ToString();
+    }
+
+    static ReturnToSenderCatalogMarkoutView BuildMarkoutView(ReturnToSenderCatalogReportView view)
+        => new()
+        {
+            Summary =
+            [
+                new("Fixtures", view.Fixtures.Passed, view.Fixtures.Skipped, view.Fixtures.Failed),
+                new("Targets", view.Targets.Passed, view.Targets.Skipped, view.Targets.Failed),
+            ],
+            ResearchEvidence = view.Research is null
+                ? null
+                : [
+                    new("Subjects", view.Research.Diff.Subjects.Count),
+                    new("RTS rows", view.Research.Diff.Subjects.SelectMany(subject => subject.Evidence).Count(row => row.Mechanism == ResearchDiffMechanism.ReturnToSender)),
+                    new("IL rows", view.Research.Diff.Subjects.SelectMany(subject => subject.Evidence).Count(row => row.Mechanism == ResearchDiffMechanism.IlBody)),
+                    .. view.Research.ChangeBuckets.Select(bucket => new ReturnToSenderResearchEvidenceRow(bucket.Key, bucket.Count)),
+                ],
+            ActionableSubjects = view.Research?.Summary.ActionableSubjects.Count > 0
+                ? [.. view.Research.Summary.ActionableSubjects.Select(ActionableRow)]
+                : null,
+            SkippedTargetReasons = view.SkippedTargetReasons.Count == 0 ? null : [.. view.SkippedTargetReasons.Select(BucketRow)],
+            FailedTargetBuckets = view.FailedTargetBuckets.Count == 0 ? null : [.. view.FailedTargetBuckets.Select(BucketRow)],
+            FailedFixtures = view.FailedFixtures.Count == 0 ? null : [.. view.FailedFixtures.SelectMany(fixture => fixture.Rows.Where(row => row.Status == GeneratedFixtureReturnToSenderStatus.Fail).Select(row => FailedRow(fixture.FixtureId, row)))],
+            PassedFixtures = view.PassedFixtures.Count == 0 ? null : [.. view.PassedFixtures.Select(fixture => new ReturnToSenderPassedFixtureRow(fixture.FixtureId))],
+        };
+
+    static ReturnToSenderActionableRow ActionableRow(ReturnToSenderActionableSubject subject)
+        => new(
+            subject.SubjectId,
+            subject.CompileBackStatus ?? subject.RtsStatus ?? "unknown",
+            subject.Detail ?? "-",
+            string.Join(", ", subject.ChangeCounts.Select(count => $"{count.ChangeId}: {count.Count}")),
+            string.Join(Environment.NewLine, subject.IlEvidence.SelectMany(evidence =>
+            {
+                var lines = new List<string>();
+                if (evidence.Failure is { } failure)
+                    lines.Add($"{evidence.ChangeId}: {failure.UnifiedLine}");
+                lines.AddRange(evidence.Rows.Select(row => $"{evidence.ChangeId}: {row.UnifiedLine}"));
+                return lines;
+            })));
+
+    static ReturnToSenderBucketRow BucketRow(ReturnToSenderCatalogReportBucket bucket)
+        => new(bucket.Key, bucket.Count);
+
+    static ReturnToSenderFailedFixtureRow FailedRow(string fixtureId, GeneratedFixtureReturnToSenderResult row)
+    {
+        string actual = row.ActualStatus?.ToString() ?? "Missing";
+        string closure = row.ClosureEvidence is null
+            ? ""
+            : $"types={row.ClosureEvidence.RequiredTypes} members={row.ClosureEvidence.RequiredMembers} roslyn-types={row.ClosureEvidence.RoslynRecoveredTypes} roslyn-member-surfaces={row.ClosureEvidence.RoslynRecoveredMemberSurfaces}";
+        string ilDiff = row.IlDiffDiagnostic is null
+            ? ""
+            : string.Join(Environment.NewLine, IlDiffPrinter.ToUnifiedLines(row.IlDiffDiagnostic));
+        return new ReturnToSenderFailedFixtureRow(
+            fixtureId,
+            row.DisplayMember,
+            actual,
+            row.Reason,
+            row.MemberAnchor?.StableSelector,
+            row.MemberAnchor?.CanonicalSignature,
+            closure,
+            row.Detail,
+            ilDiff);
     }
 
     static IReadOnlyList<ReturnToSenderCatalogReportBucket> Buckets(IEnumerable<GeneratedFixtureReturnToSenderResult> rows)
@@ -216,4 +296,76 @@ internal static class ReturnToSenderCatalogReport
         foreach (var fixture in view.PassedFixtures)
             sb.AppendLine($"  {fixture.FixtureId}");
     }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+internal sealed class ReturnToSenderCatalogMarkoutView
+{
+    [MarkoutIgnore]
+    public string Title => "ReturnToSender Catalog";
+
+    [MarkoutSection(Name = "Summary")]
+    public List<ReturnToSenderSummaryRow>? Summary { get; init; }
+
+    [MarkoutSection(Name = "Research evidence", EmptyText = "None")]
+    public List<ReturnToSenderResearchEvidenceRow>? ResearchEvidence { get; init; }
+
+    [MarkoutSection(Name = "Actionable subjects", EmptyText = "None")]
+    public List<ReturnToSenderActionableRow>? ActionableSubjects { get; init; }
+
+    [MarkoutSection(Name = "Skipped target reasons", EmptyText = "None")]
+    public List<ReturnToSenderBucketRow>? SkippedTargetReasons { get; init; }
+
+    [MarkoutSection(Name = "Failed target buckets", EmptyText = "None")]
+    public List<ReturnToSenderBucketRow>? FailedTargetBuckets { get; init; }
+
+    [MarkoutSection(Name = "Failed fixtures", EmptyText = "None")]
+    public List<ReturnToSenderFailedFixtureRow>? FailedFixtures { get; init; }
+
+    [MarkoutSection(Name = "Passed fixtures", EmptyText = "None")]
+    public List<ReturnToSenderPassedFixtureRow>? PassedFixtures { get; init; }
+}
+
+[MarkoutSerializable]
+internal sealed record ReturnToSenderSummaryRow(string Scope, int Passed, int Skipped, int Failed);
+
+[MarkoutSerializable]
+internal sealed record ReturnToSenderResearchEvidenceRow(string Metric, int Count);
+
+[MarkoutSerializable]
+internal sealed record ReturnToSenderActionableRow(
+    string Subject,
+    string Status,
+    string Detail,
+    string Changes,
+    [property: MarkoutPropertyName("IL display")] string IlDisplay);
+
+[MarkoutSerializable]
+internal sealed record ReturnToSenderBucketRow(string Bucket, int Count);
+
+[MarkoutSerializable]
+internal sealed record ReturnToSenderFailedFixtureRow(
+    string Fixture,
+    string Member,
+    string Status,
+    string Bucket,
+    [property: MarkoutPropertyName("Stable selector")] string? StableSelector,
+    [property: MarkoutPropertyName("Canonical signature")] string? CanonicalSignature,
+    string? Closure,
+    string? Detail,
+    [property: MarkoutPropertyName("IL diff")] string? IlDiff);
+
+[MarkoutSerializable]
+internal sealed record ReturnToSenderPassedFixtureRow(string Fixture);
+
+[MarkoutContextOptions(SuppressTableWarnings = true)]
+[MarkoutContext(typeof(ReturnToSenderCatalogMarkoutView))]
+[MarkoutContext(typeof(ReturnToSenderSummaryRow))]
+[MarkoutContext(typeof(ReturnToSenderResearchEvidenceRow))]
+[MarkoutContext(typeof(ReturnToSenderActionableRow))]
+[MarkoutContext(typeof(ReturnToSenderBucketRow))]
+[MarkoutContext(typeof(ReturnToSenderFailedFixtureRow))]
+[MarkoutContext(typeof(ReturnToSenderPassedFixtureRow))]
+internal sealed partial class ReturnToSenderCatalogReportContext : MarkoutSerializerContext
+{
 }


### PR DESCRIPTION
## Summary

- add `--return-to-sender-markout` for generated RTS catalog reports
- render Markout Markdown from `ReturnToSenderCatalogReportView`
- keep legacy plain text and JSON output unchanged
- add Markout view/context/section row types for Summary, Research evidence, Actionable subjects, Buckets, Failed fixtures, and Passed fixtures

This follows the recent IL/C# diff harness Markout pattern: typed view models first, Markout owns Markdown rendering.

## Validation

```text
dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-restore -- -filter "/*/*/GeneratedFixtureCatalogTests/*"
dotnet build src/dotnet-inspect/dotnet-inspect.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet
dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --return-to-sender-catalog minimal.property.literal --return-to-sender-markout --max-examples 3
dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --return-to-sender-catalog minimal.property.literal --json --return-to-sender-markout
```
