### PR TITLE
F2: inline single-use spill slots before materialization (#2386)

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -620,4 +620,29 @@ public class ExpressionInliningPassTests
         new ExpressionInliningPass().Run(full, PassContext.None);
         Assert.False(HasStoreLocal(full, 0));
     }
+
+    // increment-target guard (#2386 adversarial review): a stack slot whose only
+    // load is the operand of an increment is an lvalue — inlining it would emit
+    // an invalid `1++`. The gate declines it in both modes. This shape is
+    // unreachable from real IL (increment operands are local/argument places),
+    // but the guard keeps the pass correct by construction.
+    [Fact]
+    public void SlotFeedingIncrement_IsNotInlined()
+    {
+        IrFunction Make() => StraightLine(
+            [],
+            new StoreStackSlot(0, new Constant(1, Int32)),
+            new ExpressionStatement(new IncrementDecrement(
+                new LoadStackSlot(0, Int32), isIncrement: true, isPrefix: false)));
+
+        var gated = Make();
+        new ExpressionInliningPass(slotsOnly: true).Run(gated, PassContext.None);
+        Assert.True(HasStoreStackSlot(gated, 0));
+        Assert.Contains(gated.Descendants.OfType<LoadStackSlot>(), load => load.Slot == 0);
+        gated.CheckInvariant();
+
+        var full = Make();
+        new ExpressionInliningPass().Run(full, PassContext.None);
+        Assert.True(HasStoreStackSlot(full, 0));
+    }
 }

--- a/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ExpressionInliningPassTests.cs
@@ -567,4 +567,57 @@ public class ExpressionInliningPassTests
         Assert.True(HasStoreLocal(function, 0));
         Assert.Contains(function.Descendants.OfType<LoadLocal>(), load => load.Index == 0);
     }
+
+    // ---------------------------------------------------------------------
+    // slots-only (F2, #2386): the late pipeline run inlines single-use spill
+    // slots but must never touch user locals — by that point
+    // IncrementDecrementPass has folded `x = x + 1` into `x++`, whose hidden
+    // store makes a multiply-assigned local look single-use; inlining a
+    // constant into it would emit an invalid `1++`. These pin the gate: a
+    // stack slot inlines under slotsOnly, an identical user local does not
+    // (while the default full run still inlines it — proving the mode is the
+    // only difference).
+    // ---------------------------------------------------------------------
+
+    // slots-only positive: a single-store single-use synthetic stack slot with
+    // a pure value inlines into its consumer.
+    [Fact]
+    public void SlotsOnly_SingleUseStackSlot_Inlines()
+    {
+        var use = new MethodRef(Holder, "Use", Void, [Int32], HasThis: false);
+        var function = StraightLine(
+            [],
+            new StoreStackSlot(0, new Constant(5, Int32)),
+            new ExpressionStatement(new Call(use, isVirtual: false, [new LoadStackSlot(0, Int32)])));
+
+        new ExpressionInliningPass(slotsOnly: true).Run(function, PassContext.None);
+
+        Assert.False(HasStoreStackSlot(function, 0));
+        Assert.Empty(function.Descendants.OfType<LoadStackSlot>());
+        function.CheckInvariant();
+    }
+
+    // slots-only refuting negative: the identical shape on a user local is
+    // declined by slotsOnly (the local stays) yet still inlined by the default
+    // run — so a reconstructed `x++` can never be fed a constant late.
+    [Fact]
+    public void SlotsOnly_SingleUseUserLocal_StaysWhileDefaultInlines()
+    {
+        var use = new MethodRef(Holder, "Use", Void, [Int32], HasThis: false);
+
+        IrFunction Make() => StraightLine(
+            [Int32],
+            new StoreLocal(0, Int32, new Constant(5, Int32)),
+            new ExpressionStatement(new Call(use, isVirtual: false, [new LoadLocal(0, Int32)])));
+
+        var gated = Make();
+        new ExpressionInliningPass(slotsOnly: true).Run(gated, PassContext.None);
+        Assert.True(HasStoreLocal(gated, 0));
+        Assert.Contains(gated.Descendants.OfType<LoadLocal>(), load => load.Index == 0);
+        gated.CheckInvariant();
+
+        var full = Make();
+        new ExpressionInliningPass().Run(full, PassContext.None);
+        Assert.False(HasStoreLocal(full, 0));
+    }
 }

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -21,19 +21,41 @@ namespace ILInspector.Decompiler.Pipeline;
 /// in between writes what the value reads. Effect-free values reorder freely;
 /// the interference scan keeps a value that reads a place from crossing a write
 /// to it.</para>
+///
+/// <para><c>slotsOnly</c> restricts <see cref="InlineOnce"/> to synthetic stack
+/// slots (never user locals). This is the F2 mode (#2386): the pass runs a third
+/// time late in the pipeline — before <see cref="SlotMaterializationPass"/> — to
+/// inline the single-use spill slots that structuring and reconstruction mint
+/// after the earlier runs, which would otherwise materialize as
+/// <c>T S_n = expr;</c> declarations. It must stay slots-only there because by
+/// that point <see cref="IncrementDecrementPass"/> has folded
+/// <c>x = x + 1</c> into <c>x++</c>; a reconstructed increment hides a store
+/// from the single-store/single-load keys, so inlining a user local into it
+/// would emit an invalid <c>1++</c> (#2379 piece 1 census). Stack slots are the
+/// compiler's spill scratch and are never the target of increment
+/// reconstruction, so the slots-only late run is regression-free.</para>
 /// </summary>
 public sealed class ExpressionInliningPass : IIrPass
 {
     public string Name => "expression-inlining";
 
+    readonly bool _slotsOnly;
+
+    /// <param name="slotsOnly">
+    /// When true, <see cref="InlineOnce"/> considers only synthetic stack slots,
+    /// not user locals — the F2 late-run contract (#2386). Defaults to false so
+    /// the early full-pipeline runs are unchanged.
+    /// </param>
+    public ExpressionInliningPass(bool slotsOnly = false) => _slotsOnly = slotsOnly;
+
     public void Run(IrFunction function, PassContext context)
     {
-        while (InlineOnce(function, context) || InlineLiveRangeOnce(function, context))
+        while (InlineOnce(function, context, _slotsOnly) || InlineLiveRangeOnce(function, context))
         {
         }
     }
 
-    static bool InlineOnce(IrFunction function, PassContext context)
+    static bool InlineOnce(IrFunction function, PassContext context, bool slotsOnly)
     {
         var locals = new Dictionary<(bool IsSlot, int Index), (List<IrNode> Loads, List<IrNode> Stores, bool AddressTaken)>();
         var argumentAddresses = new HashSet<int>();
@@ -61,6 +83,12 @@ public sealed class ExpressionInliningPass : IIrPass
 
         foreach (var ((isSlot, _), (loads, stores, addressTaken)) in locals)
         {
+            // F2 (#2386): the late run inlines only synthetic stack slots. A user
+            // local reaching a reconstructed `x++` looks single-use (the folded
+            // increment hides its store), so inlining a constant into it would
+            // emit an invalid `1++`.
+            if (slotsOnly && !isSlot)
+                continue;
             if (addressTaken || loads.Count != 1 || stores.Count != 1)
                 continue;
             var store = stores[0];

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ExpressionInliningPass.cs
@@ -95,6 +95,15 @@ public sealed class ExpressionInliningPass : IIrPass
             var load = loads[0];
             if (IsInsideCatchFilter(load))
                 continue;
+            // A load that is the target of an increment/decrement is an lvalue,
+            // not a value use: replacing it with the stored expression yields an
+            // invalid `1++`. Unreachable from real IL today (a reconstructed
+            // increment's operand is always a local/argument place, and its dup
+            // slot is read twice so it is never single-load), but guarded so the
+            // pass is correct by construction rather than by reachability (#2386
+            // adversarial review).
+            if (load.Parent is IncrementDecrement)
+                continue;
             var block = (Block)store.Parent!;
             IrNode next;
             if (store.ChildIndex + 1 < block.Children.Count)
@@ -231,6 +240,12 @@ public sealed class ExpressionInliningPass : IIrPass
                     }
                 }
                 if (blocked || use is null || useStatement is null)
+                    continue;
+
+                // An increment/decrement target is an lvalue, never a value use;
+                // replacing it with the moved expression yields an invalid `1++`
+                // (see InlineOnce). Correct-by-construction guard (#2386).
+                if (use.Parent is IncrementDecrement)
                     continue;
 
                 // A value that reads places must still evaluate first at the use

--- a/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/IrPass.cs
@@ -325,6 +325,15 @@ public static class IrPasses
         // target in a Coerce node, so the printer receives a decided tree and
         // CoercionInvariant is checkable (value-typed-emission.md, slice 3).
         // Nothing may reshape sink values after this.
+        // F2 (#2386): a final slots-only inlining run collapses the single-use
+        // spill slots that structuring/reconstruction minted after the earlier
+        // ExpressionInliningPass runs, so they render as their value expression
+        // at the consumer instead of materializing as `T S_n = expr;`. It must
+        // precede SlotMaterializationPass (once a slot is a typed local there is
+        // nothing to inline) and stay slots-only (a user local reaching a
+        // reconstructed `x++` would inline to an invalid `1++`; see the pass
+        // doc and #2379 piece 1 census).
+        new ExpressionInliningPass(slotsOnly: true),
         // A decided in-domain slot (one testified type, all stores at it or
         // renderably coercible) is a finished variable: materialize it as a
         // typed local BEFORE insertion, so its minted locals are coerced at


### PR DESCRIPTION
- Advances #2386 (F2), part of #2379 piece 1 / #2095 thin-writer trajectory
- Changes: a single-use spill stack slot minted after the last `ExpressionInliningPass` run now renders as its value expression at the consumer instead of `T S_n = expr;`
- Card revision: `6a456cc8`

## Change

> Should we accept this change?

**Conclusion:** **PASS** — a slots-only `ExpressionInliningPass` run placed before `SlotMaterializationPass` inlines the residual single-use spill slots; measured 50 valid improvements, **0 regressions**, +6 fully-raised.

This is the F2 slice, informed by the [Stage-0 census](https://github.com/richlander/dotnet-inspect/issues/2386#issuecomment-4887873952). `ExpressionInliningPass` last runs at `IrPass.cs:184`; ~15 structuring/reconstruction passes then mint fresh single-use spill slots that are never offered to inlining before `SlotMaterializationPass` materializes them as `T S_n = expr;`. A final **slots-only** run collapses them.

Why slots-only is non-negotiable at this position: by then `IncrementDecrementPass` has folded `x = x + 1` into `x++`, whose hidden store makes a multiply-assigned **user local** look single-use — inlining a constant into it emits an invalid `1++` (CS0131). The census measured 12–14 such regressions for a blanket re-run; restricting to stack slots (spill scratch, never increment-reconstructed) yields **0**. Reuses the existing pass rather than adding a fifth slot def-use approximation (#2379 piece 1).

Before:

```csharp
byte[] S_256 = new byte[] { 0, 1, 2, 3, ... };
XmlCharType.s_charPropertiesIndex = S_256;

MethodSymbol S_1 = (debugEntryPoint as MethodSymbol)?.UnderlyingMethodSymbol;
MethodSymbol methodSymbol = S_1;
CSharpCompilation S_256 = methodSymbol?.DeclaringCompilation;
if (S_256 != this || !methodSymbol.IsDefinition)
```

After:

```csharp
XmlCharType.s_charPropertiesIndex = new byte[] { 0, 1, 2, 3, ... };

MethodSymbol methodSymbol = (debugEntryPoint as MethodSymbol)?.UnderlyingMethodSymbol;
if (methodSymbol?.DeclaringCompilation != this || !methodSymbol.IsDefinition)
```

## Evidence

Pinned 14-assembly corpus, 89,065 methods, merge-base `db97d546`.

| Check | Result |
| --- | --- |
| Product build | Pass |
| Focused tests | `ExpressionInliningPassTests` 23/23 (2 new F2 canaries), `SlotMaterializationPassTests` 5/5, `SlotStoreDiamondPassTests` 12/12, `IdempotenceSensorTests` 1/1 |
| Render A/B vs merge-base | 55 changed (50 structural, 0 paren-equivalent, 5 pre-existing-invalid), 0 added, 0 removed |
| Semantic gate (Roslyn syntax) | **0 newly-broken** (50 both-parse, 5 pre-existing-invalid-both) |
| Semantic gate (inline-into-mutation) | **0** new `<literal>++` / `1++` |
| Idempotence (corpus) | second-run rewrites **1299 → 1246**; `expression-inlining` 722 → 669; no new non-idempotence |
| Real witnesses | `XmlCharType::.cctor`, `DateTimeUtils::.cctor`, `CSharpCompilation::ValidateDebugEntryPoint` |

**Why the semantic gate is listed separately:** `1++` is a *semantic* error (CS0131), so the parse-tree A/B classifier (#2384) reports it as valid — the census found it would wave 12–14 blanket-run regressions through. This PR adds an explicit inline-into-mutation scan; the slots-only design makes it 0 by construction.

## Decompiler quality

> Should the corpus signal block this PR?

**Conclusion:** **PASS (advisory)** — pinned subset improves (Fully raised 88.02% → 88.03%, +6 methods; Full malformed 0); the tool's "regressions" list is purely PR quick-cap (`--compile-cap 25`) vs the daily baseline caps, not quality.

### Tool-generated quality-diff card

```
| Metric (desired direction) | Baseline | PR | Count delta |
| Fully raised (+) | 78,399 (88.02%) | 78,405 (88.03%) | +6 |
| Conditional-branch residual (-) | 2,401 (2.70%) | 2,401 (2.70%) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) | 2,286 (2.57%) | 0 |
| Full malformed (-) | 0 | 0 | 0 |
| Semantic defects (-) | 74/25,179 | 2/350 | (cap-coverage, not comparable) |
| Fidelity diffs (-) | opcode 5/36, exact 31 | opcode 3/24, exact 21 | -2 |
| Pass bugs (-) | 0 | 0 | 0 |
```

Flagged "regressions" are cap-coverage only: `validity cap 4000 → 25`, `semantic checked 25,179 → 350`, `fidelity checked 36 → 24` — the daily job runs full caps.

## Review

Adversarial review (two models) requested per repo policy — this is a behavior-changing decompiler PR. Attack surfaces: the slots-only gate vs the `1++` class, the `ForReconstruction` pipeline inheriting the late run (SlotMaterializationPass is filtered there but the F2 run is not), and EH/loop safety inherited from the existing gate.
