### PR TITLE
Migrate decompiler fixture paths to catalog

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpBodyDiffTests.cs
@@ -8,7 +8,7 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_SelfDiffHasNoRows()
     {
-        var path = DiffFixturePath("DiffFixtures.V1");
+        var path = FixtureCatalog.DiffPair.OldAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(path, path);
 
@@ -19,8 +19,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_ConstantChangeSurfacesProductCSharpRows()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
 
@@ -55,8 +55,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_GenericParameterRenameDoesNotBreakMethodIdentity()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
 
@@ -66,8 +66,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_GenericMethodCanonicalSignatureUsesMethodGenericParameter()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
 
@@ -81,8 +81,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_TokenTargetChangeIsNotSkippedByFastPath()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
 
@@ -309,8 +309,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_ProtectedMethodsAreIncludedInDefaultSurface()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ProtectedSample" });
 
@@ -327,8 +327,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_GenericArityOverloadsDoNotCollide()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "GenericOverloadSample" });
 
@@ -346,7 +346,7 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_DuplicateInputPathsDoNotThrowOrCreateRows()
     {
-        var path = DiffFixturePath("DiffFixtures.V1");
+        var path = FixtureCatalog.DiffPair.OldAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies([path, path], [path, path], typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
 
@@ -356,8 +356,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_OneSidedDuplicateInputPathsKeepMatchingStable()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies([v1, v1], [v2], typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "DiffSample" });
 
@@ -374,7 +374,7 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_DistinctPathsWithSameAssemblyIdentityRemainOccurrenceDistinct()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
         var copy = Path.Combine(Path.GetTempPath(), $"DiffFixtureSample-{Guid.NewGuid():N}.dll");
         File.Copy(v1, copy);
         try
@@ -393,8 +393,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_GenericTypeArityDoesNotCollapseDeclaringTypes()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "*GenericTypeAritySample*" });
 
@@ -412,8 +412,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_NestedGenericDeclaringArityDoesNotCollapse()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "*NestedGenericOuter*" });
 
@@ -431,8 +431,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_ConstructorsUseMemberIndexCanonicalName()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConstructorSample" });
 
@@ -446,8 +446,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_ConversionOperatorsIncludeReturnTypeInCanonicalSignature()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ConversionSample" });
 
@@ -504,8 +504,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_CheckedConversionOperatorsIncludeReturnTypeInCanonicalSignature()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CheckedConversionSample" });
 
@@ -519,8 +519,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_TypeAndMethodGenericParametersStayDistinct()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "*GenericParameterCollisionSample*" });
 
@@ -534,8 +534,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_MethodRemovalUsesMethodLevelMessage()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "MethodRemovalSample" });
 
@@ -553,8 +553,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_NoBodyToBodyUsesSyntheticBodyAddedRow()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "BodyStateSample" });
 
@@ -578,8 +578,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_BodyToNoBodyUsesSyntheticBodyRemovedRow()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v2, v1, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "BodyStateSample" });
 
@@ -603,8 +603,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void Printer_FailureRows_RenderFromStructuredFailureRows()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "BodyStateSample" });
 
@@ -622,8 +622,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_ExplicitInterfaceImplementationsAreInDefaultSurface()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "ExplicitSurface" });
 
@@ -640,8 +640,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_InternalExplicitInterfaceImplementationsStayOutOfDefaultSurface()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "InternalExplicitSurface" });
 
@@ -651,8 +651,8 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_DefaultSurfaceSkipsInternalTypesAndTheirNestedPublicTypes()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "InternalSurfaceSample" });
 
@@ -666,21 +666,12 @@ public class CSharpBodyDiffTests
     [Fact]
     public void CompareAssemblies_GlobTypeFilterCanLimitRows()
     {
-        var v1 = DiffFixturePath("DiffFixtures.V1");
-        var v2 = DiffFixturePath("DiffFixtures.V2");
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
 
         var diff = CSharpBodyDiff.CompareAssemblies(v1, v2, typeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "*NoSuchType" });
 
         Assert.Empty(diff.Rows);
     }
 
-    static string DiffFixturePath(string project)
-    {
-        var outputDirectory = new DirectoryInfo(
-            AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
-        string path = Path.GetFullPath(Path.Combine(
-            outputDirectory.FullName, "..", "..", project, outputDirectory.Name, "DiffFixtureSample.dll"));
-        Assert.True(File.Exists(path), $"Expected diff fixture assembly at {path}");
-        return path;
-    }
 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -1,3 +1,4 @@
+using DotnetInspector.Fixtures;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Metadata;
 using Microsoft.CodeAnalysis;
@@ -996,7 +997,7 @@ public class IrImporterTests
         // Release can materialize a pointer through a native-int stack slot before
         // an indirect read/write. Deref-ing the slot itself (`*S_257`) is CS0193;
         // the access must cast the native int back to the opcode's pointer type.
-        using var source = MetadataSource.Open(typeof(ILInspector.Decompiler.Fixtures.UnsafeChainA.LibraryA).Assembly.Location);
+        using var source = MetadataSource.Open(FixtureCatalog.DecompilerUnsafeChainA.AssemblyPath());
         var function = IrImporter.Import(
             source,
             typeof(ILInspector.Decompiler.Fixtures.UnsafeChainA.LibraryA).FullName!,
@@ -2716,7 +2717,7 @@ public class RaisingPassTests
         // A stackalloc expression cannot be returned directly as a pointer, nor
         // explicitly cast in expression position (CS8346). Route it through a
         // pointer local and cast that local to the signature's pointer type.
-        using var source = MetadataSource.Open(typeof(ILInspector.Decompiler.Fixtures.UnsafeChainA.LibraryA).Assembly.Location);
+        using var source = MetadataSource.Open(FixtureCatalog.DecompilerUnsafeChainA.AssemblyPath());
         var function = IrImporter.Import(
             source,
             typeof(ILInspector.Decompiler.Fixtures.UnsafeChainA.LibraryA).FullName!,

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reflection.PortableExecutable;
+using DotnetInspector.Fixtures;
 using ILInspector.Decompiler;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.DecompilerHarness;
@@ -23,11 +24,11 @@ namespace ILInspector.Decompiler.Tests;
 /// </summary>
 public class LadderRung6GateTests
 {
-    static readonly string NewUnsafePath = typeof(NewUnsafe).Assembly.Location;
-    static readonly string LegacyUnsafePath = typeof(LegacyUnsafe).Assembly.Location;
+    static readonly string NewUnsafePath = FixtureCatalog.DecompilerUnsafeNew.AssemblyPath();
+    static readonly string LegacyUnsafePath = FixtureCatalog.DecompilerUnsafeLegacy.AssemblyPath();
     static readonly string NewUnsafeType = typeof(NewUnsafe).FullName!;
     static readonly string LegacyUnsafeType = typeof(LegacyUnsafe).FullName!;
-    static readonly string ByRefFixturePath = typeof(LadderRung4.CSharp7LocalSyntax).Assembly.Location;
+    static readonly string ByRefFixturePath = FixtureCatalog.DecompilerLadderRung4.AssemblyPath();
     static readonly string ByRefFixtureType = typeof(LadderRung4.CSharp7LocalSyntax).FullName!;
 
     static readonly string[] ExpectedUnsafeMembers =


### PR DESCRIPTION
## Change

Migrates selected `ILInspector.Decompiler.Tests` built fixture assembly lookups to `FixtureCatalog`:

- `CSharpBodyDiffTests` now uses `FixtureCatalog.DiffPair` instead of a local `DiffFixturePath` helper.
- `IrImporterTests` unsafe-chain fixture imports now use `FixtureCatalog.DecompilerUnsafeChainA`.
- `LadderRung6GateTests` now uses catalog paths for new/legacy unsafe and ladder rung 4 by-ref fixtures.

This removes bespoke physical path construction for these decompiler fixture consumers while keeping type names from referenced fixture types where the tests need metadata names. No fixture library reshaping and no product behavior change.

## Validation

```bash
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity minimal
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -filter "/*/*/CSharpBodyDiffTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -filter "/*/*/LadderRung6GateTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -filter "/*/*/IrImporterTests/NativeIntAddressSlot_DerefsAsItsOwnPointerType_NotNativeInt"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -filter "/*/*/RaisingPassTests/StackAlloc_ReturningPointer_PrintsPointerLocal"
git diff --check
```

Fixture/test infrastructure only; no product behavior change.
