### PR TITLE
Target analysis diff by member resolver

### DIFF
--- a/docs/design/member-target-resolution.md
+++ b/docs/design/member-target-resolution.md
@@ -27,8 +27,8 @@ diagnostic instead of falling back to partial string matching.
 
 - Lexical command helpers may still identify source/type/member argument slots,
   but semantic member resolution should flow through `MemberTargetResolver`.
-- Commands that target API changes, such as `diff -m/--member`, should resolve
-  selectors against the old/new API surfaces and filter by the resulting
+- Commands that target API or body changes, such as `diff -m/--member`, should
+  resolve selectors against the old/new API surfaces and filter by the resulting
   `MemberAnchor` identities rather than by re-parsing display text.
 - `MemberAnchor` remains the durable user/agent-facing identity; producer-native
   references remain producer evidence and should not be replaced by selectors.

--- a/docs/workflows/discovery/api-diff.md
+++ b/docs/workflows/discovery/api-diff.md
@@ -129,6 +129,12 @@ Use a type-qualified selector when there is no `-t` context:
 dotnet-inspect diff System.Text.Json@9.0.0..10.0.0 -m JsonSerializer.Serialize<TValue>:1 -v:q
 ```
 
+Member filters also target body-signal diffs:
+
+```bash
+dotnet-inspect diff --library old/Foo.dll..new/Foo.dll -S "Analysis Diff" -m MyType.HotPath --changed
+```
+
 ## 6. Name-only output
 
 > Goal: Get a quick list of which types changed, without details.

--- a/src/ILInspector.Analysis.Tests/BodySignalDiffTests.cs
+++ b/src/ILInspector.Analysis.Tests/BodySignalDiffTests.cs
@@ -48,6 +48,24 @@ public class BodySignalDiffTests
     }
 
     [Fact]
+    public void CompareUnsafe_MethodKeyDistinguishesSameNameDifferentGenericArity()
+    {
+        var method1 = DiffMethod(TypeRef.Definition("Asm", "Ns", "UnsafeApi"), "Use");
+        var method2 = DiffMethod(TypeRef.Definition("Asm", "Ns", "UnsafeApi"), "Use") with { GenericArity = 1 };
+        var oldIndex = LibraryBodyIndex.FromEvidence(
+            [method1],
+            [new UnsafeEvidence(method1, "Unsafe operation", "stackalloc", "opcode", 0, null)]);
+        var newIndex = LibraryBodyIndex.FromEvidence(
+            [method2],
+            [new UnsafeEvidence(method2, "Unsafe operation", "stackalloc", "opcode", 0, null)]);
+
+        var diff = BodySignalDiff.CompareUnsafe(oldIndex, newIndex);
+
+        Assert.Contains(diff.Rows, row => row.Kind == BodySignalDiffKind.Removed);
+        Assert.Contains(diff.Rows, row => row.Kind == BodySignalDiffKind.Added);
+    }
+
+    [Fact]
     public void CompareUnsafe_PreservesCountOfRepeatedUnsafeOperations()
     {
         var method = DiffMethod(TypeRef.Definition("Asm", "Ns", "UnsafeApi"), "Use");

--- a/src/ILInspector.Analysis/BodySignalDiff.cs
+++ b/src/ILInspector.Analysis/BodySignalDiff.cs
@@ -134,7 +134,7 @@ public static class BodySignalDiff
             fact.Evidence);
 
     static string MethodKey(MethodIdentity method)
-        => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
+        => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{method.GenericArity}|{method.IsExtension}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
 
     sealed record UnsafeFact(string MemberKey, string Signal, string Operation, int? ILOffset, string Evidence);
 }

--- a/src/ILInspector.Analysis/ILInspector.Analysis.csproj
+++ b/src/ILInspector.Analysis/ILInspector.Analysis.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ILInspector.Analysis.Tests" />
+    <InternalsVisibleTo Include="ILInspector.Research.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Fixtures;
+using ILInspector.Analysis;
 using ILInspector.Decompiler;
 using ILInspector.Metadata;
 using ILInspector.Instructions;
@@ -333,6 +334,31 @@ public class ResearchDiffTests
             new ResearchDiffOptions(
                 ResearchDiffMechanism.BodySignals,
                 TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "NoSuchType" }));
+
+        Assert.Empty(diff.MembersWhere(member => member.HasChange("unsafe.stackalloc.added")));
+    }
+
+    [Fact]
+    public void CompareAssemblies_BodySignals_SuppressesGeneratedUnsafeRows()
+    {
+        var method = new MethodIdentity(
+            "Asm",
+            Guid.Empty,
+            TypeRef.Definition("Asm", "Generated", "<JsonContext>g__Generated|0_0"),
+            "Use",
+            [],
+            TypeRef.CoreLib("System", "Void"),
+            MetadataToken: 0x06000001,
+            IsStatic: true);
+        var oldIndex = LibraryBodyIndex.FromEvidence([method], []);
+        var newIndex = LibraryBodyIndex.FromEvidence(
+            [method],
+            [new UnsafeEvidence(method, "Unsafe operation", "stackalloc", "opcode", 0, null)]);
+
+        var diff = ResearchDiff.Compare(
+            ResearchDiffInput.FromAssembly("old.dll", bodyIndex: oldIndex),
+            ResearchDiffInput.FromAssembly("new.dll", bodyIndex: newIndex),
+            new ResearchDiffOptions(ResearchDiffMechanism.BodySignals));
 
         Assert.Empty(diff.MembersWhere(member => member.HasChange("unsafe.stackalloc.added")));
     }

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -302,6 +302,42 @@ public class ResearchDiffTests
     }
 
     [Fact]
+    public void CompareAssemblies_BodySignals_MemberTargetsKeepUnsafeRows()
+    {
+        var unfiltered = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(ResearchDiffMechanism.BodySignals));
+        var targetId = Assert.Single(unfiltered.MembersWhere(member =>
+            member.Subject.Display.Contains("AddsUnsafe", StringComparison.Ordinal)
+            && member.HasChange("unsafe.stackalloc.added"))).Subject.Id;
+
+        var filtered = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(
+                ResearchDiffMechanism.BodySignals,
+                MemberTargetIdentities: new HashSet<string>(StringComparer.Ordinal) { targetId }));
+
+        var changed = Assert.Single(filtered.MembersWhere(member => member.HasChange("unsafe.stackalloc.added")));
+        Assert.Equal(targetId, changed.Subject.Id);
+        Assert.Contains("AddsUnsafe", changed.Subject.Display);
+    }
+
+    [Fact]
+    public void CompareAssemblies_BodySignals_TypeFiltersApplyToUnsafeRows()
+    {
+        var diff = ResearchDiff.CompareAssemblies(
+            FixtureCatalog.DiffPair.OldAssemblyPath(),
+            FixtureCatalog.DiffPair.NewAssemblyPath(),
+            new ResearchDiffOptions(
+                ResearchDiffMechanism.BodySignals,
+                TypeFilters: new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "NoSuchType" }));
+
+        Assert.Empty(diff.MembersWhere(member => member.HasChange("unsafe.stackalloc.added")));
+    }
+
+    [Fact]
     public void CompareAssemblies_IlBody_QueryImplementationChanges()
     {
         var diff = ResearchDiff.CompareAssemblies(

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -338,10 +338,12 @@ public static class ResearchDiff
         {
             AddAnalysisSignalDiff(builder, oldIndex, newIndex, typeFilters, memberTargetIdentities);
 
-            var methods = MethodSubjectsByBodySignalKey(oldIndex, newIndex, memberTargetIdentities);
+            var methods = MethodSubjectsByUnsafeSignalKey(oldIndex, newIndex);
             foreach (var row in BodySignalDiff.CompareUnsafe(oldIndex, newIndex).Rows)
             {
                 var subject = methods.GetValueOrDefault(row.Member) ?? UnknownMemberSubject(row.Member);
+                if (!MatchesTypeFilters(subject.TypeName ?? "", typeFilters))
+                    continue;
                 if (!MatchesMemberTargets(subject, memberTargetIdentities))
                     continue;
                 var direction = row.Kind == BodySignalDiffKind.Added ? ResearchDiffDirection.Added : ResearchDiffDirection.Removed;
@@ -789,6 +791,12 @@ public static class ResearchDiff
            || memberTargetIdentities.Count == 0
            || memberTargetIdentities.Contains(subject.Id);
 
+    static Dictionary<string, ResearchSubjectKey> MethodSubjectsByUnsafeSignalKey(LibraryBodyIndex oldIndex, LibraryBodyIndex newIndex)
+        => oldIndex.Methods.Concat(newIndex.Methods)
+            .Select(method => (Key: UnsafeSignalMethodKey(method), Subject: SubjectFromMethod(method)))
+            .GroupBy(entry => entry.Key, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.Last().Subject, StringComparer.Ordinal);
+
     static ResearchSubjectKey ApiSubject(ApiSurface oldSurface, ApiSurface newSurface, string typeName, ApiChange change)
     {
         if (!IsMemberChange(change.Kind))
@@ -923,6 +931,9 @@ public static class ResearchDiff
 
     static string BodySignalMethodKey(MethodIdentity method)
         => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{method.GenericArity}|{method.IsExtension}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
+
+    static string UnsafeSignalMethodKey(MethodIdentity method)
+        => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
 
     static string MethodMatchKey(MethodIdentity method)
         => $"{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{method.GenericArity}|{method.IsExtension}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -338,7 +338,7 @@ public static class ResearchDiff
         {
             AddAnalysisSignalDiff(builder, oldIndex, newIndex, typeFilters, memberTargetIdentities);
 
-            var methods = MethodSubjectsByUnsafeSignalKey(oldIndex, newIndex);
+            var methods = MethodSubjectsByBodySignalKey(oldIndex, newIndex);
             foreach (var row in BodySignalDiff.CompareUnsafe(oldIndex, newIndex).Rows)
             {
                 var subject = methods.GetValueOrDefault(row.Member) ?? UnknownMemberSubject(row.Member);
@@ -791,12 +791,6 @@ public static class ResearchDiff
            || memberTargetIdentities.Count == 0
            || memberTargetIdentities.Contains(subject.Id);
 
-    static Dictionary<string, ResearchSubjectKey> MethodSubjectsByUnsafeSignalKey(LibraryBodyIndex oldIndex, LibraryBodyIndex newIndex)
-        => oldIndex.Methods.Concat(newIndex.Methods)
-            .Select(method => (Key: UnsafeSignalMethodKey(method), Subject: SubjectFromMethod(method)))
-            .GroupBy(entry => entry.Key, StringComparer.Ordinal)
-            .ToDictionary(group => group.Key, group => group.Last().Subject, StringComparer.Ordinal);
-
     static ResearchSubjectKey ApiSubject(ApiSurface oldSurface, ApiSurface newSurface, string typeName, ApiChange change)
     {
         if (!IsMemberChange(change.Kind))
@@ -931,9 +925,6 @@ public static class ResearchDiff
 
     static string BodySignalMethodKey(MethodIdentity method)
         => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{method.GenericArity}|{method.IsExtension}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
-
-    static string UnsafeSignalMethodKey(MethodIdentity method)
-        => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
 
     static string MethodMatchKey(MethodIdentity method)
         => $"{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{method.GenericArity}|{method.IsExtension}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -780,11 +780,17 @@ public static class ResearchDiff
         LibraryBodyIndex oldIndex,
         LibraryBodyIndex newIndex,
         IReadOnlySet<string>? memberTargetIdentities = null)
-        => oldIndex.Methods.Concat(newIndex.Methods)
+    {
+        var oldGeneratedFrameworkTypes = oldIndex.GeneratedFrameworkTypeNames;
+        var newGeneratedFrameworkTypes = newIndex.GeneratedFrameworkTypeNames;
+        return oldIndex.Methods
+            .Where(method => !IsGeneratedMethod(method, oldGeneratedFrameworkTypes))
+            .Concat(newIndex.Methods.Where(method => !IsGeneratedMethod(method, newGeneratedFrameworkTypes)))
             .Select(method => (Key: BodySignalMethodKey(method), Subject: SubjectFromMethod(method)))
             .Where(entry => MatchesMemberTargets(entry.Subject, memberTargetIdentities))
             .GroupBy(entry => entry.Key, StringComparer.Ordinal)
             .ToDictionary(group => group.Key, group => group.Last().Subject, StringComparer.Ordinal);
+    }
 
     static bool MatchesMemberTargets(ResearchSubjectKey subject, IReadOnlySet<string>? memberTargetIdentities)
         => memberTargetIdentities is null

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -75,7 +75,8 @@ public sealed record ResearchDiffOptions(
     ResearchDiffMechanism Mechanisms = ResearchDiffMechanism.AllAvailable,
     bool IncludeAllApi = false,
     ApiDiffScope ApiScope = ApiDiffScope.Signature,
-    IReadOnlySet<string>? TypeFilters = null);
+    IReadOnlySet<string>? TypeFilters = null,
+    IReadOnlySet<string>? MemberTargetIdentities = null);
 
 public sealed record ResearchDiffInput(
     IReadOnlyList<string> AssemblyPaths,
@@ -289,7 +290,7 @@ public static class ResearchDiff
             AddApiDiff(builder, oldInput, newInput, options.IncludeAllApi, options.ApiScope);
 
         if (options.Mechanisms.HasFlag(ResearchDiffMechanism.BodySignals))
-            AddBodySignalDiff(builder, oldInput, newInput, options.TypeFilters);
+            AddBodySignalDiff(builder, oldInput, newInput, options.TypeFilters, options.MemberTargetIdentities);
 
         if (options.Mechanisms.HasFlag(ResearchDiffMechanism.IlBody))
             AddIlBodyDiff(builder, oldInput, newInput);
@@ -326,16 +327,23 @@ public static class ResearchDiff
         }
     }
 
-    static void AddBodySignalDiff(ResultBuilder builder, ResearchDiffInput oldInput, ResearchDiffInput newInput, IReadOnlySet<string>? typeFilters)
+    static void AddBodySignalDiff(
+        ResultBuilder builder,
+        ResearchDiffInput oldInput,
+        ResearchDiffInput newInput,
+        IReadOnlySet<string>? typeFilters,
+        IReadOnlySet<string>? memberTargetIdentities)
     {
         foreach (var (oldIndex, newIndex) in PairedBodyIndexes(oldInput, newInput))
         {
-            AddAnalysisSignalDiff(builder, oldIndex, newIndex, typeFilters);
+            AddAnalysisSignalDiff(builder, oldIndex, newIndex, typeFilters, memberTargetIdentities);
 
-            var methods = MethodSubjectsByBodySignalKey(oldIndex, newIndex);
+            var methods = MethodSubjectsByBodySignalKey(oldIndex, newIndex, memberTargetIdentities);
             foreach (var row in BodySignalDiff.CompareUnsafe(oldIndex, newIndex).Rows)
             {
                 var subject = methods.GetValueOrDefault(row.Member) ?? UnknownMemberSubject(row.Member);
+                if (!MatchesMemberTargets(subject, memberTargetIdentities))
+                    continue;
                 var direction = row.Kind == BodySignalDiffKind.Added ? ResearchDiffDirection.Added : ResearchDiffDirection.Removed;
                 var suffix = direction == ResearchDiffDirection.Added ? "added" : "removed";
                 builder.Add(subject, new ResearchDiffEvidence(
@@ -349,10 +357,15 @@ public static class ResearchDiff
             }
         }
 
-        static void AddAnalysisSignalDiff(ResultBuilder builder, LibraryBodyIndex oldIndex, LibraryBodyIndex newIndex, IReadOnlySet<string>? typeFilters)
+        static void AddAnalysisSignalDiff(
+            ResultBuilder builder,
+            LibraryBodyIndex oldIndex,
+            LibraryBodyIndex newIndex,
+            IReadOnlySet<string>? typeFilters,
+            IReadOnlySet<string>? memberTargetIdentities)
         {
-            var oldSnapshot = BuildAnalysisSnapshot(oldIndex, typeFilters);
-            var newSnapshot = BuildAnalysisSnapshot(newIndex, typeFilters);
+            var oldSnapshot = BuildAnalysisSnapshot(oldIndex, typeFilters, memberTargetIdentities);
+            var newSnapshot = BuildAnalysisSnapshot(newIndex, typeFilters, memberTargetIdentities);
             foreach (var key in oldSnapshot.Keys.Union(newSnapshot.Keys, StringComparer.Ordinal))
             {
                 oldSnapshot.TryGetValue(key, out var oldMethod);
@@ -365,7 +378,10 @@ public static class ResearchDiff
             }
         }
 
-        static Dictionary<string, ResearchAnalysisMethod> BuildAnalysisSnapshot(LibraryBodyIndex index, IReadOnlySet<string>? typeFilters)
+        static Dictionary<string, ResearchAnalysisMethod> BuildAnalysisSnapshot(
+            LibraryBodyIndex index,
+            IReadOnlySet<string>? typeFilters,
+            IReadOnlySet<string>? memberTargetIdentities)
         {
             var methods = new Dictionary<string, ResearchAnalysisMethod>(StringComparer.Ordinal);
             var generatedFrameworkTypes = index.GeneratedFrameworkTypeNames;
@@ -376,11 +392,14 @@ public static class ResearchDiff
                     continue;
                 if (!MatchesTypeFilters(method.DeclaringType.ToQualifiedDisplayString(), typeFilters))
                     continue;
+                var subject = SubjectFromMethod(method);
+                if (!MatchesMemberTargets(subject, memberTargetIdentities))
+                    continue;
                 signalsByToken.TryGetValue(method.MetadataToken, out var signals);
                 var key = BodySignalMethodKey(method);
                 if (!methods.TryGetValue(key, out var entry))
                 {
-                    entry = new ResearchAnalysisMethod(SubjectFromMethod(method), signals ?? MethodSignals.None, []);
+                    entry = new ResearchAnalysisMethod(subject, signals ?? MethodSignals.None, []);
                     methods[key] = entry;
                 }
                 else
@@ -395,10 +414,13 @@ public static class ResearchDiff
                     continue;
                 if (!MatchesTypeFilters(opportunity.Method.DeclaringType.ToQualifiedDisplayString(), typeFilters))
                     continue;
+                var subject = SubjectFromMethod(opportunity.Method);
+                if (!MatchesMemberTargets(subject, memberTargetIdentities))
+                    continue;
                 var key = BodySignalMethodKey(opportunity.Method);
                 if (!methods.TryGetValue(key, out var entry))
                 {
-                    entry = new ResearchAnalysisMethod(SubjectFromMethod(opportunity.Method), MethodSignals.None, []);
+                    entry = new ResearchAnalysisMethod(subject, MethodSignals.None, []);
                     methods[key] = entry;
                 }
                 entry.Opportunities.Add(opportunity);
@@ -752,10 +774,20 @@ public static class ResearchDiff
         }
     }
 
-    static Dictionary<string, ResearchSubjectKey> MethodSubjectsByBodySignalKey(LibraryBodyIndex oldIndex, LibraryBodyIndex newIndex)
+    static Dictionary<string, ResearchSubjectKey> MethodSubjectsByBodySignalKey(
+        LibraryBodyIndex oldIndex,
+        LibraryBodyIndex newIndex,
+        IReadOnlySet<string>? memberTargetIdentities = null)
         => oldIndex.Methods.Concat(newIndex.Methods)
-            .GroupBy(BodySignalMethodKey, StringComparer.Ordinal)
-            .ToDictionary(group => group.Key, group => SubjectFromMethod(group.Last()), StringComparer.Ordinal);
+            .Select(method => (Key: BodySignalMethodKey(method), Subject: SubjectFromMethod(method)))
+            .Where(entry => MatchesMemberTargets(entry.Subject, memberTargetIdentities))
+            .GroupBy(entry => entry.Key, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.Last().Subject, StringComparer.Ordinal);
+
+    static bool MatchesMemberTargets(ResearchSubjectKey subject, IReadOnlySet<string>? memberTargetIdentities)
+        => memberTargetIdentities is null
+           || memberTargetIdentities.Count == 0
+           || memberTargetIdentities.Contains(subject.Id);
 
     static ResearchSubjectKey ApiSubject(ApiSurface oldSurface, ApiSurface newSurface, string typeName, ApiChange change)
     {

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -341,7 +341,8 @@ public static class ResearchDiff
             var methods = MethodSubjectsByBodySignalKey(oldIndex, newIndex);
             foreach (var row in BodySignalDiff.CompareUnsafe(oldIndex, newIndex).Rows)
             {
-                var subject = methods.GetValueOrDefault(row.Member) ?? UnknownMemberSubject(row.Member);
+                if (!methods.TryGetValue(row.Member, out var subject))
+                    continue;
                 if (!MatchesTypeFilters(subject.TypeName ?? "", typeFilters))
                     continue;
                 if (!MatchesMemberTargets(subject, memberTargetIdentities))

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -510,6 +510,21 @@ public class DiffCommandTests
         Assert.DoesNotContain(result.Rows, r => r.Member.Contains("ImprovesAlloc"));
     }
 
+    [Fact]
+    public void BuildAnalysisDiff_MemberFilter_RejectsNonMethodTargets()
+    {
+        var surface = DiffSurface(DiffProperty("Value"));
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            DiffCommand.BuildAnalysisDiff([], [], new DiffOptions
+            {
+                TypeFilter = ["Widget"],
+                MemberFilter = ["Value"]
+            }, surface, surface));
+
+        Assert.Contains("method-like target", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     // #1736: a hotness-only allocation regression. The allocation count is unchanged
     // (1 -> 1) but the allocation moves into a loop (allocInLoop false -> true). The raw
     // count delta is zero, so this must still surface as an in-place allocations row with
@@ -598,6 +613,15 @@ public class DiffCommandTests
                 Parameters = ParseParameters(signature ?? $"void {name}()")
             },
             Attributes = attributes?.ToList() ?? [],
+        };
+
+    static ApiMember DiffProperty(string name)
+        => new()
+        {
+            Name = name,
+            Kind = "property",
+            Signature = $"int {name}",
+            SignatureModel = new ApiSignature { MemberName = name, ReturnType = "int" }
         };
 
     static List<ApiParameter> ParseParameters(string signature)

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -532,6 +532,7 @@ public class DiffCommandTests
     [InlineData("dynamic", "System.Object")]
     [InlineData("nint", "System.IntPtr")]
     [InlineData("params int[]", "System.Int32[]")]
+    [InlineData("pinned int", "pinned System.Int32")]
     [InlineData("System.Collections.Generic.List<int>", "System.Collections.Generic.List`1<System.Int32>")]
     [InlineData("System.Collections.Generic.List<int>.Enumerator", "System.Collections.Generic.List`1.Enumerator<System.Int32>")]
     [InlineData("Outer<int>.Inner<string>", "Outer`1.Inner`1<System.Int32,System.String>")]

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -525,6 +525,27 @@ public class DiffCommandTests
         Assert.Contains("method-like target", error.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData("int*", "System.Int32*")]
+    [InlineData("int[,]", "System.Int32[,]")]
+    [InlineData("dynamic", "System.Object")]
+    [InlineData("nint", "System.IntPtr")]
+    [InlineData("System.Collections.Generic.List<int>", "System.Collections.Generic.List`1<System.Int32>")]
+    [InlineData("System.Collections.Generic.List<int>.Enumerator", "System.Collections.Generic.List`1.Enumerator<System.Int32>")]
+    [InlineData("Outer<int>.Inner<string>", "Outer`1.Inner`1<System.Int32,System.String>")]
+    public void ResearchBodyTypeName_MatchesResearchDiffSubjectSpelling(string input, string expected)
+    {
+        Assert.Equal(expected, DiffCommand.ResearchBodyTypeName(input));
+    }
+
+    [Theory]
+    [InlineData("Namespace.Outer<T>.Inner<U>", "Namespace.Outer.Inner")]
+    [InlineData("Namespace.Outer+Inner<T>", "Namespace.Outer.Inner")]
+    public void ResearchBodyDeclaringTypeName_StripsApiTypeParameters(string input, string expected)
+    {
+        Assert.Equal(expected, DiffCommand.ResearchBodyDeclaringTypeName(input));
+    }
+
     // #1736: a hotness-only allocation regression. The allocation count is unchanged
     // (1 -> 1) but the allocation moves into a loop (allocInLoop false -> true). The raw
     // count delta is zero, so this must still surface as an in-place allocations row with

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -1,5 +1,6 @@
 using DotnetInspector.Fixtures;
 using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
 using DotnetInspector.Commands;
 using DotnetInspector.Output;
 using DotnetInspector.Views;
@@ -530,6 +531,7 @@ public class DiffCommandTests
     [InlineData("int[,]", "System.Int32[,]")]
     [InlineData("dynamic", "System.Object")]
     [InlineData("nint", "System.IntPtr")]
+    [InlineData("params int[]", "System.Int32[]")]
     [InlineData("System.Collections.Generic.List<int>", "System.Collections.Generic.List`1<System.Int32>")]
     [InlineData("System.Collections.Generic.List<int>.Enumerator", "System.Collections.Generic.List`1.Enumerator<System.Int32>")]
     [InlineData("Outer<int>.Inner<string>", "Outer`1.Inner`1<System.Int32,System.String>")]
@@ -552,6 +554,42 @@ public class DiffCommandTests
     public void ResearchBodyTypeName_KeepsFullPrimitiveParameterNames()
     {
         Assert.Equal("System.Int32", DiffCommand.ResearchBodyTypeName("System.Int32"));
+    }
+
+    [Fact]
+    public void AddResearchBodyIdentity_PhysicalExtensionUsesExtensionSelector()
+    {
+        var type = new ApiType { Namespace = "DiffFixtureSample", Name = "ExtensionSample" };
+        var member = DiffMember("Twice", signature: "int Twice(int value)");
+        member.IsExtension = true;
+        member.DeclaringType = "DiffFixtureSample.ExtensionSample";
+        var target = ResolvedTarget(type, member);
+        HashSet<string> identities = new(StringComparer.Ordinal);
+
+        Assert.True(DiffCommand.AddResearchBodyIdentity(target, identities));
+
+        var expectedCanonical = "M:DiffFixtureSample.ExtensionSample.Twice(System.Int32)";
+        Assert.Contains($"extension:Twice~{MemberAnchor.ComputeFingerprint(expectedCanonical)}", identities);
+    }
+
+    [Fact]
+    public void AddResearchBodyIdentity_ProjectedExtensionUsesPhysicalDeclaringType()
+    {
+        var extendedType = new ApiType { Namespace = "System", Name = "Int32" };
+        var member = DiffMember("Twice", signature: "int Twice(int value)");
+        member.Kind = "extension-method";
+        member.IsExtension = true;
+        member.DeclaringType = "DiffFixtureSample.ExtensionSample";
+        var target = ResolvedTarget(
+            extendedType,
+            member,
+            new BodyTarget("DiffFixtureSample.ExtensionSample", "M:DiffFixtureSample.ExtensionSample.Twice(System.Int32)"));
+        HashSet<string> identities = new(StringComparer.Ordinal);
+
+        Assert.True(DiffCommand.AddResearchBodyIdentity(target, identities));
+
+        var expectedCanonical = "M:DiffFixtureSample.ExtensionSample.Twice(System.Int32)";
+        Assert.Contains($"extension:Twice~{MemberAnchor.ComputeFingerprint(expectedCanonical)}", identities);
     }
 
     // #1736: a hotness-only allocation regression. The allocation count is unchanged
@@ -652,6 +690,29 @@ public class DiffCommandTests
             Signature = $"int {name}",
             SignatureModel = new ApiSignature { MemberName = name, ReturnType = "int" }
         };
+
+    static ResolvedMemberTarget ResolvedTarget(ApiType type, ApiMember member, BodyTarget? body = null)
+    {
+        var anchor = ApiMemberIdentity.GetMemberAnchor(type, member);
+        return new ResolvedMemberTarget(
+            type,
+            ApiMemberIdentity.CreateHandle(type, member),
+            anchor,
+            anchor.StableSelector,
+            anchor.StableSelector,
+            SelectorIndex: 1,
+            DeclaringOverloadIndex: 1,
+            OverloadIndex: null,
+            DigestPrefix: null,
+            GenericArity: member.SignatureModel?.TypeParameters.Count,
+            Kind: member.Kind switch
+            {
+                "extension-method" => MemberTargetKind.ExtensionMethod,
+                "method" => MemberTargetKind.Method,
+                _ => MemberTargetKind.Unknown
+            },
+            Body: body);
+    }
 
     static List<ApiParameter> ParseParameters(string signature)
     {

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -491,6 +491,25 @@ public class DiffCommandTests
         Assert.DoesNotContain(result.Rows, r => r.Member.Contains("Stable"));
     }
 
+    [Fact]
+    public void BuildAnalysisDiff_MemberFilter_UsesResolverBackedTarget()
+    {
+        var v1 = FixtureCatalog.DiffPair.OldAssemblyPath();
+        var v2 = FixtureCatalog.DiffPair.NewAssemblyPath();
+
+        var result = DiffCommand.BuildAnalysisDiff([v1], [v2], new DiffOptions
+        {
+            TypeFilter = ["DiffSample"],
+            MemberFilter = ["RegressesAllocInLoop"],
+            ChangedOnly = true
+        });
+
+        var row = Assert.Single(result.Rows);
+        Assert.Contains("RegressesAllocInLoop", row.Member);
+        Assert.Equal("allocations", row.Signal);
+        Assert.DoesNotContain(result.Rows, r => r.Member.Contains("ImprovesAlloc"));
+    }
+
     // #1736: a hotness-only allocation regression. The allocation count is unchanged
     // (1 -> 1) but the allocation moves into a loop (allocInLoop false -> true). The raw
     // count delta is zero, so this must still surface as an in-place allocations row with

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -541,9 +541,17 @@ public class DiffCommandTests
     [Theory]
     [InlineData("Namespace.Outer<T>.Inner<U>", "Namespace.Outer.Inner")]
     [InlineData("Namespace.Outer+Inner<T>", "Namespace.Outer.Inner")]
+    [InlineData("System.Int32", "int")]
+    [InlineData("System.String", "string")]
     public void ResearchBodyDeclaringTypeName_StripsApiTypeParameters(string input, string expected)
     {
         Assert.Equal(expected, DiffCommand.ResearchBodyDeclaringTypeName(input));
+    }
+
+    [Fact]
+    public void ResearchBodyTypeName_KeepsFullPrimitiveParameterNames()
+    {
+        Assert.Equal("System.Int32", DiffCommand.ResearchBodyTypeName("System.Int32"));
     }
 
     // #1736: a hotness-only allocation regression. The allocation count is unchanged

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -713,6 +713,8 @@ public class DiffCommand
         var value = typeName.Trim();
         if (value.StartsWith("params ", StringComparison.Ordinal))
             value = value["params ".Length..].TrimStart();
+        if (value.StartsWith("pinned ", StringComparison.Ordinal))
+            return $"pinned {ResearchBodyTypeName(value["pinned ".Length..])}";
         foreach (var prefix in (ReadOnlySpan<string>)["ref readonly ", "readonly ref ", "scoped ref ", "ref ", "out ", "in "])
         {
             if (value.StartsWith(prefix, StringComparison.Ordinal))

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -360,7 +360,8 @@ public class DiffCommand
                 fromSurface ?? MergeSurfaces(fromPaths, name: null, tfm: null, includeAll: options.IncludeAll, logger: new VerboseLogger(enabled: false)) ?? new ApiSurface(),
                 toSurface ?? MergeSurfaces(toPaths, name: null, tfm: null, includeAll: options.IncludeAll, logger: new VerboseLogger(enabled: false)) ?? new ApiSurface(),
                 options.MemberFilter,
-                options.TypeFilter).MemberIdentities;
+                options.TypeFilter,
+                requireBodyTargets: true).MemberIdentities;
         var research = ResearchDiff.Compare(
             ResearchDiffInput.FromAssemblies(fromPaths),
             ResearchDiffInput.FromAssemblies(toPaths),
@@ -607,7 +608,8 @@ public class DiffCommand
         ApiSurface fromSurface,
         ApiSurface toSurface,
         IReadOnlyCollection<string> memberTargets,
-        IReadOnlyCollection<string> typeFilters)
+        IReadOnlyCollection<string> typeFilters,
+        bool requireBodyTargets = false)
     {
         HashSet<string> identities = new(StringComparer.Ordinal);
         HashSet<string> typeNames = new(StringComparer.OrdinalIgnoreCase);
@@ -615,6 +617,7 @@ public class DiffCommand
         {
             var parsed = ParseDiffMemberTarget(rawTarget, fromSurface, toSurface, typeFilters);
             var found = false;
+            var bodyFound = false;
             MemberTargetDiagnostic? diagnostic = null;
             MemberTargetDiagnostic? nonFatalDiagnostic = null;
             var oldType = FindExactType(fromSurface, parsed.TypeName);
@@ -624,6 +627,7 @@ public class DiffCommand
             {
                 var oldResult = AddResolvedIdentities(oldType, parsed.Selector, identities);
                 found |= oldResult.Found;
+                bodyFound |= oldResult.BodyFound;
                 if (oldResult.Diagnostic is { } oldDiagnostic)
                 {
                     if (IsFatalTargetDiagnostic(oldDiagnostic.Kind))
@@ -638,6 +642,7 @@ public class DiffCommand
             {
                 var newResult = AddResolvedIdentities(newType, parsed.Selector, identities);
                 found |= newResult.Found;
+                bodyFound |= newResult.BodyFound;
                 if (newResult.Diagnostic is { } newDiagnostic)
                 {
                     if (IsFatalTargetDiagnostic(newDiagnostic.Kind))
@@ -653,28 +658,30 @@ public class DiffCommand
                 throw new InvalidOperationException(diagnostic.Message);
             if (!found)
                 throw new InvalidOperationException(nonFatalDiagnostic?.Message ?? $"Member target '{rawTarget}' did not resolve in either diff input.");
+            if (requireBodyTargets && !bodyFound)
+                throw new InvalidOperationException($"Analysis Diff --member requires a method-like target; '{rawTarget}' resolved to a member with no method body.");
         }
 
         return new ResolvedDiffMemberTargets(identities, typeNames);
     }
 
-    static (bool Found, MemberTargetDiagnostic? Diagnostic) AddResolvedIdentities(ApiType type, MemberTargetSelector selector, HashSet<string> identities)
+    static (bool Found, bool BodyFound, MemberTargetDiagnostic? Diagnostic) AddResolvedIdentities(ApiType type, MemberTargetSelector selector, HashSet<string> identities)
     {
         var resolution = MemberTargetResolver.Resolve(type, selector);
         if (!resolution.Found)
-            return (false, resolution.Diagnostic);
+            return (false, false, resolution.Diagnostic);
 
         identities.Add(resolution.Target!.Anchor.StableSelector);
         identities.Add(resolution.Target.Anchor.CanonicalSignature);
-        AddResearchBodyIdentity(resolution.Target, identities);
-        return (true, null);
+        var bodyFound = AddResearchBodyIdentity(resolution.Target, identities);
+        return (true, bodyFound, null);
     }
 
-    static void AddResearchBodyIdentity(ResolvedMemberTarget target, HashSet<string> identities)
+    static bool AddResearchBodyIdentity(ResolvedMemberTarget target, HashSet<string> identities)
     {
         var member = target.ApiMember.Member;
         if (member.Kind is "property" or "field" or "event")
-            return;
+            return false;
 
         var signature = member.SignatureModel;
         var memberName = member.Kind == "constructor"
@@ -686,9 +693,10 @@ public class DiffCommand
         var parameters = signature is null
             ? "()"
             : $"({string.Join(",", signature.Parameters.Select(parameter => ResearchBodyTypeName(parameter.TypeWithModifier)))})";
-        var canonical = $"M:{target.Anchor.TypeFullName}.{memberName}{generic}{parameters}";
+        var canonical = $"M:{target.Anchor.TypeFullName.Replace('+', '.')}.{memberName}{generic}{parameters}";
         var selectorName = target.Anchor.StableSelector.Split('~')[0];
         identities.Add($"{selectorName}~{MemberAnchor.ComputeFingerprint(canonical)}");
+        return true;
     }
 
     static string ResearchBodyTypeName(string typeName)
@@ -703,14 +711,22 @@ public class DiffCommand
         if (value.EndsWith("?", StringComparison.Ordinal))
             value = value[..^1];
 
-        if (value.EndsWith("[]", StringComparison.Ordinal))
-            return $"{ResearchBodyTypeName(value[..^2])}[]";
+        if (value.EndsWith("*", StringComparison.Ordinal))
+            return $"{ResearchBodyTypeName(value[..^1])}*";
+
+        var arrayStart = value.LastIndexOf('[');
+        if (arrayStart > 0 && value.EndsWith("]", StringComparison.Ordinal))
+            return $"{ResearchBodyTypeName(value[..arrayStart])}{value[arrayStart..]}";
+
+        var nestedSegments = SplitTopLevel(value, '.').ToList();
+        if (nestedSegments.Count > 1 && nestedSegments.Any(segment => segment.Contains('<', StringComparison.Ordinal)))
+            return string.Join(".", nestedSegments.Select(ResearchBodyTypeName));
 
         var genericStart = value.IndexOf('<');
         if (genericStart > 0 && value.EndsWith(">", StringComparison.Ordinal))
         {
             var baseName = value[..genericStart];
-            var arguments = SplitGenericArguments(value[(genericStart + 1)..^1])
+            var arguments = SplitTopLevel(value[(genericStart + 1)..^1], ',')
                 .Select(ResearchBodyTypeName)
                 .ToList();
             return $"{baseName}`{arguments.Count}<{string.Join(",", arguments)}>";
@@ -729,7 +745,10 @@ public class DiffCommand
             "uint" => "System.UInt32",
             "long" => "System.Int64",
             "ulong" => "System.UInt64",
+            "nint" => "System.IntPtr",
+            "nuint" => "System.UIntPtr",
             "object" => "System.Object",
+            "dynamic" => "System.Object",
             "short" => "System.Int16",
             "ushort" => "System.UInt16",
             "string" => "System.String",
@@ -738,25 +757,25 @@ public class DiffCommand
         };
     }
 
-    static IEnumerable<string> SplitGenericArguments(string arguments)
+    static IEnumerable<string> SplitTopLevel(string value, char separator)
     {
         var depth = 0;
         var start = 0;
-        for (var i = 0; i < arguments.Length; i++)
+        for (var i = 0; i < value.Length; i++)
         {
-            var ch = arguments[i];
+            var ch = value[i];
             if (ch == '<')
                 depth++;
             else if (ch == '>')
                 depth--;
-            else if (ch == ',' && depth == 0)
+            else if (ch == separator && depth == 0)
             {
-                yield return arguments[start..i].Trim();
+                yield return value[start..i].Trim();
                 start = i + 1;
             }
         }
 
-        yield return arguments[start..].Trim();
+        yield return value[start..].Trim();
     }
 
     static bool IsFatalTargetDiagnostic(MemberTargetDiagnosticKind kind)

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -677,7 +677,7 @@ public class DiffCommand
         return (true, bodyFound, null);
     }
 
-    static bool AddResearchBodyIdentity(ResolvedMemberTarget target, HashSet<string> identities)
+    internal static bool AddResearchBodyIdentity(ResolvedMemberTarget target, HashSet<string> identities)
     {
         var member = target.ApiMember.Member;
         if (member.Kind is "property" or "field" or "event")
@@ -693,8 +693,14 @@ public class DiffCommand
         var parameters = signature is null
             ? "()"
             : $"({string.Join(",", signature.Parameters.Select(parameter => ResearchBodyTypeName(parameter.TypeWithModifier)))})";
-        var canonical = $"M:{ResearchBodyDeclaringTypeName(target.Anchor.TypeFullName)}.{memberName}{generic}{parameters}";
+        var declaringType = target.Body?.DeclaringType
+            ?? (member.IsExtension && !string.IsNullOrWhiteSpace(member.DeclaringType)
+                ? member.DeclaringType!
+                : target.Anchor.TypeFullName);
+        var canonical = $"M:{ResearchBodyDeclaringTypeName(declaringType)}.{memberName}{generic}{parameters}";
         var selectorName = target.Anchor.StableSelector.Split('~')[0];
+        if (member.IsExtension && !selectorName.StartsWith("extension:", StringComparison.Ordinal))
+            selectorName = $"extension:{selectorName}";
         identities.Add($"{selectorName}~{MemberAnchor.ComputeFingerprint(canonical)}");
         return true;
     }
@@ -705,6 +711,8 @@ public class DiffCommand
     internal static string ResearchBodyTypeName(string typeName)
     {
         var value = typeName.Trim();
+        if (value.StartsWith("params ", StringComparison.Ordinal))
+            value = value["params ".Length..].TrimStart();
         foreach (var prefix in (ReadOnlySpan<string>)["ref readonly ", "readonly ref ", "scoped ref ", "ref ", "out ", "in "])
         {
             if (value.StartsWith(prefix, StringComparison.Ordinal))

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -6,6 +6,7 @@ using DotnetInspector.Sections;
 using DotnetInspector.Services;
 using DotnetInspector.Views;
 using ILInspector.Analysis;
+using ILInspector.MetadataPrimitives;
 using ILInspector.Research;
 using Markout;
 
@@ -100,13 +101,7 @@ public class DiffCommand
             {
                 if (SelectsAnalysisDiff(options))
                 {
-                    if (options.MemberFilter.Count > 0)
-                    {
-                        Console.Error.WriteLine("Error: --member is currently supported for API diff output; Analysis Diff member targeting is a follow-up.");
-                        return 1;
-                    }
-
-                    var analysis = BuildAnalysisDiff(inputs.FromPaths, inputs.ToPaths, options);
+                    var analysis = BuildAnalysisDiff(inputs.FromPaths, inputs.ToPaths, options, inputs.FromSurface, inputs.ToSurface);
                     var view = DiffOutputFormatter.BuildAnalysisDiffView(inputs.Name, analysis.Rows, analysis.Summary, inputs.FromVersion, inputs.ToVersion);
                     if (options.Tsv || options.Jsonl)
                     {
@@ -352,14 +347,27 @@ public class DiffCommand
     // is present in both versions (an in-place change vs an added/removed member).
     internal sealed record RankedAnalysisRow(AnalysisDiffRow Row, int Magnitude, int Direction, bool InBoth, bool InLoop = false);
 
-    internal static AnalysisDiffResult BuildAnalysisDiff(IReadOnlyList<string> fromPaths, IReadOnlyList<string> toPaths, DiffOptions options)
+    internal static AnalysisDiffResult BuildAnalysisDiff(
+        IReadOnlyList<string> fromPaths,
+        IReadOnlyList<string> toPaths,
+        DiffOptions options,
+        ApiSurface? fromSurface = null,
+        ApiSurface? toSurface = null)
     {
+        var memberTargetIdentities = options.MemberFilter.Count == 0
+            ? null
+            : ResolveMemberTargetIdentities(
+                fromSurface ?? MergeSurfaces(fromPaths, name: null, tfm: null, includeAll: options.IncludeAll, logger: new VerboseLogger(enabled: false)) ?? new ApiSurface(),
+                toSurface ?? MergeSurfaces(toPaths, name: null, tfm: null, includeAll: options.IncludeAll, logger: new VerboseLogger(enabled: false)) ?? new ApiSurface(),
+                options.MemberFilter,
+                options.TypeFilter).MemberIdentities;
         var research = ResearchDiff.Compare(
             ResearchDiffInput.FromAssemblies(fromPaths),
             ResearchDiffInput.FromAssemblies(toPaths),
             new ResearchDiffOptions(
                 ResearchDiffMechanism.BodySignals,
-                TypeFilters: options.TypeFilter));
+                TypeFilters: options.TypeFilter,
+                MemberTargetIdentities: memberTargetIdentities));
         var ranked = research.Subjects
             .SelectMany(subject => subject.Evidence.Select(evidence => (subject, evidence)))
             .Where(entry => entry.evidence.Category == ResearchDiffChangeCategory.BodySignal
@@ -658,7 +666,97 @@ public class DiffCommand
 
         identities.Add(resolution.Target!.Anchor.StableSelector);
         identities.Add(resolution.Target.Anchor.CanonicalSignature);
+        AddResearchBodyIdentity(resolution.Target, identities);
         return (true, null);
+    }
+
+    static void AddResearchBodyIdentity(ResolvedMemberTarget target, HashSet<string> identities)
+    {
+        var member = target.ApiMember.Member;
+        if (member.Kind is "property" or "field" or "event")
+            return;
+
+        var signature = member.SignatureModel;
+        var memberName = member.Kind == "constructor"
+            ? "#ctor"
+            : string.IsNullOrWhiteSpace(signature?.MemberName) ? member.Name : signature!.MemberName!;
+        var generic = signature is { TypeParameters.Count: > 0 }
+            ? $"<{string.Join(",", signature.TypeParameters.Select(parameter => parameter.Name))}>"
+            : "";
+        var parameters = signature is null
+            ? "()"
+            : $"({string.Join(",", signature.Parameters.Select(parameter => ResearchBodyTypeName(parameter.TypeWithModifier)))})";
+        var canonical = $"M:{target.Anchor.TypeFullName}.{memberName}{generic}{parameters}";
+        var selectorName = target.Anchor.StableSelector.Split('~')[0];
+        identities.Add($"{selectorName}~{MemberAnchor.ComputeFingerprint(canonical)}");
+    }
+
+    static string ResearchBodyTypeName(string typeName)
+    {
+        var value = typeName.Trim();
+        foreach (var prefix in (ReadOnlySpan<string>)["ref readonly ", "readonly ref ", "scoped ref ", "ref ", "out ", "in "])
+        {
+            if (value.StartsWith(prefix, StringComparison.Ordinal))
+                return $"{ResearchBodyTypeName(value[prefix.Length..])}&";
+        }
+
+        if (value.EndsWith("?", StringComparison.Ordinal))
+            value = value[..^1];
+
+        if (value.EndsWith("[]", StringComparison.Ordinal))
+            return $"{ResearchBodyTypeName(value[..^2])}[]";
+
+        var genericStart = value.IndexOf('<');
+        if (genericStart > 0 && value.EndsWith(">", StringComparison.Ordinal))
+        {
+            var baseName = value[..genericStart];
+            var arguments = SplitGenericArguments(value[(genericStart + 1)..^1])
+                .Select(ResearchBodyTypeName)
+                .ToList();
+            return $"{baseName}`{arguments.Count}<{string.Join(",", arguments)}>";
+        }
+
+        return value switch
+        {
+            "bool" => "System.Boolean",
+            "byte" => "System.Byte",
+            "sbyte" => "System.SByte",
+            "char" => "System.Char",
+            "decimal" => "System.Decimal",
+            "double" => "System.Double",
+            "float" => "System.Single",
+            "int" => "System.Int32",
+            "uint" => "System.UInt32",
+            "long" => "System.Int64",
+            "ulong" => "System.UInt64",
+            "object" => "System.Object",
+            "short" => "System.Int16",
+            "ushort" => "System.UInt16",
+            "string" => "System.String",
+            "void" => "System.Void",
+            _ => value
+        };
+    }
+
+    static IEnumerable<string> SplitGenericArguments(string arguments)
+    {
+        var depth = 0;
+        var start = 0;
+        for (var i = 0; i < arguments.Length; i++)
+        {
+            var ch = arguments[i];
+            if (ch == '<')
+                depth++;
+            else if (ch == '>')
+                depth--;
+            else if (ch == ',' && depth == 0)
+            {
+                yield return arguments[start..i].Trim();
+                start = i + 1;
+            }
+        }
+
+        yield return arguments[start..].Trim();
     }
 
     static bool IsFatalTargetDiagnostic(MemberTargetDiagnosticKind kind)

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -700,7 +700,7 @@ public class DiffCommand
     }
 
     internal static string ResearchBodyDeclaringTypeName(string typeName)
-        => StripGenericArguments(typeName.Replace('+', '.'));
+        => ResearchBodyDeclaringPrimitiveName(StripGenericArguments(typeName.Replace('+', '.')));
 
     internal static string ResearchBodyTypeName(string typeName)
     {
@@ -724,7 +724,35 @@ public class DiffCommand
         if (TryRenderGenericTypeName(value, out var genericTypeName))
             return genericTypeName;
 
-        return value switch
+        return ResearchBodyParameterPrimitiveName(value);
+    }
+
+    static string ResearchBodyDeclaringPrimitiveName(string value)
+        => value switch
+        {
+            "System.Boolean" => "bool",
+            "System.Byte" => "byte",
+            "System.SByte" => "sbyte",
+            "System.Char" => "char",
+            "System.Decimal" => "decimal",
+            "System.Double" => "double",
+            "System.Single" => "float",
+            "System.Int32" => "int",
+            "System.UInt32" => "uint",
+            "System.Int64" => "long",
+            "System.UInt64" => "ulong",
+            "System.IntPtr" => "nint",
+            "System.UIntPtr" => "nuint",
+            "System.Object" => "object",
+            "System.Int16" => "short",
+            "System.UInt16" => "ushort",
+            "System.String" => "string",
+            "System.Void" => "void",
+            _ => value
+        };
+
+    static string ResearchBodyParameterPrimitiveName(string value)
+        => value switch
         {
             "bool" => "System.Boolean",
             "byte" => "System.Byte",
@@ -747,7 +775,6 @@ public class DiffCommand
             "void" => "System.Void",
             _ => value
         };
-    }
 
     static bool TryRenderGenericTypeName(string value, out string typeName)
     {

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -693,13 +693,16 @@ public class DiffCommand
         var parameters = signature is null
             ? "()"
             : $"({string.Join(",", signature.Parameters.Select(parameter => ResearchBodyTypeName(parameter.TypeWithModifier)))})";
-        var canonical = $"M:{target.Anchor.TypeFullName.Replace('+', '.')}.{memberName}{generic}{parameters}";
+        var canonical = $"M:{ResearchBodyDeclaringTypeName(target.Anchor.TypeFullName)}.{memberName}{generic}{parameters}";
         var selectorName = target.Anchor.StableSelector.Split('~')[0];
         identities.Add($"{selectorName}~{MemberAnchor.ComputeFingerprint(canonical)}");
         return true;
     }
 
-    static string ResearchBodyTypeName(string typeName)
+    internal static string ResearchBodyDeclaringTypeName(string typeName)
+        => StripGenericArguments(typeName.Replace('+', '.'));
+
+    internal static string ResearchBodyTypeName(string typeName)
     {
         var value = typeName.Trim();
         foreach (var prefix in (ReadOnlySpan<string>)["ref readonly ", "readonly ref ", "scoped ref ", "ref ", "out ", "in "])
@@ -718,19 +721,8 @@ public class DiffCommand
         if (arrayStart > 0 && value.EndsWith("]", StringComparison.Ordinal))
             return $"{ResearchBodyTypeName(value[..arrayStart])}{value[arrayStart..]}";
 
-        var nestedSegments = SplitTopLevel(value, '.').ToList();
-        if (nestedSegments.Count > 1 && nestedSegments.Any(segment => segment.Contains('<', StringComparison.Ordinal)))
-            return string.Join(".", nestedSegments.Select(ResearchBodyTypeName));
-
-        var genericStart = value.IndexOf('<');
-        if (genericStart > 0 && value.EndsWith(">", StringComparison.Ordinal))
-        {
-            var baseName = value[..genericStart];
-            var arguments = SplitTopLevel(value[(genericStart + 1)..^1], ',')
-                .Select(ResearchBodyTypeName)
-                .ToList();
-            return $"{baseName}`{arguments.Count}<{string.Join(",", arguments)}>";
-        }
+        if (TryRenderGenericTypeName(value, out var genericTypeName))
+            return genericTypeName;
 
         return value switch
         {
@@ -755,6 +747,63 @@ public class DiffCommand
             "void" => "System.Void",
             _ => value
         };
+    }
+
+    static bool TryRenderGenericTypeName(string value, out string typeName)
+    {
+        var segments = SplitTopLevel(value, '.').ToList();
+        List<string> renderedSegments = [];
+        List<string> genericArguments = [];
+        var sawGeneric = false;
+
+        foreach (var segment in segments)
+        {
+            var genericStart = segment.IndexOf('<');
+            if (genericStart <= 0 || !segment.EndsWith(">", StringComparison.Ordinal))
+            {
+                renderedSegments.Add(segment);
+                continue;
+            }
+
+            var arguments = SplitTopLevel(segment[(genericStart + 1)..^1], ',')
+                .Select(ResearchBodyTypeName)
+                .ToList();
+            renderedSegments.Add($"{segment[..genericStart]}`{arguments.Count}");
+            genericArguments.AddRange(arguments);
+            sawGeneric = true;
+        }
+
+        if (!sawGeneric)
+        {
+            typeName = "";
+            return false;
+        }
+
+        typeName = $"{string.Join(".", renderedSegments)}<{string.Join(",", genericArguments)}>";
+        return true;
+    }
+
+    static string StripGenericArguments(string value)
+    {
+        var result = new System.Text.StringBuilder(value.Length);
+        var depth = 0;
+        foreach (var ch in value)
+        {
+            if (ch == '<')
+            {
+                depth++;
+                continue;
+            }
+            if (ch == '>')
+            {
+                depth--;
+                continue;
+            }
+            if (depth == 0)
+                result.Append(ch);
+        }
+
+        return result.ToString();
     }
 
     static IEnumerable<string> SplitTopLevel(string value, char separator)


### PR DESCRIPTION
## Summary

- allow `diff -m/--member` to target `-S "Analysis Diff"` / body-signal rows
- pass resolver-derived member identities into `ResearchDiffOptions`
- filter ResearchDiff body-signal snapshots and unsafe rows by member target identity
- bridge API `MemberAnchor` ids to ResearchDiff body subject ids for method-body signals
- document member targeting for Analysis Diff

This follows #2398 by extending the same resolver-backed `--member` targeting from API diff output to body-signal diff output.

## Validation

- `dotnet run --project src/dotnet-inspect.Tests -c Release -p:NoWarn=NU1507 -- -class DotnetInspector.Tests.DiffCommandTests`
- `dotnet run --project src/ILInspector.Research.Tests -c Release -p:NoWarn=NU1507`
- `npx markdownlint-cli docs/design/member-target-resolution.md docs/workflows/discovery/api-diff.md`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
