### PR TITLE
Use Markout section-aware baseline metric rows

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Markout" Version="0.17.0" />
+    <PackageVersion Include="Markout" Version="0.18.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />

--- a/tools/IlDiffHarness/Program.cs
+++ b/tools/IlDiffHarness/Program.cs
@@ -564,7 +564,7 @@ static IlDiffCardTableView BuildTableView(ImmutableArray<IlDiffPairCard> pairs, 
     return new IlDiffCardTableView
     {
         Summary = SectionedSummaryRows(pairs.Length, card),
-        BaselineMetrics = comparison is null ? null : SectionedBaselineMetricRows(comparison),
+        BaselineMetrics = comparison is null ? null : BaselineMetricRows(comparison),
         FailureBuckets = SectionedBucketRows("Failure buckets", card.FailureBuckets),
         TopHunkKinds = SectionedBucketRows("Top hunk kinds", card.TopHunkKinds),
         TopOpcodeFamilies = SectionedBucketRows("Top opcode families", card.TopOpcodeFamilies),
@@ -608,16 +608,6 @@ static List<MetricChange<int>> BaselineMetricRows(BaselineComparison comparison)
     MetricCeiling("Failures", comparison.Baseline.Summary.FailureCount, comparison.Current.Summary.FailureCount, "max failures"),
 ];
 
-static List<BaselineSectionMetricChangeRow> SectionedBaselineMetricRows(BaselineComparison comparison)
-    => [.. BaselineMetricRows(comparison).Select(metric => new BaselineSectionMetricChangeRow(
-        "Baseline metric changes",
-        metric.Name,
-        metric.Before,
-        metric.After,
-        metric.Target,
-        metric.TargetLabel,
-        MetricStatusText(metric)))];
-
 static MetricChange<int> MetricDrift(string name, int baseline, int current)
     => new(name, baseline, current, Status: baseline == current ? GateStatus.Neutral : GateStatus.Warning, StatusLabel: baseline == current ? "unchanged" : "drift");
 
@@ -638,21 +628,6 @@ static GateStatus StatusForFloor(int target, int current)
 
 static string StatusLabelForFloor(int target, int current)
     => current < target ? "regression" : current > target ? "improvement" : "unchanged";
-
-static string MetricStatusText(MetricChange<int> metric)
-{
-    if (!string.IsNullOrEmpty(metric.StatusLabel))
-        return metric.StatusLabel!;
-
-    return metric.Status switch
-    {
-        GateStatus.Good => "good",
-        GateStatus.Neutral => "neutral",
-        GateStatus.Warning => "warning",
-        GateStatus.Bad => "bad",
-        _ => "unknown",
-    };
-}
 
 static IlDiffCard Aggregate(ImmutableArray<IlDiffPairCard> pairs, int maxExamples, bool snapshotPaths = false)
 {
@@ -801,7 +776,7 @@ sealed class IlDiffCardMarkdownView
     [MarkoutSection(Name = "Summary")]
     public List<IlDiffMetricRow>? Summary { get; init; }
 
-    [MarkoutSection(Name = "Baseline metric changes")]
+    [MarkoutSection(Name = "Baseline metric changes", IncludeSectionInStructuredRows = true)]
     public List<MetricChange<int>>? BaselineMetrics { get; init; }
 
     [MarkoutSection(Name = "Failure buckets", EmptyText = "None")]
@@ -832,8 +807,8 @@ sealed class IlDiffCardTableView
     [MarkoutSection(Name = "Summary")]
     public List<IlDiffSectionMetricRow>? Summary { get; init; }
 
-    [MarkoutSection(Name = "Baseline metric changes")]
-    public List<BaselineSectionMetricChangeRow>? BaselineMetrics { get; init; }
+    [MarkoutSection(Name = "Baseline metric changes", IncludeSectionInStructuredRows = true)]
+    public List<MetricChange<int>>? BaselineMetrics { get; init; }
 
     [MarkoutSection(Name = "Failure buckets", EmptyText = "None")]
     public List<IlDiffSectionBucketRow>? FailureBuckets { get; init; }
@@ -859,16 +834,6 @@ sealed record IlDiffMetricRow(string Metric, string Count);
 
 [MarkoutSerializable]
 sealed record IlDiffSectionMetricRow(string Section, string Metric, string Count);
-
-[MarkoutSerializable]
-sealed record BaselineSectionMetricChangeRow(
-    string Section,
-    string Metric,
-    int Before,
-    int After,
-    int? Target,
-    string? TargetLabel,
-    string Status);
 
 [MarkoutSerializable]
 sealed record IlDiffBucketRow(string Bucket, string Count);
@@ -919,7 +884,6 @@ sealed record IlDiffExampleTableRow(
 [MarkoutContext(typeof(IlDiffCardTableView))]
 [MarkoutContext(typeof(IlDiffMetricRow))]
 [MarkoutContext(typeof(IlDiffSectionMetricRow))]
-[MarkoutContext(typeof(BaselineSectionMetricChangeRow))]
 [MarkoutContext(typeof(IlDiffBucketRow))]
 [MarkoutContext(typeof(IlDiffSectionBucketRow))]
 [MarkoutContext(typeof(IlDiffPairSummaryRow))]


### PR DESCRIPTION
## Summary

- bump Markout to 0.18.0
- use `IncludeSectionInStructuredRows = true` on the real IL Diff baseline metric-change section
- remove the local sectioned baseline metric wrapper added before Markout 0.18 existed

This keeps Markdown on native `MetricChange<int>` and lets JSONL/TSV get the same `section` discriminator from Markout directly.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project tools/IlDiffHarness -c Release --no-build -- <DiffFixtures.V1.dll> <DiffFixtures.V2.dll> --emit-snapshot /tmp/markout018-followup-snapshot.json --max-examples 0`
- `dotnet run --project tools/IlDiffHarness -c Release --no-build -- <DiffFixtures.V1.dll> <DiffFixtures.V2.dll> --diff-baseline /tmp/markout018-followup-regression-baseline.json --format jsonl --max-examples 0` returns exit 1 for synthesized regression, emits `section: Baseline metric changes`, and parses as JSONL
- same regression baseline in Markdown still renders `Metric | Change | Target | Status`
- `npx markdownlint-cli tools/IlDiffHarness/README.md`