### PR TITLE
Use Markout goal-aware baseline metrics

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Markout" Version="0.18.0" />
+    <PackageVersion Include="Markout" Version="0.19.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />

--- a/tools/IlDiffHarness/Program.cs
+++ b/tools/IlDiffHarness/Program.cs
@@ -600,34 +600,19 @@ static string Count(int count) => count.ToString(System.Globalization.CultureInf
 
 static List<MetricChange<int>> BaselineMetricRows(BaselineComparison comparison) =>
 [
-    MetricDrift("Pairs", comparison.Baseline.Summary.PairCount, comparison.Current.Summary.PairCount),
-    MetricDrift("Compared bodies", comparison.Baseline.Summary.ComparedBodyCount, comparison.Current.Summary.ComparedBodyCount),
-    MetricFloor("Self-diff empty", comparison.Baseline.Summary.SelfDiffEmptyCount, comparison.Current.Summary.SelfDiffEmptyCount, "minimum self-diff empty"),
-    MetricDrift("Pair exact empty", comparison.Baseline.Summary.PairExactEmptyCount, comparison.Current.Summary.PairExactEmptyCount),
-    MetricDrift("Changed bodies", comparison.Baseline.Summary.ChangedBodyCount, comparison.Current.Summary.ChangedBodyCount),
-    MetricCeiling("Failures", comparison.Baseline.Summary.FailureCount, comparison.Current.Summary.FailureCount, "max failures"),
+    MetricContext("Pairs", comparison.Baseline.Summary.PairCount, comparison.Current.Summary.PairCount),
+    MetricContext("Compared bodies", comparison.Baseline.Summary.ComparedBodyCount, comparison.Current.Summary.ComparedBodyCount),
+    MetricGoal("Self-diff empty", comparison.Baseline.Summary.SelfDiffEmptyCount, comparison.Current.Summary.SelfDiffEmptyCount, "minimum self-diff empty", Goal.Higher),
+    MetricContext("Pair exact empty", comparison.Baseline.Summary.PairExactEmptyCount, comparison.Current.Summary.PairExactEmptyCount),
+    MetricContext("Changed bodies", comparison.Baseline.Summary.ChangedBodyCount, comparison.Current.Summary.ChangedBodyCount),
+    MetricGoal("Failures", comparison.Baseline.Summary.FailureCount, comparison.Current.Summary.FailureCount, "max failures", Goal.Lower),
 ];
 
-static MetricChange<int> MetricDrift(string name, int baseline, int current)
-    => new(name, baseline, current, Status: baseline == current ? GateStatus.Neutral : GateStatus.Warning, StatusLabel: baseline == current ? "unchanged" : "drift");
+static MetricChange<int> MetricContext(string name, int baseline, int current)
+    => new(name, baseline, current);
 
-static MetricChange<int> MetricCeiling(string name, int baseline, int current, string targetLabel)
-    => new(name, baseline, current, baseline, targetLabel, StatusForCeiling(baseline, current), StatusLabelForCeiling(baseline, current));
-
-static MetricChange<int> MetricFloor(string name, int baseline, int current, string targetLabel)
-    => new(name, baseline, current, baseline, targetLabel, StatusForFloor(baseline, current), StatusLabelForFloor(baseline, current));
-
-static GateStatus StatusForCeiling(int target, int current)
-    => current > target ? GateStatus.Bad : current < target ? GateStatus.Good : GateStatus.Neutral;
-
-static string StatusLabelForCeiling(int target, int current)
-    => current > target ? "regression" : current < target ? "improvement" : "unchanged";
-
-static GateStatus StatusForFloor(int target, int current)
-    => current < target ? GateStatus.Bad : current > target ? GateStatus.Good : GateStatus.Neutral;
-
-static string StatusLabelForFloor(int target, int current)
-    => current < target ? "regression" : current > target ? "improvement" : "unchanged";
+static MetricChange<int> MetricGoal(string name, int baseline, int current, string targetLabel, Goal goal)
+    => new(name, baseline, current, baseline, targetLabel) { Goal = goal };
 
 static IlDiffCard Aggregate(ImmutableArray<IlDiffPairCard> pairs, int maxExamples, bool snapshotPaths = false)
 {

--- a/tools/IlDiffHarness/README.md
+++ b/tools/IlDiffHarness/README.md
@@ -52,5 +52,6 @@ Baseline comparisons return exit code `1` for regressions (more failures, new
 failure buckets, or fewer self-diff-empty bodies) and report changed-body,
 hunk-kind, and opcode-family drift as non-failing drift. Baseline output uses
 Markout metric-change rows for scalar metrics (`Metric | Change | Target |
-Status` in Markdown, typed `before`/`after`/`target`/`status` fields in JSONL)
-and keeps detailed finding rows for bucket drift and regression evidence.
+Status` in Markdown, typed `before`/`after`/`target` fields plus goal-derived
+`direction`/`status` fields in JSONL) and keeps detailed finding rows for
+bucket drift and regression evidence.


### PR DESCRIPTION
## Summary

- bump Markout to 0.19.0
- use Markout `Goal.Higher` / `Goal.Lower` on IL Diff baseline `MetricChange<int>` rows
- remove the local floor/ceiling status helper logic now that Markout derives `direction` and `status`

## Validation

- `dotnet build tools/IlDiffHarness/IlDiffHarness.csproj -c Release --configfile nuget.config`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project tools/IlDiffHarness -c Release --no-build -- <DiffFixtures.V1.dll> <DiffFixtures.V2.dll> --emit-snapshot /tmp/markout019-snapshot.json --max-examples 0`
- synthesized failure-count regression baseline, then ran markdown and JSONL `--diff-baseline` outputs; both returned exit 1 as expected
- JSONL parses and includes goal-derived `direction` / `status` for goal-bearing rows
- `npx markdownlint-cli tools/IlDiffHarness/README.md`