### PR TITLE
Route C# diff subjects through Research member identity

### DIFF
--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -10,7 +10,7 @@ namespace ILInspector.Research.Tests;
 public class ResearchDiffTests
 {
     [Fact]
-    public void ResearchMemberIdentity_SubjectFromAnchor_PreservesAnchorIdentity()
+    public void ResearchMemberIdentity_SubjectFromAnchor_PreservesAnchorIdentityAndDisplay()
     {
         var anchor = new MemberAnchor(
             "M~1234567890",
@@ -19,11 +19,11 @@ public class ResearchDiffTests
             "Sample.Widget",
             "M");
 
-        var subject = ResearchMemberIdentity.SubjectFromAnchor(anchor);
+        var subject = ResearchMemberIdentity.SubjectFromAnchor(anchor, "Sample.Widget.M(System.Int32)");
 
         Assert.Equal(ResearchDiffSubjectKind.Member, subject.Kind);
         Assert.Equal(anchor.StableSelector, subject.Id);
-        Assert.Equal("Sample.Widget.M", subject.Display);
+        Assert.Equal("Sample.Widget.M(System.Int32)", subject.Display);
         Assert.Equal(anchor.TypeFullName, subject.TypeName);
         Assert.Equal(anchor.MemberName, subject.MemberName);
     }
@@ -443,6 +443,7 @@ public class ResearchDiffTests
         var changed = Assert.Single(diff.MembersWhere(member =>
             member.Subject.Display.Contains("SemanticReturnExpression", StringComparison.Ordinal)
             && member.HasChange("csharp.return-expression.changed")));
+        Assert.Contains("SemanticReturnExpression(System.Int32)", changed.Subject.Display, StringComparison.Ordinal);
         var evidence = Assert.Single(changed.Evidence, evidence => evidence.ChangeId == "csharp.return-expression.changed");
         Assert.Equal("value + 1", evidence.OldValue);
         Assert.Equal("value + 2", evidence.NewValue);
@@ -464,6 +465,7 @@ public class ResearchDiffTests
         var changed = Assert.Single(diff.MembersWhere(member =>
             member.Subject.Display.Contains("BodyStateSample", StringComparison.Ordinal)
             && member.HasChange("csharp.diff.old-body-missing")));
+        Assert.Contains("BodyStateSample.BodyState()", changed.Subject.Display, StringComparison.Ordinal);
         var evidence = Assert.Single(changed.Evidence, evidence => evidence.ChangeId == "csharp.diff.old-body-missing");
         Assert.Equal(ResearchDiffDirection.Added, evidence.Direction);
         Assert.NotNull(evidence.CSharpDisplayFailureRow);

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -2,12 +2,32 @@ using DotnetInspector.Fixtures;
 using ILInspector.Analysis;
 using ILInspector.Decompiler;
 using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
 using ILInspector.Instructions;
 
 namespace ILInspector.Research.Tests;
 
 public class ResearchDiffTests
 {
+    [Fact]
+    public void ResearchMemberIdentity_SubjectFromAnchor_PreservesAnchorIdentity()
+    {
+        var anchor = new MemberAnchor(
+            "M~1234567890",
+            "M:Sample.Widget.M()",
+            "1234567890",
+            "Sample.Widget",
+            "M");
+
+        var subject = ResearchMemberIdentity.SubjectFromAnchor(anchor);
+
+        Assert.Equal(ResearchDiffSubjectKind.Member, subject.Kind);
+        Assert.Equal(anchor.StableSelector, subject.Id);
+        Assert.Equal("Sample.Widget.M", subject.Display);
+        Assert.Equal(anchor.TypeFullName, subject.TypeName);
+        Assert.Equal(anchor.MemberName, subject.MemberName);
+    }
+
     [Fact]
     public void MetadataApiDiff_DefaultScope_IgnoresAttributeOnlyChanges()
     {

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -679,7 +679,7 @@ public static class ResearchDiff
 
         foreach (var row in diff.Rows)
         {
-            var subject = ResearchMemberIdentity.SubjectFromAnchor(row.Anchor);
+            var subject = ResearchMemberIdentity.SubjectFromAnchor(row.Anchor, row.Member);
             var direction = row.Kind switch
             {
                 CSharpDiffKind.Add => ResearchDiffDirection.Added,
@@ -702,7 +702,7 @@ public static class ResearchDiff
 
     static void AddCSharpFailureEvidence(ResultBuilder builder, CSharpDiffFailureRow failure)
     {
-        var subject = ResearchMemberIdentity.SubjectFromAnchor(failure.Anchor);
+        var subject = ResearchMemberIdentity.SubjectFromAnchor(failure.Anchor, failure.Member);
         var direction = failure.Kind switch
         {
             CSharpDiffFailureKind.OldBodyMissing => ResearchDiffDirection.Added,

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -679,12 +679,7 @@ public static class ResearchDiff
 
         foreach (var row in diff.Rows)
         {
-            var subject = new ResearchSubjectKey(
-                ResearchDiffSubjectKind.Member,
-                row.Anchor.StableSelector,
-                $"{row.Anchor.TypeFullName}.{row.Anchor.MemberName}",
-                row.Anchor.TypeFullName,
-                row.Anchor.MemberName);
+            var subject = ResearchMemberIdentity.SubjectFromAnchor(row.Anchor);
             var direction = row.Kind switch
             {
                 CSharpDiffKind.Add => ResearchDiffDirection.Added,
@@ -707,12 +702,7 @@ public static class ResearchDiff
 
     static void AddCSharpFailureEvidence(ResultBuilder builder, CSharpDiffFailureRow failure)
     {
-        var subject = new ResearchSubjectKey(
-            ResearchDiffSubjectKind.Member,
-            failure.Anchor.StableSelector,
-            $"{failure.Anchor.TypeFullName}.{failure.Anchor.MemberName}",
-            failure.Anchor.TypeFullName,
-            failure.Anchor.MemberName);
+        var subject = ResearchMemberIdentity.SubjectFromAnchor(failure.Anchor);
         var direction = failure.Kind switch
         {
             CSharpDiffFailureKind.OldBodyMissing => ResearchDiffDirection.Added,

--- a/src/ILInspector.Research/ResearchMemberIdentity.cs
+++ b/src/ILInspector.Research/ResearchMemberIdentity.cs
@@ -6,6 +6,14 @@ namespace ILInspector.Research;
 
 public static class ResearchMemberIdentity
 {
+    public static ResearchSubjectKey SubjectFromAnchor(MemberAnchor anchor)
+        => new(
+            ResearchDiffSubjectKind.Member,
+            anchor.StableSelector,
+            $"{anchor.TypeFullName}.{anchor.MemberName}",
+            anchor.TypeFullName,
+            anchor.MemberName);
+
     public static ResearchSubjectKey SubjectFromMethod(MethodIdentity method)
     {
         var typeName = method.DeclaringType.ToQualifiedDisplayString();

--- a/src/ILInspector.Research/ResearchMemberIdentity.cs
+++ b/src/ILInspector.Research/ResearchMemberIdentity.cs
@@ -6,11 +6,11 @@ namespace ILInspector.Research;
 
 public static class ResearchMemberIdentity
 {
-    public static ResearchSubjectKey SubjectFromAnchor(MemberAnchor anchor)
+    public static ResearchSubjectKey SubjectFromAnchor(MemberAnchor anchor, string display)
         => new(
             ResearchDiffSubjectKind.Member,
             anchor.StableSelector,
-            $"{anchor.TypeFullName}.{anchor.MemberName}",
+            display,
             anchor.TypeFullName,
             anchor.MemberName);
 


### PR DESCRIPTION
## Summary
- add `ResearchMemberIdentity.SubjectFromAnchor` as the shared anchor-to-subject projection
- route C# diff rows and failure rows through the shared helper
- cover the helper with a focused ResearchDiff test

## Validation
- `dotnet run --project src/ILInspector.Research.Tests -c Release`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity quiet`

## Review
- Adversarial review pending (MAI + Gemini, different model families from author).
