### PR TITLE
Use Markout dense goal rendering

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Markout" Version="0.19.0" />
+    <PackageVersion Include="Markout" Version="0.20.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />

--- a/tools/IlDiffHarness/README.md
+++ b/tools/IlDiffHarness/README.md
@@ -51,7 +51,8 @@ Use `--emit-snapshot <file>` to write stable JSON card data for a run. Use
 Baseline comparisons return exit code `1` for regressions (more failures, new
 failure buckets, or fewer self-diff-empty bodies) and report changed-body,
 hunk-kind, and opcode-family drift as non-failing drift. Baseline output uses
-Markout metric-change rows for scalar metrics (`Metric | Change | Target |
-Status` in Markdown, typed `before`/`after`/`target` fields plus goal-derived
-`direction`/`status` fields in JSONL) and keeps detailed finding rows for
-bucket drift and regression evidence.
+Markout metric-change rows for scalar metrics (`Metric | Change | Target` in
+Markdown, with goal markers in metric labels and goal-derived status inline in
+change cells; typed `before`/`after`/`target` fields plus goal-derived
+`direction`/`status` fields in JSONL) and keeps detailed finding rows for bucket
+drift and regression evidence.


### PR DESCRIPTION
## Summary

- bump Markout to 0.20.0
- use Markout's dense goal-aware Markdown rendering for IL Diff baseline metric rows
- update IlDiffHarness docs to describe the new `Metric | Change | Target` shape with goal markers and inline status

No harness code changes were needed because PR #2403 already moved baseline rows to goal-aware `MetricChange<int>`.

## Demo

```md
## Baseline metric changes

| Metric | Change | Target |
| ------ | ------ | ------ |
| Pairs | 1 → 1 | - |
| Compared bodies | 78 → 78 | - |
| Self-diff empty (+) | 79 → 78 (bad) | minimum self-diff empty: 79 |
| Pair exact empty | 33 → 33 | - |
| Changed bodies | 45 → 45 | - |
| Failures (-) | 0 → 7 (bad) | max failures: 0 |
```

```jsonl
{"section":"Baseline metric changes","metric":"Self-diff empty","before":79,"after":78,"target":79,"target_label":"minimum self-diff empty","direction":"decreased","status":"bad"}
{"section":"Baseline metric changes","metric":"Failures","before":0,"after":7,"target":0,"target_label":"max failures","direction":"introduced","status":"bad"}
```

## Validation

- `dotnet build tools/IlDiffHarness/IlDiffHarness.csproj -c Release --configfile nuget.config`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project tools/IlDiffHarness -c Release --no-build -- <DiffFixtures.V1.dll> <DiffFixtures.V2.dll> --emit-snapshot /tmp/markout020-snapshot.json --max-examples 0`
- synthesized regression baseline, then ran markdown and JSONL `--diff-baseline`; both returned exit 1 as expected
- JSONL parses and includes goal-derived `direction` / `status`
- `npx markdownlint-cli tools/IlDiffHarness/README.md`