### PR TITLE
Seed RTS closure roots from typed body evidence

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -180,16 +180,16 @@ public class ReturnToSenderPrototypeTests
                     Assert.Contains(first.Plan.Types, type => type.Name == "Helper");
                     Assert.Contains(first.Plan.TypeRequirements, requirement =>
                         requirement.Type.DisplayName == "Helper"
-                        && requirement.SourceFacts.Any(fact => fact.Id == "closure-root"
-                            && fact.Producer == "roslyn"
-                            && fact.Detail.StartsWith("CS0246", StringComparison.Ordinal)));
+                        && requirement.SourceFacts.Any(fact => fact.Id == "body-type"
+                            && fact.Producer == "metadata"
+                            && fact.Detail == "Helper"));
                     var evidence = ReturnToSenderClosureEvidenceBuilder.FromPlan(first.Plan);
                     Assert.Equal(2, evidence.RequiredTypes);
-                    Assert.Equal(1, evidence.RoslynRecoveredTypes);
+                    Assert.Equal(0, evidence.RoslynRecoveredTypes);
                     Assert.Contains(evidence.Requirements, requirement =>
                         requirement.Type == "Helper"
-                        && requirement.RoslynRecovered
-                        && requirement.Facts.Any(fact => fact.StartsWith("roslyn/closure-root: CS0246", StringComparison.Ordinal)));
+                        && !requirement.RoslynRecovered
+                        && requirement.Facts.Contains("metadata/body-type: Helper"));
                 },
                 second =>
                 {
@@ -228,7 +228,7 @@ public class ReturnToSenderPrototypeTests
                 $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             Assert.Contains(result.Plan.Types, type =>
                 type.Name == "Helper"
-                && type.SourceFacts.Any(fact => fact.Id == "closure-root" && fact.Producer == "roslyn")
+                && type.SourceFacts.Any(fact => fact.Id == "body-type" && fact.Producer == "metadata")
                 && type.Members.Any(member => member.Name == "Value" && member.Kind == CompileBackMemberKind.PropertyGet)
                 && type.Members.Any(member => member.Name == "Create" && member.Kind == CompileBackMemberKind.Method && member.IsStatic));
             Assert.Contains("public int Value", result.Source);
@@ -260,7 +260,7 @@ public class ReturnToSenderPrototypeTests
             var type = Assert.Single(result.Plan.Types);
             Assert.Contains(type.SourceFacts, fact =>
                 fact.Producer == "roslyn"
-                && fact.Id == "closure-root"
+                && fact.Id == "closure-member"
                 && fact.Detail.StartsWith("CS0103", StringComparison.Ordinal));
             Assert.Contains(type.Members, member => member.Name == "GetValue" && member.Kind == CompileBackMemberKind.Method);
             Assert.Contains("public int GetValue()", result.Source);
@@ -300,7 +300,7 @@ public class ReturnToSenderPrototypeTests
             Assert.Contains(result.Plan.Types, type =>
                 type.Namespace == "Other.Deep"
                 && type.Name == "Helper"
-                && type.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-root"));
+                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "body-type"));
             Assert.Contains("namespace Other.Deep", result.Source);
             Assert.Contains("public class Helper", result.Source);
         }
@@ -337,11 +337,11 @@ public class ReturnToSenderPrototypeTests
             Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
             Assert.Contains(result.Plan.Types, type =>
                 type.Name == "A"
-                && type.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-root")
+                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "body-type")
                 && type.Members.Any(member => member.Name == "Create"));
             Assert.Contains(result.Plan.Types, type =>
                 type.Name == "B"
-                && type.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-root")
+                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "body-type")
                 && type.Members.Any(member => member.Name == "Value"));
             Assert.Contains("public static B Create()", result.Source);
             Assert.Contains("public int Value", result.Source);

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -647,11 +647,13 @@ static class ReturnToSender
             allowUnsafe: true);
         var references = CompilationReferences(assemblyPath).ToArray();
         var indexes = ClosureIndexes(reader);
+        var targetRoot = TopLevelRootOf(reader, typeHandle);
         var closureRoots = new HashSet<TypeDefinitionHandle>
         {
-            TopLevelRootOf(reader, typeHandle),
+            targetRoot,
         };
         var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
+        SeedTypedClosureRoots(reader, function, targetRoot, closureRoots, closureFacts);
         const int maxRoots = 200;
         const int maxIterations = 80;
         Diagnostic? firstError = null;
@@ -800,11 +802,13 @@ static class ReturnToSender
             allowUnsafe: true);
         var references = CompilationReferences(assemblyPath).ToArray();
         var indexes = ClosureIndexes(reader);
+        var targetRoot = TopLevelRootOf(reader, typeHandle);
         var closureRoots = new HashSet<TypeDefinitionHandle>
         {
-            TopLevelRootOf(reader, typeHandle),
+            targetRoot,
         };
         var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
+        SeedTypedClosureRoots(reader, function, targetRoot, closureRoots, closureFacts);
         const int maxRoots = 200;
         const int maxIterations = 80;
         Diagnostic? firstError = null;
@@ -952,11 +956,13 @@ static class ReturnToSender
             allowUnsafe: true);
         var references = CompilationReferences(assemblyPath).ToArray();
         var indexes = ClosureIndexes(reader);
+        var targetRoot = TopLevelRootOf(reader, typeHandle);
         var closureRoots = new HashSet<TypeDefinitionHandle>
         {
-            TopLevelRootOf(reader, typeHandle),
+            targetRoot,
         };
         var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
+        SeedTypedClosureRoots(reader, function, targetRoot, closureRoots, closureFacts);
         const int maxRoots = 200;
         const int maxIterations = 80;
         Diagnostic? firstError = null;
@@ -1377,6 +1383,102 @@ static class ReturnToSender
         Dictionary<string, List<TypeDefinitionHandle>> Namespaces,
         Dictionary<TypeDefinitionHandle, string> RootNamespaces);
 
+    static void SeedTypedClosureRoots(
+        MetadataReader reader,
+        IrFunction function,
+        TypeDefinitionHandle targetRoot,
+        HashSet<TypeDefinitionHandle> closureRoots,
+        Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts)
+    {
+        string assemblyName = reader.GetString(reader.GetAssemblyDefinition().Name);
+        var definitions = TypeDefinitionsByTypeRefIdentity(reader);
+        foreach (var node in function.Descendants.Prepend(function))
+        {
+            foreach (var type in node.DirectTypes)
+                AddTypedClosureRoot(type);
+            if (node is IrExpression expression)
+                AddTypedClosureRoot(expression.ResultType);
+        }
+
+        void AddTypedClosureRoot(TypeRef? type)
+        {
+            switch (type?.Kind)
+            {
+                case TypeRefKind.Definition:
+                    if (type.Assembly != assemblyName)
+                        return;
+                    string key = TypeRefIdentityKey(type.Namespace, type.Name);
+                    if (!definitions.TryGetValue(key, out var handle))
+                        return;
+                    var root = TopLevelRootOf(reader, handle);
+                    if (root == targetRoot)
+                        return;
+                    if (!IsSupportedClosureRoot(reader, reader.GetTypeDefinition(root)))
+                        return;
+                    closureRoots.Add(root);
+                    AddClosureFact(
+                        closureFacts,
+                        root,
+                        new CompileBackFact("metadata", "body-type", TypeRefIdentityKey(type.Namespace, type.Name, separator: ".")));
+                    break;
+                case TypeRefKind.GenericInstance:
+                    AddTypedClosureRoot(type.ElementType);
+                    foreach (var argument in type.TypeArguments)
+                        AddTypedClosureRoot(argument);
+                    break;
+                case TypeRefKind.SzArray or TypeRefKind.Array
+                    or TypeRefKind.ByRef or TypeRefKind.Pointer or TypeRefKind.Pinned:
+                    AddTypedClosureRoot(type.ElementType);
+                    break;
+                case TypeRefKind.FunctionPointer:
+                    AddTypedClosureRoot(type.ElementType);
+                    foreach (var argument in type.TypeArguments)
+                        AddTypedClosureRoot(argument);
+                    break;
+            }
+        }
+    }
+
+    static Dictionary<string, TypeDefinitionHandle> TypeDefinitionsByTypeRefIdentity(MetadataReader reader)
+    {
+        var definitions = new Dictionary<string, TypeDefinitionHandle>(StringComparer.Ordinal);
+        foreach (var handle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            if (!IsSupportedClosureRoot(reader, typeDef))
+                continue;
+            var (ns, name) = TypeRefIdentity(reader, handle);
+            definitions.TryAdd(TypeRefIdentityKey(ns, name), handle);
+        }
+
+        return definitions;
+    }
+
+    static (string Namespace, string Name) TypeRefIdentity(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        var typeDef = reader.GetTypeDefinition(handle);
+        string name = reader.GetString(typeDef.Name);
+        if (!typeDef.IsNested)
+            return (reader.GetString(typeDef.Namespace), name);
+
+        var declaring = TypeRefIdentity(reader, typeDef.GetDeclaringType());
+        return (declaring.Namespace, $"{declaring.Name}+{name}");
+    }
+
+    static string TypeRefIdentityKey(string ns, string name, string separator = "|")
+        => ns.Length == 0 ? name : $"{ns}{separator}{name}";
+
+    static void AddClosureFact(
+        Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
+        TypeDefinitionHandle root,
+        CompileBackFact fact)
+    {
+        if (!closureFacts.TryGetValue(root, out var facts))
+            closureFacts[root] = facts = [];
+        if (!facts.Contains(fact))
+            facts.Add(fact);
+    }
+
     static ClosureIndex ClosureIndexes(MetadataReader reader)
     {
         var types = new Dictionary<string, List<TypeDefinitionHandle>>(StringComparer.Ordinal);
@@ -1564,12 +1666,13 @@ static class ReturnToSender
         bool changed = false;
         foreach (var root in roots)
         {
-            changed |= closureRoots.Add(root);
+            bool addedRoot = closureRoots.Add(root);
+            changed |= addedRoot;
 
             if (!closureFacts.TryGetValue(root, out var facts))
                 closureFacts[root] = facts = [];
             var rootFact = new CompileBackFact("roslyn", "closure-root", $"{diagnostic.Id}: {detail}");
-            if (!facts.Contains(rootFact))
+            if (addedRoot && !facts.Contains(rootFact))
             {
                 facts.Add(rootFact);
                 changed = true;


### PR DESCRIPTION
## Summary

- seed ReturnToSender closure roots from typed IR body/type evidence before Roslyn compile-back diagnostics
- mark type-only same-assembly closure roots as `metadata/body-type` instead of Roslyn-recovered missing-name roots
- keep Roslyn diagnostic fallback for member-surface recovery and unresolved cases

## Validation

- `dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderEvidenceTests/*"`
- `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal.property.literal --max-examples 3`

Adversarial review requested separately.