### PR TITLE
Add IL diff baseline bucket rows

### DIFF
--- a/tools/IlDiffHarness/Program.cs
+++ b/tools/IlDiffHarness/Program.cs
@@ -549,6 +549,7 @@ static IlDiffCardMarkdownView BuildMarkdownView(ImmutableArray<IlDiffPairCard> p
     {
         Summary = SummaryRows(pairs.Length, card),
         BaselineMetrics = comparison is null ? null : BaselineMetricRows(comparison),
+        BaselineBuckets = comparison is null ? null : BaselineBucketRows(comparison),
         FailureBuckets = MarkdownBucketRows(card.FailureBuckets) ?? [],
         TopHunkKinds = MarkdownBucketRows(card.TopHunkKinds) ?? [],
         TopOpcodeFamilies = MarkdownBucketRows(card.TopOpcodeFamilies) ?? [],
@@ -565,6 +566,7 @@ static IlDiffCardTableView BuildTableView(ImmutableArray<IlDiffPairCard> pairs, 
     {
         Summary = SectionedSummaryRows(pairs.Length, card),
         BaselineMetrics = comparison is null ? null : BaselineMetricRows(comparison),
+        BaselineBuckets = comparison is null ? null : BaselineBucketRows(comparison),
         FailureBuckets = SectionedBucketRows("Failure buckets", card.FailureBuckets),
         TopHunkKinds = SectionedBucketRows("Top hunk kinds", card.TopHunkKinds),
         TopOpcodeFamilies = SectionedBucketRows("Top opcode families", card.TopOpcodeFamilies),
@@ -613,6 +615,28 @@ static MetricChange<int> MetricContext(string name, int baseline, int current)
 
 static MetricChange<int> MetricGoal(string name, int baseline, int current, string targetLabel, Goal goal)
     => new(name, baseline, current, baseline, targetLabel) { Goal = goal };
+
+static List<MultiSourceRow> BaselineBucketRows(BaselineComparison comparison) =>
+[
+    BucketChangeRow("Failure buckets", comparison.Baseline.FailureBuckets ?? [], comparison.Current.FailureBuckets ?? []),
+    BucketChangeRow("Hunk kinds", comparison.Baseline.HunkKindBuckets ?? [], comparison.Current.HunkKindBuckets ?? []),
+    BucketChangeRow("Opcode families", comparison.Baseline.OpcodeFamilyBuckets ?? [], comparison.Current.OpcodeFamilyBuckets ?? []),
+];
+
+static MultiSourceRow BucketChangeRow(string label, IReadOnlyList<CardBucket> baseline, IReadOnlyList<CardBucket> current)
+    => new(label, SegmentSource("baseline", baseline), SegmentSource("current", current));
+
+static Source SegmentSource(string role, IReadOnlyList<CardBucket> buckets)
+{
+    var segments = buckets
+        .Where(bucket => bucket.Count != 0)
+        .Take(10)
+        .Select(bucket => new Segment(bucket.Name, bucket.Count))
+        .ToArray();
+    return segments.Length == 0
+        ? new Source(role, (IMarkoutCell?)null)
+        : new Source(role, new Segments(segments));
+}
 
 static IlDiffCard Aggregate(ImmutableArray<IlDiffPairCard> pairs, int maxExamples, bool snapshotPaths = false)
 {
@@ -764,6 +788,10 @@ sealed class IlDiffCardMarkdownView
     [MarkoutSection(Name = "Baseline metric changes", IncludeSectionInStructuredRows = true)]
     public List<MetricChange<int>>? BaselineMetrics { get; init; }
 
+    [MarkoutSection(Name = "Baseline bucket changes", IncludeSectionInStructuredRows = true)]
+    [MarkoutLabelHeader("Bucket set")]
+    public List<MultiSourceRow>? BaselineBuckets { get; init; }
+
     [MarkoutSection(Name = "Failure buckets", EmptyText = "None")]
     public List<IlDiffBucketRow>? FailureBuckets { get; init; }
 
@@ -794,6 +822,10 @@ sealed class IlDiffCardTableView
 
     [MarkoutSection(Name = "Baseline metric changes", IncludeSectionInStructuredRows = true)]
     public List<MetricChange<int>>? BaselineMetrics { get; init; }
+
+    [MarkoutSection(Name = "Baseline bucket changes", IncludeSectionInStructuredRows = true)]
+    [MarkoutLabelHeader("Bucket set")]
+    public List<MultiSourceRow>? BaselineBuckets { get; init; }
 
     [MarkoutSection(Name = "Failure buckets", EmptyText = "None")]
     public List<IlDiffSectionBucketRow>? FailureBuckets { get; init; }

--- a/tools/IlDiffHarness/README.md
+++ b/tools/IlDiffHarness/README.md
@@ -35,6 +35,7 @@ The card includes:
 - pair exact-empty and changed-body counts;
 - failure count and failure buckets;
 - baseline metric changes when `--diff-baseline` is used;
+- baseline bucket changes when `--diff-baseline` is used;
 - top hunk kinds and opcode families;
 - per-pair summary rows;
 - capped examples rendered through `IlDiffPrinter`.
@@ -55,4 +56,6 @@ Markout metric-change rows for scalar metrics (`Metric | Change | Target` in
 Markdown, with goal markers in metric labels and goal-derived status inline in
 change cells; typed `before`/`after`/`target` fields plus goal-derived
 `direction`/`status` fields in JSONL) and keeps detailed finding rows for bucket
-drift and regression evidence.
+drift and regression evidence. Baseline bucket output uses Markout multi-source
+rows to compare baseline/current failure buckets, hunk kinds, and opcode
+families in Markdown and as section-aware decomposed JSONL/TSV rows.


### PR DESCRIPTION
## Summary

- add a `Baseline bucket changes` section to `IlDiffHarness --diff-baseline`
- use Markout `MultiSourceRow`/`Segments` to compare baseline vs current failure buckets, hunk kinds, and opcode families
- keep detailed `Baseline findings` rows for regression and drift evidence

This extends the Markout reference pattern beyond scalar `MetricChange<T>` rows into section-aware multi-source bucket rows.

## Demo

```md
## Baseline bucket changes

| Bucket set | baseline | current |
| ---------- | -------- | ------- |
| Failure buckets | - | 4/3 |
| Hunk kinds | 102/59 | 102/59 |
| Opcode families | 55/15/8/7/7/6/5/5/4/4 | 55/15/8/7/7/6/5/5/4/4 |
```

```jsonl
{"section":"Baseline bucket changes","bucket_set":"Failure buckets","current_new_body_missing":4,"current_old_body_missing":3}
```

## Validation

- `dotnet build tools/IlDiffHarness/IlDiffHarness.csproj -c Release --configfile nuget.config`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project tools/IlDiffHarness -c Release --no-build -- <DiffFixtures.V1.dll> <DiffFixtures.V2.dll> --emit-snapshot /tmp/ildiff-bucket-snapshot.json --max-examples 0`
- synthesized regression baseline with failure buckets removed, then ran markdown and JSONL `--diff-baseline`; both returned exit 1 as expected
- JSONL parses and includes `section: Baseline bucket changes` rows with baseline/current decomposed segment fields
- `npx markdownlint-cli tools/IlDiffHarness/README.md`