### PR TITLE
Add gated IL diff harness CI smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
+      ildiff: ${{ steps.filter.outputs.ildiff }}
       ilroundtrip: ${{ steps.filter.outputs.ilroundtrip }}
       packaging: ${{ steps.filter.outputs.packaging }}
     steps:
@@ -48,6 +49,7 @@ jobs:
           fi
           CODE=false
           DOCS=false
+          ILDIFF=false
           ILROUNDTRIP=false
           PACKAGING=false
           while IFS= read -r file; do
@@ -61,6 +63,19 @@ jobs:
               eng/prepare-decompiler-pr-corpus.sh) CODE=true ;;
               *.props|*.targets|*.sln|*.slnx) CODE=true ;;
               .github/workflows/*) CODE=true ;;
+            esac
+            # IL Diff smoke coverage is intentionally separate from the full
+            # test lane: most PRs skip it, and IlDiffHarness-only changes get a
+            # cheap targeted build/smoke instead of the whole test suite.
+            case "$file" in
+              tools/IlDiffHarness/*) ILDIFF=true ;;
+              src/ILInspector.Instructions/*) ILDIFF=true ;;
+              src/ILInspector.ControlFlow/*) ILDIFF=true ;;
+              src/DiffFixtures.V1/*) ILDIFF=true ;;
+              src/DiffFixtures.V2/*) ILDIFF=true ;;
+              Directory.Packages.props) ILDIFF=true ;;
+              *.props|*.targets|*.slnx) ILDIFF=true ;;
+              .github/workflows/ci.yml) ILDIFF=true ;;
             esac
             case "$file" in
               *.md|*.txt|docs/*|skills/*) DOCS=true ;;
@@ -97,11 +112,12 @@ jobs:
           done <<< "$FILES"
           echo "code=$CODE" >> "$GITHUB_OUTPUT"
           echo "docs=$DOCS" >> "$GITHUB_OUTPUT"
+          echo "ildiff=$ILDIFF" >> "$GITHUB_OUTPUT"
           echo "ilroundtrip=$ILROUNDTRIP" >> "$GITHUB_OUTPUT"
           echo "packaging=$PACKAGING" >> "$GITHUB_OUTPUT"
           echo "Changed files:"
           echo "$FILES"
-          echo "code=$CODE docs=$DOCS ilroundtrip=$ILROUNDTRIP packaging=$PACKAGING"
+          echo "code=$CODE docs=$DOCS ildiff=$ILDIFF ilroundtrip=$ILROUNDTRIP packaging=$PACKAGING"
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -261,6 +277,107 @@ jobs:
       - name: Run IL round-trip tests
         if: matrix.rid == 'linux-x64' && needs.changes.outputs.ilroundtrip == 'true'
         run: dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
+
+  # Cheap IL Diff harness coverage. It is path-gated separately from the full
+  # test lane so most PRs do no more than their existing build/test work, while
+  # IL Diff-specific changes get a focused snapshot/baseline JSONL smoke.
+  il-diff-smoke:
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.ildiff == 'true'
+    runs-on: ubuntu-26.04
+    env:
+      DOTNET_INSPECT_TIPS: q
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/*.slnx') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Build IL Diff harness and fixtures
+        run: |
+          dotnet build tools/IlDiffHarness/IlDiffHarness.csproj -c Release
+          dotnet build src/DiffFixtures.V1/DiffFixtures.V1.csproj -c Release
+          dotnet build src/DiffFixtures.V2/DiffFixtures.V2.csproj -c Release
+
+      - name: Run IL Diff baseline smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/il-diff-smoke
+          old=artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll
+          new=artifacts/bin/DiffFixtures.V2/release/DiffFixtureSample.dll
+
+          dotnet run --project tools/IlDiffHarness -c Release --no-build -- \
+            "$old" "$new" \
+            --emit-snapshot artifacts/il-diff-smoke/snapshot.json \
+            --format jsonl \
+            --max-examples 0 \
+            > artifacts/il-diff-smoke/snapshot.jsonl
+
+          dotnet run --project tools/IlDiffHarness -c Release --no-build -- \
+            "$old" "$new" \
+            --diff-baseline artifacts/il-diff-smoke/snapshot.json \
+            --format jsonl \
+            --max-examples 0 \
+            > artifacts/il-diff-smoke/exact.jsonl
+
+          cat > /tmp/il-diff-mutate-baseline.cs <<'CS'
+          using System.Text.Json.Nodes;
+          var node = JsonNode.Parse(File.ReadAllText(args[0]))!.AsObject();
+          node["Summary"]!["FailureCount"] = 0;
+          node["FailureBuckets"] = new JsonArray();
+          File.WriteAllText(args[1], node.ToJsonString(new System.Text.Json.JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine);
+          CS
+          dotnet run /tmp/il-diff-mutate-baseline.cs -- \
+            artifacts/il-diff-smoke/snapshot.json \
+            artifacts/il-diff-smoke/regression-baseline.json
+
+          set +e
+          dotnet run --project tools/IlDiffHarness -c Release --no-build -- \
+            "$old" "$new" \
+            --diff-baseline artifacts/il-diff-smoke/regression-baseline.json \
+            --format jsonl \
+            --max-examples 0 \
+            > artifacts/il-diff-smoke/regression.jsonl
+          status=$?
+          set -e
+          test "$status" -eq 1
+
+          cat > /tmp/il-diff-parse-jsonl.cs <<'CS'
+          using System.Text.Json;
+          foreach (var path in args)
+          {
+              foreach (var line in File.ReadLines(path))
+              {
+                  if (string.IsNullOrWhiteSpace(line))
+                      continue;
+                  JsonDocument.Parse(line).Dispose();
+              }
+          }
+          CS
+          dotnet run /tmp/il-diff-parse-jsonl.cs -- \
+            artifacts/il-diff-smoke/snapshot.jsonl \
+            artifacts/il-diff-smoke/exact.jsonl \
+            artifacts/il-diff-smoke/regression.jsonl
+
+      - name: Upload IL Diff smoke artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: il-diff-smoke
+          path: artifacts/il-diff-smoke/
+          if-no-files-found: warn
 
   # Pack and smoke test on Ubuntu. This is a packaging smoke test only: it
   # validates that the tool still packs and installs. It is NOT the source of


### PR DESCRIPTION
## Summary

- add an `ildiff` changes filter to CI
- add a separate path-gated `il-diff-smoke` job for IL Diff-specific changes
- build only IlDiffHarness plus DiffFixtures V1/V2 in that job
- smoke snapshot JSONL, exact baseline JSONL, synthesized regression baseline exit 1, and JSONL parseability

The smoke job is separate from the full test lane so most PRs do not pay for it, and IlDiffHarness-only changes get targeted coverage instead of requiring the whole test suite.

## Validation

Ran the same commands locally with repo `nuget.config`:

- `dotnet build tools/IlDiffHarness/IlDiffHarness.csproj -c Release --configfile nuget.config`
- `dotnet build src/DiffFixtures.V1/DiffFixtures.V1.csproj -c Release --configfile nuget.config`
- `dotnet build src/DiffFixtures.V2/DiffFixtures.V2.csproj -c Release --configfile nuget.config`
- `dotnet run --project tools/IlDiffHarness -c Release --no-build -- <V1.dll> <V2.dll> --emit-snapshot /tmp/il-diff-smoke/snapshot.json --format jsonl --max-examples 0`
- `dotnet run --project tools/IlDiffHarness -c Release --no-build -- <V1.dll> <V2.dll> --diff-baseline /tmp/il-diff-smoke/snapshot.json --format jsonl --max-examples 0`
- synthesized regression baseline with failure count reset and failure buckets cleared; `--diff-baseline` returned exit 1
- parsed snapshot, exact, and regression JSONL outputs with `System.Text.Json`