### PR TITLE
Seed RTS closure members from typed body evidence

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -246,6 +246,46 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_EmitsGenericClosureMemberSurface()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Helper<T>
+            {
+                public int Value => 42;
+                public static Helper<T> Create() => new Helper<T>();
+            }
+
+            public class Class1
+            {
+                public int FromGeneric => Helper<int>.Create().Value;
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackPropertyGetters(assemblyPath, maxTargets: 2)
+                .Single(item => item.Plan.TargetMethod.Method == "get_FromGeneric");
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains(result.Plan.Types, type =>
+                type.Name == "Helper"
+                && type.TypeParameters.Single().Name == "T"
+                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "closure-member" && fact.Detail.EndsWith("Helper`1.Create", StringComparison.Ordinal))
+                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "closure-member" && fact.Detail.EndsWith("Helper`1.get_Value", StringComparison.Ordinal))
+                && !type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "roslyn")
+                && type.Members.Any(member => member.Name == "Value")
+                && type.Members.Any(member => member.Name == "Create"));
+            var evidence = ReturnToSenderClosureEvidenceBuilder.FromPlan(result.Plan);
+            Assert.Equal(0, evidence.RoslynRecoveredMemberSurfaces);
+            Assert.Contains("public class Helper<T>", result.Source);
+            Assert.Contains("public static Helper<T> Create()", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_EmitsTargetRootSiblingMemberSurface()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -229,8 +229,13 @@ public class ReturnToSenderPrototypeTests
             Assert.Contains(result.Plan.Types, type =>
                 type.Name == "Helper"
                 && type.SourceFacts.Any(fact => fact.Id == "body-type" && fact.Producer == "metadata")
+                && type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "metadata" && fact.Detail.EndsWith(".Create", StringComparison.Ordinal))
+                && type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "metadata" && fact.Detail.EndsWith(".get_Value", StringComparison.Ordinal))
+                && !type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "roslyn")
                 && type.Members.Any(member => member.Name == "Value" && member.Kind == CompileBackMemberKind.PropertyGet)
                 && type.Members.Any(member => member.Name == "Create" && member.Kind == CompileBackMemberKind.Method && member.IsStatic));
+            var evidence = ReturnToSenderClosureEvidenceBuilder.FromPlan(result.Plan);
+            Assert.Equal(0, evidence.RoslynRecoveredMemberSurfaces);
             Assert.Contains("public int Value", result.Source);
             Assert.Contains("public static Helper Create()", result.Source);
         }
@@ -338,11 +343,17 @@ public class ReturnToSenderPrototypeTests
             Assert.Contains(result.Plan.Types, type =>
                 type.Name == "A"
                 && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "body-type")
+                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "closure-member" && fact.Detail.EndsWith(".Create", StringComparison.Ordinal))
+                && !type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "roslyn")
                 && type.Members.Any(member => member.Name == "Create"));
             Assert.Contains(result.Plan.Types, type =>
                 type.Name == "B"
                 && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "body-type")
+                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "closure-member" && fact.Detail.EndsWith(".get_Value", StringComparison.Ordinal))
+                && !type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "roslyn")
                 && type.Members.Any(member => member.Name == "Value"));
+            var evidence = ReturnToSenderClosureEvidenceBuilder.FromPlan(result.Plan);
+            Assert.Equal(0, evidence.RoslynRecoveredMemberSurfaces);
             Assert.Contains("public static B Create()", result.Source);
             Assert.Contains("public int Value", result.Source);
         }

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -1921,7 +1921,7 @@ public static class CompileBackSourceComposer
         {
             var typeDef = reader.GetTypeDefinition(handle);
             var members = RequiredMemberDeclarations(requirement);
-            bool includeMemberSurface = requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+            bool includeMemberSurface = requirement.SourceFacts.Any(fact => fact.Id == "closure-member");
             if (includeMemberSurface)
                 AddClosureMemberSurface(reader, typeDef, requirement, members, diagnostics);
 
@@ -2001,7 +2001,7 @@ public static class CompileBackSourceComposer
                     SourceFacts: [new CompileBackFact("metadata", "nested-closure-type", identity.FullName)]);
                 var members = RequiredMemberDeclarations(requirement);
                 bool includeNestedMemberSurface = includeMemberSurface
-                    || requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+                    || requirement.SourceFacts.Any(fact => fact.Id == "closure-member");
                 if (includeNestedMemberSurface)
                     AddClosureMemberSurface(reader, nestedDef, requirement, members, diagnostics, allowUnsafeSurface: true);
                 nestedTypes.Add(new CompileBackTypeDeclaration(
@@ -2073,7 +2073,7 @@ public static class CompileBackSourceComposer
 
             allowUnsafeSurface = allowUnsafeSurface
                 || requirement.RequiredMembers.Count != 0
-                || requirement.SourceFacts.Any(fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+                || requirement.SourceFacts.Any(fact => fact.Id == "closure-member");
             var accessorMethods = new HashSet<MethodDefinitionHandle>();
             var typeContext = GenericContext.ForType(reader, typeDef);
             foreach (var fieldHandle in typeDef.GetFields())

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1398,6 +1398,7 @@ static class ReturnToSender
                 AddTypedClosureRoot(type);
             if (node is IrExpression expression)
                 AddTypedClosureRoot(expression.ResultType);
+            AddTypedClosureMemberFacts(node);
         }
 
         void AddTypedClosureRoot(TypeRef? type)
@@ -1405,15 +1406,9 @@ static class ReturnToSender
             switch (type?.Kind)
             {
                 case TypeRefKind.Definition:
-                    if (type.Assembly != assemblyName)
+                    if (TryResolveRoot(type) is not { } root)
                         return;
-                    string key = TypeRefIdentityKey(type.Namespace, type.Name);
-                    if (!definitions.TryGetValue(key, out var handle))
-                        return;
-                    var root = TopLevelRootOf(reader, handle);
                     if (root == targetRoot)
-                        return;
-                    if (!IsSupportedClosureRoot(reader, reader.GetTypeDefinition(root)))
                         return;
                     closureRoots.Add(root);
                     AddClosureFact(
@@ -1434,6 +1429,98 @@ static class ReturnToSender
                     AddTypedClosureRoot(type.ElementType);
                     foreach (var argument in type.TypeArguments)
                         AddTypedClosureRoot(argument);
+                    break;
+            }
+        }
+
+        TypeDefinitionHandle? TryResolveRoot(TypeRef? type)
+            => TryResolveHandle(type) is { } handle
+                ? TopLevelRootOf(reader, handle)
+                : null;
+
+        TypeDefinitionHandle? TryResolveHandle(TypeRef? type)
+        {
+            if (type is not { Kind: TypeRefKind.Definition } || type.Assembly != assemblyName)
+                return null;
+            string key = TypeRefIdentityKey(type.Namespace, type.Name);
+            if (!definitions.TryGetValue(key, out var handle))
+                return null;
+            return IsSupportedClosureRoot(reader, reader.GetTypeDefinition(handle)) ? handle : null;
+        }
+
+        void AddMemberFact(TypeRef declaringType, string kind, string name)
+        {
+            if (TryResolveHandle(declaringType) is not { } handle)
+                return;
+            var root = TopLevelRootOf(reader, handle);
+            if (root == targetRoot || root != handle)
+                return;
+            AddClosureFact(
+                closureFacts,
+                root,
+                new CompileBackFact("metadata", "closure-member", $"{kind}: {TypeRefIdentityKey(declaringType.Namespace, declaringType.Name, separator: ".")}.{name}"));
+        }
+
+        void AddMethodFact(MethodRef method)
+            => AddMemberFact(method.DeclaringType, "method", method.Name);
+
+        void AddFieldFact(FieldRef field)
+            => AddMemberFact(field.DeclaringType, "field", field.Name);
+
+        void AddTypedClosureMemberFacts(IrNode node)
+        {
+            switch (node)
+            {
+                case Call call:
+                    AddMethodFact(call.Callee);
+                    break;
+                case NewObject creation:
+                    AddMethodFact(creation.Constructor);
+                    break;
+                case LoadProperty load:
+                    AddMethodFact(load.Accessor);
+                    break;
+                case StoreProperty store:
+                    AddMethodFact(store.Accessor);
+                    break;
+                case EventSubscription subscription:
+                    AddMethodFact(subscription.Accessor);
+                    break;
+                case LoadFunctionPointer load:
+                    AddMethodFact(load.Method);
+                    break;
+                case AddressOfMethod address:
+                    AddMethodFact(address.Method);
+                    break;
+                case DelegateCreation creation:
+                    AddMethodFact(creation.Method);
+                    break;
+                case RecursivePropertyDeclarationPattern pattern:
+                    AddMethodFact(pattern.Accessor);
+                    break;
+                case NullCoalescingPropertyAssignment assignment:
+                    AddMethodFact(assignment.Setter);
+                    break;
+                case DeconstructionAssignment deconstruction:
+                    foreach (var target in deconstruction.Targets)
+                    {
+                        if (target.Accessor is { } accessor)
+                            AddMethodFact(accessor);
+                        if (target.Field is { } field)
+                            AddFieldFact(field);
+                    }
+                    break;
+                case LoadField load:
+                    AddFieldFact(load.Field);
+                    break;
+                case StoreField store:
+                    AddFieldFact(store.Field);
+                    break;
+                case LoadFieldAddress address:
+                    AddFieldFact(address.Field);
+                    break;
+                case NullCoalescingFieldAssignment assignment:
+                    AddFieldFact(assignment.Field);
                     break;
             }
         }

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1450,7 +1450,10 @@ static class ReturnToSender
 
         void AddMemberFact(TypeRef declaringType, string kind, string name)
         {
-            if (TryResolveHandle(declaringType) is not { } handle)
+            var definition = declaringType.Kind == TypeRefKind.GenericInstance
+                ? declaringType.ElementType ?? declaringType
+                : declaringType;
+            if (TryResolveHandle(definition) is not { } handle)
                 return;
             var root = TopLevelRootOf(reader, handle);
             if (root == targetRoot || root != handle)
@@ -1458,7 +1461,7 @@ static class ReturnToSender
             AddClosureFact(
                 closureFacts,
                 root,
-                new CompileBackFact("metadata", "closure-member", $"{kind}: {TypeRefIdentityKey(declaringType.Namespace, declaringType.Name, separator: ".")}.{name}"));
+                new CompileBackFact("metadata", "closure-member", $"{kind}: {TypeRefIdentityKey(definition.Namespace, definition.Name, separator: ".")}.{name}"));
         }
 
         void AddMethodFact(MethodRef method)


### PR DESCRIPTION
## Summary

- seed ReturnToSender closure member-surface facts from typed IR MethodRef/FieldRef/accessor evidence for non-target top-level same-assembly closure roots
- allow product compile-back composition to treat any `closure-member` fact as a member-surface request, not only Roslyn-derived facts
- keep target-root and nested-root member-surface cases on the existing Roslyn fallback until precise member requirements replace broad surface emission

## Validation

- `dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderEvidenceTests/*"`
- `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal.property.literal --max-examples 3`

Adversarial review requested separately.