### PR TITLE
Use metric-change rows in C# diff harness

### DIFF
--- a/tools/CSharpDiffHarness/Program.cs
+++ b/tools/CSharpDiffHarness/Program.cs
@@ -572,7 +572,8 @@ static string Count(int count) => count.ToString(System.Globalization.CultureInf
 
 static List<MetricChange<int>> BaselineMetricRows(BaselineComparison comparison) =>
 [
-    MetricContext("Exact pairs", comparison.Baseline.Summary.ExactPairCount, comparison.Current.Summary.ExactPairCount),
+    MetricContext("Pairs", comparison.Baseline.Summary.PairCount, comparison.Current.Summary.PairCount),
+    MetricGoal("Exact pairs", comparison.Baseline.Summary.ExactPairCount, comparison.Current.Summary.ExactPairCount, "minimum exact pairs", Goal.Higher),
     MetricGoal("Changed pairs", comparison.Baseline.Summary.ChangedPairCount, comparison.Current.Summary.ChangedPairCount, "max changed pairs", Goal.Lower),
     MetricContext("Changed members", comparison.Baseline.Summary.ChangedMemberCount, comparison.Current.Summary.ChangedMemberCount),
     MetricGoal("Rows", comparison.Baseline.Summary.RowCount, comparison.Current.Summary.RowCount, "max rows", Goal.Lower),

--- a/tools/CSharpDiffHarness/Program.cs
+++ b/tools/CSharpDiffHarness/Program.cs
@@ -471,7 +471,7 @@ static CSharpDiffCardMarkdownView BuildMarkdownView(ImmutableArray<CSharpDiffPai
         TopChangeIds = MarkdownBucketRows(card.TopChangeIds) ?? [],
         TopOperationKinds = MarkdownBucketRows(card.TopOperationKinds) ?? [],
         PairSummaries = [.. pairs.Select(pair => PairSummaryRow(pair))],
-        BaselineComparison = comparison is null ? null : BaselineRows(comparison) ?? [],
+        BaselineFindings = comparison is null ? null : BaselineRows(comparison) ?? [],
         Examples = card.Examples.IsDefaultOrEmpty ? null : [.. card.Examples.Select(ExampleMarkdownRow)],
     };
 }
@@ -488,7 +488,7 @@ static CSharpDiffCardTableView BuildTableView(ImmutableArray<CSharpDiffPairCard>
         TopChangeIds = SectionedBucketRows("Top change IDs", card.TopChangeIds),
         TopOperationKinds = SectionedBucketRows("Top operation kinds", card.TopOperationKinds),
         PairSummaries = [.. pairs.Select(pair => SectionedPairSummaryRow(pair))],
-        BaselineComparison = comparison is null ? null : SectionedBaselineRows(comparison),
+        BaselineFindings = comparison is null ? null : SectionedBaselineRows(comparison),
         Examples = card.Examples.IsDefaultOrEmpty ? null : [.. card.Examples.Select(ExampleTableRow)],
     };
 }
@@ -616,7 +616,7 @@ static List<BaselineFindingView>? BaselineRows(BaselineComparison comparison)
 static List<BaselineSectionFindingView>? SectionedBaselineRows(BaselineComparison comparison)
     => comparison.Rows.IsDefaultOrEmpty
         ? null
-        : [.. comparison.Rows.Select(row => new BaselineSectionFindingView("Baseline comparison", row.Kind, row.Metric, row.Baseline, row.Current, row.Detail))];
+        : [.. comparison.Rows.Select(row => new BaselineSectionFindingView("Baseline findings", row.Kind, row.Metric, row.Baseline, row.Current, row.Detail))];
 
 static CSharpDiffPairSummaryRow PairSummaryRow(CSharpDiffPairCard pair)
     => new(
@@ -789,8 +789,8 @@ sealed class CSharpDiffCardMarkdownView
     [MarkoutSection(Name = "Pair summaries")]
     public List<CSharpDiffPairSummaryRow>? PairSummaries { get; init; }
 
-    [MarkoutSection(Name = "Baseline comparison", EmptyText = "No baseline regressions or drift.")]
-    public List<BaselineFindingView>? BaselineComparison { get; init; }
+    [MarkoutSection(Name = "Baseline findings", EmptyText = "No baseline regressions or drift.")]
+    public List<BaselineFindingView>? BaselineFindings { get; init; }
 
     [MarkoutSection(Name = "Examples")]
     public List<CSharpDiffExampleMarkdownView>? Examples { get; init; }
@@ -824,8 +824,8 @@ sealed class CSharpDiffCardTableView
     [MarkoutSection(Name = "Pair summaries")]
     public List<CSharpDiffSectionPairSummaryRow>? PairSummaries { get; init; }
 
-    [MarkoutSection(Name = "Baseline comparison", EmptyText = "No baseline regressions or drift.")]
-    public List<BaselineSectionFindingView>? BaselineComparison { get; init; }
+    [MarkoutSection(Name = "Baseline findings", EmptyText = "No baseline regressions or drift.")]
+    public List<BaselineSectionFindingView>? BaselineFindings { get; init; }
 
     [MarkoutSection(Name = "Examples")]
     public List<CSharpDiffExampleTableRow>? Examples { get; init; }

--- a/tools/CSharpDiffHarness/Program.cs
+++ b/tools/CSharpDiffHarness/Program.cs
@@ -465,7 +465,8 @@ static CSharpDiffCardMarkdownView BuildMarkdownView(ImmutableArray<CSharpDiffPai
     return new CSharpDiffCardMarkdownView
     {
         Summary = SummaryRows(pairs.Length, card),
-        BaselineCard = comparison is null ? null : BuildBaselineDataCard(comparison.Baseline, comparison.Current, comparison),
+        BaselineMetrics = comparison is null ? null : BaselineMetricRows(comparison),
+        BaselineBuckets = comparison is null ? null : BaselineBucketRows(comparison),
         FailureBuckets = MarkdownBucketRows(card.FailureBuckets) ?? [],
         TopChangeIds = MarkdownBucketRows(card.TopChangeIds) ?? [],
         TopOperationKinds = MarkdownBucketRows(card.TopOperationKinds) ?? [],
@@ -481,7 +482,8 @@ static CSharpDiffCardTableView BuildTableView(ImmutableArray<CSharpDiffPairCard>
     return new CSharpDiffCardTableView
     {
         Summary = SectionedSummaryRows(pairs.Length, card),
-        BaselineCard = comparison is null ? null : BuildBaselineDataCard(comparison.Baseline, comparison.Current, comparison),
+        BaselineMetrics = comparison is null ? null : BaselineMetricRows(comparison),
+        BaselineBuckets = comparison is null ? null : BaselineBucketRows(comparison),
         FailureBuckets = SectionedBucketRows("Failure buckets", card.FailureBuckets),
         TopChangeIds = SectionedBucketRows("Top change IDs", card.TopChangeIds),
         TopOperationKinds = SectionedBucketRows("Top operation kinds", card.TopOperationKinds),
@@ -568,25 +570,42 @@ static List<CSharpDiffSectionMetricRow> SectionedSummaryRows(int pairCount, CSha
 
 static string Count(int count) => count.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
-static CSharpDiffBaselineDataCard BuildBaselineDataCard(CSharpDiffSnapshot baseline, CSharpDiffSnapshot current, BaselineComparison comparison)
-    => new()
-    {
-        ExactPairs = new(baseline.Summary.ExactPairCount, current.Summary.ExactPairCount),
-        ChangedPairs = new(baseline.Summary.ChangedPairCount, current.Summary.ChangedPairCount),
-        ChangedMembers = new(baseline.Summary.ChangedMemberCount, current.Summary.ChangedMemberCount),
-        Rows = new(baseline.Summary.RowCount, current.Summary.RowCount),
-        Failures = new(baseline.Summary.FailureCount, current.Summary.FailureCount),
-        FailureBuckets = new(ToSegments(baseline.FailureBuckets ?? []), ToSegments(current.FailureBuckets ?? [])),
-        ChangeIds = new(ToSegments(baseline.ChangeIdBuckets ?? []), ToSegments(current.ChangeIdBuckets ?? [])),
-        OperationKinds = new(ToSegments(baseline.OperationKindBuckets ?? []), ToSegments(current.OperationKindBuckets ?? [])),
-        Verdict = comparison.HasRegressions ? "REGRESSION" : comparison.Rows.IsDefaultOrEmpty ? "MATCH" : "DRIFT",
-    };
+static List<MetricChange<int>> BaselineMetricRows(BaselineComparison comparison) =>
+[
+    MetricContext("Exact pairs", comparison.Baseline.Summary.ExactPairCount, comparison.Current.Summary.ExactPairCount),
+    MetricGoal("Changed pairs", comparison.Baseline.Summary.ChangedPairCount, comparison.Current.Summary.ChangedPairCount, "max changed pairs", Goal.Lower),
+    MetricContext("Changed members", comparison.Baseline.Summary.ChangedMemberCount, comparison.Current.Summary.ChangedMemberCount),
+    MetricGoal("Rows", comparison.Baseline.Summary.RowCount, comparison.Current.Summary.RowCount, "max rows", Goal.Lower),
+    MetricGoal("Failures", comparison.Baseline.Summary.FailureCount, comparison.Current.Summary.FailureCount, "max failures", Goal.Lower),
+];
 
-static Segments ToSegments(IReadOnlyList<CardBucket> buckets)
-    => new([.. buckets
+static MetricChange<int> MetricContext(string name, int baseline, int current)
+    => new(name, baseline, current);
+
+static MetricChange<int> MetricGoal(string name, int baseline, int current, string targetLabel, Goal goal)
+    => new(name, baseline, current, baseline, targetLabel) { Goal = goal };
+
+static List<MultiSourceRow> BaselineBucketRows(BaselineComparison comparison) =>
+[
+    BucketChangeRow("Failure buckets", comparison.Baseline.FailureBuckets ?? [], comparison.Current.FailureBuckets ?? []),
+    BucketChangeRow("Change IDs", comparison.Baseline.ChangeIdBuckets ?? [], comparison.Current.ChangeIdBuckets ?? []),
+    BucketChangeRow("Operation kinds", comparison.Baseline.OperationKindBuckets ?? [], comparison.Current.OperationKindBuckets ?? []),
+];
+
+static MultiSourceRow BucketChangeRow(string label, IReadOnlyList<CardBucket> baseline, IReadOnlyList<CardBucket> current)
+    => new(label, SegmentSource("baseline", baseline), SegmentSource("current", current));
+
+static Source SegmentSource(string role, IReadOnlyList<CardBucket> buckets)
+{
+    var segments = buckets
         .Where(bucket => bucket.Count != 0)
         .Take(10)
-        .Select(bucket => new Segment(bucket.Name, bucket.Count))]);
+        .Select(bucket => new Segment(bucket.Name, bucket.Count))
+        .ToArray();
+    return segments.Length == 0
+        ? new Source(role, (IMarkoutCell?)null)
+        : new Source(role, new Segments(segments));
+}
 
 static List<BaselineFindingView>? BaselineRows(BaselineComparison comparison)
     => comparison.Rows.IsDefaultOrEmpty
@@ -750,8 +769,12 @@ sealed class CSharpDiffCardMarkdownView
     [MarkoutSection(Name = "Summary")]
     public List<CSharpDiffMetricRow>? Summary { get; init; }
 
-    [MarkoutSection(Name = "Baseline card")]
-    public CSharpDiffBaselineDataCard? BaselineCard { get; init; }
+    [MarkoutSection(Name = "Baseline metric changes", IncludeSectionInStructuredRows = true)]
+    public List<MetricChange<int>>? BaselineMetrics { get; init; }
+
+    [MarkoutSection(Name = "Baseline bucket changes", IncludeSectionInStructuredRows = true)]
+    [MarkoutLabelHeader("Bucket set")]
+    public List<MultiSourceRow>? BaselineBuckets { get; init; }
 
     [MarkoutSection(Name = "Failure buckets", EmptyText = "None")]
     public List<CSharpDiffBucketRow>? FailureBuckets { get; init; }
@@ -781,8 +804,12 @@ sealed class CSharpDiffCardTableView
     [MarkoutSection(Name = "Summary")]
     public List<CSharpDiffSectionMetricRow>? Summary { get; init; }
 
-    [MarkoutSection(Name = "Baseline card")]
-    public CSharpDiffBaselineDataCard? BaselineCard { get; init; }
+    [MarkoutSection(Name = "Baseline metric changes", IncludeSectionInStructuredRows = true)]
+    public List<MetricChange<int>>? BaselineMetrics { get; init; }
+
+    [MarkoutSection(Name = "Baseline bucket changes", IncludeSectionInStructuredRows = true)]
+    [MarkoutLabelHeader("Bucket set")]
+    public List<MultiSourceRow>? BaselineBuckets { get; init; }
 
     [MarkoutSection(Name = "Failure buckets", EmptyText = "None")]
     public List<CSharpDiffSectionBucketRow>? FailureBuckets { get; init; }
@@ -805,34 +832,6 @@ sealed class CSharpDiffCardTableView
 
 [MarkoutSerializable]
 sealed record CSharpDiffMetricRow(string Metric, string Count);
-
-[MarkoutSerializable]
-sealed class CSharpDiffBaselineDataCard
-{
-    [MarkoutPropertyName("exact pairs")]
-    public Change<int> ExactPairs { get; init; }
-
-    [MarkoutPropertyName("changed pairs")]
-    public Change<int> ChangedPairs { get; init; }
-
-    [MarkoutPropertyName("changed members")]
-    public Change<int> ChangedMembers { get; init; }
-
-    public Change<int> Rows { get; init; }
-
-    public Change<int> Failures { get; init; }
-
-    [MarkoutPropertyName("failure buckets")]
-    public Change<Segments> FailureBuckets { get; init; }
-
-    [MarkoutPropertyName("change IDs")]
-    public Change<Segments> ChangeIds { get; init; }
-
-    [MarkoutPropertyName("operation kinds")]
-    public Change<Segments> OperationKinds { get; init; }
-
-    public string Verdict { get; init; } = "";
-}
 
 [MarkoutSerializable]
 sealed record CSharpDiffSectionMetricRow(string Section, string Metric, string Count);
@@ -883,7 +882,6 @@ sealed record CSharpDiffExampleTableRow(
 [MarkoutContext(typeof(CSharpDiffCardMarkdownView))]
 [MarkoutContext(typeof(CSharpDiffCardTableView))]
 [MarkoutContext(typeof(CSharpDiffMetricRow))]
-[MarkoutContext(typeof(CSharpDiffBaselineDataCard))]
 [MarkoutContext(typeof(CSharpDiffSectionMetricRow))]
 [MarkoutContext(typeof(CSharpDiffBucketRow))]
 [MarkoutContext(typeof(CSharpDiffSectionBucketRow))]

--- a/tools/CSharpDiffHarness/README.md
+++ b/tools/CSharpDiffHarness/README.md
@@ -36,7 +36,7 @@ The card includes:
 - failure buckets;
 - top change IDs and operation kinds;
 - per-pair summary rows;
-- optional baseline/current data card and comparison rows;
+- optional baseline metric and bucket changes plus comparison rows;
 - capped examples rendered through `CSharpDiffPrinter`.
 
 Output defaults to Markout Markdown. Use `--format tsv` or `--format jsonl` to
@@ -47,6 +47,8 @@ Use `--emit-snapshot <file>` to write stable JSON card data for a run. Use
 `--diff-baseline <file>` to compare the current run against a previous snapshot.
 Baseline comparisons return exit code `1` for regressions (more failures, more
 changed pairs, more rows, fewer exact pairs, or new failure buckets) and report
-other metric and bucket changes as non-failing drift. The baseline card uses
-Markout composite cells (`Change<T>` and `Segments`) so Markdown stays compact
-while JSONL preserves typed baseline/current fields.
+other metric and bucket changes as non-failing drift. Baseline output uses
+Markout metric-change rows for scalar metrics (`Metric | Change | Target` in
+Markdown, with goal markers and inline status where a target applies) and
+multi-source rows for bucket changes. JSONL preserves typed baseline/current
+fields, direction/status, and segment values.


### PR DESCRIPTION
## Summary

Updates `CSharpDiffHarness` baseline output to use the Markout 0.20 goal-aware metric card model.

## Details

- Replaces the scalar baseline `Change<int>` data-card object with `MetricChange<int>` rows.
- Adds goal-aware targets for metrics with gates:
  - changed pairs: max baseline value;
  - rows: max baseline value;
  - failures: max baseline value.
- Keeps changed members/exact pairs as context metric changes without goals.
- Replaces bucket `Change<Segments>` rows with `MultiSourceRow` bucket sections for baseline/current failure buckets, change IDs, and operation kinds.
- Updates C# diff harness docs to describe the `Metric | Change | Target` scalar metric shape and multi-source bucket rows.

This mirrors the IL diff harness goal-aware Markout model while preserving the existing snapshot and baseline comparison semantics.

## Diff preview

Key shape change:

```diff
- [MarkoutSection(Name = "Baseline card")]
- public CSharpDiffBaselineDataCard? BaselineCard { get; init; }
+ [MarkoutSection(Name = "Baseline metric changes", IncludeSectionInStructuredRows = true)]
+ public List<MetricChange<int>>? BaselineMetrics { get; init; }
+
+ [MarkoutSection(Name = "Baseline bucket changes", IncludeSectionInStructuredRows = true)]
+ [MarkoutLabelHeader("Bucket set")]
+ public List<MultiSourceRow>? BaselineBuckets { get; init; }
```

Sample Markdown:

```md
| Metric | Change | Target |
| ------ | ------ | ------ |
| Changed pairs (-) | 0 → 1 (bad) | max changed pairs: 0 |
| Rows (-) | 173 → 174 (bad) | max rows: 173 |
| Failures (-) | 0 → 1 (bad) | max failures: 0 |
```

Sample JSONL:

```jsonl
{"section":"Baseline metric changes","metric":"Rows","before":173,"after":174,"target":173,"target_label":"max rows","direction":"increased","status":"bad"}
{"section":"Baseline bucket changes","bucket_set":"Failure buckets","current_old_method_has_no_c_body":1}
```

## Validation

- `dotnet build tools/CSharpDiffHarness -c Release --configfile nuget.config --verbosity minimal`
- `dotnet run --project tools/CSharpDiffHarness -c Release --no-build -- artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll artifacts/bin/DiffFixtures.V2/release/DiffFixtureSample.dll --max-examples 0 --diff-baseline /tmp/csharp-metric-baseline.json` returned exit `1` for the synthesized regression baseline
- `dotnet run --project tools/CSharpDiffHarness -c Release --no-build -- artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll artifacts/bin/DiffFixtures.V2/release/DiffFixtureSample.dll --max-examples 0 --diff-baseline /tmp/csharp-metric-baseline.json --format jsonl` returned exit `1`
- `npx markdownlint-cli --fix tools/CSharpDiffHarness/README.md && npx markdownlint-cli tools/CSharpDiffHarness/README.md`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/DiffCommandTests/*"`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore --verbosity minimal`
- `git diff --check`

## Review

Adversarial review is required for this decompiler test-tool/reporting shape change and will be posted before marking ready.
