### PR TITLE
Move ordinary analysis fixture sources

### DIFF
--- a/src/ILInspector.Analysis.Fixtures/CrossAsmShapeFixtures/Shapes.cs
+++ b/src/ILInspector.Analysis.Fixtures/CrossAsmShapeFixtures/Shapes.cs
@@ -5,14 +5,14 @@ namespace ILInspector.Analysis.CrossAsmShapeFixtures;
 // sees these types only as TypeRef/TypeSpec metadata. They let the tests assert that the
 // allocation signal classifies a `newobj` of each shape honestly (#1804):
 //
-//   * CrossValueStruct       — non-generic struct: value-type-ness is UNRESOLVABLE from the
+//   * CrossValueStruct       - non-generic struct: value-type-ness is UNRESOLVABLE from the
 //                              consumer alone (a bare TypeRef), so its `newobj` is an owned
 //                              false-positive allocation at the no-assembly-loading boundary.
-//   * CrossGenericStruct<T>  — constructed generic struct: the consumer's own TypeSpec
+//   * CrossGenericStruct<T>  - constructed generic struct: the consumer's own TypeSpec
 //                              signature blob encodes VALUETYPE, so its `newobj` IS resolved
 //                              as non-heap.
-//   * CrossRefType           — reference type: its `newobj` is a real heap allocation.
-//   * CrossEnum              — enum: a value type; cast/use must not be a heap allocation.
+//   * CrossRefType           - reference type: its `newobj` is a real heap allocation.
+//   * CrossEnum              - enum: a value type; cast/use must not be a heap allocation.
 
 public struct CrossValueStruct
 {

--- a/src/ILInspector.Analysis.Fixtures/ExceptionBaseFixtures/ExternalFixtureException.cs
+++ b/src/ILInspector.Analysis.Fixtures/ExceptionBaseFixtures/ExternalFixtureException.cs
@@ -15,10 +15,10 @@ public class ExternalFixtureException : Exception
 // adversarial) rather than silent:
 //
 //   * ExternalPseudoException ends with "Exception" but does NOT derive from
-//     System.Exception — the suffix fallback over-accepts it (a pinned false
+//     System.Exception - the suffix fallback over-accepts it (a pinned false
 //     positive boundary).
 //   * ExternalErrorState DOES derive from System.Exception but does not end with
-//     "Exception" — the suffix fallback misses it (a pinned false negative
+//     "Exception" - the suffix fallback misses it (a pinned false negative
 //     boundary).
 
 // Name ends with "Exception" but is a plain reference type, not an exception.

--- a/src/ILInspector.Analysis.Fixtures/ILInspector.Analysis.Fixtures.csproj
+++ b/src/ILInspector.Analysis.Fixtures/ILInspector.Analysis.Fixtures.csproj
@@ -15,9 +15,4 @@
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\ILInspector.Analysis.CrossAsmShapeFixtures\*.cs" Link="CrossAsmShapeFixtures\%(Filename)%(Extension)" />
-    <Compile Include="..\ILInspector.Analysis.ExceptionBaseFixtures\*.cs" Link="ExceptionBaseFixtures\%(Filename)%(Extension)" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## Summary
- move the ordinary CrossAsmShape and ExceptionBase fixture sources under `ILInspector.Analysis.Fixtures`
- remove linked sibling-source compile items so the consolidated project uses normal SDK source inclusion
- leave the remaining analysis fixture projects split because they encode semantic axes: assembly name, TFM, aliases/collisions, framework reference, or caller-graph assembly boundaries

## Validation
- `dotnet build dotnet-inspect.slnx -c Release --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json --verbosity minimal`
- `dotnet run --project tests/DotnetInspector.Fixtures.Tests -c Release --no-build --no-restore`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build --no-restore -- -trait- "Speed=Slow"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build --no-restore -- -filter "/*/*/LibraryBodyIndexTests/*"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build --no-restore -- -filter "/*/*/CrossAsmCollisionTests/*"`
- `git diff --check`

Adversarial review pending per analysis PR policy.