### PR TITLE
Move C# diff anchor identity to Metadata

### DIFF
--- a/src/ILInspector.Decompiler/CSharpBodyDiff.cs
+++ b/src/ILInspector.Decompiler/CSharpBodyDiff.cs
@@ -302,20 +302,14 @@ public static class CSharpBodyDiff
                     continue;
 
                 var signature = method.DecodeSignature(TypeRefDecoder.Instance, GenericScope.Empty);
-                var apiSignature = method.DecodeSignature(
-                    TypeRefDecoder.Instance,
-                    new GenericScope(TypeParameterNames(reader, type), MethodParameterNames(reader, method)));
                 string returnType = CanonicalTypeName(signature.ReturnType);
                 var parameters = signature.ParameterTypes.Select(CanonicalTypeName).ToImmutableArray();
                 int genericArity = method.GetGenericParameters().Count;
                 string methodGeneric = GenericParameterList(genericArity, isMethod: true);
-                string selectorName = MemberSelectorForMetadataName(methodName, IsExtensionMethod(reader, type, method));
                 string returnSuffix = IsConversionOperator(methodName) ? $"~{returnType}" : "";
                 string canonicalName = CanonicalMemberName(methodName);
                 string rawKey = $"M:{typeKey}.{canonicalName}{methodGeneric}({string.Join(",", parameters)}){returnSuffix}";
-                string apiMemberName = ApiMemberName(reader, methodName, method);
-                string anchorCanonical = $"M:{ApiTypeName(reader, typeHandle)}.{apiMemberName}{ApiParameterList(apiSignature.ParameterTypes)}";
-                var anchor = CreateMemberAnchor(ApiTypeName(reader, typeHandle), selectorName, apiMemberName, anchorCanonical);
+                var anchor = ApiMemberIdentity.CreateMethodAnchor(reader, typeHandle, method, IsExtensionMethod(reader, type, method));
                 string displayName = methodName == ".ctor" ? "#ctor" : methodName;
                 string display = $"{typeDisplay}.{displayName}{GenericAritySuffix(genericArity)}({string.Join(", ", parameters)})";
                 yield return new CSharpMethodEntry(
@@ -341,70 +335,6 @@ public static class CSharpBodyDiff
 
     static string CanonicalMemberName(string methodName)
         => methodName == ".ctor" ? "#ctor" : methodName;
-
-    static string ApiTypeName(MetadataReader reader, TypeDefinitionHandle handle)
-    {
-        var type = reader.GetTypeDefinition(handle);
-        var genericNames = type.GetGenericParameters()
-            .Select(parameter => reader.GetString(reader.GetGenericParameter(parameter).Name))
-            .ToArray();
-        string name = reader.GetString(type.Name);
-        int tick = name.IndexOf('`');
-        string simple = tick < 0 ? name : name[..tick];
-        if (genericNames.Length > 0)
-            simple += $"<{string.Join(",", genericNames)}>";
-        var declaring = type.GetDeclaringType();
-        if (!declaring.IsNil)
-            return $"{ApiTypeName(reader, declaring)}.{simple}";
-        string ns = reader.GetString(type.Namespace);
-        return string.IsNullOrEmpty(ns) ? simple : $"{ns}.{simple}";
-    }
-
-    static string ApiMemberName(MetadataReader reader, string methodName, MethodDefinition method)
-    {
-        if (methodName == ".ctor")
-            return "#ctor";
-        var genericNames = MethodParameterNames(reader, method)
-            .ToArray();
-        return genericNames.Length == 0 ? methodName : $"{methodName}<{string.Join(",", genericNames)}>";
-    }
-
-    static string ApiParameterList(IEnumerable<TypeRef> parameterTypes)
-        => $"({string.Join(",", parameterTypes.Select(ApiTypeName))})";
-
-    static string ApiTypeName(TypeRef type)
-        => type.Kind switch
-        {
-            TypeRefKind.Definition => type.Namespace.Length == 0
-                ? type.Name.Replace("+", ".", StringComparison.Ordinal)
-                : $"{type.Namespace}.{type.Name.Replace("+", ".", StringComparison.Ordinal)}",
-            TypeRefKind.GenericInstance => $"{ApiTypeName(type.ElementType!)}<{string.Join(",", type.TypeArguments.Select(ApiTypeName))}>",
-            TypeRefKind.SzArray => $"{ApiTypeName(type.ElementType!)}[]",
-            TypeRefKind.Array => $"{ApiTypeName(type.ElementType!)}[{(type.Rank == 1 ? "*" : new string(',', type.Rank - 1))}]",
-            TypeRefKind.ByRef => $"{ApiTypeName(type.ElementType!)}&",
-            TypeRefKind.Pointer => $"{ApiTypeName(type.ElementType!)}*",
-            TypeRefKind.Pinned => $"pinned {ApiTypeName(type.ElementType!)}",
-            TypeRefKind.GenericParameter or TypeRefKind.MethodGenericParameter
-                => type.GenericParameterName.Length == 0 ? $"!{type.GenericParameterIndex}" : type.GenericParameterName,
-            TypeRefKind.FunctionPointer => $"delegate*<{string.Join(",", type.TypeArguments.Select(ApiTypeName).Append(ApiTypeName(type.ElementType!)))}>",
-            _ => $"<unsupported:{type.UnsupportedReason}>",
-        };
-
-    static ImmutableArray<string> TypeParameterNames(MetadataReader reader, TypeDefinition type)
-        => ParameterNames(reader, type.GetGenericParameters());
-
-    static ImmutableArray<string> MethodParameterNames(MetadataReader reader, MethodDefinition method)
-        => ParameterNames(reader, method.GetGenericParameters());
-
-    static ImmutableArray<string> ParameterNames(MetadataReader reader, GenericParameterHandleCollection handles)
-    {
-        if (handles.Count == 0)
-            return [];
-        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
-        foreach (var handle in handles)
-            names.Add(reader.GetString(reader.GetGenericParameter(handle).Name));
-        return names.MoveToImmutable();
-    }
 
     static bool IsExtensionMethod(MetadataReader reader, TypeDefinition type, MethodDefinition method)
         => type.Attributes.HasFlag(TypeAttributes.Abstract)
@@ -447,14 +377,6 @@ public static class CSharpBodyDiff
         var prefix = isMethod ? "!!" : "!";
         return $"<{string.Join(",", Enumerable.Range(0, arity).Select(index => $"{prefix}{index}"))}>";
     }
-
-    static MemberAnchor CreateMemberAnchor(string typeFullName, string selectorName, string memberName, string canonicalSignature)
-        => new(
-            $"{selectorName}~{MemberAnchor.ComputeFingerprint(canonicalSignature)}",
-            canonicalSignature,
-            MemberAnchor.ComputeFingerprint(canonicalSignature),
-            typeFullName,
-            memberName);
 
     static string DuplicateDiscriminator(MetadataReader reader, MethodDefinition method)
     {
@@ -770,16 +692,6 @@ public static class CSharpBodyDiff
 
         return false;
     }
-
-    static string MemberSelectorForMetadataName(string methodName, bool isExtensionMethod = false)
-        => methodName switch
-        {
-            ".ctor" => ".ctor",
-            _ when isExtensionMethod => $"extension:{methodName}",
-            _ when methodName.StartsWith("op_", StringComparison.Ordinal) => $"operator:{methodName}",
-            _ when methodName.Contains('.') => $"explicit:{methodName}",
-            _ => methodName,
-        };
 
     static bool MatchesTypeFilter(string typeFullName, string filter)
     {

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
 using ILInspector.MetadataPrimitives;
 
 namespace ILInspector.Metadata;
@@ -9,6 +11,73 @@ namespace ILInspector.Metadata;
 /// </summary>
 public static class ApiMemberIdentity
 {
+    sealed class AnchorSignatureTypeProvider : ISignatureTypeProvider<string, GenericContext?>
+    {
+        public static readonly AnchorSignatureTypeProvider Instance = new();
+
+        public string GetPrimitiveType(PrimitiveTypeCode typeCode)
+            => typeCode switch
+            {
+                PrimitiveTypeCode.Boolean => "System.Boolean",
+                PrimitiveTypeCode.Byte => "System.Byte",
+                PrimitiveTypeCode.SByte => "System.SByte",
+                PrimitiveTypeCode.Char => "System.Char",
+                PrimitiveTypeCode.Int16 => "System.Int16",
+                PrimitiveTypeCode.UInt16 => "System.UInt16",
+                PrimitiveTypeCode.Int32 => "System.Int32",
+                PrimitiveTypeCode.UInt32 => "System.UInt32",
+                PrimitiveTypeCode.Int64 => "System.Int64",
+                PrimitiveTypeCode.UInt64 => "System.UInt64",
+                PrimitiveTypeCode.Single => "System.Single",
+                PrimitiveTypeCode.Double => "System.Double",
+                PrimitiveTypeCode.IntPtr => "System.IntPtr",
+                PrimitiveTypeCode.UIntPtr => "System.UIntPtr",
+                PrimitiveTypeCode.String => "System.String",
+                PrimitiveTypeCode.Object => "System.Object",
+                PrimitiveTypeCode.Void => "System.Void",
+                PrimitiveTypeCode.TypedReference => "System.TypedReference",
+                _ => typeCode.ToString(),
+            };
+
+        public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+            => TypeResolver.GetFullName(reader, reader.GetTypeDefinition(handle)).Replace('+', '.');
+
+        public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+            => TypeResolver.GetTypeNameFromReference(reader, handle).Replace('+', '.');
+
+        public string GetTypeFromSpecification(MetadataReader reader, GenericContext? context, TypeSpecificationHandle handle, byte rawTypeKind)
+            => reader.GetTypeSpecification(handle).DecodeSignature(this, context);
+
+        public string GetSZArrayType(string elementType) => $"{elementType}[]";
+
+        public string GetArrayType(string elementType, ArrayShape shape)
+            => $"{elementType}[{(shape.Rank == 1 ? "*" : new string(',', shape.Rank - 1))}]";
+
+        public string GetByReferenceType(string elementType) => $"{elementType}&";
+
+        public string GetPointerType(string elementType) => $"{elementType}*";
+
+        public string GetPinnedType(string elementType) => $"pinned {elementType}";
+
+        public string GetGenericInstantiation(string genericType, ImmutableArray<string> typeArguments)
+            => $"{genericType}<{string.Join(",", typeArguments)}>";
+
+        public string GetGenericTypeParameter(GenericContext? context, int index)
+            => context is not null && index >= 0 && index < context.TypeParameters.Count
+                ? context.TypeParameters[index]
+                : $"!{index}";
+
+        public string GetGenericMethodParameter(GenericContext? context, int index)
+            => context is not null && index >= 0 && index < context.MethodParameters.Count
+                ? context.MethodParameters[index]
+                : $"!{index}";
+
+        public string GetFunctionPointerType(MethodSignature<string> signature)
+            => $"delegate*<{string.Join(",", signature.ParameterTypes.Append(signature.ReturnType))}>";
+
+        public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
+    }
+
     public sealed record XmlDocMemberIdentity(
         string LookupKey,
         IReadOnlyList<string> NormalizedParameters,
@@ -24,6 +93,16 @@ public static class ApiMemberIdentity
         "extension-method" => $"extension:{member.Name}",
         _ => member.Name
     };
+
+    public static string GetMemberSelectorName(string metadataMethodName, bool isExtensionMethod = false)
+        => metadataMethodName switch
+        {
+            ".ctor" => ".ctor",
+            _ when isExtensionMethod => $"extension:{metadataMethodName}",
+            _ when metadataMethodName.StartsWith("op_", StringComparison.Ordinal) => $"operator:{metadataMethodName}",
+            _ when metadataMethodName.Contains('.', StringComparison.Ordinal) => $"explicit:{metadataMethodName}",
+            _ => metadataMethodName,
+        };
 
     public static ApiMemberHandle CreateHandle(ApiType type, ApiMember member)
         => new(type, member, GetMemberAnchor(type, member));
@@ -71,6 +150,22 @@ public static class ApiMemberIdentity
     public static MemberAnchor GetMemberAnchor(ApiType type, ApiMember member)
         => CreateAnchor(type, member, GetCanonicalSignature(type, member));
 
+    public static MemberAnchor CreateMethodAnchor(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        MethodDefinition method,
+        bool isExtensionMethod = false)
+    {
+        var type = reader.GetTypeDefinition(typeHandle);
+        string methodName = reader.GetString(method.Name);
+        var signature = method.DecodeSignature(AnchorSignatureTypeProvider.Instance, GenericContext.ForMethod(reader, type, method));
+        string typeFullName = FormatDefinitionName(reader, typeHandle);
+        string memberName = MethodMemberName(reader, methodName, method);
+        string canonicalSignature = $"M:{typeFullName}.{memberName}({string.Join(",", signature.ParameterTypes)})";
+        string selectorName = GetMemberSelectorName(methodName, isExtensionMethod);
+        return CreateAnchor(typeFullName, selectorName, memberName, canonicalSignature);
+    }
+
     public static MemberAnchor CreateAnchor(ApiType type, ApiMember member, string canonicalSignature)
     {
         var fingerprint = MemberAnchor.ComputeFingerprint(canonicalSignature);
@@ -81,6 +176,49 @@ public static class ApiMemberIdentity
             fingerprint,
             MetadataTypeNameFormatter.FormatFullName(type),
             member.Name);
+    }
+
+    static MemberAnchor CreateAnchor(
+        string typeFullName,
+        string selectorName,
+        string memberName,
+        string canonicalSignature)
+    {
+        var fingerprint = MemberAnchor.ComputeFingerprint(canonicalSignature);
+        return new MemberAnchor(
+            $"{selectorName}~{fingerprint}",
+            canonicalSignature,
+            fingerprint,
+            typeFullName,
+            memberName);
+    }
+
+    static string FormatDefinitionName(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        var type = reader.GetTypeDefinition(handle);
+        var genericNames = type.GetGenericParameters()
+            .Select(parameter => reader.GetString(reader.GetGenericParameter(parameter).Name))
+            .ToArray();
+        string name = reader.GetString(type.Name);
+        int tick = name.IndexOf('`');
+        string simple = tick < 0 ? name : name[..tick];
+        if (genericNames.Length > 0)
+            simple += $"<{string.Join(",", genericNames)}>";
+        var declaring = type.GetDeclaringType();
+        if (!declaring.IsNil)
+            return $"{FormatDefinitionName(reader, declaring)}.{simple}";
+        string ns = reader.GetString(type.Namespace);
+        return string.IsNullOrEmpty(ns) ? simple : $"{ns}.{simple}";
+    }
+
+    static string MethodMemberName(MetadataReader reader, string methodName, MethodDefinition method)
+    {
+        if (methodName == ".ctor")
+            return "#ctor";
+        var genericNames = method.GetGenericParameters()
+            .Select(parameter => reader.GetString(reader.GetGenericParameter(parameter).Name))
+            .ToArray();
+        return genericNames.Length == 0 ? methodName : $"{methodName}<{string.Join(",", genericNames)}>";
     }
 
     public static string GetCanonicalSignature(ApiType type, ApiMember member)

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -1,0 +1,65 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+using ILInspector.MetadataPrimitives;
+
+namespace ILInspector.Metadata.Tests;
+
+public class ApiMemberIdentityTests
+{
+    [Theory]
+    [InlineData(".ctor", false, ".ctor")]
+    [InlineData("op_Addition", false, "operator:op_Addition")]
+    [InlineData("IFoo.Bar", false, "explicit:IFoo.Bar")]
+    [InlineData("Twice", true, "extension:Twice")]
+    [InlineData("M", false, "M")]
+    public void GetMemberSelectorName_PreservesMemberIndexPrefixes(string metadataName, bool isExtension, string expected)
+    {
+        Assert.Equal(expected, ApiMemberIdentity.GetMemberSelectorName(metadataName, isExtension));
+    }
+
+    [Fact]
+    public void CreateMethodAnchor_UsesMetadataCanonicalSignature()
+    {
+        using var stream = File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var (typeHandle, method) = FindFixtureMethod(reader);
+
+        var anchor = ApiMemberIdentity.CreateMethodAnchor(reader, typeHandle, method);
+
+        Assert.Equal(
+            "M:ILInspector.Metadata.Tests.ApiMemberIdentityTests.ApiMemberIdentityFixture<T>.M<U>(System.Int32,U)",
+            anchor.CanonicalSignature);
+        Assert.Equal("ILInspector.Metadata.Tests.ApiMemberIdentityTests.ApiMemberIdentityFixture<T>", anchor.TypeFullName);
+        Assert.Equal("M<U>", anchor.MemberName);
+        Assert.StartsWith("M~", anchor.StableSelector, StringComparison.Ordinal);
+        Assert.Equal(MemberAnchor.ComputeFingerprint(anchor.CanonicalSignature), anchor.Fingerprint);
+    }
+
+    static (TypeDefinitionHandle TypeHandle, MethodDefinition Method) FindFixtureMethod(MetadataReader reader)
+    {
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            if (reader.GetString(type.Name) != "ApiMemberIdentityFixture`1")
+                continue;
+
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) == "M")
+                    return (typeHandle, method);
+            }
+        }
+
+        throw new InvalidOperationException("Fixture method not found.");
+    }
+
+    sealed class ApiMemberIdentityFixture<T>
+    {
+        public void M<U>(int value, U item)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Metadata-owned SRM method-anchor construction for API-facing `MemberAnchor` values
- route `CSharpBodyDiff` through `ApiMemberIdentity.CreateMethodAnchor` instead of local string builders
- cover selector prefixes and metadata canonical signature rendering in Metadata tests

## Dependency boundary
Decompiler still depends downward on Metadata; Research is not in the producer path.

## Validation
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -class ILInspector.Metadata.Tests.ApiMemberIdentityTests`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.CSharpBodyDiffTests`
- `dotnet run --project src/ILInspector.Research.Tests -c Release`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity quiet`

## Review
- Adversarial review pending (MAI + Gemini, different model families from author).
