### PR TITLE
Preserve syntax member evidence for RTS

### DIFF
--- a/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DeconstructionAssignmentPassTests.cs
@@ -94,6 +94,7 @@ public class DeconstructionAssignmentPassTests
         Assert.Equal(2, deconstruction.LocalIndices.Length);
         Assert.True(deconstruction.IsDeclaration);
         Assert.IsType<LoadArgument>(deconstruction.Source);
+        Assert.Equal("Deconstruct", deconstruction.ConsumedDeconstructMethod?.Name);
         Assert.DoesNotContain(function.Descendants.OfType<Call>(), c => c.Callee.Name == "Deconstruct");
     }
 

--- a/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ForeachStatementPassTests.cs
@@ -32,6 +32,10 @@ public class ForeachStatementPassTests
         var foreachStatement = Assert.Single(function.Descendants.OfType<ForeachStatement>());
         Assert.Equal("int", foreachStatement.LocalType.ToDisplayString());
         Assert.IsType<LoadArgument>(foreachStatement.Collection);
+        Assert.Contains(foreachStatement.ConsumedMemberRefs, method => method.Name == "GetEnumerator");
+        Assert.Contains(foreachStatement.ConsumedMemberRefs, method => method.Name == "MoveNext");
+        Assert.Contains(foreachStatement.ConsumedMemberRefs, method => method.Name == "get_Current");
+        Assert.Contains(foreachStatement.ConsumedMemberRefs, method => method.Name == "Dispose");
         Assert.DoesNotContain(function.Descendants.OfType<UsingStatement>(), _ => true);
         Assert.DoesNotContain(function.Descendants.OfType<WhileLoop>(), _ => true);
     }

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -286,6 +286,55 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_UsesPreservedDeconstructMemberEvidence()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Pair
+            {
+                public void Deconstruct(out int left, out int right)
+                {
+                    left = 1;
+                    right = 2;
+                }
+            }
+
+            public class Class1
+            {
+                public int Sum
+                {
+                    get
+                    {
+                        var pair = new Pair();
+                        var (left, right) = pair;
+                        return left + right;
+                    }
+                }
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackPropertyGetters(assemblyPath, maxTargets: 2)
+                .Single(item => item.Plan.TargetMethod.Method == "get_Sum");
+
+            Assert.True(
+                result.Status is FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            Assert.Contains(result.Plan.Types, type =>
+                type.Name == "Pair"
+                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "closure-member" && fact.Detail.EndsWith(".Deconstruct", StringComparison.Ordinal))
+                && !type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "roslyn")
+                && type.Members.Any(member => member.Name == "Deconstruct"));
+            var evidence = ReturnToSenderClosureEvidenceBuilder.FromPlan(result.Plan);
+            Assert.Equal(0, evidence.RoslynRecoveredMemberSurfaces);
+            Assert.Contains("public void Deconstruct", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_EmitsTargetRootSiblingMemberSurface()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UsingStatementPassTests.cs
@@ -22,6 +22,7 @@ public class UsingStatementPassTests
         var usingStatement = Assert.Single(function.Descendants.OfType<UsingStatement>());
         Assert.Equal("StringReader", usingStatement.ResourceType.ToDisplayString());
         Assert.IsType<NewObject>(usingStatement.Resource);
+        Assert.Contains(usingStatement.ConsumedMemberRefs, method => method.Name == "Dispose");
         Assert.Empty(function.Descendants.OfType<TryFinally>());
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrNodes.cs
@@ -850,11 +850,18 @@ public sealed class Fixed : IrNode
 /// </summary>
 public sealed class UsingStatement : IrNode
 {
-    public UsingStatement(int localIndex, TypeRef resourceType, IrExpression resource, BlockContainer body, bool isAwait = false)
+    public UsingStatement(
+        int localIndex,
+        TypeRef resourceType,
+        IrExpression resource,
+        BlockContainer body,
+        bool isAwait = false,
+        ImmutableArray<MethodRef> consumedMemberRefs = default)
     {
         LocalIndex = localIndex;
         ResourceType = resourceType;
         IsAwait = isAwait;
+        ConsumedMemberRefs = consumedMemberRefs.IsDefault ? [] : consumedMemberRefs;
         AddChild(resource);
         AddChild(body);
     }
@@ -862,6 +869,7 @@ public sealed class UsingStatement : IrNode
     public int LocalIndex { get; }
     public TypeRef ResourceType { get; }
     public bool IsAwait { get; }
+    public ImmutableArray<MethodRef> ConsumedMemberRefs { get; }
     public IrExpression Resource => (IrExpression)Children[0];
     public BlockContainer Body => (BlockContainer)Children[1];
 
@@ -877,16 +885,23 @@ public sealed class UsingStatement : IrNode
 /// </summary>
 public sealed class ForeachStatement : IrNode
 {
-    public ForeachStatement(int localIndex, TypeRef localType, IrExpression collection, Block body)
+    public ForeachStatement(
+        int localIndex,
+        TypeRef localType,
+        IrExpression collection,
+        Block body,
+        ImmutableArray<MethodRef> consumedMemberRefs = default)
     {
         LocalIndex = localIndex;
         LocalType = localType;
+        ConsumedMemberRefs = consumedMemberRefs.IsDefault ? [] : consumedMemberRefs;
         AddChild(collection);
         AddChild(body);
     }
 
     public int LocalIndex { get; }
     public TypeRef LocalType { get; }
+    public ImmutableArray<MethodRef> ConsumedMemberRefs { get; }
     public IrExpression Collection => (IrExpression)Children[0];
     public Block Body => (Block)Children[1];
     public override IEnumerable<TypeRef> DirectTypes => [LocalType];
@@ -1891,17 +1906,25 @@ public sealed class DeconstructionTarget : IrNode
 /// </summary>
 public sealed class DeconstructionAssignment : IrNode
 {
-    public DeconstructionAssignment(ImmutableArray<int> localIndices, ImmutableArray<TypeRef> localTypes, IrExpression source, ImmutableArray<bool> isDeclared)
-        : this([.. localIndices.Select((index, i) => DeconstructionTarget.Local(index, localTypes[i], isDeclared[i]))], source)
+    public DeconstructionAssignment(
+        ImmutableArray<int> localIndices,
+        ImmutableArray<TypeRef> localTypes,
+        IrExpression source,
+        ImmutableArray<bool> isDeclared,
+        MethodRef? consumedDeconstructMethod = null)
+        : this([.. localIndices.Select((index, i) => DeconstructionTarget.Local(index, localTypes[i], isDeclared[i]))], source, consumedDeconstructMethod)
     {
     }
 
-    public DeconstructionAssignment(ImmutableArray<DeconstructionTarget> targets, IrExpression source)
+    public DeconstructionAssignment(ImmutableArray<DeconstructionTarget> targets, IrExpression source, MethodRef? consumedDeconstructMethod = null)
     {
+        ConsumedDeconstructMethod = consumedDeconstructMethod;
         AddChild(source);
         foreach (var target in targets)
             AddChild(target);
     }
+
+    public MethodRef? ConsumedDeconstructMethod { get; }
 
     public ImmutableArray<DeconstructionTarget> Targets
         => [.. Children.Skip(1).Cast<DeconstructionTarget>()];

--- a/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/DeconstructionAssignmentPass.cs
@@ -128,7 +128,7 @@ public sealed class DeconstructionAssignmentPass : IIrPass
         if (ClassifyTargets(function, targets) is not { } resolved)
             return false;
 
-        var deconstruction = new DeconstructionAssignment(resolved.indices, resolved.types, source, resolved.isDeclared);
+        var deconstruction = new DeconstructionAssignment(resolved.indices, resolved.types, source, resolved.isDeclared, call.Callee);
         context.Stepper.StepOver("raise Deconstruct-method call to deconstruction", statement);
         statement.ReplaceWith(deconstruction);
         return true;

--- a/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/ForeachStatementPass.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace ILInspector.Decompiler.Pipeline;
 
 /// <summary>
@@ -72,7 +74,7 @@ public sealed class ForeachStatementPass : IIrPass
             match.CurrentStore.Detach();
             var body = match.Loop.Body;
             body.Detach();
-            var foreachStatement = new ForeachStatement(match.CurrentStore.Index, match.CurrentStore.Type, collection, body);
+            var foreachStatement = new ForeachStatement(match.CurrentStore.Index, match.CurrentStore.Type, collection, body, match.ConsumedMemberRefs);
             context.Stepper.StepOver("raise enumerator loop to foreach", usingStatement);
             usingStatement.ReplaceWith(foreachStatement);
         }
@@ -88,7 +90,7 @@ public sealed class ForeachStatementPass : IIrPass
             match.CurrentStore.Detach();
             var body = loop.Body;
             body.Detach();
-            var foreachStatement = new ForeachStatement(match.CurrentStore.Index, match.CurrentStore.Type, collection, body);
+            var foreachStatement = new ForeachStatement(match.CurrentStore.Index, match.CurrentStore.Type, collection, body, match.ConsumedMemberRefs);
             context.Stepper.StepOver("raise pattern enumerator loop to foreach", loop);
             loop.ReplaceWith(foreachStatement);
             match.EnumeratorStore.Detach();
@@ -166,7 +168,11 @@ public sealed class ForeachStatementPass : IIrPass
         set.UnionWith(allowed);
     }
 
-    sealed record EnumeratorMatch(IrExpression Collection, WhileLoop Loop, StoreLocal CurrentStore);
+    sealed record EnumeratorMatch(
+        IrExpression Collection,
+        WhileLoop Loop,
+        StoreLocal CurrentStore,
+        ImmutableArray<MethodRef> ConsumedMemberRefs);
 
     static EnumeratorMatch? TryMatchEnumerator(IrFunction function, UsingStatement usingStatement)
     {
@@ -208,10 +214,19 @@ public sealed class ForeachStatementPass : IIrPass
         if (loop.Body.Children.Skip(1).Any(child => ReferencesLocal(child, enumeratorIndex)))
             return null;
 
-        return new EnumeratorMatch(CollectionValue(getEnumerator.Arguments[0]), loop, currentStore);
+        return new EnumeratorMatch(
+            CollectionValue(getEnumerator.Arguments[0]),
+            loop,
+            currentStore,
+            [getEnumerator.Callee, ((Call)loop.Condition).Callee, current.Accessor, .. usingStatement.ConsumedMemberRefs]);
     }
 
-    sealed record PatternMatch(IrExpression Collection, StoreLocal EnumeratorStore, WhileLoop Loop, StoreLocal CurrentStore);
+    sealed record PatternMatch(
+        IrExpression Collection,
+        StoreLocal EnumeratorStore,
+        WhileLoop Loop,
+        StoreLocal CurrentStore,
+        ImmutableArray<MethodRef> ConsumedMemberRefs);
 
     static PatternMatch? TryMatchPattern(IrFunction function, WhileLoop loop)
     {
@@ -252,7 +267,12 @@ public sealed class ForeachStatementPass : IIrPass
         if (!ReferencedOnlyBy(function, enumeratorIndex, allowed))
             return null;
 
-        return new PatternMatch(CollectionValue(getEnumerator.Arguments[0]), enumeratorStore, loop, currentStore);
+        return new PatternMatch(
+            CollectionValue(getEnumerator.Arguments[0]),
+            enumeratorStore,
+            loop,
+            currentStore,
+            [getEnumerator.Callee, moveNext.Callee, current.Accessor]);
     }
 
     static IrExpression CollectionValue(IrExpression expression) => expression switch

--- a/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/UsingStatementPass.cs
@@ -27,7 +27,7 @@ public sealed class UsingStatementPass : IIrPass
 {
     public string Name => "using-statement";
 
-    sealed record Match(StoreLocal StoreResource, TryFinally TryFinally);
+    sealed record Match(StoreLocal StoreResource, TryFinally TryFinally, MethodRef Dispose);
     sealed record AwaitMatch(
         StoreLocal StoreResource,
         StoreLocal StoreException,
@@ -36,7 +36,8 @@ public sealed class UsingStatementPass : IIrPass
         IfStatement DisposeIf,
         IfStatement RethrowIf,
         IfStatement ReturnIf,
-        Throw? FailThrow);
+        Throw? FailThrow,
+        MethodRef Dispose);
 
     public void Run(IrFunction function, PassContext context)
     {
@@ -68,7 +69,7 @@ public sealed class UsingStatementPass : IIrPass
                 var resource = (IrExpression)match.StoreResource.DetachChildren()[0];
                 var body = match.TryCatch.TryBody;
                 body.Detach();
-                var usingStatement = new UsingStatement(match.StoreResource.Index, match.StoreResource.Type, resource, body, isAwait: true);
+                var usingStatement = new UsingStatement(match.StoreResource.Index, match.StoreResource.Type, resource, body, isAwait: true, consumedMemberRefs: [match.Dispose]);
                 stepper.StepOver("raise await dispose scaffold to await using", match.TryCatch);
                 match.StoreResource.ReplaceWith(usingStatement);
                 match.StoreException.Detach();
@@ -97,7 +98,7 @@ public sealed class UsingStatementPass : IIrPass
                 var resource = (IrExpression)match.StoreResource.DetachChildren()[0];
                 var body = match.TryFinally.TryBody;
                 body.Detach();
-                var usingStatement = new UsingStatement(match.StoreResource.Index, match.StoreResource.Type, resource, body);
+                var usingStatement = new UsingStatement(match.StoreResource.Index, match.StoreResource.Type, resource, body, consumedMemberRefs: [match.Dispose]);
                 stepper.StepOver("raise dispose try/finally to using", match.TryFinally);
                 match.TryFinally.ReplaceWith(usingStatement);
                 match.StoreResource.Detach();
@@ -156,7 +157,7 @@ public sealed class UsingStatementPass : IIrPass
         if (!IsReturnState(returnIf, storeState.Index))
             return null;
 
-        return new AwaitMatch(storeResource, storeException, storeState, tryCatch, disposeIf, rethrowIf, returnIf, failThrow);
+        return new AwaitMatch(storeResource, storeException, storeState, tryCatch, disposeIf, rethrowIf, returnIf, failThrow, dispose.Callee);
     }
 
     static AwaitMatch? TryMatchNestedAwaitUsing(IrFunction function, IReadOnlyList<IrNode> children, int i)
@@ -203,7 +204,7 @@ public sealed class UsingStatementPass : IIrPass
         if (!IsNestedReturnState(returnIf, storeState.Index))
             return null;
 
-        return new AwaitMatch(storeResource, storeException, storeState, tryCatch, disposeIf, rethrowIf, returnIf, FailThrow: null);
+        return new AwaitMatch(storeResource, storeException, storeState, tryCatch, disposeIf, rethrowIf, returnIf, FailThrow: null, dispose.Callee);
     }
 
     static bool IsAsyncDisposeOf(Call dispose, StoreLocal storeResource)
@@ -329,7 +330,7 @@ public sealed class UsingStatementPass : IIrPass
         if (tryFinally.FinallyBody.Blocks is not [{ Children: [var only] }])
             return null;
 
-        bool disposes = only switch
+        MethodRef? disposeMethod = only switch
         {
             // Reference type: finally { if (V_0) ((IDisposable)V_0).Dispose(); }
             IfStatement
@@ -337,7 +338,8 @@ public sealed class UsingStatementPass : IIrPass
                 Else: null,
                 Condition: LoadLocal guardLoad,
                 Then.Children: [ExpressionStatement { Expression: Call guardedDispose }],
-            } => guardLoad.Index == storeResource.Index && IsDisposeOf(function, guardedDispose, storeResource),
+            } when guardLoad.Index == storeResource.Index && IsDisposeOf(function, guardedDispose, storeResource)
+                => guardedDispose.Callee,
             // Value type: finally { V_0.Dispose(); } — no null guard. csc only omits
             // the guard for value-type / constrained dispose; a reference-type `using`
             // always emits the null-guarded form above. Raising an unguarded reference-
@@ -345,12 +347,13 @@ public sealed class UsingStatementPass : IIrPass
             // possible NullReferenceException into a silent no-op), so decline a known
             // reference-type resource here and leave it as the flat try/finally.
             ExpressionStatement { Expression: Call bareDispose }
-                => IsDisposeOf(function, bareDispose, storeResource)
-                    && function.TypeShapes.GetValueOrDefault(storeResource.Type) is not TypeShape.Reference,
-            _ => false,
+                when IsDisposeOf(function, bareDispose, storeResource)
+                    && function.TypeShapes.GetValueOrDefault(storeResource.Type) is not TypeShape.Reference
+                => bareDispose.Callee,
+            _ => null,
         };
 
-        return disposes ? new Match(storeResource, tryFinally) : null;
+        return disposeMethod is null ? null : new Match(storeResource, tryFinally, disposeMethod);
     }
 
     /// <summary>An <c>IDisposable.Dispose()</c> or pattern <c>Dispose()</c> call whose receiver is the resource local.</summary>

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1505,6 +1505,8 @@ static class ReturnToSender
                     AddMethodFact(assignment.Setter);
                     break;
                 case DeconstructionAssignment deconstruction:
+                    if (deconstruction.ConsumedDeconstructMethod is { } deconstruct)
+                        AddMethodFact(deconstruct);
                     foreach (var target in deconstruction.Targets)
                     {
                         if (target.Accessor is { } accessor)
@@ -1512,6 +1514,14 @@ static class ReturnToSender
                         if (target.Field is { } field)
                             AddFieldFact(field);
                     }
+                    break;
+                case ForeachStatement foreachStatement:
+                    foreach (var method in foreachStatement.ConsumedMemberRefs)
+                        AddMethodFact(method);
+                    break;
+                case UsingStatement usingStatement:
+                    foreach (var method in usingStatement.ConsumedMemberRefs)
+                        AddMethodFact(method);
                     break;
                 case LoadField load:
                     AddFieldFact(load.Field);


### PR DESCRIPTION
## Summary

- preserve consumed MethodRef evidence on raised `DeconstructionAssignment`, `ForeachStatement`, and `UsingStatement` IR nodes
- feed those preserved refs into ReturnToSender typed closure member fact seeding
- add pass-level canaries for Deconstruct/foreach/using consumed refs and an RTS canary proving Deconstruct no longer needs Roslyn member-surface recovery

Fixes #2414.

## Validation

- `dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/DeconstructionAssignmentPassTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ForeachStatementPassTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/UsingStatementPassTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderEvidenceTests/*"`
- `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal.property.literal --max-examples 3`

Adversarial review requested separately.