### PR TITLE
Route Research selectors through Metadata identity

### DIFF
--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -28,6 +28,30 @@ public class ResearchDiffTests
         Assert.Equal(anchor.MemberName, subject.MemberName);
     }
 
+    [Theory]
+    [InlineData(".ctor", false)]
+    [InlineData("op_Addition", false)]
+    [InlineData("Twice", true)]
+    [InlineData("IFoo.Bar", false)]
+    [InlineData("M", false)]
+    public void ResearchMemberIdentity_SubjectFromMethod_UsesMetadataSelectorPolicy(string methodName, bool isExtension)
+    {
+        var method = new MethodIdentity(
+            "Asm",
+            Guid.Empty,
+            TypeRef.Definition("Asm", "Sample", "Widget"),
+            methodName,
+            [],
+            TypeRef.CoreLib("System", "Void"),
+            MetadataToken: 0x06000001,
+            IsStatic: true,
+            IsExtension: isExtension);
+
+        var subject = ResearchMemberIdentity.SubjectFromMethod(method);
+
+        Assert.StartsWith($"{ApiMemberIdentity.GetMemberSelectorName(methodName, isExtension)}~", subject.Id, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void MetadataApiDiff_DefaultScope_IgnoresAttributeOnlyChanges()
     {

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -52,6 +52,21 @@ public class ResearchDiffTests
         Assert.StartsWith($"{ApiMemberIdentity.GetMemberSelectorName(methodName, isExtension)}~", subject.Id, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData(".ctor", false)]
+    [InlineData("op_Addition", false)]
+    [InlineData("Twice", true)]
+    [InlineData("IFoo.Bar", false)]
+    [InlineData("M", false)]
+    public void ResearchMemberIdentity_SelectorForMetadataName_DelegatesToMetadataPolicy(string methodName, bool isExtension)
+    {
+#pragma warning disable CS0618
+        var selector = ResearchMemberIdentity.SelectorForMetadataName(methodName, isExtension);
+#pragma warning restore CS0618
+
+        Assert.Equal(ApiMemberIdentity.GetMemberSelectorName(methodName, isExtension), selector);
+    }
+
     [Fact]
     public void MetadataApiDiff_DefaultScope_IgnoresAttributeOnlyChanges()
     {

--- a/src/ILInspector.Research/ResearchDiff.cs
+++ b/src/ILInspector.Research/ResearchDiff.cs
@@ -864,12 +864,6 @@ public static class ResearchDiff
     static ResearchSubjectKey UnknownMemberSubject(string key)
         => new(ResearchDiffSubjectKind.Member, $"member:{key}", key);
 
-    internal static class ResearchMemberSelector
-    {
-        public static string ForMetadataName(string methodName, bool isExtensionMethod = false)
-            => ResearchMemberIdentity.SelectorForMetadataName(methodName, isExtensionMethod);
-    }
-
     static string BodySignalMethodKey(MethodIdentity method)
         => $"{method.AssemblyName}|{GenericMemberIdentity.KeyFragment(method.DeclaringType)}|{method.Name}|{method.GenericArity}|{method.IsExtension}|{string.Join(",", method.ParameterTypes.Select(GenericMemberIdentity.KeyFragment))}|{GenericMemberIdentity.KeyFragment(method.ReturnType)}";
 

--- a/src/ILInspector.Research/ResearchMemberIdentity.cs
+++ b/src/ILInspector.Research/ResearchMemberIdentity.cs
@@ -18,7 +18,7 @@ public static class ResearchMemberIdentity
     {
         var typeName = method.DeclaringType.ToQualifiedDisplayString();
         var memberName = method.Name == ".ctor" ? "#ctor" : method.Name;
-        var selectorName = SelectorForMetadataName(method.Name, method.IsExtension);
+        var selectorName = ApiMemberIdentity.GetMemberSelectorName(method.Name, method.IsExtension);
         var parameters = string.Join(",", method.ParameterTypes.Select(BodyTypeName));
         var displayParameters = string.Join(", ", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
         var methodGeneric = MethodGenericList(method);
@@ -118,16 +118,6 @@ public static class ResearchMemberIdentity
                 ? method.GenericParameterNames[index]
                 : $"!!{index}"))}>";
     }
-
-    public static string SelectorForMetadataName(string methodName, bool isExtensionMethod = false)
-        => methodName switch
-        {
-            ".ctor" => ".ctor",
-            _ when isExtensionMethod => $"extension:{methodName}",
-            _ when methodName.StartsWith("op_", StringComparison.Ordinal) => $"operator:{methodName}",
-            _ when methodName.Contains('.') => $"explicit:{methodName}",
-            _ => methodName,
-        };
 
     static string DeclaringPrimitiveName(string value)
         => value switch

--- a/src/ILInspector.Research/ResearchMemberIdentity.cs
+++ b/src/ILInspector.Research/ResearchMemberIdentity.cs
@@ -119,6 +119,10 @@ public static class ResearchMemberIdentity
                 : $"!!{index}"))}>";
     }
 
+    [Obsolete("Use ApiMemberIdentity.GetMemberSelectorName instead.")]
+    public static string SelectorForMetadataName(string methodName, bool isExtensionMethod = false)
+        => ApiMemberIdentity.GetMemberSelectorName(methodName, isExtensionMethod);
+
     static string DeclaringPrimitiveName(string value)
         => value switch
         {


### PR DESCRIPTION
## Summary
- route Research body subject selector prefixes through `ApiMemberIdentity.GetMemberSelectorName`
- remove the unused Research selector shim and duplicated selector-prefix helper
- add a focused Research test for constructor/operator/extension/explicit/default selector prefixes

## Dependency boundary
Research depends downward on Metadata for selector policy; Decompiler remains independent of Research.

## Validation
- `dotnet run --project src/ILInspector.Research.Tests -c Release -- -method ILInspector.Research.Tests.ResearchDiffTests.ResearchMemberIdentity_SubjectFromMethod_UsesMetadataSelectorPolicy`
- `dotnet run --project tests/ILInspector.Metadata.Tests -c Release -- -class ILInspector.Metadata.Tests.ApiMemberIdentityTests`
- `dotnet run --project src/ILInspector.Research.Tests -c Release`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity quiet`

## Review
- Adversarial review pending (MAI + Gemini, different model families from author).
