### PR TITLE
Add fixture governance metadata

### DIFF
--- a/docs/fixture-governance.md
+++ b/docs/fixture-governance.md
@@ -1,0 +1,54 @@
+# Fixture governance
+
+Fixtures are product inputs, not ad hoc test setup. They should be built by the
+normal solution graph, registered in `FixtureCatalog`, and consumed by stable
+fixture IDs rather than by test-local path arithmetic or one-off compiler calls.
+
+## Project-boundary rule
+
+Prefer shared fixture projects when a project is only a source bucket. Keep a
+fixture project separate only when the assembly or build boundary is part of the
+evidence under test.
+
+Separate projects are justified for these semantic axes:
+
+| Axis | Why the boundary matters |
+| --- | --- |
+| Assembly identity | The test distinguishes otherwise similar types or members by source assembly. |
+| Assembly name | The output DLL name is the adversarial identity, such as `System.Linq.dll`. |
+| Compiler lowering | The compiler-produced body shape is the fixture subject. |
+| Cross-assembly boundary | References or unresolved type facts across assemblies are the evidence. |
+| Extern alias | The test needs compile-time access to a colliding external identity. |
+| Framework reference | The fixture must reference a trusted framework assembly. |
+| Module attribute | The module-level metadata is the evidence. |
+| Output kind | The fixture must be an executable or otherwise non-library output. |
+| Sidecar asset | A binary is coupled to a trace or other sidecar artifact. |
+| Target framework | The TFM changes emitted references or facade behavior. |
+| Version pair | Old and new assemblies are compared as separate binaries. |
+
+If none of those axes applies, consolidate the source into an existing fixture
+project or create one shared fixture project for that area.
+
+## Catalog metadata
+
+`FixtureDefinition.Boundaries` records the semantic axes that make a fixture's
+build or assembly shape meaningful. Tags remain useful for selection and groups;
+boundaries explain why a fixture cannot be mechanically merged or why a consumer
+must preserve a specific binary shape.
+
+Every intentionally single-fixture project should have at least one boundary
+entry. Consolidated buckets, such as `ILInspector.Analysis.Fixtures` and
+`ILInspector.Decompiler.Fixtures.Ladder`, can contain multiple fixture IDs when
+their source-level subjects do not require distinct project boundaries.
+
+## Consumer rules
+
+- Use `FixtureCatalog.Get`, `AssemblyPath`, `AssetPath`, groups, or tags instead
+  of hardcoded artifact paths.
+- Build fixtures through `dotnet build dotnet-inspect.slnx -c Release`; harnesses
+  should assume inputs are already binaries.
+- Do not add scripts or dynamic compilation for fixture binaries. If a fixture
+  needs a special build shape, encode it as an MSBuild project and catalog
+  boundary.
+- Add or update contract tests when introducing a new boundary so the semantic
+  axis cannot be erased by later cleanup.

--- a/docs/fixture-governance.md
+++ b/docs/fixture-governance.md
@@ -32,14 +32,16 @@ project or create one shared fixture project for that area.
 ## Catalog metadata
 
 `FixtureDefinition.Boundaries` records the semantic axes that make a fixture's
-build or assembly shape meaningful. Tags remain useful for selection and groups;
-boundaries explain why a fixture cannot be mechanically merged or why a consumer
-must preserve a specific binary shape.
+separate project, build, or assembly shape meaningful. Tags remain useful for
+selection and groups; boundaries explain why a fixture cannot be mechanically
+merged or why a consumer must preserve a specific binary shape.
 
-Every intentionally single-fixture project should have at least one boundary
-entry. Consolidated buckets, such as `ILInspector.Analysis.Fixtures` and
-`ILInspector.Decompiler.Fixtures.Ladder`, can contain multiple fixture IDs when
-their source-level subjects do not require distinct project boundaries.
+Every project that is not an intentional consolidated source bucket should have
+boundary metadata. Consolidated buckets, such as
+`ILInspector.Analysis.Fixtures` and `ILInspector.Decompiler.Fixtures.Ladder`,
+can contain multiple fixture IDs when their source-level subjects do not require
+distinct project boundaries; those fixture IDs should not carry project-boundary
+metadata just because consumers observe them from another assembly.
 
 ## Consumer rules
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -40,6 +40,7 @@ Agents working in this repo should preserve these principles:
 - [Analysis UX scopes](design/analysis-ux-scopes.md): shared analysis vocabulary across offset, member, type, and library scopes.
 - [IL coordinate workflows](design/il-coordinate-workflows.md): prototype workflows for explaining sparse runtime coordinates from debugger, profiler, or analyzer artifacts.
 - [IL Diff canonicalization](design/il-diff-canonicalization.md): current `CanonicalIlOperation` guarantees, boundaries, and extension points.
+- [Fixture governance](fixture-governance.md): fixture catalog, project-boundary, and semantic-axis rules.
 - [Integrations](design/integrations.md): library ecosystem integration roll-ups and focused API currency.
 - [Section model](design/section-model.md): section selection and query behavior.
 - [Hidden-fact annotations](design/hidden-fact-annotations.md): offset-keyed fact overlay semantics, validation, and projections.

--- a/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
+++ b/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
@@ -86,6 +86,7 @@ public class FixtureCatalogTests
         var fixture = FixtureCatalog.RunFasterAllocation;
 
         Assert.Contains("trace-coupled", fixture.Tags);
+        Assert.Contains(FixtureBoundary.SidecarAsset, fixture.Boundaries);
         var asset = Assert.Single(fixture.Assets);
         Assert.Equal("fixture.nettrace", asset.Name);
         Assert.EndsWith(Path.Combine("Fixtures", "RunFaster.AllocationFixture", "fixture.nettrace"), fixture.AssetPath(asset.Name));
@@ -105,6 +106,67 @@ public class FixtureCatalogTests
         AssertFixtureFileName(FixtureCatalog.AnalysisProtobuf, "Google.Protobuf.dll");
         AssertFixtureFileName(FixtureCatalog.AnalysisSpoofSystemLinq, "System.Linq.dll");
         AssertFixtureFileName(FixtureCatalog.AnalysisSpoofSystemRuntime, "System.Runtime.dll");
+
+        AssertBoundary(FixtureCatalog.AnalysisProtobuf, FixtureBoundary.AssemblyName);
+        AssertBoundary(FixtureCatalog.AnalysisSpoofSystemLinq, FixtureBoundary.AssemblyName);
+        AssertBoundary(FixtureCatalog.AnalysisSpoofSystemRuntime, FixtureBoundary.AssemblyName);
+    }
+
+    [Fact]
+    public void BoundaryMetadata_CoversIntentionalSeparateFixtureProjects()
+    {
+        var consolidatedProjects = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "ILInspector.Analysis.Fixtures",
+            "ILInspector.Decompiler.Fixtures.Ladder",
+        };
+
+        var singleFixtureProjects = FixtureCatalog.All
+            .GroupBy(fixture => fixture.ProjectName, StringComparer.Ordinal)
+            .Where(group => group.Count() == 1 && !consolidatedProjects.Contains(group.Key))
+            .Select(group => group.Single());
+
+        Assert.All(singleFixtureProjects, fixture =>
+            Assert.NotEmpty(fixture.Boundaries));
+    }
+
+    [Theory]
+    [InlineData(FixtureIds.DiffV1, FixtureBoundary.VersionPair)]
+    [InlineData(FixtureIds.DiffV2, FixtureBoundary.VersionPair)]
+    [InlineData(FixtureIds.DiffAsmCaller, FixtureBoundary.AssemblyIdentity)]
+    [InlineData(FixtureIds.AnalysisCallerGraphCaller, FixtureBoundary.CrossAssemblyBoundary)]
+    [InlineData(FixtureIds.AnalysisCallerGraphCallerTwin, FixtureBoundary.CrossAssemblyBoundary)]
+    [InlineData(FixtureIds.AnalysisCallerGraphLookalikeCaller, FixtureBoundary.CrossAssemblyBoundary)]
+    [InlineData(FixtureIds.AnalysisCallerGraphTarget, FixtureBoundary.CrossAssemblyBoundary)]
+    [InlineData(FixtureIds.AnalysisCrossAsmCollision, FixtureBoundary.ExternAlias)]
+    [InlineData(FixtureIds.AnalysisCrossAsmShape, FixtureBoundary.CrossAssemblyBoundary)]
+    [InlineData(FixtureIds.AnalysisExceptionBase, FixtureBoundary.CrossAssemblyBoundary)]
+    [InlineData(FixtureIds.AnalysisFacade, FixtureBoundary.TargetFramework)]
+    [InlineData(FixtureIds.AnalysisLookalike, FixtureBoundary.AssemblyIdentity)]
+    [InlineData(FixtureIds.AnalysisRender, FixtureBoundary.FrameworkReference)]
+    [InlineData(FixtureIds.DecompilerCheckedArithmetic, FixtureBoundary.CompilerLowering)]
+    [InlineData(FixtureIds.DecompilerClassicAsync, FixtureBoundary.CompilerLowering)]
+    [InlineData(FixtureIds.DecompilerUnsafeLegacy, FixtureBoundary.ModuleAttribute)]
+    [InlineData(FixtureIds.DecompilerUnsafeNew, FixtureBoundary.ModuleAttribute)]
+    [InlineData(FixtureIds.DecompilerUnsafeChainA, FixtureBoundary.CrossAssemblyBoundary)]
+    [InlineData(FixtureIds.DecompilerUnsafeChainB, FixtureBoundary.CrossAssemblyBoundary)]
+    [InlineData(FixtureIds.DecompilerUnsafeChainC, FixtureBoundary.OutputKind)]
+    [InlineData(FixtureIds.RunFasterAllocation, FixtureBoundary.SidecarAsset)]
+    public void BoundaryMetadata_DocumentsSemanticAxes(string fixtureId, FixtureBoundary boundary)
+    {
+        AssertBoundary(FixtureCatalog.Get(fixtureId), boundary);
+    }
+
+    [Fact]
+    public void ConsolidatedFixtureBuckets_ShareAssemblyWithoutProjectBoundaryAxes()
+    {
+        Assert.Equal(FixtureCatalog.AnalysisCrossAsmShape.ProjectName, FixtureCatalog.AnalysisExceptionBase.ProjectName);
+        Assert.Equal(FixtureCatalog.AnalysisCrossAsmShape.AssemblyPath(), FixtureCatalog.AnalysisExceptionBase.AssemblyPath());
+
+        Assert.DoesNotContain(FixtureBoundary.AssemblyName, FixtureCatalog.AnalysisCrossAsmShape.Boundaries);
+        Assert.DoesNotContain(FixtureBoundary.AssemblyName, FixtureCatalog.AnalysisExceptionBase.Boundaries);
+        Assert.DoesNotContain(FixtureBoundary.TargetFramework, FixtureCatalog.AnalysisCrossAsmShape.Boundaries);
+        Assert.DoesNotContain(FixtureBoundary.TargetFramework, FixtureCatalog.AnalysisExceptionBase.Boundaries);
     }
 
     [Fact]
@@ -113,6 +175,8 @@ public class FixtureCatalogTests
         Assert.Contains("legacy-memory-safety", FixtureCatalog.DecompilerUnsafeLegacy.Tags);
         Assert.DoesNotContain("updated-memory-safety", FixtureCatalog.DecompilerUnsafeLegacy.Tags);
         Assert.Contains("updated-memory-safety", FixtureCatalog.DecompilerUnsafeNew.Tags);
+        AssertBoundary(FixtureCatalog.DecompilerUnsafeLegacy, FixtureBoundary.ModuleAttribute);
+        AssertBoundary(FixtureCatalog.DecompilerUnsafeNew, FixtureBoundary.ModuleAttribute);
         Assert.NotEqual(
             FixtureCatalog.DecompilerUnsafeLegacy.AssemblyPath(),
             FixtureCatalog.DecompilerUnsafeNew.AssemblyPath());
@@ -128,6 +192,10 @@ public class FixtureCatalogTests
         Assert.Contains("updated-memory-safety", FixtureCatalog.DecompilerUnsafeChainB.Tags);
         Assert.Contains("legacy-memory-safety", FixtureCatalog.DecompilerUnsafeChainC.Tags);
         Assert.Contains("executable", FixtureCatalog.DecompilerUnsafeChainC.Tags);
+        AssertBoundary(FixtureCatalog.DecompilerUnsafeChainA, FixtureBoundary.CrossAssemblyBoundary);
+        AssertBoundary(FixtureCatalog.DecompilerUnsafeChainB, FixtureBoundary.CrossAssemblyBoundary);
+        AssertBoundary(FixtureCatalog.DecompilerUnsafeChainC, FixtureBoundary.CrossAssemblyBoundary);
+        AssertBoundary(FixtureCatalog.DecompilerUnsafeChainC, FixtureBoundary.OutputKind);
 
         AssertAssemblyReferences(
             FixtureCatalog.DecompilerUnsafeChainB,
@@ -144,6 +212,9 @@ public class FixtureCatalogTests
         Assert.Equal(expectedFileName, Path.GetFileName(path));
         Assert.Equal(fixture.ProjectName, new DirectoryInfo(path).Parent?.Parent?.Name);
     }
+
+    static void AssertBoundary(FixtureDefinition fixture, FixtureBoundary boundary)
+        => Assert.Contains(boundary, fixture.Boundaries);
 
     static void AssertAssemblyReferences(FixtureDefinition fixture, params string[] expectedReferences)
     {

--- a/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
+++ b/tests/DotnetInspector.Fixtures.Tests/FixtureCatalogTests.cs
@@ -115,18 +115,18 @@ public class FixtureCatalogTests
     [Fact]
     public void BoundaryMetadata_CoversIntentionalSeparateFixtureProjects()
     {
-        var consolidatedProjects = new HashSet<string>(StringComparer.Ordinal)
+        var consolidatedSourceBucketProjects = new HashSet<string>(StringComparer.Ordinal)
         {
             "ILInspector.Analysis.Fixtures",
             "ILInspector.Decompiler.Fixtures.Ladder",
         };
 
-        var singleFixtureProjects = FixtureCatalog.All
+        var separateProjectFixtures = FixtureCatalog.All
             .GroupBy(fixture => fixture.ProjectName, StringComparer.Ordinal)
-            .Where(group => group.Count() == 1 && !consolidatedProjects.Contains(group.Key))
-            .Select(group => group.Single());
+            .Where(group => !consolidatedSourceBucketProjects.Contains(group.Key))
+            .SelectMany(group => group);
 
-        Assert.All(singleFixtureProjects, fixture =>
+        Assert.All(separateProjectFixtures, fixture =>
             Assert.NotEmpty(fixture.Boundaries));
     }
 
@@ -139,8 +139,6 @@ public class FixtureCatalogTests
     [InlineData(FixtureIds.AnalysisCallerGraphLookalikeCaller, FixtureBoundary.CrossAssemblyBoundary)]
     [InlineData(FixtureIds.AnalysisCallerGraphTarget, FixtureBoundary.CrossAssemblyBoundary)]
     [InlineData(FixtureIds.AnalysisCrossAsmCollision, FixtureBoundary.ExternAlias)]
-    [InlineData(FixtureIds.AnalysisCrossAsmShape, FixtureBoundary.CrossAssemblyBoundary)]
-    [InlineData(FixtureIds.AnalysisExceptionBase, FixtureBoundary.CrossAssemblyBoundary)]
     [InlineData(FixtureIds.AnalysisFacade, FixtureBoundary.TargetFramework)]
     [InlineData(FixtureIds.AnalysisLookalike, FixtureBoundary.AssemblyIdentity)]
     [InlineData(FixtureIds.AnalysisRender, FixtureBoundary.FrameworkReference)]
@@ -161,12 +159,12 @@ public class FixtureCatalogTests
     public void ConsolidatedFixtureBuckets_ShareAssemblyWithoutProjectBoundaryAxes()
     {
         Assert.Equal(FixtureCatalog.AnalysisCrossAsmShape.ProjectName, FixtureCatalog.AnalysisExceptionBase.ProjectName);
-        Assert.Equal(FixtureCatalog.AnalysisCrossAsmShape.AssemblyPath(), FixtureCatalog.AnalysisExceptionBase.AssemblyPath());
+        Assert.Equal(FixtureCatalog.AnalysisCrossAsmShape.AssemblyFileName, FixtureCatalog.AnalysisExceptionBase.AssemblyFileName);
+        Assert.Empty(FixtureCatalog.AnalysisCrossAsmShape.Boundaries);
+        Assert.Empty(FixtureCatalog.AnalysisExceptionBase.Boundaries);
 
-        Assert.DoesNotContain(FixtureBoundary.AssemblyName, FixtureCatalog.AnalysisCrossAsmShape.Boundaries);
-        Assert.DoesNotContain(FixtureBoundary.AssemblyName, FixtureCatalog.AnalysisExceptionBase.Boundaries);
-        Assert.DoesNotContain(FixtureBoundary.TargetFramework, FixtureCatalog.AnalysisCrossAsmShape.Boundaries);
-        Assert.DoesNotContain(FixtureBoundary.TargetFramework, FixtureCatalog.AnalysisExceptionBase.Boundaries);
+        Assert.All(FixtureCatalog.DecompilerLadderFixtures.Fixtures, fixture =>
+            Assert.Empty(fixture.Boundaries));
     }
 
     [Fact]

--- a/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
+++ b/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
@@ -5,10 +5,26 @@ public sealed record FixtureDefinition(
     string ProjectName,
     string AssemblyFileName,
     IReadOnlyList<string> Tags,
+    IReadOnlyList<FixtureBoundary> Boundaries,
     IReadOnlyList<FixtureAsset> Assets)
 {
     public string AssemblyPath() => FixtureCatalog.AssemblyPath(Id);
     public string AssetPath(string name) => FixtureCatalog.AssetPath(Id, name);
+}
+
+public enum FixtureBoundary
+{
+    AssemblyIdentity,
+    AssemblyName,
+    CompilerLowering,
+    CrossAssemblyBoundary,
+    ExternAlias,
+    FrameworkReference,
+    ModuleAttribute,
+    OutputKind,
+    SidecarAsset,
+    TargetFramework,
+    VersionPair,
 }
 
 public sealed record FixtureAsset(string Name, string ProjectName, string RelativePath);
@@ -73,126 +89,147 @@ public static class FixtureCatalog
         FixtureIds.DiffV1,
         "DiffFixtures.V1",
         "DiffFixtureSample.dll",
+        Boundaries(FixtureBoundary.VersionPair),
         "diff", "version-pair", "analysis", "decompiler", "rts-candidate");
 
     public static readonly FixtureDefinition DiffV2 = Fixture(
         FixtureIds.DiffV2,
         "DiffFixtures.V2",
         "DiffFixtureSample.dll",
+        Boundaries(FixtureBoundary.VersionPair),
         "diff", "version-pair", "analysis", "decompiler", "rts-candidate");
 
     public static readonly FixtureDefinition DiffAsmCaller = Fixture(
         FixtureIds.DiffAsmCaller,
         "DiffAsmFixtures.Caller",
         "DiffAsmCaller.dll",
+        Boundaries(FixtureBoundary.AssemblyIdentity),
         "diff", "assembly-identity", "caller");
 
     public static readonly FixtureDefinition DiffAsmLibA = Fixture(
         FixtureIds.DiffAsmLibA,
         "DiffAsmFixtures.LibA",
         "DiffAsmLibA.dll",
+        Boundaries(FixtureBoundary.AssemblyIdentity),
         "diff", "assembly-identity", "same-fqn");
 
     public static readonly FixtureDefinition DiffAsmLibB = Fixture(
         FixtureIds.DiffAsmLibB,
         "DiffAsmFixtures.LibB",
         "DiffAsmLibB.dll",
+        Boundaries(FixtureBoundary.AssemblyIdentity),
         "diff", "assembly-identity", "same-fqn");
 
     public static readonly FixtureDefinition DiffAsmTarget = Fixture(
         FixtureIds.DiffAsmTarget,
         "DiffAsmFixtures.Target",
         "DiffAsmTarget.dll",
+        Boundaries(FixtureBoundary.AssemblyIdentity),
         "diff", "assembly-identity", "target");
 
     public static readonly FixtureDefinition AnalysisCallerGraphCaller = Fixture(
         FixtureIds.AnalysisCallerGraphCaller,
         "ILInspector.Analysis.CallerGraphCaller",
         "ILInspector.Analysis.CallerGraphCaller.dll",
+        Boundaries(FixtureBoundary.CrossAssemblyBoundary),
         "analysis", "caller-graph", "caller");
 
     public static readonly FixtureDefinition AnalysisCallerGraphCallerTwin = Fixture(
         FixtureIds.AnalysisCallerGraphCallerTwin,
         "ILInspector.Analysis.CallerGraphCallerTwin",
         "ILInspector.Analysis.CallerGraphCallerTwin.dll",
+        Boundaries(FixtureBoundary.CrossAssemblyBoundary),
         "analysis", "caller-graph", "caller", "twin");
 
     public static readonly FixtureDefinition AnalysisCallerGraphLookalikeCaller = Fixture(
         FixtureIds.AnalysisCallerGraphLookalikeCaller,
         "ILInspector.Analysis.CallerGraphLookalikeCaller",
         "ILInspector.Analysis.CallerGraphLookalikeCaller.dll",
+        Boundaries(FixtureBoundary.CrossAssemblyBoundary),
         "analysis", "caller-graph", "lookalike");
 
     public static readonly FixtureDefinition AnalysisCallerGraphTarget = Fixture(
         FixtureIds.AnalysisCallerGraphTarget,
         "ILInspector.Analysis.CallerGraphTarget",
         "ILInspector.Analysis.CallerGraphTarget.dll",
+        Boundaries(FixtureBoundary.CrossAssemblyBoundary),
         "analysis", "caller-graph", "target");
 
     public static readonly FixtureDefinition AnalysisCrossAsmCollision = Fixture(
         FixtureIds.AnalysisCrossAsmCollision,
         "ILInspector.Analysis.CrossAsmCollisionFixtures",
         "ILInspector.Analysis.CrossAsmCollisionFixtures.dll",
+        Boundaries(FixtureBoundary.AssemblyIdentity, FixtureBoundary.ExternAlias),
         "analysis", "cross-assembly", "collision");
 
     public static readonly FixtureDefinition AnalysisCrossAsmShape = Fixture(
         FixtureIds.AnalysisCrossAsmShape,
         "ILInspector.Analysis.Fixtures",
         "ILInspector.Analysis.Fixtures.dll",
+        Boundaries(FixtureBoundary.CrossAssemblyBoundary),
         "analysis", "cross-assembly", "shape");
 
     public static readonly FixtureDefinition AnalysisExceptionBase = Fixture(
         FixtureIds.AnalysisExceptionBase,
         "ILInspector.Analysis.Fixtures",
         "ILInspector.Analysis.Fixtures.dll",
+        Boundaries(FixtureBoundary.CrossAssemblyBoundary),
         "analysis", "exception");
 
     public static readonly FixtureDefinition AnalysisFacade = Fixture(
         FixtureIds.AnalysisFacade,
         "ILInspector.Analysis.FacadeFixtures",
         "ILInspector.Analysis.FacadeFixtures.dll",
+        Boundaries(FixtureBoundary.TargetFramework),
         "analysis", "facade", "netstandard");
 
     public static readonly FixtureDefinition AnalysisLookalike = Fixture(
         FixtureIds.AnalysisLookalike,
         "ILInspector.Analysis.LookalikeFixtures",
         "ILInspector.Analysis.LookalikeFixtures.dll",
+        Boundaries(FixtureBoundary.AssemblyIdentity),
         "analysis", "lookalike");
 
     public static readonly FixtureDefinition AnalysisProtobuf = Fixture(
         FixtureIds.AnalysisProtobuf,
         "ILInspector.Analysis.ProtobufFixtures",
         "Google.Protobuf.dll",
+        Boundaries(FixtureBoundary.AssemblyName),
         "analysis", "protobuf", "assembly-name-axis");
 
     public static readonly FixtureDefinition AnalysisRender = Fixture(
         FixtureIds.AnalysisRender,
         "ILInspector.Analysis.RenderFixtures",
         "ILInspector.Analysis.RenderFixtures.dll",
+        Boundaries(FixtureBoundary.FrameworkReference),
         "analysis", "render");
 
     public static readonly FixtureDefinition AnalysisSpoofSystemLinq = Fixture(
         FixtureIds.AnalysisSpoofSystemLinq,
         "ILInspector.Analysis.SpoofFixtures",
         "System.Linq.dll",
+        Boundaries(FixtureBoundary.AssemblyName),
         "analysis", "spoof", "assembly-name-axis", "system-linq");
 
     public static readonly FixtureDefinition AnalysisSpoofSystemRuntime = Fixture(
         FixtureIds.AnalysisSpoofSystemRuntime,
         "ILInspector.Analysis.SpoofRuntimeFixtures",
         "System.Runtime.dll",
+        Boundaries(FixtureBoundary.AssemblyName),
         "analysis", "spoof", "assembly-name-axis", "system-runtime");
 
     public static readonly FixtureDefinition DecompilerCheckedArithmetic = Fixture(
         FixtureIds.DecompilerCheckedArithmetic,
         "ILInspector.Decompiler.Fixtures.CheckedArithmetic",
         "ILInspector.Decompiler.Fixtures.CheckedArithmetic.dll",
+        Boundaries(FixtureBoundary.CompilerLowering),
         "decompiler", "checked-arithmetic", "compiler-axis");
 
     public static readonly FixtureDefinition DecompilerClassicAsync = Fixture(
         FixtureIds.DecompilerClassicAsync,
         "ILInspector.Decompiler.Fixtures.ClassicAsync",
         "ILInspector.Decompiler.Fixtures.ClassicAsync.dll",
+        Boundaries(FixtureBoundary.CompilerLowering),
         "decompiler", "async", "classic-async", "compiler-axis", "rts-candidate");
 
     public static readonly FixtureDefinition DecompilerLadderIterator = Fixture(
@@ -241,30 +278,35 @@ public static class FixtureCatalog
         FixtureIds.DecompilerUnsafeLegacy,
         "ILInspector.Decompiler.Fixtures.LegacyUnsafe",
         "ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll",
+        Boundaries(FixtureBoundary.ModuleAttribute),
         "decompiler", "unsafe", "legacy-memory-safety");
 
     public static readonly FixtureDefinition DecompilerUnsafeNew = Fixture(
         FixtureIds.DecompilerUnsafeNew,
         "ILInspector.Decompiler.Fixtures.NewUnsafe",
         "ILInspector.Decompiler.Fixtures.NewUnsafe.dll",
+        Boundaries(FixtureBoundary.ModuleAttribute),
         "decompiler", "unsafe", "updated-memory-safety");
 
     public static readonly FixtureDefinition DecompilerUnsafeChainA = Fixture(
         FixtureIds.DecompilerUnsafeChainA,
         "ILInspector.Decompiler.Fixtures.UnsafeChainA",
         "ILInspector.Decompiler.Fixtures.UnsafeChainA.dll",
+        Boundaries(FixtureBoundary.CrossAssemblyBoundary, FixtureBoundary.ModuleAttribute),
         "decompiler", "unsafe", "chain", "updated-memory-safety");
 
     public static readonly FixtureDefinition DecompilerUnsafeChainB = Fixture(
         FixtureIds.DecompilerUnsafeChainB,
         "ILInspector.Decompiler.Fixtures.UnsafeChainB",
         "ILInspector.Decompiler.Fixtures.UnsafeChainB.dll",
+        Boundaries(FixtureBoundary.CrossAssemblyBoundary, FixtureBoundary.ModuleAttribute),
         "decompiler", "unsafe", "chain", "updated-memory-safety");
 
     public static readonly FixtureDefinition DecompilerUnsafeChainC = Fixture(
         FixtureIds.DecompilerUnsafeChainC,
         "ILInspector.Decompiler.Fixtures.UnsafeChainC",
         "ILInspector.Decompiler.Fixtures.UnsafeChainC.dll",
+        Boundaries(FixtureBoundary.CrossAssemblyBoundary, FixtureBoundary.ModuleAttribute, FixtureBoundary.OutputKind),
         "decompiler", "unsafe", "chain", "legacy-memory-safety", "executable");
 
     public static readonly FixtureDefinition RunFasterAllocation = Fixture(
@@ -272,6 +314,7 @@ public static class FixtureCatalog
         "RunFaster.AllocationFixture",
         "RunFaster.AllocationFixture.dll",
         ["runfaster", "allocation", "trace-coupled"],
+        Boundaries(FixtureBoundary.SidecarAsset),
         Asset("fixture.nettrace", "runfaster.Tests", "Fixtures/RunFaster.AllocationFixture/fixture.nettrace"));
 
     public static readonly IReadOnlyList<FixtureDefinition> All =
@@ -469,13 +512,19 @@ public static class FixtureCatalog
     }
 
     static FixtureDefinition Fixture(string id, string projectName, string assemblyFileName, params string[] tags)
-        => new(id, projectName, assemblyFileName, tags, []);
+        => new(id, projectName, assemblyFileName, tags, [], []);
 
-    static FixtureDefinition Fixture(string id, string projectName, string assemblyFileName, string[] tags, params FixtureAsset[] assets)
-        => new(id, projectName, assemblyFileName, tags, assets);
+    static FixtureDefinition Fixture(string id, string projectName, string assemblyFileName, FixtureBoundary[] boundaries, params string[] tags)
+        => new(id, projectName, assemblyFileName, tags, boundaries, []);
+
+    static FixtureDefinition Fixture(string id, string projectName, string assemblyFileName, string[] tags, FixtureBoundary[] boundaries, params FixtureAsset[] assets)
+        => new(id, projectName, assemblyFileName, tags, boundaries, assets);
 
     static FixtureAsset Asset(string name, string projectName, string relativePath)
         => new(name, projectName, relativePath);
+
+    static FixtureBoundary[] Boundaries(params FixtureBoundary[] boundaries)
+        => boundaries;
 
     static string CurrentConfiguration()
     {

--- a/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
+++ b/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
@@ -166,14 +166,12 @@ public static class FixtureCatalog
         FixtureIds.AnalysisCrossAsmShape,
         "ILInspector.Analysis.Fixtures",
         "ILInspector.Analysis.Fixtures.dll",
-        Boundaries(FixtureBoundary.CrossAssemblyBoundary),
         "analysis", "cross-assembly", "shape");
 
     public static readonly FixtureDefinition AnalysisExceptionBase = Fixture(
         FixtureIds.AnalysisExceptionBase,
         "ILInspector.Analysis.Fixtures",
         "ILInspector.Analysis.Fixtures.dll",
-        Boundaries(FixtureBoundary.CrossAssemblyBoundary),
         "analysis", "exception");
 
     public static readonly FixtureDefinition AnalysisFacade = Fixture(


### PR DESCRIPTION
## Summary
- add typed `FixtureBoundary` metadata to fixture catalog entries so semantic build/assembly axes are explicit
- add fixture catalog contract coverage for intentional single-fixture project boundaries and consolidated buckets
- document fixture project-boundary rules and consumer expectations in `docs/fixture-governance.md`

## Validation
- `dotnet build dotnet-inspect.slnx -c Release --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json --verbosity minimal`
- `dotnet run --project tests/DotnetInspector.Fixtures.Tests -c Release --no-build --no-restore`
- `npx markdownlint-cli docs/fixture-governance.md docs/overview.md`
- `git diff --check`

Adversarial review pending per PR policy.