### PR TITLE
Seed precise RTS closure member requirements

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -229,11 +229,11 @@ public class ReturnToSenderPrototypeTests
             Assert.Contains(result.Plan.Types, type =>
                 type.Name == "Helper"
                 && type.SourceFacts.Any(fact => fact.Id == "body-type" && fact.Producer == "metadata")
-                && type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "metadata" && fact.Detail.EndsWith(".Create", StringComparison.Ordinal))
-                && type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "metadata" && fact.Detail.EndsWith(".get_Value", StringComparison.Ordinal))
                 && !type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "roslyn")
-                && type.Members.Any(member => member.Name == "Value" && member.Kind == CompileBackMemberKind.PropertyGet)
-                && type.Members.Any(member => member.Name == "Create" && member.Kind == CompileBackMemberKind.Method && member.IsStatic));
+                && type.Members.Any(member => member.Name == "Value" && member.Kind == CompileBackMemberKind.PropertyGet
+                    && member.SourceFacts.Any(fact => fact.Id == "typed-closure-property" && fact.Detail == "get_Value"))
+                && type.Members.Any(member => member.Name == "Create" && member.Kind == CompileBackMemberKind.Method && member.IsStatic
+                    && member.SourceFacts.Any(fact => fact.Id == "typed-closure-method" && fact.Detail == "Create")));
             var evidence = ReturnToSenderClosureEvidenceBuilder.FromPlan(result.Plan);
             Assert.Equal(0, evidence.RoslynRecoveredMemberSurfaces);
             Assert.Contains("public int Value", result.Source);
@@ -269,11 +269,11 @@ public class ReturnToSenderPrototypeTests
             Assert.Contains(result.Plan.Types, type =>
                 type.Name == "Helper"
                 && type.TypeParameters.Single().Name == "T"
-                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "closure-member" && fact.Detail.EndsWith("Helper`1.Create", StringComparison.Ordinal))
-                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "closure-member" && fact.Detail.EndsWith("Helper`1.get_Value", StringComparison.Ordinal))
                 && !type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "roslyn")
-                && type.Members.Any(member => member.Name == "Value")
-                && type.Members.Any(member => member.Name == "Create"));
+                && type.Members.Any(member => member.Name == "Value"
+                    && member.SourceFacts.Any(fact => fact.Id == "typed-closure-property" && fact.Detail == "get_Value"))
+                && type.Members.Any(member => member.Name == "Create"
+                    && member.SourceFacts.Any(fact => fact.Id == "typed-closure-method" && fact.Detail == "Create")));
             var evidence = ReturnToSenderClosureEvidenceBuilder.FromPlan(result.Plan);
             Assert.Equal(0, evidence.RoslynRecoveredMemberSurfaces);
             Assert.Contains("public class Helper<T>", result.Source);
@@ -321,9 +321,9 @@ public class ReturnToSenderPrototypeTests
                 $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             Assert.Contains(result.Plan.Types, type =>
                 type.Name == "Pair"
-                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "closure-member" && fact.Detail.EndsWith(".Deconstruct", StringComparison.Ordinal))
                 && !type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "roslyn")
-                && type.Members.Any(member => member.Name == "Deconstruct"));
+                && type.Members.Any(member => member.Name == "Deconstruct"
+                    && member.SourceFacts.Any(fact => fact.Id == "typed-closure-method" && fact.Detail == "Deconstruct")));
             var evidence = ReturnToSenderClosureEvidenceBuilder.FromPlan(result.Plan);
             Assert.Equal(0, evidence.RoslynRecoveredMemberSurfaces);
             Assert.Contains("public void Deconstruct", result.Source);
@@ -432,15 +432,15 @@ public class ReturnToSenderPrototypeTests
             Assert.Contains(result.Plan.Types, type =>
                 type.Name == "A"
                 && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "body-type")
-                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "closure-member" && fact.Detail.EndsWith(".Create", StringComparison.Ordinal))
                 && !type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "roslyn")
-                && type.Members.Any(member => member.Name == "Create"));
+                && type.Members.Any(member => member.Name == "Create"
+                    && member.SourceFacts.Any(fact => fact.Id == "typed-closure-method" && fact.Detail == "Create")));
             Assert.Contains(result.Plan.Types, type =>
                 type.Name == "B"
                 && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "body-type")
-                && type.SourceFacts.Any(fact => fact.Producer == "metadata" && fact.Id == "closure-member" && fact.Detail.EndsWith(".get_Value", StringComparison.Ordinal))
                 && !type.SourceFacts.Any(fact => fact.Id == "closure-member" && fact.Producer == "roslyn")
-                && type.Members.Any(member => member.Name == "Value"));
+                && type.Members.Any(member => member.Name == "Value"
+                    && member.SourceFacts.Any(fact => fact.Id == "typed-closure-property" && fact.Detail == "get_Value")));
             var evidence = ReturnToSenderClosureEvidenceBuilder.FromPlan(result.Plan);
             Assert.Equal(0, evidence.RoslynRecoveredMemberSurfaces);
             Assert.Contains("public static B Create()", result.Source);
@@ -760,7 +760,7 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void CompileBackFirstPropertyGetter_EmitsClosureConstFieldsWithInitializers()
+    public void CompileBackFirstPropertyGetter_DoesNotEmitUnreferencedClosureConstFields()
     {
         var assemblyPath = CompileFixture("""
             public class Helper
@@ -783,7 +783,7 @@ public class ReturnToSenderPrototypeTests
             Assert.True(
                 result.Status == FidelityCheck.CompileBackStatus.Exact,
                 $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
-            Assert.Contains("public const int ConstValue = 42;", result.Source);
+            Assert.DoesNotContain("ConstValue", result.Source);
         }
         finally
         {
@@ -792,7 +792,7 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
-    public void CompileBackFirstPropertyGetter_EmitsNonFiniteClosureConstFields()
+    public void CompileBackFirstPropertyGetter_DoesNotEmitUnreferencedNonFiniteClosureConstFields()
     {
         var assemblyPath = CompileFixture("""
             public class Helper
@@ -816,8 +816,8 @@ public class ReturnToSenderPrototypeTests
             Assert.True(
                 result.Status == FidelityCheck.CompileBackStatus.Exact,
                 $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
-            Assert.Contains("public const float FloatNaN = float.NaN;", result.Source);
-            Assert.Contains("public const double DoubleInfinity = double.PositiveInfinity;", result.Source);
+            Assert.DoesNotContain("FloatNaN", result.Source);
+            Assert.DoesNotContain("DoubleInfinity", result.Source);
         }
         finally
         {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -246,6 +246,83 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_EmitsClosureConstructorRequirement()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Helper
+            {
+                public Helper(int value)
+                {
+                    Value = value;
+                }
+
+                public int Value { get; }
+            }
+
+            public class Class1
+            {
+                public int FromHelper => new Helper(42).Value;
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackPropertyGetters(assemblyPath, maxTargets: 2)
+                .Single(item => item.Plan.TargetMethod.Method == "get_FromHelper");
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains(result.Plan.Types, type =>
+                type.Name == "Helper"
+                && type.Members.Any(member => member.Name == ".ctor"
+                    && member.Parameters.Single().Type.DisplayName == "int"
+                    && member.SourceFacts.Any(fact => fact.Id == "typed-closure-constructor" && fact.Detail == ".ctor"))
+                && type.Members.Any(member => member.Name == "Value"));
+            Assert.Contains("public Helper(int value)", result.Source);
+            Assert.Contains("public int Value", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackFirstPropertyGetter_SelectsTypedOverloadByParameterTypes()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Helper
+            {
+                public int Pick(int value) => value + 1;
+                public int Pick(string value) => value.Length;
+            }
+
+            public class Class1
+            {
+                public int FromHelper => new Helper().Pick("hello");
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackPropertyGetters(assemblyPath, maxTargets: 2)
+                .Single(item => item.Plan.TargetMethod.Method == "get_FromHelper");
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains(result.Plan.Types, type =>
+                type.Name == "Helper"
+                && type.Members.Any(member => member.Name == "Pick"
+                    && member.Parameters is [{ Type.DisplayName: "string" }]
+                    && member.SourceFacts.Any(fact => fact.Id == "typed-closure-method" && fact.Detail == "Pick"))
+                && !type.Members.Any(member => member.Name == "Pick"
+                    && member.Parameters is [{ Type.DisplayName: "int" }]));
+            Assert.Contains("public int Pick(string value)", result.Source);
+            Assert.DoesNotContain("public int Pick(int value)", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_EmitsGenericClosureMemberSurface()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -246,6 +246,38 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_DeduplicatesRepeatedPreciseClosureMembers()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Helper
+            {
+                public int Value => 42;
+                public static Helper Create() => new Helper();
+            }
+
+            public class Class1
+            {
+                public int FromHelper => Helper.Create().Value + Helper.Create().Value;
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackPropertyGetters(assemblyPath, maxTargets: 2)
+                .Single(item => item.Plan.TargetMethod.Method == "get_FromHelper");
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            var helper = Assert.Single(result.Plan.Types, type => type.Name == "Helper");
+            Assert.Equal(1, helper.Members.Count(member => member.Name == "Value" && member.Kind == CompileBackMemberKind.PropertyGet));
+            Assert.Equal(1, helper.Members.Count(member => member.Name == "Create" && member.Kind == CompileBackMemberKind.Method));
+            Assert.DoesNotContain("already contains a definition", result.Detail ?? "");
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_EmitsClosureConstructorRequirement()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -2042,7 +2042,8 @@ public static class CompileBackSourceComposer
             try
             {
                 var signature = method.DecodeSignature(TypeRefDecoder.Instance, IrImporter.CallerScope(reader, typeDef, method));
-                return signature.ParameterTypes.Length == methodRef.ParameterTypes.Length;
+                return signature.ParameterTypes.Length == methodRef.ParameterTypes.Length
+                    && signature.ParameterTypes.SequenceEqual(methodRef.ParameterTypes);
             }
             catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
             {
@@ -2122,12 +2123,12 @@ public static class CompileBackSourceComposer
         {
             var method = reader.GetMethodDefinition(methodHandle);
             string name = reader.GetString(method.Name);
+            bool isConstructor = name == ".ctor";
             if (name == ".cctor"
                 || name.Contains('<', StringComparison.Ordinal)
-                || name.Contains('.', StringComparison.Ordinal))
+                || (!isConstructor && name.Contains('.', StringComparison.Ordinal)))
                 return null;
 
-            bool isConstructor = name == ".ctor";
             if (!isConstructor && method.Attributes.HasFlag(MethodAttributes.SpecialName))
                 return null;
 

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -279,6 +279,18 @@ public sealed record CompileBackPlanningDiagnostic(string Layer, string Reason, 
 
 public static class CompileBackSourceComposer
 {
+    public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        MethodRef method)
+        => TypeProducer.TryCreateClosureMemberRequirement(reader, typeHandle, method);
+
+    public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
+        MetadataReader reader,
+        TypeDefinitionHandle typeHandle,
+        FieldRef field)
+        => TypeProducer.TryCreateClosureMemberRequirement(reader, typeHandle, field);
+
     public static CompileBackSourceResult ComposePropertyGetter(
         string assemblyPath,
         MetadataReader reader,
@@ -292,7 +304,8 @@ public static class CompileBackSourceComposer
         int overload,
         string signatureText,
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
-        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts)
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
     {
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var property = reader.GetPropertyDefinition(targetProperty);
@@ -360,7 +373,9 @@ public static class CompileBackSourceComposer
             requirements.Add(new CompileBackTypeRequirement(
                 dependencyIdentity,
                 ShellKind(reader, dependencyDef),
-                RequiredMembers: [],
+                RequiredMembers: closureMemberRequirements.TryGetValue(dependency, out var requiredMembers)
+                    ? requiredMembers.ToArray()
+                    : [],
                 PrimaryConstructor: null,
                 SourceFacts: closureFacts.TryGetValue(dependency, out var facts)
                     ? facts.ToArray()
@@ -401,7 +416,8 @@ public static class CompileBackSourceComposer
         int overload,
         string signatureText,
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
-        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts)
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
     {
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var property = reader.GetPropertyDefinition(targetProperty);
@@ -466,7 +482,9 @@ public static class CompileBackSourceComposer
             requirements.Add(new CompileBackTypeRequirement(
                 dependencyIdentity,
                 ShellKind(reader, dependencyDef),
-                RequiredMembers: [],
+                RequiredMembers: closureMemberRequirements.TryGetValue(dependency, out var requiredMembers)
+                    ? requiredMembers.ToArray()
+                    : [],
                 PrimaryConstructor: null,
                 SourceFacts: closureFacts.TryGetValue(dependency, out var facts)
                     ? facts.ToArray()
@@ -506,7 +524,8 @@ public static class CompileBackSourceComposer
         int overload,
         string signatureText,
         IReadOnlySet<TypeDefinitionHandle> closureRoots,
-        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts)
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
     {
         var targetTypeDef = reader.GetTypeDefinition(targetType);
         var method = reader.GetMethodDefinition(targetMethod);
@@ -582,7 +601,9 @@ public static class CompileBackSourceComposer
             requirements.Add(new CompileBackTypeRequirement(
                 dependencyIdentity,
                 ShellKind(reader, dependencyDef),
-                RequiredMembers: [],
+                RequiredMembers: closureMemberRequirements.TryGetValue(dependency, out var requiredMembers)
+                    ? requiredMembers.ToArray()
+                    : [],
                 PrimaryConstructor: null,
                 SourceFacts: closureFacts.TryGetValue(dependency, out var facts)
                     ? facts.ToArray()
@@ -1871,6 +1892,58 @@ public static class CompileBackSourceComposer
 
     sealed class TypeProducer
     {
+        public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
+            MetadataReader reader,
+            TypeDefinitionHandle typeHandle,
+            MethodRef methodRef)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            var typeIdentity = CompileBackTypeIdentity.FromDefinition(reader, typeDef);
+            if (TryFindPropertyForAccessor(reader, typeDef, methodRef) is { } propertyHandle)
+                return PropertyRequirement(reader, typeDef, typeIdentity, propertyHandle, methodRef.Name);
+            if (TryFindMethod(reader, typeDef, methodRef) is { } methodHandle)
+                return MethodRequirement(reader, typeDef, typeIdentity, methodHandle);
+            return null;
+        }
+
+        public static CompileBackMemberRequirement? TryCreateClosureMemberRequirement(
+            MetadataReader reader,
+            TypeDefinitionHandle typeHandle,
+            FieldRef fieldRef)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            var typeIdentity = CompileBackTypeIdentity.FromDefinition(reader, typeDef);
+            if (FindField(reader, typeDef, fieldRef.Name) is not { } fieldHandle)
+                return null;
+            var field = reader.GetFieldDefinition(fieldHandle);
+            string fieldType;
+            try
+            {
+                fieldType = field.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForType(reader, typeDef));
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return null;
+            }
+
+            if (IsUnsupportedSurfaceSignature(fieldType))
+                return null;
+
+            string fieldName = reader.GetString(field.Name);
+            return new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(typeIdentity.FullName, Identifier(fieldName), 0, $"field {fieldType}"),
+                CompileBackMemberKind.Field,
+                field.Attributes.HasFlag(FieldAttributes.Static),
+                [],
+                CompileBackTypeSignature.Display(fieldType),
+                [],
+                TryFormatConstantField(reader, field, out var constant)
+                    ? CompileBackStubBodyKind.TargetBody
+                    : CompileBackStubBodyKind.None,
+                constant,
+                [new CompileBackFact("metadata", "typed-closure-field", fieldName)]);
+        }
+
         public static IReadOnlyList<CompileBackTypeDeclaration> Produce(
             MetadataReader reader,
             IReadOnlyList<CompileBackTypeRequirement> requirements,
@@ -1910,6 +1983,207 @@ public static class CompileBackSourceComposer
             }
 
             return shells;
+        }
+
+        static PropertyDefinitionHandle? TryFindPropertyForAccessor(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            MethodRef methodRef)
+        {
+            if (!methodRef.Name.StartsWith("get_", StringComparison.Ordinal)
+                && !methodRef.Name.StartsWith("set_", StringComparison.Ordinal))
+                return null;
+
+            foreach (var propertyHandle in typeDef.GetProperties())
+            {
+                var property = reader.GetPropertyDefinition(propertyHandle);
+                var accessors = property.GetAccessors();
+                var accessorHandle = methodRef.Name.StartsWith("get_", StringComparison.Ordinal)
+                    ? accessors.Getter
+                    : accessors.Setter;
+                if (accessorHandle.IsNil)
+                    continue;
+                var accessor = reader.GetMethodDefinition(accessorHandle);
+                if (!MethodMatches(reader, typeDef, accessor, methodRef))
+                    continue;
+                return propertyHandle;
+            }
+
+            return null;
+        }
+
+        static MethodDefinitionHandle? TryFindMethod(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            MethodRef methodRef)
+        {
+            var matches = new List<MethodDefinitionHandle>();
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (!MethodMatches(reader, typeDef, method, methodRef))
+                    continue;
+                matches.Add(methodHandle);
+            }
+
+            return matches.Count == 1 ? matches[0] : null;
+        }
+
+        static bool MethodMatches(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            MethodDefinition method,
+            MethodRef methodRef)
+        {
+            if (reader.GetString(method.Name) != methodRef.Name)
+                return false;
+            if (method.GetGenericParameters().Count != methodRef.TypeArguments.Length)
+                return false;
+            try
+            {
+                var signature = method.DecodeSignature(TypeRefDecoder.Instance, IrImporter.CallerScope(reader, typeDef, method));
+                return signature.ParameterTypes.Length == methodRef.ParameterTypes.Length;
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        static CompileBackMemberRequirement? PropertyRequirement(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            CompileBackTypeIdentity typeIdentity,
+            PropertyDefinitionHandle propertyHandle,
+            string accessorName)
+        {
+            var property = reader.GetPropertyDefinition(propertyHandle);
+            var accessors = property.GetAccessors();
+            string propertyName = reader.GetString(property.Name);
+            if (propertyName.Contains('<', StringComparison.Ordinal)
+                || propertyName.Contains('.', StringComparison.Ordinal))
+                return null;
+
+            MetadataPropertyDeclaration propertyDeclaration;
+            try
+            {
+                propertyDeclaration = MetadataDeclarationQuery.GetProperty(reader, typeDef, property);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return null;
+            }
+
+            if (propertyDeclaration.Signature.ReturnType is not { } propertyReturnType
+                || IsUnsupportedSurfaceSignature(propertyReturnType))
+                return null;
+
+            var accessor = accessorName.StartsWith("get_", StringComparison.Ordinal) ? accessors.Getter : accessors.Setter;
+            var accessorMethod = accessor.IsNil ? default : reader.GetMethodDefinition(accessor);
+            bool isStatic = !accessor.IsNil && accessorMethod.Attributes.HasFlag(MethodAttributes.Static);
+            var returnType = CompileBackTypeSignature.Display(propertyReturnType);
+            bool isAutoProperty = !accessors.Getter.IsNil
+                && IsAutoProperty(reader, typeDef, property, accessors.Getter, returnType.DisplayName);
+            bool hasSetter = !accessors.Setter.IsNil;
+            bool isAbstractAccessor = !accessor.IsNil && propertyDeclaration.IsAbstract;
+            var noBodyProperty = (typeDef.Attributes & TypeAttributes.Interface) != 0 || isAbstractAccessor;
+            var stubBody = noBodyProperty
+                ? hasSetter
+                    ? CompileBackStubBodyKind.AutoPropertyGetSet
+                    : CompileBackStubBodyKind.None
+                : hasSetter && isAutoProperty
+                    ? CompileBackStubBodyKind.AutoPropertyGetSet
+                    : isAutoProperty
+                        ? CompileBackStubBodyKind.AutoProperty
+                        : hasSetter
+                            ? CompileBackStubBodyKind.ThrowGetSet
+                            : CompileBackStubBodyKind.Throw;
+            return new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(typeIdentity.FullName, Identifier(propertyName), 0, $"property {propertyReturnType}"),
+                CompileBackMemberKind.PropertyGet,
+                isStatic,
+                ToCompileBackParameters(propertyDeclaration.Signature.Parameters),
+                returnType,
+                [],
+                stubBody,
+                null,
+                [new CompileBackFact("metadata", "typed-closure-property", accessorName)],
+                propertyDeclaration.Attributes,
+                propertyDeclaration.Signature.ReturnAttributes,
+                IsAbstract: isAbstractAccessor,
+                IsVirtual: !accessor.IsNil && propertyDeclaration.IsVirtual);
+        }
+
+        static CompileBackMemberRequirement? MethodRequirement(
+            MetadataReader reader,
+            TypeDefinition typeDef,
+            CompileBackTypeIdentity typeIdentity,
+            MethodDefinitionHandle methodHandle)
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            string name = reader.GetString(method.Name);
+            if (name == ".cctor"
+                || name.Contains('<', StringComparison.Ordinal)
+                || name.Contains('.', StringComparison.Ordinal))
+                return null;
+
+            bool isConstructor = name == ".ctor";
+            if (!isConstructor && method.Attributes.HasFlag(MethodAttributes.SpecialName))
+                return null;
+
+            MethodSignature<string> signature;
+            try
+            {
+                signature = method.DecodeSignature(SignatureDecoder.Instance, GenericContext.ForMethod(reader, typeDef, method));
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or InvalidOperationException or ArgumentException)
+            {
+                return null;
+            }
+
+            var methodDeclaration = MetadataDeclarationQuery.GetMethod(reader, typeDef, method, signature);
+            var parameters = ToCompileBackParameters(methodDeclaration.Signature.Parameters);
+            if (methodDeclaration.Signature.ReturnType is not { } methodReturnType
+                || IsUnsupportedSurfaceSignature(methodReturnType)
+                || parameters.Any(parameter => IsUnsupportedSurfaceSignature(parameter.Type.DisplayName)))
+            {
+                return null;
+            }
+
+            string identifierName = Identifier(name);
+            return new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(typeIdentity.FullName, identifierName, DeclaringOverloadIndex(reader, typeDef, methodHandle, name), MethodSignatureText(identifierName, signature)),
+                isConstructor ? CompileBackMemberKind.Constructor : CompileBackMemberKind.Method,
+                method.Attributes.HasFlag(MethodAttributes.Static),
+                parameters,
+                isConstructor ? null : CompileBackTypeSignature.Display(methodReturnType),
+                ToCompileBackTypeParameters(methodDeclaration.Signature.TypeParameters),
+                (typeDef.Attributes & TypeAttributes.Interface) != 0 || IsAbstractMethod(method)
+                    ? CompileBackStubBodyKind.None
+                    : CompileBackStubBodyKind.Throw,
+                null,
+                [new CompileBackFact("metadata", isConstructor ? "typed-closure-constructor" : "typed-closure-method", name)],
+                isConstructor ? null : methodDeclaration.Attributes,
+                isConstructor ? null : methodDeclaration.Signature.ReturnAttributes,
+                IsAbstract: !isConstructor && IsAbstractMethod(method),
+                IsVirtual: !isConstructor && IsVirtualMethod(method),
+                IsOverride: false,
+                IsSealed: false);
+        }
+
+        static int DeclaringOverloadIndex(MetadataReader reader, TypeDefinition typeDef, MethodDefinitionHandle target, string name)
+        {
+            int index = 0;
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                if (reader.GetString(reader.GetMethodDefinition(methodHandle).Name) != name)
+                    continue;
+                if (methodHandle == target)
+                    return index;
+                index++;
+            }
+
+            return index;
         }
 
         static CompileBackTypeDeclaration TypeDeclaration(

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1500,7 +1500,7 @@ static class ReturnToSender
                 return;
             if (!closureMemberRequirements.TryGetValue(root, out var requirements))
                 closureMemberRequirements[root] = requirements = [];
-            if (!requirements.Contains(requirement))
+            if (!requirements.Any(existing => existing.Kind == requirement.Kind && existing.Identity == requirement.Identity))
                 requirements.Add(requirement);
         }
 

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -653,7 +653,8 @@ static class ReturnToSender
             targetRoot,
         };
         var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
-        SeedTypedClosureRoots(reader, function, targetRoot, closureRoots, closureFacts);
+        var closureMemberRequirements = new Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>>();
+        SeedTypedClosureRoots(reader, function, targetRoot, closureRoots, closureFacts, closureMemberRequirements);
         const int maxRoots = 200;
         const int maxIterations = 80;
         Diagnostic? firstError = null;
@@ -673,7 +674,8 @@ static class ReturnToSender
                 overload,
                 CorpusMethodIdentity.SignatureText(function.Signature),
                 closureRoots,
-                closureFacts);
+                closureFacts,
+                closureMemberRequirements);
             var plan = sourceResult.Plan;
 
             if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
@@ -757,7 +759,8 @@ static class ReturnToSender
                 overload,
                 CorpusMethodIdentity.SignatureText(function.Signature),
                 closureRoots,
-                closureFacts);
+                closureFacts,
+                closureMemberRequirements);
             var plan = sourceResult.Plan;
             return new Result(
                 plan,
@@ -808,7 +811,8 @@ static class ReturnToSender
             targetRoot,
         };
         var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
-        SeedTypedClosureRoots(reader, function, targetRoot, closureRoots, closureFacts);
+        var closureMemberRequirements = new Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>>();
+        SeedTypedClosureRoots(reader, function, targetRoot, closureRoots, closureFacts, closureMemberRequirements);
         const int maxRoots = 200;
         const int maxIterations = 80;
         Diagnostic? firstError = null;
@@ -827,7 +831,8 @@ static class ReturnToSender
                 overload,
                 CorpusMethodIdentity.SignatureText(function.Signature),
                 closureRoots,
-                closureFacts);
+                closureFacts,
+                closureMemberRequirements);
             var plan = sourceResult.Plan;
 
             if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
@@ -910,7 +915,8 @@ static class ReturnToSender
                 overload,
                 CorpusMethodIdentity.SignatureText(function.Signature),
                 closureRoots,
-                closureFacts);
+                closureFacts,
+                closureMemberRequirements);
             var plan = sourceResult.Plan;
             return new Result(
                 plan,
@@ -962,7 +968,8 @@ static class ReturnToSender
             targetRoot,
         };
         var closureFacts = new Dictionary<TypeDefinitionHandle, List<CompileBackFact>>();
-        SeedTypedClosureRoots(reader, function, targetRoot, closureRoots, closureFacts);
+        var closureMemberRequirements = new Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>>();
+        SeedTypedClosureRoots(reader, function, targetRoot, closureRoots, closureFacts, closureMemberRequirements);
         const int maxRoots = 200;
         const int maxIterations = 80;
         Diagnostic? firstError = null;
@@ -982,7 +989,8 @@ static class ReturnToSender
                 overload,
                 CorpusMethodIdentity.SignatureText(function.Signature),
                 closureRoots,
-                closureFacts);
+                closureFacts,
+                closureMemberRequirements);
             var plan = sourceResult.Plan;
 
             if (plan.Diagnostics.FirstOrDefault(diagnostic => diagnostic.Layer == "type identity") is { } identityDiagnostic)
@@ -1066,7 +1074,8 @@ static class ReturnToSender
                 overload,
                 CorpusMethodIdentity.SignatureText(function.Signature),
                 closureRoots,
-                closureFacts);
+                closureFacts,
+                closureMemberRequirements);
             var plan = sourceResult.Plan;
             return new Result(
                 plan,
@@ -1388,7 +1397,8 @@ static class ReturnToSender
         IrFunction function,
         TypeDefinitionHandle targetRoot,
         HashSet<TypeDefinitionHandle> closureRoots,
-        Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts)
+        Dictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
+        Dictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
     {
         string assemblyName = reader.GetString(reader.GetAssemblyDefinition().Name);
         var definitions = TypeDefinitionsByTypeRefIdentity(reader);
@@ -1461,14 +1471,38 @@ static class ReturnToSender
             AddClosureFact(
                 closureFacts,
                 root,
-                new CompileBackFact("metadata", "closure-member", $"{kind}: {TypeRefIdentityKey(definition.Namespace, definition.Name, separator: ".")}.{name}"));
+                new CompileBackFact("metadata", "typed-member-ref", $"{kind}: {TypeRefIdentityKey(definition.Namespace, definition.Name, separator: ".")}.{name}"));
         }
 
         void AddMethodFact(MethodRef method)
-            => AddMemberFact(method.DeclaringType, "method", method.Name);
+        {
+            AddMemberFact(method.DeclaringType, "method", method.Name);
+            AddMemberRequirement(method.DeclaringType, root => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, root, method));
+        }
 
         void AddFieldFact(FieldRef field)
-            => AddMemberFact(field.DeclaringType, "field", field.Name);
+        {
+            AddMemberFact(field.DeclaringType, "field", field.Name);
+            AddMemberRequirement(field.DeclaringType, root => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, root, field));
+        }
+
+        void AddMemberRequirement(TypeRef declaringType, Func<TypeDefinitionHandle, CompileBackMemberRequirement?> create)
+        {
+            var definition = declaringType.Kind == TypeRefKind.GenericInstance
+                ? declaringType.ElementType ?? declaringType
+                : declaringType;
+            if (TryResolveHandle(definition) is not { } handle)
+                return;
+            var root = TopLevelRootOf(reader, handle);
+            if (root == targetRoot || root != handle)
+                return;
+            if (create(handle) is not { } requirement)
+                return;
+            if (!closureMemberRequirements.TryGetValue(root, out var requirements))
+                closureMemberRequirements[root] = requirements = [];
+            if (!requirements.Contains(requirement))
+                requirements.Add(requirement);
+        }
 
         void AddTypedClosureMemberFacts(IrNode node)
         {


### PR DESCRIPTION
## Summary

- add composer-owned helpers that turn typed MethodRef/FieldRef evidence into precise CompileBackMemberRequirement entries
- pass precise closure member requirements from ReturnToSender into compile-back composition
- stop using metadata `closure-member` facts to request broad member surfaces for common top-level same-assembly closure roots
- update RTS tests to assert precise member facts and reduced over-emission of unrelated const fields

This follows the #2392/#2417 identity direction: RTS keeps using typed metadata/body evidence and product-owned declaration helpers instead of selector/string reparsing.

## Validation

- `dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/DeconstructionAssignmentPassTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ForeachStatementPassTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/UsingStatementPassTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderEvidenceTests/*"`
- `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal.property.literal --max-examples 3`

Adversarial review requested separately.