### PR TITLE
Pin negative constant receiver spelling

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpPrinterReceiverTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpPrinterReceiverTests.cs
@@ -9,6 +9,9 @@ public sealed class CSharpPrinterReceiverTests
 {
     static readonly TypeRef Int32Type = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef StringType = TypeRef.CoreLib("System", "String");
+    static readonly TypeRef IndexType = TypeRef.CoreLib("System", "Index");
+    static readonly TypeRef RangeType = TypeRef.CoreLib("System", "Range");
+    static readonly TypeRef RecordType = TypeRef.Definition("synthetic", "", "R");
 
     [Fact]
     public void NegativeConstant_InstanceMethodReceiver_IsParenthesized()
@@ -51,13 +54,104 @@ public sealed class CSharpPrinterReceiverTests
             "public static class Extensions { public static int Ext(this int value) => value; }");
     }
 
-    static string RenderReturn(IrExpression value, TypeRef returnType)
+    [Fact]
+    public void IndexFromEnd_ExtensionMethodReceiver_IsParenthesized()
+    {
+        var call = new Call(
+            Extension("ExtIndex", IndexType),
+            isVirtual: false,
+            [new IndexFromEnd(new Constant(1, Int32Type))]);
+
+        string body = RenderReturn(call, Int32Type);
+
+        Assert.Contains("return (^1).ExtIndex();", body);
+        Assert.DoesNotContain("return ^1.ExtIndex();", body);
+        AssertCompiles(
+            "public static int M()",
+            body,
+            "public static class Extensions { public static int ExtIndex(this Index value) => value.GetOffset(100); }");
+    }
+
+    [Fact]
+    public void RangeExpression_ExtensionMethodReceiver_IsParenthesized()
+    {
+        var call = new Call(
+            Extension("ExtRange", RangeType),
+            isVirtual: false,
+            [new RangeExpression(new Constant(1, Int32Type), new Constant(2, Int32Type))]);
+
+        string body = RenderReturn(call, Int32Type);
+
+        Assert.Contains("return (1..2).ExtRange();", body);
+        Assert.DoesNotContain("return 1..2.ExtRange();", body);
+        AssertCompiles(
+            "public static int M()",
+            body,
+            "public static class Extensions { public static int ExtRange(this Range value) => value.End.GetOffset(100); }");
+    }
+
+    [Fact]
+    public void PrefixIncrement_ExtensionMethodReceiver_IsParenthesized()
+    {
+        var call = new Call(
+            Extension("Ext", Int32Type),
+            isVirtual: false,
+            [new IncrementDecrement(new LoadArgument(0, "x", Int32Type), isIncrement: true, isPrefix: true)]);
+
+        string body = RenderReturn(call, Int32Type, [new Parameter("x", Int32Type)]);
+
+        Assert.Contains("return (++x).Ext();", body);
+        Assert.DoesNotContain("return ++x.Ext();", body);
+        AssertCompiles(
+            "public static int M(int x)",
+            body,
+            "public static class Extensions { public static int Ext(this int value) => value; }");
+    }
+
+    [Fact]
+    public void WithExpression_ExtensionMethodReceiver_IsParenthesized()
+    {
+        var call = new Call(
+            Extension("ExtRecord", RecordType),
+            isVirtual: false,
+            [
+                new WithExpression(
+                    new LoadArgument(0, "r", RecordType),
+                    [new InitializerEntry("A", [new Constant(2, Int32Type)])])
+            ]);
+
+        string body = RenderReturn(call, Int32Type, [new Parameter("r", RecordType)]);
+
+        Assert.Contains("return (r with { A = 2 }).ExtRecord();", body);
+        Assert.DoesNotContain("return r with { A = 2 }.ExtRecord();", body);
+        AssertCompiles(
+            "public static int M(R r)",
+            body,
+            """
+            public record R(int A);
+            public static class Extensions { public static int ExtRecord(this R value) => value.A; }
+            """);
+    }
+
+    static MethodRef Extension(string name, TypeRef receiverType)
+        => new(
+            TypeRef.Definition("synthetic", "", "Extensions"),
+            name,
+            Int32Type,
+            [receiverType],
+            HasThis: false)
+        {
+            IsExtension = MetadataFactState.Yes,
+        };
+
+    static string RenderReturn(IrExpression value, TypeRef returnType, IReadOnlyList<Parameter>? parameters = null)
     {
         var block = new Block(0);
         block.Add(new Return(value));
         var container = new BlockContainer();
         container.Add(block);
-        var signature = new MethodSignature(returnType, [], HasThis: false, GenericParameterCount: 0);
+        var parameterList = parameters is null ? ImmutableArray<Parameter>.Empty : [.. parameters];
+        var signature = new MethodSignature(returnType, parameterList, HasThis: false, GenericParameterCount: 0);
         var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], container);
         return CSharpPrinter.Print(function).Output!.Trim();
     }

--- a/src/ILInspector.Decompiler.Tests/CSharpPrinterReceiverTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpPrinterReceiverTests.cs
@@ -1,0 +1,109 @@
+using System.Collections.Immutable;
+using ILInspector.Decompiler.Pipeline;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ILInspector.Decompiler.Tests;
+
+public sealed class CSharpPrinterReceiverTests
+{
+    static readonly TypeRef Int32Type = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef StringType = TypeRef.CoreLib("System", "String");
+
+    [Fact]
+    public void NegativeConstant_InstanceMethodReceiver_IsParenthesized()
+    {
+        // #2151: -1.ToString() parses as -(1.ToString()), so a negative
+        // literal member receiver must spell as (-1).ToString().
+        var call = new Call(
+            new MethodRef(Int32Type, "ToString", StringType, [], HasThis: true),
+            isVirtual: false,
+            [new Constant(-1, Int32Type)]);
+
+        string body = RenderReturn(call, StringType);
+
+        Assert.Contains("return (-1).ToString();", body);
+        Assert.DoesNotContain("return -1.ToString();", body);
+        AssertCompiles("public static string M()", body);
+    }
+
+    [Fact]
+    public void NegativeConstant_ExtensionMethodReceiver_IsParenthesized()
+    {
+        var extension = new MethodRef(
+            TypeRef.Definition("synthetic", "", "Extensions"),
+            "Ext",
+            Int32Type,
+            [Int32Type],
+            HasThis: false)
+        {
+            IsExtension = MetadataFactState.Yes,
+        };
+        var call = new Call(extension, isVirtual: false, [new Constant(-1, Int32Type)]);
+
+        string body = RenderReturn(call, Int32Type);
+
+        Assert.Contains("return (-1).Ext();", body);
+        Assert.DoesNotContain("return -1.Ext();", body);
+        AssertCompiles(
+            "public static int M()",
+            body,
+            "public static class Extensions { public static int Ext(this int value) => value; }");
+    }
+
+    static string RenderReturn(IrExpression value, TypeRef returnType)
+    {
+        var block = new Block(0);
+        block.Add(new Return(value));
+        var container = new BlockContainer();
+        container.Add(block);
+        var signature = new MethodSignature(returnType, [], HasThis: false, GenericParameterCount: 0);
+        var function = new IrFunction("M", TypeRef.Definition("synthetic", "", "Holder"), signature, [], container);
+        return CSharpPrinter.Print(function).Output!.Trim();
+    }
+
+    static void AssertCompiles(string header, string body, string extraDeclarations = "")
+    {
+        var errors = Recompile(header, body, extraDeclarations)
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .Select(d => $"{d.Id}: {d.GetMessage()}")
+            .ToArray();
+        Assert.True(errors.Length == 0, "Rendered body must compile, got:\n  " + string.Join("\n  ", errors) + "\n--- body ---\n" + body);
+    }
+
+    static ImmutableArray<Diagnostic> Recompile(string methodHeader, string body, string extraDeclarations)
+    {
+        string source = $$"""
+            using System;
+            {{extraDeclarations}}
+            static class __Gate
+            {
+                {{methodHeader}}
+                {
+            {{body}}
+                }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "__gate",
+            [tree],
+            RuntimeReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        return compilation.GetDiagnostics();
+    }
+
+    static ImmutableArray<MetadataReference> RuntimeReferences()
+    {
+        var references = ImmutableArray.CreateBuilder<MetadataReference>();
+        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+            try { references.Add(MetadataReference.CreateFromFile(path)); }
+            catch { }
+        }
+        return references.ToImmutable();
+    }
+}

--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -148,24 +148,6 @@ public class PrinterPrecedenceTests
         Assert.DoesNotContain("(short)i", output);
     }
 
-    // Issue #2151: a bare negative constant as a member-access receiver misbinds —
-    // `-1.Twice()` parses as `-(1.Twice())` (CS0023). Operand treats a Constant as
-    // an atom, so the receiver must be parenthesized: `(-1).Twice()`.
-    [Fact]
-    public void ExtensionCall_OnNegativeConstantReceiver_ParenthesizesReceiver()
-    {
-        var callee = new MethodRef(
-            TypeRef.Definition("Asm", "Ns", "Ext"), "Twice", s_int, [s_int], HasThis: false)
-        {
-            IsExtension = MetadataFactState.Yes,
-        };
-        var call = new Call(callee, isVirtual: false, [new Constant(-1, s_int)]);
-
-        var output = PrintReturn(call, s_int, []);
-
-        Assert.Contains("(-1).Twice()", output);
-    }
-
     static string PrintReturn(IrExpression value, TypeRef returnType, ImmutableArray<Parameter> parameters)
     {
         var block = new Block();

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -139,6 +139,11 @@ public sealed partial class CSharpPrinter
         // bare, so it is left alone) — mirroring the cast receiver handling and
         // NeedsCastOperandParentheses (#2151).
         Constant when Operand(receiver) is [('-' or '+'), ..] literal => $"({literal})",
+        // These nodes render as operator-like surface forms, not primary
+        // member receivers. Operand leaves them bare in ordinary operand
+        // positions, but member access would bind to a child or fail to parse:
+        // `^1.M()`, `1..2.M()`, `++x.M()`, `r with { ... }.M()`.
+        IndexFromEnd or RangeExpression or IncrementDecrement or WithExpression => $"({Expression(receiver)})",
         _ => Operand(receiver),
     };
 


### PR DESCRIPTION
- Fixes #2151
- Advances #2376 phase 2 follow-up coverage
- Changes receiver rendering to parenthesize operator-like forms before member access.
- Card revision: `59351e63`

## Change

**Conclusion:** **PASS** — this keeps the existing negative-literal receiver protection and extends `ReceiverText` to other operator-like receiver forms that `Operand` may leave bare in ordinary operand positions but that misbind or fail as member receivers: `IndexFromEnd`, `RangeExpression`, `IncrementDecrement`, and `WithExpression`.

Fixed/pinned output:

```csharp
return (-1).ToString();
return (-1).Ext();
return (^1).ExtIndex();
return (1..2).ExtRange();
return (++x).Ext();
return (r with { A = 2 }).ExtRecord();
```

Rejected shapes include:

```csharp
return -1.ToString();
return ^1.ExtIndex();
return 1..2.ExtRange();
return ++x.Ext();
return r with { A = 2 }.ExtRecord();
```

## Evidence

| Check | Result |
| --- | --- |
| Focused tests | `CSharpPrinterReceiverTests` passed: 6/6 |
| Decompiler fast suite | Passed: 2,011/2,011 |
| Solution build | Passed |
| Product build | Passed |
| Render A/B | Passed: 89,065 methods, 0 changed |
| Quality card | Advisory only: pinned subset improved; capped-sample warnings match PR quick-cap vs daily baseline |

## Decompiler quality

**Conclusion:** **PASS** — render A/B is byte-identical and pinned-subset gate improved; quality-card nonzero exit is the expected capped-sample baseline-size advisory.

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 350 methods (compile-cap 25; per-sample, not corpus-wide); fidelity sampled 24 / 89,065 (0.03%)

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Fully raised (+) | 78,399 (88.02%) → 78,405 (88.03%) (good) | +6 |
| Conditional-branch residual (-) | 2,401 (2.70%) → 2,401 (2.70%) (neutral) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) → 2,286 (2.57%) (neutral) | 0 |
| Full malformed (-) | 0 → 0 (neutral) | 0 |
| Semantic defects (-) | 74 (0.29%) → 1 (0.29%) (neutral) | -73 |
| Fidelity opcode diffs (-) | 5 (13.89%) → 3 (12.50%) (good) | -2 |
| Fidelity exact (+) | 31 (86.11%) → 21 (87.50%) (good) | -10 |
| Fidelity recompile failures (-) | 0 (0.00%) → 0 (0.00%) (neutral) | 0 |
| Fidelity context failures (-) | 0 (0.00%) → 0 (0.00%) (neutral) | 0 |
| Fidelity check coverage (+) | 36 (0.04%) → 24 (0.03%) (bad) | -12 |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.03% (+0.01 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 3 (-2).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25179, current 350)
- fidelity checked methods lower than baseline (baseline 36, current 24)
```

## Review

Adversarial review pending final Gemini + MAI round after product follow-up.

## Validation

```bash
dotnet restore src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj --configfile nuget.config --verbosity minimal
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CSharpPrinterReceiverTests/*"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet restore dotnet-inspect.slnx --configfile nuget.config --verbosity minimal
dotnet build dotnet-inspect.slnx -c Release --no-restore --verbosity minimal
bash eng/prepare-decompiler-corpus.sh /tmp/corpus-2422.txt
git worktree add /tmp/ab-base-2422 --detach $(git merge-base origin/main HEAD)
dotnet restore /tmp/ab-base-2422/tools/DecompilerHarness/DecompilerHarness.csproj --configfile /tmp/ab-base-2422/nuget.config --verbosity minimal
dotnet restore tools/DecompilerHarness/DecompilerHarness.csproj --configfile nuget.config --verbosity minimal
mapfile -t assemblies < /tmp/corpus-2422.txt
dotnet run --no-restore --project /tmp/ab-base-2422/tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --emit-render-ab /tmp/base-2422.renderab
dotnet run --no-restore --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --render-ab /tmp/base-2422.renderab
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --configfile nuget.config --no-restore --verbosity minimal
dotnet run --no-restore --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json --quality-diff-card --compile-cap 25 --corpus-fidelity-cap 3 --max-examples 3
```
