### PR TITLE
Use Markout segment goals in IL diff buckets

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Markout" Version="0.20.0" />
+    <PackageVersion Include="Markout" Version="0.21.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />

--- a/tools/IlDiffHarness/Program.cs
+++ b/tools/IlDiffHarness/Program.cs
@@ -618,24 +618,39 @@ static MetricChange<int> MetricGoal(string name, int baseline, int current, stri
 
 static List<MultiSourceRow> BaselineBucketRows(BaselineComparison comparison) =>
 [
-    BucketChangeRow("Failure buckets", comparison.Baseline.FailureBuckets ?? [], comparison.Current.FailureBuckets ?? []),
-    BucketChangeRow("Hunk kinds", comparison.Baseline.HunkKindBuckets ?? [], comparison.Current.HunkKindBuckets ?? []),
-    BucketChangeRow("Opcode families", comparison.Baseline.OpcodeFamilyBuckets ?? [], comparison.Current.OpcodeFamilyBuckets ?? []),
+    BucketChangeRow("Failure buckets (-)", comparison.Baseline.FailureBuckets ?? [], comparison.Current.FailureBuckets ?? [], Goal.Lower),
+    BucketChangeRow("Hunk kinds", comparison.Baseline.HunkKindBuckets ?? [], comparison.Current.HunkKindBuckets ?? [], Goal.Context),
+    BucketChangeRow("Opcode families", comparison.Baseline.OpcodeFamilyBuckets ?? [], comparison.Current.OpcodeFamilyBuckets ?? [], Goal.Context),
 ];
 
-static MultiSourceRow BucketChangeRow(string label, IReadOnlyList<CardBucket> baseline, IReadOnlyList<CardBucket> current)
-    => new(label, SegmentSource("baseline", baseline), SegmentSource("current", current));
-
-static Source SegmentSource(string role, IReadOnlyList<CardBucket> buckets)
+static MultiSourceRow BucketChangeRow(string label, IReadOnlyList<CardBucket> baseline, IReadOnlyList<CardBucket> current, Goal goal)
 {
-    var segments = buckets
-        .Where(bucket => bucket.Count != 0)
+    var (baselineSegments, currentSegments) = PairedSegments(baseline, current);
+    return new(label, new Source("Change", new Change<Segments>(baselineSegments, currentSegments), new MarkoutCellFormat { Goal = goal }));
+}
+
+static (Segments Baseline, Segments Current) PairedSegments(IReadOnlyList<CardBucket> baseline, IReadOnlyList<CardBucket> current)
+{
+    var baselineCounts = baseline.ToDictionary(bucket => bucket.Name, bucket => bucket.Count, StringComparer.Ordinal);
+    var currentCounts = current.ToDictionary(bucket => bucket.Name, bucket => bucket.Count, StringComparer.Ordinal);
+    var labels = baselineCounts.Keys
+        .Union(currentCounts.Keys, StringComparer.Ordinal)
+        .Select(label => new
+        {
+            Label = label,
+            Count = Math.Max(baselineCounts.GetValueOrDefault(label), currentCounts.GetValueOrDefault(label))
+        })
+        .Where(row => row.Count != 0)
+        .OrderByDescending(row => row.Count)
+        .ThenBy(row => row.Label, StringComparer.Ordinal)
         .Take(10)
-        .Select(bucket => new Segment(bucket.Name, bucket.Count))
+        .Select(row => row.Label)
         .ToArray();
-    return segments.Length == 0
-        ? new Source(role, (IMarkoutCell?)null)
-        : new Source(role, new Segments(segments));
+
+    return (
+        new Segments([.. labels.Select(label => new Segment(label, baselineCounts.GetValueOrDefault(label)))]),
+        new Segments([.. labels.Select(label => new Segment(label, currentCounts.GetValueOrDefault(label)))])
+    );
 }
 
 static IlDiffCard Aggregate(ImmutableArray<IlDiffPairCard> pairs, int maxExamples, bool snapshotPaths = false)

--- a/tools/IlDiffHarness/README.md
+++ b/tools/IlDiffHarness/README.md
@@ -57,5 +57,7 @@ Markdown, with goal markers in metric labels and goal-derived status inline in
 change cells; typed `before`/`after`/`target` fields plus goal-derived
 `direction`/`status` fields in JSONL) and keeps detailed finding rows for bucket
 drift and regression evidence. Baseline bucket output uses Markout multi-source
-rows to compare baseline/current failure buckets, hunk kinds, and opcode
-families in Markdown and as section-aware decomposed JSONL/TSV rows.
+rows with `Change<Segments>` to compare baseline/current failure buckets, hunk
+kinds, and opcode families in Markdown and as section-aware decomposed JSONL/TSV
+rows; failure buckets use Markout goal derivation over the aggregate bucket
+count.


### PR DESCRIPTION
## Summary

- bump Markout to 0.21.0
- render IL Diff baseline bucket rows as goal-aware `Change<Segments>` cells
- preserve zero-valued bucket labels across before/after sides so dense Markdown can show `4/3 → 0/0 (good)`
- keep hunk/opcode bucket sets context-only while failure buckets derive aggregate goal status

## Demo

```md
## Baseline bucket changes

| Bucket set | Change |
| ---------- | ------ |
| Failure buckets (-) | 4/3 → 0/0 (good) |
| Hunk kinds | 102/59 → 0/0 |
| Opcode families | 55/15/8/7/7/6/5/5/4/4 → 0/0/0/0/0/0/0/0/0/0 |
```

```jsonl
{"section":"Baseline bucket changes","bucket_set":"Failure buckets (-)","change_before_new_body_missing":4,"change_before_old_body_missing":3,"change_after_new_body_missing":0,"change_after_old_body_missing":0,"change_direction":"resolved","change_status":"good"}
```

## Validation

- `dotnet build tools/IlDiffHarness/IlDiffHarness.csproj -c Release --configfile nuget.config`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- emitted baseline snapshot over DiffFixtures V1/V2
- ran exact and improvement baseline Markdown/JSONL smokes; JSONL parsed with `System.Text.Json`
- verified failure bucket row derives `resolved/good` and preserves zero-valued after labels
- `npx markdownlint-cli tools/IlDiffHarness/README.md`