### PR TITLE
Route RTS anchor subjects through Research identity

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderEvidenceTests.cs
@@ -95,6 +95,9 @@ public class ReturnToSenderEvidenceTests
 
         var subject = Assert.Single(research.Subjects);
         Assert.Equal(anchor.StableSelector, subject.Subject.Id);
+        Assert.Equal("TestType.Method1", subject.Subject.Display);
+        Assert.Equal("TestType", subject.Subject.TypeName);
+        Assert.Equal("Method1", subject.Subject.MemberName);
         Assert.Contains(subject.Evidence, item =>
             item.Mechanism == ResearchDiffMechanism.ReturnToSender
             && item.ChangeId == "rts.status.fail");

--- a/tools/DecompilerHarness/ReturnToSenderEvidence.cs
+++ b/tools/DecompilerHarness/ReturnToSenderEvidence.cs
@@ -151,14 +151,7 @@ internal static class ReturnToSenderEvidence
     static ResearchSubjectKey SubjectKey(ReturnToSenderEvidenceRow row)
     {
         if (row.Anchor is { } anchor)
-        {
-            return new ResearchSubjectKey(
-                ResearchDiffSubjectKind.Member,
-                anchor.StableSelector,
-                $"{anchor.TypeFullName}.{anchor.MemberName}",
-                anchor.TypeFullName,
-                anchor.MemberName);
-        }
+            return ResearchMemberIdentity.SubjectFromAnchor(anchor, $"{anchor.TypeFullName}.{anchor.MemberName}");
 
         return new ResearchSubjectKey(
             ResearchDiffSubjectKind.Member,


### PR DESCRIPTION
## Summary
- route ReturnToSender anchor-to-subject projection through `ResearchMemberIdentity.SubjectFromAnchor`
- keep the RTS fallback subject path unchanged for rows without anchors
- add a focused assertion that anchor-derived RTS subjects preserve id/display/type/member shape

## Audit result
Remaining direct `MemberAnchor` construction is limited to Metadata identity factories and synthetic test fixtures.

## Validation
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -class ILInspector.Decompiler.Tests.ReturnToSenderEvidenceTests`
- `dotnet build tools/DecompilerHarness -c Release --configfile nuget.config --verbosity quiet`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity quiet`

## Review
- Adversarial review pending (MAI + Gemini, different model families from author).
