### PR TITLE
Use segment goals for C# diff buckets

### DIFF
--- a/tools/CSharpDiffHarness/Program.cs
+++ b/tools/CSharpDiffHarness/Program.cs
@@ -588,24 +588,39 @@ static MetricChange<int> MetricGoal(string name, int baseline, int current, stri
 
 static List<MultiSourceRow> BaselineBucketRows(BaselineComparison comparison) =>
 [
-    BucketChangeRow("Failure buckets", comparison.Baseline.FailureBuckets ?? [], comparison.Current.FailureBuckets ?? []),
-    BucketChangeRow("Change IDs", comparison.Baseline.ChangeIdBuckets ?? [], comparison.Current.ChangeIdBuckets ?? []),
-    BucketChangeRow("Operation kinds", comparison.Baseline.OperationKindBuckets ?? [], comparison.Current.OperationKindBuckets ?? []),
+    BucketChangeRow("Failure buckets (-)", comparison.Baseline.FailureBuckets ?? [], comparison.Current.FailureBuckets ?? [], Goal.Lower),
+    BucketChangeRow("Change IDs", comparison.Baseline.ChangeIdBuckets ?? [], comparison.Current.ChangeIdBuckets ?? [], Goal.Context),
+    BucketChangeRow("Operation kinds", comparison.Baseline.OperationKindBuckets ?? [], comparison.Current.OperationKindBuckets ?? [], Goal.Context),
 ];
 
-static MultiSourceRow BucketChangeRow(string label, IReadOnlyList<CardBucket> baseline, IReadOnlyList<CardBucket> current)
-    => new(label, SegmentSource("baseline", baseline), SegmentSource("current", current));
-
-static Source SegmentSource(string role, IReadOnlyList<CardBucket> buckets)
+static MultiSourceRow BucketChangeRow(string label, IReadOnlyList<CardBucket> baseline, IReadOnlyList<CardBucket> current, Goal goal)
 {
-    var segments = buckets
-        .Where(bucket => bucket.Count != 0)
+    var (baselineSegments, currentSegments) = PairedSegments(baseline, current);
+    return new(label, new Source("Change", new Change<Segments>(baselineSegments, currentSegments), new MarkoutCellFormat { Goal = goal }));
+}
+
+static (Segments Baseline, Segments Current) PairedSegments(IReadOnlyList<CardBucket> baseline, IReadOnlyList<CardBucket> current)
+{
+    var baselineCounts = baseline.ToDictionary(bucket => bucket.Name, bucket => bucket.Count, StringComparer.Ordinal);
+    var currentCounts = current.ToDictionary(bucket => bucket.Name, bucket => bucket.Count, StringComparer.Ordinal);
+    var labels = baselineCounts.Keys
+        .Union(currentCounts.Keys, StringComparer.Ordinal)
+        .Select(label => new
+        {
+            Label = label,
+            Count = Math.Max(baselineCounts.GetValueOrDefault(label), currentCounts.GetValueOrDefault(label))
+        })
+        .Where(row => row.Count != 0)
+        .OrderByDescending(row => row.Count)
+        .ThenBy(row => row.Label, StringComparer.Ordinal)
         .Take(10)
-        .Select(bucket => new Segment(bucket.Name, bucket.Count))
+        .Select(row => row.Label)
         .ToArray();
-    return segments.Length == 0
-        ? new Source(role, (IMarkoutCell?)null)
-        : new Source(role, new Segments(segments));
+
+    return (
+        new Segments([.. labels.Select(label => new Segment(label, baselineCounts.GetValueOrDefault(label)))]),
+        new Segments([.. labels.Select(label => new Segment(label, currentCounts.GetValueOrDefault(label)))])
+    );
 }
 
 static List<BaselineFindingView>? BaselineRows(BaselineComparison comparison)

--- a/tools/CSharpDiffHarness/README.md
+++ b/tools/CSharpDiffHarness/README.md
@@ -50,5 +50,6 @@ changed pairs, more rows, fewer exact pairs, or new failure buckets) and report
 other metric and bucket changes as non-failing drift. Baseline output uses
 Markout metric-change rows for scalar metrics (`Metric | Change | Target` in
 Markdown, with goal markers and inline status where a target applies) and
-multi-source rows for bucket changes. JSONL preserves typed baseline/current
-fields, direction/status, and segment values.
+goal-aware segment-change rows for failure buckets. Change IDs and operation
+kinds remain context bucket rows. JSONL preserves typed baseline/current fields,
+direction/status, and segment values.


### PR DESCRIPTION
## Summary

Updates `CSharpDiffHarness` baseline bucket rows to use Markout 0.21 segment goals, matching the IL diff harness bucket shape.

## Details

- Renders failure bucket baseline rows as goal-aware `Change<Segments>` cells with `Goal.Lower`.
- Preserves zero-valued labels across before/after sides so dense Markdown and JSONL can show resolved failures.
- Keeps change IDs and operation kinds context-only with `Goal.Context`.
- Updates README wording to describe goal-aware segment-change rows for failure buckets.

## Demo

```md
## Baseline bucket changes

| Bucket set | Change |
| ---------- | ------ |
| Failure buckets (-) | 1 → 0 (good) |
| Change IDs | 76/53/27/9/3/2/2/1/1 → 0/0/0/0/0/0/0/0/0 |
| Operation kinds | 129/27/9/4/4/1 → 0/0/0/0/0/0 |
```

```jsonl
{"section":"Baseline bucket changes","bucket_set":"Failure buckets (-)","change_before_old_method_has_no_c_body":1,"change_after_old_method_has_no_c_body":0,"change_direction":"resolved","change_status":"good"}
```

## Validation

- `dotnet build tools/CSharpDiffHarness -c Release --configfile nuget.config --verbosity minimal`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity minimal`
- emitted baseline snapshot over DiffFixtures V1/V2
- ran self-diff improvement baseline Markdown/JSONL smokes; both returned exit `0`
- verified failure bucket row derives `resolved/good` and preserves zero-valued after labels
- `npx markdownlint-cli --fix tools/CSharpDiffHarness/README.md && npx markdownlint-cli tools/CSharpDiffHarness/README.md`
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/DiffCommandTests/*"`
- `git diff --check`

## Review

Adversarial review is required for this decompiler test-tool/reporting shape change and will be posted before marking ready.
