### PR TITLE
Gate union constructor fixture on SDK support

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -130,7 +130,9 @@ public class TypeSourceComposerUnionTests
                     }
                 }
             }
-            """);
+            """,
+            unsupportedDiagnostic: "CS9374",
+            skipReason: "Installed preview SDK does not yet support non-public single-parameter union constructors.");
 
         var source = ComposeType(assembly.Path, "UnionFixtures.Result");
 
@@ -1711,7 +1713,10 @@ public class TypeSourceComposerUnionTests
         return new TempAssembly(path);
     }
 
-    static async Task<TempAssembly> CompileWithSdk(string source)
+    static async Task<TempAssembly> CompileWithSdk(
+        string source,
+        string? unsupportedDiagnostic = null,
+        string? skipReason = null)
     {
         var project = TempDirectory.Create();
         File.WriteAllText(Path.Combine(project.Path, "union-fixture.csproj"), """
@@ -1726,6 +1731,13 @@ public class TypeSourceComposerUnionTests
         File.WriteAllText(Path.Combine(project.Path, "Fixture.cs"), source);
 
         var result = await RunDotnetBuild(project.Path);
+        if (result.ExitCode != 0
+            && unsupportedDiagnostic is not null
+            && result.Output.Contains(unsupportedDiagnostic, StringComparison.Ordinal))
+        {
+            Assert.Skip(skipReason ?? $"Installed preview SDK does not support diagnostic {unsupportedDiagnostic} fixture.");
+        }
+
         Assert.True(result.ExitCode == 0,
             "Union fixture must build with the preview SDK, got exit "
             + result.ExitCode + "\n--- output ---\n" + result.Output + "\n--- source ---\n" + source);

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -1719,31 +1719,39 @@ public class TypeSourceComposerUnionTests
         string? skipReason = null)
     {
         var project = TempDirectory.Create();
-        File.WriteAllText(Path.Combine(project.Path, "union-fixture.csproj"), """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-                <TargetFramework>net11.0</TargetFramework>
-                <LangVersion>preview</LangVersion>
-                <Nullable>enable</Nullable>
-              </PropertyGroup>
-            </Project>
-            """);
-        File.WriteAllText(Path.Combine(project.Path, "Fixture.cs"), source);
-
-        var result = await RunDotnetBuild(project.Path);
-        if (result.ExitCode != 0
-            && unsupportedDiagnostic is not null
-            && result.Output.Contains(unsupportedDiagnostic, StringComparison.Ordinal))
+        try
         {
-            Assert.Skip(skipReason ?? $"Installed preview SDK does not support diagnostic {unsupportedDiagnostic} fixture.");
+            File.WriteAllText(Path.Combine(project.Path, "union-fixture.csproj"), """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFramework>net11.0</TargetFramework>
+                    <LangVersion>preview</LangVersion>
+                    <Nullable>enable</Nullable>
+                  </PropertyGroup>
+                </Project>
+                """);
+            File.WriteAllText(Path.Combine(project.Path, "Fixture.cs"), source);
+
+            var result = await RunDotnetBuild(project.Path);
+            if (result.ExitCode != 0
+                && unsupportedDiagnostic is not null
+                && result.Output.Contains(unsupportedDiagnostic, StringComparison.Ordinal))
+            {
+                Assert.Skip(skipReason ?? $"Installed preview SDK does not support diagnostic {unsupportedDiagnostic} fixture.");
+            }
+
+            Assert.True(result.ExitCode == 0,
+                "Union fixture must build with the preview SDK, got exit "
+                + result.ExitCode + "\n--- output ---\n" + result.Output + "\n--- source ---\n" + source);
+
+            string dll = Path.Combine(project.Path, "bin", "Release", "net11.0", "union-fixture.dll");
+            return new TempAssembly(dll, project);
         }
-
-        Assert.True(result.ExitCode == 0,
-            "Union fixture must build with the preview SDK, got exit "
-            + result.ExitCode + "\n--- output ---\n" + result.Output + "\n--- source ---\n" + source);
-
-        string dll = Path.Combine(project.Path, "bin", "Release", "net11.0", "union-fixture.dll");
-        return new TempAssembly(dll, project);
+        catch
+        {
+            project.Dispose();
+            throw;
+        }
     }
 
     static string RenderMember(string assemblyPath, string typeName, string methodName)


### PR DESCRIPTION
## Summary

- skips only the Preview 6 union constructor fixture when the installed preview SDK reports the known unsupported `CS9374` diagnostic
- keeps the fixture active on SDKs that support the shape, and keeps all other SDK build failures as hard failures

Refs #2019.

## Validation

- `dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/UnionDeclaration_WithNonPublicExplicitConstructors_KeepsConstructorsOutOfCases"`
- `dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceComposerUnionTests/*"`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo --verbosity minimal`

## Risk

Low-risk test gate only; product decompiler behavior is unchanged.
