### PR TITLE
Share Research body identity canonical formatting

### DIFF
--- a/src/ILInspector.Research/ResearchMemberIdentity.cs
+++ b/src/ILInspector.Research/ResearchMemberIdentity.cs
@@ -6,6 +6,18 @@ namespace ILInspector.Research;
 
 public static class ResearchMemberIdentity
 {
+    readonly record struct BodyMemberIdentity(
+        string SelectorName,
+        string TypeName,
+        string MemberName,
+        string GenericList,
+        string ParameterList)
+    {
+        public string CanonicalSignature => $"M:{TypeName}.{MemberName}{GenericList}{ParameterList}";
+        public string Fingerprint => MemberAnchor.ComputeFingerprint(CanonicalSignature);
+        public string StableSelector => $"{SelectorName}~{Fingerprint}";
+    }
+
     public static ResearchSubjectKey SubjectFromAnchor(MemberAnchor anchor, string display)
         => new(
             ResearchDiffSubjectKind.Member,
@@ -16,20 +28,14 @@ public static class ResearchMemberIdentity
 
     public static ResearchSubjectKey SubjectFromMethod(MethodIdentity method)
     {
-        var typeName = method.DeclaringType.ToQualifiedDisplayString();
-        var memberName = method.Name == ".ctor" ? "#ctor" : method.Name;
-        var selectorName = ApiMemberIdentity.GetMemberSelectorName(method.Name, method.IsExtension);
-        var parameters = string.Join(",", method.ParameterTypes.Select(BodyTypeName));
+        var identity = BodyIdentityFromMethod(method);
         var displayParameters = string.Join(", ", method.ParameterTypes.Select(type => type.ToQualifiedDisplayString()));
-        var methodGeneric = MethodGenericList(method);
-        var canonical = $"M:{typeName}.{memberName}{methodGeneric}({parameters})";
-        var fingerprint = MemberAnchor.ComputeFingerprint(canonical);
         return new ResearchSubjectKey(
             ResearchDiffSubjectKind.Member,
-            $"{selectorName}~{fingerprint}",
-            $"{typeName}.{memberName}({displayParameters})",
-            typeName,
-            memberName);
+            identity.StableSelector,
+            $"{identity.TypeName}.{identity.MemberName}({displayParameters})",
+            identity.TypeName,
+            identity.MemberName);
     }
 
     public static bool TryAddTargetIdentity(ResolvedMemberTarget target, ISet<string> identities)
@@ -38,6 +44,21 @@ public static class ResearchMemberIdentity
         if (member.Kind is "property" or "field" or "event")
             return false;
 
+        identities.Add(BodyIdentityFromTarget(target).StableSelector);
+        return true;
+    }
+
+    static BodyMemberIdentity BodyIdentityFromMethod(MethodIdentity method)
+        => CreateBodyIdentity(
+            ApiMemberIdentity.GetMemberSelectorName(method.Name, method.IsExtension),
+            method.DeclaringType.ToQualifiedDisplayString(),
+            method.Name == ".ctor" ? "#ctor" : method.Name,
+            MethodGenericList(method),
+            $"({string.Join(",", method.ParameterTypes.Select(BodyTypeName))})");
+
+    static BodyMemberIdentity BodyIdentityFromTarget(ResolvedMemberTarget target)
+    {
+        var member = target.ApiMember.Member;
         var signature = member.SignatureModel;
         var memberName = member.Kind == "constructor"
             ? "#ctor"
@@ -52,13 +73,24 @@ public static class ResearchMemberIdentity
             ?? (member.IsExtension && !string.IsNullOrWhiteSpace(member.DeclaringType)
                 ? member.DeclaringType!
                 : target.Anchor.TypeFullName);
-        var canonical = $"M:{BodyDeclaringTypeName(declaringType)}.{memberName}{generic}{parameters}";
         var selectorName = target.Anchor.StableSelector.Split('~')[0];
         if (member.IsExtension && !selectorName.StartsWith("extension:", StringComparison.Ordinal))
             selectorName = $"extension:{selectorName}";
-        identities.Add($"{selectorName}~{MemberAnchor.ComputeFingerprint(canonical)}");
-        return true;
+        return CreateBodyIdentity(
+            selectorName,
+            BodyDeclaringTypeName(declaringType),
+            memberName,
+            generic,
+            parameters);
     }
+
+    static BodyMemberIdentity CreateBodyIdentity(
+        string selectorName,
+        string typeName,
+        string memberName,
+        string genericList,
+        string parameterList)
+        => new(selectorName, typeName, memberName, genericList, parameterList);
 
     public static string BodyDeclaringTypeName(string typeName)
         => DeclaringPrimitiveName(StripGenericArguments(typeName.Replace('+', '.')));

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -1,4 +1,5 @@
 using DotnetInspector.Fixtures;
+using ILInspector.Analysis;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
 using ILInspector.Research;
@@ -594,6 +595,132 @@ public class DiffCommandTests
         Assert.Contains($"extension:Twice~{MemberAnchor.ComputeFingerprint(expectedCanonical)}", identities);
     }
 
+    [Fact]
+    public void ResearchBodyIdentity_TargetAliasMatchesMethodSubjectCanonicalFormatter()
+    {
+        AssertTargetAliasMatchesMethodSubject(
+            DiffType("Sample", "Widget", DiffMember("M", signature: "void M(int[] values)")),
+            DiffMember("M", signature: "void M(int[] values)"),
+            new MethodIdentity(
+                "Asm",
+                Guid.Empty,
+                TypeRef.Definition("Asm", "Sample", "Widget"),
+                "M",
+                [TypeRef.SzArray(TypeRef.CoreLib("System", "Int32"))],
+                TypeRef.CoreLib("System", "Void"),
+                MetadataToken: 0x06000000,
+                IsStatic: true));
+
+        AssertTargetAliasMatchesMethodSubject(
+            DiffType("Sample", "Widget", DiffMember("M", signature: "void M(ref int value)")),
+            DiffMember("M", signature: "void M(ref int value)"),
+            new MethodIdentity(
+                "Asm",
+                Guid.Empty,
+                TypeRef.Definition("Asm", "Sample", "Widget"),
+                "M",
+                [TypeRef.ByRef(TypeRef.CoreLib("System", "Int32"))],
+                TypeRef.CoreLib("System", "Void"),
+                MetadataToken: 0x06000000,
+                IsStatic: true));
+
+        AssertTargetAliasMatchesMethodSubject(
+            DiffType("Sample", "Widget", DiffMember("M", signature: "void M(int* value)")),
+            DiffMember("M", signature: "void M(int* value)"),
+            new MethodIdentity(
+                "Asm",
+                Guid.Empty,
+                TypeRef.Definition("Asm", "Sample", "Widget"),
+                "M",
+                [TypeRef.Pointer(TypeRef.CoreLib("System", "Int32"))],
+                TypeRef.CoreLib("System", "Void"),
+                MetadataToken: 0x06000001,
+                IsStatic: true));
+
+        AssertTargetAliasMatchesMethodSubject(
+            DiffType("Sample", "Widget", DiffMember("M", signature: "T M<T>(T value)", genericArity: 1)),
+            DiffMember("M", signature: "T M<T>(T value)", genericArity: 1),
+            new MethodIdentity(
+                "Asm",
+                Guid.Empty,
+                TypeRef.Definition("Asm", "Sample", "Widget"),
+                "M",
+                [TypeRef.MethodGenericParameter(0, "T")],
+                TypeRef.MethodGenericParameter(0, "T"),
+                MetadataToken: 0x06000002,
+                IsStatic: true,
+                GenericArity: 1,
+                GenericParameterNames: ["T"]));
+
+        var op = DiffMember("op_Addition", signature: "Sample.Widget op_Addition(Sample.Widget left, Sample.Widget right)");
+        op.Kind = "operator";
+        AssertTargetAliasMatchesMethodSubject(
+            DiffType("Sample", "Widget", op),
+            op,
+            new MethodIdentity(
+                "Asm",
+                Guid.Empty,
+                TypeRef.Definition("Asm", "Sample", "Widget"),
+                "op_Addition",
+                [TypeRef.Definition("Asm", "Sample", "Widget"), TypeRef.Definition("Asm", "Sample", "Widget")],
+                TypeRef.Definition("Asm", "Sample", "Widget"),
+                MetadataToken: 0x06000003,
+                IsStatic: true));
+
+        var explicitImpl = DiffMember("IFoo.Bar", signature: "void IFoo.Bar()");
+        explicitImpl.Kind = "explicit-interface-implementation";
+        AssertTargetAliasMatchesMethodSubject(
+            DiffType("Sample", "Widget", explicitImpl),
+            explicitImpl,
+            new MethodIdentity(
+                "Asm",
+                Guid.Empty,
+                TypeRef.Definition("Asm", "Sample", "Widget"),
+                "IFoo.Bar",
+                [],
+                TypeRef.CoreLib("System", "Void"),
+                MetadataToken: 0x06000004,
+                IsStatic: false));
+
+        var constructor = new ApiMember
+        {
+            Name = ".ctor",
+            Kind = "constructor",
+            Signature = "void .ctor()",
+            SignatureModel = new ApiSignature { MemberName = "#ctor" }
+        };
+        AssertTargetAliasMatchesMethodSubject(
+            DiffType("Sample", "Widget", constructor),
+            constructor,
+            new MethodIdentity(
+                "Asm",
+                Guid.Empty,
+                TypeRef.Definition("Asm", "Sample", "Widget"),
+                ".ctor",
+                [],
+                TypeRef.CoreLib("System", "Void"),
+                MetadataToken: 0x06000005,
+                IsStatic: false));
+
+        var extensionType = new ApiType { Namespace = "Sample", Name = "Extensions" };
+        var extension = DiffMember("Twice", signature: "int Twice(int value)");
+        extension.IsExtension = true;
+        extension.DeclaringType = "Sample.Extensions";
+        AssertTargetAliasMatchesMethodSubject(
+            extensionType,
+            extension,
+            new MethodIdentity(
+                "Asm",
+                Guid.Empty,
+                TypeRef.Definition("Asm", "Sample", "Extensions"),
+                "Twice",
+                [TypeRef.CoreLib("System", "Int32")],
+                TypeRef.CoreLib("System", "Int32"),
+                MetadataToken: 0x06000006,
+                IsStatic: true,
+                IsExtension: true));
+    }
+
     // #1736: a hotness-only allocation regression. The allocation count is unchanged
     // (1 -> 1) but the allocation moves into a loop (allocInLoop false -> true). The raw
     // count delta is zero, so this must still surface as an in-place allocations row with
@@ -649,6 +776,17 @@ public class DiffCommandTests
         var changedOnly = DiffCommand.BuildAnalysisDiff([v1], [v1], new DiffOptions { ChangedOnly = true });
         Assert.Empty(changedOnly.Rows);
         Assert.Equal("No in-place analysis signal changes detected.", changedOnly.Summary);
+    }
+
+    static void AssertTargetAliasMatchesMethodSubject(ApiType type, ApiMember member, MethodIdentity method)
+    {
+        HashSet<string> identities = new(StringComparer.Ordinal);
+
+        Assert.True(ResearchMemberIdentity.TryAddTargetIdentity(ResolvedTarget(type, member), identities));
+
+        var targetId = Assert.Single(identities);
+        var methodSubject = ResearchMemberIdentity.SubjectFromMethod(method);
+        Assert.Equal(methodSubject.Id, targetId);
     }
 
     static ApiSurface DiffSurface(params ApiMember[] members)


### PR DESCRIPTION
## Summary
- add one internal `BodyMemberIdentity` path for Research body canonical signatures, fingerprints, and stable selectors
- route both `SubjectFromMethod(MethodIdentity)` and `TryAddTargetIdentity(ResolvedMemberTarget, ...)` through that shared formatter
- add a public-behavior drift test comparing MethodIdentity subjects and API-target aliases for arrays, byrefs, pointers, generics, operators, explicit implementations, constructors, and extensions

## Validation
- `dotnet run --project src/dotnet-inspect.Tests -c Release -- -method DotnetInspector.Tests.DiffCommandTests.ResearchBodyIdentity_TargetAliasMatchesMethodSubjectCanonicalFormatter`
- `dotnet run --project src/ILInspector.Research.Tests -c Release`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --verbosity quiet`

## Review
- Adversarial review pending (MAI + Gemini, different model families from author).
