### PR TITLE
Seed precise target RTS member requirements

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -461,11 +461,10 @@ public class ReturnToSenderPrototypeTests
                 result.Status == FidelityCheck.CompileBackStatus.Exact,
                 $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
             var type = Assert.Single(result.Plan.Types);
-            Assert.Contains(type.SourceFacts, fact =>
-                fact.Producer == "roslyn"
-                && fact.Id == "closure-member"
-                && fact.Detail.StartsWith("CS0103", StringComparison.Ordinal));
-            Assert.Contains(type.Members, member => member.Name == "GetValue" && member.Kind == CompileBackMemberKind.Method);
+            Assert.DoesNotContain(type.SourceFacts, fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+            Assert.Contains(type.Members, member => member.Name == "GetValue"
+                && member.Kind == CompileBackMemberKind.Method
+                && member.SourceFacts.Any(fact => fact.Id == "typed-closure-method" && fact.Detail == "GetValue"));
             Assert.Contains("public int GetValue()", result.Source);
         }
         finally

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -328,34 +328,38 @@ public static class CompileBackSourceComposer
         if (closureFacts.TryGetValue(targetRoot, out var targetClosureFacts))
             targetFacts.AddRange(targetClosureFacts);
 
+        var targetMembers = new List<CompileBackMemberRequirement>
+        {
+            new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(targetIdentity.FullName, propertyName, overload, signatureText),
+                CompileBackMemberKind.PropertyGet,
+                getter.Attributes.HasFlag(MethodAttributes.Static),
+                ToCompileBackParameters(propertyDeclaration.Signature.Parameters),
+                returnType,
+                TypeParameters: [],
+                targetIsAutoProperty
+                    ? CompileBackStubBodyKind.AutoProperty
+                    : accessors.Setter.IsNil
+                        ? CompileBackStubBodyKind.TargetBody
+                        : CompileBackStubBodyKind.TargetGetterWithSetter,
+                targetIsAutoProperty ? null : targetBody,
+                targetIsAutoProperty
+                    ? [
+                        new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name)),
+                        new CompileBackFact("metadata", "auto-property", propertyName)
+                    ]
+                    : [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))],
+                propertyDeclaration.Attributes,
+                MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, getter, getterSignature).Signature.ReturnAttributes)
+        };
+        AddRequiredMembers(targetMembers, closureMemberRequirements, targetRoot);
+
         var requirements = new List<CompileBackTypeRequirement>
         {
             new(
                 targetIdentity,
                 ShellKind(reader, targetTypeDef),
-                [
-                    new CompileBackMemberRequirement(
-                        new CompileBackMethodIdentity(targetIdentity.FullName, propertyName, overload, signatureText),
-                        CompileBackMemberKind.PropertyGet,
-                        getter.Attributes.HasFlag(MethodAttributes.Static),
-                        ToCompileBackParameters(propertyDeclaration.Signature.Parameters),
-                        returnType,
-                        TypeParameters: [],
-                        targetIsAutoProperty
-                            ? CompileBackStubBodyKind.AutoProperty
-                            : accessors.Setter.IsNil
-                                ? CompileBackStubBodyKind.TargetBody
-                                : CompileBackStubBodyKind.TargetGetterWithSetter,
-                        targetIsAutoProperty ? null : targetBody,
-                        targetIsAutoProperty
-                            ? [
-                                new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name)),
-                                new CompileBackFact("metadata", "auto-property", propertyName)
-                            ]
-                            : [new CompileBackFact("metadata", "target-property-getter", reader.GetString(reader.GetMethodDefinition(targetGetter).Name))],
-                        propertyDeclaration.Attributes,
-                        MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, getter, getterSignature).Signature.ReturnAttributes)
-                ],
+                targetMembers,
                 PrimaryConstructor: null,
                 targetFacts)
         };
@@ -403,6 +407,18 @@ public static class CompileBackSourceComposer
         return new CompileBackSourceResult(plan, WriteCompilationUnit(plan));
     }
 
+    static void AddRequiredMembers(
+        List<CompileBackMemberRequirement> members,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> requirementsByRoot,
+        TypeDefinitionHandle root)
+    {
+        if (!requirementsByRoot.TryGetValue(root, out var requiredMembers))
+            return;
+        foreach (var required in requiredMembers)
+            if (!members.Any(existing => existing.Kind == required.Kind && existing.Identity == required.Identity))
+                members.Add(required);
+    }
+
     public static CompileBackSourceResult ComposePropertySetter(
         string assemblyPath,
         MetadataReader reader,
@@ -439,32 +455,36 @@ public static class CompileBackSourceComposer
             targetFacts.AddRange(targetClosureFacts);
 
         var indexerParameterCount = propertySignature.ParameterTypes.Length;
+        var targetMembers = new List<CompileBackMemberRequirement>
+        {
+            new CompileBackMemberRequirement(
+                new CompileBackMethodIdentity(targetIdentity.FullName, propertyName, overload, signatureText),
+                CompileBackMemberKind.PropertySet,
+                setter.Attributes.HasFlag(MethodAttributes.Static),
+                ToCompileBackParameters(propertyDeclaration.Signature.Parameters).Take(indexerParameterCount).ToArray(),
+                returnType,
+                TypeParameters: [],
+                targetIsAutoProperty
+                    ? CompileBackStubBodyKind.AutoPropertyGetSet
+                    : property.GetAccessors().Getter.IsNil
+                        ? CompileBackStubBodyKind.TargetBody
+                        : CompileBackStubBodyKind.TargetSetterWithGetter,
+                targetIsAutoProperty ? null : targetBody,
+                targetIsAutoProperty
+                    ? [
+                        new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name)),
+                        new CompileBackFact("metadata", "auto-property", propertyName)
+                    ]
+                    : [new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name))])
+        };
+        AddRequiredMembers(targetMembers, closureMemberRequirements, targetRoot);
+
         var requirements = new List<CompileBackTypeRequirement>
         {
             new(
                 targetIdentity,
                 ShellKind(reader, targetTypeDef),
-                [
-                    new CompileBackMemberRequirement(
-                        new CompileBackMethodIdentity(targetIdentity.FullName, propertyName, overload, signatureText),
-                        CompileBackMemberKind.PropertySet,
-                        setter.Attributes.HasFlag(MethodAttributes.Static),
-                        ToCompileBackParameters(propertyDeclaration.Signature.Parameters).Take(indexerParameterCount).ToArray(),
-                        returnType,
-                        TypeParameters: [],
-                        targetIsAutoProperty
-                            ? CompileBackStubBodyKind.AutoPropertyGetSet
-                            : property.GetAccessors().Getter.IsNil
-                                ? CompileBackStubBodyKind.TargetBody
-                                : CompileBackStubBodyKind.TargetSetterWithGetter,
-                        targetIsAutoProperty ? null : targetBody,
-                        targetIsAutoProperty
-                            ? [
-                                new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name)),
-                                new CompileBackFact("metadata", "auto-property", propertyName)
-                            ]
-                            : [new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name))])
-                ],
+                targetMembers,
                 PrimaryConstructor: null,
                 targetFacts)
         };

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1477,16 +1477,24 @@ static class ReturnToSender
         void AddMethodFact(MethodRef method)
         {
             AddMemberFact(method.DeclaringType, "method", method.Name);
-            AddMemberRequirement(method.DeclaringType, root => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, root, method));
+            AddMemberRequirement(
+                method.DeclaringType,
+                root => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, root, method),
+                allowTargetRoot: method.Name is not ".ctor" and not ".cctor"
+                    && !method.Name.StartsWith("get_", StringComparison.Ordinal)
+                    && !method.Name.StartsWith("set_", StringComparison.Ordinal));
         }
 
         void AddFieldFact(FieldRef field)
         {
             AddMemberFact(field.DeclaringType, "field", field.Name);
-            AddMemberRequirement(field.DeclaringType, root => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, root, field));
+            AddMemberRequirement(
+                field.DeclaringType,
+                root => CompileBackSourceComposer.TryCreateClosureMemberRequirement(reader, root, field),
+                allowTargetRoot: false);
         }
 
-        void AddMemberRequirement(TypeRef declaringType, Func<TypeDefinitionHandle, CompileBackMemberRequirement?> create)
+        void AddMemberRequirement(TypeRef declaringType, Func<TypeDefinitionHandle, CompileBackMemberRequirement?> create, bool allowTargetRoot)
         {
             var definition = declaringType.Kind == TypeRefKind.GenericInstance
                 ? declaringType.ElementType ?? declaringType
@@ -1494,7 +1502,9 @@ static class ReturnToSender
             if (TryResolveHandle(definition) is not { } handle)
                 return;
             var root = TopLevelRootOf(reader, handle);
-            if (root == targetRoot || root != handle)
+            if (root == targetRoot && !allowTargetRoot)
+                return;
+            if (root != handle)
                 return;
             if (create(handle) is not { } requirement)
                 return;


### PR DESCRIPTION
## Summary

- merge precise typed member requirements into target property getter/setter shells
- allow ReturnToSender to seed exact ordinary target-root method requirements while still excluding target fields/accessors/ctors and nested roots
- update the target sibling canary to prove `GetValue` is emitted from typed precise evidence instead of Roslyn `closure-member` fallback

This is deliberately narrower than all target member refs: method targets with record/helper-specific shell logic remain unchanged to avoid broadening or duplicate-helper regressions.

## Validation

- `dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderEvidenceTests/*"`
- `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal.property.literal --max-examples 3`

Adversarial review requested separately.