### PR TITLE
Disambiguate conversion-operator member identity by return type

### DIFF
--- a/docs/design/member-target-resolution.md
+++ b/docs/design/member-target-resolution.md
@@ -40,10 +40,14 @@ Member identity has two related vocabularies:
 
 Conversion operators are a special API-identity case: C# overloads
 `op_Implicit`, `op_Explicit`, and `op_CheckedExplicit` by return type. Their
-API canonical signatures therefore include the DocId-style return suffix
+API canonical signatures therefore include a product-owned return-type suffix
 `~ReturnType`, for example
 `M:System.Decimal.op_Explicit(System.Decimal)~int`. Without the suffix, all
-conversions with the same source parameter collapse to one anchor digest.
+conversions with the same source parameter collapse to one anchor digest. The
+suffix deliberately uses the same delimiter shape as XML documentation member
+identity so XML lookup and API anchors do not invent divergent spellings for the
+same return-type disambiguator; XML documentation is precedent, not the owning
+authority for the API identity grammar.
 
 ## Boundaries
 

--- a/docs/design/member-target-resolution.md
+++ b/docs/design/member-target-resolution.md
@@ -23,6 +23,28 @@ Diagnostics are typed (`MemberTargetDiagnosticKind`) and include candidate
 anchors for ambiguous or out-of-range selections. CLI commands should render the
 diagnostic instead of falling back to partial string matching.
 
+## Identity ownership
+
+Member identity has two related vocabularies:
+
+- **API identity** is owned by `ILInspector.Metadata.ApiMemberIdentity`. It
+  creates `MemberAnchor` values, selector prefixes (`operator:`, `explicit:`,
+  `extension:`), canonical signatures, and stable selector fingerprints. Product
+  producers such as C# body diff should call this layer instead of building
+  anchors locally.
+- **Body identity** is owned by `ILInspector.Research.ResearchMemberIdentity`.
+  It formats `MethodIdentity` subjects and API-derived `ResolvedMemberTarget`
+  body aliases through one body canonicalization path. Body identity deliberately
+  has a different type-name vocabulary from API identity because it mirrors
+  `LibraryBodyIndex`/`MethodIdentity` evidence.
+
+Conversion operators are a special API-identity case: C# overloads
+`op_Implicit`, `op_Explicit`, and `op_CheckedExplicit` by return type. Their
+API canonical signatures therefore include the DocId-style return suffix
+`~ReturnType`, for example
+`M:System.Decimal.op_Explicit(System.Decimal)~int`. Without the suffix, all
+conversions with the same source parameter collapse to one anchor digest.
+
 ## Boundaries
 
 - Lexical command helpers may still identify source/type/member argument slots,
@@ -37,3 +59,7 @@ diagnostic instead of falling back to partial string matching.
   references remain producer evidence and should not be replaced by selectors.
 - The resolver lives in `ILInspector.Metadata`, so it stays SRM-only and has no
   decompiler dependency.
+- Do not add local selector, canonical-signature, fingerprint, or
+  anchor-construction helpers in producers. Add or extend the owning identity
+  layer instead, then cover the bridge with a round-trip or alias-vs-subject
+  test.

--- a/src/ILInspector.Decompiler.Tests/CSharpBodyDiffTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpBodyDiffTests.cs
@@ -455,7 +455,9 @@ public class CSharpBodyDiffTests
             row.Anchor.CanonicalSignature.Contains("op_Implicit", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
         Assert.StartsWith("operator:op_Implicit~", row.Anchor.StableSelector, StringComparison.Ordinal);
-        Assert.Equal("M:DiffFixtureSample.ConversionSample.op_Implicit(DiffFixtureSample.ConversionSample)", row.Anchor.CanonicalSignature);
+        Assert.Equal("M:DiffFixtureSample.ConversionSample.op_Implicit(DiffFixtureSample.ConversionSample)~System.Int32", row.Anchor.CanonicalSignature);
+        // The string-returning op_Implicit body is unchanged across V1/V2, so it is not a
+        // changed row; the int-returning one is disambiguated by ~System.Int32 above.
         Assert.DoesNotContain(diff.Rows, row => row.Anchor.CanonicalSignature.EndsWith("~System.String", StringComparison.Ordinal));
     }
 
@@ -513,7 +515,7 @@ public class CSharpBodyDiffTests
             row.Anchor.CanonicalSignature.Contains("op_CheckedExplicit", StringComparison.Ordinal)
             && row.Kind == CSharpDiffKind.Remove);
         Assert.StartsWith("operator:op_CheckedExplicit~", row.Anchor.StableSelector, StringComparison.Ordinal);
-        Assert.Equal("M:DiffFixtureSample.CheckedConversionSample.op_CheckedExplicit(DiffFixtureSample.CheckedConversionSample)", row.Anchor.CanonicalSignature);
+        Assert.Equal("M:DiffFixtureSample.CheckedConversionSample.op_CheckedExplicit(DiffFixtureSample.CheckedConversionSample)~System.Int32", row.Anchor.CanonicalSignature);
     }
 
     [Fact]

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -162,6 +162,10 @@ public static class ApiMemberIdentity
         string typeFullName = FormatDefinitionName(reader, typeHandle);
         string memberName = MethodMemberName(reader, methodName, method);
         string canonicalSignature = $"M:{typeFullName}.{memberName}({string.Join(",", signature.ParameterTypes)})";
+        // Conversion operators overload on return type; disambiguate them here too so this
+        // SRM-direct anchor producer matches TryGetCanonicalSignature and does not collide.
+        if (IsConversionOperator(methodName) && !string.IsNullOrWhiteSpace(signature.ReturnType))
+            canonicalSignature += $"~{signature.ReturnType}";
         string selectorName = GetMemberSelectorName(methodName, isExtensionMethod);
         return CreateAnchor(typeFullName, selectorName, memberName, canonicalSignature);
     }

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -285,8 +285,9 @@ public static class ApiMemberIdentity
         var canonical = $"{kindCode}:{declaringType}.{memberName}{NormalizeCanonicalParameters(signature.ParameterTypesSummary)}";
         // Conversion operators overload on return type, so the parameter list alone
         // is an ambiguous identity (every System.Decimal.op_Explicit(Decimal) collides).
-        // Append the return type using the DocId "~ReturnType" convention, matching
-        // TryGetXmlDocMemberIdentity, so each conversion gets a distinct anchor.
+        // Append a product-owned return-type suffix. It intentionally uses the
+        // same "~ReturnType" delimiter as XML doc identity so conversion anchors
+        // and XML lookups do not grow divergent spellings for the same fact.
         if (IsConversionOperator(member.Name) && !string.IsNullOrWhiteSpace(signature.ReturnType))
             canonical += $"~{NormalizeCanonicalCommas(signature.ReturnType!)}";
         canonicalSignature = canonical;

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -758,7 +758,7 @@ public static class ApiMemberIdentity
                 .Replace('<', '{')
                 .Replace('>', '}');
 
-    static bool IsConversionOperator(string memberName)
+    internal static bool IsConversionOperator(string memberName)
         => memberName is "op_Implicit" or "op_Explicit" or "op_CheckedExplicit";
 
     static bool TryGetArraySuffix(string type, out string elementType, out string suffix)

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -162,8 +162,8 @@ public static class ApiMemberIdentity
         string typeFullName = FormatDefinitionName(reader, typeHandle);
         string memberName = MethodMemberName(reader, methodName, method);
         string canonicalSignature = $"M:{typeFullName}.{memberName}({string.Join(",", signature.ParameterTypes)})";
-        // Conversion operators overload on return type; disambiguate them here too so this
-        // SRM-direct anchor producer matches TryGetCanonicalSignature and does not collide.
+        // Conversion operators overload on return type; apply the same disambiguation rule
+        // here so this SRM-direct anchor producer does not collide (its own full-name vocabulary).
         if (IsConversionOperator(methodName) && !string.IsNullOrWhiteSpace(signature.ReturnType))
             canonicalSignature += $"~{signature.ReturnType}";
         string selectorName = GetMemberSelectorName(methodName, isExtensionMethod);
@@ -250,7 +250,12 @@ public static class ApiMemberIdentity
             ? "#ctor"
             : ExtractMemberNameWithGeneric(signature, member.Name);
         var parameters = ExtractCanonicalParameterList(signature);
-        return $"{kindCode}:{declaringType}.{memberName}{parameters}";
+        var canonical = $"{kindCode}:{declaringType}.{memberName}{parameters}";
+        // Mirror the conversion-operator return-type disambiguation so member identity
+        // is not dependent on whether SignatureModel was populated (the Try path above).
+        if (IsConversionOperator(member.Name) && !string.IsNullOrWhiteSpace(member.ReturnType))
+            canonical += $"~{NormalizeCanonicalCommas(member.ReturnType!)}";
+        return canonical;
     }
 
     public static bool TryGetCanonicalSignature(ApiType type, ApiMember member, out string canonicalSignature)

--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -282,7 +282,14 @@ public static class ApiMemberIdentity
                   ? member.Name
                   : signature.MemberName!);
         memberName = NormalizeCanonicalCommas(memberName);
-        canonicalSignature = $"{kindCode}:{declaringType}.{memberName}{NormalizeCanonicalParameters(signature.ParameterTypesSummary)}";
+        var canonical = $"{kindCode}:{declaringType}.{memberName}{NormalizeCanonicalParameters(signature.ParameterTypesSummary)}";
+        // Conversion operators overload on return type, so the parameter list alone
+        // is an ambiguous identity (every System.Decimal.op_Explicit(Decimal) collides).
+        // Append the return type using the DocId "~ReturnType" convention, matching
+        // TryGetXmlDocMemberIdentity, so each conversion gets a distinct anchor.
+        if (IsConversionOperator(member.Name) && !string.IsNullOrWhiteSpace(signature.ReturnType))
+            canonical += $"~{NormalizeCanonicalCommas(signature.ReturnType!)}";
+        canonicalSignature = canonical;
         return true;
     }
 

--- a/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
+++ b/src/ILInspector.Metadata/ApiSurfaceExtractor.cs
@@ -173,6 +173,11 @@ public static class ApiSurfaceExtractor
                     IsSealed = isOverride && (methodAttributes & MethodAttributes.Final) != 0,
                     Signature = signature.Text,
                     SignatureModel = signature.Model,
+                    // Conversion operators overload on return type. SignatureModel is
+                    // [JsonIgnore], so persist the return type on the serialized member
+                    // too, letting the canonical-signature fallback disambiguate them on a
+                    // round-tripped ApiSurface (where SignatureModel is gone).
+                    ReturnType = ApiMemberIdentity.IsConversionOperator(methodName) ? signature.Model?.ReturnType : null,
                     MetadataToken = MetadataTokens.GetToken(methodHandle),
                     IsUnsafe = HasUnsafeSignature(signature.Text)
                         || AttributeReader.HasRequiresUnsafeAttribute(reader, method.GetCustomAttributes()),

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -65,6 +65,27 @@ public class ApiMemberIdentityTests
         Assert.Contains(anchors, anchor => anchor.CanonicalSignature.EndsWith("~long", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void CreateMethodAnchor_DisambiguatesConversionOperatorsByReturnType()
+    {
+        using var stream = File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+
+        var conversions = FindConversionOperatorMethods(reader);
+        Assert.Equal(2, conversions.Count);
+
+        var canonicals = conversions
+            .Select(entry => ApiMemberIdentity.CreateMethodAnchor(reader, entry.TypeHandle, entry.Method).CanonicalSignature)
+            .ToList();
+
+        // The SRM-direct producer must also disambiguate the two op_Explicit conversions
+        // that differ only by return type (its own full-name vocabulary: ~System.Int32/~System.Int64).
+        Assert.Equal(2, canonicals.Distinct(StringComparer.Ordinal).Count());
+        Assert.Contains(canonicals, canonical => canonical.EndsWith("~System.Int32", StringComparison.Ordinal));
+        Assert.Contains(canonicals, canonical => canonical.EndsWith("~System.Int64", StringComparison.Ordinal));
+    }
+
     static (TypeDefinitionHandle TypeHandle, MethodDefinition Method) FindFixtureMethod(MetadataReader reader)
     {
         foreach (var typeHandle in reader.TypeDefinitions)
@@ -82,6 +103,26 @@ public class ApiMemberIdentityTests
         }
 
         throw new InvalidOperationException("Fixture method not found.");
+    }
+
+    static List<(TypeDefinitionHandle TypeHandle, MethodDefinition Method)> FindConversionOperatorMethods(MetadataReader reader)
+    {
+        var result = new List<(TypeDefinitionHandle, MethodDefinition)>();
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            if (reader.GetString(type.Name) != nameof(ConversionOperatorFixture))
+                continue;
+
+            foreach (var methodHandle in type.GetMethods())
+            {
+                var method = reader.GetMethodDefinition(methodHandle);
+                if (reader.GetString(method.Name) == "op_Explicit")
+                    result.Add((typeHandle, method));
+            }
+        }
+
+        return result;
     }
 
     sealed class ApiMemberIdentityFixture<T>

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Text.Json;
 using ILInspector.Metadata;
 using ILInspector.MetadataPrimitives;
 
@@ -84,6 +85,35 @@ public class ApiMemberIdentityTests
         Assert.Equal(2, canonicals.Distinct(StringComparer.Ordinal).Count());
         Assert.Contains(canonicals, canonical => canonical.EndsWith("~System.Int32", StringComparison.Ordinal));
         Assert.Contains(canonicals, canonical => canonical.EndsWith("~System.Int64", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FallbackCanonicalSignature_DisambiguatesConversionOperators_AfterJsonRoundTrip()
+    {
+        using var stream = File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        // Round-trip through JSON. SignatureModel is [JsonIgnore], so the deserialized
+        // members have no SignatureModel and exercise the GetCanonicalSignature fallback.
+        var json = JsonSerializer.Serialize(surface);
+        var roundTripped = JsonSerializer.Deserialize<ApiSurface>(json)!;
+
+        var type = roundTripped.Types.Single(t => t.Name.EndsWith(nameof(ConversionOperatorFixture), StringComparison.Ordinal));
+        var conversions = type.Members
+            .Where(member => member.Kind == "operator" && member.Name == "op_Explicit")
+            .ToList();
+        Assert.Equal(2, conversions.Count);
+        Assert.All(conversions, member => Assert.Null(member.SignatureModel));
+
+        // The fallback must still disambiguate by return type on the round-tripped surface,
+        // using the persisted ApiMember.ReturnType.
+        var canonicals = conversions
+            .Select(member => ApiMemberIdentity.GetCanonicalSignature(type, member))
+            .ToList();
+        Assert.Equal(2, canonicals.Distinct(StringComparer.Ordinal).Count());
+        Assert.Contains(canonicals, canonical => canonical.EndsWith("~int", StringComparison.Ordinal));
+        Assert.Contains(canonicals, canonical => canonical.EndsWith("~long", StringComparison.Ordinal));
     }
 
     static (TypeDefinitionHandle TypeHandle, MethodDefinition Method) FindFixtureMethod(MetadataReader reader)

--- a/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
+++ b/tests/ILInspector.Metadata.Tests/ApiMemberIdentityTests.cs
@@ -37,6 +37,34 @@ public class ApiMemberIdentityTests
         Assert.Equal(MemberAnchor.ComputeFingerprint(anchor.CanonicalSignature), anchor.Fingerprint);
     }
 
+    [Fact]
+    public void GetMemberAnchor_DisambiguatesConversionOperatorsByReturnType()
+    {
+        using var stream = File.OpenRead(typeof(ApiMemberIdentityTests).Assembly.Location);
+        using var peReader = new PEReader(stream);
+        var surface = ApiSurfaceExtractor.Extract(peReader, includeAll: true);
+
+        var type = surface.Types.Single(t => t.Name.EndsWith(nameof(ConversionOperatorFixture), StringComparison.Ordinal));
+        var conversions = type.Members
+            .Where(member => member.Kind == "operator" && member.Name == "op_Explicit")
+            .ToList();
+
+        // Two explicit conversions that differ ONLY by return type (op_Explicit(Fixture)).
+        Assert.Equal(2, conversions.Count);
+
+        var anchors = conversions
+            .Select(member => ApiMemberIdentity.GetMemberAnchor(type, member))
+            .ToList();
+
+        // Return type must be part of the canonical identity, so the two conversions
+        // get distinct canonical signatures and fingerprints (no ambiguous anchor).
+        Assert.Equal(2, anchors.Select(anchor => anchor.CanonicalSignature).Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(2, anchors.Select(anchor => anchor.Fingerprint).Distinct(StringComparer.Ordinal).Count());
+        Assert.All(anchors, anchor => Assert.Contains("op_Explicit", anchor.CanonicalSignature, StringComparison.Ordinal));
+        Assert.Contains(anchors, anchor => anchor.CanonicalSignature.EndsWith("~int", StringComparison.Ordinal));
+        Assert.Contains(anchors, anchor => anchor.CanonicalSignature.EndsWith("~long", StringComparison.Ordinal));
+    }
+
     static (TypeDefinitionHandle TypeHandle, MethodDefinition Method) FindFixtureMethod(MetadataReader reader)
     {
         foreach (var typeHandle in reader.TypeDefinitions)
@@ -61,5 +89,12 @@ public class ApiMemberIdentityTests
         public void M<U>(int value, U item)
         {
         }
+    }
+
+    readonly struct ConversionOperatorFixture
+    {
+        public static explicit operator int(ConversionOperatorFixture value) => 0;
+
+        public static explicit operator long(ConversionOperatorFixture value) => 0;
     }
 }


### PR DESCRIPTION
## Summary

Conversion operators (`op_Implicit` / `op_Explicit` / `op_CheckedExplicit`) overload
on **return type**, but the member-identity canonical signature dropped the return
type, so every conversion of a type collapsed to one canonical (and one anchor
fingerprint) — an ambiguous member identity.

The fix appends the return type so each conversion gets a distinct anchor, in **all
three** `ApiMemberIdentity` canonicalization paths:

- `TryGetCanonicalSignature` (ApiSurface path)
- `CreateMethodAnchor` (SRM-direct path, used by `CSharpBodyDiff`)
- `GetCanonicalSignature` fallback (`SignatureModel == null`, e.g. round-tripped
  `ApiSurface` where `SignatureModel` is `[JsonIgnore]`)

The suffix is a **product-owned** return-type disambiguator that shares the `~`
delimiter shape with XML-doc member identity (XML doc is precedent, not the owning
authority — see `docs/design/member-target-resolution.md`). Each producer emits it
in **its own** vocabulary (keyword `~byte` on the ApiSurface path, ECMA `~System.Byte`
on the SRM-direct path); that per-producer vocabulary split is pre-existing and is
tracked for consolidation in #2440. **Only conversion operators change**; every other
member's canonical (and its published stable-selector digest) is byte-identical, and
the previously-colliding operator digests were already ambiguous, so no working
selector regresses.

## How this was found — Return Address (RA) conformance sweep

First result from a member-identity conformance sweep (the signature-identity sibling
of Return-to-Sender): render each member's identity via the product `ApiMemberIdentity`
API and deliver it back through `MemberTargetResolver`, counting collisions /
undeliverable addresses. On `System.Private.CoreLib` (45,388 members):

| Metric | Before | After |
| ------ | -----: | ----: |
| Delivered (unique round-trip) | 99.63% | **99.95%** |
| Canonical collisions | 131 | **0** |
| Undeliverable | 167 | 24 |

One product-layer fix closed the entire `op_Explicit` / `op_Implicit` /
`op_CheckedExplicit` tail. Example collapse before the fix — one anchor for every
numeric target:

```text
M:System.Decimal.op_Explicit(System.Decimal)
  -> byte / sbyte / char / short / ushort / int / uint / long / ulong / float / double
```

The remaining 24 undeliverable are a distinct, smaller class (12 bool/enum-constant
fields, 12 method/property digest) tracked for follow-up.

## Design note

Identity/type knowledge stays in the **product** (`ApiMemberIdentity`, Metadata layer);
the RA sweep is a thin observer that only calls product APIs. `ResearchMemberIdentity`
has a separate body-identity canonical builder (different vocabulary) that is **not**
aligned here; there is no live regression (`DiffCommand` / `TryAddTargetIdentity`
identity tests pass). Unifying the producers into one product-owned identity authority
(full-name in Metadata, keyword mapping in Decompiler, equivalence API in Research) is
the follow-up in **#2440**, which the RA equivalence sweep will measure and guard.

## Validation

- `ILInspector.Metadata.Tests` 361/0 (adds surface-path + SRM-direct conversion-operator tests)
- `ILInspector.Decompiler.Tests` 2006/0 (incl. updated `CSharpBodyDiffTests` — the `ConversionSample` fixture has two implicit operators differing only by return type)
- `dotnet-inspect.Tests` 1665/0 (10 skipped; incl. `DiffCommand` identity tests)
- `ILInspector.Research.Tests` 58/0
- `ILInspector.Analysis.Tests` 390/0
- RA sweep over CoreLib: canonical collisions 131 -> **0**, delivered 99.63% -> **99.95%**

## Review

Member-identity/digest behavior change -> two-model adversarial review
(GPT-5.5 + Gemini 3.1 Pro). See reconciliation comment.
