### PR TITLE
Name assertion obligation dischargers in dumps

### DIFF
--- a/docs/design/assertion-lane-effects.md
+++ b/docs/design/assertion-lane-effects.md
@@ -97,8 +97,9 @@ in rough dependency order:
    `--dump --assertions`. Still open: promote it from a report/diff signal to a
    hard zero-gate, which needs an allowlist of the known `PrinterOwned` residuals
    so only *new* survivors fail.
-2. Track **obligation lifetime** — stages between accrual and discharge — as a
+2. **Landed ([#2284](https://github.com/richlander/dotnet-inspect/pull/2284)):**
+   track **obligation lifetime** — stages between accrual and discharge — as a
    construction-quality metric. Lifetime trending down means passes decide early
    rather than retrofitting a claim late.
-3. Attribute discharge to a named pass, then graduate to the per-pass effect
-   signatures above.
+3. Attribute discharge to a named pass in local dumps, then graduate to the
+   per-pass effect signatures above.

--- a/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
@@ -293,6 +293,33 @@ public class AssertionScanTests
     }
 
     [Fact]
+    public void AssertionPrinter_NamesKnownDischargerForObligation()
+    {
+        var summary = AssertionScan.EvaluateFunction(
+            "synthetic",
+            "synthetic.dll",
+            "Samples.Holder",
+            "EnumReturn",
+            overload: 0,
+            Function(Returning(new LoadArgument(0, "raw", Int32)), Enum32, new Parameter("raw", Int32)));
+        var dischargePassByStageIdentity = summary.Violations.ToDictionary(
+            v => v.StageIdentity,
+            v => v.DischargePass,
+            StringComparer.Ordinal);
+
+        var function = Function(
+            Returning(new LoadArgument(0, "raw", Int32)),
+            Enum32,
+            new Parameter("raw", Int32));
+        var printer = new AssertionPrinter.StatefulPrinter(3, dischargePassByStageIdentity);
+
+        var stage1 = printer.Dump(function);
+
+        Assert.Contains("OBLIGATION (informational; discharged by coercion-insertion)", stage1);
+        Assert.DoesNotContain("UNSOUND", stage1);
+    }
+
+    [Fact]
     public void AssertionPrinter_DefaultSingleStage_TreatsViolationAsUnsound()
     {
         var function = Function(

--- a/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
+++ b/src/ILInspector.Decompiler.Tests/AssertionScanTests.cs
@@ -320,6 +320,24 @@ public class AssertionScanTests
     }
 
     [Fact]
+    public void AssertionPrinter_RejectsReuseAcrossFunctions()
+    {
+        var printer = new AssertionPrinter.StatefulPrinter(totalStages: 3);
+        var first = Function(
+            Returning(new LoadArgument(0, "raw", Int32)),
+            Enum32,
+            new Parameter("raw", Int32));
+        var second = Function(
+            Returning(new LoadArgument(0, "raw", Int32)),
+            Enum32,
+            new Parameter("raw", Int32));
+
+        printer.Dump(first);
+
+        Assert.Throws<InvalidOperationException>(() => printer.Dump(second));
+    }
+
+    [Fact]
     public void AssertionPrinter_DefaultSingleStage_TreatsViolationAsUnsound()
     {
         var function = Function(

--- a/tools/DecompilerHarness/AssertionPrinter.cs
+++ b/tools/DecompilerHarness/AssertionPrinter.cs
@@ -20,6 +20,8 @@ public static class AssertionPrinter
     public sealed class StatefulPrinter
     {
         readonly int _finalStage;
+        readonly IReadOnlyDictionary<string, string> _dischargePassByStageIdentity;
+        readonly Dictionary<string, Dictionary<IrNode, int>> _occurrenceOrdinals = new(StringComparer.Ordinal);
         int _stage;
         bool _firstUnsoundFlagged;
 
@@ -30,8 +32,19 @@ public static class AssertionPrinter
         /// <c>UNSOUND</c> rather than an <c>OBLIGATION</c>. Defaults to 1 (every
         /// stage treated as final) for single-stage callers.
         /// </param>
-        public StatefulPrinter(int totalStages = 1)
-            => _finalStage = totalStages;
+        /// <param name="dischargePassByStageIdentity">
+        /// Optional precomputed map from pass-independent assertion identity to
+        /// the pass that discharged it. When provided, non-final obligations can
+        /// name their observed discharger instead of forcing readers to infer it
+        /// from later stages.
+        /// </param>
+        public StatefulPrinter(
+            int totalStages = 1,
+            IReadOnlyDictionary<string, string>? dischargePassByStageIdentity = null)
+        {
+            _finalStage = totalStages;
+            _dischargePassByStageIdentity = dischargePassByStageIdentity ?? new Dictionary<string, string>(StringComparer.Ordinal);
+        }
 
         public string Dump(IrFunction function)
         {
@@ -40,7 +53,14 @@ public static class AssertionPrinter
             var sb = new StringBuilder();
 
             var allViolations = AssertionEvaluator.EvaluateAssumptions(function)
-                .SelectMany(r => r.Violations)
+                .SelectMany(predicate => predicate.Violations.Select(violation =>
+                {
+                    string node = violation.Node.GetType().Name;
+                    string sinkType = AssertionScan.SinkType(violation.Message);
+                    string identity = $"{predicate.Name}|{node}|{sinkType}|{violation.Message}";
+                    int ordinal = OccurrenceOrdinal(identity, violation.Node);
+                    return new AssertionMarker(violation.Node, violation.Message, $"{identity}#{ordinal}");
+                }))
                 .ToList();
             var unannotated = InverseLedger.Unannotated(typeof(IrFunction).Assembly).ToHashSet(StringComparer.Ordinal);
 
@@ -68,7 +88,7 @@ public static class AssertionPrinter
 
                 // Match violation by exact reference identity, not a lossy substring of Describe()
                 var related = allViolations.FirstOrDefault(v => ReferenceEquals(v.Node, node));
-                if (related.Node != null)
+                if (related is not null)
                 {
                     if (isFinalStage)
                     {
@@ -82,7 +102,11 @@ public static class AssertionPrinter
                     {
                         // Stage-relative: a downstream pass is contracted to
                         // discharge this typing obligation before the final stage.
-                        sb.Append(' ', indent * 2).AppendLine($"// OBLIGATION (informational): {related.Message}");
+                        string suffix = _dischargePassByStageIdentity.TryGetValue(related.StageIdentity, out var discharger)
+                            && discharger.Length > 0
+                            ? $"; discharged by {discharger}"
+                            : "";
+                        sb.Append(' ', indent * 2).AppendLine($"// OBLIGATION (informational{suffix}): {related.Message}");
                     }
                 }
 
@@ -97,5 +121,18 @@ public static class AssertionPrinter
             sb.AppendLine($"// fidelity: {function.Fidelity}");
             return sb.ToString();
         }
+
+        int OccurrenceOrdinal(string identity, IrNode node)
+        {
+            if (!_occurrenceOrdinals.TryGetValue(identity, out var byNode))
+                _occurrenceOrdinals[identity] = byNode = new Dictionary<IrNode, int>(ReferenceEqualityComparer.Instance);
+            if (byNode.TryGetValue(node, out int ordinal))
+                return ordinal;
+            ordinal = byNode.Count;
+            byNode.Add(node, ordinal);
+            return ordinal;
+        }
+
+        sealed record AssertionMarker(IrNode Node, string Message, string StageIdentity);
     }
 }

--- a/tools/DecompilerHarness/AssertionPrinter.cs
+++ b/tools/DecompilerHarness/AssertionPrinter.cs
@@ -22,6 +22,7 @@ public static class AssertionPrinter
         readonly int _finalStage;
         readonly IReadOnlyDictionary<string, string> _dischargePassByStageIdentity;
         readonly Dictionary<string, Dictionary<IrNode, int>> _occurrenceOrdinals = new(StringComparer.Ordinal);
+        IrFunction? _function;
         int _stage;
         bool _firstUnsoundFlagged;
 
@@ -48,6 +49,11 @@ public static class AssertionPrinter
 
         public string Dump(IrFunction function)
         {
+            if (_function is null)
+                _function = function;
+            else if (!ReferenceEquals(_function, function))
+                throw new InvalidOperationException("AssertionPrinter.StatefulPrinter is single-method; create a new instance for each IrFunction.");
+
             _stage++;
             bool isFinalStage = _stage >= _finalStage;
             var sb = new StringBuilder();

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -1001,8 +1001,24 @@ static class Program
             if (function is null)
                 continue;
 
+            var dischargePassByStageIdentity = new Dictionary<string, string>(StringComparer.Ordinal);
+            if (IrImporter.Import(source, typeName, methodName, overloadIndex) is { } functionForHints)
+            {
+                var assertionSummary = AssertionScan.EvaluateFunction(
+                    source.AssemblyName,
+                    assemblyPath,
+                    typeName,
+                    methodName,
+                    overloadIndex,
+                    functionForHints,
+                    ImportSeam(source));
+                foreach (var violation in assertionSummary.Violations)
+                    if (!violation.FinalStageSurvivor && violation.DischargePass.Length > 0)
+                        dischargePassByStageIdentity[violation.StageIdentity] = violation.DischargePass;
+            }
+
             Console.WriteLine($"// {dumpMethod} in {Path.GetFileName(assemblyPath)} (pipeline: next, assertions)");
-            var printer = new AssertionPrinter.StatefulPrinter(IrPasses.Default.Length + 1);
+            var printer = new AssertionPrinter.StatefulPrinter(IrPasses.Default.Length + 1, dischargePassByStageIdentity);
             var stages = IrPasses.RunWithStages(function, IrPasses.Default, printer.Dump, ImportSeam(source));
             Console.Write(StageDump.Format(stages));
             return 0;

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -63,11 +63,14 @@ for the assertion-dump discipline.
 observed. At a non-final stage it prints `OBLIGATION (informational)` — the
 rewrite accrued a typing claim a downstream pass is contracted to discharge (e.g.
 coercion insertion wrapping the sink), so a mid-pipeline marker is bookkeeping,
-not a defect. Only an assertion that survives to the **final** stage prints
-`❌ UNSOUND (error)` (the first one flagged `FIRST UNSOUND SURVIVOR`): nothing
-downstream remains to discharge it, so the rendered output leans on an unproven
-claim. "Final stage is zero UNSOUND" is the real soundness statement; the
-intermediate obligations are the pipeline working as designed.
+not a defect. When the dump can match the obligation to the scan's observed
+lifetime, the marker names the discharging pass, e.g.
+`OBLIGATION (informational; discharged by coercion-insertion)`. Only an assertion
+that survives to the **final** stage prints `❌ UNSOUND (error)` (the first one
+flagged `FIRST UNSOUND SURVIVOR`): nothing downstream remains to discharge it,
+so the rendered output leans on an unproven claim. "Final stage is zero UNSOUND"
+is the real soundness statement; the intermediate obligations are the pipeline
+working as designed.
 
 Add `--assertion-fixture-guarantee` to materialize the generated inverse-node
 fixture assembly and include it in annotation coverage. The report prints a


### PR DESCRIPTION
## Summary

Finishes the concrete #2269 "name the discharging pass where known" gap for the local assertion dump. `--assertions` now precomputes the same assertion lifetime data used by `--assertion-scan`, passes discharge hints into `AssertionPrinter.StatefulPrinter`, and renders intermediate markers such as:

```text
OBLIGATION (informational; discharged by coercion-insertion)
```

Final-stage survivors still render as `UNSOUND (error)`; this only enriches non-final obligation bookkeeping so readers no longer have to infer the discharger from later stages. `StatefulPrinter` is also now explicitly single-method so assertion ordinals and first-survivor state cannot leak across reused instances.

## Evidence

- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/AssertionScanTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `npx markdownlint-cli tools/DecompilerHarness/README.md docs/design/assertion-lane-effects.md`
- Smoke: generated `assertion.inverse-node-coverage` fixture `CoercedEnum` dump shows `OBLIGATION (informational; discharged by coercion-insertion)` and no `UNSOUND` in intermediate lines.

## Scope

Harness/test/docs only; no product decompiler path changes. The remaining #2269 design step is the stronger per-pass effect-signature contract; this PR just names the observed discharger in local dumps.

## Review

Two-model adversarial review complete: Gemini found one lifecycle issue, fixed by `62fdb124`; MAI found no blocking issues. Reconciliation is posted in the PR comments.
