### PR TITLE
Add gated C# diff harness CI smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-26.04
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      csharpdiff: ${{ steps.filter.outputs.csharpdiff }}
       docs: ${{ steps.filter.outputs.docs }}
       ildiff: ${{ steps.filter.outputs.ildiff }}
       ilroundtrip: ${{ steps.filter.outputs.ilroundtrip }}
@@ -48,6 +49,7 @@ jobs:
             FILES=$(git diff --name-only "$BEFORE"..."${{ github.sha }}")
           fi
           CODE=false
+          CSHARPDIFF=false
           DOCS=false
           ILDIFF=false
           ILROUNDTRIP=false
@@ -63,6 +65,20 @@ jobs:
               eng/prepare-decompiler-pr-corpus.sh) CODE=true ;;
               *.props|*.targets|*.sln|*.slnx) CODE=true ;;
               .github/workflows/*) CODE=true ;;
+            esac
+            # C# Diff smoke coverage is separate from the full test lane for the
+            # same reason as IL Diff: CSharpDiffHarness-only changes get a
+            # focused card/snapshot smoke instead of the entire test suite.
+            case "$file" in
+              tools/CSharpDiffHarness/*) CSHARPDIFF=true ;;
+              src/ILInspector.Decompiler/*) CSHARPDIFF=true ;;
+              src/ILInspector.Instructions/*) CSHARPDIFF=true ;;
+              src/ILInspector.ControlFlow/*) CSHARPDIFF=true ;;
+              src/DiffFixtures.V1/*) CSHARPDIFF=true ;;
+              src/DiffFixtures.V2/*) CSHARPDIFF=true ;;
+              Directory.Packages.props) CSHARPDIFF=true ;;
+              *.props|*.targets|*.slnx) CSHARPDIFF=true ;;
+              .github/workflows/ci.yml) CSHARPDIFF=true ;;
             esac
             # IL Diff smoke coverage is intentionally separate from the full
             # test lane: most PRs skip it, and IlDiffHarness-only changes get a
@@ -111,13 +127,14 @@ jobs:
             esac
           done <<< "$FILES"
           echo "code=$CODE" >> "$GITHUB_OUTPUT"
+          echo "csharpdiff=$CSHARPDIFF" >> "$GITHUB_OUTPUT"
           echo "docs=$DOCS" >> "$GITHUB_OUTPUT"
           echo "ildiff=$ILDIFF" >> "$GITHUB_OUTPUT"
           echo "ilroundtrip=$ILROUNDTRIP" >> "$GITHUB_OUTPUT"
           echo "packaging=$PACKAGING" >> "$GITHUB_OUTPUT"
           echo "Changed files:"
           echo "$FILES"
-          echo "code=$CODE docs=$DOCS ildiff=$ILDIFF ilroundtrip=$ILROUNDTRIP packaging=$PACKAGING"
+          echo "code=$CODE csharpdiff=$CSHARPDIFF docs=$DOCS ildiff=$ILDIFF ilroundtrip=$ILROUNDTRIP packaging=$PACKAGING"
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -277,6 +294,107 @@ jobs:
       - name: Run IL round-trip tests
         if: matrix.rid == 'linux-x64' && needs.changes.outputs.ilroundtrip == 'true'
         run: dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
+
+  # Cheap C# Diff harness coverage. Path-gated separately from the full test
+  # lane so CSharpDiffHarness/card changes get focused snapshot/baseline JSONL
+  # coverage without forcing most PRs through extra work.
+  csharp-diff-smoke:
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.csharpdiff == 'true'
+    runs-on: ubuntu-26.04
+    env:
+      DOTNET_INSPECT_TIPS: q
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/*.slnx') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Build C# Diff harness and fixtures
+        run: |
+          dotnet build tools/CSharpDiffHarness/CSharpDiffHarness.csproj -c Release
+          dotnet build src/DiffFixtures.V1/DiffFixtures.V1.csproj -c Release
+          dotnet build src/DiffFixtures.V2/DiffFixtures.V2.csproj -c Release
+
+      - name: Run C# Diff baseline smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/csharp-diff-smoke
+          old=artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll
+          new=artifacts/bin/DiffFixtures.V2/release/DiffFixtureSample.dll
+
+          dotnet run --project tools/CSharpDiffHarness -c Release --no-build -- \
+            "$old" "$new" \
+            --emit-snapshot artifacts/csharp-diff-smoke/snapshot.json \
+            --format jsonl \
+            --max-examples 0 \
+            > artifacts/csharp-diff-smoke/snapshot.jsonl
+
+          dotnet run --project tools/CSharpDiffHarness -c Release --no-build -- \
+            "$old" "$new" \
+            --diff-baseline artifacts/csharp-diff-smoke/snapshot.json \
+            --format jsonl \
+            --max-examples 0 \
+            > artifacts/csharp-diff-smoke/exact.jsonl
+
+          cat > /tmp/csharp-diff-mutate-baseline.cs <<'CS'
+          using System.Text.Json.Nodes;
+          var node = JsonNode.Parse(File.ReadAllText(args[0]))!.AsObject();
+          node["Summary"]!["FailureCount"] = 0;
+          node["FailureBuckets"] = new JsonArray();
+          File.WriteAllText(args[1], node.ToJsonString(new System.Text.Json.JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine);
+          CS
+          dotnet run /tmp/csharp-diff-mutate-baseline.cs -- \
+            artifacts/csharp-diff-smoke/snapshot.json \
+            artifacts/csharp-diff-smoke/regression-baseline.json
+
+          set +e
+          dotnet run --project tools/CSharpDiffHarness -c Release --no-build -- \
+            "$old" "$new" \
+            --diff-baseline artifacts/csharp-diff-smoke/regression-baseline.json \
+            --format jsonl \
+            --max-examples 0 \
+            > artifacts/csharp-diff-smoke/regression.jsonl
+          status=$?
+          set -e
+          test "$status" -eq 1
+
+          cat > /tmp/csharp-diff-parse-jsonl.cs <<'CS'
+          using System.Text.Json;
+          foreach (var path in args)
+          {
+              foreach (var line in File.ReadLines(path))
+              {
+                  if (string.IsNullOrWhiteSpace(line))
+                      continue;
+                  JsonDocument.Parse(line).Dispose();
+              }
+          }
+          CS
+          dotnet run /tmp/csharp-diff-parse-jsonl.cs -- \
+            artifacts/csharp-diff-smoke/snapshot.jsonl \
+            artifacts/csharp-diff-smoke/exact.jsonl \
+            artifacts/csharp-diff-smoke/regression.jsonl
+
+      - name: Upload C# Diff smoke artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: csharp-diff-smoke
+          path: artifacts/csharp-diff-smoke/
+          if-no-files-found: warn
 
   # Cheap IL Diff harness coverage. It is path-gated separately from the full
   # test lane so most PRs do no more than their existing build/test work, while


### PR DESCRIPTION
## Summary

- add a `csharpdiff` changes filter to CI
- add a separate path-gated `csharp-diff-smoke` job for C# Diff-specific changes
- build only CSharpDiffHarness plus DiffFixtures V1/V2 in that job
- smoke snapshot JSONL, exact baseline JSONL, synthesized regression baseline exit 1, and JSONL parseability

The smoke job is separate from the full test lane so most PRs do not pay for it, and CSharpDiffHarness-only changes get targeted coverage instead of requiring the whole test suite.

## Validation

Ran the same commands locally with repo `nuget.config`:

- `dotnet build tools/CSharpDiffHarness/CSharpDiffHarness.csproj -c Release --configfile nuget.config`
- `dotnet build src/DiffFixtures.V1/DiffFixtures.V1.csproj -c Release --configfile nuget.config`
- `dotnet build src/DiffFixtures.V2/DiffFixtures.V2.csproj -c Release --configfile nuget.config`
- `dotnet run --project tools/CSharpDiffHarness -c Release --no-build -- <V1.dll> <V2.dll> --emit-snapshot /tmp/csharp-diff-smoke/snapshot.json --format jsonl --max-examples 0`
- `dotnet run --project tools/CSharpDiffHarness -c Release --no-build -- <V1.dll> <V2.dll> --diff-baseline /tmp/csharp-diff-smoke/snapshot.json --format jsonl --max-examples 0`
- synthesized regression baseline with failure count reset and failure buckets cleared; `--diff-baseline` returned exit 1
- parsed snapshot, exact, and regression JSONL outputs with `System.Text.Json`