### PR TITLE
Seed precise nested RTS member requirements

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -875,6 +875,75 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_EmitsOuterRequirementForNestedMethodTarget()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public int GetOuterValue() => 42;
+
+                public class Inner
+                {
+                    public int FromOuter() => new Class1().GetOuterValue();
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1.Inner", "FromOuter", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            var root = Assert.Single(result.Plan.Types);
+            Assert.Contains(root.Members, member => member.Name == "GetOuterValue"
+                && member.SourceFacts.Any(fact => fact.Id == "typed-closure-method" && fact.Detail == "GetOuterValue"));
+            var inner = Assert.Single(root.NestedTypes);
+            Assert.Contains(inner.Members, member => member.Name == "FromOuter"
+                && member.SourceFacts.Any(fact => fact.Id == "target-method"));
+            Assert.Contains("public int GetOuterValue()", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackTargets_EmitsNestedRequirementForTopLevelMethodTarget()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public class Inner
+                {
+                    public static int GetValue() => 42;
+                }
+
+                public int FromNested() => Inner.GetValue();
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "FromNested", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            var root = Assert.Single(result.Plan.Types);
+            Assert.Contains(root.NestedTypes, nested =>
+                nested.Name == "Inner"
+                && nested.Members.Any(member => member.Name == "GetValue"
+                    && member.SourceFacts.Any(fact => fact.Id == "typed-closure-method" && fact.Detail == "GetValue")));
+            Assert.Contains("public static int GetValue()", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_DoesNotSurfaceOuterMembersForTypeOnlyNestedClosure()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -802,6 +802,79 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackFirstPropertyGetter_EmitsNestedClosureMemberRequirement()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Outer
+            {
+                internal static int Leak() => 13;
+
+                public class Inner
+                {
+                    public static int GetValue() => 42;
+                }
+            }
+
+            public class Class1
+            {
+                public int FromNested => Outer.Inner.GetValue();
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            Assert.Contains(result.Plan.Types, type =>
+                type.Name == "Outer"
+                && !type.Members.Any(member => member.Name == "Leak")
+                && type.NestedTypes.Any(nested =>
+                    nested.Name == "Inner"
+                    && nested.Members.Any(member => member.Name == "GetValue"
+                        && member.SourceFacts.Any(fact => fact.Id == "typed-closure-method" && fact.Detail == "GetValue"))));
+            Assert.Contains("public static int GetValue()", result.Source);
+            Assert.DoesNotContain("Leak", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
+    public void CompileBackFirstPropertyGetter_EmitsTargetNestedMemberRequirement()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public class Inner
+                {
+                    public static int GetValue() => 42;
+                }
+
+                public int FromNested => Inner.GetValue();
+            }
+            """);
+        try
+        {
+            var result = ReturnToSender.CompileBackFirstPropertyGetter(assemblyPath);
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            var type = Assert.Single(result.Plan.Types);
+            Assert.Contains(type.NestedTypes, nested =>
+                nested.Name == "Inner"
+                && nested.Members.Any(member => member.Name == "GetValue"
+                    && member.SourceFacts.Any(fact => fact.Id == "typed-closure-method" && fact.Detail == "GetValue")));
+            Assert.DoesNotContain(type.SourceFacts, fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+            Assert.Contains("public static int GetValue()", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_DoesNotSurfaceOuterMembersForTypeOnlyNestedClosure()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -1061,6 +1061,38 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_EmitsNestedTargetMemberRequirement()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public class Inner
+                {
+                    public int FromSibling() => GetValue();
+                    public int GetValue() => 42;
+                }
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1.Inner", "FromSibling", 0)]));
+
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+            var inner = Assert.Single(Assert.Single(result.Plan.Types).NestedTypes);
+            Assert.Contains(inner.Members, member => member.Name == "GetValue"
+                && member.SourceFacts.Any(fact => fact.Id == "typed-closure-method" && fact.Detail == "GetValue"));
+            Assert.DoesNotContain(inner.SourceFacts, fact => fact.Producer == "roslyn" && fact.Id == "closure-member");
+            Assert.Contains("public int GetValue()", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackTargets_RoundTripsConstructorAssigningGetOnlyAutoProperty()
     {
         var assemblyPath = CompileFixture("""

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -363,27 +363,14 @@ public static class CompileBackSourceComposer
                 PrimaryConstructor: null,
                 targetFacts)
         };
+        AddClosureTypeRequirements(requirements, reader, targetRoot, closureFacts, closureMemberRequirements);
 
         foreach (var dependency in closureRoots.OrderBy(handle => MetadataTokens.GetToken(handle)))
         {
             if (dependency == targetRoot)
                 continue;
 
-            var dependencyDef = reader.GetTypeDefinition(dependency);
-            var dependencyIdentity = CompileBackTypeIdentity.FromDefinition(reader, dependencyDef);
-            if (requirements.Any(requirement => requirement.Type.MetadataFullName == dependencyIdentity.MetadataFullName))
-                continue;
-
-            requirements.Add(new CompileBackTypeRequirement(
-                dependencyIdentity,
-                ShellKind(reader, dependencyDef),
-                RequiredMembers: closureMemberRequirements.TryGetValue(dependency, out var requiredMembers)
-                    ? requiredMembers.ToArray()
-                    : [],
-                PrimaryConstructor: null,
-                SourceFacts: closureFacts.TryGetValue(dependency, out var facts)
-                    ? facts.ToArray()
-                    : [new CompileBackFact("closure", "closure-root", dependencyIdentity.FullName)]));
+            AddClosureTypeRequirements(requirements, reader, dependency, closureFacts, closureMemberRequirements);
         }
 
         var declarations = TypeProducer.Produce(reader, requirements, diagnostics);
@@ -417,6 +404,43 @@ public static class CompileBackSourceComposer
         foreach (var required in requiredMembers)
             if (!members.Any(existing => existing.Kind == required.Kind && existing.Identity == required.Identity))
                 members.Add(required);
+    }
+
+    static void AddClosureTypeRequirements(
+        List<CompileBackTypeRequirement> requirements,
+        MetadataReader reader,
+        TypeDefinitionHandle root,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackFact>> closureFacts,
+        IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
+    {
+        AddClosureTypeRequirement(root);
+        foreach (var handle in closureMemberRequirements.Keys
+            .Where(handle => handle != root && TopLevelRootOf(reader, handle) == root)
+            .OrderBy(handle => MetadataTokens.GetToken(handle)))
+        {
+            AddClosureTypeRequirement(handle);
+        }
+
+        void AddClosureTypeRequirement(TypeDefinitionHandle handle)
+        {
+            var typeDef = reader.GetTypeDefinition(handle);
+            var identity = CompileBackTypeIdentity.FromDefinition(reader, typeDef);
+            if (requirements.Any(requirement => requirement.Type.MetadataFullName == identity.MetadataFullName))
+                return;
+
+            requirements.Add(new CompileBackTypeRequirement(
+                identity,
+                ShellKind(reader, typeDef),
+                RequiredMembers: closureMemberRequirements.TryGetValue(handle, out var requiredMembers)
+                    ? requiredMembers.ToArray()
+                    : [],
+                PrimaryConstructor: null,
+                SourceFacts: closureFacts.TryGetValue(handle, out var facts)
+                    ? facts.ToArray()
+                    : handle == root
+                        ? [new CompileBackFact("closure", "closure-root", identity.FullName)]
+                        : [new CompileBackFact("metadata", "nested-closure-member-owner", identity.FullName)]));
+        }
     }
 
     public static CompileBackSourceResult ComposePropertySetter(
@@ -488,27 +512,14 @@ public static class CompileBackSourceComposer
                 PrimaryConstructor: null,
                 targetFacts)
         };
+        AddClosureTypeRequirements(requirements, reader, targetRoot, closureFacts, closureMemberRequirements);
 
         foreach (var dependency in closureRoots.OrderBy(handle => MetadataTokens.GetToken(handle)))
         {
             if (dependency == targetRoot)
                 continue;
 
-            var dependencyDef = reader.GetTypeDefinition(dependency);
-            var dependencyIdentity = CompileBackTypeIdentity.FromDefinition(reader, dependencyDef);
-            if (requirements.Any(requirement => requirement.Type.MetadataFullName == dependencyIdentity.MetadataFullName))
-                continue;
-
-            requirements.Add(new CompileBackTypeRequirement(
-                dependencyIdentity,
-                ShellKind(reader, dependencyDef),
-                RequiredMembers: closureMemberRequirements.TryGetValue(dependency, out var requiredMembers)
-                    ? requiredMembers.ToArray()
-                    : [],
-                PrimaryConstructor: null,
-                SourceFacts: closureFacts.TryGetValue(dependency, out var facts)
-                    ? facts.ToArray()
-                    : [new CompileBackFact("closure", "closure-root", dependencyIdentity.FullName)]));
+            AddClosureTypeRequirements(requirements, reader, dependency, closureFacts, closureMemberRequirements);
         }
 
         var declarations = TypeProducer.Produce(reader, requirements, diagnostics);
@@ -613,21 +624,7 @@ public static class CompileBackSourceComposer
             if (dependency == targetRoot)
                 continue;
 
-            var dependencyDef = reader.GetTypeDefinition(dependency);
-            var dependencyIdentity = CompileBackTypeIdentity.FromDefinition(reader, dependencyDef);
-            if (requirements.Any(requirement => requirement.Type.MetadataFullName == dependencyIdentity.MetadataFullName))
-                continue;
-
-            requirements.Add(new CompileBackTypeRequirement(
-                dependencyIdentity,
-                ShellKind(reader, dependencyDef),
-                RequiredMembers: closureMemberRequirements.TryGetValue(dependency, out var requiredMembers)
-                    ? requiredMembers.ToArray()
-                    : [],
-                PrimaryConstructor: null,
-                SourceFacts: closureFacts.TryGetValue(dependency, out var facts)
-                    ? facts.ToArray()
-                    : [new CompileBackFact("closure", "closure-root", dependencyIdentity.FullName)]));
+            AddClosureTypeRequirements(requirements, reader, dependency, closureFacts, closureMemberRequirements);
         }
 
         var declarations = TypeProducer.Produce(reader, requirements, diagnostics);

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -352,7 +352,7 @@ public static class CompileBackSourceComposer
                 propertyDeclaration.Attributes,
                 MetadataDeclarationQuery.GetMethod(reader, targetTypeDef, getter, getterSignature).Signature.ReturnAttributes)
         };
-        AddRequiredMembers(targetMembers, closureMemberRequirements, targetRoot);
+        AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
         var requirements = new List<CompileBackTypeRequirement>
         {
@@ -402,9 +402,15 @@ public static class CompileBackSourceComposer
         if (!requirementsByRoot.TryGetValue(root, out var requiredMembers))
             return;
         foreach (var required in requiredMembers)
-            if (!members.Any(existing => existing.Kind == required.Kind && existing.Identity == required.Identity))
+            if (!members.Any(existing => SameMemberDeclaration(existing, required)))
                 members.Add(required);
     }
+
+    static bool SameMemberDeclaration(CompileBackMemberRequirement left, CompileBackMemberRequirement right)
+        => left.Kind == right.Kind
+            && left.Identity.Type == right.Identity.Type
+            && left.Identity.Method == right.Identity.Method
+            && left.Identity.Signature == right.Identity.Signature;
 
     static void AddClosureTypeRequirements(
         List<CompileBackTypeRequirement> requirements,
@@ -501,7 +507,7 @@ public static class CompileBackSourceComposer
                     ]
                     : [new CompileBackFact("metadata", "target-property-setter", reader.GetString(setter.Name))])
         };
-        AddRequiredMembers(targetMembers, closureMemberRequirements, targetRoot);
+        AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
         var requirements = new List<CompileBackTypeRequirement>
         {
@@ -608,6 +614,8 @@ public static class CompileBackSourceComposer
         {
             targetMembers.Add(typedEqualsSibling);
         }
+        if (!targetTypeDef.GetDeclaringType().IsNil)
+            AddRequiredMembers(targetMembers, closureMemberRequirements, targetType);
 
         var requirements = new List<CompileBackTypeRequirement>
         {

--- a/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
+++ b/src/ILInspector.Decompiler/CompileBackSourceComposer.cs
@@ -420,8 +420,9 @@ public static class CompileBackSourceComposer
         IReadOnlyDictionary<TypeDefinitionHandle, List<CompileBackMemberRequirement>> closureMemberRequirements)
     {
         AddClosureTypeRequirement(root);
-        foreach (var handle in closureMemberRequirements.Keys
+        foreach (var handle in closureMemberRequirements.Keys.Concat(closureFacts.Keys)
             .Where(handle => handle != root && TopLevelRootOf(reader, handle) == root)
+            .Distinct()
             .OrderBy(handle => MetadataTokens.GetToken(handle)))
         {
             AddClosureTypeRequirement(handle);
@@ -626,6 +627,7 @@ public static class CompileBackSourceComposer
                 primaryConstructor,
                 targetFacts)
         };
+        AddClosureTypeRequirements(requirements, reader, targetRoot, closureFacts, closureMemberRequirements);
 
         foreach (var dependency in closureRoots.OrderBy(handle => MetadataTokens.GetToken(handle)))
         {

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1466,11 +1466,11 @@ static class ReturnToSender
             if (TryResolveHandle(definition) is not { } handle)
                 return;
             var root = TopLevelRootOf(reader, handle);
-            if (root == targetRoot || root != handle)
+            if (root == targetRoot && handle == root)
                 return;
             AddClosureFact(
                 closureFacts,
-                root,
+                handle,
                 new CompileBackFact("metadata", "typed-member-ref", $"{kind}: {TypeRefIdentityKey(definition.Namespace, definition.Name, separator: ".")}.{name}"));
         }
 
@@ -1502,14 +1502,12 @@ static class ReturnToSender
             if (TryResolveHandle(definition) is not { } handle)
                 return;
             var root = TopLevelRootOf(reader, handle);
-            if (root == targetRoot && !allowTargetRoot)
-                return;
-            if (root != handle)
+            if (root == targetRoot && handle == root && !allowTargetRoot)
                 return;
             if (create(handle) is not { } requirement)
                 return;
-            if (!closureMemberRequirements.TryGetValue(root, out var requirements))
-                closureMemberRequirements[root] = requirements = [];
+            if (!closureMemberRequirements.TryGetValue(handle, out var requirements))
+                closureMemberRequirements[handle] = requirements = [];
             if (!requirements.Any(existing => existing.Kind == requirement.Kind && existing.Identity == requirement.Identity))
                 requirements.Add(requirement);
         }


### PR DESCRIPTION
## Summary

- propagate precise closure member requirements keyed by nested type handles into nested compile-back shells
- allow ReturnToSender to seed exact nested same-assembly member requirements without broad outer member surface emission
- add closure-nested and target-nested canaries proving exact `GetValue` emission while outer `Leak` members stay absent

This keeps top-level target-root broadening constrained while allowing the nested declaring type itself to own exact requirements.

## Validation

- `dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderEvidenceTests/*"`
- `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal.property.literal --max-examples 3`

Adversarial review requested separately.