### PR TITLE
Refresh analysis corpus baseline

### DIFF
--- a/tools/AnalysisHarness/corpus/analysis-baseline.json
+++ b/tools/AnalysisHarness/corpus/analysis-baseline.json
@@ -9,6 +9,7 @@
       "Allocations": 89,
       "ExceptionConstructions": 5,
       "Shapes": {
+        "async-state-machine": 1,
         "box-value-type": 1,
         "capturing-delegate": 2
       }
@@ -73,6 +74,7 @@
         "enumerator-allocation": 77,
         "instance-method-group-delegate": 29,
         "linq-scan-in-loop": 53,
+        "materialize-in-loop": 3,
         "scan-method-in-loop-call": 45,
         "small-array": 97,
         "string-build-in-loop": 3
@@ -158,7 +160,7 @@
       "Shapes": {
         "box-value-type": 285,
         "capturing-delegate": 116,
-        "enumerator-allocation": 22,
+        "enumerator-allocation": 21,
         "instance-method-group-delegate": 97,
         "linq-scan-in-loop": 3,
         "scan-method-in-loop-call": 1,


### PR DESCRIPTION
## Summary

Refreshes `tools/AnalysisHarness/corpus/analysis-baseline.json` after reviewing current AnalysisHarness corpus drift. The prior baseline reported 0 regressions, 3 drift, and 0 added/removed; this update accepts the drift as current analyzer behavior rather than masking a regression.

Accepted drift:
- `DotnetInspector.Core.dll`: `async-state-machine` 0 -> 1 (`Downloader.GetAsyncEnumerator`, low confidence, not in loop).
- `ILInspector.Decompiler.dll`: `materialize-in-loop` 0 -> 3 (`IrImporter.PropagateAndSpill` x2, `SwitchRaisingPass.GrowRegion` x1).
- `Microsoft.CodeAnalysis.dll`: `enumerator-allocation` 22 -> 21; one old row dropped: `Microsoft.CodeAnalysis.Debugging.CustomDebugInfoReader.GetCSharpGroupedImportStrings`.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-restore` — 392/392 pass
- `dotnet run --project tools/AnalysisHarness -c Release --no-restore -- --generated-fixtures` — 11 fixtures, 22 targets pass
- `dotnet run --project tools/AnalysisHarness -c Release --no-restore -- --paydirt-recall artifacts/bin/ILInspector.Decompiler/release/ILInspector.Decompiler.dll --reference tools/AnalysisHarness/corpus/paydirt-reference.json` — 3/3 present
- `dotnet run --project tools/AnalysisHarness -c Release --no-restore -- --corpus-list /tmp/analysis-corpus-assemblies.txt --diff-corpus-baseline tools/AnalysisHarness/corpus/analysis-baseline.json --emit-corpus-snapshot /tmp/analysis-current-snapshot-rebased.json` — 0 regressions, 0 drift, 0 added/removed

## Adversarial review

Two isolated-worktree reviews found no blockers.

- Gemini 3.1 Pro verified the harness flow in `/tmp/review-analysis-baseline-gemini`, reproduced `0 regression(s), 0 drift, 0 added/removed`, and confirmed the emitted snapshot matched the committed baseline.
- MAI-Code-1-Flash reviewed `/tmp/review-analysis-baseline-mai`, classified the movement as accepted drift from recent analyzer behavior changes, and found the JSON shape/order consistent with the baseline schema.

No follow-up commit was needed because neither review produced an actionable finding.