### PR TITLE
Close row 6 unsafe pointer gaps

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
@@ -3,6 +3,30 @@ namespace ILInspector.Decompiler.Fixtures.LegacyUnsafe;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+public static class StringPinningResiduals
+{
+    public static unsafe int FixedStringFirstChar(string value)
+    {
+        fixed (char* p = value)
+            return p[0];
+    }
+}
+
+public static class StackallocInitializerResiduals
+{
+    public static unsafe int StackallocPointerInitializer()
+    {
+        int* values = stackalloc int[] { 1, 2, 3 };
+        return values[0] + values[2];
+    }
+
+    public static int StackallocSpanInitializer()
+    {
+        Span<int> values = stackalloc[] { 1, 2, 3 };
+        return values[0] + values[2];
+    }
+}
+
 /// <summary>
 /// Legacy-rules unsafe fixtures. Each method uses the member <c>unsafe</c>
 /// modifier, which under pre-memory-safety semantics makes the whole body an

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
@@ -3,6 +3,38 @@ namespace ILInspector.Decompiler.Fixtures.NewUnsafe;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+public static class StringPinningResiduals
+{
+    public static int FixedStringFirstChar(string value)
+    {
+        fixed (char* p = value)
+        {
+            unsafe
+            {
+                return p[0];
+            }
+        }
+    }
+}
+
+public static class StackallocInitializerResiduals
+{
+    public static int StackallocPointerInitializer()
+    {
+        int* values = stackalloc int[] { 1, 2, 3 };
+        unsafe
+        {
+            return values[0] + values[2];
+        }
+    }
+
+    public static int StackallocSpanInitializer()
+    {
+        Span<int> values = stackalloc[] { 1, 2, 3 };
+        return values[0] + values[2];
+    }
+}
+
 /// <summary>
 /// New-rules unsafe fixtures. This assembly is compiled with
 /// <c>/features:updated-memory-safety-rules</c>, so the compiler enforces the

--- a/src/ILInspector.Decompiler.Tests/FixedBufferSkeletonFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/FixedBufferSkeletonFixture.cs
@@ -5,4 +5,6 @@ public unsafe struct FixedBufferSkeletonFixture
     public fixed byte Buffer[16];
 
     public int Value() => 42;
+
+    public int SumFirstTwo() => Buffer[0] + Buffer[1];
 }

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -175,6 +175,9 @@ public class LadderRung6GateTests
         var pointPointer = TypeRef.Pointer(point);
         var fieldX = new FieldRef(point, "X", Int32);
         var fieldY = new FieldRef(point, "Y", Int32);
+        var backingField = new FieldRef(point, "<Value>k__BackingField", Int32) { BackingPropertyName = "Value" };
+        var captureField = new FieldRef(point, "<seed>P", Int32);
+        var getter = new MethodRef(point, "get_Total", Int32, [], HasThis: true);
         var p = new LoadArgument(0, "p", pointPointer);
         var body = CSharpPrinter.Print(Function(
             "ReadPointerField",
@@ -190,17 +193,26 @@ public class LadderRung6GateTests
                     isUnsigned: false,
                     new LoadField(fieldX, (IrExpression)p.Clone()),
                     new LoadField(fieldY, (IrExpression)p.Clone()))),
+            new ExpressionStatement(new LoadField(backingField, (IrExpression)p.Clone())),
+            new ExpressionStatement(new LoadField(captureField, (IrExpression)p.Clone())),
+            new ExpressionStatement(new LoadProperty(getter, (IrExpression)p.Clone(), [])),
             new Return(new LoadField(fieldX, (IrExpression)p.Clone())))).Output!;
 
         Assert.Contains("p->X += p->Y;", body);
+        Assert.Contains("_ = p->Value;", body);
+        Assert.Contains("_ = p->seed;", body);
+        Assert.Contains("_ = p->Total;", body);
         Assert.Contains("return p->X;", body);
         Assert.DoesNotContain("p.X", body);
         Assert.DoesNotContain("p.Y", body);
+        Assert.DoesNotContain("p.Value", body);
+        Assert.DoesNotContain("p.seed", body);
+        Assert.DoesNotContain("p.Total", body);
         AssertNoErrors(
             RecompileNewRules(
                 "static unsafe int M(Point* p)",
                 body,
-                "public struct Point { public int X; public int Y; }"),
+                "public struct Point { public int X; public int Y; public int Value { get; } public int seed; public int Total { get; } }"),
             body);
     }
 

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -178,6 +178,7 @@ public class LadderRung6GateTests
         var backingField = new FieldRef(point, "<Value>k__BackingField", Int32) { BackingPropertyName = "Value" };
         var captureField = new FieldRef(point, "<seed>P", Int32);
         var getter = new MethodRef(point, "get_Total", Int32, [], HasThis: true);
+        var sum = new MethodRef(point, "Sum", Int32, [], HasThis: true);
         var p = new LoadArgument(0, "p", pointPointer);
         var body = CSharpPrinter.Print(Function(
             "ReadPointerField",
@@ -196,23 +197,26 @@ public class LadderRung6GateTests
             new ExpressionStatement(new LoadField(backingField, (IrExpression)p.Clone())),
             new ExpressionStatement(new LoadField(captureField, (IrExpression)p.Clone())),
             new ExpressionStatement(new LoadProperty(getter, (IrExpression)p.Clone(), [])),
+            new ExpressionStatement(new Call(sum, isVirtual: false, [(IrExpression)p.Clone()])),
             new Return(new LoadField(fieldX, (IrExpression)p.Clone())))).Output!;
 
         Assert.Contains("p->X += p->Y;", body);
         Assert.Contains("_ = p->Value;", body);
         Assert.Contains("_ = p->seed;", body);
         Assert.Contains("_ = p->Total;", body);
+        Assert.Contains("p->Sum();", body);
         Assert.Contains("return p->X;", body);
         Assert.DoesNotContain("p.X", body);
         Assert.DoesNotContain("p.Y", body);
         Assert.DoesNotContain("p.Value", body);
         Assert.DoesNotContain("p.seed", body);
         Assert.DoesNotContain("p.Total", body);
+        Assert.DoesNotContain("p.Sum", body);
         AssertNoErrors(
             RecompileNewRules(
                 "static unsafe int M(Point* p)",
                 body,
-                "public struct Point { public int X; public int Y; public int Value { get; } public int seed; public int Total { get; } }"),
+                "public struct Point { public int X; public int Y; public int Value { get; } public int seed; public int Total { get; } public int Sum() => X + Y; }"),
             body);
     }
 

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -10,6 +10,8 @@ using Microsoft.CodeAnalysis.CSharp;
 
 using LegacyUnsafe = ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures;
 using NewUnsafe = ILInspector.Decompiler.Fixtures.NewUnsafe.UnsafeFixtures;
+using NewStackallocInitializers = ILInspector.Decompiler.Fixtures.NewUnsafe.StackallocInitializerResiduals;
+using NewStringPinning = ILInspector.Decompiler.Fixtures.NewUnsafe.StringPinningResiduals;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -30,6 +32,10 @@ public class LadderRung6GateTests
     static readonly string LegacyUnsafeType = typeof(LegacyUnsafe).FullName!;
     static readonly string ByRefFixturePath = FixtureCatalog.DecompilerLadderRung4.AssemblyPath();
     static readonly string ByRefFixtureType = typeof(LadderRung4.CSharp7LocalSyntax).FullName!;
+    static readonly string FixedBufferFixturePath = typeof(FixedBufferSkeletonFixture).Assembly.Location;
+    static readonly string FixedBufferFixtureType = typeof(FixedBufferSkeletonFixture).FullName!;
+    static readonly string StringPinningType = typeof(NewStringPinning).FullName!;
+    static readonly string StackallocInitializerType = typeof(NewStackallocInitializers).FullName!;
 
     static readonly string[] ExpectedUnsafeMembers =
     [
@@ -163,6 +169,42 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6PointerFieldAccess_RendersArrowAndRecompiles()
+    {
+        var point = TypeRef.Definition("Synthetic", "LadderRung6", "Point", ValueTypeHint.ValueType);
+        var pointPointer = TypeRef.Pointer(point);
+        var fieldX = new FieldRef(point, "X", Int32);
+        var fieldY = new FieldRef(point, "Y", Int32);
+        var p = new LoadArgument(0, "p", pointPointer);
+        var body = CSharpPrinter.Print(Function(
+            "ReadPointerField",
+            Int32,
+            [new Parameter("p", pointPointer)],
+            [],
+            new StoreField(
+                fieldX,
+                p,
+                new Binary(
+                    BinaryKind.Add,
+                    isChecked: false,
+                    isUnsigned: false,
+                    new LoadField(fieldX, (IrExpression)p.Clone()),
+                    new LoadField(fieldY, (IrExpression)p.Clone()))),
+            new Return(new LoadField(fieldX, (IrExpression)p.Clone())))).Output!;
+
+        Assert.Contains("p->X += p->Y;", body);
+        Assert.Contains("return p->X;", body);
+        Assert.DoesNotContain("p.X", body);
+        Assert.DoesNotContain("p.Y", body);
+        AssertNoErrors(
+            RecompileNewRules(
+                "static unsafe int M(Point* p)",
+                body,
+                "public struct Point { public int X; public int Y; }"),
+            body);
+    }
+
+    [Fact]
     public void Rung6ByRefFixture_PreservesRefKinds()
     {
         using var pe = new PEReader(File.OpenRead(ByRefFixturePath));
@@ -217,6 +259,34 @@ public class LadderRung6GateTests
         Assert.DoesNotContain("pinned", raisedPinnedOutput);
     }
 
+    [Fact]
+    public void Rung6FixedBufferAndStringPinningResiduals_DegradeHonestly()
+    {
+        var fixedBuffer = LoadRaisedMembers(FixedBufferFixturePath, FixedBufferFixtureType)
+            .Single(m => m.Name == "SumFirstTwo");
+        Assert.Equal(DecompilationFidelity.Partial, fixedBuffer.Function.Fidelity);
+        Assert.Contains(FidelityRemarks.Collect(fixedBuffer.Function), r => r.Code == DiagnosticIds.UnrepresentableMetadataName);
+        Assert.Contains("FixedElementField", fixedBuffer.Body);
+
+        var stringPinning = LoadRaisedMembers(NewUnsafePath, StringPinningType)
+            .Single(m => m.Name == "FixedStringFirstChar");
+        Assert.Equal(DecompilationFidelity.Partial, stringPinning.Function.Fidelity);
+        Assert.Contains("pinned ref char", stringPinning.Body);
+    }
+
+    [Fact]
+    public void Rung6StackallocInitializerResiduals_DegradeHonestly()
+    {
+        var members = LoadRaisedMembers(NewUnsafePath, StackallocInitializerType);
+        foreach (var name in new[] { "StackallocPointerInitializer", "StackallocSpanInitializer" })
+        {
+            var member = members.Single(m => m.Name == name);
+            Assert.Equal(DecompilationFidelity.Partial, member.Function.Fidelity);
+            Assert.Contains(FidelityRemarks.Collect(member.Function), r => r.Code == DiagnosticIds.UnsupportedConstruct);
+            Assert.Contains("cpblk", member.Body);
+        }
+    }
+
     static void AssertExactCompileBack(string assemblyPath, string typeName, string methodName)
     {
         var result = Assert.Single(
@@ -263,12 +333,20 @@ public class LadderRung6GateTests
         string methodHeader,
         string body,
         params MetadataReference[] extraReferences)
+        => RecompileNewRules(methodHeader, body, "", extraReferences);
+
+    static ImmutableArray<Diagnostic> RecompileNewRules(
+        string methodHeader,
+        string body,
+        string extraDeclarations,
+        params MetadataReference[] extraReferences)
     {
         string source = $$"""
             using System;
             using ILInspector.Decompiler.Fixtures.NewUnsafe;
             using System.Runtime.CompilerServices;
             using System.Runtime.InteropServices;
+            {{extraDeclarations}}
             static class __Gate
             {
                 {{methodHeader}}

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -252,6 +252,8 @@ public sealed partial class CSharpPrinter
         }
         if (call.Callee.Name == "Invoke" && receiver is Lambda lambda)
             return $"(({TypeText(lambda.DelegateType)}){Operand(lambda)}).Invoke({rest})";
+        if (PointerMemberReceiver(receiver, call.Callee.DeclaringType) is { } pointerReceiver)
+            return $"{pointerReceiver}->{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
         if (receiver is LoadArgument { Index: 0, Name: "this" })
         {
             // Non-virtual this-receiver call to a base-declared method is

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -33,6 +33,11 @@ public sealed partial class CSharpPrinter
             };
         }
         string fieldName = CSharpNaming.EscapeIdentifier(field.Name);
+        if (instance?.ResultType is { Kind: TypeRefKind.Pointer, ElementType: { } pointee }
+            && pointee.Equals(field.DeclaringType))
+        {
+            return $"{Operand(instance)}->{fieldName}";
+        }
         return instance switch
         {
             null => $"{TypeText(field.DeclaringType)}.{fieldName}",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -6,37 +6,41 @@ namespace ILInspector.Decompiler.Pipeline;
 public sealed partial class CSharpPrinter
 {
     string FieldTarget(FieldRef field, IrExpression? instance)
-    {        // An auto-property backing field, <Prop>k__BackingField, has no spellable
+    {
+        string fieldName = CSharpNaming.EscapeIdentifier(field.Name);
+        string memberName = field.BackingPropertyName is { } property
+            ? CSharpNaming.EscapeIdentifier(property)
+            : CSharpNaming.PrimaryConstructorCaptureName(field.Name) is { } capture
+                ? CSharpNaming.EscapeIdentifier(capture)
+                : fieldName;
+        if (PointerMemberReceiver(instance, field.DeclaringType) is { } pointerReceiver)
+            return $"{pointerReceiver}->{memberName}";
+
+        // An auto-property backing field, <Prop>k__BackingField, has no spellable
         // C# name; render it as the property it backs. `this.` qualifies the
         // instance form so a constructor assignment whose parameter shadows the
         // property still binds to it (and is legal even for a get-only property).
-        if (field.BackingPropertyName is { } property)
+        if (field.BackingPropertyName is { } backedProperty)
             return instance switch
             {
-                null => $"{TypeText(field.DeclaringType)}.{CSharpNaming.EscapeIdentifier(property)}",
-                LoadArgument { Index: 0, Name: "this" } => $"this.{CSharpNaming.EscapeIdentifier(property)}",
-                _ => $"{ReceiverText(instance)}.{CSharpNaming.EscapeIdentifier(property)}",
+                null => $"{TypeText(field.DeclaringType)}.{CSharpNaming.EscapeIdentifier(backedProperty)}",
+                LoadArgument { Index: 0, Name: "this" } => $"this.{CSharpNaming.EscapeIdentifier(backedProperty)}",
+                _ => $"{ReceiverText(instance)}.{CSharpNaming.EscapeIdentifier(backedProperty)}",
             };
         // A C# 12 primary-constructor capture field, <param>P, has no spellable C#
         // name; its source spelling is the primary-constructor parameter, which is
         // in scope across the whole type. Render it as an ordinary field named for
         // the parameter, with the same shadow qualification (the constructor's own
         // parameter shadows it, so `this.` reaches the field).
-        if (CSharpNaming.PrimaryConstructorCaptureName(field.Name) is { } capture)
+        if (CSharpNaming.PrimaryConstructorCaptureName(field.Name) is { } captureName)
         {
-            string captured = CSharpNaming.EscapeIdentifier(capture);
+            string captured = CSharpNaming.EscapeIdentifier(captureName);
             return instance switch
             {
                 null => $"{TypeText(field.DeclaringType)}.{captured}",
-                LoadArgument { Index: 0, Name: "this" } => IsShadowedByLocal(capture) ? $"this.{captured}" : captured,
+                LoadArgument { Index: 0, Name: "this" } => IsShadowedByLocal(captureName) ? $"this.{captured}" : captured,
                 _ => $"{ReceiverText(instance)}.{captured}",
             };
-        }
-        string fieldName = CSharpNaming.EscapeIdentifier(field.Name);
-        if (instance?.ResultType is { Kind: TypeRefKind.Pointer, ElementType: { } pointee }
-            && pointee.Equals(field.DeclaringType))
-        {
-            return $"{Operand(instance)}->{fieldName}";
         }
         return instance switch
         {
@@ -52,6 +56,14 @@ public sealed partial class CSharpPrinter
 
     string PropertyTarget(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, string name, bool isVirtual = true)
     {
+        string escapedName = CSharpNaming.EscapeIdentifier(name);
+        if (PointerMemberReceiver(instance, accessor.DeclaringType) is { } pointerReceiver)
+        {
+            return indexArguments.Count == 0
+                ? $"{pointerReceiver}->{escapedName}"
+                : $"(*{pointerReceiver})[{Arguments(indexArguments)}]";
+        }
+
         string receiver = instance switch
         {
             // A NON-virtual this-receiver access to a base-declared member is
@@ -70,10 +82,15 @@ public sealed partial class CSharpPrinter
         // whatever its metadata name (String's is Chars, not Item).
         if (instance is not null && indexArguments.Count > 0)
             return $"{(receiver.Length == 0 ? "this" : receiver)}[{Arguments(indexArguments)}]";
-        string escapedName = CSharpNaming.EscapeIdentifier(name);
         string dotted = receiver.Length == 0 ? escapedName : $"{receiver}.{escapedName}";
         return indexArguments.Count == 0 ? dotted : $"{dotted}[{Arguments(indexArguments)}]";
     }
+
+    string? PointerMemberReceiver(IrExpression? instance, TypeRef declaringType)
+        => instance?.ResultType is { Kind: TypeRefKind.Pointer, ElementType: { } pointee }
+            && pointee.Equals(declaringType)
+            ? Operand(instance)
+            : null;
 
     bool QualifyThisMember(string memberName, TypeRef? valueType)
         => IsShadowedByLocal(memberName) || MemberNameCollidesWithTypeName(memberName, valueType);


### PR DESCRIPTION
Closes #2427.
Closes #2428.
Closes #2429.
Part of #1599 row 6.

## Fix

**Conclusion:** **PASS** — pointer field access now renders valid `->` C#, and the fixed-buffer/string-pinning plus stackalloc-initializer row-6 gaps are explicitly owned as honest residuals.

False `Full` claim:

```csharp
Point* p = (Point*)(&point);
p.X += p.Y;
return p.X;
```

Fixed output:

```csharp
Point* p = (Point*)(&point);
unsafe
{
    p->X += p->Y;
    return p->X;
}
```

## Scope

- **Root cause:** field access rendering treated a pointer receiver like a normal value receiver and emitted `p.X`.
- **Fix shape:** when the field receiver is `T*` and the field belongs to `T`, render `p->Field`; add a Roslyn recompile canary.
- **Owned residuals:** fixed-buffer/string-pinning and stackalloc initializer shapes are now explicit row-6 residual canaries, not untracked row gaps.

## Evidence

| Check | Result |
| --- | --- |
| Product/test/fixture build | Pass; 3 pre-existing nullable warnings in `ILInspector.Metadata.Tests` |
| Focused tests | `LadderRung6GateTests` + `PointerArithmeticScalingTests`: 21/21 |
| Fixed-buffer skeleton canary | `SkeletonSkipsFixedBufferBackingFieldTypes`: 3/3 |
| Unsafe fixture validity | 22 Full / 6 Partial; 0 malformed Full; 0 semantic defects among Full |
| Unsafe fixture fidelity | 22 Full exact; 0 opcode diffs; 6 expected residual recompile failures |
| Unsafe fixture gaps | 22 fully raised; 6 owned residuals (#2427/#2428) |
| PR quick corpus card | matched pinned-subset tolerances |
| Targeted render A/B | no regressions; fixture assemblies did not pair identities (28 added/removed) |

PR quick card caveat: aggregate rates are affected by corpus drift from the pinned baseline, but the pinned-subset gate is neutral.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -noLogo -noColor \
  -class ILInspector.Decompiler.Tests.LadderRung6GateTests \
  -class ILInspector.Decompiler.Tests.PointerArithmeticScalingTests

dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -noLogo -noColor \
  -filter "/*/*/SkeletonEmitTests/SkeletonSkipsFixedBufferBackingFieldTypes"

dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo --verbosity quiet

dotnet run --project tools/DecompilerHarness -c Release -- \
  artifacts/bin/ILInspector.Decompiler.Fixtures.NewUnsafe/release/ILInspector.Decompiler.Fixtures.NewUnsafe.dll \
  artifacts/bin/ILInspector.Decompiler.Fixtures.LegacyUnsafe/release/ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll \
  --validity-check --fidelity-check --compile-cap 100 --max-examples 20

dotnet run --project tools/DecompilerHarness -c Release -- \
  artifacts/bin/ILInspector.Decompiler.Fixtures.NewUnsafe/release/ILInspector.Decompiler.Fixtures.NewUnsafe.dll \
  artifacts/bin/ILInspector.Decompiler.Fixtures.LegacyUnsafe/release/ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll \
  --fidelity-check --max-examples 20

bash eng/prepare-decompiler-pr-corpus.sh /tmp/pr-corpus-2429.txt
mapfile -t assemblies < /tmp/pr-corpus-2429.txt
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
  --diff-corpus-baseline tools/DecompilerHarness/corpus/pr-quick-baseline.json \
  --quality-diff-card \
  --corpus-method-cap 100 \
  --compile-cap 0 \
  --corpus-fidelity-cap 0 \
  --max-examples 3
```

## Review

Adversarial review requested; reconciliation will be posted as a PR comment before marking ready.
