### PR TITLE
Share diff harness plumbing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
               src/ILInspector.ControlFlow/*) CSHARPDIFF=true ;;
               src/DiffFixtures.V1/*) CSHARPDIFF=true ;;
               src/DiffFixtures.V2/*) CSHARPDIFF=true ;;
+              tools/DiffHarnessCommon/*) CSHARPDIFF=true ;;
               Directory.Packages.props) CSHARPDIFF=true ;;
               *.props|*.targets|*.slnx) CSHARPDIFF=true ;;
               .github/workflows/ci.yml) CSHARPDIFF=true ;;
@@ -89,6 +90,7 @@ jobs:
               src/ILInspector.ControlFlow/*) ILDIFF=true ;;
               src/DiffFixtures.V1/*) ILDIFF=true ;;
               src/DiffFixtures.V2/*) ILDIFF=true ;;
+              tools/DiffHarnessCommon/*) ILDIFF=true ;;
               Directory.Packages.props) ILDIFF=true ;;
               *.props|*.targets|*.slnx) ILDIFF=true ;;
               .github/workflows/ci.yml) ILDIFF=true ;;

--- a/dotnet-inspect.slnx
+++ b/dotnet-inspect.slnx
@@ -60,6 +60,7 @@
     <Project Path="tools/AnalysisHarness/AnalysisHarness.csproj" />
     <Project Path="tools/CSharpDiffHarness/CSharpDiffHarness.csproj" />
     <Project Path="tools/DecompilerHarness/DecompilerHarness.csproj" />
+    <Project Path="tools/DiffHarnessCommon/DiffHarnessCommon.csproj" />
     <Project Path="tools/IlDiffHarness/IlDiffHarness.csproj" />
   </Folder>
 </Solution>

--- a/tools/CSharpDiffHarness/CSharpDiffHarness.csproj
+++ b/tools/CSharpDiffHarness/CSharpDiffHarness.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../DiffHarnessCommon/DiffHarnessCommon.csproj" />
     <ProjectReference Include="../../src/ILInspector.Decompiler/ILInspector.Decompiler.csproj" />
     <PackageReference Include="Markout" />
   </ItemGroup>

--- a/tools/CSharpDiffHarness/Program.cs
+++ b/tools/CSharpDiffHarness/Program.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 
+using ILInspector.DiffHarnessCommon;
 using ILInspector.Decompiler;
 using Markout;
 using Markout.Formatting;
@@ -71,7 +72,7 @@ for (int i = 0; i < args.Length; i++)
 
             break;
         case "--format":
-            if (i + 1 >= args.Length || !TryParseOutputFormat(args[++i], out outputFormat))
+            if (i + 1 >= args.Length || !DiffHarnessCommon.TryParseOutputFormat(args[++i], out outputFormat))
             {
                 Console.Error.WriteLine("--format requires one of: markdown, tsv, jsonl.");
                 return 2;
@@ -136,7 +137,7 @@ if (pairsManifest is not null)
 
     try
     {
-        pairs.AddRange(ReadManifest(pairsManifest));
+        pairs.AddRange(DiffHarnessCommon.ReadManifest(pairsManifest));
     }
     catch (Exception ex) when (ex is InvalidOperationException or IOException or UnauthorizedAccessException)
     {
@@ -193,40 +194,6 @@ catch (Exception ex) when (ex is IOException or InvalidOperationException or Arg
 {
     Console.Error.WriteLine(ex.Message);
     return 2;
-}
-
-static IEnumerable<AssemblyPair> ReadManifest(string manifestPath)
-{
-    string manifestDirectory = Path.GetDirectoryName(Path.GetFullPath(manifestPath)) ?? Directory.GetCurrentDirectory();
-    int lineNumber = 0;
-    foreach (var rawLine in File.ReadLines(manifestPath))
-    {
-        lineNumber++;
-        string line = rawLine.Trim();
-        if (line.Length == 0 || line.StartsWith('#'))
-            continue;
-
-        var parts = line.Split('\t', StringSplitOptions.TrimEntries);
-        if (parts.Length != 2 || parts[0].Length == 0 || parts[1].Length == 0)
-            throw new InvalidOperationException($"Invalid pair manifest line {lineNumber}: expected old<TAB>new.");
-
-        yield return new AssemblyPair(ResolveManifestPath(manifestDirectory, parts[0]), ResolveManifestPath(manifestDirectory, parts[1]));
-    }
-}
-
-static string ResolveManifestPath(string manifestDirectory, string path)
-    => Path.IsPathFullyQualified(path) ? path : Path.GetFullPath(Path.Combine(manifestDirectory, path));
-
-static bool TryParseOutputFormat(string value, out OutputFormat format)
-{
-    format = value.ToLowerInvariant() switch
-    {
-        "markdown" or "md" => OutputFormat.Markdown,
-        "tsv" => OutputFormat.Tsv,
-        "jsonl" => OutputFormat.Jsonl,
-        _ => (OutputFormat)(-1),
-    };
-    return format is OutputFormat.Markdown or OutputFormat.Tsv or OutputFormat.Jsonl;
 }
 
 static CSharpDiffPairCard BuildPairCard(AssemblyPair pair)
@@ -350,8 +317,8 @@ static CSharpDiffSnapshot BuildSnapshot(ImmutableArray<CSharpDiffPairCard> pairs
             RowCount: card.RowCount,
             FailureCount: card.FailureCount),
         Pairs: pairs.Select(pair => new CSharpDiffSnapshotPair(
-            Old: SnapshotPath(pair.OldPath),
-            New: SnapshotPath(pair.NewPath),
+            Old: DiffHarnessCommon.RelativeSnapshotPath(pair.OldPath),
+            New: DiffHarnessCommon.RelativeSnapshotPath(pair.NewPath),
             IsExact: pair.Card.IsExact,
             ChangedMemberCount: pair.Card.ChangedMemberCount,
             RowCount: pair.Card.RowCount,
@@ -534,7 +501,7 @@ static CSharpDiffCard Aggregate(ImmutableArray<CSharpDiffPairCard> pairs, int ma
             if (examples.Count >= maxExamples)
                 break;
             examples.Add(RenderExample(
-                $"{PathLabel(pair.OldPath, snapshotPaths)} to {PathLabel(pair.NewPath, snapshotPaths)} :: {example.Member}",
+                $"{DiffHarnessCommon.PathLabel(pair.OldPath, snapshotPaths, DiffHarnessCommon.RelativeSnapshotPath)} to {DiffHarnessCommon.PathLabel(pair.NewPath, snapshotPaths, DiffHarnessCommon.RelativeSnapshotPath)} :: {example.Member}",
                 example));
         }
     }
@@ -635,8 +602,8 @@ static List<BaselineSectionFindingView>? SectionedBaselineRows(BaselineCompariso
 
 static CSharpDiffPairSummaryRow PairSummaryRow(CSharpDiffPairCard pair)
     => new(
-        DisplayPath(pair.OldPath),
-        DisplayPath(pair.NewPath),
+        DiffHarnessCommon.DisplayPath(pair.OldPath),
+        DiffHarnessCommon.DisplayPath(pair.NewPath),
         pair.Card.IsExact ? "yes" : "no",
         Count(pair.Card.ChangedMemberCount),
         Count(pair.Card.RowCount),
@@ -654,21 +621,6 @@ static CSharpDiffSectionPairSummaryRow SectionedPairSummaryRow(CSharpDiffPairCar
         row.Rows,
         row.Failures);
 }
-
-static string DisplayPath(string path)
-{
-    string fullPath = Path.GetFullPath(path);
-    string relative = Path.GetRelativePath(Directory.GetCurrentDirectory(), fullPath);
-    return relative.StartsWith("..", StringComparison.Ordinal)
-        ? fullPath
-        : relative;
-}
-
-static string SnapshotPath(string path)
-    => Path.GetRelativePath(Directory.GetCurrentDirectory(), Path.GetFullPath(path)).Replace('\\', '/');
-
-static string PathLabel(string path, bool snapshotPath)
-    => snapshotPath ? SnapshotPath(path) : DisplayPath(path);
 
 static List<CSharpDiffBucketRow>? MarkdownBucketRows(ImmutableArray<CardBucket> buckets)
     => buckets.IsDefaultOrEmpty
@@ -696,16 +648,7 @@ sealed class ExampleGroup(string member)
     public List<CSharpDiffFailureRow> Failures { get; } = [];
 }
 
-sealed record AssemblyPair(string OldPath, string NewPath);
-
 sealed record CSharpDiffPairCard(string OldPath, string NewPath, CSharpDiffCard Card);
-
-enum OutputFormat
-{
-    Markdown,
-    Tsv,
-    Jsonl,
-}
 
 sealed record CSharpDiffCard(
     bool IsExact,

--- a/tools/DiffHarnessCommon/DiffHarnessCommon.cs
+++ b/tools/DiffHarnessCommon/DiffHarnessCommon.cs
@@ -1,0 +1,64 @@
+namespace ILInspector.DiffHarnessCommon;
+
+public enum OutputFormat
+{
+    Markdown,
+    Tsv,
+    Jsonl,
+}
+
+public sealed record AssemblyPair(string OldPath, string NewPath);
+
+public static class DiffHarnessCommon
+{
+    public static bool TryParseOutputFormat(string value, out OutputFormat format)
+    {
+        format = value.ToLowerInvariant() switch
+        {
+            "markdown" or "md" => OutputFormat.Markdown,
+            "tsv" => OutputFormat.Tsv,
+            "jsonl" => OutputFormat.Jsonl,
+            _ => (OutputFormat)(-1),
+        };
+        return format is OutputFormat.Markdown or OutputFormat.Tsv or OutputFormat.Jsonl;
+    }
+
+    public static IEnumerable<AssemblyPair> ReadManifest(string manifestPath)
+    {
+        string manifestDirectory = Path.GetDirectoryName(Path.GetFullPath(manifestPath)) ?? Directory.GetCurrentDirectory();
+        int lineNumber = 0;
+        foreach (var rawLine in File.ReadLines(manifestPath))
+        {
+            lineNumber++;
+            string line = rawLine.Trim();
+            if (line.Length == 0 || line.StartsWith('#'))
+                continue;
+
+            var parts = line.Split('\t', StringSplitOptions.TrimEntries);
+            if (parts.Length != 2 || parts[0].Length == 0 || parts[1].Length == 0)
+                throw new InvalidOperationException($"Invalid pair manifest line {lineNumber}: expected old<TAB>new.");
+
+            yield return new AssemblyPair(ResolveManifestPath(manifestDirectory, parts[0]), ResolveManifestPath(manifestDirectory, parts[1]));
+        }
+    }
+
+    public static string DisplayPath(string path)
+    {
+        string fullPath = Path.GetFullPath(path);
+        string relative = Path.GetRelativePath(Directory.GetCurrentDirectory(), fullPath);
+        return relative.StartsWith("..", StringComparison.Ordinal)
+            ? fullPath
+            : relative;
+    }
+
+    public static string AbsoluteSnapshotPath(string path) => Path.GetFullPath(path);
+
+    public static string RelativeSnapshotPath(string path)
+        => Path.GetRelativePath(Directory.GetCurrentDirectory(), Path.GetFullPath(path)).Replace('\\', '/');
+
+    public static string PathLabel(string path, bool snapshotPath, Func<string, string> snapshotPathFormatter)
+        => snapshotPath ? snapshotPathFormatter(path) : DisplayPath(path);
+
+    static string ResolveManifestPath(string manifestDirectory, string path)
+        => Path.IsPathFullyQualified(path) ? path : Path.GetFullPath(Path.Combine(manifestDirectory, path));
+}

--- a/tools/DiffHarnessCommon/DiffHarnessCommon.csproj
+++ b/tools/DiffHarnessCommon/DiffHarnessCommon.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <LangVersion>preview</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/tools/IlDiffHarness/IlDiffHarness.csproj
+++ b/tools/IlDiffHarness/IlDiffHarness.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../DiffHarnessCommon/DiffHarnessCommon.csproj" />
     <ProjectReference Include="../../src/ILInspector.Instructions/ILInspector.Instructions.csproj" />
     <PackageReference Include="Markout" />
   </ItemGroup>

--- a/tools/IlDiffHarness/Program.cs
+++ b/tools/IlDiffHarness/Program.cs
@@ -3,6 +3,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Text.Json;
 
+using ILInspector.DiffHarnessCommon;
 using ILInspector.Instructions;
 using Markout;
 using Markout.Formatting;
@@ -73,7 +74,7 @@ for (int i = pairs.Count == 0 ? 0 : 2; i < args.Length; i++)
             }
             break;
         case "--format":
-            if (i + 1 >= args.Length || !TryParseOutputFormat(args[++i], out outputFormat))
+            if (i + 1 >= args.Length || !DiffHarnessCommon.TryParseOutputFormat(args[++i], out outputFormat))
             {
                 Console.Error.WriteLine("--format requires one of: markdown, tsv, jsonl.");
                 return 2;
@@ -118,7 +119,7 @@ if (pairsManifest is not null)
 
     try
     {
-        pairs.AddRange(ReadManifest(pairsManifest));
+        pairs.AddRange(DiffHarnessCommon.ReadManifest(pairsManifest));
     }
     catch (Exception ex) when (ex is InvalidOperationException or IOException or UnauthorizedAccessException)
     {
@@ -175,40 +176,6 @@ catch (Exception ex) when (ex is BadImageFormatException or IOException or Inval
 {
     Console.Error.WriteLine(ex.Message);
     return 2;
-}
-
-static IEnumerable<AssemblyPair> ReadManifest(string manifestPath)
-{
-    string manifestDirectory = Path.GetDirectoryName(Path.GetFullPath(manifestPath)) ?? Directory.GetCurrentDirectory();
-    int lineNumber = 0;
-    foreach (var rawLine in File.ReadLines(manifestPath))
-    {
-        lineNumber++;
-        string line = rawLine.Trim();
-        if (line.Length == 0 || line.StartsWith('#'))
-            continue;
-
-        var parts = line.Split('\t', StringSplitOptions.TrimEntries);
-        if (parts.Length != 2 || parts[0].Length == 0 || parts[1].Length == 0)
-            throw new InvalidOperationException($"Invalid pair manifest line {lineNumber}: expected old<TAB>new.");
-
-        yield return new AssemblyPair(ResolveManifestPath(manifestDirectory, parts[0]), ResolveManifestPath(manifestDirectory, parts[1]));
-    }
-}
-
-static string ResolveManifestPath(string manifestDirectory, string path)
-    => Path.IsPathFullyQualified(path) ? path : Path.GetFullPath(Path.Combine(manifestDirectory, path));
-
-static bool TryParseOutputFormat(string value, out OutputFormat format)
-{
-    format = value.ToLowerInvariant() switch
-    {
-        "markdown" or "md" => OutputFormat.Markdown,
-        "tsv" => OutputFormat.Tsv,
-        "jsonl" => OutputFormat.Jsonl,
-        _ => (OutputFormat)(-1),
-    };
-    return format is OutputFormat.Markdown or OutputFormat.Tsv or OutputFormat.Jsonl;
 }
 
 static IlDiffPairCard BuildPairCard(AssemblyPair pair, int maxExamples)
@@ -432,8 +399,8 @@ static IlDiffSnapshot BuildSnapshot(ImmutableArray<IlDiffPairCard> pairs, int ma
             ChangedBodyCount: card.ChangedBodyCount,
             FailureCount: card.FailureCount),
         Pairs: pairs.Select(pair => new IlDiffSnapshotPair(
-            Old: SnapshotPath(pair.OldPath),
-            New: SnapshotPath(pair.NewPath),
+            Old: DiffHarnessCommon.AbsoluteSnapshotPath(pair.OldPath),
+            New: DiffHarnessCommon.AbsoluteSnapshotPath(pair.NewPath),
             ComparedBodyCount: pair.Card.ComparedBodyCount,
             SelfDiffEmptyCount: pair.Card.SelfDiffExactCount,
             PairExactEmptyCount: pair.Card.PairExactCount,
@@ -684,7 +651,7 @@ static IlDiffCard Aggregate(ImmutableArray<IlDiffPairCard> pairs, int maxExample
                 break;
             examples.Add(example with
             {
-                Method = $"{PathLabel(pair.OldPath, snapshotPaths)} to {PathLabel(pair.NewPath, snapshotPaths)} :: {example.Method}"
+                Method = $"{DiffHarnessCommon.PathLabel(pair.OldPath, snapshotPaths, DiffHarnessCommon.AbsoluteSnapshotPath)} to {DiffHarnessCommon.PathLabel(pair.NewPath, snapshotPaths, DiffHarnessCommon.AbsoluteSnapshotPath)} :: {example.Method}"
             });
         }
     }
@@ -703,8 +670,8 @@ static IlDiffCard Aggregate(ImmutableArray<IlDiffPairCard> pairs, int maxExample
 
 static IlDiffPairSummaryRow PairSummaryRow(IlDiffPairCard pair)
     => new(
-        DisplayPath(pair.OldPath),
-        DisplayPath(pair.NewPath),
+        DiffHarnessCommon.DisplayPath(pair.OldPath),
+        DiffHarnessCommon.DisplayPath(pair.NewPath),
         pair.Card.ComparedBodyCount.ToString(System.Globalization.CultureInfo.InvariantCulture),
         pair.Card.SelfDiffExactCount.ToString(System.Globalization.CultureInfo.InvariantCulture),
         pair.Card.PairExactCount.ToString(System.Globalization.CultureInfo.InvariantCulture),
@@ -735,20 +702,6 @@ static List<BaselineSectionFindingView>? SectionedBaselineRows(BaselineCompariso
         ? null
         : [.. comparison.Rows.Select(row => new BaselineSectionFindingView("Baseline findings", row.Kind, row.Metric, row.Baseline, row.Current, row.Detail))];
 
-static string DisplayPath(string path)
-{
-    string fullPath = Path.GetFullPath(path);
-    string relative = Path.GetRelativePath(Directory.GetCurrentDirectory(), fullPath);
-    return relative.StartsWith("..", StringComparison.Ordinal)
-        ? fullPath
-        : relative;
-}
-
-static string SnapshotPath(string path) => Path.GetFullPath(path);
-
-static string PathLabel(string path, bool snapshotPath)
-    => snapshotPath ? SnapshotPath(path) : DisplayPath(path);
-
 static List<IlDiffBucketRow>? MarkdownBucketRows(ImmutableArray<CardBucket> buckets)
     => buckets.IsDefaultOrEmpty
         ? null
@@ -765,16 +718,7 @@ static IlDiffExampleMarkdownView ExampleMarkdownRow(IlDiffExample example)
 static IlDiffExampleTableRow ExampleTableRow(IlDiffExample example)
     => new("Examples", example.Method, example.UnifiedDiff);
 
-sealed record AssemblyPair(string OldPath, string NewPath);
-
 sealed record IlDiffPairCard(string OldPath, string NewPath, IlDiffCard Card);
-
-enum OutputFormat
-{
-    Markdown,
-    Tsv,
-    Jsonl,
-}
 
 sealed record IlDiffCard(
     int ComparedBodyCount,


### PR DESCRIPTION
## Summary

Implements the first low-risk slice of #2437.

- add `tools/DiffHarnessCommon` for shared harness plumbing
- share `AssemblyPair`, `OutputFormat`, output-format parsing, pair manifest parsing, display paths, and snapshot path helpers
- update `IlDiffHarness` and `CSharpDiffHarness` to consume the shared helpers
- route `tools/DiffHarnessCommon/*` changes through both `il-diff-smoke` and `csharp-diff-smoke`

Producer/card logic remains local to each harness.

## Validation

- `dotnet build tools/IlDiffHarness/IlDiffHarness.csproj -c Release --configfile nuget.config`
- `dotnet build tools/CSharpDiffHarness/CSharpDiffHarness.csproj -c Release --configfile nuget.config`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- IL Diff and C# Diff JSONL smokes over DiffFixtures V1/V2, including exact baseline and manifest input paths
- parsed IL/C# JSONL outputs with `System.Text.Json`