### PR TITLE
Render pointer field receivers with arrow

### DIFF
--- a/docs/decompiler-taste.md
+++ b/docs/decompiler-taste.md
@@ -49,6 +49,26 @@ Conflicts between class 1 and class 2 are rare by construction — most fixer su
 
 - LINQ query syntax (`from x in xs select f`) compiles to the *same* `Enumerable.Where/Select/...` calls as the fluent chain — query expressions are translated during binding, before any lowering, so the two forms are IL-identical. With no anchor to choose between them, the oracle decides: the runtime writes fluent method chains, so that is what we render. We do not re-sugar back to `from..select`. (This is why the `Query` row in the lowering ledger is `Declined` — a no-anchor mechanism distinct from `Unhandled`/owed, not a gap to fill.)
 
+### Pointer member syntax
+
+Pointer member access has a C# spelling choice for named members and a different
+one for indexer-like access:
+
+- Prefer `p->Member` for fields, properties, and instance methods on a pointer
+  receiver.
+- Prefer `(*p)[i]` for indexer access on the pointed-to value.
+- Keep extension-shaped calls with pointer receiver parameters in static form
+  (`Extensions.M(p)`) unless the receiver parameter is a by-ref `this ref T`
+  extension over the pointee; C# does not allow `this T*`.
+
+The style oracle decides the spelling where syntax permits more than one valid
+form. `dotnet/runtime`'s `.editorconfig` has no pointer-specific rule, so the
+dominant runtime source style is the oracle: runtime code commonly writes
+`pMT->IsValueType`, `pMT->ComponentSize`, and `pException->InternalPreserveStackTrace()`,
+while indexer-like pointer dereference appears as `(*array)[i]`. Those examples
+also match the semantic boundary: `p->Member` is the direct pointer-member
+syntax, while `p[i]` is pointer arithmetic, not an indexer call on the pointee.
+
 ## Names
 
 Without a PDB, locals are slot names (`V_0`, `S_0`) shared with the Annotated IL view — the two views stay name-aligned by construction. With a PDB, source names are used. Synthesizing readable names (`size`, `array`, `item`) where no PDB exists is an open design question: it is the largest remaining cosmetic gap against source, but it would break view alignment unless opt-in.

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -312,6 +312,55 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6PointerInterfaceMembers_RenderPointerSyntaxAndRecompile()
+    {
+        var typeParameter = TypeRef.GenericParameter(0, "T");
+        var pointer = TypeRef.Pointer(typeParameter);
+        var iface = TypeRef.Definition("Synthetic", "LadderRung6", "IPointLike", ValueTypeHint.ReferenceType);
+        var p = new LoadArgument(0, "p", pointer);
+        var property = new MethodRef(iface, "get_P", Int32, [], HasThis: true);
+        var indexer = new MethodRef(iface, "get_Item", Int32, [Int32], HasThis: true);
+        var method = new MethodRef(iface, "M", Int32, [], HasThis: true);
+        var sum = new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new Binary(
+                BinaryKind.Add,
+                isChecked: false,
+                isUnsigned: false,
+                new LoadProperty(property, p, []),
+                new LoadProperty(indexer, (IrExpression)p.Clone(), [new Constant(1, Int32)])),
+            new Call(method, isVirtual: true, [(IrExpression)p.Clone()]));
+        var body = CSharpPrinter.Print(Function(
+            "ReadInterfacePointerMembers",
+            Int32,
+            [new Parameter("p", pointer)],
+            [],
+            new Return(sum))).Output!;
+
+        Assert.Contains("p->P", body);
+        Assert.Contains("(*p)[1]", body);
+        Assert.Contains("p->M()", body);
+        Assert.DoesNotContain("p.P", body);
+        Assert.DoesNotContain("p[1]", body);
+        Assert.DoesNotContain("p.M()", body);
+        AssertNoErrors(
+            RecompileNewRules(
+                "static unsafe int M<T>(T* p) where T : unmanaged, IPointLike",
+                body,
+                """
+                public interface IPointLike
+                {
+                    int P { get; }
+                    int this[int i] { get; }
+                    int M();
+                }
+                """),
+            body);
+    }
+
+    [Fact]
     public void Rung6PointerInheritedObjectMethod_RendersArrowAndRecompiles()
     {
         var point = TypeRef.Definition("Synthetic", "LadderRung6", "Point", ValueTypeHint.ValueType);

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -199,6 +199,119 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6PointerBackingPropertyAccess_RendersArrowAndRecompiles()
+    {
+        var record = TypeRef.Definition("Synthetic", "LadderRung6", "PropertyPoint", ValueTypeHint.ValueType);
+        var recordPointer = TypeRef.Pointer(record);
+        var backing = new FieldRef(record, "<X>k__BackingField", Int32)
+        {
+            BackingPropertyName = "X",
+        };
+        var body = CSharpPrinter.Print(Function(
+            "ReadPointerBackingProperty",
+            Int32,
+            [new Parameter("p", recordPointer)],
+            [],
+            new Return(new LoadField(backing, new LoadArgument(0, "p", recordPointer))))).Output!;
+
+        Assert.Contains("return p->X;", body);
+        Assert.DoesNotContain("p.X", body);
+        AssertNoErrors(
+            RecompileNewRules(
+                "static unsafe int M(PropertyPoint* p)",
+                body,
+                "public struct PropertyPoint { public int X { get; set; } }"),
+            body);
+    }
+
+    [Fact]
+    public void Rung6PointerPrimaryConstructorCaptureAccess_RendersArrowAndRecompiles()
+    {
+        var capture = TypeRef.Definition("Synthetic", "LadderRung6", "CapturePoint", ValueTypeHint.ValueType);
+        var capturePointer = TypeRef.Pointer(capture);
+        var field = new FieldRef(capture, "<X>P", Int32);
+        var body = CSharpPrinter.Print(Function(
+            "ReadPointerPrimaryConstructorCapture",
+            Int32,
+            [new Parameter("p", capturePointer)],
+            [],
+            new Return(new LoadField(field, new LoadArgument(0, "p", capturePointer))))).Output!;
+
+        Assert.Contains("return p->X;", body);
+        Assert.DoesNotContain("p.X", body);
+        AssertNoErrors(
+            RecompileNewRules(
+                "static unsafe int M(CapturePoint* p)",
+                body,
+                "public struct CapturePoint { public int X; }"),
+            body);
+    }
+
+    [Fact]
+    public void Rung6PointerPropertiesIndexersAndMethods_RenderPointerSyntaxAndRecompile()
+    {
+        var point = TypeRef.Definition("Synthetic", "LadderRung6", "Point", ValueTypeHint.ValueType);
+        var pointPointer = TypeRef.Pointer(point);
+        var p = new LoadArgument(0, "p", pointPointer);
+        var property = new MethodRef(point, "get_P", Int32, [], HasThis: true);
+        var indexer = new MethodRef(point, "get_Item", Int32, [Int32], HasThis: true);
+        var method = new MethodRef(point, "M", Int32, [], HasThis: true);
+        var extension = new MethodRef(TypeRef.Definition("Synthetic", "", "Extensions"), "ExtPtr", Int32, [pointPointer], HasThis: false)
+        {
+            IsExtension = MetadataFactState.Yes,
+        };
+        var sum = new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new Binary(
+                BinaryKind.Add,
+                isChecked: false,
+                isUnsigned: false,
+                new Binary(
+                    BinaryKind.Add,
+                    isChecked: false,
+                    isUnsigned: false,
+                    new LoadProperty(property, p, []),
+                    new LoadProperty(indexer, (IrExpression)p.Clone(), [new Constant(1, Int32)])),
+                new Call(method, isVirtual: false, [(IrExpression)p.Clone()])),
+            new Call(extension, isVirtual: false, [(IrExpression)p.Clone()]));
+        var body = CSharpPrinter.Print(Function(
+            "ReadPointerMembers",
+            Int32,
+            [new Parameter("p", pointPointer)],
+            [],
+            new Return(sum))).Output!;
+
+        Assert.Contains("p->P", body);
+        Assert.Contains("(*p)[1]", body);
+        Assert.Contains("p->M()", body);
+        Assert.Contains("Extensions.ExtPtr(p)", body);
+        Assert.DoesNotContain("p.P", body);
+        Assert.DoesNotContain("p[1]", body);
+        Assert.DoesNotContain("p.M()", body);
+        Assert.DoesNotContain("p.ExtPtr()", body);
+        AssertNoErrors(
+            RecompileNewRules(
+                "static unsafe int M(Point* p)",
+                body,
+                """
+                public unsafe struct Point
+                {
+                    public int X;
+                    public int P { get; set; }
+                    public int this[int i] => X + i;
+                    public int M() => X;
+                }
+                public static unsafe class Extensions
+                {
+                    public static int ExtPtr(Point* p) => p->X;
+                }
+                """),
+            body);
+    }
+
+    [Fact]
     public void Rung6ByRefFixture_PreservesRefKinds()
     {
         using var pe = new PEReader(File.OpenRead(ByRefFixturePath));

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -361,6 +361,57 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6PointerArithmeticReceiver_ParenthesizesBeforeMemberAccess()
+    {
+        var point = TypeRef.Definition("Synthetic", "LadderRung6", "Point", ValueTypeHint.ValueType);
+        var pointPointer = TypeRef.Pointer(point);
+        var p = new LoadArgument(0, "p", pointPointer);
+        var next = new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            p,
+            new Constant(4, Int32));
+        var field = new FieldRef(point, "X", Int32);
+        var indexer = new MethodRef(point, "get_Item", Int32, [Int32], HasThis: true);
+        var method = new MethodRef(point, "M", Int32, [], HasThis: true);
+        var sum = new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new Binary(
+                BinaryKind.Add,
+                isChecked: false,
+                isUnsigned: false,
+                new LoadField(field, next),
+                new LoadProperty(indexer, (IrExpression)next.Clone(), [new Constant(1, Int32)])),
+            new Call(method, isVirtual: false, [(IrExpression)next.Clone()]));
+        var body = CSharpPrinter.Print(Function(
+            "ReadPointerArithmeticReceiver",
+            Int32,
+            [new Parameter("p", pointPointer)],
+            [],
+            new Return(sum))).Output!;
+
+        Assert.Contains("((Point*)((byte*)p + 4))->X", body);
+        Assert.Contains("(*((Point*)((byte*)p + 4)))[1]", body);
+        Assert.Contains("((Point*)((byte*)p + 4))->M()", body);
+        AssertNoErrors(
+            RecompileNewRules(
+                "static unsafe int M(Point* p)",
+                body,
+                """
+                public struct Point
+                {
+                    public int X;
+                    public int this[int i] => X + i;
+                    public int M() => X;
+                }
+                """),
+            body);
+    }
+
+    [Fact]
     public void Rung6PointerInheritedObjectMethod_RendersArrowAndRecompiles()
     {
         var point = TypeRef.Definition("Synthetic", "LadderRung6", "Point", ValueTypeHint.ValueType);

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -163,6 +163,42 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6PointerFieldAccess_RendersArrowAndRecompiles()
+    {
+        var point = TypeRef.Definition("Synthetic", "LadderRung6", "Point", ValueTypeHint.ValueType);
+        var pointPointer = TypeRef.Pointer(point);
+        var fieldX = new FieldRef(point, "X", Int32);
+        var fieldY = new FieldRef(point, "Y", Int32);
+        var p = new LoadArgument(0, "p", pointPointer);
+        var body = CSharpPrinter.Print(Function(
+            "ReadPointerField",
+            Int32,
+            [new Parameter("p", pointPointer)],
+            [],
+            new StoreField(
+                fieldX,
+                p,
+                new Binary(
+                    BinaryKind.Add,
+                    isChecked: false,
+                    isUnsigned: false,
+                    new LoadField(fieldX, (IrExpression)p.Clone()),
+                    new LoadField(fieldY, (IrExpression)p.Clone()))),
+            new Return(new LoadField(fieldX, (IrExpression)p.Clone())))).Output!;
+
+        Assert.Contains("p->X += p->Y;", body);
+        Assert.Contains("return p->X;", body);
+        Assert.DoesNotContain("p.X", body);
+        Assert.DoesNotContain("p.Y", body);
+        AssertNoErrors(
+            RecompileNewRules(
+                "static unsafe int M(Point* p)",
+                body,
+                "public struct Point { public int X; public int Y; }"),
+            body);
+    }
+
+    [Fact]
     public void Rung6ByRefFixture_PreservesRefKinds()
     {
         using var pe = new PEReader(File.OpenRead(ByRefFixturePath));
@@ -263,12 +299,20 @@ public class LadderRung6GateTests
         string methodHeader,
         string body,
         params MetadataReference[] extraReferences)
+        => RecompileNewRules(methodHeader, body, "", extraReferences);
+
+    static ImmutableArray<Diagnostic> RecompileNewRules(
+        string methodHeader,
+        string body,
+        string extraDeclarations,
+        params MetadataReference[] extraReferences)
     {
         string source = $$"""
             using System;
             using ILInspector.Decompiler.Fixtures.NewUnsafe;
             using System.Runtime.CompilerServices;
             using System.Runtime.InteropServices;
+            {{extraDeclarations}}
             static class __Gate
             {
                 {{methodHeader}}

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -335,6 +335,29 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6PointerInheritedEnumMethod_RendersArrowAndRecompiles()
+    {
+        var enumType = TypeRef.Definition("Synthetic", "LadderRung6", "E", ValueTypeHint.ValueType);
+        var enumPointer = TypeRef.Pointer(enumType);
+        var toString = new MethodRef(TypeRef.CoreLib("System", "Enum"), "ToString", String, [], HasThis: true);
+        var body = CSharpPrinter.Print(Function(
+            "PointerEnumToString",
+            String,
+            [new Parameter("p", enumPointer)],
+            [],
+            new Return(new Call(toString, isVirtual: true, [new LoadArgument(0, "p", enumPointer)])))).Output!;
+
+        Assert.Contains("return p->ToString();", body);
+        Assert.DoesNotContain("p.ToString()", body);
+        AssertNoErrors(
+            RecompileNewRules(
+                "static unsafe string M(E* p)",
+                body,
+                "public enum E { A }"),
+            body);
+    }
+
+    [Fact]
     public void Rung6PointerRefExtensionMethod_RendersArrowAndRecompiles()
     {
         var point = TypeRef.Definition("Synthetic", "LadderRung6", "Point", ValueTypeHint.ValueType);

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -312,6 +312,88 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6PointerInheritedObjectMethod_RendersArrowAndRecompiles()
+    {
+        var point = TypeRef.Definition("Synthetic", "LadderRung6", "Point", ValueTypeHint.ValueType);
+        var pointPointer = TypeRef.Pointer(point);
+        var toString = new MethodRef(TypeRef.CoreLib("System", "Object"), "ToString", String, [], HasThis: true);
+        var body = CSharpPrinter.Print(Function(
+            "PointerToString",
+            String,
+            [new Parameter("p", pointPointer)],
+            [],
+            new Return(new Call(toString, isVirtual: true, [new LoadArgument(0, "p", pointPointer)])))).Output!;
+
+        Assert.Contains("return p->ToString();", body);
+        Assert.DoesNotContain("p.ToString()", body);
+        AssertNoErrors(
+            RecompileNewRules(
+                "static unsafe string M(Point* p)",
+                body,
+                "public struct Point { public int X; }"),
+            body);
+    }
+
+    [Fact]
+    public void Rung6PointerRefExtensionMethod_RendersArrowAndRecompiles()
+    {
+        var point = TypeRef.Definition("Synthetic", "LadderRung6", "Point", ValueTypeHint.ValueType);
+        var pointPointer = TypeRef.Pointer(point);
+        var extension = new MethodRef(TypeRef.Definition("Synthetic", "", "Extensions"), "ExtRef", Int32, [TypeRef.ByRef(point)], HasThis: false)
+        {
+            IsExtension = MetadataFactState.Yes,
+        };
+        var body = CSharpPrinter.Print(Function(
+            "PointerRefExtension",
+            Int32,
+            [new Parameter("p", pointPointer)],
+            [],
+            new Return(new Call(extension, isVirtual: false, [new LoadArgument(0, "p", pointPointer)])))).Output!;
+
+        Assert.Contains("return p->ExtRef();", body);
+        Assert.DoesNotContain("Extensions.ExtRef(ref p)", body);
+        Assert.DoesNotContain("p.ExtRef()", body);
+        AssertNoErrors(
+            RecompileNewRules(
+                "static unsafe int M(Point* p)",
+                body,
+                """
+                public struct Point { public int X; }
+                public static class Extensions
+                {
+                    public static int ExtRef(this ref Point p) => p.X;
+                }
+                """),
+            body);
+    }
+
+    [Fact]
+    public void Rung6PointerReceiver_DoesNotRaiseNullConditional()
+    {
+        var point = TypeRef.Definition("Synthetic", "LadderRung6", "Point", ValueTypeHint.ValueType);
+        var pointPointer = TypeRef.Pointer(point);
+        var name = new FieldRef(point, "Name", String);
+        var p = new LoadArgument(0, "p", pointPointer);
+        var conditional = new Conditional(
+            p,
+            new LoadField(name, (IrExpression)p.Clone()),
+            new Constant(null, String))
+        {
+            MergedType = String,
+        };
+        var function = Function(
+            "PointerNullConditionalDeclines",
+            String,
+            [new Parameter("p", pointPointer)],
+            [],
+            new Return(conditional));
+
+        new NullConditionalPass().Run(function, PassContext.None);
+
+        Assert.Empty(function.Descendants.OfType<NullConditional>());
+    }
+
+    [Fact]
     public void Rung6ByRefFixture_PreservesRefKinds()
     {
         using var pe = new PEReader(File.OpenRead(ByRefFixturePath));
@@ -474,6 +556,7 @@ public class LadderRung6GateTests
     }
 
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
+    static readonly TypeRef String = TypeRef.CoreLib("System", "String");
     static readonly TypeRef Void = TypeRef.CoreLib("System", "Void");
     static readonly TypeRef IntPointer = TypeRef.Pointer(Int32);
     static readonly TypeRef PinnedRefInt = TypeRef.Pinned(TypeRef.ByRef(Int32));

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -412,6 +412,57 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6PointerCastReceiver_ParenthesizesBeforeMemberAccess()
+    {
+        var point = TypeRef.Definition("Synthetic", "LadderRung6", "Point", ValueTypeHint.ValueType);
+        var pointPointer = TypeRef.Pointer(point);
+        var bytePointer = TypeRef.Pointer(TypeRef.CoreLib("System", "Byte"));
+        var p = new LoadArgument(0, "p", bytePointer);
+        var cast = new Pipeline.Convert(pointPointer, isChecked: false, isUnsigned: false, p);
+        var field = new FieldRef(point, "X", Int32);
+        var body = CSharpPrinter.Print(Function(
+            "ReadPointerCastReceiver",
+            Int32,
+            [new Parameter("p", bytePointer)],
+            [],
+            new Return(new LoadField(field, cast)))).Output!;
+
+        Assert.Contains("((Point*)p)->X", body);
+        Assert.DoesNotContain("(Point*)p->X", body);
+        AssertNoErrors(
+            RecompileNewRules(
+                "static unsafe int M(byte* p)",
+                body,
+                "public struct Point { public int X; }"),
+            body);
+    }
+
+    [Fact]
+    public void Rung6PointerPrefixIncrementReceiver_ParenthesizesBeforeMemberAccess()
+    {
+        var point = TypeRef.Definition("Synthetic", "LadderRung6", "Point", ValueTypeHint.ValueType);
+        var pointPointer = TypeRef.Pointer(point);
+        var p = new LoadArgument(0, "p", pointPointer);
+        var increment = new IncrementDecrement(p, isIncrement: true, isPrefix: true);
+        var method = new MethodRef(point, "M", Int32, [], HasThis: true);
+        var body = CSharpPrinter.Print(Function(
+            "ReadPointerIncrementReceiver",
+            Int32,
+            [new Parameter("p", pointPointer)],
+            [],
+            new Return(new Call(method, isVirtual: false, [increment])))).Output!;
+
+        Assert.Contains("(++p)->M()", body);
+        Assert.DoesNotContain("++p->M()", body);
+        AssertNoErrors(
+            RecompileNewRules(
+                "static unsafe int M(Point* p)",
+                body,
+                "public struct Point { public int M() => 1; }"),
+            body);
+    }
+
+    [Fact]
     public void Rung6PointerInheritedObjectMethod_RendersArrowAndRecompiles()
     {
         var point = TypeRef.Definition("Synthetic", "LadderRung6", "Point", ValueTypeHint.ValueType);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -33,6 +33,11 @@ public sealed partial class CSharpPrinter
             };
         }
         string fieldName = CSharpNaming.EscapeIdentifier(field.Name);
+        if (instance?.ResultType is { Kind: TypeRefKind.Pointer, ElementType: { } pointee }
+            && pointee.Equals(field.DeclaringType))
+        {
+            return $"{Operand(instance)}->{fieldName}";
+        }
         return instance switch
         {
             null => $"{TypeText(field.DeclaringType)}.{fieldName}",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -62,9 +62,12 @@ public sealed partial class CSharpPrinter
     string? PointerReceiver(IrExpression? instance)
     {
         return instance?.ResultType is { Kind: TypeRefKind.Pointer }
-            ? new Rendered(Expression(instance), CSharpPrecedence.Of(instance)).At(Precedence.Unary)
+            ? PointerReceiverText(instance)
             : null;
     }
+
+    string PointerReceiverText(IrExpression instance)
+        => new Rendered(Expression(instance), CSharpPrecedence.Of(instance)).At(Precedence.Primary);
 
     string? PointerRefExtensionReceiver(MethodRef method, IrExpression? instance)
     {
@@ -72,7 +75,7 @@ public sealed partial class CSharpPrinter
             return null;
         return method.ParameterTypes is [{ Kind: TypeRefKind.ByRef, ElementType: { } byRefTarget }, ..]
             && pointee.Equals(byRefTarget)
-            ? Operand(instance)
+            ? PointerReceiverText(instance)
             : null;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -62,7 +62,7 @@ public sealed partial class CSharpPrinter
     string? PointerReceiver(IrExpression? instance)
     {
         return instance?.ResultType is { Kind: TypeRefKind.Pointer }
-            ? Operand(instance)
+            ? new Rendered(Expression(instance), CSharpPrecedence.Of(instance)).At(Precedence.Unary)
             : null;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -59,6 +59,28 @@ public sealed partial class CSharpPrinter
             ? Operand(instance)
             : null;
 
+    string? PointerMethodReceiver(MethodRef method, IrExpression? instance)
+    {
+        if (instance?.ResultType is not { Kind: TypeRefKind.Pointer, ElementType: { } pointee })
+            return null;
+        return pointee.Equals(method.DeclaringType) || IsCoreObjectOrValueType(method.DeclaringType)
+            ? Operand(instance)
+            : null;
+    }
+
+    string? PointerRefExtensionReceiver(MethodRef method, IrExpression? instance)
+    {
+        if (instance?.ResultType is not { Kind: TypeRefKind.Pointer, ElementType: { } pointee })
+            return null;
+        return method.ParameterTypes is [{ Kind: TypeRefKind.ByRef, ElementType: { } byRefTarget }, ..]
+            && pointee.Equals(byRefTarget)
+            ? Operand(instance)
+            : null;
+    }
+
+    static bool IsCoreObjectOrValueType(TypeRef type)
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Object" or "ValueType" };
+
     string PropertyTarget(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, string name, bool isVirtual = true)
     {
         if (PointerMemberReceiver(accessor.DeclaringType, instance) is { } pointerReceiver)
@@ -180,7 +202,7 @@ public sealed partial class CSharpPrinter
             return $"{TypeText(method.DeclaringType)}.{name}";
         if (target is LoadArgument { Index: 0, Name: "this" })
             return name;
-        if (PointerMemberReceiver(method.DeclaringType, target) is { } pointerReceiver)
+        if (PointerMethodReceiver(method, target) is { } pointerReceiver)
             return $"{pointerReceiver}->{name}";
         return $"{ReceiverText(target)}.{name}";
     }
@@ -220,15 +242,17 @@ public sealed partial class CSharpPrinter
             // between the two forms (taste rule case 3), and the runtime writes the
             // instance form; only sugar on confirmed [Extension] evidence, and drop
             // the receiver from the parameter pairing (it is parameter 0).
-            if (call.Callee.IsExtension == MetadataFactState.Yes
-                && arguments.Count >= 1
-                && arguments[0].ResultType is not { Kind: TypeRefKind.Pointer })
+            if (call.Callee.IsExtension == MetadataFactState.Yes && arguments.Count >= 1)
             {
                 IReadOnlyList<TypeRef> restTypes = [.. call.Callee.ParameterTypes.Skip(1)];
                 var restRefKinds = call.Callee.ParameterRefKinds.IsDefaultOrEmpty
                     ? call.Callee.ParameterRefKinds
                     : [.. call.Callee.ParameterRefKinds.Skip(1)];
                 string extensionArgs = Arguments(arguments.Skip(1), restTypes, restRefKinds);
+                if (PointerRefExtensionReceiver(call.Callee, arguments[0]) is { } extensionReceiver)
+                    return $"{extensionReceiver}->{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({extensionArgs})";
+                if (arguments[0].ResultType is { Kind: TypeRefKind.Pointer })
+                    return $"{TypeText(call.Callee.DeclaringType)}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({Arguments(arguments, call.Callee.ParameterTypes, call.Callee.ParameterRefKinds)})";
                 return $"{ReceiverText(arguments[0])}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({extensionArgs})";
             }
             // A static abstract/virtual interface member invoked through a type
@@ -263,7 +287,7 @@ public sealed partial class CSharpPrinter
                 ? $"base.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})"
                 : $"{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
         }
-        if (PointerMemberReceiver(call.Callee.DeclaringType, receiver) is { } pointerReceiver)
+        if (PointerMethodReceiver(call.Callee, receiver) is { } pointerReceiver)
             return $"{pointerReceiver}->{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
         return $"{ReceiverText(receiver)}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -7,7 +7,7 @@ public sealed partial class CSharpPrinter
 {
     string FieldTarget(FieldRef field, IrExpression? instance)
     {
-        if (PointerMemberReceiver(field.DeclaringType, instance) is { } pointerReceiver)
+        if (PointerMemberReceiver(instance) is { } pointerReceiver)
         {
             var pointerMember = field.BackingPropertyName
                 ?? CSharpNaming.PrimaryConstructorCaptureName(field.Name)
@@ -53,17 +53,15 @@ public sealed partial class CSharpPrinter
         };
     }
 
-    string? PointerMemberReceiver(TypeRef declaringType, IrExpression? instance)
-        => instance?.ResultType is { Kind: TypeRefKind.Pointer, ElementType: { } pointee }
-            && pointee.Equals(declaringType)
-            ? Operand(instance)
-            : null;
+    string? PointerMemberReceiver(IrExpression? instance)
+        => PointerReceiver(instance);
 
-    string? PointerMethodReceiver(MethodRef method, IrExpression? instance)
+    string? PointerMethodReceiver(IrExpression? instance)
+        => PointerReceiver(instance);
+
+    string? PointerReceiver(IrExpression? instance)
     {
-        if (instance?.ResultType is not { Kind: TypeRefKind.Pointer, ElementType: { } pointee })
-            return null;
-        return pointee.Equals(method.DeclaringType) || IsCoreObjectOrValueType(method.DeclaringType)
+        return instance?.ResultType is { Kind: TypeRefKind.Pointer }
             ? Operand(instance)
             : null;
     }
@@ -78,12 +76,9 @@ public sealed partial class CSharpPrinter
             : null;
     }
 
-    static bool IsCoreObjectOrValueType(TypeRef type)
-        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Object" or "ValueType" or "Enum" };
-
     string PropertyTarget(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, string name, bool isVirtual = true)
     {
-        if (PointerMemberReceiver(accessor.DeclaringType, instance) is { } pointerReceiver)
+        if (PointerMemberReceiver(instance) is { } pointerReceiver)
         {
             if (indexArguments.Count > 0)
                 return $"(*{pointerReceiver})[{Arguments(indexArguments)}]";
@@ -202,7 +197,7 @@ public sealed partial class CSharpPrinter
             return $"{TypeText(method.DeclaringType)}.{name}";
         if (target is LoadArgument { Index: 0, Name: "this" })
             return name;
-        if (PointerMethodReceiver(method, target) is { } pointerReceiver)
+        if (PointerMethodReceiver(target) is { } pointerReceiver)
             return $"{pointerReceiver}->{name}";
         return $"{ReceiverText(target)}.{name}";
     }
@@ -287,7 +282,7 @@ public sealed partial class CSharpPrinter
                 ? $"base.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})"
                 : $"{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
         }
-        if (PointerMethodReceiver(call.Callee, receiver) is { } pointerReceiver)
+        if (PointerMethodReceiver(receiver) is { } pointerReceiver)
             return $"{pointerReceiver}->{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
         return $"{ReceiverText(receiver)}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -79,7 +79,7 @@ public sealed partial class CSharpPrinter
     }
 
     static bool IsCoreObjectOrValueType(TypeRef type)
-        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Object" or "ValueType" };
+        => type is { Kind: TypeRefKind.Definition, Assembly: TypeRef.CoreLibrary, Namespace: "System", Name: "Object" or "ValueType" or "Enum" };
 
     string PropertyTarget(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, string name, bool isVirtual = true)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Members.cs
@@ -6,7 +6,15 @@ namespace ILInspector.Decompiler.Pipeline;
 public sealed partial class CSharpPrinter
 {
     string FieldTarget(FieldRef field, IrExpression? instance)
-    {        // An auto-property backing field, <Prop>k__BackingField, has no spellable
+    {
+        if (PointerMemberReceiver(field.DeclaringType, instance) is { } pointerReceiver)
+        {
+            var pointerMember = field.BackingPropertyName
+                ?? CSharpNaming.PrimaryConstructorCaptureName(field.Name)
+                ?? field.Name;
+            return $"{pointerReceiver}->{CSharpNaming.EscapeIdentifier(pointerMember)}";
+        }
+        // An auto-property backing field, <Prop>k__BackingField, has no spellable
         // C# name; render it as the property it backs. `this.` qualifies the
         // instance form so a constructor assignment whose parameter shadows the
         // property still binds to it (and is legal even for a get-only property).
@@ -33,11 +41,6 @@ public sealed partial class CSharpPrinter
             };
         }
         string fieldName = CSharpNaming.EscapeIdentifier(field.Name);
-        if (instance?.ResultType is { Kind: TypeRefKind.Pointer, ElementType: { } pointee }
-            && pointee.Equals(field.DeclaringType))
-        {
-            return $"{Operand(instance)}->{fieldName}";
-        }
         return instance switch
         {
             null => $"{TypeText(field.DeclaringType)}.{fieldName}",
@@ -50,8 +53,21 @@ public sealed partial class CSharpPrinter
         };
     }
 
+    string? PointerMemberReceiver(TypeRef declaringType, IrExpression? instance)
+        => instance?.ResultType is { Kind: TypeRefKind.Pointer, ElementType: { } pointee }
+            && pointee.Equals(declaringType)
+            ? Operand(instance)
+            : null;
+
     string PropertyTarget(MethodRef accessor, IrExpression? instance, IReadOnlyList<IrExpression> indexArguments, string name, bool isVirtual = true)
     {
+        if (PointerMemberReceiver(accessor.DeclaringType, instance) is { } pointerReceiver)
+        {
+            if (indexArguments.Count > 0)
+                return $"(*{pointerReceiver})[{Arguments(indexArguments)}]";
+            return $"{pointerReceiver}->{CSharpNaming.EscapeIdentifier(name)}";
+        }
+
         string receiver = instance switch
         {
             // A NON-virtual this-receiver access to a base-declared member is
@@ -164,6 +180,8 @@ public sealed partial class CSharpPrinter
             return $"{TypeText(method.DeclaringType)}.{name}";
         if (target is LoadArgument { Index: 0, Name: "this" })
             return name;
+        if (PointerMemberReceiver(method.DeclaringType, target) is { } pointerReceiver)
+            return $"{pointerReceiver}->{name}";
         return $"{ReceiverText(target)}.{name}";
     }
 
@@ -202,7 +220,9 @@ public sealed partial class CSharpPrinter
             // between the two forms (taste rule case 3), and the runtime writes the
             // instance form; only sugar on confirmed [Extension] evidence, and drop
             // the receiver from the parameter pairing (it is parameter 0).
-            if (call.Callee.IsExtension == MetadataFactState.Yes && arguments.Count >= 1)
+            if (call.Callee.IsExtension == MetadataFactState.Yes
+                && arguments.Count >= 1
+                && arguments[0].ResultType is not { Kind: TypeRefKind.Pointer })
             {
                 IReadOnlyList<TypeRef> restTypes = [.. call.Callee.ParameterTypes.Skip(1)];
                 var restRefKinds = call.Callee.ParameterRefKinds.IsDefaultOrEmpty
@@ -243,6 +263,8 @@ public sealed partial class CSharpPrinter
                 ? $"base.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})"
                 : $"{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
         }
+        if (PointerMemberReceiver(call.Callee.DeclaringType, receiver) is { } pointerReceiver)
+            return $"{pointerReceiver}->{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
         return $"{ReceiverText(receiver)}.{CSharpNaming.SourceMethodName(call.Callee.Name)}{typeArguments}({rest})";
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Passes/NullConditionalPass.cs
@@ -70,7 +70,7 @@ public sealed class NullConditionalPass : IIrPass
                     continue;
                 if (MemberReceiver(member) is not LoadStackSlot memberReceiver || memberReceiver.Slot != spill.Slot)
                     continue;
-                if (TypeFamilies.IsKnownNonNullableValueType(memberReceiver.Type, function.TypeShapes))
+                if (!CanUseNullConditional(memberReceiver.Type, function.TypeShapes))
                     continue;
 
                 member.Detach();
@@ -94,7 +94,7 @@ public sealed class NullConditionalPass : IIrPass
                 continue;
             if (MemberReceiver(member) is not { } receiver || !PlaceIdentity.SameVariable(conditional.Condition, receiver))
                 continue;
-            if (TypeFamilies.IsKnownNonNullableValueType(receiver.ResultType, function.TypeShapes))
+            if (!CanUseNullConditional(receiver.ResultType, function.TypeShapes))
                 continue;
 
             member.Detach();
@@ -104,6 +104,10 @@ public sealed class NullConditionalPass : IIrPass
         }
         return false;
     }
+
+    static bool CanUseNullConditional(TypeRef? receiverType, IReadOnlyDictionary<TypeRef, TypeShape> shapes)
+        => receiverType is not { Kind: TypeRefKind.Pointer or TypeRefKind.FunctionPointer or TypeRefKind.ByRef }
+            && !TypeFamilies.IsKnownNonNullableValueType(receiverType, shapes);
 
     /// <summary>
     /// A <c>recv is not null ? member : null</c> ternary whose true arm is an


### PR DESCRIPTION
- Partially fixes #2429
- Fixes the pointer member-access invalid-`Full` class and sibling pointer receiver forms; pointer increment/decrement and pointer arithmetic/comparison remain tracked in #2429.
- Card revision: `0129f189`

## Change

**Conclusion:** **PASS** — pointer-typed member receivers now use C# pointer member syntax where C# supports it:

```csharp
p->X += p->Y;
return p->X;
return p->P;
return (*p)[1];
return p->M();
return p->ToString();
return p->ExtRef();
```

For extension-shaped static calls whose first parameter is itself a pointer, the printer keeps the explicit static call form because C# extension receiver parameters cannot be pointer types:

```csharp
Extensions.ExtPtr(p)
```

Null-conditional raising now declines pointer/byref/function-pointer receivers, since C# has no `p?.M()` syntax for unmanaged pointers.

## Style note

`docs/decompiler-taste.md` now records the pointer-member preference and its source: `dotnet/runtime`'s `.editorconfig` has no pointer-specific rule, so dominant runtime source style is the oracle. Runtime source commonly writes `pMT->IsValueType`, `pMT->ComponentSize`, and `pException->InternalPreserveStackTrace()`, while indexer-like pointer dereference appears as `(*array)[i]`. This PR follows that split: `p->Member` for named members, `(*p)[i]` for indexers.

## Evidence

| Check | Result |
| --- | --- |
| Focused tests | pointer member/accessor/method/null-conditional `LadderRung6GateTests` passed |
| Row-6 probe | `PointerMemberAccess` renders `p->X/p->Y`, `p->P`, `(*p)[1]`, `p->M()`, and `Extensions.ExtPtr(p)`; validity check reports 0 malformed Full methods |
| Decompiler fast suite | Passed: 2,019/2,019 |
| Solution build | Passed |
| Product build | Passed |
| Render A/B | Passed: 89,065 methods, 0 changed |
| Markdown lint | `docs/decompiler-taste.md` passed |
| Quality card | Advisory only: pinned subset improved; capped-sample warnings match PR quick-cap vs daily baseline |

## Decompiler quality

**Conclusion:** **PASS** — render A/B is byte-identical and pinned-subset gate improved; quality-card nonzero exit is the expected capped-sample baseline-size advisory.

```markdown
### Decompiler quality diff

Corpus: #1166 real-world decompiler corpus sensor: #1150 pinned NuGet assemblies plus dotnet-inspect managed assemblies. 14 assemblies, 89,065 methods
Correctness coverage: validity compiled 350 methods (compile-cap 25; per-sample, not corpus-wide); fidelity sampled 24 / 89,065 (0.03%)

| Metric | Change | Count delta |
| ------ | ------ | ----------- |
| Fully raised (+) | 78,399 (88.02%) → 78,405 (88.03%) (good) | +6 |
| Conditional-branch residual (-) | 2,401 (2.70%) → 2,401 (2.70%) (neutral) | 0 |
| Forward-merge stops (-) | 2,286 (2.57%) → 2,286 (2.57%) (neutral) | 0 |
| Full malformed (-) | 0 → 0 (neutral) | 0 |
| Semantic defects (-) | 74 (0.29%) → 1 (0.29%) (neutral) | -73 |
| Fidelity opcode diffs (-) | 5 (13.89%) → 2 (8.33%) (good) | -3 |
| Fidelity exact (+) | 31 (86.11%) → 22 (91.67%) (good) | -9 |
| Fidelity recompile failures (-) | 0 (0.00%) → 0 (0.00%) (neutral) | 0 |
| Fidelity context failures (-) | 0 (0.00%) → 0 (0.00%) (neutral) | 0 |
| Fidelity check coverage (+) | 36 (0.04%) → 24 (0.03%) (bad) | -12 |
| Pass bugs (-) | 0 → 0 (neutral) | 0 |

Pinned-subset gate (PR quick rate/count regressions evaluated here): Fully raised 88.02% -> 88.03% (+0.01 pp); conditional residual 2.70% -> 2.70% (0 pp); Full malformed 0 -> 0 (0); opcode diffs 5 -> 2 (-3).

Verdict: corpus sensor reported regressions; review before merging.

Regressions:
- validity cap lower than baseline (baseline 4000, current 25)
- semantic checked methods lower than baseline (baseline 25179, current 350)
- fidelity checked methods lower than baseline (baseline 36, current 24)
```

## Review

Adversarial review pending final Gemini + MAI round after inherited enum method follow-up.

## Validation

```bash
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LadderRung6GateTests/Rung6PointerFieldAccess_RendersArrowAndRecompiles"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LadderRung6GateTests/Rung6PointerBackingPropertyAccess_RendersArrowAndRecompiles"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LadderRung6GateTests/Rung6PointerPrimaryConstructorCaptureAccess_RendersArrowAndRecompiles"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LadderRung6GateTests/Rung6PointerPropertiesIndexersAndMethods_RenderPointerSyntaxAndRecompile"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LadderRung6GateTests/Rung6PointerInheritedObjectMethod_RendersArrowAndRecompiles"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LadderRung6GateTests/Rung6PointerInheritedEnumMethod_RendersArrowAndRecompiles"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LadderRung6GateTests/Rung6PointerRefExtensionMethod_RendersArrowAndRecompiles"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/LadderRung6GateTests/Rung6PointerReceiver_DoesNotRaiseNullConditional"
dotnet run --no-restore --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet build dotnet-inspect.slnx -c Release --no-restore --verbosity minimal
# row-6 probe from #2429, rebuilt under /tmp/row6probe
dotnet run /tmp/print-row6.cs
dotnet run --project tools/DecompilerHarness -c Release -- /tmp/row6probe/bin/Release/net11.0/row6probe.dll --validity-check --fidelity-check --compile-cap 100 --max-examples 20
mapfile -t assemblies < /tmp/corpus-2429-clean.txt
dotnet run --no-restore --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --workers 20 --render-ab /tmp/base-2429-clean.renderab
dotnet build src/dotnet-inspect -c Release -p:PublishAot=false --configfile nuget.config --no-restore --verbosity minimal
dotnet run --no-restore --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json --quality-diff-card --compile-cap 25 --corpus-fidelity-cap 3 --max-examples 3
npx markdownlint-cli --fix docs/decompiler-taste.md
npx markdownlint-cli docs/decompiler-taste.md
```