### PR TITLE
Add leak-triage candidate buckets

### DIFF
--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -34,6 +34,20 @@ public sealed class LeakTriageAnalyzerTests
     }
 
     [Fact]
+    public void DetailedAnalysis_ReportsMeasurementCandidatesWithoutChangingFindings()
+    {
+        var result = FixtureResult();
+
+        AssertSingleShape(result.Findings, nameof(ArrayPoolLeakFixtures.UseAfterReturn), "arraypool-use-after-return");
+        AssertSingleShape(result.Findings, nameof(ArrayPoolLeakFixtures.RentNotReturnedOnSomePath), "arraypool-rent-not-returned");
+        AssertSingleShape(result.Findings, nameof(ArrayPoolLeakFixtures.DoubleReturn), "arraypool-double-return");
+
+        AssertCandidate(result, nameof(ArrayPoolLeakFixtures.UseAfterReturn), "use-after-return-candidate");
+        AssertCandidate(result, nameof(ArrayPoolLeakFixtures.RentNotReturnedOnSomePath), "normal-path-leak-candidate");
+        AssertCandidate(result, nameof(ArrayPoolLeakFixtures.DoubleReturn), "double-return-candidate");
+    }
+
+    [Fact]
     public void AmbiguousArrayPoolFixtures_FailClosed()
     {
         var findings = FixtureFindings();
@@ -41,6 +55,45 @@ public sealed class LeakTriageAnalyzerTests
         Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.CrossMethodReturn)));
         Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.FieldStoredArray)));
         Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.NonSharedPoolRent)));
+        Assert.Empty(ForMethod(findings, nameof(ArrayPoolLeakFixtures.ReturnsRentedArray)));
+    }
+
+    [Fact]
+    public void DetailedAnalysis_BucketsSuppressedOwnershipShapes()
+    {
+        var crossMethod = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenRent),
+            0x0A,
+            0x06,
+            .. Call(TokenUnknown),
+            0x2A,
+        ], []);
+        var fieldStore = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenRent),
+            0x0A,
+            0x06,
+            0x80, .. TokenBytes(TokenField),
+            0x2A,
+        ], []);
+        var returned = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenRent),
+            0x0A,
+            0x06,
+            0x2A,
+        ], []);
+
+        AssertCandidate(crossMethod, nameof(Synthetic), "cross-method-suppressed");
+        AssertCandidate(fieldStore, nameof(Synthetic), "alias-or-field-suppressed");
+        AssertCandidate(returned, nameof(Synthetic), "ownership-transfer-suppressed");
+
+        var result = FixtureResult();
+        AssertCandidate(result, nameof(ArrayPoolLeakFixtures.NonSharedPoolRent), "ownership-transfer-suppressed");
     }
 
     [Fact]
@@ -67,6 +120,30 @@ public sealed class LeakTriageAnalyzerTests
     }
 
     [Fact]
+    public void DetailedAnalysis_IncompleteDataflow_IsSuppressedBucket()
+    {
+        byte[] externalBranch = [0x2B, 0x7F, 0x2A]; // br.s outside the method, then ret
+        var method = new MethodIdentity(
+            "Fixture",
+            Guid.Empty,
+            TypeRef.Definition("Fixture", "Fixtures", "Incomplete"),
+            "Malformed",
+            [],
+            TypeRef.CoreLib("System", "Void"),
+            0x06000001,
+            IsStatic: true);
+
+        var result = LeakTriageAnalyzer.AnalyzeMethodDetailed(
+            method,
+            externalBranch,
+            Array.Empty<ExceptionRegion>(),
+            _ => MemberRef.Unsupported("not used"));
+
+        Assert.Empty(result.Findings);
+        AssertCandidate(result, "Malformed", "incomplete-cfg-or-rd-suppressed");
+    }
+
+    [Fact]
     public void FaultHandlerReturn_DoesNotSatisfyNormalLeavePath()
     {
         var findings = AnalyzeSynthetic([
@@ -85,15 +162,45 @@ public sealed class LeakTriageAnalyzerTests
         AssertSingleShape(findings, nameof(Synthetic), "arraypool-rent-not-returned");
     }
 
+    [Fact]
+    public void DetailedAnalysis_ExceptionPathLeak_IsSeparateCandidateBucket()
+    {
+        var result = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenRent),
+            0x0A,
+            .. Newobj(TokenUnknown),
+            0x7A,
+        ], []);
+
+        AssertSingleShape(result.Findings, nameof(Synthetic), "arraypool-rent-not-returned");
+        AssertCandidate(result, nameof(Synthetic), "exception-path-leak-candidate");
+    }
+
+    static LeakTriageResult FixtureResult()
+    {
+        var result = LeakTriageAnalyzer.AnalyzeAssemblyDetailed(typeof(ArrayPoolLeakFixtures).Assembly.Location);
+        return result with
+        {
+            Findings = [.. result.Findings.Where(finding => finding.Method.DeclaringType.Name == nameof(ArrayPoolLeakFixtures))],
+            Candidates = [.. result.Candidates.Where(candidate => candidate.Method.DeclaringType.Name == nameof(ArrayPoolLeakFixtures))],
+        };
+    }
+
     static ImmutableArray<LeakTriageFinding> FixtureFindings()
-        => [.. LeakTriageAnalyzer.AnalyzeAssembly(typeof(ArrayPoolLeakFixtures).Assembly.Location)
-            .Where(finding => finding.Method.DeclaringType.Name == nameof(ArrayPoolLeakFixtures))];
+        => FixtureResult().Findings;
 
     const int TokenShared = 0x0A000001;
     const int TokenRent = 0x0A000002;
     const int TokenReturn = 0x0A000003;
+    const int TokenUnknown = 0x0A000004;
+    const int TokenField = 0x0A000005;
 
     static ImmutableArray<LeakTriageFinding> AnalyzeSynthetic(byte[] il, IReadOnlyCollection<ExceptionRegion> exceptionRegions)
+        => AnalyzeSyntheticDetailed(il, exceptionRegions).Findings;
+
+    static LeakTriageResult AnalyzeSyntheticDetailed(byte[] il, IReadOnlyCollection<ExceptionRegion> exceptionRegions)
     {
         var method = new MethodIdentity(
             "Fixture",
@@ -104,7 +211,7 @@ public sealed class LeakTriageAnalyzerTests
             TypeRef.CoreLib("System", "Void"),
             0x06000001,
             IsStatic: true);
-        return LeakTriageAnalyzer.AnalyzeMethod(method, il, exceptionRegions, ResolveSyntheticMember);
+        return LeakTriageAnalyzer.AnalyzeMethodDetailed(method, il, exceptionRegions, ResolveSyntheticMember);
     }
 
     static MemberRef ResolveSyntheticMember(int token)
@@ -119,12 +226,14 @@ public sealed class LeakTriageAnalyzerTests
             TokenShared => new MemberRef(arrayPoolOfByte, "get_Shared", [], arrayPoolOfByte, MemberKind.Method),
             TokenRent => new MemberRef(arrayPoolOfByte, "Rent", [TypeRef.CoreLib("System", "Int32")], byteArray, MemberKind.Method) { HasThis = true },
             TokenReturn => new MemberRef(arrayPoolOfByte, "Return", [byteArray], TypeRef.CoreLib("System", "Void"), MemberKind.Method) { HasThis = true },
+            TokenUnknown => new MemberRef(TypeRef.Definition("Fixture", "Fixtures", "Unknown"), "Use", [], TypeRef.CoreLib("System", "Void"), MemberKind.Method),
             _ => MemberRef.Unsupported($"unknown token 0x{token:X8}"),
         };
     }
 
     static byte[] Call(int token) => [0x28, .. TokenBytes(token)];
     static byte[] Callvirt(int token) => [0x6F, .. TokenBytes(token)];
+    static byte[] Newobj(int token) => [0x73, .. TokenBytes(token)];
     static byte[] TokenBytes(int token) => BitConverter.GetBytes(token);
 
     static readonly ConstructorInfo s_exceptionRegionConstructor =
@@ -146,6 +255,12 @@ public sealed class LeakTriageAnalyzerTests
 
     static IEnumerable<LeakTriageFinding> ForMethod(ImmutableArray<LeakTriageFinding> findings, string methodName)
         => findings.Where(finding => finding.Method.Name == methodName);
+
+    static void AssertCandidate(LeakTriageResult result, string methodName, string shape)
+    {
+        var candidate = Assert.Single(result.Candidates.Where(candidate => candidate.Method.Name == methodName && candidate.Shape == shape));
+        Assert.Equal(shape, candidate.Shape);
+    }
 
     static void AssertSingleShape(ImmutableArray<LeakTriageFinding> findings, string methodName, string shape)
     {
@@ -288,6 +403,20 @@ internal sealed class ArrayPoolLeakFixtures
     {
         var buffer = pool.Rent(16);
         buffer[0] = 1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static byte[] ReturnsRentedArray()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        return buffer;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ThrowAfterRent()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        throw new InvalidOperationException(buffer.Length.ToString());
     }
 
     static void ReturnHelper(byte[] buffer)

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -120,7 +120,7 @@ public sealed class LeakTriageAnalyzerTests
     }
 
     [Fact]
-    public void DetailedAnalysis_IncompleteDataflow_IsSuppressedBucket()
+    public void DetailedAnalysis_IncompleteDataflowWithoutRent_HasNoSuppressedBucket()
     {
         byte[] externalBranch = [0x2B, 0x7F, 0x2A]; // br.s outside the method, then ret
         var method = new MethodIdentity(
@@ -140,7 +140,23 @@ public sealed class LeakTriageAnalyzerTests
             _ => MemberRef.Unsupported("not used"));
 
         Assert.Empty(result.Findings);
-        AssertCandidate(result, "Malformed", "incomplete-cfg-or-rd-suppressed");
+        Assert.Empty(result.Candidates);
+    }
+
+    [Fact]
+    public void DetailedAnalysis_IncompleteDataflowWithRent_IsSuppressedBucket()
+    {
+        var result = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenRent),
+            0x0A,
+            0x2B, 0x7F,
+            0x2A,
+        ], []);
+
+        Assert.Empty(result.Findings);
+        AssertCandidate(result, nameof(Synthetic), "incomplete-cfg-or-rd-suppressed");
     }
 
     [Fact]

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -16,9 +16,23 @@ public sealed record LeakTriageFinding(
     int RentOffset,
     int? ILOffset);
 
+public sealed record LeakTriageCandidate(
+    MethodIdentity Method,
+    string Shape,
+    string Evidence,
+    int? RentOffset,
+    int? ILOffset);
+
+public sealed record LeakTriageResult(
+    ImmutableArray<LeakTriageFinding> Findings,
+    ImmutableArray<LeakTriageCandidate> Candidates);
+
 public static class LeakTriageAnalyzer
 {
     public static ImmutableArray<LeakTriageFinding> AnalyzeAssembly(string path)
+        => AnalyzeAssemblyDetailed(path).Findings;
+
+    public static LeakTriageResult AnalyzeAssemblyDetailed(string path)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
 
@@ -29,6 +43,7 @@ public static class LeakTriageAnalyzer
         var assemblyName = reader.GetString(assembly.Name);
         var mvid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
         var findings = ImmutableArray.CreateBuilder<LeakTriageFinding>();
+        var candidates = ImmutableArray.CreateBuilder<LeakTriageCandidate>();
 
         foreach (var typeHandle in reader.TypeDefinitions)
         {
@@ -53,11 +68,13 @@ public static class LeakTriageAnalyzer
                         MetadataTokens.GetToken(methodHandle),
                         (methodDef.Attributes & MethodAttributes.Static) != 0);
                     var body = peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
-                    findings.AddRange(AnalyzeMethod(
+                    var result = AnalyzeMethodDetailed(
                         method,
                         body.GetILBytes() ?? [],
                         body.ExceptionRegions,
-                        token => MemberResolver.ResolveMethod(reader, MetadataTokens.EntityHandle(token), scope)));
+                        token => MemberResolver.ResolveMethod(reader, MetadataTokens.EntityHandle(token), scope));
+                    findings.AddRange(result.Findings);
+                    candidates.AddRange(result.Candidates);
                 }
                 catch (Exception ex) when (IsRecoverable(ex))
                 {
@@ -67,10 +84,17 @@ public static class LeakTriageAnalyzer
             }
         }
 
-        return findings.ToImmutable();
+        return new LeakTriageResult(findings.ToImmutable(), candidates.ToImmutable());
     }
 
     public static ImmutableArray<LeakTriageFinding> AnalyzeMethod(
+        MethodIdentity method,
+        byte[] il,
+        IReadOnlyCollection<ExceptionRegion> exceptionRegions,
+        Func<int, MemberRef> resolveMethod)
+        => AnalyzeMethodDetailed(method, il, exceptionRegions, resolveMethod).Findings;
+
+    public static LeakTriageResult AnalyzeMethodDetailed(
         MethodIdentity method,
         byte[] il,
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
@@ -82,35 +106,41 @@ public static class LeakTriageAnalyzer
         ArgumentNullException.ThrowIfNull(resolveMethod);
 
         if (il.Length == 0)
-            return [];
+            return Empty;
 
         try
         {
             var instructions = InstructionDecoder.Decode(il);
             var graph = BlockGraph.Build(il.Length, instructions, exceptionRegions);
             if (!graph.IsComplete)
-                return [];
+                return Suppressed(method, "incomplete-cfg-or-rd-suppressed", graph.IncompleteReason ?? "Incomplete CFG/RD evidence.", null, null);
 
             var reaching = ReachingDefinitions.Analyze(il, ArgumentSlotCount(method), exceptionRegions);
             if (!reaching.IsComplete)
-                return [];
+                return Suppressed(method, "incomplete-cfg-or-rd-suppressed", reaching.IncompleteReason ?? "Incomplete CFG/RD evidence.", null, null);
 
             var calls = BuildCallMap(instructions, resolveMethod);
-            var rents = FindRents(method, instructions, graph, reaching, calls).ToImmutableArray();
+            var candidates = ImmutableArray.CreateBuilder<LeakTriageCandidate>();
+            var rents = FindRents(method, instructions, graph, reaching, calls, candidates).ToImmutableArray();
             if (rents.Length == 0)
-                return [];
+                return new LeakTriageResult([], candidates.ToImmutable());
 
             var findings = ImmutableArray.CreateBuilder<LeakTriageFinding>();
             foreach (var rent in rents)
-                AnalyzeRent(method, instructions, graph, reaching, calls, rent, findings);
+                AnalyzeRent(method, instructions, graph, reaching, calls, rent, findings, candidates);
 
-            return findings.ToImmutable();
+            return new LeakTriageResult(findings.ToImmutable(), candidates.ToImmutable());
         }
         catch (Exception ex) when (IsRecoverable(ex))
         {
-            return [];
+            return Suppressed(method, "incomplete-cfg-or-rd-suppressed", ex.Message, null, null);
         }
     }
+
+    static LeakTriageResult Empty { get; } = new([], []);
+
+    static LeakTriageResult Suppressed(MethodIdentity method, string shape, string evidence, int? rentOffset, int? ilOffset)
+        => new([], [new LeakTriageCandidate(method, shape, evidence, rentOffset, ilOffset)]);
 
     static void AnalyzeRent(
         MethodIdentity method,
@@ -119,7 +149,8 @@ public static class LeakTriageAnalyzer
         ReachingDefinitionsResult reaching,
         IReadOnlyDictionary<int, MemberRef> calls,
         RentedLocal rent,
-        ImmutableArray<LeakTriageFinding>.Builder findings)
+        ImmutableArray<LeakTriageFinding>.Builder findings,
+        ImmutableArray<LeakTriageCandidate>.Builder candidates)
     {
         var releases = ImmutableArray.CreateBuilder<int>();
         var safeUses = ImmutableArray.CreateBuilder<int>();
@@ -129,12 +160,13 @@ public static class LeakTriageAnalyzer
         {
             if (use.Address)
             {
+                AddCandidate(candidates, method, "alias-or-field-suppressed", "Rented array address is observed.", rent.RentOffset, use.Offset);
                 ambiguous = true;
                 break;
             }
 
-            var kind = ClassifyUse(instructions, calls, use.Offset, rent.Slot);
-            switch (kind)
+            var classification = ClassifyUse(instructions, calls, use.Offset, rent.Slot);
+            switch (classification.Kind)
             {
                 case UseKind.Release:
                     releases.Add(use.Offset);
@@ -143,6 +175,7 @@ public static class LeakTriageAnalyzer
                     safeUses.Add(use.Offset);
                     break;
                 default:
+                    AddCandidate(candidates, method, classification.CandidateShape, classification.Evidence, rent.RentOffset, use.Offset);
                     ambiguous = true;
                     break;
             }
@@ -156,9 +189,18 @@ public static class LeakTriageAnalyzer
 
         // Multiple releases often encode correlated branch predicates (`if (c) return; if (!c) return`).
         // Without predicate facts, fail closed on leaks and only keep same-block misuse shapes below.
-        if (releaseOffsets.Length <= 1
-            && PathExitsWithoutRelease(instructions, graph, calls, rent.StoreOffset, releaseOffsets))
+        var exitKind = releaseOffsets.Length <= 1
+            ? PathExitsWithoutRelease(instructions, graph, calls, rent.StoreOffset, releaseOffsets)
+            : LeakExitKind.None;
+        if (exitKind != LeakExitKind.None)
         {
+            AddCandidate(
+                candidates,
+                method,
+                exitKind == LeakExitKind.Exception ? "exception-path-leak-candidate" : "normal-path-leak-candidate",
+                $"ArrayPool<T>.Shared.Rent at IL_{rent.RentOffset:X4} reaches an unreleased {(exitKind == LeakExitKind.Exception ? "exception" : "normal")} exit.",
+                rent.RentOffset,
+                rent.RentOffset);
             findings.Add(new LeakTriageFinding(
                 method,
                 "arraypool-rent-not-returned",
@@ -172,18 +214,33 @@ public static class LeakTriageAnalyzer
         if (releaseOffsets.Length > 0
             && safeUseOffsets.Any(use => releaseOffsets.Any(release => ReachesInSameBlock(graph, release, use))))
         {
+            int useAfterReturn = safeUseOffsets.Where(use => releaseOffsets.Any(release => ReachesInSameBlock(graph, release, use))).Min();
+            AddCandidate(
+                candidates,
+                method,
+                "use-after-return-candidate",
+                $"Use of rented array reaches past Return at IL_{releaseOffsets.Min():X4}.",
+                rent.RentOffset,
+                useAfterReturn);
             findings.Add(new LeakTriageFinding(
                 method,
                 "arraypool-use-after-return",
                 $"Use of rented array reaches past Return at IL_{releaseOffsets.Min():X4}.",
                 "high",
                 rent.RentOffset,
-                safeUseOffsets.Where(use => releaseOffsets.Any(release => ReachesInSameBlock(graph, release, use))).Min()));
+                useAfterReturn));
         }
 
         if (releaseOffsets.Length > 1
             && releaseOffsets.Any(first => releaseOffsets.Any(second => first != second && ReachesInSameBlock(graph, first, second))))
         {
+            AddCandidate(
+                candidates,
+                method,
+                "double-return-candidate",
+                $"Rented array can reach a second Return after IL_{releaseOffsets.Min():X4}.",
+                rent.RentOffset,
+                releaseOffsets.Skip(1).DefaultIfEmpty(releaseOffsets[0]).Min());
             findings.Add(new LeakTriageFinding(
                 method,
                 "arraypool-double-return",
@@ -194,7 +251,16 @@ public static class LeakTriageAnalyzer
         }
     }
 
-    static bool PathExitsWithoutRelease(
+    static void AddCandidate(
+        ImmutableArray<LeakTriageCandidate>.Builder candidates,
+        MethodIdentity method,
+        string shape,
+        string evidence,
+        int? rentOffset,
+        int? ilOffset)
+        => candidates.Add(new LeakTriageCandidate(method, shape, evidence, rentOffset, ilOffset));
+
+    static LeakExitKind PathExitsWithoutRelease(
         ImmutableArray<DecodedInstruction> instructions,
         BlockGraph graph,
         IReadOnlyDictionary<int, MemberRef> calls,
@@ -203,12 +269,13 @@ public static class LeakTriageAnalyzer
     {
         int startBlock = graph.BlockIndexAt(startOffset);
         if (startBlock < 0)
-            return false;
+            return LeakExitKind.None;
 
         var releaseSet = releases.ToHashSet();
         var visited = new HashSet<(int Block, bool Released)>();
         var stack = new Stack<(int Block, bool Released, int StartOffset)>();
         stack.Push((startBlock, Released: false, StartOffset: startOffset));
+        bool sawExceptionExit = false;
 
         while (stack.Count > 0)
         {
@@ -220,12 +287,17 @@ public static class LeakTriageAnalyzer
             bool released = ProcessBlockForRelease(instructions, calls, block, blockStartOffset, releaseSet, releasedIn);
             var successors = block.Edges.Successors;
             if (!released && block.Edges.ExitsMethod && successors.Count == 0)
-                return true;
+            {
+                if (BlockExitsByException(instructions, calls, block))
+                    sawExceptionExit = true;
+                else
+                    return LeakExitKind.Normal;
+            }
             foreach (int successor in successors)
                 stack.Push((successor, released, graph.Blocks[successor].Start));
         }
 
-        return false;
+        return sawExceptionExit ? LeakExitKind.Exception : LeakExitKind.None;
     }
 
     static bool ProcessBlockForRelease(
@@ -255,6 +327,22 @@ public static class LeakTriageAnalyzer
            || (calls.TryGetValue(instruction.Offset, out var callee)
                && FrameworkIdentity.IsCoreLibraryType(callee.DeclaringType, "System", "ThrowHelper"));
 
+    static bool BlockExitsByException(
+        ImmutableArray<DecodedInstruction> instructions,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        InstructionBlock block)
+    {
+        foreach (var instruction in instructions)
+        {
+            if (instruction.Offset < block.Start || instruction.Offset >= block.End)
+                continue;
+            if (IsDefinitelyThrowingCall(instruction, calls))
+                return true;
+        }
+
+        return false;
+    }
+
     static bool ReachesInSameBlock(BlockGraph graph, int fromOffset, int toOffset)
     {
         int fromBlock = graph.BlockIndexAt(fromOffset);
@@ -267,22 +355,50 @@ public static class LeakTriageAnalyzer
         ImmutableArray<DecodedInstruction> instructions,
         BlockGraph graph,
         ReachingDefinitionsResult reaching,
-        IReadOnlyDictionary<int, MemberRef> calls)
+        IReadOnlyDictionary<int, MemberRef> calls,
+        ImmutableArray<LeakTriageCandidate>.Builder candidates)
     {
         foreach (var instruction in instructions)
         {
             if (!calls.TryGetValue(instruction.Offset, out var callee) || !IsArrayPoolRent(callee))
                 continue;
             if (!RentUsesSharedReceiver(instructions, graph, calls, instruction.Offset))
+            {
+                AddCandidate(
+                    candidates,
+                    method,
+                    "ownership-transfer-suppressed",
+                    $"ArrayPool<T>.Rent at IL_{instruction.Offset:X4} does not use the Shared receiver.",
+                    instruction.Offset,
+                    instruction.Offset);
                 continue;
+            }
             if (!TryFindNextNonNop(instructions, instruction.NextOffset, out var store)
                 || !TryReadStoreLocal(store, out int slot))
+            {
+                AddCandidate(
+                    candidates,
+                    method,
+                    "ownership-transfer-suppressed",
+                    $"ArrayPool<T>.Shared.Rent at IL_{instruction.Offset:X4} is not stored to a modeled local.",
+                    instruction.Offset,
+                    instruction.Offset);
                 continue;
+            }
 
             var definition = reaching.Definitions.FirstOrDefault(d =>
                 !d.IsArgument && d.Slot == slot && d.Offset == store.Offset);
             if (definition is null)
+            {
+                AddCandidate(
+                    candidates,
+                    method,
+                    "incomplete-cfg-or-rd-suppressed",
+                    $"ArrayPool<T>.Shared.Rent local definition at IL_{store.Offset:X4} is missing from reaching definitions.",
+                    instruction.Offset,
+                    store.Offset);
                 continue;
+            }
 
             yield return new RentedLocal(instruction.Offset, store.Offset, slot, definition);
         }
@@ -315,7 +431,7 @@ public static class LeakTriageAnalyzer
         return false;
     }
 
-    static UseKind ClassifyUse(
+    static UseClassification ClassifyUse(
         ImmutableArray<DecodedInstruction> instructions,
         IReadOnlyDictionary<int, MemberRef> calls,
         int loadOffset,
@@ -323,7 +439,7 @@ public static class LeakTriageAnalyzer
     {
         if (!TryFindInstruction(instructions, loadOffset, out int index, out var load)
             || !IsLoadLocal(load, slot))
-            return UseKind.Ambiguous;
+            return UseClassification.OwnershipTransfer("Rented array use could not be classified.");
 
         int extra = 0;
         for (int i = index + 1; i < instructions.Length; i++)
@@ -336,21 +452,25 @@ public static class LeakTriageAnalyzer
                 continue;
             }
             if (opcode == ILOpCode.Ldlen)
-                return extra == 0 ? UseKind.LocalUse : UseKind.Ambiguous;
+                return extra == 0 ? UseClassification.LocalUse : UseClassification.OwnershipTransfer("Rented array length use is ambiguous.");
             if (IsElementRead(opcode))
-                return extra == 1 ? UseKind.LocalUse : UseKind.Ambiguous;
+                return extra == 1 ? UseClassification.LocalUse : UseClassification.OwnershipTransfer("Rented array element read is ambiguous.");
             if (IsElementStore(opcode))
-                return extra == 2 ? UseKind.LocalUse : UseKind.Ambiguous;
+                return extra == 2 ? UseClassification.LocalUse : UseClassification.OwnershipTransfer("Rented array element store is ambiguous.");
+            if (IsFieldStore(opcode) || IsLocalStore(opcode))
+                return UseClassification.AliasOrField("Rented array is stored into another location.");
+            if (opcode == ILOpCode.Ret)
+                return UseClassification.OwnershipTransfer("Rented array escapes through the return value.");
             if (calls.TryGetValue(instruction.Offset, out var callee))
             {
                 if (IsArrayPoolReturn(callee) && extra < callee.ParameterTypes.Length)
-                    return UseKind.Release;
-                return UseKind.Ambiguous;
+                    return UseClassification.Release;
+                return UseClassification.CrossMethod($"Rented array is passed to {callee.DeclaringType.Name}::{callee.Name}.");
             }
-            return UseKind.Ambiguous;
+            return UseClassification.OwnershipTransfer($"Rented array reaches unsupported opcode {opcode}.");
         }
 
-        return UseKind.Ambiguous;
+        return UseClassification.OwnershipTransfer("Rented array use reaches the end of the instruction stream.");
     }
 
     static IReadOnlyDictionary<int, MemberRef> BuildCallMap(
@@ -440,6 +560,13 @@ public static class LeakTriageAnalyzer
             or ILOpCode.Stelem_i4 or ILOpCode.Stelem_i8 or ILOpCode.Stelem_r4 or ILOpCode.Stelem_r8
             or ILOpCode.Stelem_ref;
 
+    static bool IsFieldStore(ILOpCode opcode)
+        => opcode is ILOpCode.Stfld or ILOpCode.Stsfld;
+
+    static bool IsLocalStore(ILOpCode opcode)
+        => opcode is ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3
+            or ILOpCode.Stloc_s or ILOpCode.Stloc;
+
     static bool IsArrayPoolRent(MemberRef member)
         => member.Kind != MemberKind.Unsupported
            && member.Name == "Rent"
@@ -496,5 +623,21 @@ public static class LeakTriageAnalyzer
         Release,
         LocalUse,
         Ambiguous,
+    }
+
+    readonly record struct UseClassification(UseKind Kind, string CandidateShape, string Evidence)
+    {
+        public static UseClassification Release { get; } = new(UseKind.Release, "", "");
+        public static UseClassification LocalUse { get; } = new(UseKind.LocalUse, "", "");
+        public static UseClassification AliasOrField(string evidence) => new(UseKind.Ambiguous, "alias-or-field-suppressed", evidence);
+        public static UseClassification CrossMethod(string evidence) => new(UseKind.Ambiguous, "cross-method-suppressed", evidence);
+        public static UseClassification OwnershipTransfer(string evidence) => new(UseKind.Ambiguous, "ownership-transfer-suppressed", evidence);
+    }
+
+    enum LeakExitKind
+    {
+        None,
+        Normal,
+        Exception,
     }
 }

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -108,9 +108,15 @@ public static class LeakTriageAnalyzer
         if (il.Length == 0)
             return Empty;
 
+        bool hasArrayPoolRent = false;
         try
         {
             var instructions = InstructionDecoder.Decode(il);
+            var calls = BuildCallMap(instructions, resolveMethod);
+            hasArrayPoolRent = calls.Values.Any(IsArrayPoolRent);
+            if (!hasArrayPoolRent)
+                return Empty;
+
             var graph = BlockGraph.Build(il.Length, instructions, exceptionRegions);
             if (!graph.IsComplete)
                 return Suppressed(method, "incomplete-cfg-or-rd-suppressed", graph.IncompleteReason ?? "Incomplete CFG/RD evidence.", null, null);
@@ -119,7 +125,6 @@ public static class LeakTriageAnalyzer
             if (!reaching.IsComplete)
                 return Suppressed(method, "incomplete-cfg-or-rd-suppressed", reaching.IncompleteReason ?? "Incomplete CFG/RD evidence.", null, null);
 
-            var calls = BuildCallMap(instructions, resolveMethod);
             var candidates = ImmutableArray.CreateBuilder<LeakTriageCandidate>();
             var rents = FindRents(method, instructions, graph, reaching, calls, candidates).ToImmutableArray();
             if (rents.Length == 0)
@@ -133,7 +138,9 @@ public static class LeakTriageAnalyzer
         }
         catch (Exception ex) when (IsRecoverable(ex))
         {
-            return Suppressed(method, "incomplete-cfg-or-rd-suppressed", ex.Message, null, null);
+            return hasArrayPoolRent
+                ? Suppressed(method, "incomplete-cfg-or-rd-suppressed", ex.Message, null, null)
+                : Empty;
         }
     }
 
@@ -179,6 +186,8 @@ public static class LeakTriageAnalyzer
                     ambiguous = true;
                     break;
             }
+            if (ambiguous)
+                break;
         }
 
         if (ambiguous)

--- a/tools/AnalysisHarness/LeakTriageSensor.cs
+++ b/tools/AnalysisHarness/LeakTriageSensor.cs
@@ -5,7 +5,7 @@ using ILInspector.Analysis;
 
 namespace ILInspector.AnalysisHarness;
 
-/// <summary>One example finding: its shape and the method it fired on.</summary>
+/// <summary>One example row: its shape and the method it fired on.</summary>
 public sealed record LeakTriageExample(string Shape, string Method);
 
 /// <summary>Per-assembly leak-triage result: whether it opened, its finding count, and the shapes hit with a few example methods.</summary>
@@ -15,25 +15,31 @@ public sealed record LeakTriageAssembly(
     bool TimedOut,
     int Findings,
     IReadOnlyDictionary<string, int> Shapes,
-    IReadOnlyList<LeakTriageExample> Examples);
+    IReadOnlyList<LeakTriageExample> Examples,
+    int Candidates = 0,
+    IReadOnlyDictionary<string, int>? CandidateShapes = null,
+    IReadOnlyList<LeakTriageExample>? CandidateExamples = null);
 
 /// <summary>A leak-triage corpus report: per-assembly rows plus aggregate shape totals.</summary>
 public sealed record LeakTriageReport(
     IReadOnlyList<LeakTriageAssembly> Assemblies,
     IReadOnlyDictionary<string, int> TotalsByShape,
-    int Total);
+    int Total,
+    IReadOnlyDictionary<string, int>? CandidateTotalsByShape = null,
+    int CandidateTotal = 0);
 
 public enum LeakTriageFormat { Markdown, Tsv, Jsonl }
 
 /// <summary>
 /// The leak-triage corpus sensor: sweeps <see cref="LeakTriageAnalyzer"/> over a fixed corpus
-/// and reports where the fail-closed ArrayPool analysis fires - total findings, the shape
-/// histogram, and example methods per shape. This is the evidence engine that must show a
-/// non-zero, high-precision signal before any user-facing `Leak Triage` section is wired
-/// (#1992): the analyzer is precision-first, so an empty corpus card means recall, not the
-/// section, is the next lever. There is no product surface here - the harness measures. The
-/// card is a single-run census with no baseline, so it renders as plain sectioned rows (no
-/// composite/delta cells); a `--diff-baseline` mode is the natural home for those.
+/// and reports where the fail-closed ArrayPool analysis fires - total findings, finding shape
+/// histogram, candidate/suppression buckets, and example methods. This is the evidence engine
+/// that must show a non-zero, high-precision signal before any user-facing `Leak Triage` section
+/// is wired (#1992): the analyzer is precision-first, so an empty findings card plus non-empty
+/// candidate buckets means recall (not the section) is the next lever. There is no product
+/// surface here - the harness measures. The card is a single-run census with no baseline, so it
+/// renders as plain sectioned rows (no composite/delta cells); a `--diff-baseline` mode is the
+/// natural home for those.
 /// </summary>
 public static class LeakTriageSensor
 {
@@ -45,11 +51,21 @@ public static class LeakTriageSensor
         assemblies.Sort((a, b) => string.CompareOrdinal(a.Name, b.Name));
 
         var totals = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        var candidateTotals = new SortedDictionary<string, int>(StringComparer.Ordinal);
         foreach (var assembly in assemblies)
+        {
             foreach (var (shape, count) in assembly.Shapes)
                 totals[shape] = totals.GetValueOrDefault(shape) + count;
+            foreach (var (shape, count) in assembly.CandidateShapes ?? new Dictionary<string, int>())
+                candidateTotals[shape] = candidateTotals.GetValueOrDefault(shape) + count;
+        }
 
-        return new LeakTriageReport(assemblies, totals, assemblies.Sum(a => a.Findings));
+        return new LeakTriageReport(
+            assemblies,
+            totals,
+            assemblies.Sum(a => a.Findings),
+            candidateTotals,
+            assemblies.Sum(a => a.Candidates));
     }
 
     // Bound each assembly so one pathological input cannot hang the sweep; a timeout is a stable
@@ -70,16 +86,34 @@ public static class LeakTriageSensor
         string name = Path.GetFileName(path);
         try
         {
-            var findings = LeakTriageAnalyzer.AnalyzeAssembly(path);
+            var result = LeakTriageAnalyzer.AnalyzeAssemblyDetailed(path);
             var shapes = new SortedDictionary<string, int>(StringComparer.Ordinal);
             var examples = new List<LeakTriageExample>();
-            foreach (var finding in findings)
+            foreach (var finding in result.Findings)
             {
                 shapes[finding.Shape] = shapes.GetValueOrDefault(finding.Shape) + 1;
                 if (examples.Count < examplesPerAssembly)
                     examples.Add(new LeakTriageExample(finding.Shape, $"{finding.Method.DeclaringType.Name}::{finding.Method.Name}"));
             }
-            return new LeakTriageAssembly(name, Opened: true, TimedOut: false, findings.Length, shapes, examples);
+            var candidateShapes = new SortedDictionary<string, int>(StringComparer.Ordinal);
+            var candidateExamples = new List<LeakTriageExample>();
+            foreach (var candidate in result.Candidates)
+            {
+                candidateShapes[candidate.Shape] = candidateShapes.GetValueOrDefault(candidate.Shape) + 1;
+                if (candidateExamples.Count < examplesPerAssembly)
+                    candidateExamples.Add(new LeakTriageExample(candidate.Shape, $"{candidate.Method.DeclaringType.Name}::{candidate.Method.Name}"));
+            }
+
+            return new LeakTriageAssembly(
+                name,
+                Opened: true,
+                TimedOut: false,
+                result.Findings.Length,
+                shapes,
+                examples,
+                result.Candidates.Length,
+                candidateShapes,
+                candidateExamples);
         }
         // This is the per-assembly boundary running on a background thread, so ANY unhandled
         // failure would terminate the whole sweep (a corpus path that is a directory throws
@@ -130,10 +164,17 @@ public static class LeakTriageSensor
             ("failed", report.Assemblies.Count(a => !a.Opened && !a.TimedOut).ToString()),
             ("timed out", report.Assemblies.Count(a => a.TimedOut).ToString()),
             ("total findings", report.Total.ToString()),
+            ("total candidates", report.CandidateTotal.ToString()),
         };
 
     static IReadOnlyList<(string Shape, string Count)> ShapeRows(LeakTriageReport report)
         => [.. report.TotalsByShape
+            .OrderByDescending(kv => kv.Value)
+            .ThenBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => (kv.Key, kv.Value.ToString()))];
+
+    static IReadOnlyList<(string Shape, string Count)> CandidateShapeRows(LeakTriageReport report)
+        => [.. (report.CandidateTotalsByShape ?? new Dictionary<string, int>())
             .OrderByDescending(kv => kv.Value)
             .ThenBy(kv => kv.Key, StringComparer.Ordinal)
             .Select(kv => (kv.Key, kv.Value.ToString()))];
@@ -144,12 +185,20 @@ public static class LeakTriageSensor
             .OrderByDescending(a => a.Findings)
             .SelectMany(a => a.Examples.Take(maxExamples).Select(e => (a.Name, e.Shape, e.Method)))];
 
+    static IReadOnlyList<(string Assembly, string Shape, string Method)> CandidateRows(LeakTriageReport report, int maxExamples)
+        => [.. report.Assemblies
+            .Where(a => a.Candidates > 0)
+            .OrderByDescending(a => a.Candidates)
+            .SelectMany(a => (a.CandidateExamples ?? []).Take(maxExamples).Select(e => (a.Name, e.Shape, e.Method)))];
+
     static LeakTriageCardMarkdownView BuildMarkdownView(LeakTriageReport report, int maxExamples)
         => new()
         {
             Summary = [.. SummaryRows(report).Select(r => new LeakTriageMetricRow(r.Metric, r.Value))],
             ByShape = [.. ShapeRows(report).Select(r => new LeakTriageShapeRow(r.Shape, r.Count))],
             Findings = [.. FindingRows(report, maxExamples).Select(r => new LeakTriageFindingRow(r.Assembly, r.Shape, r.Method))],
+            CandidateBuckets = [.. CandidateShapeRows(report).Select(r => new LeakTriageShapeRow(r.Shape, r.Count))],
+            Candidates = [.. CandidateRows(report, maxExamples).Select(r => new LeakTriageFindingRow(r.Assembly, r.Shape, r.Method))],
         };
 
     static LeakTriageCardTableView BuildTableView(LeakTriageReport report, int maxExamples)
@@ -158,6 +207,8 @@ public static class LeakTriageSensor
             Summary = [.. SummaryRows(report).Select(r => new LeakTriageSectionMetricRow("Summary", r.Metric, r.Value))],
             ByShape = [.. ShapeRows(report).Select(r => new LeakTriageSectionShapeRow("By shape", r.Shape, r.Count))],
             Findings = [.. FindingRows(report, maxExamples).Select(r => new LeakTriageSectionFindingRow("Findings", r.Assembly, r.Shape, r.Method))],
+            CandidateBuckets = [.. CandidateShapeRows(report).Select(r => new LeakTriageSectionShapeRow("Candidate buckets", r.Shape, r.Count))],
+            Candidates = [.. CandidateRows(report, maxExamples).Select(r => new LeakTriageSectionFindingRow("Candidates", r.Assembly, r.Shape, r.Method))],
         };
 }
 
@@ -175,6 +226,12 @@ sealed class LeakTriageCardMarkdownView
 
     [MarkoutSection(Name = "Findings", EmptyText = "None")]
     public List<LeakTriageFindingRow>? Findings { get; init; }
+
+    [MarkoutSection(Name = "Candidate buckets", EmptyText = "None")]
+    public List<LeakTriageShapeRow>? CandidateBuckets { get; init; }
+
+    [MarkoutSection(Name = "Candidates", EmptyText = "None")]
+    public List<LeakTriageFindingRow>? Candidates { get; init; }
 }
 
 [MarkoutSerializable]
@@ -191,6 +248,12 @@ sealed class LeakTriageCardTableView
 
     [MarkoutSection(Name = "Findings")]
     public List<LeakTriageSectionFindingRow>? Findings { get; init; }
+
+    [MarkoutSection(Name = "Candidate buckets")]
+    public List<LeakTriageSectionShapeRow>? CandidateBuckets { get; init; }
+
+    [MarkoutSection(Name = "Candidates")]
+    public List<LeakTriageSectionFindingRow>? Candidates { get; init; }
 }
 
 [MarkoutSerializable]

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -114,7 +114,8 @@ maintainer-owned upkeep: they are documented conventions, not automatic CI gates
 ## Leak triage corpus sensor (#1992)
 
 `--leak-triage` sweeps the fail-closed ArrayPool leak-triage analyzer
-(`LeakTriageAnalyzer`) over a corpus and reports where it fires, as a
+(`LeakTriageAnalyzer`) over a corpus and reports where it fires, plus
+measurement-only candidate/suppression buckets, as a
 [Markout](https://github.com/richlander/markout) card:
 
 ```bash
@@ -123,20 +124,26 @@ dotnet "$DLL" --leak-triage assemblies.txt --tsv            # section-tagged TSV
 dotnet "$DLL" --leak-triage assemblies.txt --jsonl          # one heterogeneous JSON record per row
 ```
 
-The card has three sections — a **Summary** (assemblies / opened / failed / timed out / total
-findings), a **By shape** histogram (`arraypool-rent-not-returned`, `arraypool-use-after-return`,
-`arraypool-double-return`), and **Findings** (assembly / shape / method, `--top` bounding examples
-per assembly). One declarative Markout model renders the dense Markdown table and decomposes into
-section-tagged TSV/JSONL. It is a single-run census with no baseline, so it uses plain sectioned
-rows, not composite/delta cells; a `--diff-baseline` mode against a committed snapshot is the
-natural home for those (`Change`/`[MarkoutDelta]`). Each assembly is bounded by a per-assembly
-timeout, and any per-assembly input failure (a directory path, a truncated PE) becomes an
-`Opened=false` row rather than crashing the sweep.
+The card has five sections — a **Summary** (assemblies / opened / failed / timed out / total
+findings / total candidates), a **By shape** histogram (`arraypool-rent-not-returned`,
+`arraypool-use-after-return`, `arraypool-double-return`), **Findings** (assembly / shape / method,
+`--top` bounding examples per assembly), **Candidate buckets**, and **Candidates**. Candidate
+buckets are not product findings; they measure recall gates such as
+`normal-path-leak-candidate`, `exception-path-leak-candidate`,
+`use-after-return-candidate`, `ownership-transfer-suppressed`,
+`alias-or-field-suppressed`, `cross-method-suppressed`, and
+`incomplete-cfg-or-rd-suppressed`. One declarative Markout model renders the dense Markdown table
+and decomposes into section-tagged TSV/JSONL. It is a single-run census with no baseline, so it
+uses plain sectioned rows, not composite/delta cells; a `--diff-baseline` mode against a committed
+snapshot is the natural home for those (`Change`/`[MarkoutDelta]`). Each assembly is bounded by a
+per-assembly timeout, and any per-assembly input failure (a directory path, a truncated PE) becomes
+an `Opened=false` row rather than crashing the sweep.
 
 This is the evidence engine that must earn any user-facing `Leak Triage` section: the analyzer
 fails closed on incomplete CFG/RD, non-`Shared` pools, aliases, field stores, cross-method
-ownership, and ambiguous uses, so an **empty card on real code means recall — not a product
-section — is the next lever**. A 2026-07-05 run over CoreLib, `Microsoft.CodeAnalysis`, and
+ownership, and ambiguous uses, so an **empty findings card on real code means recall — not a
+product section — is the next lever**. Use the candidate buckets to decide which recall gate to
+model next. A 2026-07-05 run over CoreLib, `Microsoft.CodeAnalysis`, and
 `Microsoft.CodeAnalysis.CSharp` produced **0 findings** (all gates suppressed), while the fixture
 assembly's three known-misuse methods surfaced exactly once each. Wire the section only once this
 card shows non-zero, high-precision rows on real assemblies.


### PR DESCRIPTION
## Summary

Follow-up to #2390 and part of #2439 slice 1. This keeps leak triage measurement-only and does not wire product UI.

- adds `LeakTriageCandidate` / `LeakTriageResult` alongside existing findings
- preserves existing `AnalyzeAssembly` / `AnalyzeMethod` finding APIs
- records candidate/suppression buckets for normal-path leaks, exception-path leaks, use-after-return, double-return, ownership transfer, alias/field, cross-method, and incomplete CFG/RD
- extends `AnalysisHarness --leak-triage` Markout output with `total candidates`, `Candidate buckets`, and `Candidates` sections
- documents that candidate buckets are measurement rows, not product findings

## Measurement

Fixture assembly:

- findings: 3 (same three known misuse shapes)
- candidates: 8
- candidate buckets: `use-after-return-candidate`, `normal-path-leak-candidate`, `double-return-candidate`, `ownership-transfer-suppressed`

ArrayPool-heavy NuGet corpus (75 package DLLs from QuanTAlib, MimeKit, ZLinq, prometheus-net, Pipelines.Sockets.Unofficial, TouchSocket, CliWrap, etc.):

- opened: 75 / 75
- findings: 0
- candidates: 1,359
- candidate buckets:
  - `ownership-transfer-suppressed`: 820
  - `cross-method-suppressed`: 492
  - `alias-or-field-suppressed`: 47

This confirms the next recall lever is ownership/cross-method modeling, not product UI.

## Validation

- `dotnet build src/ILInspector.Analysis.Tests/ILInspector.Analysis.Tests.csproj -c Release --configfile nuget.config --nologo`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -filter "/*/*/LeakTriageAnalyzerTests/*"`
- `dotnet build tools/AnalysisHarness/AnalysisHarness.csproj -c Release --configfile nuget.config --nologo`
- `dotnet run --project tools/AnalysisHarness -c Release --no-build -- --leak-triage /tmp/leak-fixture-corpus.txt --top 20`
- `dotnet run --project tools/AnalysisHarness -c Release --no-build -- --leak-triage /tmp/leak-fixture-corpus.txt --top 5 --jsonl`
- `dotnet run --project tools/AnalysisHarness -c Release --no-build -- --leak-triage /tmp/leak-nuget-assemblies.txt --top 30`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build`
- `npx markdownlint-cli tools/AnalysisHarness/README.md`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo`
- `git diff --check`

## Review

Analysis/harness measurement change; adversarial review requested separately per repo policy.
