### PR TITLE
Add measurement-only ArrayPool resource-lifecycle census (#2439 Slice 1)

### DIFF
--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -261,6 +261,21 @@ internal sealed class ArrayPoolLeakFixtures
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ConditionalReturnInFinally(bool flag)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        try
+        {
+            buffer[0] = 1;
+        }
+        finally
+        {
+            if (flag) // the Return does not post-dominate the finally: the flag-false path leaks
+                ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static void UseAfterReturn()
     {
         var buffer = ArrayPool<byte>.Shared.Rent(16);

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -246,6 +246,21 @@ internal sealed class ArrayPoolLeakFixtures
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void RentThenCallBeforeTryFinally()
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(16);
+        Consume(1); // throwing call in the gap before the protecting try - an exception here skips the finally
+        try
+        {
+            buffer[0] = 1;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static void UseAfterReturn()
     {
         var buffer = ArrayPool<byte>.Shared.Rent(16);

--- a/src/ILInspector.Analysis.Tests/ResourceLifecycleCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/ResourceLifecycleCensusTests.cs
@@ -1,0 +1,204 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.Analysis.Tests;
+
+/// <summary>
+/// Slice-1 census behavior (#2439): the measurement-only ArrayPool lifecycle census partitions
+/// recognized acquires into candidate and suppression buckets without touching the finding path
+/// (the unchanged <see cref="LeakTriageAnalyzer"/> findings are pinned by
+/// <see cref="LeakTriageAnalyzerTests"/>). Candidate buckets are asserted against the shared
+/// <see cref="ArrayPoolLeakFixtures"/>; escape/incomplete suppression buckets need synthetic IL
+/// because the release-build fixtures for those shapes never store the rented array to a local,
+/// so they are not recognized as acquires at all.
+/// </summary>
+public sealed class ResourceLifecycleCensusTests
+{
+    [Fact]
+    public void CandidateBuckets_MatchFixtureShapes()
+    {
+        Assert.Equal(
+            ["exception-path-leak-candidate"],
+            BucketsFor(nameof(ArrayPoolLeakFixtures.CorrectRentReturn)));
+
+        Assert.Equal(
+            ["exception-path-leak-candidate", "normal-path-leak-candidate"],
+            BucketsFor(nameof(ArrayPoolLeakFixtures.RentNotReturnedOnSomePath)));
+
+        Assert.Equal(
+            ["exception-path-leak-candidate", "use-after-return-candidate"],
+            BucketsFor(nameof(ArrayPoolLeakFixtures.UseAfterReturn)));
+
+        Assert.Equal(
+            ["double-return-candidate", "exception-path-leak-candidate"],
+            BucketsFor(nameof(ArrayPoolLeakFixtures.DoubleReturn)));
+
+        // Correlated multi-release: the census is deliberately raw (no predicate facts), so the
+        // impossible (c && !c)-false path shows up as both a normal-path leak and a double return.
+        // This is the pre-graduation over-count Slice 4 must refine, not a defect.
+        Assert.Equal(
+            ["double-return-candidate", "exception-path-leak-candidate", "normal-path-leak-candidate"],
+            BucketsFor(nameof(ArrayPoolLeakFixtures.CorrelatedReturnOnAllPaths)));
+
+        // Correct return on every branch, but no try/finally: only exception-unsafe.
+        Assert.Equal(
+            ["exception-path-leak-candidate"],
+            BucketsFor(nameof(ArrayPoolLeakFixtures.ReturnOnAllPaths)));
+    }
+
+    [Fact]
+    public void FinallyProtectedFixtures_ProduceNoFacts()
+    {
+        // A Return inside a covering finally/fault is safe on both normal and exception paths, so
+        // it hits no bucket at all - including the nested finally/leave shape from #2380.
+        Assert.Empty(BucketsFor(nameof(ArrayPoolLeakFixtures.TryFinallyReturn)));
+        Assert.Empty(BucketsFor(nameof(ArrayPoolLeakFixtures.TryFinallyThrowReturn)));
+        Assert.Empty(BucketsFor(nameof(ArrayPoolLeakFixtures.NestedFinallyLeaveReturn)));
+    }
+
+    [Fact]
+    public void UnmodeledCall_SuppressedAsCrossMethod()
+    {
+        var result = CensusSynthetic([
+            .. Call(TokenShared),        // IL_0000 ArrayPool<byte>.Shared
+            0x1F, 0x10,                  // IL_0005 ldc.i4.s 16
+            .. Callvirt(TokenRent),      // IL_0007 Rent
+            0x0A,                        // IL_000C stloc.0
+            0x06,                        // IL_000D ldloc.0
+            .. Call(TokenConsume),       // IL_000E Consume(byte[])  (unmodeled)
+            0x2A,                        // IL_0013 ret
+        ]);
+
+        var fact = Assert.Single(result.Facts);
+        Assert.Equal("cross-method-suppressed", fact.Bucket);
+        Assert.Equal(1, result.AcquiresObserved);
+    }
+
+    [Fact]
+    public void FieldStore_SuppressedAsAliasOrField()
+    {
+        var result = CensusSynthetic([
+            .. Call(TokenShared),        // IL_0000
+            0x1F, 0x10,                  // IL_0005 ldc.i4.s 16
+            .. Callvirt(TokenRent),      // IL_0007
+            0x0A,                        // IL_000C stloc.0
+            0x06,                        // IL_000D ldloc.0
+            0x80, 0x01, 0x00, 0x00, 0x04, // IL_000E stsfld (field token)
+            0x2A,                        // IL_0013 ret
+        ]);
+
+        var fact = Assert.Single(result.Facts);
+        Assert.Equal("alias-or-field-suppressed", fact.Bucket);
+    }
+
+    [Fact]
+    public void LocalAlias_SuppressedAsAliasOrField()
+    {
+        var result = CensusSynthetic([
+            .. Call(TokenShared),        // IL_0000
+            0x1F, 0x10,                  // IL_0005 ldc.i4.s 16
+            .. Callvirt(TokenRent),      // IL_0007
+            0x0A,                        // IL_000C stloc.0
+            0x06,                        // IL_000D ldloc.0
+            0x0B,                        // IL_000E stloc.1 (alias)
+            0x2A,                        // IL_000F ret
+        ]);
+
+        var fact = Assert.Single(result.Facts);
+        Assert.Equal("alias-or-field-suppressed", fact.Bucket);
+    }
+
+    [Fact]
+    public void ReturnedArray_SuppressedAsOwnershipTransfer()
+    {
+        var result = CensusSynthetic([
+            .. Call(TokenShared),        // IL_0000
+            0x1F, 0x10,                  // IL_0005 ldc.i4.s 16
+            .. Callvirt(TokenRent),      // IL_0007
+            0x0A,                        // IL_000C stloc.0
+            0x06,                        // IL_000D ldloc.0
+            0x2A,                        // IL_000E ret (returns the rented array)
+        ]);
+
+        var fact = Assert.Single(result.Facts);
+        Assert.Equal("ownership-transfer-suppressed", fact.Bucket);
+    }
+
+    [Fact]
+    public void RentWithIncompleteCfg_SuppressedAsIncomplete()
+    {
+        // A br.s to an offset outside the method leaves an unmodeled external edge, so the CFG is
+        // incomplete; a Rent is present, so the method is measured as incomplete rather than dropped.
+        var result = CensusSynthetic([
+            .. Call(TokenShared),        // IL_0000
+            0x1F, 0x10,                  // IL_0005 ldc.i4.s 16
+            .. Callvirt(TokenRent),      // IL_0007
+            0x0A,                        // IL_000C stloc.0
+            0x2B, 0x7F,                  // IL_000D br.s +127 (external target)
+            0x2A,                        // IL_000F ret
+        ]);
+
+        var fact = Assert.Single(result.Facts);
+        Assert.Equal("incomplete-cfg-or-rd-suppressed", fact.Bucket);
+        Assert.Equal(0, result.AcquiresObserved);
+    }
+
+    [Fact]
+    public void MethodWithoutRent_ProducesNothing()
+    {
+        var result = CensusSynthetic([0x2A]); // ret
+        Assert.Empty(result.Facts);
+        Assert.Equal(0, result.AcquiresObserved);
+    }
+
+    static ImmutableArray<string> BucketsFor(string methodName)
+        => [.. ResourceLifecycleCensus.CensusAssembly(typeof(ArrayPoolLeakFixtures).Assembly.Location)
+            .Facts
+            .Where(f => f.Method.DeclaringType.Name == nameof(ArrayPoolLeakFixtures) && f.Method.Name == methodName)
+            .Select(f => f.Bucket)
+            .Distinct()
+            .OrderBy(b => b, StringComparer.Ordinal)];
+
+    const int TokenShared = 0x0A000001;
+    const int TokenRent = 0x0A000002;
+    const int TokenReturn = 0x0A000003;
+    const int TokenConsume = 0x0A000004;
+
+    static ResourceLifecycleCensusResult CensusSynthetic(byte[] il)
+    {
+        var byteArray = TypeRef.SzArray(TypeRef.CoreLib("System", "Byte"));
+        var method = new MethodIdentity(
+            "Fixture",
+            Guid.Empty,
+            TypeRef.Definition("Fixture", "Fixtures", "Synthetic"),
+            "Synthetic",
+            [],
+            byteArray,
+            0x06000001,
+            IsStatic: true);
+        return ResourceLifecycleCensus.CensusMethod(method, il, Array.Empty<ExceptionRegion>(), ResolveSyntheticMember);
+    }
+
+    static MemberRef ResolveSyntheticMember(int token)
+    {
+        var arrayPoolOfByte = TypeRef.GenericInstance(
+            TypeRef.Definition("System.Buffers", "System.Buffers", "ArrayPool`1"),
+            [TypeRef.CoreLib("System", "Byte")]);
+        var byteArray = TypeRef.SzArray(TypeRef.CoreLib("System", "Byte"));
+
+        return token switch
+        {
+            TokenShared => new MemberRef(arrayPoolOfByte, "get_Shared", [], arrayPoolOfByte, MemberKind.Method),
+            TokenRent => new MemberRef(arrayPoolOfByte, "Rent", [TypeRef.CoreLib("System", "Int32")], byteArray, MemberKind.Method) { HasThis = true },
+            TokenReturn => new MemberRef(arrayPoolOfByte, "Return", [byteArray], TypeRef.CoreLib("System", "Void"), MemberKind.Method) { HasThis = true },
+            TokenConsume => new MemberRef(TypeRef.Definition("Fixture", "Fixtures", "Helper"), "Consume", [byteArray], TypeRef.CoreLib("System", "Void"), MemberKind.Method),
+            _ => MemberRef.Unsupported($"unknown token 0x{token:X8}"),
+        };
+    }
+
+    static byte[] Call(int token) => [0x28, .. BitConverter.GetBytes(token)];
+    static byte[] Callvirt(int token) => [0x6F, .. BitConverter.GetBytes(token)];
+}

--- a/src/ILInspector.Analysis.Tests/ResourceLifecycleCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/ResourceLifecycleCensusTests.cs
@@ -154,6 +154,18 @@ public sealed class ResourceLifecycleCensusTests
         Assert.Equal(0, result.AcquiresObserved);
     }
 
+    [Fact]
+    public void ThrowingCallBeforeProtectingTry_StaysExceptionCandidate()
+    {
+        // A call sits between the rent and the protecting try, so an exception there bypasses the
+        // finally: the Return-in-finally must NOT clear the exception-path candidate (the false
+        // negative both reviewers found on PR #2447). The finding path stays clean, so this is a
+        // census-only signal.
+        Assert.Equal(
+            ["exception-path-leak-candidate"],
+            BucketsFor(nameof(ArrayPoolLeakFixtures.RentThenCallBeforeTryFinally)));
+    }
+
     static ImmutableArray<string> BucketsFor(string methodName)
         => [.. ResourceLifecycleCensus.CensusAssembly(typeof(ArrayPoolLeakFixtures).Assembly.Location)
             .Facts

--- a/src/ILInspector.Analysis.Tests/ResourceLifecycleCensusTests.cs
+++ b/src/ILInspector.Analysis.Tests/ResourceLifecycleCensusTests.cs
@@ -166,6 +166,17 @@ public sealed class ResourceLifecycleCensusTests
             BucketsFor(nameof(ArrayPoolLeakFixtures.RentThenCallBeforeTryFinally)));
     }
 
+    [Fact]
+    public void ConditionalReturnInFinally_StaysExceptionCandidate()
+    {
+        // The Return is inside the finally but guarded by an unrelated flag, so it does not
+        // post-dominate the handler entry: the flag-false path leaks on both normal and exception
+        // unwind. The census must NOT clear either leak candidate (reviewer GPT-5.5, PR #2447).
+        Assert.Equal(
+            ["exception-path-leak-candidate", "normal-path-leak-candidate"],
+            BucketsFor(nameof(ArrayPoolLeakFixtures.ConditionalReturnInFinally)));
+    }
+
     static ImmutableArray<string> BucketsFor(string methodName)
         => [.. ResourceLifecycleCensus.CensusAssembly(typeof(ArrayPoolLeakFixtures).Assembly.Location)
             .Facts

--- a/src/ILInspector.Analysis/AnalysisMethodBodies.cs
+++ b/src/ILInspector.Analysis/AnalysisMethodBodies.cs
@@ -1,0 +1,98 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+
+namespace ILInspector.Analysis;
+
+/// <summary>One method body, with everything a body-level correctness analyzer needs: the
+/// method identity, its raw IL, its exception regions, and a metadata-token resolver.</summary>
+internal readonly record struct AnalysisMethodBody(
+    MethodIdentity Method,
+    byte[] Il,
+    ImmutableArray<ExceptionRegion> ExceptionRegions,
+    Func<int, MemberRef> ResolveMethod);
+
+/// <summary>
+/// Shared, fail-closed SRM plumbing that walks an assembly's method bodies. Both the
+/// <see cref="LeakTriageAnalyzer"/> finding path and the <see cref="ResourceLifecycleCensus"/>
+/// measurement path enumerate exactly the same bodies with the same identities and the same
+/// token resolver, so a body one path sees and the other misses can never be an enumeration
+/// artifact. Per-method metadata failures are swallowed (a body that cannot be read is simply
+/// not yielded); body-level analysis owns its own recoverable-failure handling.
+/// </summary>
+internal static class AnalysisMethodBodies
+{
+    public static IEnumerable<AnalysisMethodBody> Enumerate(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        using var stream = File.OpenRead(path);
+        using var peReader = new PEReader(stream);
+        var reader = peReader.GetMetadataReader();
+        var assembly = reader.GetAssemblyDefinition();
+        var assemblyName = reader.GetString(assembly.Name);
+        var mvid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
+
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeHandle);
+            foreach (var methodHandle in typeDef.GetMethods())
+            {
+                var methodDef = reader.GetMethodDefinition(methodHandle);
+                if (methodDef.RelativeVirtualAddress == 0)
+                    continue;
+
+                AnalysisMethodBody? body;
+                try
+                {
+                    var scope = CreateScope(reader, typeDef, methodDef);
+                    var signature = methodDef.DecodeSignature(TypeRefDecoder.Instance, scope);
+                    var method = new MethodIdentity(
+                        assemblyName,
+                        mvid,
+                        TypeRefDecoder.Instance.GetTypeFromDefinition(reader, typeHandle, 0),
+                        reader.GetString(methodDef.Name),
+                        signature.ParameterTypes,
+                        signature.ReturnType,
+                        MetadataTokens.GetToken(methodHandle),
+                        (methodDef.Attributes & MethodAttributes.Static) != 0);
+                    var methodBody = peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
+                    body = new AnalysisMethodBody(
+                        method,
+                        methodBody.GetILBytes() ?? [],
+                        methodBody.ExceptionRegions,
+                        token => MemberResolver.ResolveMethod(reader, MetadataTokens.EntityHandle(token), scope));
+                }
+                catch (Exception ex) when (IsRecoverable(ex))
+                {
+                    // Fail-closed: malformed or unsupported method metadata yields no body.
+                    body = null;
+                }
+
+                if (body is { } value)
+                    yield return value;
+            }
+        }
+    }
+
+    public static int ArgumentSlotCount(MethodIdentity method)
+        => method.ParameterTypes.Length + (method.IsStatic ? 0 : 1);
+
+    public static bool IsRecoverable(Exception ex)
+        => ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException or IndexOutOfRangeException;
+
+    static GenericScope CreateScope(MetadataReader reader, TypeDefinition typeDef, MethodDefinition methodDef)
+        => new(GenericParameterNames(reader, typeDef.GetGenericParameters()), GenericParameterNames(reader, methodDef.GetGenericParameters()));
+
+    static ImmutableArray<string> GenericParameterNames(MetadataReader reader, GenericParameterHandleCollection handles)
+    {
+        if (handles.Count == 0)
+            return [];
+        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
+        foreach (var handle in handles)
+            names.Add(reader.GetString(reader.GetGenericParameter(handle).Name));
+        return names.MoveToImmutable();
+    }
+}

--- a/src/ILInspector.Analysis/ArrayPoolRecognizers.cs
+++ b/src/ILInspector.Analysis/ArrayPoolRecognizers.cs
@@ -1,0 +1,190 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Analysis;
+
+/// <summary>One recognized <c>ArrayPool&lt;T&gt;.Shared.Rent</c> acquisition: the rent call, the
+/// store that names the rented array, its local slot, and the reaching-definition it creates.</summary>
+internal sealed record ArrayPoolAcquire(int RentOffset, int StoreOffset, int Slot, LocalDefinition Definition);
+
+/// <summary>
+/// The purely syntactic ArrayPool acquire/release/use recognizers shared by
+/// <see cref="LeakTriageAnalyzer"/> (findings) and <see cref="ResourceLifecycleCensus"/>
+/// (measurement). This is the single source of truth for "what IL shape is a Rent / Return /
+/// Shared receiver / element access", so the finding path and the census census cannot drift on
+/// what counts as ArrayPool ownership. Slice 2 (#2439) generalizes these into pluggable,
+/// per-resource-family recognizers; keeping them isolated here is the seam.
+/// </summary>
+internal static class ArrayPoolRecognizers
+{
+    public static IEnumerable<ArrayPoolAcquire> FindAcquires(
+        ImmutableArray<DecodedInstruction> instructions,
+        BlockGraph graph,
+        ReachingDefinitionsResult reaching,
+        IReadOnlyDictionary<int, MemberRef> calls)
+    {
+        foreach (var instruction in instructions)
+        {
+            if (!calls.TryGetValue(instruction.Offset, out var callee) || !IsArrayPoolRent(callee))
+                continue;
+            if (!RentUsesSharedReceiver(instructions, graph, calls, instruction.Offset))
+                continue;
+            if (!TryFindNextNonNop(instructions, instruction.NextOffset, out var store)
+                || !TryReadStoreLocal(store, out int slot))
+                continue;
+
+            var definition = reaching.Definitions.FirstOrDefault(d =>
+                !d.IsArgument && d.Slot == slot && d.Offset == store.Offset);
+            if (definition is null)
+                continue;
+
+            yield return new ArrayPoolAcquire(instruction.Offset, store.Offset, slot, definition);
+        }
+    }
+
+    public static bool RentUsesSharedReceiver(
+        ImmutableArray<DecodedInstruction> instructions,
+        BlockGraph graph,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        int rentOffset)
+    {
+        int blockIndex = graph.BlockIndexAt(rentOffset);
+        if (blockIndex < 0)
+            return false;
+        var block = graph.Blocks[blockIndex];
+        for (int i = instructions.Length - 1, inspected = 0; i >= 0; i--)
+        {
+            var instruction = instructions[i];
+            if (instruction.Offset < block.Start)
+                return false;
+            if (instruction.Offset >= rentOffset || instruction.OpCode == ILOpCode.Nop)
+                continue;
+            if (calls.TryGetValue(instruction.Offset, out var callee))
+                return IsArrayPoolSharedGetter(callee);
+            if (!IsSimpleArgumentPush(instruction.OpCode))
+                return false;
+            if (++inspected > 4)
+                return false;
+        }
+        return false;
+    }
+
+    public static IReadOnlyDictionary<int, MemberRef> BuildCallMap(
+        ImmutableArray<DecodedInstruction> instructions,
+        Func<int, MemberRef> resolveMethod)
+    {
+        var calls = new Dictionary<int, MemberRef>();
+        foreach (var instruction in instructions)
+        {
+            if (instruction.OpCode is not (ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj))
+                continue;
+            calls[instruction.Offset] = resolveMethod(checked((int)instruction.OperandValue));
+        }
+        return calls;
+    }
+
+    public static bool TryFindNextNonNop(ImmutableArray<DecodedInstruction> instructions, int offset, out DecodedInstruction instruction)
+    {
+        foreach (var candidate in instructions)
+        {
+            if (candidate.Offset < offset || candidate.OpCode == ILOpCode.Nop)
+                continue;
+            instruction = candidate;
+            return true;
+        }
+        instruction = default!;
+        return false;
+    }
+
+    public static bool TryFindInstruction(ImmutableArray<DecodedInstruction> instructions, int offset, out int index, out DecodedInstruction instruction)
+    {
+        for (int i = 0; i < instructions.Length; i++)
+        {
+            if (instructions[i].Offset != offset)
+                continue;
+            index = i;
+            instruction = instructions[i];
+            return true;
+        }
+        index = -1;
+        instruction = default!;
+        return false;
+    }
+
+    public static bool TryReadStoreLocal(DecodedInstruction instruction, out int slot)
+    {
+        slot = instruction.OpCode switch
+        {
+            ILOpCode.Stloc_0 => 0,
+            ILOpCode.Stloc_1 => 1,
+            ILOpCode.Stloc_2 => 2,
+            ILOpCode.Stloc_3 => 3,
+            ILOpCode.Stloc_s or ILOpCode.Stloc => checked((int)instruction.OperandValue),
+            _ => -1,
+        };
+        return slot >= 0;
+    }
+
+    public static bool IsLoadLocal(DecodedInstruction instruction, int slot)
+        => instruction.OpCode switch
+        {
+            ILOpCode.Ldloc_0 => slot == 0,
+            ILOpCode.Ldloc_1 => slot == 1,
+            ILOpCode.Ldloc_2 => slot == 2,
+            ILOpCode.Ldloc_3 => slot == 3,
+            ILOpCode.Ldloc_s or ILOpCode.Ldloc => instruction.OperandValue == slot,
+            _ => false,
+        };
+
+    public static bool IsSimpleArgumentPush(ILOpCode opcode)
+        => opcode is ILOpCode.Ldc_i4_m1 or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1 or ILOpCode.Ldc_i4_2
+            or ILOpCode.Ldc_i4_3 or ILOpCode.Ldc_i4_4 or ILOpCode.Ldc_i4_5 or ILOpCode.Ldc_i4_6
+            or ILOpCode.Ldc_i4_7 or ILOpCode.Ldc_i4_8 or ILOpCode.Ldc_i4_s or ILOpCode.Ldc_i4
+            or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3
+            or ILOpCode.Ldarg_s or ILOpCode.Ldarg
+            or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
+            or ILOpCode.Ldloc_s or ILOpCode.Ldloc
+            or ILOpCode.Ldnull;
+
+    public static bool IsElementRead(ILOpCode opcode)
+        => opcode is ILOpCode.Ldelem or ILOpCode.Ldelem_i or ILOpCode.Ldelem_i1 or ILOpCode.Ldelem_i2
+            or ILOpCode.Ldelem_i4 or ILOpCode.Ldelem_i8 or ILOpCode.Ldelem_r4 or ILOpCode.Ldelem_r8
+            or ILOpCode.Ldelem_u1 or ILOpCode.Ldelem_u2 or ILOpCode.Ldelem_u4 or ILOpCode.Ldelem_ref;
+
+    public static bool IsElementStore(ILOpCode opcode)
+        => opcode is ILOpCode.Stelem or ILOpCode.Stelem_i or ILOpCode.Stelem_i1 or ILOpCode.Stelem_i2
+            or ILOpCode.Stelem_i4 or ILOpCode.Stelem_i8 or ILOpCode.Stelem_r4 or ILOpCode.Stelem_r8
+            or ILOpCode.Stelem_ref;
+
+    public static bool IsArrayPoolRent(MemberRef member)
+        => member.Kind != MemberKind.Unsupported
+           && member.Name == "Rent"
+           && member.HasThis
+           && member.ParameterTypes.Length == 1
+           && FrameworkIdentity.IsCoreLibraryType(member.ParameterTypes[0], "System", "Int32")
+           && member.ReturnType.Kind == TypeRefKind.SzArray
+           && IsArrayPoolType(member.DeclaringType);
+
+    public static bool IsArrayPoolReturn(MemberRef member)
+        => member.Kind != MemberKind.Unsupported
+           && member.Name == "Return"
+           && member.HasThis
+           && member.ReturnType.Equals(TypeRef.CoreLib("System", "Void"))
+           && member.ParameterTypes.Length is 1 or 2
+           && member.ParameterTypes[0].Kind == TypeRefKind.SzArray
+           && IsArrayPoolType(member.DeclaringType);
+
+    public static bool IsArrayPoolSharedGetter(MemberRef member)
+        => member.Kind != MemberKind.Unsupported
+           && member.Name == "get_Shared"
+           && !member.HasThis
+           && member.ParameterTypes.Length == 0
+           && IsArrayPoolType(member.DeclaringType)
+           && IsArrayPoolType(member.ReturnType);
+
+    public static bool IsArrayPoolType(TypeRef type)
+        => FrameworkIdentity.IsKnownFrameworkType(type, "System.Buffers", "System.Buffers", "ArrayPool`1")
+           || FrameworkIdentity.IsCoreLibraryType(type, "System.Buffers", "ArrayPool`1");
+}

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -1,8 +1,5 @@
 using System.Collections.Immutable;
-using System.Reflection;
 using System.Reflection.Metadata;
-using System.Reflection.Metadata.Ecma335;
-using System.Reflection.PortableExecutable;
 
 using ILInspector.Instructions;
 
@@ -22,50 +19,9 @@ public static class LeakTriageAnalyzer
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
 
-        using var stream = File.OpenRead(path);
-        using var peReader = new PEReader(stream);
-        var reader = peReader.GetMetadataReader();
-        var assembly = reader.GetAssemblyDefinition();
-        var assemblyName = reader.GetString(assembly.Name);
-        var mvid = reader.GetGuid(reader.GetModuleDefinition().Mvid);
         var findings = ImmutableArray.CreateBuilder<LeakTriageFinding>();
-
-        foreach (var typeHandle in reader.TypeDefinitions)
-        {
-            var typeDef = reader.GetTypeDefinition(typeHandle);
-            foreach (var methodHandle in typeDef.GetMethods())
-            {
-                var methodDef = reader.GetMethodDefinition(methodHandle);
-                if (methodDef.RelativeVirtualAddress == 0)
-                    continue;
-
-                try
-                {
-                    var scope = CreateScope(reader, typeDef, methodDef);
-                    var signature = methodDef.DecodeSignature(TypeRefDecoder.Instance, scope);
-                    var method = new MethodIdentity(
-                        assemblyName,
-                        mvid,
-                        TypeRefDecoder.Instance.GetTypeFromDefinition(reader, typeHandle, 0),
-                        reader.GetString(methodDef.Name),
-                        signature.ParameterTypes,
-                        signature.ReturnType,
-                        MetadataTokens.GetToken(methodHandle),
-                        (methodDef.Attributes & MethodAttributes.Static) != 0);
-                    var body = peReader.GetMethodBody(methodDef.RelativeVirtualAddress);
-                    findings.AddRange(AnalyzeMethod(
-                        method,
-                        body.GetILBytes() ?? [],
-                        body.ExceptionRegions,
-                        token => MemberResolver.ResolveMethod(reader, MetadataTokens.EntityHandle(token), scope)));
-                }
-                catch (Exception ex) when (IsRecoverable(ex))
-                {
-                    // Correctness triage is fail-closed: malformed or unsupported method
-                    // evidence yields no accusations for that method.
-                }
-            }
-        }
+        foreach (var body in AnalysisMethodBodies.Enumerate(path))
+            findings.AddRange(AnalyzeMethod(body.Method, body.Il, body.ExceptionRegions, body.ResolveMethod));
 
         return findings.ToImmutable();
     }
@@ -91,12 +47,12 @@ public static class LeakTriageAnalyzer
             if (!graph.IsComplete)
                 return [];
 
-            var reaching = ReachingDefinitions.Analyze(il, ArgumentSlotCount(method), exceptionRegions);
+            var reaching = ReachingDefinitions.Analyze(il, AnalysisMethodBodies.ArgumentSlotCount(method), exceptionRegions);
             if (!reaching.IsComplete)
                 return [];
 
-            var calls = BuildCallMap(instructions, resolveMethod);
-            var rents = FindRents(method, instructions, graph, reaching, calls).ToImmutableArray();
+            var calls = ArrayPoolRecognizers.BuildCallMap(instructions, resolveMethod);
+            var rents = ArrayPoolRecognizers.FindAcquires(instructions, graph, reaching, calls).ToImmutableArray();
             if (rents.Length == 0)
                 return [];
 
@@ -106,7 +62,7 @@ public static class LeakTriageAnalyzer
 
             return findings.ToImmutable();
         }
-        catch (Exception ex) when (IsRecoverable(ex))
+        catch (Exception ex) when (AnalysisMethodBodies.IsRecoverable(ex))
         {
             return [];
         }
@@ -118,7 +74,7 @@ public static class LeakTriageAnalyzer
         BlockGraph graph,
         ReachingDefinitionsResult reaching,
         IReadOnlyDictionary<int, MemberRef> calls,
-        RentedLocal rent,
+        ArrayPoolAcquire rent,
         ImmutableArray<LeakTriageFinding>.Builder findings)
     {
         var releases = ImmutableArray.CreateBuilder<int>();
@@ -262,67 +218,14 @@ public static class LeakTriageAnalyzer
         return fromBlock >= 0 && fromBlock == toBlock && fromOffset < toOffset;
     }
 
-    static IEnumerable<RentedLocal> FindRents(
-        MethodIdentity method,
-        ImmutableArray<DecodedInstruction> instructions,
-        BlockGraph graph,
-        ReachingDefinitionsResult reaching,
-        IReadOnlyDictionary<int, MemberRef> calls)
-    {
-        foreach (var instruction in instructions)
-        {
-            if (!calls.TryGetValue(instruction.Offset, out var callee) || !IsArrayPoolRent(callee))
-                continue;
-            if (!RentUsesSharedReceiver(instructions, graph, calls, instruction.Offset))
-                continue;
-            if (!TryFindNextNonNop(instructions, instruction.NextOffset, out var store)
-                || !TryReadStoreLocal(store, out int slot))
-                continue;
-
-            var definition = reaching.Definitions.FirstOrDefault(d =>
-                !d.IsArgument && d.Slot == slot && d.Offset == store.Offset);
-            if (definition is null)
-                continue;
-
-            yield return new RentedLocal(instruction.Offset, store.Offset, slot, definition);
-        }
-    }
-
-    static bool RentUsesSharedReceiver(
-        ImmutableArray<DecodedInstruction> instructions,
-        BlockGraph graph,
-        IReadOnlyDictionary<int, MemberRef> calls,
-        int rentOffset)
-    {
-        int blockIndex = graph.BlockIndexAt(rentOffset);
-        if (blockIndex < 0)
-            return false;
-        var block = graph.Blocks[blockIndex];
-        for (int i = instructions.Length - 1, inspected = 0; i >= 0; i--)
-        {
-            var instruction = instructions[i];
-            if (instruction.Offset < block.Start)
-                return false;
-            if (instruction.Offset >= rentOffset || instruction.OpCode == ILOpCode.Nop)
-                continue;
-            if (calls.TryGetValue(instruction.Offset, out var callee))
-                return IsArrayPoolSharedGetter(callee);
-            if (!IsSimpleArgumentPush(instruction.OpCode))
-                return false;
-            if (++inspected > 4)
-                return false;
-        }
-        return false;
-    }
-
     static UseKind ClassifyUse(
         ImmutableArray<DecodedInstruction> instructions,
         IReadOnlyDictionary<int, MemberRef> calls,
         int loadOffset,
         int slot)
     {
-        if (!TryFindInstruction(instructions, loadOffset, out int index, out var load)
-            || !IsLoadLocal(load, slot))
+        if (!ArrayPoolRecognizers.TryFindInstruction(instructions, loadOffset, out int index, out var load)
+            || !ArrayPoolRecognizers.IsLoadLocal(load, slot))
             return UseKind.Ambiguous;
 
         int extra = 0;
@@ -330,20 +233,20 @@ public static class LeakTriageAnalyzer
         {
             var instruction = instructions[i];
             var opcode = instruction.OpCode;
-            if (IsSimpleArgumentPush(opcode))
+            if (ArrayPoolRecognizers.IsSimpleArgumentPush(opcode))
             {
                 extra++;
                 continue;
             }
             if (opcode == ILOpCode.Ldlen)
                 return extra == 0 ? UseKind.LocalUse : UseKind.Ambiguous;
-            if (IsElementRead(opcode))
+            if (ArrayPoolRecognizers.IsElementRead(opcode))
                 return extra == 1 ? UseKind.LocalUse : UseKind.Ambiguous;
-            if (IsElementStore(opcode))
+            if (ArrayPoolRecognizers.IsElementStore(opcode))
                 return extra == 2 ? UseKind.LocalUse : UseKind.Ambiguous;
             if (calls.TryGetValue(instruction.Offset, out var callee))
             {
-                if (IsArrayPoolReturn(callee) && extra < callee.ParameterTypes.Length)
+                if (ArrayPoolRecognizers.IsArrayPoolReturn(callee) && extra < callee.ParameterTypes.Length)
                     return UseKind.Release;
                 return UseKind.Ambiguous;
             }
@@ -352,144 +255,6 @@ public static class LeakTriageAnalyzer
 
         return UseKind.Ambiguous;
     }
-
-    static IReadOnlyDictionary<int, MemberRef> BuildCallMap(
-        ImmutableArray<DecodedInstruction> instructions,
-        Func<int, MemberRef> resolveMethod)
-    {
-        var calls = new Dictionary<int, MemberRef>();
-        foreach (var instruction in instructions)
-        {
-            if (instruction.OpCode is not (ILOpCode.Call or ILOpCode.Callvirt or ILOpCode.Newobj))
-                continue;
-            calls[instruction.Offset] = resolveMethod(checked((int)instruction.OperandValue));
-        }
-        return calls;
-    }
-
-    static bool TryFindNextNonNop(ImmutableArray<DecodedInstruction> instructions, int offset, out DecodedInstruction instruction)
-    {
-        foreach (var candidate in instructions)
-        {
-            if (candidate.Offset < offset || candidate.OpCode == ILOpCode.Nop)
-                continue;
-            instruction = candidate;
-            return true;
-        }
-        instruction = default!;
-        return false;
-    }
-
-    static bool TryFindInstruction(ImmutableArray<DecodedInstruction> instructions, int offset, out int index, out DecodedInstruction instruction)
-    {
-        for (int i = 0; i < instructions.Length; i++)
-        {
-            if (instructions[i].Offset != offset)
-                continue;
-            index = i;
-            instruction = instructions[i];
-            return true;
-        }
-        index = -1;
-        instruction = default!;
-        return false;
-    }
-
-    static bool TryReadStoreLocal(DecodedInstruction instruction, out int slot)
-    {
-        slot = instruction.OpCode switch
-        {
-            ILOpCode.Stloc_0 => 0,
-            ILOpCode.Stloc_1 => 1,
-            ILOpCode.Stloc_2 => 2,
-            ILOpCode.Stloc_3 => 3,
-            ILOpCode.Stloc_s or ILOpCode.Stloc => checked((int)instruction.OperandValue),
-            _ => -1,
-        };
-        return slot >= 0;
-    }
-
-    static bool IsLoadLocal(DecodedInstruction instruction, int slot)
-        => instruction.OpCode switch
-        {
-            ILOpCode.Ldloc_0 => slot == 0,
-            ILOpCode.Ldloc_1 => slot == 1,
-            ILOpCode.Ldloc_2 => slot == 2,
-            ILOpCode.Ldloc_3 => slot == 3,
-            ILOpCode.Ldloc_s or ILOpCode.Ldloc => instruction.OperandValue == slot,
-            _ => false,
-        };
-
-    static bool IsSimpleArgumentPush(ILOpCode opcode)
-        => opcode is ILOpCode.Ldc_i4_m1 or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1 or ILOpCode.Ldc_i4_2
-            or ILOpCode.Ldc_i4_3 or ILOpCode.Ldc_i4_4 or ILOpCode.Ldc_i4_5 or ILOpCode.Ldc_i4_6
-            or ILOpCode.Ldc_i4_7 or ILOpCode.Ldc_i4_8 or ILOpCode.Ldc_i4_s or ILOpCode.Ldc_i4
-            or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3
-            or ILOpCode.Ldarg_s or ILOpCode.Ldarg
-            or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
-            or ILOpCode.Ldloc_s or ILOpCode.Ldloc
-            or ILOpCode.Ldnull;
-
-    static bool IsElementRead(ILOpCode opcode)
-        => opcode is ILOpCode.Ldelem or ILOpCode.Ldelem_i or ILOpCode.Ldelem_i1 or ILOpCode.Ldelem_i2
-            or ILOpCode.Ldelem_i4 or ILOpCode.Ldelem_i8 or ILOpCode.Ldelem_r4 or ILOpCode.Ldelem_r8
-            or ILOpCode.Ldelem_u1 or ILOpCode.Ldelem_u2 or ILOpCode.Ldelem_u4 or ILOpCode.Ldelem_ref;
-
-    static bool IsElementStore(ILOpCode opcode)
-        => opcode is ILOpCode.Stelem or ILOpCode.Stelem_i or ILOpCode.Stelem_i1 or ILOpCode.Stelem_i2
-            or ILOpCode.Stelem_i4 or ILOpCode.Stelem_i8 or ILOpCode.Stelem_r4 or ILOpCode.Stelem_r8
-            or ILOpCode.Stelem_ref;
-
-    static bool IsArrayPoolRent(MemberRef member)
-        => member.Kind != MemberKind.Unsupported
-           && member.Name == "Rent"
-           && member.HasThis
-           && member.ParameterTypes.Length == 1
-           && FrameworkIdentity.IsCoreLibraryType(member.ParameterTypes[0], "System", "Int32")
-           && member.ReturnType.Kind == TypeRefKind.SzArray
-           && IsArrayPoolType(member.DeclaringType);
-
-    static bool IsArrayPoolReturn(MemberRef member)
-        => member.Kind != MemberKind.Unsupported
-           && member.Name == "Return"
-           && member.HasThis
-           && member.ReturnType.Equals(TypeRef.CoreLib("System", "Void"))
-           && member.ParameterTypes.Length is 1 or 2
-           && member.ParameterTypes[0].Kind == TypeRefKind.SzArray
-           && IsArrayPoolType(member.DeclaringType);
-
-    static bool IsArrayPoolSharedGetter(MemberRef member)
-        => member.Kind != MemberKind.Unsupported
-           && member.Name == "get_Shared"
-           && !member.HasThis
-           && member.ParameterTypes.Length == 0
-           && IsArrayPoolType(member.DeclaringType)
-           && IsArrayPoolType(member.ReturnType);
-
-    static bool IsArrayPoolType(TypeRef type)
-        => FrameworkIdentity.IsKnownFrameworkType(type, "System.Buffers", "System.Buffers", "ArrayPool`1")
-           || FrameworkIdentity.IsCoreLibraryType(type, "System.Buffers", "ArrayPool`1");
-
-    static int ArgumentSlotCount(MethodIdentity method)
-        => method.ParameterTypes.Length + (method.IsStatic ? 0 : 1);
-
-    static GenericScope CreateScope(MetadataReader reader, TypeDefinition typeDef, MethodDefinition methodDef)
-        => new(GenericParameterNames(reader, typeDef.GetGenericParameters()), GenericParameterNames(reader, methodDef.GetGenericParameters()));
-
-    static ImmutableArray<string> GenericParameterNames(MetadataReader reader, GenericParameterHandleCollection handles)
-    {
-        if (handles.Count == 0)
-            return [];
-        var names = ImmutableArray.CreateBuilder<string>(handles.Count);
-        foreach (var handle in handles)
-            names.Add(reader.GetString(reader.GetGenericParameter(handle).Name));
-        return names.MoveToImmutable();
-    }
-
-    static bool IsRecoverable(Exception ex)
-        => ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException or IndexOutOfRangeException;
-
-    sealed record RentedLocal(int RentOffset, int StoreOffset, int Slot, LocalDefinition Definition);
 
     enum UseKind
     {

--- a/src/ILInspector.Analysis/ResourceLifecycleCensus.cs
+++ b/src/ILInspector.Analysis/ResourceLifecycleCensus.cs
@@ -222,7 +222,7 @@ public static class ResourceLifecycleCensus
                 $"ArrayPool Rent at IL_{acquire.RentOffset:X4} reaches a normal return without a Return on some path."));
         }
 
-        if (!ReleaseProtectedByFinally(graph.Regions, acquire.RentOffset, releases))
+        if (!ReleaseProtectedByFinally(instructions, graph.Regions, acquire, releases))
         {
             int? detail = releases.Count > 0 ? releases.Min() : null;
             facts.Add(new ResourceLifecycleFact(
@@ -319,25 +319,64 @@ public static class ResourceLifecycleCensus
     }
 
     // The acquire is exception-safe only when some Return runs inside a finally/fault handler
-    // whose protected region covers the acquire (the Rent precedes the handler body). Otherwise
-    // an exception between Rent and a normal-flow Return escapes without releasing.
+    // that actually covers the acquired value: either the store sits inside the protected try, or
+    // it sits immediately before the try with only inert (non-throwing) ops in the gap. A Return
+    // in a finally whose try starts *after* a throwing op (a call, an element access, ...) does
+    // NOT cover an exception from that op - the finally is never entered - so the acquire is still
+    // an exception-path leak candidate. (Reviewers GPT-5.5 + Gemini 3.1 Pro, PR #2447.)
     static bool ReleaseProtectedByFinally(
+        ImmutableArray<DecodedInstruction> instructions,
         ImmutableArray<ExceptionRegionModel> regions,
-        int rentOffset,
+        ArrayPoolAcquire acquire,
         IReadOnlyList<int> releases)
     {
+        if (releases.Count == 0)
+            return false;
+
+        int storeNext = StoreNextOffset(instructions, acquire.StoreOffset);
         foreach (int release in releases)
         {
             foreach (var region in regions)
             {
-                if (region.Kind is HandlerKind.Finally or HandlerKind.Fault
-                    && region.ContainsHandler(release)
-                    && rentOffset < region.HandlerStart)
+                if (region.Kind is not (HandlerKind.Finally or HandlerKind.Fault) || !region.ContainsHandler(release))
+                    continue;
+                if (region.ContainsTry(acquire.StoreOffset))
+                    return true;
+                if (acquire.StoreOffset < region.TryStart && GapIsInert(instructions, storeNext, region.TryStart))
                     return true;
             }
         }
         return false;
     }
+
+    static int StoreNextOffset(ImmutableArray<DecodedInstruction> instructions, int storeOffset)
+    {
+        foreach (var instruction in instructions)
+            if (instruction.Offset == storeOffset)
+                return instruction.NextOffset;
+        return storeOffset + 1;
+    }
+
+    // Every instruction in [fromOffset, toOffset) is a straight-line, non-throwing op, so an
+    // exception cannot escape the gap before the protecting try is entered. Deliberately narrow:
+    // anything unrecognized (a call, an element access, a branch) makes the gap non-inert.
+    static bool GapIsInert(ImmutableArray<DecodedInstruction> instructions, int fromOffset, int toOffset)
+    {
+        foreach (var instruction in instructions)
+        {
+            if (instruction.Offset < fromOffset || instruction.Offset >= toOffset)
+                continue;
+            if (!IsInertGapOp(instruction.OpCode))
+                return false;
+        }
+        return true;
+    }
+
+    static bool IsInertGapOp(ILOpCode opcode)
+        => ArrayPoolRecognizers.IsSimpleArgumentPush(opcode)
+            || IsLocalOrArgumentStore(opcode)
+            || opcode is ILOpCode.Nop or ILOpCode.Dup or ILOpCode.Pop
+                or ILOpCode.Ldc_i8 or ILOpCode.Ldc_r4 or ILOpCode.Ldc_r8;
 
     // The smallest target offset that is reachable strictly after some source offset: same block
     // and later in program order, or in any block reachable via >=1 successor edge (covers loops).

--- a/src/ILInspector.Analysis/ResourceLifecycleCensus.cs
+++ b/src/ILInspector.Analysis/ResourceLifecycleCensus.cs
@@ -1,0 +1,457 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+
+using ILInspector.Instructions;
+
+namespace ILInspector.Analysis;
+
+/// <summary>The canonical Slice-1 resource-lifecycle census bucket names (#2439). Candidate
+/// buckets are measurement-only queries a clean acquire may satisfy several of at once;
+/// suppression buckets are terminal reasons a single acquire was set aside as unreasoned.</summary>
+public static class ResourceLifecycleBuckets
+{
+    // Candidate buckets (a clean acquire may fall into more than one).
+    public const string NormalPathLeakCandidate = "normal-path-leak-candidate";
+    public const string ExceptionPathLeakCandidate = "exception-path-leak-candidate";
+    public const string UseAfterReturnCandidate = "use-after-return-candidate";
+    public const string DoubleReturnCandidate = "double-return-candidate";
+
+    // Suppression buckets (terminal; exactly one per suppressed acquire).
+    public const string OwnershipTransferSuppressed = "ownership-transfer-suppressed";
+    public const string AliasOrFieldSuppressed = "alias-or-field-suppressed";
+    public const string CrossMethodSuppressed = "cross-method-suppressed";
+    public const string IncompleteCfgOrRdSuppressed = "incomplete-cfg-or-rd-suppressed";
+
+    /// <summary>Every bucket in a stable, human-meaningful order (candidates, then suppressions).</summary>
+    public static readonly ImmutableArray<string> All =
+    [
+        NormalPathLeakCandidate,
+        ExceptionPathLeakCandidate,
+        UseAfterReturnCandidate,
+        DoubleReturnCandidate,
+        OwnershipTransferSuppressed,
+        AliasOrFieldSuppressed,
+        CrossMethodSuppressed,
+        IncompleteCfgOrRdSuppressed,
+    ];
+}
+
+/// <summary>One typed resource-lifecycle observation for one acquire: the resource family, the
+/// bucket it fell into, the acquire IL offset, an optional detail offset (release/use/escape
+/// site), and a short human evidence string. This is a fact, not a finding: it never feeds a
+/// user-facing accusation.</summary>
+public sealed record ResourceLifecycleFact(
+    MethodIdentity Method,
+    string ResourceKind,
+    string Bucket,
+    int AcquireOffset,
+    int? DetailOffset,
+    string Evidence);
+
+/// <summary>A per-scope census result: the raw facts plus the number of acquires the census was
+/// able to reason about (the candidate/suppressed denominator; excludes methods dropped as
+/// incomplete).</summary>
+public sealed record ResourceLifecycleCensusResult(
+    ImmutableArray<ResourceLifecycleFact> Facts,
+    int AcquiresObserved);
+
+/// <summary>
+/// A read-only, measurement-only census of ArrayPool resource lifecycles (#2439 Slice 1).
+/// It consumes exactly the substrate the <see cref="LeakTriageAnalyzer"/> finding path does —
+/// the EH-aware <see cref="BlockGraph"/>, the reaching-definition slot webs, and the shared
+/// <see cref="ArrayPoolRecognizers"/> — but instead of accusing, it partitions every recognized
+/// <c>ArrayPool&lt;T&gt;.Shared.Rent</c> acquire into typed candidate and suppression buckets so
+/// the size and shape of each bucket can be measured on real corpora before any of them graduate
+/// to a user-facing finding. It wires no product surface and changes no existing finding.
+///
+/// <para>Precision boundary: a use the census cannot positively classify as a release or a
+/// local, non-escaping use (address-of, field/alias store, method return, unmodeled call) marks
+/// the acquire as an <em>escape</em>, and an escaped acquire is terminally suppressed rather than
+/// measured for leaks — the same fail-closed posture as the finding path, just recorded instead
+/// of dropped. Candidate buckets are deliberately raw: unlike the finding path they do not
+/// fail-closed on correlated-branch multi-release, so a `normal-path-leak-candidate` count is a
+/// pre-graduation upper bound that Slice 4 must refine with predicate facts, not a bug.</para>
+/// </summary>
+public static class ResourceLifecycleCensus
+{
+    const string ResourceKind = "arraypool";
+
+    public static ResourceLifecycleCensusResult CensusAssembly(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var facts = ImmutableArray.CreateBuilder<ResourceLifecycleFact>();
+        int acquires = 0;
+        foreach (var body in AnalysisMethodBodies.Enumerate(path))
+        {
+            var result = CensusMethod(body.Method, body.Il, body.ExceptionRegions, body.ResolveMethod);
+            facts.AddRange(result.Facts);
+            acquires += result.AcquiresObserved;
+        }
+
+        return new ResourceLifecycleCensusResult(facts.ToImmutable(), acquires);
+    }
+
+    public static ResourceLifecycleCensusResult CensusMethod(
+        MethodIdentity method,
+        byte[] il,
+        IReadOnlyCollection<ExceptionRegion> exceptionRegions,
+        Func<int, MemberRef> resolveMethod)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+        ArgumentNullException.ThrowIfNull(il);
+        ArgumentNullException.ThrowIfNull(exceptionRegions);
+        ArgumentNullException.ThrowIfNull(resolveMethod);
+
+        if (il.Length == 0)
+            return Empty;
+
+        try
+        {
+            var instructions = InstructionDecoder.Decode(il);
+            var graph = BlockGraph.Build(il.Length, instructions, exceptionRegions);
+            var calls = ArrayPoolRecognizers.BuildCallMap(instructions, resolveMethod);
+
+            int firstRentOffset = -1;
+            foreach (var instruction in instructions)
+            {
+                if (calls.TryGetValue(instruction.Offset, out var callee) && ArrayPoolRecognizers.IsArrayPoolRent(callee))
+                {
+                    firstRentOffset = instruction.Offset;
+                    break;
+                }
+            }
+
+            if (firstRentOffset < 0)
+                return Empty;
+
+            var reaching = ReachingDefinitions.Analyze(il, AnalysisMethodBodies.ArgumentSlotCount(method), exceptionRegions);
+            if (!graph.IsComplete || !reaching.IsComplete)
+            {
+                var reason = graph.IncompleteReason ?? reaching.IncompleteReason ?? "incomplete dataflow";
+                return new ResourceLifecycleCensusResult(
+                    [new ResourceLifecycleFact(
+                        method,
+                        ResourceKind,
+                        ResourceLifecycleBuckets.IncompleteCfgOrRdSuppressed,
+                        firstRentOffset,
+                        firstRentOffset,
+                        $"ArrayPool Rent at IL_{firstRentOffset:X4} not measured: {reason}")],
+                    AcquiresObserved: 0);
+            }
+
+            var terminators = BuildTerminators(graph, instructions);
+            var facts = ImmutableArray.CreateBuilder<ResourceLifecycleFact>();
+            int acquires = 0;
+            foreach (var acquire in ArrayPoolRecognizers.FindAcquires(instructions, graph, reaching, calls))
+            {
+                acquires++;
+                CensusAcquire(method, instructions, graph, reaching, calls, terminators, acquire, facts);
+            }
+
+            return new ResourceLifecycleCensusResult(facts.ToImmutable(), acquires);
+        }
+        catch (Exception ex) when (AnalysisMethodBodies.IsRecoverable(ex))
+        {
+            return Empty;
+        }
+    }
+
+    static void CensusAcquire(
+        MethodIdentity method,
+        ImmutableArray<DecodedInstruction> instructions,
+        BlockGraph graph,
+        ReachingDefinitionsResult reaching,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        DecodedInstruction?[] terminators,
+        ArrayPoolAcquire acquire,
+        ImmutableArray<ResourceLifecycleFact>.Builder facts)
+    {
+        var releases = new List<int>();
+        var safeUses = new List<int>();
+        (string Bucket, int Offset, string Detail)? escape = null;
+
+        foreach (var use in reaching.UsesOf(acquire.Definition))
+        {
+            if (use.Address)
+            {
+                escape = ChooseEscape(escape, (ResourceLifecycleBuckets.AliasOrFieldSuppressed, use.Offset, "rented array address taken"));
+                continue;
+            }
+
+            switch (ClassifyUse(instructions, calls, use.Offset, acquire.Slot))
+            {
+                case ExtendedUseKind.Release:
+                    releases.Add(use.Offset);
+                    break;
+                case ExtendedUseKind.LocalUse:
+                    safeUses.Add(use.Offset);
+                    break;
+                case ExtendedUseKind.ReturnFromMethod:
+                    escape = ChooseEscape(escape, (ResourceLifecycleBuckets.OwnershipTransferSuppressed, use.Offset, "rented array returned from method"));
+                    break;
+                case ExtendedUseKind.FieldStore:
+                    escape = ChooseEscape(escape, (ResourceLifecycleBuckets.AliasOrFieldSuppressed, use.Offset, "rented array stored to a field"));
+                    break;
+                case ExtendedUseKind.AliasStore:
+                    escape = ChooseEscape(escape, (ResourceLifecycleBuckets.AliasOrFieldSuppressed, use.Offset, "rented array aliased to another local/argument"));
+                    break;
+                case ExtendedUseKind.UnknownCall:
+                    escape = ChooseEscape(escape, (ResourceLifecycleBuckets.CrossMethodSuppressed, use.Offset, "rented array passed to an unmodeled call"));
+                    break;
+                default:
+                    escape = ChooseEscape(escape, (ResourceLifecycleBuckets.CrossMethodSuppressed, use.Offset, "rented array reaches an unmodeled use"));
+                    break;
+            }
+        }
+
+        if (escape is { } terminal)
+        {
+            facts.Add(new ResourceLifecycleFact(
+                method, ResourceKind, terminal.Bucket, acquire.RentOffset, terminal.Offset,
+                $"ArrayPool Rent at IL_{acquire.RentOffset:X4}: {terminal.Detail}."));
+            return;
+        }
+
+        var releaseSet = releases.ToHashSet();
+
+        if (ReachesNormalExitWithoutRelease(instructions, graph, terminators, acquire.StoreOffset, releaseSet))
+        {
+            facts.Add(new ResourceLifecycleFact(
+                method, ResourceKind, ResourceLifecycleBuckets.NormalPathLeakCandidate, acquire.RentOffset, acquire.RentOffset,
+                $"ArrayPool Rent at IL_{acquire.RentOffset:X4} reaches a normal return without a Return on some path."));
+        }
+
+        if (!ReleaseProtectedByFinally(graph.Regions, acquire.RentOffset, releases))
+        {
+            int? detail = releases.Count > 0 ? releases.Min() : null;
+            facts.Add(new ResourceLifecycleFact(
+                method, ResourceKind, ResourceLifecycleBuckets.ExceptionPathLeakCandidate, acquire.RentOffset, detail,
+                $"ArrayPool Rent at IL_{acquire.RentOffset:X4} has no Return inside a covering finally/fault, so an exception before Return leaks."));
+        }
+
+        int? useAfter = FirstReachableAfter(graph, releases, safeUses);
+        if (useAfter is { } useOffset)
+        {
+            facts.Add(new ResourceLifecycleFact(
+                method, ResourceKind, ResourceLifecycleBuckets.UseAfterReturnCandidate, acquire.RentOffset, useOffset,
+                $"Use of the rented array at IL_{useOffset:X4} is reachable after a Return."));
+        }
+
+        int? secondRelease = FirstReachableAfter(graph, releases, releases);
+        if (secondRelease is { } releaseOffset)
+        {
+            facts.Add(new ResourceLifecycleFact(
+                method, ResourceKind, ResourceLifecycleBuckets.DoubleReturnCandidate, acquire.RentOffset, releaseOffset,
+                $"A second Return at IL_{releaseOffset:X4} is reachable after an earlier Return."));
+        }
+    }
+
+    // Deterministic terminal-suppression precedence when an acquire escapes in several ways at
+    // once: the most structurally definitive "we lost the array" wins, so the census is stable.
+    static (string Bucket, int Offset, string Detail) ChooseEscape(
+        (string Bucket, int Offset, string Detail)? current,
+        (string Bucket, int Offset, string Detail) candidate)
+    {
+        if (current is not { } existing)
+            return candidate;
+        return Rank(candidate.Bucket) < Rank(existing.Bucket) ? candidate : existing;
+
+        static int Rank(string bucket) => bucket switch
+        {
+            ResourceLifecycleBuckets.AliasOrFieldSuppressed => 0,
+            ResourceLifecycleBuckets.CrossMethodSuppressed => 1,
+            ResourceLifecycleBuckets.OwnershipTransferSuppressed => 2,
+            _ => 3,
+        };
+    }
+
+    // A normal (ret) exit is reachable from the acquire's store along a path with no Return.
+    // Follows every CFG successor (including EH survivor edges, so a covering finally's Return
+    // masks the path) but only ret terminals count as normal exits; throw/rethrow are dead ends
+    // for the normal-path query and are measured separately by ReleaseProtectedByFinally.
+    static bool ReachesNormalExitWithoutRelease(
+        ImmutableArray<DecodedInstruction> instructions,
+        BlockGraph graph,
+        DecodedInstruction?[] terminators,
+        int storeOffset,
+        IReadOnlySet<int> releases)
+    {
+        int startBlock = graph.BlockIndexAt(storeOffset);
+        if (startBlock < 0)
+            return false;
+
+        var visited = new HashSet<(int Block, bool Released)>();
+        var stack = new Stack<(int Block, bool Released, int StartOffset)>();
+        stack.Push((startBlock, false, storeOffset));
+
+        while (stack.Count > 0)
+        {
+            var (blockIndex, releasedIn, blockStartOffset) = stack.Pop();
+            if (!visited.Add((blockIndex, releasedIn)))
+                continue;
+
+            var block = graph.Blocks[blockIndex];
+            bool released = releasedIn;
+            foreach (var instruction in instructions)
+            {
+                if (instruction.Offset < block.Start || instruction.Offset >= block.End || instruction.Offset < blockStartOffset)
+                    continue;
+                if (releases.Contains(instruction.Offset))
+                    released = true;
+            }
+
+            var terminator = terminators[blockIndex];
+            if (terminator?.OpCode is ILOpCode.Ret)
+            {
+                if (!released)
+                    return true;
+                continue;
+            }
+            if (terminator?.OpCode is ILOpCode.Throw or ILOpCode.Rethrow)
+                continue;
+
+            foreach (int successor in block.Edges.Successors)
+                stack.Push((successor, released, graph.Blocks[successor].Start));
+        }
+
+        return false;
+    }
+
+    // The acquire is exception-safe only when some Return runs inside a finally/fault handler
+    // whose protected region covers the acquire (the Rent precedes the handler body). Otherwise
+    // an exception between Rent and a normal-flow Return escapes without releasing.
+    static bool ReleaseProtectedByFinally(
+        ImmutableArray<ExceptionRegionModel> regions,
+        int rentOffset,
+        IReadOnlyList<int> releases)
+    {
+        foreach (int release in releases)
+        {
+            foreach (var region in regions)
+            {
+                if (region.Kind is HandlerKind.Finally or HandlerKind.Fault
+                    && region.ContainsHandler(release)
+                    && rentOffset < region.HandlerStart)
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    // The smallest target offset that is reachable strictly after some source offset: same block
+    // and later in program order, or in any block reachable via >=1 successor edge (covers loops).
+    static int? FirstReachableAfter(BlockGraph graph, IReadOnlyList<int> sources, IReadOnlyList<int> targets)
+    {
+        int? best = null;
+        foreach (int source in sources)
+        {
+            int sourceBlock = graph.BlockIndexAt(source);
+            if (sourceBlock < 0)
+                continue;
+            var reachable = SuccessorClosure(graph, sourceBlock);
+            foreach (int target in targets)
+            {
+                if (source == target)
+                    continue;
+                int targetBlock = graph.BlockIndexAt(target);
+                if (targetBlock < 0)
+                    continue;
+                bool after = reachable.Contains(targetBlock) || (targetBlock == sourceBlock && source < target);
+                if (after && (best is null || target < best))
+                    best = target;
+            }
+        }
+        return best;
+    }
+
+    static HashSet<int> SuccessorClosure(BlockGraph graph, int fromBlock)
+    {
+        var seen = new HashSet<int>();
+        var stack = new Stack<int>();
+        foreach (int successor in graph.Blocks[fromBlock].Edges.Successors)
+            stack.Push(successor);
+        while (stack.Count > 0)
+        {
+            int block = stack.Pop();
+            if (!seen.Add(block))
+                continue;
+            foreach (int successor in graph.Blocks[block].Edges.Successors)
+                stack.Push(successor);
+        }
+        return seen;
+    }
+
+    static DecodedInstruction?[] BuildTerminators(BlockGraph graph, ImmutableArray<DecodedInstruction> instructions)
+    {
+        var terminators = new DecodedInstruction?[graph.Blocks.Length];
+        foreach (var instruction in instructions)
+        {
+            int blockIndex = graph.BlockIndexAt(instruction.Offset);
+            if (blockIndex >= 0)
+                terminators[blockIndex] = instruction;
+        }
+        return terminators;
+    }
+
+    static ExtendedUseKind ClassifyUse(
+        ImmutableArray<DecodedInstruction> instructions,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        int loadOffset,
+        int slot)
+    {
+        if (!ArrayPoolRecognizers.TryFindInstruction(instructions, loadOffset, out int index, out var load)
+            || !ArrayPoolRecognizers.IsLoadLocal(load, slot))
+            return ExtendedUseKind.Ambiguous;
+
+        int extra = 0;
+        for (int i = index + 1; i < instructions.Length; i++)
+        {
+            var instruction = instructions[i];
+            var opcode = instruction.OpCode;
+            if (ArrayPoolRecognizers.IsSimpleArgumentPush(opcode))
+            {
+                extra++;
+                continue;
+            }
+            if (opcode == ILOpCode.Ldlen)
+                return extra == 0 ? ExtendedUseKind.LocalUse : ExtendedUseKind.Ambiguous;
+            if (ArrayPoolRecognizers.IsElementRead(opcode))
+                return extra == 1 ? ExtendedUseKind.LocalUse : ExtendedUseKind.Ambiguous;
+            if (ArrayPoolRecognizers.IsElementStore(opcode))
+                return extra == 2 ? ExtendedUseKind.LocalUse : ExtendedUseKind.Ambiguous;
+            if (opcode is ILOpCode.Ret)
+                return extra == 0 ? ExtendedUseKind.ReturnFromMethod : ExtendedUseKind.Ambiguous;
+            if (opcode is ILOpCode.Stfld or ILOpCode.Stsfld)
+                return ExtendedUseKind.FieldStore;
+            if (IsLocalOrArgumentStore(opcode))
+                return ExtendedUseKind.AliasStore;
+            if (calls.TryGetValue(instruction.Offset, out var callee))
+            {
+                if (ArrayPoolRecognizers.IsArrayPoolReturn(callee) && extra < callee.ParameterTypes.Length)
+                    return ExtendedUseKind.Release;
+                return ExtendedUseKind.UnknownCall;
+            }
+            return ExtendedUseKind.Ambiguous;
+        }
+
+        return ExtendedUseKind.Ambiguous;
+    }
+
+    static bool IsLocalOrArgumentStore(ILOpCode opcode)
+        => opcode is ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3
+            or ILOpCode.Stloc_s or ILOpCode.Stloc or ILOpCode.Starg_s or ILOpCode.Starg;
+
+    static readonly ResourceLifecycleCensusResult Empty = new([], 0);
+
+    enum ExtendedUseKind
+    {
+        Release,
+        LocalUse,
+        ReturnFromMethod,
+        FieldStore,
+        AliasStore,
+        UnknownCall,
+        Ambiguous,
+    }
+}

--- a/src/ILInspector.Analysis/ResourceLifecycleCensus.cs
+++ b/src/ILInspector.Analysis/ResourceLifecycleCensus.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Reflection.Metadata;
 
+using ILInspector.ControlFlow;
 using ILInspector.Instructions;
 
 namespace ILInspector.Analysis;
@@ -222,7 +223,7 @@ public static class ResourceLifecycleCensus
                 $"ArrayPool Rent at IL_{acquire.RentOffset:X4} reaches a normal return without a Return on some path."));
         }
 
-        if (!ReleaseProtectedByFinally(instructions, graph.Regions, acquire, releases))
+        if (!ReleaseProtectedByFinally(graph, instructions, acquire, releases))
         {
             int? detail = releases.Count > 0 ? releases.Min() : null;
             facts.Add(new ResourceLifecycleFact(
@@ -318,15 +319,16 @@ public static class ResourceLifecycleCensus
         return false;
     }
 
-    // The acquire is exception-safe only when some Return runs inside a finally/fault handler
-    // that actually covers the acquired value: either the store sits inside the protected try, or
-    // it sits immediately before the try with only inert (non-throwing) ops in the gap. A Return
-    // in a finally whose try starts *after* a throwing op (a call, an element access, ...) does
-    // NOT cover an exception from that op - the finally is never entered - so the acquire is still
-    // an exception-path leak candidate. (Reviewers GPT-5.5 + Gemini 3.1 Pro, PR #2447.)
+    // The acquire is exception-safe only when some Return provably runs during unwinding: it must
+    // sit inside a covering finally/fault handler whose protected try covers the acquired value
+    // (store inside the try, or immediately before it with an inert gap) AND the Return must
+    // post-dominate the handler entry, so a conditional Return in the handler
+    // (`finally { if (c) Return(buf); }`) does NOT count - the `c`-false path leaves the handler
+    // without releasing. A throwing op between the rent and the try, or a non-dominating handler
+    // Return, both keep the exception-path candidate. (Reviewers GPT-5.5 + Gemini 3.1 Pro, PR #2447.)
     static bool ReleaseProtectedByFinally(
+        BlockGraph graph,
         ImmutableArray<DecodedInstruction> instructions,
-        ImmutableArray<ExceptionRegionModel> regions,
         ArrayPoolAcquire acquire,
         IReadOnlyList<int> releases)
     {
@@ -334,15 +336,26 @@ public static class ResourceLifecycleCensus
             return false;
 
         int storeNext = StoreNextOffset(instructions, acquire.StoreOffset);
+        PostDominators? postDominators = null;
         foreach (int release in releases)
         {
-            foreach (var region in regions)
+            foreach (var region in graph.Regions)
             {
                 if (region.Kind is not (HandlerKind.Finally or HandlerKind.Fault) || !region.ContainsHandler(release))
                     continue;
-                if (region.ContainsTry(acquire.StoreOffset))
-                    return true;
-                if (acquire.StoreOffset < region.TryStart && GapIsInert(instructions, storeNext, region.TryStart))
+
+                bool storeCovered = region.ContainsTry(acquire.StoreOffset)
+                    || (acquire.StoreOffset < region.TryStart && GapIsInert(instructions, storeNext, region.TryStart));
+                if (!storeCovered)
+                    continue;
+
+                int handlerBlock = graph.BlockIndexAt(region.HandlerStart);
+                int releaseBlock = graph.BlockIndexAt(release);
+                if (handlerBlock < 0 || releaseBlock < 0)
+                    continue;
+
+                postDominators ??= PostDominators.Of([.. graph.Blocks.Select(block => block.Edges)]);
+                if (postDominators.PostDominates(releaseBlock, handlerBlock))
                     return true;
             }
         }

--- a/tools/AnalysisHarness/Program.cs
+++ b/tools/AnalysisHarness/Program.cs
@@ -47,6 +47,15 @@ const string Usage =
           for #1992 - the analyzer is precision-first, so an empty card means recall (not a
           user-facing section) is the next lever. --top bounds examples per assembly.
 
+      --resource-lifecycle <file> [--top N] [--tsv | --jsonl]
+          Sweep the measurement-only ArrayPool resource-lifecycle census over a corpus (one
+          assembly path per line in <file>) and report the candidate/suppression bucket census:
+          acquires observed, the bucket histogram (normal-path vs exception-path leak candidates,
+          use-after/double-return candidates, and ownership/alias/cross-method/incomplete
+          suppressions), and example methods per bucket, as a Markout card. This changes no
+          existing finding (#2439 Slice 1); it exists to size each bucket before any graduates to
+          a user-facing finding. Formats match --leak-triage; --top bounds examples per bucket.
+
       Common: --json machine-readable output; --keep keep generated fixture projects.
     """;
 
@@ -74,6 +83,7 @@ string? annotationParityCategory = null;
 string? annotationParityExpected = null;
 string? annotationParityActual = null;
 string? leakTriageList = null;
+string? lifecycleList = null;
 bool tsv = false;
 bool jsonl = false;
 int top = 20;
@@ -117,6 +127,9 @@ for (int i = 0; i < args.Length; i++)
         case "--leak-triage":
             leakTriageList = NextPathValue(args, ref i);
             break;
+        case "--resource-lifecycle":
+            lifecycleList = NextPathValue(args, ref i);
+            break;
         case "--tsv":
             tsv = true;
             break;
@@ -148,11 +161,11 @@ for (int i = 0; i < args.Length; i++)
     }
 }
 
-// --tsv/--jsonl are leak-triage-specific format selectors; other modes use --json.
-// Reject them outside --leak-triage rather than silently accepting-and-ignoring them.
-if ((tsv || jsonl) && leakTriageList is null)
+// --tsv/--jsonl are tabular-format selectors for the census cards; other modes use --json.
+// Reject them elsewhere rather than silently accepting-and-ignoring them.
+if ((tsv || jsonl) && leakTriageList is null && lifecycleList is null)
 {
-    Console.Error.WriteLine("--tsv and --jsonl apply only to --leak-triage; other modes use --json.");
+    Console.Error.WriteLine("--tsv and --jsonl apply only to --leak-triage / --resource-lifecycle; other modes use --json.");
     return 2;
 }
 
@@ -173,6 +186,9 @@ if (annotationParityExpected is not null)
 
 if (leakTriageList is not null)
     return RunLeakTriage(leakTriageList, top, tsv, jsonl || json);
+
+if (lifecycleList is not null)
+    return RunResourceLifecycle(lifecycleList, top, tsv, jsonl || json);
 
 if (corpusList is not null)
     return RunCorpus(corpusList, diffBaseline, emitSnapshot, json);
@@ -261,6 +277,37 @@ static int RunLeakTriage(string corpusList, int top, bool tsv, bool jsonl)
 
     var report = LeakTriageSensor.Measure(paths, examplesPerAssembly: top);
     Console.Write(LeakTriageSensor.Format(report, top, format));
+    return 0;
+}
+
+static int RunResourceLifecycle(string corpusList, int top, bool tsv, bool jsonl)
+{
+    if (!File.Exists(corpusList))
+    {
+        Console.Error.WriteLine($"Corpus list not found: {corpusList}");
+        return 2;
+    }
+
+    if (tsv && jsonl)
+    {
+        Console.Error.WriteLine("--tsv and --jsonl are mutually exclusive.");
+        return 2;
+    }
+
+    LifecycleFormat format = jsonl ? LifecycleFormat.Jsonl : tsv ? LifecycleFormat.Tsv : LifecycleFormat.Markdown;
+
+    var paths = File.ReadAllLines(corpusList)
+        .Select(line => line.Trim())
+        .Where(line => line.Length > 0 && !line.StartsWith('#'))
+        .ToList();
+    if (paths.Count == 0)
+    {
+        Console.Error.WriteLine($"Corpus list is empty: {corpusList}");
+        return 2;
+    }
+
+    var report = ResourceLifecycleSensor.Measure(paths, examplesPerAssembly: top);
+    Console.Write(ResourceLifecycleSensor.Format(report, top, format));
     return 0;
 }
 

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -141,6 +141,35 @@ section — is the next lever**. A 2026-07-05 run over CoreLib, `Microsoft.CodeA
 assembly's three known-misuse methods surfaced exactly once each. Wire the section only once this
 card shows non-zero, high-precision rows on real assemblies.
 
+## Resource lifecycle census (#2439 Slice 1)
+
+`--resource-lifecycle` sweeps the **measurement-only** ArrayPool resource-lifecycle census
+(`ResourceLifecycleCensus`) over a corpus and reports the candidate/suppression bucket census,
+as a [Markout](https://github.com/richlander/markout) card:
+
+```bash
+dotnet "$DLL" --resource-lifecycle assemblies.txt --top 5     # Markdown card (default)
+dotnet "$DLL" --resource-lifecycle assemblies.txt --tsv       # section-tagged TSV
+dotnet "$DLL" --resource-lifecycle assemblies.txt --jsonl     # one JSON record per row
+```
+
+Unlike `--leak-triage`, this changes **no** user-facing finding: it consumes the same CFG +
+def-use substrate but, instead of accusing, partitions every recognized
+`ArrayPool<T>.Shared.Rent` acquire into typed buckets so their size and shape can be measured
+before any bucket graduates to a finding (Slice 4). The card has three sections — a **Summary**
+(assemblies / opened / failed / timed out / acquires observed / candidate / suppressed / total
+facts), a **By bucket** histogram, and **Examples** (bucket / assembly / method, `--top` bounding
+examples per bucket).
+
+Buckets: candidate buckets `normal-path-leak-candidate`, `exception-path-leak-candidate`,
+`use-after-return-candidate`, `double-return-candidate` (a clean acquire may satisfy several at
+once — candidate reachability is deliberately raw, so a correlated-branch multi-return shows up as
+both a normal-path leak and a double return); suppression buckets `ownership-transfer-suppressed`,
+`alias-or-field-suppressed`, `cross-method-suppressed`, `incomplete-cfg-or-rd-suppressed` (each
+terminal — a suppressed acquire never counts toward a leak). The normal-path vs exception-path
+split matters because exception-path candidates are only clearly actionable when the exception is
+commonly caught one layer higher; measuring them separately is the point of the slice.
+
 ## Allocation convergence parity
 
 The Rung 4 allocation-convergence build must prove that a candidate

--- a/tools/AnalysisHarness/ResourceLifecycleSensor.cs
+++ b/tools/AnalysisHarness/ResourceLifecycleSensor.cs
@@ -1,0 +1,264 @@
+using Markout;
+using Markout.Formatting;
+
+using ILInspector.Analysis;
+
+namespace ILInspector.AnalysisHarness;
+
+/// <summary>One example row: a bucket and the method it fired on.</summary>
+public sealed record LifecycleExample(string Bucket, string Method);
+
+/// <summary>Per-assembly census result: whether it opened, acquires observed, fact count, the
+/// bucket histogram, and a few example methods per bucket.</summary>
+public sealed record LifecycleAssembly(
+    string Name,
+    bool Opened,
+    bool TimedOut,
+    int AcquiresObserved,
+    int Facts,
+    IReadOnlyDictionary<string, int> Buckets,
+    IReadOnlyList<LifecycleExample> Examples);
+
+/// <summary>A resource-lifecycle census report: per-assembly rows plus aggregate bucket totals.</summary>
+public sealed record LifecycleReport(
+    IReadOnlyList<LifecycleAssembly> Assemblies,
+    IReadOnlyDictionary<string, int> TotalsByBucket,
+    int TotalAcquires,
+    int TotalFacts);
+
+public enum LifecycleFormat { Markdown, Tsv, Jsonl }
+
+/// <summary>
+/// The resource-lifecycle corpus sensor (#2439 Slice 1): sweeps the measurement-only
+/// <see cref="ResourceLifecycleCensus"/> over a fixed corpus and reports the census - acquires
+/// observed, the candidate/suppression bucket histogram, and example methods per bucket. This is
+/// pure measurement: there is no product surface and it changes no <see cref="LeakTriageAnalyzer"/>
+/// finding. It exists so the size and shape of each bucket (normal-path vs exception-path leaks,
+/// ownership/alias/cross-method suppressions) can be measured on ArrayPool-heavy packages before
+/// any bucket graduates to a user-facing finding (Slice 4).
+/// </summary>
+public static class ResourceLifecycleSensor
+{
+    static readonly IReadOnlySet<string> CandidateBuckets = new HashSet<string>(StringComparer.Ordinal)
+    {
+        ResourceLifecycleBuckets.NormalPathLeakCandidate,
+        ResourceLifecycleBuckets.ExceptionPathLeakCandidate,
+        ResourceLifecycleBuckets.UseAfterReturnCandidate,
+        ResourceLifecycleBuckets.DoubleReturnCandidate,
+    };
+
+    public static LifecycleReport Measure(IReadOnlyList<string> assemblyPaths, int perAssemblyTimeoutSeconds = 120, int examplesPerAssembly = 5)
+    {
+        var assemblies = new List<LifecycleAssembly>(assemblyPaths.Count);
+        foreach (var path in assemblyPaths)
+            assemblies.Add(MeasureWithTimeout(path, perAssemblyTimeoutSeconds, examplesPerAssembly));
+        assemblies.Sort((a, b) => string.CompareOrdinal(a.Name, b.Name));
+
+        var totals = new SortedDictionary<string, int>(StringComparer.Ordinal);
+        foreach (var assembly in assemblies)
+            foreach (var (bucket, count) in assembly.Buckets)
+                totals[bucket] = totals.GetValueOrDefault(bucket) + count;
+
+        return new LifecycleReport(
+            assemblies,
+            totals,
+            assemblies.Sum(a => a.AcquiresObserved),
+            assemblies.Sum(a => a.Facts));
+    }
+
+    // Bound each assembly so one pathological input cannot hang the sweep; the census is already
+    // fail-closed per method, so this is belt-and-braces.
+    static LifecycleAssembly MeasureWithTimeout(string path, int timeoutSeconds, int examplesPerAssembly)
+    {
+        string name = Path.GetFileName(path);
+        LifecycleAssembly? result = null;
+        var worker = new Thread(() => result = MeasureOne(path, examplesPerAssembly)) { IsBackground = true };
+        worker.Start();
+        if (worker.Join(TimeSpan.FromSeconds(timeoutSeconds)) && result is not null)
+            return result;
+        return new LifecycleAssembly(name, Opened: false, TimedOut: true, 0, 0, new Dictionary<string, int>(), []);
+    }
+
+    static LifecycleAssembly MeasureOne(string path, int examplesPerAssembly)
+    {
+        string name = Path.GetFileName(path);
+        try
+        {
+            var census = ResourceLifecycleCensus.CensusAssembly(path);
+            var buckets = new SortedDictionary<string, int>(StringComparer.Ordinal);
+            var examples = new List<LifecycleExample>();
+            var seenPerBucket = new Dictionary<string, int>(StringComparer.Ordinal);
+            foreach (var fact in census.Facts)
+            {
+                buckets[fact.Bucket] = buckets.GetValueOrDefault(fact.Bucket) + 1;
+                int seen = seenPerBucket.GetValueOrDefault(fact.Bucket);
+                if (seen < examplesPerAssembly)
+                {
+                    examples.Add(new LifecycleExample(fact.Bucket, $"{fact.Method.DeclaringType.Name}::{fact.Method.Name}"));
+                    seenPerBucket[fact.Bucket] = seen + 1;
+                }
+            }
+            return new LifecycleAssembly(name, Opened: true, TimedOut: false, census.AcquiresObserved, census.Facts.Length, buckets, examples);
+        }
+        // Per-assembly boundary on a background thread: convert any input failure (directory,
+        // truncated PE, ...) into a failed row and keep sweeping.
+        catch (Exception)
+        {
+            return new LifecycleAssembly(name, Opened: false, TimedOut: false, 0, 0, new Dictionary<string, int>(), []);
+        }
+    }
+
+    public static string Format(LifecycleReport report, int maxExamples, LifecycleFormat format)
+    {
+        var output = new StringWriter();
+        if (format == LifecycleFormat.Markdown)
+        {
+            MarkoutSerializer.Serialize(
+                BuildMarkdownView(report, maxExamples),
+                output,
+                new MarkdownFormatter(),
+                LifecycleViewContext.Default,
+                new MarkoutWriterOptions());
+        }
+        else
+        {
+            MarkoutSerializer.Serialize(
+                BuildTableView(report, maxExamples),
+                output,
+                new TableFormatter(showHeader: true),
+                LifecycleViewContext.Default,
+                format == LifecycleFormat.Tsv
+                    ? new MarkoutWriterOptions { TableMode = MarkoutTableMode.Tsv }
+                    : new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl });
+        }
+
+        string rendered = output.ToString();
+        return format == LifecycleFormat.Jsonl
+            ? string.Join(Environment.NewLine, rendered.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)) + Environment.NewLine
+            : rendered;
+    }
+
+    static IReadOnlyList<(string Metric, string Value)> SummaryRows(LifecycleReport report)
+    {
+        int candidates = report.TotalsByBucket.Where(kv => CandidateBuckets.Contains(kv.Key)).Sum(kv => kv.Value);
+        return new (string, string)[]
+        {
+            ("assemblies", report.Assemblies.Count.ToString()),
+            ("opened", report.Assemblies.Count(a => a.Opened).ToString()),
+            ("failed", report.Assemblies.Count(a => !a.Opened && !a.TimedOut).ToString()),
+            ("timed out", report.Assemblies.Count(a => a.TimedOut).ToString()),
+            ("acquires observed", report.TotalAcquires.ToString()),
+            ("candidate facts", candidates.ToString()),
+            ("suppressed facts", (report.TotalFacts - candidates).ToString()),
+            ("total facts", report.TotalFacts.ToString()),
+        };
+    }
+
+    // Buckets in canonical order (candidates, then suppressions), skipping any that never fired.
+    static IReadOnlyList<(string Bucket, string Count)> BucketRows(LifecycleReport report)
+        => [.. ResourceLifecycleBuckets.All
+            .Where(bucket => report.TotalsByBucket.ContainsKey(bucket))
+            .Select(bucket => (bucket, report.TotalsByBucket[bucket].ToString()))];
+
+    // Up to maxExamples example methods per bucket, gathered across assemblies in bucket order.
+    static IReadOnlyList<(string Bucket, string Assembly, string Method)> ExampleRows(LifecycleReport report, int maxExamples)
+    {
+        var rows = new List<(string Bucket, string Assembly, string Method)>();
+        foreach (var bucket in ResourceLifecycleBuckets.All)
+        {
+            int taken = 0;
+            foreach (var assembly in report.Assemblies)
+            {
+                foreach (var example in assembly.Examples.Where(e => e.Bucket == bucket))
+                {
+                    if (taken >= maxExamples)
+                        break;
+                    rows.Add((bucket, assembly.Name, example.Method));
+                    taken++;
+                }
+                if (taken >= maxExamples)
+                    break;
+            }
+        }
+        return rows;
+    }
+
+    static LifecycleCardMarkdownView BuildMarkdownView(LifecycleReport report, int maxExamples)
+        => new()
+        {
+            Summary = [.. SummaryRows(report).Select(r => new LifecycleMetricRow(r.Metric, r.Value))],
+            ByBucket = [.. BucketRows(report).Select(r => new LifecycleBucketRow(r.Bucket, r.Count))],
+            Examples = [.. ExampleRows(report, maxExamples).Select(r => new LifecycleExampleRow(r.Bucket, r.Assembly, r.Method))],
+        };
+
+    static LifecycleCardTableView BuildTableView(LifecycleReport report, int maxExamples)
+        => new()
+        {
+            Summary = [.. SummaryRows(report).Select(r => new LifecycleSectionMetricRow("Summary", r.Metric, r.Value))],
+            ByBucket = [.. BucketRows(report).Select(r => new LifecycleSectionBucketRow("By bucket", r.Bucket, r.Count))],
+            Examples = [.. ExampleRows(report, maxExamples).Select(r => new LifecycleSectionExampleRow("Examples", r.Bucket, r.Assembly, r.Method))],
+        };
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+sealed class LifecycleCardMarkdownView
+{
+    [MarkoutIgnore]
+    public string Title => "Resource Lifecycle Census";
+
+    [MarkoutSection(Name = "Summary")]
+    public List<LifecycleMetricRow>? Summary { get; init; }
+
+    [MarkoutSection(Name = "By bucket", EmptyText = "None - no recognized ArrayPool acquire reached a candidate or suppression bucket.")]
+    public List<LifecycleBucketRow>? ByBucket { get; init; }
+
+    [MarkoutSection(Name = "Examples", EmptyText = "None")]
+    public List<LifecycleExampleRow>? Examples { get; init; }
+}
+
+[MarkoutSerializable]
+sealed class LifecycleCardTableView
+{
+    [MarkoutIgnore]
+    public string Title => "Resource Lifecycle Census";
+
+    [MarkoutSection(Name = "Summary")]
+    public List<LifecycleSectionMetricRow>? Summary { get; init; }
+
+    [MarkoutSection(Name = "By bucket")]
+    public List<LifecycleSectionBucketRow>? ByBucket { get; init; }
+
+    [MarkoutSection(Name = "Examples")]
+    public List<LifecycleSectionExampleRow>? Examples { get; init; }
+}
+
+[MarkoutSerializable]
+sealed record LifecycleMetricRow(string Metric, string Count);
+
+[MarkoutSerializable]
+sealed record LifecycleSectionMetricRow(string Section, string Metric, string Count);
+
+[MarkoutSerializable]
+sealed record LifecycleBucketRow(string Bucket, string Count);
+
+[MarkoutSerializable]
+sealed record LifecycleSectionBucketRow(string Section, string Bucket, string Count);
+
+[MarkoutSerializable]
+sealed record LifecycleExampleRow(string Bucket, string Assembly, string Method);
+
+[MarkoutSerializable]
+sealed record LifecycleSectionExampleRow(string Section, string Bucket, string Assembly, string Method);
+
+[MarkoutContextOptions(SuppressTableWarnings = true)]
+[MarkoutContext(typeof(LifecycleCardMarkdownView))]
+[MarkoutContext(typeof(LifecycleCardTableView))]
+[MarkoutContext(typeof(LifecycleMetricRow))]
+[MarkoutContext(typeof(LifecycleSectionMetricRow))]
+[MarkoutContext(typeof(LifecycleBucketRow))]
+[MarkoutContext(typeof(LifecycleSectionBucketRow))]
+[MarkoutContext(typeof(LifecycleExampleRow))]
+[MarkoutContext(typeof(LifecycleSectionExampleRow))]
+partial class LifecycleViewContext : MarkoutSerializerContext
+{
+}


### PR DESCRIPTION
Closes the first slice of #2439.

## Intent

Build a **read-only, measurement-only** resource-lifecycle census above the CFG +
def-use substrate (#2380/#2383/#2387) that runs alongside the shipped ArrayPool
leak-triage analyzer (#2390) without changing any finding. It separates **resource
facts** from **resource findings**: every recognized `ArrayPool<T>.Shared.Rent`
acquire is partitioned into typed candidate/suppression buckets so their size and
shape can be measured on real corpora before any graduates to a user-facing finding
(Slice 4). No product UI is wired.

## What landed

- **Shared recognizers, no drift.** `ArrayPoolRecognizers` (extracted verbatim from
  `LeakTriageAnalyzer`) is now the single source of truth for the Rent/Return/Shared
  IL shapes; `AnalysisMethodBodies` is the shared SRM body-walk. Both the finding
  path and the census enumerate the same bodies with the same identities and classify
  the same shapes. This is a behavior-preserving refactor — the existing
  `LeakTriageAnalyzerTests` pin the findings unchanged.
- **`ResourceLifecycleCensus`** (ILInspector.Analysis): per acquire, emits candidate
  buckets `normal-path-leak-candidate`, `exception-path-leak-candidate`,
  `use-after-return-candidate`, `double-return-candidate` (a clean acquire may satisfy
  several), or a **terminal** suppression `ownership-transfer-suppressed`,
  `alias-or-field-suppressed`, `cross-method-suppressed`,
  `incomplete-cfg-or-rd-suppressed`.
- **`analysis-harness --resource-lifecycle <file> [--top N] [--tsv|--jsonl]`** +
  `ResourceLifecycleSensor` Markout card (Summary / By bucket / Examples).

## Design notes (attack surface)

- **Candidate reachability is deliberately raw.** Unlike the finding path, the census
  does *not* fail-closed on correlated-branch multi-release, so a correlated
  `if(c)Return; if(!c)Return` shows up as both `normal-path-leak-candidate` and
  `double-return-candidate`. That over-count is the pre-graduation upper bound Slice 4
  must refine with predicate facts — measured on purpose, not a bug.
- **Escapes are fail-closed and terminal.** Any use the census cannot prove is a
  release or a local, non-escaping use (address-of, field/alias store, method return,
  unmodeled call) suppresses the whole acquire rather than measuring it for leaks —
  same posture as the finding path, recorded instead of dropped. Terminal precedence
  when several escapes co-occur: alias-or-field > cross-method > ownership-transfer.
- **Normal vs exception split.** Normal-path uses a `ret`-terminal CFG reachability
  walk (throw/rethrow are dead ends). Exception-path uses covering-finally/fault
  coverage: an acquire is exception-safe only when a Return runs inside a finally/fault
  handler whose protected region covers the Rent. This is the genuinely new capability
  (enabled by the #2380 nested-finally CFG fix).

## Tests

`ResourceLifecycleCensusTests` (8) cover every bucket: fixtures for the candidate
shapes (incl. the finally-protected clean cases and the nested-finally/leave shape
from #2380), and **synthetic IL** for the escape/incomplete suppressions — required
because release-build IL elides the local for single-use escaping rents, so those
C# fixtures are never recognized as acquires. Full `ILInspector.Analysis.Tests`: 400
passed (incl. the 5 unchanged `LeakTriageAnalyzerTests`).

## Corpus measurement

`--resource-lifecycle` over ArrayPool-heavy packages (MimeKit, CliWrap,
prometheus-net, Pipelines.Sockets.Unofficial, ZLinq, TouchSocket) + CoreLib + Roslyn
(80 assemblies):

| Metric | Count |
| ------ | ----- |
| acquires observed | 42 |
| candidate facts | 0 |
| suppressed facts | 42 |

| Bucket | Count |
| ------ | ----- |
| cross-method-suppressed | 36 |
| alias-or-field-suppressed | 6 |

**Honest finding:** real ArrayPool usage almost always passes the buffer to another
method (`Stream.Read`, `Array.Copy`, ...) or aliases it, so the precision-first
census suppresses nearly every acquire and candidate buckets are empty. That measures
the exact gap Slice 2/3 closes with "pass-to-known-safe-consumer" Use recognizers.
Candidate detection is proven by the fixture + synthetic tests.

## Verification

- `dotnet build dotnet-inspect.slnx -c Release` — succeeds.
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release` — 400 passed.
- `markdownlint` on the changed README — clean.

## Adversarial review

Two-model adversarial review requested per policy (I run as Claude Opus 4.8, so
reviewers are from the other roster entries). Reconciliation will be posted here.
