### PR TITLE
Pin stackalloc initializer residuals

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
@@ -3,6 +3,21 @@ namespace ILInspector.Decompiler.Fixtures.LegacyUnsafe;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+public static class StackallocInitializerResiduals
+{
+    public static unsafe int StackallocPointerInitializer()
+    {
+        int* values = stackalloc int[] { 1, 2, 3 };
+        return values[0] + values[2];
+    }
+
+    public static int StackallocSpanInitializer()
+    {
+        Span<int> values = stackalloc[] { 1, 2, 3 };
+        return values[0] + values[2];
+    }
+}
+
 /// <summary>
 /// Legacy-rules unsafe fixtures. Each method uses the member <c>unsafe</c>
 /// modifier, which under pre-memory-safety semantics makes the whole body an

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
@@ -3,6 +3,24 @@ namespace ILInspector.Decompiler.Fixtures.NewUnsafe;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+public static class StackallocInitializerResiduals
+{
+    public static int StackallocPointerInitializer()
+    {
+        int* values = stackalloc int[] { 1, 2, 3 };
+        unsafe
+        {
+            return values[0] + values[2];
+        }
+    }
+
+    public static int StackallocSpanInitializer()
+    {
+        Span<int> values = stackalloc[] { 1, 2, 3 };
+        return values[0] + values[2];
+    }
+}
+
 /// <summary>
 /// New-rules unsafe fixtures. This assembly is compiled with
 /// <c>/features:updated-memory-safety-rules</c>, so the compiler enforces the

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -8,7 +8,9 @@ using ILInspector.Metadata;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
+using LegacyStackallocInitializers = ILInspector.Decompiler.Fixtures.LegacyUnsafe.StackallocInitializerResiduals;
 using LegacyUnsafe = ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures;
+using NewStackallocInitializers = ILInspector.Decompiler.Fixtures.NewUnsafe.StackallocInitializerResiduals;
 using NewUnsafe = ILInspector.Decompiler.Fixtures.NewUnsafe.UnsafeFixtures;
 
 namespace ILInspector.Decompiler.Tests;
@@ -30,6 +32,8 @@ public class LadderRung6GateTests
     static readonly string LegacyUnsafeType = typeof(LegacyUnsafe).FullName!;
     static readonly string ByRefFixturePath = FixtureCatalog.DecompilerLadderRung4.AssemblyPath();
     static readonly string ByRefFixtureType = typeof(LadderRung4.CSharp7LocalSyntax).FullName!;
+    static readonly string StackallocInitializerType = typeof(NewStackallocInitializers).FullName!;
+    static readonly string LegacyStackallocInitializerType = typeof(LegacyStackallocInitializers).FullName!;
 
     static readonly string[] ExpectedUnsafeMembers =
     [
@@ -215,6 +219,25 @@ public class LadderRung6GateTests
         var raisedPinnedOutput = CSharpPrinter.Print(raisedPinned).Output;
         Assert.Contains("fixed (int* V_0 = ", raisedPinnedOutput);
         Assert.DoesNotContain("pinned", raisedPinnedOutput);
+    }
+
+    [Fact]
+    public void Rung6StackallocInitializerResiduals_DegradeHonestly()
+    {
+        AssertStackallocInitializerResiduals(NewUnsafePath, StackallocInitializerType);
+        AssertStackallocInitializerResiduals(LegacyUnsafePath, LegacyStackallocInitializerType);
+    }
+
+    static void AssertStackallocInitializerResiduals(string assemblyPath, string typeName)
+    {
+        var members = LoadRaisedMembers(assemblyPath, typeName);
+        foreach (var name in new[] { "StackallocPointerInitializer", "StackallocSpanInitializer" })
+        {
+            var member = members.Single(m => m.Name == name);
+            Assert.Equal(DecompilationFidelity.Partial, member.Function.Fidelity);
+            Assert.Contains(FidelityRemarks.Collect(member.Function), r => r.Code == DiagnosticIds.UnsupportedConstruct);
+            Assert.Contains("cpblk", member.Body);
+        }
     }
 
     static void AssertExactCompileBack(string assemblyPath, string typeName, string methodName)


### PR DESCRIPTION
Closes #2428.
Part of #1599 row 6.

## Fix

**Conclusion:** **PASS** — stackalloc pointer/Span initializer lowerings are now explicit row-6 owned residuals instead of untracked gaps.

Current output remains honest `Partial`:

```csharp
byte* S_256 = stackalloc byte[12];
ReadOnlySpan<int> V_1 = new int[] { 1, 2, 3 };
_ = S_256;
_ = S_256;
_ = V_1[0];
_ = 12;
/* Unsupported IL_001E cpblk: opcode is outside the slice */
```

## Scope

- Adds new/legacy unsafe fixture methods for `stackalloc int[] { 1, 2, 3 }` and `stackalloc[] { 1, 2, 3 }`.
- Adds `LadderRung6GateTests` assertions that both methods degrade honestly with `DEC0004` / `UnsupportedConstruct` and visible `cpblk`.
- Does not claim recovery; this is ownership of the row-6 residual.

## Evidence

| Check | Result |
| --- | --- |
| Focused row-6 gate | `LadderRung6GateTests` 9/9 |
| Unsafe fixture validity | 22 Full / 4 Partial; 0 malformed Full; 0 semantic defects among Full |
| Unsafe fixture gaps | 22 fully raised; 4 owned stackalloc-initializer residuals |
| Unsafe fixture fidelity | 22 Full exact; 0 opcode diffs; 4 expected residual recompile failures |
| Solution build | Pass; 3 pre-existing nullable warnings in `ILInspector.Metadata.Tests` |

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -noLogo -noColor \
  -class ILInspector.Decompiler.Tests.LadderRung6GateTests

dotnet run --project tools/DecompilerHarness -c Release -- \
  artifacts/bin/ILInspector.Decompiler.Fixtures.NewUnsafe/release/ILInspector.Decompiler.Fixtures.NewUnsafe.dll \
  artifacts/bin/ILInspector.Decompiler.Fixtures.LegacyUnsafe/release/ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll \
  --validity-check --fidelity-check --compile-cap 100 --max-examples 20

dotnet run --project tools/DecompilerHarness -c Release -- \
  artifacts/bin/ILInspector.Decompiler.Fixtures.NewUnsafe/release/ILInspector.Decompiler.Fixtures.NewUnsafe.dll \
  artifacts/bin/ILInspector.Decompiler.Fixtures.LegacyUnsafe/release/ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll \
  --gaps --max-examples 20

dotnet run --project tools/DecompilerHarness -c Release -- \
  artifacts/bin/ILInspector.Decompiler.Fixtures.NewUnsafe/release/ILInspector.Decompiler.Fixtures.NewUnsafe.dll \
  artifacts/bin/ILInspector.Decompiler.Fixtures.LegacyUnsafe/release/ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll \
  --fidelity-check --max-examples 20

dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo --verbosity quiet
```

## Review

Adversarial review requested; reconciliation will be posted before marking ready.
