### PR TITLE
Add pinned C# diff harness baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,10 +346,10 @@ jobs:
 
           dotnet run --project tools/CSharpDiffHarness -c Release --no-build -- \
             "$old" "$new" \
-            --diff-baseline artifacts/csharp-diff-smoke/snapshot.json \
+            --diff-baseline tools/CSharpDiffHarness/corpus/diff-fixtures-baseline.json \
             --format jsonl \
             --max-examples 0 \
-            > artifacts/csharp-diff-smoke/exact.jsonl
+            > artifacts/csharp-diff-smoke/baseline.jsonl
 
           cat > /tmp/csharp-diff-mutate-baseline.cs <<'CS'
           using System.Text.Json.Nodes;
@@ -387,7 +387,7 @@ jobs:
           CS
           dotnet run /tmp/csharp-diff-parse-jsonl.cs -- \
             artifacts/csharp-diff-smoke/snapshot.jsonl \
-            artifacts/csharp-diff-smoke/exact.jsonl \
+            artifacts/csharp-diff-smoke/baseline.jsonl \
             artifacts/csharp-diff-smoke/regression.jsonl
 
       - name: Upload C# Diff smoke artifact

--- a/tools/CSharpDiffHarness/README.md
+++ b/tools/CSharpDiffHarness/README.md
@@ -53,3 +53,20 @@ Markdown, with goal markers and inline status where a target applies) and
 goal-aware segment-change rows for failure buckets. Change IDs and operation
 kinds remain context bucket rows. JSONL preserves typed baseline/current fields,
 direction/status, and segment values.
+
+`tools/CSharpDiffHarness/corpus/diff-fixtures-baseline.json` is the pinned
+baseline for the CI `csharp-diff-smoke` job over `DiffFixtures.V1` /
+`DiffFixtures.V2`. Update it intentionally when C# diff row/failure semantics or
+fixture output changes:
+
+```bash
+dotnet build tools/CSharpDiffHarness/CSharpDiffHarness.csproj -c Release --configfile nuget.config
+dotnet build src/DiffFixtures.V1/DiffFixtures.V1.csproj -c Release --configfile nuget.config
+dotnet build src/DiffFixtures.V2/DiffFixtures.V2.csproj -c Release --configfile nuget.config
+dotnet run --project tools/CSharpDiffHarness -c Release --no-build -- \
+  artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll \
+  artifacts/bin/DiffFixtures.V2/release/DiffFixtureSample.dll \
+  --emit-snapshot tools/CSharpDiffHarness/corpus/diff-fixtures-baseline.json \
+  --format jsonl \
+  --max-examples 0
+```

--- a/tools/CSharpDiffHarness/corpus/diff-fixtures-baseline.json
+++ b/tools/CSharpDiffHarness/corpus/diff-fixtures-baseline.json
@@ -1,0 +1,92 @@
+{
+  "SchemaVersion": 1,
+  "Summary": {
+    "PairCount": 1,
+    "ExactPairCount": 0,
+    "ChangedPairCount": 1,
+    "ChangedMemberCount": 47,
+    "RowCount": 174,
+    "FailureCount": 1
+  },
+  "Pairs": [
+    {
+      "Old": "artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll",
+      "New": "artifacts/bin/DiffFixtures.V2/release/DiffFixtureSample.dll",
+      "IsExact": false,
+      "ChangedMemberCount": 47,
+      "RowCount": 174,
+      "FailureCount": 1
+    }
+  ],
+  "FailureBuckets": [
+    {
+      "Name": "Old method has no C# body.",
+      "Count": 1
+    }
+  ],
+  "ChangeIdBuckets": [
+    {
+      "Name": "csharp.line.added",
+      "Count": 76
+    },
+    {
+      "Name": "csharp.line.removed",
+      "Count": 53
+    },
+    {
+      "Name": "csharp.return-expression.changed",
+      "Count": 27
+    },
+    {
+      "Name": "csharp.call.changed",
+      "Count": 9
+    },
+    {
+      "Name": "csharp.method.removed",
+      "Count": 3
+    },
+    {
+      "Name": "csharp.switch.case.added",
+      "Count": 2
+    },
+    {
+      "Name": "csharp.switch.case.removed",
+      "Count": 2
+    },
+    {
+      "Name": "csharp.method.added",
+      "Count": 1
+    },
+    {
+      "Name": "csharp.method.body-added",
+      "Count": 1
+    }
+  ],
+  "OperationKindBuckets": [
+    {
+      "Name": "Line",
+      "Count": 129
+    },
+    {
+      "Name": "ReturnExpression",
+      "Count": 27
+    },
+    {
+      "Name": "Invocation",
+      "Count": 9
+    },
+    {
+      "Name": "Method",
+      "Count": 4
+    },
+    {
+      "Name": "SwitchCase",
+      "Count": 4
+    },
+    {
+      "Name": "MethodBody",
+      "Count": 1
+    }
+  ],
+  "Examples": []
+}


### PR DESCRIPTION
## Summary

Adds a pinned C# diff harness snapshot baseline and wires CI smoke to compare against it.

## Details

- Adds `tools/CSharpDiffHarness/corpus/diff-fixtures-baseline.json` for the `DiffFixtures.V1` / `DiffFixtures.V2` pair.
- Updates `csharp-diff-smoke` to compare current output against the committed baseline instead of comparing the current snapshot to itself.
- Keeps the synthetic regression JSONL check.
- Updates `tools/CSharpDiffHarness/README.md` with baseline maintenance instructions.

This makes C# diff harness drift visible in CI while retaining the existing mechanics smoke.

## Validation

- `dotnet build tools/CSharpDiffHarness/CSharpDiffHarness.csproj -c Release --configfile nuget.config --verbosity minimal`
- `dotnet build src/DiffFixtures.V1/DiffFixtures.V1.csproj -c Release --configfile nuget.config --verbosity minimal`
- `dotnet build src/DiffFixtures.V2/DiffFixtures.V2.csproj -c Release --configfile nuget.config --verbosity minimal`
- emitted current snapshot JSONL
- compared current output against `tools/CSharpDiffHarness/corpus/diff-fixtures-baseline.json`
- synthesized regression baseline and verified `--diff-baseline` returned exit `1`
- parsed snapshot/baseline/regression JSONL with `System.Text.Json`
- `npx markdownlint-cli --fix tools/CSharpDiffHarness/README.md && npx markdownlint-cli tools/CSharpDiffHarness/README.md`
- `git diff --check`

## Review

Adversarial review is required for this CI/test-tool baseline change and will be posted before marking ready.
