### PR TITLE
Add Return Address equivalence census sensor (#2440 work item 1)

### DIFF
--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -52,6 +52,9 @@ static class Program
         string? diffValidityDefects = null;
         bool fidelityCheck = false;
         bool returnToSender = false;
+        bool returnAddress = false;
+        bool censusTsv = false;
+        bool censusJsonl = false;
         bool returnToSenderAb = false;
         bool returnToSenderCatalog = false;
         bool returnToSenderMarkout = false;
@@ -139,6 +142,9 @@ static class Program
                 case "--diff-validity-defects": diffValidityDefects = args[++i]; break;
                 case "--fidelity-check": fidelityCheck = true; break;
                 case "--return-to-sender": returnToSender = true; break;
+                case "--return-address": returnAddress = true; break;
+                case "--tsv": censusTsv = true; break;
+                case "--jsonl": censusJsonl = true; break;
                 case "--return-to-sender-ab": returnToSenderAb = true; break;
                 case "--return-to-sender-markout": returnToSenderMarkout = true; break;
                 case "--return-to-sender-source-probe": returnToSenderSourceProbe = true; break;
@@ -297,6 +303,14 @@ static class Program
 
         if (returnToSender)
             return ReturnToSender.Run(assemblies, cap, maxExamples);
+
+        if (returnAddress)
+            return ReturnAddressCensus.Run(
+                assemblies,
+                maxExamples,
+                censusJsonl || json ? RaCensusFormat.Jsonl
+                    : censusTsv ? RaCensusFormat.Tsv
+                    : RaCensusFormat.Markdown);
 
         if (returnToSenderAb)
             return ReturnToSender.RunComparison(assemblies, cap, maxExamples);
@@ -1504,6 +1518,12 @@ static class Program
                                 build module/type shells for the first property
                                 getter in each assembly, compile, and compare IL
                                 opcodes.
+          --return-address        equivalence census: compare the two product
+                                member-identity producers (GetMemberAnchor vs
+                                CreateMethodAnchor) per member and report the
+                                agreement rate plus example divergences. Thin
+                                observer; --tsv/--jsonl select the format,
+                                --max-examples caps divergence rows. See #2440.
           --return-to-sender-ab   compare current compile-back and ReturnToSender
                                 over the same ReturnToSender property-getter targets.
           --return-to-sender-source-probe

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -1302,7 +1302,16 @@ static class Program
         foreach (var input in inputs)
         {
             if (Directory.Exists(input))
-                result.AddRange(Directory.EnumerateFiles(input, "*.dll").Where(IsManaged).Order());
+            {
+                try
+                {
+                    result.AddRange(Directory.EnumerateFiles(input, "*.dll").Where(IsManaged).Order());
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    Console.Error.WriteLine($"Warning: cannot read directory '{input}' ({ex.GetType().Name}), skipping.");
+                }
+            }
             else if (File.Exists(input))
                 result.Add(input);
             else

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -607,6 +607,35 @@ product path. The breadth gate is `TypeBindGateTests` in
 the whole running-runtime CoreLib and fails on any collision outside the
 allowlist.
 
+### Return Address equivalence census (`--return-address`)
+
+`--return-address` runs the Return Address (RA) equivalence census: the
+signature-identity sibling of Return-to-Sender. For every method-like member in
+the input assemblies it compares the two product member-identity producers,
+matched by metadata token:
+
+- **A** = `ApiMemberIdentity.GetMemberAnchor` (the ApiSurface path used by the
+  member index / resolver);
+- **B** = `ApiMemberIdentity.CreateMethodAnchor` (the SRM-direct path used by
+  `CSharpBodyDiff`).
+
+It reports the **agreement rate** (how many members get a byte-identical canonical
+signature from both producers) plus capped example divergences. It is a thin
+observer: it only compares product-produced canonical strings and embeds no
+type/name knowledge, so the divergence *axis* breakdown (keyword vs full-name,
+generic arity, byref, nullability) is a separate analysis (see issue #2440). As
+the member-identity consolidation lands, the agreement rate should climb toward
+100%; the sensor is the leading-signal guard for that work.
+
+```bash
+dotnet run --project tools/DecompilerHarness -c Release -- <assemblies> --return-address
+```
+
+Output is a Markout card (Markdown by default; `--tsv` and `--jsonl` select the
+tabular and JSONL renderings). `--max-examples N` caps the divergence rows. The
+sweep never crashes on unreadable inputs — a bad path is reported as an unopened
+assembly.
+
 ## Usage
 
 ```bash

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -633,8 +633,10 @@ dotnet run --project tools/DecompilerHarness -c Release -- <assemblies> --return
 
 Output is a Markout card (Markdown by default; `--tsv` and `--jsonl` select the
 tabular and JSONL renderings). `--max-examples N` caps the divergence rows. The
-sweep never crashes on unreadable inputs — a bad path is reported as an unopened
-assembly.
+summary also reports `unmatched` — method-defs (accessors, compiler-generated,
+or API-filtered) that have no ApiSurface member, so they are counted for coverage
+but never miscompared. The sweep never crashes on unreadable file inputs — a bad
+path is reported as an unopened assembly.
 
 ## Usage
 

--- a/tools/DecompilerHarness/ReturnAddressCensus.cs
+++ b/tools/DecompilerHarness/ReturnAddressCensus.cs
@@ -25,6 +25,7 @@ internal sealed record RaCensusAssembly(
     bool Opened,
     int Matched,
     int Agree,
+    int Unmatched,
     IReadOnlyList<RaCensusExample> Examples);
 
 internal sealed record RaCensusReport(IReadOnlyList<RaCensusAssembly> Assemblies);
@@ -53,7 +54,7 @@ internal static class ReturnAddressCensus
         {
             using var session = AssemblyInspectionSession.Open(path);
             if (!session.HasMetadata)
-                return new RaCensusAssembly(name, Opened: false, 0, 0, []);
+                return new RaCensusAssembly(name, Opened: false, 0, 0, 0, []);
             var surface = session.ApiSurface(includeAll: true);
 
             // token -> (ApiType, ApiMember) for method-like members.
@@ -71,7 +72,7 @@ internal static class ReturnAddressCensus
             using var pe = new PEReader(File.OpenRead(path));
             var reader = pe.GetMetadataReader();
 
-            int matched = 0, agree = 0;
+            int matched = 0, agree = 0, unmatched = 0;
             var examples = new List<RaCensusExample>();
             foreach (var typeHandle in reader.TypeDefinitions)
             {
@@ -80,7 +81,13 @@ internal static class ReturnAddressCensus
                 {
                     var token = MetadataTokens.GetToken(methodHandle);
                     if (!byToken.TryGetValue(token, out var pair))
+                    {
+                        // A method-def not represented in the API surface (accessors,
+                        // compiler-generated, or filtered) — counted for coverage, never
+                        // miscompared.
+                        unmatched++;
                         continue;
+                    }
 
                     string a, b;
                     try
@@ -101,13 +108,13 @@ internal static class ReturnAddressCensus
                 }
             }
 
-            return new RaCensusAssembly(name, Opened: true, matched, agree, examples);
+            return new RaCensusAssembly(name, Opened: true, matched, agree, unmatched, examples);
         }
         catch (Exception)
         {
             // A census over arbitrary user paths must never crash the sweep (a directory,
             // an unreadable file, or a truncated PE all surface here).
-            return new RaCensusAssembly(name, Opened: false, 0, 0, []);
+            return new RaCensusAssembly(name, Opened: false, 0, 0, 0, []);
         }
     }
 
@@ -143,6 +150,7 @@ internal static class ReturnAddressCensus
 
     static int TotalMatched(RaCensusReport report) => report.Assemblies.Sum(a => a.Matched);
     static int TotalAgree(RaCensusReport report) => report.Assemblies.Sum(a => a.Agree);
+    static int TotalUnmatched(RaCensusReport report) => report.Assemblies.Sum(a => a.Unmatched);
 
     static string Pct(int n, int total) => total == 0 ? "n/a" : $"{100.0 * n / total:0.00}%";
 
@@ -157,6 +165,7 @@ internal static class ReturnAddressCensus
             ("agree", agree.ToString()),
             ("agree rate", Pct(agree, matched)),
             ("diverge", (matched - agree).ToString()),
+            ("unmatched (not in surface)", TotalUnmatched(report).ToString()),
         };
     }
 
@@ -166,7 +175,7 @@ internal static class ReturnAddressCensus
             Summary = SummaryRows(report).Select(r => new RaCensusMetricRow(r.Metric, r.Value)).ToList(),
             PerAssembly = report.Assemblies
                 .Where(a => a.Opened)
-                .Select(a => new RaCensusAssemblyRow(a.Name, a.Matched, a.Agree, a.Matched - a.Agree, Pct(a.Agree, a.Matched)))
+                .Select(a => new RaCensusAssemblyRow(a.Name, a.Matched, a.Agree, a.Matched - a.Agree, a.Unmatched, Pct(a.Agree, a.Matched)))
                 .ToList(),
             Divergences = report.Assemblies
                 .SelectMany(a => a.Examples)
@@ -181,7 +190,7 @@ internal static class ReturnAddressCensus
             Summary = SummaryRows(report).Select(r => new RaCensusSectionMetricRow("Summary", r.Metric, r.Value)).ToList(),
             PerAssembly = report.Assemblies
                 .Where(a => a.Opened)
-                .Select(a => new RaCensusSectionAssemblyRow("Per assembly", a.Name, a.Matched, a.Agree, a.Matched - a.Agree, Pct(a.Agree, a.Matched)))
+                .Select(a => new RaCensusSectionAssemblyRow("Per assembly", a.Name, a.Matched, a.Agree, a.Matched - a.Agree, a.Unmatched, Pct(a.Agree, a.Matched)))
                 .ToList(),
             Divergences = report.Assemblies
                 .SelectMany(a => a.Examples)
@@ -230,10 +239,10 @@ internal sealed record RaCensusMetricRow(string Metric, string Value);
 internal sealed record RaCensusSectionMetricRow(string Section, string Metric, string Value);
 
 [MarkoutSerializable]
-internal sealed record RaCensusAssemblyRow(string Assembly, int Matched, int Agree, int Diverge, [property: MarkoutPropertyName("Agree rate")] string AgreeRate);
+internal sealed record RaCensusAssemblyRow(string Assembly, int Matched, int Agree, int Diverge, int Unmatched, [property: MarkoutPropertyName("Agree rate")] string AgreeRate);
 
 [MarkoutSerializable]
-internal sealed record RaCensusSectionAssemblyRow(string Section, string Assembly, int Matched, int Agree, int Diverge, [property: MarkoutPropertyName("Agree rate")] string AgreeRate);
+internal sealed record RaCensusSectionAssemblyRow(string Section, string Assembly, int Matched, int Agree, int Diverge, int Unmatched, [property: MarkoutPropertyName("Agree rate")] string AgreeRate);
 
 [MarkoutSerializable]
 internal sealed record RaCensusDivergenceRow(string Member, [property: MarkoutPropertyName("A (surface)")] string A, [property: MarkoutPropertyName("B (SRM-direct)")] string B);

--- a/tools/DecompilerHarness/ReturnAddressCensus.cs
+++ b/tools/DecompilerHarness/ReturnAddressCensus.cs
@@ -1,0 +1,255 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using ILInspector.Metadata;
+using Markout;
+using Markout.Formatting;
+
+namespace ILInspector.DecompilerHarness;
+
+// Return Address (RA) equivalence census: do the product's two Metadata member-identity
+// producers agree per member?
+//   A = ApiMemberIdentity.GetMemberAnchor   (ApiSurface path)
+//   B = ApiMemberIdentity.CreateMethodAnchor (SRM-direct path, used by CSharpBodyDiff)
+// This is a thin observer: it only compares product-produced canonical signatures by
+// string equality and reports the agreement rate. It embeds no type/name knowledge —
+// the axis breakdown of divergence is a separate analysis (see issue #2440). As the
+// identity consolidation lands, the agreement rate should climb toward 100%.
+
+internal enum RaCensusFormat { Markdown, Tsv, Jsonl }
+
+internal sealed record RaCensusExample(string Member, string A, string B);
+
+internal sealed record RaCensusAssembly(
+    string Name,
+    bool Opened,
+    int Matched,
+    int Agree,
+    IReadOnlyList<RaCensusExample> Examples);
+
+internal sealed record RaCensusReport(IReadOnlyList<RaCensusAssembly> Assemblies);
+
+internal static class ReturnAddressCensus
+{
+    public static int Run(IReadOnlyList<string> assemblies, int maxExamples, RaCensusFormat format)
+    {
+        var report = Measure(assemblies, maxExamples);
+        Console.Write(Format(report, maxExamples, format));
+        return 0;
+    }
+
+    static RaCensusReport Measure(IReadOnlyList<string> assemblies, int maxExamples)
+    {
+        var rows = new List<RaCensusAssembly>(assemblies.Count);
+        foreach (var path in assemblies)
+            rows.Add(MeasureOne(path, maxExamples));
+        return new RaCensusReport(rows);
+    }
+
+    static RaCensusAssembly MeasureOne(string path, int maxExamples)
+    {
+        var name = Path.GetFileName(path);
+        try
+        {
+            using var session = AssemblyInspectionSession.Open(path);
+            if (!session.HasMetadata)
+                return new RaCensusAssembly(name, Opened: false, 0, 0, []);
+            var surface = session.ApiSurface(includeAll: true);
+
+            // token -> (ApiType, ApiMember) for method-like members.
+            var byToken = new Dictionary<int, (ApiType Type, ApiMember Member)>();
+            foreach (var type in surface.Types)
+                foreach (var member in type.Members)
+                {
+                    if (member.MetadataToken is not { } token)
+                        continue;
+                    if (member.Kind is not ("method" or "operator" or "constructor" or "explicit-interface-implementation"))
+                        continue;
+                    byToken[token] = (type, member);
+                }
+
+            using var pe = new PEReader(File.OpenRead(path));
+            var reader = pe.GetMetadataReader();
+
+            int matched = 0, agree = 0;
+            var examples = new List<RaCensusExample>();
+            foreach (var typeHandle in reader.TypeDefinitions)
+            {
+                var typeDef = reader.GetTypeDefinition(typeHandle);
+                foreach (var methodHandle in typeDef.GetMethods())
+                {
+                    var token = MetadataTokens.GetToken(methodHandle);
+                    if (!byToken.TryGetValue(token, out var pair))
+                        continue;
+
+                    string a, b;
+                    try
+                    {
+                        a = ApiMemberIdentity.GetMemberAnchor(pair.Type, pair.Member).CanonicalSignature;
+                        b = ApiMemberIdentity.CreateMethodAnchor(reader, typeHandle, reader.GetMethodDefinition(methodHandle)).CanonicalSignature;
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+
+                    matched++;
+                    if (a == b)
+                        agree++;
+                    else if (examples.Count < maxExamples)
+                        examples.Add(new RaCensusExample($"{pair.Type.FullName}::{pair.Member.Name}", a, b));
+                }
+            }
+
+            return new RaCensusAssembly(name, Opened: true, matched, agree, examples);
+        }
+        catch (Exception)
+        {
+            // A census over arbitrary user paths must never crash the sweep (a directory,
+            // an unreadable file, or a truncated PE all surface here).
+            return new RaCensusAssembly(name, Opened: false, 0, 0, []);
+        }
+    }
+
+    static string Format(RaCensusReport report, int maxExamples, RaCensusFormat format)
+    {
+        var output = new StringWriter();
+        if (format == RaCensusFormat.Markdown)
+        {
+            MarkoutSerializer.Serialize(
+                BuildMarkdownView(report, maxExamples),
+                output,
+                new MarkdownFormatter(),
+                RaCensusViewContext.Default,
+                new MarkoutWriterOptions());
+        }
+        else
+        {
+            MarkoutSerializer.Serialize(
+                BuildTableView(report, maxExamples),
+                output,
+                new TableFormatter(showHeader: true),
+                RaCensusViewContext.Default,
+                format == RaCensusFormat.Tsv
+                    ? new MarkoutWriterOptions { TableMode = MarkoutTableMode.Tsv }
+                    : new MarkoutWriterOptions { TableMode = MarkoutTableMode.Jsonl });
+        }
+
+        string rendered = output.ToString();
+        return format == RaCensusFormat.Jsonl
+            ? string.Join(Environment.NewLine, rendered.ReplaceLineEndings("\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)) + Environment.NewLine
+            : rendered;
+    }
+
+    static int TotalMatched(RaCensusReport report) => report.Assemblies.Sum(a => a.Matched);
+    static int TotalAgree(RaCensusReport report) => report.Assemblies.Sum(a => a.Agree);
+
+    static string Pct(int n, int total) => total == 0 ? "n/a" : $"{100.0 * n / total:0.00}%";
+
+    static IReadOnlyList<(string Metric, string Value)> SummaryRows(RaCensusReport report)
+    {
+        int matched = TotalMatched(report), agree = TotalAgree(report);
+        return new (string, string)[]
+        {
+            ("assemblies", report.Assemblies.Count.ToString()),
+            ("opened", report.Assemblies.Count(a => a.Opened).ToString()),
+            ("matched members", matched.ToString()),
+            ("agree", agree.ToString()),
+            ("agree rate", Pct(agree, matched)),
+            ("diverge", (matched - agree).ToString()),
+        };
+    }
+
+    static RaCensusMarkdownView BuildMarkdownView(RaCensusReport report, int maxExamples)
+        => new()
+        {
+            Summary = SummaryRows(report).Select(r => new RaCensusMetricRow(r.Metric, r.Value)).ToList(),
+            PerAssembly = report.Assemblies
+                .Where(a => a.Opened)
+                .Select(a => new RaCensusAssemblyRow(a.Name, a.Matched, a.Agree, a.Matched - a.Agree, Pct(a.Agree, a.Matched)))
+                .ToList(),
+            Divergences = report.Assemblies
+                .SelectMany(a => a.Examples)
+                .Take(maxExamples)
+                .Select(e => new RaCensusDivergenceRow(e.Member, e.A, e.B))
+                .ToList(),
+        };
+
+    static RaCensusTableView BuildTableView(RaCensusReport report, int maxExamples)
+        => new()
+        {
+            Summary = SummaryRows(report).Select(r => new RaCensusSectionMetricRow("Summary", r.Metric, r.Value)).ToList(),
+            PerAssembly = report.Assemblies
+                .Where(a => a.Opened)
+                .Select(a => new RaCensusSectionAssemblyRow("Per assembly", a.Name, a.Matched, a.Agree, a.Matched - a.Agree, Pct(a.Agree, a.Matched)))
+                .ToList(),
+            Divergences = report.Assemblies
+                .SelectMany(a => a.Examples)
+                .Take(maxExamples)
+                .Select(e => new RaCensusSectionDivergenceRow("Divergences", e.Member, e.A, e.B))
+                .ToList(),
+        };
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+internal sealed class RaCensusMarkdownView
+{
+    [MarkoutIgnore]
+    public string Title => "Return Address equivalence census";
+
+    [MarkoutSection(Name = "Summary")]
+    public List<RaCensusMetricRow>? Summary { get; init; }
+
+    [MarkoutSection(Name = "Per assembly", EmptyText = "None")]
+    public List<RaCensusAssemblyRow>? PerAssembly { get; init; }
+
+    [MarkoutSection(Name = "Divergences", EmptyText = "None - the two producers agree on every matched member.")]
+    public List<RaCensusDivergenceRow>? Divergences { get; init; }
+}
+
+[MarkoutSerializable(TitleProperty = nameof(Title), AutoFields = false)]
+internal sealed class RaCensusTableView
+{
+    [MarkoutIgnore]
+    public string Title => "Return Address equivalence census";
+
+    [MarkoutSection(Name = "Summary")]
+    public List<RaCensusSectionMetricRow>? Summary { get; init; }
+
+    [MarkoutSection(Name = "Per assembly")]
+    public List<RaCensusSectionAssemblyRow>? PerAssembly { get; init; }
+
+    [MarkoutSection(Name = "Divergences")]
+    public List<RaCensusSectionDivergenceRow>? Divergences { get; init; }
+}
+
+[MarkoutSerializable]
+internal sealed record RaCensusMetricRow(string Metric, string Value);
+
+[MarkoutSerializable]
+internal sealed record RaCensusSectionMetricRow(string Section, string Metric, string Value);
+
+[MarkoutSerializable]
+internal sealed record RaCensusAssemblyRow(string Assembly, int Matched, int Agree, int Diverge, [property: MarkoutPropertyName("Agree rate")] string AgreeRate);
+
+[MarkoutSerializable]
+internal sealed record RaCensusSectionAssemblyRow(string Section, string Assembly, int Matched, int Agree, int Diverge, [property: MarkoutPropertyName("Agree rate")] string AgreeRate);
+
+[MarkoutSerializable]
+internal sealed record RaCensusDivergenceRow(string Member, [property: MarkoutPropertyName("A (surface)")] string A, [property: MarkoutPropertyName("B (SRM-direct)")] string B);
+
+[MarkoutSerializable]
+internal sealed record RaCensusSectionDivergenceRow(string Section, string Member, [property: MarkoutPropertyName("A (surface)")] string A, [property: MarkoutPropertyName("B (SRM-direct)")] string B);
+
+[MarkoutContextOptions(SuppressTableWarnings = true)]
+[MarkoutContext(typeof(RaCensusMarkdownView))]
+[MarkoutContext(typeof(RaCensusTableView))]
+[MarkoutContext(typeof(RaCensusMetricRow))]
+[MarkoutContext(typeof(RaCensusSectionMetricRow))]
+[MarkoutContext(typeof(RaCensusAssemblyRow))]
+[MarkoutContext(typeof(RaCensusSectionAssemblyRow))]
+[MarkoutContext(typeof(RaCensusDivergenceRow))]
+[MarkoutContext(typeof(RaCensusSectionDivergenceRow))]
+internal sealed partial class RaCensusViewContext : MarkoutSerializerContext
+{
+}


### PR DESCRIPTION
## Summary

Adds `--return-address` to `DecompilerHarness`: the **Return Address (RA) equivalence
census**, the signature-identity sibling of Return-to-Sender and **work item 1 of #2440**
(member-identity consolidation).

For every method-like member in the input assemblies, it compares the two product
member-identity producers, matched by metadata token:

- **A** = `ApiMemberIdentity.GetMemberAnchor` (ApiSurface path — member index / resolver)
- **B** = `ApiMemberIdentity.CreateMethodAnchor` (SRM-direct path — used by `CSharpBodyDiff`)

It reports the **agreement rate** (members with a byte-identical canonical signature from
both producers) plus capped example divergences. As the identity consolidation lands, the
agreement rate is the leading-signal guard that should climb toward 100%.

## Design — thin observer

The sensor only compares **product-produced canonical strings** by equality and embeds
**no type/name knowledge**. The divergence *axis* breakdown (keyword vs full-name, generic
arity, byref, nullability, `params`, funcptr) is a separate one-time analysis, posted on
#2440 — it is deliberately **not** baked into the harness, per the "tools stay thin; the
product owns identity/type knowledge" rule.

## First number (CoreLib, net9.0)

```text
matched members : 32046
agree           : 7895
agree rate      : 24.64%
diverge         : 24151
```

The #2440 census analysis showed ~96% of that divergence is reconcilable C#-display-isms
(no structural identity divergence), which validates the consolidation direction: B's
full-name grammar is the identity; A's C# spellings are the display projection.

## Output

Markout card — Markdown (default), `--tsv`, `--jsonl`. `--max-examples N` caps divergence
rows. Crash-contained: a bad path is reported as an unopened assembly, never a crash.

```bash
dotnet run --project tools/DecompilerHarness -c Release -- <assemblies> --return-address [--tsv|--jsonl] [--max-examples N]
```

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — succeeds.
- `--return-address` on CoreLib: 32,046 matched / 24.64% agree (matches the standalone spike).
- All three formats render; JSONL parses as single-line records; Markdown escapes table cells.
- Bad inputs (directory / non-PE / missing) → `opened: 0`, exit 0, EmptyText — no crash.
- `markdownlint` clean on the README.

## Review

Harness-only observer, no product-behavior change, but non-trivial logic (token matching,
Markout dual-view) → two-model adversarial review (GPT-5.5 + Gemini) per policy.
