### PR TITLE
Pin fixed buffer and string pinning residuals

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
@@ -3,6 +3,19 @@ namespace ILInspector.Decompiler.Fixtures.LegacyUnsafe;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+public unsafe struct FixedBufferResiduals
+{
+    public fixed int Data[4];
+
+    public int Sum()
+    {
+        int sum = 0;
+        for (int i = 0; i < 4; i++)
+            sum += Data[i];
+        return sum;
+    }
+}
+
 public static class StringPinningResiduals
 {
     public static unsafe int FixedStringFirstChar(string value)

--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
@@ -3,6 +3,15 @@ namespace ILInspector.Decompiler.Fixtures.LegacyUnsafe;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+public static class StringPinningResiduals
+{
+    public static unsafe int FixedStringFirstChar(string value)
+    {
+        fixed (char* p = value)
+            return p[0];
+    }
+}
+
 public static class StackallocInitializerResiduals
 {
     public static unsafe int StackallocPointerInitializer()

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
@@ -3,6 +3,20 @@ namespace ILInspector.Decompiler.Fixtures.NewUnsafe;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+public static class StringPinningResiduals
+{
+    public static int FixedStringFirstChar(string value)
+    {
+        fixed (char* p = value)
+        {
+            unsafe
+            {
+                return p[0];
+            }
+        }
+    }
+}
+
 public static class StackallocInitializerResiduals
 {
     public static int StackallocPointerInitializer()

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
@@ -3,6 +3,24 @@ namespace ILInspector.Decompiler.Fixtures.NewUnsafe;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+public struct FixedBufferResiduals
+{
+    public fixed int Data[4];
+
+    public int Sum()
+    {
+        int sum = 0;
+        for (int i = 0; i < 4; i++)
+        {
+            unsafe
+            {
+                sum += Data[i];
+            }
+        }
+        return sum;
+    }
+}
+
 public static class StringPinningResiduals
 {
     public static int FixedStringFirstChar(string value)

--- a/src/ILInspector.Decompiler.Tests/FixedBufferSkeletonFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/FixedBufferSkeletonFixture.cs
@@ -5,6 +5,4 @@ public unsafe struct FixedBufferSkeletonFixture
     public fixed byte Buffer[16];
 
     public int Value() => 42;
-
-    public int SumFirstTwo() => Buffer[0] + Buffer[1];
 }

--- a/src/ILInspector.Decompiler.Tests/FixedBufferSkeletonFixture.cs
+++ b/src/ILInspector.Decompiler.Tests/FixedBufferSkeletonFixture.cs
@@ -5,4 +5,6 @@ public unsafe struct FixedBufferSkeletonFixture
     public fixed byte Buffer[16];
 
     public int Value() => 42;
+
+    public int SumFirstTwo() => Buffer[0] + Buffer[1];
 }

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -8,9 +8,11 @@ using ILInspector.Metadata;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
+using LegacyStringPinning = ILInspector.Decompiler.Fixtures.LegacyUnsafe.StringPinningResiduals;
 using LegacyStackallocInitializers = ILInspector.Decompiler.Fixtures.LegacyUnsafe.StackallocInitializerResiduals;
 using LegacyUnsafe = ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures;
 using NewStackallocInitializers = ILInspector.Decompiler.Fixtures.NewUnsafe.StackallocInitializerResiduals;
+using NewStringPinning = ILInspector.Decompiler.Fixtures.NewUnsafe.StringPinningResiduals;
 using NewUnsafe = ILInspector.Decompiler.Fixtures.NewUnsafe.UnsafeFixtures;
 
 namespace ILInspector.Decompiler.Tests;
@@ -32,6 +34,10 @@ public class LadderRung6GateTests
     static readonly string LegacyUnsafeType = typeof(LegacyUnsafe).FullName!;
     static readonly string ByRefFixturePath = FixtureCatalog.DecompilerLadderRung4.AssemblyPath();
     static readonly string ByRefFixtureType = typeof(LadderRung4.CSharp7LocalSyntax).FullName!;
+    static readonly string FixedBufferFixturePath = typeof(FixedBufferSkeletonFixture).Assembly.Location;
+    static readonly string FixedBufferFixtureType = typeof(FixedBufferSkeletonFixture).FullName!;
+    static readonly string StringPinningType = typeof(NewStringPinning).FullName!;
+    static readonly string LegacyStringPinningType = typeof(LegacyStringPinning).FullName!;
     static readonly string StackallocInitializerType = typeof(NewStackallocInitializers).FullName!;
     static readonly string LegacyStackallocInitializerType = typeof(LegacyStackallocInitializers).FullName!;
 
@@ -219,6 +225,27 @@ public class LadderRung6GateTests
         var raisedPinnedOutput = CSharpPrinter.Print(raisedPinned).Output;
         Assert.Contains("fixed (int* V_0 = ", raisedPinnedOutput);
         Assert.DoesNotContain("pinned", raisedPinnedOutput);
+    }
+
+    [Fact]
+    public void Rung6FixedBufferAndStringPinningResiduals_DegradeHonestly()
+    {
+        var fixedBuffer = LoadRaisedMembers(FixedBufferFixturePath, FixedBufferFixtureType)
+            .Single(m => m.Name == "SumFirstTwo");
+        Assert.Equal(DecompilationFidelity.Partial, fixedBuffer.Function.Fidelity);
+        Assert.Contains(FidelityRemarks.Collect(fixedBuffer.Function), r => r.Code == DiagnosticIds.UnrepresentableMetadataName);
+        Assert.Contains("FixedElementField", fixedBuffer.Body);
+
+        AssertStringPinningResidual(NewUnsafePath, StringPinningType);
+        AssertStringPinningResidual(LegacyUnsafePath, LegacyStringPinningType);
+    }
+
+    static void AssertStringPinningResidual(string assemblyPath, string typeName)
+    {
+        var member = LoadRaisedMembers(assemblyPath, typeName)
+            .Single(m => m.Name == "FixedStringFirstChar");
+        Assert.Equal(DecompilationFidelity.Partial, member.Function.Fidelity);
+        Assert.Contains("pinned ref char", member.Body);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -8,9 +8,11 @@ using ILInspector.Metadata;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
+using LegacyFixedBuffer = ILInspector.Decompiler.Fixtures.LegacyUnsafe.FixedBufferResiduals;
 using LegacyStringPinning = ILInspector.Decompiler.Fixtures.LegacyUnsafe.StringPinningResiduals;
 using LegacyStackallocInitializers = ILInspector.Decompiler.Fixtures.LegacyUnsafe.StackallocInitializerResiduals;
 using LegacyUnsafe = ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures;
+using NewFixedBuffer = ILInspector.Decompiler.Fixtures.NewUnsafe.FixedBufferResiduals;
 using NewStackallocInitializers = ILInspector.Decompiler.Fixtures.NewUnsafe.StackallocInitializerResiduals;
 using NewStringPinning = ILInspector.Decompiler.Fixtures.NewUnsafe.StringPinningResiduals;
 using NewUnsafe = ILInspector.Decompiler.Fixtures.NewUnsafe.UnsafeFixtures;
@@ -34,8 +36,8 @@ public class LadderRung6GateTests
     static readonly string LegacyUnsafeType = typeof(LegacyUnsafe).FullName!;
     static readonly string ByRefFixturePath = FixtureCatalog.DecompilerLadderRung4.AssemblyPath();
     static readonly string ByRefFixtureType = typeof(LadderRung4.CSharp7LocalSyntax).FullName!;
-    static readonly string FixedBufferFixturePath = typeof(FixedBufferSkeletonFixture).Assembly.Location;
-    static readonly string FixedBufferFixtureType = typeof(FixedBufferSkeletonFixture).FullName!;
+    static readonly string FixedBufferType = typeof(NewFixedBuffer).FullName!;
+    static readonly string LegacyFixedBufferType = typeof(LegacyFixedBuffer).FullName!;
     static readonly string StringPinningType = typeof(NewStringPinning).FullName!;
     static readonly string LegacyStringPinningType = typeof(LegacyStringPinning).FullName!;
     static readonly string StackallocInitializerType = typeof(NewStackallocInitializers).FullName!;
@@ -230,14 +232,20 @@ public class LadderRung6GateTests
     [Fact]
     public void Rung6FixedBufferAndStringPinningResiduals_DegradeHonestly()
     {
-        var fixedBuffer = LoadRaisedMembers(FixedBufferFixturePath, FixedBufferFixtureType)
-            .Single(m => m.Name == "SumFirstTwo");
-        Assert.Equal(DecompilationFidelity.Partial, fixedBuffer.Function.Fidelity);
-        Assert.Contains(FidelityRemarks.Collect(fixedBuffer.Function), r => r.Code == DiagnosticIds.UnrepresentableMetadataName);
-        Assert.Contains("FixedElementField", fixedBuffer.Body);
+        AssertFixedBufferResidual(NewUnsafePath, FixedBufferType);
+        AssertFixedBufferResidual(LegacyUnsafePath, LegacyFixedBufferType);
 
         AssertStringPinningResidual(NewUnsafePath, StringPinningType);
         AssertStringPinningResidual(LegacyUnsafePath, LegacyStringPinningType);
+    }
+
+    static void AssertFixedBufferResidual(string assemblyPath, string typeName)
+    {
+        var member = LoadRaisedMembers(assemblyPath, typeName)
+            .Single(m => m.Name == "Sum");
+        Assert.Equal(DecompilationFidelity.Partial, member.Function.Fidelity);
+        Assert.Contains(FidelityRemarks.Collect(member.Function), r => r.Code == DiagnosticIds.UnrepresentableMetadataName);
+        Assert.Contains("FixedElementField", member.Body);
     }
 
     static void AssertStringPinningResidual(string assemblyPath, string typeName)


### PR DESCRIPTION
Closes #2427.
Part of #1599 row 6.

## Fix

**Conclusion:** **PASS** — fixed-buffer element access and fixed string pinning are now explicit row-6 owned residuals instead of untracked gaps.

Current fixed-buffer output remains honest `Partial`:

```csharp
sum += (((ref Buffer.FixedElementField) + (((nint)i) * 1)));
```

Current fixed-string pinning output remains honest `Partial`:

```csharp
pinned ref char V_0;
nuint S_0;
...
return *(ushort*)S_0;
```

## Scope

- Adds a fixed-buffer body canary to `FixedBufferSkeletonFixture`.
- Adds new/legacy unsafe fixture methods for fixed string pinning.
- Adds `LadderRung6GateTests` assertions that both shapes degrade honestly as `Partial`.
- Does not claim recovery; this is residual ownership for row 6.

## Evidence

| Check | Result |
| --- | --- |
| Focused row-6 gate | `LadderRung6GateTests` 10/10 |
| Unsafe fixture validity | 22 Full / 8 Partial; 0 malformed Full; 0 semantic defects among Full |
| Unsafe fixture gaps | 22 fully raised; 8 owned residuals (4 stackalloc initializer, 2 fixed buffer, 2 string pinning) |
| Unsafe fixture fidelity | 22 Full exact; 0 opcode diffs; 8 expected residual recompile failures |
| Solution build | Pass; 3 pre-existing nullable warnings in `ILInspector.Metadata.Tests` |

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -noLogo -noColor \
  -class ILInspector.Decompiler.Tests.LadderRung6GateTests

dotnet run --project tools/DecompilerHarness -c Release -- \
  artifacts/bin/ILInspector.Decompiler.Fixtures.NewUnsafe/release/ILInspector.Decompiler.Fixtures.NewUnsafe.dll \
  artifacts/bin/ILInspector.Decompiler.Fixtures.LegacyUnsafe/release/ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll \
  --validity-check --fidelity-check --compile-cap 100 --max-examples 20

dotnet run --project tools/DecompilerHarness -c Release -- \
  artifacts/bin/ILInspector.Decompiler.Fixtures.NewUnsafe/release/ILInspector.Decompiler.Fixtures.NewUnsafe.dll \
  artifacts/bin/ILInspector.Decompiler.Fixtures.LegacyUnsafe/release/ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll \
  --gaps --max-examples 20

dotnet run --project tools/DecompilerHarness -c Release -- \
  artifacts/bin/ILInspector.Decompiler.Fixtures.NewUnsafe/release/ILInspector.Decompiler.Fixtures.NewUnsafe.dll \
  artifacts/bin/ILInspector.Decompiler.Fixtures.LegacyUnsafe/release/ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll \
  --fidelity-check --max-examples 20

dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo --verbosity quiet
```

## Review

Adversarial review requested; reconciliation will be posted before marking ready.

