### PR TITLE
Add semantic lane to render A/B

### DIFF
--- a/docs/decompiler-raise-discipline.md
+++ b/docs/decompiler-raise-discipline.md
@@ -12,10 +12,14 @@ work inside it without re-buying the lessons.
 - **Render-text A/B is standing evidence for any raise/printer-affecting PR.**
   Emit a base dump at the explicit merge-base ref and diff the head against it
   (`DecompilerHarness --emit-render-ab` / `--render-ab`, with `--workers`).
-  Every changed method gets classified into an intended class; an unclassified
-  diff is a finding, not noise. The base is the one dangerous degree of
-  freedom — a stale base once turned 97 changed methods into 359 phantom ones
-  (#2170), twice. Never diff against a hand-managed dump.
+  Every changed method gets classified into an intended spelling class
+  (`structural`, `paren-equivalent`, or `unparsed`) and a semantic transition
+  (`valid->valid`, `invalid->valid`, `valid->invalid`, or `invalid->invalid`).
+  For expression-moving changes, the semantic lane is required evidence; a
+  `valid->invalid` method is gate-fatal even when the body still parses (for
+  example `1++`). An unclassified diff is a finding, not noise. The base is the
+  one dangerous degree of freedom — a stale base once turned 97 changed methods
+  into 359 phantom ones (#2170), twice. Never diff against a hand-managed dump.
 - **No claimed win before the A/B lands.** Census counters and structural
   metrics move before rendering truth is known; slice 4's blocking corruption
   (#2170 review round 1) was found by reviewers running the A/B the author had

--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -82,6 +82,8 @@
              Link="AssertionScan.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\IdempotenceSensor.cs"
              Link="IdempotenceSensor.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\RenderAbSensor.cs"
+             Link="RenderAbSensor.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\AnnotationCheck.cs"
              Link="AnnotationCheck.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\VolatileFieldDetector.cs"

--- a/src/ILInspector.Decompiler.Tests/RenderAbSensorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RenderAbSensorTests.cs
@@ -22,10 +22,16 @@ public class RenderAbSensorTests
             [key] = new(
                 "T",
                 "M",
+                "()",
+                typeof(RenderAbSensorTests).Assembly.Location,
+                "fixture.dll",
                 "return 1++;",
-                function,
-                new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal),
-                ProductParameterList: null),
+                new RenderAbSensor.SemanticContext(
+                    "T",
+                    "M",
+                    function,
+                    new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal),
+                    ProductParameterList: null)),
         };
 
         string output = CaptureConsole(() => RenderAbSensor.Compare(baseline, current, maxExamples: 5), expectedExitCode: 2);

--- a/src/ILInspector.Decompiler.Tests/RenderAbSensorTests.cs
+++ b/src/ILInspector.Decompiler.Tests/RenderAbSensorTests.cs
@@ -1,0 +1,70 @@
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.DecompilerHarness;
+
+namespace ILInspector.Decompiler.Tests;
+
+[Collection(ConsoleMutatorCollection.Name)]
+public class RenderAbSensorTests
+{
+    static readonly object ConsoleGate = new();
+
+    [Fact]
+    public void RenderAbSemanticLane_CatchesParseValidCompileInvalidRegression()
+    {
+        const string key = "fixture.dll!T::M()";
+        var function = SyntheticFunction();
+        var baseline = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [key] = "return 1;",
+        };
+        var current = new Dictionary<string, RenderAbSensor.RenderedMethod>(StringComparer.Ordinal)
+        {
+            [key] = new(
+                "T",
+                "M",
+                "return 1++;",
+                function,
+                new Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal),
+                ProductParameterList: null),
+        };
+
+        string output = CaptureConsole(() => RenderAbSensor.Compare(baseline, current, maxExamples: 5), expectedExitCode: 2);
+
+        Assert.Contains("Changed: 1", output);
+        Assert.Contains("Semantic: valid->valid: 0, invalid->valid: 0, valid->invalid: 1, invalid->invalid: 0", output);
+        Assert.Contains("==== Semantic Regressions (valid->invalid) ====", output);
+        Assert.Contains("return 1++;", output);
+    }
+
+    static IrFunction SyntheticFunction()
+        => new(
+            "M",
+            TypeRef.CoreLib("Synthetic", "T"),
+            new MethodSignature(
+                TypeRef.CoreLib("System", "Int32"),
+                [],
+                HasThis: false,
+                GenericParameterCount: 0),
+            [],
+            new BlockContainer());
+
+    static string CaptureConsole(Func<int> action, int expectedExitCode)
+    {
+        lock (ConsoleGate)
+        {
+            var originalOut = Console.Out;
+            using var writer = new StringWriter();
+            try
+            {
+                Console.SetOut(writer);
+                int exitCode = action();
+                Assert.Equal(expectedExitCode, exitCode);
+                return writer.ToString();
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+    }
+}

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -227,6 +227,23 @@ and per-row sampled denominators for semantic validity and compile-back fidelity
 so reviewers can tell when evidence is strong or thin. Paste that block as the
 PR's aggregate corpus evidence; do not re-key the table by hand.
 
+**Render A/B** (`--emit-render-ab` / `--render-ab`): the before/after text
+oracle for raise and printer changes. The first run writes a method-keyed JSON
+baseline of rendered bodies; the second run compares the current render against
+that baseline and reports changed, added, and removed methods. Changed methods
+are classified on two axes:
+
+- spelling: `structural`, `paren-equivalent`, or `unparsed`;
+- semantic validity over the changed set only: `valid->valid`,
+  `invalid->valid`, `valid->invalid`, or `invalid->invalid`.
+
+The semantic lane wraps each changed body in the same validity-check method shell
+and binds it with the validity diagnostic filters. It catches regressions that
+still parse, such as `1++`, without paying a corpus-wide compile cost. A
+`valid->invalid` transition is a semantic regression; expression-moving PRs
+should report the semantic line explicitly, e.g. `A/B: 55 changed (40
+paren-equivalent, 15 structural; semantic: 0 valid->invalid)`.
+
 Add `--emit-corpus-delta <file>` with `--diff-corpus-baseline` to write the
 changed per-method rows as JSON. The quality card stays compact and names the
 artifact path; reviewers and follow-up scripts can use the JSON to pick changed

--- a/tools/DecompilerHarness/RenderAbSensor.cs
+++ b/tools/DecompilerHarness/RenderAbSensor.cs
@@ -80,8 +80,6 @@ internal static class RenderAbSensor
             var portablePath = CorpusSensor.PortablePath(assemblyPath);
             using var source = MetadataSource.Open(assemblyPath, context: metadata);
             _ = source.ResolveShape(TypeRef.CoreLib("System", "Int32"));
-            var constraints = ShellConstraints.Build(source);
-            var productSignatures = ValidityCheck.ProductSignatureQueues(source.Pe);
             var stableSample = IrImporter.GetStableSampleCandidates(source, methodCap).ToList();
 
             Parallel.ForEach(stableSample, options, item =>
@@ -89,10 +87,6 @@ internal static class RenderAbSensor
                 var typeName = item.TypeName;
                 var methodName = item.MethodName;
                 var function = item.Build(source);
-                string? productSignatureParameters = ValidityCheck.DequeueProductParameterList(productSignatures, typeName, methodName);
-                string? productParameterList = function.Signature.Parameters.Any(p => p.HasDefault)
-                    ? productSignatureParameters
-                    : null;
                 
                 try
                 {
@@ -109,10 +103,11 @@ internal static class RenderAbSensor
                         renders.TryAdd(key, new RenderedMethod(
                             typeName,
                             methodName,
+                            signature,
+                            assemblyPath,
+                            portablePath,
                             rendered.Trim(),
-                            function,
-                            constraints,
-                            productParameterList));
+                            PrecomputedSemanticContext: null));
                     }
                 }
                 catch
@@ -144,6 +139,7 @@ internal static class RenderAbSensor
         var references = ValidityCheck.RuntimeReferences();
         var parseOptions = ValidityCheck.ParseOptions();
         var compileOptions = ValidityCheck.CompileOptions();
+        var semanticContexts = new Dictionary<string, SemanticContext?>(StringComparer.Ordinal);
 
         foreach (var kvp in current)
         {
@@ -158,8 +154,13 @@ internal static class RenderAbSensor
                 changed++;
                 var diffClass = Classify(before, sample.Body);
                 byClass[diffClass]++;
-                var beforeValidity = CheckSemantic(sample, before, references, parseOptions, compileOptions);
-                var afterValidity = CheckSemantic(sample, sample.Body, references, parseOptions, compileOptions);
+                if (!semanticContexts.TryGetValue(kvp.Key, out var context))
+                {
+                    context = sample.PrecomputedSemanticContext ?? BuildSemanticContext(sample);
+                    semanticContexts[kvp.Key] = context;
+                }
+                var beforeValidity = CheckSemantic(context, before, references, parseOptions, compileOptions);
+                var afterValidity = CheckSemantic(context, sample.Body, references, parseOptions, compileOptions);
                 var transition = SemanticTransitionOf(beforeValidity, afterValidity);
                 bySemantic[transition]++;
                 if (transition == SemanticTransition.ValidToInvalid)
@@ -269,22 +270,68 @@ internal static class RenderAbSensor
         };
 
     static ValidityCheck.RenderedBodyResult CheckSemantic(
-        RenderedMethod sample,
+        SemanticContext? context,
         string body,
         ImmutableArray<MetadataReference> references,
         CSharpParseOptions parseOptions,
         CSharpCompilationOptions compileOptions)
-        => ValidityCheck.EvaluateRenderedBody(
-            sample.Function,
+    {
+        if (context is null)
+        {
+            return new ValidityCheck.RenderedBodyResult(
+                [new ValidityCheck.ValidityDiagnostic("RENDERABCTX", "could not rebuild current method shell for semantic render A/B")],
+                SemanticChecked: false,
+                []);
+        }
+
+        return ValidityCheck.EvaluateRenderedBody(
+            context.Function,
             body,
-            sample.TypeName,
-            sample.MethodName,
-            sample.Constraints,
-            sample.ProductParameterList,
+            context.TypeName,
+            context.MethodName,
+            context.Constraints,
+            context.ProductParameterList,
             references,
             parseOptions,
             compileOptions,
             bindSemantics: true);
+    }
+
+    static SemanticContext? BuildSemanticContext(RenderedMethod sample)
+    {
+        using var metadata = CorpusMetadata.Create([sample.AssemblyPath]);
+        using var source = MetadataSource.Open(sample.AssemblyPath, context: metadata);
+        _ = source.ResolveShape(TypeRef.CoreLib("System", "Int32"));
+        var constraints = ShellConstraints.Build(source);
+        var productSignatures = ValidityCheck.ProductSignatureQueues(source.Pe);
+
+        foreach (var item in IrImporter.GetStableSampleCandidates(source, int.MaxValue))
+        {
+            var function = item.Build(source);
+            string signature = CorpusMethodIdentity.SignatureText(function.Signature);
+            string key = $"{sample.PortablePath}!{item.TypeName}::{item.MethodName}{signature}";
+            string? productSignatureParameters = ValidityCheck.DequeueProductParameterList(productSignatures, item.TypeName, item.MethodName);
+            string? productParameterList = function.Signature.Parameters.Any(p => p.HasDefault)
+                ? productSignatureParameters
+                : null;
+
+            if (!StringComparer.Ordinal.Equals(key, sample.Key))
+                continue;
+
+            try
+            {
+                _ = CSharpPrinter.PrintRaised(function).Output;
+            }
+            catch
+            {
+                return null;
+            }
+
+            return new SemanticContext(item.TypeName, item.MethodName, function, constraints, productParameterList);
+        }
+
+        return null;
+    }
 
     static IEnumerable<ValidityCheck.ValidityDiagnostic> Diagnostics(ValidityCheck.RenderedBodyResult result)
         => result.IsMalformed ? result.MalformedDiagnostics : result.SemanticDiagnostics;
@@ -323,7 +370,18 @@ internal static class RenderAbSensor
     internal sealed record RenderedMethod(
         string TypeName,
         string MethodName,
+        string Signature,
+        string AssemblyPath,
+        string PortablePath,
         string Body,
+        SemanticContext? PrecomputedSemanticContext = null)
+    {
+        public string Key => $"{PortablePath}!{TypeName}::{MethodName}{Signature}";
+    }
+
+    internal sealed record SemanticContext(
+        string TypeName,
+        string MethodName,
         IrFunction Function,
         IReadOnlyDictionary<string, Dictionary<string, string>> Constraints,
         string? ProductParameterList);

--- a/tools/DecompilerHarness/RenderAbSensor.cs
+++ b/tools/DecompilerHarness/RenderAbSensor.cs
@@ -284,6 +284,9 @@ internal static class RenderAbSensor
                 []);
         }
 
+        bool bindSemantics = context.Function.Fidelity == DecompilationFidelity.Full
+            && !context.TypeName.Contains('<', StringComparison.Ordinal)
+            && !context.MethodName.Contains('<', StringComparison.Ordinal);
         return ValidityCheck.EvaluateRenderedBody(
             context.Function,
             body,
@@ -294,7 +297,7 @@ internal static class RenderAbSensor
             references,
             parseOptions,
             compileOptions,
-            bindSemantics: true);
+            bindSemantics);
     }
 
     static SemanticContext? BuildSemanticContext(RenderedMethod sample)

--- a/tools/DecompilerHarness/RenderAbSensor.cs
+++ b/tools/DecompilerHarness/RenderAbSensor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -30,7 +31,7 @@ internal static class RenderAbSensor
         
         if (emitPath is not null)
         {
-            var json = JsonSerializer.Serialize(current, new JsonSerializerOptions { WriteIndented = true });
+            var json = JsonSerializer.Serialize(ToBodyDictionary(current), new JsonSerializerOptions { WriteIndented = true });
             File.WriteAllText(emitPath, json);
             Console.WriteLine($"Wrote baseline to {emitPath} ({current.Count} methods).");
             if (diffPath is null)
@@ -64,13 +65,13 @@ internal static class RenderAbSensor
         }
     }
 
-    static Dictionary<string, string> CollectRenders(
+    static Dictionary<string, RenderedMethod> CollectRenders(
         IReadOnlyList<string> assemblies,
         int methodCap,
         int? workers,
         bool sequential)
     {
-        var renders = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+        var renders = new ConcurrentDictionary<string, RenderedMethod>(StringComparer.Ordinal);
         var options = new ParallelOptions { MaxDegreeOfParallelism = sequential ? 1 : (workers ?? Math.Max(1, Environment.ProcessorCount - 2)) };
         using var metadata = CorpusMetadata.Create(assemblies);
 
@@ -79,6 +80,8 @@ internal static class RenderAbSensor
             var portablePath = CorpusSensor.PortablePath(assemblyPath);
             using var source = MetadataSource.Open(assemblyPath, context: metadata);
             _ = source.ResolveShape(TypeRef.CoreLib("System", "Int32"));
+            var constraints = ShellConstraints.Build(source);
+            var productSignatures = ValidityCheck.ProductSignatureQueues(source.Pe);
             var stableSample = IrImporter.GetStableSampleCandidates(source, methodCap).ToList();
 
             Parallel.ForEach(stableSample, options, item =>
@@ -86,6 +89,10 @@ internal static class RenderAbSensor
                 var typeName = item.TypeName;
                 var methodName = item.MethodName;
                 var function = item.Build(source);
+                string? productSignatureParameters = ValidityCheck.DequeueProductParameterList(productSignatures, typeName, methodName);
+                string? productParameterList = function.Signature.Parameters.Any(p => p.HasDefault)
+                    ? productSignatureParameters
+                    : null;
                 
                 try
                 {
@@ -99,7 +106,13 @@ internal static class RenderAbSensor
                     {
                         string signature = CorpusMethodIdentity.SignatureText(function.Signature);
                         string key = $"{portablePath}!{typeName}::{methodName}{signature}";
-                        renders.TryAdd(key, rendered.Trim());
+                        renders.TryAdd(key, new RenderedMethod(
+                            typeName,
+                            methodName,
+                            rendered.Trim(),
+                            function,
+                            constraints,
+                            productParameterList));
                     }
                 }
                 catch
@@ -112,26 +125,47 @@ internal static class RenderAbSensor
                       .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.Ordinal);
     }
 
-    static int Compare(Dictionary<string, string> baseline, Dictionary<string, string> current, int maxExamples)
+    static Dictionary<string, string> ToBodyDictionary(Dictionary<string, RenderedMethod> renders)
+        => renders.ToDictionary(kv => kv.Key, kv => kv.Value.Body, StringComparer.Ordinal);
+
+    internal static int Compare(Dictionary<string, string> baseline, Dictionary<string, RenderedMethod> current, int maxExamples)
     {
         int total = 0, changed = 0, added = 0, removed = 0;
         var byClass = new Dictionary<DiffClass, int> { [DiffClass.Structural] = 0, [DiffClass.ParenEquivalent] = 0, [DiffClass.Unparsed] = 0 };
-        var diffs = new List<(string Key, string Before, string After, DiffClass Class)>();
+        var bySemantic = new Dictionary<SemanticTransition, int>
+        {
+            [SemanticTransition.ValidToValid] = 0,
+            [SemanticTransition.InvalidToValid] = 0,
+            [SemanticTransition.ValidToInvalid] = 0,
+            [SemanticTransition.InvalidToInvalid] = 0,
+        };
+        var diffs = new List<(string Key, string Before, string After, DiffClass Class, SemanticTransition Semantic)>();
+        var semanticRegressions = new List<(string Key, string Before, string After, ValidityCheck.RenderedBodyResult BeforeValidity, ValidityCheck.RenderedBodyResult AfterValidity)>();
+        var references = ValidityCheck.RuntimeReferences();
+        var parseOptions = ValidityCheck.ParseOptions();
+        var compileOptions = ValidityCheck.CompileOptions();
 
         foreach (var kvp in current)
         {
             total++;
+            var sample = kvp.Value;
             if (!baseline.TryGetValue(kvp.Key, out var before))
             {
                 added++;
             }
-            else if (before != kvp.Value)
+            else if (before != sample.Body)
             {
                 changed++;
-                var diffClass = Classify(before, kvp.Value);
+                var diffClass = Classify(before, sample.Body);
                 byClass[diffClass]++;
+                var beforeValidity = CheckSemantic(sample, before, references, parseOptions, compileOptions);
+                var afterValidity = CheckSemantic(sample, sample.Body, references, parseOptions, compileOptions);
+                var transition = SemanticTransitionOf(beforeValidity, afterValidity);
+                bySemantic[transition]++;
+                if (transition == SemanticTransition.ValidToInvalid)
+                    semanticRegressions.Add((kvp.Key, before, sample.Body, beforeValidity, afterValidity));
                 if (diffs.Count < maxExamples * 10) // Collect some for examples
-                    diffs.Add((kvp.Key, before, kvp.Value, diffClass));
+                    diffs.Add((kvp.Key, before, sample.Body, diffClass, transition));
             }
         }
 
@@ -145,6 +179,15 @@ internal static class RenderAbSensor
         Console.WriteLine(changed == 0
             ? "Changed: 0"
             : $"Changed: {changed} (structural: {byClass[DiffClass.Structural]}, paren-equivalent: {byClass[DiffClass.ParenEquivalent]}, unparsed: {byClass[DiffClass.Unparsed]})");
+        if (changed > 0)
+        {
+            Console.WriteLine(
+                "Semantic: "
+                + $"valid->valid: {bySemantic[SemanticTransition.ValidToValid]}, "
+                + $"invalid->valid: {bySemantic[SemanticTransition.InvalidToValid]}, "
+                + $"valid->invalid: {bySemantic[SemanticTransition.ValidToInvalid]}, "
+                + $"invalid->invalid: {bySemantic[SemanticTransition.InvalidToInvalid]}");
+        }
         Console.WriteLine($"Added:   {added}");
         Console.WriteLine($"Removed: {removed}");
 
@@ -160,7 +203,7 @@ internal static class RenderAbSensor
         {
             if (printed >= maxExamples)
                 break;
-            Console.WriteLine($"\nMethod: {diff.Key} [{DiffClassLabel(diff.Class)}]");
+            Console.WriteLine($"\nMethod: {diff.Key} [{DiffClassLabel(diff.Class)}, {SemanticTransitionLabel(diff.Semantic)}]");
             Console.WriteLine("--- Baseline ---");
             Console.WriteLine(diff.Before);
             Console.WriteLine("--- Current ---");
@@ -168,7 +211,24 @@ internal static class RenderAbSensor
             printed++;
         }
 
-        return 1;
+        if (semanticRegressions.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("==== Semantic Regressions (valid->invalid) ====");
+            foreach (var regression in semanticRegressions.Take(maxExamples))
+            {
+                Console.WriteLine($"\nMethod: {regression.Key}");
+                Console.WriteLine("Diagnostics:");
+                foreach (var diagnostic in Diagnostics(regression.AfterValidity).Take(5))
+                    Console.WriteLine($"  {diagnostic.Id}: {diagnostic.Message}");
+                Console.WriteLine("--- Baseline ---");
+                Console.WriteLine(regression.Before);
+                Console.WriteLine("--- Current ---");
+                Console.WriteLine(regression.After);
+            }
+        }
+
+        return semanticRegressions.Count > 0 ? 2 : 1;
     }
 
     /// <summary>
@@ -182,12 +242,52 @@ internal static class RenderAbSensor
     /// </summary>
     enum DiffClass { Structural, Unparsed, ParenEquivalent }
 
+    enum SemanticTransition { ValidToValid, InvalidToValid, ValidToInvalid, InvalidToInvalid }
+
     static string DiffClassLabel(DiffClass diffClass) => diffClass switch
     {
         DiffClass.Structural => "structural",
         DiffClass.ParenEquivalent => "paren-equivalent",
         _ => "unparsed",
     };
+
+    static string SemanticTransitionLabel(SemanticTransition transition) => transition switch
+    {
+        SemanticTransition.ValidToValid => "semantic valid->valid",
+        SemanticTransition.InvalidToValid => "semantic invalid->valid",
+        SemanticTransition.ValidToInvalid => "semantic valid->invalid",
+        _ => "semantic invalid->invalid",
+    };
+
+    static SemanticTransition SemanticTransitionOf(ValidityCheck.RenderedBodyResult before, ValidityCheck.RenderedBodyResult after)
+        => (before.IsValid, after.IsValid) switch
+        {
+            (true, true) => SemanticTransition.ValidToValid,
+            (false, true) => SemanticTransition.InvalidToValid,
+            (true, false) => SemanticTransition.ValidToInvalid,
+            _ => SemanticTransition.InvalidToInvalid,
+        };
+
+    static ValidityCheck.RenderedBodyResult CheckSemantic(
+        RenderedMethod sample,
+        string body,
+        ImmutableArray<MetadataReference> references,
+        CSharpParseOptions parseOptions,
+        CSharpCompilationOptions compileOptions)
+        => ValidityCheck.EvaluateRenderedBody(
+            sample.Function,
+            body,
+            sample.TypeName,
+            sample.MethodName,
+            sample.Constraints,
+            sample.ProductParameterList,
+            references,
+            parseOptions,
+            compileOptions,
+            bindSemantics: true);
+
+    static IEnumerable<ValidityCheck.ValidityDiagnostic> Diagnostics(ValidityCheck.RenderedBodyResult result)
+        => result.IsMalformed ? result.MalformedDiagnostics : result.SemanticDiagnostics;
 
     static DiffClass Classify(string before, string after)
     {
@@ -219,4 +319,12 @@ internal static class RenderAbSensor
         public override SyntaxNode? VisitParenthesizedExpression(ParenthesizedExpressionSyntax node)
             => Visit(node.Expression);
     }
+
+    internal sealed record RenderedMethod(
+        string TypeName,
+        string MethodName,
+        string Body,
+        IrFunction Function,
+        IReadOnlyDictionary<string, Dictionary<string, string>> Constraints,
+        string? ProductParameterList);
 }

--- a/tools/DecompilerHarness/ValidityCheck.cs
+++ b/tools/DecompilerHarness/ValidityCheck.cs
@@ -79,6 +79,16 @@ static class ValidityCheck
         public bool HasSemanticDefect => SemanticDiagnostics.Length > 0;
     }
 
+    internal sealed record RenderedBodyResult(
+        ImmutableArray<ValidityDiagnostic> MalformedDiagnostics,
+        bool SemanticChecked,
+        ImmutableArray<ValidityDiagnostic> SemanticDiagnostics)
+    {
+        public bool IsMalformed => MalformedDiagnostics.Length > 0;
+        public bool HasSemanticDefect => SemanticDiagnostics.Length > 0;
+        public bool IsValid => !IsMalformed && SemanticChecked && !HasSemanticDefect;
+    }
+
     public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples, string? emitDefectsPath = null, string? diffDefectsPath = null, bool lowered = false)
     {
         var results = Evaluate(assemblies, cap, lowered);
@@ -137,27 +147,8 @@ static class ValidityCheck
     internal static IReadOnlyList<MethodResult> Evaluate(IReadOnlyList<string> assemblies, int cap = int.MaxValue, bool lowered = false, bool importSiblingBodies = false, int? workers = null, bool sequential = false)
     {
         var references = RuntimeReferences();
-        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
-        var compileOptions = new CSharpCompilationOptions(
-            OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true,
-            nullableContextOptions: NullableContextOptions.Disable)
-            .WithSpecificDiagnosticOptions(new Dictionary<string, ReportDiagnostic>())
-            // Import ALL members of the referenced runtime assemblies, including
-            // private ones. When a decompiled body legitimately calls a non-public
-            // overload of the target assembly (e.g. the internal `Span<T>(ref T, int)`
-            // ctor, or the PRIVATE generic helper `Enum.ToString<TUnderlying, TStorage>`
-            // that the public `Enum.ToString()` dispatches to), the external shell
-            // cannot access it; without the member imported, Roslyn never sees the
-            // intended overload and mis-binds to a public sibling, reporting a
-            // misleading diagnostic that is purely a shell artifact — CS1615/CS1620
-            // (wrong ref/out keyword) for an internal ctor, or CS0308 ("the non-generic
-            // method 'Enum.ToString()' cannot be used with type arguments") for a
-            // private generic overload, where the faithful `Enum.ToString<sbyte, byte>`
-            // call binds to the public non-generic sibling. Importing All lets Roslyn
-            // recognize the intended-but-inaccessible member (reporting CS0122, already
-            // filtered as visibility noise) instead of these phantom binding errors;
-            // the recovered call is correct and round-trips to the same member.
-            .WithMetadataImportOptions(MetadataImportOptions.All);
+        var parseOptions = ParseOptions();
+        var compileOptions = CompileOptions();
 
         int semChecked = 0;
         var results = new ConcurrentBag<MethodResult>();
@@ -214,18 +205,21 @@ static class ValidityCheck
                         return;
                     bool full = function.Fidelity == DecompilationFidelity.Full;
 
-                    string shell = Shell(function, rendered, typeName, methodName, constraints, productParameterList);
-                    var tree = CSharpSyntaxTree.ParseText(shell, parseOptions);
-                    var malformed = ImmutableArray.CreateBuilder<ValidityDiagnostic>();
-                    malformed.AddRange(SignatureDefaultDiagnostics(function, productParameterList));
-                    malformed.AddRange(tree.GetDiagnostics().Where(IsError)
-                        .Select(d => new ValidityDiagnostic(d.Id, d.GetMessage())));
-                    malformed.AddRange(IllegalStatements(tree)
-                        .Select(s => new ValidityDiagnostic("CS0201", "illegal statement: " + s.ToString().Trim())));
+                    var syntaxOnly = EvaluateRenderedBody(
+                        function,
+                        rendered,
+                        typeName,
+                        methodName,
+                        constraints,
+                        productParameterList,
+                        references,
+                        parseOptions,
+                        compileOptions,
+                        bindSemantics: false);
 
-                    if (malformed.Count > 0)
+                    if (syntaxOnly.IsMalformed)
                     {
-                        results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, malformed.ToImmutable(), SemanticChecked: false, []));
+                        results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, syntaxOnly.MalformedDiagnostics, SemanticChecked: false, []));
                         return; // parallel return
                     }
 
@@ -240,18 +234,18 @@ static class ValidityCheck
                         results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, [], SemanticChecked: false, []));
                         return; // parallel return
                     }
-                    var compilation = CSharpCompilation.Create("check", [tree], references, compileOptions);
-                    var semanticModel = compilation.GetSemanticModel(tree);
-                    var defects = compilation.GetDiagnostics()
-                        .Where(IsError)
-                        .Where(d => !BindingNoise.Contains(d.Id))
-                        .Where(d => !IsShellArtifact(d))
-                        .Where(d => !IsGenericArityCollisionNoise(d, tree, function))
-                        .Where(d => !IsSimpleNameStaticTypeCollisionNoise(d, tree, function))
-                        .Where(d => !IsDeclaringTypeStaticPropertyCtorAssignmentNoise(d, tree, function, semanticModel))
-                        .Select(d => new ValidityDiagnostic(d.Id, d.GetMessage()))
-                        .ToImmutableArray();
-                    results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, [], SemanticChecked: true, defects));
+                    var semantic = EvaluateRenderedBody(
+                        function,
+                        rendered,
+                        typeName,
+                        methodName,
+                        constraints,
+                        productParameterList,
+                        references,
+                        parseOptions,
+                        compileOptions,
+                        bindSemantics: true);
+                    results.Add(new MethodResult(typeName, methodName, CorpusMethodIdentity.SignatureText(function.Signature), full, [], SemanticChecked: true, semantic.SemanticDiagnostics));
                 });
             }
         }
@@ -259,6 +253,69 @@ static class ValidityCheck
             .ThenBy(r => r.MethodName, StringComparer.Ordinal)
             .ThenBy(r => r.Signature, StringComparer.Ordinal)
             .ToList();
+    }
+
+    internal static CSharpParseOptions ParseOptions()
+        => new(LanguageVersion.Preview);
+
+    internal static CSharpCompilationOptions CompileOptions()
+        => new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true,
+                nullableContextOptions: NullableContextOptions.Disable)
+            .WithSpecificDiagnosticOptions(new Dictionary<string, ReportDiagnostic>())
+            // Import ALL members of the referenced runtime assemblies, including
+            // private ones. When a decompiled body legitimately calls a non-public
+            // overload of the target assembly (e.g. the internal `Span<T>(ref T, int)`
+            // ctor, or the PRIVATE generic helper `Enum.ToString<TUnderlying, TStorage>`
+            // that the public `Enum.ToString()` dispatches to), the external shell
+            // cannot access it; without the member imported, Roslyn never sees the
+            // intended overload and mis-binds to a public sibling, reporting a
+            // misleading diagnostic that is purely a shell artifact — CS1615/CS1620
+            // (wrong ref/out keyword) for an internal ctor, or CS0308 ("the non-generic
+            // method 'Enum.ToString()' cannot be used with type arguments") for a
+            // private generic overload, where the faithful `Enum.ToString<sbyte, byte>`
+            // call binds to the public non-generic sibling. Importing All lets Roslyn
+            // recognize the intended-but-inaccessible member (reporting CS0122, already
+            // filtered as visibility noise) instead of these phantom binding errors;
+            // the recovered call is correct and round-trips to the same member.
+            .WithMetadataImportOptions(MetadataImportOptions.All);
+
+    internal static RenderedBodyResult EvaluateRenderedBody(
+        IrFunction function,
+        string body,
+        string typeName,
+        string methodName,
+        IReadOnlyDictionary<string, Dictionary<string, string>> constraints,
+        string? productParameterList,
+        ImmutableArray<MetadataReference> references,
+        CSharpParseOptions parseOptions,
+        CSharpCompilationOptions compileOptions,
+        bool bindSemantics)
+    {
+        string shell = Shell(function, body, typeName, methodName, constraints, productParameterList);
+        var tree = CSharpSyntaxTree.ParseText(shell, parseOptions);
+        var malformed = ImmutableArray.CreateBuilder<ValidityDiagnostic>();
+        malformed.AddRange(SignatureDefaultDiagnostics(function, productParameterList));
+        malformed.AddRange(tree.GetDiagnostics().Where(IsError)
+            .Select(d => new ValidityDiagnostic(d.Id, d.GetMessage())));
+        malformed.AddRange(IllegalStatements(tree)
+            .Select(s => new ValidityDiagnostic("CS0201", "illegal statement: " + s.ToString().Trim())));
+
+        if (malformed.Count > 0 || !bindSemantics)
+            return new RenderedBodyResult(malformed.ToImmutable(), SemanticChecked: false, []);
+
+        var compilation = CSharpCompilation.Create("check", [tree], references, compileOptions);
+        var semanticModel = compilation.GetSemanticModel(tree);
+        var defects = compilation.GetDiagnostics()
+            .Where(IsError)
+            .Where(d => !BindingNoise.Contains(d.Id))
+            .Where(d => !IsShellArtifact(d))
+            .Where(d => !IsGenericArityCollisionNoise(d, tree, function))
+            .Where(d => !IsSimpleNameStaticTypeCollisionNoise(d, tree, function))
+            .Where(d => !IsDeclaringTypeStaticPropertyCtorAssignmentNoise(d, tree, function, semanticModel))
+            .Select(d => new ValidityDiagnostic(d.Id, d.GetMessage()))
+            .ToImmutableArray();
+        return new RenderedBodyResult([], SemanticChecked: true, defects);
     }
 
     static void Record(Dictionary<string, SortedSet<string>> map, string method, IEnumerable<string> codes)
@@ -374,7 +431,7 @@ static class ValidityCheck
         }
     }
 
-    static Dictionary<string, Queue<string>> ProductSignatureQueues(PEReader pe)
+    internal static Dictionary<string, Queue<string>> ProductSignatureQueues(PEReader pe)
     {
         var result = new Dictionary<string, Queue<string>>(StringComparer.Ordinal);
         ApiSurface surface;
@@ -393,7 +450,7 @@ static class ValidityCheck
         return result;
     }
 
-    static string? DequeueProductParameterList(Dictionary<string, Queue<string>> signatures, string typeName, string methodName)
+    internal static string? DequeueProductParameterList(Dictionary<string, Queue<string>> signatures, string typeName, string methodName)
     {
         string key = $"{typeName}::{methodName}";
         if (!signatures.TryGetValue(key, out var queue) || queue.Count == 0)


### PR DESCRIPTION
## Summary

Closes #2445. Extends `DecompilerHarness --render-ab` so changed methods are classified on both spelling and semantic-validity axes.

- Keeps the existing render baseline JSON shape as `method-key -> rendered body`.
- Adds changed-method-only semantic checks using the existing `ValidityCheck` shell, parse/compile options, and diagnostic filters.
- Reports `valid->valid`, `invalid->valid`, `valid->invalid`, and `invalid->invalid`; `valid->invalid` exits 2 and prints diagnostics.
- Rebuilds semantic shell context only for matched changed methods, avoiding both corpus-wide compile cost and retaining every `IrFunction` graph.
- Documents the new Render A/B evidence contract and adds a regression test for parse-valid but compile-invalid `return 1++;`.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo`
- `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --no-restore --nologo`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/RenderAbSensorTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ValidityCoverageReportingTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ValidityShellNoiseTests/*"`
- `npx markdownlint-cli docs/decompiler-raise-discipline.md tools/DecompilerHarness/README.md`
- Render A/B smoke: emit and compare a 5-method no-change baseline for `ILInspector.Decompiler.dll` -> `Changed: 0`

Note: a full `ILInspector.Decompiler.Tests` run was started but stopped after remaining in slow corpus work for an extended period; the focused tests above cover the changed harness and validity paths.

## Adversarial review

Two-model review was run in isolated worktrees with Gemini 3.1 Pro and MAI-Code-1-Flash.

- Gemini initial pass: no blockers on the first semantic-lane implementation.
- MAI initial pass: found two real issues — product signature queues were dequeued inside the parallel render loop, and every current `IrFunction` graph was retained in the render dictionary. Fixed by storing only lightweight render metadata and rebuilding semantic context only for changed methods.
- Gemini follow-up: found semantic binding drift for generated-name and non-Full methods versus `ValidityCheck`. Fixed by gating semantic binding to Full + non-generated-name methods; ineligible rows remain invalid/unchecked.
- Final Gemini + MAI pass on the latest head: no blockers. Both verified baseline compatibility, changed-method-only compile cost, no retained `IrFunction` graphs in production, no parallel queue mutation, validity-shell reuse, and exit-code behavior.
