### PR TITLE
Surface exception-path leak candidates across call boundaries

### DIFF
--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -97,6 +97,50 @@ public sealed class LeakTriageAnalyzerTests
     }
 
     [Fact]
+    public void DetailedAnalysis_CrossMethodBeforeReturn_IsExceptionPathCandidate()
+    {
+        var result = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenRent),
+            0x0A,
+            0x06,
+            .. Call(TokenUnknown),
+            .. Call(TokenShared),
+            0x06,
+            .. Callvirt(TokenReturn),
+            0x2A,
+        ], []);
+
+        Assert.Empty(result.Findings);
+        AssertCandidate(result, nameof(Synthetic), "cross-method-suppressed");
+        AssertCandidate(result, nameof(Synthetic), "exception-path-leak-candidate");
+    }
+
+    [Fact]
+    public void DetailedAnalysis_FinallyProtectedCrossMethod_DoesNotAddExceptionPathCandidate()
+    {
+        var result = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),       // IL_0000 ArrayPool<byte>.Shared
+            0x1F, 0x10,                // IL_0005 ldc.i4.s 16
+            .. Callvirt(TokenRent),     // IL_0007 Rent
+            0x0A,                       // IL_000C stloc.0
+            0x06,                       // IL_000D ldloc.0
+            .. Call(TokenUnknown),      // IL_000E call Unknown.Use
+            0xDE, 0x0C,                 // IL_0013 leave.s IL_0021
+            .. Call(TokenShared),       // IL_0015 ArrayPool<byte>.Shared
+            0x06,                       // IL_001A ldloc.0
+            .. Callvirt(TokenReturn),   // IL_001B Return
+            0xDC,                       // IL_0020 endfinally
+            0x2A,                       // IL_0021 ret
+        ], [Region(ExceptionRegionKind.Finally, tryOffset: 13, tryLength: 8, handlerOffset: 21, handlerLength: 12)]);
+
+        Assert.Empty(result.Findings);
+        AssertCandidate(result, nameof(Synthetic), "cross-method-suppressed");
+        AssertNoCandidate(result, nameof(Synthetic), "exception-path-leak-candidate");
+    }
+
+    [Fact]
     public void IncompleteDataflow_FailsClosed()
     {
         byte[] externalBranch = [0x2B, 0x7F, 0x2A]; // br.s outside the method, then ret
@@ -277,6 +321,9 @@ public sealed class LeakTriageAnalyzerTests
         var candidate = Assert.Single(result.Candidates.Where(candidate => candidate.Method.Name == methodName && candidate.Shape == shape));
         Assert.Equal(shape, candidate.Shape);
     }
+
+    static void AssertNoCandidate(LeakTriageResult result, string methodName, string shape)
+        => Assert.DoesNotContain(result.Candidates, candidate => candidate.Method.Name == methodName && candidate.Shape == shape);
 
     static void AssertSingleShape(ImmutableArray<LeakTriageFinding> findings, string methodName, string shape)
     {

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -132,7 +132,7 @@ public static class LeakTriageAnalyzer
 
             var findings = ImmutableArray.CreateBuilder<LeakTriageFinding>();
             foreach (var rent in rents)
-                AnalyzeRent(method, instructions, graph, reaching, calls, rent, findings, candidates);
+                AnalyzeRent(method, instructions, graph, reaching, calls, exceptionRegions, rent, findings, candidates);
 
             return new LeakTriageResult(findings.ToImmutable(), candidates.ToImmutable());
         }
@@ -155,21 +155,26 @@ public static class LeakTriageAnalyzer
         BlockGraph graph,
         ReachingDefinitionsResult reaching,
         IReadOnlyDictionary<int, MemberRef> calls,
+        IReadOnlyCollection<ExceptionRegion> exceptionRegions,
         RentedLocal rent,
         ImmutableArray<LeakTriageFinding>.Builder findings,
         ImmutableArray<LeakTriageCandidate>.Builder candidates)
     {
         var releases = ImmutableArray.CreateBuilder<int>();
         var safeUses = ImmutableArray.CreateBuilder<int>();
-        bool ambiguous = false;
+        AmbiguousUse? firstAmbiguous = null;
 
         foreach (var use in reaching.UsesOf(rent.Definition))
         {
             if (use.Address)
             {
-                AddCandidate(candidates, method, "alias-or-field-suppressed", "Rented array address is observed.", rent.RentOffset, use.Offset);
-                ambiguous = true;
-                break;
+                if (firstAmbiguous is null)
+                {
+                    const string shape = "alias-or-field-suppressed";
+                    AddCandidate(candidates, method, shape, "Rented array address is observed.", rent.RentOffset, use.Offset);
+                    firstAmbiguous = new AmbiguousUse(use.Offset, shape);
+                }
+                continue;
             }
 
             var classification = ClassifyUse(instructions, calls, use.Offset, rent.Slot);
@@ -182,19 +187,34 @@ public static class LeakTriageAnalyzer
                     safeUses.Add(use.Offset);
                     break;
                 default:
-                    AddCandidate(candidates, method, classification.CandidateShape, classification.Evidence, rent.RentOffset, use.Offset);
-                    ambiguous = true;
+                    if (firstAmbiguous is null)
+                    {
+                        AddCandidate(candidates, method, classification.CandidateShape, classification.Evidence, rent.RentOffset, use.Offset);
+                        firstAmbiguous = new AmbiguousUse(use.Offset, classification.CandidateShape);
+                    }
                     break;
             }
-            if (ambiguous)
-                break;
         }
-
-        if (ambiguous)
-            return;
 
         var releaseOffsets = releases.ToImmutable();
         var safeUseOffsets = safeUses.ToImmutable();
+
+        if (firstAmbiguous is { } ambiguous)
+        {
+            if (ambiguous.Shape == "cross-method-suppressed"
+                && !ReleasedBeforeUseInSameBlock(graph, releaseOffsets, ambiguous.Offset)
+                && !HasCleanupReleaseForUse(exceptionRegions, releaseOffsets, ambiguous.Offset))
+            {
+                AddCandidate(
+                    candidates,
+                    method,
+                    "exception-path-leak-candidate",
+                    $"Rented array crosses a method boundary at IL_{ambiguous.Offset:X4} before a modeled cleanup; an exception can bypass Return.",
+                    rent.RentOffset,
+                    ambiguous.Offset);
+            }
+            return;
+        }
 
         // Multiple releases often encode correlated branch predicates (`if (c) return; if (!c) return`).
         // Without predicate facts, fail closed on leaks and only keep same-block misuse shapes below.
@@ -358,6 +378,30 @@ public static class LeakTriageAnalyzer
         int toBlock = graph.BlockIndexAt(toOffset);
         return fromBlock >= 0 && fromBlock == toBlock && fromOffset < toOffset;
     }
+
+    static bool ReleasedBeforeUseInSameBlock(BlockGraph graph, ImmutableArray<int> releases, int useOffset)
+        => releases.Any(release => ReachesInSameBlock(graph, release, useOffset));
+
+    static bool HasCleanupReleaseForUse(
+        IReadOnlyCollection<ExceptionRegion> exceptionRegions,
+        ImmutableArray<int> releases,
+        int useOffset)
+    {
+        foreach (var region in exceptionRegions)
+        {
+            if (region.Kind is not (ExceptionRegionKind.Finally or ExceptionRegionKind.Fault))
+                continue;
+            if (!ContainsOffset(region.TryOffset, region.TryLength, useOffset))
+                continue;
+            if (releases.Any(release => ContainsOffset(region.HandlerOffset, region.HandlerLength, release)))
+                return true;
+        }
+
+        return false;
+    }
+
+    static bool ContainsOffset(int start, int length, int offset)
+        => offset >= start && offset < start + length;
 
     static IEnumerable<RentedLocal> FindRents(
         MethodIdentity method,
@@ -626,6 +670,8 @@ public static class LeakTriageAnalyzer
         => ex is BadImageFormatException or InvalidOperationException or ArgumentException or OverflowException or IndexOutOfRangeException;
 
     sealed record RentedLocal(int RentOffset, int StoreOffset, int Slot, LocalDefinition Definition);
+
+    sealed record AmbiguousUse(int Offset, string Shape);
 
     enum UseKind
     {

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -132,12 +132,15 @@ buckets are not product findings; they measure recall gates such as
 `normal-path-leak-candidate`, `exception-path-leak-candidate`,
 `use-after-return-candidate`, `ownership-transfer-suppressed`,
 `alias-or-field-suppressed`, `cross-method-suppressed`, and
-`incomplete-cfg-or-rd-suppressed`. One declarative Markout model renders the dense Markdown table
-and decomposes into section-tagged TSV/JSONL. It is a single-run census with no baseline, so it
-uses plain sectioned rows, not composite/delta cells; a `--diff-baseline` mode against a committed
-snapshot is the natural home for those (`Change`/`[MarkoutDelta]`). Each assembly is bounded by a
-per-assembly timeout, and any per-assembly input failure (a directory path, a truncated PE) becomes
-an `Opened=false` row rather than crashing the sweep.
+`incomplete-cfg-or-rd-suppressed`. Candidate rows can overlap: for example, a cross-method
+suppression can also carry an exception-path candidate when the normal path may still release or
+transfer ownership but an unprotected call boundary can throw first. One declarative Markout model
+renders the dense Markdown table and decomposes into section-tagged TSV/JSONL. It is a single-run
+census with no baseline, so it uses plain sectioned rows, not composite/delta cells; a
+`--diff-baseline` mode against a committed snapshot is the natural home for those
+(`Change`/`[MarkoutDelta]`). Each assembly is bounded by a per-assembly timeout, and any
+per-assembly input failure (a directory path, a truncated PE) becomes an `Opened=false` row rather
+than crashing the sweep.
 
 This is the evidence engine that must earn any user-facing `Leak Triage` section: the analyzer
 fails closed on incomplete CFG/RD, non-`Shared` pools, aliases, field stores, cross-method


### PR DESCRIPTION
## Summary
- add a measurement-only `exception-path-leak-candidate` when an ArrayPool rent crosses an unprotected method boundary before modeled cleanup
- keep findings fail-closed: ambiguous cross-method/ownership rows still do not become product findings
- suppress the extra exception-path candidate when a finally/fault handler returns the rented local

## Evidence
- Manual signal examples from the 75-DLL ArrayPool-heavy package corpus:
  - `Pipelines.Sockets.Unofficial` `StreamConnection.AsyncPipeStream.ReadByte()` rents, calls `Read(new Memory<byte>(arr, 0, 1))`, then returns; an exception from `Read` can bypass `Return`.
  - ZLinq `ToArrayPool()`/lookup builder paths rent and then execute enumerator/delegate/comparer code before ownership transfer/cleanup; user code can throw.
  - Prometheus wrapper examples use try/finally and remain suppressions, not exception-path candidates.
- Corpus impact after this change: 75 opened / 0 failed / 0 timed out; findings stay 0; total candidates increase from 936 to 1127 with 191 `exception-path-leak-candidate` rows.

## Validation
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-restore -- -filter "/*/*/LeakTriageAnalyzerTests/*"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-restore`
- `npx markdownlint-cli tools/AnalysisHarness/README.md`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- `dotnet tools/AnalysisHarness/bin/Release/net11.0/analysis-harness.dll --leak-triage /tmp/leak-nuget-assemblies.txt --top 20 --jsonl`