### PR TITLE
Add RTS fixture source oracle probe

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
+++ b/src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj
@@ -66,6 +66,8 @@
              Link="ReturnToSenderEvidence.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ReturnToSenderClosureEvidence.cs"
              Link="ReturnToSenderClosureEvidence.cs" />
+    <Compile Include="..\..\tools\DecompilerHarness\ReturnToSenderSourceProbe.cs"
+             Link="ReturnToSenderSourceProbe.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\ReturnToSenderCatalogReport.cs"
              Link="ReturnToSenderCatalogReport.cs" />
     <Compile Include="..\..\tools\DecompilerHarness\GeneratedFixtures.cs"

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -130,6 +130,36 @@ public class ReturnToSenderFixtureCatalogTests
         }
     }
 
+    [Fact]
+    public void ReturnToSenderSourceProbe_MissingSourcePathIsSourceUnavailable()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public class Class1
+            {
+                public int M() => 1;
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "M", Overload: 0)],
+                [Path.Combine(fixture.Directory, "missing.cs")]));
+
+            Assert.Equal(ReturnToSenderSourceOutcome.SourceUnavailable, result.Outcome);
+            Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.CompileBackStatus);
+            Assert.Equal("fixture-source-unavailable", result.Reason);
+            Assert.Contains("source index could not be built", result.Detail, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
     static (string Directory, string AssemblyPath, IReadOnlyList<string> SourcePaths) CompileSourceFixture(
         params (string FileName, string Source)[] sources)
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -160,6 +160,102 @@ public class ReturnToSenderFixtureCatalogTests
         }
     }
 
+    [Fact]
+    public void ReturnToSenderSourceProbe_DoesNotIndexErasedPartialMethodDefinition()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public partial class Class1
+            {
+                partial void M();
+
+                public int M(int value) => value;
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "M", Overload: 0)],
+                fixture.SourcePaths));
+
+            Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome);
+            Assert.Equal("returnvalue;", Normalize(result.ExpectedBody));
+            Assert.Equal("returnvalue;", Normalize(result.ActualBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_DoesNotIndexExplicitInterfaceImplementationUnderPublicName()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public interface IValue
+            {
+                int M();
+            }
+
+            public class Class1 : IValue
+            {
+                int IValue.M() => 0;
+
+                public int M() => 1;
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "M", Overload: 0)],
+                fixture.SourcePaths));
+
+            Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome);
+            Assert.Equal("return1;", Normalize(result.ExpectedBody));
+            Assert.Equal("return1;", Normalize(result.ActualBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_IndexesIndexerGetter()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public class Class1
+            {
+                public int this[int index] => index;
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "get_Item", Overload: 0)],
+                fixture.SourcePaths));
+
+            Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome);
+            Assert.Equal("returnindex;", Normalize(result.ExpectedBody));
+            Assert.Equal("returnindex;", Normalize(result.ActualBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
     static (string Directory, string AssemblyPath, IReadOnlyList<string> SourcePaths) CompileSourceFixture(
         params (string FileName, string Source)[] sources)
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -256,6 +256,42 @@ public class ReturnToSenderFixtureCatalogTests
         }
     }
 
+    [Fact]
+    public void ReturnToSenderSourceProbe_IndexesUnsignedRightShiftOperator()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public readonly struct Class1
+            {
+                readonly int _value;
+
+                public Class1(int value)
+                {
+                    _value = value;
+                }
+
+                public static Class1 operator >>>(Class1 value, int shift)
+                    => new Class1(value._value >>> shift);
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "op_UnsignedRightShift", Overload: 0)],
+                fixture.SourcePaths));
+
+            Assert.NotEqual(ReturnToSenderSourceOutcome.SourceUnavailable, result.Outcome);
+            Assert.Equal("returnnewClass1(value._value>>>shift);", Normalize(result.ExpectedBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
     static (string Directory, string AssemblyPath, IReadOnlyList<string> SourcePaths) CompileSourceFixture(
         params (string FileName, string Source)[] sources)
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -2,6 +2,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 
 using DotnetInspector.Fixtures;
+using ILInspector.DecompilerHarness;
 
 namespace ILInspector.Decompiler.Tests;
 
@@ -21,4 +22,43 @@ public class ReturnToSenderFixtureCatalogTests
             Assert.NotEmpty(peReader.GetMetadataReader().MethodDefinitions);
         });
     }
+
+    [Fact]
+    public void FixtureCatalog_ExposesCheckedInSourcePaths()
+    {
+        var sourcePaths = FixtureCatalog.DiffV1.SourcePaths();
+
+        Assert.Contains(sourcePaths, path => path.EndsWith("DiffSample.cs", StringComparison.Ordinal));
+        Assert.All(sourcePaths, path =>
+        {
+            Assert.True(File.Exists(path), path);
+            Assert.DoesNotContain($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", path);
+            Assert.DoesNotContain($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", path);
+        });
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_ClassifiesFixtureSourceMatch()
+    {
+        var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DiffV1.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget(
+                    "DiffFixtureSample.DiffSample",
+                    "Stable",
+                    Overload: 0),
+            ]));
+
+        Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome);
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.CompileBackStatus);
+        Assert.Equal("valid_match", result.Reason);
+        Assert.EndsWith("DiffSample.cs", result.SourcePath, StringComparison.Ordinal);
+        Assert.Equal("return42;", Normalize(result.ExpectedBody));
+        Assert.Equal("return42;", Normalize(result.ActualBody));
+    }
+
+    static string? Normalize(string? text)
+        => text is null
+            ? null
+            : string.Concat(text.Where(c => !char.IsWhiteSpace(c)));
 }

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -4,6 +4,9 @@ using System.Reflection.PortableExecutable;
 using DotnetInspector.Fixtures;
 using ILInspector.DecompilerHarness;
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
 namespace ILInspector.Decompiler.Tests;
 
 public class ReturnToSenderFixtureCatalogTests
@@ -55,6 +58,113 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.EndsWith("DiffSample.cs", result.SourcePath, StringComparison.Ordinal);
         Assert.Equal("return42;", Normalize(result.ExpectedBody));
         Assert.Equal("return42;", Normalize(result.ActualBody));
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_IndexesPartialClassOverloadsAcrossSourceFiles()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.Part1.cs", """
+            namespace SourceProbe;
+
+            public partial class Class1
+            {
+                public int M() => 1;
+            }
+            """),
+            ("Class1.Part2.cs", """
+            namespace SourceProbe;
+
+            public partial class Class1
+            {
+                public int M(int value) => value;
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "M", Overload: 1)],
+                fixture.SourcePaths));
+
+            Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome);
+            Assert.Equal("valid_match", result.Reason);
+            Assert.Equal("returnvalue;", Normalize(result.ExpectedBody));
+            Assert.Equal("returnvalue;", Normalize(result.ActualBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_IndexesBodylessOverloads()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public abstract class Class1
+            {
+                public abstract int M();
+
+                public int M(int value) => value;
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "M", Overload: 1)],
+                fixture.SourcePaths));
+
+            Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome);
+            Assert.Equal("valid_match", result.Reason);
+            Assert.Equal("returnvalue;", Normalize(result.ExpectedBody));
+            Assert.Equal("returnvalue;", Normalize(result.ActualBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    static (string Directory, string AssemblyPath, IReadOnlyList<string> SourcePaths) CompileSourceFixture(
+        params (string FileName, string Source)[] sources)
+    {
+        string directory = Path.Combine(Path.GetTempPath(), $"rts-source-probe-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var sourcePaths = new List<string>();
+        foreach (var (fileName, source) in sources)
+        {
+            string path = Path.Combine(directory, fileName);
+            File.WriteAllText(path, source);
+            sourcePaths.Add(path);
+        }
+
+        string assemblyPath = Path.Combine(directory, "SourceProbe.dll");
+        var references = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var trees = sourcePaths.Select(path =>
+            CSharpSyntaxTree.ParseText(
+                File.ReadAllText(path),
+                new CSharpParseOptions(LanguageVersion.Preview),
+                path));
+        var compilation = CSharpCompilation.Create(
+            Path.GetFileNameWithoutExtension(assemblyPath),
+            trees,
+            references,
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                optimizationLevel: OptimizationLevel.Release,
+                nullableContextOptions: NullableContextOptions.Disable,
+                allowUnsafe: true));
+
+        var emit = compilation.Emit(assemblyPath);
+        Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
+        return (directory, assemblyPath, sourcePaths);
     }
 
     static string? Normalize(string? text)

--- a/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
+++ b/tests/DotnetInspector.Fixtures/FixtureCatalog.cs
@@ -9,6 +9,8 @@ public sealed record FixtureDefinition(
     IReadOnlyList<FixtureAsset> Assets)
 {
     public string AssemblyPath() => FixtureCatalog.AssemblyPath(Id);
+    public string ProjectDirectory() => FixtureCatalog.ProjectDirectory(Id);
+    public IReadOnlyList<string> SourcePaths() => FixtureCatalog.SourcePaths(Id);
     public string AssetPath(string name) => FixtureCatalog.AssetPath(Id, name);
 }
 
@@ -484,6 +486,26 @@ public static class FixtureCatalog
             path);
     }
 
+    public static string ProjectDirectory(string id)
+    {
+        var fixture = Get(id);
+        string root = RepositoryRoot();
+        string path = Path.Combine(root, "src", fixture.ProjectName);
+        if (Directory.Exists(path))
+            return path;
+
+        throw new DirectoryNotFoundException(
+            $"Expected fixture source project '{fixture.Id}' at {path}.");
+    }
+
+    public static IReadOnlyList<string> SourcePaths(string id)
+    {
+        string projectDirectory = ProjectDirectory(id);
+        return [.. Directory.EnumerateFiles(projectDirectory, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !HasPathSegment(path, "bin") && !HasPathSegment(path, "obj"))
+            .Order(StringComparer.Ordinal)];
+    }
+
     public static string AssetPath(string id, string assetName)
     {
         var fixture = Get(id);
@@ -523,6 +545,10 @@ public static class FixtureCatalog
 
     static FixtureBoundary[] Boundaries(params FixtureBoundary[] boundaries)
         => boundaries;
+
+    static bool HasPathSegment(string path, string segment)
+        => path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Any(part => string.Equals(part, segment, StringComparison.OrdinalIgnoreCase));
 
     static string CurrentConfiguration()
     {

--- a/tools/DecompilerHarness/Program.cs
+++ b/tools/DecompilerHarness/Program.cs
@@ -1521,10 +1521,11 @@ static class Program
           --return-to-sender-ab   compare current compile-back and ReturnToSender
                                 over the same ReturnToSender property-getter targets.
           --return-to-sender-source-probe
-                                derive source-aware metadata fragments from the
-                                input assemblies, run ReturnToSender over those
-                                targets, and report missing-fragment/source
-                                buckets alongside compile-back status.
+                                run ReturnToSender over fixture/library targets and,
+                                for FixtureCatalog inputs, compare decompiled target
+                                bodies against checked-in fixture source slices;
+                                reports valid_match, valid_different, invalid,
+                                source_unavailable, and unsupported_target buckets.
           --return-to-sender-fixtures <group>
                                 add built fixture assemblies from a FixtureCatalog
                                 group (for example rts.candidates) as inputs for

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -158,6 +158,13 @@ spellable `System.Attribute` base before attribute usages can compile.
 Use `--return-to-sender-fixtures rts.candidates` with `--return-to-sender`,
 `--return-to-sender-ab`, or `--return-to-sender-source-probe` to add built
 fixture assemblies from `FixtureCatalog` as inputs without generating source.
+The source probe reuses RTS target discovery/import/render/compile-back plumbing
+and, for catalog fixtures, compares the decompiled target body against the
+checked-in fixture source slice. It reports coarse source-fidelity outcomes:
+`valid_match`, `valid_different`, `invalid`, `source_unavailable`, and
+`unsupported_target`; valid-but-different rows are intentionally classified
+coarsely first so later Roslyn-assisted analysis can grow stable taxonomy
+buckets.
 Rows may carry two independent expectations: a Roslyn `SyntaxKind` shape verdict
 for the intended C# idiom, and a compile-back opcode verdict for semantic
 fidelity. A row can therefore be opcode-exact while still exposing a shape

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -1,10 +1,41 @@
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Text.RegularExpressions;
 
+using DotnetInspector.Fixtures;
 using ILInspector.Metadata;
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 namespace ILInspector.DecompilerHarness;
+
+enum ReturnToSenderSourceOutcome
+{
+    ValidMatch,
+    ValidDifferent,
+    Invalid,
+    SourceUnavailable,
+    UnsupportedTarget,
+}
+
+sealed record ReturnToSenderSourceProbeResult(
+    ReturnToSender.RequestedTarget Target,
+    ReturnToSenderSourceOutcome Outcome,
+    FidelityCheck.CompileBackStatus? CompileBackStatus,
+    string Reason,
+    string? Detail,
+    string? SourcePath,
+    string? ExpectedBody,
+    string? ActualBody)
+{
+    public bool Passed => Outcome == ReturnToSenderSourceOutcome.ValidMatch;
+    public bool Different => Outcome == ReturnToSenderSourceOutcome.ValidDifferent;
+    public bool Failed => Outcome == ReturnToSenderSourceOutcome.Invalid;
+    public bool Skipped => Outcome is ReturnToSenderSourceOutcome.SourceUnavailable or ReturnToSenderSourceOutcome.UnsupportedTarget;
+}
 
 static class ReturnToSenderSourceProbe
 {
@@ -12,97 +43,325 @@ static class ReturnToSenderSourceProbe
 
     public static int Run(IReadOnlyList<string> assemblies, int cap, int maxExamples)
     {
-        int attempted = 0, passed = 0, failed = 0, skipped = 0;
-        var buckets = new SortedDictionary<string, int>(StringComparer.Ordinal);
-        var examples = new List<string>();
+        var results = Evaluate(assemblies, cap);
+        int passed = results.Count(result => result.Passed);
+        int different = results.Count(result => result.Different);
+        int failed = results.Count(result => result.Failed);
+        int skipped = results.Count(result => result.Skipped);
+        var buckets = results
+            .GroupBy(result => result.Reason, StringComparer.Ordinal)
+            .OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key, StringComparer.Ordinal)
+            .ToArray();
 
-        foreach (var assemblyPath in assemblies)
-        {
-            if (attempted >= cap)
-                break;
-
-            var targets = DiscoverTargets(assemblyPath, cap - attempted);
-            if (targets.Count == 0)
-                continue;
-
-            var results = ReturnToSender.CompileBackTargets(
-                    assemblyPath,
-                    targets.Select(target => target.Target).Distinct().ToArray())
-                .ToDictionary(
-                    result => Key(
-                        result.Plan.TargetMethod.Type,
-                        result.Plan.TargetMethod.Method,
-                        result.Plan.TargetMethod.Overload),
-                    StringComparer.Ordinal);
-
-            foreach (var target in targets)
-            {
-                attempted++;
-                if (!results.TryGetValue(Key(target.Target.Type, target.Target.Method, target.Target.Overload), out var result))
-                {
-                    skipped++;
-                    AddBucket("unsupported-rts-target");
-                    AddExample(target, "Skipped", "unsupported-rts-target", null);
-                    continue;
-                }
-
-                if (result.Status != FidelityCheck.CompileBackStatus.Exact)
-                {
-                    failed++;
-                    var bucket = result.Status == FidelityCheck.CompileBackStatus.RecompileFail
-                        ? DiagnosticCode(result.Detail)
-                        : result.Status.ToString();
-                    AddBucket(bucket);
-                    AddExample(target, result.Status.ToString(), bucket, result.Detail);
-                    continue;
-                }
-
-                var missing = target.ExpectedFragments.FirstOrDefault(fragment => !result.Source.Contains(fragment, StringComparison.Ordinal));
-                if (missing is not null)
-                {
-                    failed++;
-                    AddBucket("source-fragment-missing");
-                    AddExample(target, "Exact", "source-fragment-missing", $"missing expected source fragment: {missing}");
-                    continue;
-                }
-
-                passed++;
-            }
-        }
-
-        Console.WriteLine($"RETURNTOSENDER SOURCE PROBE over {attempted} target(s)");
+        Console.WriteLine($"RETURNTOSENDER SOURCE PROBE over {results.Count} target(s)");
         Console.WriteLine();
-        Console.WriteLine($"  Passed : {passed}");
-        Console.WriteLine($"  Failed : {failed}");
-        Console.WriteLine($"  Skipped: {skipped}");
-        if (buckets.Count > 0)
+        Console.WriteLine($"  ValidMatch       : {results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.ValidMatch)}");
+        Console.WriteLine($"  ValidDifferent   : {results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.ValidDifferent)}");
+        Console.WriteLine($"  Invalid          : {results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.Invalid)}");
+        Console.WriteLine($"  SourceUnavailable: {results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.SourceUnavailable)}");
+        Console.WriteLine($"  UnsupportedTarget: {results.Count(result => result.Outcome == ReturnToSenderSourceOutcome.UnsupportedTarget)}");
+        Console.WriteLine();
+        Console.WriteLine($"  Passed   : {passed}");
+        Console.WriteLine($"  Different: {different}");
+        Console.WriteLine($"  Failed   : {failed}");
+        Console.WriteLine($"  Skipped  : {skipped}");
+        if (buckets.Length > 0)
         {
             Console.WriteLine();
             Console.WriteLine("Buckets:");
-            foreach (var bucket in buckets.OrderByDescending(bucket => bucket.Value).ThenBy(bucket => bucket.Key, StringComparer.Ordinal))
-                Console.WriteLine($"  {bucket.Value}: {bucket.Key}");
+            foreach (var bucket in buckets)
+                Console.WriteLine($"  {bucket.Count()}: {bucket.Key}");
         }
-        if (examples.Count > 0)
+        var examples = results
+            .Where(result => result.Outcome != ReturnToSenderSourceOutcome.ValidMatch)
+            .Take(maxExamples)
+            .ToArray();
+        if (examples.Length > 0)
         {
             Console.WriteLine();
-            Console.WriteLine($"Examples (first {examples.Count}):");
+            Console.WriteLine($"Examples (first {examples.Length}):");
             foreach (var example in examples)
-                Console.WriteLine(example);
+            {
+                Console.WriteLine($"  {example.Target.Type}::{example.Target.Method}#{example.Target.Overload}  outcome={OutcomeId(example.Outcome)}  rts={example.CompileBackStatus?.ToString() ?? "missing"}  bucket={example.Reason}");
+                if (!string.IsNullOrWhiteSpace(example.Detail))
+                    Console.WriteLine($"      detail: {example.Detail}");
+                if (!string.IsNullOrWhiteSpace(example.SourcePath))
+                    Console.WriteLine($"      source: {example.SourcePath}");
+            }
         }
 
         return failed == 0 ? 0 : 1;
+    }
 
-        void AddBucket(string bucket)
-            => buckets[bucket] = buckets.GetValueOrDefault(bucket) + 1;
-
-        void AddExample(ProbeTarget target, string status, string bucket, string? detail)
+    public static IReadOnlyList<ReturnToSenderSourceProbeResult> Evaluate(IReadOnlyList<string> assemblies, int cap)
+    {
+        var results = new List<ReturnToSenderSourceProbeResult>();
+        foreach (var assemblyPath in assemblies)
         {
-            if (examples.Count >= maxExamples)
-                return;
+            if (results.Count >= cap)
+                break;
 
-            examples.Add(detail is null
-                ? $"  {target.Target.Type}::{target.Target.Method}#{target.Target.Overload}  rts={status}  bucket={bucket}"
-                : $"  {target.Target.Type}::{target.Target.Method}#{target.Target.Overload}  rts={status}  bucket={bucket}\n      detail: {detail}");
+            var targets = DiscoverTargets(assemblyPath, cap - results.Count);
+            results.AddRange(EvaluateTargets(assemblyPath, targets.Select(target => target.Target).ToArray()));
+        }
+
+        return results.Count > cap ? results.Take(cap).ToArray() : results;
+    }
+
+    public static IReadOnlyList<ReturnToSenderSourceProbeResult> EvaluateTargets(
+        string assemblyPath,
+        IReadOnlyList<ReturnToSender.RequestedTarget> targets)
+    {
+        if (targets.Count == 0)
+            return [];
+
+        var sourceIndex = FixtureSourceIndex.TryCreate(assemblyPath);
+        var rtsResults = ReturnToSender.CompileBackTargets(assemblyPath, targets.Distinct().ToArray())
+            .ToDictionary(
+                result => Key(
+                    result.Plan.TargetMethod.Type,
+                    result.Plan.TargetMethod.Method,
+                    result.Plan.TargetMethod.Overload),
+                StringComparer.Ordinal);
+
+        var results = new List<ReturnToSenderSourceProbeResult>();
+        foreach (var target in targets)
+        {
+            if (!rtsResults.TryGetValue(Key(target.Type, target.Method, target.Overload), out var result))
+            {
+                results.Add(new ReturnToSenderSourceProbeResult(
+                    target,
+                    ReturnToSenderSourceOutcome.UnsupportedTarget,
+                    CompileBackStatus: null,
+                    "unsupported-rts-target",
+                    Detail: null,
+                    SourcePath: null,
+                    ExpectedBody: null,
+                    ActualBody: null));
+                continue;
+            }
+
+            if (result.Status == FidelityCheck.CompileBackStatus.RecompileFail)
+            {
+                results.Add(new ReturnToSenderSourceProbeResult(
+                    target,
+                    ReturnToSenderSourceOutcome.Invalid,
+                    result.Status,
+                    DiagnosticCode(result.Detail),
+                    result.Detail,
+                    SourcePath: null,
+                    ExpectedBody: null,
+                    ActualBody: result.TargetBody));
+                continue;
+            }
+
+            if (result.Status is not (FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff))
+            {
+                results.Add(new ReturnToSenderSourceProbeResult(
+                    target,
+                    ReturnToSenderSourceOutcome.SourceUnavailable,
+                    result.Status,
+                    FailureReason(result),
+                    result.Detail,
+                    SourcePath: null,
+                    ExpectedBody: null,
+                    ActualBody: result.TargetBody));
+                continue;
+            }
+
+            if (sourceIndex is null)
+            {
+                results.Add(new ReturnToSenderSourceProbeResult(
+                    target,
+                    ReturnToSenderSourceOutcome.SourceUnavailable,
+                    result.Status,
+                    "fixture-source-unavailable",
+                    "assembly is not registered in FixtureCatalog",
+                    SourcePath: null,
+                    ExpectedBody: null,
+                    ActualBody: result.TargetBody));
+                continue;
+            }
+
+            if (!sourceIndex.TryFind(target, out var sourceMember))
+            {
+                results.Add(new ReturnToSenderSourceProbeResult(
+                    target,
+                    ReturnToSenderSourceOutcome.SourceUnavailable,
+                    result.Status,
+                    "source-slice-unavailable",
+                    $"no source member matched {target.Type}::{target.Method}#{target.Overload}",
+                    SourcePath: null,
+                    ExpectedBody: null,
+                    ActualBody: result.TargetBody));
+                continue;
+            }
+
+            string expected = sourceMember.Body;
+            string actual = result.TargetBody;
+            if (NormalizeBody(expected) == NormalizeBody(actual))
+            {
+                results.Add(new ReturnToSenderSourceProbeResult(
+                    target,
+                    ReturnToSenderSourceOutcome.ValidMatch,
+                    result.Status,
+                    "valid_match",
+                    Detail: null,
+                    sourceMember.SourcePath,
+                    expected,
+                    actual));
+                continue;
+            }
+
+            results.Add(new ReturnToSenderSourceProbeResult(
+                target,
+                ReturnToSenderSourceOutcome.ValidDifferent,
+                result.Status,
+                "valid_different.unclassified",
+                Detail: "decompiled body is Roslyn-valid but differs from the fixture source slice",
+                sourceMember.SourcePath,
+                expected,
+                actual));
+        }
+
+        return results;
+    }
+
+    sealed record SourceMember(string Type, string Method, int Overload, string SourcePath, string Body);
+
+    sealed class FixtureSourceIndex
+    {
+        readonly Dictionary<string, SourceMember> _members;
+
+        FixtureSourceIndex(Dictionary<string, SourceMember> members)
+        {
+            _members = members;
+        }
+
+        public static FixtureSourceIndex? TryCreate(string assemblyPath)
+        {
+            foreach (var fixture in FixtureCatalog.All)
+            {
+                string fixtureAssemblyPath;
+                try
+                {
+                    fixtureAssemblyPath = fixture.AssemblyPath();
+                }
+                catch (IOException)
+                {
+                    continue;
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    continue;
+                }
+
+                if (!string.Equals(
+                    Path.GetFullPath(fixtureAssemblyPath),
+                    Path.GetFullPath(assemblyPath),
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var members = new Dictionary<string, SourceMember>(StringComparer.Ordinal);
+                foreach (var sourcePath in fixture.SourcePaths())
+                    AddSourceFile(members, sourcePath);
+                return new FixtureSourceIndex(members);
+            }
+
+            return null;
+        }
+
+        public bool TryFind(ReturnToSender.RequestedTarget target, out SourceMember member)
+            => _members.TryGetValue(Key(target.Type, target.Method, target.Overload), out member!);
+
+        static void AddSourceFile(Dictionary<string, SourceMember> members, string sourcePath)
+        {
+            var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(sourcePath), path: sourcePath);
+            var root = tree.GetCompilationUnitRoot();
+            foreach (var member in SourceMembers(root, sourcePath))
+                members.TryAdd(Key(member.Type, member.Method, member.Overload), member);
+        }
+
+        static IEnumerable<SourceMember> SourceMembers(CompilationUnitSyntax root, string sourcePath)
+        {
+            foreach (var member in SourceMembers(root.Members, namespaceName: "", containingTypes: [], sourcePath))
+                yield return member;
+        }
+
+        static IEnumerable<SourceMember> SourceMembers(
+            SyntaxList<MemberDeclarationSyntax> declarations,
+            string namespaceName,
+            IReadOnlyList<string> containingTypes,
+            string sourcePath)
+        {
+            foreach (var declaration in declarations)
+            {
+                switch (declaration)
+                {
+                    case BaseNamespaceDeclarationSyntax ns:
+                    {
+                        string nextNamespace = namespaceName.Length == 0
+                            ? ns.Name.ToString()
+                            : $"{namespaceName}.{ns.Name}";
+                        foreach (var member in SourceMembers(ns.Members, nextNamespace, containingTypes, sourcePath))
+                            yield return member;
+                        break;
+                    }
+                    case TypeDeclarationSyntax type:
+                    {
+                        string typeName = type.Identifier.ValueText;
+                        var typeStack = containingTypes.Concat([typeName]).ToArray();
+                        string fullType = namespaceName.Length == 0
+                            ? string.Join(".", typeStack)
+                            : $"{namespaceName}.{string.Join(".", typeStack)}";
+
+                        foreach (var member in TypeMembers(type, fullType, sourcePath))
+                            yield return member;
+                        foreach (var member in SourceMembers(type.Members, namespaceName, typeStack, sourcePath))
+                            yield return member;
+                        break;
+                    }
+                }
+            }
+
+            static IEnumerable<SourceMember> TypeMembers(TypeDeclarationSyntax type, string fullType, string path)
+            {
+                var overloads = new Dictionary<string, int>(StringComparer.Ordinal);
+                foreach (var member in type.Members)
+                {
+                    switch (member)
+                    {
+                        case MethodDeclarationSyntax method when BodyText(method) is { } body:
+                        {
+                            string methodName = method.Identifier.ValueText;
+                            yield return new SourceMember(fullType, methodName, NextOverload(overloads, methodName), path, body);
+                            break;
+                        }
+                        case ConstructorDeclarationSyntax constructor when BodyText(constructor) is { } body:
+                        {
+                            const string methodName = ".ctor";
+                            yield return new SourceMember(fullType, methodName, NextOverload(overloads, methodName), path, body);
+                            break;
+                        }
+                        case PropertyDeclarationSyntax property when GetterBodyText(property) is { } body:
+                        {
+                            string methodName = $"get_{property.Identifier.ValueText}";
+                            yield return new SourceMember(fullType, methodName, NextOverload(overloads, methodName), path, body);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            static int NextOverload(Dictionary<string, int> overloads, string methodName)
+            {
+                int overload = overloads.GetValueOrDefault(methodName);
+                overloads[methodName] = overload + 1;
+                return overload;
+            }
         }
     }
 
@@ -166,9 +425,6 @@ static class ReturnToSenderSourceProbe
                 fragments.AddRange(AttributeReader.RenderAttributes(reader, method.GetCustomAttributes(), qualifyNames: true)
                     .Select(attribute => $"[{attribute}]"));
                 AddReturnAndParameterFragments(reader, method.GetParameters(), fragments);
-                if (fragments.Count == 0)
-                    continue;
-
                 targets.Add(new ProbeTarget(new ReturnToSender.RequestedTarget(fullType, methodName, overload), fragments.Distinct(StringComparer.Ordinal).ToArray()));
             }
 
@@ -196,9 +452,6 @@ static class ReturnToSenderSourceProbe
                 fragments.AddRange(AttributeReader.RenderAttributes(reader, property.GetCustomAttributes(), qualifyNames: true)
                     .Select(attribute => $"[{attribute}]"));
                 AddReturnAndParameterFragments(reader, getter.GetParameters(), fragments);
-                if (fragments.Count == 0)
-                    continue;
-
                 targets.Add(new ProbeTarget(new ReturnToSender.RequestedTarget(fullType, methodName, overload), fragments.Distinct(StringComparer.Ordinal).ToArray()));
             }
         }
@@ -232,11 +485,73 @@ static class ReturnToSenderSourceProbe
 
     static string Key(string type, string method, int overload) => $"{type}::{method}#{overload}";
 
+    static string OutcomeId(ReturnToSenderSourceOutcome outcome)
+        => outcome switch
+        {
+            ReturnToSenderSourceOutcome.ValidMatch => "valid_match",
+            ReturnToSenderSourceOutcome.ValidDifferent => "valid_different",
+            ReturnToSenderSourceOutcome.Invalid => "invalid",
+            ReturnToSenderSourceOutcome.SourceUnavailable => "source_unavailable",
+            ReturnToSenderSourceOutcome.UnsupportedTarget => "unsupported_target",
+            _ => outcome.ToString(),
+        };
+
+    static string? BodyText(MethodDeclarationSyntax method)
+    {
+        if (method.Body is { } body)
+            return StatementsText(body);
+        if (method.ExpressionBody is { } expressionBody)
+            return ExpressionBodyText(method.ReturnType, expressionBody.Expression);
+        return null;
+    }
+
+    static string? BodyText(ConstructorDeclarationSyntax constructor)
+    {
+        if (constructor.Body is { } body)
+            return StatementsText(body);
+        if (constructor.ExpressionBody is { } expressionBody)
+            return $"{expressionBody.Expression};";
+        return null;
+    }
+
+    static string? GetterBodyText(PropertyDeclarationSyntax property)
+    {
+        if (property.ExpressionBody is { } expressionBody)
+            return $"return {expressionBody.Expression};";
+        var getter = property.AccessorList?.Accessors.FirstOrDefault(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration));
+        if (getter?.Body is { } body)
+            return StatementsText(body);
+        if (getter?.ExpressionBody is { } getterExpression)
+            return $"return {getterExpression.Expression};";
+        return null;
+    }
+
+    static string ExpressionBodyText(TypeSyntax returnType, ExpressionSyntax expression)
+        => returnType is PredefinedTypeSyntax predefined
+            && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword)
+            ? $"{expression};"
+            : $"return {expression};";
+
+    static string StatementsText(BlockSyntax body)
+        => string.Join(Environment.NewLine, body.Statements.Select(statement => statement.ToString()));
+
+    static string NormalizeBody(string text)
+        => Regex.Replace(text, @"\s+", "");
+
     static string DiagnosticCode(string? detail)
     {
         if (string.IsNullOrWhiteSpace(detail))
             return "recompile-fail";
-        var match = System.Text.RegularExpressions.Regex.Match(detail, @"CS\d{4}");
+        var match = Regex.Match(detail, @"CS\d{4}");
         return match.Success ? match.Value : "recompile-fail";
     }
+
+    static string FailureReason(ReturnToSender.Result result)
+        => result.Status switch
+        {
+            FidelityCheck.CompileBackStatus.RecompileFail => DiagnosticCode(result.Detail),
+            FidelityCheck.CompileBackStatus.ContextFail => string.IsNullOrWhiteSpace(result.Detail) ? "context-fail" : result.Detail,
+            FidelityCheck.CompileBackStatus.OpcodeDiff => "opcode-diff",
+            _ => result.Status.ToString(),
+        };
 }

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -164,6 +164,8 @@ static class ReturnToSenderSourceProbe
                 continue;
             }
 
+            SourceMember? sourceMember = null;
+            bool sourceFound = sourceIndex?.TryFind(target, out sourceMember) == true;
             if (result.Status is FidelityCheck.CompileBackStatus.RecompileFail
                 or FidelityCheck.CompileBackStatus.ContextFail)
             {
@@ -173,8 +175,8 @@ static class ReturnToSenderSourceProbe
                     result.Status,
                     FailureReason(result),
                     result.Detail,
-                    SourcePath: null,
-                    ExpectedBody: null,
+                    SourcePath: sourceMember?.SourcePath,
+                    ExpectedBody: sourceMember?.Body,
                     ActualBody: result.TargetBody));
                 continue;
             }
@@ -207,7 +209,7 @@ static class ReturnToSenderSourceProbe
                 continue;
             }
 
-            if (!sourceIndex.TryFind(target, out var sourceMember))
+            if (!sourceFound || sourceMember is null)
             {
                 results.Add(new ReturnToSenderSourceProbeResult(
                     target,
@@ -771,6 +773,7 @@ static class ReturnToSenderSourceProbe
             SyntaxKind.CaretToken => "op_ExclusiveOr",
             SyntaxKind.LessThanLessThanToken => "op_LeftShift",
             SyntaxKind.GreaterThanGreaterThanToken => "op_RightShift",
+            SyntaxKind.GreaterThanGreaterThanGreaterThanToken => "op_UnsignedRightShift",
             SyntaxKind.EqualsEqualsToken => "op_Equality",
             SyntaxKind.ExclamationEqualsToken => "op_Inequality",
             SyntaxKind.LessThanToken => "op_LessThan",

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -117,6 +117,23 @@ static class ReturnToSenderSourceProbe
             return [];
 
         var sourceIndex = FixtureSourceIndex.TryCreate(assemblyPath);
+        return EvaluateTargets(assemblyPath, targets, sourceIndex);
+    }
+
+    public static IReadOnlyList<ReturnToSenderSourceProbeResult> EvaluateTargets(
+        string assemblyPath,
+        IReadOnlyList<ReturnToSender.RequestedTarget> targets,
+        IReadOnlyList<string> sourcePaths)
+        => EvaluateTargets(assemblyPath, targets, FixtureSourceIndex.Create(sourcePaths));
+
+    static IReadOnlyList<ReturnToSenderSourceProbeResult> EvaluateTargets(
+        string assemblyPath,
+        IReadOnlyList<ReturnToSender.RequestedTarget> targets,
+        FixtureSourceIndex? sourceIndex)
+    {
+        if (targets.Count == 0)
+            return [];
+
         var rtsResults = ReturnToSender.CompileBackTargets(assemblyPath, targets.Distinct().ToArray())
             .ToDictionary(
                 result => Key(
@@ -142,13 +159,14 @@ static class ReturnToSenderSourceProbe
                 continue;
             }
 
-            if (result.Status == FidelityCheck.CompileBackStatus.RecompileFail)
+            if (result.Status is FidelityCheck.CompileBackStatus.RecompileFail
+                or FidelityCheck.CompileBackStatus.ContextFail)
             {
                 results.Add(new ReturnToSenderSourceProbeResult(
                     target,
                     ReturnToSenderSourceOutcome.Invalid,
                     result.Status,
-                    DiagnosticCode(result.Detail),
+                    FailureReason(result),
                     result.Detail,
                     SourcePath: null,
                     ExpectedBody: null,
@@ -239,23 +257,21 @@ static class ReturnToSenderSourceProbe
             _members = members;
         }
 
+        public static FixtureSourceIndex Create(IReadOnlyList<string> sourcePaths)
+        {
+            var members = new Dictionary<string, SourceMember>(StringComparer.Ordinal);
+            var overloads = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
+            foreach (var sourcePath in sourcePaths)
+                AddSourceFile(members, overloads, sourcePath);
+            return new FixtureSourceIndex(members);
+        }
+
         public static FixtureSourceIndex? TryCreate(string assemblyPath)
         {
             foreach (var fixture in FixtureCatalog.All)
             {
-                string fixtureAssemblyPath;
-                try
-                {
-                    fixtureAssemblyPath = fixture.AssemblyPath();
-                }
-                catch (IOException)
-                {
+                if (!TryGetFixtureAssemblyPath(fixture, out var fixtureAssemblyPath))
                     continue;
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    continue;
-                }
 
                 if (!string.Equals(
                     Path.GetFullPath(fixtureAssemblyPath),
@@ -265,29 +281,63 @@ static class ReturnToSenderSourceProbe
                     continue;
                 }
 
-                var members = new Dictionary<string, SourceMember>(StringComparer.Ordinal);
-                foreach (var sourcePath in fixture.SourcePaths())
-                    AddSourceFile(members, sourcePath);
-                return new FixtureSourceIndex(members);
+                if (!TryGetSourcePaths(fixture, out var sourcePaths))
+                    return null;
+
+                return Create(sourcePaths);
             }
 
             return null;
         }
 
+        static bool TryGetFixtureAssemblyPath(FixtureDefinition fixture, out string path)
+        {
+            try
+            {
+                path = fixture.AssemblyPath();
+                return true;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                path = "";
+                return false;
+            }
+        }
+
+        static bool TryGetSourcePaths(FixtureDefinition fixture, out IReadOnlyList<string> paths)
+        {
+            try
+            {
+                paths = fixture.SourcePaths();
+                return true;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                paths = [];
+                return false;
+            }
+        }
+
         public bool TryFind(ReturnToSender.RequestedTarget target, out SourceMember member)
             => _members.TryGetValue(Key(target.Type, target.Method, target.Overload), out member!);
 
-        static void AddSourceFile(Dictionary<string, SourceMember> members, string sourcePath)
+        static void AddSourceFile(
+            Dictionary<string, SourceMember> members,
+            Dictionary<string, Dictionary<string, int>> overloads,
+            string sourcePath)
         {
             var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(sourcePath), path: sourcePath);
             var root = tree.GetCompilationUnitRoot();
-            foreach (var member in SourceMembers(root, sourcePath))
+            foreach (var member in SourceMembers(root, sourcePath, overloads))
                 members.TryAdd(Key(member.Type, member.Method, member.Overload), member);
         }
 
-        static IEnumerable<SourceMember> SourceMembers(CompilationUnitSyntax root, string sourcePath)
+        static IEnumerable<SourceMember> SourceMembers(
+            CompilationUnitSyntax root,
+            string sourcePath,
+            Dictionary<string, Dictionary<string, int>> overloads)
         {
-            foreach (var member in SourceMembers(root.Members, namespaceName: "", containingTypes: [], sourcePath))
+            foreach (var member in SourceMembers(root.Members, namespaceName: "", containingTypes: [], sourcePath, overloads))
                 yield return member;
         }
 
@@ -295,7 +345,8 @@ static class ReturnToSenderSourceProbe
             SyntaxList<MemberDeclarationSyntax> declarations,
             string namespaceName,
             IReadOnlyList<string> containingTypes,
-            string sourcePath)
+            string sourcePath,
+            Dictionary<string, Dictionary<string, int>> overloads)
         {
             foreach (var declaration in declarations)
             {
@@ -306,7 +357,7 @@ static class ReturnToSenderSourceProbe
                         string nextNamespace = namespaceName.Length == 0
                             ? ns.Name.ToString()
                             : $"{namespaceName}.{ns.Name}";
-                        foreach (var member in SourceMembers(ns.Members, nextNamespace, containingTypes, sourcePath))
+                        foreach (var member in SourceMembers(ns.Members, nextNamespace, containingTypes, sourcePath, overloads))
                             yield return member;
                         break;
                     }
@@ -318,38 +369,80 @@ static class ReturnToSenderSourceProbe
                             ? string.Join(".", typeStack)
                             : $"{namespaceName}.{string.Join(".", typeStack)}";
 
-                        foreach (var member in TypeMembers(type, fullType, sourcePath))
+                        foreach (var member in TypeMembers(type, fullType, sourcePath, overloads))
                             yield return member;
-                        foreach (var member in SourceMembers(type.Members, namespaceName, typeStack, sourcePath))
+                        foreach (var member in SourceMembers(type.Members, namespaceName, typeStack, sourcePath, overloads))
                             yield return member;
                         break;
                     }
                 }
             }
 
-            static IEnumerable<SourceMember> TypeMembers(TypeDeclarationSyntax type, string fullType, string path)
+            static IEnumerable<SourceMember> TypeMembers(
+                TypeDeclarationSyntax type,
+                string fullType,
+                string path,
+                Dictionary<string, Dictionary<string, int>> overloadsByType)
             {
-                var overloads = new Dictionary<string, int>(StringComparer.Ordinal);
+                if (!overloadsByType.TryGetValue(fullType, out var overloads))
+                    overloadsByType[fullType] = overloads = new Dictionary<string, int>(StringComparer.Ordinal);
+
                 foreach (var member in type.Members)
                 {
                     switch (member)
                     {
-                        case MethodDeclarationSyntax method when BodyText(method) is { } body:
+                        case MethodDeclarationSyntax method:
                         {
                             string methodName = method.Identifier.ValueText;
-                            yield return new SourceMember(fullType, methodName, NextOverload(overloads, methodName), path, body);
+                            int overload = NextOverload(overloads, methodName);
+                            if (BodyText(method) is { } body)
+                                yield return new SourceMember(fullType, methodName, overload, path, body);
                             break;
                         }
-                        case ConstructorDeclarationSyntax constructor when BodyText(constructor) is { } body:
+                        case ConstructorDeclarationSyntax constructor:
                         {
                             const string methodName = ".ctor";
-                            yield return new SourceMember(fullType, methodName, NextOverload(overloads, methodName), path, body);
+                            int overload = NextOverload(overloads, methodName);
+                            if (BodyText(constructor) is { } body)
+                                yield return new SourceMember(fullType, methodName, overload, path, body);
                             break;
                         }
-                        case PropertyDeclarationSyntax property when GetterBodyText(property) is { } body:
+                        case PropertyDeclarationSyntax property:
                         {
-                            string methodName = $"get_{property.Identifier.ValueText}";
-                            yield return new SourceMember(fullType, methodName, NextOverload(overloads, methodName), path, body);
+                            if (HasGetter(property))
+                            {
+                                string methodName = $"get_{property.Identifier.ValueText}";
+                                int overload = NextOverload(overloads, methodName);
+                                if (GetterBodyText(property) is { } body)
+                                    yield return new SourceMember(fullType, methodName, overload, path, body);
+                            }
+
+                            if (HasSetter(property))
+                            {
+                                string methodName = $"set_{property.Identifier.ValueText}";
+                                int overload = NextOverload(overloads, methodName);
+                                if (SetterBodyText(property) is { } body)
+                                    yield return new SourceMember(fullType, methodName, overload, path, body);
+                            }
+
+                            break;
+                        }
+                        case OperatorDeclarationSyntax op:
+                        {
+                            string methodName = OperatorMetadataName(op);
+                            int overload = NextOverload(overloads, methodName);
+                            if (BodyText(op) is { } body)
+                                yield return new SourceMember(fullType, methodName, overload, path, body);
+                            break;
+                        }
+                        case ConversionOperatorDeclarationSyntax conversion:
+                        {
+                            string methodName = conversion.ImplicitOrExplicitKeyword.IsKind(SyntaxKind.ImplicitKeyword)
+                                ? "op_Implicit"
+                                : "op_Explicit";
+                            int overload = NextOverload(overloads, methodName);
+                            if (BodyText(conversion) is { } body)
+                                yield return new SourceMember(fullType, methodName, overload, path, body);
                             break;
                         }
                     }
@@ -514,6 +607,24 @@ static class ReturnToSenderSourceProbe
         return null;
     }
 
+    static string? BodyText(OperatorDeclarationSyntax op)
+    {
+        if (op.Body is { } body)
+            return StatementsText(body);
+        if (op.ExpressionBody is { } expressionBody)
+            return ExpressionBodyText(op.ReturnType, expressionBody.Expression);
+        return null;
+    }
+
+    static string? BodyText(ConversionOperatorDeclarationSyntax conversion)
+    {
+        if (conversion.Body is { } body)
+            return StatementsText(body);
+        if (conversion.ExpressionBody is { } expressionBody)
+            return ExpressionBodyText(conversion.Type, expressionBody.Expression);
+        return null;
+    }
+
     static string? GetterBodyText(PropertyDeclarationSyntax property)
     {
         if (property.ExpressionBody is { } expressionBody)
@@ -526,6 +637,25 @@ static class ReturnToSenderSourceProbe
         return null;
     }
 
+    static string? SetterBodyText(PropertyDeclarationSyntax property)
+    {
+        var setter = property.AccessorList?.Accessors.FirstOrDefault(accessor =>
+            accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration));
+        if (setter?.Body is { } body)
+            return StatementsText(body);
+        if (setter?.ExpressionBody is { } setterExpression)
+            return $"{setterExpression.Expression};";
+        return null;
+    }
+
+    static bool HasGetter(PropertyDeclarationSyntax property)
+        => property.ExpressionBody is not null
+            || property.AccessorList?.Accessors.Any(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration)) == true;
+
+    static bool HasSetter(PropertyDeclarationSyntax property)
+        => property.AccessorList?.Accessors.Any(accessor =>
+            accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration)) == true;
+
     static string ExpressionBodyText(TypeSyntax returnType, ExpressionSyntax expression)
         => returnType is PredefinedTypeSyntax predefined
             && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword)
@@ -537,6 +667,34 @@ static class ReturnToSenderSourceProbe
 
     static string NormalizeBody(string text)
         => Regex.Replace(text, @"\s+", "");
+
+    static string OperatorMetadataName(OperatorDeclarationSyntax op)
+        => op.OperatorToken.Kind() switch
+        {
+            SyntaxKind.PlusToken => op.ParameterList.Parameters.Count == 1 ? "op_UnaryPlus" : "op_Addition",
+            SyntaxKind.MinusToken => op.ParameterList.Parameters.Count == 1 ? "op_UnaryNegation" : "op_Subtraction",
+            SyntaxKind.ExclamationToken => "op_LogicalNot",
+            SyntaxKind.TildeToken => "op_OnesComplement",
+            SyntaxKind.PlusPlusToken => "op_Increment",
+            SyntaxKind.MinusMinusToken => "op_Decrement",
+            SyntaxKind.TrueKeyword => "op_True",
+            SyntaxKind.FalseKeyword => "op_False",
+            SyntaxKind.AsteriskToken => "op_Multiply",
+            SyntaxKind.SlashToken => "op_Division",
+            SyntaxKind.PercentToken => "op_Modulus",
+            SyntaxKind.AmpersandToken => "op_BitwiseAnd",
+            SyntaxKind.BarToken => "op_BitwiseOr",
+            SyntaxKind.CaretToken => "op_ExclusiveOr",
+            SyntaxKind.LessThanLessThanToken => "op_LeftShift",
+            SyntaxKind.GreaterThanGreaterThanToken => "op_RightShift",
+            SyntaxKind.EqualsEqualsToken => "op_Equality",
+            SyntaxKind.ExclamationEqualsToken => "op_Inequality",
+            SyntaxKind.LessThanToken => "op_LessThan",
+            SyntaxKind.GreaterThanToken => "op_GreaterThan",
+            SyntaxKind.LessThanEqualsToken => "op_LessThanOrEqual",
+            SyntaxKind.GreaterThanEqualsToken => "op_GreaterThanOrEqual",
+            _ => op.OperatorToken.ValueText,
+        };
 
     static string DiagnosticCode(string? detail)
     {

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -124,12 +124,17 @@ static class ReturnToSenderSourceProbe
         string assemblyPath,
         IReadOnlyList<ReturnToSender.RequestedTarget> targets,
         IReadOnlyList<string> sourcePaths)
-        => EvaluateTargets(assemblyPath, targets, FixtureSourceIndex.Create(sourcePaths));
+        => EvaluateTargets(
+            assemblyPath,
+            targets,
+            FixtureSourceIndex.TryCreate(sourcePaths),
+            "source index could not be built from the supplied source paths");
 
     static IReadOnlyList<ReturnToSenderSourceProbeResult> EvaluateTargets(
         string assemblyPath,
         IReadOnlyList<ReturnToSender.RequestedTarget> targets,
-        FixtureSourceIndex? sourceIndex)
+        FixtureSourceIndex? sourceIndex,
+        string sourceUnavailableDetail = "assembly is not registered in FixtureCatalog")
     {
         if (targets.Count == 0)
             return [];
@@ -195,7 +200,7 @@ static class ReturnToSenderSourceProbe
                     ReturnToSenderSourceOutcome.SourceUnavailable,
                     result.Status,
                     "fixture-source-unavailable",
-                    "assembly is not registered in FixtureCatalog",
+                    sourceUnavailableDetail,
                     SourcePath: null,
                     ExpectedBody: null,
                     ActualBody: result.TargetBody));
@@ -257,12 +262,16 @@ static class ReturnToSenderSourceProbe
             _members = members;
         }
 
-        public static FixtureSourceIndex Create(IReadOnlyList<string> sourcePaths)
+        public static FixtureSourceIndex? TryCreate(IReadOnlyList<string> sourcePaths)
         {
             var members = new Dictionary<string, SourceMember>(StringComparer.Ordinal);
             var overloads = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
             foreach (var sourcePath in sourcePaths)
-                AddSourceFile(members, overloads, sourcePath);
+            {
+                if (!TryAddSourceFile(members, overloads, sourcePath))
+                    return null;
+            }
+
             return new FixtureSourceIndex(members);
         }
 
@@ -284,7 +293,7 @@ static class ReturnToSenderSourceProbe
                 if (!TryGetSourcePaths(fixture, out var sourcePaths))
                     return null;
 
-                return Create(sourcePaths);
+                return TryCreate(sourcePaths);
             }
 
             return null;
@@ -321,15 +330,26 @@ static class ReturnToSenderSourceProbe
         public bool TryFind(ReturnToSender.RequestedTarget target, out SourceMember member)
             => _members.TryGetValue(Key(target.Type, target.Method, target.Overload), out member!);
 
-        static void AddSourceFile(
+        static bool TryAddSourceFile(
             Dictionary<string, SourceMember> members,
             Dictionary<string, Dictionary<string, int>> overloads,
             string sourcePath)
         {
-            var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(sourcePath), path: sourcePath);
+            string source;
+            try
+            {
+                source = File.ReadAllText(sourcePath);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+            {
+                return false;
+            }
+
+            var tree = CSharpSyntaxTree.ParseText(source, path: sourcePath);
             var root = tree.GetCompilationUnitRoot();
             foreach (var member in SourceMembers(root, sourcePath, overloads))
                 members.TryAdd(Key(member.Type, member.Method, member.Overload), member);
+            return true;
         }
 
         static IEnumerable<SourceMember> SourceMembers(

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -411,8 +411,12 @@ static class ReturnToSenderSourceProbe
                 {
                     switch (member)
                     {
+                        case MethodDeclarationSyntax { ExplicitInterfaceSpecifier: not null }:
+                            break;
                         case MethodDeclarationSyntax method:
                         {
+                            if (IsBodylessPartial(method))
+                                break;
                             string methodName = method.Identifier.ValueText;
                             int overload = NextOverload(overloads, methodName);
                             if (BodyText(method) is { } body)
@@ -427,6 +431,8 @@ static class ReturnToSenderSourceProbe
                                 yield return new SourceMember(fullType, methodName, overload, path, body);
                             break;
                         }
+                        case PropertyDeclarationSyntax { ExplicitInterfaceSpecifier: not null }:
+                            break;
                         case PropertyDeclarationSyntax property:
                         {
                             if (HasGetter(property))
@@ -442,6 +448,28 @@ static class ReturnToSenderSourceProbe
                                 string methodName = $"set_{property.Identifier.ValueText}";
                                 int overload = NextOverload(overloads, methodName);
                                 if (SetterBodyText(property) is { } body)
+                                    yield return new SourceMember(fullType, methodName, overload, path, body);
+                            }
+
+                            break;
+                        }
+                        case IndexerDeclarationSyntax { ExplicitInterfaceSpecifier: not null }:
+                            break;
+                        case IndexerDeclarationSyntax indexer:
+                        {
+                            if (HasGetter(indexer))
+                            {
+                                const string methodName = "get_Item";
+                                int overload = NextOverload(overloads, methodName);
+                                if (GetterBodyText(indexer) is { } body)
+                                    yield return new SourceMember(fullType, methodName, overload, path, body);
+                            }
+
+                            if (HasSetter(indexer))
+                            {
+                                const string methodName = "set_Item";
+                                int overload = NextOverload(overloads, methodName);
+                                if (SetterBodyText(indexer) is { } body)
                                     yield return new SourceMember(fullType, methodName, overload, path, body);
                             }
 
@@ -618,6 +646,11 @@ static class ReturnToSenderSourceProbe
         return null;
     }
 
+    static bool IsBodylessPartial(MethodDeclarationSyntax method)
+        => method.Modifiers.Any(SyntaxKind.PartialKeyword)
+            && method.Body is null
+            && method.ExpressionBody is null;
+
     static string? BodyText(ConstructorDeclarationSyntax constructor)
     {
         if (constructor.Body is { } body)
@@ -657,9 +690,32 @@ static class ReturnToSenderSourceProbe
         return null;
     }
 
+    static string? GetterBodyText(IndexerDeclarationSyntax indexer)
+    {
+        if (indexer.ExpressionBody is { } expressionBody)
+            return $"return {expressionBody.Expression};";
+        var getter = indexer.AccessorList?.Accessors.FirstOrDefault(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration));
+        if (getter?.Body is { } body)
+            return StatementsText(body);
+        if (getter?.ExpressionBody is { } getterExpression)
+            return $"return {getterExpression.Expression};";
+        return null;
+    }
+
     static string? SetterBodyText(PropertyDeclarationSyntax property)
     {
         var setter = property.AccessorList?.Accessors.FirstOrDefault(accessor =>
+            accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration));
+        if (setter?.Body is { } body)
+            return StatementsText(body);
+        if (setter?.ExpressionBody is { } setterExpression)
+            return $"{setterExpression.Expression};";
+        return null;
+    }
+
+    static string? SetterBodyText(IndexerDeclarationSyntax indexer)
+    {
+        var setter = indexer.AccessorList?.Accessors.FirstOrDefault(accessor =>
             accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration));
         if (setter?.Body is { } body)
             return StatementsText(body);
@@ -674,6 +730,14 @@ static class ReturnToSenderSourceProbe
 
     static bool HasSetter(PropertyDeclarationSyntax property)
         => property.AccessorList?.Accessors.Any(accessor =>
+            accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration)) == true;
+
+    static bool HasGetter(IndexerDeclarationSyntax indexer)
+        => indexer.ExpressionBody is not null
+            || indexer.AccessorList?.Accessors.Any(accessor => accessor.IsKind(SyntaxKind.GetAccessorDeclaration)) == true;
+
+    static bool HasSetter(IndexerDeclarationSyntax indexer)
+        => indexer.AccessorList?.Accessors.Any(accessor =>
             accessor.IsKind(SyntaxKind.SetAccessorDeclaration) || accessor.IsKind(SyntaxKind.InitAccessorDeclaration)) == true;
 
     static string ExpressionBodyText(TypeSyntax returnType, ExpressionSyntax expression)


### PR DESCRIPTION
- Advances #2452
- Changes harness-only RTS source probe behavior; product output is unchanged
- Evidence revision: `f733d548`

## Change

**Conclusion:** **REVIEW** — RTS now has a fixture-source oracle path that reuses the existing target/import/render/compile-back front half and classifies source-fidelity outcomes against checked-in fixture source slices.

Before:

```text
--return-to-sender-source-probe checked metadata-derived source fragments in RTS generated source.
```

After:

```text
RETURNTOSENDER SOURCE PROBE over 8 target(s)

  ValidMatch       : 6
  ValidDifferent   : 2
  Invalid          : 0
  SourceUnavailable: 0
  UnsupportedTarget: 0
```

## Scope and safety

- **Root cause:** fixture-backed source fidelity was not measurable; RTS only knew compile-back status and metadata fragment presence.
- **Fix shape:** expose FixtureCatalog source paths and add a Roslyn-backed harness-only source-slice index in `ReturnToSenderSourceProbe`.
- **Product impact:** none; changes are in tests, fixture catalog helpers, and DecompilerHarness.
- **Scope boundary:** valid-but-different rows are classified as `valid_different.unclassified`; richer taste/semantic taxonomy is left for follow-up rows from real deltas.
- **RTS boundary:** RTS still owns target/import/render/compile-back orchestration; the new oracle reads checked-in fixture source only in the harness layer.

## Evidence

| Check | Result |
| --- | --- |
| Product build | `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore` passed |
| Focused tests | `ReturnToSenderFixtureCatalogTests` passed |
| Targeted source probe | `rts.candidates`, cap 8: 6 `valid_match`, 2 `valid_different.unclassified`, 0 invalid/source-unavailable/unsupported |
| Markdown | `npx markdownlint-cli tools/DecompilerHarness/README.md` passed |

## Source-fidelity probe

Run:

```bash
dotnet run --project tools/DecompilerHarness -c Release --no-restore -- \
  --return-to-sender-fixtures rts.candidates \
  --return-to-sender-source-probe \
  --cap 8 \
  --max-examples 8
```

Output:

```text
RETURNTOSENDER SOURCE PROBE over 8 target(s)

  ValidMatch       : 6
  ValidDifferent   : 2
  Invalid          : 0
  SourceUnavailable: 0
  UnsupportedTarget: 0

  Passed   : 6
  Different: 2
  Failed   : 0
  Skipped  : 0

Buckets:
  6: valid_match
  2: valid_different.unclassified
```

The first valid-but-different examples are `DiffFixtureSample.DiffSample::MultipleHunks#0` and `DiffFixtureSample.DiffSample::CallToken#0`; both are RTS `Exact`, so they prove the middle bucket: Roslyn-valid and opcode-exact, but not source-slice identical.

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `valid_different.unclassified` taxonomy | left as frontier | first slice lands coarse rows; Roslyn-assisted/taste-aware buckets should grow from observed deltas |
| arbitrary package/source lookup | not changed | fixture-source oracle is intentionally FixtureCatalog-backed |
| product C# rendering | not changed | this is harness-only measurement |

## Build-event validation

**Conclusion:** not applicable — this is a harness/test measurement change; local build and harness smoke cover the changed path.

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini Pro | Pending | Adversarial review requested |
| MAI Flash | Pending | Adversarial review requested |

**Review conclusion:** **REVIEW** — pending two-model adversarial review.

## Validation

```bash
dotnet restore src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/*"
dotnet restore tools/DecompilerHarness/DecompilerHarness.csproj --configfile nuget.config
dotnet build tools/DecompilerHarness -c Release --no-restore
dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 8 --max-examples 8
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --no-restore
npx markdownlint-cli tools/DecompilerHarness/README.md
```
