### PR TITLE
Use precedence model for interpolation format holes

### DIFF
--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -11,6 +11,7 @@ public class PrinterPrecedenceTests
     static readonly TypeRef s_bool = TypeRef.CoreLib("System", "Boolean");
     static readonly TypeRef s_int = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef s_uint = TypeRef.CoreLib("System", "UInt32");
+    static readonly TypeRef s_string = TypeRef.CoreLib("System", "String");
 
     static IrFunction Raised(string methodName)
     {
@@ -146,6 +147,57 @@ public class PrinterPrecedenceTests
             [new Parameter("flag", s_bool), new Parameter("s", s_short), new Parameter("i", s_int)]);
 
         Assert.DoesNotContain("(short)i", output);
+    }
+
+    [Fact]
+    public void InterpolationHole_BinaryExpressionWithFormat_RendersBare()
+    {
+        var value = new Binary(BinaryKind.Add, false, false,
+            new LoadArgument(0, "a", s_int),
+            new LoadArgument(1, "b", s_int));
+        var interpolation = new InterpolatedStringExpression(
+            [InterpolatedStringPart.FormattedValue(0, new InterpolationFormat(0, HasAlignment: false, "X"))],
+            [value]);
+
+        var output = PrintReturn(
+            interpolation,
+            s_string,
+            [new Parameter("a", s_int), new Parameter("b", s_int)]);
+
+        Assert.Contains("return $\"{a + b:X}\";", output);
+        Assert.DoesNotContain("{(a + b):X}", output);
+    }
+
+    [Fact]
+    public void InterpolationHole_ConditionalWithFormat_StaysParenthesized()
+    {
+        var conditional = new Conditional(
+            new LoadArgument(0, "flag", s_bool),
+            new LoadArgument(1, "a", s_int),
+            new LoadArgument(2, "b", s_int));
+        var interpolation = new InterpolatedStringExpression(
+            [InterpolatedStringPart.FormattedValue(0, new InterpolationFormat(0, HasAlignment: false, "X"))],
+            [conditional]);
+
+        var output = PrintReturn(
+            interpolation,
+            s_string,
+            [new Parameter("flag", s_bool), new Parameter("a", s_int), new Parameter("b", s_int)]);
+
+        Assert.Contains("return $\"{(flag ? a : b):X}\";", output);
+        Assert.DoesNotContain("{flag ? a : b:X}", output);
+    }
+
+    [Fact]
+    public void CastOperand_NamedTargetNegativeLiteral_StaysParenthesized()
+    {
+        var enumType = TypeRef.Definition("Synthetic", "", "E");
+        var convert = new Pipeline.Convert(enumType, isChecked: false, isUnsigned: false, new Constant(-1, s_int));
+
+        var output = PrintReturn(convert, enumType, []);
+
+        Assert.Contains("return (E)(-1);", output);
+        Assert.DoesNotContain("return (E)-1;", output);
     }
 
     static string PrintReturn(IrExpression value, TypeRef returnType, ImmutableArray<Parameter> parameters)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.RaisedExpressions.cs
@@ -220,7 +220,7 @@ public sealed partial class CSharpPrinter
             }
             else if (part.ExpressionIndex >= 0 && part.ExpressionIndex < node.FormattedValues.Count)
             {
-                sb.Append('{').Append(InterpolatedExpression(node.FormattedValues[part.ExpressionIndex]));
+                sb.Append('{').Append(InterpolatedExpression(node.FormattedValues[part.ExpressionIndex], part.Format?.FormatString is not null));
                 if (part.Format is { } format)
                 {
                     if (format.HasAlignment)
@@ -234,10 +234,15 @@ public sealed partial class CSharpPrinter
         return sb.Append('"').ToString();
     }
 
-    string InterpolatedExpression(IrExpression value)
-        => value is LoadArgument or LoadLocal or LoadStackSlot or Constant or LoadField or LoadProperty or Call
-            ? Expression(value)
-            : $"({Expression(value)})";
+    string InterpolatedExpression(IrExpression value, bool hasFormat)
+    {
+        // A format clause's ':' competes with the conditional operator's ':',
+        // so conditional-precedence fragments wrap when a format is present.
+        // Without a format clause, preserve the historical conservative
+        // parenthesization until broad interpolation-hole churn has its own A/B.
+        var demand = hasFormat ? Precedence.NullCoalescing : Precedence.Primary;
+        return RenderedExpression(value).At(demand);
+    }
 
     static string InterpolatedLiteralText(string value)
     {

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2180,6 +2180,18 @@ public sealed partial class CSharpPrinter
             // would be `bool == int` (CS0019), so it is its own truth value (#2377).
             || (operand is LoadStackSlot load && TypeFamilies.IsBoolean(StackSlotRenderType(load.Slot, load.Type)));
 
+    Rendered RenderedExpression(IrExpression node)
+    {
+        string text = Expression(node);
+        if (node is Call call && OperatorCallPrecedence(call) is { } operatorPrecedence)
+            return new Rendered(text, operatorPrecedence);
+        if (IsWholeExpressionWrapper(text, "checked(") || IsWholeExpressionWrapper(text, "unchecked("))
+            return Rendered.Primary(text);
+        if (node is Coerce && IsSimpleAtomText(text))
+            return Rendered.Primary(text);
+        return new Rendered(text, CSharpPrecedence.Of(node));
+    }
+
     /// <summary>Parenthesizes compound operands; leaves atoms bare. Conservative until the precedence visitor exists.</summary>
     string Operand(IrExpression node)
     {
@@ -2822,6 +2834,37 @@ public sealed partial class CSharpPrinter
         _ => false,
     };
 
+    static Precedence? OperatorCallPrecedence(Call call)
+    {
+        var arguments = call.Arguments;
+        string name = call.Callee.Name;
+        if (name.StartsWith("op_Checked", StringComparison.Ordinal))
+            name = "op_" + name["op_Checked".Length..];
+
+        return arguments.Count switch
+        {
+            2 => name switch
+            {
+                "op_Equality" or "op_Inequality" => Precedence.Equality,
+                "op_LessThan" or "op_LessThanOrEqual" or "op_GreaterThan" or "op_GreaterThanOrEqual" => Precedence.Relational,
+                "op_Addition" or "op_Subtraction" => Precedence.Additive,
+                "op_Multiply" or "op_Division" or "op_Modulus" => Precedence.Multiplicative,
+                "op_BitwiseAnd" => Precedence.BitwiseAnd,
+                "op_BitwiseOr" => Precedence.BitwiseOr,
+                "op_ExclusiveOr" => Precedence.BitwiseXor,
+                "op_LeftShift" or "op_RightShift" or "op_UnsignedRightShift" => Precedence.Shift,
+                _ => null,
+            },
+            1 => name switch
+            {
+                "op_UnaryNegation" or "op_UnaryPlus" or "op_LogicalNot" or "op_OnesComplement"
+                    or "op_Implicit" or "op_Explicit" => Precedence.Unary,
+                _ => null,
+            },
+            _ => null,
+        };
+    }
+
     /// <summary>
     /// True when <paramref name="type"/> is a value type, so an <c>isinst</c>
     /// type-test must spell <c>obj is T</c> — <c>obj as T</c> is CS0077 on a
@@ -2894,10 +2937,8 @@ public sealed partial class CSharpPrinter
 
     string ConversionOperatorSpelling(TypeRef target, IrExpression value)
     {
-        string operand = OperatorOperand(value);
         string targetText = TypeText(target);
-        if (NeedsCastOperandParentheses(operand, targetText))
-            operand = $"({operand})";
+        string operand = CastOperand(OperatorOperand(value), targetText);
         return $"({targetText}){operand}";
     }
 
@@ -3223,19 +3264,21 @@ public sealed partial class CSharpPrinter
             && TypeFamilies.WideningZeroExtendSibling(EffectiveType(convert.Operand), convert.Target) is { } zeroExtendWiden)
             operand = $"({TypeText(zeroExtendWiden)}){operand}";
         string targetText = TypeText(convert.Target);
-        // A cast whose operand begins with a unary `-`/`+` is parsed as binary
-        // subtraction/addition (CS0075) unless the target spelling is a predefined
-        // keyword type the parser treats as cast-disambiguating. `nint`/`nuint`
-        // are contextual keywords and named types are not, so `(nint)-1` misparses
-        // — wrap the operand: `(nint)(-1)`. The parens are opcode-identical.
-        if (NeedsCastOperandParentheses(operand, targetText))
-            operand = $"({operand})";
+        operand = CastOperand(operand, targetText);
         string cast = $"({targetText}){operand}";
         if (wrap)
             return $"checked({cast})";
         return uncheckedOverflow ? $"unchecked({cast})" : cast;
     }
 
+    static string CastOperand(string operand, string targetText)
+        => NeedsCastOperandParentheses(operand, targetText) ? $"({operand})" : operand;
+
+    // A cast whose operand begins with a unary `-`/`+` is parsed as binary
+    // subtraction/addition (CS0075) unless the target spelling is a predefined
+    // keyword type the parser treats as cast-disambiguating. `nint`/`nuint`
+    // are contextual keywords and named types are not, so `(nint)-1` misparses
+    // — wrap the operand: `(nint)(-1)`. The parens are opcode-identical.
     static bool NeedsCastOperandParentheses(string operand, string targetText)
         => operand.Length > 0
             && operand[0] is '-' or '+'


### PR DESCRIPTION
## Summary

Continues #2376 after phase 1 by routing interpolation format holes through the existing `Rendered`/`Precedence` model and centralizing cast-operand ambiguity handling.

- Interpolation holes with a format clause now use precedence demand instead of blanket non-atom wrapping: binary/additive holes can render as `{a + b:X}`, while conditional holes still wrap as `{(flag ? a : b):X}` so the format `:` cannot bind to the ternary.
- No-format interpolation holes intentionally keep the historical conservative parens; broad no-format hole churn is left for a dedicated later A/B slice.
- Cast operands now go through one `CastOperand` helper for the existing `(E)(-1)` / `(nint)(-1)` ambiguity rule.

## Evidence

- Focused canaries:
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/PrinterPrecedenceTests/InterpolationHole_BinaryExpressionWithFormat_RendersBare"`
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/PrinterPrecedenceTests/InterpolationHole_ConditionalWithFormat_StaysParenthesized"`
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/PrinterPrecedenceTests/CastOperand_NamedTargetNegativeLiteral_StaysParenthesized"`
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/CSharpPrecedenceTests/*"`
- Fast decompiler suite: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- Build: `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- Render A/B over 89,065 methods vs explicit merge-base (`e2991718`), `--workers 20`:
  - `Changed: 11 (structural: 0, paren-equivalent: 10, unparsed: 1)`
  - `Semantic: valid->valid: 10, invalid->valid: 0, valid->invalid: 0, invalid->invalid: 1`
  - The single unparsed row is the existing invalid `StageDump::DiffHunks` decompile shape; the changed spelling is interpolation-hole paren removal only.

## Review

Two-model adversarial review complete. Gemini and MAI both report clean reviews with no blocking findings; reconciliation is posted in the PR comments.
