### PR TITLE
Adopt Markout 0.22.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="MarkdownTable.Formatting" Version="0.3.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Markout" Version="0.21.0" />
+    <PackageVersion Include="Markout" Version="0.22.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.21" />
     <PackageVersion Include="NuGet.Versioning" Version="7.3.0" />
     <PackageVersion Include="NuGetFetch" Version="0.6.2" />

--- a/tools/CSharpDiffHarness/README.md
+++ b/tools/CSharpDiffHarness/README.md
@@ -51,8 +51,8 @@ other metric and bucket changes as non-failing drift. Baseline output uses
 Markout metric-change rows for scalar metrics (`Metric | Change | Target` in
 Markdown, with goal markers and inline status where a target applies) and
 goal-aware segment-change rows for failure buckets. Change IDs and operation
-kinds remain context bucket rows. JSONL preserves typed baseline/current fields,
-direction/status, and segment values.
+kinds remain context bucket rows. JSONL preserves decomposed typed
+`change_before_*` / `change_after_*` segment fields plus direction/status.
 
 `tools/CSharpDiffHarness/corpus/diff-fixtures-baseline.json` is the pinned
 baseline for the CI `csharp-diff-smoke` job over `DiffFixtures.V1` /


### PR DESCRIPTION
## Summary

- Bump Markout from 0.21.0 to 0.22.0.
- Update the C# Diff harness README to describe the decomposed `change_before_*` / `change_after_*` JSONL bucket shape.

## Validation

- `dotnet restore dotnet-inspect.slnx --configfile nuget.config`
- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- `dotnet run --project tools/CSharpDiffHarness -c Release --no-build -- artifacts/bin/DiffFixtures.V1/release/DiffFixtureSample.dll artifacts/bin/DiffFixtures.V2/release/DiffFixtureSample.dll --emit-snapshot tools/CSharpDiffHarness/corpus/diff-fixtures-baseline.json --format jsonl --max-examples 0`
- C# Diff CI smoke locally: snapshot JSONL, pinned-baseline JSONL, regression-baseline exit 1, JSONL parse
- IL Diff CI smoke locally: snapshot JSONL, exact-baseline JSONL, regression-baseline exit 1, JSONL parse
- `npx markdownlint-cli --fix tools/CSharpDiffHarness/README.md`
- `npx markdownlint-cli tools/CSharpDiffHarness/README.md`

Note: regenerating `tools/CSharpDiffHarness/corpus/diff-fixtures-baseline.json` produced no content change; Markout 0.22 affects rendered card rows, not the stable snapshot data.