### PR TITLE
Extract full-name member-canonical grammar into one Metadata core (#2440 wi2)

### DIFF
--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -161,11 +161,15 @@ public static class ApiMemberIdentity
         var signature = method.DecodeSignature(AnchorSignatureTypeProvider.Instance, GenericContext.ForMethod(reader, type, method));
         string typeFullName = FormatDefinitionName(reader, typeHandle);
         string memberName = MethodMemberName(reader, methodName, method);
-        string canonicalSignature = $"M:{typeFullName}.{memberName}({string.Join(",", signature.ParameterTypes)})";
-        // Conversion operators overload on return type; apply the same disambiguation rule
-        // here so this SRM-direct anchor producer does not collide (its own full-name vocabulary).
-        if (IsConversionOperator(methodName) && !string.IsNullOrWhiteSpace(signature.ReturnType))
-            canonicalSignature += $"~{signature.ReturnType}";
+        // Route the SRM-direct producer through the single full-name grammar core so it
+        // cannot drift from other producers. Conversion operators overload on return type,
+        // so pass the return type for their disambiguation suffix only.
+        string canonicalSignature = MemberCanonicalSignature.Build(
+            "M",
+            typeFullName,
+            memberName,
+            signature.ParameterTypes,
+            IsConversionOperator(methodName) ? signature.ReturnType : null);
         string selectorName = GetMemberSelectorName(methodName, isExtensionMethod);
         return CreateAnchor(typeFullName, selectorName, memberName, canonicalSignature);
     }

--- a/src/ILInspector.Metadata/MemberCanonicalSignature.cs
+++ b/src/ILInspector.Metadata/MemberCanonicalSignature.cs
@@ -1,0 +1,41 @@
+namespace ILInspector.Metadata;
+
+/// <summary>
+/// The single authoritative full-name member canonical-signature grammar (issue #2440).
+///
+/// Member identity is <c>System.Int32</c>, not <c>int</c>: the canonical signature that
+/// backs a <see cref="ILInspector.MetadataPrimitives.MemberAnchor"/> fingerprint uses ECMA
+/// full type names, because this is a metadata/IL inspector and C# keyword spelling is a
+/// display projection, not identity.
+///
+/// Producers decode their source-specific shape (a <c>MethodDefinition</c>, an
+/// <c>ApiMember</c>, or a higher-layer <c>MethodIdentity</c> adapted above Metadata) into
+/// these neutral string inputs and call <see cref="Build"/>. They must not format the
+/// canonical themselves, so every producer emits one grammar and the anchors agree.
+/// </summary>
+public static class MemberCanonicalSignature
+{
+    /// <summary>
+    /// Builds a full-name canonical signature from neutral inputs.
+    /// </summary>
+    /// <param name="kind">DocId kind code: <c>"M"</c> (method/constructor/operator), <c>"P"</c>, <c>"F"</c>, or <c>"E"</c>.</param>
+    /// <param name="typeFullName">Declaring type full name including generic parameters (for example <c>System.Collections.Generic.List&lt;T&gt;</c>).</param>
+    /// <param name="memberName">Member name including method generic parameters (for example <c>M&lt;U&gt;</c>); <c>#ctor</c> for constructors.</param>
+    /// <param name="parameterTypeFullNames">Full-name parameter type strings; ignored for <c>P</c>/<c>F</c>/<c>E</c>.</param>
+    /// <param name="conversionReturnType">Full-name return type for a conversion operator (which overloads on return type), otherwise <see langword="null"/>.</param>
+    public static string Build(
+        string kind,
+        string typeFullName,
+        string memberName,
+        IReadOnlyList<string> parameterTypeFullNames,
+        string? conversionReturnType = null)
+    {
+        if (kind is "P" or "F" or "E")
+            return $"{kind}:{typeFullName}.{memberName}";
+
+        var signature = $"{kind}:{typeFullName}.{memberName}({string.Join(",", parameterTypeFullNames)})";
+        return string.IsNullOrWhiteSpace(conversionReturnType)
+            ? signature
+            : $"{signature}~{conversionReturnType}";
+    }
+}

--- a/tests/ILInspector.Metadata.Tests/MemberCanonicalSignatureTests.cs
+++ b/tests/ILInspector.Metadata.Tests/MemberCanonicalSignatureTests.cs
@@ -1,0 +1,53 @@
+using ILInspector.Metadata;
+
+namespace ILInspector.Metadata.Tests;
+
+public class MemberCanonicalSignatureTests
+{
+    [Fact]
+    public void Build_Method_UsesFullNameGrammar()
+    {
+        Assert.Equal(
+            "M:System.String.Substring(System.Int32)",
+            MemberCanonicalSignature.Build("M", "System.String", "Substring", ["System.Int32"]));
+    }
+
+    [Fact]
+    public void Build_NoParameters_EmitsEmptyParentheses()
+    {
+        Assert.Equal(
+            "M:System.Object.ToString()",
+            MemberCanonicalSignature.Build("M", "System.Object", "ToString", []));
+    }
+
+    [Fact]
+    public void Build_ConversionOperator_AppendsReturnTypeSuffix()
+    {
+        Assert.Equal(
+            "M:System.Decimal.op_Explicit(System.Decimal)~System.Byte",
+            MemberCanonicalSignature.Build("M", "System.Decimal", "op_Explicit", ["System.Decimal"], "System.Byte"));
+    }
+
+    [Fact]
+    public void Build_NullOrWhitespaceReturnType_OmitsSuffix()
+    {
+        Assert.Equal(
+            "M:System.Decimal.op_Explicit(System.Decimal)",
+            MemberCanonicalSignature.Build("M", "System.Decimal", "op_Explicit", ["System.Decimal"], conversionReturnType: null));
+        Assert.Equal(
+            "M:System.Decimal.op_Explicit(System.Decimal)",
+            MemberCanonicalSignature.Build("M", "System.Decimal", "op_Explicit", ["System.Decimal"], conversionReturnType: "  "));
+    }
+
+    [Theory]
+    [InlineData("P", "P:System.String.Length")]
+    [InlineData("F", "F:System.String.Empty")]
+    [InlineData("E", "E:System.AppDomain.ProcessExit")]
+    public void Build_PropertyFieldEvent_HasNoParameterList(string kind, string expected)
+    {
+        var memberName = kind switch { "P" => "Length", "F" => "Empty", _ => "ProcessExit" };
+        var typeName = kind == "E" ? "System.AppDomain" : "System.String";
+        // Parameter list is ignored for P/F/E even if provided.
+        Assert.Equal(expected, MemberCanonicalSignature.Build(kind, typeName, memberName, ["System.Int32"]));
+    }
+}


### PR DESCRIPTION
## Summary

**#2440 work item 2, step 1**: introduce the single authoritative full-name member
canonical-signature grammar and route the first producer through it.

New `MemberCanonicalSignature.Build` (in `ILInspector.Metadata`) is the one place that
formats a member canonical signature — `System.Int32`, not `int`, because identity is
language-neutral and the C# keyword spelling is a display projection (per the #2440
decision). It takes **neutral string inputs** (declaring type full name, member name,
parameter type full names, optional conversion return type), so producers decode their
source-specific shape into those strings and call `Build` instead of formatting the
canonical themselves — no more drift between the ≥3 hand-rolled copies that made the
conversion-operator fix (#2433) land in three places.

This step routes the **SRM-direct** producer (`ApiMemberIdentity.CreateMethodAnchor`,
already full-name) through the core. It is a **pure, byte-identical refactor**:

- existing `ApiMemberIdentityTests` (which assert exact `CreateMethodAnchor` canonicals,
  including the conversion-operator `~System.Int32`/`~System.Int64` suffix) are unchanged;
- the RA equivalence census `B` column is unchanged — CoreLib **24.64% agree / 32,046
  matched / 6,462 unmatched**, identical to before;
- new `MemberCanonicalSignatureTests` cover the grammar directly (method, no-parameters,
  conversion-operator suffix, null/whitespace-suffix omission, and the `P`/`F`/`E` kinds).

## Scope / what is deliberately not here

- The **ApiSurface/keyword producer** (`TryGetCanonicalSignature`) and its **published
  stable-selector digest** are untouched. Migrating it onto the full-name grammar changes
  the published digest and is the later **versioned migration** (work item 5).
- The **type-name renderer** unification (the census's residual `B != C` 17.3% comes from
  `AnchorSignatureTypeProvider` vs Research's `BodyTypeName`, not from the format grammar)
  and the **Research/`MethodIdentity` adapter** are follow-ups. The core takes neutral
  inputs precisely so those adapters can route through it later.

## Validation

- `dotnet build dotnet-inspect.slnx -c Release` — succeeds.
- `ILInspector.Metadata.Tests` 369/0 (adds `MemberCanonicalSignatureTests`).
- `ILInspector.Decompiler.Tests` 2018/0 (`CSharpBodyDiff` consumes `CreateMethodAnchor`).
- `dotnet-inspect.Tests` 1666/0 (10 skipped) — member-index goldens unchanged.
- RA census on CoreLib: `B` byte-identical (24.64% agree).

## Review

Member-identity/canonicalization refactor (byte-identical, but identity-adjacent) →
two-model adversarial review (GPT-5.5 + Gemini) per policy.
