### PR TITLE
runfaster: add leak-watch dynamic memory-growth classifier

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ System.Text.Json.JsonSerializer (System.Text.Json 10.0.2)
 | [Output Shapes](design/output-shapes.md) | The Document → Table → Vector → Scalar shape ladder, how Markout produces it, and how the output flags select a shape. |
 | [Graph Signal Annotations](design/graph-signal-annotations.md) | Projecting analysis signals (alloc/copy/unsafe, and exception-risk follow-ups) onto call-graph nodes via `--fields`. |
 | [Allocation Triage Pre-Filters](design/allocation-triage-prefilters.md) | Which allocation candidates Performance Triage surfaces, why the pre-filters prune cold-by-construction shapes, and what realized cost the static side cannot predict. |
+| [Dynamic Leak-Watch](design/dynamic-leak-watch.md) | The retention axis: how `runfaster leak-watch` separates a managed leak from a churn storm from native/committed growth, and why static triage and the allocation-tick join cannot. |
 | [Rendering Model](design/rendering-model.md) | Historical/current rendering model notes; prefer [Progressive Disclosure](design/progressive-disclosure.md) for current agent-facing behavior. |
 | [Section Model](design/section-model.md) | Section selection design notes; use with [Progressive Disclosure](design/progressive-disclosure.md). |
 | [Schema Query](design/schema-query.md) | `-D`/`-S` schema/query implementation notes. |

--- a/docs/design/allocation-triage-prefilters.md
+++ b/docs/design/allocation-triage-prefilters.md
@@ -7,6 +7,9 @@ joined against real allocation traces.
 
 Related docs:
 
+- [Dynamic Leak-Watch](dynamic-leak-watch.md) — the dynamic retention axis that
+  complements this static cost-shape side (managed leak vs churn storm vs
+  native/committed growth).
 - [Graph signal annotations](graph-signal-annotations.md) — the signal/leverage
   triage axes allocation rows plug into
 - [Hidden-fact annotations](hidden-fact-annotations.md) — the per-method

--- a/docs/design/dynamic-leak-watch.md
+++ b/docs/design/dynamic-leak-watch.md
@@ -1,0 +1,109 @@
+# Dynamic Leak-Watch
+
+The retention axis of allocation analysis: how `runfaster leak-watch` separates a
+managed leak from a collectible churn storm from native/committed growth, why the
+static [Allocation Triage pre-filters](allocation-triage-prefilters.md) and the
+`runfaster` allocation-tick join cannot do this on their own, and the investigation
+that motivated it.
+
+Related docs:
+
+- [Allocation Triage pre-filters](allocation-triage-prefilters.md) — the static
+  cost-shape side and what it can and cannot predict about realized cost.
+- The static ArrayPool leak-triage in `src/ILInspector.Analysis/LeakTriage.cs` —
+  the static shape that leak-watch is the dynamic complement to.
+
+## The investigation
+
+`ILInspector.Decompiler.Tests` drove resident memory to 10–16 GB on the CI host.
+The same run was reproduced locally on macOS (24 GB) with
+`dotnet-counters`/`dotnet-gcdump`/`vmmap`:
+
+- Resident set climbed 4.5 GB → 11.3 GB while CPU sat at 400–650%.
+- Live managed heap peaked at 4.9 GB; GC-committed tracked it at 5.4 GB (not an
+  over-commit).
+- `vmmap` attributed 6.1 GB / 25,472 regions to the GC heap (`VM_ALLOCATE`).
+- Forcing a collection (via `dotnet-gcdump`) dropped the **live** heap to 561 MB —
+  the bulk was collectible churn, not retention — but resident set stayed at
+  7.3 GB. The retained roots were all Roslyn caches
+  (`TextKeyedCache<SyntaxToken/Trivia>`, `GreenNode`, `Microsoft.CodeAnalysis`
+  symbol tables).
+
+**Root cause.** The suite has ~20 in-process `CSharpCompilation.Create` sites, each
+rebuilding the ~185 trusted-platform `MetadataReference`s per compile, run in
+parallel by the xUnit v3 runner. That drives Roslyn metadata churn → gen2
+promotion → multi-GB GC-committed segments the runtime returns to the OS lazily.
+The cheap fix is a shared, process-lifetime `MetadataReference` cache (Roslyn
+`MetadataReference`/`AssemblyMetadata` are immutable and meant to be shared); an
+isolated micro-benchmark of the exact pattern (400 parallel compiles) measured
+**3,950 MB → 433 MB allocated** and **6–12.9 GB → ~0.27 GB peak working set**.
+
+## Three growths that look alike
+
+From the outside — a rising resident set — three very different causes are
+indistinguishable:
+
+| Verdict | Signature | Actionable cause |
+| --- | --- | --- |
+| `ManagedRetention` | live GC heap stays high at steady state, above baseline, and a collection does not return it | a genuine managed leak — capture a gcdump, inspect retained types |
+| `ChurnStorm` | high allocation rate / GC pause, heap peaks then a collection returns it near baseline | allocation rate / parallelism, **not** a leak |
+| `NativeOrCommittedGrowth` | working set stays far above the live heap (and the gap *grew*) | native allocation or GC-committed regions returned to the OS lazily |
+
+The incident above is `NativeOrCommittedGrowth`: the working set held 10.5 GB,
+2.3× the 4.57 GB live-heap peak, with the native gap widening ~1 GB over the
+window — the growth is off the managed heap.
+
+`leak-watch` consumes a `dotnet-counters` `System.Runtime` CSV (it does not spawn
+tools — same "bring your diagnostic artifact" model as the rest of `runfaster`)
+and classifies on the **steady-state** footprint (the last complete sample) versus
+the baseline: `managedRetained = liveHeap − baseline`,
+`nativeGap = workingSet − liveHeap`, and whether the native gap *grew*.
+
+## Could static Performance Triage or the runfaster join have found this?
+
+This is the discoverability question, and the answer sharpens where each layer's
+signal actually lives.
+
+### Static Allocation Triage — No
+
+Static analysis owns **cost-shape**: the kind of an allocation, whether it sits on
+a loop back-edge, whether it is cold-by-construction. It is correct and capable at
+that (see the pre-filters doc). But a leak is not a cost-shape — it is a
+**lifetime/retention** property: the same `new MetadataReference[]` is a
+non-event when the references are shared and a multi-GB problem when they are
+rebuilt-per-call and promoted. Static analysis cannot see call frequency or object
+lifetime, so it cannot rank this, and should not pretend to.
+
+### The runfaster allocation-tick join — Partial, and it over-flags
+
+The `runfaster` join ranks hot allocators by bytes **allocated** and (for
+non-inlined code) pins them to static sites by IL offset. On this workload it would
+correctly rank the Roslyn allocators at the top — but bytes-allocated measures
+**churn**, not **retention**. The forced-GC evidence shows the live heap is 561 MB
+against 4.9 GB allocated: the join would flag a churn storm as if it were a leak.
+An allocation-tick join has no retention axis.
+
+### The missing piece — a retention/survivorship signal
+
+`leak-watch` adds exactly that axis. It does not rank allocators; it answers "is
+the footprint that is growing actually **retained**?" — the question the other two
+layers structurally cannot.
+
+### Per-type is viable here; per-site is not
+
+This is the counterpoint to the survivorship work in #2260. That work found that a
+*per-site* promotion ratio smears across shared types and produces catastrophic
+false negatives on real leaks. But a *per-type* retention signal is sound and is
+exactly what this incident needs: the Roslyn types dominate both the allocated and
+the live sets, so a gcdump's alive-bytes-by-type join names the retained roots
+without any per-site attribution. Leak-watch stays at the coarse process-level
+counters axis; a gcdump is the per-type drill-down when its verdict is
+`ManagedRetention`.
+
+## Summary
+
+Static analysis is correct and capable on cost-shape; the allocation-tick join
+reliably narrows static signal to hot allocators; neither can separate churn from
+retention. `leak-watch` is the small, dependency-free retention layer that closes
+that gap, and it correctly classifies the motivating incident as native/committed
+growth rather than a managed leak.

--- a/src/runfaster.Tests/LeakWatchTests.cs
+++ b/src/runfaster.Tests/LeakWatchTests.cs
@@ -157,6 +157,27 @@ public class LeakWatchTests
     }
 
     [Fact]
+    public void Analyze_LeakAlongsideCollectibleChurn_IsManagedRetention()
+    {
+        // A real leak (100 MB → ~1 GB retained) plus transient churn on top. A gen2
+        // collection reclaims the churn but the leak stays resident: the partial reclaim
+        // must not mask the retained growth.
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 300 * MB, 100 * MB, 80 * MB),
+            Sample(2, 1600 * MB, 1200 * MB, 1100 * MB, allocated: 400 * MB, gen2Collections: 1),
+            // churn (200 MB) reclaimed, but ~1 GB leak stays.
+            Sample(4, 1500 * MB, 1000 * MB, 950 * MB, allocated: 400 * MB),
+            Sample(6, 1550 * MB, 1050 * MB, 1000 * MB, allocated: 400 * MB),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.ManagedRetention, result.Verdict);
+        Assert.False(result.HeapReclaimedByGen2);
+    }
+
+    [Fact]
     public void CountersCsv_ParsesGroupedTimestampsAndComputesLiveHeap()
     {
         var lines = new[]

--- a/src/runfaster.Tests/LeakWatchTests.cs
+++ b/src/runfaster.Tests/LeakWatchTests.cs
@@ -256,6 +256,64 @@ public class LeakWatchTests
     }
 
     [Fact]
+    public void Analyze_MonotonicTailAboveThreshold_IsManagedRetention()
+    {
+        // GPT: a monotonic tail (10 GB → 10.4 GB → 10.8 GB) crosses the retention
+        // threshold at the FINAL sample. A middle-of-tail estimator would fall below it
+        // and report Healthy (and spuriously imply reclaim); the last sample must win.
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 10500 * MB, 10000 * MB, 9500 * MB),
+            Sample(2, 10900 * MB, 10400 * MB, 9900 * MB),
+            Sample(4, 11300 * MB, 10800 * MB, 10300 * MB),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.ManagedRetention, result.Verdict);
+        Assert.False(result.HeapReclaimedByGen2);
+    }
+
+    [Fact]
+    public void Analyze_TerminalCollectionEndsTrace_IsNotManagedRetention()
+    {
+        // Gemini: a high-churn window whose FINAL sample is a forced collection (the GC
+        // a gcdump capture triggers) that reclaims the heap to baseline. The last sample
+        // holds the true reclaimed footprint; a middle-of-tail estimator would keep the
+        // pre-collection peak and falsely report a managed leak.
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 500 * MB, 100 * MB, 80 * MB),
+            Sample(2, 10240 * MB, 10000 * MB, 9500 * MB, allocated: 8000L * MB, gcPause: 1.4),
+            Sample(4, 10240 * MB, 10000 * MB, 9500 * MB, allocated: 8000L * MB, gcPause: 1.4),
+            Sample(6, 500 * MB, 100 * MB, 80 * MB, gen2Collections: 1),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.NotEqual(LeakWatchVerdict.ManagedRetention, result.Verdict);
+        Assert.NotEqual(LeakWatchVerdict.NativeOrCommittedGrowth, result.Verdict);
+    }
+
+    [Fact]
+    public void Analyze_SlowLinearLeak_IsManagedRetention()
+    {
+        // Gemini: a slow linear leak climbing 100 MB → 600 MB → 1100 MB across the tail.
+        // A middle-of-tail estimator evaluates 600 MB (below threshold) and misses the
+        // 1 GB leak; the last sample captures its full size.
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 200 * MB, 100 * MB, 80 * MB),
+            Sample(2, 700 * MB, 600 * MB, 550 * MB),
+            Sample(4, 1200 * MB, 1100 * MB, 1050 * MB),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.ManagedRetention, result.Verdict);
+    }
+
+    [Fact]
     public void CountersCsv_ParsesGroupedTimestampsAndComputesLiveHeap()
     {
         var lines = new[]

--- a/src/runfaster.Tests/LeakWatchTests.cs
+++ b/src/runfaster.Tests/LeakWatchTests.cs
@@ -104,6 +104,59 @@ public class LeakWatchTests
     }
 
     [Fact]
+    public void Analyze_CollectionBeforeLaterGrowth_IsManagedRetention_NotHealthy()
+    {
+        // A gen2 collection early, then the live heap grows monotonically past its old
+        // peak: the early collection must NOT count as reclaiming the later growth.
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 600 * MB, 400 * MB, 300 * MB, gen2Collections: 1),
+            Sample(2, 900 * MB, 700 * MB, 600 * MB),
+            Sample(4, 1400 * MB, 1200 * MB, 1100 * MB),
+            Sample(6, 1900 * MB, 1700 * MB, 1600 * MB),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.ManagedRetention, result.Verdict);
+        Assert.False(result.HeapReclaimedByGen2);
+    }
+
+    [Fact]
+    public void Analyze_StableHighNativeBaseline_IsHealthy_NotGrowth()
+    {
+        // Large fixed gap between working set and live heap, but flat: a native/committed
+        // baseline, not growth. Must not be flagged NativeOrCommittedGrowth.
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 1 * GB, 100 * MB, 80 * MB),
+            Sample(2, 1 * GB, 100 * MB, 80 * MB),
+            Sample(4, 1 * GB, 100 * MB, 80 * MB),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.Healthy, result.Verdict);
+    }
+
+    [Fact]
+    public void Analyze_LeakFromNearZeroHeap_IsManagedRetention()
+    {
+        // A leak that starts from a near-empty heap must still be caught (no
+        // multiply-by-zero blind spot in the growth test).
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 60 * MB, 4 * MB, 2 * MB),
+            Sample(2, 700 * MB, 640 * MB, 600 * MB),
+            Sample(4, 1400 * MB, 1300 * MB, 1200 * MB),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.ManagedRetention, result.Verdict);
+    }
+
+    [Fact]
     public void CountersCsv_ParsesGroupedTimestampsAndComputesLiveHeap()
     {
         var lines = new[]

--- a/src/runfaster.Tests/LeakWatchTests.cs
+++ b/src/runfaster.Tests/LeakWatchTests.cs
@@ -314,6 +314,47 @@ public class LeakWatchTests
     }
 
     [Fact]
+    public void Analyze_ManagedGrowthUnderStableNativeBaseline_IsManagedRetention()
+    {
+        // GPT: a fixed native gap (constant ~3 GB) with the managed heap growing on top
+        // (512 MB → 2 GB). The only growth is managed retention; a large-but-static
+        // native gap must not steal the verdict.
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 3584 * MB, 512 * MB, 400 * MB),
+            Sample(2, 4096 * MB, 1024 * MB, 900 * MB),
+            Sample(4, 5120 * MB, 2048 * MB, 1900 * MB),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.ManagedRetention, result.Verdict);
+    }
+
+    [Fact]
+    public void CountersCsv_DropsTruncatedFinalBlockWithoutHeapRows()
+    {
+        // GPT + Gemini: a Ctrl+C capture leaves the final timestamp block with a
+        // working-set row but no heap-generation rows. That block must be dropped, not
+        // emitted with a live heap of 0 (which would invert the steady-state verdict).
+        var csv = new[]
+        {
+            "Timestamp,Provider,Counter Name,Counter Type,Mean/Increment",
+            "2026-01-01T00:00:00Z,System.Runtime,dotnet.process.memory.working_set (By),Metric,1000000000",
+            "2026-01-01T00:00:00Z,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=gen2],Metric,900000000",
+            "2026-01-01T00:00:02Z,System.Runtime,dotnet.process.memory.working_set (By),Metric,1100000000",
+            "2026-01-01T00:00:02Z,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=gen2],Metric,1000000000",
+            // Truncated final block: working set only, no heap rows.
+            "2026-01-01T00:00:04Z,System.Runtime,dotnet.process.memory.working_set (By),Metric,1200000000",
+        };
+
+        var samples = LeakWatchCountersCsv.Parse(csv);
+
+        Assert.Equal(2, samples.Count);
+        Assert.All(samples, s => Assert.True(s.LiveHeap > 0));
+    }
+
+    [Fact]
     public void CountersCsv_ParsesGroupedTimestampsAndComputesLiveHeap()
     {
         var lines = new[]
@@ -344,11 +385,13 @@ public class LeakWatchTests
             "Timestamp,Provider,Counter Name,Counter Type,Mean/Increment",
             "t1,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=gen2],Metric,100",
             "t2,System.Runtime,dotnet.process.memory.working_set (By),Metric,200",
+            "t2,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=gen2],Metric,150",
         };
 
         var samples = LeakWatchCountersCsv.Parse(lines);
 
-        // Only the timestamp carrying a working-set reading yields a sample.
+        // t1 carries no working-set reading and is skipped; only the complete t2 block
+        // (working set + heap) yields a sample.
         Assert.Single(samples);
         Assert.Equal(200, samples[0].WorkingSet);
     }

--- a/src/runfaster.Tests/LeakWatchTests.cs
+++ b/src/runfaster.Tests/LeakWatchTests.cs
@@ -334,24 +334,28 @@ public class LeakWatchTests
     [Fact]
     public void CountersCsv_DropsTruncatedFinalBlockWithoutHeapRows()
     {
-        // GPT + Gemini: a Ctrl+C capture leaves the final timestamp block with a
-        // working-set row but no heap-generation rows. That block must be dropped, not
-        // emitted with a live heap of 0 (which would invert the steady-state verdict).
+        // GPT + Gemini: a Ctrl+C capture tears the final timestamp block — before any
+        // heap row, OR mid-heap (some generations flushed, others not). Either way the
+        // block must be dropped, not emitted with a live heap computed from a subset of
+        // generations (which would erase whole generations and invert the verdict).
         var csv = new[]
         {
             "Timestamp,Provider,Counter Name,Counter Type,Mean/Increment",
             "2026-01-01T00:00:00Z,System.Runtime,dotnet.process.memory.working_set (By),Metric,1000000000",
             "2026-01-01T00:00:00Z,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=gen2],Metric,900000000",
+            "2026-01-01T00:00:00Z,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=loh],Metric,50000000",
             "2026-01-01T00:00:02Z,System.Runtime,dotnet.process.memory.working_set (By),Metric,1100000000",
             "2026-01-01T00:00:02Z,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=gen2],Metric,1000000000",
-            // Truncated final block: working set only, no heap rows.
+            "2026-01-01T00:00:02Z,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=loh],Metric,50000000",
+            // Torn final block: working set + loh present, gen2 truncated by EOF.
             "2026-01-01T00:00:04Z,System.Runtime,dotnet.process.memory.working_set (By),Metric,1200000000",
+            "2026-01-01T00:00:04Z,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=loh],Metric,50000000",
         };
 
         var samples = LeakWatchCountersCsv.Parse(csv);
 
         Assert.Equal(2, samples.Count);
-        Assert.All(samples, s => Assert.True(s.LiveHeap > 0));
+        Assert.All(samples, s => Assert.True(s.LiveHeap > 500_000_000));
     }
 
     [Fact]
@@ -365,6 +369,7 @@ public class LeakWatchTests
             "07/06/2026 12:45:38,System.Runtime,dotnet.process.memory.working_set (By),Metric,8000000000",
             "07/06/2026 12:45:38,System.Runtime,dotnet.gc.heap.total_allocated (By / 2 sec),Metric,1000000000",
             "07/06/2026 12:45:40,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=gen2],Metric,3200000000",
+            "07/06/2026 12:45:40,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=loh],Metric,500000000",
             "07/06/2026 12:45:40,System.Runtime,dotnet.process.memory.working_set (By),Metric,9000000000",
         };
 

--- a/src/runfaster.Tests/LeakWatchTests.cs
+++ b/src/runfaster.Tests/LeakWatchTests.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace runfaster.Tests;
+
+public class LeakWatchTests
+{
+    const long MB = 1024L * 1024;
+    const long GB = 1024L * MB;
+
+    static LeakWatchSample Sample(
+        double seconds,
+        long workingSet,
+        long liveHeap,
+        long gen2,
+        long allocated = 0,
+        double gen2Collections = 0,
+        double gcPause = 0,
+        int threads = 8)
+        => new(seconds, workingSet, liveHeap, gen2, workingSet, allocated, gen2Collections, gcPause, threads);
+
+    [Fact]
+    public void Analyze_HealthyTrajectory_WorkingSetTracksHeap()
+    {
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 400 * MB, 300 * MB, 200 * MB),
+            Sample(2, 420 * MB, 310 * MB, 210 * MB),
+            Sample(4, 410 * MB, 305 * MB, 205 * MB),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.Healthy, result.Verdict);
+    }
+
+    [Fact]
+    public void Analyze_NativeGrowth_WorkingSetStaysAboveHeapAfterCollection()
+    {
+        // Live heap climbs then a gen2 collection reclaims it, but the working set
+        // never comes back down — the RSS-doesn't-follow-heap signature.
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 3 * GB, 3 * GB, 3 * GB, allocated: 1 * GB, gcPause: 0.5),
+            Sample(2, 7 * GB, 4 * GB, 4 * GB, allocated: 2 * GB, gcPause: 0.6),
+            Sample(4, 10 * GB, 4500 * MB, 4500 * MB, allocated: 2 * GB, gcPause: 0.7),
+            // gen2 collection: gen2/live drop sharply, working set holds.
+            Sample(6, 10 * GB, 600 * MB, 400 * MB, allocated: 2 * GB, gen2Collections: 1, gcPause: 0.6),
+            Sample(8, 10 * GB, 700 * MB, 500 * MB, allocated: 2 * GB, gcPause: 0.5),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.NativeOrCommittedGrowth, result.Verdict);
+        Assert.True(result.HeapReclaimedByGen2);
+        // The retained floor is the post-collection working set, far above the live heap.
+        Assert.True(result.RetainedFloorAfterGen2 - result.LiveHeapAtFloor > 5 * GB);
+    }
+
+    [Fact]
+    public void Analyze_ManagedRetention_HeapGrowsAndSurvivesCollection()
+    {
+        // The live heap grows monotonically and no gen2 collection reclaims it: a
+        // genuine managed leak. Working set tracks the heap (no native gap).
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 500 * MB, 400 * MB, 300 * MB, allocated: 200 * MB),
+            Sample(2, 900 * MB, 800 * MB, 700 * MB, allocated: 200 * MB),
+            Sample(4, 1400 * MB, 1300 * MB, 1200 * MB, allocated: 200 * MB),
+            Sample(6, 1900 * MB, 1800 * MB, 1700 * MB, allocated: 200 * MB),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.ManagedRetention, result.Verdict);
+        Assert.False(result.HeapReclaimedByGen2);
+    }
+
+    [Fact]
+    public void Analyze_ChurnStorm_HighAllocReclaimedWithoutNativeGap()
+    {
+        // High allocation churn with heavy GC pause, but a gen2 collection reclaims
+        // the heap and the working set stays close to the (small) live heap.
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 500 * MB, 350 * MB, 250 * MB, allocated: 3 * GB, gcPause: 0.6),
+            Sample(2, 700 * MB, 600 * MB, 500 * MB, allocated: 3 * GB, gcPause: 0.7),
+            Sample(4, 650 * MB, 200 * MB, 120 * MB, allocated: 3 * GB, gen2Collections: 1, gcPause: 0.6),
+            Sample(6, 620 * MB, 250 * MB, 150 * MB, allocated: 3 * GB, gcPause: 0.6),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.ChurnStorm, result.Verdict);
+        Assert.True(result.HeapReclaimedByGen2);
+    }
+
+    [Fact]
+    public void Analyze_TooFewSamples_IsInconclusive()
+    {
+        var result = LeakWatchAnalyzer.Analyze([Sample(0, 1 * GB, 500 * MB, 400 * MB)], LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.Inconclusive, result.Verdict);
+    }
+
+    [Fact]
+    public void CountersCsv_ParsesGroupedTimestampsAndComputesLiveHeap()
+    {
+        var lines = new[]
+        {
+            "Timestamp,Provider,Counter Name,Counter Type,Mean/Increment",
+            "07/06/2026 12:45:38,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=gen2],Metric,3000000000",
+            "07/06/2026 12:45:38,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=loh],Metric,500000000",
+            "07/06/2026 12:45:38,System.Runtime,dotnet.process.memory.working_set (By),Metric,8000000000",
+            "07/06/2026 12:45:38,System.Runtime,dotnet.gc.heap.total_allocated (By / 2 sec),Metric,1000000000",
+            "07/06/2026 12:45:40,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=gen2],Metric,3200000000",
+            "07/06/2026 12:45:40,System.Runtime,dotnet.process.memory.working_set (By),Metric,9000000000",
+        };
+
+        var samples = LeakWatchCountersCsv.Parse(lines);
+
+        Assert.Equal(2, samples.Count);
+        Assert.Equal(8_000_000_000, samples[0].WorkingSet);
+        Assert.Equal(3_500_000_000, samples[0].LiveHeap); // gen2 + loh
+        Assert.Equal(1_000_000_000, samples[0].AllocatedInWindow);
+        Assert.Equal(2.0, samples[1].SecondsFromStart, 3);
+    }
+
+    [Fact]
+    public void CountersCsv_RowsWithoutWorkingSet_AreSkipped()
+    {
+        var lines = new[]
+        {
+            "Timestamp,Provider,Counter Name,Counter Type,Mean/Increment",
+            "t1,System.Runtime,dotnet.gc.last_collection.heap.size (By)[gc.heap.generation=gen2],Metric,100",
+            "t2,System.Runtime,dotnet.process.memory.working_set (By),Metric,200",
+        };
+
+        var samples = LeakWatchCountersCsv.Parse(lines);
+
+        // Only the timestamp carrying a working-set reading yields a sample.
+        Assert.Single(samples);
+        Assert.Equal(200, samples[0].WorkingSet);
+    }
+}

--- a/src/runfaster.Tests/LeakWatchTests.cs
+++ b/src/runfaster.Tests/LeakWatchTests.cs
@@ -178,6 +178,84 @@ public class LeakWatchTests
     }
 
     [Fact]
+    public void Analyze_LargeHeapRetainedBelowDoubling_IsManagedRetention()
+    {
+        // GPT: a large existing heap can retain multiple GB without doubling. Growth of
+        // 10 GB → 15 GB (+5 GB) with the working set tracking it is managed retention,
+        // not Healthy — the ×2 factor must not gate out large absolute retention.
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 10500 * MB, 10000 * MB, 9500 * MB),
+            Sample(2, 13000 * MB, 12500 * MB, 12000 * MB),
+            Sample(4, 15500 * MB, 15000 * MB, 14500 * MB),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.ManagedRetention, result.Verdict);
+    }
+
+    [Fact]
+    public void Analyze_PureNativeLeakOnFlatHeap_IsNativeOrCommittedGrowth()
+    {
+        // Gemini: the managed heap stays flat at 1 GB while the working set leaks from
+        // 1 GB to 10 GB. A peak-anchored floor search saw a zero gap; steady-state must
+        // see the 9 GB native gap.
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 1024 * MB, 1000 * MB, 900 * MB),
+            Sample(2, 4096 * MB, 1000 * MB, 900 * MB),
+            Sample(4, 7168 * MB, 1000 * MB, 900 * MB),
+            Sample(6, 10240 * MB, 1000 * MB, 900 * MB),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.NativeOrCommittedGrowth, result.Verdict);
+    }
+
+    [Fact]
+    public void Analyze_SteadyLeakAfterEarlyChurnSpike_IsManagedRetention()
+    {
+        // Gemini: an early churn spike (100 MB → 10 GB → reclaimed to 100 MB) followed
+        // by a steady uncollected 5 GB leak at the end. A peak-anchored model finds the
+        // post-spike trough and declares reclaim; steady-state must see the end leak.
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 400 * MB, 100 * MB, 80 * MB),
+            Sample(2, 10240 * MB, 10000 * MB, 9500 * MB, allocated: 8000L * MB, gen2Collections: 1),
+            Sample(4, 500 * MB, 100 * MB, 80 * MB, gen2Collections: 1),
+            Sample(6, 5200 * MB, 5000 * MB, 4800 * MB),
+            Sample(8, 5300 * MB, 5100 * MB, 4900 * MB),
+            Sample(10, 5250 * MB, 5050 * MB, 4850 * MB),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.ManagedRetention, result.Verdict);
+    }
+
+    [Fact]
+    public void Analyze_CommittedGapAfterChurnSpike_IsNativeOrCommittedGrowth()
+    {
+        // Gemini: heap and WS both spike to 10 GB (churn); the heap correctly drops to
+        // 1 GB but the working set stays at 5 GB — a 4 GB committed-memory gap. A
+        // peak/peak gapRatio is 1.0 and misses it; steady-state gapRatio is 5.0.
+        var samples = new List<LeakWatchSample>
+        {
+            Sample(0, 1024 * MB, 900 * MB, 800 * MB),
+            Sample(2, 10240 * MB, 10000 * MB, 9500 * MB, allocated: 8000L * MB, gen2Collections: 1),
+            Sample(4, 5120 * MB, 1000 * MB, 900 * MB, gen2Collections: 1),
+            Sample(6, 5120 * MB, 1000 * MB, 900 * MB),
+            Sample(8, 5120 * MB, 1000 * MB, 900 * MB),
+        };
+
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+
+        Assert.Equal(LeakWatchVerdict.NativeOrCommittedGrowth, result.Verdict);
+    }
+
+    [Fact]
     public void CountersCsv_ParsesGroupedTimestampsAndComputesLiveHeap()
     {
         var lines = new[]

--- a/src/runfaster/LeakWatch.cs
+++ b/src/runfaster/LeakWatch.cs
@@ -124,6 +124,12 @@ static class LeakWatchAnalyzer
         // is, by construction, not live managed objects — native allocation or
         // GC-committed segments the runtime returns to the OS lazily.
         long nativeGap = wsRetained - liveHeapRetained;
+        // How much the native gap GREW over the window: RSS growth that outpaces the
+        // managed heap. A fixed native baseline (a large gap present from the start) that
+        // the managed heap then grows on top of is managed retention, not native growth —
+        // only a WIDENING gap indicates native/committed growth.
+        long baselineGap = wsFirst - liveHeapFirst;
+        long nativeGapGrowth = nativeGap - baselineGap;
 
         // The heap peaked well above where it SETTLED and settled near baseline: the
         // transient-churn signature (peaked high, came back down). Independent of whether
@@ -174,7 +180,8 @@ static class LeakWatchAnalyzer
 
         bool highChurn = duration > 0 && pauseFraction >= thresholds.PauseFraction;
 
-        if (workingSetGrew && gapRatio >= thresholds.GapRatio && nativeGap >= thresholds.RetainedGapBytes)
+        if (workingSetGrew && gapRatio >= thresholds.GapRatio && nativeGap >= thresholds.RetainedGapBytes
+            && nativeGapGrowth >= thresholds.RetainedGapBytes)
         {
             verdict = LeakWatchVerdict.NativeOrCommittedGrowth;
             headline = $"Native/committed growth: working set grew to {Fmt(wsPeak)} and holds {Fmt(wsRetained)} ({gapRatio:F1}× the {Fmt(liveHeapRetained)} live heap) — staying {Fmt(nativeGap)} above the live heap{afterCollectionClause}. RSS is not following the heap down — native allocation or GC-committed regions returned to the OS lazily.";
@@ -273,8 +280,15 @@ static class LeakWatchCountersCsv
         for (int i = 0; i < order.Count; i++)
         {
             var map = byTimestamp[order[i]];
-            // A sample must at least carry a working-set reading to be meaningful.
+            // A sample must carry a working-set reading to be meaningful.
             if (!map.TryGetValue(WorkingSet, out double ws))
+                continue;
+            // ...and a live-heap reading. dotnet-counters flushes a timestamp block's
+            // rows sequentially, so an abruptly-terminated capture (Ctrl+C) commonly
+            // leaves the final block with a working-set row but no heap-generation rows.
+            // Emitting that truncated block would read the live heap as 0 and invert the
+            // steady-state verdict, so drop any block without heap data.
+            if (!HasHeapReading(map))
                 continue;
 
             long liveHeap = (long)(
@@ -309,6 +323,18 @@ static class LeakWatchCountersCsv
 
     static double Gen(Dictionary<string, double> map, string gen)
         => Get(map, $"dotnet.gc.last_collection.heap.size (By)[gc.heap.generation={gen}]");
+
+    // A timestamp block is complete enough to trust as a steady-state anchor only if it
+    // carries at least one live-heap generation reading.
+    static bool HasHeapReading(Dictionary<string, double> map)
+    {
+        foreach (var k in map.Keys)
+        {
+            if (k.StartsWith("dotnet.gc.last_collection.heap.size", StringComparison.Ordinal))
+                return true;
+        }
+        return false;
+    }
 
     static double Get(Dictionary<string, double> map, string name)
         => map.TryGetValue(name, out double v) ? v : 0;

--- a/src/runfaster/LeakWatch.cs
+++ b/src/runfaster/LeakWatch.cs
@@ -1,0 +1,342 @@
+using System.Collections.Immutable;
+using System.Globalization;
+
+// Dynamic leak / memory-growth signal for a long-running process, consuming a
+// dotnet-counters `System.Runtime` timeseries (CSV). This is the complement to the
+// static ArrayPool leak-triage in ILInspector.Analysis: static analysis sees a
+// managed-heap-visible IL shape; this sees the runtime accounting that separates
+// three very different growth causes that look alike from the outside:
+//
+//   * managed retention   — the live GC heap grows and a gen2 collection does NOT
+//                           reclaim it (a genuine managed leak);
+//   * churn storm         — a high allocation rate promotes objects to gen2, but a
+//                           gen2 collection DOES reclaim them (collectible; the cost
+//                           is allocation rate / parallelism, not a leak);
+//   * native / committed  — the working set stays far above the live heap even after
+//     growth                a gen2 collection reclaims it (RSS does not follow the
+//                           heap down: native allocation or GC-committed regions the
+//                           runtime returns to the OS lazily).
+//
+// An allocation-rate join (runfaster correlate) ranks hot allocators but measures
+// bytes *allocated*, not bytes *retained*, so it cannot tell a churn storm from a
+// leak. This verb adds that retention axis.
+
+enum LeakWatchVerdict
+{
+    Inconclusive,
+    Healthy,
+    ChurnStorm,
+    ManagedRetention,
+    NativeOrCommittedGrowth,
+}
+
+// One time sample of runtime memory counters. Rate counters (allocated, gen2
+// collections, GC pause) are per-window increments as emitted by dotnet-counters.
+readonly record struct LeakWatchSample(
+    double SecondsFromStart,
+    long WorkingSet,
+    long LiveHeap,
+    long Gen2,
+    long Committed,
+    long AllocatedInWindow,
+    double Gen2CollectionsInWindow,
+    double GcPauseSecondsInWindow,
+    int Threads);
+
+sealed record LeakWatchThresholds(
+    double GapRatio = 2.0,
+    double ManagedGrowthFactor = 2.0,
+    double RetainedGapBytes = 512L * 1024 * 1024,
+    double PauseFraction = 0.20)
+{
+    public static LeakWatchThresholds Default { get; } = new();
+}
+
+sealed record LeakWatchResult(
+    LeakWatchVerdict Verdict,
+    string Headline,
+    long WorkingSetFirst,
+    long WorkingSetPeak,
+    long WorkingSetLast,
+    long LiveHeapPeak,
+    long RetainedFloorAfterGen2,
+    long LiveHeapAtFloor,
+    double GapRatio,
+    long TotalAllocated,
+    double DurationSeconds,
+    double GcPauseFraction,
+    int Gen2Collections,
+    bool HeapReclaimedByGen2,
+    int ThreadGrowth,
+    ImmutableArray<string> Notes);
+
+static class LeakWatchAnalyzer
+{
+    public static LeakWatchResult Analyze(IReadOnlyList<LeakWatchSample> samples, LeakWatchThresholds thresholds)
+    {
+        if (samples.Count < 2)
+        {
+            return new LeakWatchResult(
+                LeakWatchVerdict.Inconclusive,
+                "Not enough samples to establish a trajectory (need at least 2).",
+                samples.Count > 0 ? samples[0].WorkingSet : 0,
+                samples.Count > 0 ? samples[0].WorkingSet : 0,
+                samples.Count > 0 ? samples[0].WorkingSet : 0,
+                0, 0, 0, 0, 0, 0, 0, 0, false, 0, []);
+        }
+
+        long wsFirst = samples[0].WorkingSet;
+        long wsLast = samples[^1].WorkingSet;
+        long wsPeak = samples.Max(s => s.WorkingSet);
+        long liveHeapPeak = samples.Max(s => s.LiveHeap);
+        long liveHeapFirst = samples[0].LiveHeap;
+        long liveHeapLast = samples[^1].LiveHeap;
+        double duration = Math.Max(samples[^1].SecondsFromStart - samples[0].SecondsFromStart, 0);
+        long totalAllocated = samples.Sum(s => s.AllocatedInWindow);
+        double totalPause = samples.Sum(s => s.GcPauseSecondsInWindow);
+        double pauseFraction = duration > 0 ? totalPause / duration : 0;
+        int gen2Collections = (int)Math.Round(samples.Sum(s => s.Gen2CollectionsInWindow));
+        int threadGrowth = samples.Max(s => s.Threads) - samples[0].Threads;
+
+        // A gen2 collection is evidenced either by the collections-rate counter firing
+        // or by the last-collection gen2 size dropping below the running maximum.
+        long runningGen2Max = long.MinValue;
+        int lastGen2CollectionIndex = -1;
+        long gen2HighWater = 0;
+        long gen2AfterLowest = long.MaxValue;
+        for (int i = 0; i < samples.Count; i++)
+        {
+            var s = samples[i];
+            gen2HighWater = Math.Max(gen2HighWater, s.Gen2);
+            bool collected = s.Gen2CollectionsInWindow > 0
+                || (runningGen2Max != long.MinValue && s.Gen2 < runningGen2Max - thresholds.RetainedGapBytes / 4);
+            if (collected)
+            {
+                lastGen2CollectionIndex = i;
+                gen2AfterLowest = Math.Min(gen2AfterLowest, s.Gen2);
+            }
+            runningGen2Max = Math.Max(runningGen2Max, s.Gen2);
+        }
+
+        bool heapReclaimedByGen2 = lastGen2CollectionIndex >= 0
+            && gen2AfterLowest < gen2HighWater - thresholds.RetainedGapBytes / 4;
+
+        // The working-set floor and the live heap after the last observed gen2
+        // collection: does RSS follow the heap down?
+        long retainedFloorAfterGen2 = wsLast;
+        long liveHeapAtFloor = liveHeapLast;
+        if (lastGen2CollectionIndex >= 0)
+        {
+            retainedFloorAfterGen2 = long.MaxValue;
+            for (int i = lastGen2CollectionIndex; i < samples.Count; i++)
+            {
+                if (samples[i].WorkingSet < retainedFloorAfterGen2)
+                {
+                    retainedFloorAfterGen2 = samples[i].WorkingSet;
+                    liveHeapAtFloor = samples[i].LiveHeap;
+                }
+            }
+        }
+
+        double gapRatio = liveHeapPeak > 0 ? (double)wsPeak / liveHeapPeak : 0;
+        long retainedGap = retainedFloorAfterGen2 - liveHeapAtFloor;
+
+        var notes = ImmutableArray.CreateBuilder<string>();
+        notes.Add($"Working set: {Fmt(wsFirst)} → peak {Fmt(wsPeak)} → {Fmt(wsLast)} over {duration:F0}s.");
+        notes.Add($"Live GC heap: {Fmt(liveHeapFirst)} → peak {Fmt(liveHeapPeak)} → {Fmt(liveHeapLast)}.");
+        if (duration > 0)
+            notes.Add($"Allocation churn: {Fmt(totalAllocated)} allocated ({Fmt((long)(totalAllocated / duration))}/s).");
+        notes.Add($"GC pause: {pauseFraction * 100:F0}% of wall time ({gen2Collections} gen2 collection(s) observed).");
+        if (threadGrowth > 0)
+            notes.Add($"Thread count grew by {threadGrowth} over the window.");
+
+        // Decision order: a genuine managed leak (heap not reclaimed) is the most
+        // serious; then RSS-not-returned after a real reclaim; then a collectible
+        // churn storm; else healthy.
+        LeakWatchVerdict verdict;
+        string headline;
+
+        bool liveHeapGrew = liveHeapLast > liveHeapFirst * thresholds.ManagedGrowthFactor
+            && liveHeapPeak > liveHeapFirst * thresholds.ManagedGrowthFactor;
+        bool highChurn = duration > 0 && pauseFraction >= thresholds.PauseFraction;
+
+        if (liveHeapGrew && !heapReclaimedByGen2)
+        {
+            verdict = LeakWatchVerdict.ManagedRetention;
+            headline = $"Managed retention: live GC heap grew to {Fmt(liveHeapPeak)} and a gen2 collection did not reclaim it — a managed leak. Capture a gcdump and inspect the top retained types.";
+            notes.Add("The growth is on the managed heap and survives collection: this is the class the static ArrayPool leak-triage targets, and a gcdump will name the retained roots.");
+        }
+        else if (gapRatio >= thresholds.GapRatio && retainedGap >= thresholds.RetainedGapBytes)
+        {
+            verdict = LeakWatchVerdict.NativeOrCommittedGrowth;
+            headline = $"Native/committed growth: working set peaked at {Fmt(wsPeak)} ({gapRatio:F1}× the {Fmt(liveHeapPeak)} live-heap peak) and stayed {Fmt(retainedGap)} above the live heap after a gen2 collection. RSS is not following the heap down — native allocation or GC-committed regions returned to the OS lazily.";
+            if (heapReclaimedByGen2)
+                notes.Add($"A gen2 collection reclaimed the managed heap (to ~{Fmt(gen2AfterLowest)} gen2), but the working set held {Fmt(retainedFloorAfterGen2)} — the gap is off the managed heap.");
+            if (highChurn)
+                notes.Add("High allocation churn + GC pause alongside this suggests an allocation storm (e.g. heavy parallel work) driving both promotion and committed growth; reducing allocation rate / parallelism typically shrinks the footprint.");
+        }
+        else if (highChurn && heapReclaimedByGen2)
+        {
+            verdict = LeakWatchVerdict.ChurnStorm;
+            headline = $"Churn storm (collectible): {Fmt(totalAllocated)} allocated with {pauseFraction * 100:F0}% GC pause, but a gen2 collection reclaims the heap — high allocation rate, not a leak. Reduce allocation rate or parallelism.";
+            notes.Add("An allocation-rate join would rank the hot allocators here, but the heap is collectible: this is churn, not retention.");
+        }
+        else if (gapRatio >= thresholds.GapRatio)
+        {
+            verdict = LeakWatchVerdict.NativeOrCommittedGrowth;
+            headline = $"Elevated footprint: working set ({Fmt(wsPeak)}) ran {gapRatio:F1}× the live-heap peak ({Fmt(liveHeapPeak)}). Watch for native or GC-committed growth; a longer sample or a gcdump will confirm whether it is retained.";
+        }
+        else
+        {
+            verdict = LeakWatchVerdict.Healthy;
+            headline = $"Healthy: working set ({Fmt(wsPeak)} peak) tracks the live heap ({Fmt(liveHeapPeak)} peak); no retention or native-growth signature.";
+        }
+
+        return new LeakWatchResult(
+            verdict, headline, wsFirst, wsPeak, wsLast, liveHeapPeak,
+            retainedFloorAfterGen2, liveHeapAtFloor, gapRatio, totalAllocated,
+            duration, pauseFraction, gen2Collections, heapReclaimedByGen2,
+            Math.Max(threadGrowth, 0), notes.ToImmutable());
+    }
+
+    static string Fmt(long bytes)
+    {
+        double b = bytes;
+        string[] units = ["B", "KB", "MB", "GB", "TB"];
+        int u = 0;
+        while (Math.Abs(b) >= 1024 && u < units.Length - 1)
+        {
+            b /= 1024;
+            u++;
+        }
+        return $"{b:0.##} {units[u]}";
+    }
+}
+
+// Parses a `dotnet-counters collect --format csv` file of System.Runtime counters
+// into per-timestamp samples. Robust to counter ordering and missing rows.
+static class LeakWatchCountersCsv
+{
+    const string WorkingSet = "dotnet.process.memory.working_set (By)";
+    const string Committed = "dotnet.gc.last_collection.memory.committed_size (By)";
+    const string ThreadCount = "dotnet.thread_pool.thread.count ({thread})";
+
+    public static IReadOnlyList<LeakWatchSample> Parse(IEnumerable<string> lines)
+    {
+        // Group metric rows by timestamp, preserving first-seen order.
+        var order = new List<string>();
+        var byTimestamp = new Dictionary<string, Dictionary<string, double>>(StringComparer.Ordinal);
+
+        bool header = true;
+        foreach (var line in lines)
+        {
+            if (header)
+            {
+                header = false;
+                if (line.StartsWith("Timestamp", StringComparison.OrdinalIgnoreCase))
+                    continue;
+            }
+            var cols = SplitCsv(line);
+            if (cols.Count < 5)
+                continue;
+            string timestamp = cols[0];
+            string name = cols[2];
+            if (!double.TryParse(cols[4], NumberStyles.Float, CultureInfo.InvariantCulture, out double value))
+                continue;
+            if (!byTimestamp.TryGetValue(timestamp, out var map))
+            {
+                map = new Dictionary<string, double>(StringComparer.Ordinal);
+                byTimestamp[timestamp] = map;
+                order.Add(timestamp);
+            }
+            map[name] = value;
+        }
+
+        var samples = new List<LeakWatchSample>(order.Count);
+        double? firstSeconds = null;
+        DateTime? firstTime = null;
+        for (int i = 0; i < order.Count; i++)
+        {
+            var map = byTimestamp[order[i]];
+            // A sample must at least carry a working-set reading to be meaningful.
+            if (!map.TryGetValue(WorkingSet, out double ws))
+                continue;
+
+            long liveHeap = (long)(
+                Gen(map, "gen0") + Gen(map, "gen1") + Gen(map, "gen2") + Gen(map, "loh") + Gen(map, "poh"));
+
+            double seconds;
+            if (DateTime.TryParse(order[i], CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var t))
+            {
+                firstTime ??= t;
+                seconds = (t - firstTime.Value).TotalSeconds;
+            }
+            else
+            {
+                firstSeconds ??= i * 1.0;
+                seconds = i - firstSeconds.Value;
+            }
+
+            samples.Add(new LeakWatchSample(
+                SecondsFromStart: seconds,
+                WorkingSet: (long)ws,
+                LiveHeap: liveHeap,
+                Gen2: (long)Gen(map, "gen2"),
+                Committed: (long)Get(map, Committed),
+                AllocatedInWindow: (long)GetPrefix(map, "dotnet.gc.heap.total_allocated"),
+                Gen2CollectionsInWindow: GetGen2Collections(map),
+                GcPauseSecondsInWindow: GetPrefix(map, "dotnet.gc.pause.time"),
+                Threads: (int)Get(map, ThreadCount)));
+        }
+
+        return samples;
+    }
+
+    static double Gen(Dictionary<string, double> map, string gen)
+        => Get(map, $"dotnet.gc.last_collection.heap.size (By)[gc.heap.generation={gen}]");
+
+    static double Get(Dictionary<string, double> map, string name)
+        => map.TryGetValue(name, out double v) ? v : 0;
+
+    static double GetPrefix(Dictionary<string, double> map, string prefix)
+    {
+        foreach (var (k, v) in map)
+        {
+            if (k.StartsWith(prefix, StringComparison.Ordinal))
+                return v;
+        }
+        return 0;
+    }
+
+    static double GetGen2Collections(Dictionary<string, double> map)
+    {
+        foreach (var (k, v) in map)
+        {
+            if (k.StartsWith("dotnet.gc.collections", StringComparison.Ordinal)
+                && k.Contains("generation=gen2", StringComparison.Ordinal))
+                return v;
+        }
+        return 0;
+    }
+
+    static List<string> SplitCsv(string line)
+    {
+        var result = new List<string>();
+        var sb = new System.Text.StringBuilder();
+        bool quoted = false;
+        foreach (char c in line)
+        {
+            if (c == '"')
+                quoted = !quoted;
+            else if (c == ',' && !quoted)
+            {
+                result.Add(sb.ToString());
+                sb.Clear();
+            }
+            else
+                sb.Append(c);
+        }
+        result.Add(sb.ToString());
+        return result;
+    }
+}

--- a/src/runfaster/LeakWatch.cs
+++ b/src/runfaster/LeakWatch.cs
@@ -274,6 +274,22 @@ static class LeakWatchCountersCsv
             map[name] = value;
         }
 
+        // The complete heap-generation key set = the richest block's set. dotnet-counters
+        // emits each generation (gen0/gen1/gen2/loh/poh) as a SEPARATE CSV row, and the
+        // exact set varies by runtime version (poh did not exist before .NET 5). A
+        // Ctrl+C capture can tear a block anywhere — before all heap rows, or in the
+        // middle of them — so validating by "any heap row present" or a fixed generation
+        // list is unsafe. Deriving the reference set from the data lets us drop any block
+        // (terminal or mid-stream) whose generation set is incomplete, while keeping a
+        // complete final block (which the last-sample steady-state model depends on).
+        var referenceGens = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var ts in order)
+        {
+            var gens = HeapGenKeys(byTimestamp[ts]);
+            if (gens.Count > referenceGens.Count)
+                referenceGens = gens;
+        }
+
         var samples = new List<LeakWatchSample>(order.Count);
         double? firstSeconds = null;
         DateTime? firstTime = null;
@@ -283,12 +299,11 @@ static class LeakWatchCountersCsv
             // A sample must carry a working-set reading to be meaningful.
             if (!map.TryGetValue(WorkingSet, out double ws))
                 continue;
-            // ...and a live-heap reading. dotnet-counters flushes a timestamp block's
-            // rows sequentially, so an abruptly-terminated capture (Ctrl+C) commonly
-            // leaves the final block with a working-set row but no heap-generation rows.
-            // Emitting that truncated block would read the live heap as 0 and invert the
-            // steady-state verdict, so drop any block without heap data.
-            if (!HasHeapReading(map))
+            // ...and a COMPLETE live-heap reading. A block missing any of the reference
+            // generation rows (a torn Ctrl+C capture) would compute the live heap from a
+            // subset — erasing whole generations — and invert the steady-state verdict,
+            // so drop any block whose generation set is not complete.
+            if (referenceGens.Count == 0 || !referenceGens.IsSubsetOf(HeapGenKeys(map)))
                 continue;
 
             long liveHeap = (long)(
@@ -324,16 +339,17 @@ static class LeakWatchCountersCsv
     static double Gen(Dictionary<string, double> map, string gen)
         => Get(map, $"dotnet.gc.last_collection.heap.size (By)[gc.heap.generation={gen}]");
 
-    // A timestamp block is complete enough to trust as a steady-state anchor only if it
-    // carries at least one live-heap generation reading.
-    static bool HasHeapReading(Dictionary<string, double> map)
+    // The heap-generation keys present in a timestamp block. dotnet-counters emits each
+    // generation as a separate row; a complete block carries the full set.
+    static HashSet<string> HeapGenKeys(Dictionary<string, double> map)
     {
+        var gens = new HashSet<string>(StringComparer.Ordinal);
         foreach (var k in map.Keys)
         {
             if (k.StartsWith("dotnet.gc.last_collection.heap.size", StringComparison.Ordinal))
-                return true;
+                gens.Add(k);
         }
-        return false;
+        return gens;
     }
 
     static double Get(Dictionary<string, double> map, string name)

--- a/src/runfaster/LeakWatch.cs
+++ b/src/runfaster/LeakWatch.cs
@@ -101,63 +101,44 @@ static class LeakWatchAnalyzer
         long reclaimThreshold = (long)(thresholds.RetainedGapBytes / 4);
         long liveHeapBase = Math.Max(liveHeapFirst, 16L * 1024 * 1024);
 
-        // Index of the live-heap high-water mark.
-        int liveHeapPeakIndex = 0;
-        for (int i = 1; i < samples.Count; i++)
-        {
-            if (samples[i].LiveHeap > samples[liveHeapPeakIndex].LiveHeap)
-                liveHeapPeakIndex = i;
-        }
-
-        // The level the live heap SETTLES to from its peak onward — the retained floor.
-        // A managed leak is distinguished not by whether the heap dropped at all (a
-        // collection reclaiming transient churn can still leave a large leak behind) but
-        // by whether that floor stays far above the baseline. Reclaiming 200 MB of churn
-        // while 10 GB stays resident is retention, not a clean collection.
-        long retainedLiveFloor = samples[liveHeapPeakIndex].LiveHeap;
-        int retainedFloorIndex = liveHeapPeakIndex;
-        for (int i = liveHeapPeakIndex; i < samples.Count; i++)
-        {
-            if (samples[i].LiveHeap < retainedLiveFloor)
-            {
-                retainedLiveFloor = samples[i].LiveHeap;
-                retainedFloorIndex = i;
-            }
-        }
+        // Steady-state ("retained") footprint at the END of the window, resistant to a
+        // single final-sample blip (a GC dip or a transient spike) by taking the median
+        // of the last few samples. Retention is about what the process is STILL holding
+        // at the end relative to its baseline — not the global peak. Anchoring to global
+        // peaks blinds the model to leaks smaller than a historical transient spike, and
+        // to steady-state gaps that never peaked (a pure native leak on a flat heap).
+        long liveHeapRetained = TailMedian(samples, static s => s.LiveHeap);
+        long wsRetained = TailMedian(samples, static s => s.WorkingSet);
 
         bool gen2CollectionObserved = samples.Any(s => s.Gen2CollectionsInWindow > 0);
 
-        // The heap grew significantly from its baseline.
-        bool grewSignificantly = liveHeapPeak >= liveHeapBase * thresholds.ManagedGrowthFactor
-            && liveHeapPeak - liveHeapFirst >= thresholds.RetainedGapBytes;
-        // A collection returned the heap toward its baseline (came back down), as opposed
-        // to reclaiming only a slice while a large amount stays resident.
-        bool heapReturnedToBaseline = retainedLiveFloor <= liveHeapBase * 3 / 2
-            && liveHeapPeak - retainedLiveFloor >= reclaimThreshold;
-        // "Reclaimed" for verdict purposes: a collection brought the heap back toward
-        // baseline (independent of whether it had grown significantly first).
+        // How much managed heap is still held above baseline at the end of the window.
+        long managedRetained = liveHeapRetained - liveHeapBase;
+        // How much RSS is still held above the live managed heap at the end: this memory
+        // is, by construction, not live managed objects — native allocation or
+        // GC-committed segments the runtime returns to the OS lazily.
+        long nativeGap = wsRetained - liveHeapRetained;
+
+        // The heap peaked well above where it SETTLED and settled near baseline: the
+        // transient-churn signature (peaked high, came back down). Independent of whether
+        // it had grown significantly first, so ChurnStorm still fires on collected churn.
+        bool heapReturnedToBaseline = liveHeapPeak - liveHeapRetained >= reclaimThreshold
+            && liveHeapRetained <= liveHeapBase * 3 / 2;
         bool heapReclaimedByGen2 = heapReturnedToBaseline;
 
-        // The working-set floor at/after the retained live-heap floor: does RSS follow
-        // the heap down?
-        long retainedFloorAfterGen2 = long.MaxValue;
-        long liveHeapAtFloor = samples[retainedFloorIndex].LiveHeap;
-        for (int i = retainedFloorIndex; i < samples.Count; i++)
-        {
-            if (samples[i].WorkingSet < retainedFloorAfterGen2)
-            {
-                retainedFloorAfterGen2 = samples[i].WorkingSet;
-                liveHeapAtFloor = samples[i].LiveHeap;
-            }
-        }
-        long liveHeapFloorAfterPeak = retainedLiveFloor;
-
-        // Working set must actually GROW over the window for a growth verdict; a stable
-        // high native baseline (large gap but flat) is not growth.
+        // Working set must actually GROW over the window for a native/committed growth
+        // verdict: a stable high native baseline (large gap but flat) is a fixed
+        // footprint, not a leak.
         bool workingSetGrew = wsPeak >= wsFirst + thresholds.RetainedGapBytes;
 
-        double gapRatio = liveHeapPeak > 0 ? (double)wsPeak / liveHeapPeak : 0;
-        long retainedGap = retainedFloorAfterGen2 - liveHeapAtFloor;
+        // gapRatio compares the STEADY-STATE working set to the steady-state live heap
+        // (not global peak to global peak): a committed-memory gap that persists after
+        // the heap drops from a churn spike would be invisible to a peak/peak ratio.
+        double gapRatio = liveHeapRetained > 0 ? (double)wsRetained / liveHeapRetained : 0;
+        long retainedGap = nativeGap;
+        long retainedFloorAfterGen2 = wsRetained;
+        long liveHeapAtFloor = liveHeapRetained;
+        long liveHeapFloorAfterPeak = liveHeapRetained;
         string afterCollectionClause = heapReclaimedByGen2 || gen2CollectionObserved
             ? " after a gen2 collection reclaimed the heap"
             : "";
@@ -171,45 +152,51 @@ static class LeakWatchAnalyzer
         if (threadGrowth > 0)
             notes.Add($"Thread count grew by {threadGrowth} over the window.");
 
-        // Decision order: a genuine managed leak (heap grows and is NOT reclaimed) is
-        // the most serious; then RSS-not-returned while the working set grows; then a
-        // collectible churn storm; else healthy. All growth verdicts require the
-        // working set (or live heap) to actually grow — a stable high baseline is not a
-        // leak.
+        // Decision order:
+        //  1. Native/committed growth (RSS held far above the live heap at steady state,
+        //     and the working set grew) is checked FIRST: RSS above the live heap is
+        //     unambiguously not-live-managed-objects, so when both a native gap and a
+        //     heap rise coexist (e.g. an uncollected churn window with committed
+        //     over-reservation) the native gap is the certain signal.
+        //  2. Managed retention (the live heap is still held far above baseline at the
+        //     end) — a genuine managed leak.
+        //  3. Collectible churn storm (high GC pause, heap peaked and came back).
+        //  4. Healthy.
+        // All growth verdicts are evaluated at steady state (tail), not global peak.
         LeakWatchVerdict verdict;
         string headline;
 
         bool highChurn = duration > 0 && pauseFraction >= thresholds.PauseFraction;
 
-        if (grewSignificantly && !heapReturnedToBaseline)
-        {
-            verdict = LeakWatchVerdict.ManagedRetention;
-            headline = $"Managed retention: live GC heap grew to {Fmt(liveHeapPeak)} and stayed at {Fmt(retainedLiveFloor)} at its post-peak floor — a collection did not return it to baseline, so it is a managed leak. Capture a gcdump and inspect the top retained types.";
-            notes.Add("The growth is on the managed heap and survives collection: this is the class the static ArrayPool leak-triage targets, and a gcdump will name the retained roots.");
-        }
-        else if (workingSetGrew && gapRatio >= thresholds.GapRatio && retainedGap >= thresholds.RetainedGapBytes)
+        if (workingSetGrew && gapRatio >= thresholds.GapRatio && nativeGap >= thresholds.RetainedGapBytes)
         {
             verdict = LeakWatchVerdict.NativeOrCommittedGrowth;
-            headline = $"Native/committed growth: working set grew to {Fmt(wsPeak)} ({gapRatio:F1}× the {Fmt(liveHeapPeak)} live-heap peak) and stayed {Fmt(retainedGap)} above the live heap{afterCollectionClause}. RSS is not following the heap down — native allocation or GC-committed regions returned to the OS lazily.";
+            headline = $"Native/committed growth: working set grew to {Fmt(wsPeak)} and holds {Fmt(wsRetained)} ({gapRatio:F1}× the {Fmt(liveHeapRetained)} live heap) — staying {Fmt(nativeGap)} above the live heap{afterCollectionClause}. RSS is not following the heap down — native allocation or GC-committed regions returned to the OS lazily.";
             if (heapReclaimedByGen2)
-                notes.Add($"The live heap fell to {Fmt(liveHeapFloorAfterPeak)} after its peak, but the working set held {Fmt(retainedFloorAfterGen2)} — the gap is off the managed heap.");
+                notes.Add($"The live heap fell to {Fmt(liveHeapFloorAfterPeak)} from its {Fmt(liveHeapPeak)} peak, but the working set held {Fmt(retainedFloorAfterGen2)} — the gap is off the managed heap.");
             else
                 notes.Add("No collection was observed reclaiming the heap in this window; the gap is measured at the end of the sample. A longer sample (spanning a gen2 collection) or a gcdump confirms whether the managed heap is collectible.");
             if (highChurn)
                 notes.Add("High allocation churn + GC pause alongside this suggests an allocation storm (e.g. heavy parallel work) driving both promotion and committed growth; reducing allocation rate / parallelism typically shrinks the footprint.");
         }
+        else if (managedRetained >= thresholds.RetainedGapBytes)
+        {
+            verdict = LeakWatchVerdict.ManagedRetention;
+            headline = $"Managed retention: the live GC heap is holding {Fmt(liveHeapRetained)} at steady state — {Fmt(managedRetained)} above its {Fmt(liveHeapBase)} baseline — and a collection did not return it, so it is a managed leak. Capture a gcdump and inspect the top retained types.";
+            notes.Add("The growth is on the managed heap and survives collection: this is the class the static ArrayPool leak-triage targets, and a gcdump will name the retained roots.");
+        }
         else if (highChurn && heapReclaimedByGen2)
         {
             verdict = LeakWatchVerdict.ChurnStorm;
-            headline = $"Churn storm (collectible): {Fmt(totalAllocated)} allocated with {pauseFraction * 100:F0}% GC pause, but a collection reclaims the heap — high allocation rate, not a leak. Reduce allocation rate or parallelism.";
+            headline = $"Churn storm (collectible): {Fmt(totalAllocated)} allocated with {pauseFraction * 100:F0}% GC pause, but the heap peaked at {Fmt(liveHeapPeak)} and settled back to {Fmt(liveHeapRetained)} — high allocation rate, not a leak. Reduce allocation rate or parallelism.";
             notes.Add("An allocation-rate join would rank the hot allocators here, but the heap is collectible: this is churn, not retention.");
         }
         else
         {
             verdict = LeakWatchVerdict.Healthy;
             headline = workingSetGrew
-                ? $"No leak signature: working set grew to {Fmt(wsPeak)} but tracks the live heap ({Fmt(liveHeapPeak)} peak) — no retention or native-growth gap."
-                : $"Healthy: working set ({Fmt(wsPeak)} peak) is stable and tracks the live heap ({Fmt(liveHeapPeak)} peak); no growth signature.";
+                ? $"No leak signature: working set grew to {Fmt(wsPeak)} but the steady-state {Fmt(wsRetained)} tracks the {Fmt(liveHeapRetained)} live heap — no retention or native-growth gap."
+                : $"Healthy: working set ({Fmt(wsPeak)} peak) is stable and tracks the live heap ({Fmt(liveHeapRetained)} retained); no growth signature.";
             if (!workingSetGrew && gapRatio >= thresholds.GapRatio)
                 notes.Add($"The working set sits {gapRatio:F1}× above the live heap but is stable (not growing): a fixed native/committed baseline, not a leak.");
         }
@@ -219,6 +206,19 @@ static class LeakWatchAnalyzer
             retainedFloorAfterGen2, liveHeapAtFloor, gapRatio, totalAllocated,
             duration, pauseFraction, gen2Collections, heapReclaimedByGen2,
             Math.Max(threadGrowth, 0), notes.ToImmutable());
+    }
+
+    // Steady-state estimator: the median of the last few samples, resistant to a single
+    // final-sample blip (a transient GC dip or spike) while still reflecting the
+    // end-of-window footprint rather than a historical peak.
+    static long TailMedian(IReadOnlyList<LeakWatchSample> samples, Func<LeakWatchSample, long> selector)
+    {
+        int k = Math.Min(3, samples.Count);
+        var tail = new long[k];
+        for (int i = 0; i < k; i++)
+            tail[i] = selector(samples[samples.Count - k + i]);
+        Array.Sort(tail);
+        return tail[tail.Length / 2];
     }
 
     static string Fmt(long bytes)

--- a/src/runfaster/LeakWatch.cs
+++ b/src/runfaster/LeakWatch.cs
@@ -99,10 +99,9 @@ static class LeakWatchAnalyzer
         int threadGrowth = samples.Max(s => s.Threads) - samples[0].Threads;
 
         long reclaimThreshold = (long)(thresholds.RetainedGapBytes / 4);
+        long liveHeapBase = Math.Max(liveHeapFirst, 16L * 1024 * 1024);
 
-        // Index of the live-heap high-water mark. "Reclaimed" only counts if the TOTAL
-        // live heap (not just gen2) falls substantially AFTER that peak — a collection
-        // that fired before later monotonic growth must not mask a real leak.
+        // Index of the live-heap high-water mark.
         int liveHeapPeakIndex = 0;
         for (int i = 1; i < samples.Count; i++)
         {
@@ -110,47 +109,48 @@ static class LeakWatchAnalyzer
                 liveHeapPeakIndex = i;
         }
 
-        bool heapReclaimedAfterPeak = false;
-        int reclaimIndex = -1;
-        long liveHeapFloorAfterPeak = liveHeapPeak;
-        for (int i = liveHeapPeakIndex + 1; i < samples.Count; i++)
+        // The level the live heap SETTLES to from its peak onward — the retained floor.
+        // A managed leak is distinguished not by whether the heap dropped at all (a
+        // collection reclaiming transient churn can still leave a large leak behind) but
+        // by whether that floor stays far above the baseline. Reclaiming 200 MB of churn
+        // while 10 GB stays resident is retention, not a clean collection.
+        long retainedLiveFloor = samples[liveHeapPeakIndex].LiveHeap;
+        int retainedFloorIndex = liveHeapPeakIndex;
+        for (int i = liveHeapPeakIndex; i < samples.Count; i++)
         {
-            if (samples[i].LiveHeap < liveHeapPeak - reclaimThreshold)
+            if (samples[i].LiveHeap < retainedLiveFloor)
             {
-                heapReclaimedAfterPeak = true;
-                if (samples[i].LiveHeap < liveHeapFloorAfterPeak)
-                {
-                    liveHeapFloorAfterPeak = samples[i].LiveHeap;
-                    reclaimIndex = i;
-                }
+                retainedLiveFloor = samples[i].LiveHeap;
+                retainedFloorIndex = i;
             }
         }
-        bool gen2CollectionObserved = samples.Any(s => s.Gen2CollectionsInWindow > 0);
-        bool heapReclaimedByGen2 = heapReclaimedAfterPeak;
 
-        // The working-set floor after the live-heap was reclaimed: does RSS follow the
-        // heap down? Only meaningful when a reclaim was actually observed; otherwise the
-        // relevant gap is simply the end-of-window gap.
-        long retainedFloorAfterGen2;
-        long liveHeapAtFloor;
-        if (reclaimIndex >= 0)
+        bool gen2CollectionObserved = samples.Any(s => s.Gen2CollectionsInWindow > 0);
+
+        // The heap grew significantly from its baseline.
+        bool grewSignificantly = liveHeapPeak >= liveHeapBase * thresholds.ManagedGrowthFactor
+            && liveHeapPeak - liveHeapFirst >= thresholds.RetainedGapBytes;
+        // A collection returned the heap toward its baseline (came back down), as opposed
+        // to reclaiming only a slice while a large amount stays resident.
+        bool heapReturnedToBaseline = retainedLiveFloor <= liveHeapBase * 3 / 2
+            && liveHeapPeak - retainedLiveFloor >= reclaimThreshold;
+        // "Reclaimed" for verdict purposes: a collection brought the heap back toward
+        // baseline (independent of whether it had grown significantly first).
+        bool heapReclaimedByGen2 = heapReturnedToBaseline;
+
+        // The working-set floor at/after the retained live-heap floor: does RSS follow
+        // the heap down?
+        long retainedFloorAfterGen2 = long.MaxValue;
+        long liveHeapAtFloor = samples[retainedFloorIndex].LiveHeap;
+        for (int i = retainedFloorIndex; i < samples.Count; i++)
         {
-            retainedFloorAfterGen2 = long.MaxValue;
-            liveHeapAtFloor = liveHeapLast;
-            for (int i = reclaimIndex; i < samples.Count; i++)
+            if (samples[i].WorkingSet < retainedFloorAfterGen2)
             {
-                if (samples[i].WorkingSet < retainedFloorAfterGen2)
-                {
-                    retainedFloorAfterGen2 = samples[i].WorkingSet;
-                    liveHeapAtFloor = samples[i].LiveHeap;
-                }
+                retainedFloorAfterGen2 = samples[i].WorkingSet;
+                liveHeapAtFloor = samples[i].LiveHeap;
             }
         }
-        else
-        {
-            retainedFloorAfterGen2 = wsLast;
-            liveHeapAtFloor = liveHeapLast;
-        }
+        long liveHeapFloorAfterPeak = retainedLiveFloor;
 
         // Working set must actually GROW over the window for a growth verdict; a stable
         // high native baseline (large gap but flat) is not growth.
@@ -179,16 +179,12 @@ static class LeakWatchAnalyzer
         LeakWatchVerdict verdict;
         string headline;
 
-        // Growth relative to a small floor so a heap that starts near zero is not missed.
-        long liveHeapBase = Math.Max(liveHeapFirst, 16L * 1024 * 1024);
-        bool liveHeapGrew = liveHeapPeak > liveHeapBase * thresholds.ManagedGrowthFactor
-            && liveHeapPeak - liveHeapFirst >= thresholds.RetainedGapBytes;
         bool highChurn = duration > 0 && pauseFraction >= thresholds.PauseFraction;
 
-        if (liveHeapGrew && !heapReclaimedByGen2)
+        if (grewSignificantly && !heapReturnedToBaseline)
         {
             verdict = LeakWatchVerdict.ManagedRetention;
-            headline = $"Managed retention: live GC heap grew to {Fmt(liveHeapPeak)} and no collection reclaimed it — a managed leak. Capture a gcdump and inspect the top retained types.";
+            headline = $"Managed retention: live GC heap grew to {Fmt(liveHeapPeak)} and stayed at {Fmt(retainedLiveFloor)} at its post-peak floor — a collection did not return it to baseline, so it is a managed leak. Capture a gcdump and inspect the top retained types.";
             notes.Add("The growth is on the managed heap and survives collection: this is the class the static ArrayPool leak-triage targets, and a gcdump will name the retained roots.");
         }
         else if (workingSetGrew && gapRatio >= thresholds.GapRatio && retainedGap >= thresholds.RetainedGapBytes)

--- a/src/runfaster/LeakWatch.cs
+++ b/src/runfaster/LeakWatch.cs
@@ -101,14 +101,20 @@ static class LeakWatchAnalyzer
         long reclaimThreshold = (long)(thresholds.RetainedGapBytes / 4);
         long liveHeapBase = Math.Max(liveHeapFirst, 16L * 1024 * 1024);
 
-        // Steady-state ("retained") footprint at the END of the window, resistant to a
-        // single final-sample blip (a GC dip or a transient spike) by taking the median
-        // of the last few samples. Retention is about what the process is STILL holding
-        // at the end relative to its baseline — not the global peak. Anchoring to global
-        // peaks blinds the model to leaks smaller than a historical transient spike, and
-        // to steady-state gaps that never peaked (a pure native leak on a flat heap).
-        long liveHeapRetained = TailMedian(samples, static s => s.LiveHeap);
-        long wsRetained = TailMedian(samples, static s => s.WorkingSet);
+        // Steady-state ("retained") footprint = the LAST sample. Retention is about what
+        // the process is STILL holding at the end relative to its baseline — not the
+        // global peak (which blinds the model to leaks smaller than a historical spike,
+        // and to steady gaps that never peaked). The last sample is the most current
+        // truth: it respects a terminal collection (e.g. the forced GC a gcdump capture
+        // triggers, ending the trace on the real reclaimed footprint) and captures the
+        // full size of a still-climbing linear leak — a mid-tail smoother (median) would
+        // corrupt both (a monotonic tail's median falls below the final level; a
+        // terminal-GC tail's median stays at the pre-collection peak). The one residual
+        // is a single transient upward spike on the final sample, which can over-flag
+        // ManagedRetention; a gcdump disambiguates that, and it errs toward catching
+        // leaks rather than hiding them.
+        long liveHeapRetained = liveHeapLast;
+        long wsRetained = wsLast;
 
         bool gen2CollectionObserved = samples.Any(s => s.Gen2CollectionsInWindow > 0);
 
@@ -206,19 +212,6 @@ static class LeakWatchAnalyzer
             retainedFloorAfterGen2, liveHeapAtFloor, gapRatio, totalAllocated,
             duration, pauseFraction, gen2Collections, heapReclaimedByGen2,
             Math.Max(threadGrowth, 0), notes.ToImmutable());
-    }
-
-    // Steady-state estimator: the median of the last few samples, resistant to a single
-    // final-sample blip (a transient GC dip or spike) while still reflecting the
-    // end-of-window footprint rather than a historical peak.
-    static long TailMedian(IReadOnlyList<LeakWatchSample> samples, Func<LeakWatchSample, long> selector)
-    {
-        int k = Math.Min(3, samples.Count);
-        var tail = new long[k];
-        for (int i = 0; i < k; i++)
-            tail[i] = selector(samples[samples.Count - k + i]);
-        Array.Sort(tail);
-        return tail[tail.Length / 2];
     }
 
     static string Fmt(long bytes)

--- a/src/runfaster/LeakWatch.cs
+++ b/src/runfaster/LeakWatch.cs
@@ -98,37 +98,46 @@ static class LeakWatchAnalyzer
         int gen2Collections = (int)Math.Round(samples.Sum(s => s.Gen2CollectionsInWindow));
         int threadGrowth = samples.Max(s => s.Threads) - samples[0].Threads;
 
-        // A gen2 collection is evidenced either by the collections-rate counter firing
-        // or by the last-collection gen2 size dropping below the running maximum.
-        long runningGen2Max = long.MinValue;
-        int lastGen2CollectionIndex = -1;
-        long gen2HighWater = 0;
-        long gen2AfterLowest = long.MaxValue;
-        for (int i = 0; i < samples.Count; i++)
+        long reclaimThreshold = (long)(thresholds.RetainedGapBytes / 4);
+
+        // Index of the live-heap high-water mark. "Reclaimed" only counts if the TOTAL
+        // live heap (not just gen2) falls substantially AFTER that peak — a collection
+        // that fired before later monotonic growth must not mask a real leak.
+        int liveHeapPeakIndex = 0;
+        for (int i = 1; i < samples.Count; i++)
         {
-            var s = samples[i];
-            gen2HighWater = Math.Max(gen2HighWater, s.Gen2);
-            bool collected = s.Gen2CollectionsInWindow > 0
-                || (runningGen2Max != long.MinValue && s.Gen2 < runningGen2Max - thresholds.RetainedGapBytes / 4);
-            if (collected)
-            {
-                lastGen2CollectionIndex = i;
-                gen2AfterLowest = Math.Min(gen2AfterLowest, s.Gen2);
-            }
-            runningGen2Max = Math.Max(runningGen2Max, s.Gen2);
+            if (samples[i].LiveHeap > samples[liveHeapPeakIndex].LiveHeap)
+                liveHeapPeakIndex = i;
         }
 
-        bool heapReclaimedByGen2 = lastGen2CollectionIndex >= 0
-            && gen2AfterLowest < gen2HighWater - thresholds.RetainedGapBytes / 4;
+        bool heapReclaimedAfterPeak = false;
+        int reclaimIndex = -1;
+        long liveHeapFloorAfterPeak = liveHeapPeak;
+        for (int i = liveHeapPeakIndex + 1; i < samples.Count; i++)
+        {
+            if (samples[i].LiveHeap < liveHeapPeak - reclaimThreshold)
+            {
+                heapReclaimedAfterPeak = true;
+                if (samples[i].LiveHeap < liveHeapFloorAfterPeak)
+                {
+                    liveHeapFloorAfterPeak = samples[i].LiveHeap;
+                    reclaimIndex = i;
+                }
+            }
+        }
+        bool gen2CollectionObserved = samples.Any(s => s.Gen2CollectionsInWindow > 0);
+        bool heapReclaimedByGen2 = heapReclaimedAfterPeak;
 
-        // The working-set floor and the live heap after the last observed gen2
-        // collection: does RSS follow the heap down?
-        long retainedFloorAfterGen2 = wsLast;
-        long liveHeapAtFloor = liveHeapLast;
-        if (lastGen2CollectionIndex >= 0)
+        // The working-set floor after the live-heap was reclaimed: does RSS follow the
+        // heap down? Only meaningful when a reclaim was actually observed; otherwise the
+        // relevant gap is simply the end-of-window gap.
+        long retainedFloorAfterGen2;
+        long liveHeapAtFloor;
+        if (reclaimIndex >= 0)
         {
             retainedFloorAfterGen2 = long.MaxValue;
-            for (int i = lastGen2CollectionIndex; i < samples.Count; i++)
+            liveHeapAtFloor = liveHeapLast;
+            for (int i = reclaimIndex; i < samples.Count; i++)
             {
                 if (samples[i].WorkingSet < retainedFloorAfterGen2)
                 {
@@ -137,9 +146,21 @@ static class LeakWatchAnalyzer
                 }
             }
         }
+        else
+        {
+            retainedFloorAfterGen2 = wsLast;
+            liveHeapAtFloor = liveHeapLast;
+        }
+
+        // Working set must actually GROW over the window for a growth verdict; a stable
+        // high native baseline (large gap but flat) is not growth.
+        bool workingSetGrew = wsPeak >= wsFirst + thresholds.RetainedGapBytes;
 
         double gapRatio = liveHeapPeak > 0 ? (double)wsPeak / liveHeapPeak : 0;
         long retainedGap = retainedFloorAfterGen2 - liveHeapAtFloor;
+        string afterCollectionClause = heapReclaimedByGen2 || gen2CollectionObserved
+            ? " after a gen2 collection reclaimed the heap"
+            : "";
 
         var notes = ImmutableArray.CreateBuilder<string>();
         notes.Add($"Working set: {Fmt(wsFirst)} → peak {Fmt(wsPeak)} → {Fmt(wsLast)} over {duration:F0}s.");
@@ -150,46 +171,51 @@ static class LeakWatchAnalyzer
         if (threadGrowth > 0)
             notes.Add($"Thread count grew by {threadGrowth} over the window.");
 
-        // Decision order: a genuine managed leak (heap not reclaimed) is the most
-        // serious; then RSS-not-returned after a real reclaim; then a collectible
-        // churn storm; else healthy.
+        // Decision order: a genuine managed leak (heap grows and is NOT reclaimed) is
+        // the most serious; then RSS-not-returned while the working set grows; then a
+        // collectible churn storm; else healthy. All growth verdicts require the
+        // working set (or live heap) to actually grow — a stable high baseline is not a
+        // leak.
         LeakWatchVerdict verdict;
         string headline;
 
-        bool liveHeapGrew = liveHeapLast > liveHeapFirst * thresholds.ManagedGrowthFactor
-            && liveHeapPeak > liveHeapFirst * thresholds.ManagedGrowthFactor;
+        // Growth relative to a small floor so a heap that starts near zero is not missed.
+        long liveHeapBase = Math.Max(liveHeapFirst, 16L * 1024 * 1024);
+        bool liveHeapGrew = liveHeapPeak > liveHeapBase * thresholds.ManagedGrowthFactor
+            && liveHeapPeak - liveHeapFirst >= thresholds.RetainedGapBytes;
         bool highChurn = duration > 0 && pauseFraction >= thresholds.PauseFraction;
 
         if (liveHeapGrew && !heapReclaimedByGen2)
         {
             verdict = LeakWatchVerdict.ManagedRetention;
-            headline = $"Managed retention: live GC heap grew to {Fmt(liveHeapPeak)} and a gen2 collection did not reclaim it — a managed leak. Capture a gcdump and inspect the top retained types.";
+            headline = $"Managed retention: live GC heap grew to {Fmt(liveHeapPeak)} and no collection reclaimed it — a managed leak. Capture a gcdump and inspect the top retained types.";
             notes.Add("The growth is on the managed heap and survives collection: this is the class the static ArrayPool leak-triage targets, and a gcdump will name the retained roots.");
         }
-        else if (gapRatio >= thresholds.GapRatio && retainedGap >= thresholds.RetainedGapBytes)
+        else if (workingSetGrew && gapRatio >= thresholds.GapRatio && retainedGap >= thresholds.RetainedGapBytes)
         {
             verdict = LeakWatchVerdict.NativeOrCommittedGrowth;
-            headline = $"Native/committed growth: working set peaked at {Fmt(wsPeak)} ({gapRatio:F1}× the {Fmt(liveHeapPeak)} live-heap peak) and stayed {Fmt(retainedGap)} above the live heap after a gen2 collection. RSS is not following the heap down — native allocation or GC-committed regions returned to the OS lazily.";
+            headline = $"Native/committed growth: working set grew to {Fmt(wsPeak)} ({gapRatio:F1}× the {Fmt(liveHeapPeak)} live-heap peak) and stayed {Fmt(retainedGap)} above the live heap{afterCollectionClause}. RSS is not following the heap down — native allocation or GC-committed regions returned to the OS lazily.";
             if (heapReclaimedByGen2)
-                notes.Add($"A gen2 collection reclaimed the managed heap (to ~{Fmt(gen2AfterLowest)} gen2), but the working set held {Fmt(retainedFloorAfterGen2)} — the gap is off the managed heap.");
+                notes.Add($"The live heap fell to {Fmt(liveHeapFloorAfterPeak)} after its peak, but the working set held {Fmt(retainedFloorAfterGen2)} — the gap is off the managed heap.");
+            else
+                notes.Add("No collection was observed reclaiming the heap in this window; the gap is measured at the end of the sample. A longer sample (spanning a gen2 collection) or a gcdump confirms whether the managed heap is collectible.");
             if (highChurn)
                 notes.Add("High allocation churn + GC pause alongside this suggests an allocation storm (e.g. heavy parallel work) driving both promotion and committed growth; reducing allocation rate / parallelism typically shrinks the footprint.");
         }
         else if (highChurn && heapReclaimedByGen2)
         {
             verdict = LeakWatchVerdict.ChurnStorm;
-            headline = $"Churn storm (collectible): {Fmt(totalAllocated)} allocated with {pauseFraction * 100:F0}% GC pause, but a gen2 collection reclaims the heap — high allocation rate, not a leak. Reduce allocation rate or parallelism.";
+            headline = $"Churn storm (collectible): {Fmt(totalAllocated)} allocated with {pauseFraction * 100:F0}% GC pause, but a collection reclaims the heap — high allocation rate, not a leak. Reduce allocation rate or parallelism.";
             notes.Add("An allocation-rate join would rank the hot allocators here, but the heap is collectible: this is churn, not retention.");
-        }
-        else if (gapRatio >= thresholds.GapRatio)
-        {
-            verdict = LeakWatchVerdict.NativeOrCommittedGrowth;
-            headline = $"Elevated footprint: working set ({Fmt(wsPeak)}) ran {gapRatio:F1}× the live-heap peak ({Fmt(liveHeapPeak)}). Watch for native or GC-committed growth; a longer sample or a gcdump will confirm whether it is retained.";
         }
         else
         {
             verdict = LeakWatchVerdict.Healthy;
-            headline = $"Healthy: working set ({Fmt(wsPeak)} peak) tracks the live heap ({Fmt(liveHeapPeak)} peak); no retention or native-growth signature.";
+            headline = workingSetGrew
+                ? $"No leak signature: working set grew to {Fmt(wsPeak)} but tracks the live heap ({Fmt(liveHeapPeak)} peak) — no retention or native-growth gap."
+                : $"Healthy: working set ({Fmt(wsPeak)} peak) is stable and tracks the live heap ({Fmt(liveHeapPeak)} peak); no growth signature.";
+            if (!workingSetGrew && gapRatio >= thresholds.GapRatio)
+                notes.Add($"The working set sits {gapRatio:F1}× above the live heap but is stable (not growing): a fixed native/committed baseline, not a leak.");
         }
 
         return new LeakWatchResult(

--- a/src/runfaster/Program.cs
+++ b/src/runfaster/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Diagnostics.Tracing.Etlx;
 
 var root = new RootCommand("runfaster - correlate dotnet-* diagnostic artifacts with static .NET library allocation evidence");
 root.Subcommands.Add(CreateCorrelateCommand());
+root.Subcommands.Add(CreateLeakWatchCommand());
 root.SetAction(parseResult =>
 {
     if (parseResult.Tokens.Count == 0)
@@ -138,6 +139,115 @@ static Command CreateCorrelateCommand()
     });
 
     return command;
+}
+
+static Command CreateLeakWatchCommand()
+{
+    var command = new Command("leak-watch", "Classify process memory growth (managed retention vs churn vs native/committed) from a dotnet-counters System.Runtime CSV");
+
+    var countersOption = new Option<string>("--counters")
+    {
+        Description = "dotnet-counters CSV: `dotnet-counters collect --process-id <pid> --counters System.Runtime --format csv -o <file>`",
+        Required = true,
+    };
+    var gcdumpReportOption = new Option<string>("--gcdump-report")
+    {
+        Description = "Optional `dotnet-gcdump report <file.gcdump>` text: top retained types shown alongside the verdict",
+    };
+    var jsonOption = new Option<bool>("--json") { Description = "Emit the result as JSON" };
+
+    command.Options.Add(countersOption);
+    command.Options.Add(gcdumpReportOption);
+    command.Options.Add(jsonOption);
+
+    command.SetAction(parseResult =>
+    {
+        string countersPath = parseResult.GetValue(countersOption)!;
+        if (!File.Exists(countersPath))
+        {
+            Console.Error.WriteLine($"Error: counters file not found: {countersPath}");
+            return 1;
+        }
+
+        var samples = LeakWatchCountersCsv.Parse(File.ReadLines(countersPath));
+        var result = LeakWatchAnalyzer.Analyze(samples, LeakWatchThresholds.Default);
+        string? gcdumpReportPath = parseResult.GetValue(gcdumpReportOption);
+
+        if (parseResult.GetValue(jsonOption))
+            RenderLeakWatchJson(result, samples.Count);
+        else
+            RenderLeakWatchMarkdown(result, samples.Count, gcdumpReportPath);
+        return 0;
+    });
+
+    return command;
+}
+
+static void RenderLeakWatchMarkdown(LeakWatchResult result, int sampleCount, string? gcdumpReportPath)
+{
+    Console.WriteLine("# runfaster leak-watch");
+    Console.WriteLine();
+    Console.WriteLine($"Samples: {sampleCount.ToString(CultureInfo.InvariantCulture)} | Verdict: `{result.Verdict}`");
+    Console.WriteLine();
+    Console.WriteLine("## Conclusion");
+    Console.WriteLine();
+    Console.WriteLine(result.Headline);
+    Console.WriteLine();
+    Console.WriteLine("## Evidence");
+    Console.WriteLine();
+    foreach (var note in result.Notes)
+        Console.WriteLine($"- {note}");
+    Console.WriteLine();
+
+    if (gcdumpReportPath is { Length: > 0 } && File.Exists(gcdumpReportPath))
+    {
+        Console.WriteLine("## Top retained types (gcdump)");
+        Console.WriteLine();
+        Console.WriteLine("These survive a forced collection (gcdump triggers a gen2), so they name the retained roots — the 'what' behind a managed-retention verdict.");
+        Console.WriteLine();
+        Console.WriteLine("```text");
+        foreach (var line in File.ReadLines(gcdumpReportPath).Where(l => l.Trim().Length > 0).Take(12))
+            Console.WriteLine(line);
+        Console.WriteLine("```");
+        Console.WriteLine();
+    }
+
+    Console.WriteLine("## Reading the verdict");
+    Console.WriteLine();
+    Console.WriteLine("- `ManagedRetention` — the live heap grows and a gen2 collection does not reclaim it (a managed leak; a gcdump names the roots).");
+    Console.WriteLine("- `NativeOrCommittedGrowth` — the working set stays far above the live heap after a gen2 collection (native allocation or GC-committed regions returned to the OS lazily).");
+    Console.WriteLine("- `ChurnStorm` — a high allocation rate promotes to gen2 but the heap is reclaimed (allocation rate / parallelism, not a leak).");
+    Console.WriteLine("- `Healthy` — working set tracks the live heap.");
+}
+
+static void RenderLeakWatchJson(LeakWatchResult result, int sampleCount)
+{
+    using var stream = Console.OpenStandardOutput();
+    using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+    writer.WriteStartObject();
+    writer.WriteNumber("samples", sampleCount);
+    writer.WriteString("verdict", result.Verdict.ToString());
+    writer.WriteString("headline", result.Headline);
+    writer.WriteNumber("workingSetFirst", result.WorkingSetFirst);
+    writer.WriteNumber("workingSetPeak", result.WorkingSetPeak);
+    writer.WriteNumber("workingSetLast", result.WorkingSetLast);
+    writer.WriteNumber("liveHeapPeak", result.LiveHeapPeak);
+    writer.WriteNumber("retainedFloorAfterGen2", result.RetainedFloorAfterGen2);
+    writer.WriteNumber("liveHeapAtFloor", result.LiveHeapAtFloor);
+    writer.WriteNumber("gapRatio", result.GapRatio);
+    writer.WriteNumber("totalAllocated", result.TotalAllocated);
+    writer.WriteNumber("durationSeconds", result.DurationSeconds);
+    writer.WriteNumber("gcPauseFraction", result.GcPauseFraction);
+    writer.WriteNumber("gen2Collections", result.Gen2Collections);
+    writer.WriteBoolean("heapReclaimedByGen2", result.HeapReclaimedByGen2);
+    writer.WriteNumber("threadGrowth", result.ThreadGrowth);
+    writer.WriteStartArray("notes");
+    foreach (var note in result.Notes)
+        writer.WriteStringValue(note);
+    writer.WriteEndArray();
+    writer.WriteEndObject();
+    writer.Flush();
+    Console.WriteLine();
 }
 
 static Option<string[]> CreateInputOption(string name, string description) => new(name)


### PR DESCRIPTION
## Summary

Adds a `runfaster leak-watch` verb — a **dynamic memory-growth classifier** that reads a `dotnet-counters` `System.Runtime` CSV timeseries and separates three growth causes that look identical from the outside but need different fixes.

Motivated by a real incident: `ILInspector.Decompiler.Tests` reaching 10-16 GB RSS. Neither existing signal catches it cleanly — static Performance Triage sees cost-*shape* (not lifetime/frequency), and the `correlate` allocation-tick join ranks bytes *allocated* (churn), which cannot tell a collectible churn storm from a leak. This adds the missing **retention axis**.

## Verdicts

| Verdict | Signature | Fix direction |
| --- | --- | --- |
| `ManagedRetention` | live heap grows, gen2 collection does **not** reclaim it | managed leak — gcdump names the roots |
| `NativeOrCommittedGrowth` | working set stays far above the live heap **after** a gen2 collection | native alloc / GC-committed regions returned lazily |
| `ChurnStorm` | high alloc rate promotes to gen2 but the heap **is** reclaimed | allocation rate / parallelism, not a leak |
| `Healthy` | working set tracks the live heap | — |

Optionally takes `--gcdump-report <dotnet-gcdump report output>` to show the top retained types (the "what") beside the verdict.

## Validated on the real incident

```
runfaster leak-watch --counters counters.csv --gcdump-report report.txt
=> Verdict: NativeOrCommittedGrowth
   working set 10.5 GB (2.3× the 4.57 GB live-heap peak), 5.9 GB above the heap
   churn 446 MB/s, 46% GC pause; gcdump: Roslyn TextKeyedCache/GreenNode caches
```

## Tests

- 7 unit tests: one per verdict class (Healthy / NativeOrCommittedGrowth / ManagedRetention / ChurnStorm), plus CSV parsing (grouping, live-heap sum, working-set-required row skip).
- 45/45 runfaster.Tests pass.

Prototype in the CoreCLR-only `runfaster` tool; no product-path change. Complements (does not touch) the static `ILInspector.Analysis` leak-triage.

## Adversarial review

Requested from two models; reconciliation to follow.
