### PR TITLE
Add Deep Inspect opt-in validation lanes

### DIFF
--- a/.claude/skills/deep-inspect-analysis/SKILL.md
+++ b/.claude/skills/deep-inspect-analysis/SKILL.md
@@ -1,60 +1,62 @@
 ---
-name: daily-decompiler-analysis
-description: Use for morning triage of decompiler-daily runs, corpus snapshots, pinned-subset drift, and routing failures into issues or tracker updates.
+name: deep-inspect-analysis
+description: Use for opt-in Deep Inspect run triage: test lane failures, census artifacts, pinned-subset drift, and routing findings into issues or tracker updates.
 ---
 
-# Daily decompiler analysis
+# Deep Inspect analysis
 
-Use this skill when the user asks for "daily decompiler analysis" or wants the
-morning decompiler signal reviewed. Produce a short status report: whether the
-nightly decompiler signal is green, whether corpus health moved, and whether any
-result needs a durable issue, tracker row, rebaseline note, or no-action note.
+Use this skill when the user asks for Deep Inspect analysis or wants an opt-in
+validation/census run reviewed. Produce a short status report: whether the test
+lane passed, whether census health moved, and whether any result needs a durable
+issue, tracker row, rebaseline note, or no-action note.
 
 Run from the repository root and prefer `gh` for GitHub Actions and issue data.
 
 ## Read the latest runs
 
-Start with recent `decompiler-daily.yml` runs:
+Start with recent `deep-inspect.yml` runs:
 
 ```bash
-gh run list --workflow decompiler-daily.yml --limit 10 \
+gh run list --workflow deep-inspect.yml --limit 10 \
   --json databaseId,status,conclusion,createdAt,updatedAt,event,headBranch,headSha,url
 ```
 
-Pick the newest completed run, but scan the last few runs for repeated or newly
-appearing failures. For failed runs, classify the failing step before diagnosing:
+Pick the relevant completed run. Check whether it ran `lane=test`, `lane=census`,
+or `lane=all`, then classify failures by lane:
 
 ```bash
 gh run view <run-id> --json jobs,conclusion,status,createdAt,updatedAt
 gh run view <run-id> --log-failed
 ```
 
-Use these failure classes: setup/build, `ILInspector.Decompiler.Tests`,
-corpus-prep, corpus sensor, artifact upload, cancelled/environmental.
+Test-lane failure classes: setup/build, full decompiler tests, full analysis
+tests, ILAssembler restore, IL round-trip sweep, cancelled/environmental.
+Census-lane failure classes: corpus prep, corpus sensor, validity scan, validity
+sweep, assertion scan, analysis corpus sensor, paydirt recall, artifact upload,
+cancelled/environmental.
 
-## Read the corpus snapshot
+## Read census artifacts
 
-If the run produced a `decompiler-corpus-snapshot` artifact, download it to
-`/tmp`:
+If the run produced `deep-inspect-census`, download it to `/tmp`:
 
 ```bash
-rm -rf /tmp/decompiler-daily-<run-id>
-mkdir -p /tmp/decompiler-daily-<run-id>
-gh run download <run-id> -n decompiler-corpus-snapshot \
-  -D /tmp/decompiler-daily-<run-id>
+rm -rf /tmp/deep-inspect-<run-id>
+mkdir -p /tmp/deep-inspect-<run-id>
+gh run download <run-id> -n deep-inspect-census \
+  -D /tmp/deep-inspect-<run-id>
 ```
 
-Summarize the snapshot first:
+Summarize the corpus snapshot first:
 
 ```bash
 jq '{generatedUtc, validityCompileCap, fidelityCompileCap, methodCap, metrics}' \
-  /tmp/decompiler-daily-<run-id>/corpus-snapshot.json
+  /tmp/deep-inspect-<run-id>/deep-inspect/corpus-snapshot.json
 ```
 
 Then list actionable rows:
 
 ```bash
-snapshot=/tmp/decompiler-daily-<run-id>/corpus-snapshot.json
+snapshot=/tmp/deep-inspect-<run-id>/deep-inspect/corpus-snapshot.json
 
 printf '\nFULL_MALFORMED\n'
 jq -r '.methods[] | select((.validity // "") | startswith("full-malformed:")) |
@@ -75,13 +77,13 @@ jq -r '.methods[] | select(.passBug != null) |
 
 ## Separate pinned signal from repo-growth drift
 
-Daily aggregate counts include dotnet-inspect self assemblies, so repo growth can
-move totals without a decompiler regression. Treat the pinned NuGet subset as the
+Aggregate counts include dotnet-inspect self assemblies, so repo growth can move
+totals without a decompiler regression. Treat the pinned NuGet subset as the
 stable regression signal and report aggregate drift separately.
 
 ```bash
 baseline=tools/DecompilerHarness/corpus/real-world-baseline.json
-snapshot=/tmp/decompiler-daily-<run-id>/corpus-snapshot.json
+snapshot=/tmp/deep-inspect-<run-id>/deep-inspect/corpus-snapshot.json
 
 jq -n --slurpfile b "$baseline" --slurpfile c "$snapshot" '
   def pinned($s):
@@ -114,20 +116,20 @@ Use `docs/decompiler-correctness-pipeline.md` vocabulary:
 - Stage 9: corpus-card movement or baseline staleness.
 - Stage 10: changed-method fidelity/skeleton failures.
 
-Before creating new work, check #1584 for nightly triage comments and #1568 for
-active burndowns. The current pattern is to cluster repeated rows into focused
+Before creating new work, check #1584 for triage comments and #1568 for active
+burndowns. The current pattern is to cluster repeated rows into focused
 burndowns like #1687 (invalid Full printer) or #1688 (changed-method fidelity
 skeleton), not to file one issue per assembly.
 
 ## Report shape
 
-Keep the morning report short:
+Keep the report short:
 
 ```md
-Daily decompiler analysis: <green | failed | moved>
+Deep Inspect analysis: <green | failed | moved>
 
-- Latest run: <id>, <sha>, <conclusion>, <duration/link>.
-- Failure class: <none | test | corpus sensor | environment>, with root cause if known.
+- Latest run: <id>, <sha>, <lane>, <conclusion>, <duration/link>.
+- Failure class: <none | test | census | environment>, with root cause if known.
 - Corpus health: fully raised, conditional residual, forward-merge, Full malformed,
   semantic defects, pass bugs, fidelity exact/opcode-diff/recompile/context counts.
 - Pinned-subset signal: <unchanged | improved | regressed>; separate aggregate drift.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 # Cancel superseded PR runs (e.g. when an agent pushes again to the same branch)
 # so only the latest commit of a PR consumes a full CI run. Pushes to main are
 # not cancelled, but they only run the lightweight changes/markdownlint legs
-# (test/pack/pack-rid are PR-only), so there is little to cancel. release.yml
+# (test/pack are PR-only), so there is little to cancel. release.yml
 # builds all release packages fresh at publish time and does not consume CI
 # artifacts.
 concurrency:
@@ -110,15 +110,15 @@ jobs:
               *.props|*.targets|*.sln|*.slnx) ILROUNDTRIP=true ;;
             esac
             # Packaging/pack-smoke validation only needs to run when something
-            # that affects the *packaged* tool changes. pack/pack-rid only run
+            # that affects the *packaged* tool changes. The pack job runs
             # `dotnet pack src/dotnet-inspect`, so the output is determined by
             # that project's csproj plus shared build infra (root + src build
             # props/targets, global.json/nuget config) and the pack workflow
             # itself. Test/harness csproj changes and unrelated workflow edits
             # don't affect the package, so they must not trip this. Most PRs
             # (e.g. decompiler raises) touch none of these, keeping pack off the
-            # hot PR path. pack/pack-rid are a PR-only packaging smoke test and
-            # never produce release artifacts: release.yml builds all packages
+            # hot PR path. The pack job is a PR-only packaging smoke test and
+            # never produces release artifacts: release.yml builds all packages
             # fresh at publish time from the resolved commit SHA.
             case "$file" in
               src/dotnet-inspect/dotnet-inspect.csproj) PACKAGING=true ;;
@@ -500,11 +500,11 @@ jobs:
           if-no-files-found: warn
 
   # Pack and smoke test on Ubuntu. This is a packaging smoke test only: it
-  # validates that the tool still packs and installs. It is NOT the source of
-  # release artifacts (release.yml builds those itself at publish time), so it
-  # runs only on PRs that touch build/packaging configuration. Most PRs (e.g.
-  # decompiler raises) skip it, which removes two jobs from the per-PR runner
-  # demand and shortens queue times under concurrent-agent load.
+  # validates the pointer package, the any fallback, one RID-specific AOT pack,
+  # and local tool install/smoke. It is NOT the source of release artifacts
+  # (release.yml builds those itself at publish time), so it runs only on PRs
+  # that touch build/packaging configuration. Most PRs (e.g. decompiler raises)
+  # skip it, which removes packaging work from the hot PR path.
   pack:
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.packaging == 'true'
@@ -625,38 +625,3 @@ jobs:
 
       - name: Uninstall tool
         run: dotnet tool uninstall --global dotnet-inspect
-
-  # Linux-arm64 AOT pack smoke test. Like the `pack` job, this only verifies
-  # that the RID-specific AOT package builds; it is not a release artifact
-  # source (release.yml builds all RID packages at publish time). Gated to PRs
-  # that touch build/packaging configuration so it stays off the hot PR path.
-  pack-rid:
-    needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.packaging == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - rid: linux-arm64
-            os: ubuntu-26.04-arm
-
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '11.0.x'
-          dotnet-quality: 'preview'
-
-      - name: Pack RID-specific package
-        run: dotnet pack src/dotnet-inspect -c Release -r ${{ matrix.rid }} -p:OfficialAotBuild=true
-
-      - name: Upload RID package
-        uses: actions/upload-artifact@v7
-        with:
-          name: package-${{ matrix.rid }}
-          path: artifacts/package/release/*.nupkg
-          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,9 @@ jobs:
             case "$file" in
               *.md|*.txt|docs/*|skills/*) DOCS=true ;;
             esac
-            # The IL round-trip oracle is also expensive (vendored ILAssembler
-            # round-trip over a broad corpus). It depends on ILInspector.Metadata
-            # -> { DotnetInspector.Core, ILInspector.MetadataPrimitives } plus the
+            # The IL round-trip oracle has a fast PR subset plus a slow assembly
+            # sweep. It depends on ILInspector.Metadata ->
+            # { DotnetInspector.Core, ILInspector.MetadataPrimitives } plus the
             # vendored ILAssembler restore script and the test project itself.
             case "$file" in
               tests/DotnetInspector.ILRoundtrip.Tests/*) ILROUNDTRIP=true ;;
@@ -256,8 +256,8 @@ jobs:
           echo "$ILASM_DIR" >> "$GITHUB_PATH"
           echo "$ILDASM_DIR" >> "$GITHUB_PATH"
 
-      - name: Run CLI tests
-        run: dotnet run --project src/dotnet-inspect.Tests -c Release
+      - name: Run CLI tests (fast)
+        run: dotnet run --project src/dotnet-inspect.Tests -c Release -- -trait- "Speed=Slow"
 
       - name: Run instruction-substrate tests
         run: dotnet run --project src/ILInspector.Instructions.Tests -c Release
@@ -274,8 +274,8 @@ jobs:
       # Fast decompiler unit tests: pass logic, printer, importer facts, identity,
       # and classification regressions. Slow compile-back/recompile, corpus-sweep,
       # and fidelity tests are tagged [Trait("Speed", "Slow")] and excluded here;
-      # the full suite (including those) runs in decompiler-daily.yml. Mark any new
-      # Roslyn-heavy/recompile test Slow so it stays out of the PR gate.
+      # the full suite (including those) runs in Deep Inspect / publish. Mark any
+      # new Roslyn-heavy/recompile test Slow so it stays out of the PR gate.
       - name: Run decompiler unit tests (fast)
         run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
 
@@ -285,17 +285,17 @@ jobs:
       - name: Run runfaster tests
         run: dotnet run --project src/runfaster.Tests -c Release
 
-      # The IL round-trip oracle (vendored managed ILAssembler) is
-      # platform-neutral at the IL level, so one leg suffices. It is expensive,
-      # so it only runs when the round-trip tests or their source dependencies
-      # change (see the `ilroundtrip` filter in the changes job).
+      # Fast IL round-trip oracle: focused fixture and handwritten IL cases run
+      # in PR CI when the round-trip tests or source dependencies change. The
+      # assembly-wide sweep is tagged [Trait("Speed", "Slow")] and runs in
+      # Deep Inspect / publish / full local runs.
       - name: Restore vendored ILAssembler
         if: matrix.rid == 'linux-x64' && needs.changes.outputs.ilroundtrip == 'true'
         run: bash eng/restore-ilassembler.sh
 
-      - name: Run IL round-trip tests
+      - name: Run IL round-trip tests (fast)
         if: matrix.rid == 'linux-x64' && needs.changes.outputs.ilroundtrip == 'true'
-        run: dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
+        run: dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release -- -trait- "Speed=Slow"
 
   # Cheap C# Diff harness coverage. Path-gated separately from the full test
   # lane so CSharpDiffHarness/card changes get focused snapshot/baseline JSONL

--- a/.github/workflows/deep-inspect.yml
+++ b/.github/workflows/deep-inspect.yml
@@ -1,9 +1,17 @@
-name: Decompiler Daily
+name: Deep Inspect
 
 on:
-  schedule:
-    - cron: '0 9 * * *'
   workflow_dispatch:
+    inputs:
+      lane:
+        description: 'Which opt-in lane to run'
+        required: true
+        default: test
+        type: choice
+        options:
+          - test
+          - census
+          - all
 
 env:
   DOTNET_NOLOGO: true
@@ -11,11 +19,13 @@ env:
   DOTNET_INSPECT_TIPS: q
 
 concurrency:
-  group: decompiler-daily-${{ github.ref }}
+  group: deep-inspect-${{ github.ref }}-${{ inputs.lane }}
   cancel-in-progress: true
 
 jobs:
-  decompiler:
+  test:
+    name: Test lane
+    if: inputs.lane == 'test' || inputs.lane == 'all'
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
@@ -26,8 +36,19 @@ jobs:
           dotnet-version: '11.0.x'
           dotnet-quality: 'preview'
 
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/*.slnx') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Build managed tool
         run: dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+
+      - name: Run CLI tests (including slow integration)
+        run: dotnet run --project src/dotnet-inspect.Tests -c Release
 
       - name: Install ilasm/ildasm
         continue-on-error: true
@@ -53,14 +74,41 @@ jobs:
           echo "$ILASM_DIR" >> "$GITHUB_PATH"
           echo "$ILDASM_DIR" >> "$GITHUB_PATH"
 
-      - name: Run decompiler tests
+      - name: Run decompiler tests (including slow)
         run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release
 
-      # Analysis tests including the Slow generated-fixture catalogue (#1819), which the PR
-      # lane excludes for cost. The daily run is the catalogue's automated home: it materializes
-      # and grades every fixture so the analysis ledger does not drift unobserved.
       - name: Run analysis tests (including slow)
         run: dotnet run --project src/ILInspector.Analysis.Tests -c Release
+
+      - name: Restore vendored ILAssembler
+        run: bash eng/restore-ilassembler.sh
+
+      - name: Run IL round-trip tests (including slow sweep)
+        run: dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
+
+  census:
+    name: Census lane
+    if: inputs.lane == 'census' || inputs.lane == 'all'
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/*.slnx') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Build managed tool
+        run: dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
 
       - name: Prepare real-world corpus
         run: bash eng/prepare-decompiler-corpus.sh corpus-assemblies.txt
@@ -69,9 +117,9 @@ jobs:
         shell: bash
         run: |
           mapfile -t assemblies < corpus-assemblies.txt
-          mkdir -p artifacts/decompiler-daily
+          mkdir -p artifacts/deep-inspect
           dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
-            --emit-corpus-snapshot artifacts/decompiler-daily/corpus-snapshot.json \
+            --emit-corpus-snapshot artifacts/deep-inspect/corpus-snapshot.json \
             --diff-corpus-baseline tools/DecompilerHarness/corpus/real-world-baseline.json \
             --compile-cap 25 \
             --corpus-fidelity-cap 3 \
@@ -82,23 +130,23 @@ jobs:
         run: |
           set -o pipefail
           mapfile -t assemblies < corpus-assemblies.txt
-          mkdir -p artifacts/decompiler-daily
+          mkdir -p artifacts/deep-inspect
           dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
             --validity-predicate-scan \
             --max-examples 10 \
-            | tee artifacts/decompiler-daily/validity-predicate-scan.txt
+            | tee artifacts/deep-inspect/validity-predicate-scan.txt
 
       - name: Run uncapped validity sweep
         shell: bash
         run: |
           set -o pipefail
           mapfile -t assemblies < corpus-assemblies.txt
-          mkdir -p artifacts/decompiler-daily
+          mkdir -p artifacts/deep-inspect
           dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
             --validity-check \
             --compile-cap all \
             --max-examples 10 \
-            | tee artifacts/decompiler-daily/validity-check-uncapped.txt
+            | tee artifacts/deep-inspect/validity-check-uncapped.txt
 
       - name: Run assertion scan coverage report
         continue-on-error: true
@@ -117,39 +165,28 @@ jobs:
           echo "$status" > artifacts/assertion-scan/exit-code.txt
           exit 0
 
-      # Analysis corpus stability sensor (#1818, Layer 2): same pinned corpus, but it checks
-      # analyzer robustness (every assembly opens, no analyzer-diagnostic jump) against a
-      # committed baseline. Signal-count drift is reported, not failed; only a regression
-      # (stops opening / times out / diagnostics increase) is nonzero.
       - name: Run analysis corpus sensor
         shell: bash
         run: |
-          mkdir -p artifacts/analysis-daily
+          mkdir -p artifacts/analysis-census
           dotnet run --project tools/AnalysisHarness -c Release -- \
             --corpus-list corpus-assemblies.txt \
-            --emit-corpus-snapshot artifacts/analysis-daily/analysis-corpus-snapshot.json \
+            --emit-corpus-snapshot artifacts/analysis-census/analysis-corpus-snapshot.json \
             --diff-corpus-baseline tools/AnalysisHarness/corpus/analysis-baseline.json
 
-      # Analysis recall gate (#1818, Layer 3): curated paydirt sites are a
-      # mechanical oracle once selected. Keep this daily/manual, not PR CI.
       - name: Run analysis paydirt recall
         run: |
           dotnet run --project tools/AnalysisHarness -c Release -- \
             --paydirt-recall artifacts/bin/ILInspector.Decompiler/release/ILInspector.Decompiler.dll \
             --reference tools/AnalysisHarness/corpus/paydirt-reference.json
 
-      - name: Upload corpus snapshot
+      - name: Upload deep inspect artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: decompiler-corpus-snapshot
-          path: artifacts/decompiler-daily/
-          if-no-files-found: warn
-
-      - name: Upload assertion scan report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: assertion-scan-report
-          path: artifacts/assertion-scan/
+          name: deep-inspect-census
+          path: |
+            artifacts/deep-inspect/
+            artifacts/assertion-scan/
+            artifacts/analysis-census/
           if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,73 @@ jobs:
   # so per-PR/per-merge CI never has to build or upload release artifacts.
   # Windows/macOS build on their native runners; the Linux RIDs build here too
   # (they used to be produced by CI's pack/pack-rid jobs).
-  build-native:
+  deep-inspect-test:
     needs: resolve
+    runs-on: ubuntu-26.04
+    if: github.event.inputs.confirm == 'publish'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '11.0.x'
+          dotnet-quality: 'preview'
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.csproj', '**/*.props', '**/*.targets', '**/*.slnx') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Build managed tool
+        run: dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
+
+      - name: Run CLI tests (including slow integration)
+        run: dotnet run --project src/dotnet-inspect.Tests -c Release
+
+      - name: Install ilasm/ildasm
+        continue-on-error: true
+        shell: bash
+        run: |
+          RID=linux-x64
+          VERSION=11.0.0-preview.1.26104.118
+          PACKAGES_DIR=$(mktemp -d)
+          PROJ_DIR=$(mktemp -d)
+          cat > "$PROJ_DIR/iltools.csproj" <<EOF
+          <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup><TargetFramework>net11.0</TargetFramework></PropertyGroup>
+            <ItemGroup>
+              <PackageDownload Include="runtime.${RID}.Microsoft.NETCore.ILAsm" Version="[${VERSION}]" />
+              <PackageDownload Include="runtime.${RID}.Microsoft.NETCore.ILDAsm" Version="[${VERSION}]" />
+            </ItemGroup>
+          </Project>
+          EOF
+          dotnet restore "$PROJ_DIR/iltools.csproj" --packages "$PACKAGES_DIR" --source https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet11/nuget/v3/index.json --source https://api.nuget.org/v3/index.json
+          ILASM_DIR="$PACKAGES_DIR/runtime.$RID.microsoft.netcore.ilasm/$VERSION/runtimes/$RID/native"
+          ILDASM_DIR="$PACKAGES_DIR/runtime.$RID.microsoft.netcore.ildasm/$VERSION/runtimes/$RID/native"
+          chmod +x "$ILASM_DIR"/* "$ILDASM_DIR"/* 2>/dev/null || true
+          echo "$ILASM_DIR" >> "$GITHUB_PATH"
+          echo "$ILDASM_DIR" >> "$GITHUB_PATH"
+
+      - name: Run decompiler tests (including slow)
+        run: dotnet run --project src/ILInspector.Decompiler.Tests -c Release
+
+      - name: Run analysis tests (including slow)
+        run: dotnet run --project src/ILInspector.Analysis.Tests -c Release
+
+      - name: Restore vendored ILAssembler
+        run: bash eng/restore-ilassembler.sh
+
+      - name: Run IL round-trip tests (including slow sweep)
+        run: dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
+
+  build-native:
+    needs: [resolve, deep-inspect-test]
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +144,7 @@ jobs:
   # TFM-agnostic pointer. These used to come from CI's pack job; they are now
   # built here at publish time so CI never produces release artifacts.
   build-portable:
-    needs: resolve
+    needs: [resolve, deep-inspect-test]
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v6
@@ -118,7 +183,7 @@ jobs:
           if-no-files-found: error
 
   publish:
-    needs: [resolve, build-native, build-portable]
+    needs: [resolve, deep-inspect-test, build-native, build-portable]
     runs-on: ubuntu-26.04
     if: github.event.inputs.confirm == 'publish'
     environment: nuget

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
   # Build the RID-specific Native AOT packages. These run only at publish time
   # so per-PR/per-merge CI never has to build or upload release artifacts.
   # Windows/macOS build on their native runners; the Linux RIDs build here too
-  # (they used to be produced by CI's pack/pack-rid jobs).
+  # (they used to be partially smoke-tested by CI's pack jobs).
   deep-inspect-test:
     needs: resolve
     runs-on: ubuntu-26.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ dotnet run --project src/ILInspector.Analysis.Tests -c Release
 dotnet run --project src/ILInspector.Decompiler.Tests -c Release
 dotnet run --project src/DotnetInspector.Services.Tests -c Release
 dotnet run --project tests/ILInspector.Metadata.Tests -c Release
+dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release -- -trait- "Speed=Slow"
 dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
 ```
 
@@ -157,8 +158,10 @@ Some tests in `dotnet-inspect.Tests` require `ilasm`/`ildasm` and will skip if n
 
 `DotnetInspector.ILRoundtrip.Tests` requires the vendored managed ILAssembler
 (orphan branch `vendor/ilassembler`); run `eng/restore-ilassembler.sh` once to
-materialize it at `external/ILAssembler`. Edits under `external/ILAssembler`
-commit directly to the vendor branch — see its README for the fork policy.
+materialize it at `external/ILAssembler`. Use `-- -trait- "Speed=Slow"` for the
+fast PR subset; run the unfiltered command for the full assembly-wide sweep.
+Edits under `external/ILAssembler` commit directly to the vendor branch — see its
+README for the fork policy.
 
 ## Output Verbosity Contract
 
@@ -275,7 +278,7 @@ CI is intentionally lean so this stays cheap. Do not re-expand it without a
 reason:
 
 - `test` runs on PRs only; push-to-main is not re-tested (the PR validates the
-  merge commit, and `decompiler-daily.yml` is the daily safety net).
+  merge commit; Deep Inspect and publish provide opt-in/full safety nets).
 - `pack`/`pack-rid` run only on PRs that change build/packaging config.
 - Release packages are built at publish time in `release.yml`, so CI never
   produces release artifacts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,7 +279,7 @@ reason:
 
 - `test` runs on PRs only; push-to-main is not re-tested (the PR validates the
   merge commit; Deep Inspect and publish provide opt-in/full safety nets).
-- `pack`/`pack-rid` run only on PRs that change build/packaging config.
+- `pack` runs only on PRs that change build/packaging config.
 - Release packages are built at publish time in `release.yml`, so CI never
   produces release artifacts.
 

--- a/docs/decompiler-corpus-delta-repro.md
+++ b/docs/decompiler-corpus-delta-repro.md
@@ -40,7 +40,7 @@ to regenerate the card from the current PR head.
 ## Reproduce the PR quick quality card
 
 The PR quick card must use the PR quick corpus script with the PR quick baseline.
-Do not mix it with the daily/manual corpus script or baseline.
+Do not mix it with the Deep Inspect corpus script or baseline.
 
 ```bash
 dotnet build src/dotnet-inspect -c Release -p:PublishAot=false
@@ -80,10 +80,10 @@ The JSON delta records method-level changes such as `fullyRaised`, `residual`,
 yet have per-method snapshot rows require their own evidence layer before a full
 row-level delta can be reproduced.
 
-## Reproduce the daily/manual real-world card
+## Reproduce the Deep Inspect real-world card
 
 Use this broader card when reviewing risky decompiler behavior or validating a
-manual corpus claim. It uses the daily/manual corpus script and baseline.
+manual corpus claim. It uses the Deep Inspect corpus script and baseline.
 
 ```bash
 dotnet build src/dotnet-inspect -c Release -p:PublishAot=false

--- a/docs/decompiler-correctness-pipeline.md
+++ b/docs/decompiler-correctness-pipeline.md
@@ -47,7 +47,7 @@ The correctness system should have these properties:
 | 6 | Altitude boss | idiom scorecard, `LoweringCoverage`, sidecar rows | The output reached the intended C# idiom. | Soundness around near misses. |
 | 7 | Structure boss | `--gaps`, `--structuring-stops`, `--by-shape` | Which control-flow or fidelity shapes remain unraised. | That raised shapes are semantically faithful. |
 | 8 | Opcode boss | `--fidelity-check`, fixture fidelity gates, lowered fidelity gates | Decompiled body recompiles to the same canonical opcode stream. | Methods the check cannot recompile. |
-| 9 | Corpus boss | `--diff-corpus-baseline`, `--quality-diff-card`, daily corpus, PR quick corpus | Aggregate movement across real assemblies, including regressions and coverage. | That the changed methods were opcode-checked. |
+| 9 | Corpus boss | `--diff-corpus-baseline`, `--quality-diff-card`, Deep Inspect corpus, PR quick corpus | Aggregate movement across real assemblies, including regressions and coverage. | That the changed methods were opcode-checked. |
 | 10 | Changed-method boss | `--emit-corpus-delta`, `--fidelity-method-delta` | The methods a behavior PR changed are identified and attempted by compile-back fidelity. | That uncheckable changed methods are safe. |
 | 11 | Final boss | changed-method fidelity over the risky target population, improved examples, still-flat near misses, adversarial review | A risky raise/structuring PR has evidence over the methods it actually changed and its nearest false positives. | Whole-program semantic equivalence. |
 
@@ -103,16 +103,25 @@ Notes:
   of the entry gate for behavior changes, but iterate against a class filter and
   run the full suite before requesting review.
 - **PR CI runs only the fast unit subset.** The `test` job in `ci.yml` runs
-  `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait-
-  "Speed=Slow"` plus `ILInspector.Analysis.Tests`, gating pass logic, printer,
-  importer facts, identity, and classification regressions in seconds. The slow
-  compile-back/recompile, corpus-sweep, bind, scorecard, and fidelity tests are
-  tagged `[Trait("Speed", "Slow")]` and run only in `decompiler-daily.yml`
-  (alongside the corpus sensor). **Mark any new Roslyn-heavy / recompile /
-  corpus-sweeping test `[Trait("Speed", "Slow")]`** — at the class level for a
+  `dotnet run --project src/dotnet-inspect.Tests -c Release -- -trait-
+  "Speed=Slow"`, `dotnet run --project src/ILInspector.Decompiler.Tests -c
+  Release -- -trait- "Speed=Slow"`, and the matching fast Analysis/IL
+  round-trip filters. These gate command surface, pass logic, printer, importer
+  facts, identity, and classification regressions without the broad integration
+  and sweep costs. The slow CLI integration, compile-back/recompile,
+  corpus-sweep, bind, scorecard, fidelity, and broad differential tests are
+  tagged `[Trait("Speed", "Slow")]` and run only in Deep Inspect / publish /
+  full local runs. **Mark any new Roslyn-heavy / recompile / corpus-sweeping or
+  broad integration test `[Trait("Speed", "Slow")]`** — at the class level for a
   wholly-slow class, or the method level for one slow case in an otherwise fast
   class — so it stays out of the PR gate. A green PR CI run therefore does *not*
   prove the slow suite is green; run the full suite locally before review.
+- The IL round-trip oracle follows the same shape: PR CI runs
+  `dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release --
+  -trait- "Speed=Slow"` when IL round-trip inputs change, while the unfiltered
+  `DotnetInspector.ILRoundtrip.Tests` command keeps the assembly-wide sweep in
+  Deep Inspect / publish / full local coverage. Mark new broad/corpus-style
+  round-trip checks `[Trait("Speed", "Slow")]`.
 - A green entry gate is necessary, never sufficient: it says nothing about
   validity, fidelity, or corpus health. Do not report it as if it did.
 

--- a/docs/decompiler-quality.md
+++ b/docs/decompiler-quality.md
@@ -512,7 +512,7 @@ the rate increased from, for example, `82.17%` to `82.66%`. Counts still use raw
 signed count deltas in `Count delta`.
 
 For behaviour-preserving refactors, the existing #1174/#1166 real-world corpus
-sensor values are enough when you need the broader daily/manual signal:
+sensor values are enough when you need the broader Deep Inspect signal:
 
 Run the sensor with the same command documented in the harness README. The
 `--quality-diff-card` flag is what emits the PR-ready Markdown block:

--- a/skills/deep-inspect/SKILL.md
+++ b/skills/deep-inspect/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: dotnet-inspect-deep-inspect
+version: 0.1.0
+description: Run and interpret opt-in expensive validation lanes: full slow tests, IL round-trip sweep, corpus sensors, validity scans, and analysis census.
+---
+
+# dotnet-inspect: Deep Inspect
+
+Use this skill when a change needs expensive evidence outside normal PR CI.
+Deep Inspect is opt-in: run it manually when preparing risky PRs, and the test
+lane also runs during publish before packages are built.
+
+## Lanes
+
+| Lane | Use for | Runs |
+| ---- | ------- | ---- |
+| `test` | Blocking proof before publish or risky merges | Full decompiler tests, full analysis tests, vendored ILAssembler restore, full IL round-trip sweep. |
+| `census` | Observational broad signal and triage | Real-world corpus sensor, validity predicate scan, uncapped validity sweep, assertion scan, analysis corpus sensor, paydirt recall. |
+| `all` | Release-candidate deep read | Both lanes. |
+
+Run manually:
+
+```bash
+gh workflow run deep-inspect.yml -f lane=test
+gh workflow run deep-inspect.yml -f lane=census
+gh workflow run deep-inspect.yml -f lane=all
+```
+
+Inspect recent runs and artifacts:
+
+```bash
+gh run list --workflow deep-inspect.yml --limit 10
+gh run view <run-id> --log-failed
+gh run download <run-id> -D /tmp/deep-inspect-<run-id>
+```
+
+## Local equivalents
+
+For the test lane:
+
+```bash
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release
+dotnet run --project src/ILInspector.Analysis.Tests -c Release
+bash eng/restore-ilassembler.sh
+dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release
+```
+
+For the fast PR subsets:
+
+```bash
+dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
+dotnet run --project src/ILInspector.Analysis.Tests -c Release -- -trait- "Speed=Slow"
+dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release -- -trait- "Speed=Slow"
+```
+
+For the census lane, prefer the workflow so artifacts are retained. If running
+locally, use the same scripts/baselines as `deep-inspect.yml` and preserve the
+generated snapshots/cards under `/tmp` or `artifacts/` for review.
+
+## Reading results
+
+- Treat `test` failures as blockers: reproduce locally, identify the first
+  failing proof, and fix or explicitly defer before publish.
+- Treat `census` output as triage signal unless a command exits nonzero by
+  design. Compare snapshots against committed baselines and route meaningful
+  drift to issues or follow-up PRs.
+- Do not add broad/corpus-style tests to PR CI. Mark them
+  `[Trait("Speed", "Slow")]` and keep them in Deep Inspect / publish / full
+  local runs.

--- a/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityGateTests.cs
@@ -100,7 +100,7 @@ public class FidelityGateTests
         // CharConditionalElementStore (#1784): the char ternary element store
         // spills to temps and recompiles to a different (valid) stream. Honest
         // over-render. Pre-existing slow-docket gap surfaced by running the gate
-        // locally — the lowered/sugared gates are Speed=Slow (daily only).
+        // locally — the lowered/sugared gates are Speed=Slow (Deep Inspect / publish only).
         "CharConditionalElementStore",
         // Unmasked by the in/out skeleton-parameter fix (#1931): these CfgSampleClass
         // methods were RecompileFail before — the whole reconstructed type failed to

--- a/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LoweredFidelityGateTests.cs
@@ -81,7 +81,7 @@ public class LoweredFidelityGateTests
         // FidelityGateTests docket — the ConditionalStoreChainPass ternary
         // (sel == 0 ? 11 : ...) re-lowers differently than the per-arm stores. It
         // diffs identically in the lowered view; this entry was missing because the
-        // lowered gate is Speed=Slow and only runs in the daily, not PR CI. Verified
+        // lowered gate is Speed=Slow and only runs in Deep Inspect / publish, not PR CI. Verified
         // pre-existing (fails with MixedShortCircuitChainPass off as well).
         "SwitchStoreThenUse",
         // CharConditionalElementStore (#1784) and WhileNestedContinueKeepsArmExclusive:

--- a/src/ILInspector.Decompiler.Tests/SubstrateLeaderDifferentialTests.cs
+++ b/src/ILInspector.Decompiler.Tests/SubstrateLeaderDifferentialTests.cs
@@ -18,6 +18,7 @@ namespace ILInspector.Decompiler.Tests;
 /// proves no under-split and quantifies the extra granularity that the eventual minimal-CFG
 /// refactor would move to an Analysis Layer-1 concern.
 /// </summary>
+[Trait("Speed", "Slow")]
 public class SubstrateLeaderDifferentialTests
 {
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -16,6 +16,7 @@ namespace DotnetInspector.Tests;
 /// Uses platform libraries and the test assembly itself as data sources — no network required.
 /// </summary>
 [Collection("Console")]
+[Trait("Speed", "Slow")]
 public class CommandExecutionTests
 {
     private static readonly string TestAssemblyPath =

--- a/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
+++ b/src/dotnet-inspect.Tests/HttpClientFactoryTests.cs
@@ -253,19 +253,22 @@ public class HttpClientFactoryTests : IDisposable
     {
         using var diagram = RequestMermaidDiagram.Start();
         using var scope = NetworkTelemetry.Scope(NetworkTrafficKind.PlatformResolution);
+        var category = $"platform-frameworks-{Guid.NewGuid():N}";
+        var key = $"installed-frameworks-{Guid.NewGuid():N}";
 
-        CacheTelemetry.Record("platform-frameworks", "installed-frameworks", CacheAccessResult.Hit);
-        CacheTelemetry.Record("platform-frameworks", "installed-frameworks", CacheAccessResult.Hit);
-        CacheTelemetry.Record("platform-frameworks", "installed-frameworks", CacheAccessResult.Miss);
-        CacheTelemetry.Record("platform-frameworks", "installed-frameworks", CacheAccessResult.Miss);
-        CacheTelemetry.Record("platform-frameworks", "installed-frameworks", CacheAccessResult.Store);
-        CacheTelemetry.Record("platform-frameworks", "installed-frameworks", CacheAccessResult.Hit);
+        CacheTelemetry.Record(category, key, CacheAccessResult.Hit);
+        CacheTelemetry.Record(category, key, CacheAccessResult.Hit);
+        CacheTelemetry.Record(category, key, CacheAccessResult.Miss);
+        CacheTelemetry.Record(category, key, CacheAccessResult.Miss);
+        CacheTelemetry.Record(category, key, CacheAccessResult.Store);
+        CacheTelemetry.Record(category, key, CacheAccessResult.Hit);
 
         var mermaid = diagram.ToMermaid();
+        var label = $"{category} {key}";
 
-        Assert.Equal(1, CountOccurrences(mermaid, "cache hit<br/>platform-frameworks installed-frameworks"));
-        Assert.Equal(2, CountOccurrences(mermaid, "cache miss<br/>platform-frameworks installed-frameworks"));
-        Assert.Equal(1, CountOccurrences(mermaid, "cache store<br/>platform-frameworks installed-frameworks"));
+        Assert.Equal(1, CountOccurrences(mermaid, $"cache hit<br/>{label}"));
+        Assert.Equal(2, CountOccurrences(mermaid, $"cache miss<br/>{label}"));
+        Assert.Equal(1, CountOccurrences(mermaid, $"cache store<br/>{label}"));
     }
 
     private static async Task<string> CaptureTrafficLogAsync(

--- a/src/dotnet-inspect/Commands/SkillCommand.cs
+++ b/src/dotnet-inspect/Commands/SkillCommand.cs
@@ -44,6 +44,7 @@ public class SkillCommand
         new SkillEntry("signals", "dotnet-inspect.skills.signals.md"),
         new SkillEntry("sourcelink", "dotnet-inspect.skills.sourcelink.md"),
         new SkillEntry("decompiler", "dotnet-inspect.skills.decompiler.md"),
+        new SkillEntry("deep-inspect", "dotnet-inspect.skills.deep-inspect.md"),
         new SkillEntry("performance", "dotnet-inspect.skills.performance.md"),
         new SkillEntry("relationships", "dotnet-inspect.skills.relationships.md"),
     ];

--- a/src/dotnet-inspect/dotnet-inspect.csproj
+++ b/src/dotnet-inspect/dotnet-inspect.csproj
@@ -50,6 +50,7 @@
     <EmbeddedResource Include="../../skills/signals/SKILL.md" LogicalName="dotnet-inspect.skills.signals.md" />
     <EmbeddedResource Include="../../skills/sourcelink/SKILL.md" LogicalName="dotnet-inspect.skills.sourcelink.md" />
     <EmbeddedResource Include="../../skills/decompiler/SKILL.md" LogicalName="dotnet-inspect.skills.decompiler.md" />
+    <EmbeddedResource Include="../../skills/deep-inspect/SKILL.md" LogicalName="dotnet-inspect.skills.deep-inspect.md" />
     <EmbeddedResource Include="../../skills/performance/SKILL.md" LogicalName="dotnet-inspect.skills.performance.md" />
     <EmbeddedResource Include="../../skills/relationships/SKILL.md" LogicalName="dotnet-inspect.skills.relationships.md" />
   </ItemGroup>

--- a/tests/DotnetInspector.ILRoundtrip.Tests/ILSweepTests.cs
+++ b/tests/DotnetInspector.ILRoundtrip.Tests/ILSweepTests.cs
@@ -11,6 +11,7 @@ namespace DotnetInspector.ILRoundtrip.Tests;
 /// here means either a canonical-IL rendering regression or a vendored
 /// assembler regression after a sync.
 /// </summary>
+[Trait("Speed", "Slow")]
 public class ILSweepTests
 {
     public static TheoryData<string> SweptAssemblies => new(

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -107,9 +107,9 @@ loop+high triage candidate (a recall regression). `--precision-sample` emits the
 candidates as a labeling worksheet — there is no automatic precision oracle, so an agent/human
 labels true vs false positive.
 
-The daily workflow runs the generated-fixture catalogue, corpus stability sensor, and paydirt
-recall gate. Precision labeling, baseline refreshes, and recall-reference edits remain
-maintainer-owned upkeep: they are documented conventions, not automatic CI gates.
+Deep Inspect's census lane runs the generated-fixture catalogue, corpus stability sensor,
+and paydirt recall gate. Precision labeling, baseline refreshes, and recall-reference
+edits remain maintainer-owned upkeep: they are documented conventions, not automatic CI gates.
 
 ## Leak triage corpus sensor (#1992)
 
@@ -182,7 +182,7 @@ Use this convention for precision pilots and recurring reviews:
 - **Storage:** post the labeled worksheet as an issue or PR comment on the tracker that requested
   the sample. Do not commit labels unless they are promoted into curated recall references.
 - **Cadence:** run on demand for behavior changes, ranking changes, new shape families, or a
-  suspected false-positive cluster. Do not add it to PR CI or daily automation.
+  suspected false-positive cluster. Do not add it to PR CI or automatic schedules.
 - **Sample size:** start with `--top 20` for a normal review. Use a smaller sample only for a pilot
   that validates the convention itself; state the sample size in the comment.
 - **Bar:** a sample is healthy when at least 80% of labeled rows are true positives and no
@@ -261,7 +261,7 @@ dotnet run --project tools/AnalysisHarness -c Release -- \
   --reference tools/AnalysisHarness/corpus/paydirt-reference.json
 ```
 
-Daily failure triage:
+Deep Inspect failure triage:
 
 | Symptom | First classification | Expected action |
 | --- | --- | --- |

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -117,12 +117,12 @@ dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
   --max-examples 10
 ```
 
-`decompiler-daily.yml` runs the same corpus plus the generated fixture guarantee
-as a report-only artifact named `assertion-scan-report`. The artifact's
+Deep Inspect's census lane runs the same corpus plus the generated fixture
+guarantee as a report-only artifact named `assertion-scan-report`. The artifact's
 `assertion-scan.txt` lists exercised and unexercised `[InverseOf]` nodes by
 cause; a non-empty importer-emitted list is follow-up work for corpus/fixture
 breadth, while a non-empty pass-raised list or fixture regression alarm is a
-raise-pass or fixture-gap investigation signal, not a failed daily gate.
+raise-pass or fixture-gap investigation signal, not a failed PR gate.
 
 **Generated fixtures** (`--generated-fixtures [id|prefix|list]`): builds selected
 generated-fixture catalogue entries into a temporary class library, runs the
@@ -185,11 +185,11 @@ library?" loop. `--top-patterns N` limits the global/per-library pattern lists,
 `--top-libraries N` limits the detailed library sections to the noisiest
 libraries, and `--json` emits the same data as structured JSON.
 
-**Real-world corpus sensor** (`--diff-corpus-baseline`): the daily/manual
+**Real-world corpus sensor** (`--diff-corpus-baseline`): the Deep Inspect
 baseline for #1166. It measures the fixed #1150 corpus — pinned NuGet assemblies
 plus dotnet-inspect's own assemblies — and compares the run against
-`tools/DecompilerHarness/corpus/real-world-baseline.json`. The scheduled
-Decompiler Daily workflow tracks fully-raised rate,
+`tools/DecompilerHarness/corpus/real-world-baseline.json`. Deep Inspect's census
+lane tracks fully-raised rate,
 `structuring: conditional-branch`, forward-merge structuring stops
 (`cond-target-past-region` + `forward-branch-not-region-exit`), Full malformed
 output, semantic validity defects, compile-back fidelity defects, and pass bugs.
@@ -197,8 +197,8 @@ The validity and fidelity caps are per assembly so the sensor samples every
 corpus member at bounded cost without adding that cost to every PR. When you
 want to compare a baseline cap with a larger exploratory cap, repeat
 `--corpus-fidelity-cap` (or use a comma-separated list) and the harness prints a
-fidelity coverage series with the same per-bucket failure breakdown for each cap. The fidelity sample records useful compile-back outcomes (`Exact`/`OpcodeDiff`) while surfacing recompile- and context-failure buckets for triage. Each daily run
-uploads the current JSON snapshot as the `decompiler-corpus-snapshot` artifact so
+fidelity coverage series with the same per-bucket failure breakdown for each cap. The fidelity sample records useful compile-back outcomes (`Exact`/`OpcodeDiff`) while surfacing recompile- and context-failure buckets for triage. Each Deep Inspect census run
+uploads the current JSON snapshot as an artifact so
 trends can be compared without scraping logs.
 
 Standalone `--fidelity-check` reports also print bounded examples for every
@@ -292,7 +292,7 @@ rather than repo growth. Aggregate fully-raised, conditional-residual, and
 forward-merge rate movement still appears in the table and in an advisory block
 when it crosses tolerance, but it is not a normal PR quick hard gate. Risky
 decompiler changes can opt back into aggregate rate hard-fails with
-`--quality-card-risky`, and non-card/daily runs still use the aggregate rates.
+`--quality-card-risky`, and non-card Deep Inspect runs still use the aggregate rates.
 Pass-bug crashes always gate on the full aggregate. The pinned gate is computed
 from the per-method snapshots both baseline and current carry, so no baseline
 regen is required; it falls back to aggregate counts/rates when a snapshot lacks
@@ -302,22 +302,22 @@ Expand the fixed corpus only after that targeting step shows a shape gap. Prefer
 deterministic, pinned assemblies that add many examples of the missing lowering
 family (for example forward-merge or retained-label control flow), then refresh
 the baseline and prove a no-op `--emit-corpus-delta` stays empty. Keep the PR
-quick corpus small; broad shape additions belong in the daily/manual corpus
+quick corpus small; broad shape additions belong in the Deep Inspect corpus
 unless they are cheap and stable enough for every PR.
 
 **PR quick corpus** (`tools/DecompilerHarness/corpus/pr-quick-baseline.json`):
 CI also runs a small artifact-producing corpus sensor after the managed tool
 build. It takes a deterministic hash-ranked sample of 100 methods per assembly
 across a mixed 15-assembly set: System.Private.CoreLib, the pinned package
-libraries used by the daily corpus, and dotnet-inspect's managed product
+libraries used by the Deep Inspect corpus, and dotnet-inspect's managed product
 assemblies. The hash-ranked sample avoids the order churn of "first N" metadata
 rows while still staying small. The run skips the expensive semantic validity
-and compile-back fidelity oracles so it stays small; the daily workflow remains
+and compile-back fidelity oracles so it stays small; the Deep Inspect census lane remains
 the authoritative full-corpus signal.
 
 Keep the corpus-prep script paired with its matching baseline. The PR quick card
 uses `eng/prepare-decompiler-pr-corpus.sh` with
-`tools/DecompilerHarness/corpus/pr-quick-baseline.json`; the daily/manual
+`tools/DecompilerHarness/corpus/pr-quick-baseline.json`; the Deep Inspect
 real-world card uses `eng/prepare-decompiler-corpus.sh` with
 `tools/DecompilerHarness/corpus/real-world-baseline.json`. Do not mix the full
 corpus script with the PR quick baseline, or the card will report artificial
@@ -496,8 +496,8 @@ conditional arms that need a numeric cast to their merged join type, and
 conditionals whose result type needs a numeric cast at a typed sink. Use this as
 the "discovered class -> predicate -> corpus-wide census" loop; use
 `--validity-check` or `--diff-validity-defects` as the binding oracle for a fix.
-The daily workflow runs both this scan and an uncapped validity sweep, while PR
-quality cards keep capped validity for cost.
+Deep Inspect's census lane runs both this scan and an uncapped validity sweep,
+while PR quality cards keep capped validity for cost.
 
 *Defect tracking — prove a fix regressed nothing.* A raw count (e.g. "CS0266: 263") tells you a bucket shrank but not *which* methods changed, so it cannot distinguish a real fix from a fix that also broke something else. `--emit-validity-defects <file>` writes the per-method defect map (one `Type::Method<TAB>CODE,CODE` row per method) before your change; after the change, `--diff-validity-defects <file>` re-runs the check and prints the differential against that baseline — **REGRESSED** (methods that gained a code) and **IMPROVED** (methods that lost one), per code. A clean fix shows entries only under IMPROVED with an empty REGRESSED; any REGRESSED row is a method your change broke. Only methods checked in *both* runs are compared (cap-boundary methods are excluded), so keep `--compile-cap` identical across the baseline and diff runs. This is the regression-proof loop behind a "N→M occurrences, 0 regressions" claim.
 


### PR DESCRIPTION
## Summary

- Replace the scheduled `decompiler-daily.yml` workflow with manual-only `Deep Inspect` lanes:
  - `test`: full slow test proof lane.
  - `census`: observational corpus/sensor lane.
  - `all`: both lanes.
- Run the Deep Inspect `test` lane as a publish prerequisite before packages build/push.
- Keep PR CI lean by excluding `[Trait(\"Speed\", \"Slow\")]` from CLI, decompiler, analysis, and IL round-trip test commands.
- Tag broad/slow tests: CLI command integration, CoreLib substrate leader differential, and IL round-trip assembly sweep.
- Add `dotnet-inspect skill deep-inspect` and rename the project skill from daily decompiler analysis to Deep Inspect analysis.

## Fast-lane measurements

Local timings after build on this branch:

| Lane | Command | Result |
| --- | --- | --- |
| CLI fast | `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -trait- \"Speed=Slow\"` | 1189 tests, ~1:17 |
| Decompiler fast | `dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-build -- -trait- \"Speed=Slow\"` | 2032 tests, ~0:39 |
| Analysis fast | `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-build -- -trait- \"Speed=Slow\"` | 397 tests, ~0:20 |
| IL round-trip fast | `dotnet run --project tests/DotnetInspector.ILRoundtrip.Tests -c Release --no-build -- -trait- \"Speed=Slow\"` | 18 tests, <1s |

CLI is still the slowest “fast” lane. This PR moves the largest CLI integration class out of PR CI, but the remaining CLI suite is still ~77s locally and should be treated as a future optimization target rather than truly tiny.

## Validation

- `dotnet restore dotnet-inspect.slnx --configfile nuget.config`
- `dotnet build dotnet-inspect.slnx -c Release --no-restore`
- Fast CLI/decompiler/analysis/IL round-trip commands listed above
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build -- -class DotnetInspector.Tests.SkillCommandTests`
- `dotnet run --project src/dotnet-inspect -c Release --no-build -- skill list --tsv | grep deep-inspect`
- `npx markdownlint-cli AGENTS.md docs/decompiler-corpus-delta-repro.md docs/decompiler-correctness-pipeline.md docs/decompiler-quality.md tools/AnalysisHarness/README.md tools/DecompilerHarness/README.md skills/deep-inspect/SKILL.md .claude/skills/deep-inspect-analysis/SKILL.md`