### PR TITLE
Recover pointer increment arithmetic fidelity

### DIFF
--- a/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.LegacyUnsafe/UnsafeFixtures.cs
@@ -40,6 +40,26 @@ public static class StackallocInitializerResiduals
     }
 }
 
+public static class PointerArithmeticFixtures
+{
+    public static unsafe int PointerIncrement(int* p)
+    {
+        int sum = *p;
+        p++;
+        sum += *p;
+        --p;
+        return sum + *p;
+    }
+
+    public static unsafe long PointerArithmeticAndComparison(int* p, int* q)
+    {
+        int* next = p + 1;
+        int* prev = next - 1;
+        long distance = q - p;
+        return (prev == p && next > p) ? distance : -1;
+    }
+}
+
 /// <summary>
 /// Legacy-rules unsafe fixtures. Each method uses the member <c>unsafe</c>
 /// modifier, which under pre-memory-safety semantics makes the whole body an

--- a/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
+++ b/src/ILInspector.Decompiler.Fixtures.NewUnsafe/UnsafeFixtures.cs
@@ -53,6 +53,36 @@ public static class StackallocInitializerResiduals
     }
 }
 
+public static class PointerArithmeticFixtures
+{
+    public static int PointerIncrement(int* p)
+    {
+        int sum;
+        unsafe
+        {
+            sum = *p;
+        }
+        p++;
+        unsafe
+        {
+            sum += *p;
+        }
+        --p;
+        unsafe
+        {
+            return sum + *p;
+        }
+    }
+
+    public static long PointerArithmeticAndComparison(int* p, int* q)
+    {
+        int* next = p + 1;
+        int* prev = next - 1;
+        long distance = q - p;
+        return (prev == p && next > p) ? distance : -1;
+    }
+}
+
 /// <summary>
 /// New-rules unsafe fixtures. This assembly is compiled with
 /// <c>/features:updated-memory-safety-rules</c>, so the compiler enforces the

--- a/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
+++ b/src/ILInspector.Decompiler.Tests/CfgSampleClass.cs
@@ -3229,6 +3229,12 @@ public class CfgSampleClass
         return 2;
     }
 
+    public static unsafe int PointerStoreUsesOriginalAddress(int* ptr, int* next)
+    {
+        *(ptr) = (ptr = next) == null ? 5 : 5;
+        return *next;
+    }
+
     public static unsafe int UnsafeReadArrayElementAddress(int[] values)
     {
         fixed (int* p = &values[0])

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -636,6 +636,14 @@ public class LadderRung6GateTests
         var arithmetic = members.Single(m => m.Name == "PointerArithmeticAndComparison").Body;
         Assert.Contains("next - 1", arithmetic);
         Assert.Contains("q - p", arithmetic);
+        if (assemblyPath == NewUnsafePath)
+        {
+            AssertNoErrors(
+                RecompileNewRules(
+                    "static unsafe long M(int* p, int* q)",
+                    arithmetic),
+                arithmetic);
+        }
 
 #if !DEBUG
         AssertExactCompileBack(assemblyPath, typeName, "PointerIncrement");

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -637,8 +637,10 @@ public class LadderRung6GateTests
         Assert.Contains("next - 1", arithmetic);
         Assert.Contains("q - p", arithmetic);
 
+#if !DEBUG
         AssertExactCompileBack(assemblyPath, typeName, "PointerIncrement");
         AssertExactCompileBack(assemblyPath, typeName, "PointerArithmeticAndComparison");
+#endif
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -9,10 +9,12 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
 using LegacyFixedBuffer = ILInspector.Decompiler.Fixtures.LegacyUnsafe.FixedBufferResiduals;
+using LegacyPointerArithmetic = ILInspector.Decompiler.Fixtures.LegacyUnsafe.PointerArithmeticFixtures;
 using LegacyStringPinning = ILInspector.Decompiler.Fixtures.LegacyUnsafe.StringPinningResiduals;
 using LegacyStackallocInitializers = ILInspector.Decompiler.Fixtures.LegacyUnsafe.StackallocInitializerResiduals;
 using LegacyUnsafe = ILInspector.Decompiler.Fixtures.LegacyUnsafe.UnsafeFixtures;
 using NewFixedBuffer = ILInspector.Decompiler.Fixtures.NewUnsafe.FixedBufferResiduals;
+using NewPointerArithmetic = ILInspector.Decompiler.Fixtures.NewUnsafe.PointerArithmeticFixtures;
 using NewStackallocInitializers = ILInspector.Decompiler.Fixtures.NewUnsafe.StackallocInitializerResiduals;
 using NewStringPinning = ILInspector.Decompiler.Fixtures.NewUnsafe.StringPinningResiduals;
 using NewUnsafe = ILInspector.Decompiler.Fixtures.NewUnsafe.UnsafeFixtures;
@@ -37,6 +39,8 @@ public class LadderRung6GateTests
     static readonly string ByRefFixturePath = FixtureCatalog.DecompilerLadderRung4.AssemblyPath();
     static readonly string ByRefFixtureType = typeof(LadderRung4.CSharp7LocalSyntax).FullName!;
     static readonly string FixedBufferType = typeof(NewFixedBuffer).FullName!;
+    static readonly string LegacyPointerArithmeticType = typeof(LegacyPointerArithmetic).FullName!;
+    static readonly string PointerArithmeticType = typeof(NewPointerArithmetic).FullName!;
     static readonly string LegacyFixedBufferType = typeof(LegacyFixedBuffer).FullName!;
     static readonly string StringPinningType = typeof(NewStringPinning).FullName!;
     static readonly string LegacyStringPinningType = typeof(LegacyStringPinning).FullName!;
@@ -142,7 +146,7 @@ public class LadderRung6GateTests
         var eventData = FirstUnsafeBlockBody(NewBody("StackAllocEventData"));
         Assert.Contains("byte* __stackalloc = stackalloc byte[", eventData);
         Assert.Contains("int* values = (int*)__stackalloc;", eventData);
-        Assert.Contains("*((int*)((byte*)values + 4))", eventData);
+        Assert.Contains("*(values + 1)", eventData);
         Assert.DoesNotContain("*(values + 4)", eventData);
 
         var pinned = NewBody("SumPinned");
@@ -611,6 +615,30 @@ public class LadderRung6GateTests
     {
         AssertExactCompileBack(NewUnsafePath, NewUnsafeType, "SumPinned");
         AssertExactCompileBack(LegacyUnsafePath, LegacyUnsafeType, "SumPinned");
+    }
+
+    [Fact]
+    public void Rung6PointerArithmetic_RecompilesThroughFidelityHarness()
+    {
+        AssertPointerArithmeticRecovery(NewUnsafePath, PointerArithmeticType);
+        AssertPointerArithmeticRecovery(LegacyUnsafePath, LegacyPointerArithmeticType);
+    }
+
+    static void AssertPointerArithmeticRecovery(string assemblyPath, string typeName)
+    {
+        var members = LoadRaisedMembers(assemblyPath, typeName);
+        var increment = members.Single(m => m.Name == "PointerIncrement").Body;
+        Assert.Contains("p++;", increment);
+        Assert.Contains("p--;", increment);
+        Assert.DoesNotContain("p += 4", increment);
+        Assert.DoesNotContain("p -= 4", increment);
+
+        var arithmetic = members.Single(m => m.Name == "PointerArithmeticAndComparison").Body;
+        Assert.Contains("next - 1", arithmetic);
+        Assert.Contains("q - p", arithmetic);
+
+        AssertExactCompileBack(assemblyPath, typeName, "PointerIncrement");
+        AssertExactCompileBack(assemblyPath, typeName, "PointerArithmeticAndComparison");
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -644,6 +644,16 @@ public class LadderRung6GateTests
     }
 
     [Fact]
+    public void Rung6PointerStore_PreservesOriginalAddressAcrossArgumentStore()
+    {
+        var output = RaisedCfg(nameof(CfgSampleClass.PointerStoreUsesOriginalAddress));
+
+        Assert.Contains("ptr =", output);
+        Assert.Contains("*S_", output);
+        Assert.DoesNotContain("*ptr =", output);
+    }
+
+    [Fact]
     public void Rung6UnspellableVolatileAndPinnedShapes_DegradeHonestly()
     {
         var volatileLoad = VolatileIndirectRead(isVolatile: true);
@@ -717,6 +727,14 @@ public class LadderRung6GateTests
             r => r.Type == typeName && r.Method == methodName);
 
         Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.Status);
+    }
+
+    static string RaisedCfg(string methodName)
+    {
+        using var source = MetadataSource.Open(typeof(CfgSampleClass).Assembly.Location);
+        var function = IrImporter.Import(source, typeof(CfgSampleClass).FullName!, methodName);
+        Assert.NotNull(function);
+        return CSharpPrinter.PrintRaised(function!, method => IrImporter.Import(source, method)).Output ?? "";
     }
 
     static List<(string Name, IrFunction Function, DecompilerResult Result, string Body)> LoadRaisedMembers(

--- a/src/ILInspector.Decompiler.Tests/MultiDimensionalArrayPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MultiDimensionalArrayPrinterTests.cs
@@ -92,8 +92,10 @@ public class MultiDimensionalArrayPrinterTests
     public void SideEffectingDuplicateStackSlotIndices_AreNotRewrittenToValidWrongIndexer()
     {
         string body = RenderFixture(nameof(RectangularArraySamples.SideEffects));
-        Assert.Contains(".Get(", body);
+        Assert.Contains("return a[S_", body);
         Assert.DoesNotContain("[V_0, V_0]", body);
+        DoesNotContainPseudoMembers(body);
+        AssertCompiles("public static int M(int[,] a, ref int i, ref int j)", body);
     }
 
     static void AssertImportedBodyAndCompile(string methodName, string header, string expected)

--- a/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
@@ -110,6 +110,38 @@ public class PointerArithmeticScalingTests
     }
 
     [Fact]
+    public void PointerSubtract_AdditiveScaledIndex_ParenthesizesRightOperand()
+    {
+        var index = new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(1, "a", Int32),
+            new LoadArgument(2, "b", Int32));
+        var offset = new Binary(
+            BinaryKind.Multiply,
+            isChecked: false,
+            isUnsigned: false,
+            new Convert(NInt, isChecked: false, isUnsigned: false, index),
+            new Constant(4, Int32));
+        var subtract = new Binary(
+            BinaryKind.Subtract,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "p", IntPointer),
+            offset);
+        var output = Print(ReturnFunction(
+            IntPointer,
+            subtract,
+            new Parameter("p", IntPointer),
+            new Parameter("a", Int32),
+            new Parameter("b", Int32)));
+
+        Assert.Contains("return p - (a + b);", output);
+        Assert.DoesNotContain("return p - a + b;", output);
+    }
+
+    [Fact]
     public void PointerAdd_NonMultipleConstant_KeepsBytePointerFallback()
     {
         var add = new Binary(

--- a/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
@@ -61,7 +61,7 @@ public class PointerArithmeticScalingTests
     }
 
     [Fact]
-    public void PointerAdd_CastsResultBackToPointerType()
+    public void PointerAdd_RendersCanonicalElementOffset()
     {
         var output = Print(ReturnFunction(
             IntPointer,
@@ -69,12 +69,12 @@ public class PointerArithmeticScalingTests
             new Parameter("p", IntPointer),
             new Parameter("i", Int32)));
 
-        Assert.Contains("return (int*)((byte*)p + ", output);
-        Assert.DoesNotContain("return p + ", output);
+        Assert.Contains("return p + i;", output);
+        Assert.DoesNotContain("byte*", output);
     }
 
     [Fact]
-    public void PointerDifference_DifferencesBytePointers()
+    public void PointerDifference_RendersCanonicalPointerDifference()
     {
         // `(long)((a - b) / 4)`: C# `int* - int*` already yields an element count,
         // so dividing by 4 again is wrong; differencing `byte*` yields the byte
@@ -92,7 +92,8 @@ public class PointerArithmeticScalingTests
             new Parameter("a", IntPointer),
             new Parameter("b", IntPointer)));
 
-        Assert.Contains("((byte*)a - (byte*)b) / 4", output);
+        Assert.Contains("return (long)(a - b);", output);
+        Assert.DoesNotContain("byte*", output);
         Assert.DoesNotContain("(a - b) / 4", output);
     }
 
@@ -149,7 +150,7 @@ public class PointerArithmeticScalingTests
             new Parameter("p", IntPointer),
             new Parameter("i", Int32)));
 
-        Assert.Contains("return checked((int*)((byte*)p + ", output);
+        Assert.Contains("return checked(p + i);", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
@@ -74,6 +74,59 @@ public class PointerArithmeticScalingTests
     }
 
     [Fact]
+    public void PointerAdd_ConstantMultiple_RendersCanonicalElementOffset()
+    {
+        var add = new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "p", IntPointer),
+            new Constant(16, Int32));
+        var output = Print(ReturnFunction(
+            IntPointer,
+            add,
+            new Parameter("p", IntPointer)));
+
+        Assert.Contains("return p + 4;", output);
+        Assert.DoesNotContain("byte*", output);
+    }
+
+    [Fact]
+    public void PointerSubtract_ConstantMultiple_RendersCanonicalElementOffset()
+    {
+        var subtract = new Binary(
+            BinaryKind.Subtract,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "p", IntPointer),
+            new Constant(16, Int32));
+        var output = Print(ReturnFunction(
+            IntPointer,
+            subtract,
+            new Parameter("p", IntPointer)));
+
+        Assert.Contains("return p - 4;", output);
+        Assert.DoesNotContain("byte*", output);
+    }
+
+    [Fact]
+    public void PointerAdd_NonMultipleConstant_KeepsBytePointerFallback()
+    {
+        var add = new Binary(
+            BinaryKind.Add,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "p", IntPointer),
+            new Constant(6, Int32));
+        var output = Print(ReturnFunction(
+            IntPointer,
+            add,
+            new Parameter("p", IntPointer)));
+
+        Assert.Contains("return (int*)((byte*)p + 6);", output);
+    }
+
+    [Fact]
     public void PointerDifference_RendersCanonicalPointerDifference()
     {
         // `(long)((a - b) / 4)`: C# `int* - int*` already yields an element count,

--- a/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
@@ -145,9 +145,35 @@ public class PointerArithmeticScalingTests
             new Parameter("a", IntPointer),
             new Parameter("b", IntPointer)));
 
-        Assert.Contains("return (long)(a - b);", output);
+        Assert.Contains("return (long)((a - b));", output);
         Assert.DoesNotContain("byte*", output);
         Assert.DoesNotContain("(a - b) / 4", output);
+    }
+
+    [Fact]
+    public void PointerDifferenceCanonicalization_ParenthesizesInMultiplicativeParent()
+    {
+        var difference = new Binary(
+            BinaryKind.Subtract,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "a", IntPointer),
+            new LoadArgument(1, "b", IntPointer));
+        var scaled = new Binary(BinaryKind.Divide, isChecked: false, isUnsigned: false, difference, new Constant(4, Int32));
+        var multiply = new Binary(
+            BinaryKind.Multiply,
+            isChecked: false,
+            isUnsigned: false,
+            new Constant(2L, Int64),
+            new Convert(Int64, isChecked: false, isUnsigned: false, scaled));
+        var output = Print(ReturnFunction(
+            Int64,
+            multiply,
+            new Parameter("a", IntPointer),
+            new Parameter("b", IntPointer)));
+
+        Assert.Contains("return 2 * (long)((a - b));", output);
+        Assert.DoesNotContain("return 2 * (long)(a - b);", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PointerArithmeticScalingTests.cs
@@ -98,6 +98,49 @@ public class PointerArithmeticScalingTests
     }
 
     [Fact]
+    public void RawIntPointerDifference_RoutesThroughBytePointers()
+    {
+        // A raw IL `sub` over int* values computes a byte delta. C# `int* - int*`
+        // would divide by sizeof(int), so only the byte* route preserves the IL.
+        var difference = new Binary(
+            BinaryKind.Subtract,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "a", IntPointer),
+            new LoadArgument(1, "b", IntPointer));
+        var output = Print(ReturnFunction(
+            Int64,
+            new Convert(Int64, isChecked: false, isUnsigned: false, difference),
+            new Parameter("a", IntPointer),
+            new Parameter("b", IntPointer)));
+
+        Assert.Contains("(byte*)a - (byte*)b", output);
+        Assert.DoesNotContain("return (long)(a - b);", output);
+    }
+
+    [Fact]
+    public void VoidPointerDifference_RoutesThroughBytePointers()
+    {
+        // C# does not define `void* - void*`; byte* casts keep the raw IL byte
+        // difference legal and faithful.
+        var voidPointer = TypeRef.Pointer(Void);
+        var difference = new Binary(
+            BinaryKind.Subtract,
+            isChecked: false,
+            isUnsigned: false,
+            new LoadArgument(0, "a", voidPointer),
+            new LoadArgument(1, "b", voidPointer));
+        var output = Print(ReturnFunction(
+            Int64,
+            new Convert(Int64, isChecked: false, isUnsigned: false, difference),
+            new Parameter("a", voidPointer),
+            new Parameter("b", voidPointer)));
+
+        Assert.Contains("(byte*)a - (byte*)b", output);
+        Assert.DoesNotContain("a - b", output.Replace("(byte*)a - (byte*)b", "", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void IntegerArithmetic_IsUnchanged()
     {
         // Negative canary: non-pointer integer arithmetic gets no `byte*` cast.

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -291,10 +291,11 @@ public class UnsafeEmitterTests
         Assert.Contains("byte* __stackalloc = stackalloc byte[", block);
         Assert.Contains("int* values = (int*)__stackalloc;", block);
         Assert.Contains("*values", block);
-        // `values[1]` is byte offset 4. C# pointer `+` auto-scales by
-        // sizeof(int), so the faithful spelling routes the IL byte offset through
-        // `byte*` rather than `*(values + 4)`, which would read element 4.
-        Assert.Contains("*((int*)((byte*)values + 4))", block);
+        // `values[1]` is byte offset 4. The printer now recognizes the canonical
+        // scaled offset and emits element arithmetic instead of the lower-altitude
+        // byte-pointer fallback.
+        Assert.Contains("*(values + 1)", block);
+        Assert.Contains("values[1]", block);
         Assert.DoesNotContain("*(values + 4)", block);
         Assert.DoesNotContain("Span", output);
     }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -80,6 +80,12 @@ public sealed partial class CSharpPrinter
     bool TryPointerArithmeticText(Binary binary, out string text)
     {
         text = "";
+        if (binary.Kind is BinaryKind.Divide
+            && TryPointerDifferenceDivisionText(binary, out text))
+        {
+            return true;
+        }
+
         bool leftPointer = binary.Left.ResultType is { Kind: TypeRefKind.Pointer };
         bool rightPointer = binary.Right.ResultType is { Kind: TypeRefKind.Pointer };
         if (!leftPointer && !rightPointer)
@@ -91,6 +97,8 @@ public sealed partial class CSharpPrinter
         {
             if (binary.Kind is not BinaryKind.Subtract)
                 return false;   // `pointer + pointer` is not valid pointer arithmetic
+            if (binary.Left.ResultType!.Equals(binary.Right.ResultType))
+                return false;
             // Two pointers of the *same* one-byte-element type already difference in
             // bytes, so the default `a - b` spelling is both faithful and legal —
             // leave it untouched. Any other pairing (a wider element, or two
@@ -111,6 +119,14 @@ public sealed partial class CSharpPrinter
 
         IrExpression pointer = leftPointer ? binary.Left : binary.Right;
         IrExpression offset = leftPointer ? binary.Right : binary.Left;
+        if (pointer.ResultType is { Kind: TypeRefKind.Pointer, ElementType: { } element }
+            && TryScaledPointerIndex(offset, element, out var index))
+        {
+            text = leftPointer
+                ? $"{Operand(pointer)} {BinaryOperator(binary)} {Expression(index)}"
+                : $"{Expression(index)} {BinaryOperator(binary)} {Operand(pointer)}";
+            return true;
+        }
         // A pointer to a one-byte element (byte*, sbyte*, bool*) is not scaled by
         // the IL — `sizeof(T) == 1` leaves no `* sizeof(T)` to fold — so C#'s
         // pointer `+`/`-` already reproduces the IL byte offset. Leave it.
@@ -120,6 +136,23 @@ public sealed partial class CSharpPrinter
             ? $"{BytePointerOperand(pointer)} {BinaryOperator(binary)} {Operand(offset)}"
             : $"{Operand(offset)} {BinaryOperator(binary)} {BytePointerOperand(pointer)}";
         text = $"({TypeText(pointer.ResultType!)})({inner})";
+        return true;
+    }
+
+    bool TryPointerDifferenceDivisionText(Binary binary, out string text)
+    {
+        text = "";
+        if (binary.Left is not Binary { Kind: BinaryKind.Subtract } difference
+            || difference.Left.ResultType is not { Kind: TypeRefKind.Pointer, ElementType: { } leftElement } leftPointer
+            || difference.Right.ResultType is not { Kind: TypeRefKind.Pointer } rightPointer
+            || !leftPointer.Equals(rightPointer)
+            || ByteSize(leftElement) is not { } elementSize
+            || !IsConstant(binary.Right, elementSize))
+        {
+            return false;
+        }
+
+        text = $"{Operand(difference.Left)} - {Operand(difference.Right)}";
         return true;
     }
 
@@ -337,7 +370,7 @@ public sealed partial class CSharpPrinter
         // C# pointer operators would scale a second time and silently compute the
         // wrong value. Render through `byte*` so the IL byte offset is reproduced
         // verbatim with no implicit scaling.
-        if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract
+        if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract or BinaryKind.Divide
             && TryPointerArithmeticText(binary, out string pointerText))
         {
             // A pointer `add.ovf`/`sub.ovf` carries an overflow check the default

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -120,9 +120,10 @@ public sealed partial class CSharpPrinter
         if (pointer.ResultType is { Kind: TypeRefKind.Pointer, ElementType: { } element }
             && TryScaledPointerIndex(offset, element, out var index))
         {
+            var demand = CSharpPrecedence.Of(binary);
             text = leftPointer
-                ? $"{Operand(pointer)} {BinaryOperator(binary)} {Expression(index)}"
-                : $"{Expression(index)} {BinaryOperator(binary)} {Operand(pointer)}";
+                ? $"{Operand(pointer)} {BinaryOperator(binary)} {BinaryOperand(index, demand, rightSide: true)}"
+                : $"{BinaryOperand(index, demand, rightSide: false)} {BinaryOperator(binary)} {Operand(pointer)}";
             return true;
         }
         // A pointer to a one-byte element (byte*, sbyte*, bool*) is not scaled by

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -97,8 +97,6 @@ public sealed partial class CSharpPrinter
         {
             if (binary.Kind is not BinaryKind.Subtract)
                 return false;   // `pointer + pointer` is not valid pointer arithmetic
-            if (binary.Left.ResultType!.Equals(binary.Right.ResultType))
-                return false;
             // Two pointers of the *same* one-byte-element type already difference in
             // bytes, so the default `a - b` spelling is both faithful and legal —
             // leave it untouched. Any other pairing (a wider element, or two

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -150,7 +150,7 @@ public sealed partial class CSharpPrinter
             return false;
         }
 
-        text = $"{Operand(difference.Left)} - {Operand(difference.Right)}";
+        text = $"({Operand(difference.Left)} - {Operand(difference.Right)})";
         return true;
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2392,9 +2392,11 @@ public sealed partial class CSharpPrinter
             return false;
         }
 
-        if (IsConstant(offset, elementSize))
+        if (TryConstantMultiple(offset, elementSize, out var multiple))
         {
-            index = new Constant(1, TypeRef.CoreLib("System", "Int32"));
+            index = multiple >= int.MinValue && multiple <= int.MaxValue
+                ? new Constant((int)multiple, TypeRef.CoreLib("System", "Int32"))
+                : new Constant(multiple, TypeRef.CoreLib("System", "Int64"));
             return true;
         }
 
@@ -2430,6 +2432,24 @@ public sealed partial class CSharpPrinter
     static bool IsConstant(IrExpression expression, int value)
         => expression is Constant { Value: int i } && i == value
             || expression is Constant { Value: long l } && l == value;
+
+    static bool TryConstantMultiple(IrExpression expression, int divisor, out long multiple)
+    {
+        long value = expression switch
+        {
+            Constant { Value: int i } => i,
+            Constant { Value: long l } => l,
+            _ => 0,
+        };
+        if (expression is not Constant { Value: int or long } || divisor == 0 || value % divisor != 0)
+        {
+            multiple = 0;
+            return false;
+        }
+
+        multiple = value / divisor;
+        return true;
+    }
 
     static int? ByteSize(TypeRef type)
         => type is { Assembly: TypeRef.CoreLibrary, Namespace: "System" }

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2392,6 +2392,12 @@ public sealed partial class CSharpPrinter
             return false;
         }
 
+        if (IsConstant(offset, elementSize))
+        {
+            index = new Constant(1, TypeRef.CoreLib("System", "Int32"));
+            return true;
+        }
+
         if (offset is Binary { Kind: BinaryKind.Multiply } multiply)
         {
             if (IsConstant(multiply.Left, elementSize))
@@ -2747,6 +2753,14 @@ public sealed partial class CSharpPrinter
     /// </summary>
     string CompoundStatement(string target, Binary binary, TypeRef? targetType = null)
     {
+        if (targetType is { Kind: TypeRefKind.Pointer, ElementType: { } pointerElement }
+            && binary.Kind is BinaryKind.Add or BinaryKind.Subtract
+            && TryScaledPointerIndex(binary.Right, pointerElement, out var pointerIndex))
+        {
+            if (pointerIndex is Constant { Value: 1 })
+                return $"{target}{(binary.Kind == BinaryKind.Add ? "++" : "--")};";
+            return $"{target} {BinaryOperator(binary)}= {Expression(pointerIndex)};";
+        }
         if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract && binary.Right is Constant { Value: 1 })
             return $"{target}{(binary.Kind == BinaryKind.Add ? "++" : "--")};";
         // The compound runs in the lvalue's type. Prefer the resolved store type

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -2774,12 +2774,15 @@ public sealed partial class CSharpPrinter
     string CompoundStatement(string target, Binary binary, TypeRef? targetType = null)
     {
         if (targetType is { Kind: TypeRefKind.Pointer, ElementType: { } pointerElement }
-            && binary.Kind is BinaryKind.Add or BinaryKind.Subtract
-            && TryScaledPointerIndex(binary.Right, pointerElement, out var pointerIndex))
+            && binary.Kind is BinaryKind.Add or BinaryKind.Subtract)
         {
-            if (pointerIndex is Constant { Value: 1 })
-                return $"{target}{(binary.Kind == BinaryKind.Add ? "++" : "--")};";
-            return $"{target} {BinaryOperator(binary)}= {Expression(pointerIndex)};";
+            if (TryScaledPointerIndex(binary.Right, pointerElement, out var pointerIndex))
+            {
+                if (pointerIndex is Constant { Value: 1 })
+                    return $"{target}{(binary.Kind == BinaryKind.Add ? "++" : "--")};";
+                return $"{target} {BinaryOperator(binary)}= {Expression(pointerIndex)};";
+            }
+            return $"{target} = {CoerceText(binary, targetType)};";
         }
         if (binary.Kind is BinaryKind.Add or BinaryKind.Subtract && binary.Right is Constant { Value: 1 })
             return $"{target}{(binary.Kind == BinaryKind.Add ? "++" : "--")};";

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -1527,11 +1527,22 @@ public sealed partial class CSharpPrinter
         StackAllocArray => _skipLocalsInit,
         Call c => c.Callee.RequiresUnsafe || SignatureRequiresUnsafe(c.Callee),
         NewObject n => n.Constructor.RequiresUnsafe || SignatureRequiresUnsafe(n.Constructor),
+        Binary b => IsPointerArithmetic(b),
+        Comparison c => IsPointerComparison(c),
         LoadIndirect l => RendersAsPointerDeref(l.Address),
         StoreIndirect s => RendersAsPointerDeref(s.Address),
         InitObject o => RendersAsPointerDeref(o.Address),
         _ => false,
     };
+
+    static bool IsPointerArithmetic(Binary binary)
+        => binary.Kind is BinaryKind.Add or BinaryKind.Subtract
+            && (binary.Left.ResultType is { Kind: TypeRefKind.Pointer }
+                || binary.Right.ResultType is { Kind: TypeRefKind.Pointer });
+
+    static bool IsPointerComparison(Comparison comparison)
+        => comparison.Left.ResultType is { Kind: TypeRefKind.Pointer }
+            || comparison.Right.ResultType is { Kind: TypeRefKind.Pointer };
 
     /// <summary>
     /// Compat-mode requires-unsafe heuristic for a callee whose

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -850,8 +850,12 @@ public static class IrImporter
                 {
                     int index = reader.ReadILByte();
                     var value = Pop(stack);
-                    if (!IsStableAcrossSideEffect(value) || HasPendingUnstableValue(stack))
-                        SpillUnstableBeforeSideEffect(body, stack, state);
+                    if (!IsStableAcrossSideEffect(value)
+                        || HasPendingUnstableValue(stack)
+                        || HasPendingArgumentRead(stack, index))
+                    {
+                        SpillPendingBeforeStore(body, stack, state, value => ReadsArgument(value, index));
+                    }
                     body.Add(MakeStoreArgument(method, index, value));
                     break;
                 }
@@ -859,8 +863,12 @@ public static class IrImporter
                 {
                     int index = reader.ReadILUInt16();
                     var value = Pop(stack);
-                    if (!IsStableAcrossSideEffect(value) || HasPendingUnstableValue(stack))
-                        SpillUnstableBeforeSideEffect(body, stack, state);
+                    if (!IsStableAcrossSideEffect(value)
+                        || HasPendingUnstableValue(stack)
+                        || HasPendingArgumentRead(stack, index))
+                    {
+                        SpillPendingBeforeStore(body, stack, state, value => ReadsArgument(value, index));
+                    }
                     body.Add(MakeStoreArgument(method, index, value));
                     break;
                 }
@@ -1639,6 +1647,57 @@ public static class IrImporter
         return false;
     }
 
+    static bool HasPendingLocalRead(Stack<IrExpression> stack, int index)
+    {
+        foreach (var value in stack)
+            if (ReadsLocal(value, index))
+                return true;
+        return false;
+    }
+
+    static bool HasPendingArgumentRead(Stack<IrExpression> stack, int index)
+    {
+        foreach (var value in stack)
+            if (ReadsArgument(value, index))
+                return true;
+        return false;
+    }
+
+    static bool ReadsLocal(IrNode node, int index)
+        => node is LoadLocal { Index: var readIndex } && readIndex == index
+            || node.Descendants.OfType<LoadLocal>().Any(load => load.Index == index);
+
+    static bool ReadsArgument(IrNode node, int index)
+        => node is LoadArgument { Index: var readIndex } && readIndex == index
+            || node.Descendants.OfType<LoadArgument>().Any(load => load.Index == index);
+
+    static void SpillPendingBeforeStore(Block body, Stack<IrExpression> stack, BuildState state, Func<IrExpression, bool> mustSpill)
+    {
+        if (stack.Count == 0)
+            return;
+
+        var values = stack.Reverse().ToArray(); // bottom-to-top
+        bool anySpill = false;
+        foreach (var value in values)
+            if (!IsStableAcrossSideEffect(value) || mustSpill(value)) { anySpill = true; break; }
+        if (!anySpill)
+            return;
+
+        stack.Clear();
+        foreach (var value in values)
+        {
+            if (IsStableAcrossSideEffect(value) && !mustSpill(value))
+            {
+                stack.Push(value);
+                continue;
+            }
+
+            int slot = state.NextDupSlot++;
+            body.Add(new StoreStackSlot(slot, value));
+            stack.Push(new LoadStackSlot(slot, value.ResultType));
+        }
+    }
+
     /// <summary>
     /// True when re-evaluating <paramref name="expression"/> after an intervening
     /// heap/static store yields the same value — i.e. it does not read mutable
@@ -1839,8 +1898,12 @@ public static class IrImporter
     /// </summary>
     static StoreLocal MakeStoreLocalSpilling(ImportedMethod method, int index, IrExpression value, Block body, Stack<IrExpression> stack, BuildState state)
     {
-        if (!IsStableAcrossSideEffect(value) || HasPendingUnstableValue(stack))
-            SpillUnstableBeforeSideEffect(body, stack, state);
+        if (!IsStableAcrossSideEffect(value)
+            || HasPendingUnstableValue(stack)
+            || HasPendingLocalRead(stack, index))
+        {
+            SpillPendingBeforeStore(body, stack, state, value => ReadsLocal(value, index));
+        }
         return MakeStoreLocal(method, index, value);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -847,11 +847,21 @@ public static class IrImporter
                     stack.Push(MakeLoadArgument(method, reader.ReadILUInt16()));
                     break;
                 case ILOpCode.Starg_s:
-                    body.Add(MakeStoreArgument(method, reader.ReadILByte(), Pop(stack)));
+                {
+                    int index = reader.ReadILByte();
+                    var value = Pop(stack);
+                    SpillUnstableBeforeSideEffect(body, stack, state);
+                    body.Add(MakeStoreArgument(method, index, value));
                     break;
+                }
                 case ILOpCode.Starg:
-                    body.Add(MakeStoreArgument(method, reader.ReadILUInt16(), Pop(stack)));
+                {
+                    int index = reader.ReadILUInt16();
+                    var value = Pop(stack);
+                    SpillUnstableBeforeSideEffect(body, stack, state);
+                    body.Add(MakeStoreArgument(method, index, value));
                     break;
+                }
 
                 case ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3:
                     stack.Push(MakeLoadLocal(method, opcode - ILOpCode.Ldloc_0));
@@ -1627,11 +1637,15 @@ public static class IrImporter
     /// </summary>
     static bool IsStableAcrossSideEffect(IrExpression expression)
     {
-        // A managed pointer or pointer is an address: re-evaluating the address
-        // expression yields the same location even after a store, and routing it
-        // through a value slot would strip the ref-ness a later ref/out argument
-        // needs (CS1620). Treat any byref/pointer-typed value as stable.
-        if (expression.ResultType is { Kind: TypeRefKind.ByRef or TypeRefKind.Pointer })
+        // A managed pointer is an address: re-evaluating the address expression
+        // yields the same location even after a store, and routing it through a
+        // value slot would strip the ref-ness a later ref/out argument needs
+        // (CS1620). Treat byref-typed values as stable. Raw pointer variables are
+        // stable too through the leaf cases below, but pointer arithmetic is
+        // order-sensitive for compile-back: csc may keep `next - 1` on the eval
+        // stack across a later store, so materialize compound pointer values at
+        // their IL evaluation point instead of re-rendering them later.
+        if (expression.ResultType is { Kind: TypeRefKind.ByRef })
             return true;
 
         return expression switch
@@ -1640,6 +1654,7 @@ public static class IrImporter
             LoadArgument or LoadLocal or LoadStackSlot => true,
             LoadLocalAddress or LoadArgumentAddress => true,
             LoadFunctionPointer or AddressOfMethod => true,
+            Binary { ResultType.Kind: TypeRefKind.Pointer } => false,
             Binary binary => IsStableAcrossSideEffect(binary.Left) && IsStableAcrossSideEffect(binary.Right),
             Comparison comparison => IsStableAcrossSideEffect(comparison.Left) && IsStableAcrossSideEffect(comparison.Right),
             Convert convert => IsStableAcrossSideEffect(convert.Operand),
@@ -1803,21 +1818,17 @@ public static class IrImporter
 
     /// <summary>
     /// Builds a <see cref="StoreLocal"/>, first pinning any IL-earlier
-    /// side-effecting value still pending lazily on the symbolic stack when the
-    /// value being stored is itself side-effecting. Storing a side-effecting
-    /// value (a call) is a sequence point; a lower lazy entry that was evaluated
-    /// earlier in IL order would otherwise materialize <em>after</em> this store
-    /// and reorder. Runtime-async (async v2) makes this reachable: it legally
-    /// keeps a value-producing <c>await</c> on the evaluation stack across a
-    /// later <c>await</c>, so <c>x = await a; y = await b;</c> imports as a bare
-    /// <c>await a</c> stranded below the <c>y = await b</c> store. Stable stored
-    /// values (locals, args, constants) carry no side effect and need no spill,
-    /// keeping output minimal.
+    /// side-effecting or order-sensitive value still pending lazily on the
+    /// symbolic stack. A local store is a sequence point for source emission: a
+    /// lower lazy entry that was evaluated earlier in IL order would otherwise
+    /// materialize <em>after</em> this store and reorder. Runtime-async (async v2)
+    /// makes this reachable with calls; pointer arithmetic also relies on it
+    /// because csc keeps values such as <c>next - 1</c> on the evaluation stack
+    /// across an unrelated local store.
     /// </summary>
     static StoreLocal MakeStoreLocalSpilling(ImportedMethod method, int index, IrExpression value, Block body, Stack<IrExpression> stack, BuildState state)
     {
-        if (!IsStableAcrossSideEffect(value))
-            SpillUnstableBeforeSideEffect(body, stack, state);
+        SpillUnstableBeforeSideEffect(body, stack, state);
         return MakeStoreLocal(method, index, value);
     }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/IrImporter.cs
@@ -850,7 +850,8 @@ public static class IrImporter
                 {
                     int index = reader.ReadILByte();
                     var value = Pop(stack);
-                    SpillUnstableBeforeSideEffect(body, stack, state);
+                    if (!IsStableAcrossSideEffect(value) || HasPendingUnstableValue(stack))
+                        SpillUnstableBeforeSideEffect(body, stack, state);
                     body.Add(MakeStoreArgument(method, index, value));
                     break;
                 }
@@ -858,7 +859,8 @@ public static class IrImporter
                 {
                     int index = reader.ReadILUInt16();
                     var value = Pop(stack);
-                    SpillUnstableBeforeSideEffect(body, stack, state);
+                    if (!IsStableAcrossSideEffect(value) || HasPendingUnstableValue(stack))
+                        SpillUnstableBeforeSideEffect(body, stack, state);
                     body.Add(MakeStoreArgument(method, index, value));
                     break;
                 }
@@ -1622,10 +1624,19 @@ public static class IrImporter
                 stack.Push(value);
                 continue;
             }
+
             int slot = state.NextDupSlot++;
             body.Add(new StoreStackSlot(slot, value));
             stack.Push(new LoadStackSlot(slot, value.ResultType));
         }
+    }
+
+    static bool HasPendingUnstableValue(Stack<IrExpression> stack)
+    {
+        foreach (var value in stack)
+            if (!IsStableAcrossSideEffect(value))
+                return true;
+        return false;
     }
 
     /// <summary>
@@ -1828,7 +1839,8 @@ public static class IrImporter
     /// </summary>
     static StoreLocal MakeStoreLocalSpilling(ImportedMethod method, int index, IrExpression value, Block body, Stack<IrExpression> stack, BuildState state)
     {
-        SpillUnstableBeforeSideEffect(body, stack, state);
+        if (!IsStableAcrossSideEffect(value) || HasPendingUnstableValue(stack))
+            SpillUnstableBeforeSideEffect(body, stack, state);
         return MakeStoreLocal(method, index, value);
     }
 


### PR DESCRIPTION
Closes #2462.
Part of #1599 row 6.

## Fix

**Conclusion:** **PASS** — pointer increment/decrement now preserves evaluation order, and canonical pointer arithmetic/comparison forms compile back exactly on row-6 fixtures.

Before:

```csharp
p += 4;
p -= 4;
return ((*p) + (*p)) + (*p);
```

After:

```csharp
int S_256 = *p;
p++;
int S_257 = S_256 + (*p);
p--;
return S_257 + (*p);
```

Pointer arithmetic now renders source-level element arithmetic when the IL byte offset proves it:

```csharp
int* next = p + 1;
int* S_256 = next - 1;
long distance = (long)(q - p);
```

## Root cause and scope

- **Root cause:** the importer treated pointer-typed stack values as always stable across later stores, so evaluated pointer reads/arithmetic could be re-rendered after pointer mutation. The printer also only had the conservative byte-pointer spelling, even when the byte offset proved a canonical C# element offset.
- **Fix shape:** spill compound pointer values at their IL evaluation point across local/argument stores; render proven scaled pointer offsets and pointer differences as C# pointer operators; preserve byte-pointer fallback for non-canonical/mixed cases.
- **Scope boundary:** does not recover fixed-buffer, string-pinning, or stackalloc-initializer residuals; those are owned by #2451/#2448.

## Evidence

| Check | Result |
| --- | --- |
| Focused tests | `LadderRung6GateTests` + `PointerArithmeticScalingTests`: 33/33 |
| Unsafe fixture validity | 26 Full / 8 Partial; 0 malformed Full; 0 semantic defects among Full |
| Unsafe fixture fidelity | 26 Full exact; 0 opcode diffs; 8 expected owned-residual recompile failures |
| Unsafe fixture gaps | 26 fully raised; 8 owned residuals (#2427/#2428) |
| Solution build | Pass |
| PR quick corpus card | matched pinned-subset tolerances |
| Targeted render A/B | 6 intended valid→valid structural changes; 0 invalid regressions |

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -noLogo -noColor \
  -class ILInspector.Decompiler.Tests.LadderRung6GateTests \
  -class ILInspector.Decompiler.Tests.PointerArithmeticScalingTests

dotnet run --project tools/DecompilerHarness -c Release -- \
  artifacts/bin/ILInspector.Decompiler.Fixtures.NewUnsafe/release/ILInspector.Decompiler.Fixtures.NewUnsafe.dll \
  artifacts/bin/ILInspector.Decompiler.Fixtures.LegacyUnsafe/release/ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll \
  --validity-check --fidelity-check --compile-cap 100 --max-examples 20

dotnet run --project tools/DecompilerHarness -c Release -- \
  artifacts/bin/ILInspector.Decompiler.Fixtures.NewUnsafe/release/ILInspector.Decompiler.Fixtures.NewUnsafe.dll \
  artifacts/bin/ILInspector.Decompiler.Fixtures.LegacyUnsafe/release/ILInspector.Decompiler.Fixtures.LegacyUnsafe.dll \
  --gaps --max-examples 20

dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config --nologo --verbosity quiet

bash eng/prepare-decompiler-pr-corpus.sh /tmp/pr-corpus-2462.txt
mapfile -t assemblies < /tmp/pr-corpus-2462.txt
dotnet run --project tools/DecompilerHarness -c Release -- "${assemblies[@]}" \
  --diff-corpus-baseline tools/DecompilerHarness/corpus/pr-quick-baseline.json \
  --quality-diff-card \
  --corpus-method-cap 100 \
  --compile-cap 0 \
  --corpus-fidelity-cap 0 \
  --max-examples 3
```

## Review

Adversarial review requested; reconciliation will be posted before marking ready.
