### PR TITLE
Disambiguate conversion operators in Research body identity (fix #2433 regression)

### DIFF
--- a/src/ILInspector.Metadata/ApiMemberIdentity.cs
+++ b/src/ILInspector.Metadata/ApiMemberIdentity.cs
@@ -762,7 +762,7 @@ public static class ApiMemberIdentity
                 .Replace('<', '{')
                 .Replace('>', '}');
 
-    internal static bool IsConversionOperator(string memberName)
+    public static bool IsConversionOperator(string memberName)
         => memberName is "op_Implicit" or "op_Explicit" or "op_CheckedExplicit";
 
     static bool TryGetArraySuffix(string type, out string elementType, out string suffix)

--- a/src/ILInspector.Research.Tests/ResearchDiffTests.cs
+++ b/src/ILInspector.Research.Tests/ResearchDiffTests.cs
@@ -52,6 +52,25 @@ public class ResearchDiffTests
         Assert.StartsWith($"{ApiMemberIdentity.GetMemberSelectorName(methodName, isExtension)}~", subject.Id, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ResearchMemberIdentity_SubjectFromMethod_DisambiguatesConversionOperatorsByReturnType()
+    {
+        // Two op_Explicit conversions that differ only by return type must get distinct body
+        // identities, matching the API-side anchor so C# and IL evidence group (regression #2433).
+        var widget = TypeRef.Definition("Asm", "Sample", "Widget");
+        var toInt = new MethodIdentity(
+            "Asm", Guid.Empty, widget, "op_Explicit", [widget],
+            TypeRef.CoreLib("System", "Int32"), MetadataToken: 0x06000001, IsStatic: true);
+        var toLong = toInt with { ReturnType = TypeRef.CoreLib("System", "Int64"), MetadataToken = 0x06000002 };
+
+        var idInt = ResearchMemberIdentity.SubjectFromMethod(toInt).Id;
+        var idLong = ResearchMemberIdentity.SubjectFromMethod(toLong).Id;
+
+        Assert.StartsWith("operator:op_Explicit~", idInt, StringComparison.Ordinal);
+        Assert.StartsWith("operator:op_Explicit~", idLong, StringComparison.Ordinal);
+        Assert.NotEqual(idInt, idLong);
+    }
+
     [Theory]
     [InlineData(".ctor", false)]
     [InlineData("op_Addition", false)]

--- a/src/ILInspector.Research/ResearchMemberIdentity.cs
+++ b/src/ILInspector.Research/ResearchMemberIdentity.cs
@@ -11,9 +11,10 @@ public static class ResearchMemberIdentity
         string TypeName,
         string MemberName,
         string GenericList,
-        string ParameterList)
+        string ParameterList,
+        string ReturnSuffix)
     {
-        public string CanonicalSignature => $"M:{TypeName}.{MemberName}{GenericList}{ParameterList}";
+        public string CanonicalSignature => $"M:{TypeName}.{MemberName}{GenericList}{ParameterList}{ReturnSuffix}";
         public string Fingerprint => MemberAnchor.ComputeFingerprint(CanonicalSignature);
         public string StableSelector => $"{SelectorName}~{Fingerprint}";
     }
@@ -54,7 +55,13 @@ public static class ResearchMemberIdentity
             method.DeclaringType.ToQualifiedDisplayString(),
             method.Name == ".ctor" ? "#ctor" : method.Name,
             MethodGenericList(method),
-            $"({string.Join(",", method.ParameterTypes.Select(BodyTypeName))})");
+            $"({string.Join(",", method.ParameterTypes.Select(BodyTypeName))})",
+            // Conversion operators overload on return type; append the same disambiguation
+            // suffix as the API-side anchor (ApiMemberIdentity) so body identity and API
+            // identity agree for conversion operators (issue #2440 / regression from #2433).
+            ApiMemberIdentity.IsConversionOperator(method.Name)
+                ? $"~{BodyTypeName(method.ReturnType)}"
+                : "");
 
     static BodyMemberIdentity BodyIdentityFromTarget(ResolvedMemberTarget target)
     {
@@ -81,7 +88,12 @@ public static class ResearchMemberIdentity
             BodyDeclaringTypeName(declaringType),
             memberName,
             generic,
-            parameters);
+            parameters,
+            // Mirror the conversion-operator return-type disambiguation used by the API
+            // anchor and the method-body path, so all identity producers agree.
+            ApiMemberIdentity.IsConversionOperator(member.Name) && !string.IsNullOrWhiteSpace(signature?.ReturnType)
+                ? $"~{BodyParameterTypeName(signature!.ReturnType!)}"
+                : "");
     }
 
     static BodyMemberIdentity CreateBodyIdentity(
@@ -89,8 +101,9 @@ public static class ResearchMemberIdentity
         string typeName,
         string memberName,
         string genericList,
-        string parameterList)
-        => new(selectorName, typeName, memberName, genericList, parameterList);
+        string parameterList,
+        string returnSuffix)
+        => new(selectorName, typeName, memberName, genericList, parameterList, returnSuffix);
 
     public static string BodyDeclaringTypeName(string typeName)
         => DeclaringPrimitiveName(StripGenericArguments(typeName.Replace('+', '.')));


### PR DESCRIPTION
## Summary

**Fixes a red-on-main regression introduced by #2433.**

#2433 added the conversion-operator `~ReturnType` disambiguation suffix to the API-side
anchor (`ApiMemberIdentity.CreateMethodAnchor`), but the **Research body identity**
(`ResearchMemberIdentity.SubjectFromMethod` and the resolved-target path) did not follow.
So for a conversion operator:

- the **C# evidence** anchor (from `CSharpBodyDiff` → `CreateMethodAnchor`) carries the `~ReturnType` suffix;
- the **IL-body evidence** anchor (from `SubjectFromMethod`) does not.

The two anchors diverge, so `ResearchDiff` no longer groups the C# and IL evidence on one
subject. That regressed:

```text
ResearchDiffTests.CompareAssemblies_CSharpAndIlEvidence_GroupOnConversionOperatorAnchor
```

which **passes at #2433's parent (`2fe194a6`) and fails after `205e4ec0`** — verified by
bisect. The #2433 review missed it because the Research suite was run on an earlier head,
not the final one (the "run tests on the *final* head" lesson).

## Fix

Append the same conversion-operator return-type disambiguation suffix in the Research body
identity (both the `MethodIdentity` body path and the resolved-target path), so body
identity and API identity agree for conversion operators and their evidence groups again.
The suffix is rendered with the body identity's own full-name renderer (`BodyTypeName` /
`BodyParameterTypeName`), matching the API anchor for members where the two already agree
(which includes this fixture). `ApiMemberIdentity.IsConversionOperator` is now `public`
(shared identity knowledge). This converges the Research body identity toward the API
anchor for conversion operators — the #2440 consolidation direction.

## Validation

- `ILInspector.Research.Tests` 59/0 — restored end-to-end grouping test **green**, plus a
  new focused unit guard (`SubjectFromMethod_DisambiguatesConversionOperatorsByReturnType`:
  two `op_Explicit` differing only by return type get distinct subjects).
- `ILInspector.Metadata.Tests` 369/0, `ILInspector.Decompiler.Tests` 2033/0,
  `dotnet-inspect.Tests` 1666/0 (10 skipped) — the resolved-target change did not regress
  `DiffCommand --member`.
- `dotnet build dotnet-inspect.slnx -c Release` succeeds.

## Review

Member-identity behavior change (fingerprint-affecting for conversion operators) →
two-model adversarial review (GPT-5.5 + Gemini) per policy.
