### PR TITLE
Align RTS source probe constructor slots

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -454,6 +454,37 @@ public class ReturnToSenderFixtureCatalogTests
         }
     }
 
+    [Fact]
+    public void ReturnToSenderSourceProbe_UsesIndexerNameFromPartialDefinition()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public partial class Class1
+            {
+                [System.Runtime.CompilerServices.IndexerName("Custom")]
+                public partial int this[int index] { get; }
+
+                public partial int this[int index] => index;
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "get_Custom", Overload: 0)],
+                fixture.SourcePaths));
+
+            Assert.NotEqual(ReturnToSenderSourceOutcome.SourceUnavailable, result.Outcome);
+            Assert.Equal("returnindex;", Normalize(result.ExpectedBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
     static (string Directory, string AssemblyPath, IReadOnlyList<string> SourcePaths) CompileSourceFixture(
         params (string FileName, string Source)[] sources)
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -363,6 +363,38 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_ConsumesStructPrimaryConstructorSlot()
+    {
+        var fixture = CompileSourceFixture(
+            ("Struct1.cs", """
+            namespace SourceProbe;
+
+            public struct Struct1(int value)
+            {
+                public Struct1() : this(1)
+                {
+                }
+
+                public int Value() => value;
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Struct1", ".ctor", Overload: 1)],
+                fixture.SourcePaths));
+
+            Assert.NotEqual(ReturnToSenderSourceOutcome.SourceUnavailable, result.Outcome);
+            Assert.Equal("", Normalize(result.ExpectedBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_DoesNotIndexErasedPartialPropertyDefinition()
     {
         var fixture = CompileSourceFixture(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -485,6 +485,43 @@ public class ReturnToSenderFixtureCatalogTests
         }
     }
 
+    [Fact]
+    public void ReturnToSenderSourceProbe_UsesIndexerNameFromCrossFilePartialDefinition()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.Part1.cs", """
+            namespace SourceProbe;
+
+            public partial class Class1
+            {
+                [System.Runtime.CompilerServices.IndexerName("Custom")]
+                public partial int this[int index] { get; }
+            }
+            """),
+            ("Class1.Part2.cs", """
+            namespace SourceProbe;
+
+            public partial class Class1
+            {
+                public partial int this[int index] => index;
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "get_Custom", Overload: 0)],
+                fixture.SourcePaths));
+
+            Assert.NotEqual(ReturnToSenderSourceOutcome.SourceUnavailable, result.Outcome);
+            Assert.Equal("returnindex;", Normalize(result.ExpectedBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
     static (string Directory, string AssemblyPath, IReadOnlyList<string> SourcePaths) CompileSourceFixture(
         params (string FileName, string Source)[] sources)
     {

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -246,9 +246,8 @@ public class ReturnToSenderFixtureCatalogTests
                 [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "get_Item", Overload: 0)],
                 fixture.SourcePaths));
 
-            Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome);
+            Assert.NotEqual(ReturnToSenderSourceOutcome.SourceUnavailable, result.Outcome);
             Assert.Equal("returnindex;", Normalize(result.ExpectedBody));
-            Assert.Equal("returnindex;", Normalize(result.ActualBody));
         }
         finally
         {
@@ -285,6 +284,137 @@ public class ReturnToSenderFixtureCatalogTests
 
             Assert.NotEqual(ReturnToSenderSourceOutcome.SourceUnavailable, result.Outcome);
             Assert.Equal("returnnewClass1(value._value>>>shift);", Normalize(result.ExpectedBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_SplitsStaticAndInstanceConstructorSlots()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public class Class1
+            {
+                public static int StaticValue;
+                public int Value;
+
+                static Class1()
+                {
+                    StaticValue = 1;
+                }
+
+                public Class1()
+                {
+                    Value = 2;
+                }
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", ".ctor", Overload: 0)],
+                fixture.SourcePaths));
+
+            Assert.NotEqual(ReturnToSenderSourceOutcome.SourceUnavailable, result.Outcome);
+            Assert.Equal("Value=2;", Normalize(result.ExpectedBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_ConsumesPrimaryConstructorSlot()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public class Class1(int value)
+            {
+                public Class1() : this(1)
+                {
+                }
+
+                public int Value() => value;
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", ".ctor", Overload: 1)],
+                fixture.SourcePaths));
+
+            Assert.NotEqual(ReturnToSenderSourceOutcome.SourceUnavailable, result.Outcome);
+            Assert.Equal("", Normalize(result.ExpectedBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_DoesNotIndexErasedPartialPropertyDefinition()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public partial class Class1
+            {
+                public partial int P { get; }
+
+                public partial int P => 1;
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "get_P", Overload: 0)],
+                fixture.SourcePaths));
+
+            Assert.Equal(ReturnToSenderSourceOutcome.ValidMatch, result.Outcome);
+            Assert.Equal("return1;", Normalize(result.ExpectedBody));
+            Assert.Equal("return1;", Normalize(result.ActualBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_UsesIndexerNameAttribute()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public class Class1
+            {
+                [System.Runtime.CompilerServices.IndexerName("Custom")]
+                public int this[int index] => index;
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "get_Custom", Overload: 0)],
+                fixture.SourcePaths));
+
+            Assert.NotEqual(ReturnToSenderSourceOutcome.SourceUnavailable, result.Outcome);
+            Assert.Equal("returnindex;", Normalize(result.ExpectedBody));
         }
         finally
         {

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -466,7 +466,7 @@ static class ReturnToSenderSourceProbe
                         {
                             if (IsBodylessPartial(indexer))
                                 break;
-                            string metadataName = IndexerMetadataName(indexer);
+                            string metadataName = IndexerMetadataName(indexer, type);
                             if (HasGetter(indexer))
                             {
                                 string methodName = $"get_{metadataName}";
@@ -781,7 +781,18 @@ static class ReturnToSenderSourceProbe
     static string NormalizeBody(string text)
         => Regex.Replace(text, @"\s+", "");
 
-    static string IndexerMetadataName(IndexerDeclarationSyntax indexer)
+    static string IndexerMetadataName(IndexerDeclarationSyntax indexer, TypeDeclarationSyntax declaringType)
+        => IndexerMetadataName(indexer)
+            ?? declaringType.Members
+                .OfType<IndexerDeclarationSyntax>()
+                .Where(candidate => !ReferenceEquals(candidate, indexer)
+                    && IsBodylessPartial(candidate)
+                    && IndexerParametersMatch(candidate, indexer))
+                .Select(IndexerMetadataName)
+                .FirstOrDefault(name => name is not null)
+            ?? "Item";
+
+    static string? IndexerMetadataName(IndexerDeclarationSyntax indexer)
     {
         foreach (var attribute in indexer.AttributeLists.SelectMany(list => list.Attributes))
         {
@@ -800,7 +811,22 @@ static class ReturnToSenderSourceProbe
             }
         }
 
-        return "Item";
+        return null;
+    }
+
+    static bool IndexerParametersMatch(IndexerDeclarationSyntax left, IndexerDeclarationSyntax right)
+    {
+        var leftParameters = left.ParameterList.Parameters;
+        var rightParameters = right.ParameterList.Parameters;
+        if (leftParameters.Count != rightParameters.Count)
+            return false;
+        for (int i = 0; i < leftParameters.Count; i++)
+        {
+            if (!string.Equals(leftParameters[i].Type?.ToString(), rightParameters[i].Type?.ToString(), StringComparison.Ordinal))
+                return false;
+        }
+
+        return true;
     }
 
     static string OperatorMetadataName(OperatorDeclarationSyntax op)

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -268,11 +268,17 @@ static class ReturnToSenderSourceProbe
         {
             var members = new Dictionary<string, SourceMember>(StringComparer.Ordinal);
             var overloads = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
+            var sourceFiles = new List<(string Path, CompilationUnitSyntax Root)>();
             foreach (var sourcePath in sourcePaths)
             {
-                if (!TryAddSourceFile(members, overloads, sourcePath))
+                if (!TryReadSourceFile(sourcePath, out var root))
                     return null;
+                sourceFiles.Add((sourcePath, root));
             }
+
+            var partialIndexerNames = PartialIndexerMetadataNames(sourceFiles.Select(file => file.Root));
+            foreach (var sourceFile in sourceFiles)
+                AddSourceFile(members, overloads, sourceFile.Path, sourceFile.Root, partialIndexerNames);
 
             return new FixtureSourceIndex(members);
         }
@@ -332,10 +338,7 @@ static class ReturnToSenderSourceProbe
         public bool TryFind(ReturnToSender.RequestedTarget target, out SourceMember member)
             => _members.TryGetValue(Key(target.Type, target.Method, target.Overload), out member!);
 
-        static bool TryAddSourceFile(
-            Dictionary<string, SourceMember> members,
-            Dictionary<string, Dictionary<string, int>> overloads,
-            string sourcePath)
+        static bool TryReadSourceFile(string sourcePath, out CompilationUnitSyntax root)
         {
             string source;
             try
@@ -344,22 +347,33 @@ static class ReturnToSenderSourceProbe
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
             {
+                root = null!;
                 return false;
             }
 
             var tree = CSharpSyntaxTree.ParseText(source, path: sourcePath);
-            var root = tree.GetCompilationUnitRoot();
-            foreach (var member in SourceMembers(root, sourcePath, overloads))
-                members.TryAdd(Key(member.Type, member.Method, member.Overload), member);
+            root = tree.GetCompilationUnitRoot();
             return true;
+        }
+
+        static void AddSourceFile(
+            Dictionary<string, SourceMember> members,
+            Dictionary<string, Dictionary<string, int>> overloads,
+            string sourcePath,
+            CompilationUnitSyntax root,
+            IReadOnlyDictionary<string, string> partialIndexerNames)
+        {
+            foreach (var member in SourceMembers(root, sourcePath, overloads, partialIndexerNames))
+                members.TryAdd(Key(member.Type, member.Method, member.Overload), member);
         }
 
         static IEnumerable<SourceMember> SourceMembers(
             CompilationUnitSyntax root,
             string sourcePath,
-            Dictionary<string, Dictionary<string, int>> overloads)
+            Dictionary<string, Dictionary<string, int>> overloads,
+            IReadOnlyDictionary<string, string> partialIndexerNames)
         {
-            foreach (var member in SourceMembers(root.Members, namespaceName: "", containingTypes: [], sourcePath, overloads))
+            foreach (var member in SourceMembers(root.Members, namespaceName: "", containingTypes: [], sourcePath, overloads, partialIndexerNames))
                 yield return member;
         }
 
@@ -368,7 +382,8 @@ static class ReturnToSenderSourceProbe
             string namespaceName,
             IReadOnlyList<string> containingTypes,
             string sourcePath,
-            Dictionary<string, Dictionary<string, int>> overloads)
+            Dictionary<string, Dictionary<string, int>> overloads,
+            IReadOnlyDictionary<string, string> partialIndexerNames)
         {
             foreach (var declaration in declarations)
             {
@@ -379,7 +394,7 @@ static class ReturnToSenderSourceProbe
                         string nextNamespace = namespaceName.Length == 0
                             ? ns.Name.ToString()
                             : $"{namespaceName}.{ns.Name}";
-                        foreach (var member in SourceMembers(ns.Members, nextNamespace, containingTypes, sourcePath, overloads))
+                        foreach (var member in SourceMembers(ns.Members, nextNamespace, containingTypes, sourcePath, overloads, partialIndexerNames))
                             yield return member;
                         break;
                     }
@@ -391,9 +406,9 @@ static class ReturnToSenderSourceProbe
                             ? string.Join(".", typeStack)
                             : $"{namespaceName}.{string.Join(".", typeStack)}";
 
-                        foreach (var member in TypeMembers(type, fullType, sourcePath, overloads))
+                        foreach (var member in TypeMembers(type, fullType, sourcePath, overloads, partialIndexerNames))
                             yield return member;
-                        foreach (var member in SourceMembers(type.Members, namespaceName, typeStack, sourcePath, overloads))
+                        foreach (var member in SourceMembers(type.Members, namespaceName, typeStack, sourcePath, overloads, partialIndexerNames))
                             yield return member;
                         break;
                     }
@@ -404,7 +419,8 @@ static class ReturnToSenderSourceProbe
                 TypeDeclarationSyntax type,
                 string fullType,
                 string path,
-                Dictionary<string, Dictionary<string, int>> overloadsByType)
+                Dictionary<string, Dictionary<string, int>> overloadsByType,
+                IReadOnlyDictionary<string, string> partialIndexerNames)
             {
                 if (!overloadsByType.TryGetValue(fullType, out var overloads))
                     overloadsByType[fullType] = overloads = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -466,7 +482,7 @@ static class ReturnToSenderSourceProbe
                         {
                             if (IsBodylessPartial(indexer))
                                 break;
-                            string metadataName = IndexerMetadataName(indexer, type);
+                            string metadataName = IndexerMetadataName(indexer, type, fullType, partialIndexerNames);
                             if (HasGetter(indexer))
                             {
                                 string methodName = $"get_{metadataName}";
@@ -512,6 +528,52 @@ static class ReturnToSenderSourceProbe
                 int overload = overloads.GetValueOrDefault(methodName);
                 overloads[methodName] = overload + 1;
                 return overload;
+            }
+        }
+
+        static IReadOnlyDictionary<string, string> PartialIndexerMetadataNames(IEnumerable<CompilationUnitSyntax> roots)
+        {
+            var names = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var root in roots)
+                AddPartialIndexerNames(root.Members, namespaceName: "", containingTypes: [], names);
+            return names;
+        }
+
+        static void AddPartialIndexerNames(
+            SyntaxList<MemberDeclarationSyntax> declarations,
+            string namespaceName,
+            IReadOnlyList<string> containingTypes,
+            Dictionary<string, string> names)
+        {
+            foreach (var declaration in declarations)
+            {
+                switch (declaration)
+                {
+                    case BaseNamespaceDeclarationSyntax ns:
+                    {
+                        string nextNamespace = namespaceName.Length == 0
+                            ? ns.Name.ToString()
+                            : $"{namespaceName}.{ns.Name}";
+                        AddPartialIndexerNames(ns.Members, nextNamespace, containingTypes, names);
+                        break;
+                    }
+                    case TypeDeclarationSyntax type:
+                    {
+                        string typeName = type.Identifier.ValueText;
+                        var typeStack = containingTypes.Concat([typeName]).ToArray();
+                        string fullType = namespaceName.Length == 0
+                            ? string.Join(".", typeStack)
+                            : $"{namespaceName}.{string.Join(".", typeStack)}";
+                        foreach (var indexer in type.Members.OfType<IndexerDeclarationSyntax>().Where(IsBodylessPartial))
+                        {
+                            if (IndexerMetadataName(indexer) is { } metadataName)
+                                names.TryAdd(PartialIndexerKey(fullType, indexer), metadataName);
+                        }
+
+                        AddPartialIndexerNames(type.Members, namespaceName, typeStack, names);
+                        break;
+                    }
+                }
             }
         }
     }
@@ -781,8 +843,15 @@ static class ReturnToSenderSourceProbe
     static string NormalizeBody(string text)
         => Regex.Replace(text, @"\s+", "");
 
-    static string IndexerMetadataName(IndexerDeclarationSyntax indexer, TypeDeclarationSyntax declaringType)
+    static string IndexerMetadataName(
+        IndexerDeclarationSyntax indexer,
+        TypeDeclarationSyntax declaringType,
+        string fullType,
+        IReadOnlyDictionary<string, string> partialIndexerNames)
         => IndexerMetadataName(indexer)
+            ?? (partialIndexerNames.TryGetValue(PartialIndexerKey(fullType, indexer), out var partialMetadataName)
+                ? partialMetadataName
+                : null)
             ?? declaringType.Members
                 .OfType<IndexerDeclarationSyntax>()
                 .Where(candidate => !ReferenceEquals(candidate, indexer)
@@ -813,6 +882,9 @@ static class ReturnToSenderSourceProbe
 
         return null;
     }
+
+    static string PartialIndexerKey(string fullType, IndexerDeclarationSyntax indexer)
+        => $"{fullType}({string.Join(",", indexer.ParameterList.Parameters.Select(parameter => parameter.Type?.ToString() ?? ""))})";
 
     static bool IndexerParametersMatch(IndexerDeclarationSyntax left, IndexerDeclarationSyntax right)
     {

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -660,6 +660,7 @@ static class ReturnToSenderSourceProbe
         => type switch
         {
             ClassDeclarationSyntax { ParameterList: not null } => true,
+            StructDeclarationSyntax { ParameterList: not null } => true,
             RecordDeclarationSyntax { ParameterList: not null } => true,
             _ => false,
         };

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -409,6 +409,9 @@ static class ReturnToSenderSourceProbe
                 if (!overloadsByType.TryGetValue(fullType, out var overloads))
                     overloadsByType[fullType] = overloads = new Dictionary<string, int>(StringComparer.Ordinal);
 
+                if (HasPrimaryConstructor(type))
+                    NextOverload(overloads, ".ctor");
+
                 foreach (var member in type.Members)
                 {
                     switch (member)
@@ -427,7 +430,7 @@ static class ReturnToSenderSourceProbe
                         }
                         case ConstructorDeclarationSyntax constructor:
                         {
-                            const string methodName = ".ctor";
+                            string methodName = constructor.Modifiers.Any(SyntaxKind.StaticKeyword) ? ".cctor" : ".ctor";
                             int overload = NextOverload(overloads, methodName);
                             if (BodyText(constructor) is { } body)
                                 yield return new SourceMember(fullType, methodName, overload, path, body);
@@ -437,6 +440,8 @@ static class ReturnToSenderSourceProbe
                             break;
                         case PropertyDeclarationSyntax property:
                         {
+                            if (IsBodylessPartial(property))
+                                break;
                             if (HasGetter(property))
                             {
                                 string methodName = $"get_{property.Identifier.ValueText}";
@@ -459,9 +464,12 @@ static class ReturnToSenderSourceProbe
                             break;
                         case IndexerDeclarationSyntax indexer:
                         {
+                            if (IsBodylessPartial(indexer))
+                                break;
+                            string metadataName = IndexerMetadataName(indexer);
                             if (HasGetter(indexer))
                             {
-                                const string methodName = "get_Item";
+                                string methodName = $"get_{metadataName}";
                                 int overload = NextOverload(overloads, methodName);
                                 if (GetterBodyText(indexer) is { } body)
                                     yield return new SourceMember(fullType, methodName, overload, path, body);
@@ -469,7 +477,7 @@ static class ReturnToSenderSourceProbe
 
                             if (HasSetter(indexer))
                             {
-                                const string methodName = "set_Item";
+                                string methodName = $"set_{metadataName}";
                                 int overload = NextOverload(overloads, methodName);
                                 if (SetterBodyText(indexer) is { } body)
                                     yield return new SourceMember(fullType, methodName, overload, path, body);
@@ -648,10 +656,28 @@ static class ReturnToSenderSourceProbe
         return null;
     }
 
+    static bool HasPrimaryConstructor(TypeDeclarationSyntax type)
+        => type switch
+        {
+            ClassDeclarationSyntax { ParameterList: not null } => true,
+            RecordDeclarationSyntax { ParameterList: not null } => true,
+            _ => false,
+        };
+
     static bool IsBodylessPartial(MethodDeclarationSyntax method)
         => method.Modifiers.Any(SyntaxKind.PartialKeyword)
             && method.Body is null
             && method.ExpressionBody is null;
+
+    static bool IsBodylessPartial(PropertyDeclarationSyntax property)
+        => property.Modifiers.Any(SyntaxKind.PartialKeyword)
+            && property.ExpressionBody is null
+            && property.AccessorList?.Accessors.All(accessor => accessor.Body is null && accessor.ExpressionBody is null) == true;
+
+    static bool IsBodylessPartial(IndexerDeclarationSyntax indexer)
+        => indexer.Modifiers.Any(SyntaxKind.PartialKeyword)
+            && indexer.ExpressionBody is null
+            && indexer.AccessorList?.Accessors.All(accessor => accessor.Body is null && accessor.ExpressionBody is null) == true;
 
     static string? BodyText(ConstructorDeclarationSyntax constructor)
     {
@@ -753,6 +779,28 @@ static class ReturnToSenderSourceProbe
 
     static string NormalizeBody(string text)
         => Regex.Replace(text, @"\s+", "");
+
+    static string IndexerMetadataName(IndexerDeclarationSyntax indexer)
+    {
+        foreach (var attribute in indexer.AttributeLists.SelectMany(list => list.Attributes))
+        {
+            string name = attribute.Name.ToString();
+            if (!name.EndsWith("IndexerName", StringComparison.Ordinal)
+                && !name.EndsWith("IndexerNameAttribute", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (attribute.ArgumentList?.Arguments.FirstOrDefault()?.Expression is LiteralExpressionSyntax literal
+                && literal.IsKind(SyntaxKind.StringLiteralExpression)
+                && literal.Token.ValueText is { Length: > 0 } value)
+            {
+                return value;
+            }
+        }
+
+        return "Item";
+    }
 
     static string OperatorMetadataName(OperatorDeclarationSyntax op)
         => op.OperatorToken.Kind() switch


### PR DESCRIPTION
- Follows #2456 / #2452
- Changes harness-only RTS source-slice indexing for constructor/indexer/property edge cases
- Evidence revision: `ef45aeb2`

## Change

**Conclusion:** **REVIEW** — closes the constructor/indexer source-index drift found after #2456 merged by aligning source-slice slot accounting with metadata for static constructors, primary constructors, partial properties/indexers, and custom indexer names.

Before:

```text
Source extractor could map .ctor#0 to a static constructor body or miss a primary constructor slot before secondary constructors.
```

After:

```text
ReturnToSenderFixtureCatalogTests: 14 passed
RETURNTOSENDER SOURCE PROBE over 8 target(s)
  ValidMatch       : 6
  ValidDifferent   : 2
  Invalid          : 0
  SourceUnavailable: 0
  UnsupportedTarget: 0
```

## Scope and safety

- **Root cause:** Roslyn source member extraction did not consume source slots exactly like emitted metadata for constructor and indexer edge cases.
- **Fix shape:** split `.cctor` from `.ctor`, consume primary-constructor `.ctor` slots, skip erased partial properties/indexers, and honor `[IndexerName]` when mapping indexers.
- **Product impact:** none; harness/test-only source oracle logic.
- **Scope boundary:** richer valid-different taxonomy remains future work; this PR only prevents source-slice target drift.
- **RTS boundary:** unchanged; RTS still owns target/import/render/compile-back orchestration, while Roslyn source parsing remains harness-only.

## Evidence

| Check | Result |
| --- | --- |
| Focused tests | `ReturnToSenderFixtureCatalogTests` passed, 14 tests |
| Harness build | `dotnet build tools/DecompilerHarness -c Release --no-restore` passed |
| Source probe smoke | `rts.candidates`, cap 8: 6 `valid_match`, 2 `valid_different.unclassified`, 0 invalid/source-unavailable/unsupported |
| Solution build | `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config` passed |
| Markdown | `npx markdownlint-cli tools/DecompilerHarness/README.md` passed |

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `valid_different.unclassified` taxonomy | not changed | first source oracle keeps coarse catalog signal |
| product decompiler output | not changed | this is a source-probe indexing correction |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini Pro | Pending | Final review requested |
| MAI Flash | Pending | Final review requested |

## Validation

```bash
dotnet restore src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/*"
dotnet restore tools/DecompilerHarness/DecompilerHarness.csproj --configfile nuget.config
dotnet build tools/DecompilerHarness -c Release --no-restore
dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 8 --max-examples 8
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
npx markdownlint-cli tools/DecompilerHarness/README.md
```
