### PR TITLE
Use precedence model for binary operands

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CheckedUncheckedInsertTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CheckedUncheckedInsertTests.cs
@@ -54,7 +54,7 @@ public class CheckedUncheckedInsertTests
     [Fact]
     public void CheckedAdd_DivUnChild_WrapsSynthesizedCasts()
         => Assert.Equal(
-            "return checked(a + (unchecked((uint)b) / unchecked((uint)c)));",
+            "return checked(a + unchecked((uint)b) / unchecked((uint)c));",
             Render(Checked(BinaryKind.Add, A, Unsigned(BinaryKind.Divide, B, C))));
 
     // Paren safety: when the div.un sub-expression is an operand of an op of equal
@@ -144,12 +144,11 @@ public class CheckedUncheckedInsertTests
             Render(CheckedConvert(s_short, Plain(BinaryKind.Add, A, B))));
 
     // Positive canary: an implicit widening conversion (int -> long) never flips to
-    // conv.ovf inside checked, so it is left bare — no unchecked wrapper (the cast's
-    // usual operand parens are unchanged by #1425).
+    // conv.ovf inside checked, so it is left bare — no unchecked wrapper.
     [Fact]
     public void CheckedAdd_PlainWideningConvertChild_StaysBare()
         => Assert.Equal(
-            "return checked(d + ((long)a));",
+            "return checked(d + (long)a);",
             Render(Checked(BinaryKind.Add, D, PlainConvert(s_long, A))));
 
     // Positive canary: an all-checked expression keeps a single outer wrapper and
@@ -157,7 +156,7 @@ public class CheckedUncheckedInsertTests
     [Fact]
     public void CheckedAdd_AllCheckedChildren_SingleWrapperNoUnchecked()
         => Assert.Equal(
-            "return checked(a + (b * c));",
+            "return checked(a + b * c);",
             Render(Checked(BinaryKind.Add, A, Checked(BinaryKind.Multiply, B, C))));
 
     // Positive canary: a plain add with no enclosing checked context is untouched.
@@ -167,11 +166,10 @@ public class CheckedUncheckedInsertTests
             "return a + b;",
             Render(Plain(BinaryKind.Add, A, B)));
 
-    // Positive canary: nested checked-in-checked still collapses to a single
-    // wrapper (the inner add keeps its usual operand parens, unchanged by #1425).
+    // Positive canary: nested checked-in-checked still collapses to a single wrapper.
     [Fact]
     public void CheckedAdd_NestedCheckedChild_CollapsesToSingleWrapper()
         => Assert.Equal(
-            "return checked((a + b) + c);",
+            "return checked(a + b + c);",
             Render(Checked(BinaryKind.Add, Checked(BinaryKind.Add, A, B), C)));
 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2529,7 +2529,7 @@ public class RaisingPassTests
         Assert.Equal(1, output.Split("RecordIndex()", StringSplitOptions.None).Length - 1);
         Assert.Contains("ref int", output);
         Assert.Contains("= ref a[CfgSampleClass.RecordIndex()];", output);
-        Assert.Contains(") + v;", output);
+        Assert.Contains("+ v;", output);
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung4GateTests.cs
@@ -96,7 +96,7 @@ public class LadderRung4GateTests
         var recursiveLocal = Body("RecursiveLocalFunction");
         Assert.Contains("return Fact(value);", recursiveLocal);
         Assert.Contains("static int Fact(int n)", recursiveLocal);
-        Assert.Contains("return n * (Fact(n - 1));", recursiveLocal);
+        Assert.Contains("return n * Fact(n - 1);", recursiveLocal);
         Assert.DoesNotContain("CSharp7LocalSyntax.Fact", recursiveLocal);
         Assert.DoesNotContain("g__", recursiveLocal);
 

--- a/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LambdaRaisingPassTests.cs
@@ -93,7 +93,7 @@ public class LambdaRaisingPassTests
 
     [Fact]
     public void MultipleCaptures_AllSubstitutedIntoRaisedBody()
-        => Assert.Equal("return x => (x + a) - b;", PrintRaised(nameof(CfgSampleClass.TwoCaptureLambda)));
+        => Assert.Equal("return x => x + a - b;", PrintRaised(nameof(CfgSampleClass.TwoCaptureLambda)));
 
     [Fact]
     public void LocalBearingBody_RaisesBlockLambdaWithNestedLocalScope()

--- a/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LocalFunctionRaisingPassTests.cs
@@ -89,7 +89,7 @@ public class LocalFunctionRaisingPassTests
 
         Assert.Contains("return Fact(n);", output);
         Assert.Contains("static int Fact(int v)", output);
-        Assert.Contains("return v * (Fact(v - 1));", output);
+        Assert.Contains("return v * Fact(v - 1);", output);
         Assert.DoesNotContain("CfgSampleClass.Fact", output);
         Assert.DoesNotContain("g__", output);
     }

--- a/src/ILInspector.Decompiler.Tests/MixedSignArithmeticConstantTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignArithmeticConstantTests.cs
@@ -66,7 +66,7 @@ public class MixedSignArithmeticConstantTests
     [Fact]
     public void NestedConstantArithmetic_WrapsOnlyOutermost_Left()
         => Assert.Equal(
-            "return unchecked(((uint)-1 * 2) + 3);",
+            "return unchecked((uint)-1 * 2 + 3);",
             Render(Arith(BinaryKind.Add,
                 Arith(BinaryKind.Multiply, new Constant(-1, s_int), new Constant(2u, s_uint)),
                 new Constant(3u, s_uint))));

--- a/src/ILInspector.Decompiler.Tests/MixedSignBitwiseTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignBitwiseTests.cs
@@ -55,6 +55,6 @@ public class MixedSignBitwiseTests
         // so the outer `+ count` (uint) stays unsigned without a spurious cast.
         var output = Render(nameof(CfgSampleClass.NestedMixedSignArithmetic));
 
-        Assert.Contains("(a * (uint)b) + count", output);
+        Assert.Contains("a * (uint)b + count", output);
     }
 }

--- a/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
+++ b/src/ILInspector.Decompiler.Tests/PrinterPrecedenceTests.cs
@@ -200,6 +200,44 @@ public class PrinterPrecedenceTests
         Assert.DoesNotContain("return (E)-1;", output);
     }
 
+    [Fact]
+    public void BinaryOperand_TighterLeftChild_RendersBare()
+    {
+        var multiply = new Binary(BinaryKind.Multiply, false, false,
+            new LoadArgument(0, "a", s_int),
+            new LoadArgument(1, "b", s_int));
+        var add = new Binary(BinaryKind.Add, false, false,
+            multiply,
+            new LoadArgument(2, "c", s_int));
+
+        var output = PrintReturn(
+            add,
+            s_int,
+            [new Parameter("a", s_int), new Parameter("b", s_int), new Parameter("c", s_int)]);
+
+        Assert.Contains("return a * b + c;", output);
+        Assert.DoesNotContain("(a * b) + c", output);
+    }
+
+    [Fact]
+    public void BinaryOperand_RightEqualPrecedenceChild_StaysParenthesized()
+    {
+        var nested = new Binary(BinaryKind.Subtract, false, false,
+            new LoadArgument(1, "b", s_int),
+            new LoadArgument(2, "c", s_int));
+        var subtract = new Binary(BinaryKind.Subtract, false, false,
+            new LoadArgument(0, "a", s_int),
+            nested);
+
+        var output = PrintReturn(
+            subtract,
+            s_int,
+            [new Parameter("a", s_int), new Parameter("b", s_int), new Parameter("c", s_int)]);
+
+        Assert.Contains("return a - (b - c);", output);
+        Assert.DoesNotContain("return a - b - c;", output);
+    }
+
     static string PrintReturn(IrExpression value, TypeRef returnType, ImmutableArray<Parameter> parameters)
     {
         var block = new Block();

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.Numerics.cs
@@ -392,16 +392,17 @@ public sealed partial class CSharpPrinter
             && IsIntegerConstantExpression(binary)
             && IsUnsignedFixedWidthInteger(EffectiveType(binary))
             && !mixedSign;
+        var demand = CSharpPrecedence.Of(binary);
         string left = mixedSign ? BitwiseUnsignedOperand(binary.Left, wrapConstantCast: !covered)
             : castLeft ? UnsignedOperand(binary.Left)
             : preserveUnsignedConstants ? UnsignedConstantArithmeticOperand(binary.Left, EffectiveType(binary))
-            : Operand(binary.Left);
+            : BinaryOperand(binary.Left, demand, rightSide: false);
         bool isShift = binary.Kind is BinaryKind.ShiftLeft or BinaryKind.ShiftRight;
         string right = isShift ? ShiftCount(binary)
             : mixedSign ? BitwiseUnsignedOperand(binary.Right, wrapConstantCast: !covered)
             : castBoth ? UnsignedOperand(binary.Right)
             : preserveUnsignedConstants ? UnsignedConstantArithmeticOperand(binary.Right, EffectiveType(binary))
-            : Operand(binary.Right);
+            : BinaryOperand(binary.Right, demand, rightSide: true);
         string text = $"{left} {BinaryOperator(binary)} {right}";
         // add.ovf/sub.ovf/mul.ovf (and their .un forms) carry an overflow check
         // the default (unchecked) C# context would drop — spell it explicitly so
@@ -411,6 +412,19 @@ public sealed partial class CSharpPrinter
             return $"checked({text})";
         return uncheckedConstant || uncheckedOverflow ? $"unchecked({text})" : text;
     }
+
+    string BinaryOperand(IrExpression operand, Precedence parentPrecedence, bool rightSide)
+    {
+        // Binary operators are left-associative in C#. The right operand is the
+        // hazard side for equal-precedence children (`a - (b - c)`, `a << (b << c)`),
+        // so demand the next-tighter level there. The left side can associate
+        // bare at equal precedence (`(a - b) - c`).
+        var demand = rightSide ? TighterThan(parentPrecedence) : parentPrecedence;
+        return RenderedExpression(operand).At(demand);
+    }
+
+    static Precedence TighterThan(Precedence precedence)
+        => precedence == Precedence.Primary ? Precedence.Primary : (Precedence)((int)precedence + 1);
 
     string? EnumArithmeticText(Binary binary)
     {


### PR DESCRIPTION
## Summary

Continues #2376 by moving default binary operands onto the `Rendered`/`Precedence` model with explicit left/right associativity handling.

- Left operands render bare at equal precedence; right operands demand the next-tighter level so `a - (b - c)` and shift hazards stay parenthesized.
- Special unsigned/coercion/constant-overflow paths remain unchanged; this only replaces the default `Operand(...)` fallback for binary operands.
- Tests pin both the paren-equivalent simplifications and the right-side equal-precedence hazard.

## Evidence

- Focused/affected tests:
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/PrinterPrecedenceTests/BinaryOperand_TighterLeftChild_RendersBare"`
  - `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/PrinterPrecedenceTests/BinaryOperand_RightEqualPrecedenceChild_StaysParenthesized"`
  - affected printer/string canaries in `CheckedUncheckedInsertTests`, `MixedSignArithmeticConstantTests`, `MixedSignBitwiseTests`, `LambdaRaisingPassTests`, `LocalFunctionRaisingPassTests`, `LadderRung4GateTests`
- Fast decompiler suite: `dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"`
- Build: `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`
- Render A/B over 89,065 methods vs explicit merge-base (`4d628c9f` first run, current merge-base `3dcf43f1` after rebase), `--workers 20`:
  - `Changed: 1040 (structural: 60, paren-equivalent: 899, unparsed: 81)`
  - `Semantic: valid->valid: 887, invalid->valid: 0, valid->invalid: 0, invalid->invalid: 153`
  - Selected structural rows are semantic-neutral precedence simplifications, e.g. `(hash * prime) + other` → `hash * prime + other`; semantic lane reports **0 valid→invalid**.

## Review

Two-model adversarial review complete. Gemini and MAI both report clean reviews with no blocking findings; reconciliation is posted in the PR comments.
