### PR TITLE
Add decompiler taste decision evidence

### DIFF
--- a/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSourceRendererTests.cs
@@ -1,3 +1,4 @@
+using ILInspector.Decompiler;
 using ILInspector.Decompiler.Annotations;
 using ILInspector.Decompiler.Pipeline;
 using ILInspector.Research;
@@ -130,5 +131,31 @@ public class MixedSourceRendererTests
 
         Assert.NotNull(result.Trace);
         Assert.Equal(DecompilerSymbolSource.None, result.Trace!.Symbols);
+    }
+
+    [Fact]
+    public void DecompilerResult_MetadataDoesNotChangeEquality()
+    {
+        var left = new DecompilerResult("return 1;\n", DecompilationFidelity.Full, [])
+        {
+            Metadata = new DecompilerResultMetadata(
+                DecompilerOptions.Default,
+                [
+                    new DecompilerDecision("type-name.framework-imported", "taste", "System.Math", "test")
+                    {
+                        OldValue = "System.Math",
+                        NewValue = "Math",
+                    },
+                ]),
+        };
+        var right = new DecompilerResult("return 1;\n", DecompilationFidelity.Full, [])
+        {
+            Metadata = new DecompilerResultMetadata(
+                DecompilerOptions.Default with { ReadableLocalNames = true },
+                []),
+        };
+
+        Assert.Equal(left, right);
+        Assert.Equal(left.GetHashCode(), right.GetHashCode());
     }
 }

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -171,6 +171,56 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_KnownTasteMatchesGenericFrameworkTypes()
+    {
+        var decision = new DecompilerDecision(
+            "type-name.framework-imported",
+            "taste",
+            "System.Collections.Generic.List`1",
+            "test decision")
+        {
+            OldValue = "System.Collections.Generic.List",
+            NewValue = "List",
+        };
+
+        Assert.True(TryKnownTasteDifferenceForTest(
+            "System.Collections.Generic.List<int> values = null;",
+            "List<int> values = null;",
+            [decision],
+            out _));
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_KnownTasteUsesMostSpecificNestedFrameworkType()
+    {
+        var environment = new DecompilerDecision(
+            "type-name.framework-imported",
+            "taste",
+            "System.Environment",
+            "environment decision")
+        {
+            OldValue = "System.Environment",
+            NewValue = "Environment",
+        };
+        var specialFolder = new DecompilerDecision(
+            "type-name.framework-imported",
+            "taste",
+            "System.Environment+SpecialFolder",
+            "special folder decision")
+        {
+            OldValue = "System.Environment.SpecialFolder",
+            NewValue = "SpecialFolder",
+        };
+
+        Assert.True(TryKnownTasteDifferenceForTest(
+            "System.Environment.SpecialFolder folder = System.Environment.SpecialFolder.ApplicationData;",
+            "SpecialFolder folder = SpecialFolder.ApplicationData;",
+            [environment, specialFolder],
+            out var detail));
+        Assert.Contains("special folder", detail);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_IndexesPartialClassOverloadsAcrossSourceFiles()
     {
         var fixture = CompileSourceFixture(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -191,6 +191,37 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_KnownTasteRewritesNestedGenericArguments()
+    {
+        var task = new DecompilerDecision(
+            "type-name.framework-imported",
+            "taste",
+            "System.Threading.Tasks.Task`1",
+            "task decision")
+        {
+            OldValue = "System.Threading.Tasks.Task",
+            NewValue = "Task",
+        };
+        var list = new DecompilerDecision(
+            "type-name.framework-imported",
+            "taste",
+            "System.Collections.Generic.List`1",
+            "list decision")
+        {
+            OldValue = "System.Collections.Generic.List",
+            NewValue = "List",
+        };
+
+        Assert.True(TryKnownTasteDifferenceForTest(
+            "System.Threading.Tasks.Task<System.Collections.Generic.List<int>> values = null;",
+            "Task<List<int>> values = null;",
+            [task, list],
+            out var detail));
+        Assert.Contains("task", detail);
+        Assert.Contains("list", detail);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_KnownTasteUsesMostSpecificNestedFrameworkType()
     {
         var environment = new DecompilerDecision(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -3,6 +3,8 @@ using System.Reflection.PortableExecutable;
 
 using DotnetInspector.Fixtures;
 using ILInspector.DecompilerHarness;
+using ILInspector.Decompiler.Pipeline;
+using ILInspector.Metadata;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -58,6 +60,45 @@ public class ReturnToSenderFixtureCatalogTests
         Assert.EndsWith("DiffSample.cs", result.SourcePath, StringComparison.Ordinal);
         Assert.Equal("return42;", Normalize(result.ExpectedBody));
         Assert.Equal("return42;", Normalize(result.ActualBody));
+    }
+
+    [Fact]
+    public void DecompilerResult_ExposesEffectiveOptionsAndTasteDecisions()
+    {
+        using var source = MetadataSource.Open(FixtureCatalog.DiffV1.AssemblyPath());
+        var function = IrImporter.Import(source, "DiffFixtureSample.DiffSample", "CallToken", 0);
+        Assert.NotNull(function);
+
+        var result = CSharpPrinter.PrintRaised(function, method => IrImporter.Import(source, method));
+
+        Assert.True(result.EffectiveOptions.PreferFrameworkTypeImports);
+        Assert.False(result.EffectiveOptions.ReadableLocalNames);
+        var decision = Assert.Single(result.Decisions, decision =>
+            decision.RuleId == "type-name.framework-imported"
+            && decision.Category == "taste"
+            && decision.Subject == "System.Math");
+        Assert.Contains("System.Math", decision.Detail);
+        Assert.Contains("Math", result.Output);
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_ClassifiesKnownTasteDifferenceFromProductDecision()
+    {
+        var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+            FixtureCatalog.DiffV1.AssemblyPath(),
+            [
+                new ReturnToSender.RequestedTarget(
+                    "DiffFixtureSample.DiffSample",
+                    "CallToken",
+                    Overload: 0),
+            ]));
+
+        Assert.Equal(ReturnToSenderSourceOutcome.ValidDifferent, result.Outcome);
+        Assert.Equal(FidelityCheck.CompileBackStatus.Exact, result.CompileBackStatus);
+        Assert.Equal("valid_different.known_taste", result.Reason);
+        Assert.Contains("System.Math", result.Detail);
+        Assert.Equal("returnSystem.Math.Abs(value);", Normalize(result.ExpectedBody));
+        Assert.Equal("returnMath.Abs(value);", Normalize(result.ActualBody));
     }
 
     [Fact]

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Reflection;
 
 using DotnetInspector.Fixtures;
 using ILInspector.DecompilerHarness;
@@ -135,6 +136,38 @@ public class ReturnToSenderFixtureCatalogTests
         {
             Directory.Delete(fixture.Directory, recursive: true);
         }
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_KnownTasteDoesNotRewriteStringLiterals()
+    {
+        var decision = new DecompilerDecision(
+            "type-name.framework-imported",
+            "taste",
+            "System.Math",
+            "test decision");
+
+        Assert.False(TryKnownTasteDifferenceForTest(
+            """var text = "System.Math";""",
+            """var text = "Math";""",
+            [decision],
+            out _));
+    }
+
+    [Fact]
+    public void ReturnToSenderSourceProbe_KnownTasteDoesNotRewritePrefixCollisions()
+    {
+        var decision = new DecompilerDecision(
+            "type-name.framework-imported",
+            "taste",
+            "System.Console",
+            "test decision");
+
+        Assert.False(TryKnownTasteDifferenceForTest(
+            "System.ConsoleColor value;",
+            "ConsoleColor value;",
+            [decision],
+            out _));
     }
 
     [Fact]
@@ -632,6 +665,22 @@ public class ReturnToSenderFixtureCatalogTests
         var emit = compilation.Emit(assemblyPath);
         Assert.True(emit.Success, string.Join(Environment.NewLine, emit.Diagnostics));
         return (directory, assemblyPath, sourcePaths);
+    }
+
+    static bool TryKnownTasteDifferenceForTest(
+        string expected,
+        string actual,
+        IReadOnlyList<DecompilerDecision> decisions,
+        out string? detail)
+    {
+        var method = typeof(ReturnToSenderSourceProbe).GetMethod(
+            "TryKnownTasteDifference",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        object?[] args = [expected, actual, decisions, null];
+        bool result = (bool)method.Invoke(null, args)!;
+        detail = (string?)args[3];
+        return result;
     }
 
     static string? Normalize(string? text)

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -222,6 +222,27 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_KnownTastePreservesNestedGenericTypeArguments()
+    {
+        var list = new DecompilerDecision(
+            "type-name.framework-imported",
+            "taste",
+            "System.Collections.Generic.List`1",
+            "list decision")
+        {
+            OldValue = "System.Collections.Generic.List",
+            NewValue = "List",
+        };
+
+        Assert.True(TryKnownTasteDifferenceForTest(
+            "System.Collections.Generic.List<int>.Enumerator enumerator = default;",
+            "List<int>.Enumerator enumerator = default;",
+            [list],
+            out var detail));
+        Assert.Contains("list", detail);
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_KnownTasteUsesMostSpecificNestedFrameworkType()
     {
         var environment = new DecompilerDecision(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -243,6 +243,38 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_ClassifiesOpenGenericNestedFrameworkType()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public class Class1
+            {
+                public System.Type M()
+                    => typeof(System.Collections.Generic.List<>.Enumerator);
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "M", Overload: 0)],
+                fixture.SourcePaths));
+
+            Assert.Equal(ReturnToSenderSourceOutcome.ValidDifferent, result.Outcome);
+            Assert.Equal("valid_different.known_taste", result.Reason);
+            Assert.Contains("System.Collections.Generic.List", result.Detail);
+            Assert.Equal("returntypeof(System.Collections.Generic.List<>.Enumerator);", Normalize(result.ExpectedBody));
+            Assert.Equal("returntypeof(List<>.Enumerator);", Normalize(result.ActualBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_KnownTasteUsesMostSpecificNestedFrameworkType()
     {
         var environment = new DecompilerDecision(

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -102,6 +102,42 @@ public class ReturnToSenderFixtureCatalogTests
     }
 
     [Fact]
+    public void ReturnToSenderSourceProbe_ClassifiesKnownTasteDifferenceAcrossMultipleFrameworkImports()
+    {
+        var fixture = CompileSourceFixture(
+            ("Class1.cs", """
+            namespace SourceProbe;
+
+            public class Class1
+            {
+                public int M(int value)
+                {
+                    System.Console.WriteLine(value);
+                    return System.Math.Abs(value);
+                }
+            }
+            """));
+        try
+        {
+            var result = Assert.Single(ReturnToSenderSourceProbe.EvaluateTargets(
+                fixture.AssemblyPath,
+                [new ReturnToSender.RequestedTarget("SourceProbe.Class1", "M", Overload: 0)],
+                fixture.SourcePaths));
+
+            Assert.Equal(ReturnToSenderSourceOutcome.ValidDifferent, result.Outcome);
+            Assert.Equal("valid_different.known_taste", result.Reason);
+            Assert.Contains("System.Console", result.Detail);
+            Assert.Contains("System.Math", result.Detail);
+            Assert.Equal("System.Console.WriteLine(value);returnSystem.Math.Abs(value);", Normalize(result.ExpectedBody));
+            Assert.Equal("Console.WriteLine(value);returnMath.Abs(value);", Normalize(result.ActualBody));
+        }
+        finally
+        {
+            Directory.Delete(fixture.Directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ReturnToSenderSourceProbe_IndexesPartialClassOverloadsAcrossSourceFiles()
     {
         var fixture = CompileSourceFixture(

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -33,6 +33,38 @@ public readonly record struct DecompilerDiagnostic(string Id, string Message)
     public override string ToString() => $"{Id}: {Message}";
 }
 
+/// <summary>
+/// Product-owned decompiler rendering choices. Hosts and harnesses can inspect
+/// the effective options instead of reverse-engineering taste decisions from
+/// rendered text.
+/// </summary>
+public sealed record DecompilerOptions
+{
+    /// <summary>
+    /// Local names without PDB evidence may render as synthesized readable names.
+    /// Off by default so the shipped output remains IL/PDB-aligned.
+    /// </summary>
+    public bool ReadableLocalNames { get; init; }
+
+    /// <summary>
+    /// Framework type names may render in imported/simple form when the C# file
+    /// shape supplies the namespace. This is the shipped taste choice.
+    /// </summary>
+    public bool PreferFrameworkTypeImports { get; init; } = true;
+
+    public static DecompilerOptions Default { get; } = new();
+}
+
+/// <summary>
+/// A typed explanation for an intentional decompiler rendering choice. This is
+/// product evidence: harnesses may project it, but should not own the rule.
+/// </summary>
+public sealed record DecompilerDecision(
+    string RuleId,
+    string Category,
+    string Subject,
+    string Detail);
+
 /// <summary>Stable diagnostic identifiers. Never renumber or reuse.</summary>
 public static class DiagnosticIds
 {
@@ -175,6 +207,12 @@ public sealed record DecompilerResult(
     /// one (only the C# render entry points populate it today).
     /// </summary>
     public DecompilerTrace? Trace { get; init; }
+
+    /// <summary>The product options in force for this result.</summary>
+    public DecompilerOptions EffectiveOptions { get; init; } = DecompilerOptions.Default;
+
+    /// <summary>Product-owned decision evidence explaining intentional render choices.</summary>
+    public IReadOnlyList<DecompilerDecision> Decisions { get; init; } = [];
 
     public static DecompilerResult Success(string output)
         => new(output, DecompilationFidelity.Full, []);

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace ILInspector.Decompiler;
 
 /// <summary>
@@ -67,6 +69,13 @@ public sealed record DecompilerDecision(
 {
     public string? OldValue { get; init; }
     public string? NewValue { get; init; }
+}
+
+public sealed record DecompilerResultMetadata(
+    DecompilerOptions EffectiveOptions,
+    IReadOnlyList<DecompilerDecision> Decisions)
+{
+    public static DecompilerResultMetadata Default { get; } = new(DecompilerOptions.Default, []);
 }
 
 /// <summary>Stable diagnostic identifiers. Never renumber or reuse.</summary>
@@ -173,6 +182,8 @@ public sealed record DecompilerResult(
     DecompilationFidelity Fidelity,
     IReadOnlyList<DecompilerDiagnostic> Diagnostics)
 {
+    static readonly ConditionalWeakTable<DecompilerResult, MetadataBox> s_metadata = new();
+
     public bool Succeeded => Output is not null;
 
     /// <summary>
@@ -212,17 +223,37 @@ public sealed record DecompilerResult(
     /// </summary>
     public DecompilerTrace? Trace { get; init; }
 
+    /// <summary>
+    /// Product-owned metadata that explains intentional render choices. The
+    /// holder keeps this evolving evidence off <see cref="DecompilerResult"/>'s
+    /// historical record equality surface.
+    /// </summary>
+    public DecompilerResultMetadata Metadata
+    {
+        get => s_metadata.TryGetValue(this, out var box) ? box.Value : DecompilerResultMetadata.Default;
+        init
+        {
+            s_metadata.Remove(this);
+            s_metadata.Add(this, new MetadataBox(value));
+        }
+    }
+
     /// <summary>The product options in force for this result.</summary>
-    public DecompilerOptions EffectiveOptions { get; init; } = DecompilerOptions.Default;
+    public DecompilerOptions EffectiveOptions => Metadata.EffectiveOptions;
 
     /// <summary>Product-owned decision evidence explaining intentional render choices.</summary>
-    public IReadOnlyList<DecompilerDecision> Decisions { get; init; } = [];
+    public IReadOnlyList<DecompilerDecision> Decisions => Metadata.Decisions;
 
     public static DecompilerResult Success(string output)
         => new(output, DecompilationFidelity.Full, []);
 
     public static DecompilerResult Failure(string diagnosticId, string message)
         => new(null, DecompilationFidelity.Failed, [new DecompilerDiagnostic(diagnosticId, message)]);
+
+    sealed class MetadataBox(DecompilerResultMetadata value)
+    {
+        public DecompilerResultMetadata Value { get; } = value;
+    }
 
     /// <summary>
     /// Runs a pipeline entry point, converting exceptions into diagnostics.

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace ILInspector.Decompiler;
 
 /// <summary>
@@ -182,8 +180,6 @@ public sealed record DecompilerResult(
     DecompilationFidelity Fidelity,
     IReadOnlyList<DecompilerDiagnostic> Diagnostics)
 {
-    static readonly ConditionalWeakTable<DecompilerResult, MetadataBox> s_metadata = new();
-
     public bool Succeeded => Output is not null;
 
     /// <summary>
@@ -228,15 +224,7 @@ public sealed record DecompilerResult(
     /// holder keeps this evolving evidence off <see cref="DecompilerResult"/>'s
     /// historical record equality surface.
     /// </summary>
-    public DecompilerResultMetadata Metadata
-    {
-        get => s_metadata.TryGetValue(this, out var box) ? box.Value : DecompilerResultMetadata.Default;
-        init
-        {
-            s_metadata.Remove(this);
-            s_metadata.Add(this, new MetadataBox(value));
-        }
-    }
+    public DecompilerResultMetadata Metadata { get; init; } = DecompilerResultMetadata.Default;
 
     /// <summary>The product options in force for this result.</summary>
     public DecompilerOptions EffectiveOptions => Metadata.EffectiveOptions;
@@ -250,9 +238,29 @@ public sealed record DecompilerResult(
     public static DecompilerResult Failure(string diagnosticId, string message)
         => new(null, DecompilationFidelity.Failed, [new DecompilerDiagnostic(diagnosticId, message)]);
 
-    sealed class MetadataBox(DecompilerResultMetadata value)
+    public bool Equals(DecompilerResult? other)
+        => other is not null
+            && EqualityComparer<string?>.Default.Equals(Output, other.Output)
+            && Fidelity == other.Fidelity
+            && EqualityComparer<IReadOnlyList<DecompilerDiagnostic>>.Default.Equals(Diagnostics, other.Diagnostics)
+            && EqualityComparer<string?>.Default.Equals(ConstructorChain, other.ConstructorChain)
+            && EqualityComparer<IReadOnlyList<(string Field, string Value)>>.Default.Equals(FieldInitializers, other.FieldInitializers)
+            && RequiresAsyncBodyModifier == other.RequiresAsyncBodyModifier
+            && ContainsAwaitExpression == other.ContainsAwaitExpression
+            && EqualityComparer<DecompilerTrace?>.Default.Equals(Trace, other.Trace);
+
+    public override int GetHashCode()
     {
-        public DecompilerResultMetadata Value { get; } = value;
+        var hash = new HashCode();
+        hash.Add(Output);
+        hash.Add(Fidelity);
+        hash.Add(Diagnostics);
+        hash.Add(ConstructorChain);
+        hash.Add(FieldInitializers);
+        hash.Add(RequiresAsyncBodyModifier);
+        hash.Add(ContainsAwaitExpression);
+        hash.Add(Trace);
+        return hash.ToHashCode();
     }
 
     /// <summary>

--- a/src/ILInspector.Decompiler/DecompilerResult.cs
+++ b/src/ILInspector.Decompiler/DecompilerResult.cs
@@ -63,7 +63,11 @@ public sealed record DecompilerDecision(
     string RuleId,
     string Category,
     string Subject,
-    string Detail);
+    string Detail)
+{
+    public string? OldValue { get; init; }
+    public string? NewValue { get; init; }
+}
 
 /// <summary>Stable diagnostic identifiers. Never renumber or reuse.</summary>
 public static class DiagnosticIds

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3517,8 +3517,7 @@ public sealed partial class CSharpPrinter
             return;
         if (HasGenericEnclosingSegment(definition.Name))
         {
-            if (type.Kind == TypeRefKind.GenericInstance)
-                RecordNestedGenericEnclosingImportDecisions(definition, rendered);
+            RecordNestedGenericEnclosingImportDecisions(definition, rendered);
             return;
         }
 

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -215,8 +215,7 @@ public sealed partial class CSharpPrinter
             FieldInitializers = _fieldInitializers,
             RequiresAsyncBodyModifier = function.RequiresAsyncBodyModifier,
             ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
-            EffectiveOptions = EffectiveDecompilerOptions(),
-            Decisions = [.. _decisions],
+            Metadata = new DecompilerResultMetadata(EffectiveDecompilerOptions(), [.. _decisions]),
         };
 
     DecompilerOptions EffectiveDecompilerOptions()

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3519,8 +3519,6 @@ public sealed partial class CSharpPrinter
         string simpleName = TypeNamePath(definition.Name);
         if (rendered.Contains(definition.Namespace + ".", StringComparison.Ordinal))
             return;
-        if (!rendered.Contains(simpleName, StringComparison.Ordinal))
-            return;
 
         AddDecision(
             "type-name.framework-imported",

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -41,6 +41,8 @@ public sealed partial class CSharpPrinter
 
     readonly PrinterOptions _options;
     readonly HashSet<string> _reservedScopeNames;
+    readonly List<DecompilerDecision> _decisions = [];
+    readonly HashSet<string> _decisionKeys = [];
 
     CSharpPrinter(IrFunction function, PrinterOptions? options = null, IEnumerable<string>? reservedScopeNames = null)
     {
@@ -108,13 +110,7 @@ public sealed partial class CSharpPrinter
             var printer = new CSharpPrinter(function) { _statementLines = sink };
             string output = printer.PrintBody(function);
             statementLines = sink;
-            return new DecompilerResult(output, function.Fidelity, [.. function.Diagnostics])
-            {
-                ConstructorChain = printer._constructorChain,
-                FieldInitializers = printer._fieldInitializers,
-                RequiresAsyncBodyModifier = function.RequiresAsyncBodyModifier,
-                ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
-            };
+            return printer.Result(output, function);
         }
         catch (Exception ex)
         {
@@ -175,13 +171,7 @@ public sealed partial class CSharpPrinter
             var printer = new CSharpPrinter(function) { _statementLines = sink };
             string output = printer.PrintBody(function);
             statementLines = sink;
-            return new DecompilerResult(output, function.Fidelity, [.. function.Diagnostics])
-            {
-                ConstructorChain = printer._constructorChain,
-                FieldInitializers = printer._fieldInitializers,
-                RequiresAsyncBodyModifier = function.RequiresAsyncBodyModifier,
-                ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
-            };
+            return printer.Result(output, function);
         }
         catch (Exception ex)
         {
@@ -210,18 +200,37 @@ public sealed partial class CSharpPrinter
         {
             var printer = new CSharpPrinter(function, options);
             string output = printer.PrintBody(function);
-            return new DecompilerResult(output, function.Fidelity, [.. function.Diagnostics])
-            {
-                ConstructorChain = printer._constructorChain,
-                FieldInitializers = printer._fieldInitializers,
-                RequiresAsyncBodyModifier = function.RequiresAsyncBodyModifier,
-                ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
-            };
+            return printer.Result(output, function);
         }
         catch (Exception ex)
         {
             return DecompilerResult.Failure(DiagnosticIds.InternalError, $"{ex.GetType().Name}: {ex.Message}");
         }
+    }
+
+    DecompilerResult Result(string output, IrFunction function)
+        => new(output, function.Fidelity, [.. function.Diagnostics])
+        {
+            ConstructorChain = _constructorChain,
+            FieldInitializers = _fieldInitializers,
+            RequiresAsyncBodyModifier = function.RequiresAsyncBodyModifier,
+            ContainsAwaitExpression = function.Descendants.OfType<AwaitExpression>().Any(),
+            EffectiveOptions = EffectiveDecompilerOptions(),
+            Decisions = [.. _decisions],
+        };
+
+    DecompilerOptions EffectiveDecompilerOptions()
+        => new()
+        {
+            ReadableLocalNames = _options.ReadableLocalNames,
+            PreferFrameworkTypeImports = true,
+        };
+
+    void AddDecision(string ruleId, string category, string subject, string detail)
+    {
+        string key = $"{ruleId}\0{category}\0{subject}\0{detail}";
+        if (_decisionKeys.Add(key))
+            _decisions.Add(new DecompilerDecision(ruleId, category, subject, detail));
     }
 
     /// <summary>Stores that double as declarations: the local's first program-order reference, at statement level in the entry block.</summary>
@@ -3483,8 +3492,33 @@ public sealed partial class CSharpPrinter
         // innermost name is in scope (Enumerator inside List<T>.GetEnumerator).
         string text = type.ToDisplayString(_function.DeclaringType);
         int tick = text.IndexOf('`');
-        return tick < 0 ? text : text[..tick];
+        string rendered = tick < 0 ? text : text[..tick];
+        RecordFrameworkTypeImportDecision(type, rendered);
+        return rendered;
     }
+
+    void RecordFrameworkTypeImportDecision(TypeRef type, string rendered)
+    {
+        var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
+        if (definition is not { Kind: TypeRefKind.Definition, Namespace.Length: > 0 })
+            return;
+        if (!IsFrameworkNamespace(definition.Namespace))
+            return;
+        string fullName = $"{definition.Namespace}.{CSharpNaming.TypeNameSegment(definition.Name)}";
+        if (rendered.Contains(definition.Namespace + ".", StringComparison.Ordinal))
+            return;
+        if (!rendered.Contains(CSharpNaming.TypeNameSegment(definition.Name), StringComparison.Ordinal))
+            return;
+
+        AddDecision(
+            "type-name.framework-imported",
+            "taste",
+            fullName,
+            $"Rendered framework type '{fullName}' as imported/simple name '{rendered}'.");
+    }
+
+    static bool IsFrameworkNamespace(string ns)
+        => ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal);
 
     string DeclarationTypeText(TypeRef type, IrExpression initializer)
         => initializer is AnonymousObject anonymous && type.Equals(anonymous.Type)

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -226,11 +226,17 @@ public sealed partial class CSharpPrinter
             PreferFrameworkTypeImports = true,
         };
 
-    void AddDecision(string ruleId, string category, string subject, string detail)
+    void AddDecision(string ruleId, string category, string subject, string detail, string? oldValue = null, string? newValue = null)
     {
-        string key = $"{ruleId}\0{category}\0{subject}\0{detail}";
+        string key = $"{ruleId}\0{category}\0{subject}\0{detail}\0{oldValue}\0{newValue}";
         if (_decisionKeys.Add(key))
-            _decisions.Add(new DecompilerDecision(ruleId, category, subject, detail));
+        {
+            _decisions.Add(new DecompilerDecision(ruleId, category, subject, detail)
+            {
+                OldValue = oldValue,
+                NewValue = newValue,
+            });
+        }
     }
 
     /// <summary>Stores that double as declarations: the local's first program-order reference, at statement level in the entry block.</summary>
@@ -3499,23 +3505,58 @@ public sealed partial class CSharpPrinter
 
     void RecordFrameworkTypeImportDecision(TypeRef type, string rendered)
     {
+        foreach (var nested in DescendantTypes(type))
+            RecordFrameworkTypeImportDecisionCore(nested, rendered);
+    }
+
+    void RecordFrameworkTypeImportDecisionCore(TypeRef type, string rendered)
+    {
         var definition = type.Kind == TypeRefKind.GenericInstance ? type.ElementType ?? type : type;
         if (definition is not { Kind: TypeRefKind.Definition, Namespace.Length: > 0 })
             return;
         if (!IsFrameworkNamespace(definition.Namespace))
             return;
-        string fullName = $"{definition.Namespace}.{CSharpNaming.TypeNameSegment(definition.Name)}";
+        string fullName = FrameworkMetadataName(definition);
+        string simpleName = CSharpNaming.TypeNameSegment(definition.Name);
         if (rendered.Contains(definition.Namespace + ".", StringComparison.Ordinal))
             return;
-        if (!rendered.Contains(CSharpNaming.TypeNameSegment(definition.Name), StringComparison.Ordinal))
+        if (!rendered.Contains(simpleName, StringComparison.Ordinal))
             return;
 
         AddDecision(
             "type-name.framework-imported",
             "taste",
             fullName,
-            $"Rendered framework type '{fullName}' as imported/simple name '{rendered}'.");
+            $"Rendered framework type '{fullName}' as imported/simple name '{simpleName}'.",
+            oldValue: FrameworkSourceName(definition),
+            newValue: simpleName);
     }
+
+    static IEnumerable<TypeRef> DescendantTypes(TypeRef type)
+    {
+        yield return type;
+        if (type.ElementType is { } element)
+        {
+            foreach (var descendant in DescendantTypes(element))
+                yield return descendant;
+        }
+        foreach (var argument in type.TypeArguments)
+        {
+            foreach (var descendant in DescendantTypes(argument))
+                yield return descendant;
+        }
+    }
+
+    static string FrameworkMetadataName(TypeRef type)
+        => type.Namespace.Length == 0 ? CSharpNaming.TypeNameSegment(type.Name) : $"{type.Namespace}.{type.Name}";
+
+    static string FrameworkSourceName(TypeRef type)
+        => type.Namespace.Length == 0
+            ? TypeNamePath(type.Name)
+            : $"{type.Namespace}.{TypeNamePath(type.Name)}";
+
+    static string TypeNamePath(string metadataName)
+        => string.Join(".", metadataName.Split('+').Select(CSharpNaming.TypeNameSegment));
 
     static bool IsFrameworkNamespace(string ns)
         => ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3515,6 +3515,13 @@ public sealed partial class CSharpPrinter
             return;
         if (!IsFrameworkNamespace(definition.Namespace))
             return;
+        if (HasGenericEnclosingSegment(definition.Name))
+        {
+            if (type.Kind == TypeRefKind.GenericInstance)
+                RecordNestedGenericEnclosingImportDecisions(definition, rendered);
+            return;
+        }
+
         string fullName = FrameworkMetadataName(definition);
         string simpleName = TypeNamePath(definition.Name);
         if (rendered.Contains(definition.Namespace + ".", StringComparison.Ordinal))
@@ -3527,6 +3534,31 @@ public sealed partial class CSharpPrinter
             $"Rendered framework type '{fullName}' as imported/simple name '{simpleName}'.",
             oldValue: FrameworkSourceName(definition),
             newValue: simpleName);
+    }
+
+    void RecordNestedGenericEnclosingImportDecisions(TypeRef definition, string rendered)
+    {
+        var segments = definition.Name.Split('+');
+        var sourceSegments = new List<string>(segments.Length);
+        for (int i = 0; i < segments.Length - 1; i++)
+        {
+            sourceSegments.Add(CSharpNaming.TypeNameSegment(segments[i]));
+            if (GenericArity(segments[i]) == 0)
+                continue;
+
+            string oldValue = $"{definition.Namespace}.{string.Join(".", sourceSegments)}";
+            string newValue = string.Join(".", sourceSegments);
+            if (rendered.Contains(definition.Namespace + ".", StringComparison.Ordinal))
+                continue;
+
+            AddDecision(
+                "type-name.framework-imported",
+                "taste",
+                $"{definition.Namespace}.{string.Join("+", segments.Take(i + 1))}",
+                $"Rendered framework type '{oldValue}' as imported/simple name '{newValue}'.",
+                oldValue: oldValue,
+                newValue: newValue);
+        }
     }
 
     static IEnumerable<TypeRef> DescendantTypes(TypeRef type)
@@ -3554,6 +3586,19 @@ public sealed partial class CSharpPrinter
 
     static string TypeNamePath(string metadataName)
         => string.Join(".", metadataName.Split('+').Select(CSharpNaming.TypeNameSegment));
+
+    static bool HasGenericEnclosingSegment(string metadataName)
+    {
+        var segments = metadataName.Split('+');
+        return segments.Length > 1
+            && segments.Take(segments.Length - 1).Any(segment => GenericArity(segment) > 0);
+    }
+
+    static int GenericArity(string metadataName)
+    {
+        int tick = metadataName.IndexOf('`', StringComparison.Ordinal);
+        return tick >= 0 && int.TryParse(metadataName[(tick + 1)..], out int arity) ? arity : 0;
+    }
 
     static bool IsFrameworkNamespace(string ns)
         => ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal);

--- a/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
+++ b/src/ILInspector.Decompiler/Pipeline/Ir/CSharpPrinter.cs
@@ -3517,7 +3517,7 @@ public sealed partial class CSharpPrinter
         if (!IsFrameworkNamespace(definition.Namespace))
             return;
         string fullName = FrameworkMetadataName(definition);
-        string simpleName = CSharpNaming.TypeNameSegment(definition.Name);
+        string simpleName = TypeNamePath(definition.Name);
         if (rendered.Contains(definition.Namespace + ".", StringComparison.Ordinal))
             return;
         if (!rendered.Contains(simpleName, StringComparison.Ordinal))

--- a/tools/DecompilerHarness/README.md
+++ b/tools/DecompilerHarness/README.md
@@ -162,9 +162,12 @@ The source probe reuses RTS target discovery/import/render/compile-back plumbing
 and, for catalog fixtures, compares the decompiled target body against the
 checked-in fixture source slice. It reports coarse source-fidelity outcomes:
 `valid_match`, `valid_different`, `invalid`, `source_unavailable`, and
-`unsupported_target`; valid-but-different rows are intentionally classified
-coarsely first so later Roslyn-assisted analysis can grow stable taxonomy
-buckets.
+`unsupported_target`. Valid-but-different rows may be split by product-owned
+decompiler decision evidence, such as `valid_different.known_taste` for a
+documented taste rule versus `valid_different.unclassified` for source deltas
+that still need analysis. Roslyn-assisted source comparison stays in the harness;
+the product decompiler owns effective options and typed decisions that explain
+intentional output choices.
 Rows may carry two independent expectations: a Roslyn `SyntaxKind` shape verdict
 for the intended C# idiom, and a compile-back opcode verdict for semantic
 fidelity. A row can therefore be opcode-exact while still exposing a shape

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -31,7 +31,8 @@ static class ReturnToSender
         string? Detail,
         string TargetBody = "",
         IlDiffDisplayResult? IlDiffDiagnostic = null,
-        MemberAnchor? MemberAnchor = null);
+        MemberAnchor? MemberAnchor = null,
+        IReadOnlyList<DecompilerDecision>? Decisions = null);
 
     public sealed record RequestedTarget(string Type, string Method, int Overload);
 
@@ -725,7 +726,8 @@ static class ReturnToSender
                     null,
                     TargetBody: printed.Output,
                     IlDiffDiagnostic: ilDiffDiagnostic,
-                    MemberAnchor: memberAnchor);
+                    MemberAnchor: memberAnchor,
+                    Decisions: printed.Decisions);
             }
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
@@ -882,7 +884,8 @@ static class ReturnToSender
                     null,
                     TargetBody: printed.Output,
                     IlDiffDiagnostic: ilDiffDiagnostic,
-                    MemberAnchor: memberAnchor);
+                    MemberAnchor: memberAnchor,
+                    Decisions: printed.Decisions);
             }
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
@@ -1040,7 +1043,8 @@ static class ReturnToSender
                     null,
                     TargetBody: printed.Output,
                     IlDiffDiagnostic: ilDiffDiagnostic,
-                    MemberAnchor: memberAnchor);
+                    MemberAnchor: memberAnchor,
+                    Decisions: printed.Decisions);
             }
 
             var errors = emit.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();

--- a/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
+++ b/tools/DecompilerHarness/ReturnToSenderSourceProbe.cs
@@ -4,6 +4,7 @@ using System.Reflection.PortableExecutable;
 using System.Text.RegularExpressions;
 
 using DotnetInspector.Fixtures;
+using ILInspector.Decompiler;
 using ILInspector.Metadata;
 
 using Microsoft.CodeAnalysis;
@@ -239,12 +240,16 @@ static class ReturnToSenderSourceProbe
                 continue;
             }
 
+            var decisions = result.Decisions ?? [];
+            string reason = TryKnownTasteDifference(expected, actual, decisions, out var tasteDetail)
+                ? "valid_different.known_taste"
+                : "valid_different.unclassified";
             results.Add(new ReturnToSenderSourceProbeResult(
                 target,
                 ReturnToSenderSourceOutcome.ValidDifferent,
                 result.Status,
-                "valid_different.unclassified",
-                Detail: "decompiled body is Roslyn-valid but differs from the fixture source slice",
+                reason,
+                Detail: tasteDetail ?? "decompiled body is Roslyn-valid but differs from the fixture source slice",
                 sourceMember.SourcePath,
                 expected,
                 actual));
@@ -899,6 +904,141 @@ static class ReturnToSenderSourceProbe
         }
 
         return true;
+    }
+
+    static bool TryKnownTasteDifference(
+        string expected,
+        string actual,
+        IReadOnlyList<DecompilerDecision> decisions,
+        out string? detail)
+    {
+        var rewrites = decisions
+            .Where(decision => decision is { Category: "taste", RuleId: "type-name.framework-imported" })
+            .Select(decision =>
+            {
+                string oldValue = decision.OldValue ?? decision.Subject.Replace('+', '.');
+                int lastDot = oldValue.LastIndexOf('.');
+                return lastDot < 0 || lastDot == oldValue.Length - 1
+                    ? null
+                    : new FrameworkTypeRewrite(
+                        oldValue,
+                        decision.NewValue ?? oldValue[(lastDot + 1)..],
+                        decision);
+            })
+            .Where(rewrite => rewrite is not null)
+            .Select(rewrite => rewrite!)
+            .ToArray();
+        if (rewrites.Length == 0)
+        {
+            detail = null;
+            return false;
+        }
+
+        string wrapped = "{" + Environment.NewLine + expected + Environment.NewLine + "}";
+        var tree = CSharpSyntaxTree.ParseText(wrapped);
+        var root = tree.GetCompilationUnitRoot();
+        var rewriter = new FrameworkTypeNameRewriter(rewrites);
+        var rewrittenRoot = rewriter.Visit(root);
+        if (rewrittenRoot is null || rewriter.Applied.Count == 0)
+        {
+            detail = null;
+            return false;
+        }
+
+        string rewrittenExpected = rewrittenRoot.ToFullString();
+        int openBrace = rewrittenExpected.IndexOf('{');
+        int closeBrace = rewrittenExpected.LastIndexOf('}');
+        if (openBrace >= 0 && closeBrace > openBrace)
+            rewrittenExpected = rewrittenExpected[(openBrace + 1)..closeBrace];
+
+        if (NormalizeBody(rewrittenExpected) == NormalizeBody(actual))
+        {
+            detail = string.Join("; ", rewriter.Applied.Distinct().Select(decision => decision.Detail));
+            return true;
+        }
+
+        detail = null;
+        return false;
+    }
+
+    sealed record FrameworkTypeRewrite(string FullName, string SimpleName, DecompilerDecision Decision);
+
+    sealed class FrameworkTypeNameRewriter(IReadOnlyList<FrameworkTypeRewrite> rewrites) : CSharpSyntaxRewriter
+    {
+        public List<DecompilerDecision> Applied { get; } = [];
+
+        public override SyntaxNode? VisitQualifiedName(QualifiedNameSyntax node)
+        {
+            var rewrite = FindRewrite(node);
+            var visited = (QualifiedNameSyntax)base.VisitQualifiedName(node)!;
+            return rewrite is not null
+                ? ApplyRewrite(visited, rewrite)
+                : RewriteName(visited) ?? visited;
+        }
+
+        public override SyntaxNode? VisitAliasQualifiedName(AliasQualifiedNameSyntax node)
+        {
+            var rewrite = FindRewrite(node);
+            var visited = (AliasQualifiedNameSyntax)base.VisitAliasQualifiedName(node)!;
+            return rewrite is not null
+                ? ApplyRewrite(visited, rewrite)
+                : RewriteName(visited) ?? visited;
+        }
+
+        public override SyntaxNode? VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+        {
+            var rewrite = FindRewrite(node);
+            var visited = (MemberAccessExpressionSyntax)base.VisitMemberAccessExpression(node)!;
+            return rewrite is not null
+                ? ApplyRewrite(visited, rewrite)
+                : RewriteName(visited) ?? visited;
+        }
+
+        SyntaxNode? RewriteName(SyntaxNode node)
+            => FindRewrite(node) is { } rewrite ? ApplyRewrite(node, rewrite) : null;
+
+        FrameworkTypeRewrite? FindRewrite(SyntaxNode node)
+        {
+            string canonical = CanonicalNameText(node);
+            return rewrites
+                .Where(rewrite => canonical == rewrite.FullName)
+                .OrderByDescending(rewrite => rewrite.FullName.Length)
+                .FirstOrDefault();
+        }
+
+        SyntaxNode ApplyRewrite(SyntaxNode node, FrameworkTypeRewrite rewrite)
+        {
+            Applied.Add(rewrite.Decision);
+            return ReplacementName(node, rewrite.SimpleName).WithTriviaFrom(node);
+        }
+
+        static string CanonicalNameText(SyntaxNode node)
+            => node switch
+            {
+                GenericNameSyntax generic => generic.Identifier.ValueText,
+                QualifiedNameSyntax qualified => $"{CanonicalNameText(qualified.Left)}.{CanonicalNameText(qualified.Right)}",
+                AliasQualifiedNameSyntax aliasQualified => $"{aliasQualified.Alias.Identifier.ValueText}::{CanonicalNameText(aliasQualified.Name)}",
+                MemberAccessExpressionSyntax memberAccess => $"{CanonicalNameText(memberAccess.Expression)}.{CanonicalNameText(memberAccess.Name)}",
+                IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+                PredefinedTypeSyntax predefined => predefined.Keyword.ValueText,
+                NameSyntax name => name.ToString(),
+                _ => node.ToString(),
+            };
+
+        static SimpleNameSyntax ReplacementName(SyntaxNode original, string simpleName)
+            => original switch
+            {
+                GenericNameSyntax generic => SyntaxFactory.GenericName(
+                    SyntaxFactory.Identifier(simpleName),
+                    generic.TypeArgumentList),
+                QualifiedNameSyntax { Right: GenericNameSyntax generic } => SyntaxFactory.GenericName(
+                    SyntaxFactory.Identifier(simpleName),
+                    generic.TypeArgumentList),
+                MemberAccessExpressionSyntax { Name: GenericNameSyntax generic } => SyntaxFactory.GenericName(
+                    SyntaxFactory.Identifier(simpleName),
+                    generic.TypeArgumentList),
+                _ => SyntaxFactory.IdentifierName(simpleName),
+            };
     }
 
     static string OperatorMetadataName(OperatorDeclarationSyntax op)


### PR DESCRIPTION
- Advances #2468
- Changes product decompiler result metadata plus harness classification; product output is unchanged
- Evidence revision: `835a07dc`

## Change

**Conclusion:** **REVIEW** — adds product-owned effective options and typed decision evidence, then uses the first taste decision (`System.Math` rendered as imported `Math`) to split an RTS source-oracle valid difference into `valid_different.known_taste`.

Before:

```text
Buckets:
  6: valid_match
  2: valid_different.unclassified
```

After:

```text
Buckets:
  6: valid_match
  1: valid_different.known_taste
  1: valid_different.unclassified
```

## Scope and safety

- **Root cause:** RTS could detect valid source differences but had no product-owned evidence to distinguish intentional taste from unknown mismatches.
- **Fix shape:** add `DecompilerOptions` and `DecompilerDecision` to `DecompilerResult`; `CSharpPrinter` records `type-name.framework-imported` taste decisions; RTS carries those decisions and classifies matching source deltas as known taste.
- **Product impact:** no rendered C# output change.
- **Scope boundary:** one observed decision class only; broader taste taxonomy remains future work.
- **RTS boundary:** RTS consumes product decisions; it does not own taste rules.

## Evidence

| Check | Result |
| --- | --- |
| Focused tests | `ReturnToSenderFixtureCatalogTests` passed, 12 tests |
| Harness build | `dotnet build tools/DecompilerHarness -c Release --no-restore` passed |
| Source probe smoke | `rts.candidates`, cap 8: 6 `valid_match`, 1 `valid_different.known_taste`, 1 `valid_different.unclassified`, 0 invalid/source-unavailable/unsupported |
| Solution build | `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config` passed |
| Markdown | `npx markdownlint-cli tools/DecompilerHarness/README.md` passed |

## Source-oracle smoke

```text
RETURNTOSENDER SOURCE PROBE over 8 target(s)

  ValidMatch       : 6
  ValidDifferent   : 2
  Invalid          : 0
  SourceUnavailable: 0
  UnsupportedTarget: 0

  Passed   : 6
  Different: 2
  Failed   : 0
  Skipped  : 0

Buckets:
  6: valid_match
  1: valid_different.known_taste
  1: valid_different.unclassified
```

Known-taste example:

```text
DiffFixtureSample.DiffSample::CallToken#0  outcome=valid_different  rts=Exact  bucket=valid_different.known_taste
    detail: Rendered framework type 'System.Math' as imported/simple name 'Math'.
```

## Frontiers and non-actions

| Item | Status | Reason |
| --- | --- | --- |
| `MultipleHunks` | left `valid_different.unclassified` | no product decision currently explains the source-shape delta |
| option matrix | not expanded | first slice only exposes effective options and one real decision |
| Roslyn source analysis | not moved | remains harness-only |

## Review

| Reviewer | Result | Notes |
| --- | --- | --- |
| Gemini Pro | Pending | Review requested |
| MAI Flash | Pending | Review requested |

## Validation

```bash
dotnet restore src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj --configfile nuget.config
dotnet run --project src/ILInspector.Decompiler.Tests -c Release --no-restore -- -filter "/*/*/ReturnToSenderFixtureCatalogTests/*"
dotnet build tools/DecompilerHarness -c Release --no-restore
dotnet run --project tools/DecompilerHarness -c Release --no-restore -- --return-to-sender-fixtures rts.candidates --return-to-sender-source-probe --cap 8 --max-examples 8
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
npx markdownlint-cli tools/DecompilerHarness/README.md
```
