### PR TITLE
Suppress nonthrowing leak setup boundaries

### DIFF
--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -141,6 +141,62 @@ public sealed class LeakTriageAnalyzerTests
     }
 
     [Fact]
+    public void DetailedAnalysis_NonThrowingSetupBoundary_DoesNotAddExceptionPathCandidate()
+    {
+        var keepAlive = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenRent),
+            0x0A,
+            0x06,
+            .. Call(TokenKeepAlive),
+            0x2A,
+        ], []);
+        var arrayCopy = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenRent),
+            0x0A,
+            0x06,
+            0x06,
+            0x17,
+            .. Call(TokenArrayCopy),
+            0x2A,
+        ], []);
+
+        Assert.Empty(keepAlive.Findings);
+        AssertCandidate(keepAlive, nameof(Synthetic), "cross-method-suppressed");
+        AssertNoCandidate(keepAlive, nameof(Synthetic), "exception-path-leak-candidate");
+
+        Assert.Empty(arrayCopy.Findings);
+        AssertCandidate(arrayCopy, nameof(Synthetic), "cross-method-suppressed");
+        AssertNoCandidate(arrayCopy, nameof(Synthetic), "exception-path-leak-candidate");
+    }
+
+    [Fact]
+    public void DetailedAnalysis_ThrowingBoundaryAfterSetup_IsExceptionPathCandidate()
+    {
+        var result = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenRent),
+            0x0A,
+            0x06,
+            .. Call(TokenKeepAlive),
+            0x06,
+            .. Call(TokenUnknown),
+            .. Call(TokenShared),
+            0x06,
+            .. Callvirt(TokenReturn),
+            0x2A,
+        ], []);
+
+        Assert.Empty(result.Findings);
+        AssertCandidate(result, nameof(Synthetic), "cross-method-suppressed");
+        AssertCandidate(result, nameof(Synthetic), "exception-path-leak-candidate");
+    }
+
+    [Fact]
     public void IncompleteDataflow_FailsClosed()
     {
         byte[] externalBranch = [0x2B, 0x7F, 0x2A]; // br.s outside the method, then ret
@@ -256,6 +312,8 @@ public sealed class LeakTriageAnalyzerTests
     const int TokenReturn = 0x0A000003;
     const int TokenUnknown = 0x0A000004;
     const int TokenField = 0x0A000005;
+    const int TokenKeepAlive = 0x0A000006;
+    const int TokenArrayCopy = 0x0A000007;
 
     static ImmutableArray<LeakTriageFinding> AnalyzeSynthetic(byte[] il, IReadOnlyCollection<ExceptionRegion> exceptionRegions)
         => AnalyzeSyntheticDetailed(il, exceptionRegions).Findings;
@@ -287,6 +345,13 @@ public sealed class LeakTriageAnalyzerTests
             TokenRent => new MemberRef(arrayPoolOfByte, "Rent", [TypeRef.CoreLib("System", "Int32")], byteArray, MemberKind.Method) { HasThis = true },
             TokenReturn => new MemberRef(arrayPoolOfByte, "Return", [byteArray], TypeRef.CoreLib("System", "Void"), MemberKind.Method) { HasThis = true },
             TokenUnknown => new MemberRef(TypeRef.Definition("Fixture", "Fixtures", "Unknown"), "Use", [], TypeRef.CoreLib("System", "Void"), MemberKind.Method),
+            TokenKeepAlive => new MemberRef(TypeRef.CoreLib("System", "GC"), "KeepAlive", [TypeRef.CoreLib("System", "Object")], TypeRef.CoreLib("System", "Void"), MemberKind.Method),
+            TokenArrayCopy => new MemberRef(
+                TypeRef.CoreLib("System", "Array"),
+                "Copy",
+                [TypeRef.CoreLib("System", "Array"), TypeRef.CoreLib("System", "Array"), TypeRef.CoreLib("System", "Int32")],
+                TypeRef.CoreLib("System", "Void"),
+                MemberKind.Method),
             _ => MemberRef.Unsupported($"unknown token 0x{token:X8}"),
         };
     }

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -163,6 +163,17 @@ public sealed class LeakTriageAnalyzerTests
             .. Call(TokenArrayCopy),
             0x2A,
         ], []);
+        var systemMemorySpanClear = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenRent),
+            0x0A,
+            0x06,
+            0x16,
+            .. Call(TokenSystemMemoryAsSpan),
+            .. Call(TokenSystemMemorySpanClear),
+            0x2A,
+        ], []);
 
         Assert.Empty(keepAlive.Findings);
         AssertCandidate(keepAlive, nameof(Synthetic), "cross-method-suppressed");
@@ -171,6 +182,10 @@ public sealed class LeakTriageAnalyzerTests
         Assert.Empty(arrayCopy.Findings);
         AssertCandidate(arrayCopy, nameof(Synthetic), "cross-method-suppressed");
         AssertNoCandidate(arrayCopy, nameof(Synthetic), "exception-path-leak-candidate");
+
+        Assert.Empty(systemMemorySpanClear.Findings);
+        AssertCandidate(systemMemorySpanClear, nameof(Synthetic), "cross-method-suppressed");
+        AssertNoCandidate(systemMemorySpanClear, nameof(Synthetic), "exception-path-leak-candidate");
     }
 
     [Fact]
@@ -314,6 +329,8 @@ public sealed class LeakTriageAnalyzerTests
     const int TokenField = 0x0A000005;
     const int TokenKeepAlive = 0x0A000006;
     const int TokenArrayCopy = 0x0A000007;
+    const int TokenSystemMemoryAsSpan = 0x0A000008;
+    const int TokenSystemMemorySpanClear = 0x0A000009;
 
     static ImmutableArray<LeakTriageFinding> AnalyzeSynthetic(byte[] il, IReadOnlyCollection<ExceptionRegion> exceptionRegions)
         => AnalyzeSyntheticDetailed(il, exceptionRegions).Findings;
@@ -338,6 +355,9 @@ public sealed class LeakTriageAnalyzerTests
             TypeRef.Definition("System.Buffers", "System.Buffers", "ArrayPool`1"),
             [TypeRef.CoreLib("System", "Byte")]);
         var byteArray = TypeRef.SzArray(TypeRef.CoreLib("System", "Byte"));
+        var systemMemorySpanOfByte = TypeRef.GenericInstance(
+            TypeRef.Definition("System.Memory", "System", "Span`1", trustedFrameworkAssembly: true),
+            [TypeRef.CoreLib("System", "Byte")]);
 
         return token switch
         {
@@ -352,6 +372,19 @@ public sealed class LeakTriageAnalyzerTests
                 [TypeRef.CoreLib("System", "Array"), TypeRef.CoreLib("System", "Array"), TypeRef.CoreLib("System", "Int32")],
                 TypeRef.CoreLib("System", "Void"),
                 MemberKind.Method),
+            TokenSystemMemoryAsSpan => new MemberRef(
+                TypeRef.Definition("System.Memory", "System", "MemoryExtensions", trustedFrameworkAssembly: true),
+                "AsSpan",
+                [byteArray, TypeRef.CoreLib("System", "Int32")],
+                systemMemorySpanOfByte,
+                MemberKind.Method),
+            TokenSystemMemorySpanClear => new MemberRef(
+                systemMemorySpanOfByte,
+                "Clear",
+                [],
+                TypeRef.CoreLib("System", "Void"),
+                MemberKind.Method)
+            { HasThis = true },
             _ => MemberRef.Unsupported($"unknown token 0x{token:X8}"),
         };
     }

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -698,7 +698,8 @@ public static class LeakTriageAnalyzer
         if (type.Kind != TypeRefKind.GenericInstance || type.ElementType is not { } definition)
             return false;
 
-        return FrameworkIdentity.IsCoreLibraryType(definition, "System", "Span`1");
+        return FrameworkIdentity.IsCoreLibraryType(definition, "System", "Span`1")
+            || FrameworkIdentity.IsKnownFrameworkType(definition, "System.Memory", "System", "Span`1");
     }
 
     static int ArgumentSlotCount(MethodIdentity method)

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -162,6 +162,7 @@ public static class LeakTriageAnalyzer
     {
         var releases = ImmutableArray.CreateBuilder<int>();
         var safeUses = ImmutableArray.CreateBuilder<int>();
+        var throwingBoundaries = ImmutableArray.CreateBuilder<int>();
         AmbiguousUse? firstAmbiguous = null;
 
         foreach (var use in reaching.UsesOf(rent.Definition))
@@ -192,6 +193,8 @@ public static class LeakTriageAnalyzer
                         AddCandidate(candidates, method, classification.CandidateShape, classification.Evidence, rent.RentOffset, use.Offset);
                         firstAmbiguous = new AmbiguousUse(use.Offset, classification.CandidateShape);
                     }
+                    if (classification.CandidateShape == "cross-method-suppressed" && !classification.NonThrowingSetupBoundary)
+                        throwingBoundaries.Add(use.Offset);
                     break;
             }
         }
@@ -202,16 +205,15 @@ public static class LeakTriageAnalyzer
         if (firstAmbiguous is { } ambiguous)
         {
             if (ambiguous.Shape == "cross-method-suppressed"
-                && !ReleasedBeforeUseInSameBlock(graph, releaseOffsets, ambiguous.Offset)
-                && !HasCleanupReleaseForUse(exceptionRegions, releaseOffsets, ambiguous.Offset))
+                && FirstUnprotectedThrowingBoundary(graph, exceptionRegions, releaseOffsets, throwingBoundaries.ToImmutable()) is { } throwingBoundary)
             {
                 AddCandidate(
                     candidates,
                     method,
                     "exception-path-leak-candidate",
-                    $"Rented array crosses a method boundary at IL_{ambiguous.Offset:X4} before a modeled cleanup; an exception can bypass Return.",
+                    $"Rented array crosses a method boundary at IL_{throwingBoundary:X4} before a modeled cleanup; an exception can bypass Return.",
                     rent.RentOffset,
-                    ambiguous.Offset);
+                    throwingBoundary);
             }
             return;
         }
@@ -382,6 +384,24 @@ public static class LeakTriageAnalyzer
     static bool ReleasedBeforeUseInSameBlock(BlockGraph graph, ImmutableArray<int> releases, int useOffset)
         => releases.Any(release => ReachesInSameBlock(graph, release, useOffset));
 
+    static int? FirstUnprotectedThrowingBoundary(
+        BlockGraph graph,
+        IReadOnlyCollection<ExceptionRegion> exceptionRegions,
+        ImmutableArray<int> releases,
+        ImmutableArray<int> throwingBoundaries)
+    {
+        foreach (int boundary in throwingBoundaries)
+        {
+            if (!ReleasedBeforeUseInSameBlock(graph, releases, boundary)
+                && !HasCleanupReleaseForUse(exceptionRegions, releases, boundary))
+            {
+                return boundary;
+            }
+        }
+
+        return null;
+    }
+
     static bool HasCleanupReleaseForUse(
         IReadOnlyCollection<ExceptionRegion> exceptionRegions,
         ImmutableArray<int> releases,
@@ -518,7 +538,9 @@ public static class LeakTriageAnalyzer
             {
                 if (IsArrayPoolReturn(callee) && extra < callee.ParameterTypes.Length)
                     return UseClassification.Release;
-                return UseClassification.CrossMethod($"Rented array is passed to {callee.DeclaringType.Name}::{callee.Name}.");
+                return UseClassification.CrossMethod(
+                    $"Rented array is passed to {callee.DeclaringType.Name}::{callee.Name}.",
+                    IsNonThrowingSetupBoundary(callee));
             }
             return UseClassification.OwnershipTransfer($"Rented array reaches unsupported opcode {opcode}.");
         }
@@ -650,6 +672,35 @@ public static class LeakTriageAnalyzer
         => FrameworkIdentity.IsKnownFrameworkType(type, "System.Buffers", "System.Buffers", "ArrayPool`1")
            || FrameworkIdentity.IsCoreLibraryType(type, "System.Buffers", "ArrayPool`1");
 
+    static bool IsNonThrowingSetupBoundary(MemberRef member)
+    {
+        if (member.Kind == MemberKind.Unsupported)
+            return false;
+
+        if (member.Name == "KeepAlive" && FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "GC"))
+            return true;
+
+        if (member.Name == "Copy" && FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "Array"))
+            return true;
+
+        if (member.Name == "AsSpan"
+            && (FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "MemoryExtensions")
+                || FrameworkIdentity.IsKnownFrameworkType(member.DeclaringType, "System.Memory", "System", "MemoryExtensions")))
+        {
+            return true;
+        }
+
+        return member.Name == "Clear" && IsSpanType(member.DeclaringType);
+    }
+
+    static bool IsSpanType(TypeRef type)
+    {
+        if (type.Kind != TypeRefKind.GenericInstance || type.ElementType is not { } definition)
+            return false;
+
+        return FrameworkIdentity.IsCoreLibraryType(definition, "System", "Span`1");
+    }
+
     static int ArgumentSlotCount(MethodIdentity method)
         => method.ParameterTypes.Length + (method.IsStatic ? 0 : 1);
 
@@ -680,12 +731,12 @@ public static class LeakTriageAnalyzer
         Ambiguous,
     }
 
-    readonly record struct UseClassification(UseKind Kind, string CandidateShape, string Evidence)
+    readonly record struct UseClassification(UseKind Kind, string CandidateShape, string Evidence, bool NonThrowingSetupBoundary = false)
     {
         public static UseClassification Release { get; } = new(UseKind.Release, "", "");
         public static UseClassification LocalUse { get; } = new(UseKind.LocalUse, "", "");
         public static UseClassification AliasOrField(string evidence) => new(UseKind.Ambiguous, "alias-or-field-suppressed", evidence);
-        public static UseClassification CrossMethod(string evidence) => new(UseKind.Ambiguous, "cross-method-suppressed", evidence);
+        public static UseClassification CrossMethod(string evidence, bool nonThrowingSetupBoundary) => new(UseKind.Ambiguous, "cross-method-suppressed", evidence, nonThrowingSetupBoundary);
         public static UseClassification OwnershipTransfer(string evidence) => new(UseKind.Ambiguous, "ownership-transfer-suppressed", evidence);
     }
 

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -136,11 +136,13 @@ are not product findings; they measure recall gates such as
 `alias-or-field-suppressed`, `cross-method-suppressed`, and
 `incomplete-cfg-or-rd-suppressed`. Candidate rows can overlap: for example, a cross-method
 suppression can also carry an exception-path candidate when the normal path may still release or
-transfer ownership but an unprotected call boundary can throw first. One declarative Markout model
-renders the dense Markdown table and decomposes into section-tagged TSV/JSONL. It is a single-run
-census with no baseline, so it uses plain sectioned rows, not composite/delta cells; a
-`--diff-baseline` mode against a committed snapshot is the natural home for those
-(`Change`/`[MarkoutDelta]`). Each assembly is bounded by a per-assembly timeout, and any
+transfer ownership but an unprotected call boundary can throw first. The exception-path candidate
+bucket suppresses known nonthrowing setup calls such as `GC.KeepAlive`, `Array.Copy`, and
+`MemoryExtensions.AsSpan`; these remain cross-method suppressions rather than product findings. One
+declarative Markout model renders the dense Markdown table and decomposes into section-tagged
+TSV/JSONL. It is a single-run census with no baseline, so it uses plain sectioned rows, not
+composite/delta cells; a `--diff-baseline` mode against a committed snapshot is the natural home
+for those (`Change`/`[MarkoutDelta]`). Each assembly is bounded by a per-assembly timeout, and any
 per-assembly input failure (a directory path, a truncated PE) becomes an `Opened=false` row rather
 than crashing the sweep.
 


### PR DESCRIPTION
## Summary
- narrow `exception-path-leak-candidate` to skip known nonthrowing setup calls (`GC.KeepAlive`, `Array.Copy`, `MemoryExtensions.AsSpan`, `Span<T>.Clear`)
- keep the existing `cross-method-suppressed` row so measurement still records the ownership gate
- preserve later throwing boundaries after setup, so a setup call followed by an unknown/external call still gets an exception-path candidate

## Evidence
- Precision sample: #1992 comment https://github.com/richlander/dotnet-inspect/issues/1992#issuecomment-4897591385
- 75-DLL ArrayPool-heavy package corpus after this change: 75 opened / 0 failed / 0 timed out; findings stay 0; total candidates drop from 1127 to 958; `exception-path-leak-candidate` drops from 191 to 22.
- Remaining exception-path examples include the strong `Pipelines.Sockets.Unofficial` `AsyncPipeStream.ReadByte` row (`IL_0096` -> `IL_009D`), plus still-measurement-only `SequenceBuilder<T>.Resize`, `ValueStringBuilder.Expand`, and a few QuanTAlib rows.

## Validation
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-restore -- -filter "/*/*/LeakTriageAnalyzerTests/*"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-restore`
- `dotnet build tools/AnalysisHarness/AnalysisHarness.csproj -c Release --configfile nuget.config -p:IsAotCompatible=false -p:PublishAot=false`
- `dotnet tools/AnalysisHarness/bin/Release/net11.0/analysis-harness.dll --leak-triage /tmp/leak-nuget-assemblies.txt --top 1000 --jsonl`
- `npx markdownlint-cli tools/AnalysisHarness/README.md`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`