### PR TITLE
Cache the Roslyn trusted-platform reference set in decompiler tests

### DIFF
--- a/src/ILInspector.Decompiler.Tests/CSharpPrinterReceiverTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CSharpPrinterReceiverTests.cs
@@ -188,16 +188,5 @@ public sealed class CSharpPrinterReceiverTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var references = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                continue;
-            try { references.Add(MetadataReference.CreateFromFile(path)); }
-            catch { }
-        }
-        return references.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 }

--- a/src/ILInspector.Decompiler.Tests/CharElementStorePrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CharElementStorePrinterTests.cs
@@ -65,16 +65,5 @@ public class CharElementStorePrinterTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var references = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                continue;
-            try { references.Add(MetadataReference.CreateFromFile(path)); }
-            catch { }
-        }
-        return references.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 }

--- a/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CoerceChokePointTests.cs
@@ -1597,16 +1597,5 @@ public class CoerceChokePointTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var references = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                continue;
-            try { references.Add(MetadataReference.CreateFromFile(path)); }
-            catch { }
-        }
-        return references.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 }

--- a/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
+++ b/src/ILInspector.Decompiler.Tests/CrossAssemblyMethodFactsTests.cs
@@ -374,20 +374,7 @@ public class CrossAssemblyMethodFactsTests
         }
 
         static ImmutableArray<MetadataReference> RuntimeReferences()
-        {
-            var trustedPlatformAssemblies =
-                (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-                    .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
-            var references = ImmutableArray.CreateBuilder<MetadataReference>();
-            foreach (var path in trustedPlatformAssemblies)
-            {
-                if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                    continue;
-                try { references.Add(MetadataReference.CreateFromFile(path)); }
-                catch { }
-            }
-            return references.ToImmutable();
-        }
+            => RoslynTestReferences.TrustedPlatform;
 
         public void Dispose() => Directory.Delete(_directory, recursive: true);
     }

--- a/src/ILInspector.Decompiler.Tests/DefaultParameterValidityTests.cs
+++ b/src/ILInspector.Decompiler.Tests/DefaultParameterValidityTests.cs
@@ -88,18 +88,7 @@ public class DefaultParameterValidityTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var builder = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (var path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                continue;
-            try { builder.Add(MetadataReference.CreateFromFile(path)); }
-            catch { }
-        }
-        return builder.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 
     static void AssertInvalid(
         IReadOnlyDictionary<string, List<string>> results,

--- a/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/EnumCastPrinterTests.cs
@@ -626,16 +626,5 @@ public class EnumCastPrinterTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var references = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                continue;
-            try { references.Add(MetadataReference.CreateFromFile(path)); }
-            catch { }
-        }
-        return references.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 }

--- a/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FidelityCheckGeneratedFilterTests.cs
@@ -755,9 +755,7 @@ public class FidelityCheckGeneratedFilterTests
         var directory = Path.Combine(Path.GetTempPath(), $"fidelity-generated-filter-{Guid.NewGuid():N}");
         Directory.CreateDirectory(directory);
         var path = Path.Combine(directory, "fixture.dll");
-        var references = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-            .Select(path => MetadataReference.CreateFromFile(path));
+        var references = RoslynTestReferences.TrustedPlatform.AsEnumerable();
         var compilation = CSharpCompilation.Create(
             Path.GetFileNameWithoutExtension(path),
             [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],

--- a/src/ILInspector.Decompiler.Tests/FinallyDisposePrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/FinallyDisposePrinterTests.cs
@@ -82,16 +82,5 @@ public class FinallyDisposePrinterTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var references = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                continue;
-            try { references.Add(MetadataReference.CreateFromFile(path)); }
-            catch { }
-        }
-        return references.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 }

--- a/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/IrImporterTests.cs
@@ -2077,10 +2077,7 @@ public class RaisingPassTests
             }
             """;
         var tree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
-        var references = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-            .Distinct(StringComparer.Ordinal)
-            .Select(path => MetadataReference.CreateFromFile(path));
+        var references = RoslynTestReferences.TrustedPlatform.AsEnumerable();
         var compilation = CSharpCompilation.Create(
             "RefLocalCanary",
             [tree],

--- a/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung6GateTests.cs
@@ -772,20 +772,7 @@ public class LadderRung6GateTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var trustedPlatformAssemblies =
-            (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-                .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
-        var references = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (var path in trustedPlatformAssemblies)
-        {
-            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                continue;
-            try { references.Add(MetadataReference.CreateFromFile(path)); }
-            catch { }
-        }
-        return references.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 
     static readonly TypeRef Int32 = TypeRef.CoreLib("System", "Int32");
     static readonly TypeRef String = TypeRef.CoreLib("System", "String");

--- a/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
+++ b/src/ILInspector.Decompiler.Tests/LadderRung9GateTests.cs
@@ -225,17 +225,5 @@ public class LadderRung9GateTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var references = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                continue;
-            try { references.Add(MetadataReference.CreateFromFile(path)); }
-            catch { }
-        }
-
-        return references.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 }

--- a/src/ILInspector.Decompiler.Tests/MemberNameCollisionRenderingTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MemberNameCollisionRenderingTests.cs
@@ -107,16 +107,7 @@ public class MemberNameCollisionRenderingTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var references = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                references.Add(MetadataReference.CreateFromFile(path));
-        }
-        return references.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 }
 
 public class ListNamePropertySpecimen

--- a/src/ILInspector.Decompiler.Tests/MixedSignComparisonTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MixedSignComparisonTests.cs
@@ -240,17 +240,7 @@ public class MixedSignComparisonTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var references = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                continue;
-            references.Add(MetadataReference.CreateFromFile(path));
-        }
-        return references.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 }
 
 public static class UnsignedComparisonSpecimens

--- a/src/ILInspector.Decompiler.Tests/MultiDimensionalArrayPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/MultiDimensionalArrayPrinterTests.cs
@@ -153,16 +153,5 @@ public class MultiDimensionalArrayPrinterTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var references = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                continue;
-            try { references.Add(MetadataReference.CreateFromFile(path)); }
-            catch { }
-        }
-        return references.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 }

--- a/src/ILInspector.Decompiler.Tests/NestedScopeNameCollisionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NestedScopeNameCollisionTests.cs
@@ -264,12 +264,5 @@ public class NestedScopeNameCollisionTests
     }
 
     static IEnumerable<MetadataReference> RuntimeReferences()
-    {
-        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                yield return MetadataReference.CreateFromFile(path);
-        }
-    }
+        => RoslynTestReferences.TrustedPlatform;
 }

--- a/src/ILInspector.Decompiler.Tests/NonFiniteConstantPrinterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/NonFiniteConstantPrinterTests.cs
@@ -133,16 +133,5 @@ public class NonFiniteConstantPrinterTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var references = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                continue;
-            try { references.Add(MetadataReference.CreateFromFile(path)); }
-            catch { }
-        }
-        return references.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 }

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderFixtureCatalogTests.cs
@@ -306,9 +306,7 @@ public class ReturnToSenderFixtureCatalogTests
         }
 
         string assemblyPath = Path.Combine(directory, "SourceProbe.dll");
-        var references = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-            .Select(path => MetadataReference.CreateFromFile(path));
+        var references = RoslynTestReferences.TrustedPlatform.AsEnumerable();
         var trees = sourcePaths.Select(path =>
             CSharpSyntaxTree.ParseText(
                 File.ReadAllText(path),

--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -2836,9 +2836,7 @@ public class ReturnToSenderPrototypeTests
         directory ??= Path.Combine(Path.GetTempPath(), $"return-to-sender-{Guid.NewGuid():N}");
         Directory.CreateDirectory(directory);
         var path = Path.Combine(directory, $"{assemblyName}.dll");
-        var references = (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
-            .Select(path => MetadataReference.CreateFromFile(path))
+        var references = RoslynTestReferences.TrustedPlatform
             .Concat(additionalReferences ?? []);
         var compilation = CSharpCompilation.Create(
             Path.GetFileNameWithoutExtension(path),

--- a/src/ILInspector.Decompiler.Tests/RoslynTestReferences.cs
+++ b/src/ILInspector.Decompiler.Tests/RoslynTestReferences.cs
@@ -17,10 +17,13 @@ static class RoslynTestReferences
     static readonly Lazy<ImmutableArray<MetadataReference>> s_trustedPlatform = new(() =>
     {
         var builder = ImmutableArray.CreateBuilder<MetadataReference>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
         foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
             .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
         {
             if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (!seen.Add(path))
                 continue;
             try { builder.Add(MetadataReference.CreateFromFile(path)); }
             catch { }

--- a/src/ILInspector.Decompiler.Tests/RoslynTestReferences.cs
+++ b/src/ILInspector.Decompiler.Tests/RoslynTestReferences.cs
@@ -1,0 +1,30 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+
+namespace ILInspector.Decompiler.Tests;
+
+// Shared, process-lifetime cache of the trusted-platform MetadataReference set used
+// by the in-process Roslyn compile-fixture helpers across the suite. Roslyn
+// MetadataReference / AssemblyMetadata are immutable and thread-safe and are meant
+// to be shared across compilations, so building the ~185-reference set once — rather
+// than re-reading every framework assembly on every compile in each of ~20 test
+// files — removes a large amount of redundant metadata mapping and allocation churn
+// under the parallel test runner.
+static class RoslynTestReferences
+{
+    public static ImmutableArray<MetadataReference> TrustedPlatform => s_trustedPlatform.Value;
+
+    static readonly Lazy<ImmutableArray<MetadataReference>> s_trustedPlatform = new(() =>
+    {
+        var builder = ImmutableArray.CreateBuilder<MetadataReference>();
+        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+            try { builder.Add(MetadataReference.CreateFromFile(path)); }
+            catch { }
+        }
+        return builder.ToImmutable();
+    });
+}

--- a/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceComposerUnionTests.cs
@@ -1833,17 +1833,7 @@ public class TypeSourceComposerUnionTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var references = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (string path in (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                continue;
-            references.Add(MetadataReference.CreateFromFile(path));
-        }
-        return references.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 
     sealed class TempAssembly(string path, TempDirectory? directory = null) : IDisposable
     {

--- a/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
+++ b/src/ILInspector.Decompiler.Tests/UnsafeEmitterTests.cs
@@ -462,18 +462,5 @@ public class UnsafeEmitterTests
     }
 
     static ImmutableArray<MetadataReference> RuntimeReferences()
-    {
-        var trustedPlatformAssemblies =
-            (AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? "")
-                .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
-        var references = ImmutableArray.CreateBuilder<MetadataReference>();
-        foreach (var path in trustedPlatformAssemblies)
-        {
-            if (!path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
-                continue;
-            try { references.Add(MetadataReference.CreateFromFile(path)); }
-            catch { /* skip an unreadable TPA entry */ }
-        }
-        return references.ToImmutable();
-    }
+        => RoslynTestReferences.TrustedPlatform;
 }


### PR DESCRIPTION
## What

Cache the trusted-platform `MetadataReference` set used by the in-process Roslyn
compile-fixture helpers across `ILInspector.Decompiler.Tests`, instead of
rebuilding the ~185 framework references on every `CSharpCompilation.Create` in
each of ~20 test files under the parallel xUnit v3 runner.

- New `RoslynTestReferences.TrustedPlatform`: a process-lifetime
  `Lazy<ImmutableArray<MetadataReference>>`. Roslyn `MetadataReference` /
  `AssemblyMetadata` are immutable and thread-safe and are meant to be shared
  across compilations, so building the set once is both correct and the
  recommended usage.
- 20 compile-fixture sites routed to it (the per-compile
  `TRUSTED_PLATFORM_ASSEMBLIES` loops are removed). The unrelated SRM resolver
  cache in `TestAssemblyReferenceResolvers` is left as-is.

## Why

`ILInspector.Decompiler.Tests` drove CI resident memory to 10–16 GB. The root
cause: ~20 in-process `CSharpCompilation.Create` sites each rebuilt the ~185
`MetadataReference.CreateFromFile` over `TRUSTED_PLATFORM_ASSEMBLIES` per compile,
run in parallel, producing Roslyn metadata churn → gen2 promotion → multi-GB
GC-committed segments the runtime returns to the OS lazily. Full investigation and
the discoverability analysis: `docs/design/dynamic-leak-watch.md` (PR #2463).

## Evidence

Isolated micro-benchmark of the exact pattern (400 parallel `CSharpCompilation`s,
185 trusted-platform refs, `MaxDegreeOfParallelism=16`), rebuilding refs per
compile vs a single shared cached set:

| mode | allocated | peak working set | elapsed |
| --- | --- | --- | --- |
| uncached (per-compile refs) | ~3,950 MB | 6.0–12.9 GB | 18–19 s |
| cached (shared refs) | ~433 MB | ~0.27 GB | 1.7 s |

~9× less allocated, 20–47× lower peak working set, ~11× faster on the compile
loop alone.

## Correctness

The cached references resolve identically to the per-compile ones — all 20 routed
compile-fixture test classes pass (397 tests, 1 pre-existing preview-SDK skip):

- `EnumCastPrinterTests`, `UnsafeEmitterTests`, `IrImporterTests`,
  `CrossAssemblyMethodFactsTests`, `LadderRung6GateTests`,
  `FidelityCheckGeneratedFilterTests`, `NestedScopeNameCollisionTests`,
  `CharElementStorePrinterTests`, `CoerceChokePointTests`,
  `CSharpPrinterReceiverTests` — 231 pass.
- `DefaultParameterValidityTests`, `FinallyDisposePrinterTests`,
  `LadderRung9GateTests`, `MemberNameCollisionRenderingTests`,
  `MixedSignComparisonTests`, `MultiDimensionalArrayPrinterTests`,
  `NonFiniteConstantPrinterTests`, `TypeSourceComposerUnionTests`,
  `ReturnToSenderPrototypeTests`, `ReturnToSenderFixtureCatalogTests` — 166 pass.

## Scope note

This is the cache lever only. Capping the runner's parallelism is a separate,
independent lever; the micro-benchmark shows the cache alone removes the
Roslyn-compile footprint (the remaining suite RSS is the decompiler corpus sweep,
which this change does not touch), so a parallelism cap is not bundled here.
