### PR TITLE
Narrow unresolved RTS CS1061 fallback

### DIFF
--- a/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
+++ b/src/ILInspector.Decompiler.Tests/ReturnToSenderPrototypeTests.cs
@@ -342,6 +342,40 @@ public class ReturnToSenderPrototypeTests
     }
 
     [Fact]
+    public void CompileBackTargets_KeepsTypeResolvedCs1061PropertyFallback()
+    {
+        var assemblyPath = CompileFixture("""
+            public class Class1
+            {
+                public int Other => 42;
+
+                public int FromOther(Class1 self) => self.Other;
+            }
+            """);
+        try
+        {
+            var result = Assert.Single(ReturnToSender.CompileBackTargets(
+                assemblyPath,
+                [new ReturnToSender.RequestedTarget("Class1", "FromOther", 0)]));
+
+            Assert.True(
+                result.Status is FidelityCheck.CompileBackStatus.Exact or FidelityCheck.CompileBackStatus.OpcodeDiff,
+                $"{result.Status}: {result.Detail}{Environment.NewLine}{result.Source}");
+            var type = Assert.Single(result.Plan.Types);
+            Assert.Contains(type.SourceFacts, fact =>
+                fact.Producer == "roslyn"
+                && fact.Id == "closure-member"
+                && fact.Detail.StartsWith("CS1061", StringComparison.Ordinal));
+            Assert.Contains(type.Members, member => member.Name == "Other" && member.Kind == CompileBackMemberKind.PropertyGet);
+            Assert.Contains("public int Other", result.Source);
+        }
+        finally
+        {
+            DeleteFixture(assemblyPath);
+        }
+    }
+
+    [Fact]
     public void CompileBackFirstPropertyGetter_EmitsClosureConstructorRequirement()
     {
         var assemblyPath = CompileFixture("""

--- a/tools/DecompilerHarness/ReturnToSender.cs
+++ b/tools/DecompilerHarness/ReturnToSender.cs
@@ -1704,13 +1704,6 @@ static class ReturnToSender
                     var key = typeName.Contains('.', StringComparison.Ordinal) ? typeName : NormalizeTypeName(typeName);
                     var typeGrew = AddRoots(indexes, index, key, diagnostic, $"{typeName}.{names[1]}", targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts, out var typeResolved);
                     grew |= typeGrew;
-                    if (!typeResolved)
-                    {
-                        string memberName = names[1];
-                        grew |= AddRoots(indexes, indexes.Methods, NormalizeTypeName(memberName), diagnostic, memberName, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
-                        grew |= AddRoots(indexes, indexes.Properties, NormalizeTypeName(memberName), diagnostic, memberName, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
-                        grew |= AddRoots(indexes, indexes.Fields, memberName, diagnostic, memberName, targetNamespace, preferredRoot, addMemberSurfaceFact: true, closureRoots, closureFacts);
-                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

- remove the CS1061 unresolved-type member-name search fallback from ReturnToSender `AddClosureRoots`
- keep type-resolved CS1061 recovery intact for target-root member surface cases
- keep CS0103 field/member fallback and prior CS0117 type-resolved fallback intact
- add a canary proving target-root explicit-receiver property access still recovers through type-resolved CS1061 fallback

This stacks after #2472 and removes another string-only unresolved-type recovery path while retaining the live target-root fallback path.

## Validation

- `dotnet build src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderPrototypeTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/GeneratedFixtureCatalogTests/*"`
- `dotnet run --project src/ILInspector.Decompiler.Tests/ILInspector.Decompiler.Tests.csproj -c Release --no-build -- -filter "/*/*/ReturnToSenderEvidenceTests/*"`
- `dotnet build tools/DecompilerHarness/DecompilerHarness.csproj -c Release --configfile nuget.config --verbosity quiet`
- `dotnet run --project tools/DecompilerHarness -c Release --no-build -- --return-to-sender-catalog minimal.property.literal --max-examples 3`

Adversarial review requested separately.