### PR TITLE
Fix CLI hard-run usability issues

### DIFF
--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3838,6 +3838,28 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_OutputFlagBeforeBareToken_KeepsBareTokenAsRouteTarget()
+    {
+        var (exit, output, error) = await RunAppAsync("--json", "frobnicate");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("Package 'frobnicate' not found", error);
+        Assert.DoesNotContain("Package '--json' not found", error);
+    }
+
+    [Fact]
+    public async Task Router_ValueOptionBeforeBareToken_SkipsOptionValueWhenFindingRouteTarget()
+    {
+        var (exit, output, error) = await RunAppAsync("--type", "Widget", "frobnicate");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.Contains("Package 'frobnicate' not found", error);
+        Assert.DoesNotContain("Package 'Widget' not found", error);
+    }
+
+    [Fact]
     public async Task Type_BareStringAlias_RendersCoreLibString()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3827,6 +3827,17 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_HelpBeforeBareToken_StillExplainsPackageRouting()
+    {
+        var (exit, output, error) = await RunAppAsync("--help", "frobnicate");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Inspect a NuGet package", output);
+        Assert.DoesNotContain("Auto-route bare input", output);
+        Assert.Contains("interpreting bare token 'frobnicate' as a package or platform target", error);
+    }
+
+    [Fact]
     public async Task Type_BareStringAlias_RendersCoreLibString()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3838,6 +3838,16 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_BareDiscoveryHelp_DoesNotCallOptionABareToken()
+    {
+        var (exit, output, error) = await RunAppAsync("-S", "Methods", "--help");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Discover types in a package or library", output);
+        Assert.DoesNotContain("interpreting bare token '-S'", error);
+    }
+
+    [Fact]
     public async Task Router_OutputFlagBeforeBareToken_KeepsBareTokenAsRouteTarget()
     {
         var (exit, output, error) = await RunAppAsync("--json", "frobnicate");

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3860,6 +3860,17 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Router_MemberOptionBeforeBareToken_SkipsMemberValueWhenFindingRouteTarget()
+    {
+        var (exit, output, error) = await RunAppAsync("--member", "Keep", "frobnicate");
+
+        Assert.Equal(1, exit);
+        Assert.Empty(output);
+        Assert.DoesNotContain("Package 'Keep' not found", error);
+        Assert.DoesNotContain("Unrecognized option '--member'", error);
+    }
+
+    [Fact]
     public async Task Type_BareStringAlias_RendersCoreLibString()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/CommandExecutionTests.cs
+++ b/src/dotnet-inspect.Tests/CommandExecutionTests.cs
@@ -3804,6 +3804,29 @@ public class CommandExecutionTests
     }
 
     [Fact]
+    public async Task Extensions_JsonlAfterPackage_RendersJsonlAndDoesNotWarnAboutPackageFlag()
+    {
+        var (exit, output, error) = await RunAppAsync(
+            "extensions", "IEnumerable<T>", "--platform", "System.Linq", "--jsonl", "--rows", "-n", "2", "--tips", "q");
+
+        Assert.Equal(0, exit);
+        Assert.Empty(error);
+        Assert.StartsWith("{", output.TrimStart());
+        Assert.DoesNotContain("# Extension Methods", output);
+    }
+
+    [Fact]
+    public async Task Router_BareHelp_ExplainsPackageRouting()
+    {
+        var (exit, output, error) = await RunAppAsync("frobnicate", "--help");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Inspect a NuGet package", output);
+        Assert.Contains("interpreting bare token 'frobnicate' as a package or platform target", error);
+        Assert.Contains("dotnet-inspect --help", error);
+    }
+
+    [Fact]
     public async Task Type_BareStringAlias_RendersCoreLibString()
     {
         var (exit, output, error) = await RunAppAsync(

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -1,3 +1,4 @@
+using System.CommandLine;
 using DotnetInspector;
 using DotnetInspector.CommandLine;
 using DotnetInspector.Commands;
@@ -1075,11 +1076,42 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void ExtensionsCommand_WithJsonlAfterPackage_DoesNotTreatFlagAsPackage()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        var result = root.Parse(["extensions", "ILogger", "--package", "Microsoft.Extensions.Logging.Abstractions", "--jsonl"]);
+
+        Assert.Empty(result.Errors);
+        var command = result.CommandResult.Command;
+        var packageOption = command.Options.OfType<Option<string[]>>().Single(option => option.Name == "--package");
+        var jsonlOption = command.Options.OfType<Option<bool>>().Single(option => option.Name == "--jsonl");
+        var packages = result.GetValue(packageOption) ?? [];
+
+        Assert.Equal(["Microsoft.Extensions.Logging.Abstractions"], packages);
+        Assert.True(result.GetValue(jsonlOption));
+    }
+
+    [Fact]
     public void ExtensionsCommand_WithNoArgs_ParsesCorrectly()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(["extensions"]);
 
         Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void MemberCommand_ProjectOptionConsumesSingleValueSoTrailingSelectorStaysPositional()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        var result = root.Parse(["member", "ILogger", "--project", "app.csproj", "Log:1"]);
+
+        Assert.Empty(result.Errors);
+        var command = result.CommandResult.Command;
+        var argsArgument = command.Arguments.OfType<Argument<string[]>>().Single(argument => argument.Name == "args");
+        var projectOption = command.Options.OfType<Option<string[]>>().Single(option => option.Name == "--project");
+
+        Assert.Equal(["ILogger", "Log:1"], result.GetValue(argsArgument) ?? []);
+        Assert.Equal(["app.csproj"], result.GetValue(projectOption) ?? []);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -1092,6 +1092,21 @@ public class CommandLineTests
     }
 
     [Fact]
+    public void ExtensionsCommand_RepeatedPackageOptions_KeepTrailingTargetPositional()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        var result = root.Parse(["extensions", "--package", "Pkg1", "--package", "Pkg2", "ILogger"]);
+
+        Assert.Empty(result.Errors);
+        var command = result.CommandResult.Command;
+        var targetArgument = command.Arguments.OfType<Argument<string?>>().Single(argument => argument.Name == "type");
+        var packageOption = command.Options.OfType<Option<string[]>>().Single(option => option.Name == "--package");
+
+        Assert.Equal("ILogger", result.GetValue(targetArgument));
+        Assert.Equal(["Pkg1", "Pkg2"], result.GetValue(packageOption) ?? []);
+    }
+
+    [Fact]
     public void ExtensionsCommand_WithNoArgs_ParsesCorrectly()
     {
         var result = CommandLineBuilder.CreateRootCommand().Parse(["extensions"]);
@@ -1112,6 +1127,21 @@ public class CommandLineTests
 
         Assert.Equal(["ILogger", "Log:1"], result.GetValue(argsArgument) ?? []);
         Assert.Equal(["app.csproj"], result.GetValue(projectOption) ?? []);
+    }
+
+    [Fact]
+    public void MemberCommand_MemberOptionConsumesSingleValueSoTrailingTargetStaysPositional()
+    {
+        var root = CommandLineBuilder.CreateRootCommand();
+        var result = root.Parse(["member", "-m", "Method1", "TargetType", "--package", "Pkg"]);
+
+        Assert.Empty(result.Errors);
+        var command = result.CommandResult.Command;
+        var argsArgument = command.Arguments.OfType<Argument<string[]>>().Single(argument => argument.Name == "args");
+        var memberOption = command.Options.OfType<Option<string[]>>().Single(option => option.Name == "-m");
+
+        Assert.Equal(["TargetType"], result.GetValue(argsArgument) ?? []);
+        Assert.Equal(["Method1"], result.GetValue(memberOption) ?? []);
     }
 
     [Fact]

--- a/src/dotnet-inspect.Tests/CommandLineTests.cs
+++ b/src/dotnet-inspect.Tests/CommandLineTests.cs
@@ -470,6 +470,23 @@ public class CommandLineTests
         Assert.Equal(["router", "System.Text.Json", "--versions"], result);
     }
 
+    [Theory]
+    [InlineData("--version", "9.0.0", "System.Text.Json")]
+    [InlineData("--where", "Field=Value", "System.Text.Json")]
+    [InlineData("--match", "first", "System.Text.Json")]
+    [InlineData("--path", "lib/*", "System.Text.Json")]
+    [InlineData("--il-offset", "0x06000001+0x0", "System.Text.Json")]
+    [InlineData("--extract-resources", "/tmp/out", "System.Text.Json")]
+    [InlineData("--row", "1", "System.Text.Json")]
+    [InlineData("--top", "5", "System.Text.Json")]
+    [InlineData("--triage-shape", "box-value-type", "System.Text.Json")]
+    public void PreprocessArgs_LeadingValuedOption_SkipsValueAndRoutesBareTarget(string option, string value, string target)
+    {
+        var result = CommandLineBuilder.PreprocessArgs([option, value, target]);
+
+        Assert.Equal(["router", target, option, value], result);
+    }
+
     [Fact]
     public void PreprocessArgs_MergesRepeatedSelectIntoOneSemicolonValue()
     {

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -95,6 +95,52 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public void BuildDetailedChangesView_RendersMemberLevelRowsForJsonl()
+    {
+        var oldType = DiffType("Sample", "Widget", DiffMember("Echo", signature: "string Echo(string value)"));
+        var newType = DiffType("Sample", "Widget", DiffMember("Echo", signature: "string Echo(string value, int repeat)"));
+        var change = new ApiChange(
+            ChangeKind.MemberSignatureChanged,
+            ChangeClassification.Breaking,
+            "Member 'Echo' signature changed",
+            "string Echo(string value)",
+            "string Echo(string value, int repeat)",
+            Subject: ApiChangeSubject.Member(oldType, oldType.Members.Single(), newType, newType.Members.Single()));
+
+        var view = DiffOutputFormatter.BuildDetailedChangesView(
+            "Sample",
+            [new TypeDiff("Sample.Widget", [change])],
+            "old.dll",
+            "new.dll");
+
+        var row = Assert.Single(view.Rows!);
+        Assert.Equal("x", row.Change);
+        Assert.Equal("breaking", row.Classification);
+        Assert.Equal("Widget", row.Type);
+        Assert.StartsWith("Echo~", row.Member);
+        Assert.Equal("MemberSignatureChanged", row.Kind);
+        Assert.Equal("string Echo(string value)", row.Old);
+        Assert.Equal("string Echo(string value, int repeat)", row.New);
+    }
+
+    [Fact]
+    public async Task ApplyFilters_EmptyMemberFilteredDiff_ReportsMemberFilterNotTypeFilter()
+    {
+        var (_, _, error) = await ConsoleCapture.RunAsync(() =>
+        {
+            DiffCommand.ApplyFilters(new ApiDiff(), new DiffOptions
+            {
+                TypeFilter = ["Widget"],
+                MemberFilter = ["Keep"]
+            });
+            return Task.FromResult(0);
+        });
+
+        Assert.Contains("member filter matched no changed members", error);
+        Assert.DoesNotContain("type filter matched no changed types", error);
+    }
+
+    [Fact]
     public void BuildApiDiff_UsesResearchSignatureScopeByDefault()
     {
         var oldSurface = DiffSurface(DiffMember("Existing", ["A"]));

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -124,11 +124,18 @@ public class DiffCommandTests
     }
 
     [Fact]
-    public async Task ApplyFilters_EmptyMemberFilteredDiff_ReportsMemberFilterNotTypeFilter()
+    public async Task BuildApiDiff_EmptyMemberFilteredDiff_ReportsMemberFilterNotTypeFilter()
     {
         var (_, _, error) = await ConsoleCapture.RunAsync(() =>
         {
-            DiffCommand.ApplyFilters(new ApiDiff(), new DiffOptions
+            var oldSurface = DiffSurface(
+                DiffMember("Keep", signature: "void Keep()"),
+                DiffMember("Changed", signature: "void Changed()"));
+            var newSurface = DiffSurface(
+                DiffMember("Keep", signature: "void Keep()"),
+                DiffMember("Changed", signature: "int Changed()"));
+
+            DiffCommand.BuildApiDiff(oldSurface, newSurface, new DiffOptions
             {
                 TypeFilter = ["Widget"],
                 MemberFilter = ["Keep"]
@@ -137,6 +144,24 @@ public class DiffCommandTests
         });
 
         Assert.Contains("member filter matched no changed members", error);
+        Assert.DoesNotContain("type filter matched no changed types", error);
+    }
+
+    [Fact]
+    public async Task BuildApiDiff_ZeroChangeDiffWithMemberFilter_DoesNotBlameMemberFilter()
+    {
+        var (_, _, error) = await ConsoleCapture.RunAsync(() =>
+        {
+            var surface = DiffSurface(DiffMember("Keep", signature: "void Keep()"));
+            DiffCommand.BuildApiDiff(surface, surface, new DiffOptions
+            {
+                TypeFilter = ["Widget"],
+                MemberFilter = ["Keep"]
+            });
+            return Task.FromResult(0);
+        });
+
+        Assert.DoesNotContain("member filter matched no changed members", error);
         Assert.DoesNotContain("type filter matched no changed types", error);
     }
 

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -166,6 +166,30 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public async Task BuildApiDiff_TypeFilterWithNoChangedTypesAndMemberFilter_ReportsTypeFilter()
+    {
+        var (_, _, error) = await ConsoleCapture.RunAsync(() =>
+        {
+            var oldSurface = DiffSurface(
+                DiffType("Sample", "Quiet", DiffMember("Keep", signature: "void Keep()")),
+                DiffType("Sample", "Changed", DiffMember("Changed", signature: "void Changed()")));
+            var newSurface = DiffSurface(
+                DiffType("Sample", "Quiet", DiffMember("Keep", signature: "void Keep()")),
+                DiffType("Sample", "Changed", DiffMember("Changed", signature: "int Changed()")));
+
+            DiffCommand.BuildApiDiff(oldSurface, newSurface, new DiffOptions
+            {
+                TypeFilter = ["Quiet"],
+                MemberFilter = ["Keep"]
+            });
+            return Task.FromResult(0);
+        });
+
+        Assert.Contains("type filter matched no changed types: Quiet", error);
+        Assert.DoesNotContain("member filter matched no changed members", error);
+    }
+
+    [Fact]
     public async Task ApplyFilters_ClassificationFilteredMemberDiff_ReportsClassificationFilter()
     {
         var type = DiffType("Sample", "Widget", DiffMember("Added", signature: "void Added()"));

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -141,6 +141,41 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public async Task ApplyFilters_ClassificationFilteredMemberDiff_ReportsClassificationFilter()
+    {
+        var type = DiffType("Sample", "Widget", DiffMember("Added", signature: "void Added()"));
+        var diff = new ApiDiff
+        {
+            TypeDiffs =
+            [
+                new TypeDiff("Sample.Widget",
+                [
+                    new ApiChange(
+                        ChangeKind.MemberAdded,
+                        ChangeClassification.Additive,
+                        "Member 'Added' was added",
+                        NewValue: "void Added()",
+                        Subject: ApiChangeSubject.Member(null, null, type, type.Members.Single()))
+                ])
+            ]
+        };
+
+        var (_, _, error) = await ConsoleCapture.RunAsync(() =>
+        {
+            DiffCommand.ApplyFilters(diff, new DiffOptions
+            {
+                TypeFilter = ["Widget"],
+                MemberFilter = ["Added"],
+                Breaking = true
+            });
+            return Task.FromResult(0);
+        });
+
+        Assert.Contains("classification filter removed all changes", error);
+        Assert.DoesNotContain("member filter matched no changed members", error);
+    }
+
+    [Fact]
     public void BuildApiDiff_UsesResearchSignatureScopeByDefault()
     {
         var oldSurface = DiffSurface(DiffMember("Existing", ["A"]));

--- a/src/dotnet-inspect.Tests/DiffCommandTests.cs
+++ b/src/dotnet-inspect.Tests/DiffCommandTests.cs
@@ -190,6 +190,35 @@ public class DiffCommandTests
     }
 
     [Fact]
+    public async Task TypeFilterMissWithMemberFilter_DoesNotPrintDuplicateTypeFilterNotes()
+    {
+        var oldSurface = DiffSurface(
+            DiffType("Sample", "Quiet", DiffMember("Keep", signature: "void Keep()")),
+            DiffType("Sample", "Changed", DiffMember("Changed", signature: "void Changed()")));
+        var newSurface = DiffSurface(
+            DiffType("Sample", "Quiet", DiffMember("Keep", signature: "void Keep()")),
+            DiffType("Sample", "Changed", DiffMember("Changed", signature: "int Changed()")));
+
+        var (_, _, error) = await ConsoleCapture.RunAsync(() =>
+        {
+            var diff = DiffCommand.BuildApiDiff(oldSurface, newSurface, new DiffOptions
+            {
+                TypeFilter = ["Quiet"],
+                MemberFilter = ["Sample.Changed.Changed"]
+            });
+            DiffCommand.ApplyFilters(diff, new DiffOptions
+            {
+                TypeFilter = ["Quiet"],
+                MemberFilter = ["Sample.Changed.Changed"]
+            });
+            return Task.FromResult(0);
+        });
+
+        Assert.Equal(1, CountOccurrences(error, "type filter matched no changed types: Quiet"));
+        Assert.DoesNotContain("member filter matched no changed members", error);
+    }
+
+    [Fact]
     public async Task ApplyFilters_ClassificationFilteredMemberDiff_ReportsClassificationFilter()
     {
         var type = DiffType("Sample", "Widget", DiffMember("Added", signature: "void Added()"));
@@ -222,6 +251,18 @@ public class DiffCommandTests
 
         Assert.Contains("classification filter removed all changes", error);
         Assert.DoesNotContain("member filter matched no changed members", error);
+    }
+
+    private static int CountOccurrences(string value, string substring)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = value.IndexOf(substring, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += substring.Length;
+        }
+        return count;
     }
 
     [Fact]

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -65,13 +65,13 @@ public static class ApiCommandDefinitions
         var memberOption = new Option<string[]>("-m")
         {
             Description = "Filter members by name or limit count (-m 5)",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         memberOption.Aliases.Add("--member");
         var kindOption = new Option<string[]>("-k")
         {
             Description = "Filter by kind (class, struct, interface, enum, delegate, method, property, field, event, constructor)",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         kindOption.Aliases.Add("--kind");
 
@@ -173,7 +173,7 @@ public static class ApiCommandDefinitions
         var memberOption = new Option<string[]>("-m")
         {
             Description = "Filter members by name (supports globs, Type.Member dotted syntax)",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         memberOption.Aliases.Add("--member");
         var ctorOption = new Option<bool>("--ctor") { Description = "Filter members to constructors (shorthand for -m .ctor)" };
@@ -184,7 +184,7 @@ public static class ApiCommandDefinitions
         var binOption = new Option<string[]>("--bin")
         {
             Description = "Scan output directory(s) for inbound callers of the selected member (Callers section). Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         binOption.Aliases.Add("--directory");
         var callerProjectOption = new Option<string[]>("--project")
@@ -195,12 +195,12 @@ public static class ApiCommandDefinitions
         var callerPackageOption = new Option<string[]>("--caller-package")
         {
             Description = "Download and scan package(s) for inbound callers (Callers section). Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var kindOption = new Option<string[]>("-k")
         {
             Description = "Filter by member kind (method, property, field, event, constructor)",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         kindOption.Aliases.Add("--kind");
 

--- a/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/ApiCommandDefinitions.cs
@@ -190,7 +190,7 @@ public static class ApiCommandDefinitions
         var callerProjectOption = new Option<string[]>("--project")
         {
             Description = "Source: restored project.assets.json context when no other source is supplied; also scans restored dependencies for inbound callers. Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var callerPackageOption = new Option<string[]>("--caller-package")
         {

--- a/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/InspectionCommandDefinitions.cs
@@ -43,13 +43,13 @@ public static class InspectionCommandDefinitions
         var typeFilterOption = new Option<string[]>("-t")
         {
             Description = "Filter to specific type(s)",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         typeFilterOption.Aliases.Add("--type");
         var memberFilterOption = new Option<string[]>("-m")
         {
             Description = "Filter to specific member selector(s); use with --type or pass Type.Member",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         memberFilterOption.Aliases.Add("--member");
         var nameOnlyOption = new Option<bool>("--name-only") { Description = "Show only type names that changed" };

--- a/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/PackageCommandDefinitions.cs
@@ -30,7 +30,7 @@ public static class PackageCommandDefinitions
         {
             Description = "List package files with sizes (the Files section), scoped to a file, directory, glob, @readme (AGENTS.md > README.md > PACKAGE.md), or @agents. Can repeat. Pass --path with no value for the whole package.",
             Arity = ArgumentArity.ZeroOrMore,
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var pathMatchOption = new Option<string?>("--match") { Description = "For repeated --path: all (default) or first matching selector per package" };
         var skipEmptyOption = new Option<bool>("--skip-empty") { Description = "With multi-package Files rows, omit packages with no matching files" };

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -50,7 +50,7 @@ public static class RouterCommandDefinition
                 return 1;
             }
 
-            if (ContainsHelpOption(tokens))
+            if (ContainsHelpOption(tokens) && !tokens[0].StartsWith('-', StringComparison.Ordinal))
             {
                 Console.Error.WriteLine($"Note: interpreting bare token '{tokens[0]}' as a package or platform target.");
                 Console.Error.WriteLine("      Use 'dotnet-inspect --help' to list commands, or 'dotnet-inspect package --help' for package help.");

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -136,6 +136,9 @@ public static class RouterCommandDefinition
                     return ["package", target, .. tail];
             }
 
+            if (ContainsOption(tokens, "--member") || ContainsOption(tokens, "-m"))
+                return ["member", target, .. tail];
+
             if (ContainsOption(tokens, "--library"))
                 return ["package", .. tokens];
 

--- a/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/RouterCommandDefinition.cs
@@ -50,6 +50,13 @@ public static class RouterCommandDefinition
                 return 1;
             }
 
+            if (ContainsHelpOption(tokens))
+            {
+                Console.Error.WriteLine($"Note: interpreting bare token '{tokens[0]}' as a package or platform target.");
+                Console.Error.WriteLine("      Use 'dotnet-inspect --help' to list commands, or 'dotnet-inspect package --help' for package help.");
+                Console.Error.WriteLine();
+            }
+
             RequestTelemetry.Breadcrumb("router-hit", string.Join(' ', tokens));
             var rewritten = await RouterTokenRewriter.RewriteAsync(tokens);
             RequestTelemetry.Breadcrumb(
@@ -110,6 +117,9 @@ public static class RouterCommandDefinition
             .Select(candidate => candidate.Command)
             .FirstOrDefault();
     }
+
+    private static bool ContainsHelpOption(IEnumerable<string> tokens)
+        => tokens.Any(token => token is "--help" or "-h" or "-?");
 
     private static class RouterTokenRewriter
     {

--- a/src/dotnet-inspect/CommandLine/Commands/SearchCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/SearchCommandDefinitions.cs
@@ -308,7 +308,10 @@ public static class SearchCommandDefinitions
         extCommand.Options.Add(typeFilterOption);
         extCommand.Options.Add(opts.Json);
         extCommand.Options.Add(compactOption);
+        opts.AddTableOptionsTo(extCommand);
         extCommand.Options.Add(packagePrefixOption);
+        extCommand.Options.Add(opts.Columns);
+        extCommand.Options.Add(opts.Fields);
         opts.AddCountOptionTo(extCommand);
         opts.AddOutputOptionsTo(extCommand);
         opts.AddNuGetOptionsTo(extCommand);
@@ -365,6 +368,12 @@ public static class SearchCommandDefinitions
                 Count = parseResult.GetValue(opts.Count),
                 JsonOutput = parseResult.GetValue(opts.Json),
                 CompactJson = parseResult.GetValue(compactOption),
+                OneLine = opts.ResolveOneLine(parseResult),
+                Tsv = opts.ResolveTsv(parseResult),
+                Jsonl = opts.ResolveJsonl(parseResult),
+                NoHeader = parseResult.GetValue(opts.NoHeaders),
+                Columns = opts.ParseColumns(parseResult),
+                Fields = opts.ParseFields(parseResult),
                 Verbose = parseResult.GetValue(opts.Verbose),
                 Verbosity = opts.ParseVerbosity(parseResult),
                 PackagePrefix = packagePrefix,

--- a/src/dotnet-inspect/CommandLine/Commands/SearchCommandDefinitions.cs
+++ b/src/dotnet-inspect/CommandLine/Commands/SearchCommandDefinitions.cs
@@ -24,12 +24,12 @@ public static class SearchCommandDefinitions
         var packageOption = new Option<string[]>("--package")
         {
             Description = "Search in package(s) (name or name@version). Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var assemblyOption = new Option<string[]>("--library")
         {
             Description = "Search in library file(s). Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var platformOption = CommandLineHelpers.CreatePlatformSearchOption();
         var platformLibraryOption = CommandLineHelpers.CreatePlatformLibrarySearchOption();
@@ -39,12 +39,12 @@ public static class SearchCommandDefinitions
         var projectOption = new Option<string[]>("--project")
         {
             Description = "Search project dependencies via project.assets.json. Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var binOption = new Option<string[]>("--bin")
         {
             Description = "Search all DLLs in output directory(s). Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var tfmOption = new Option<string?>("--tfm") { Description = "Select library or target framework by TFM (e.g., net8.0)" };
         var allOption = new Option<bool>("--all") { Description = "Include non-public, hidden, and obsolete types" };
@@ -131,12 +131,12 @@ public static class SearchCommandDefinitions
         var packageOption = new Option<string[]>("--package")
         {
             Description = "Search in package(s) (name or name@version). Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var assemblyOption = new Option<string[]>("--library")
         {
             Description = "Search in library file(s). Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var platformOption = CommandLineHelpers.CreatePlatformSearchOption();
         var platformLibraryOption = CommandLineHelpers.CreatePlatformLibrarySearchOption();
@@ -146,7 +146,7 @@ public static class SearchCommandDefinitions
         var projectOption = new Option<string[]>("--project")
         {
             Description = "Search project dependencies via project.assets.json. Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var tfmOption = new Option<string?>("--tfm") { Description = "Target framework (e.g., net8.0)" };
         var allOption = new Option<bool>("--all") { Description = "Include non-public, hidden, and obsolete types" };
@@ -259,12 +259,12 @@ public static class SearchCommandDefinitions
         var packageOption = new Option<string[]>("--package")
         {
             Description = "Search in package(s) (name or name@version). Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var assemblyOption = new Option<string[]>("--library")
         {
             Description = "Search in library file(s). Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var platformOption = CommandLineHelpers.CreatePlatformSearchOption();
         var platformLibraryOption = CommandLineHelpers.CreatePlatformLibrarySearchOption();
@@ -274,7 +274,7 @@ public static class SearchCommandDefinitions
         var projectOption = new Option<string[]>("--project")
         {
             Description = "Search project dependencies via project.assets.json. Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var reachableOption = new Option<bool>("--reachable")
         {
@@ -399,12 +399,12 @@ public static class SearchCommandDefinitions
         var packageOption = new Option<string[]>("--package")
         {
             Description = "Search in package(s) (name or name@version). Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var assemblyOption = new Option<string[]>("--library")
         {
             Description = "Search in library file(s). Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var platformOption = CommandLineHelpers.CreatePlatformSearchOption();
         var platformLibraryOption = CommandLineHelpers.CreatePlatformLibrarySearchOption();
@@ -414,7 +414,7 @@ public static class SearchCommandDefinitions
         var projectOption = new Option<string[]>("--project")
         {
             Description = "Search project dependencies via project.assets.json. Can repeat.",
-            AllowMultipleArgumentsPerToken = true
+            AllowMultipleArgumentsPerToken = false
         };
         var tfmOption = new Option<string?>("--tfm") { Description = "Target framework (e.g., net8.0)" };
         var compactOption = new Option<bool>("--compact") { Description = "Minified JSON (use with --json)" };

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -95,12 +95,20 @@ public static class ArgumentPreprocessor
         int firstPositional = -1;
         for (int i = 0; i < args.Length; i++)
         {
-            if (!args[i].StartsWith('-'))
+            var token = args[i];
+            if (!token.StartsWith('-'))
             {
-                // Skip the value token that follows -n, --head, or --tail (it's a number, not a command)
-                if (i > 0 && (args[i - 1] == "-n" || args[i - 1] == "--head" || args[i - 1] == "--tail")) continue;
                 firstPositional = i;
                 break;
+            }
+
+            var optionName = token.Split('=', 2)[0];
+            if (OptionsWithFollowingValue.Contains(optionName)
+                && !token.Contains('=', StringComparison.Ordinal)
+                && i + 1 < args.Length
+                && !args[i + 1].StartsWith("-", StringComparison.Ordinal))
+            {
+                i++;
             }
         }
 
@@ -114,9 +122,7 @@ public static class ArgumentPreprocessor
 
             // Route bare names through the router command (platform-preferred, NuGet fallback)
             RequestTelemetry.Breadcrumb("implicit-router", args[firstPositional]);
-            if (HasHelpBefore(args, firstPositional))
-                return ["router", args[firstPositional], .. args[..firstPositional], .. args[(firstPositional + 1)..]];
-            return ["router", .. args];
+            return ["router", args[firstPositional], .. args[..firstPositional], .. args[(firstPositional + 1)..]];
         }
 
         // Bare discovery flags (-S, --select) with no positional args → route to router
@@ -146,9 +152,6 @@ public static class ArgumentPreprocessor
         "--tips", "-S", "-s", "--select", "--section", "-D", "--discover"
     };
     internal const string EscapedAtCategoryPrefix = "__dotnet_inspect_at__";
-
-    private static bool HasHelpBefore(string[] args, int firstPositional)
-        => args[..firstPositional].Any(token => token is "--help" or "-h" or "-?");
 
     private static string[] RewriteValuedPlatformForSearchCommands(string[] args)
     {

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -114,6 +114,8 @@ public static class ArgumentPreprocessor
 
             // Route bare names through the router command (platform-preferred, NuGet fallback)
             RequestTelemetry.Breadcrumb("implicit-router", args[firstPositional]);
+            if (HasHelpBefore(args, firstPositional))
+                return ["router", args[firstPositional], .. args[..firstPositional], .. args[(firstPositional + 1)..]];
             return ["router", .. args];
         }
 
@@ -144,6 +146,9 @@ public static class ArgumentPreprocessor
         "--tips", "-S", "-s", "--select", "--section", "-D", "--discover"
     };
     internal const string EscapedAtCategoryPrefix = "__dotnet_inspect_at__";
+
+    private static bool HasHelpBefore(string[] args, int firstPositional)
+        => args[..firstPositional].Any(token => token is "--help" or "-h" or "-?");
 
     private static string[] RewriteValuedPlatformForSearchCommands(string[] args)
     {

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -149,7 +149,10 @@ public static class ArgumentPreprocessor
         "--package", "--library", "--assembly", "--project", "--bin", "--directory",
         "--platform", CommandLineHelpers.PlatformLibraryOptionName, "--framework", "--tfm",
         "-t", "--type", "-m", "--member", "-k", "--kind", "--index",
-        "--caller-package", "--caller-project",
+        "--caller-package", "--caller-project", "--match", "--path",
+        "--il-offset", "--il-offsets", "--extract-resources", "--version", "--versions",
+        "--out", "--take", "--row", "--where", "--order-by",
+        "--min-confidence", "--triage-shape", "--top", "--session",
         "--package-prefix", "--depth", "-n", "--head", "--tail", "--source",
         "--add-source", "--nugetconfig", "--columns", "--fields", "-v", "-T",
         "--tips", "-S", "-s", "--select", "--section", "-D", "--discover"

--- a/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
+++ b/src/dotnet-inspect/CommandLine/Helpers/ArgumentPreprocessor.cs
@@ -146,7 +146,10 @@ public static class ArgumentPreprocessor
     };
     private static readonly HashSet<string> OptionsWithFollowingValue = new(StringComparer.OrdinalIgnoreCase)
     {
-        "--package", "--library", "--project", "--bin", "--tfm", "-t", "--type",
+        "--package", "--library", "--assembly", "--project", "--bin", "--directory",
+        "--platform", CommandLineHelpers.PlatformLibraryOptionName, "--framework", "--tfm",
+        "-t", "--type", "-m", "--member", "-k", "--kind", "--index",
+        "--caller-package", "--caller-project",
         "--package-prefix", "--depth", "-n", "--head", "--tail", "--source",
         "--add-source", "--nugetconfig", "--columns", "--fields", "-v", "-T",
         "--tips", "-S", "-s", "--select", "--section", "-D", "--discover"

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -523,10 +523,6 @@ public class DiffCommand
         {
             Console.Error.WriteLine("Note: classification filter removed all changes after type/member filters.");
         }
-        else if (filtered.Count == 0 && options.MemberFilter.Count > 0 && (typeDiffs.Count > 0 || beforeTypeFilterCount == 0))
-        {
-            Console.Error.WriteLine($"Note: member filter matched no changed members after other filters: {string.Join(", ", options.MemberFilter)}.");
-        }
         else if (filtered.Count == 0 && beforeTypeFilterCount > 0 && options.TypeFilter.Count > 0 && typeDiffs.Count > 0)
         {
             Console.Error.WriteLine("Note: classification filter removed all changes for the matched type filter.");
@@ -534,6 +530,11 @@ public class DiffCommand
 
         return filtered;
     }
+
+    private static IReadOnlyList<TypeDiff> ApplyTypeFilterOnly(IReadOnlyList<TypeDiff> typeDiffs, IReadOnlyCollection<string> typeFilters)
+        => typeFilters.Count == 0
+            ? typeDiffs
+            : typeDiffs.Where(td => MatchesAnyDiffTypeFilter(td.TypeFullName, typeFilters)).ToList();
 
     private static bool MatchesAnyDiffTypeFilter(string typeFullName, IEnumerable<string> filters)
     {
@@ -588,9 +589,15 @@ public class DiffCommand
                     ApiScope: ApiDiffScope.Signature)).ApiDiff
             ?? new ApiDiff();
 
-        return options.MemberFilter.Count == 0
-            ? diff
-            : FilterApiDiffByMemberTargets(diff, fromSurface, toSurface, options);
+        if (options.MemberFilter.Count == 0)
+            return diff;
+
+        var candidateTypeDiffs = ApplyTypeFilterOnly(diff.TypeDiffs, options.TypeFilter);
+        var filtered = FilterApiDiffByMemberTargets(diff, fromSurface, toSurface, options);
+        if (filtered.TypeDiffs.Count == 0 && candidateTypeDiffs.Count > 0)
+            Console.Error.WriteLine($"Note: member filter matched no changed members after type filters: {string.Join(", ", options.MemberFilter)}.");
+
+        return filtered;
     }
 
     internal static ApiDiff FilterApiDiffByMemberTargets(ApiDiff diff, ApiSurface fromSurface, ApiSurface toSurface, DiffOptions options)

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -512,7 +512,7 @@ public class DiffCommand
                 .Where(td => MatchesAnyDiffTypeFilter(td.TypeFullName, options.TypeFilter))
                 .ToList();
 
-            if (typeDiffs.Count == 0 && beforeTypeFilterCount > 0)
+            if (typeDiffs.Count == 0 && beforeTypeFilterCount > 0 && options.MemberFilter.Count == 0)
                 Console.Error.WriteLine($"Note: type filter matched no changed types: {string.Join(", ", options.TypeFilter)}.");
         }
 
@@ -522,10 +522,6 @@ public class DiffCommand
         if (filtered.Count == 0 && typeDiffs.Count > 0 && classificationFilterActive)
         {
             Console.Error.WriteLine("Note: classification filter removed all changes after type/member filters.");
-        }
-        else if (filtered.Count == 0 && beforeTypeFilterCount > 0 && options.TypeFilter.Count > 0 && typeDiffs.Count > 0)
-        {
-            Console.Error.WriteLine("Note: classification filter removed all changes for the matched type filter.");
         }
 
         return filtered;

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -593,6 +593,9 @@ public class DiffCommand
             return diff;
 
         var candidateTypeDiffs = ApplyTypeFilterOnly(diff.TypeDiffs, options.TypeFilter);
+        if (candidateTypeDiffs.Count == 0 && diff.TypeDiffs.Count > 0 && options.TypeFilter.Count > 0)
+            Console.Error.WriteLine($"Note: type filter matched no changed types: {string.Join(", ", options.TypeFilter)}.");
+
         var filtered = FilterApiDiffByMemberTargets(diff, fromSurface, toSurface, options);
         if (filtered.TypeDiffs.Count == 0 && candidateTypeDiffs.Count > 0)
             Console.Error.WriteLine($"Note: member filter matched no changed members after type filters: {string.Join(", ", options.MemberFilter)}.");

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -123,12 +123,24 @@ public class DiffCommand
                 if (options.OneLine)
                 {
                     var typeDiffs = ApplyFilters(diff, options);
-                    var view = DiffOutputFormatter.BuildOneLineView(inputs.Name, typeDiffs, inputs.FromVersion, inputs.ToVersion);
-                    OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
-                        options.Columns, options.Fields,
-                        (writer, formatter, writerOptions) =>
-                            MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions),
-                        options.Rows);
+                    if (SelectsDetailedChanges(options))
+                    {
+                        var view = DiffOutputFormatter.BuildDetailedChangesView(inputs.Name, typeDiffs, inputs.FromVersion, inputs.ToVersion);
+                        OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
+                            options.Columns, options.Fields,
+                            (writer, formatter, writerOptions) =>
+                                MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions),
+                            options.Rows);
+                    }
+                    else
+                    {
+                        var view = DiffOutputFormatter.BuildOneLineView(inputs.Name, typeDiffs, inputs.FromVersion, inputs.ToVersion);
+                        OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
+                            options.Columns, options.Fields,
+                            (writer, formatter, writerOptions) =>
+                                MarkoutSerializer.Serialize(view, writer, formatter, DiffViewContext.Default, writerOptions),
+                            options.Rows);
+                    }
                 }
                 else
                 {
@@ -338,6 +350,9 @@ public class DiffCommand
         => options.AllocRegressionsOnly
             || options.IncludeSections?.Contains("Analysis Diff") == true;
 
+    private static bool SelectsDetailedChanges(DiffOptions options)
+        => options.IncludeSections?.Contains("Changes") == true;
+
     internal sealed record AnalysisDiffResult(List<AnalysisDiffRow> Rows, string Summary);
 
     // A diff row plus the metadata used to rank and classify it. Magnitude is the
@@ -488,6 +503,7 @@ public class DiffCommand
     internal static IReadOnlyList<TypeDiff> ApplyFilters(ApiDiff diff, DiffOptions options)
     {
         var typeDiffs = diff.TypeDiffs;
+        var beforeTypeFilterCount = typeDiffs.Count;
 
         // Apply type filter post-Compare
         if (options.TypeFilter.Count > 0)
@@ -496,12 +512,22 @@ public class DiffCommand
                 .Where(td => MatchesAnyDiffTypeFilter(td.TypeFullName, options.TypeFilter))
                 .ToList();
 
-            if (typeDiffs.Count == 0)
+            if (typeDiffs.Count == 0 && beforeTypeFilterCount > 0)
                 Console.Error.WriteLine($"Note: type filter matched no changed types: {string.Join(", ", options.TypeFilter)}.");
         }
 
         // Apply classification filter
-        return FilterByClassification(typeDiffs, options);
+        var filtered = FilterByClassification(typeDiffs, options);
+        if (filtered.Count == 0 && options.MemberFilter.Count > 0 && (typeDiffs.Count > 0 || beforeTypeFilterCount == 0))
+        {
+            Console.Error.WriteLine($"Note: member filter matched no changed members after other filters: {string.Join(", ", options.MemberFilter)}.");
+        }
+        else if (filtered.Count == 0 && beforeTypeFilterCount > 0 && options.TypeFilter.Count > 0 && typeDiffs.Count > 0)
+        {
+            Console.Error.WriteLine("Note: classification filter removed all changes for the matched type filter.");
+        }
+
+        return filtered;
     }
 
     private static bool MatchesAnyDiffTypeFilter(string typeFullName, IEnumerable<string> filters)

--- a/src/dotnet-inspect/Commands/DiffCommand.cs
+++ b/src/dotnet-inspect/Commands/DiffCommand.cs
@@ -518,7 +518,12 @@ public class DiffCommand
 
         // Apply classification filter
         var filtered = FilterByClassification(typeDiffs, options);
-        if (filtered.Count == 0 && options.MemberFilter.Count > 0 && (typeDiffs.Count > 0 || beforeTypeFilterCount == 0))
+        var classificationFilterActive = options.Breaking || options.Additive;
+        if (filtered.Count == 0 && typeDiffs.Count > 0 && classificationFilterActive)
+        {
+            Console.Error.WriteLine("Note: classification filter removed all changes after type/member filters.");
+        }
+        else if (filtered.Count == 0 && options.MemberFilter.Count > 0 && (typeDiffs.Count > 0 || beforeTypeFilterCount == 0))
         {
             Console.Error.WriteLine($"Note: member filter matched no changed members after other filters: {string.Join(", ", options.MemberFilter)}.");
         }

--- a/src/dotnet-inspect/Commands/ExtensionsCommand.cs
+++ b/src/dotnet-inspect/Commands/ExtensionsCommand.cs
@@ -73,6 +73,10 @@ public class ExtensionsCommand
             {
                 WriteCount(results);
             }
+            else if (options.OneLine || options.Tsv || options.Jsonl || options.NoHeader)
+            {
+                WriteTableOutput(targetType, results, options);
+            }
             else
             {
                 WriteMarkoutOutput(targetType, results, options.Verbosity, options.Rows);
@@ -190,6 +194,16 @@ public class ExtensionsCommand
         var view = ExtensionsOutputFormatter.BuildView(targetType, results, verbosity);
         OutputFormatter.WriteLimitedMarkdown(Console.Out,
             MarkoutSerializer.Serialize(view, SearchViewContext.Default), rows);
+    }
+
+    private static void WriteTableOutput(string targetType, List<ExtensionMethodResult> results, ExtensionsOptions options)
+    {
+        var view = ExtensionsOutputFormatter.BuildView(targetType, results, options.Verbosity);
+        OutputFormatter.WriteProjectedTable(Console.Out, !options.NoHeader, options.Tsv, options.Jsonl,
+            options.Columns, options.Fields,
+            (writer, formatter, writerOptions) =>
+                MarkoutSerializer.Serialize(view, writer, formatter, SearchViewContext.Default, writerOptions),
+            options.Rows);
     }
 
     /// <summary>

--- a/src/dotnet-inspect/Options/ExtensionsOptions.cs
+++ b/src/dotnet-inspect/Options/ExtensionsOptions.cs
@@ -83,6 +83,36 @@ public record ExtensionsOptions : IAssemblySourceOptions
     public bool CompactJson { get; init; }
 
     /// <summary>
+    /// Output as a pretty table.
+    /// </summary>
+    public bool OneLine { get; init; }
+
+    /// <summary>
+    /// Output as normalized tab-separated values.
+    /// </summary>
+    public bool Tsv { get; init; }
+
+    /// <summary>
+    /// Output as JSON Lines.
+    /// </summary>
+    public bool Jsonl { get; init; }
+
+    /// <summary>
+    /// Suppress table/TSV column headers.
+    /// </summary>
+    public bool NoHeader { get; init; }
+
+    /// <summary>
+    /// Project table columns.
+    /// </summary>
+    public string[]? Columns { get; init; }
+
+    /// <summary>
+    /// Project field rows.
+    /// </summary>
+    public string[]? Fields { get; init; }
+
+    /// <summary>
     /// Show progress messages on stderr.
     /// </summary>
     public bool Verbose { get; init; }
@@ -116,5 +146,5 @@ public record ExtensionsOptions : IAssemblySourceOptions
     /// <summary>
     /// True when output is raw text (not rendered markdown).
     /// </summary>
-    public bool IsRawOutput => JsonOutput;
+    public bool IsRawOutput => JsonOutput || OneLine || Tsv || Jsonl || NoHeader;
 }

--- a/src/dotnet-inspect/Output/DiffOutputFormatter.cs
+++ b/src/dotnet-inspect/Output/DiffOutputFormatter.cs
@@ -65,6 +65,30 @@ public static class DiffOutputFormatter
         };
     }
 
+    public static DiffDetailedChangesView BuildDetailedChangesView(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion)
+    {
+        int totalBreaking = 0, totalAdditive = 0, totalPotentiallyBreaking = 0;
+        foreach (var td in typeDiffs)
+        {
+            totalBreaking += td.BreakingCount;
+            totalAdditive += td.AdditiveCount;
+            totalPotentiallyBreaking += td.PotentiallyBreakingCount;
+        }
+
+        var rows = typeDiffs
+            .OrderBy(td => td.TypeFullName, StringComparer.Ordinal)
+            .SelectMany(td => td.Changes.Select(change => BuildDetailedRow(td.TypeFullName, change)))
+            .ToList();
+
+        return new DiffDetailedChangesView
+        {
+            Title = $"API Diff: {name}",
+            Versions = $"{fromVersion} -> {toVersion}",
+            Summary = FormatSummaryCounts(totalBreaking, totalAdditive, totalPotentiallyBreaking),
+            Rows = rows.Count > 0 ? rows : null
+        };
+    }
+
     public static DiffFullView BuildFullView(string name, IReadOnlyList<TypeDiff> typeDiffs, string fromVersion, string toVersion)
     {
         var view = new DiffFullView
@@ -165,4 +189,38 @@ public static class DiffOutputFormatter
 
         return rows.Count > 0 ? rows : null;
     }
+
+    private static DiffDetailedChangeRow BuildDetailedRow(string typeFullName, ApiChange change)
+        => new(
+            ChangeSymbol(change.Classification, change.Kind),
+            ClassificationText(change.Classification),
+            TypeMatcher.GetSimpleName(typeFullName),
+            change.Subject?.OldMember?.StableSelector
+                ?? change.Subject?.NewMember?.StableSelector
+                ?? "",
+            ChangeKindText(change.Kind),
+            change.Message,
+            change.OldValue ?? "",
+            change.NewValue ?? "");
+
+    private static string ChangeSymbol(ChangeClassification classification, ChangeKind kind)
+        => kind switch
+        {
+            ChangeKind.TypeAdded or ChangeKind.MemberAdded => "+",
+            ChangeKind.TypeRemoved or ChangeKind.MemberRemoved => "-",
+            _ when classification == ChangeClassification.Breaking => "x",
+            _ => "~"
+        };
+
+    private static string ClassificationText(ChangeClassification classification)
+        => classification switch
+        {
+            ChangeClassification.Breaking => "breaking",
+            ChangeClassification.Additive => "additive",
+            ChangeClassification.PotentiallyBreaking => "potentially-breaking",
+            _ => classification.ToString()
+        };
+
+    private static string ChangeKindText(ChangeKind kind)
+        => kind.ToString();
 }

--- a/src/dotnet-inspect/Sections/DiffSections.cs
+++ b/src/dotnet-inspect/Sections/DiffSections.cs
@@ -16,7 +16,7 @@ public static class DiffSections
     public static DocumentSchema CreateSchema()
     {
         return new DocumentSchema()
-            .Add(Changes.Name, "column", "Change", "Type", "Detail")
+            .Add(Changes.Name, "column", "Change", "Classification", "Type", "Member", "Kind", "Detail", "Old", "New")
             .Add(AnalysisDiff.Name, "section", "Member", "Signal", "Old", "New", "Delta", "Shape", "Evidence");
     }
 

--- a/src/dotnet-inspect/Services/SharedOptions.cs
+++ b/src/dotnet-inspect/Services/SharedOptions.cs
@@ -62,7 +62,7 @@ public class SharedOptions
     public Option<string[]> PerformanceTriageShape { get; } = new("--triage-shape")
     {
         Description = "Performance Triage: include only shape(s), comma-separated or repeated; run -S \"Performance Triage\" to see shapes",
-        AllowMultipleArgumentsPerToken = true
+        AllowMultipleArgumentsPerToken = false
     };
     public Option<int?> PerformanceTriageTop { get; } = new("--top") { Description = "Performance Triage: show the top N ranked rows" };
     public Option<string[]> RowWhere { get; } = new("--where")
@@ -79,12 +79,12 @@ public class SharedOptions
     public Option<string[]> Source { get; } = new("--source")
     {
         Description = "NuGet source URL (replaces defaults, can repeat)",
-        AllowMultipleArgumentsPerToken = true
+        AllowMultipleArgumentsPerToken = false
     };
     public Option<string[]> AddSource { get; } = new("--add-source")
     {
         Description = "NuGet source URL to add (can repeat)",
-        AllowMultipleArgumentsPerToken = true
+        AllowMultipleArgumentsPerToken = false
     };
     public Option<string?> NuGetConfig { get; } = new("--nugetconfig")
     {

--- a/src/dotnet-inspect/Views/DiffViews.cs
+++ b/src/dotnet-inspect/Views/DiffViews.cs
@@ -18,6 +18,30 @@ public class DiffOneLineView
 [MarkoutSerializable]
 public record DiffOneLineRow(string Change, string Type, string Detail);
 
+[MarkoutSerializable(
+    TitleProperty = nameof(Title),
+    FieldLayout = FieldLayout.Table)]
+public class DiffDetailedChangesView
+{
+    [MarkoutIgnore] public string Title { get; set; } = "";
+    public string Versions { get; set; } = "";
+    public string Summary { get; set; } = "";
+
+    [MarkoutSection(Name = "Changes")]
+    public List<DiffDetailedChangeRow>? Rows { get; set; }
+}
+
+[MarkoutSerializable]
+public record DiffDetailedChangeRow(
+    string Change,
+    string Classification,
+    string Type,
+    string Member,
+    string Kind,
+    string Detail,
+    string Old,
+    string New);
+
 /// <summary>
 /// View model for full diff rendering. Uses GroupBy to partition changes
 /// by type name, rendering each type as a subheading with its changes as list items.
@@ -72,6 +96,8 @@ public record DiffChangeRow(
 [MarkoutContextOptions(SuppressTableWarnings = true)]
 [MarkoutContext(typeof(DiffOneLineView))]
 [MarkoutContext(typeof(DiffOneLineRow))]
+[MarkoutContext(typeof(DiffDetailedChangesView))]
+[MarkoutContext(typeof(DiffDetailedChangeRow))]
 [MarkoutContext(typeof(DiffFullView))]
 [MarkoutContext(typeof(DiffChangeRow))]
 [MarkoutContext(typeof(AnalysisDiffView))]


### PR DESCRIPTION
## Summary

Fixes the CLI-only hard-run usability issues found in the release package pass:

- keep `member --project <csproj> Log:1` from treating `Log:1` as another project path
- wire `extensions` table/TSV/JSONL output and projections so output flags are not swallowed as package IDs
- add a note when bare-token `--help` is routed as package/platform help
- make explicitly selected diff `Changes` machine output include member-level detail (`member`, `kind`, `old`, `new`, classification)
- report member-filtered no-change diffs as member-filter misses instead of blaming the type filter

Fixes #2477
Fixes #2478
Fixes #2479
Fixes #2481
Fixes #2483

Does not address non-CLI follow-ups #2475, #2476, #2480, or #2482.

## Validation

- `dotnet build src/dotnet-inspect.Tests/dotnet-inspect.Tests.csproj -c Release --no-restore -p:PublishAot=false`
- focused regression methods for parser, extensions output, router help, and diff detail rows: 6 passed
- `dotnet run --project src/dotnet-inspect.Tests -c Release --no-build`: 1673 total, 0 failed, 10 skipped
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`: succeeded; 3 existing nullable warnings in `tests/ILInspector.Metadata.Tests`

Adversarial review requested separately per repo policy; results will be posted as a PR comment.
