### PR TITLE
Suppress copy and clear setup leak boundaries

### DIFF
--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -174,6 +174,27 @@ public sealed class LeakTriageAnalyzerTests
             .. Call(TokenSystemMemorySpanClear),
             0x2A,
         ], []);
+        var arrayClear = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenRent),
+            0x0A,
+            0x06,
+            0x16,
+            0x1F, 0x10,
+            .. Call(TokenArrayClear),
+            0x2A,
+        ], []);
+        var spanCopyTo = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenRent),
+            0x0A,
+            0x06,
+            .. Call(TokenSpanImplicit),
+            .. Call(TokenSpanCopyTo),
+            0x2A,
+        ], []);
 
         Assert.Empty(keepAlive.Findings);
         AssertCandidate(keepAlive, nameof(Synthetic), "cross-method-suppressed");
@@ -186,6 +207,14 @@ public sealed class LeakTriageAnalyzerTests
         Assert.Empty(systemMemorySpanClear.Findings);
         AssertCandidate(systemMemorySpanClear, nameof(Synthetic), "cross-method-suppressed");
         AssertNoCandidate(systemMemorySpanClear, nameof(Synthetic), "exception-path-leak-candidate");
+
+        Assert.Empty(arrayClear.Findings);
+        AssertCandidate(arrayClear, nameof(Synthetic), "cross-method-suppressed");
+        AssertNoCandidate(arrayClear, nameof(Synthetic), "exception-path-leak-candidate");
+
+        Assert.Empty(spanCopyTo.Findings);
+        AssertCandidate(spanCopyTo, nameof(Synthetic), "cross-method-suppressed");
+        AssertNoCandidate(spanCopyTo, nameof(Synthetic), "exception-path-leak-candidate");
     }
 
     [Fact]
@@ -331,6 +360,9 @@ public sealed class LeakTriageAnalyzerTests
     const int TokenArrayCopy = 0x0A000007;
     const int TokenSystemMemoryAsSpan = 0x0A000008;
     const int TokenSystemMemorySpanClear = 0x0A000009;
+    const int TokenArrayClear = 0x0A00000A;
+    const int TokenSpanCopyTo = 0x0A00000B;
+    const int TokenSpanImplicit = 0x0A00000C;
 
     static ImmutableArray<LeakTriageFinding> AnalyzeSynthetic(byte[] il, IReadOnlyCollection<ExceptionRegion> exceptionRegions)
         => AnalyzeSyntheticDetailed(il, exceptionRegions).Findings;
@@ -357,6 +389,9 @@ public sealed class LeakTriageAnalyzerTests
         var byteArray = TypeRef.SzArray(TypeRef.CoreLib("System", "Byte"));
         var systemMemorySpanOfByte = TypeRef.GenericInstance(
             TypeRef.Definition("System.Memory", "System", "Span`1", trustedFrameworkAssembly: true),
+            [TypeRef.CoreLib("System", "Byte")]);
+        var coreLibSpanOfByte = TypeRef.GenericInstance(
+            TypeRef.CoreLib("System", "Span`1"),
             [TypeRef.CoreLib("System", "Byte")]);
 
         return token switch
@@ -385,6 +420,25 @@ public sealed class LeakTriageAnalyzerTests
                 TypeRef.CoreLib("System", "Void"),
                 MemberKind.Method)
             { HasThis = true },
+            TokenArrayClear => new MemberRef(
+                TypeRef.CoreLib("System", "Array"),
+                "Clear",
+                [TypeRef.CoreLib("System", "Array"), TypeRef.CoreLib("System", "Int32"), TypeRef.CoreLib("System", "Int32")],
+                TypeRef.CoreLib("System", "Void"),
+                MemberKind.Method),
+            TokenSpanCopyTo => new MemberRef(
+                coreLibSpanOfByte,
+                "CopyTo",
+                [coreLibSpanOfByte],
+                TypeRef.CoreLib("System", "Void"),
+                MemberKind.Method)
+            { HasThis = true },
+            TokenSpanImplicit => new MemberRef(
+                coreLibSpanOfByte,
+                "op_Implicit",
+                [byteArray],
+                coreLibSpanOfByte,
+                MemberKind.Method),
             _ => MemberRef.Unsupported($"unknown token 0x{token:X8}"),
         };
     }

--- a/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
+++ b/src/ILInspector.Analysis.Tests/LeakTriageAnalyzerTests.cs
@@ -195,6 +195,19 @@ public sealed class LeakTriageAnalyzerTests
             .. Call(TokenSpanCopyTo),
             0x2A,
         ], []);
+        var stagedSpanCopyTo = AnalyzeSyntheticDetailed([
+            .. Call(TokenShared),
+            0x1F, 0x10,
+            .. Callvirt(TokenRent),
+            0x0A,
+            0x06,
+            .. Call(TokenSpanImplicit),
+            0x0B,
+            0x12, 0x01,
+            0x07,
+            .. Call(TokenSpanCopyTo),
+            0x2A,
+        ], []);
 
         Assert.Empty(keepAlive.Findings);
         AssertCandidate(keepAlive, nameof(Synthetic), "cross-method-suppressed");
@@ -215,6 +228,10 @@ public sealed class LeakTriageAnalyzerTests
         Assert.Empty(spanCopyTo.Findings);
         AssertCandidate(spanCopyTo, nameof(Synthetic), "cross-method-suppressed");
         AssertNoCandidate(spanCopyTo, nameof(Synthetic), "exception-path-leak-candidate");
+
+        Assert.Empty(stagedSpanCopyTo.Findings);
+        AssertCandidate(stagedSpanCopyTo, nameof(Synthetic), "cross-method-suppressed");
+        AssertNoCandidate(stagedSpanCopyTo, nameof(Synthetic), "exception-path-leak-candidate");
     }
 
     [Fact]

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -540,7 +540,7 @@ public static class LeakTriageAnalyzer
                     return UseClassification.Release;
                 return UseClassification.CrossMethod(
                     $"Rented array is passed to {callee.DeclaringType.Name}::{callee.Name}.",
-                    IsNonThrowingSetupBoundary(callee));
+                    IsNonThrowingSetupBoundary(instructions, calls, i, callee));
             }
             return UseClassification.OwnershipTransfer($"Rented array reaches unsupported opcode {opcode}.");
         }
@@ -672,7 +672,11 @@ public static class LeakTriageAnalyzer
         => FrameworkIdentity.IsKnownFrameworkType(type, "System.Buffers", "System.Buffers", "ArrayPool`1")
            || FrameworkIdentity.IsCoreLibraryType(type, "System.Buffers", "ArrayPool`1");
 
-    static bool IsNonThrowingSetupBoundary(MemberRef member)
+    static bool IsNonThrowingSetupBoundary(
+        ImmutableArray<DecodedInstruction> instructions,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        int callIndex,
+        MemberRef member)
     {
         if (member.Kind == MemberKind.Unsupported)
             return false;
@@ -683,6 +687,9 @@ public static class LeakTriageAnalyzer
         if (member.Name == "Copy" && FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "Array"))
             return true;
 
+        if (member.Name == "Clear" && FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "Array"))
+            return true;
+
         if (member.Name == "AsSpan"
             && (FrameworkIdentity.IsCoreLibraryType(member.DeclaringType, "System", "MemoryExtensions")
                 || FrameworkIdentity.IsKnownFrameworkType(member.DeclaringType, "System.Memory", "System", "MemoryExtensions")))
@@ -690,7 +697,35 @@ public static class LeakTriageAnalyzer
             return true;
         }
 
+        if (member.Name == "op_Implicit"
+            && member.ParameterTypes.Length == 1
+            && member.ParameterTypes[0].Kind == TypeRefKind.SzArray
+            && IsSpanType(member.ReturnType)
+            && NextCallIsSpanCopyTo(instructions, calls, callIndex))
+        {
+            return true;
+        }
+
         return member.Name == "Clear" && IsSpanType(member.DeclaringType);
+    }
+
+    static bool NextCallIsSpanCopyTo(
+        ImmutableArray<DecodedInstruction> instructions,
+        IReadOnlyDictionary<int, MemberRef> calls,
+        int callIndex)
+    {
+        for (int i = callIndex + 1; i < instructions.Length; i++)
+        {
+            var instruction = instructions[i];
+            if (instruction.OpCode == ILOpCode.Nop)
+                continue;
+
+            return calls.TryGetValue(instruction.Offset, out var next)
+                && next.Name == "CopyTo"
+                && IsSpanType(next.DeclaringType);
+        }
+
+        return false;
     }
 
     static bool IsSpanType(TypeRef type)

--- a/src/ILInspector.Analysis/LeakTriage.cs
+++ b/src/ILInspector.Analysis/LeakTriage.cs
@@ -714,19 +714,31 @@ public static class LeakTriageAnalyzer
         IReadOnlyDictionary<int, MemberRef> calls,
         int callIndex)
     {
-        for (int i = callIndex + 1; i < instructions.Length; i++)
+        for (int i = callIndex + 1, skipped = 0; i < instructions.Length; i++)
         {
             var instruction = instructions[i];
             if (instruction.OpCode == ILOpCode.Nop)
                 continue;
 
-            return calls.TryGetValue(instruction.Offset, out var next)
-                && next.Name == "CopyTo"
-                && IsSpanType(next.DeclaringType);
+            if (calls.TryGetValue(instruction.Offset, out var next))
+                return next.Name == "CopyTo" && IsSpanType(next.DeclaringType);
+
+            if (IsCopyToArgumentSetup(instruction.OpCode) && skipped++ < 6)
+                continue;
+
+            return false;
         }
 
         return false;
     }
+
+    static bool IsCopyToArgumentSetup(ILOpCode opcode)
+        => opcode is ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2 or ILOpCode.Stloc_3
+            or ILOpCode.Stloc_s or ILOpCode.Stloc
+            or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2 or ILOpCode.Ldloc_3
+            or ILOpCode.Ldloc_s or ILOpCode.Ldloc or ILOpCode.Ldloca_s or ILOpCode.Ldloca
+            or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2 or ILOpCode.Ldarg_3
+            or ILOpCode.Ldarg_s or ILOpCode.Ldarg or ILOpCode.Ldarga_s or ILOpCode.Ldarga;
 
     static bool IsSpanType(TypeRef type)
     {

--- a/tools/AnalysisHarness/README.md
+++ b/tools/AnalysisHarness/README.md
@@ -137,14 +137,15 @@ are not product findings; they measure recall gates such as
 `incomplete-cfg-or-rd-suppressed`. Candidate rows can overlap: for example, a cross-method
 suppression can also carry an exception-path candidate when the normal path may still release or
 transfer ownership but an unprotected call boundary can throw first. The exception-path candidate
-bucket suppresses known nonthrowing setup calls such as `GC.KeepAlive`, `Array.Copy`, and
-`MemoryExtensions.AsSpan`; these remain cross-method suppressions rather than product findings. One
-declarative Markout model renders the dense Markdown table and decomposes into section-tagged
-TSV/JSONL. It is a single-run census with no baseline, so it uses plain sectioned rows, not
-composite/delta cells; a `--diff-baseline` mode against a committed snapshot is the natural home
-for those (`Change`/`[MarkoutDelta]`). Each assembly is bounded by a per-assembly timeout, and any
-per-assembly input failure (a directory path, a truncated PE) becomes an `Opened=false` row rather
-than crashing the sweep.
+bucket suppresses known nonthrowing setup calls such as `GC.KeepAlive`, `Array.Copy`,
+`Array.Clear`, `MemoryExtensions.AsSpan`, `Span<T>.Clear`, and array-to-`Span<T>` conversion that
+feeds an immediate `Span<T>.CopyTo`; these remain cross-method suppressions rather than product
+findings. One declarative Markout model renders the dense Markdown table and decomposes into
+section-tagged TSV/JSONL. It is a single-run census with no baseline, so it uses plain sectioned
+rows, not composite/delta cells; a `--diff-baseline` mode against a committed snapshot is the
+natural home for those (`Change`/`[MarkoutDelta]`). Each assembly is bounded by a per-assembly
+timeout, and any per-assembly input failure (a directory path, a truncated PE) becomes an
+`Opened=false` row rather than crashing the sweep.
 
 This is the evidence engine that must earn any user-facing `Leak Triage` section: the analyzer
 fails closed on incomplete CFG/RD, non-`Shared` pools, aliases, field stores, cross-method


### PR DESCRIPTION
## Summary
- suppress additional nonthrowing setup boundaries in leak-triage exception-path candidates: `Array.Clear` and array-to-`Span<T>` conversion immediately feeding `Span<T>.CopyTo`
- keep the existing `cross-method-suppressed` measurement rows; this only narrows overlapping `exception-path-leak-candidate` rows
- leave strong external/unknown boundaries intact, including `AsyncPipeStream.ReadByte` and `SequenceBuilder<T>.Resize`

## Evidence
- Builds on #2473 and the precision sample: https://github.com/richlander/dotnet-inspect/issues/1992#issuecomment-4897591385
- 75-DLL ArrayPool-heavy package corpus after #2473: 75 opened / 0 failed / 0 timed out; 0 findings; 958 candidates; 22 `exception-path-leak-candidate` rows.
- After this change: 75 opened / 0 failed / 0 timed out; findings stay 0; total candidates drop to 948; `exception-path-leak-candidate` drops to 12.
- Remaining exception-path rows are only:
  - `Pipelines.Sockets.Unofficial` `AsyncPipeStream.ReadByte` (6 TFM rows)
  - `Pipelines.Sockets.Unofficial` `SequenceBuilder<T>.Resize` (6 TFM rows)

## Validation
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-restore -- -filter "/*/*/LeakTriageAnalyzerTests/*"`
- `dotnet run --project src/ILInspector.Analysis.Tests -c Release --no-restore`
- `dotnet build tools/AnalysisHarness/AnalysisHarness.csproj -c Release --configfile nuget.config -p:IsAotCompatible=false -p:PublishAot=false`
- `dotnet tools/AnalysisHarness/bin/Release/net11.0/analysis-harness.dll --leak-triage /tmp/leak-nuget-assemblies.txt --top 1000 --jsonl`
- `npx markdownlint-cli tools/AnalysisHarness/README.md`
- `dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config`