### PR TITLE
Avoid duplicate whole-type decompiler attributes

### DIFF
--- a/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
+++ b/src/ILInspector.Decompiler.Tests/TypeSourceCheckTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using ILInspector.DecompilerHarness;
@@ -376,6 +377,24 @@ public class TypeSourceCheckTests
     }
 
     [Fact]
+    public void Evaluate_OnAttributedMemberFixture_DoesNotDuplicateAttributes()
+    {
+        string path = typeof(TypeSourceDuplicateAttributeFixture).Assembly.Location;
+        using var pe = new PEReader(File.OpenRead(path));
+        var api = ApiSurfaceExtractor.Extract(pe);
+        var type = Assert.Single(api.Types, t => t.FullName == typeof(TypeSourceDuplicateAttributeFixture).FullName);
+        var source = TypeSourceComposer.Compose(type, path, pdbPath: null);
+        Assert.NotNull(source);
+
+        Assert.Contains("[RequiresUnreferencedCode(\"trim\")]", source);
+        Assert.Contains("[RequiresDynamicCode(\"aot\")]", source);
+        Assert.DoesNotContain("System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode", source);
+        Assert.DoesNotContain("System.Diagnostics.CodeAnalysis.RequiresDynamicCode", source);
+        Assert.Equal(1, CountOccurrences(source, "RequiresUnreferencedCode"));
+        Assert.Equal(1, CountOccurrences(source, "RequiresDynamicCode"));
+    }
+
+    [Fact]
     public void WrongTypeKind_IsCaught()
     {
         var type = Type("N", "C", "struct", Member("Foo", "method"));
@@ -561,6 +580,18 @@ public class TypeSourceCheckTests
             $"{typeName} type source must compile, got:\n  {string.Join("\n  ", diagnostics)}\n--- source ---\n{source}");
     }
 
+    static int CountOccurrences(string text, string value)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+        return count;
+    }
+
 }
 
 public class TypeSourceNullableConstraintMatrix<TNotNull, TClassNullable, TUnmanaged, TNullableInterface>
@@ -593,6 +624,13 @@ public class @class<@event>
     public int @int { get; set; }
 
     public int @void() => @delegate;
+}
+
+public sealed class TypeSourceDuplicateAttributeFixture
+{
+    [RequiresUnreferencedCode("trim")]
+    [RequiresDynamicCode("aot")]
+    public int Dangerous() => 1;
 }
 
 public class TypeSourceFieldInitializerFixture

--- a/src/ILInspector.Decompiler/TypeSourceComposer.cs
+++ b/src/ILInspector.Decompiler/TypeSourceComposer.cs
@@ -181,6 +181,7 @@ public static class TypeSourceComposer
     {
         ForceAsync = forceAsync,
         ForceUnsafe = forceUnsafe,
+        IncludeCustomAttributes = false,
         IncludeObsoleteAttribute = false,
         OmitInterfaceMemberModifiers = true
     };
@@ -461,6 +462,9 @@ public static class TypeSourceComposer
                     if (!first) sb.AppendLine();
                     first = false;
                     any = true;
+                    foreach (var attribute in AttributeReader.RenderEventAttributes(
+                        reader, typeHandle, member.Name, bodyNamespaces))
+                        sb.AppendLine($"    [{attribute}]");
                     string declaration = CSharpDeclarationWriter.RenderMemberDeclaration(
                         type,
                         member,

--- a/src/ILInspector.Metadata/AttributeReader.cs
+++ b/src/ILInspector.Metadata/AttributeReader.cs
@@ -484,6 +484,19 @@ public static class AttributeReader
         return [];
     }
 
+    /// <summary>Renders the attributes on an event, found by name within the type.</summary>
+    public static List<string> RenderEventAttributes(
+        MetadataReader reader, TypeDefinitionHandle typeHandle, string eventName, SortedSet<string>? namespaces = null)
+    {
+        var typeDef = reader.GetTypeDefinition(typeHandle);
+        foreach (var eventHandle in typeDef.GetEvents())
+        {
+            if (reader.GetString(reader.GetEventDefinition(eventHandle).Name) == eventName)
+                return RenderAttributes(reader, eventHandle, namespaces);
+        }
+        return [];
+    }
+
     static string? TryRenderAttribute(MetadataReader reader, CustomAttribute attr, bool qualifyName)
     {
         if (AttributeDecoder.TryDecode(reader, attr) is not { } value)

--- a/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
+++ b/src/ILInspector.Metadata/CSharpDeclarationWriter.cs
@@ -25,6 +25,7 @@ public sealed record CSharpDeclarationOptions
     public bool TerminateMemberDeclaration { get; init; }
     public bool ForceAsync { get; init; }
     public bool ForceUnsafe { get; init; }
+    public bool IncludeCustomAttributes { get; init; } = true;
     public bool IncludeObsoleteAttribute { get; init; } = true;
     public bool OmitInterfaceMemberModifiers { get; init; }
 }
@@ -86,7 +87,7 @@ public static class CSharpDeclarationWriter
             .Concat(memberList.SelectMany(CollectMemberTypeReferences));
         var plan = TypeNamePlan.Create(references, options);
 
-        List<string> lines = [plan.Apply(RenderTypeDeclarationCore(type))];
+        List<string> lines = [plan.Apply(RenderTypeDeclarationCore(type, options))];
         lines.Add("{");
         foreach (var member in memberList)
         {
@@ -109,7 +110,7 @@ public static class CSharpDeclarationWriter
     {
         options ??= new CSharpDeclarationOptions();
         var plan = TypeNamePlan.Create(CollectTypeReferences(type), options);
-        return plan.Apply(RenderTypeDeclarationCore(type));
+        return plan.Apply(RenderTypeDeclarationCore(type, options));
     }
 
     static string ComposeUnit(IReadOnlyList<string> bodyLines, IReadOnlyList<string> usings, CSharpDeclarationOptions options)
@@ -134,7 +135,7 @@ public static class CSharpDeclarationWriter
         return sb.ToString().TrimEnd();
     }
 
-    static string RenderTypeDeclarationCore(ApiType type)
+    static string RenderTypeDeclarationCore(ApiType type, CSharpDeclarationOptions options)
     {
         var parts = new List<string> { "public" };
         if (type.Kind == "class")
@@ -169,7 +170,7 @@ public static class CSharpDeclarationWriter
             declaration += " : " + string.Join(", ", bases);
 
         declaration = AppendTypeParameterConstraints(declaration, type.TypeParameters);
-        return type.Attributes.Count == 0
+        return !options.IncludeCustomAttributes || type.Attributes.Count == 0
             ? declaration
             : $"[{string.Join(", ", type.Attributes)}] {declaration}";
     }
@@ -243,8 +244,11 @@ public static class CSharpDeclarationWriter
             signature = EscapeParameterLists(signature);
 
         List<string> parts = [];
-        foreach (var attribute in member.Attributes)
-            parts.Add($"[{attribute}]");
+        if (options.IncludeCustomAttributes)
+        {
+            foreach (var attribute in member.Attributes)
+                parts.Add($"[{attribute}]");
+        }
         if (options.IncludeObsoleteAttribute && member.IsObsolete)
             parts.Add(FormatObsoleteAttribute(member.ObsoleteMessage));
         if (member.SignatureModel?.ReturnAttributes is { Count: > 0 } returnAttributes)


### PR DESCRIPTION
Fixes #2480

## Change

**Conclusion:** **PASS** — whole-type Decompiled Source now has one owner for member/type custom attributes, so it no longer emits both short metadata attributes and fully-qualified API-model attributes on the same declaration.

Before:

```csharp
[RequiresUnreferencedCode(...)]
[RequiresDynamicCode(...)]
[System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(...)] [System.Diagnostics.CodeAnalysis.RequiresDynamicCode(...)] public static ...
```

After:

```csharp
[RequiresUnreferencedCode(...)]
[RequiresDynamicCode(...)]
public static ...
```

`TypeSourceComposer` now suppresses API-model custom attributes when asking `CSharpDeclarationWriter` for declarations, while preserving return/parameter attributes from the structured signature model. The whole-type composer continues to emit metadata attributes itself for types, methods, properties, fields, and now events.

## Evidence

| Check | Result |
| --- | --- |
| Focused regression | `TypeSourceCheckTests.Evaluate_OnAttributedMemberFixture_DoesNotDuplicateAttributes` passed |
| Type-source tests | `TypeSourceCheckTests` passed |
| API declaration tests | `ApiSurfaceExtractorTests` passed |
| Decompiler fast suite | Passed before rebase: 2052 passed |
| Product repro | `JsonSerializer` whole-type `Decompiled Source` no longer contains fully-qualified duplicate `RequiresUnreferencedCode` / `RequiresDynamicCode` attributes |
| Solution build | Passed on rebased head; 3 existing nullable warnings in `tests/ILInspector.Metadata.Tests` |

## Decompiler quality

**Conclusion:** **PASS** — this is a whole-type source composition fix, not a method-body raise/printer semantics change; corpus render A/B and quality card are not applicable because method-body output is unchanged by construction.

## Review

Two-model adversarial review requested separately per repo policy; reconciliation will be posted as a PR comment.

## Validation

```bash
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceCheckTests/Evaluate_OnAttributedMemberFixture_DoesNotDuplicateAttributes"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -filter "/*/*/TypeSourceCheckTests/*"
dotnet run --project src/dotnet-inspect.Tests -c Release -- -filter "/*/*/ApiSurfaceExtractorTests/*"
dotnet run --project src/ILInspector.Decompiler.Tests -c Release -- -trait- "Speed=Slow"
dotnet run --project src/dotnet-inspect -c Release -- type JsonSerializer --platform System.Text.Json -S "Decompiled Source" --bare -n 160
dotnet build dotnet-inspect.slnx -c Release --configfile nuget.config
```
